### PR TITLE
resrc_mtr: introduce scanned keys statistics

### DIFF
--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -2125,7 +2125,14 @@ mod tests {
                     let resource_tag = Arc::new(TagInfos::from_rpc_context(&context));
 
                     let mut records = HashMap::default();
-                    records.insert(resource_tag, RawRecord { cpu_time: 10 });
+                    records.insert(
+                        resource_tag,
+                        RawRecord {
+                            cpu_time: 10,
+                            read_keys: 0,
+                            write_keys: 0,
+                        },
+                    );
                     records
                 },
             });

--- a/components/resource_metering/src/client.rs
+++ b/components/resource_metering/src/client.rs
@@ -87,6 +87,8 @@ impl Client for GrpcClient {
                 req.set_resource_group_tag(tag);
                 req.set_record_list_timestamp_sec(record.timestamps);
                 req.set_record_list_cpu_time_ms(record.cpu_time_list);
+                req.set_record_list_read_keys(record.read_keys_list);
+                req.set_record_list_write_keys(record.write_keys_list);
                 if let Err(err) = tx.send((req, WriteFlags::default())).await {
                     warn!("failed to send records"; "error" => ?err);
                     return;
@@ -97,6 +99,8 @@ impl Client for GrpcClient {
                 let mut req = ResourceUsageRecord::default();
                 req.set_record_list_timestamp_sec(others.keys().copied().collect());
                 req.set_record_list_cpu_time_ms(others.values().map(|r| r.cpu_time).collect());
+                req.set_record_list_read_keys(others.values().map(|r| r.read_keys).collect());
+                req.set_record_list_write_keys(others.values().map(|r| r.write_keys).collect());
                 if let Err(err) = tx.send((req, WriteFlags::default())).await {
                     warn!("failed to send records"; "error" => ?err);
                     return;

--- a/components/resource_metering/src/lib.rs
+++ b/components/resource_metering/src/lib.rs
@@ -21,7 +21,10 @@ pub use client::{Client, GrpcClient};
 pub use collector::{Collector, CollectorHandle, CollectorId, CollectorRegHandle};
 pub use config::{Config, ConfigManager};
 pub use model::*;
-pub use recorder::{init_recorder, CpuRecorder, Recorder, RecorderBuilder, RecorderHandle};
+pub use recorder::{
+    init_recorder, record_read_keys, record_write_keys, CpuRecorder, RecorderBuilder,
+    RecorderHandle, SummaryRecorder,
+};
 pub use reporter::{Reporter, Task};
 
 pub const MAX_THREAD_REGISTER_RETRY: u32 = 10;
@@ -31,6 +34,7 @@ use crate::localstorage::{LocalStorage, LocalStorageRef, STORAGE};
 
 use std::intrinsics::unlikely;
 use std::pin::Pin;
+use std::sync::atomic::Ordering::{Relaxed, SeqCst};
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
@@ -73,9 +77,10 @@ impl ResourceMeteringTag {
             assert!(!ls.is_set, "nested attachment is not allowed");
             ls.attached_tag.store(Some(self.infos.clone()));
             ls.is_set = true;
+            ls.summary_cur_record.reset();
 
             Guard {
-                _tag: self.infos.clone(),
+                tag: self.infos.clone(),
             }
         })
     }
@@ -90,8 +95,13 @@ impl ResourceMeteringTag {
 /// [ResourceMeteringTag]: crate::ResourceMeteringTag
 /// [ResourceMeteringTag::attach]: crate::ResourceMeteringTag::attach
 pub struct Guard {
-    _tag: Arc<TagInfos>,
+    tag: Arc<TagInfos>,
 }
+
+// Unlike attached_tag in STORAGE, summary_records will continue to grow as the
+// request arrives. If the recorder thread is not working properly, these maps
+// will never be cleaned up, so here we need to make some restrictions.
+const MAX_SUMMARY_RECORDS_LEN: usize = 1000;
 
 impl Drop for Guard {
     fn drop(&mut self) {
@@ -99,6 +109,28 @@ impl Drop for Guard {
             let mut ls = s.borrow_mut();
             ls.attached_tag.store(None);
             ls.is_set = false;
+            if !ls.summary_enable.load(SeqCst) {
+                return;
+            }
+            if self.tag.extra_attachment.is_empty() {
+                return;
+            }
+            let cur_record = ls.summary_cur_record.take_and_reset();
+            if cur_record.read_keys.load(Relaxed) == 0 && cur_record.write_keys.load(Relaxed) == 0 {
+                return;
+            }
+            let mut records = ls.summary_records.lock().unwrap();
+            match records.get(&self.tag) {
+                Some(record) => {
+                    record.merge(&cur_record);
+                }
+                None => {
+                    // See MAX_SUMMARY_RECORDS_LEN.
+                    if records.len() < MAX_SUMMARY_RECORDS_LEN {
+                        records.insert(self.tag.clone(), cur_record);
+                    }
+                }
+            }
         })
     }
 }
@@ -254,14 +286,14 @@ mod tests {
             };
             {
                 let guard = tag.attach();
-                assert_eq!(guard._tag, tag.infos);
+                assert_eq!(guard.tag, tag.infos);
                 STORAGE.with(|s| {
                     let ls = s.borrow_mut();
                     let local_tag = ls.attached_tag.swap(None);
                     assert!(local_tag.is_some());
                     let tag_infos = local_tag.unwrap();
                     assert_eq!(tag_infos, tag.infos);
-                    assert_eq!(tag_infos, guard._tag);
+                    assert_eq!(tag_infos, guard.tag);
                     assert!(ls.attached_tag.swap(Some(tag_infos)).is_none());
                 });
                 // drop here.

--- a/components/resource_metering/src/localstorage.rs
+++ b/components/resource_metering/src/localstorage.rs
@@ -1,11 +1,14 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
+use crate::model::SummaryRecord;
 use crate::TagInfos;
 
 use std::cell::RefCell;
-use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::sync::{Arc, Mutex};
 
 use arc_swap::ArcSwapOption;
+use collections::HashMap;
 
 thread_local! {
     /// `STORAGE` is a thread-localized instance of [LocalStorage].
@@ -22,6 +25,9 @@ pub struct LocalStorage {
     pub register_failed_times: u32,
     pub is_set: bool,
     pub attached_tag: Arc<ArcSwapOption<TagInfos>>,
+    pub summary_enable: Arc<AtomicBool>,
+    pub summary_cur_record: Arc<SummaryRecord>,
+    pub summary_records: Arc<Mutex<HashMap<Arc<TagInfos>, SummaryRecord>>>,
 }
 
 /// This structure is transmitted as a event in [STORAGE_CHAN].

--- a/components/resource_metering/src/recorder/summary.rs
+++ b/components/resource_metering/src/recorder/summary.rs
@@ -1,0 +1,100 @@
+// Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
+
+use crate::localstorage::{LocalStorage, STORAGE};
+use crate::recorder::SubRecorder;
+use crate::RawRecords;
+
+use std::sync::atomic::Ordering::{Relaxed, SeqCst};
+
+use collections::HashMap;
+
+/// Records how many keys have been read in the current context.
+pub fn record_read_keys(count: u32) {
+    STORAGE.with(|s| {
+        s.borrow()
+            .summary_cur_record
+            .read_keys
+            .fetch_add(count, Relaxed);
+    })
+}
+
+/// Records how many keys have been written in the current context.
+pub fn record_write_keys(count: u32) {
+    STORAGE.with(|s| {
+        s.borrow()
+            .summary_cur_record
+            .write_keys
+            .fetch_add(count, Relaxed);
+    })
+}
+
+/// An implementation of [SubRecorder] for collecting summary data.
+///
+/// `SummaryRecorder` uses some special methods ([record_read_keys]/[record_write_keys])
+/// to collect external statistical information.
+///
+/// See [SubRecorder] for more relevant designs.
+///
+/// [SubRecorder]: crate::recorder::SubRecorder
+pub struct SummaryRecorder {
+    enabled: bool,
+}
+
+impl SummaryRecorder {
+    pub fn new(enabled: bool) -> Self {
+        Self { enabled }
+    }
+}
+
+impl SubRecorder for SummaryRecorder {
+    fn collect(
+        &mut self,
+        records: &mut RawRecords,
+        thread_stores: &mut HashMap<usize, LocalStorage>,
+    ) {
+        thread_stores.iter_mut().for_each(|(_, ls)| {
+            let summary = { std::mem::take(&mut *ls.summary_records.lock().unwrap()) };
+            for (k, v) in summary {
+                records.records.entry(k).or_default().merge_summary(&v);
+            }
+            // The request currently being polled has not yet been merged into the hashmap,
+            // so it needs to be processed separately. (For example, a slow request that is
+            // blocking needs to reflect in real time how many keys have been read currently)
+            if let Some(t) = ls.attached_tag.load_full() {
+                if t.extra_attachment.is_empty() {
+                    return;
+                }
+                let s = ls.summary_cur_record.take_and_reset();
+                records.records.entry(t).or_default().merge_summary(&s);
+            }
+            // Update latest switch.
+            ls.summary_enable.store(self.enabled, SeqCst);
+        });
+    }
+
+    fn pause(
+        &mut self,
+        _records: &mut RawRecords,
+        thread_stores: &mut HashMap<usize, LocalStorage>,
+    ) {
+        thread_stores.iter().for_each(|(_, ls)| {
+            ls.summary_enable.store(false, SeqCst);
+        });
+        self.enabled = false;
+    }
+
+    fn reset(
+        &mut self,
+        _records: &mut RawRecords,
+        thread_stores: &mut HashMap<usize, LocalStorage>,
+    ) {
+        thread_stores.iter().for_each(|(_, ls)| {
+            ls.summary_enable.store(true, SeqCst);
+        });
+        self.enabled = true;
+    }
+
+    fn thread_created(&mut self, _id: usize, store: &LocalStorage) {
+        store.summary_enable.store(self.enabled, SeqCst);
+    }
+}

--- a/components/resource_metering/src/reporter.rs
+++ b/components/resource_metering/src/reporter.rs
@@ -191,7 +191,11 @@ mod tests {
                 peer_id: 0,
                 extra_attachment: b"12345".to_vec(),
             }),
-            RawRecord { cpu_time: 1 },
+            RawRecord {
+                cpu_time: 1,
+                read_keys: 2,
+                write_keys: 3,
+            },
         );
         r.run(Task::Records(Arc::new(RawRecords {
             begin_unix_time_secs: 123,

--- a/components/resource_metering/tests/summary_test.rs
+++ b/components/resource_metering/tests/summary_test.rs
@@ -1,0 +1,142 @@
+// Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
+
+use collections::HashMap;
+use kvproto::kvrpcpb::Context;
+use online_config::{ConfigChange, ConfigManager, ConfigValue};
+use resource_metering::{
+    Client, Config, Record, RecorderBuilder, Records, Reporter, SummaryRecorder,
+};
+use std::sync::atomic::AtomicU64;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+use tikv_util::config::ReadableDuration;
+use tikv_util::worker::LazyWorker;
+
+const PRECISION_MS: u64 = 1000;
+const REPORT_INTERVAL_MS: u64 = 3000;
+
+#[derive(Default, Clone)]
+struct MockClient {
+    data: Arc<Mutex<HashMap<Vec<u8>, Record>>>,
+}
+
+impl Client for MockClient {
+    fn upload_records(&mut self, _address: &str, records: Records) {
+        let mut data = self.data.lock().unwrap();
+        records.records.iter().for_each(|(k, v)| {
+            data.insert(k.clone(), v.clone());
+        });
+    }
+}
+
+impl MockClient {
+    fn get(&self, k: &[u8]) -> Option<Record> {
+        self.data.lock().unwrap().get(k).cloned()
+    }
+
+    fn clear(&self) {
+        self.data.lock().unwrap().clear();
+    }
+}
+
+#[test]
+fn test_summary() {
+    let client = MockClient::default();
+
+    let mut cfg = Config::default();
+    cfg.receiver_address = "127.0.0.1:12345".to_owned();
+    cfg.report_receiver_interval = ReadableDuration::millis(REPORT_INTERVAL_MS);
+    let (rh, crh, tf) = RecorderBuilder::default()
+        .enable(cfg.enabled)
+        .precision_ms(Arc::new(AtomicU64::new(PRECISION_MS)))
+        .add_sub_recorder(Box::new(SummaryRecorder::new(cfg.enabled)))
+        .spawn()
+        .expect("failed to create resource metering thread");
+    let mut worker = LazyWorker::new("test-worker");
+    worker.start_with_timer(Reporter::new(
+        client.clone(),
+        cfg.clone(),
+        crh,
+        worker.scheduler(),
+    ));
+    let mut cfg_manager = resource_metering::ConfigManager::new(cfg, worker.scheduler(), rh);
+
+    /* At this point we are ready for everything except turning on the switch. */
+
+    // expect no data
+    {
+        let tf = tf.clone();
+        let client = client.clone();
+        thread::spawn(move || {
+            {
+                let mut ctx = Context::default();
+                ctx.set_resource_group_tag(b"TAG-1".to_vec());
+                let tag = tf.new_tag(&ctx);
+                let _g = tag.attach();
+                resource_metering::record_read_keys(123);
+                resource_metering::record_write_keys(456);
+            }
+            thread::sleep(Duration::from_millis(REPORT_INTERVAL_MS + 500)); // wait report
+            assert!(client.get(&b"TAG-1".to_vec()).is_none());
+            client.clear();
+        })
+        .join()
+        .unwrap();
+    }
+
+    // turn on
+    let mut change = ConfigChange::new();
+    change.insert("enabled".to_owned(), ConfigValue::Bool(true));
+    cfg_manager.dispatch(change).unwrap();
+
+    // expect can get data
+    {
+        let tf = tf.clone();
+        let client = client.clone();
+        thread::spawn(move || {
+            {
+                let mut ctx = Context::default();
+                ctx.set_resource_group_tag(b"TAG-1".to_vec());
+                let tag = tf.new_tag(&ctx);
+                let _g = tag.attach();
+                thread::sleep(Duration::from_millis(PRECISION_MS * 2)); // wait config apply
+                resource_metering::record_read_keys(123);
+                resource_metering::record_write_keys(456);
+            }
+            thread::sleep(Duration::from_millis(REPORT_INTERVAL_MS + 500)); // wait report
+            let r = client.get(&b"TAG-1".to_vec()).unwrap();
+            assert_eq!(r.read_keys_list.iter().sum::<u32>(), 123);
+            assert_eq!(r.write_keys_list.iter().sum::<u32>(), 456);
+            client.clear();
+        })
+        .join()
+        .unwrap();
+    }
+
+    // turn off
+    let mut change = ConfigChange::new();
+    change.insert("enabled".to_owned(), ConfigValue::Bool(false));
+    cfg_manager.dispatch(change).unwrap();
+
+    // expect no data
+    thread::spawn(move || {
+        {
+            let mut ctx = Context::default();
+            ctx.set_resource_group_tag(b"TAG-1".to_vec());
+            let tag = tf.new_tag(&ctx);
+            let _g = tag.attach();
+            thread::sleep(Duration::from_millis(PRECISION_MS * 2)); // wait config apply
+            resource_metering::record_read_keys(123);
+            resource_metering::record_write_keys(456);
+        }
+        thread::sleep(Duration::from_millis(REPORT_INTERVAL_MS + 500)); // wait report
+        assert!(client.get(&b"TAG-1".to_vec()).is_none());
+        client.clear();
+    })
+    .join()
+    .unwrap();
+
+    // stop worker
+    worker.stop();
+}

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -115,6 +115,7 @@ struct ServerMeta {
     raw_apply_router: ApplyRouter<RocksEngine>,
     gc_worker: GcWorker<RaftKv<RocksEngine, SimulateStoreTransport>, SimulateStoreTransport>,
     rts_worker: Option<LazyWorker<resolved_ts::Task<RocksSnapshot>>>,
+    res_meter_worker: LazyWorker<resource_metering::Task>,
 }
 
 type PendingServices = Vec<Box<dyn Fn() -> Service>>;
@@ -200,6 +201,24 @@ impl ServerCluster {
 
     pub fn get_concurrency_manager(&self, node_id: u64) -> ConcurrencyManager {
         self.concurrency_managers.get(&node_id).unwrap().clone()
+    }
+
+    fn init_resource_metering(
+        &self,
+        cfg: &resource_metering::Config,
+    ) -> (ResourceTagFactory, LazyWorker<resource_metering::Task>) {
+        let (_, crh, rtf) =
+            resource_metering::init_recorder(cfg.enabled, cfg.precision.as_millis());
+        let mut worker = WorkerBuilder::new("resource-metering-reporter")
+            .pending_capacity(30)
+            .create()
+            .lazy_build("resource-metering-reporter");
+        let mut client = resource_metering::GrpcClient::default();
+        client.set_env(self.env.clone());
+        let reporter =
+            resource_metering::Reporter::new(client, cfg.clone(), crh, worker.scheduler());
+        worker.start_with_timer(reporter);
+        (rtf, worker)
     }
 }
 
@@ -306,6 +325,10 @@ impl Simulator for ServerCluster {
             None
         };
 
+        // Start resource metering.
+        let (res_tag_factory, res_meter_worker) =
+            self.init_resource_metering(&cfg.resource_metering);
+
         let check_leader_runner = CheckLeaderRunner::new(store_meta.clone());
         let check_leader_scheduler = bg_worker.start("check-leader", check_leader_runner);
 
@@ -319,7 +342,7 @@ impl Simulator for ServerCluster {
             lock_mgr.get_storage_dynamic_configs(),
             Arc::new(FlowController::empty()),
             pd_sender,
-            ResourceTagFactory::new_for_test(),
+            res_tag_factory.clone(),
         )?;
         self.storages.insert(node_id, raft_engine);
 
@@ -368,7 +391,7 @@ impl Simulator for ServerCluster {
             cop_read_pool.handle(),
             concurrency_manager.clone(),
             PerfLevel::EnableCount,
-            ResourceTagFactory::new_for_test(),
+            res_tag_factory,
         );
         let copr_v2 = coprocessor_v2::Endpoint::new(&cfg.coprocessor_v2);
         let mut server = None;
@@ -506,6 +529,7 @@ impl Simulator for ServerCluster {
                 sim_trans: simulate_trans,
                 gc_worker,
                 rts_worker,
+                res_meter_worker,
             },
         );
         self.addrs.insert(node_id, format!("{}", addr));
@@ -535,6 +559,7 @@ impl Simulator for ServerCluster {
             if let Some(worker) = meta.rts_worker {
                 worker.stop_worker();
             }
+            meta.res_meter_worker.stop_worker();
         }
     }
 

--- a/src/storage/mvcc/reader/point_getter.rs
+++ b/src/storage/mvcc/reader/point_getter.rs
@@ -294,6 +294,7 @@ impl<S: Snapshot> PointGetter<S> {
             match write.write_type {
                 WriteType::Put => {
                     self.statistics.write.processed_keys += 1;
+                    resource_metering::record_read_keys(1);
 
                     if self.omit_value {
                         return Ok(Some(vec![]));

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -468,6 +468,7 @@ impl<S: EngineSnapshot> MvccReader<S> {
             }
             if keys.len() >= limit {
                 self.statistics.write.processed_keys += keys.len();
+                resource_metering::record_read_keys(keys.len() as u32);
                 return Ok((keys, start));
             }
             let key =

--- a/src/storage/mvcc/reader/scanner/backward.rs
+++ b/src/storage/mvcc/reader/scanner/backward.rs
@@ -197,6 +197,7 @@ impl<S: Snapshot> BackwardKvScanner<S> {
             if let Some(v) = result? {
                 self.statistics.write.processed_keys += 1;
                 self.statistics.processed_size += current_user_key.len() + v.len();
+                resource_metering::record_read_keys(1);
                 return Ok(Some((current_user_key, v)));
             }
         }

--- a/src/storage/mvcc/reader/scanner/forward.rs
+++ b/src/storage/mvcc/reader/scanner/forward.rs
@@ -285,6 +285,7 @@ impl<S: Snapshot, P: ScanPolicy<S>> ForwardScanner<S, P> {
                     )? {
                         self.statistics.write.processed_keys += 1;
                         self.statistics.processed_size += self.scan_policy.output_size(&output);
+                        resource_metering::record_read_keys(1);
                         return Ok(Some(output));
                     }
                 }

--- a/tests/integrations/resource_metering/mod.rs
+++ b/tests/integrations/resource_metering/mod.rs
@@ -1,5 +1,6 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
+pub mod test_read_keys;
 pub mod test_suite;
 
 #[cfg(target_os = "linux")]

--- a/tests/integrations/resource_metering/test_read_keys.rs
+++ b/tests/integrations/resource_metering/test_read_keys.rs
@@ -1,0 +1,300 @@
+// Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
+
+use crate::resource_metering::test_suite::MockReceiverServer;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use concurrency_manager::ConcurrencyManager;
+use crossbeam::channel::{unbounded, Receiver, RecvTimeoutError, Sender};
+use engine_rocks::PerfLevel;
+use grpcio::{ChannelBuilder, Environment};
+use kvproto::coprocessor;
+use kvproto::kvrpcpb::*;
+use kvproto::resource_usage_agent::ResourceUsageRecord;
+use kvproto::tikvpb::*;
+use protobuf::Message;
+use resource_metering::{Records, ResourceTagFactory};
+use test_coprocessor::{DAGSelect, ProductTable, Store};
+use test_raftstore::*;
+use test_util::alloc_port;
+use tidb_query_datatype::codec::Datum;
+use tikv::config::CoprReadPoolConfig;
+use tikv::coprocessor::{readpool_impl, Endpoint};
+use tikv::read_pool::ReadPool;
+use tikv::storage::{Engine, RocksEngine, TestEngineBuilder};
+use tikv_util::config::ReadableDuration;
+use tikv_util::thread_group::GroupProperties;
+use tikv_util::worker::Builder as WorkerBuilder;
+use tikv_util::HandyRwLock;
+use tipb::SelectResponse;
+
+#[test]
+#[ignore = "the case is unstable, ref #11689"]
+pub fn test_read_keys() {
+    // Create & start receiver server.
+    let (tx, rx) = unbounded();
+    let mut server = MockReceiverServer::new(tx);
+    let port = alloc_port();
+    let env = Arc::new(Environment::new(1));
+    server.start_server(port, env.clone());
+
+    // Create cluster.
+    let (_cluster, client, mut ctx) = new_cluster(port, env);
+
+    // Set resource group tag for enable resource metering.
+    ctx.set_resource_group_tag("TEST-TAG".into());
+
+    let mut ts = 0;
+
+    // Write 10 key-value pairs.
+    for n in 0..10 {
+        let n = n.to_string().into_bytes();
+        let (k, v) = (n.clone(), n);
+
+        // Prewrite.
+        ts += 1;
+        let prewrite_start_version = ts;
+        let mut mutation = Mutation::default();
+        mutation.set_op(Op::Put);
+        mutation.set_key(k.clone());
+        mutation.set_value(v.clone());
+        must_kv_prewrite(
+            &client,
+            ctx.clone(),
+            vec![mutation],
+            k.clone(),
+            prewrite_start_version,
+        );
+
+        // Commit.
+        ts += 1;
+        let commit_version = ts;
+        must_kv_commit(
+            &client,
+            ctx.clone(),
+            vec![k.clone()],
+            prewrite_start_version,
+            commit_version,
+            commit_version,
+        );
+    }
+
+    // PointGet
+    ts += 1;
+    let mut get_req = GetRequest::default();
+    get_req.set_context(ctx.clone());
+    get_req.set_key(b"0".to_vec());
+    get_req.set_version(ts);
+    let _ = client.kv_get(&get_req).unwrap(); // trigger thread register
+    std::thread::sleep(Duration::from_secs(2));
+    recv_read_keys(&rx);
+    let get_resp = client.kv_get(&get_req).unwrap();
+    assert!(!get_resp.has_region_error());
+    assert!(!get_resp.has_error());
+    let scan_detail_v2 = get_resp.get_exec_details_v2().get_scan_detail_v2();
+    assert_eq!(scan_detail_v2.get_total_versions(), 1);
+    assert_eq!(scan_detail_v2.get_processed_versions(), 1);
+    assert!(scan_detail_v2.get_processed_versions_size() > 0);
+    assert_eq!(get_resp.value, b"0".to_vec());
+
+    // Wait & receive & assert.
+    assert_eq!(must_recv_read_keys(&rx), 1);
+
+    // Scan 0 ~ 4.
+    ts += 1;
+    let mut scan_req = ScanRequest::default();
+    scan_req.set_context(ctx.clone());
+    scan_req.set_start_key(b"0".to_vec());
+    scan_req.set_limit(5);
+    scan_req.set_version(ts);
+    let scan_resp = client.kv_scan(&scan_req).unwrap();
+    assert!(!scan_resp.has_region_error());
+    assert_eq!(scan_resp.pairs.len(), 5);
+
+    // Wait & receive & assert.
+    assert_eq!(must_recv_read_keys(&rx), 5);
+
+    // Scan 0 ~ 9.
+    ts += 1;
+    let mut scan_req = ScanRequest::default();
+    scan_req.set_context(ctx.clone());
+    scan_req.set_start_key(b"0".to_vec());
+    scan_req.set_limit(100);
+    scan_req.set_version(ts);
+    let scan_resp = client.kv_scan(&scan_req).unwrap();
+    assert!(!scan_resp.has_region_error());
+    assert_eq!(scan_resp.pairs.len(), 10);
+
+    // Wait & receive & assert.
+    assert_eq!(must_recv_read_keys(&rx), 10);
+
+    // Shutdown receiver server.
+    tokio::runtime::Runtime::new().unwrap().block_on(async {
+        server.shutdown_server().await;
+    });
+}
+
+fn new_cluster(port: u16, env: Arc<Environment>) -> (Cluster<ServerCluster>, TikvClient, Context) {
+    let (cluster, leader, ctx) = must_new_and_configure_cluster(|cluster| {
+        cluster.cfg.resource_metering.enabled = true;
+        cluster.cfg.resource_metering.receiver_address = format!("127.0.0.1:{}", port);
+        cluster.cfg.resource_metering.precision = ReadableDuration::millis(100);
+        cluster.cfg.resource_metering.report_receiver_interval = ReadableDuration::millis(400);
+    });
+    let channel =
+        ChannelBuilder::new(env).connect(&cluster.sim.rl().get_addr(leader.get_store_id()));
+    let client = TikvClient::new(channel);
+    (cluster, client, ctx)
+}
+
+fn must_recv_read_keys(rx: &Receiver<Vec<ResourceUsageRecord>>) -> u32 {
+    const MAX_WAIT_SECS: u32 = 30;
+    let duration = Duration::from_secs(1);
+    for _ in 0..MAX_WAIT_SECS {
+        std::thread::sleep(duration);
+        let read_keys = recv_read_keys(rx);
+        if read_keys > 0 {
+            return read_keys;
+        }
+    }
+    panic!("no read_keys");
+}
+
+fn recv_read_keys(rx: &Receiver<Vec<ResourceUsageRecord>>) -> u32 {
+    let mut total = 0;
+    while let Ok(records) = rx.try_recv() {
+        for r in &records {
+            total += r.get_record_list_read_keys().iter().sum::<u32>();
+        }
+    }
+    total
+}
+
+#[test]
+#[ignore = "the case is unstable, ref #11689"]
+fn test_read_keys_coprocessor() {
+    // Start resource metering.
+    let mut cfg = resource_metering::Config::default();
+    cfg.enabled = true;
+    cfg.receiver_address = "mock-receiver".to_owned();
+    cfg.precision = ReadableDuration::millis(100);
+    cfg.report_receiver_interval = ReadableDuration::millis(400);
+    let (_, crh, rtf) = resource_metering::init_recorder(cfg.enabled, cfg.precision.as_millis());
+    let mut worker = WorkerBuilder::new("resource-metering-reporter")
+        .pending_capacity(30)
+        .create()
+        .lazy_build("resource-metering-reporter");
+    let client = MockClient::new();
+    let reporter =
+        resource_metering::Reporter::new(client.clone(), cfg.clone(), crh, worker.scheduler());
+    worker.start_with_timer(reporter);
+
+    // Init data.
+    let data = vec![
+        (1, Some("name:0"), 2),
+        (2, Some("name:4"), 3),
+        (4, Some("name:3"), 1),
+        (5, Some("name:1"), 4),
+    ];
+    let product = ProductTable::new();
+    let endpoint = init_coprocessor_with_data(&product, &data, rtf);
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap();
+
+    // Do DAG select to register runtime thread.
+    let mut req = DAGSelect::from(&product).build();
+    let mut ctx = Context::default();
+    ctx.set_resource_group_tag("TEST-TAG".into());
+    req.set_context(ctx);
+    runtime.block_on(handle_select(&endpoint, req.clone()));
+
+    // Clear current result.
+    let _ = client.wait_read_keys(Duration::from_secs(3));
+
+    // Do DAG select again.
+    runtime.block_on(handle_select(&endpoint, req));
+
+    // Wait & receive & assert.
+    assert_eq!(client.wait_read_keys(Duration::from_secs(30)).unwrap(), 4);
+
+    // Cleanup.
+    worker.stop_worker();
+}
+
+fn init_coprocessor_with_data(
+    tbl: &ProductTable,
+    vals: &[(i64, Option<&str>, i64)],
+    tag_factory: ResourceTagFactory,
+) -> Endpoint<RocksEngine> {
+    let engine = TestEngineBuilder::new().build().unwrap();
+    let mut store = Store::from_engine(engine);
+    store.begin();
+    for &(id, name, count) in vals {
+        store
+            .insert_into(tbl)
+            .set(&tbl["id"], Datum::I64(id))
+            .set(&tbl["name"], name.map(str::as_bytes).into())
+            .set(&tbl["count"], Datum::I64(count))
+            .execute_with_ctx(Context::default());
+    }
+    store.commit_with_ctx(Context::default());
+    tikv_util::thread_group::set_properties(Some(GroupProperties::default()));
+    let pool = ReadPool::from(readpool_impl::build_read_pool_for_test(
+        &CoprReadPoolConfig::default_for_test(),
+        store.get_engine(),
+    ));
+    let cm = ConcurrencyManager::new(1.into());
+    Endpoint::new(
+        &tikv::server::Config::default(),
+        pool.handle(),
+        cm,
+        PerfLevel::EnableCount,
+        tag_factory,
+    )
+}
+
+async fn handle_select<E>(copr: &Endpoint<E>, req: coprocessor::Request) -> SelectResponse
+where
+    E: Engine,
+{
+    let resp = copr
+        .parse_and_handle_unary_request(req, None)
+        .await
+        .consume();
+    assert!(!resp.get_data().is_empty(), "{:?}", resp);
+    let mut sel_resp = SelectResponse::default();
+    sel_resp.merge_from_bytes(resp.get_data()).unwrap();
+    sel_resp
+}
+
+#[derive(Clone)]
+struct MockClient {
+    tx: Sender<u32>,
+    rx: Receiver<u32>,
+}
+
+impl MockClient {
+    fn new() -> Self {
+        let (tx, rx) = unbounded();
+        Self { tx, rx }
+    }
+
+    fn wait_read_keys(&self, timeout: Duration) -> Result<u32, RecvTimeoutError> {
+        self.rx.recv_timeout(timeout)
+    }
+}
+
+impl resource_metering::Client for MockClient {
+    fn upload_records(&mut self, _address: &str, records: Records) {
+        let mut read_keys = 0;
+        for r in records.records.values() {
+            read_keys += r.read_keys_list.iter().sum::<u32>();
+        }
+        for r in records.others.values() {
+            read_keys += r.read_keys;
+        }
+        self.tx.send(read_keys).unwrap();
+    }
+}

--- a/tests/integrations/resource_metering/test_suite/mod.rs
+++ b/tests/integrations/resource_metering/test_suite/mod.rs
@@ -2,6 +2,8 @@
 
 mod mock_receiver_server;
 
+pub use mock_receiver_server::MockReceiverServer;
+
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -12,7 +14,6 @@ use futures::{select, FutureExt};
 use grpcio::Environment;
 use kvproto::kvrpcpb::{ApiVersion, Context};
 use kvproto::resource_usage_agent::ResourceUsageRecord;
-use mock_receiver_server::MockReceiverServer;
 use resource_metering::{init_recorder, Config, ConfigManager, Task, TEST_TAG_PREFIX};
 use tempfile::TempDir;
 use tikv::config::{ConfigController, Module, TiKvConfig};


### PR DESCRIPTION
### What problem does this PR solve?

close https://github.com/tikv/tikv/issues/11690

Added support for the collection and reporting of the scanned keys.

### What is changed and how it works?

What's Changed:

- Added `SummaryRecorder` which implements `SubRecorder`.
- Three fields have been added to `LocalStorage` for statistics of scanned keys.
- Added the statistical logic of scanned keys in the context of ResourceMeteringTag.
- Added some fields related to scanned keys to the structure in `model.rs`.
- Handle extra fields in `client.rs`.

### Related changes

- [pingcap/kvproto#814](https://github.com/pingcap/kvproto/pull/814)

### Check List

Tests

- Unit test
- Integration test

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM

### Release note

```release-note
Support the statistics of scanned keys in resource metering.
```