### PR TITLE
tidb_query_expr: refactor lower_utf8

### DIFF
--- a/components/tidb_query_expr/src/impl_string.rs
+++ b/components/tidb_query_expr/src/impl_string.rs
@@ -525,9 +525,9 @@ pub fn right_utf8(lhs: BytesRef, rhs: &Int, writer: BytesWriter) -> Result<Bytes
 
 #[rpn_fn(writer)]
 #[inline]
-pub fn upper_utf8(arg: BytesRef, writer: BytesWriter) -> Result<BytesGuard> {
+pub fn lower_utf8(arg: BytesRef, writer: BytesWriter) -> Result<BytesGuard> {
     let s = str::from_utf8(arg)?;
-    let res = s.chars().flat_map(char::to_uppercase);
+    let res = s.chars().flat_map(char::to_lowercase);
     Ok(writer.write_from_char_iter(res))
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

For a large string, upper_utf8 may allocate a large temporary buffer.

Problem Summary:

### What is changed and how it works?

call ```to_lowercase``` by chunk

#11084 has changed upper_utf8. This PR optimized memory in lowe_utf8
What's Changed:

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```