### PR TITLE
raftstore: set region size & keys when restarting

### DIFF
--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -594,6 +594,7 @@ where
         engines: Engines<EK, ER>,
         region: &metapb::Region,
         peer: metapb::Peer,
+        approximate_size_and_keys: Option<(u64, u64)>,
     ) -> Result<Peer<EK, ER>> {
         if peer.get_id() == raft::INVALID_ID {
             return Err(box_err!("invalid peer id"));
@@ -686,6 +687,11 @@ where
             persisted_number: 0,
             apply_snap_ctx: None,
         };
+
+        if let Some((size, keys)) = approximate_size_and_keys {
+            peer.approximate_size = size;
+            peer.approximate_keys = keys;
+        }
 
         // If this region has only one peer and I am the one, campaign directly.
         if region.get_peers().len() == 1 && region.get_peers()[0].get_store_id() == store_id {


### PR DESCRIPTION
Signed-off-by: p4tr1ck <patrick.li@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #11114  <!-- REMOVE this line if no issue to close -->

Problem Summary: PD to perform a lot of scheduling caused by the reported region size error

### What is changed and how it works?

What's Changed: Read approximate size and keys from engine when peers is restarting

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
fix the problem pd to perform large scheduling during rolling update.
```