### PR TITLE
[DNM] Add rich panic logs to DeltaScanner for debugging purpose

### DIFF
--- a/components/txn_types/src/write.rs
+++ b/components/txn_types/src/write.rs
@@ -123,7 +123,7 @@ impl Write {
     }
 }
 
-#[derive(PartialEq, Clone)]
+#[derive(PartialEq, Clone, Debug)]
 pub struct WriteRef<'a> {
     pub write_type: WriteType,
     pub start_ts: TimeStamp,

--- a/src/storage/mvcc/reader/mod.rs
+++ b/src/storage/mvcc/reader/mod.rs
@@ -9,6 +9,7 @@ pub use self::reader::{check_need_gc, MvccReader};
 pub use self::scanner::test_util;
 pub use self::scanner::{
     has_data_in_range, seek_for_valid_write, DeltaScanner, EntryScanner, Scanner, ScannerBuilder,
+    SeekForValidWriteDebugInfo,
 };
 
 #[derive(Debug, PartialEq, Clone, Copy)]

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -1026,11 +1026,12 @@ impl<S: Snapshot> MvccTxn<S> {
                     let write_cursor = self.reader.write_cursor.as_mut().unwrap();
                     // Skip the current write record.
                     write_cursor.next(&mut self.reader.statistics.write);
-                    let write = seek_for_valid_write(
+                    let write = seek_for_valid_write::<_, S>(
                         write_cursor,
                         key,
                         self.start_ts,
                         &mut self.reader.statistics,
+                        None,
                     )?;
                     write.map(|w| OldValue {
                         short_value: w.short_value,


### PR DESCRIPTION
Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: -

Problem Summary: This PR makes the information printed in the panic in DeltaScanner more rich for diagnosing the reason of the panic.


### Related changes

- 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```