### PR TITLE
tikv_util: fix test-cgroup feature compile error

### DIFF
--- a/components/tikv_util/src/sys/cgroup.rs
+++ b/components/tikv_util/src/sys/cgroup.rs
@@ -476,7 +476,7 @@ mod tests {
 
         // cgroup-v2 $ cgset -r memory.max=1G tikv-test
         // cgroup-v1 $ cgset -r memory.limit_in_bytes=1G tikv-test
-        let mut child = if is_cgroup2_unified_mode() {
+        let mut child = if is_cgroup2_unified_mode().unwrap() {
             Command::new("cgset")
                 .args(&["-r", "memory.max=1G", &group])
                 .spawn()
@@ -492,7 +492,7 @@ mod tests {
         // cgroup-v2 $ cgset -r cpu.max='1000000 1000000' tikv-test
         // cgroup-v1 $ cgset -r cpu.cfs_quota_us=1000000 tikv-test
         // cgroup-v1 $ cgset -r cpu.cfs_period_us=1000000 tikv-test
-        if is_cgroup2_unified_mode() {
+        if is_cgroup2_unified_mode().unwrap() {
             let mut child = Command::new("cgset")
                 .args(&["-r", "cpu.max=1000000 1000000", &group])
                 .spawn()


### PR DESCRIPTION
Signed-off-by: wuaoxiang <wuaoxiang@stargraph.cn>

### What problem does this PR solve?

Fix `cargo test --package=tikv_util --features test-cgroup` compile error

Fix #11188 

### Check List

Tests

- Unit test

### Release note

```release-note
None
```
