### PR TITLE
storage: return start TS of mismatching lock in TxnNotFound 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2127,7 +2127,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#3c7bd947cf9bb0be346131e1c4097a69b3465b8f"
+source = "git+https://github.com/sticnarf/kvproto.git?branch=optimistic-deadlock#e29dae53fafa9a69088f0162b500d767c9af362c"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,6 +183,9 @@ rusoto_mock = { git = "https://github.com/tikv/rusoto", branch = "gh1482-s3-addr
 rusoto_s3 = { git = "https://github.com/tikv/rusoto", branch = "gh1482-s3-addr-styles" }
 rusoto_sts = { git = "https://github.com/tikv/rusoto", branch = "gh1482-s3-addr-styles" }
 
+[patch.'https://github.com/pingcap/kvproto.git']
+kvproto = { git = "https://github.com/sticnarf/kvproto.git", branch = "optimistic-deadlock" }
+
 [target.'cfg(target_os = "linux")'.dependencies]
 procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "5125fc1a69496b73b26b3c08b6e8afc3c665a56e" }
 

--- a/src/storage/errors.rs
+++ b/src/storage/errors.rs
@@ -300,11 +300,16 @@ pub fn extract_key_error(err: &Error) -> kvrpcpb::KeyError {
             key_error.set_retryable(format!("{:?}", err));
         }
         Error(box ErrorInner::Txn(TxnError(box TxnErrorInner::Mvcc(MvccError(
-            box MvccErrorInner::TxnNotFound { start_ts, key },
+            box MvccErrorInner::TxnNotFound {
+                start_ts,
+                key,
+                lock_ts,
+            },
         ))))) => {
             let mut txn_not_found = kvrpcpb::TxnNotFound::default();
             txn_not_found.set_start_ts(start_ts.into_inner());
             txn_not_found.set_primary_key(key.to_owned());
+            txn_not_found.set_lock_ts(lock_ts.into_inner());
             key_error.set_txn_not_found(txn_not_found);
         }
         Error(box ErrorInner::Txn(TxnError(box TxnErrorInner::Mvcc(MvccError(

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -69,8 +69,12 @@ pub enum ErrorInner {
         key: Vec<u8>,
     },
 
-    #[error("txn not found {} key: {}", .start_ts, log_wrappers::Value::key(.key))]
-    TxnNotFound { start_ts: TimeStamp, key: Vec<u8> },
+    #[error("txn not found {} key: {}, lock_ts: {}", .start_ts, log_wrappers::Value::key(.key), .lock_ts)]
+    TxnNotFound {
+        start_ts: TimeStamp,
+        key: Vec<u8>,
+        lock_ts: TimeStamp,
+    },
 
     #[error(
         "lock type not match, start_ts:{}, key:{}, pessimistic:{}",
@@ -166,9 +170,14 @@ impl ErrorInner {
                 commit_ts: *commit_ts,
                 key: key.to_owned(),
             }),
-            ErrorInner::TxnNotFound { start_ts, key } => Some(ErrorInner::TxnNotFound {
+            ErrorInner::TxnNotFound {
+                start_ts,
+                key,
+                lock_ts,
+            } => Some(ErrorInner::TxnNotFound {
                 start_ts: *start_ts,
                 key: key.to_owned(),
+                lock_ts: *lock_ts,
             }),
             ErrorInner::LockTypeNotMatch {
                 start_ts,

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -208,6 +208,7 @@ pub(crate) fn make_txn_error(
             "txnnotfound" => ErrorInner::TxnNotFound {
                 start_ts,
                 key: key.to_raw().unwrap(),
+                lock_ts: TimeStamp::zero(),
             },
             "locktypenotmatch" => ErrorInner::LockTypeNotMatch {
                 start_ts,

--- a/src/storage/txn/actions/check_txn_status.rs
+++ b/src/storage/txn/actions/check_txn_status.rs
@@ -103,9 +103,11 @@ pub fn check_txn_status_missing_lock(
         TxnCommitRecord::OverlappedRollback { .. } => Ok(TxnStatus::RolledBack),
         TxnCommitRecord::None { overlapped_write } => {
             if MissingLockAction::ReturnError == action {
+                let lock_ts = mismatch_lock.map(|l| l.ts).unwrap_or_default();
                 return Err(ErrorInner::TxnNotFound {
                     start_ts: reader.start_ts,
                     key: primary_key.into_raw()?,
+                    lock_ts,
                 }
                 .into());
             }

--- a/src/storage/txn/commands/mod.rs
+++ b/src/storage/txn/commands/mod.rs
@@ -885,4 +885,24 @@ pub mod test_util {
         engine.write(&ctx, ret.to_be_write).unwrap();
         Ok(())
     }
+
+    pub fn assert_txn_not_found(
+        err: Error,
+        expected_start_ts: impl Into<TimeStamp>,
+        expected_lock_ts: impl Into<TimeStamp>,
+        expected_key: &[u8],
+    ) {
+        match err {
+            Error(box ErrorInner::Mvcc(MvccError(box MvccErrorInner::TxnNotFound {
+                start_ts,
+                key,
+                lock_ts,
+            }))) => {
+                assert_eq!(start_ts, expected_start_ts.into());
+                assert_eq!(lock_ts, expected_lock_ts.into());
+                assert_eq!(key, expected_key)
+            }
+            e => panic!("unexpected error: {:?}", e),
+        }
+    }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: ref #11148

To resolve another case of optimistic deadlock. See #11148 for details.

### What is changed and how it works?

When `CheckTxnStatus` or `TxnHeartbeat` encounters a mismatching lock, return the lock TS in the `TxnNotFound` error.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Avoid deadlock in optimistic transactions.
```