### PR TITLE
Add data_key to get_regions_in_range

### DIFF
--- a/components/raftstore/src/coprocessor/region_info_accessor.rs
+++ b/components/raftstore/src/coprocessor/region_info_accessor.rs
@@ -382,6 +382,8 @@ impl RegionCollector {
         callback: Callback<Vec<Region>>,
     ) {
         let mut regions = vec![];
+        let start_key = data_key(&start_key);
+        let end_key = data_key(&end_key);
         for (_, region_id) in self
             .region_ranges
             .range((Included(start_key), Included(end_key)))


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #11217 <!-- REMOVE this line if no issue to close -->

Problem Summary: GcKeys never actually garbage collects key ranges due to encoding issue.

### What is changed and how it works?

Add data key prefix so that GcKeys actually garbage collects keys

What's Changed:

### Related changes

- Need to cherry-pick to the release branch if appropriate

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No test included - can somebody on the PingCAP side take adding appropriate testing?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix issue with garbage collection not properly collecting delete markers.
```