### PR TITLE
engine_rocks: switch rust-rocksdb to branch tikv-5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2411,7 +2411,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#dcc1f836a2ae7a7ee71b6aed8cd4107e04a4b829"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-5.2#19c76fe08b1f8ad1aeddf7270303fdf489393404"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -2430,7 +2430,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tikv/rust-rocksdb.git#dcc1f836a2ae7a7ee71b6aed8cd4107e04a4b829"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-5.2#19c76fe08b1f8ad1aeddf7270303fdf489393404"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -4109,7 +4109,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#dcc1f836a2ae7a7ee71b6aed8cd4107e04a4b829"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-5.2#19c76fe08b1f8ad1aeddf7270303fdf489393404"
 dependencies = [
  "libc 0.2.100",
  "librocksdb_sys",

--- a/components/engine_rocks/Cargo.toml
+++ b/components/engine_rocks/Cargo.toml
@@ -74,6 +74,7 @@ fail = "0.4"
 git = "https://github.com/tikv/rust-rocksdb.git"
 package = "rocksdb"
 features = ["encryption", "static_libcpp"]
+branch = "tikv-5.2"
 
 [dev-dependencies]
 rand = "0.8"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: #11226

### What is changed and how it works?

What's Changed:

Switch rust-rocksdb to branch tikv-5.2.

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```