### PR TITLE
raftstore: reduce some cpu waste of apply thread

### DIFF
--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -631,7 +631,7 @@ impl<T: 'static + RaftStoreRouter<E>, E: KvEngine> Endpoint<T, E> {
     pub fn on_multi_batch(&mut self, multi: Vec<CmdBatch>, old_value_cb: OldValueCallback) {
         fail_point!("cdc_before_handle_multi_batch", |_| {});
         for batch in multi {
-            let region_id = batch.region.get_id();
+            let region_id = batch.region_id;
             let mut deregister = None;
             if let Some(delegate) = self.capture_regions.get_mut(&region_id) {
                 if delegate.has_failed() {

--- a/components/cdc/src/observer.rs
+++ b/components/cdc/src/observer.rs
@@ -194,7 +194,7 @@ mod tests {
         let observe_info = CmdObserveInfo::from_handle(ObserveHandle::new(), ObserveHandle::new());
         let engine = TestEngineBuilder::new().build().unwrap().get_rocksdb();
 
-        let mut cb = CmdBatch::new(&observe_info, Region::default());
+        let mut cb = CmdBatch::new(&observe_info, &Region::default());
         cb.push(&observe_info, 0, Cmd::default());
         <CdcObserver as CmdObserver<RocksEngine>>::on_flush_applied_cmd_batch(
             &observer,
@@ -212,7 +212,7 @@ mod tests {
 
         // Stop observing cmd
         observe_info.cdc_id.stop_observing();
-        let mut cb = CmdBatch::new(&observe_info, Region::default());
+        let mut cb = CmdBatch::new(&observe_info, &Region::default());
         cb.push(&observe_info, 0, Cmd::default());
         <CdcObserver as CmdObserver<RocksEngine>>::on_flush_applied_cmd_batch(
             &observer,

--- a/components/cdc/src/observer.rs
+++ b/components/cdc/src/observer.rs
@@ -194,7 +194,7 @@ mod tests {
         let observe_info = CmdObserveInfo::from_handle(ObserveHandle::new(), ObserveHandle::new());
         let engine = TestEngineBuilder::new().build().unwrap().get_rocksdb();
 
-        let mut cb = CmdBatch::new(&observe_info, &Region::default());
+        let mut cb = CmdBatch::new(&observe_info, 0);
         cb.push(&observe_info, 0, Cmd::default());
         <CdcObserver as CmdObserver<RocksEngine>>::on_flush_applied_cmd_batch(
             &observer,
@@ -212,7 +212,7 @@ mod tests {
 
         // Stop observing cmd
         observe_info.cdc_id.stop_observing();
-        let mut cb = CmdBatch::new(&observe_info, &Region::default());
+        let mut cb = CmdBatch::new(&observe_info, 0);
         cb.push(&observe_info, 0, Cmd::default());
         <CdcObserver as CmdObserver<RocksEngine>>::on_flush_applied_cmd_batch(
             &observer,

--- a/components/keys/src/lib.rs
+++ b/components/keys/src/lib.rs
@@ -210,6 +210,12 @@ pub fn data_key(key: &[u8]) -> Vec<u8> {
     v
 }
 
+pub fn data_key_with_buffer(key: &[u8], buffer: &mut Vec<u8>) {
+    buffer.clear();
+    buffer.extend_from_slice(DATA_PREFIX_KEY);
+    buffer.extend_from_slice(key);
+}
+
 pub fn origin_key(key: &[u8]) -> &[u8] {
     assert!(
         validate_data_key(key),

--- a/components/keys/src/lib.rs
+++ b/components/keys/src/lib.rs
@@ -434,6 +434,8 @@ mod tests {
         let mut buffer = vec![];
         data_key_with_buffer(b"abc", &mut buffer);
         assert_eq!(buffer, data_key(b"abc"));
+        data_key_with_buffer(b"cde", &mut buffer);
+        assert_eq!(buffer, data_key(b"cde"));
 
         let mut region = Region::default();
         // uninitialised region should not be passed in `enc_start_key` and `enc_end_key`.

--- a/components/keys/src/lib.rs
+++ b/components/keys/src/lib.rs
@@ -429,8 +429,11 @@ mod tests {
 
     #[test]
     fn test_data_key() {
-        assert!(validate_data_key(&data_key(b"abc")));
         assert!(!validate_data_key(b"abc"));
+        assert!(validate_data_key(&data_key(b"abc")));
+        let mut buffer = vec![];
+        data_key_with_buffer(b"abc", &mut buffer);
+        assert_eq!(buffer, data_key(b"abc"));
 
         let mut region = Region::default();
         // uninitialised region should not be passed in `enc_start_key` and `enc_end_key`.

--- a/components/raftstore/src/coprocessor/dispatcher.rs
+++ b/components/raftstore/src/coprocessor/dispatcher.rs
@@ -507,7 +507,7 @@ impl<E: KvEngine> CoprocessorHost<E> {
         }
         for batch in &cmd_batches {
             for cmd in &batch.cmds {
-                self.post_apply(&Region::default_instance(), cmd);
+                self.post_apply(Region::default_instance(), cmd);
             }
         }
         for observer in &self.registry.cmd_observers {

--- a/components/raftstore/src/coprocessor/dispatcher.rs
+++ b/components/raftstore/src/coprocessor/dispatcher.rs
@@ -733,7 +733,7 @@ mod tests {
         assert_all!(&[&ob.called], &[55]);
 
         let observe_info = CmdObserveInfo::from_handle(ObserveHandle::new(), ObserveHandle::new());
-        let mut cb = CmdBatch::new(&observe_info, &Region::default());
+        let mut cb = CmdBatch::new(&observe_info, 0);
         cb.push(&observe_info, 0, Cmd::default());
         host.on_flush_applied_cmd_batch(cb.level, vec![cb], &PanicEngine);
         // `post_apply` + `on_flush_applied_cmd_batch` => 13 + 6 = 19

--- a/components/raftstore/src/coprocessor/dispatcher.rs
+++ b/components/raftstore/src/coprocessor/dispatcher.rs
@@ -9,16 +9,12 @@ use engine_traits::{CfName, KvEngine};
 use kvproto::metapb::Region;
 use kvproto::pdpb::CheckPolicy;
 use kvproto::raft_cmdpb::{ComputeHashRequest, RaftCmdRequest};
-use lazy_static::lazy_static;
+use protobuf::Message;
 use raft::eraftpb;
 use tikv_util::box_try;
 
 use super::*;
 use crate::store::CasualRouter;
-
-lazy_static! {
-    static ref EMPTY_REGION: Region = Region::default();
-}
 
 struct Entry<T> {
     priority: u32,
@@ -511,7 +507,7 @@ impl<E: KvEngine> CoprocessorHost<E> {
         }
         for batch in &cmd_batches {
             for cmd in &batch.cmds {
-                self.post_apply(&EMPTY_REGION, cmd);
+                self.post_apply(&Region::default_instance(), cmd);
             }
         }
         for observer in &self.registry.cmd_observers {

--- a/components/raftstore/src/coprocessor/mod.rs
+++ b/components/raftstore/src/coprocessor/mod.rs
@@ -77,7 +77,7 @@ pub trait AdminObserver: Coprocessor {
     fn pre_apply_admin(&self, _: &mut ObserverContext<'_>, _: &AdminRequest) {}
 
     /// Hook to call after applying admin request.
-    /// For now, the `region` in `ObserverContext` is a empty region.
+    /// For now, the `region` in `ObserverContext` is an empty region.
     fn post_apply_admin(&self, _: &mut ObserverContext<'_>, _: &AdminResponse) {}
 }
 
@@ -93,7 +93,7 @@ pub trait QueryObserver: Coprocessor {
     fn pre_apply_query(&self, _: &mut ObserverContext<'_>, _: &[Request]) {}
 
     /// Hook to call after applying write request.
-    /// For now, the `region` in `ObserverContext` is a empty region.
+    /// For now, the `region` in `ObserverContext` is an empty region.
     fn post_apply_query(&self, _: &mut ObserverContext<'_>, _: &Cmd) {}
 }
 

--- a/components/raftstore/src/coprocessor/mod.rs
+++ b/components/raftstore/src/coprocessor/mod.rs
@@ -77,6 +77,7 @@ pub trait AdminObserver: Coprocessor {
     fn pre_apply_admin(&self, _: &mut ObserverContext<'_>, _: &AdminRequest) {}
 
     /// Hook to call after applying admin request.
+    /// For now, the `region` in `ObserverContext` is a empty region.
     fn post_apply_admin(&self, _: &mut ObserverContext<'_>, _: &AdminResponse) {}
 }
 
@@ -92,6 +93,7 @@ pub trait QueryObserver: Coprocessor {
     fn pre_apply_query(&self, _: &mut ObserverContext<'_>, _: &[Request]) {}
 
     /// Hook to call after applying write request.
+    /// For now, the `region` in `ObserverContext` is a empty region.
     fn post_apply_query(&self, _: &mut ObserverContext<'_>, _: &Cmd) {}
 }
 
@@ -274,30 +276,30 @@ pub struct CmdBatch {
     pub level: ObserveLevel,
     pub cdc_id: ObserveID,
     pub rts_id: ObserveID,
-    pub region: Region,
+    pub region_id: u64,
     pub cmds: Vec<Cmd>,
 }
 
 impl CmdBatch {
-    pub fn new(observe_info: &CmdObserveInfo, region: Region) -> CmdBatch {
+    pub fn new(observe_info: &CmdObserveInfo, region: &Region) -> CmdBatch {
         CmdBatch {
             level: observe_info.observe_level(),
             cdc_id: observe_info.cdc_id.id,
             rts_id: observe_info.rts_id.id,
-            region,
+            region_id: region.get_id(),
             cmds: Vec::new(),
         }
     }
 
     pub fn push(&mut self, observe_info: &CmdObserveInfo, region_id: u64, cmd: Cmd) {
-        assert_eq!(region_id, self.region.get_id());
+        assert_eq!(region_id, self.region_id);
         assert_eq!(observe_info.cdc_id.id, self.cdc_id);
         assert_eq!(observe_info.rts_id.id, self.rts_id);
         self.cmds.push(cmd)
     }
 
     pub fn into_iter(self, region_id: u64) -> IntoIter<Cmd> {
-        assert_eq!(self.region.get_id(), region_id);
+        assert_eq!(region_id, self.region_id);
         self.cmds.into_iter()
     }
 

--- a/components/raftstore/src/coprocessor/mod.rs
+++ b/components/raftstore/src/coprocessor/mod.rs
@@ -281,12 +281,12 @@ pub struct CmdBatch {
 }
 
 impl CmdBatch {
-    pub fn new(observe_info: &CmdObserveInfo, region: &Region) -> CmdBatch {
+    pub fn new(observe_info: &CmdObserveInfo, region_id: u64) -> CmdBatch {
         CmdBatch {
             level: observe_info.observe_level(),
             cdc_id: observe_info.cdc_id.id,
             rts_id: observe_info.rts_id.id,
-            region_id: region.get_id(),
+            region_id,
             cmds: Vec::new(),
         }
     }

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -1222,6 +1222,8 @@ where
         ctx.exec_log_term = term;
         ctx.kv_wb_mut().set_save_point();
         let mut origin_epoch = None;
+        // Remember if the raft cmd fails to be applied, it must have no side effects.
+        // E.g. `RaftApplyState` must not be changed.
         let (resp, exec_result) = match self.exec_raft_cmd(ctx, req) {
             Ok(a) => {
                 ctx.kv_wb_mut().pop_save_point().unwrap();

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -3234,7 +3234,7 @@ where
         for cached_entries in apply.entries {
             let (mut e, sz) = cached_entries.take_entries();
             dangle_size += sz;
-            if entries.is_empty() {
+            if e.is_empty() {
                 let rid = self.delegate.region_id();
                 let StdRange { start, end } = cached_entries.range;
                 e = Vec::with_capacity((end - start) as usize);
@@ -3599,7 +3599,7 @@ where
 
                     if let Some(batch) = batch_apply.as_mut() {
                         if batch.try_batch(&mut apply) {
-                            return;
+                            continue;
                         } else {
                             self.handle_apply(apply_ctx, batch_apply.take().unwrap());
                             if let Some(ref mut state) = self.delegate.yield_state {

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -1506,22 +1506,22 @@ where
                 self.metrics.lock_cf_written_bytes += value.len() as u64;
             }
             // TODO: check whether cf exists or not.
-            wb.put_cf(cf, &key, value).unwrap_or_else(|e| {
+            wb.put_cf(cf, key, value).unwrap_or_else(|e| {
                 panic!(
                     "{} failed to write ({}, {}) to cf {}: {:?}",
                     self.tag,
-                    log_wrappers::Value::key(&key),
+                    log_wrappers::Value::key(key),
                     log_wrappers::Value::value(value),
                     cf,
                     e
                 )
             });
         } else {
-            wb.put(&key, value).unwrap_or_else(|e| {
+            wb.put(key, value).unwrap_or_else(|e| {
                 panic!(
                     "{} failed to write ({}, {}): {:?}",
                     self.tag,
-                    log_wrappers::Value::key(&key),
+                    log_wrappers::Value::key(key),
                     log_wrappers::Value::value(value),
                     e
                 );
@@ -1543,11 +1543,11 @@ where
         if !req.get_delete().get_cf().is_empty() {
             let cf = req.get_delete().get_cf();
             // TODO: check whether cf exists or not.
-            wb.delete_cf(cf, &key).unwrap_or_else(|e| {
+            wb.delete_cf(cf, key).unwrap_or_else(|e| {
                 panic!(
                     "{} failed to delete {}: {}",
                     self.tag,
-                    log_wrappers::Value::key(&key),
+                    log_wrappers::Value::key(key),
                     e
                 )
             });
@@ -1559,11 +1559,11 @@ where
                 self.metrics.delete_keys_hint += 1;
             }
         } else {
-            wb.delete(&key).unwrap_or_else(|e| {
+            wb.delete(key).unwrap_or_else(|e| {
                 panic!(
                     "{} failed to delete {}: {}",
                     self.tag,
-                    log_wrappers::Value::key(&key),
+                    log_wrappers::Value::key(key),
                     e
                 )
             });

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -47,7 +47,6 @@ use raft::eraftpb::{
     ConfChange, ConfChangeType, ConfChangeV2, Entry, EntryType, Snapshot as RaftSnapshot,
 };
 use raft_proto::ConfChangeI;
-use smallvec::{smallvec, SmallVec};
 use sst_importer::SSTImporter;
 use tikv_alloc::trace::TraceEvent;
 use tikv_util::config::{Tracker, VersionTrack};
@@ -2843,7 +2842,7 @@ where
     pub peer_id: u64,
     pub region_id: u64,
     pub term: u64,
-    pub entries: SmallVec<[CachedEntries; 1]>,
+    pub entries: CachedEntries,
     pub cbs: Vec<Proposal<S>>,
 }
 
@@ -2860,7 +2859,7 @@ impl<S: Snapshot> Apply<S> {
             peer_id,
             region_id,
             term,
-            entries: smallvec![entries],
+            entries,
             cbs,
         }
     }
@@ -2879,17 +2878,6 @@ impl<S: Snapshot> Apply<S> {
                     *t = now.unwrap();
                 }
             }
-        }
-    }
-
-    fn try_batch(&mut self, other: &mut Apply<S>) -> bool {
-        assert_eq!(self.region_id, other.region_id);
-        if self.peer_id == other.peer_id && self.term == other.term {
-            self.entries.append(&mut other.entries);
-            self.cbs.append(&mut other.cbs);
-            true
-        } else {
-            false
         }
     }
 }
@@ -3224,34 +3212,23 @@ where
         fail_point!("on_handle_apply_2", self.delegate.id() == 2, |_| {});
         fail_point!("on_handle_apply", |_| {});
 
-        if self.delegate.pending_remove || self.delegate.stopped {
+        if apply.entries.range.is_empty() || self.delegate.pending_remove || self.delegate.stopped {
             return;
         }
 
-        let mut entries = Vec::new();
-
-        let mut dangle_size = 0;
-        for cached_entries in apply.entries {
-            let (mut e, sz) = cached_entries.take_entries();
-            dangle_size += sz;
-            if e.is_empty() {
-                let rid = self.delegate.region_id();
-                let StdRange { start, end } = cached_entries.range;
-                e = Vec::with_capacity((end - start) as usize);
-                self.delegate
-                    .raft_engine
-                    .fetch_entries_to(rid, start, end, None, &mut e)
-                    .unwrap();
-            }
-            if entries.is_empty() {
-                entries = e;
-            } else {
-                entries.extend(e);
-            }
-        }
+        let (mut entries, dangle_size) = apply.entries.take_entries();
         if dangle_size > 0 {
             MEMTRACE_ENTRY_CACHE.trace(TraceEvent::Sub(dangle_size));
             RAFT_ENTRIES_CACHES_GAUGE.sub(dangle_size as i64);
+        }
+        if entries.is_empty() {
+            let rid = self.delegate.region_id();
+            let StdRange { start, end } = apply.entries.range;
+            entries = Vec::with_capacity((end - start) as usize);
+            self.delegate
+                .raft_engine
+                .fetch_entries_to(rid, start, end, None, &mut entries)
+                .unwrap();
         }
 
         self.delegate.metrics = ApplyMetrics::default();
@@ -3273,10 +3250,6 @@ where
         }
 
         self.append_proposal(apply.cbs.drain(..));
-        // If there is any apply task, we change this fsm to normal-priority.
-        // When it meets a ingest-request or a delete-range request, it will change to
-        // low-priority.
-        self.delegate.priority = Priority::Normal;
         self.delegate
             .handle_raft_committed_entries(apply_ctx, entries.drain(..));
         fail_point!("post_handle_apply_1003", self.delegate.id() == 1003, |_| {});
@@ -3565,67 +3538,38 @@ where
         msgs: &mut Vec<Msg<EK>>,
     ) {
         let mut drainer = msgs.drain(..);
-        let mut batch_apply = None;
         loop {
-            let msg = match drainer.next() {
-                Some(m) => m,
-                None => {
-                    if let Some(apply) = batch_apply {
-                        self.handle_apply(apply_ctx, apply);
-                    }
-                    break;
-                }
-            };
-
-            if batch_apply.is_some() {
-                match &msg {
-                    Msg::Apply { .. } => (),
-                    _ => {
-                        self.handle_apply(apply_ctx, batch_apply.take().unwrap());
-                        if let Some(ref mut state) = self.delegate.yield_state {
-                            state.pending_msgs.push(msg);
-                            state.pending_msgs.extend(drainer);
-                            break;
-                        }
-                    }
-                }
-            }
-
-            match msg {
-                Msg::Apply { start, mut apply } => {
+            match drainer.next() {
+                Some(Msg::Apply { start, apply }) => {
                     apply_ctx
                         .apply_wait
                         .observe(start.saturating_elapsed_secs());
-
-                    if let Some(batch) = batch_apply.as_mut() {
-                        if batch.try_batch(&mut apply) {
-                            continue;
-                        } else {
-                            self.handle_apply(apply_ctx, batch_apply.take().unwrap());
-                            if let Some(ref mut state) = self.delegate.yield_state {
-                                state.pending_msgs.push(Msg::Apply { start, apply });
-                                state.pending_msgs.extend(drainer);
-                                break;
-                            }
-                        }
+                    // If there is any apply task, we change this fsm to normal-priority.
+                    // When it meets a ingest-request or a delete-range request, it will change to
+                    // low-priority.
+                    self.delegate.priority = Priority::Normal;
+                    self.handle_apply(apply_ctx, apply);
+                    if let Some(ref mut state) = self.delegate.yield_state {
+                        state.pending_msgs = drainer.collect();
+                        break;
                     }
-                    batch_apply = Some(apply);
                 }
-                Msg::Registration(reg) => self.handle_registration(reg),
-                Msg::Destroy(d) => self.handle_destroy(apply_ctx, d),
-                Msg::LogsUpToDate(cul) => self.logs_up_to_date_for_merge(apply_ctx, cul),
-                Msg::Noop => {}
-                Msg::Snapshot(snap_task) => self.handle_snapshot(apply_ctx, snap_task),
-                Msg::Change {
+                Some(Msg::Registration(reg)) => self.handle_registration(reg),
+                Some(Msg::Destroy(d)) => self.handle_destroy(apply_ctx, d),
+                Some(Msg::LogsUpToDate(cul)) => self.logs_up_to_date_for_merge(apply_ctx, cul),
+                Some(Msg::Noop) => {}
+                Some(Msg::Snapshot(snap_task)) => self.handle_snapshot(apply_ctx, snap_task),
+                Some(Msg::Change {
                     cmd,
                     region_epoch,
                     cb,
-                } => self.handle_change(apply_ctx, cmd, region_epoch, cb),
+                }) => self.handle_change(apply_ctx, cmd, region_epoch, cb),
                 #[cfg(any(test, feature = "testexport"))]
-                Msg::Validate(_, f) => {
+                Some(Msg::Validate(_, f)) => {
                     let delegate: *const u8 = unsafe { mem::transmute(&self.delegate) };
                     f(delegate)
                 }
+                None => break,
             }
         }
     }

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -5727,4 +5727,9 @@ mod tests {
         });
         res.unwrap_err();
     }
+
+    #[test]
+    fn test_xxx() {
+        println!("{}", std::mem::size_of::<RaftApplyState>());
+    }
 }

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -322,7 +322,7 @@ impl<S: Snapshot> ApplyCallbackBatch<S> {
         }
     }
 
-    fn push_batch(&mut self, observe_info: &CmdObserveInfo, region: Region) {
+    fn push_batch(&mut self, observe_info: &CmdObserveInfo, region: &Region) {
         let cb = CmdBatch::new(observe_info, region);
         self.batch_max_level = cmp::max(self.batch_max_level, cb.level);
         self.cmd_batch.push(cb);
@@ -475,7 +475,7 @@ where
     /// After all delegates are handled, `write_to_db` method should be called.
     pub fn prepare_for(&mut self, delegate: &mut ApplyDelegate<EK>) {
         self.applied_batch
-            .push_batch(&delegate.observe_info, delegate.region.clone());
+            .push_batch(&delegate.observe_info, &delegate.region);
     }
 
     /// Commits all changes have done for delegate. `persistent` indicates whether

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -47,6 +47,7 @@ use raft::eraftpb::{
     ConfChange, ConfChangeType, ConfChangeV2, Entry, EntryType, Snapshot as RaftSnapshot,
 };
 use raft_proto::ConfChangeI;
+use smallvec::{smallvec, SmallVec};
 use sst_importer::SSTImporter;
 use tikv_alloc::trace::TraceEvent;
 use tikv_util::config::{Tracker, VersionTrack};
@@ -2842,7 +2843,7 @@ where
     pub peer_id: u64,
     pub region_id: u64,
     pub term: u64,
-    pub entries: CachedEntries,
+    pub entries: SmallVec<[CachedEntries; 1]>,
     pub cbs: Vec<Proposal<S>>,
 }
 
@@ -2859,7 +2860,7 @@ impl<S: Snapshot> Apply<S> {
             peer_id,
             region_id,
             term,
-            entries,
+            entries: smallvec![entries],
             cbs,
         }
     }
@@ -2878,6 +2879,17 @@ impl<S: Snapshot> Apply<S> {
                     *t = now.unwrap();
                 }
             }
+        }
+    }
+
+    fn try_batch(&mut self, other: &mut Apply<S>) -> bool {
+        assert_eq!(self.region_id, other.region_id);
+        if self.peer_id == other.peer_id && self.term == other.term {
+            self.entries.append(&mut other.entries);
+            self.cbs.append(&mut other.cbs);
+            true
+        } else {
+            false
         }
     }
 }
@@ -3212,23 +3224,34 @@ where
         fail_point!("on_handle_apply_2", self.delegate.id() == 2, |_| {});
         fail_point!("on_handle_apply", |_| {});
 
-        if apply.entries.range.is_empty() || self.delegate.pending_remove || self.delegate.stopped {
+        if self.delegate.pending_remove || self.delegate.stopped {
             return;
         }
 
-        let (mut entries, dangle_size) = apply.entries.take_entries();
+        let mut entries = Vec::new();
+
+        let mut dangle_size = 0;
+        for cached_entries in apply.entries {
+            let (mut e, sz) = cached_entries.take_entries();
+            dangle_size += sz;
+            if entries.is_empty() {
+                let rid = self.delegate.region_id();
+                let StdRange { start, end } = cached_entries.range;
+                e = Vec::with_capacity((end - start) as usize);
+                self.delegate
+                    .raft_engine
+                    .fetch_entries_to(rid, start, end, None, &mut e)
+                    .unwrap();
+            }
+            if entries.is_empty() {
+                entries = e;
+            } else {
+                entries.extend(e);
+            }
+        }
         if dangle_size > 0 {
             MEMTRACE_ENTRY_CACHE.trace(TraceEvent::Sub(dangle_size));
             RAFT_ENTRIES_CACHES_GAUGE.sub(dangle_size as i64);
-        }
-        if entries.is_empty() {
-            let rid = self.delegate.region_id();
-            let StdRange { start, end } = apply.entries.range;
-            entries = Vec::with_capacity((end - start) as usize);
-            self.delegate
-                .raft_engine
-                .fetch_entries_to(rid, start, end, None, &mut entries)
-                .unwrap();
         }
 
         self.delegate.metrics = ApplyMetrics::default();
@@ -3250,6 +3273,10 @@ where
         }
 
         self.append_proposal(apply.cbs.drain(..));
+        // If there is any apply task, we change this fsm to normal-priority.
+        // When it meets a ingest-request or a delete-range request, it will change to
+        // low-priority.
+        self.delegate.priority = Priority::Normal;
         self.delegate
             .handle_raft_committed_entries(apply_ctx, entries.drain(..));
         fail_point!("post_handle_apply_1003", self.delegate.id() == 1003, |_| {});
@@ -3538,38 +3565,67 @@ where
         msgs: &mut Vec<Msg<EK>>,
     ) {
         let mut drainer = msgs.drain(..);
+        let mut batch_apply = None;
         loop {
-            match drainer.next() {
-                Some(Msg::Apply { start, apply }) => {
+            let msg = match drainer.next() {
+                Some(m) => m,
+                None => {
+                    if let Some(apply) = batch_apply {
+                        self.handle_apply(apply_ctx, apply);
+                    }
+                    break;
+                }
+            };
+
+            if batch_apply.is_some() {
+                match &msg {
+                    Msg::Apply { .. } => (),
+                    _ => {
+                        self.handle_apply(apply_ctx, batch_apply.take().unwrap());
+                        if let Some(ref mut state) = self.delegate.yield_state {
+                            state.pending_msgs.push(msg);
+                            state.pending_msgs.extend(drainer);
+                            break;
+                        }
+                    }
+                }
+            }
+
+            match msg {
+                Msg::Apply { start, mut apply } => {
                     apply_ctx
                         .apply_wait
                         .observe(start.saturating_elapsed_secs());
-                    // If there is any apply task, we change this fsm to normal-priority.
-                    // When it meets a ingest-request or a delete-range request, it will change to
-                    // low-priority.
-                    self.delegate.priority = Priority::Normal;
-                    self.handle_apply(apply_ctx, apply);
-                    if let Some(ref mut state) = self.delegate.yield_state {
-                        state.pending_msgs = drainer.collect();
-                        break;
+
+                    if let Some(batch) = batch_apply.as_mut() {
+                        if batch.try_batch(&mut apply) {
+                            return;
+                        } else {
+                            self.handle_apply(apply_ctx, batch_apply.take().unwrap());
+                            if let Some(ref mut state) = self.delegate.yield_state {
+                                state.pending_msgs.push(Msg::Apply { start, apply });
+                                state.pending_msgs.extend(drainer);
+                                break;
+                            }
+                        }
                     }
+                    batch_apply = Some(apply);
                 }
-                Some(Msg::Registration(reg)) => self.handle_registration(reg),
-                Some(Msg::Destroy(d)) => self.handle_destroy(apply_ctx, d),
-                Some(Msg::LogsUpToDate(cul)) => self.logs_up_to_date_for_merge(apply_ctx, cul),
-                Some(Msg::Noop) => {}
-                Some(Msg::Snapshot(snap_task)) => self.handle_snapshot(apply_ctx, snap_task),
-                Some(Msg::Change {
+                Msg::Registration(reg) => self.handle_registration(reg),
+                Msg::Destroy(d) => self.handle_destroy(apply_ctx, d),
+                Msg::LogsUpToDate(cul) => self.logs_up_to_date_for_merge(apply_ctx, cul),
+                Msg::Noop => {}
+                Msg::Snapshot(snap_task) => self.handle_snapshot(apply_ctx, snap_task),
+                Msg::Change {
                     cmd,
                     region_epoch,
                     cb,
-                }) => self.handle_change(apply_ctx, cmd, region_epoch, cb),
+                } => self.handle_change(apply_ctx, cmd, region_epoch, cb),
                 #[cfg(any(test, feature = "testexport"))]
-                Some(Msg::Validate(_, f)) => {
+                Msg::Validate(_, f) => {
                     let delegate: *const u8 = unsafe { mem::transmute(&self.delegate) };
                     f(delegate)
                 }
-                None => break,
             }
         }
     }

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -5749,9 +5749,4 @@ mod tests {
         });
         res.unwrap_err();
     }
-
-    #[test]
-    fn test_xxx() {
-        println!("{}", std::mem::size_of::<RaftApplyState>());
-    }
 }

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -309,8 +309,8 @@ impl<S: Snapshot> ApplyCallbackBatch<S> {
         }
     }
 
-    fn push_batch(&mut self, observe_info: &CmdObserveInfo, region: &Region) {
-        let cb = CmdBatch::new(observe_info, region);
+    fn push_batch(&mut self, observe_info: &CmdObserveInfo, region_id: u64) {
+        let cb = CmdBatch::new(observe_info, region_id);
         self.batch_max_level = cmp::max(self.batch_max_level, cb.level);
         self.cmd_batch.push(cb);
     }
@@ -464,7 +464,7 @@ where
     /// After all delegates are handled, `write_to_db` method should be called.
     pub fn prepare_for(&mut self, delegate: &mut ApplyDelegate<EK>) {
         self.applied_batch
-            .push_batch(&delegate.observe_info, &delegate.region);
+            .push_batch(&delegate.observe_info, delegate.region.get_id());
     }
 
     /// Commits all changes have done for delegate. `persistent` indicates whether

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -2184,13 +2184,6 @@ where
             "{} is applying snapshot when it is ready to handle committed entries",
             self.tag
         );
-        if !committed_entries.is_empty() {
-            // We must renew current_time because this value may be created a long time ago.
-            // If we do not renew it, this time may be smaller than propose_time of a command,
-            // which was proposed in another thread while this thread receives its AppendEntriesResponse
-            // and is ready to calculate its commit-log-duration.
-            ctx.current_time.replace(monotonic_raw_now());
-        }
         // Leader needs to update lease.
         let mut lease_to_be_updated = self.is_leader();
         for entry in committed_entries.iter().rev() {
@@ -2201,6 +2194,11 @@ where
                     .proposals
                     .find_propose_time(entry.get_term(), entry.get_index());
                 if let Some(propose_time) = propose_time {
+                    // We must renew current_time because this value may be created a long time ago.
+                    // If we do not renew it, this time may be smaller than propose_time of a command,
+                    // which was proposed in another thread while this thread receives its AppendEntriesResponse
+                    // and is ready to calculate its commit-log-duration.
+                    ctx.current_time.replace(monotonic_raw_now());
                     ctx.raft_metrics.commit_log.observe(duration_to_sec(
                         (ctx.current_time.unwrap() - propose_time).to_std().unwrap(),
                     ));

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -2251,8 +2251,7 @@ where
                 cbs,
             );
             apply.on_schedule(&ctx.raft_metrics);
-            self.mut_store()
-                .trace_cached_entries(apply.entries[0].clone());
+            self.mut_store().trace_cached_entries(apply.entries.clone());
             if needs_evict_entry_cache(ctx.cfg.evict_cache_on_memory_ratio) {
                 // Compact all cached entries instead of half evict.
                 self.mut_store().evict_cache(false);

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -2255,7 +2255,8 @@ where
                 cbs,
             );
             apply.on_schedule(&ctx.raft_metrics);
-            self.mut_store().trace_cached_entries(apply.entries.clone());
+            self.mut_store()
+                .trace_cached_entries(apply.entries[0].clone());
             if needs_evict_entry_cache(ctx.cfg.evict_cache_on_memory_ratio) {
                 // Compact all cached entries instead of half evict.
                 self.mut_store().evict_cache(false);

--- a/components/raftstore/src/store/worker/raftlog_gc.rs
+++ b/components/raftstore/src/store/worker/raftlog_gc.rs
@@ -97,6 +97,9 @@ impl<EK: KvEngine, ER: RaftEngine, R: CasualRouter<EK>> Runner<EK, ER, R> {
     }
 
     fn flush(&mut self) {
+        if self.tasks.is_empty() {
+            return;
+        }
         // Sync wal of kv_db to make sure the data before apply_index has been persisted to disk.
         self.engines.kv.sync().unwrap_or_else(|e| {
             panic!("failed to sync kv_engine in raft_log_gc: {:?}", e);

--- a/components/resolved_ts/src/endpoint.rs
+++ b/components/resolved_ts/src/endpoint.rs
@@ -501,7 +501,7 @@ where
             .into_iter()
             .filter_map(|batch| {
                 if !batch.is_empty() {
-                    if let Some(observe_region) = self.regions.get_mut(&batch.region.get_id()) {
+                    if let Some(observe_region) = self.regions.get_mut(&batch.region_id) {
                         let observe_id = batch.rts_id;
                         let region_id = observe_region.meta.id;
                         if observe_region.handle.id == observe_id {
@@ -517,7 +517,7 @@ where
                             });
                         } else {
                             debug!("resolved ts CmdBatch discarded";
-                                "region_id" => batch.region.get_id(),
+                                "region_id" => batch.region_id,
                                 "observe_id" => ?batch.rts_id,
                                 "current" => ?observe_region.handle.id,
                             );

--- a/components/resolved_ts/src/observer.rs
+++ b/components/resolved_ts/src/observer.rs
@@ -193,7 +193,7 @@ mod test {
 
         // Both cdc and resolved-ts worker are observing
         let observe_info = CmdObserveInfo::from_handle(ObserveHandle::new(), ObserveHandle::new());
-        let mut cb = CmdBatch::new(&observe_info, &Region::default());
+        let mut cb = CmdBatch::new(&observe_info, 0);
         cb.push(&observe_info, 0, cmd.clone());
         observer.on_flush_applied_cmd_batch(cb.level, &mut vec![cb], &engine);
         // Observe all data
@@ -202,7 +202,7 @@ mod test {
         // Only cdc is observing
         let observe_info = CmdObserveInfo::from_handle(ObserveHandle::new(), ObserveHandle::new());
         observe_info.rts_id.stop_observing();
-        let mut cb = CmdBatch::new(&observe_info, &Region::default());
+        let mut cb = CmdBatch::new(&observe_info, 0);
         cb.push(&observe_info, 0, cmd.clone());
         observer.on_flush_applied_cmd_batch(cb.level, &mut vec![cb], &engine);
         // Still observe all data
@@ -211,7 +211,7 @@ mod test {
         // Only resolved-ts worker is observing
         let observe_info = CmdObserveInfo::from_handle(ObserveHandle::new(), ObserveHandle::new());
         observe_info.cdc_id.stop_observing();
-        let mut cb = CmdBatch::new(&observe_info, &Region::default());
+        let mut cb = CmdBatch::new(&observe_info, 0);
         cb.push(&observe_info, 0, cmd.clone());
         observer.on_flush_applied_cmd_batch(cb.level, &mut vec![cb], &engine);
         // Only observe lock related data
@@ -222,7 +222,7 @@ mod test {
         let observe_info = CmdObserveInfo::from_handle(ObserveHandle::new(), ObserveHandle::new());
         observe_info.rts_id.stop_observing();
         observe_info.cdc_id.stop_observing();
-        let mut cb = CmdBatch::new(&observe_info, &Region::default());
+        let mut cb = CmdBatch::new(&observe_info, 0);
         cb.push(&observe_info, 0, cmd);
         observer.on_flush_applied_cmd_batch(cb.level, &mut vec![cb], &engine);
         // Observe no data

--- a/components/resolved_ts/src/observer.rs
+++ b/components/resolved_ts/src/observer.rs
@@ -139,7 +139,6 @@ mod test {
     use super::*;
     use engine_rocks::RocksSnapshot;
     use engine_traits::{CF_DEFAULT, CF_LOCK, CF_WRITE};
-    use kvproto::metapb::Region;
     use kvproto::raft_cmdpb::*;
     use std::time::Duration;
     use tikv::storage::kv::TestEngineBuilder;

--- a/components/resolved_ts/src/observer.rs
+++ b/components/resolved_ts/src/observer.rs
@@ -193,7 +193,7 @@ mod test {
 
         // Both cdc and resolved-ts worker are observing
         let observe_info = CmdObserveInfo::from_handle(ObserveHandle::new(), ObserveHandle::new());
-        let mut cb = CmdBatch::new(&observe_info, Region::default());
+        let mut cb = CmdBatch::new(&observe_info, &Region::default());
         cb.push(&observe_info, 0, cmd.clone());
         observer.on_flush_applied_cmd_batch(cb.level, &mut vec![cb], &engine);
         // Observe all data
@@ -202,7 +202,7 @@ mod test {
         // Only cdc is observing
         let observe_info = CmdObserveInfo::from_handle(ObserveHandle::new(), ObserveHandle::new());
         observe_info.rts_id.stop_observing();
-        let mut cb = CmdBatch::new(&observe_info, Region::default());
+        let mut cb = CmdBatch::new(&observe_info, &Region::default());
         cb.push(&observe_info, 0, cmd.clone());
         observer.on_flush_applied_cmd_batch(cb.level, &mut vec![cb], &engine);
         // Still observe all data
@@ -211,7 +211,7 @@ mod test {
         // Only resolved-ts worker is observing
         let observe_info = CmdObserveInfo::from_handle(ObserveHandle::new(), ObserveHandle::new());
         observe_info.cdc_id.stop_observing();
-        let mut cb = CmdBatch::new(&observe_info, Region::default());
+        let mut cb = CmdBatch::new(&observe_info, &Region::default());
         cb.push(&observe_info, 0, cmd.clone());
         observer.on_flush_applied_cmd_batch(cb.level, &mut vec![cb], &engine);
         // Only observe lock related data
@@ -222,7 +222,7 @@ mod test {
         let observe_info = CmdObserveInfo::from_handle(ObserveHandle::new(), ObserveHandle::new());
         observe_info.rts_id.stop_observing();
         observe_info.cdc_id.stop_observing();
-        let mut cb = CmdBatch::new(&observe_info, Region::default());
+        let mut cb = CmdBatch::new(&observe_info, &Region::default());
         cb.push(&observe_info, 0, cmd);
         observer.on_flush_applied_cmd_batch(cb.level, &mut vec![cb], &engine);
         // Observe no data

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -980,14 +980,8 @@ impl<T: Simulator> Cluster<T> {
     }
 
     pub fn must_put_cf(&mut self, cf: &str, key: &[u8], value: &[u8]) {
-        match self.batch_put(key, vec![new_put_cf_cmd(cf, key, value)]) {
-            Ok(resp) => {
-                assert_eq!(resp.get_responses().len(), 1);
-                assert_eq!(resp.get_responses()[0].get_cmd_type(), CmdType::Put);
-            }
-            Err(e) => {
-                panic!("has error: {:?}", e);
-            }
+        if let Err(e) = self.batch_put(key, vec![new_put_cf_cmd(cf, key, value)]) {
+            panic!("has error: {:?}", e);
         }
     }
 
@@ -1023,8 +1017,6 @@ impl<T: Simulator> Cluster<T> {
         if resp.get_header().has_error() {
             panic!("response {:?} has error", resp);
         }
-        assert_eq!(resp.get_responses().len(), 1);
-        assert_eq!(resp.get_responses()[0].get_cmd_type(), CmdType::Delete);
     }
 
     pub fn must_delete_range_cf(&mut self, cf: &str, start: &[u8], end: &[u8]) {
@@ -1037,8 +1029,6 @@ impl<T: Simulator> Cluster<T> {
         if resp.get_header().has_error() {
             panic!("response {:?} has error", resp);
         }
-        assert_eq!(resp.get_responses().len(), 1);
-        assert_eq!(resp.get_responses()[0].get_cmd_type(), CmdType::DeleteRange);
     }
 
     pub fn must_notify_delete_range_cf(&mut self, cf: &str, start: &[u8], end: &[u8]) {
@@ -1048,8 +1038,6 @@ impl<T: Simulator> Cluster<T> {
         if resp.get_header().has_error() {
             panic!("response {:?} has error", resp);
         }
-        assert_eq!(resp.get_responses().len(), 1);
-        assert_eq!(resp.get_responses()[0].get_cmd_type(), CmdType::DeleteRange);
     }
 
     pub fn must_flush_cf(&mut self, cf: &str, sync: bool) {

--- a/tests/failpoints/cases/test_async_io.rs
+++ b/tests/failpoints/cases/test_async_io.rs
@@ -105,6 +105,10 @@ fn test_async_io_cannot_destroy_when_persist_snapshot() {
 
     cluster.must_transfer_leader(region.get_id(), peer_1);
 
+    cluster.must_put(b"k", b"v");
+    // Make sure peer 3 exists
+    must_get_equal(&cluster.get_engine(3), b"k", b"v");
+
     let dropped_msgs = Arc::new(Mutex::new(Vec::new()));
     let send_filter = Box::new(
         RegionPacketFilter::new(region.get_id(), 3)


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close https://github.com/tikv/tikv/issues/11251

Problem Summary:
See https://github.com/tikv/tikv/issues/11251, this PR removes many useless `Response`.
Furthermore, this PR reduces some other waste.
1. the clone of `Region` in `prepare_for` function. This cloned `Region` is used for `post_apply_query` and `post_apply_admin` but for now no function really need this `Region`. I use a empty `Region` instead.
2. the clone of `RaftApplyState` when creating `ExecContext` in `apply_raft_cmd`. The `RaftApplyState` is cloned each time a raft cmd is applied. 
3. allocation for key in `handle_put` and `handle_delete`. Use a buffer instead of allocating every time. (Although the jemalloc is good enough to reduce most of the real allocation in this case, why not totally remove it? )


### What is changed and how it works?

What's Changed:
As above mentioned.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

- No

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None.
```