### PR TITLE
resource_metering: fix config enable not working

### DIFF
--- a/components/resource_metering/src/cpu/recorder/dummy.rs
+++ b/components/resource_metering/src/cpu/recorder/dummy.rs
@@ -17,6 +17,6 @@ pub struct Guard {
     _p: PhantomData<*const ()>,
 }
 
-pub fn init_recorder() -> RecorderHandle {
+pub fn init_recorder(_: bool) -> RecorderHandle {
     RecorderHandle::default()
 }

--- a/components/resource_metering/src/cpu/recorder/linux.rs
+++ b/components/resource_metering/src/cpu/recorder/linux.rs
@@ -29,12 +29,12 @@ use super::RecorderHandle;
 const RECORD_FREQUENCY: f64 = 99.0;
 const GC_INTERVAL_SECS: u64 = 15 * 60;
 
-pub fn init_recorder() -> RecorderHandle {
+pub fn init_recorder(enabled: bool) -> RecorderHandle {
     lazy_static! {
         static ref HANDLE: RecorderHandle = {
             let config = crate::Config::default();
 
-            let pause = Arc::new(AtomicBool::new(config.enabled));
+            let pause = Arc::new(AtomicBool::new(!config.enabled));
             let pause0 = pause.clone();
             let precision_ms = Arc::new(AtomicU64::new(config.precision.0.as_millis() as _));
             let precision_ms0 = precision_ms.clone();
@@ -60,6 +60,11 @@ pub fn init_recorder() -> RecorderHandle {
                 .expect("Failed to create recorder thread");
             RecorderHandle::new(join_handle, pause0, precision_ms0)
         };
+    }
+    if enabled {
+        HANDLE.resume();
+    } else {
+        HANDLE.pause();
     }
     HANDLE.clone()
 }

--- a/components/resource_metering/src/lib.rs
+++ b/components/resource_metering/src/lib.rs
@@ -77,7 +77,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Config {
         Config {
-            enabled: true,
+            enabled: false,
             receiver_address: "".to_string(),
             report_receiver_interval: ReadableDuration::minutes(1),
             max_resource_groups: 2000,

--- a/components/resource_metering/tests/cpu_recorder.rs
+++ b/components/resource_metering/tests/cpu_recorder.rs
@@ -161,8 +161,7 @@ mod linux {
 
     #[test]
     fn test_cpu_record() {
-        let handle = init_recorder();
-        handle.resume();
+        let handle = init_recorder(true);
         fail::cfg("cpu-record-test-filter", "return").unwrap();
 
         defer! {{

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -887,9 +887,8 @@ impl<ER: RaftEngine> TiKVServer<ER> {
         }
 
         // Start resource metering.
-        let resource_metering_cpu_recorder = resource_metering::cpu::recorder::init_recorder(
-            self.config.resource_metering.enabled
-        );
+        let resource_metering_cpu_recorder =
+            resource_metering::cpu::recorder::init_recorder(self.config.resource_metering.enabled);
         let mut resource_metering_reporter_worker = Box::new(
             WorkerBuilder::new("resource-metering-reporter")
                 .pending_capacity(30)

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -887,7 +887,9 @@ impl<ER: RaftEngine> TiKVServer<ER> {
         }
 
         // Start resource metering.
-        let resource_metering_cpu_recorder = resource_metering::cpu::recorder::init_recorder();
+        let resource_metering_cpu_recorder = resource_metering::cpu::recorder::init_recorder(
+            self.config.resource_metering.enabled
+        );
         let mut resource_metering_reporter_worker = Box::new(
             WorkerBuilder::new("resource-metering-reporter")
                 .pending_capacity(30)

--- a/tests/integrations/resource_metering/test_suite/mod.rs
+++ b/tests/integrations/resource_metering/test_suite/mod.rs
@@ -57,7 +57,7 @@ impl TestSuite {
         tikv_cfg.resource_metering.report_receiver_interval = ReadableDuration::secs(5);
 
         let resource_metering_cfg = tikv_cfg.resource_metering.clone();
-        let cfg_controller = ConfigController::new(tikv_cfg);
+        let cfg_controller = ConfigController::new(tikv_cfg.clone());
         cfg_controller.register(
             Module::ResourceMetering,
             Box::new(ConfigManager::new(

--- a/tests/integrations/resource_metering/test_suite/mod.rs
+++ b/tests/integrations/resource_metering/test_suite/mod.rs
@@ -63,7 +63,7 @@ impl TestSuite {
             Box::new(ConfigManager::new(
                 resource_metering_cfg.clone(),
                 scheduler.clone(),
-                init_recorder(),
+                init_recorder(tikv_cfg.resource_metering.enabled),
             )),
         );
         let env = Arc::new(Environment::new(2));


### PR DESCRIPTION
Signed-off-by: Zhenchi <zhongzc_arch@outlook.com>

### What problem does this PR solve?

Issue Number: close #11235 <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

Enable/Disable resource metering during initialize recording thread.

What's Changed:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test
- Manual test (add detailed scripts or steps below)
- No code

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix resource-metering.enabled not working
```