### PR TITLE
generate heap profile to data dir

### DIFF
--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -1201,6 +1201,7 @@ impl<ER: RaftEngine> TiKVServer<ER> {
                 self.cfg_controller.take().unwrap(),
                 Arc::new(self.config.security.clone()),
                 self.router.clone(),
+                self.store_path.clone(),
             ) {
                 Ok(status_server) => Box::new(status_server),
                 Err(e) => {

--- a/src/server/status_server/mod.rs
+++ b/src/server/status_server/mod.rs
@@ -118,8 +118,8 @@ where
             cfg_controller,
             router,
             security_config,
-            _snap: PhantomData,
             store_path,
+            _snap: PhantomData,
         })
     }
 
@@ -168,7 +168,7 @@ where
             .into_stream();
         let (tx, rx) = oneshot::channel();
         let callback = move || tx.send(()).unwrap_or_default();
-        let res = Handle::current().spawn(activate_heap_profile(period, callback, store_path));
+        let res = Handle::current().spawn(activate_heap_profile(period, store_path, callback));
         if rx.await.is_ok() {
             let msg = "activate heap profile success";
             Ok(make_response(StatusCode::OK, msg))
@@ -671,6 +671,9 @@ where
                             (Method::GET, "/debug/pprof/heap_deactivate") => {
                                 Self::deactivate_heap_prof(req)
                             }
+                            // (Method::GET, "/debug/pprof/heap") => {
+                            //     Self::dump_heap_prof_to_resp(req).await
+                            // }
                             (Method::GET, "/config") => {
                                 Self::get_config(req, &cfg_controller).await
                             }
@@ -680,9 +683,6 @@ where
                             (Method::GET, "/debug/pprof/profile") => {
                                 Self::dump_cpu_prof_to_resp(req).await
                             }
-                            // (Method::GET, "/debug/pprof/heap") => {
-                            //     Self::dump_heap_prof_to_resp(req).await
-                            // }
                             (Method::GET, "/debug/fail_point") => {
                                 info!("debug fail point API start");
                                 fail_point!("debug_fail_point");

--- a/src/server/status_server/mod.rs
+++ b/src/server/status_server/mod.rs
@@ -10,6 +10,7 @@ use self::profile::{
 use std::error::Error as StdError;
 use std::marker::PhantomData;
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use std::pin::Pin;
 use std::str::{self, FromStr};
 use std::sync::Arc;
@@ -81,6 +82,7 @@ pub struct StatusServer<E, R> {
     cfg_controller: ConfigController,
     router: R,
     security_config: Arc<SecurityConfig>,
+    store_path: PathBuf,
     _snap: PhantomData<E>,
 }
 
@@ -95,6 +97,7 @@ where
         cfg_controller: ConfigController,
         security_config: Arc<SecurityConfig>,
         router: R,
+        store_path: PathBuf,
     ) -> Result<Self> {
         let thread_pool = Builder::new_multi_thread()
             .enable_all()
@@ -116,6 +119,7 @@ where
             router,
             security_config,
             _snap: PhantomData,
+            store_path,
         })
     }
 
@@ -140,7 +144,10 @@ where
         Ok(response)
     }
 
-    async fn activate_heap_prof(req: Request<Body>) -> hyper::Result<Response<Body>> {
+    async fn activate_heap_prof(
+        req: Request<Body>,
+        store_path: PathBuf,
+    ) -> hyper::Result<Response<Body>> {
         let query = req.uri().query().unwrap_or("");
         let query_pairs: HashMap<_, _> = url::form_urlencoded::parse(query.as_bytes()).collect();
 
@@ -161,7 +168,7 @@ where
             .into_stream();
         let (tx, rx) = oneshot::channel();
         let callback = move || tx.send(()).unwrap_or_default();
-        let res = Handle::current().spawn(activate_heap_profile(period, callback));
+        let res = Handle::current().spawn(activate_heap_profile(period, callback, store_path));
         if rx.await.is_ok() {
             let msg = "activate heap profile success";
             Ok(make_response(StatusCode::OK, msg))
@@ -609,12 +616,14 @@ where
         let security_config = self.security_config.clone();
         let cfg_controller = self.cfg_controller.clone();
         let router = self.router.clone();
+        let store_path = self.store_path.clone();
         // Start to serve.
         let server = builder.serve(make_service_fn(move |conn: &C| {
             let x509 = conn.get_x509();
             let security_config = security_config.clone();
             let cfg_controller = cfg_controller.clone();
             let router = router.clone();
+            let store_path = store_path.clone();
             async move {
                 // Create a status service.
                 Ok::<_, hyper::Error>(service_fn(move |req: Request<Body>| {
@@ -622,6 +631,7 @@ where
                     let security_config = security_config.clone();
                     let cfg_controller = cfg_controller.clone();
                     let router = router.clone();
+                    let store_path = store_path.clone();
                     async move {
                         let path = req.uri().path().to_owned();
                         let method = req.method().to_owned();
@@ -656,14 +666,11 @@ where
                             (Method::GET, "/status") => Ok(Response::default()),
                             (Method::GET, "/debug/pprof/heap_list") => Self::list_heap_prof(req),
                             (Method::GET, "/debug/pprof/heap_activate") => {
-                                Self::activate_heap_prof(req).await
+                                Self::activate_heap_prof(req, store_path).await
                             }
                             (Method::GET, "/debug/pprof/heap_deactivate") => {
                                 Self::deactivate_heap_prof(req)
                             }
-                            // (Method::GET, "/debug/pprof/heap") => {
-                            //     Self::dump_heap_prof_to_resp(req).await
-                            // }
                             (Method::GET, "/config") => {
                                 Self::get_config(req, &cfg_controller).await
                             }
@@ -673,6 +680,9 @@ where
                             (Method::GET, "/debug/pprof/profile") => {
                                 Self::dump_cpu_prof_to_resp(req).await
                             }
+                            // (Method::GET, "/debug/pprof/heap") => {
+                            //     Self::dump_heap_prof_to_resp(req).await
+                            // }
                             (Method::GET, "/debug/fail_point") => {
                                 info!("debug fail point API start");
                                 fail_point!("debug_fail_point");
@@ -995,6 +1005,7 @@ mod tests {
             ConfigController::default(),
             Arc::new(SecurityConfig::default()),
             MockRouter,
+            std::env::temp_dir(),
         )
         .unwrap();
         let addr = "127.0.0.1:0".to_owned();
@@ -1042,6 +1053,7 @@ mod tests {
             ConfigController::default(),
             Arc::new(SecurityConfig::default()),
             MockRouter,
+            std::env::temp_dir(),
         )
         .unwrap();
         let addr = "127.0.0.1:0".to_owned();
@@ -1086,6 +1098,7 @@ mod tests {
             ConfigController::default(),
             Arc::new(SecurityConfig::default()),
             MockRouter,
+            std::env::temp_dir(),
         )
         .unwrap();
         let addr = "127.0.0.1:0".to_owned();
@@ -1201,6 +1214,7 @@ mod tests {
             ConfigController::default(),
             Arc::new(SecurityConfig::default()),
             MockRouter,
+            std::env::temp_dir(),
         )
         .unwrap();
         let addr = "127.0.0.1:0".to_owned();
@@ -1279,6 +1293,7 @@ mod tests {
             ConfigController::default(),
             Arc::new(new_security_cfg(Some(allowed_cn))),
             MockRouter,
+            std::env::temp_dir(),
         )
         .unwrap();
         let addr = "127.0.0.1:0".to_owned();
@@ -1351,6 +1366,7 @@ mod tests {
             ConfigController::default(),
             Arc::new(SecurityConfig::default()),
             MockRouter,
+            std::env::temp_dir(),
         )
         .unwrap();
         let addr = "127.0.0.1:0".to_owned();
@@ -1380,6 +1396,7 @@ mod tests {
             ConfigController::default(),
             Arc::new(SecurityConfig::default()),
             MockRouter,
+            std::env::temp_dir(),
         )
         .unwrap();
         let addr = "127.0.0.1:0".to_owned();
@@ -1407,6 +1424,7 @@ mod tests {
             ConfigController::default(),
             Arc::new(SecurityConfig::default()),
             MockRouter,
+            std::env::temp_dir(),
         )
         .unwrap();
         let addr = "127.0.0.1:0".to_owned();

--- a/src/server/status_server/profile.rs
+++ b/src/server/status_server/profile.rs
@@ -121,8 +121,8 @@ where
 /// `deactivate_heap_profile` can only be called after it's notified from `callback`.
 pub async fn activate_heap_profile<S, F>(
     dump_period: S,
-    callback: F,
     store_path: PathBuf,
+    callback: F,
 ) -> Result<(), String>
 where
     S: Stream<Item = Result<(), String>> + Send + Unpin + 'static,
@@ -381,7 +381,7 @@ mod tests {
         assert_eq!(block_on(res2).unwrap().unwrap_err(), expected);
 
         let (_tx2, rx2) = mpsc::channel(1);
-        let res2 = rt.spawn(activate_heap_profile(rx2, || {}, std::env::temp_dir()));
+        let res2 = rt.spawn(activate_heap_profile(rx2, std::env::temp_dir(), || {}));
         assert_eq!(block_on(res2).unwrap().unwrap_err(), expected);
 
         drop(tx1);
@@ -398,7 +398,7 @@ mod tests {
 
         // Test activated profiling can be stopped by canceling the period stream.
         let (tx, rx) = mpsc::channel(1);
-        let res = rt.spawn(activate_heap_profile(rx, || {}, std::env::temp_dir()));
+        let res = rt.spawn(activate_heap_profile(rx, std::env::temp_dir(), || {}));
         drop(tx);
         assert!(block_on(res).unwrap().is_ok());
 
@@ -410,8 +410,8 @@ mod tests {
         let (_tx, _rx) = mpsc::channel(1);
         let res = rt.spawn(activate_heap_profile(
             _rx,
-            on_activated,
             std::env::temp_dir(),
+            on_activated,
         ));
         assert!(check_activated());
         assert!(deactivate_heap_profile());
@@ -428,7 +428,7 @@ mod tests {
 
         // Test heap profiling can be stopped by sending an error.
         let (mut tx, rx) = mpsc::channel(1);
-        let res = rt.spawn(activate_heap_profile(rx, || {}, std::env::temp_dir()));
+        let res = rt.spawn(activate_heap_profile(rx, std::env::temp_dir(), || {}));
         block_on(tx.send(Err("test".to_string()))).unwrap();
         assert!(block_on(res).unwrap().is_err());
 
@@ -440,8 +440,8 @@ mod tests {
         let (_tx, _rx) = mpsc::channel(1);
         let res = rt.spawn(activate_heap_profile(
             _rx,
-            on_activated,
             std::env::temp_dir(),
+            on_activated,
         ));
         assert!(check_activated());
         assert!(deactivate_heap_profile());

--- a/src/server/status_server/profile.rs
+++ b/src/server/status_server/profile.rs
@@ -129,7 +129,10 @@ where
     F: FnOnce() + Send + 'static,
 {
     let (tx, rx) = oneshot::channel();
-    let dir = TempDir::new_in(store_path).map_err(|e| format!("create temp directory: {}", e))?;
+    let dir = tempfile::Builder::new()
+        .prefix("heap-")
+        .tempdir_in(store_path)
+        .map_err(|e| format!("create temp directory: {}", e))?;
     let dir_path = dir.path().to_str().unwrap().to_owned();
 
     let on_start = move || {

--- a/src/server/status_server/profile.rs
+++ b/src/server/status_server/profile.rs
@@ -4,6 +4,7 @@ pub use self::test_utils::TEST_PROFILE_MUTEX;
 
 use std::fs::{File, Metadata};
 use std::io::Read;
+use std::path::PathBuf;
 use std::pin::Pin;
 use std::process::Command;
 use std::sync::Mutex as StdMutex;
@@ -118,13 +119,17 @@ where
 
 /// Activate heap profile and call `callback` if successfully.
 /// `deactivate_heap_profile` can only be called after it's notified from `callback`.
-pub async fn activate_heap_profile<S, F>(dump_period: S, callback: F) -> Result<(), String>
+pub async fn activate_heap_profile<S, F>(
+    dump_period: S,
+    callback: F,
+    store_path: PathBuf,
+) -> Result<(), String>
 where
     S: Stream<Item = Result<(), String>> + Send + Unpin + 'static,
     F: FnOnce() + Send + 'static,
 {
     let (tx, rx) = oneshot::channel();
-    let dir = TempDir::new().map_err(|e| format!("create temp directory: {}", e))?;
+    let dir = TempDir::new_in(store_path).map_err(|e| format!("create temp directory: {}", e))?;
     let dir_path = dir.path().to_str().unwrap().to_owned();
 
     let on_start = move || {
@@ -373,7 +378,7 @@ mod tests {
         assert_eq!(block_on(res2).unwrap().unwrap_err(), expected);
 
         let (_tx2, rx2) = mpsc::channel(1);
-        let res2 = rt.spawn(activate_heap_profile(rx2, || {}));
+        let res2 = rt.spawn(activate_heap_profile(rx2, || {}, std::env::temp_dir()));
         assert_eq!(block_on(res2).unwrap().unwrap_err(), expected);
 
         drop(tx1);
@@ -390,7 +395,7 @@ mod tests {
 
         // Test activated profiling can be stopped by canceling the period stream.
         let (tx, rx) = mpsc::channel(1);
-        let res = rt.spawn(activate_heap_profile(rx, || {}));
+        let res = rt.spawn(activate_heap_profile(rx, || {}, std::env::temp_dir()));
         drop(tx);
         assert!(block_on(res).unwrap().is_ok());
 
@@ -400,7 +405,11 @@ mod tests {
         let check_activated = move || rx.recv().is_err();
 
         let (_tx, _rx) = mpsc::channel(1);
-        let res = rt.spawn(activate_heap_profile(_rx, on_activated));
+        let res = rt.spawn(activate_heap_profile(
+            _rx,
+            on_activated,
+            std::env::temp_dir(),
+        ));
         assert!(check_activated());
         assert!(deactivate_heap_profile());
         assert!(block_on(res).unwrap().is_ok());
@@ -416,7 +425,7 @@ mod tests {
 
         // Test heap profiling can be stopped by sending an error.
         let (mut tx, rx) = mpsc::channel(1);
-        let res = rt.spawn(activate_heap_profile(rx, || {}));
+        let res = rt.spawn(activate_heap_profile(rx, || {}, std::env::temp_dir()));
         block_on(tx.send(Err("test".to_string()))).unwrap();
         assert!(block_on(res).unwrap().is_err());
 
@@ -426,7 +435,11 @@ mod tests {
         let check_activated = move || rx.recv().is_err();
 
         let (_tx, _rx) = mpsc::channel(1);
-        let res = rt.spawn(activate_heap_profile(_rx, on_activated));
+        let res = rt.spawn(activate_heap_profile(
+            _rx,
+            on_activated,
+            std::env::temp_dir(),
+        ));
         assert!(check_activated());
         assert!(deactivate_heap_profile());
         assert!(block_on(res).unwrap().is_ok());

--- a/tests/integrations/server/status_server.rs
+++ b/tests/integrations/server/status_server.rs
@@ -48,6 +48,7 @@ fn test_region_meta_endpoint() {
         ConfigController::default(),
         Arc::new(SecurityConfig::default()),
         router.unwrap(),
+        std::env::temp_dir(),
     )
     .unwrap();
     let addr = format!("127.0.0.1:{}", test_util::alloc_port());


### PR DESCRIPTION
Signed-off-by: 5kbpers <tangminghua@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #11265

Problem Summary:
Currently we generate heap profile to /tmp, then the files may be lost after pod restarting in docker environment.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
* generate heap profile to data dir

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```