### PR TITLE
tikv_util: upgrade `gag` from 0.1 to 1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1347,6 +1347,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "filedescriptor"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed3d8a5e20435ff00469e51a0d82049bae66504b5c429920dadf9bb54d47b3f"
+dependencies = [
+ "libc 0.2.106",
+ "thiserror",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1641,11 +1652,11 @@ dependencies = [
 
 [[package]]
 name = "gag"
-version = "0.1.10"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cc0b9f53275dc5fada808f1d2f82e3688a6c14d735633d1590b7be8eb2307b5"
+checksum = "a713bee13966e9fbffdf7193af71d54a6b35a0bb34997cd6c9519ebeb5005972"
 dependencies = [
- "libc 0.2.106",
+ "filedescriptor",
  "tempfile",
 ]
 

--- a/cmd/tikv-ctl/Cargo.toml
+++ b/cmd/tikv-ctl/Cargo.toml
@@ -53,7 +53,7 @@ fs2 = "0.4"
 futures = "0.3"
 kvproto = { git = "https://github.com/pingcap/kvproto.git" }
 tokio = { version = "1.5", features = ["rt-multi-thread", "time"] }
-gag = "0.1"
+gag = "1.0"
 grpcio = { version = "0.9",  default-features = false, features = ["openssl-vendored", "protobuf-codec"] }
 hex = "0.4"
 keys = { path = "../../components/keys", default-features = false }

--- a/components/tikv_util/Cargo.toml
+++ b/components/tikv_util/Cargo.toml
@@ -62,12 +62,10 @@ page_size = "0.4"
 procfs = { version = "0.9", default-features = false }
 
 [dev-dependencies]
+gag = "1.0"
 panic_hook = { path = "../panic_hook" }
 protobuf = "2"
 regex = "1.0"
 tempfile = "3.0"
 toml = "0.5"
 utime = "0.2"
-
-[target.'cfg(unix)'.dev-dependencies]
-gag = "0.1.10"

--- a/components/tikv_util/src/lib.rs
+++ b/components/tikv_util/src/lib.rs
@@ -568,7 +568,6 @@ mod tests {
     use tempfile::Builder;
 
     #[test]
-    #[cfg(unix)]
     fn test_panic_hook() {
         use gag::BufferRedirect;
         use slog::{self, Drain, OwnedKVList, Record};


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: #11276 

Problem Summary:

### What is changed and how it works?

The `gag` dependency was outdated. This PR updates `gag` to 1.0 which works on both Unix and Windows.

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```