### PR TITLE
raftstore: Fix compaction guard panic on non-data key

### DIFF
--- a/components/raftstore/src/store/compaction_guard.rs
+++ b/components/raftstore/src/store/compaction_guard.rs
@@ -91,6 +91,9 @@ pub struct CompactionGuardGenerator<P: RegionInfoProvider> {
 
 impl<P: RegionInfoProvider> CompactionGuardGenerator<P> {
     fn initialize(&mut self) {
+        // The range may include non-data keys which are not included in any region,
+        // such as `STORE_IDENT_KEY`, `REGION_RAFT_KEY` and `REGION_META_KEY`,
+        // so check them and get covered regions only for the range of data keys.
         let res = match (
             self.smallest_key.starts_with(keys::DATA_PREFIX_KEY),
             self.largest_key.starts_with(keys::DATA_PREFIX_KEY),

--- a/components/raftstore/src/store/compaction_guard.rs
+++ b/components/raftstore/src/store/compaction_guard.rs
@@ -91,30 +91,51 @@ pub struct CompactionGuardGenerator<P: RegionInfoProvider> {
 
 impl<P: RegionInfoProvider> CompactionGuardGenerator<P> {
     fn initialize(&mut self) {
-        self.use_guard = match self.provider.get_regions_in_range(
-            origin_key(&self.smallest_key),
-            origin_key(&self.largest_key),
+        let res = match (
+            self.smallest_key.starts_with(keys::DATA_PREFIX_KEY),
+            self.largest_key.starts_with(keys::DATA_PREFIX_KEY),
         ) {
-            Ok(regions) => {
-                // The regions returned from region_info_provider should have been sorted,
-                // but we sort it again just in case.
-                COMPACTION_GUARD_ACTION_COUNTER.get(self.cf_name).init.inc();
-                let mut boundaries = regions
-                    .iter()
-                    .map(|region| data_end_key(&region.end_key))
-                    .collect::<Vec<Vec<u8>>>();
-                boundaries.sort();
-                self.boundaries = boundaries;
-                true
+            (true, true) => Some((
+                origin_key(&self.smallest_key),
+                origin_key(&self.largest_key),
+            )),
+            (true, false) => Some((origin_key(&self.smallest_key), "".as_bytes())),
+            (false, true) => Some(("".as_bytes(), origin_key(&self.largest_key))),
+            (false, false) => {
+                if self.smallest_key.as_slice() < keys::DATA_MIN_KEY
+                    && self.largest_key.as_slice() >= keys::DATA_MAX_KEY
+                {
+                    Some(("".as_bytes(), "".as_bytes()))
+                } else {
+                    None
+                }
             }
-            Err(e) => {
-                COMPACTION_GUARD_ACTION_COUNTER
-                    .get(self.cf_name)
-                    .init_failure
-                    .inc();
-                warn!("failed to initialize compaction guard generator"; "err" => ?e);
-                false
+        };
+        self.use_guard = if let Some((start, end)) = res {
+            match self.provider.get_regions_in_range(start, end) {
+                Ok(regions) => {
+                    // The regions returned from region_info_provider should have been sorted,
+                    // but we sort it again just in case.
+                    COMPACTION_GUARD_ACTION_COUNTER.get(self.cf_name).init.inc();
+                    let mut boundaries = regions
+                        .iter()
+                        .map(|region| data_end_key(&region.end_key))
+                        .collect::<Vec<Vec<u8>>>();
+                    boundaries.sort();
+                    self.boundaries = boundaries;
+                    true
+                }
+                Err(e) => {
+                    COMPACTION_GUARD_ACTION_COUNTER
+                        .get(self.cf_name)
+                        .init_failure
+                        .inc();
+                    warn!("failed to initialize compaction guard generator"; "err" => ?e);
+                    false
+                }
             }
+        } else {
+            false
         };
         self.pos = 0;
         self.initialized = true;
@@ -185,6 +206,51 @@ mod tests {
     use kvproto::metapb::Region;
     use std::{str, sync::Arc};
     use tempfile::TempDir;
+
+    #[test]
+    fn test_compaction_guard_non_data() {
+        let mut guard = CompactionGuardGenerator {
+            cf_name: CfNames::default,
+            smallest_key: vec![],
+            largest_key: vec![],
+            min_output_file_size: 8 << 20, // 8MB
+            provider: MockRegionInfoProvider::new(vec![]),
+            initialized: false,
+            use_guard: false,
+            boundaries: vec![],
+            pos: 0,
+        };
+
+        guard.smallest_key = keys::LOCAL_MIN_KEY.to_vec();
+        guard.largest_key = keys::LOCAL_MAX_KEY.to_vec();
+        guard.initialize();
+        assert_eq!(guard.use_guard, false);
+
+        guard.smallest_key = keys::LOCAL_MIN_KEY.to_vec();
+        guard.largest_key = keys::DATA_MIN_KEY.to_vec();
+        guard.initialize();
+        assert_eq!(guard.use_guard, true);
+
+        guard.smallest_key = keys::LOCAL_MIN_KEY.to_vec();
+        guard.largest_key = keys::DATA_MAX_KEY.to_vec();
+        guard.initialize();
+        assert_eq!(guard.use_guard, true);
+
+        guard.smallest_key = keys::DATA_MIN_KEY.to_vec();
+        guard.largest_key = keys::DATA_MAX_KEY.to_vec();
+        guard.initialize();
+        assert_eq!(guard.use_guard, true);
+
+        guard.smallest_key = keys::DATA_MIN_KEY.to_vec();
+        guard.largest_key = vec![keys::DATA_PREFIX + 10];
+        guard.initialize();
+        assert_eq!(guard.use_guard, true);
+
+        guard.smallest_key = keys::DATA_MAX_KEY.to_vec();
+        guard.largest_key = vec![keys::DATA_PREFIX + 10];
+        guard.initialize();
+        assert_eq!(guard.use_guard, false);
+    }
 
     #[test]
     fn test_compaction_guard_should_partition() {


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close https://github.com/tikv/tikv/issues/11290 <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed: Check if it is a non-data key when calling `origin_key` in compaction guard.

### Related changes

- None

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```