### PR TITLE
tikv_util: ProcessCollector should use IntGauge to provide better performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3210,7 +3210,6 @@ checksum = "ab8809e0c18450a2db0f236d2a44ec0b4c1412d0eb936233579f0990faa5d5cd"
 dependencies = [
  "bitflags",
  "byteorder",
- "chrono",
  "flate2",
  "hex 0.4.2",
  "lazy_static",

--- a/components/tikv_util/Cargo.toml
+++ b/components/tikv_util/Cargo.toml
@@ -59,7 +59,7 @@ yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
 [target.'cfg(target_os = "linux")'.dependencies]
 procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "5125fc1a69496b73b26b3c08b6e8afc3c665a56e" }
 page_size = "0.4"
-procfs = "0.9"
+procfs = { version = "0.9", default-features = false }
 
 [dev-dependencies]
 panic_hook = { path = "../panic_hook" }

--- a/components/tikv_util/src/metrics/process_linux.rs
+++ b/components/tikv_util/src/metrics/process_linux.rs
@@ -7,31 +7,28 @@ use std::io::{Error, ErrorKind, Result};
 
 use lazy_static::lazy_static;
 use prometheus::core::{Collector, Desc};
-use prometheus::{proto, Counter, Gauge, Opts};
-use std::sync::Mutex;
+use prometheus::{proto, IntCounter, IntGauge, Opts};
 
 /// Monitors current process.
 pub fn monitor_process() -> Result<()> {
-    let pid = unsafe { libc::getpid() };
-    let tc = ProcessCollector::new(pid);
-    prometheus::register(Box::new(tc)).map_err(|e| Error::new(ErrorKind::Other, e.to_string()))
+    let pc = ProcessCollector::new();
+    prometheus::register(Box::new(pc)).map_err(|e| Error::new(ErrorKind::Other, e.to_string()))
 }
 
 /// A collector to collect process metrics.
 pub struct ProcessCollector {
-    pid: libc::pid_t,
     descs: Vec<Desc>,
-    cpu_total: Mutex<Counter>,
-    vsize: Gauge,
-    rss: Gauge,
-    start_time: Gauge,
+    cpu_total: IntCounter,
+    vsize: IntGauge,
+    rss: IntGauge,
+    start_time: IntGauge,
 }
 
 impl ProcessCollector {
-    pub fn new(pid: libc::pid_t) -> Self {
+    pub fn new() -> Self {
         let mut descs = Vec::new();
 
-        let cpu_total = Counter::with_opts(Opts::new(
+        let cpu_total = IntCounter::with_opts(Opts::new(
             "process_cpu_seconds_total",
             "Total user and system CPU time spent in \
                  seconds.",
@@ -39,32 +36,37 @@ impl ProcessCollector {
         .unwrap();
         descs.extend(cpu_total.desc().into_iter().cloned());
 
-        let vsize = Gauge::with_opts(Opts::new(
+        let vsize = IntGauge::with_opts(Opts::new(
             "process_virtual_memory_bytes",
             "Virtual memory size in bytes.",
         ))
         .unwrap();
         descs.extend(vsize.desc().into_iter().cloned());
 
-        let rss = Gauge::with_opts(Opts::new(
+        let rss = IntGauge::with_opts(Opts::new(
             "process_resident_memory_bytes",
             "Resident memory size in bytes.",
         ))
         .unwrap();
         descs.extend(rss.desc().into_iter().cloned());
 
-        let start_time = Gauge::with_opts(Opts::new(
+        let start_time = IntGauge::with_opts(Opts::new(
             "process_start_time_seconds",
             "Start time of the process since unix epoch \
                  in seconds.",
         ))
         .unwrap();
         descs.extend(start_time.desc().into_iter().cloned());
+        // proc_start_time init once because it is immutable
+        if let Ok(boot_time) = procfs::boot_time_secs() {
+            if let Ok(p) = procfs::process::Process::myself() {
+                start_time.set(p.stat.starttime as i64 / *CLK_TCK + boot_time as i64);
+            }
+        }
 
         Self {
-            pid,
             descs,
-            cpu_total: Mutex::new(cpu_total),
+            cpu_total,
             vsize,
             rss,
             start_time,
@@ -78,7 +80,7 @@ impl Collector for ProcessCollector {
     }
 
     fn collect(&self) -> Vec<proto::MetricFamily> {
-        let p = match procfs::process::Process::new(self.pid) {
+        let p = match procfs::process::Process::myself() {
             Ok(p) => p,
             Err(..) => {
                 // we can't construct a Process object, so there's no stats to gather
@@ -87,29 +89,19 @@ impl Collector for ProcessCollector {
         };
 
         // memory
-        self.vsize.set(p.stat.vsize as f64);
-        self.rss.set(p.stat.rss as f64 * *PAGESIZE);
-
-        // proc_start_time
-        if let Some(boot_time) = *BOOT_TIME {
-            self.start_time
-                .set(p.stat.starttime as f64 / *CLK_TCK + boot_time);
-        }
+        self.vsize.set(p.stat.vsize as i64);
+        self.rss.set(p.stat.rss * *PAGESIZE);
 
         // cpu
         let cpu_total_mfs = {
-            let cpu_total = self.cpu_total.lock().unwrap();
-            let total = (p.stat.utime + p.stat.stime) as f64 / *CLK_TCK;
-            let past = cpu_total.get();
-            let delta = total - past;
-            if delta > 0.0 {
-                cpu_total.inc_by(delta);
-            }
+            let total = (p.stat.utime + p.stat.stime) / *CLK_TCK as u64;
+            let past = self.cpu_total.get();
+            self.cpu_total.inc_by(total - past);
 
-            cpu_total.collect()
+            self.cpu_total.collect()
         };
 
-        // collect MetricFamilys.
+        // collect MetricFamilies.
         let mut mfs = Vec::with_capacity(4);
         mfs.extend(cpu_total_mfs);
         mfs.extend(self.vsize.collect());
@@ -121,20 +113,16 @@ impl Collector for ProcessCollector {
 
 lazy_static! {
     // getconf CLK_TCK
-    static ref CLK_TCK: f64 = {
+    static ref CLK_TCK: i64 = {
         unsafe {
-            libc::sysconf(libc::_SC_CLK_TCK) as f64
+            libc::sysconf(libc::_SC_CLK_TCK)
         }
     };
 
     // getconf PAGESIZE
-    static ref PAGESIZE: f64 = {
+    static ref PAGESIZE: i64 = {
         unsafe {
-            libc::sysconf(libc::_SC_PAGESIZE) as f64
+            libc::sysconf(libc::_SC_PAGESIZE)
         }
     };
-}
-
-lazy_static! {
-    static ref BOOT_TIME: Option<f64> = procfs::boot_time_secs().ok().map(|i| i as f64);
 }


### PR DESCRIPTION
### What problem does this PR solve?

improve ProcessCollector performance

close #11306 

### Check List

Tests

- Unit test

### Release note

```release-note
None
```
