### PR TITLE
resource_metering: shorten the duration of integration test to be <1min

### DIFF
--- a/components/resource_metering/src/config.rs
+++ b/components/resource_metering/src/config.rs
@@ -10,10 +10,10 @@ use serde_derive::{Deserialize, Serialize};
 use tikv_util::config::ReadableDuration;
 use tikv_util::worker::Scheduler;
 
-const MIN_PRECISION: ReadableDuration = ReadableDuration::secs(1);
+const MIN_PRECISION: ReadableDuration = ReadableDuration::millis(100);
 const MAX_PRECISION: ReadableDuration = ReadableDuration::hours(1);
 const MAX_MAX_RESOURCE_GROUPS: usize = 5_000;
-const MIN_REPORT_RECEIVER_INTERVAL: ReadableDuration = ReadableDuration::secs(5);
+const MIN_REPORT_RECEIVER_INTERVAL: ReadableDuration = ReadableDuration::millis(500);
 
 /// Public configuration of resource metering module.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, OnlineConfig)]

--- a/src/server/status_server/mod.rs
+++ b/src/server/status_server/mod.rs
@@ -1258,6 +1258,7 @@ mod tests {
             ConfigController::default(),
             Arc::new(SecurityConfig::default()),
             MockRouter,
+            std::env::temp_dir(),
         )
         .unwrap();
         let addr = "127.0.0.1:0".to_owned();

--- a/tests/integrations/resource_metering/test_receiver.rs
+++ b/tests/integrations/resource_metering/test_receiver.rs
@@ -2,70 +2,52 @@
 
 use super::test_suite::TestSuite;
 
-use std::iter;
 use std::thread::sleep;
 use std::time::Duration;
 
-use rand::prelude::*;
 use test_util::alloc_port;
 
-const ONE_SEC: Duration = Duration::from_secs(1);
+const ERROR_DELAY: Duration = Duration::from_millis(100);
 
 pub fn case_alter_receiver_addr(test_suite: &mut TestSuite) {
     test_suite.reset();
     let port = alloc_port();
     test_suite.start_receiver_at(port);
     test_suite.cfg_enabled(true);
-    test_suite.cfg_max_resource_groups(5);
 
     // Workload
-    // [req-{1..5} * 10, req-{6..10} * 1]
-    let mut wl = iter::repeat(1..=5)
-        .take(10)
-        .flatten()
-        .chain(6..=10)
-        .map(|n| format!("req-{}", n))
-        .collect::<Vec<_>>();
-    wl.shuffle(&mut rand::thread_rng());
-    test_suite.setup_workload(wl);
+    // [req-1, req-2]
+    test_suite.setup_workload(vec!["req-1", "req-2"]);
 
     // | Address | Enabled |
     // |   x     |    o    |
-    sleep(test_suite.get_current_cfg().report_receiver_interval.0 + ONE_SEC);
+    sleep(test_suite.get_current_cfg().report_receiver_interval.0 + ERROR_DELAY);
     assert!(test_suite.fetch_reported_cpu_time().is_empty());
 
     // | Address | Enabled |
     // |   o     |    o    |
     test_suite.cfg_receiver_address(format!("127.0.0.1:{}", port));
-    sleep(test_suite.get_current_cfg().report_receiver_interval.0 + ONE_SEC);
+    sleep(test_suite.get_current_cfg().report_receiver_interval.0 + ERROR_DELAY);
     let res = test_suite.fetch_reported_cpu_time();
-    assert_eq!(res.len(), 6);
+    assert_eq!(res.len(), 2);
     assert!(res.contains_key("req-1"));
     assert!(res.contains_key("req-2"));
-    assert!(res.contains_key("req-3"));
-    assert!(res.contains_key("req-4"));
-    assert!(res.contains_key("req-5"));
-    assert!(res.contains_key(""));
 
     // | Address | Enabled |
     // |   !     |    o    |
     test_suite.cfg_receiver_address(format!("127.0.0.1:{}", port + 1));
     test_suite.flush_receiver();
-    sleep(test_suite.get_current_cfg().report_receiver_interval.0 + ONE_SEC);
+    sleep(test_suite.get_current_cfg().report_receiver_interval.0 + ERROR_DELAY);
     assert!(test_suite.fetch_reported_cpu_time().is_empty());
 
     // | Address | Enabled |
     // |   o     |    o    |
     test_suite.cfg_receiver_address(format!("127.0.0.1:{}", port));
-    sleep(test_suite.get_current_cfg().report_receiver_interval.0 + ONE_SEC);
+    sleep(test_suite.get_current_cfg().report_receiver_interval.0 + ERROR_DELAY);
     let res = test_suite.fetch_reported_cpu_time();
-    assert_eq!(res.len(), 6);
+    assert_eq!(res.len(), 2);
     assert!(res.contains_key("req-1"));
     assert!(res.contains_key("req-2"));
-    assert!(res.contains_key("req-3"));
-    assert!(res.contains_key("req-4"));
-    assert!(res.contains_key("req-5"));
-    assert!(res.contains_key(""));
 }
 
 pub fn case_receiver_blocking(test_suite: &mut TestSuite) {
@@ -73,64 +55,36 @@ pub fn case_receiver_blocking(test_suite: &mut TestSuite) {
     let port = alloc_port();
     test_suite.start_receiver_at(port);
     test_suite.cfg_enabled(true);
-    test_suite.cfg_max_resource_groups(5);
     test_suite.cfg_receiver_address(format!("127.0.0.1:{}", port));
 
     // Workload
-    // [req-{1..5} * 10, req-{6..10} * 1]
-    let mut wl = iter::repeat(1..=5)
-        .take(10)
-        .flatten()
-        .chain(6..=10)
-        .map(|n| format!("req-{}", n))
-        .collect::<Vec<_>>();
-    wl.shuffle(&mut rand::thread_rng());
-    test_suite.setup_workload(wl);
+    // [req-1, req-2]
+    test_suite.setup_workload(vec!["req-1", "req-2"]);
 
     // | Block Receiver |
     // |      x      |
-    sleep(test_suite.get_current_cfg().report_receiver_interval.0 + ONE_SEC);
+    sleep(test_suite.get_current_cfg().report_receiver_interval.0 + ERROR_DELAY);
     let res = test_suite.fetch_reported_cpu_time();
-    assert_eq!(res.len(), 6);
+    assert_eq!(res.len(), 2);
     assert!(res.contains_key("req-1"));
     assert!(res.contains_key("req-2"));
-    assert!(res.contains_key("req-3"));
-    assert!(res.contains_key("req-4"));
-    assert!(res.contains_key("req-5"));
-    assert!(res.contains_key(""));
 
     // | Block Receiver |
-    // |      o      |
-    fail::cfg("mock-receiver", "sleep(5000)").unwrap();
+    // |        o       |
+    fail::cfg("mock-receiver", "sleep(1000)").unwrap();
     test_suite.flush_receiver();
-    sleep(test_suite.get_current_cfg().report_receiver_interval.0 + ONE_SEC);
+    sleep(test_suite.get_current_cfg().report_receiver_interval.0 + ERROR_DELAY);
     assert!(test_suite.fetch_reported_cpu_time().is_empty());
 
-    // Workload
-    // [req-{1..5} * 1, req-{6..10} * 10]
-    test_suite.cancel_workload();
-    let mut wl = iter::repeat(6..=10)
-        .take(10)
-        .flatten()
-        .chain(1..=5)
-        .map(|n| format!("req-{}", n))
-        .collect::<Vec<_>>();
-    wl.shuffle(&mut rand::thread_rng());
-    test_suite.setup_workload(wl);
-
     // | Block Receiver |
-    // |      x      |
+    // |        x       |
     fail::remove("mock-receiver");
     test_suite.flush_receiver();
-    sleep(test_suite.get_current_cfg().report_receiver_interval.0 + ONE_SEC);
+    sleep(test_suite.get_current_cfg().report_receiver_interval.0 + ERROR_DELAY);
     let res = test_suite.fetch_reported_cpu_time();
-    assert_eq!(res.len(), 6);
-    assert!(res.contains_key("req-6"));
-    assert!(res.contains_key("req-7"));
-    assert!(res.contains_key("req-8"));
-    assert!(res.contains_key("req-9"));
-    assert!(res.contains_key("req-10"));
-    assert!(res.contains_key(""));
+    assert_eq!(res.len(), 2);
+    assert!(res.contains_key("req-1"));
+    assert!(res.contains_key("req-2"));
 }
 
 pub fn case_receiver_shutdown(test_suite: &mut TestSuite) {
@@ -138,62 +92,34 @@ pub fn case_receiver_shutdown(test_suite: &mut TestSuite) {
     let port = alloc_port();
     test_suite.start_receiver_at(port);
     test_suite.cfg_enabled(true);
-    test_suite.cfg_max_resource_groups(5);
     test_suite.cfg_receiver_address(format!("127.0.0.1:{}", port));
 
     // Workload
-    // [req-{1..5} * 10, req-{6..10} * 1]
-    let mut wl = iter::repeat(1..=5)
-        .take(10)
-        .flatten()
-        .chain(6..=10)
-        .map(|n| format!("req-{}", n))
-        .collect::<Vec<_>>();
-    wl.shuffle(&mut rand::thread_rng());
-    test_suite.setup_workload(wl);
+    // [req-1, req-2]
+    test_suite.setup_workload(vec!["req-1", "req-2"]);
 
     // | Receiver Alive |
     // |      o      |
-    sleep(test_suite.get_current_cfg().report_receiver_interval.0 + ONE_SEC);
+    sleep(test_suite.get_current_cfg().report_receiver_interval.0 + ERROR_DELAY);
     let res = test_suite.fetch_reported_cpu_time();
-    assert_eq!(res.len(), 6);
+    assert_eq!(res.len(), 2);
     assert!(res.contains_key("req-1"));
     assert!(res.contains_key("req-2"));
-    assert!(res.contains_key("req-3"));
-    assert!(res.contains_key("req-4"));
-    assert!(res.contains_key("req-5"));
-    assert!(res.contains_key(""));
 
     // | Receiver Alive |
-    // |      x      |
+    // |        x       |
     test_suite.shutdown_receiver();
     test_suite.flush_receiver();
-    sleep(test_suite.get_current_cfg().report_receiver_interval.0 + ONE_SEC);
+    sleep(test_suite.get_current_cfg().report_receiver_interval.0 + ERROR_DELAY);
     assert!(test_suite.fetch_reported_cpu_time().is_empty());
 
-    // Workload
-    // [req-{1..5} * 1, req-{6..10} * 10]
-    test_suite.cancel_workload();
-    let mut wl = iter::repeat(6..=10)
-        .take(10)
-        .flatten()
-        .chain(1..=5)
-        .map(|n| format!("req-{}", n))
-        .collect::<Vec<_>>();
-    wl.shuffle(&mut rand::thread_rng());
-    test_suite.setup_workload(wl);
-
     // | Receiver Alive |
-    // |      o      |
+    // |        o       |
     test_suite.start_receiver_at(port);
     test_suite.flush_receiver();
-    sleep(test_suite.get_current_cfg().report_receiver_interval.0 + ONE_SEC);
+    sleep(test_suite.get_current_cfg().report_receiver_interval.0 + ERROR_DELAY);
     let res = test_suite.fetch_reported_cpu_time();
-    assert_eq!(res.len(), 6);
-    assert!(res.contains_key("req-6"));
-    assert!(res.contains_key("req-7"));
-    assert!(res.contains_key("req-8"));
-    assert!(res.contains_key("req-9"));
-    assert!(res.contains_key("req-10"));
-    assert!(res.contains_key(""));
+    assert_eq!(res.len(), 2);
+    assert!(res.contains_key("req-1"));
+    assert!(res.contains_key("req-2"));
 }


### PR DESCRIPTION
Signed-off-by: Zhenchi <zhongzc_arch@outlook.com>

### What problem does this PR solve?

Issue Number: close #11229

Problem Summary: test_resource_metering is too slow.

### What is changed and how it works?

Alter some test configs.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

![image](https://user-images.githubusercontent.com/29565014/141085918-e00eae64-7e6e-4f40-982b-a561901aa451.png)

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
none
```