### PR TITLE
copr: add duration_string_time_diff function

### DIFF
--- a/components/tidb_query_expr/src/impl_time.rs
+++ b/components/tidb_query_expr/src/impl_time.rs
@@ -849,6 +849,22 @@ pub fn string_string_time_diff(
     duration_duration_time_diff(ctx, &arg1, &arg2)
 }
 
+#[rpn_fn(capture = [ctx])]
+#[inline]
+pub fn duration_string_time_diff(
+    ctx: &mut EvalContext,
+    arg1: &Duration,
+    arg2: BytesRef,
+) -> Result<Option<Duration>> {
+    let arg2 = std::str::from_utf8(arg2).map_err(Error::Encoding)?;
+    let arg2 = match Duration::parse(ctx, arg2, MAX_FSP) {
+        Ok(arg) => arg,
+        Err(_) => return Ok(None),
+    };
+
+    duration_duration_time_diff(ctx, arg1, &arg2)
+}
+
 /// Cast Duration into string representation and drop subsec if possible.
 fn duration_to_string(duration: Duration) -> String {
     match duration.subsec_micros() {
@@ -2518,6 +2534,66 @@ mod tests {
                 .push_param(string1)
                 .push_param(string2)
                 .evaluate::<Duration>(ScalarFuncSig::StringStringTimeDiff)
+                .unwrap();
+            assert_eq!(output, expected, "got {}", output.unwrap().to_string());
+        }
+    }
+
+    #[test]
+    fn test_duration_string_time_diff() {
+        let cases = vec![
+            (Some("00:02:02"), Some("00:01:01"), Some("00:01:01")),
+            (Some("12:00:00"), Some("00:00:01"), Some("11:59:59")),
+            (Some("24:00:00"), Some("00:00:01"), Some("23:59:59")),
+            (Some("24:00:01"), Some("00:00:02"), Some("23:59:59")),
+            (None, None, None),
+            // corner case
+            (
+                Some("00:59:59.999999"),
+                Some("01:00:00.000000"),
+                Some("-00:00:00.000001"),
+            ),
+            (
+                Some("00:59:59.999999"),
+                Some("-00:00:00.000001"),
+                Some("01:00:00.000000"),
+            ),
+            (
+                Some("-00:00:00.000001"),
+                Some("00:00:00.000001"),
+                Some("-00:00:00.000002"),
+            ),
+            (
+                Some("-00:00:00.000001"),
+                Some("-00:00:00.000001"),
+                Some("00:00:00.000000"),
+            ),
+            // overflow or underflow case
+            (
+                Some("-00:00:01"),
+                Some("838:59:59.000000"),
+                Some("-838:59:59.000000"),
+            ),
+            (
+                Some("838:59:59.000000"),
+                Some("-00:00:01"),
+                Some("838:59:59.000000"),
+            ),
+            (
+                Some("838:59:59.000000"),
+                Some("-838:59:59.000000"),
+                Some("838:59:59.000000"),
+            ),
+        ];
+        let mut ctx = EvalContext::default();
+        for (duration, string, exp) in cases {
+            let expected = exp.map(|exp| Duration::parse(&mut ctx, exp, MAX_FSP).unwrap());
+            let duration = duration.map(|arg1| Duration::parse(&mut ctx, arg1, MAX_FSP).unwrap());
+            let string = string.map(|str| str.as_bytes().to_vec());
+            let output = RpnFnScalarEvaluator::new()
+                .push_param(duration)
+                .push_param(string)
+                .evaluate::<Duration>(ScalarFuncSig::DurationStringTimeDiff)
                 .unwrap();
             assert_eq!(output, expected, "got {}", output.unwrap().to_string());
         }

--- a/components/tidb_query_expr/src/lib.rs
+++ b/components/tidb_query_expr/src/lib.rs
@@ -707,6 +707,7 @@ fn map_expr_node_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
         ScalarFuncSig::DurationDurationTimeDiff => duration_duration_time_diff_fn_meta(),
         ScalarFuncSig::StringDurationTimeDiff => string_duration_time_diff_fn_meta(),
         ScalarFuncSig::StringStringTimeDiff => string_string_time_diff_fn_meta(),
+        ScalarFuncSig::DurationStringTimeDiff => duration_string_time_diff_fn_meta(),
         _ => return Err(other_err!(
             "ScalarFunction {:?} is not supported in batch mode",
             value


### PR DESCRIPTION
Signed-off-by: Jayice <1185430411@qq.com>

Hi,i participated in TiKV community for the first time

### What problem does this PR solve?

according to
(https://github.com/tikv/tikv/issues/5751#issuecomment-909765143)


Problem Summary:
migrating `duration_string_time_diff` from TiDB

### What is changed and how it works?


What's Changed:

implement ` duration_string_time_diff`

### Related changes

- No Related Changes

Tests 

- Unit test

### Release note 

```release-note
implement  duration_string_time_diff
```