### PR TITLE
cdc: introduce TsFilter into incremental scan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,6 +498,7 @@ dependencies = [
  "futures 0.3.15",
  "futures-timer",
  "grpcio",
+ "keys",
  "kvproto",
  "lazy_static",
  "log_wrappers",

--- a/components/backup/src/writer.rs
+++ b/components/backup/src/writer.rs
@@ -425,6 +425,7 @@ mod tests {
     use std::path::Path;
     use tempfile::TempDir;
     use tikv::storage::TestEngineBuilder;
+    use txn_types::OldValue;
 
     type CfKvs<'a> = (engine_traits::CfName, &'a [(&'a [u8], &'a [u8])]);
 
@@ -522,7 +523,7 @@ mod tests {
                 vec![TxnEntry::Commit {
                     default: (vec![], vec![]),
                     write: (vec![b'a'], vec![b'a']),
-                    old_value: None,
+                    old_value: OldValue::None,
                 }]
                 .into_iter(),
                 false,
@@ -562,12 +563,12 @@ mod tests {
                     TxnEntry::Commit {
                         default: (vec![b'a'], vec![b'a']),
                         write: (vec![b'a'], vec![b'a']),
-                        old_value: None,
+                        old_value: OldValue::None,
                     },
                     TxnEntry::Commit {
                         default: (vec![], vec![]),
                         write: (vec![b'b'], vec![]),
-                        old_value: None,
+                        old_value: OldValue::None,
                     },
                 ]
                 .into_iter(),

--- a/components/cdc/Cargo.toml
+++ b/components/cdc/Cargo.toml
@@ -24,9 +24,11 @@ failpoints = ["tikv/failpoints"]
 [dependencies]
 bitflags = "1.0"
 crossbeam = "0.8"
+engine_rocks = { path = "../engine_rocks", default-features = false }
 engine_traits = { path = "../engine_traits", default-features = false }
 futures = "0.3"
 grpcio = { version = "0.9",  default-features = false, features = ["openssl-vendored", "protobuf-codec"] }
+keys = { path = "../keys" }
 kvproto = { git = "https://github.com/pingcap/kvproto.git" }
 pd_client = { path = "../pd_client", default-features = false }
 raft = { version = "0.6.0-alpha", default-features = false, features = ["protobuf-codec"] }

--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -453,7 +453,7 @@ impl Delegate {
                         current_rows_size = 0;
                     }
                     current_rows_size += row_size;
-                    row.old_value = old_value.unwrap_or_default();
+                    row.old_value = old_value.finalized().unwrap_or_default();
                     rows.last_mut().unwrap().push(row);
                 }
                 Some(TxnEntry::Commit {
@@ -480,7 +480,7 @@ impl Delegate {
                         continue;
                     }
                     set_event_row_type(&mut row, EventLogType::Committed);
-                    row.old_value = old_value.unwrap_or_default();
+                    row.old_value = old_value.finalized().unwrap_or_default();
                     let row_size = row.key.len() + row.value.len();
                     if current_rows_size + row_size >= CDC_EVENT_MAX_BYTES {
                         rows.push(Vec::with_capacity(entries_len));
@@ -535,13 +535,7 @@ impl Delegate {
                     .with_label_values(&["all"])
                     .observe(start.saturating_elapsed().as_secs_f64());
                 if let Some(statistics) = statistics {
-                    for (cf, cf_details) in statistics.details().iter() {
-                        for (tag, count) in cf_details.iter() {
-                            CDC_OLD_VALUE_SCAN_DETAILS
-                                .with_label_values(&[*cf, *tag])
-                                .inc_by(*count as u64);
-                        }
-                    }
+                    flush_oldvalue_stats(&statistics, TAG_DELTA_CHANGE);
                 }
             }
         };

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -2,17 +2,21 @@
 
 use std::f64::INFINITY;
 use std::fmt;
-use std::marker::PhantomData;
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 
 use collections::{HashMap, HashSet};
 use concurrency_manager::ConcurrencyManager;
 use crossbeam::atomic::AtomicCell;
-use engine_traits::{KvEngine, Snapshot as EngineSnapshot};
+use engine_rocks::PROP_MAX_TS;
+use engine_traits::{
+    KvEngine, Range, Snapshot as EngineSnapshot, TablePropertiesCollection, TablePropertiesExt,
+    UserCollectedProperties, CF_WRITE,
+};
 use fail::fail_point;
 use futures::compat::Future01CompatExt;
 use grpcio::Environment;
+use keys::{data_end_key, data_key};
 use kvproto::cdcpb::{
     ChangeDataRequest, ClusterIdMismatch as ErrorClusterIdMismatch,
     DuplicateRequest as ErrorDuplicateRequest, Error as EventError, Event, Event_oneof_event,
@@ -34,9 +38,10 @@ use security::SecurityManager;
 use tikv::config::CdcConfig;
 use tikv::storage::kv::{PerfStatisticsInstant, Snapshot};
 use tikv::storage::mvcc::{DeltaScanner, ScannerBuilder};
-use tikv::storage::txn::TxnEntry;
-use tikv::storage::txn::TxnEntryScanner;
+use tikv::storage::txn::{TxnEntry, TxnEntryScanner};
+use tikv::storage::{Cursor, Statistics};
 use tikv_kv::PerfStatisticsDelta;
+use tikv_util::codec::number;
 use tikv_util::sys::inspector::{self_thread_inspector, ThreadInspector};
 use tikv_util::time::{Instant, Limiter};
 use tikv_util::timer::SteadyTimer;
@@ -44,12 +49,12 @@ use tikv_util::worker::{Runnable, RunnableWithTimer, ScheduleError, Scheduler};
 use tikv_util::{box_err, debug, error, impl_display_as_debug, info, warn};
 use tokio::runtime::{Builder, Runtime};
 use tokio::sync::{Mutex, Semaphore};
-use txn_types::{Key, Lock, LockType, TimeStamp, TxnExtra, TxnExtraScheduler};
+use txn_types::{Key, Lock, LockType, OldValue, TimeStamp, TxnExtra, TxnExtraScheduler};
 
 use crate::channel::{CdcEvent, MemoryQuota, SendError};
 use crate::delegate::{Delegate, Downstream, DownstreamID, DownstreamState};
 use crate::metrics::*;
-use crate::old_value::{OldValueCache, OldValueCallback};
+use crate::old_value::{OldValueCache, OldValueCallback, OldValueReader};
 use crate::service::{Conn, ConnID, FeatureGate};
 use crate::{CdcObserver, Error, Result};
 
@@ -227,7 +232,7 @@ pub struct Endpoint<T, E> {
     connections: HashMap<ConnID, Conn>,
     scheduler: Scheduler<Task>,
     raft_router: T,
-    engine: PhantomData<E>,
+    engine: E,
     observer: CdcObserver,
 
     pd_client: Arc<dyn PdClient>,
@@ -270,6 +275,7 @@ impl<T: 'static + RaftStoreRouter<E>, E: KvEngine> Endpoint<T, E> {
         pd_client: Arc<dyn PdClient>,
         scheduler: Scheduler<Task>,
         raft_router: T,
+        engine: E,
         observer: CdcObserver,
         store_meta: Arc<StdMutex<StoreMeta>>,
         concurrency_manager: ConcurrencyManager,
@@ -323,7 +329,7 @@ impl<T: 'static + RaftStoreRouter<E>, E: KvEngine> Endpoint<T, E> {
             workers,
             scan_concurrency_semaphore,
             raft_router,
-            engine: PhantomData,
+            engine,
             observer,
             store_meta,
             concurrency_manager,
@@ -595,6 +601,7 @@ impl<T: 'static + RaftStoreRouter<E>, E: KvEngine> Endpoint<T, E> {
         }
         let region_epoch = request.take_region_epoch();
         let mut init = Initializer {
+            engine: self.engine.clone(),
             sched,
             region_id,
             region_epoch,
@@ -610,6 +617,7 @@ impl<T: 'static + RaftStoreRouter<E>, E: KvEngine> Endpoint<T, E> {
             observe_id,
             checkpoint_ts: checkpoint_ts.into(),
             build_resolver: is_new_delegate,
+            ts_filter_ratio: self.config.incremental_scan_ts_filter_ratio,
         };
 
         let raft_router = self.raft_router.clone();
@@ -625,6 +633,7 @@ impl<T: 'static + RaftStoreRouter<E>, E: KvEngine> Endpoint<T, E> {
                 }
                 Err(e) => {
                     CDC_SCAN_TASKS.with_label_values(&["abort"]).inc();
+                    error!("cdc initialize fail: {}", e; "region_id" => region_id);
                     init.deregister_downstream(e)
                 }
             }
@@ -940,7 +949,8 @@ impl<T: 'static + RaftStoreRouter<E>, E: KvEngine> Endpoint<T, E> {
     }
 }
 
-struct Initializer {
+struct Initializer<E> {
+    engine: E,
     sched: Scheduler<Task>,
     sink: crate::channel::Sink,
 
@@ -959,10 +969,11 @@ struct Initializer {
     max_scan_batch_size: usize,
 
     build_resolver: bool,
+    ts_filter_ratio: f64,
 }
 
-impl Initializer {
-    async fn initialize<T: 'static + RaftStoreRouter<E>, E: KvEngine>(
+impl<E: KvEngine> Initializer<E> {
+    async fn initialize<T: 'static + RaftStoreRouter<E>>(
         &mut self,
         change_cmd: ChangeObserver,
         raft_router: T,
@@ -1066,7 +1077,9 @@ impl Initializer {
         debug!("cdc async incremental scan";
             "region_id" => region_id,
             "downstream_id" => ?downstream_id,
-            "observe_id" => ?self.observe_id);
+            "observe_id" => ?self.observe_id,
+            "start_key" => log_wrappers::Value::key(snap.lower_bound().unwrap_or_default()),
+            "end_key" => log_wrappers::Value::key(snap.upper_bound().unwrap_or_default()));
 
         let mut resolver = if self.build_resolver {
             Some(Resolver::new(region_id))
@@ -1074,18 +1087,26 @@ impl Initializer {
             None
         };
 
-        fail_point!("cdc_incremental_scan_start");
+        let (mut hint_min_ts, mut old_value_reader, mut old_value_cursor) = (None, None, None);
+        if self.txn_extra_op == TxnExtraOp::Noop {
+            hint_min_ts = Some(self.checkpoint_ts);
+        } else if self.ts_filter_is_helpful(&snap) {
+            hint_min_ts = Some(self.checkpoint_ts);
+            old_value_reader = Some(OldValueReader::new(snap.clone()));
+        }
 
-        let start = Instant::now_coarse();
-        // Time range: (checkpoint_ts, current]
-        let current = TimeStamp::max();
-        let mut scanner = ScannerBuilder::new(snap, current)
+        // Time range: (checkpoint_ts, max]
+        let mut scanner = ScannerBuilder::new(snap, TimeStamp::max())
             .fill_cache(false)
             .range(None, None)
+            .hint_min_ts(hint_min_ts)
             .build_delta_scanner(self.checkpoint_ts, self.txn_extra_op)
             .unwrap();
+
+        fail_point!("cdc_incremental_scan_start");
         let conn_id = self.conn_id;
         let mut done = false;
+        let start = Instant::now_coarse();
         while !done {
             // When downstream_state is Stopped, it means the corresponding
             // delegate is stopped. The initialization can be safely canceled.
@@ -1097,9 +1118,16 @@ impl Initializer {
                     "conn_id" => ?conn_id);
                 return Err(box_err!("scan canceled"));
             }
-            let entries = self.scan_batch(&mut scanner, resolver.as_mut()).await?;
-            // If the last element is None, it means scanning is finished.
+            let entries = self
+                .scan_batch(
+                    &mut scanner,
+                    old_value_reader.as_mut(),
+                    &mut old_value_cursor,
+                    resolver.as_mut(),
+                )
+                .await?;
             if let Some(None) = entries.last() {
+                // If the last element is None, it means scanning is finished.
                 done = true;
             }
             debug!("cdc scan entries"; "len" => entries.len(), "region_id" => region_id);
@@ -1121,6 +1149,8 @@ impl Initializer {
     fn do_scan<S: Snapshot>(
         &self,
         scanner: &mut DeltaScanner<S>,
+        mut old_value_reader: Option<&mut OldValueReader<S>>,
+        old_value_cursor: &mut Option<Cursor<S::Iter>>,
         entries: &mut Vec<Option<TxnEntry>>,
     ) -> Result<ScanStat> {
         let mut total_bytes = 0;
@@ -1130,10 +1160,14 @@ impl Initializer {
         let perf_instant = PerfStatisticsInstant::new();
         let inspector = self_thread_inspector().ok();
         let old_io_stat = inspector.as_ref().and_then(|x| x.io_stat().unwrap_or(None));
+        let mut stats = Statistics::default();
         while total_bytes <= self.max_scan_batch_bytes && total_size < self.max_scan_batch_size {
             total_size += 1;
             match scanner.next_entry()? {
-                Some(entry) => {
+                Some(mut entry) => {
+                    if let Some(ref mut reader) = old_value_reader {
+                        Self::read_old_value(reader, old_value_cursor, &mut entry, &mut stats)?;
+                    }
                     total_bytes += entry.size();
                     entries.push(Some(entry));
                 }
@@ -1143,6 +1177,7 @@ impl Initializer {
                 }
             }
         }
+        flush_oldvalue_stats(&stats, TAG_INCREMENTAL_SCAN);
         let new_io_stat = inspector.as_ref().and_then(|x| x.io_stat().unwrap_or(None));
         let disk_read = match (old_io_stat, new_io_stat) {
             (Some(s1), Some(s2)) => Some((s2.read - s1.read) as usize),
@@ -1157,9 +1192,30 @@ impl Initializer {
         })
     }
 
+    fn read_old_value<S: Snapshot>(
+        old_value_reader: &mut OldValueReader<S>,
+        old_value_cursor: &mut Option<Cursor<S::Iter>>,
+        entry: &mut TxnEntry,
+        stats: &mut Statistics,
+    ) -> Result<()> {
+        let old_value = entry.old_value();
+        if let OldValue::SeekWrite(ref key) = old_value {
+            if old_value_cursor.is_none() {
+                *old_value_cursor = Some(old_value_reader.new_write_cursor(key, false));
+            }
+            match old_value_reader.near_seek_old_value(key, old_value_cursor.as_mut(), stats)? {
+                Some(v) => *old_value = OldValue::value(v),
+                None => *old_value = OldValue::None,
+            }
+        }
+        Ok(())
+    }
+
     async fn scan_batch<S: Snapshot>(
         &self,
         scanner: &mut DeltaScanner<S>,
+        old_value_reader: Option<&mut OldValueReader<S>>,
+        old_value_cursor: &mut Option<Cursor<S::Iter>>,
         resolver: Option<&mut Resolver>,
     ) -> Result<Vec<Option<TxnEntry>>> {
         let mut entries = Vec::with_capacity(self.max_scan_batch_size);
@@ -1167,7 +1223,7 @@ impl Initializer {
             emit,
             disk_read,
             perf_delta,
-        } = self.do_scan(scanner, &mut entries)?;
+        } = self.do_scan(scanner, old_value_reader, old_value_cursor, &mut entries)?;
 
         CDC_SCAN_BYTES.inc_by(emit as _);
         TLS_CDC_PERF_STATS.with(|x| *x.borrow_mut() += perf_delta);
@@ -1269,6 +1325,53 @@ impl Initializer {
         if let Err(e) = self.sched.schedule(Task::Deregister(deregister)) {
             error!("cdc schedule cdc task failed"; "error" => ?e);
         }
+    }
+
+    fn ts_filter_is_helpful<S: Snapshot>(&self, snap: &S) -> bool {
+        if self.ts_filter_ratio < f64::EPSILON {
+            return false;
+        }
+
+        let start_key = data_key(snap.lower_bound().unwrap_or_default());
+        let end_key = data_end_key(snap.upper_bound().unwrap_or_default());
+        let range = Range::new(&start_key, &end_key);
+        let collection = match self.engine.table_properties_collection(CF_WRITE, &[range]) {
+            Ok(collection) => collection,
+            Err(_) => return false,
+        };
+
+        let hint_min_ts = self.checkpoint_ts.into_inner();
+        let (mut total_count, mut filtered_count, mut tables) = (0, 0, 0);
+        collection.iter_user_collected_properties(|prop| {
+            tables += 1;
+            if let Some((_, keys)) = prop.approximate_size_and_keys(&start_key, &end_key) {
+                total_count += keys;
+                if Self::parse_u64_prop(prop, PROP_MAX_TS)
+                    .map_or(false, |max_ts| max_ts < hint_min_ts)
+                {
+                    filtered_count += keys;
+                }
+            }
+            true
+        });
+
+        let valid_count = total_count - filtered_count;
+        let use_ts_filter = valid_count as f64 / total_count as f64 <= self.ts_filter_ratio;
+        info!("cdc incremental scan uses ts filter: {}", use_ts_filter;
+            "region_id" => self.region_id,
+            "hint_min_ts" => hint_min_ts,
+            "mvcc_versions" => total_count,
+            "filtered_versions" => filtered_count,
+            "tables" => tables);
+        use_ts_filter
+    }
+
+    fn parse_u64_prop(
+        prop: &<<E as TablePropertiesExt>::TablePropertiesCollection as TablePropertiesCollection>::UserCollectedProperties,
+        field: &str,
+    ) -> Option<u64> {
+        prop.get(field.as_bytes())
+            .and_then(|mut x| number::decode_u64(&mut x).ok())
     }
 }
 
@@ -1414,7 +1517,7 @@ mod tests {
 
     use collections::HashSet;
     use engine_rocks::RocksEngine;
-    use engine_traits::DATA_CFS;
+    use engine_traits::{MiscExt, CF_WRITE};
     use futures::executor::block_on;
     use futures::StreamExt;
     use kvproto::cdcpb::Header;
@@ -1424,11 +1527,12 @@ mod tests {
     use raftstore::store::msg::CasualMessage;
     use raftstore::store::util::RegionReadProgress;
     use raftstore::store::{ReadDelegate, RegionSnapshot, TrackVer};
-    use tempfile::TempDir;
     use test_raftstore::{MockRaftStoreRouter, TestPdClient};
     use tikv::server::DEFAULT_CLUSTER_ID;
     use tikv::storage::kv::Engine;
-    use tikv::storage::txn::tests::{must_acquire_pessimistic_lock, must_prewrite_put};
+    use tikv::storage::txn::tests::{
+        must_acquire_pessimistic_lock, must_commit, must_prewrite_delete, must_prewrite_put,
+    };
     use tikv::storage::TestEngineBuilder;
     use tikv_util::config::{ReadableDuration, ReadableSize};
     use tikv_util::worker::{dummy_scheduler, LazyWorker, ReceiverWrapper};
@@ -1460,10 +1564,11 @@ mod tests {
     fn mock_initializer(
         speed_limit: usize,
         buffer: usize,
+        engine: Option<RocksEngine>,
     ) -> (
         LazyWorker<Task>,
         Runtime,
-        Initializer,
+        Initializer<RocksEngine>,
         Receiver<Task>,
         crate::channel::Drain,
     ) {
@@ -1478,6 +1583,12 @@ mod tests {
             .unwrap();
         let downstream_state = Arc::new(AtomicCell::new(DownstreamState::Normal));
         let initializer = Initializer {
+            engine: engine.unwrap_or_else(|| {
+                TestEngineBuilder::new()
+                    .build_without_cache()
+                    .unwrap()
+                    .kv_engine()
+            }),
             sched: receiver_worker.scheduler(),
             sink,
 
@@ -1494,6 +1605,7 @@ mod tests {
             max_scan_batch_size: 1024,
             txn_extra_op: TxnExtraOp::Noop,
             build_resolver: true,
+            ts_filter_ratio: 1.0, // always enable it.
         };
 
         (receiver_worker, pool, initializer, rx, drain)
@@ -1501,6 +1613,7 @@ mod tests {
 
     fn mock_endpoint(
         cfg: &CdcConfig,
+        engine: Option<RocksEngine>,
     ) -> (
         Endpoint<MockRaftStoreRouter, RocksEngine>,
         MockRaftStoreRouter,
@@ -1540,6 +1653,12 @@ mod tests {
             pd_client,
             task_sched,
             raft_router.clone(),
+            engine.unwrap_or_else(|| {
+                TestEngineBuilder::new()
+                    .build_without_cache()
+                    .unwrap()
+                    .kv_engine()
+            }),
             observer,
             store_meta,
             ConcurrencyManager::new(1.into()),
@@ -1552,12 +1671,7 @@ mod tests {
 
     #[test]
     fn test_initializer_build_resolver() {
-        let temp = TempDir::new().unwrap();
-        let engine = TestEngineBuilder::new()
-            .path(temp.path())
-            .cfs(DATA_CFS)
-            .build()
-            .unwrap();
+        let engine = TestEngineBuilder::new().build_without_cache().unwrap();
 
         let mut expected_locks = BTreeMap::<TimeStamp, HashSet<Arc<[u8]>>>::new();
 
@@ -1587,7 +1701,7 @@ mod tests {
         // Buffer must be large enough to unblock async incremental scan.
         let buffer = 1000;
         let (mut worker, pool, mut initializer, rx, mut drain) =
-            mock_initializer(total_bytes, buffer);
+            mock_initializer(total_bytes, buffer, Some(engine.kv_engine()));
         let check_result = || loop {
             let task = rx.recv().unwrap();
             match task {
@@ -1647,12 +1761,70 @@ mod tests {
         worker.stop();
     }
 
+    // Test `hint_min_ts` works fine with `ExtraOp::ReadOldValue`.
+    // Whether `DeltaScanner` emits correct old values or not is already tested by
+    // another case `test_old_value_with_hint_min_ts`, so here we only care about
+    // hanlding `OldValue::SeekWrite` with `OldValueReader`.
+    #[test]
+    fn test_incremental_scanner_with_hint_min_ts() {
+        let engine = TestEngineBuilder::new().build_without_cache().unwrap();
+        let check_handling_old_value_seek_write = || {
+            // Do incremental scan with different `hint_min_ts` values.
+            for checkpoint_ts in [200, 100, 150] {
+                let (mut worker, pool, mut initializer, _rx, mut drain) =
+                    mock_initializer(usize::MAX, 1000, Some(engine.kv_engine()));
+                initializer.txn_extra_op = TxnExtraOp::ReadOldValue;
+                initializer.checkpoint_ts = checkpoint_ts.into();
+                let mut drain = drain.drain();
+
+                let snap = engine.snapshot(Default::default()).unwrap();
+                let th = pool.spawn(async move {
+                    initializer
+                        .async_incremental_scan(snap, Region::default())
+                        .await
+                        .unwrap();
+                });
+
+                while let Some((event, _)) = block_on(drain.next()) {
+                    let event = match event {
+                        CdcEvent::Event(x) if x.event.is_some() => x.event.unwrap(),
+                        _ => continue,
+                    };
+                    let entries = match event {
+                        Event_oneof_event::Entries(mut x) => x.take_entries().into_vec(),
+                        _ => continue,
+                    };
+                    for entry in entries.into_iter().filter(|x| x.start_ts == 200) {
+                        // Check old value is expected in all cases.
+                        assert_eq!(entry.get_old_value(), b"value100");
+                    }
+                }
+                block_on(th).unwrap();
+                worker.stop();
+            }
+        };
+
+        // Create the initial data with CF_WRITE L0: |zkey_110, zkey1_160|
+        must_prewrite_put(&engine, b"zkey", b"value100", b"zkey", 100);
+        must_commit(&engine, b"zkey", 100, 110);
+        must_prewrite_put(&engine, b"zzzz", b"value150", b"zzzz", 150);
+        must_commit(&engine, b"zzzz", 150, 160);
+        engine.kv_engine().flush_cf(CF_WRITE, true).unwrap();
+        must_prewrite_delete(&engine, b"zkey", b"zkey", 200);
+        check_handling_old_value_seek_write(); // For TxnEntry::Prewrite.
+
+        // CF_WRITE L0: |zkey_110, zkey1_160|, |zkey_210|
+        must_commit(&engine, b"zkey", 200, 210);
+        engine.kv_engine().flush_cf(CF_WRITE, false).unwrap();
+        check_handling_old_value_seek_write(); // For TxnEntry::Commit.
+    }
+
     #[test]
     fn test_initializer_deregister_downstream() {
         let total_bytes = 1;
         let buffer = 1;
         let (mut worker, _pool, mut initializer, rx, _drain) =
-            mock_initializer(total_bytes, buffer);
+            mock_initializer(total_bytes, buffer, None);
 
         // Errors reported by region should deregister region.
         initializer.build_resolver = false;
@@ -1697,7 +1869,7 @@ mod tests {
         let total_bytes = 1;
         let buffer = 1;
         let (mut worker, pool, mut initializer, _rx, _drain) =
-            mock_initializer(total_bytes, buffer);
+            mock_initializer(total_bytes, buffer, None);
 
         let change_cmd = ChangeObserver::from_cdc(1, ObserveHandle::new());
         let raft_router = MockRaftStoreRouter::new();
@@ -1743,7 +1915,7 @@ mod tests {
     #[test]
     fn test_change_endpoint_cfg() {
         let cfg = CdcConfig::default();
-        let (mut ep, _raft_router, mut _task_rx) = mock_endpoint(&cfg);
+        let (mut ep, _raft_router, mut _task_rx) = mock_endpoint(&cfg, None);
 
         // Modify min_ts_interval and hibernate_regions_compatible.
         {
@@ -1867,7 +2039,7 @@ mod tests {
     fn test_raftstore_is_busy() {
         let quota = crate::channel::MemoryQuota::new(usize::MAX);
         let (tx, _rx) = channel::channel(1, quota);
-        let (mut ep, raft_router, mut task_rx) = mock_endpoint(&CdcConfig::default());
+        let (mut ep, raft_router, mut task_rx) = mock_endpoint(&CdcConfig::default(), None);
         // Fill the channel.
         let _raft_rx = raft_router.add_region(1 /* region id */, 1 /* cap */);
         loop {
@@ -1912,10 +2084,11 @@ mod tests {
 
     #[test]
     fn test_register() {
-        let (mut ep, raft_router, mut task_rx) = mock_endpoint(&CdcConfig {
+        let cfg = CdcConfig {
             min_ts_interval: ReadableDuration(Duration::from_secs(60)),
             ..Default::default()
-        });
+        };
+        let (mut ep, raft_router, mut task_rx) = mock_endpoint(&cfg, None);
         let _raft_rx = raft_router.add_region(1 /* region id */, 100 /* cap */);
         let quota = crate::channel::MemoryQuota::new(usize::MAX);
         let (tx, mut rx) = channel::channel(1, quota);
@@ -2053,10 +2226,11 @@ mod tests {
 
     #[test]
     fn test_feature_gate() {
-        let (mut ep, raft_router, _task_rx) = mock_endpoint(&CdcConfig {
+        let cfg = CdcConfig {
             min_ts_interval: ReadableDuration(Duration::from_secs(60)),
             ..Default::default()
-        });
+        };
+        let (mut ep, raft_router, _task_rx) = mock_endpoint(&cfg, None);
         let _raft_rx = raft_router.add_region(1 /* region id */, 100 /* cap */);
 
         let quota = crate::channel::MemoryQuota::new(usize::MAX);
@@ -2186,7 +2360,7 @@ mod tests {
 
     #[test]
     fn test_deregister() {
-        let (mut ep, raft_router, _task_rx) = mock_endpoint(&CdcConfig::default());
+        let (mut ep, raft_router, _task_rx) = mock_endpoint(&CdcConfig::default(), None);
         let _raft_rx = raft_router.add_region(1 /* region id */, 100 /* cap */);
         let quota = crate::channel::MemoryQuota::new(usize::MAX);
         let (tx, mut rx) = channel::channel(1, quota);
@@ -2305,10 +2479,11 @@ mod tests {
 
     #[test]
     fn test_broadcast_resolved_ts() {
-        let (mut ep, raft_router, _task_rx) = mock_endpoint(&CdcConfig {
+        let cfg = CdcConfig {
             min_ts_interval: ReadableDuration(Duration::from_secs(60)),
             ..Default::default()
-        });
+        };
+        let (mut ep, raft_router, _task_rx) = mock_endpoint(&cfg, None);
 
         // Open two connections a and b, registers region 1, 2 to conn a and
         // region 3 to conn b.
@@ -2415,7 +2590,7 @@ mod tests {
     // too, because epoch not match.
     #[test]
     fn test_deregister_conn_then_delegate() {
-        let (mut ep, raft_router, _task_rx) = mock_endpoint(&CdcConfig::default());
+        let (mut ep, raft_router, _task_rx) = mock_endpoint(&CdcConfig::default(), None);
         let _raft_rx = raft_router.add_region(1 /* region id */, 100 /* cap */);
         let quota = crate::channel::MemoryQuota::new(usize::MAX);
 

--- a/components/cdc/tests/mod.rs
+++ b/components/cdc/tests/mod.rs
@@ -169,6 +169,7 @@ impl TestSuiteBuilder {
                 pd_cli.clone(),
                 worker.scheduler(),
                 raft_router,
+                cluster.engines[id].kv.clone(),
                 cdc_ob,
                 cluster.store_metas[id].clone(),
                 cm.clone(),

--- a/components/engine_rocks/src/mvcc_properties.rs
+++ b/components/engine_rocks/src/mvcc_properties.rs
@@ -5,16 +5,16 @@ use crate::{RocksEngine, UserProperties};
 use engine_traits::{MvccProperties, MvccPropertiesExt, Result};
 use txn_types::TimeStamp;
 
-pub(crate) const PROP_NUM_ERRORS: &str = "tikv.num_errors";
-pub(crate) const PROP_MIN_TS: &str = "tikv.min_ts";
-pub(crate) const PROP_MAX_TS: &str = "tikv.max_ts";
-pub(crate) const PROP_NUM_ROWS: &str = "tikv.num_rows";
-pub(crate) const PROP_NUM_PUTS: &str = "tikv.num_puts";
-pub(crate) const PROP_NUM_DELETES: &str = "tikv.num_deletes";
-pub(crate) const PROP_NUM_VERSIONS: &str = "tikv.num_versions";
-pub(crate) const PROP_MAX_ROW_VERSIONS: &str = "tikv.max_row_versions";
-pub(crate) const PROP_ROWS_INDEX: &str = "tikv.rows_index";
-pub(crate) const PROP_ROWS_INDEX_DISTANCE: u64 = 10000;
+pub const PROP_NUM_ERRORS: &str = "tikv.num_errors";
+pub const PROP_MIN_TS: &str = "tikv.min_ts";
+pub const PROP_MAX_TS: &str = "tikv.max_ts";
+pub const PROP_NUM_ROWS: &str = "tikv.num_rows";
+pub const PROP_NUM_PUTS: &str = "tikv.num_puts";
+pub const PROP_NUM_DELETES: &str = "tikv.num_deletes";
+pub const PROP_NUM_VERSIONS: &str = "tikv.num_versions";
+pub const PROP_MAX_ROW_VERSIONS: &str = "tikv.max_row_versions";
+pub const PROP_ROWS_INDEX: &str = "tikv.rows_index";
+pub const PROP_ROWS_INDEX_DISTANCE: u64 = 10000;
 
 pub struct RocksMvccProperties;
 

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -871,6 +871,7 @@ impl<ER: RaftEngine> TiKVServer<ER> {
             self.pd_client.clone(),
             cdc_scheduler.clone(),
             self.router.clone(),
+            self.engines.as_ref().unwrap().engines.kv.clone(),
             cdc_ob,
             engines.store_meta.clone(),
             self.concurrency_manager.clone(),

--- a/components/txn_types/src/types.rs
+++ b/components/txn_types/src/types.rs
@@ -347,19 +347,21 @@ impl From<kvrpcpb::Mutation> for Mutation {
     }
 }
 
-/// `OldValue` is used by cdc to read the previous value associated with some key during the prewrite process
+/// `OldValue` is used by cdc to read the previous value associated with some key during the
+/// prewrite process.
 #[derive(Debug, Clone, PartialEq)]
 pub enum OldValue {
-    /// A real `OldValue`
+    /// A real `OldValue`.
     Value { value: Value },
-    /// A timestamp of an old value in case a value is not inlined in Write
+    /// A timestamp of an old value in case a value is not inlined in Write.
     ValueTimeStamp { start_ts: TimeStamp },
-    /// `None` means we don't found a previous value
+    /// `None` means we don't found a previous value.
     None,
-    /// `Unspecified` means one of the following:
-    ///   - The user doesn't care about the previous value
-    ///   - We don't sure if there is a previous value
+    /// The user doesn't care about the previous value.
     Unspecified,
+    /// Not sure whether the old value exists or not. users can seek CF_WRITE to the give position
+    /// to take a look.
+    SeekWrite(Key),
 }
 
 impl Default for OldValue {
@@ -369,8 +371,34 @@ impl Default for OldValue {
 }
 
 impl OldValue {
-    pub fn valid(&self) -> bool {
-        !matches!(self, OldValue::Unspecified)
+    pub fn value(value: Value) -> Self {
+        OldValue::Value { value }
+    }
+
+    pub fn seek_write(raw_user_key: &[u8], ts: u64) -> Self {
+        let key = Key::from_raw(raw_user_key).append_ts(ts.into());
+        OldValue::SeekWrite(key)
+    }
+
+    /// `resolved` means it's either something or `None`.
+    pub fn resolved(&self) -> bool {
+        match self {
+            Self::Value { .. } | Self::ValueTimeStamp { .. } | Self::None => true,
+            Self::Unspecified | Self::SeekWrite(_) => false,
+        }
+    }
+
+    /// The finalized `OldValue::Value` content, or `None` for `OldValue::Unspecified`.
+    ///
+    /// # Panics
+    ///
+    /// Panic if it's `OldValue::ValueTimeStamp` or `OldValue::SeekWrite`.
+    pub fn finalized(self) -> Option<Value> {
+        match self {
+            Self::Value { value } => Some(value),
+            Self::None | Self::Unspecified => None,
+            _ => panic!("OldValue must be finalized"),
+        }
     }
 
     pub fn size(&self) -> usize {
@@ -568,7 +596,7 @@ mod tests {
     }
 
     #[test]
-    fn test_old_value_valid() {
+    fn test_old_value_resolved() {
         let cases = vec![
             (OldValue::Unspecified, false),
             (OldValue::None, true),
@@ -576,7 +604,7 @@ mod tests {
             (OldValue::ValueTimeStamp { start_ts: 0.into() }, true),
         ];
         for (old_value, v) in cases {
-            assert_eq!(old_value.valid(), v);
+            assert_eq!(old_value.resolved(), v);
         }
     }
 }

--- a/components/txn_types/src/types.rs
+++ b/components/txn_types/src/types.rs
@@ -402,11 +402,14 @@ impl OldValue {
     }
 
     pub fn size(&self) -> usize {
-        let value_size = match self {
+        self.value_size() + std::mem::size_of::<OldValue>()
+    }
+
+    pub fn value_size(&self) -> usize {
+        match self {
             OldValue::Value { value } => value.len(),
             _ => 0,
-        };
-        value_size + std::mem::size_of::<OldValue>()
+        }
     }
 }
 

--- a/src/storage/mvcc/reader/scanner/forward.rs
+++ b/src/storage/mvcc/reader/scanner/forward.rs
@@ -5,7 +5,7 @@ use std::{borrow::Cow, cmp::Ordering};
 
 use engine_traits::CF_DEFAULT;
 use kvproto::kvrpcpb::{ExtraOp, IsolationLevel};
-use txn_types::{Key, Lock, LockType, TimeStamp, Value, WriteRef, WriteType};
+use txn_types::{Key, Lock, LockType, OldValue, TimeStamp, Value, WriteRef, WriteType};
 
 use super::ScannerConfig;
 use crate::storage::kv::SEEK_BOUND;
@@ -543,7 +543,7 @@ impl<S: Snapshot> ScanPolicy<S> for LatestEntryPolicy {
                     break Some(TxnEntry::Commit {
                         default: entry_default,
                         write: entry_write,
-                        old_value: None,
+                        old_value: OldValue::None,
                     });
                 }
                 WriteType::Delete => {
@@ -551,7 +551,7 @@ impl<S: Snapshot> ScanPolicy<S> for LatestEntryPolicy {
                         break Some(TxnEntry::Commit {
                             default: (Vec::new(), Vec::new()),
                             write: (write_key.to_vec(), write_value.to_vec()),
-                            old_value: None,
+                            old_value: OldValue::None,
                         });
                     } else {
                         break None;
@@ -631,6 +631,41 @@ impl DeltaEntryPolicy {
     pub fn new(from_ts: TimeStamp, extra_op: ExtraOp) -> Self {
         Self { from_ts, extra_op }
     }
+
+    fn fetch_old_value<S: Snapshot>(
+        current_user_key: &Key,
+        cfg: &ScannerConfig<S>,
+        cursors: &mut Cursors<S>,
+        statistics: &mut Statistics,
+        after_ts: TimeStamp,
+        gc_fence_ts: TimeStamp,
+    ) -> Result<OldValue> {
+        let seek_after = || {
+            let seek_after = current_user_key.clone().append_ts(after_ts);
+            OldValue::SeekWrite(seek_after)
+        };
+
+        if let Some(v) = super::seek_for_valid_value(
+            &mut cursors.write,
+            cursors.default.as_mut().unwrap(),
+            current_user_key,
+            after_ts,
+            gc_fence_ts,
+            statistics,
+        )? {
+            if let Some(hint_min_ts) = cfg.hint_min_ts {
+                let k = cursors.write.key(&mut statistics.write);
+                if Key::decode_ts_from(k).unwrap() < hint_min_ts {
+                    return Ok(seek_after());
+                }
+            }
+            Ok(OldValue::value(v))
+        } else if cfg.hint_min_ts.is_some() {
+            Ok(seek_after())
+        } else {
+            Ok(OldValue::None)
+        }
+    }
 }
 
 impl<S: Snapshot> ScanPolicy<S> for DeltaEntryPolicy {
@@ -665,22 +700,22 @@ impl<S: Snapshot> ScanPolicy<S> for DeltaEntryPolicy {
             } else {
                 Ok((vec![], vec![]))
             };
-            let old_value = if self.extra_op == ExtraOp::ReadOldValue
-                && (lock.lock_type == LockType::Put || lock.lock_type == LockType::Delete)
+
+            let mut old_value = OldValue::None;
+            if self.extra_op == ExtraOp::ReadOldValue
+                && matches!(lock.lock_type, LockType::Put | LockType::Delete)
             {
                 // When meet a lock, the write cursor must indicate the same user key.
                 // Seek for the last valid committed here.
-                super::seek_for_valid_value(
-                    &mut cursors.write,
-                    cursors.default.as_mut().unwrap(),
+                old_value = Self::fetch_old_value(
                     &current_user_key,
+                    cfg,
+                    cursors,
+                    statistics,
                     std::cmp::max(lock.ts, lock.for_update_ts),
                     self.from_ts,
-                    statistics,
-                )?
-            } else {
-                None
-            };
+                )?;
+            }
             load_default_res.map(|default| {
                 HandleRes::Return(TxnEntry::Prewrite {
                     default,
@@ -698,7 +733,7 @@ impl<S: Snapshot> ScanPolicy<S> for DeltaEntryPolicy {
     fn handle_write(
         &mut self,
         current_user_key: Key,
-        _cfg: &mut ScannerConfig<S>,
+        cfg: &mut ScannerConfig<S>,
         cursors: &mut Cursors<S>,
         statistics: &mut Statistics,
     ) -> Result<HandleRes<Self::Output>> {
@@ -763,20 +798,19 @@ impl<S: Snapshot> ScanPolicy<S> for DeltaEntryPolicy {
             // Move to the next write record early for getting the old value.
             cursors.write.next(&mut statistics.write);
 
-            let old_value = if self.extra_op == ExtraOp::ReadOldValue
-                && (write_type == WriteType::Put || write_type == WriteType::Delete)
+            let mut old_value = OldValue::None;
+            if self.extra_op == ExtraOp::ReadOldValue
+                && matches!(write_type, WriteType::Put | WriteType::Delete)
             {
-                super::seek_for_valid_value(
-                    &mut cursors.write,
-                    cursors.default.as_mut().unwrap(),
+                old_value = Self::fetch_old_value(
                     &current_user_key,
-                    commit_ts,
-                    self.from_ts,
+                    cfg,
+                    cursors,
                     statistics,
-                )?
-            } else {
-                None
-            };
+                    commit_ts.prev(),
+                    self.from_ts,
+                )?;
+            }
 
             let res = Ok(HandleRes::Return(TxnEntry::Commit {
                 default,
@@ -830,7 +864,6 @@ pub mod test_util {
     };
     use crate::storage::Engine;
 
-    #[derive(Default)]
     pub struct EntryBuilder {
         pub key: Vec<u8>,
         pub value: Vec<u8>,
@@ -838,7 +871,21 @@ pub mod test_util {
         pub start_ts: TimeStamp,
         pub commit_ts: TimeStamp,
         pub for_update_ts: TimeStamp,
-        pub old_value: Option<Vec<u8>>,
+        pub old_value: OldValue,
+    }
+
+    impl Default for EntryBuilder {
+        fn default() -> Self {
+            EntryBuilder {
+                key: vec![],
+                value: vec![],
+                primary: vec![],
+                start_ts: 0.into(),
+                commit_ts: 0.into(),
+                for_update_ts: 0.into(),
+                old_value: OldValue::None,
+            }
+        }
     }
 
     impl EntryBuilder {
@@ -867,7 +914,7 @@ pub mod test_util {
             self
         }
         pub fn old_value(&mut self, old_value: &[u8]) -> &mut Self {
-            self.old_value = Some(old_value.to_owned());
+            self.old_value = OldValue::value(old_value.to_owned());
             self
         }
         pub fn build_commit(&self, wt: WriteType, is_short_value: bool) -> TxnEntry {
@@ -937,7 +984,7 @@ pub mod test_util {
             TxnEntry::Commit {
                 default: (vec![], vec![]),
                 write: (write_key.into_encoded(), write_value.as_ref().to_bytes()),
-                old_value: None,
+                old_value: OldValue::None,
             }
         }
     }

--- a/src/storage/txn/commands/acquire_pessimistic_lock.rs
+++ b/src/storage/txn/commands/acquire_pessimistic_lock.rs
@@ -109,7 +109,7 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for AcquirePessimisticLock 
                     if self.return_values {
                         res.as_mut().unwrap().push(val);
                     }
-                    if old_value.valid() {
+                    if old_value.resolved() {
                         let key = k.append_ts(txn.start_ts);
                         // MutationType is unknown in AcquirePessimisticLock stage.
                         let mutation_type = None;

--- a/src/storage/txn/commands/prewrite.rs
+++ b/src/storage/txn/commands/prewrite.rs
@@ -485,7 +485,7 @@ impl<K: PrewriteKind> Prewriter<K> {
                     if need_min_commit_ts && final_min_commit_ts < ts {
                         final_min_commit_ts = ts;
                     }
-                    if old_value.valid() {
+                    if old_value.resolved() {
                         let key = key.append_ts(txn.start_ts);
                         self.old_values
                             .insert(key, (old_value, Some(mutation_type)));

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -9,7 +9,7 @@ use crate::storage::mvcc::{
     EntryScanner, Error as MvccError, ErrorInner as MvccErrorInner, NewerTsCheckState, PointGetter,
     PointGetterBuilder, Scanner as MvccScanner, ScannerBuilder,
 };
-use txn_types::{Key, KvPair, TimeStamp, TsSet, Value, WriteRef};
+use txn_types::{Key, KvPair, OldValue, TimeStamp, TsSet, Value, WriteRef};
 
 pub trait Store: Send {
     /// The scanner type returned by `scanner()`.
@@ -135,14 +135,27 @@ pub enum TxnEntry {
     Prewrite {
         default: KvPair,
         lock: KvPair,
-        old_value: Option<Value>,
+        old_value: OldValue,
     },
     Commit {
         default: KvPair,
         write: KvPair,
-        old_value: Option<Value>,
+        old_value: OldValue,
     },
     // TOOD: Add more entry if needed.
+}
+
+impl TxnEntry {
+    pub fn old_value(&mut self) -> &mut OldValue {
+        match self {
+            TxnEntry::Prewrite {
+                ref mut old_value, ..
+            } => old_value,
+            TxnEntry::Commit {
+                ref mut old_value, ..
+            } => old_value,
+        }
+    }
 }
 
 impl TxnEntry {
@@ -193,7 +206,7 @@ impl TxnEntry {
                 size += default.1.len();
                 size += write.0.len();
                 size += write.1.len();
-                size += old_value.as_ref().map_or(0, |v| v.len())
+                size += old_value.size();
             }
             TxnEntry::Prewrite {
                 default,
@@ -204,7 +217,7 @@ impl TxnEntry {
                 size += default.1.len();
                 size += lock.0.len();
                 size += lock.1.len();
-                size += old_value.as_ref().map_or(0, |v| v.len())
+                size += old_value.size();
             }
         }
         size
@@ -1326,7 +1339,7 @@ mod tests {
             TxnEntry::Prewrite {
                 default: (vec![0; 10], vec![0; 10]),
                 lock: (vec![0; 10], vec![0; 10]),
-                old_value: None,
+                old_value: OldValue::None,
             }
             .size(),
             40
@@ -1336,7 +1349,7 @@ mod tests {
             TxnEntry::Prewrite {
                 default: (vec![0; 10], vec![0; 10]),
                 lock: (vec![0; 10], vec![0; 10]),
-                old_value: Some(vec![0; 10]),
+                old_value: OldValue::value(vec![0; 10]),
             }
             .size(),
             50
@@ -1346,7 +1359,7 @@ mod tests {
             TxnEntry::Commit {
                 default: (vec![0; 10], vec![0; 10]),
                 write: (vec![0; 10], vec![0; 10]),
-                old_value: None,
+                old_value: OldValue::None,
             }
             .size(),
             40
@@ -1356,7 +1369,7 @@ mod tests {
             TxnEntry::Commit {
                 default: (vec![0; 10], vec![0; 10]),
                 write: (vec![0; 10], vec![0; 10]),
-                old_value: Some(vec![0; 10]),
+                old_value: OldValue::value(vec![0; 10]),
             }
             .size(),
             50

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -206,7 +206,7 @@ impl TxnEntry {
                 size += default.1.len();
                 size += write.0.len();
                 size += write.1.len();
-                size += old_value.size();
+                size += old_value.value_size();
             }
             TxnEntry::Prewrite {
                 default,
@@ -217,7 +217,7 @@ impl TxnEntry {
                 size += default.1.len();
                 size += lock.0.len();
                 size += lock.1.len();
-                size += old_value.size();
+                size += old_value.value_size();
             }
         }
         size

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -730,6 +730,7 @@ fn test_serde_custom_tikv_config() {
         incremental_scan_threads: 3,
         incremental_scan_concurrency: 4,
         incremental_scan_speed_limit: ReadableSize(7),
+        incremental_scan_ts_filter_ratio: 0.7,
         old_value_cache_memory_quota: ReadableSize::mb(14),
         sink_memory_quota: ReadableSize::mb(7),
     };

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -616,6 +616,7 @@ hibernate-regions-compatible = false
 incremental-scan-threads = 3
 incremental-scan-concurrency = 4
 incremental-scan-speed-limit = 7
+incremental-scan-ts-filter-ratio = 0.7
 old-value-cache-memory-quota = "14MB"
 sink-memory-quota = "7MB"
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #11384.

### What is changed and how it works?

* Add a new configuration `cdc.incremental-scan-use-ts-filter`, which indicates `TsFilter` can be used for incremental scan or not
* Only use TsFilter if it can filter more than 2/3 recoreds
* Use `OldValueReader` to re-fetch old values when `TsFilter` is used

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```