### PR TITLE
rafstore: fix commit state check in apply thread

### DIFF
--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -2887,15 +2887,18 @@ impl<S: Snapshot> Apply<S> {
         assert_eq!(self.region_id, other.region_id);
         assert_eq!(self.peer_id, other.peer_id);
         if self.entries_size + other.entries_size <= MAX_APPLY_BATCH_SIZE {
-            self.entries.append(&mut other.entries);
-            self.cbs.append(&mut other.cbs);
             assert!(other.term >= self.term);
             self.term = other.term;
+
             assert!(other.commit_index >= self.commit_index);
             self.commit_index = other.commit_index;
             assert!(other.commit_term >= self.commit_term);
             self.commit_term = other.commit_term;
+
+            self.entries.append(&mut other.entries);
             self.entries_size += other.entries_size;
+
+            self.cbs.append(&mut other.cbs);
             true
         } else {
             false

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -2246,10 +2246,20 @@ where
             } else {
                 vec![]
             };
+            // Note that the `commit_index` and `commit_term` here may be used to
+            // forward the commit index. So it must be less than or equal to persist
+            // index.
+            let commit_index = cmp::min(
+                self.raft_group.raft.raft_log.committed,
+                self.raft_group.raft.raft_log.persisted,
+            );
+            let commit_term = self.get_store().term(commit_index).unwrap();
             let mut apply = Apply::new(
                 self.peer_id(),
                 self.region_id,
                 self.term(),
+                commit_index,
+                commit_term,
                 committed_entries,
                 cbs,
             );

--- a/tests/failpoints/cases/test_early_apply.rs
+++ b/tests/failpoints/cases/test_early_apply.rs
@@ -77,3 +77,73 @@ fn test_multi_early_apply() {
     fail::remove(store_1_fp);
     must_get_equal(&cluster.get_engine(1), b"k11", b"v22");
 }
+
+/// Test if the commit state check of apply msg is ok.
+/// In the previous implementation, the commit state check uses the state of last
+/// committed entry and it relies on the guarantee that the commit index and term
+/// of the last committed entry must be monotonically increasing even between restarting.
+/// However, this guarantee can be broken by
+///     1. memory limitation of fetching committed entries
+///     2. batching apply msg
+/// Now the commit state uses the minimum of persist index and commit index from the peer
+/// to fix this issue. 
+/// For simplicity, this test uses region merge to ensure that the apply state will be written
+/// to kv db before crash.
+#[test]
+fn test_early_apply_yield_followed_with_many_entries() {
+    let mut cluster = new_node_cluster(0, 3);
+    cluster.pd_client.disable_default_operator();
+
+    configure_for_merge(&mut cluster);
+    cluster.run();
+
+    cluster.must_put(b"k1", b"v1");
+
+    let region = cluster.get_region(b"k1");
+    cluster.must_split(&region, b"k2");
+
+    let left = cluster.get_region(b"k1");
+    let right = cluster.get_region(b"k2");
+
+    cluster.must_put(b"k2", b"v2");
+
+    must_get_equal(&cluster.get_engine(3), b"k1", b"v1");
+    must_get_equal(&cluster.get_engine(3), b"k2", b"v2");
+
+    let left_peer_1 = find_peer(&left, 1).unwrap().to_owned();
+    cluster.must_transfer_leader(left.get_id(), left_peer_1);
+
+    let right_peer_2 = find_peer(&right, 2).unwrap().to_owned();
+    cluster.must_transfer_leader(right.get_id(), right_peer_2);
+
+    let before_handle_normal_3_fp = "before_handle_normal_3";
+    fail::cfg(before_handle_normal_3_fp, "pause").unwrap();
+
+    // Put another key before CommitMerge to make write-to-kv-db really happen
+    cluster.must_put(b"k3", b"v3");
+
+    cluster.pd_client.must_merge(left.get_id(), right.get_id());
+
+    let large_val = vec![b'a'; 1024 * 1024];
+    // The size of these entries should be larger than MAX_COMMITTED_SIZE_PER_READY
+    for i in 0..50 {
+        cluster.must_put(format!("k1{}", i).as_bytes(), large_val.as_slice());
+    }
+    cluster.must_put(b"k150", b"v150");
+
+    let after_handle_catch_up_logs_for_merge_1003_fp = "after_handle_catch_up_logs_for_merge_1003";
+    fail::cfg(after_handle_catch_up_logs_for_merge_1003_fp, "return").unwrap();
+
+    fail::remove(before_handle_normal_3_fp);
+
+    // Wait for apply state writting to kv db
+    sleep_ms(200);
+
+    cluster.shutdown();
+
+    fail::remove(after_handle_catch_up_logs_for_merge_1003_fp);
+
+    cluster.start().unwrap();
+
+    must_get_equal(&cluster.get_engine(3), b"k150", b"v150");
+}

--- a/tests/failpoints/cases/test_early_apply.rs
+++ b/tests/failpoints/cases/test_early_apply.rs
@@ -86,7 +86,7 @@ fn test_multi_early_apply() {
 ///     1. memory limitation of fetching committed entries
 ///     2. batching apply msg
 /// Now the commit state uses the minimum of persist index and commit index from the peer
-/// to fix this issue. 
+/// to fix this issue.
 /// For simplicity, this test uses region merge to ensure that the apply state will be written
 /// to kv db before crash.
 #[test]


### PR DESCRIPTION
Signed-off-by: gengliqi <gengliqiii@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #11396

Problem Summary:

In the previous implementation, the commit state check uses the state of last committed entry and it relies on the guarantee that the commit index and term of the last committed entry must be monotonically increasing even between restarting.
However, this guarantee can be broken by
     1. memory limitation of fetching committed entries
     2. batching apply msg
Now the commit state uses the minimum of persist index and commit index from the peer to fix this issue. 
For simplicity, this test uses region merge to ensure that the apply state will be written to kv db before crash.

### What is changed and how it works?

What's Changed:
Mentioned before.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

Side effects

- No

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None.
```