### PR TITLE
raftstore: increase batch for raftlog-gc-worker (release-5.1-20211115)

### DIFF
--- a/components/engine_rocks/src/raft_engine.rs
+++ b/components/engine_rocks/src/raft_engine.rs
@@ -107,7 +107,7 @@ impl RocksEngine {
         if from >= to {
             return Ok(0);
         }
-        if from == 0 || (to - from) as usize > Self::WRITE_BATCH_MAX_KEYS * 2 {
+        if from == 0 {
             let start_key = keys::raft_log_key(raft_group_id, 0);
             let prefix = keys::raft_log_prefix(raft_group_id);
             match self.seek(&start_key)? {
@@ -217,7 +217,7 @@ impl RaftEngine for RocksEngine {
     }
 
     fn gc(&self, raft_group_id: u64, from: u64, to: u64) -> Result<usize> {
-        let mut raft_wb = self.write_batch_with_cap(4 * 1024);
+        let mut raft_wb = self.write_batch_with_cap(1024);
         let total = self.gc_impl(raft_group_id, from, to, &mut raft_wb)?;
         // TODO: disable WAL here.
         if !WriteBatch::is_empty(&raft_wb) {

--- a/components/engine_rocks/src/raft_engine.rs
+++ b/components/engine_rocks/src/raft_engine.rs
@@ -104,9 +104,6 @@ impl RocksEngine {
         to: u64,
         raft_wb: &mut RocksWriteBatch,
     ) -> Result<usize> {
-        if from >= to {
-            return Ok(0);
-        }
         if from == 0 {
             let start_key = keys::raft_log_key(raft_group_id, 0);
             let prefix = keys::raft_log_prefix(raft_group_id);
@@ -115,6 +112,9 @@ impl RocksEngine {
                 // No need to gc.
                 _ => return Ok(0),
             }
+        }
+        if from >= to {
+            return Ok(0);
         }
 
         for idx in from..to {

--- a/components/engine_rocks/src/raft_engine.rs
+++ b/components/engine_rocks/src/raft_engine.rs
@@ -96,6 +96,38 @@ impl RaftEngineReadOnly for RocksEngine {
         Err(Error::EntriesUnavailable)
     }
 }
+impl RocksEngine {
+    fn gc_impl(
+        &self,
+        raft_group_id: u64,
+        mut from: u64,
+        to: u64,
+        raft_wb: &mut RocksWriteBatch,
+    ) -> Result<usize> {
+        if from >= to {
+            return Ok(0);
+        }
+        if from == 0 || (to - from) as usize > Self::WRITE_BATCH_MAX_KEYS * 2 {
+            let start_key = keys::raft_log_key(raft_group_id, 0);
+            let prefix = keys::raft_log_prefix(raft_group_id);
+            match self.seek(&start_key)? {
+                Some((k, _)) if k.starts_with(&prefix) => from = box_try!(keys::raft_log_index(&k)),
+                // No need to gc.
+                _ => return Ok(0),
+            }
+        }
+
+        for idx in from..to {
+            let key = keys::raft_log_key(raft_group_id, idx);
+            raft_wb.delete(&key)?;
+            if raft_wb.count() >= Self::WRITE_BATCH_MAX_KEYS * 2 {
+                raft_wb.write()?;
+                raft_wb.clear();
+            }
+        }
+        Ok((to - from) as usize)
+    }
+}
 
 // FIXME: RaftEngine should probably be implemented generically
 // for all KvEngines, but is currently implemented separately for
@@ -171,35 +203,27 @@ impl RaftEngine for RocksEngine {
         self.put_msg(&keys::raft_state_key(raft_group_id), state)
     }
 
-    fn gc(&self, raft_group_id: u64, mut from: u64, to: u64) -> Result<usize> {
-        if from >= to {
-            return Ok(0);
-        }
-        if from == 0 {
-            let start_key = keys::raft_log_key(raft_group_id, 0);
-            let prefix = keys::raft_log_prefix(raft_group_id);
-            match self.seek(&start_key)? {
-                Some((k, _)) if k.starts_with(&prefix) => from = box_try!(keys::raft_log_index(&k)),
-                // No need to gc.
-                _ => return Ok(0),
-            }
-        }
-
+    fn batch_gc(&self, groups: Vec<(u64, u64, u64)>) -> Result<usize> {
+        let mut total = 0;
         let mut raft_wb = self.write_batch_with_cap(4 * 1024);
-        for idx in from..to {
-            let key = keys::raft_log_key(raft_group_id, idx);
-            raft_wb.delete(&key)?;
-            if raft_wb.count() >= Self::WRITE_BATCH_MAX_KEYS {
-                raft_wb.write()?;
-                raft_wb.clear();
-            }
+        for (raft_group_id, from, to) in groups {
+            total += self.gc_impl(raft_group_id, from, to, &mut raft_wb)?;
         }
-
         // TODO: disable WAL here.
         if !WriteBatch::is_empty(&raft_wb) {
             raft_wb.write()?;
         }
-        Ok((to - from) as usize)
+        Ok(total)
+    }
+
+    fn gc(&self, raft_group_id: u64, from: u64, to: u64) -> Result<usize> {
+        let mut raft_wb = self.write_batch_with_cap(4 * 1024);
+        let total = self.gc_impl(raft_group_id, from, to, &mut raft_wb)?;
+        // TODO: disable WAL here.
+        if !WriteBatch::is_empty(&raft_wb) {
+            raft_wb.write()?;
+        }
+        Ok(total)
     }
 
     fn purge_expired_files(&self) -> Result<Vec<u64>> {

--- a/components/engine_traits/src/raft_engine.rs
+++ b/components/engine_traits/src/raft_engine.rs
@@ -59,6 +59,14 @@ pub trait RaftEngine: RaftEngineReadOnly + Clone + Sync + Send + 'static {
     /// Generally, `from` can be passed in `0`.
     fn gc(&self, raft_group_id: u64, from: u64, to: u64) -> Result<usize>;
 
+    fn batch_gc(&self, groups: Vec<(u64, u64, u64)>) -> Result<usize> {
+        let mut total = 0;
+        for (group, from, to) in groups {
+            total += self.gc(group, from, to)?;
+        }
+        Ok(total)
+    }
+
     /// Purge expired logs files and return a set of Raft group ids
     /// which needs to be compacted ASAP.
     fn purge_expired_files(&self) -> Result<Vec<u64>>;

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -2372,6 +2372,8 @@ where
             // New peer derive write flow from parent region,
             // this will be used by balance write flow.
             new_peer.peer.peer_stat = self.fsm.peer.peer_stat.clone();
+            new_peer.peer.last_compacted_idx =
+                new_peer.apply_state().get_truncated_state().get_index() + 1;
             let campaigned = new_peer.peer.maybe_campaign(is_leader);
             new_peer.has_ready |= campaigned;
 

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -1970,6 +1970,7 @@ where
         if !ready.snapshot().is_empty() {
             // Snapshot's metadata has been applied.
             self.last_applying_idx = self.get_store().truncated_index();
+            self.last_compacted_idx = self.last_applying_idx + 1;
             self.raft_group.advance_append_async(ready);
             // The ready is persisted, but we don't want to handle following light
             // ready immediately to avoid flow out of control, so use

--- a/components/raftstore/src/store/worker/raftlog_gc.rs
+++ b/components/raftstore/src/store/worker/raftlog_gc.rs
@@ -15,7 +15,7 @@ use tikv_util::{box_try, debug, error, warn};
 use crate::store::worker::metrics::*;
 use crate::store::{CasualMessage, CasualRouter};
 
-const MAX_GC_REGION_BATCH: usize = 128;
+const MAX_GC_REGION_BATCH: usize = 256;
 const COMPACT_LOG_INTERVAL: Duration = Duration::from_secs(60);
 
 pub enum Task {

--- a/components/raftstore/src/store/worker/raftlog_gc.rs
+++ b/components/raftstore/src/store/worker/raftlog_gc.rs
@@ -15,7 +15,7 @@ use tikv_util::{box_try, debug, error, warn};
 use crate::store::worker::metrics::*;
 use crate::store::{CasualMessage, CasualRouter};
 
-const MAX_GC_REGION_BATCH: usize = 256;
+const MAX_GC_REGION_BATCH: usize = 512;
 const COMPACT_LOG_INTERVAL: Duration = Duration::from_secs(60);
 
 pub enum Task {

--- a/components/raftstore/src/store/worker/raftlog_gc.rs
+++ b/components/raftstore/src/store/worker/raftlog_gc.rs
@@ -229,7 +229,7 @@ mod tests {
         for (task, expected_collectd, not_exist_range, exist_range) in tbls {
             runner.run(task);
             runner.flush();
-            let res = rx.recv_timeout(Duration::from_secs(3)).unwrap();
+            let res = rx.recv_timeout(Duration::from_secs(11)).unwrap();
             assert_eq!(res, expected_collectd);
             raft_log_must_not_exist(&raft_db, 1, not_exist_range.0, not_exist_range.1);
             raft_log_must_exist(&raft_db, 1, exist_range.0, exist_range.1);

--- a/components/raftstore/src/store/worker/raftlog_gc.rs
+++ b/components/raftstore/src/store/worker/raftlog_gc.rs
@@ -10,7 +10,7 @@ use engine_traits::{Engines, KvEngine, RaftEngine};
 use file_system::{IOType, WithIOType};
 use tikv_util::time::{Duration, Instant};
 use tikv_util::worker::{Runnable, RunnableWithTimer};
-use tikv_util::{box_try, debug, error, warn};
+use tikv_util::{box_try, debug, error, info, warn};
 
 use crate::store::worker::metrics::*;
 use crate::store::{CasualMessage, CasualRouter};
@@ -110,7 +110,7 @@ impl<EK: KvEngine, ER: RaftEngine, R: CasualRouter<EK>> Runner<EK, ER, R> {
                     if start_idx == 0 {
                         RAFT_LOG_GC_SEEK_OPERATIONS.inc();
                     } else if end_idx > start_idx + MAX_REGION_NORMAL_GC_LOG_NUMBER {
-                        warn!("gc raft log with a large range"; "region_id" => region_id,
+                        info!("gc raft log with a large range"; "region_id" => region_id,
                             "start_index" => start_idx,
                             "end_index" => end_idx);
                     }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close https://github.com/tikv/tikv/issues/11404


### What is changed and how it works?

Batch more deleted keys together. As we all know ,the deleted key must be much small than the entry which has been put. So 256 is too small for every writebatch in raftlog-gc-worker.
And the gc tasks of most of regions are small. They are often smaller than 100. So I batch the keys of multiple regions and write them together.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```