### PR TITLE
use assert_matches!()

### DIFF
--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -1575,6 +1575,7 @@ impl TxnExtraScheduler for CdcTxnExtraScheduler {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches::assert_matches;
     use std::collections::BTreeMap;
     use std::fmt::Display;
     use std::sync::atomic::AtomicU64;
@@ -2421,7 +2422,10 @@ mod tests {
             err: Some(Error::request(err_header.clone())),
         };
         ep.run(Task::Deregister(deregister));
-        assert!(channel::recv_timeout(&mut rx, Duration::from_millis(200)).is_err());
+        assert_matches!(
+            channel::recv_timeout(&mut rx, Duration::from_millis(200)),
+            Err(_)
+        );
         assert_eq!(ep.capture_regions.len(), 1);
 
         let deregister = Deregister::Downstream {

--- a/components/cdc/tests/failpoints/mod.rs
+++ b/components/cdc/tests/failpoints/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
 #![feature(custom_test_frameworks)]
+#![feature(assert_matches)]
 #![test_runner(test_util::run_failpoint_tests)]
 
 mod test_endpoint;

--- a/components/cdc/tests/failpoints/test_endpoint.rs
+++ b/components/cdc/tests/failpoints/test_endpoint.rs
@@ -1,5 +1,6 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::assert_matches::assert_matches;
 use std::thread;
 use std::time::Duration;
 
@@ -289,7 +290,7 @@ fn test_no_resolved_ts_before_downstream_initialized() {
         for _ in 0..10 {
             let _ = receive_events[0](false);
             let mut rx = event_feeds[1].replace(None).unwrap();
-            assert!(recv_timeout(&mut rx, Duration::from_secs(1)).is_err());
+            assert_matches!(recv_timeout(&mut rx, Duration::from_secs(1)), Err(_));
             event_feeds[1].replace(Some(rx));
         }
     });

--- a/components/cdc/tests/failpoints/test_resolve.rs
+++ b/components/cdc/tests/failpoints/test_resolve.rs
@@ -7,6 +7,7 @@ use kvproto::cdcpb::*;
 use kvproto::kvrpcpb::*;
 use pd_client::PdClient;
 use raft::eraftpb::ConfChangeType;
+use std::assert_matches::assert_matches;
 use std::time::Duration;
 use test_raftstore::*;
 use tikv_util::config::*;
@@ -254,7 +255,7 @@ fn test_joint_confchange() {
         receive_resolved_ts(&receive_event);
         tx.send(()).unwrap();
     });
-    assert!(rx.recv_timeout(Duration::from_secs(2)).is_err());
+    assert_matches!(rx.recv_timeout(Duration::from_secs(2)), Err(_));
 
     fail::remove(update_region_fp);
     fail::remove(deregister_fp);

--- a/components/cloud/aws/src/lib.rs
+++ b/components/cloud/aws/src/lib.rs
@@ -1,5 +1,5 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
-
+#![feature(assert_matches)]
 mod kms;
 pub use kms::{AwsKms, ENCRYPTION_VENDOR_NAME_AWS_KMS};
 

--- a/components/cloud/aws/src/s3.rs
+++ b/components/cloud/aws/src/s3.rs
@@ -554,7 +554,7 @@ mod tests {
         });
         assert!(S3Storage::new(config.clone()).is_ok());
         config.bucket.region = StringNonEmpty::opt("foo".to_string());
-        assert_matches!(S3Storage::new(config), Err(_));
+        assert!(S3Storage::new(config).is_err());
     }
 
     #[cfg(feature = "failpoints")]

--- a/components/cloud/aws/src/s3.rs
+++ b/components/cloud/aws/src/s3.rs
@@ -538,6 +538,7 @@ mod tests {
     use super::*;
     use rusoto_core::signature::SignedRequest;
     use rusoto_mock::MockRequestDispatcher;
+    use std::assert_matches::assert_matches;
     use tikv_util::stream::block_on_external_io;
 
     #[test]
@@ -553,7 +554,7 @@ mod tests {
         });
         assert!(S3Storage::new(config.clone()).is_ok());
         config.bucket.region = StringNonEmpty::opt("foo".to_string());
-        assert!(S3Storage::new(config).is_err());
+        assert_matches!(S3Storage::new(config), Err(_));
     }
 
     #[cfg(feature = "failpoints")]
@@ -602,7 +603,7 @@ mod tests {
             )
             .await;
         fail::remove(s3_put_obj_err_fp);
-        assert!(resp.is_err());
+        assert_matches!(resp, Err(_));
 
         // test timeout
         let s3_timeout_injected_fp = "s3_timeout_injected";
@@ -621,7 +622,7 @@ mod tests {
             .await;
         fail::remove(s3_sleep_injected_fp);
         // timeout occur due to delay 200ms
-        assert!(resp.is_err());
+        assert_matches!(resp, Err(_));
 
         // inject 50ms delay
         fail::cfg(s3_sleep_injected_fp, "return(50)").unwrap();

--- a/components/codec/src/buffer.rs
+++ b/components/codec/src/buffer.rs
@@ -285,6 +285,7 @@ impl<T: BufferWriter + ?Sized> BufferWriter for Box<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches::assert_matches;
 
     #[test]
     fn test_buffer_reader_cursor() {
@@ -339,7 +340,7 @@ mod tests {
 
         // Read more bytes than available
         buffer.set_position(39);
-        assert!(buffer.read_bytes(2).is_err());
+        assert_matches!(buffer.read_bytes(2), Err(_));
         assert_eq!(buffer.position(), 39);
         assert_eq!(buffer.bytes(), &base[39..40]);
     }
@@ -374,14 +375,14 @@ mod tests {
         assert_eq!(buffer, &base[21..40]);
         assert_eq!(buffer.bytes(), &base[21..40]);
 
-        assert!(buffer.read_bytes(20).is_err());
+        assert_matches!(buffer.read_bytes(20), Err(_));
 
         buffer.advance(19);
         assert_eq!(buffer, &[]);
         assert_eq!(buffer.bytes(), &[]);
 
         assert_eq!(buffer.read_bytes(0).unwrap(), &[]);
-        assert!(buffer.read_bytes(1).is_err());
+        assert_matches!(buffer.read_bytes(1), Err(_));
     }
 
     #[test]
@@ -420,7 +421,7 @@ mod tests {
             assert_eq!(buffer.position(), 20);
 
             // Write more bytes than available size
-            assert!(buffer.write_bytes(&base_write[20..]).is_err());
+            assert_matches!(buffer.write_bytes(&base_write[20..]), Err(_));
             assert_eq!(&buffer.get_ref()[0..20], &base_write[0..20]);
             assert_eq!(&buffer.get_ref()[20..], &base[20..]);
             assert_eq!(buffer.position(), 20);
@@ -519,7 +520,7 @@ mod tests {
             let mut buf_slice = &mut buffer[20..];
 
             // Buffer remain 20, write 21 bytes shall fail.
-            assert!(buf_slice.write_bytes(&base_write[20..41]).is_err());
+            assert_matches!(buf_slice.write_bytes(&base_write[20..41]), Err(_));
 
             // Write remaining 20 bytes
             buf_slice.bytes_mut(20)[..20].clone_from_slice(&base_write[20..40]);

--- a/components/codec/src/byte.rs
+++ b/components/codec/src/byte.rs
@@ -558,6 +558,7 @@ mod tests {
 
     use super::*;
     use crate::number;
+    use std::assert_matches::assert_matches;
 
     #[test]
     fn test_mem_cmp_encoded_len() {
@@ -950,7 +951,7 @@ mod tests {
             let result = panic_hook::recover_safe(move || {
                 let _ = MemComparableByteCodec::encode_all(src.as_slice(), dest.as_mut_slice());
             });
-            assert!(result.is_err());
+            assert_matches!(result, Err(_));
 
             let mut src_in_place = vec![0; dest_len];
             let result = panic_hook::recover_safe(move || {
@@ -959,7 +960,7 @@ mod tests {
                     src_len,
                 );
             });
-            assert!(result.is_err());
+            assert_matches!(result, Err(_));
         }
     }
 
@@ -1119,7 +1120,7 @@ mod tests {
                 invalid_src.as_slice(),
                 dest.as_mut_slice(),
             );
-            assert!(result.is_err());
+            assert_matches!(result, Err(_));
         }
     }
 
@@ -1140,7 +1141,7 @@ mod tests {
                         dest.as_mut_slice(),
                     );
                 });
-                assert!(result.is_err());
+                assert_matches!(result, Err(_));
             }
             {
                 let mut dest = vec![0; src.len()];

--- a/components/codec/src/lib.rs
+++ b/components/codec/src/lib.rs
@@ -3,6 +3,7 @@
 #![cfg_attr(test, feature(test))]
 #![feature(core_intrinsics)]
 #![feature(min_specialization)]
+#![feature(assert_matches)]
 
 #[cfg(test)]
 extern crate test;

--- a/components/codec/src/number.rs
+++ b/components/codec/src/number.rs
@@ -1067,6 +1067,7 @@ impl<T: BufferWriter> NumberEncoder for T {}
 #[cfg(test)]
 mod tests {
     use protobuf::CodedOutputStream;
+    use std::assert_matches::assert_matches;
 
     fn get_u8_samples() -> Vec<u8> {
         vec![
@@ -1260,20 +1261,20 @@ mod tests {
                 // Encode to a `Cursor` (backed by Vec) without sufficient capacity
                 let buf: Vec<u8> = vec![];
                 let mut cursor = std::io::Cursor::new(buf);
-                assert!(super::NumberEncoder::$buf_enc(&mut cursor, sample).is_err());
+                assert_matches!(super::NumberEncoder::$buf_enc(&mut cursor, sample), Err(_));
                 assert_eq!(cursor.position(), 0);
                 assert_eq!(cursor.get_ref().len(), 0);
 
                 // Note that Vec capacity is not counted in Cursor.
                 let buf: Vec<u8> = Vec::with_capacity(len);
                 let mut cursor = std::io::Cursor::new(buf);
-                assert!(super::NumberEncoder::$buf_enc(&mut cursor, sample).is_err());
+                assert_matches!(super::NumberEncoder::$buf_enc(&mut cursor, sample), Err(_));
                 assert_eq!(cursor.position(), 0);
                 assert_eq!(cursor.get_ref().len(), 0);
 
                 let buf: Vec<u8> = vec![0; len - 1];
                 let mut cursor = std::io::Cursor::new(buf);
-                assert!(super::NumberEncoder::$buf_enc(&mut cursor, sample).is_err());
+                assert_matches!(super::NumberEncoder::$buf_enc(&mut cursor, sample), Err(_));
                 assert_eq!(cursor.position(), 0);
                 assert_eq!(cursor.get_ref().len(), len - 1);
 
@@ -1323,7 +1324,10 @@ mod tests {
                         let buf = payload.clone();
                         let mut cursor = std::io::Cursor::new(buf);
                         cursor.set_position(pos as u64);
-                        assert!(super::NumberEncoder::$buf_enc(&mut cursor, sample).is_err());
+                        assert_matches!(
+                            super::NumberEncoder::$buf_enc(&mut cursor, sample),
+                            Err(_)
+                        );
                         // underlying buffer and position should be unchanged
                         assert_eq!(&cursor.get_ref().as_slice(), &payload.as_slice());
                         assert_eq!(cursor.position(), pos as u64);
@@ -1333,19 +1337,19 @@ mod tests {
                 // Decode from a `Cursor` without sufficient capacity
                 let buf: Vec<u8> = vec![];
                 let mut cursor = std::io::Cursor::new(buf);
-                assert!(super::NumberDecoder::$buf_dec(&mut cursor).is_err());
+                assert_matches!(super::NumberDecoder::$buf_dec(&mut cursor), Err(_));
                 assert_eq!(cursor.position(), 0);
                 assert_eq!(cursor.get_ref().len(), 0);
 
                 let buf: Vec<u8> = Vec::with_capacity(len);
                 let mut cursor = std::io::Cursor::new(buf);
-                assert!(super::NumberDecoder::$buf_dec(&mut cursor).is_err());
+                assert_matches!(super::NumberDecoder::$buf_dec(&mut cursor), Err(_));
                 assert_eq!(cursor.position(), 0);
                 assert_eq!(cursor.get_ref().len(), 0);
 
                 let buf: Vec<u8> = vec![0; len - 1];
                 let mut cursor = std::io::Cursor::new(buf);
-                assert!(super::NumberDecoder::$buf_dec(&mut cursor).is_err());
+                assert_matches!(super::NumberDecoder::$buf_dec(&mut cursor), Err(_));
                 assert_eq!(cursor.position(), 0);
                 assert_eq!(cursor.get_ref().len(), len - 1);
 
@@ -1396,7 +1400,7 @@ mod tests {
                         let buf = payload.clone();
                         let mut cursor = std::io::Cursor::new(buf);
                         cursor.set_position(pos as u64);
-                        assert!(super::NumberDecoder::$buf_dec(&mut cursor).is_err());
+                        assert_matches!(super::NumberDecoder::$buf_dec(&mut cursor), Err(_));
                         // underlying buffer and position should be unchanged
                         assert_eq!(&cursor.get_ref().as_slice(), &payload.as_slice());
                         assert_eq!(cursor.position(), pos as u64);
@@ -1659,7 +1663,7 @@ mod tests {
                 // Incomplete buffer, we should got errors in decoding, but get `len` as length
                 for l in 0..len {
                     let result = super::NumberCodec::$dec(&base_buf[0..l]);
-                    assert!(result.is_err());
+                    assert_matches!(result, Err(_));
 
                     let result = super::NumberCodec::get_first_encoded_var_int_len(&base_buf[0..l]);
                     assert_eq!(result, l);
@@ -1677,7 +1681,10 @@ mod tests {
                         let buf = payload.clone();
                         let mut cursor = std::io::Cursor::new(buf);
                         cursor.set_position(pos as u64);
-                        assert!(super::NumberEncoder::$buf_enc(&mut cursor, sample).is_err());
+                        assert_matches!(
+                            super::NumberEncoder::$buf_enc(&mut cursor, sample),
+                            Err(_)
+                        );
                         // underlying buffer and position should be unchanged
                         assert_eq!(&cursor.get_ref().as_slice(), &payload.as_slice());
                         assert_eq!(cursor.position(), pos as u64);
@@ -1718,7 +1725,10 @@ mod tests {
                         let buf = payload.clone();
                         let mut cursor = std::io::Cursor::new(buf);
                         cursor.set_position(pos as u64);
-                        assert!(super::NumberEncoder::$buf_enc(&mut cursor, sample).is_err());
+                        assert_matches!(
+                            super::NumberEncoder::$buf_enc(&mut cursor, sample),
+                            Err(_)
+                        );
                         // underlying buffer and position should be unchanged
                         assert_eq!(&cursor.get_ref().as_slice(), &payload.as_slice());
                         assert_eq!(cursor.position(), pos as u64);
@@ -1734,7 +1744,7 @@ mod tests {
                         let buf = payload.clone();
                         let mut cursor = std::io::Cursor::new(buf);
                         cursor.set_position(pos as u64);
-                        assert!(super::NumberDecoder::$buf_dec(&mut cursor).is_err());
+                        assert_matches!(super::NumberDecoder::$buf_dec(&mut cursor), Err(_));
                         // underlying buffer and position should be unchanged
                         assert_eq!(&cursor.get_ref().as_slice(), &payload.as_slice());
                         assert_eq!(cursor.position(), pos as u64);

--- a/components/encryption/src/manager/mod.rs
+++ b/components/encryption/src/manager/mod.rs
@@ -755,6 +755,7 @@ mod tests {
     use engine_traits::EncryptionMethod as DBEncryptionMethod;
     use file_system::{remove_file, File};
     use matches::assert_matches;
+    use std::assert_matches::assert_matches;
     use tempfile::TempDir;
     use test_util::create_test_key_file;
 
@@ -937,7 +938,7 @@ mod tests {
         let mut previous_key = new_mock_backend();
         previous_key.track("previous".to_string());
         let manager = new_mock_key_manager(&tmp_dir, None, current_key, previous_key);
-        assert!(manager.is_err());
+        assert_matches!(manager, Err(_));
         assert_eq!(encrypt_called("current"), 1);
         assert_eq!(encrypt_called("previous"), 0);
         assert_eq!(decrypt_called("current"), 1);
@@ -978,7 +979,7 @@ mod tests {
 
         remove_file(tmp_dir.path().join(KEY_DICT_NAME)).unwrap();
         let manager = new_key_manager_def(&tmp_dir, None);
-        assert!(manager.is_err());
+        assert_matches!(manager, Err(_));
     }
 
     #[test]
@@ -992,7 +993,7 @@ mod tests {
 
         remove_file(tmp_dir.path().join(FILE_DICT_NAME)).unwrap();
         let manager = new_key_manager_def(&tmp_dir, None);
-        assert!(manager.is_err());
+        assert_matches!(manager, Err(_));
     }
 
     #[test]
@@ -1253,7 +1254,7 @@ mod tests {
 
         let result = new_key_manager(&tmp_dir, None, wrong_key, previous);
         // When the master key is invalid, the key manager left a empty file dict and return errors.
-        assert!(result.is_err());
+        assert_matches!(result, Err(_));
         let previous = Box::new(PlaintextBackend::default()) as Box<dyn Backend>;
         let result = new_key_manager(&tmp_dir, None, right_key, previous);
         assert!(result.is_ok());

--- a/components/engine_rocks/src/config.rs
+++ b/components/engine_rocks/src/config.rs
@@ -297,6 +297,7 @@ numeric_enum_serializing_mod! {recovery_mode_serde DBRecoveryMode {
 mod tests {
     use super::*;
     use rocksdb::DBCompressionType;
+    use std::assert_matches::assert_matches;
 
     #[test]
     fn test_parse_compression_type() {
@@ -333,23 +334,26 @@ mod tests {
         }
 
         // length is wrong.
-        assert!(toml::from_str::<CompressionTypeHolder>("tp = [\"no\"]").is_err());
-        assert!(
+        assert_matches!(
+            toml::from_str::<CompressionTypeHolder>("tp = [\"no\"]"),
+            Err(_)
+        );
+        assert_matches!(
             toml::from_str::<CompressionTypeHolder>(
                 r#"tp = [
             "no", "no", "no", "no", "no", "no", "no", "no"
         ]"#
-            )
-            .is_err()
+            ),
+            Err(_)
         );
         // value is wrong.
-        assert!(
+        assert_matches!(
             toml::from_str::<CompressionTypeHolder>(
                 r#"tp = [
             "no", "no", "no", "no", "no", "no", "yes"
         ]"#
-            )
-            .is_err()
+            ),
+            Err(_)
         );
     }
 }

--- a/components/engine_rocks/src/engine.rs
+++ b/components/engine_rocks/src/engine.rs
@@ -193,6 +193,7 @@ mod tests {
     use crate::raw_util;
     use engine_traits::{Iterable, KvEngine, Peekable, SyncMutable};
     use kvproto::metapb::Region;
+    use std::assert_matches::assert_matches;
     use std::sync::Arc;
     use tempfile::Builder;
 
@@ -247,7 +248,7 @@ mod tests {
         engine.put_cf(cf, b"k1", b"v2").unwrap();
 
         assert_eq!(&*engine.get_value(b"k1").unwrap().unwrap(), b"v1");
-        assert!(engine.get_value_cf("foo", b"k1").is_err());
+        assert_matches!(engine.get_value_cf("foo", b"k1"), Err(_));
         assert_eq!(&*engine.get_value_cf(cf, b"k1").unwrap().unwrap(), b"v2");
     }
 

--- a/components/engine_rocks/src/event_listener.rs
+++ b/components/engine_rocks/src/event_listener.rs
@@ -1,6 +1,7 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
 use crate::rocks_metrics::*;
+use std::assert_matches::assert_matches;
 
 use file_system::{get_io_type, set_io_type, IOType};
 use rocksdb::{
@@ -96,7 +97,7 @@ impl rocksdb::EventListener for RocksEventListener {
     }
 
     fn on_background_error(&self, reason: DBBackgroundErrorReason, result: Result<(), String>) {
-        assert!(result.is_err());
+        assert_matches!(result, Err(_));
         if let Err(err) = result {
             if matches!(
                 reason,

--- a/components/engine_rocks/src/lib.rs
+++ b/components/engine_rocks/src/lib.rs
@@ -1,5 +1,5 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
-
+#![feature(assert_matches)]
 //! Implementation of engine_traits for RocksDB
 //!
 //! This is a work-in-progress attempt to abstract all the features needed by

--- a/components/engine_rocks/src/ttl_properties.rs
+++ b/components/engine_rocks/src/ttl_properties.rs
@@ -115,6 +115,7 @@ impl TablePropertiesCollectorFactory<TtlPropertiesCollector> for TtlPropertiesCo
 mod tests {
     use super::*;
     use engine_traits::util::append_expire_ts;
+    use std::assert_matches::assert_matches;
     use tikv_util::time::UnixSecs;
 
     #[test]
@@ -146,10 +147,10 @@ mod tests {
         assert_eq!(props.min_expire_ts, 1);
 
         let case2 = [("za", 0)];
-        assert!(get_properties(&case2).is_err());
+        assert_matches!(get_properties(&case2), Err(_));
 
         let case3 = [];
-        assert!(get_properties(&case3).is_err());
+        assert_matches!(get_properties(&case3), Err(_));
 
         let case4 = [("za", 1)];
         let props = get_properties(&case4).unwrap();

--- a/components/engine_traits_tests/src/ctor.rs
+++ b/components/engine_traits_tests/src/ctor.rs
@@ -8,6 +8,7 @@ use engine_test::ctor::{CFOptions, ColumnFamilyOptions, DBOptions, EngineConstru
 use engine_test::kv::KvTestEngine;
 use engine_traits::{KvEngine, SyncMutable, ALL_CFS};
 
+use std::assert_matches::assert_matches;
 use std::fs;
 
 #[test]
@@ -71,7 +72,7 @@ fn new_engine_readonly_dir() {
     let path = path.to_str().unwrap();
     let err = KvTestEngine::new_engine(path, None, ALL_CFS, None);
 
-    assert!(err.is_err());
+    assert_matches!(err, Err(_));
 }
 
 #[test]
@@ -95,5 +96,5 @@ fn new_engine_opt_readonly_dir() {
         .collect();
     let err = KvTestEngine::new_engine_opt(path, db_opts, cf_opts);
 
-    assert!(err.is_err());
+    assert_matches!(err, Err(_));
 }

--- a/components/engine_traits_tests/src/delete_range.rs
+++ b/components/engine_traits_tests/src/delete_range.rs
@@ -3,14 +3,15 @@
 use super::default_engine;
 use engine_traits::SyncMutable;
 use panic_hook::recover_safe;
+use std::assert_matches::assert_matches;
 
 #[test]
 fn delete_range_cf_bad_cf() {
     let db = default_engine();
-    assert!(
+    assert_matches!(
         recover_safe(|| {
             db.engine.delete_range_cf("bogus", b"a", b"b").unwrap();
-        })
-        .is_err()
+        }),
+        Err(_)
     );
 }

--- a/components/engine_traits_tests/src/iterator.rs
+++ b/components/engine_traits_tests/src/iterator.rs
@@ -4,6 +4,7 @@ use super::default_engine;
 use engine_traits::SeekKey;
 use engine_traits::{Iterable, Iterator, KvEngine};
 use panic_hook::recover_safe;
+use std::assert_matches::assert_matches;
 
 fn iter_empty<E, I, IF>(e: &E, i: IF)
 where
@@ -15,19 +16,19 @@ where
 
     assert_eq!(iter.valid().unwrap(), false);
 
-    assert!(iter.prev().is_err());
-    assert!(iter.next().is_err());
-    assert!(
+    assert_matches!(iter.prev(), Err(_));
+    assert_matches!(iter.next(), Err(_));
+    assert_matches!(
         recover_safe(|| {
             iter.key();
-        })
-        .is_err()
+        }),
+        Err(_)
     );
-    assert!(
+    assert_matches!(
         recover_safe(|| {
             iter.value();
-        })
-        .is_err()
+        }),
+        Err(_)
     );
 
     assert_eq!(iter.seek(SeekKey::Start).unwrap(), false);
@@ -86,17 +87,17 @@ where
 
     assert!(!iter.valid().unwrap());
 
-    assert!(
+    assert_matches!(
         recover_safe(|| {
             iter.key();
-        })
-        .is_err()
+        }),
+        Err(_)
     );
-    assert!(
+    assert_matches!(
         recover_safe(|| {
             iter.value();
-        })
-        .is_err()
+        }),
+        Err(_)
     );
 }
 
@@ -148,17 +149,17 @@ where
 
     assert!(!iter.valid().unwrap());
 
-    assert!(
+    assert_matches!(
         recover_safe(|| {
             iter.key();
-        })
-        .is_err()
+        }),
+        Err(_)
     );
-    assert!(
+    assert_matches!(
         recover_safe(|| {
             iter.value();
-        })
-        .is_err()
+        }),
+        Err(_)
     );
 }
 

--- a/components/engine_traits_tests/src/scenario_writes.rs
+++ b/components/engine_traits_tests/src/scenario_writes.rs
@@ -6,6 +6,7 @@ use engine_traits::{Mutable, WriteBatch, WriteBatchExt};
 use engine_traits::{Peekable, Result, SyncMutable};
 use engine_traits::{ALL_CFS, CF_DEFAULT, CF_WRITE};
 use panic_hook::recover_safe;
+use std::assert_matches::assert_matches;
 
 #[allow(clippy::enum_variant_names)]
 #[derive(Eq, PartialEq)]
@@ -278,9 +279,9 @@ scenario_test! { delete_range_reverse_range {
     db.put(b"c", b"").unwrap();
     db.put(b"d", b"").unwrap();
 
-    assert!(recover_safe(|| {
+    assert_matches!(recover_safe(|| {
         db.delete_range(b"d", b"b").unwrap();
-    }).is_err());
+    }),Err(_));
 
     assert!(db.get_value(b"b").unwrap().is_some());
     assert!(db.get_value(b"c").unwrap().is_some());

--- a/components/engine_traits_tests/src/sst.rs
+++ b/components/engine_traits_tests/src/sst.rs
@@ -3,6 +3,7 @@
 //! Tests for `SstExt`
 
 use panic_hook::recover_safe;
+use std::assert_matches::assert_matches;
 use std::fs;
 
 use super::tempdir;
@@ -158,19 +159,19 @@ fn delete() -> Result<()> {
 
     assert_eq!(iter.valid()?, false);
 
-    assert!(iter.prev().is_err());
-    assert!(iter.next().is_err());
-    assert!(
+    assert_matches!(iter.prev(), Err(_));
+    assert_matches!(iter.next(), Err(_));
+    assert_matches!(
         recover_safe(|| {
             iter.key();
-        })
-        .is_err()
+        }),
+        Err(_)
     );
-    assert!(
+    assert_matches!(
         recover_safe(|| {
             iter.value();
-        })
-        .is_err()
+        }),
+        Err(_)
     );
 
     assert_eq!(iter.seek(SeekKey::Start)?, false);

--- a/components/engine_traits_tests/src/write_batch.rs
+++ b/components/engine_traits_tests/src/write_batch.rs
@@ -4,6 +4,7 @@ use super::{assert_engine_error, default_engine};
 use engine_test::kv::KvTestEngine;
 use engine_traits::{Mutable, Peekable, SyncMutable, WriteBatch, WriteBatchExt};
 use panic_hook::recover_safe;
+use std::assert_matches::assert_matches;
 
 #[test]
 fn write_batch_none_no_commit() {
@@ -281,11 +282,11 @@ fn write_batch_delete_range_backward_range() {
     let mut wb = db.engine.write_batch();
 
     wb.delete_range(b"c", b"a").unwrap();
-    assert!(
+    assert_matches!(
         recover_safe(|| {
             wb.write().unwrap();
-        })
-        .is_err()
+        }),
+        Err(_)
     );
 
     assert!(db.engine.get_value(b"a").unwrap().is_some());
@@ -320,11 +321,11 @@ fn write_batch_delete_range_backward_range_partial_commit() {
     wb.put(b"f", b"").unwrap();
     wb.delete(b"a").unwrap();
 
-    assert!(
+    assert_matches!(
         recover_safe(|| {
             wb.write().unwrap();
-        })
-        .is_err()
+        }),
+        Err(_)
     );
 
     assert!(db.engine.get_value(b"a").unwrap().is_some());

--- a/components/external_storage/export/src/export.rs
+++ b/components/external_storage/export/src/export.rs
@@ -232,6 +232,7 @@ pub fn make_cloud_backend(config: CloudDynamic) -> StorageBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches::assert_matches;
     use tempfile::Builder;
 
     #[test]
@@ -253,7 +254,7 @@ mod tests {
         create_storage(&backend, Default::default()).unwrap();
 
         let backend = StorageBackend::default();
-        assert!(create_storage(&backend, Default::default()).is_err());
+        assert_matches!(create_storage(&backend, Default::default()), Err(_));
     }
 }
 

--- a/components/file_system/src/lib.rs
+++ b/components/file_system/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![feature(test)]
 #![feature(duration_consts_2)]
+#![feature(assert_matches)]
 
 #[macro_use]
 extern crate lazy_static;
@@ -436,6 +437,7 @@ pub fn reserve_space_for_recover<P: AsRef<Path>>(data_dir: P, file_size: u64) ->
 mod tests {
     use rand::distributions::Alphanumeric;
     use rand::{thread_rng, Rng};
+    use std::assert_matches::assert_matches;
     use std::io::Write;
     use std::iter;
     use tempfile::{Builder, TempDir};
@@ -474,7 +476,7 @@ mod tests {
 
         // Ensure it works for non-existent file.
         let non_existent_file = dir_path.join("non_existent_file");
-        assert!(get_file_size(&non_existent_file).is_err());
+        assert_matches!(get_file_size(&non_existent_file), Err(_));
     }
 
     #[test]

--- a/components/keys/src/lib.rs
+++ b/components/keys/src/lib.rs
@@ -2,6 +2,8 @@
 
 // #[PerformanceCriticalPath] Common key utitlies.
 
+#![feature(assert_matches)]
+
 //! TiKV key building
 
 #[allow(unused_extern_crates)]

--- a/components/raftstore/src/coprocessor/config.rs
+++ b/components/raftstore/src/coprocessor/config.rs
@@ -122,6 +122,7 @@ impl std::ops::Deref for SplitCheckConfigManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches::assert_matches;
 
     #[test]
     fn test_config_validate() {
@@ -131,11 +132,11 @@ mod tests {
         cfg = Config::default();
         cfg.region_max_size = ReadableSize(10);
         cfg.region_split_size = ReadableSize(20);
-        assert!(cfg.validate().is_err());
+        assert_matches!(cfg.validate(), Err(_));
 
         cfg = Config::default();
         cfg.region_max_keys = 10;
         cfg.region_split_keys = 20;
-        assert!(cfg.validate().is_err());
+        assert_matches!(cfg.validate(), Err(_));
     }
 }

--- a/components/raftstore/src/coprocessor/split_observer.rs
+++ b/components/raftstore/src/coprocessor/split_observer.rs
@@ -163,6 +163,7 @@ mod tests {
     use byteorder::{BigEndian, WriteBytesExt};
     use kvproto::metapb::Region;
     use kvproto::raft_cmdpb::{AdminCmdType, AdminRequest, SplitRequest};
+    use std::assert_matches::assert_matches;
     use tidb_query_datatype::codec::{datum, table, Datum};
     use tidb_query_datatype::expr::EvalContext;
     use tikv_util::codec::bytes::encode_bytes;
@@ -254,7 +255,7 @@ mod tests {
         req = new_batch_split_request(split_keys.clone());
         // Although invalid keys should be skipped, but if all keys are
         // invalid, errors should be reported.
-        assert!(observer.pre_propose_admin(&mut ctx, &mut req).is_err());
+        assert_matches!(observer.pre_propose_admin(&mut ctx, &mut req), Err(_));
 
         let mut key = new_row_key(1, 2, 0);
         let mut expected_key = key[..key.len() - 8].to_vec();

--- a/components/raftstore/src/lib.rs
+++ b/components/raftstore/src/lib.rs
@@ -6,6 +6,7 @@
 #![feature(div_duration)]
 #![feature(min_specialization)]
 #![feature(box_patterns)]
+#![feature(assert_matches)]
 #![recursion_limit = "256"]
 
 #[cfg(test)]

--- a/components/raftstore/src/store/bootstrap.rs
+++ b/components/raftstore/src/store/bootstrap.rs
@@ -127,6 +127,7 @@ mod tests {
     use super::*;
     use engine_traits::Engines;
     use engine_traits::{Peekable, CF_DEFAULT};
+    use std::assert_matches::assert_matches;
 
     #[test]
     fn test_bootstrap() {
@@ -146,7 +147,7 @@ mod tests {
         let region = initial_region(1, 1, 1);
 
         assert!(bootstrap_store(&engines, 1, 1).is_ok());
-        assert!(bootstrap_store(&engines, 1, 1).is_err());
+        assert_matches!(bootstrap_store(&engines, 1, 1), Err(_));
 
         assert!(prepare_bootstrap_cluster(&engines, &region).is_ok());
         assert!(

--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -771,6 +771,7 @@ impl std::ops::Deref for RaftstoreConfigManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches::assert_matches;
 
     #[test]
     fn test_config_validate() {
@@ -786,12 +787,12 @@ mod tests {
         );
 
         cfg.raft_heartbeat_ticks = 0;
-        assert!(cfg.validate().is_err());
+        assert_matches!(cfg.validate(), Err(_));
 
         cfg = Config::new();
         cfg.raft_election_timeout_ticks = 10;
         cfg.raft_heartbeat_ticks = 10;
-        assert!(cfg.validate().is_err());
+        assert_matches!(cfg.validate(), Err(_));
 
         cfg = Config::new();
         cfg.raft_min_election_timeout_ticks = 5;
@@ -802,66 +803,66 @@ mod tests {
         cfg.validate().unwrap();
 
         cfg.raft_heartbeat_ticks = 11;
-        assert!(cfg.validate().is_err());
+        assert_matches!(cfg.validate(), Err(_));
 
         cfg = Config::new();
         cfg.raft_log_gc_threshold = 0;
-        assert!(cfg.validate().is_err());
+        assert_matches!(cfg.validate(), Err(_));
 
         cfg = Config::new();
         cfg.raft_log_gc_size_limit = ReadableSize(0);
-        assert!(cfg.validate().is_err());
+        assert_matches!(cfg.validate(), Err(_));
 
         cfg = Config::new();
         cfg.raft_base_tick_interval = ReadableDuration::secs(1);
         cfg.raft_election_timeout_ticks = 10;
         cfg.raft_store_max_leader_lease = ReadableDuration::secs(20);
-        assert!(cfg.validate().is_err());
+        assert_matches!(cfg.validate(), Err(_));
 
         cfg = Config::new();
         cfg.raft_log_gc_count_limit = 100;
         cfg.merge_max_log_gap = 110;
-        assert!(cfg.validate().is_err());
+        assert_matches!(cfg.validate(), Err(_));
 
         cfg = Config::new();
         cfg.merge_check_tick_interval = ReadableDuration::secs(0);
-        assert!(cfg.validate().is_err());
+        assert_matches!(cfg.validate(), Err(_));
 
         cfg = Config::new();
         cfg.raft_base_tick_interval = ReadableDuration::secs(1);
         cfg.raft_election_timeout_ticks = 10;
         cfg.peer_stale_state_check_interval = ReadableDuration::secs(5);
-        assert!(cfg.validate().is_err());
+        assert_matches!(cfg.validate(), Err(_));
 
         cfg = Config::new();
         cfg.peer_stale_state_check_interval = ReadableDuration::minutes(2);
         cfg.abnormal_leader_missing_duration = ReadableDuration::minutes(1);
-        assert!(cfg.validate().is_err());
+        assert_matches!(cfg.validate(), Err(_));
 
         cfg = Config::new();
         cfg.abnormal_leader_missing_duration = ReadableDuration::minutes(2);
         cfg.max_leader_missing_duration = ReadableDuration::minutes(1);
-        assert!(cfg.validate().is_err());
+        assert_matches!(cfg.validate(), Err(_));
 
         cfg = Config::new();
         cfg.local_read_batch_size = 0;
-        assert!(cfg.validate().is_err());
+        assert_matches!(cfg.validate(), Err(_));
 
         cfg = Config::new();
         cfg.apply_batch_system.max_batch_size = Some(0);
-        assert!(cfg.validate().is_err());
+        assert_matches!(cfg.validate(), Err(_));
 
         cfg = Config::new();
         cfg.apply_batch_system.pool_size = 0;
-        assert!(cfg.validate().is_err());
+        assert_matches!(cfg.validate(), Err(_));
 
         cfg = Config::new();
         cfg.store_batch_system.max_batch_size = Some(0);
-        assert!(cfg.validate().is_err());
+        assert_matches!(cfg.validate(), Err(_));
 
         cfg = Config::new();
         cfg.store_batch_system.pool_size = 0;
-        assert!(cfg.validate().is_err());
+        assert_matches!(cfg.validate(), Err(_));
 
         cfg = Config::new();
         cfg.hibernate_regions = true;
@@ -885,13 +886,13 @@ mod tests {
 
         cfg = Config::new();
         cfg.future_poll_size = 0;
-        assert!(cfg.validate().is_err());
+        assert_matches!(cfg.validate(), Err(_));
 
         cfg = Config::new();
         cfg.raft_base_tick_interval = ReadableDuration::secs(1);
         cfg.raft_election_timeout_ticks = 11;
         cfg.raft_store_max_leader_lease = ReadableDuration::secs(11);
-        assert!(cfg.validate().is_err());
+        assert_matches!(cfg.validate(), Err(_));
 
         cfg = Config::new();
         cfg.hibernate_regions = true;

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -4175,6 +4175,7 @@ mod memtrace {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches::assert_matches;
     use std::cell::RefCell;
     use std::rc::Rc;
     use std::sync::atomic::*;
@@ -4521,7 +4522,7 @@ mod tests {
         // unregistered region should be ignored and notify failed.
         let resp = resp_rx.recv_timeout(Duration::from_secs(3)).unwrap();
         assert!(resp.get_header().get_error().has_region_not_found());
-        assert!(rx.try_recv().is_err());
+        assert_matches!(rx.try_recv(), Err(_));
 
         let (cc_tx, cc_rx) = mpsc::channel();
         let pops = vec![
@@ -4623,7 +4624,7 @@ mod tests {
             "{:?}",
             resp
         );
-        assert!(rx.try_recv().is_err());
+        assert_matches!(rx.try_recv(), Err(_));
 
         system.shutdown();
     }
@@ -5487,29 +5488,29 @@ mod tests {
         let mut region = Region::default();
 
         // Check uuid and cf name
-        assert!(check_sst_for_ingestion(&sst, &region).is_err());
+        assert_matches!(check_sst_for_ingestion(&sst, &region), Err(_));
         sst.set_uuid(Uuid::new_v4().as_bytes().to_vec());
         sst.set_cf_name(CF_DEFAULT.to_owned());
         check_sst_for_ingestion(&sst, &region).unwrap();
         sst.set_cf_name("test".to_owned());
-        assert!(check_sst_for_ingestion(&sst, &region).is_err());
+        assert_matches!(check_sst_for_ingestion(&sst, &region), Err(_));
         sst.set_cf_name(CF_WRITE.to_owned());
         check_sst_for_ingestion(&sst, &region).unwrap();
 
         // Check region id
         region.set_id(1);
         sst.set_region_id(2);
-        assert!(check_sst_for_ingestion(&sst, &region).is_err());
+        assert_matches!(check_sst_for_ingestion(&sst, &region), Err(_));
         sst.set_region_id(1);
         check_sst_for_ingestion(&sst, &region).unwrap();
 
         // Check region epoch
         region.mut_region_epoch().set_conf_ver(1);
-        assert!(check_sst_for_ingestion(&sst, &region).is_err());
+        assert_matches!(check_sst_for_ingestion(&sst, &region), Err(_));
         sst.mut_region_epoch().set_conf_ver(1);
         check_sst_for_ingestion(&sst, &region).unwrap();
         region.mut_region_epoch().set_version(1);
-        assert!(check_sst_for_ingestion(&sst, &region).is_err());
+        assert_matches!(check_sst_for_ingestion(&sst, &region), Err(_));
         sst.mut_region_epoch().set_version(1);
         check_sst_for_ingestion(&sst, &region).unwrap();
 
@@ -5518,9 +5519,9 @@ mod tests {
         region.set_end_key(vec![8]);
         sst.mut_range().set_start(vec![1]);
         sst.mut_range().set_end(vec![8]);
-        assert!(check_sst_for_ingestion(&sst, &region).is_err());
+        assert_matches!(check_sst_for_ingestion(&sst, &region), Err(_));
         sst.mut_range().set_start(vec![2]);
-        assert!(check_sst_for_ingestion(&sst, &region).is_err());
+        assert_matches!(check_sst_for_ingestion(&sst, &region), Err(_));
         sst.mut_range().set_end(vec![7]);
         check_sst_for_ingestion(&sst, &region).unwrap();
     }

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -4618,6 +4618,7 @@ mod tests {
     use crate::store::util::u64_to_timespec;
     use kvproto::raft_cmdpb;
     use protobuf::ProtobufEnum;
+    use std::assert_matches::assert_matches;
 
     #[test]
     fn test_sync_log() {
@@ -4807,7 +4808,7 @@ mod tests {
                 applied_to_index_term: true,
                 lease_state: LeaseState::Valid,
             };
-            assert!(inspector.inspect(&req).is_err());
+            assert_matches!(inspector.inspect(&req), Err(_));
         }
     }
 

--- a/components/raftstore/src/store/region_snapshot.rs
+++ b/components/raftstore/src/store/region_snapshot.rs
@@ -390,6 +390,7 @@ mod tests {
     use engine_traits::{Engines, KvEngine, Peekable, RaftEngine, SyncMutable};
     use keys::data_key;
     use kvproto::metapb::{Peer, Region};
+    use std::assert_matches::assert_matches;
     use tempfile::Builder;
     use tikv_util::worker;
 
@@ -503,7 +504,7 @@ mod tests {
         assert!(v0.is_none());
 
         let v4 = snap.get_value(b"key5");
-        assert!(v4.is_err());
+        assert_matches!(v4, Err(_));
     }
 
     #[allow(clippy::type_complexity)]

--- a/components/raftstore/src/store/replication_mode.rs
+++ b/components/raftstore/src/store/replication_mode.rs
@@ -181,6 +181,7 @@ mod tests {
     use crate::store::util::new_peer;
     use kvproto::metapb;
     use kvproto::replication_modepb::{ReplicationMode, ReplicationStatus};
+    use std::assert_matches::assert_matches;
     use std::panic;
 
     fn new_label(key: &str, value: &str) -> metapb::StoreLabel {
@@ -315,6 +316,6 @@ mod tests {
                 .group
                 .register_store(1, vec![label1.clone(), label3.clone()])
         });
-        assert!(res.is_err(), "existing group id can't be changed.");
+        assert_matches!(res, Err(_), "existing group id can't be changed.");
     }
 }

--- a/components/resource_metering/src/config.rs
+++ b/components/resource_metering/src/config.rs
@@ -136,6 +136,7 @@ impl online_config::ConfigManager for ConfigManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches::assert_matches;
     use tikv_util::config::ReadableDuration;
 
     #[test]
@@ -157,7 +158,7 @@ mod tests {
             max_resource_groups: 2000,
             precision: ReadableDuration::secs(1),
         };
-        assert!(cfg.validate().is_err());
+        assert_matches!(cfg.validate(), Err(_));
         let cfg = Config {
             enabled: false,
             receiver_address: "127.0.0.1:6666".to_string(),
@@ -165,7 +166,7 @@ mod tests {
             max_resource_groups: usize::MAX, // invalid
             precision: ReadableDuration::secs(1),
         };
-        assert!(cfg.validate().is_err());
+        assert_matches!(cfg.validate(), Err(_));
         let cfg = Config {
             enabled: false,
             receiver_address: "127.0.0.1:6666".to_string(),
@@ -173,6 +174,6 @@ mod tests {
             max_resource_groups: 2000,
             precision: ReadableDuration::days(999), // invalid
         };
-        assert!(cfg.validate().is_err());
+        assert_matches!(cfg.validate().,Err(_));
     }
 }

--- a/components/resource_metering/src/config.rs
+++ b/components/resource_metering/src/config.rs
@@ -174,6 +174,6 @@ mod tests {
             max_resource_groups: 2000,
             precision: ReadableDuration::days(999), // invalid
         };
-        assert_matches!(cfg.validate().,Err(_));
+        assert_matches!(cfg.validate(),Err(_));
     }
 }

--- a/components/resource_metering/src/lib.rs
+++ b/components/resource_metering/src/lib.rs
@@ -4,6 +4,7 @@
 
 #![feature(shrink_to)]
 #![feature(hash_drain_filter)]
+#![feature(assert_matches)]
 
 use crate::localstorage::STORAGE;
 

--- a/components/sst_importer/src/lib.rs
+++ b/components/sst_importer/src/lib.rs
@@ -2,6 +2,7 @@
 
 //! Importing RocksDB SST files into TiKV
 #![feature(min_specialization)]
+#![feature(assert_matches)]
 
 #[macro_use]
 extern crate lazy_static;

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -554,6 +554,7 @@ mod tests {
     use super::*;
     use crate::import_file::ImportPath;
     use crate::*;
+    use std::assert_matches::assert_matches;
 
     fn do_test_import_dir(key_manager: Option<Arc<DataKeyManager>>) {
         let temp_dir = Builder::new().prefix("test_import_dir").tempdir().unwrap();
@@ -572,7 +573,7 @@ mod tests {
             check_file_not_exists(&path.clone, key_manager.as_deref());
 
             // Cannot create the same file again.
-            assert!(dir.create(&meta, key_manager.clone()).is_err());
+            assert_matches!(dir.create(&meta, key_manager.clone()), Err(_));
         }
 
         // Test ImportDir::delete()
@@ -664,7 +665,7 @@ mod tests {
             );
             f.append(data).unwrap();
             // Invalid crc32 and length.
-            assert!(f.finish().is_err());
+            assert_matches!(f.finish(), Err(_));
             check_file_exists(&path.temp, data_key_manager.as_deref());
             check_file_not_exists(&path.save, data_key_manager.as_deref());
         }

--- a/components/sst_importer/src/sst_writer.rs
+++ b/components/sst_importer/src/sst_writer.rs
@@ -241,6 +241,7 @@ mod tests {
 
     use super::*;
     use crate::{Config, SSTImporter};
+    use std::assert_matches::assert_matches;
 
     #[test]
     fn test_write_txn_sst() {
@@ -344,6 +345,6 @@ mod tests {
         let mut w = importer.new_raw_writer::<TestEngine>(&db, meta).unwrap();
         let mut batch = RawWriteBatch::default();
         batch.set_ttl(10);
-        assert!(w.write(batch).is_err());
+        assert_matches!(w.write(batch), Err(_));
     }
 }

--- a/components/test_storage/src/assert_storage.rs
+++ b/components/test_storage/src/assert_storage.rs
@@ -1,5 +1,7 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::assert_matches::assert_matches;
+
 use kvproto::kvrpcpb::{ApiVersion, Context, LockInfo};
 
 use test_raftstore::{Cluster, ServerCluster, SimulateEngine};
@@ -241,10 +243,9 @@ impl<E: Engine> AssertionStorage<E> {
     }
 
     pub fn get_err(&self, key: &[u8], ts: impl Into<TimeStamp>) {
-        assert!(
-            self.store
-                .get(self.ctx.clone(), key.to_vec(), ts.into())
-                .is_err()
+        assert_matches!(
+            self.store.get(self.ctx.clone(), key.to_vec(), ts.into()),
+            Err(_)
         );
     }
 
@@ -275,10 +276,9 @@ impl<E: Engine> AssertionStorage<E> {
 
     pub fn batch_get_err(&self, keys: &[&[u8]], ts: impl Into<TimeStamp>) {
         let keys: Vec<Vec<u8>> = keys.iter().map(|x| x.to_vec()).collect();
-        assert!(
-            self.store
-                .batch_get(self.ctx.clone(), &keys, ts.into())
-                .is_err()
+        assert_matches!(
+            self.store.batch_get(self.ctx.clone(), &keys, ts.into()),
+            Err(_)
         );
     }
 
@@ -297,10 +297,9 @@ impl<E: Engine> AssertionStorage<E> {
     }
 
     pub fn batch_get_command_err(&self, keys: &[&[u8]], ts: u64) {
-        assert!(
-            self.store
-                .batch_get_command(self.ctx.clone(), keys, ts)
-                .is_err()
+        assert_matches!(
+            self.store.batch_get_command(self.ctx.clone(), keys, ts),
+            Err(_)
         );
     }
 
@@ -336,7 +335,7 @@ impl<E: Engine> AssertionStorage<E> {
     ) where
         T: std::fmt::Debug,
     {
-        assert!(resp.is_err());
+        assert_matches!(resp, Err(_));
         let err = resp.unwrap_err();
         match err {
             StorageError(box StorageErrorInner::Txn(TxnError(
@@ -388,15 +387,14 @@ impl<E: Engine> AssertionStorage<E> {
         _commit_ts: impl Into<TimeStamp>,
     ) {
         let start_ts = start_ts.into();
-        assert!(
-            self.store
-                .prewrite(
-                    self.ctx.clone(),
-                    vec![Mutation::Put((Key::from_raw(key), value.to_vec()))],
-                    key.to_vec(),
-                    start_ts,
-                )
-                .is_err()
+        assert_matches!(
+            self.store.prewrite(
+                self.ctx.clone(),
+                vec![Mutation::Put((Key::from_raw(key), value.to_vec()))],
+                key.to_vec(),
+                start_ts,
+            ),
+            Err(_)
         );
     }
 
@@ -646,15 +644,14 @@ impl<E: Engine> AssertionStorage<E> {
         start_ts: impl Into<TimeStamp>,
         current_ts: impl Into<TimeStamp>,
     ) {
-        assert!(
-            self.store
-                .cleanup(
-                    self.ctx.clone(),
-                    Key::from_raw(key),
-                    start_ts.into(),
-                    current_ts.into()
-                )
-                .is_err()
+        assert_matches!(
+            self.store.cleanup(
+                self.ctx.clone(),
+                Key::from_raw(key),
+                start_ts.into(),
+                current_ts.into()
+            ),
+            Err(_)
         );
     }
 
@@ -667,10 +664,9 @@ impl<E: Engine> AssertionStorage<E> {
 
     pub fn rollback_err(&self, keys: Vec<&[u8]>, start_ts: impl Into<TimeStamp>) {
         let keys: Vec<Key> = keys.iter().map(|x| Key::from_raw(x)).collect();
-        assert!(
-            self.store
-                .rollback(self.ctx.clone(), keys, start_ts.into())
-                .is_err()
+        assert_matches!(
+            self.store.rollback(self.ctx.clone(), keys, start_ts.into()),
+            Err(_)
         );
     }
 

--- a/components/test_storage/src/lib.rs
+++ b/components/test_storage/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
 
 #![feature(box_patterns)]
+#![feature(assert_matches)]
 
 #[macro_use]
 extern crate tikv_util;

--- a/components/tidb_query_aggr/src/lib.rs
+++ b/components/tidb_query_aggr/src/lib.rs
@@ -5,6 +5,7 @@
 #![allow(incomplete_features)]
 #![feature(proc_macro_hygiene)]
 #![feature(specialization)]
+#![feature(assert_matches)]
 
 #[macro_use(box_try)]
 extern crate tikv_util;
@@ -366,6 +367,7 @@ where
 mod tests {
     use super::*;
 
+    use std::assert_matches::assert_matches;
     use tidb_query_datatype::EvalType;
 
     #[test]
@@ -436,7 +438,7 @@ mod tests {
                 Real::new(1.0).ok().as_ref()
             );
         });
-        assert!(result.is_err());
+        assert_matches!(result, Err(_));
 
         let result = panic_hook::recover_safe(|| {
             let mut s = s.clone();
@@ -446,7 +448,7 @@ mod tests {
                 Some(&[1u8] as BytesRef)
             );
         });
-        assert!(result.is_err());
+        assert_matches!(result, Err(_));
 
         // Push result to Real VectorValue should success.
         let mut target = vec![VectorValue::with_capacity(0, EvalType::Real)];
@@ -483,13 +485,13 @@ mod tests {
             let mut target: Vec<VectorValue> = Vec::new();
             let _ = (&mut s as &mut dyn AggrFunctionState).push_result(&mut ctx, &mut target[..]);
         });
-        assert!(result.is_err());
+        assert_matches!(result, Err(_));
 
         let result = panic_hook::recover_safe(|| {
             let mut s = s.clone();
             let mut target: Vec<VectorValue> = vec![VectorValue::with_capacity(0, EvalType::Int)];
             let _ = (&mut s as &mut dyn AggrFunctionState).push_result(&mut ctx, &mut target[..]);
         });
-        assert!(result.is_err());
+        assert_matches!(result, Err(_));
     }
 }

--- a/components/tidb_query_datatype/src/codec/convert.rs
+++ b/components/tidb_query_datatype/src/codec/convert.rs
@@ -1102,6 +1102,7 @@ fn no_exp_float_str_to_int_str(valid_float: &str, mut dot_idx: usize) -> Cow<'_,
 mod tests {
     #![allow(clippy::float_cmp)]
 
+    use std::assert_matches::assert_matches;
     use std::fmt::Debug;
     use std::sync::Arc;
     use std::{f64, i64, isize, u64};
@@ -1400,14 +1401,14 @@ mod tests {
         let mut ctx = EvalContext::default();
         let bs = b"123bb".to_vec();
         let val = bs.to_int(&mut ctx, FieldTypeTp::LongLong);
-        assert!(val.is_err());
+        assert_matches!(val, Err(_));
         assert_eq!(val.unwrap_err().code(), ERR_TRUNCATE_WRONG_VALUE);
 
         // Invalid UTF8 chars
         let mut ctx = EvalContext::default();
         let invalid_utf8: Vec<u8> = vec![0, 159, 146, 150];
         let val = invalid_utf8.to_int(&mut ctx, FieldTypeTp::LongLong);
-        assert!(val.is_err());
+        assert_matches!(val, Err(_));
         assert_eq!(val.unwrap_err().code(), WARN_DATA_TRUNCATED);
 
         // IGNORE_TRUNCATE
@@ -1555,7 +1556,7 @@ mod tests {
         // SHOULD_CLIP_TO_ZERO
         let mut ctx = EvalContext::new(Arc::new(EvalConfig::from_flag(Flag::IN_INSERT_STMT)));
         let r = (-12345_i64).to_uint(&mut ctx, FieldTypeTp::LongLong);
-        assert!(r.is_err());
+        assert_matches!(r, Err(_));
 
         // SHOULD_CLIP_TO_ZERO | OVERFLOW_AS_WARNING
         let mut ctx = EvalContext::new(Arc::new(EvalConfig::from_flag(
@@ -1893,11 +1894,11 @@ mod tests {
         // test overflow
         let mut ctx = EvalContext::default();
         let val: Result<f64> = f64::INFINITY.to_string().as_bytes().convert(&mut ctx);
-        assert!(val.is_err());
+        assert_matches!(val, Err(_));
 
         let mut ctx = EvalContext::default();
         let val: Result<f64> = f64::NEG_INFINITY.to_string().as_bytes().convert(&mut ctx);
-        assert!(val.is_err());
+        assert_matches!(val, Err(_));
 
         // TRUNCATE_AS_WARNING
         let mut ctx = EvalContext::new(Arc::new(EvalConfig::from_flag(Flag::TRUNCATE_AS_WARNING)));

--- a/components/tidb_query_datatype/src/codec/data_type/mod.rs
+++ b/components/tidb_query_datatype/src/codec/data_type/mod.rs
@@ -652,6 +652,7 @@ impl<'a> EvaluableRef<'a> for SetRef<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches::assert_matches;
     use std::f64;
 
     #[test]
@@ -680,8 +681,9 @@ mod tests {
                     assert_eq!(rb.unwrap(), val);
                 }
                 None => {
-                    assert!(
-                        rb.is_err(),
+                    assert_matches!(
+                        rb,
+                        Err(_),
                         "index: {}, {:?} should not be converted, but got: {:?}",
                         i,
                         v,
@@ -698,7 +700,7 @@ mod tests {
             .as_bytes()
             .to_vec()
             .as_mysql_bool(&mut ctx);
-        assert!(val.is_err());
+        assert_matches!(val, Err(_));
 
         let mut ctx = EvalContext::default();
         let val: Result<bool> = f64::NEG_INFINITY
@@ -706,7 +708,7 @@ mod tests {
             .as_bytes()
             .to_vec()
             .as_mysql_bool(&mut ctx);
-        assert!(val.is_err());
+        assert_matches!(val, Err(_));
     }
 
     #[test]

--- a/components/tidb_query_datatype/src/codec/datum.rs
+++ b/components/tidb_query_datatype/src/codec/datum.rs
@@ -1148,6 +1148,7 @@ mod tests {
     use crate::codec::mysql::{Decimal, Duration, Time, MAX_FSP};
     use crate::expr::{EvalConfig, EvalContext};
 
+    use std::assert_matches::assert_matches;
     use std::cmp::Ordering;
     use std::slice::from_ref;
     use std::str::FromStr;
@@ -1962,7 +1963,7 @@ mod tests {
         ];
 
         for d in illegal_cases {
-            assert!(d.cast_as_json().is_err());
+            assert_matches!(d.cast_as_json(), Err(_));
         }
     }
 
@@ -1983,7 +1984,7 @@ mod tests {
         let illegal_cases = vec![Datum::Max, Datum::Min];
 
         for d in illegal_cases {
-            assert!(d.into_json().is_err());
+            assert_matches!(d.into_json(), Err(_));
         }
     }
 

--- a/components/tidb_query_datatype/src/codec/mysql/binary_literal.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/binary_literal.rs
@@ -207,6 +207,7 @@ impl Ord for BinaryLiteral {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches::assert_matches;
 
     #[test]
     fn test_trim_leading_zero_bytes() {
@@ -273,7 +274,7 @@ mod tests {
         }
 
         let lit = BinaryLiteral::from_u64(100, -2);
-        assert!(lit.is_err());
+        assert_matches!(lit, Err(_));
     }
 
     #[test]
@@ -409,7 +410,7 @@ mod tests {
         for (input, exptected, err) in cs {
             if err {
                 let lit = BinaryLiteral::from_bit_str(input);
-                assert!(lit.is_err(), "input: {}, lit: {:?}", input, lit);
+                assert_matches!(lit, Err(_), "input: {}, lit: {:?}", input, lit);
             } else {
                 let lit = BinaryLiteral::from_bit_str(input).unwrap();
                 assert_eq!(lit.0, exptected);
@@ -459,11 +460,9 @@ mod tests {
         let mut ctx = EvalContext::default();
         for (s, expected, err) in cs {
             if err {
-                assert!(
-                    BinaryLiteral::from_hex_str(s)
-                        .unwrap()
-                        .to_uint(&mut ctx)
-                        .is_err()
+                assert_matches!(
+                    BinaryLiteral::from_hex_str(s).unwrap().to_uint(&mut ctx),
+                    Err(_)
                 );
             } else {
                 let lit = BinaryLiteral::from_hex_str(s).unwrap();

--- a/components/tidb_query_datatype/src/codec/mysql/decimal.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/decimal.rs
@@ -2397,6 +2397,7 @@ mod tests {
 
     use crate::codec::error::ERR_DATA_OUT_OF_RANGE;
     use crate::expr::{EvalConfig, Flag};
+    use std::assert_matches::assert_matches;
     use std::cmp::Ordering;
     use std::collections::hash_map::DefaultHasher;
     use std::f64::EPSILON;
@@ -2484,7 +2485,7 @@ mod tests {
             );
             match expect {
                 Err(e) => {
-                    assert!(r.is_err(), "{}", log.as_str());
+                    assert_matches!(r, Err(_), "{}", log.as_str());
                     match e {
                         Error::InvalidDataType(_) => (),
                         _ => panic!("{}", log.as_str()),
@@ -3029,7 +3030,7 @@ mod tests {
         // error cases
         let cases = vec![b"1e18446744073709551620"];
         for case in cases {
-            assert!(Decimal::from_bytes(case).is_err());
+            assert_matches!(Decimal::from_bytes(case),Err(_));
         }
     }
 
@@ -3683,7 +3684,7 @@ mod tests {
         // OVERFLOWING
         let big = (0..85).map(|_| '9').collect::<String>();
         let val: Result<Decimal> = big.as_bytes().convert(&mut ctx);
-        assert!(val.is_err(), "expected error, but got {:?}", val);
+        assert_matches!(val, Err(_), "expected error, but got {:?}", val);
         assert_eq!(val.unwrap_err().code(), ERR_DATA_OUT_OF_RANGE);
 
         // OVERFLOW_AS_WARNING

--- a/components/tidb_query_datatype/src/codec/mysql/json/json_keys.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/json/json_keys.rs
@@ -53,7 +53,9 @@ fn json_keys(j: &JsonRef<'_>) -> Result<Option<Json>> {
 mod tests {
     use super::super::path_expr::parse_json_path_expr;
     use super::*;
+    use std::assert_matches::assert_matches;
     use std::str::FromStr;
+
     #[test]
     fn test_json_keys() {
         let mut test_cases = vec![
@@ -123,7 +125,7 @@ mod tests {
                     i, expected, result,
                 );
             } else {
-                assert!(got.is_err(), "#{} expect modify error but got {:?}", i, got);
+                assert_matches!(got, Err(_), "#{} expect modify error but got {:?}", i, got);
             }
         }
     }

--- a/components/tidb_query_datatype/src/codec/mysql/json/json_remove.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/json/json_remove.rs
@@ -30,6 +30,7 @@ impl<'a> JsonRef<'a> {
 mod tests {
     use super::super::path_expr::parse_json_path_expr;
     use super::*;
+    use std::assert_matches::assert_matches;
 
     #[test]
     fn test_json_remove() {
@@ -72,7 +73,7 @@ mod tests {
                 let j = r.unwrap();
                 assert_eq!(e, j, "#{} expect remove json {:?} == {:?}", i, j, e);
             } else {
-                assert!(r.is_err(), "#{} expect remove error but got {:?}", i, r);
+                assert_matches!(r, Err(_), "#{} expect remove error but got {:?}", i, r);
             }
         }
     }

--- a/components/tidb_query_datatype/src/codec/mysql/json/json_unquote.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/json/json_unquote.rs
@@ -83,6 +83,7 @@ fn decode_escaped_unicode(s: &str) -> Result<char> {
 mod tests {
     use super::super::Json;
     use super::*;
+    use std::assert_matches::assert_matches;
     use std::collections::BTreeMap;
 
     #[test]
@@ -137,7 +138,7 @@ mod tests {
                     i, expected, got
                 );
             } else {
-                assert!(r.is_err(), "#{} expected error but got {:?}", i, r);
+                assert_matches!(r, Err(_), "#{} expected error but got {:?}", i, r);
             }
         }
 

--- a/components/tidb_query_datatype/src/codec/mysql/json/mod.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/json/mod.rs
@@ -494,6 +494,7 @@ impl crate::codec::data_type::AsMySQLBool for Json {
 mod tests {
     use super::*;
 
+    use std::assert_matches::assert_matches;
     use std::sync::Arc;
 
     use crate::codec::error::ERR_TRUNCATE_WRONG_VALUE;
@@ -530,7 +531,7 @@ mod tests {
             ],
         ];
         for d in cases {
-            assert!(json_object(d).is_err());
+            assert_matches!(json_object(d), Err(_));
         }
 
         let cases = vec![

--- a/components/tidb_query_datatype/src/codec/mysql/json/path_expr.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/json/path_expr.rs
@@ -150,6 +150,8 @@ pub fn parse_json_path_expr(path_expr: &str) -> Result<PathExpression> {
 mod tests {
     use super::*;
 
+    use std::assert_matches::assert_matches;
+
     #[test]
     fn test_path_expression_flag() {
         let mut e = PathExpression {
@@ -227,7 +229,7 @@ mod tests {
                     i, expected, got
                 );
             } else {
-                assert!(r.is_err(), "#{} expect error but got {:?}", i, r);
+                assert_matches!(r, Err(_), "#{} expect error but got {:?}", i, r);
             }
         }
     }

--- a/components/tidb_query_datatype/src/codec/mysql/json/serde.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/json/serde.rs
@@ -216,6 +216,7 @@ impl<'de> Deserialize<'de> for Json {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches::assert_matches;
 
     #[test]
     fn test_from_str_for_object() {
@@ -264,7 +265,7 @@ mod tests {
         let illegal_cases = vec!["[pxx,apaa]", "hpeheh", ""];
         for json_str in illegal_cases {
             let resp = Json::from_str(json_str);
-            assert!(resp.is_err());
+            assert_matches!(resp, Err(_));
         }
     }
 }

--- a/components/tidb_query_datatype/src/codec/mysql/time/mod.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/time/mod.rs
@@ -2564,7 +2564,7 @@ mod tests {
                 strict_mode: true,
                 ..TimeEnv::default()
             });
-            assert_matches!(Time::parse_datetime(&mut ctx, case, 0, false));
+            assert_matches!(Time::parse_datetime(&mut ctx, case, 0, false),Err(_));
         }
 
         Ok(())

--- a/components/tidb_query_datatype/src/codec/mysql/time/mod.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/time/mod.rs
@@ -2564,7 +2564,7 @@ mod tests {
                 strict_mode: true,
                 ..TimeEnv::default()
             });
-            assert_matches!(Time::parse_datetime(&mut ctx, case, 0, false)v);
+            assert_matches!(Time::parse_datetime(&mut ctx, case, 0, false));
         }
 
         Ok(())

--- a/components/tidb_query_datatype/src/codec/mysql/time/mod.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/time/mod.rs
@@ -1961,6 +1961,7 @@ mod tests {
     use crate::codec::mysql::{MAX_FSP, UNSPECIFIED_FSP};
     use crate::expr::EvalConfig;
 
+    use std::assert_matches::assert_matches;
     use std::sync::Arc;
 
     #[derive(Debug)]
@@ -2042,7 +2043,10 @@ mod tests {
 
         let should_fail = vec![-1111, 1, 100, 700_100, 100_000_000, 100_000_101_000_000];
         for case in should_fail {
-            assert!(Time::parse_from_i64(&mut ctx, case, TimeType::DateTime, 0).is_err());
+            assert_matches!(
+                Time::parse_from_i64(&mut ctx, case, TimeType::DateTime, 0),
+                Err(_)
+            );
         }
         Ok(())
     }
@@ -2153,7 +2157,7 @@ mod tests {
         ];
 
         for case in should_fail {
-            assert!(Time::parse_date(&mut ctx, case).is_err());
+            assert_matches!(Time::parse_date(&mut ctx, case), Err(_));
         }
         Ok(())
     }
@@ -2266,7 +2270,7 @@ mod tests {
         ];
 
         for (case, fsp) in should_fail {
-            assert!(Time::parse_datetime(&mut ctx, case, fsp, false).is_err());
+            assert_matches!(Time::parse_datetime(&mut ctx, case, fsp, false), Err(_));
         }
         Ok(())
     }
@@ -2525,7 +2529,10 @@ mod tests {
             ..TimeEnv::default()
         });
 
-        assert!(Time::parse_datetime(&mut ctx, "0000-00-00 00:00:00", 0, false).is_err());
+        assert_matches!(
+            Time::parse_datetime(&mut ctx, "0000-00-00 00:00:00", 0, false),
+            Err(_)
+        );
 
         // Enable NO_ZERO_DATE, STRICT_MODE and IGNORE_TRUNCATE.
         // If zero-date is encountered, an error is returned.
@@ -2557,7 +2564,7 @@ mod tests {
                 strict_mode: true,
                 ..TimeEnv::default()
             });
-            assert!(Time::parse_datetime(&mut ctx, case, 0, false).is_err());
+            assert_matches!(Time::parse_datetime(&mut ctx, case, 0, false)v);
         }
 
         Ok(())
@@ -2603,7 +2610,7 @@ mod tests {
                 strict_mode: true,
                 ..TimeEnv::default()
             });
-            assert!(Time::parse_datetime(&mut ctx, case, 0, false).is_err());
+            assert_matches!(Time::parse_datetime(&mut ctx, case, 0, false), Err(_));
         }
 
         Ok(())

--- a/components/tidb_query_datatype/src/codec/table.rs
+++ b/components/tidb_query_datatype/src/codec/table.rs
@@ -544,6 +544,7 @@ mod tests {
     use collections::{HashMap, HashSet};
 
     use super::*;
+    use std::assert_matches::assert_matches;
 
     const TABLE_ID: i64 = 1;
     const INDEX_ID: i64 = 1;
@@ -791,13 +792,13 @@ mod tests {
         let mut range = KeyRange::default();
         range.set_end(small_key.clone());
         range.set_start(large_key);
-        assert!(check_table_ranges(&[range]).is_err());
+        assert_matches!(check_table_ranges(&[range]), Err(_));
 
         // test invalid end
         let mut range = KeyRange::default();
         range.set_start(small_key);
         range.set_end(b"xx".to_vec());
-        assert!(check_table_ranges(&[range]).is_err());
+        assert_matches!(check_table_ranges(&[range]), Err(_));
     }
 
     #[test]
@@ -808,7 +809,7 @@ mod tests {
             assert_eq!(tid, decode_table_id(&k).unwrap());
             let k = encode_index_seek_key(tid, 1, &k);
             assert_eq!(tid, decode_table_id(&k).unwrap());
-            assert!(decode_table_id(b"xxx").is_err());
+            assert_matches!(decode_table_id(b"xxx"), Err(_));
         }
     }
 
@@ -816,15 +817,27 @@ mod tests {
     fn test_check_key_type() {
         let record_key = encode_row_key(TABLE_ID, 1);
         assert!(check_key_type(record_key.as_slice(), RECORD_PREFIX_SEP).is_ok());
-        assert!(check_key_type(record_key.as_slice(), INDEX_PREFIX_SEP).is_err());
+        assert_matches!(
+            check_key_type(record_key.as_slice(), INDEX_PREFIX_SEP),
+            Err(_)
+        );
 
         let (_, index_key) =
             generate_index_data_for_test(TABLE_ID, INDEX_ID, 1, &Datum::I64(1), true);
-        assert!(check_key_type(index_key.as_slice(), RECORD_PREFIX_SEP).is_err());
+        assert_matches!(
+            check_key_type(index_key.as_slice(), RECORD_PREFIX_SEP),
+            Err(_)
+        );
         assert!(check_key_type(index_key.as_slice(), INDEX_PREFIX_SEP).is_ok());
 
         let too_small_key = vec![0];
-        assert!(check_key_type(too_small_key.as_slice(), RECORD_PREFIX_SEP).is_err());
-        assert!(check_key_type(too_small_key.as_slice(), INDEX_PREFIX_SEP).is_err());
+        assert_matches!(
+            check_key_type(too_small_key.as_slice(), RECORD_PREFIX_SEP),
+            Err(_)
+        );
+        assert_matches!(
+            check_key_type(too_small_key.as_slice(), INDEX_PREFIX_SEP),
+            Err(_)
+        );
     }
 }

--- a/components/tidb_query_datatype/src/def/eval_type.rs
+++ b/components/tidb_query_datatype/src/def/eval_type.rs
@@ -91,6 +91,7 @@ mod tests {
     use super::*;
     use crate::FieldTypeAccessor;
     use crate::FieldTypeTp::*;
+    use std::assert_matches::assert_matches;
     use std::convert::TryFrom;
 
     #[test]
@@ -135,7 +136,7 @@ mod tests {
             if let Some(etype) = etype {
                 assert_eq!(ftt.unwrap(), etype);
             } else {
-                assert!(ftt.is_err());
+                assert_matches!(ftt, Err(_));
             }
         }
     }

--- a/components/tidb_query_datatype/src/def/field_type.rs
+++ b/components/tidb_query_datatype/src/def/field_type.rs
@@ -419,6 +419,7 @@ impl FieldTypeAccessor for ColumnInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches::assert_matches;
     use std::i32;
 
     fn field_types() -> Vec<FieldTypeTp> {
@@ -515,7 +516,7 @@ mod tests {
             if let Some(c) = expected {
                 assert_eq!(coll.unwrap(), c);
             } else {
-                assert!(coll.is_err());
+                assert_matches!(coll, Err(_));
             }
         }
     }

--- a/components/tidb_query_datatype/src/expr/ctx.rs
+++ b/components/tidb_query_datatype/src/expr/ctx.rs
@@ -326,6 +326,7 @@ impl EvalContext {
 mod tests {
     use super::super::Error;
     use super::*;
+    use std::assert_matches::assert_matches;
     use std::sync::Arc;
 
     #[test]
@@ -333,7 +334,7 @@ mod tests {
         // ignore_truncate = false, truncate_as_warning = false
         let mut ctx = EvalContext::new(Arc::new(EvalConfig::new()));
         assert!(ctx.handle_truncate(false).is_ok());
-        assert!(ctx.handle_truncate(true).is_err());
+        assert_matches!(ctx.handle_truncate(true), Err(_));
         assert!(ctx.take_warnings().warnings.is_empty());
         // ignore_truncate = false;
         let mut ctx = EvalContext::new(Arc::new(EvalConfig::default_for_test()));

--- a/components/tidb_query_datatype/src/lib.rs
+++ b/components/tidb_query_datatype/src/lib.rs
@@ -6,6 +6,7 @@
 #![feature(min_specialization)]
 #![feature(test)]
 #![feature(str_internals)]
+#![feature(assert_matches)]
 
 #[macro_use]
 extern crate num_derive;

--- a/components/tidb_query_executors/src/lib.rs
+++ b/components/tidb_query_executors/src/lib.rs
@@ -13,6 +13,7 @@
 #![feature(const_fn_fn_ptr_basics)]
 #![feature(const_fn_trait_bound)]
 #![feature(const_mut_refs)]
+#![feature(assert_matches)]
 
 #[macro_use(box_try, warn)]
 extern crate tikv_util;

--- a/components/tidb_query_executors/src/limit_executor.rs
+++ b/components/tidb_query_executors/src/limit_executor.rs
@@ -81,6 +81,7 @@ mod tests {
 
     use crate::util::mock_executor::MockExecutor;
     use crate::util::mock_executor::MockScanExecutor;
+    use std::assert_matches::assert_matches;
     use tidb_query_datatype::codec::batch::LazyBatchColumnVec;
     use tidb_query_datatype::codec::data_type::VectorValue;
     use tidb_query_datatype::expr::EvalWarnings;
@@ -126,7 +127,7 @@ mod tests {
         let r = exec.next_batch(1);
         assert_eq!(&r.logical_rows, &[1, 2]);
         assert_eq!(r.physical_columns.rows_len(), 3);
-        assert!(r.is_drained.is_err());
+        assert_matches!(r.is_drained, Err(_));
     }
 
     #[test]

--- a/components/tidb_query_executors/src/selection_executor.rs
+++ b/components/tidb_query_executors/src/selection_executor.rs
@@ -221,6 +221,7 @@ mod tests {
     use tidb_query_datatype::FieldTypeTp;
 
     use crate::util::mock_executor::MockExecutor;
+    use std::assert_matches::assert_matches;
     use tidb_query_datatype::codec::batch::LazyBatchColumnVec;
     use tidb_query_datatype::expr::EvalWarnings;
 
@@ -659,6 +660,6 @@ mod tests {
 
         let r = exec.next_batch(1);
         assert!(r.logical_rows.is_empty());
-        assert!(r.is_drained.is_err());
+        assert_matches!(r.is_drained, Err(_));
     }
 }

--- a/components/tidb_query_executors/src/table_scan_executor.rs
+++ b/components/tidb_query_executors/src/table_scan_executor.rs
@@ -399,6 +399,7 @@ mod tests {
     use tipb::ColumnInfo;
     use tipb::FieldType;
 
+    use std::assert_matches::assert_matches;
     use tidb_query_common::execute_stats::*;
     use tidb_query_common::storage::test_fixture::FixtureStorage;
     use tidb_query_common::util::convert_to_prefix_next;
@@ -891,7 +892,7 @@ mod tests {
             .unwrap();
 
             let mut result = executor.next_batch(10);
-            assert!(result.is_drained.is_err());
+            assert_matches!(result.is_drained, Err(_));
             assert_eq!(result.physical_columns.columns_len(), 3);
             assert_eq!(result.physical_columns.rows_len(), 2);
             assert!(result.physical_columns[0].is_decoded());
@@ -998,7 +999,7 @@ mod tests {
             .unwrap();
 
             let mut result = executor.next_batch(10);
-            assert!(result.is_drained.is_err());
+            assert_matches!(result.is_drained, Err(_));
             assert_eq!(result.physical_columns.columns_len(), 2);
             assert_eq!(result.physical_columns.rows_len(), 1);
             assert!(result.physical_columns[0].is_decoded());
@@ -1035,7 +1036,7 @@ mod tests {
             .unwrap();
 
             let mut result = executor.next_batch(1);
-            assert!(!result.is_drained.is_err());
+            assert_matches!(!result.is_drained, Err(_));
             assert_eq!(result.physical_columns.columns_len(), 2);
             assert_eq!(result.physical_columns.rows_len(), 1);
             assert!(result.physical_columns[0].is_decoded());
@@ -1053,7 +1054,7 @@ mod tests {
             );
 
             let result = executor.next_batch(1);
-            assert!(result.is_drained.is_err());
+            assert_matches!(result.is_drained, Err(_));
             assert_eq!(result.physical_columns.columns_len(), 2);
             assert_eq!(result.physical_columns.rows_len(), 0);
         }
@@ -1074,7 +1075,7 @@ mod tests {
             .unwrap();
 
             let result = executor.next_batch(10);
-            assert!(result.is_drained.is_err());
+            assert_matches!(result.is_drained, Err(_));
             assert_eq!(result.physical_columns.columns_len(), 2);
             assert_eq!(result.physical_columns.rows_len(), 0);
         }
@@ -1095,7 +1096,7 @@ mod tests {
             .unwrap();
 
             let mut result = executor.next_batch(10);
-            assert!(!result.is_drained.is_err());
+            assert_matches!(!result.is_drained, Err(_));
             assert_eq!(result.physical_columns.columns_len(), 2);
             assert_eq!(result.physical_columns.rows_len(), 2);
             assert!(result.physical_columns[0].is_decoded());
@@ -1129,7 +1130,7 @@ mod tests {
             .unwrap();
 
             let result = executor.next_batch(10);
-            assert!(result.is_drained.is_err());
+            assert_matches!(result.is_drained, Err(_));
             assert_eq!(result.physical_columns.columns_len(), 2);
             assert_eq!(result.physical_columns.rows_len(), 0);
         }

--- a/components/tidb_query_expr/src/impl_arithmetic.rs
+++ b/components/tidb_query_expr/src/impl_arithmetic.rs
@@ -507,6 +507,7 @@ impl ArithmeticOpWithCtx for RealDivide {
 mod tests {
     use super::*;
 
+    use std::assert_matches::assert_matches;
     use std::str::FromStr;
 
     use tidb_query_datatype::builder::FieldTypeBuilder;
@@ -580,7 +581,7 @@ mod tests {
                 .push_param(rhs)
                 .evaluate(ScalarFuncSig::PlusReal);
             if is_err {
-                assert!(output.is_err())
+                assert_matches!(output, Err(_))
             } else {
                 let output = output.unwrap();
                 assert_eq!(output, expected, "lhs={:?}, rhs={:?}", lhs, rhs);
@@ -657,7 +658,7 @@ mod tests {
                 .push_param_with_field_type(rhs, rhs_field_type)
                 .evaluate(ScalarFuncSig::MinusInt);
             if is_err {
-                assert!(output.is_err())
+                assert_matches!(output, Err(_))
             } else {
                 let output = output.unwrap();
                 assert_eq!(output, expected, "lhs={:?}, rhs={:?}", lhs, rhs);
@@ -693,7 +694,7 @@ mod tests {
                 .push_param(rhs)
                 .evaluate(ScalarFuncSig::MinusReal);
             if is_err {
-                assert!(output.is_err())
+                assert_matches!(output, Err(_))
             } else {
                 let output = output.unwrap();
                 assert_eq!(output, expected, "lhs={:?}, rhs={:?}", lhs, rhs);
@@ -965,7 +966,7 @@ mod tests {
                 .push_param_with_field_type(lhs, lhs_field_type)
                 .push_param_with_field_type(rhs, rhs_field_type)
                 .evaluate(ScalarFuncSig::IntDivideInt);
-            assert!(output.is_err(), "lhs={:?}, rhs={:?}", lhs, rhs);
+            assert_matches!(output, Err(_), "lhs={:?}, rhs={:?}", lhs, rhs);
         }
     }
 
@@ -1010,7 +1011,7 @@ mod tests {
                 .push_param(rhs)
                 .evaluate(ScalarFuncSig::IntDivideDecimal);
 
-            assert!(output.is_err(), "lhs={:?}, rhs={:?}", lhs, rhs);
+            assert_matches!(output, Err(_), "lhs={:?}, rhs={:?}", lhs, rhs);
         }
     }
 
@@ -1035,12 +1036,12 @@ mod tests {
         ];
 
         for (lhs, rhs) in should_fail {
-            assert!(
+            assert_matches!(
                 RpnFnScalarEvaluator::new()
                     .push_param(lhs)
                     .push_param(rhs)
-                    .evaluate::<Real>(ScalarFuncSig::MultiplyReal)
-                    .is_err(),
+                    .evaluate::<Real>(ScalarFuncSig::MultiplyReal),
+                Err(_),
                 "{} * {} should fail",
                 lhs,
                 rhs
@@ -1068,12 +1069,12 @@ mod tests {
 
         let should_fail = vec![(std::i64::MAX, 2), (std::i64::MIN, -1)];
         for (lhs, rhs) in should_fail {
-            assert!(
+            assert_matches!(
                 RpnFnScalarEvaluator::new()
                     .push_param_with_field_type(lhs, FieldTypeTp::LongLong)
                     .push_param_with_field_type(rhs, FieldTypeTp::LongLong)
-                    .evaluate::<Int>(ScalarFuncSig::MultiplyInt)
-                    .is_err(),
+                    .evaluate::<Int>(ScalarFuncSig::MultiplyInt),
+                Err(_),
                 "{} * {} should fail",
                 lhs,
                 rhs
@@ -1103,7 +1104,7 @@ mod tests {
 
         let should_fail = vec![(-2, 1), (std::i64::MIN, 2)];
         for (lhs, rhs) in should_fail {
-            assert!(
+            assert_matches!(
                 RpnFnScalarEvaluator::new()
                     .push_param_with_field_type(lhs, FieldTypeTp::LongLong)
                     .push_param_with_field_type(
@@ -1112,8 +1113,8 @@ mod tests {
                             .tp(FieldTypeTp::LongLong)
                             .flag(FieldTypeFlag::UNSIGNED)
                     )
-                    .evaluate::<Int>(ScalarFuncSig::MultiplyInt)
-                    .is_err(),
+                    .evaluate::<Int>(ScalarFuncSig::MultiplyInt),
+                Err(_),
                 "{} * {} should fail",
                 lhs,
                 rhs
@@ -1152,7 +1153,7 @@ mod tests {
 
         let should_fail = vec![(std::u64::MAX as i64, 2)];
         for (lhs, rhs) in should_fail {
-            assert!(
+            assert_matches!(
                 RpnFnScalarEvaluator::new()
                     .push_param_with_field_type(
                         lhs,
@@ -1166,8 +1167,8 @@ mod tests {
                             .tp(FieldTypeTp::LongLong)
                             .flag(FieldTypeFlag::UNSIGNED)
                     )
-                    .evaluate::<Int>(ScalarFuncSig::MultiplyIntUnsigned)
-                    .is_err(),
+                    .evaluate::<Int>(ScalarFuncSig::MultiplyIntUnsigned),
+                Err(_),
                 "{} * {} should fail",
                 lhs,
                 rhs
@@ -1220,12 +1221,12 @@ mod tests {
 
         let overflow = vec![(std::f64::MAX, 0.0001)];
         for (lhs, rhs) in overflow {
-            assert!(
+            assert_matches!(
                 RpnFnScalarEvaluator::new()
                     .push_param(lhs)
                     .push_param(rhs)
-                    .evaluate::<Real>(ScalarFuncSig::DivideReal)
-                    .is_err()
+                    .evaluate::<Real>(ScalarFuncSig::DivideReal),
+                Err(_)
             )
         }
     }
@@ -1295,7 +1296,7 @@ mod tests {
                 if is_ok {
                     assert!(result.unwrap().is_none());
                 } else {
-                    assert!(result.is_err());
+                    assert_matches!(result, Err(_));
                 }
 
                 if has_warning {

--- a/components/tidb_query_expr/src/impl_cast.rs
+++ b/components/tidb_query_expr/src/impl_cast.rs
@@ -1443,6 +1443,7 @@ mod tests {
     use crate::impl_cast::*;
     use crate::types::test_util::RpnFnScalarEvaluator;
     use crate::RpnFnCallExtra;
+    use std::assert_matches::assert_matches;
     use std::collections::BTreeMap;
     use std::fmt::{Debug, Display};
     use std::sync::Arc;
@@ -2373,7 +2374,7 @@ mod tests {
                 assert!(output.is_ok(), "input: {:?}", input);
                 assert_eq!(output.unwrap().unwrap(), exp, "input={:?}", input);
             } else {
-                assert!(output.is_err());
+                assert_matches!(output, Err(_));
             }
         }
     }
@@ -3602,7 +3603,7 @@ mod tests {
                     input
                 );
             } else {
-                assert!(output.is_err());
+                assert_matches!(output, Err(_));
             }
         }
     }
@@ -6046,7 +6047,7 @@ mod tests {
                                 ctx.warnings.warnings,
                                 expect_err
                             );
-                            assert!(result.is_err(), "log: {}", log)
+                            assert_matches!(result, Err(_), "log: {}", log)
                         }
                     },
                     Ok(v) => {

--- a/components/tidb_query_expr/src/impl_encryption.rs
+++ b/components/tidb_query_expr/src/impl_encryption.rs
@@ -195,6 +195,7 @@ pub fn random_bytes(_ctx: &mut EvalContext, arg: Option<&Int>) -> Result<Option<
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches::assert_matches;
     use tipb::ScalarFuncSig;
 
     use super::*;
@@ -447,11 +448,11 @@ mod tests {
         ];
 
         for len in overflow_tests {
-            assert!(
+            assert_matches!(
                 RpnFnScalarEvaluator::new()
                     .push_param(len)
-                    .evaluate::<Bytes>(ScalarFuncSig::RandomBytes)
-                    .is_err(),
+                    .evaluate::<Bytes>(ScalarFuncSig::RandomBytes),
+                Err(_)
             );
         }
 

--- a/components/tidb_query_expr/src/impl_json.rs
+++ b/components/tidb_query_expr/src/impl_json.rs
@@ -335,6 +335,8 @@ mod tests {
 
     use crate::types::test_util::RpnFnScalarEvaluator;
 
+    use std::assert_matches::assert_matches;
+
     #[test]
     fn test_json_depth() {
         let cases = vec![
@@ -585,7 +587,7 @@ mod tests {
                 .push_params(err_args)
                 .evaluate(ScalarFuncSig::JsonObjectSig);
 
-            assert!(output.is_err());
+            assert_matches!(output, Err(_));
         }
     }
 
@@ -949,7 +951,7 @@ mod tests {
             if is_success {
                 assert_eq!(output.unwrap(), expected, "{:?}", vargs);
             } else {
-                assert!(output.is_err());
+                assert_matches!(output, Err(_));
             }
         }
     }

--- a/components/tidb_query_expr/src/impl_math.rs
+++ b/components/tidb_query_expr/src/impl_math.rs
@@ -698,6 +698,7 @@ impl Default for MySQLRng {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches::assert_matches;
     use std::str::FromStr;
     use std::{f64, i64};
     use tidb_query_datatype::builder::FieldTypeBuilder;
@@ -838,7 +839,7 @@ mod tests {
             let output = RpnFnScalarEvaluator::new().push_param(arg).evaluate(sig);
 
             if is_err {
-                assert!(output.is_err());
+                assert_matches!(output, Err(_));
             } else {
                 let output = output.unwrap();
                 assert_eq!(output, expect_output, "{:?}", arg);
@@ -1185,7 +1186,7 @@ mod tests {
             let output: Result<Option<Real>> = RpnFnScalarEvaluator::new()
                 .push_param(Some(Real::from(x)))
                 .evaluate(ScalarFuncSig::Exp);
-            assert!(output.is_err());
+            assert_matches!(output, Err(_));
         }
     }
 
@@ -1294,11 +1295,11 @@ mod tests {
                 .unwrap();
             assert!((output.unwrap().into_inner() - expect).abs() < std::f64::EPSILON);
         }
-        assert!(
+        assert_matches!(
             RpnFnScalarEvaluator::new()
                 .push_param(Some(Real::from(0.0_f64)))
-                .evaluate::<Real>(ScalarFuncSig::Cot)
-                .is_err()
+                .evaluate::<Real>(ScalarFuncSig::Cot),
+            Err(_)
         );
     }
 
@@ -1348,12 +1349,12 @@ mod tests {
         ];
 
         for (lhs, rhs) in invalid_cases {
-            assert!(
+            assert_matches!(
                 RpnFnScalarEvaluator::new()
                     .push_param(lhs)
                     .push_param(rhs)
-                    .evaluate::<Real>(ScalarFuncSig::Pow)
-                    .is_err()
+                    .evaluate::<Real>(ScalarFuncSig::Pow),
+                Err(_)
             );
         }
     }

--- a/components/tidb_query_expr/src/impl_op.rs
+++ b/components/tidb_query_expr/src/impl_op.rs
@@ -268,6 +268,7 @@ mod tests {
 
     use super::*;
     use crate::test_util::RpnFnScalarEvaluator;
+    use std::assert_matches::assert_matches;
     use tidb_query_datatype::codec::mysql::TimeType;
     use tidb_query_datatype::expr::EvalContext;
 
@@ -402,7 +403,7 @@ mod tests {
                 .unwrap();
             assert_eq!(output, expect_output, "{:?}", arg);
         }
-        assert!(
+        assert_matches!(
             RpnFnScalarEvaluator::new()
                 .push_param_with_field_type(
                     Some((std::i64::MAX as u64 + 2) as i64),
@@ -411,8 +412,8 @@ mod tests {
                         .flag(FieldTypeFlag::UNSIGNED)
                         .build()
                 )
-                .evaluate::<Int>(ScalarFuncSig::UnaryMinusInt)
-                .is_err()
+                .evaluate::<Int>(ScalarFuncSig::UnaryMinusInt),
+            Err(_)
         );
 
         let signed_test_cases = vec![
@@ -429,11 +430,11 @@ mod tests {
                 .unwrap();
             assert_eq!(output, expect_output, "{:?}", arg);
         }
-        assert!(
+        assert_matches!(
             RpnFnScalarEvaluator::new()
                 .push_param(std::i64::MIN)
-                .evaluate::<Int>(ScalarFuncSig::UnaryMinusInt)
-                .is_err()
+                .evaluate::<Int>(ScalarFuncSig::UnaryMinusInt),
+            Err(_)
         );
     }
 

--- a/components/tidb_query_expr/src/impl_string.rs
+++ b/components/tidb_query_expr/src/impl_string.rs
@@ -1050,6 +1050,7 @@ fn substring(input: BytesRef, pos: Int, len: Int, writer: BytesWriter) -> Result
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches::assert_matches;
     use std::{f64, i64};
 
     use tidb_query_datatype::builder::FieldTypeBuilder;
@@ -3775,7 +3776,7 @@ mod tests {
             .push_param(args.1)
             .push_param(args.2)
             .evaluate(ScalarFuncSig::Trim3Args);
-        assert!(got.is_err());
+        assert_matches!(got, Err(_));
 
         let invalid_utf8_cases = vec![
             (
@@ -3865,7 +3866,7 @@ mod tests {
             let output = RpnFnScalarEvaluator::new()
                 .push_param(arg)
                 .evaluate::<i64>(ScalarFuncSig::CharLengthUtf8);
-            assert!(output.is_err());
+            assert_matches!(output, Err(_));
         }
     }
 

--- a/components/tidb_query_expr/src/impl_time.rs
+++ b/components/tidb_query_expr/src/impl_time.rs
@@ -885,6 +885,7 @@ fn datetime_to_string(mut datetime: DateTime) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches::assert_matches;
 
     use tipb::ScalarFuncSig;
 
@@ -2355,7 +2356,7 @@ mod tests {
                         .build(),
                 )
                 .evaluate::<Duration>(ScalarFuncSig::MakeTime);
-            assert!(output.is_err());
+            assert_matches!(output, Err(_));
         }
     }
 

--- a/components/tidb_query_expr/src/lib.rs
+++ b/components/tidb_query_expr/src/lib.rs
@@ -14,6 +14,7 @@
 #![feature(const_fn_fn_ptr_basics)]
 #![feature(const_fn_trait_bound)]
 #![feature(const_mut_refs)]
+#![feature(assert_matches)]
 
 #[macro_use(box_err, box_try, try_opt)]
 extern crate tikv_util;

--- a/components/tidb_query_expr/src/types/expr_builder.rs
+++ b/components/tidb_query_expr/src/types/expr_builder.rs
@@ -477,6 +477,7 @@ mod tests {
     use tipb::ScalarFuncSig;
     use tipb_helper::ExprDefBuilder;
 
+    use std::assert_matches::assert_matches;
     use tidb_query_common::Result;
 
     /// An RPN function for test. It accepts 1 int argument, returns float.
@@ -568,14 +569,14 @@ mod tests {
             .push_child(ExprDefBuilder::constant_real(3.0))
             .build();
         let exp = RpnExpressionBuilder::build_from_expr_tree_with_fn_mapper(node, fn_mapper, 0);
-        assert!(exp.is_err());
+        assert_matches!(exp, Err(_));
 
         // Incorrect number of arguments
         let node = ExprDefBuilder::scalar_func(ScalarFuncSig::CastIntAsTime, FieldTypeTp::VarChar)
             .push_child(ExprDefBuilder::constant_int(1))
             .build();
         let exp = RpnExpressionBuilder::build_from_expr_tree_with_fn_mapper(node, fn_mapper, 0);
-        assert!(exp.is_err());
+        assert_matches!(exp, Err(_));
 
         let node = ExprDefBuilder::scalar_func(ScalarFuncSig::CastIntAsTime, FieldTypeTp::VarChar)
             .push_child(ExprDefBuilder::constant_int(1))
@@ -583,7 +584,7 @@ mod tests {
             .push_child(ExprDefBuilder::constant_real(1.0))
             .build();
         let exp = RpnExpressionBuilder::build_from_expr_tree_with_fn_mapper(node, fn_mapper, 0);
-        assert!(exp.is_err());
+        assert_matches!(exp, Err(_));
 
         // Incorrect argument type
         let node = ExprDefBuilder::scalar_func(ScalarFuncSig::CastIntAsTime, FieldTypeTp::VarChar)
@@ -591,7 +592,7 @@ mod tests {
             .push_child(ExprDefBuilder::constant_int(5))
             .build();
         let exp = RpnExpressionBuilder::build_from_expr_tree_with_fn_mapper(node, fn_mapper, 0);
-        assert!(exp.is_err());
+        assert_matches!(exp, Err(_));
     }
 
     #[test]
@@ -627,7 +628,7 @@ mod tests {
                 .push_child(ExprDefBuilder::constant_int(1))
                 .build();
         let exp = RpnExpressionBuilder::build_from_expr_tree_with_fn_mapper(node, fn_mapper, 0);
-        assert!(exp.is_err());
+        assert_matches!(exp, Err(_));
 
         // Incorrect argument type
         let node =
@@ -635,7 +636,7 @@ mod tests {
                 .push_child(ExprDefBuilder::constant_real(1.0))
                 .build();
         let exp = RpnExpressionBuilder::build_from_expr_tree_with_fn_mapper(node, fn_mapper, 0);
-        assert!(exp.is_err());
+        assert_matches!(exp, Err(_));
 
         let node =
             ExprDefBuilder::scalar_func(ScalarFuncSig::CastIntAsDuration, FieldTypeTp::Double)
@@ -643,7 +644,7 @@ mod tests {
                 .push_child(ExprDefBuilder::constant_real(1.0))
                 .build();
         let exp = RpnExpressionBuilder::build_from_expr_tree_with_fn_mapper(node, fn_mapper, 0);
-        assert!(exp.is_err());
+        assert_matches!(exp, Err(_));
 
         let node =
             ExprDefBuilder::scalar_func(ScalarFuncSig::CastIntAsDuration, FieldTypeTp::Double)
@@ -651,7 +652,7 @@ mod tests {
                 .push_child(ExprDefBuilder::constant_real(1.0))
                 .build();
         let exp = RpnExpressionBuilder::build_from_expr_tree_with_fn_mapper(node, fn_mapper, 0);
-        assert!(exp.is_err());
+        assert_matches!(exp, Err(_));
 
         let node =
             ExprDefBuilder::scalar_func(ScalarFuncSig::CastIntAsDuration, FieldTypeTp::Double)
@@ -660,7 +661,7 @@ mod tests {
                 .push_child(ExprDefBuilder::constant_int(1))
                 .build();
         let exp = RpnExpressionBuilder::build_from_expr_tree_with_fn_mapper(node, fn_mapper, 0);
-        assert!(exp.is_err());
+        assert_matches!(exp, Err(_));
     }
 
     #[test]
@@ -678,7 +679,7 @@ mod tests {
             .push_child(ExprDefBuilder::constant_real(3.0))
             .build();
         let exp = RpnExpressionBuilder::build_from_expr_tree_with_fn_mapper(node, fn_mapper, 0);
-        assert!(exp.is_err());
+        assert_matches!(exp, Err(_));
 
         // Incorrect return type
         let node = ExprDefBuilder::scalar_func(ScalarFuncSig::CastIntAsJson, FieldTypeTp::Double)
@@ -686,7 +687,7 @@ mod tests {
             .push_child(ExprDefBuilder::constant_real(5.0))
             .build();
         let exp = RpnExpressionBuilder::build_from_expr_tree_with_fn_mapper(node, fn_mapper, 0);
-        assert!(exp.is_err());
+        assert_matches!(exp, Err(_));
 
         // Incorrect types
         let node = ExprDefBuilder::scalar_func(ScalarFuncSig::CastIntAsJson, FieldTypeTp::LongLong)
@@ -695,7 +696,7 @@ mod tests {
             .push_child(ExprDefBuilder::constant_int(42))
             .build();
         let exp = RpnExpressionBuilder::build_from_expr_tree_with_fn_mapper(node, fn_mapper, 0);
-        assert!(exp.is_err());
+        assert_matches!(exp, Err(_));
     }
 
     #[test]
@@ -712,7 +713,7 @@ mod tests {
         let node =
             ExprDefBuilder::scalar_func(ScalarFuncSig::CastRealAsInt, FieldTypeTp::Double).build();
         let exp = RpnExpressionBuilder::build_from_expr_tree_with_fn_mapper(node, fn_mapper, 0);
-        assert!(exp.is_err());
+        assert_matches!(exp, Err(_));
 
         // Incorrect return type
         let node = ExprDefBuilder::scalar_func(ScalarFuncSig::CastRealAsInt, FieldTypeTp::LongLong)
@@ -720,7 +721,7 @@ mod tests {
             .push_child(ExprDefBuilder::constant_int(5))
             .build();
         let exp = RpnExpressionBuilder::build_from_expr_tree_with_fn_mapper(node, fn_mapper, 0);
-        assert!(exp.is_err());
+        assert_matches!(exp, Err(_));
     }
 
     #[test]
@@ -821,16 +822,16 @@ mod tests {
     fn test_max_columns_check() {
         // Col offset = 0. The minimum success max_columns is 1.
         let node = ExprDefBuilder::column_ref(0, FieldTypeTp::LongLong).build();
-        assert!(
-            RpnExpressionBuilder::build_from_expr_tree_with_fn_mapper(node.clone(), fn_mapper, 0)
-                .is_err()
+        assert_matches!(
+            RpnExpressionBuilder::build_from_expr_tree_with_fn_mapper(node.clone(), fn_mapper, 0),
+            Err(_)
         );
         for i in 1..10 {
             assert!(
                 RpnExpressionBuilder::build_from_expr_tree_with_fn_mapper(
                     node.clone(),
                     fn_mapper,
-                    i
+                    i,
                 )
                 .is_ok()
             );
@@ -839,13 +840,13 @@ mod tests {
         // Col offset = 3. The minimum success max_columns is 4.
         let node = ExprDefBuilder::column_ref(3, FieldTypeTp::LongLong).build();
         for i in 0..=3 {
-            assert!(
+            assert_matches!(
                 RpnExpressionBuilder::build_from_expr_tree_with_fn_mapper(
                     node.clone(),
                     fn_mapper,
-                    i
-                )
-                .is_err()
+                    i,
+                ),
+                Err(_)
             );
         }
         for i in 4..10 {
@@ -853,7 +854,7 @@ mod tests {
                 RpnExpressionBuilder::build_from_expr_tree_with_fn_mapper(
                     node.clone(),
                     fn_mapper,
-                    i
+                    i,
                 )
                 .is_ok()
             );
@@ -868,13 +869,13 @@ mod tests {
                 .build();
 
         for i in 0..=5 {
-            assert!(
+            assert_matches!(
                 RpnExpressionBuilder::build_from_expr_tree_with_fn_mapper(
                     node.clone(),
                     fn_mapper,
-                    i
-                )
-                .is_err()
+                    i,
+                ),
+                Err(_)
             );
         }
         for i in 6..10 {
@@ -882,7 +883,7 @@ mod tests {
                 RpnExpressionBuilder::build_from_expr_tree_with_fn_mapper(
                     node.clone(),
                     fn_mapper,
-                    i
+                    i,
                 )
                 .is_ok()
             );

--- a/components/tidb_query_expr/src/types/expr_eval.rs
+++ b/components/tidb_query_expr/src/types/expr_eval.rs
@@ -282,6 +282,7 @@ mod tests {
     use crate::impl_arithmetic::*;
     use crate::impl_compare::*;
     use crate::{RpnExpressionBuilder, RpnFnMeta};
+    use std::assert_matches::assert_matches;
     use test::{black_box, Bencher};
     use tidb_query_common::Result;
     use tidb_query_datatype::codec::batch::LazyBatchColumn;
@@ -407,7 +408,7 @@ mod tests {
             // smaller row number
             let _ = exp.eval(&mut ctx, &schema, &mut c, &logical_rows, 4);
         });
-        assert!(hooked_eval.is_err());
+        assert_matches!(hooked_eval, Err(_));
 
         let mut c = columns;
         let exp = RpnExpressionBuilder::new_for_test()
@@ -418,7 +419,7 @@ mod tests {
             // larger row number
             let _ = exp.eval(&mut ctx, &schema, &mut c, &logical_rows, 6);
         });
-        assert!(hooked_eval.is_err());
+        assert_matches!(hooked_eval, Err(_));
     }
 
     /// Single function call node (i.e. nullary function)
@@ -912,7 +913,7 @@ mod tests {
         let hooked_eval = panic_hook::recover_safe(|| {
             let _ = exp.eval(&mut ctx, &[], &mut columns, &[], 3);
         });
-        assert!(hooked_eval.is_err());
+        assert_matches!(hooked_eval, Err(_));
     }
 
     /// Irregular RPN expression (contains unused node). Should panic.
@@ -936,7 +937,7 @@ mod tests {
         let hooked_eval = panic_hook::recover_safe(|| {
             let _ = exp.eval(&mut ctx, &[], &mut columns, &[], 3);
         });
-        assert!(hooked_eval.is_err());
+        assert_matches!(hooked_eval, Err(_));
     }
 
     /// Eval type does not match. Should panic.
@@ -958,7 +959,7 @@ mod tests {
         let hooked_eval = panic_hook::recover_safe(|| {
             let _ = exp.eval(&mut ctx, &[], &mut columns, &[], 3);
         });
-        assert!(hooked_eval.is_err());
+        assert_matches!(hooked_eval, Err(_));
     }
 
     /// Parse from an expression tree then evaluate.

--- a/components/tikv_kv/src/btree_engine.rs
+++ b/components/tikv_kv/src/btree_engine.rs
@@ -290,6 +290,7 @@ pub mod tests {
     use super::*;
     use crate::{Cursor, ScanMode};
     use engine_traits::IterOptions;
+    use std::assert_matches::assert_matches;
 
     #[test]
     fn test_btree_engine() {
@@ -407,6 +408,9 @@ pub mod tests {
     #[test]
     fn test_get_not_exist_cf() {
         let engine = BTreeEngine::new(&[]);
-        assert!(::panic_hook::recover_safe(|| engine.get_cf("not_exist_cf")).is_err());
+        assert_matches!(
+            ::panic_hook::recover_safe(|| engine.get_cf("not_exist_cf")),
+            Err(_)
+        );
     }
 }

--- a/components/tikv_kv/src/cursor.rs
+++ b/components/tikv_kv/src/cursor.rs
@@ -569,6 +569,7 @@ mod tests {
     use engine_traits::{IterOptions, SyncMutable, CF_DEFAULT};
     use keys::data_key;
     use kvproto::metapb::{Peer, Region};
+    use std::assert_matches::assert_matches;
     use std::sync::Arc;
     use tempfile::Builder;
     use txn_types::Key;
@@ -637,9 +638,9 @@ mod tests {
             iter.seek(&Key::from_encoded_slice(b"a3"), &mut statistics)
                 .unwrap()
         );
-        assert!(
-            iter.seek(&Key::from_encoded_slice(b"a9"), &mut statistics)
-                .is_err()
+        assert_matches!(
+            iter.seek(&Key::from_encoded_slice(b"a9"), &mut statistics),
+            Err(_)
         );
 
         assert!(
@@ -651,9 +652,9 @@ mod tests {
             iter.seek_for_prev(&Key::from_encoded_slice(b"a3"), &mut statistics)
                 .unwrap()
         );
-        assert!(
-            iter.seek_for_prev(&Key::from_encoded_slice(b"a1"), &mut statistics)
-                .is_err()
+        assert_matches!(
+            iter.seek_for_prev(&Key::from_encoded_slice(b"a1"), &mut statistics),
+            Err(_)
         );
     }
 
@@ -695,13 +696,13 @@ mod tests {
                 .reverse_seek(&Key::from_encoded_slice(b"a3"), &mut statistics)
                 .unwrap()
         );
-        assert!(
-            iter.reverse_seek(&Key::from_encoded_slice(b"a1"), &mut statistics)
-                .is_err()
+        assert_matches!(
+            iter.reverse_seek(&Key::from_encoded_slice(b"a1"), &mut statistics),
+            Err(_)
         );
-        assert!(
-            iter.reverse_seek(&Key::from_encoded_slice(b"a8"), &mut statistics)
-                .is_err()
+        assert_matches!(
+            iter.reverse_seek(&Key::from_encoded_slice(b"a8"), &mut statistics),
+            Err(_)
         );
 
         assert!(iter.seek_to_last(&mut statistics));

--- a/components/tikv_kv/src/lib.rs
+++ b/components/tikv_kv/src/lib.rs
@@ -6,6 +6,7 @@
 
 #![feature(min_specialization)]
 #![feature(negative_impls)]
+#![feature(assert_matches)]
 
 #[macro_use]
 extern crate derive_more;

--- a/components/tikv_util/src/codec/bytes.rs
+++ b/components/tikv_util/src/codec/bytes.rs
@@ -335,6 +335,7 @@ pub fn is_encoded_from(encoded: &[u8], raw: &[u8], desc: bool) -> bool {
 mod tests {
     use super::*;
     use crate::codec::{bytes, number};
+    use std::assert_matches::assert_matches;
     use std::cmp::Ordering;
 
     #[test]
@@ -440,8 +441,8 @@ mod tests {
         ];
 
         for mut x in invalid_bytes {
-            assert!(decode_bytes(&mut x.as_slice(), false).is_err());
-            assert!(decode_bytes_in_place(&mut x, false).is_err());
+            assert_matches!(decode_bytes(&mut x.as_slice(), false), Err(_));
+            assert_matches!(decode_bytes_in_place(&mut x, false), Err(_));
         }
     }
 

--- a/components/tikv_util/src/config.rs
+++ b/components/tikv_util/src/config.rs
@@ -1529,7 +1529,7 @@ mod tests {
         ];
         for src in illegal_cases {
             let src_str = format!("s = {:?}", src);
-            assert!(toml::from_str::<SizeHolder>(&src_str).is_err(), "{}", src);
+            assert_matches!(toml::from_str::<SizeHolder>(&src_str),Err(_), "{}", src);
         }
     }
 
@@ -1601,7 +1601,7 @@ mod tests {
         let illegal_cases = vec!["1H", "1M", "1S", "1MS", "1h1h", "h"];
         for src in illegal_cases {
             let src_str = format!("d = {:?}", src);
-            assert(toml::from_str::<DurHolder>(&src_str).is_err(), "{}", src);
+            assert_matches!(toml::from_str::<DurHolder>(&src_str),Err(_), "{}", src);
         }
         assert_matches!(toml::from_str::<DurHolder>("d = 23"), Err(_));
     }

--- a/components/tikv_util/src/config.rs
+++ b/components/tikv_util/src/config.rs
@@ -1426,6 +1426,7 @@ mod tests {
     use std::fs::File;
     use std::io::Write;
     use std::path::Path;
+    use std::assert_matches::assert_matches;
 
     use super::*;
     use tempfile::Builder;
@@ -1528,7 +1529,7 @@ mod tests {
         ];
         for src in illegal_cases {
             let src_str = format!("s = {:?}", src);
-            assert_matches!(toml::from_str::<SizeHolder>(&src_str), Err(_), "{}", src);
+            assert!(toml::from_str::<SizeHolder>(&src_str).is_err(), "{}", src);
         }
     }
 
@@ -1600,7 +1601,7 @@ mod tests {
         let illegal_cases = vec!["1H", "1M", "1S", "1MS", "1h1h", "h"];
         for src in illegal_cases {
             let src_str = format!("d = {:?}", src);
-            assert_matches!(toml::from_str::<DurHolder>(&src_str), Err(_), "{}", src);
+            assert(toml::from_str::<DurHolder>(&src_str).is_err(), "{}", src);
         }
         assert_matches!(toml::from_str::<DurHolder>("d = 23"), Err(_));
     }

--- a/components/tikv_util/src/config.rs
+++ b/components/tikv_util/src/config.rs
@@ -1010,6 +1010,7 @@ mod check_data_dir {
 
     #[cfg(test)]
     mod tests {
+        use std::assert_matches::assert_matches;
         use std::fs::File;
         use std::io::Write;
         use std::os::unix::fs::symlink;
@@ -1039,21 +1040,21 @@ securityfs /sys/kernel/security securityfs rw,nosuid,nodev,noexec,relatime 0 0
 
             // not found
             let f2 = get_fs_info("/tmp", &mnt_file);
-            assert!(f2.is_err());
+            assert_matches!(f2, Err(_));
         }
 
         #[test]
         fn test_get_rotational_info() {
             // test device not exist
             let ret = get_rotational_info("/dev/invalid");
-            assert!(ret.is_err());
+            assert_matches!(ret, Err(_));
         }
 
         #[test]
         fn test_check_data_dir() {
             // test invalid data_path
             let ret = check_data_dir("/sys/invalid", "/proc/mounts");
-            assert!(ret.is_err());
+            assert_matches!(ret, Err(_));
             // get real path's fs_info
             let tmp_dir = Builder::new()
                 .prefix("test-check-data-dir")
@@ -1527,7 +1528,7 @@ mod tests {
         ];
         for src in illegal_cases {
             let src_str = format!("s = {:?}", src);
-            assert!(toml::from_str::<SizeHolder>(&src_str).is_err(), "{}", src);
+            assert_matches!(toml::from_str::<SizeHolder>(&src_str), Err(_), "{}", src);
         }
     }
 
@@ -1599,9 +1600,9 @@ mod tests {
         let illegal_cases = vec!["1H", "1M", "1S", "1MS", "1h1h", "h"];
         for src in illegal_cases {
             let src_str = format!("d = {:?}", src);
-            assert!(toml::from_str::<DurHolder>(&src_str).is_err(), "{}", src);
+            assert_matches!(toml::from_str::<DurHolder>(&src_str), Err(_), "{}", src);
         }
-        assert!(toml::from_str::<DurHolder>("d = 23").is_err());
+        assert_matches!(toml::from_str::<DurHolder>("d = 23"), Err(_));
     }
 
     #[test]
@@ -1668,7 +1669,7 @@ mod tests {
         {
             File::create(&path2).unwrap();
         }
-        assert!(canonicalize_path(&path2).is_err());
+        assert_matches!(canonicalize_path(&path2), Err(_));
         assert!(Path::new(&path2).exists());
     }
 
@@ -1793,11 +1794,11 @@ mod tests {
         let tmp_file = format!("{}", tmp_path.join("test-get-file-count.txt").display());
         create_file(&tmp_file, b"");
         let ret = check_data_dir_empty(tmp_path.to_str().unwrap(), "");
-        assert!(ret.is_err());
+        assert_matches!(ret, Err(_));
         let ret = check_data_dir_empty(tmp_path.to_str().unwrap(), "txt");
-        assert!(ret.is_err());
+        assert_matches!(ret, Err(_));
         let ret = check_data_dir_empty(tmp_path.to_str().unwrap(), "xt");
-        assert!(ret.is_ok());
+        assert_matches!(ret, Err(_));
     }
 
     #[test]

--- a/components/tikv_util/src/config.rs
+++ b/components/tikv_util/src/config.rs
@@ -1529,7 +1529,7 @@ mod tests {
         ];
         for src in illegal_cases {
             let src_str = format!("s = {:?}", src);
-            assert_matches!(toml::from_str::<SizeHolder>(&src_str),Err(_), "{}", src);
+            assert!(toml::from_str::<SizeHolder>(&src_str).is_err(), "{}", src);
         }
     }
 
@@ -1601,7 +1601,7 @@ mod tests {
         let illegal_cases = vec!["1H", "1M", "1S", "1MS", "1h1h", "h"];
         for src in illegal_cases {
             let src_str = format!("d = {:?}", src);
-            assert_matches!(toml::from_str::<DurHolder>(&src_str),Err(_), "{}", src);
+            assert!(toml::from_str::<DurHolder>(&src_str).is_err(), "{}", src);
         }
         assert!(toml::from_str::<DurHolder>("d = 23").is_err());
     }

--- a/components/tikv_util/src/config.rs
+++ b/components/tikv_util/src/config.rs
@@ -1603,7 +1603,7 @@ mod tests {
             let src_str = format!("d = {:?}", src);
             assert_matches!(toml::from_str::<DurHolder>(&src_str),Err(_), "{}", src);
         }
-        assert_matches!(toml::from_str::<DurHolder>("d = 23"), Err(_));
+        assert!(toml::from_str::<DurHolder>("d = 23").is_err());
     }
 
     #[test]

--- a/components/tikv_util/src/lib.rs
+++ b/components/tikv_util/src/lib.rs
@@ -3,6 +3,7 @@
 #![cfg_attr(test, feature(test))]
 #![feature(thread_id_value)]
 #![feature(box_patterns)]
+#![feature(assert_matches)]
 
 #[cfg(test)]
 extern crate test;

--- a/components/tikv_util/src/logger/file_log.rs
+++ b/components/tikv_util/src/logger/file_log.rs
@@ -234,6 +234,7 @@ impl Rotator for RotateBySize {
 mod tests {
     use super::*;
 
+    use std::assert_matches::assert_matches;
     use std::ffi::OsStr;
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
     use tempfile::TempDir;
@@ -464,7 +465,7 @@ mod tests {
 
         // Rename failed.
         logger.write_all(&[0xff; 1025]).unwrap();
-        assert!(logger.flush().is_err());
+        assert_eq!(logger.flush(), Err(_));
 
         // dropping the logger still should not panic.
         drop(logger);

--- a/components/tikv_util/src/logger/file_log.rs
+++ b/components/tikv_util/src/logger/file_log.rs
@@ -465,7 +465,7 @@ mod tests {
 
         // Rename failed.
         logger.write_all(&[0xff; 1025]).unwrap();
-        assert_eq!(logger.flush(), Err(_));
+        assert_matches!(logger.flush(), Err(_));
 
         // dropping the logger still should not panic.
         drop(logger);

--- a/components/tikv_util/src/metrics/threads_linux.rs
+++ b/components/tikv_util/src/metrics/threads_linux.rs
@@ -1,6 +1,5 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::assert_matches::assert_matches;
 use std::fs;
 use std::io::{Error, ErrorKind, Result};
 use std::sync::Mutex;

--- a/components/tikv_util/src/metrics/threads_linux.rs
+++ b/components/tikv_util/src/metrics/threads_linux.rs
@@ -1,5 +1,6 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::assert_matches::assert_matches;
 use std::fs;
 use std::io::{Error, ErrorKind, Result};
 use std::sync::Mutex;
@@ -504,6 +505,7 @@ impl TidRetriever {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches::assert_matches;
     use std::env::temp_dir;
     use std::io::Write;
     use std::time::Duration;
@@ -737,7 +739,7 @@ mod tests {
 
         let (raw_name, _) = get_thread_name("(@#)").unwrap();
         assert_eq!(sanitize_thread_name(1, raw_name), "1");
-        assert!(get_thread_name("invalid_stat").is_err());
+        assert_matches!(get_thread_name("invalid_stat"), Err(_));
     }
 
     #[test]

--- a/components/tikv_util/src/yatp_pool/future_pool.rs
+++ b/components/tikv_util/src/yatp_pool/future_pool.rs
@@ -411,14 +411,13 @@ mod tests {
             spawn_long_time_future(&read_pool, 4, 400).unwrap(),
         );
         // no available results (running = 4)
-        assert_matches!(rx.recv_timeout(Duration::from_millis(50))        assert_matches!(rx.try_recv(),Err(_));
-        );
+        assert_matches!(rx.recv_timeout(Duration::from_millis(50)),,Err(_));
 
         // full
-        assert_matches!(spawn_long_time_future(&read_pool, 5, 100), Err(_));
+        assert!(spawn_long_time_future(&read_pool, 5, 100).is_err());
 
         // full
-        assert_matches!(spawn_long_time_future(&read_pool, 6, 100), Err(_));
+        assert!(spawn_long_time_future(&read_pool, 6, 100).is_err());
 
         // wait a future completes (running = 3)
         assert_eq!(rx.recv().unwrap(), Ok(1));
@@ -427,7 +426,7 @@ mod tests {
         wait_on_new_thread(tx, spawn_long_time_future(&read_pool, 7, 5).unwrap());
 
         // full
-        assert_matches!(spawn_long_time_future(&read_pool, 8, 100), Err(_));
+        assert!(spawn_long_time_future(&read_pool, 8, 100).is_err());
 
         assert!(rx.recv().is_ok());
         assert!(rx.recv().is_ok());

--- a/components/tikv_util/src/yatp_pool/future_pool.rs
+++ b/components/tikv_util/src/yatp_pool/future_pool.rs
@@ -411,7 +411,7 @@ mod tests {
             spawn_long_time_future(&read_pool, 4, 400).unwrap(),
         );
         // no available results (running = 4)
-        assert_matches!(rx.recv_timeout(Duration::from_millis(50)),,Err(_));
+        assert_matches!(rx.recv_timeout(Duration::from_millis(50)),Err(_));
 
         // full
         assert!(spawn_long_time_future(&read_pool, 5, 100).is_err());

--- a/components/txn_types/src/lib.rs
+++ b/components/txn_types/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![feature(box_patterns)]
 #![feature(min_specialization)]
+#![feature(assert_matches)]
 
 #[allow(unused_extern_crates)]
 extern crate tikv_alloc;

--- a/components/txn_types/src/lock.rs
+++ b/components/txn_types/src/lock.rs
@@ -373,6 +373,7 @@ impl Lock {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches::assert_matches;
 
     #[test]
     fn test_lock_type() {
@@ -585,7 +586,7 @@ mod tests {
         }
 
         // Test `Lock::parse()` handles incorrect input.
-        assert!(Lock::parse(b"").is_err());
+        assert_matches!(Lock::parse(b""), Err(_));
 
         let lock = Lock::new(
             LockType::Lock,
@@ -598,7 +599,7 @@ mod tests {
             TimeStamp::zero(),
         );
         let mut v = lock.to_bytes();
-        assert!(Lock::parse(&v[..4]).is_err());
+        assert_matches!(Lock::parse(&v[..4]), Err(_));
         // Test `Lock::parse()` ignores unknown bytes.
         v.extend(b"unknown");
         let l = Lock::parse(&v).unwrap();

--- a/components/txn_types/src/timestamp.rs
+++ b/components/txn_types/src/timestamp.rs
@@ -180,6 +180,7 @@ impl TsSet {
 mod tests {
     use super::*;
     use crate::types::Key;
+    use std::assert_matches::assert_matches;
 
     #[test]
     fn test_ts() {
@@ -196,7 +197,7 @@ mod tests {
     fn test_split_ts() {
         let k = b"k";
         let ts = TimeStamp(123);
-        assert!(Key::split_on_ts_for(k).is_err());
+        assert_matches!(Key::split_on_ts_for(k), Err(_));
         let enc = Key::from_encoded_slice(k).append_ts(ts);
         let res = Key::split_on_ts_for(enc.as_encoded()).unwrap();
         assert_eq!(res, (k.as_ref(), ts));

--- a/components/txn_types/src/types.rs
+++ b/components/txn_types/src/types.rs
@@ -434,6 +434,7 @@ impl WriteBatchFlags {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches::assert_matches;
 
     #[test]
     fn test_flags() {
@@ -451,7 +452,7 @@ mod tests {
     #[test]
     fn test_flags_panic() {
         for _ in 0..100 {
-            assert!(
+            assert_matches!(
                 panic_hook::recover_safe(|| {
                     // r must be an invalid flags if it is not zero
                     let r = rand::random::<u64>() & !WriteBatchFlags::all().bits();
@@ -459,8 +460,8 @@ mod tests {
                     if r == 0 {
                         panic!("panic for zero");
                     }
-                })
-                .is_err()
+                }),
+                Err(_)
             );
         }
     }

--- a/components/txn_types/src/write.rs
+++ b/components/txn_types/src/write.rs
@@ -442,11 +442,11 @@ mod tests {
         }
 
         // Test `Write::parse()` handles incorrect input.
-        assert_matches!(WriteRef::parse(b""), Err(_));
+        assert!(WriteRef::parse(b"").is_err());
 
         let lock = Write::new(WriteType::Lock, 1.into(), Some(b"short_value".to_vec()));
         let mut v = lock.as_ref().to_bytes();
-        assert_matches!(WriteRef::parse(&v[..1]), Err(_));
+        assert!(WriteRef::parse(&v[..1]).is_err());
         assert_eq!(Write::parse_type(&v).unwrap(), lock.write_type);
         // Test `Write::parse()` ignores unknown bytes.
         v.extend(b"unknown");

--- a/components/txn_types/src/write.rs
+++ b/components/txn_types/src/write.rs
@@ -377,6 +377,7 @@ impl WriteRef<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches::assert_matches;
 
     #[test]
     fn test_write_type() {
@@ -441,11 +442,11 @@ mod tests {
         }
 
         // Test `Write::parse()` handles incorrect input.
-        assert!(WriteRef::parse(b"").is_err());
+        assert_matches!(WriteRef::parse(b""), Err(_));
 
         let lock = Write::new(WriteType::Lock, 1.into(), Some(b"short_value".to_vec()));
         let mut v = lock.as_ref().to_bytes();
-        assert!(WriteRef::parse(&v[..1]).is_err());
+        assert_matches!(WriteRef::parse(&v[..1]), Err(_));
         assert_eq!(Write::parse_type(&v).unwrap(), lock.write_type);
         // Test `Write::parse()` ignores unknown bytes.
         v.extend(b"unknown");

--- a/components/txn_types/src/write.rs
+++ b/components/txn_types/src/write.rs
@@ -377,7 +377,6 @@ impl WriteRef<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::assert_matches::assert_matches;
 
     #[test]
     fn test_write_type() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1734,26 +1734,26 @@ mod unified_read_pool_tests {
             min_thread_count: 0,
             ..cfg
         };
-        assert!(invalid_cfg.validate().is_err());
+        assert_matches!(invalid_cfg.validate(), Err(_));
 
         let invalid_cfg = UnifiedReadPoolConfig {
             min_thread_count: 2,
             max_thread_count: 1,
             ..cfg
         };
-        assert!(invalid_cfg.validate().is_err());
+        assert_matches!(invalid_cfg.validate(), Err(_));
 
         let invalid_cfg = UnifiedReadPoolConfig {
             stack_size: ReadableSize::mb(1),
             ..cfg
         };
-        assert!(invalid_cfg.validate().is_err());
+        assert_matches!(invalid_cfg.validate(), Err(_));
 
         let invalid_cfg = UnifiedReadPoolConfig {
             max_tasks_per_worker: 1,
             ..cfg
         };
-        assert!(invalid_cfg.validate().is_err());
+        assert_matches!(invalid_cfg.validate(), Err(_));
     }
 }
 
@@ -1897,41 +1897,41 @@ macro_rules! readpool_config {
 
                 let mut invalid_cfg = cfg.clone();
                 invalid_cfg.high_concurrency = 0;
-                assert!(invalid_cfg.validate().is_err());
+                assert_matches!(invalid_cfg.validate(),Err(_));
 
                 let mut invalid_cfg = cfg.clone();
                 invalid_cfg.normal_concurrency = 0;
-                assert!(invalid_cfg.validate().is_err());
+                assert_matches!(invalid_cfg.validate(),Err(_));
 
                 let mut invalid_cfg = cfg.clone();
                 invalid_cfg.low_concurrency = 0;
-                assert!(invalid_cfg.validate().is_err());
+                assert_matches!(invalid_cfg.validate(),Err(_));
 
                 let mut invalid_cfg = cfg.clone();
                 invalid_cfg.stack_size = ReadableSize::mb(1);
-                assert!(invalid_cfg.validate().is_err());
+                assert_matches!(invalid_cfg.validate(),Err(_));
 
                 let mut invalid_cfg = cfg.clone();
                 invalid_cfg.max_tasks_per_worker_high = 0;
-                assert!(invalid_cfg.validate().is_err());
+                assert_matches!(invalid_cfg.validate(),Err(_));
                 invalid_cfg.max_tasks_per_worker_high = 1;
-                assert!(invalid_cfg.validate().is_err());
+                assert_matches!(invalid_cfg.validate(),Err(_));
                 invalid_cfg.max_tasks_per_worker_high = 100;
                 assert!(cfg.validate().is_ok());
 
                 let mut invalid_cfg = cfg.clone();
                 invalid_cfg.max_tasks_per_worker_normal = 0;
-                assert!(invalid_cfg.validate().is_err());
+                assert_matches!(invalid_cfg.validate(),Err(_));
                 invalid_cfg.max_tasks_per_worker_normal = 1;
-                assert!(invalid_cfg.validate().is_err());
+                assert_matches!(invalid_cfg.validate(),Err(_));
                 invalid_cfg.max_tasks_per_worker_normal = 100;
                 assert!(cfg.validate().is_ok());
 
                 let mut invalid_cfg = cfg.clone();
                 invalid_cfg.max_tasks_per_worker_low = 0;
-                assert!(invalid_cfg.validate().is_err());
+                assert_matches!(invalid_cfg.validate(),Err(_));
                 invalid_cfg.max_tasks_per_worker_low = 1;
-                assert!(invalid_cfg.validate().is_err());
+                assert_matches!(invalid_cfg.validate(),Err(_));
                 invalid_cfg.max_tasks_per_worker_low = 100;
                 assert!(cfg.validate().is_ok());
 
@@ -2045,7 +2045,7 @@ mod readpool_tests {
             stack_size: ReadableSize::mb(0),
             max_tasks_per_worker: 0,
         };
-        assert!(unified.validate().is_err());
+        assert_matches!(unified.validate(), Err(_));
         let storage = StorageReadPoolConfig {
             use_unified_pool: Some(false),
             ..Default::default()
@@ -2072,7 +2072,7 @@ mod readpool_tests {
             high_concurrency: 0,
             ..Default::default()
         };
-        assert!(storage.validate().is_err());
+        assert_matches!(storage.validate(), Err(_));
         let coprocessor = CoprReadPoolConfig {
             use_unified_pool: Some(false),
             ..Default::default()
@@ -2083,7 +2083,7 @@ mod readpool_tests {
             coprocessor,
         };
         assert!(!invalid_cfg.is_unified_pool_enabled());
-        assert!(invalid_cfg.validate().is_err());
+        assert_matches!(invalid_cfg.validate(), Err(_));
     }
 
     #[test]
@@ -2094,7 +2094,7 @@ mod readpool_tests {
             max_thread_count: 0,
             ..Default::default()
         };
-        assert!(unified.validate().is_err());
+        assert_matches!(unified.validate(), Err(_));
         let storage = StorageReadPoolConfig {
             use_unified_pool: Some(true),
             ..Default::default()
@@ -2109,7 +2109,7 @@ mod readpool_tests {
         };
         cfg.adjust_use_unified_pool();
         assert!(cfg.is_unified_pool_enabled());
-        assert!(cfg.validate().is_err());
+        assert_matches!(cfg.validate(), Err(_));
     }
 
     #[test]
@@ -2153,7 +2153,7 @@ mod readpool_tests {
             ..Default::default()
         };
         assert!(cfg.is_unified_pool_enabled());
-        assert!(cfg.validate().is_err());
+        assert_matches!(cfg.validate(), Err(_));
         cfg.storage.low_concurrency = 1;
         assert!(cfg.validate().is_ok());
 
@@ -2174,7 +2174,7 @@ mod readpool_tests {
             ..Default::default()
         };
         assert!(cfg.is_unified_pool_enabled());
-        assert!(cfg.validate().is_err());
+        assert_matches!(cfg.validate(), Err(_));
         cfg.coprocessor.low_concurrency = 1;
         assert!(cfg.validate().is_ok());
     }
@@ -3275,6 +3275,7 @@ mod tests {
     use raft_log_engine::RecoveryMode;
     use raftstore::coprocessor::region_info_accessor::MockRegionInfoProvider;
     use slog::Level;
+    use std::assert_matches::assert_matches;
     use std::sync::Arc;
     use std::time::Duration;
     use tikv_util::worker::{dummy_scheduler, ReceiverWrapper};
@@ -3301,25 +3302,25 @@ mod tests {
         assert!(tikv_cfg.check_critical_cfg_with(&last_cfg).is_ok());
 
         tikv_cfg.rocksdb.wal_dir = "/data/wal_dir".to_owned();
-        assert!(tikv_cfg.check_critical_cfg_with(&last_cfg).is_err());
+        assert_matches!(tikv_cfg.check_critical_cfg_with(&last_cfg), Err(_));
 
         last_cfg.rocksdb.wal_dir = "/data/wal_dir".to_owned();
         assert!(tikv_cfg.check_critical_cfg_with(&last_cfg).is_ok());
 
         tikv_cfg.raftdb.wal_dir = "/raft/wal_dir".to_owned();
-        assert!(tikv_cfg.check_critical_cfg_with(&last_cfg).is_err());
+        assert_matches!(tikv_cfg.check_critical_cfg_with(&last_cfg), Err(_));
 
         last_cfg.raftdb.wal_dir = "/raft/wal_dir".to_owned();
         assert!(tikv_cfg.check_critical_cfg_with(&last_cfg).is_ok());
 
         tikv_cfg.storage.data_dir = "/data1".to_owned();
-        assert!(tikv_cfg.check_critical_cfg_with(&last_cfg).is_err());
+        assert_matches!(tikv_cfg.check_critical_cfg_with(&last_cfg), Err(_));
 
         last_cfg.storage.data_dir = "/data1".to_owned();
         assert!(tikv_cfg.check_critical_cfg_with(&last_cfg).is_ok());
 
         tikv_cfg.raft_store.raftdb_path = "/raft_path".to_owned();
-        assert!(tikv_cfg.check_critical_cfg_with(&last_cfg).is_err());
+        assert_matches!(tikv_cfg.check_critical_cfg_with(&last_cfg), Err(_));
 
         last_cfg.raft_store.raftdb_path = "/raft_path".to_owned();
         assert!(tikv_cfg.check_critical_cfg_with(&last_cfg).is_ok());
@@ -3392,7 +3393,7 @@ mod tests {
         tikv_cfg.pd.endpoints = vec!["".to_owned()];
         let dur = tikv_cfg.raft_store.raft_heartbeat_interval();
         tikv_cfg.server.grpc_keepalive_time = ReadableDuration(dur);
-        assert!(tikv_cfg.validate().is_err());
+        assert_matches!(tikv_cfg.validate(), Err(_));
         tikv_cfg.server.grpc_keepalive_time = ReadableDuration(dur * 2);
         tikv_cfg.validate().unwrap();
     }
@@ -3406,7 +3407,7 @@ mod tests {
         tikv_cfg.rocksdb.writecf.block_size = ReadableSize::gb(10);
         tikv_cfg.rocksdb.raftcf.block_size = ReadableSize::gb(10);
         tikv_cfg.raftdb.defaultcf.block_size = ReadableSize::gb(10);
-        assert!(tikv_cfg.validate().is_err());
+        assert_matches!(tikv_cfg.validate(), Err(_));
         tikv_cfg.rocksdb.defaultcf.block_size = ReadableSize::kb(10);
         tikv_cfg.rocksdb.lockcf.block_size = ReadableSize::kb(10);
         tikv_cfg.rocksdb.writecf.block_size = ReadableSize::kb(10);
@@ -3519,7 +3520,7 @@ mod tests {
         for (name, value) in cases {
             let mut change = HashMap::new();
             change.insert(name, value);
-            assert!(to_config_change(change).is_err());
+            assert_matches!(to_config_change(change), Err(_));
         }
     }
 
@@ -3656,20 +3657,17 @@ mod tests {
         cfg_controller.register(Module::ResolvedTs, Box::new(TestConfigManager(tx)));
 
         // Return error if try to update not support config or unknow config
-        assert!(
-            cfg_controller
-                .update_config("resolved-ts.enable", "false")
-                .is_err()
+        assert_matches!(
+            cfg_controller.update_config("resolved-ts.enable", "false"),
+            Err(_)
         );
-        assert!(
-            cfg_controller
-                .update_config("resolved-ts.scan-lock-pool-size", "10")
-                .is_err()
+        assert_matches!(
+            cfg_controller.update_config("resolved-ts.scan-lock-pool-size", "10"),
+            Err(_)
         );
-        assert!(
-            cfg_controller
-                .update_config("resolved-ts.xxx", "false")
-                .is_err()
+        assert_matches!(
+            cfg_controller.update_config("resolved-ts.xxx", "false"),
+            Err(_)
         );
 
         let mut resolved_ts_cfg = cfg_controller.get_current().resolved_ts;
@@ -3690,10 +3688,9 @@ mod tests {
         );
 
         // Return error if try to update `advance-ts-interval` to an invalid value
-        assert!(
-            cfg_controller
-                .update_config("resolved-ts.advance-ts-interval", "0m")
-                .is_err()
+        assert_matches!(
+            cfg_controller.update_config("resolved-ts.advance-ts-interval", "0m"),
+            Err(_)
         );
         assert_eq!(
             resolved_ts_cfg.advance_ts_interval,
@@ -3783,10 +3780,9 @@ mod tests {
 
         // Can not update block cache through storage module
         // when shared block cache is disabled
-        assert!(
-            cfg_controller
-                .update_config("storage.block-cache.capacity", "512MB")
-                .is_err()
+        assert_matches!(
+            cfg_controller.update_config("storage.block-cache.capacity", "512MB"),
+            Err(_)
         );
     }
 
@@ -3821,10 +3817,9 @@ mod tests {
         let (db, cfg_controller, ..) = new_engines(cfg);
 
         // Can not update shared block cache through rocksdb module
-        assert!(
-            cfg_controller
-                .update_config("rocksdb.defaultcf.block-cache-size", "256MB")
-                .is_err()
+        assert_matches!(
+            cfg_controller.update_config("rocksdb.defaultcf.block-cache-size", "256MB"),
+            Err(_)
         );
 
         cfg_controller
@@ -4047,7 +4042,7 @@ mod tests {
 
         // Test validating memory_usage_limit when it's greater than max.
         cfg.memory_usage_limit.0 = Some(ReadableSize(SysQuota::memory_limit_in_bytes() * 2));
-        assert!(cfg.validate().is_err());
+        assert_matches!(cfg.validate(), Err(_));
 
         // Test memory_usage_limit is based on block cache size if it's not configured.
         cfg.memory_usage_limit = OptionReadableSize(None);
@@ -4356,7 +4351,7 @@ mod tests {
         let r = panic_hook::recover_safe(|| {
             let _: DefaultCfConfig = toml::from_str(bad_string_config).unwrap();
         });
-        assert!(r.is_err());
+        assert_matches!(r, Err(_));
 
         let bad_string_config = r#"
             compaction-style = 4
@@ -4364,7 +4359,7 @@ mod tests {
         let r = panic_hook::recover_safe(|| {
             let _: DefaultCfConfig = toml::from_str(bad_string_config).unwrap();
         });
-        assert!(r.is_err());
+        assert_matches!(r, Err(_));
 
         // rate-limiter-mode defalut values is 2
         let config_str = r#"

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -633,6 +633,7 @@ fn make_error_response(e: Error) -> coppb::Response {
 mod tests {
     use super::*;
 
+    use std::assert_matches::assert_matches;
     use std::sync::{atomic, mpsc};
     use std::thread;
     use std::vec;
@@ -831,7 +832,10 @@ mod tests {
             None,
             PerfLevel::EnableCount,
         );
-        assert!(block_on(copr.handle_unary_request(outdated_req_ctx, handler_builder)).is_err());
+        assert_matches!(
+            block_on(copr.handle_unary_request(outdated_req_ctx, handler_builder)),
+            Err(_)
+        );
     }
 
     #[test]
@@ -976,7 +980,7 @@ mod tests {
 
         // verify
         for _ in 2..5 {
-            assert!(rx.recv().unwrap().is_err());
+            assert_matches!(rx.recv().unwrap(), Err(_));
         }
         for i in 0..2 {
             let resp = rx.recv().unwrap().unwrap();

--- a/src/coprocessor/interceptors/deadline.rs
+++ b/src/coprocessor/interceptors/deadline.rs
@@ -39,6 +39,7 @@ where
 mod tests {
     use super::*;
 
+    use std::assert_matches::assert_matches;
     use std::{thread, time::Duration};
     use tokio::task::yield_now;
 
@@ -57,6 +58,6 @@ mod tests {
         assert!(res.is_ok());
 
         let res = check_deadline(work(100), Deadline::from_now(Duration::from_millis(500))).await;
-        assert!(res.is_err());
+        assert_matches!(res, Err(_));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@
 #![feature(drain_filter)]
 #![feature(negative_impls)]
 #![feature(deadline_api)]
+#![feature(assert_matches)]
 
 #[macro_use(fail_point)]
 extern crate fail;

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -425,6 +425,7 @@ fn validate_label_value(s: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches::assert_matches;
     use tikv_util::config::ReadableDuration;
 
     #[test]
@@ -438,23 +439,23 @@ mod tests {
 
         let mut invalid_cfg = cfg.clone();
         invalid_cfg.concurrent_send_snap_limit = 0;
-        assert!(invalid_cfg.validate().is_err());
+        assert_matches!(invalid_cfg.validate(), Err(_));
 
         let mut invalid_cfg = cfg.clone();
         invalid_cfg.concurrent_recv_snap_limit = 0;
-        assert!(invalid_cfg.validate().is_err());
+        assert_matches!(invalid_cfg.validate(), Err(_));
 
         let mut invalid_cfg = cfg.clone();
         invalid_cfg.end_point_recursion_limit = 0;
-        assert!(invalid_cfg.validate().is_err());
+        assert_matches!(invalid_cfg.validate(), Err(_));
 
         let mut invalid_cfg = cfg.clone();
         invalid_cfg.end_point_request_max_handle_duration = ReadableDuration::secs(0);
-        assert!(invalid_cfg.validate().is_err());
+        assert_matches!(invalid_cfg.validate(), Err(_));
 
         invalid_cfg = Config::default();
         invalid_cfg.addr = "0.0.0.0:1000".to_owned();
-        assert!(invalid_cfg.validate().is_err());
+        assert_matches!(invalid_cfg.validate(), Err(_));
         invalid_cfg.advertise_addr = "127.0.0.1:1000".to_owned();
         invalid_cfg.validate().unwrap();
 
@@ -465,21 +466,21 @@ mod tests {
         }
         assert!(invalid_cfg.advertise_status_addr.is_empty());
         invalid_cfg.advertise_status_addr = "0.0.0.0:1000".to_owned();
-        assert!(invalid_cfg.validate().is_err());
+        assert_matches!(invalid_cfg.validate(), Err(_));
 
         invalid_cfg = Config::default();
         invalid_cfg.advertise_addr = "127.0.0.1:1000".to_owned();
         invalid_cfg.advertise_status_addr = "127.0.0.1:1000".to_owned();
-        assert!(invalid_cfg.validate().is_err());
+        assert_matches!(invalid_cfg.validate(), Err(_));
 
         invalid_cfg = Config::default();
         invalid_cfg.grpc_stream_initial_window_size = ReadableSize(i32::MAX as u64 + 1);
-        assert!(invalid_cfg.validate().is_err());
+        assert_matches!(invalid_cfg.validate(), Err(_));
 
         cfg.labels.insert("k1".to_owned(), "v1".to_owned());
         cfg.validate().unwrap();
         cfg.labels.insert("k2".to_owned(), "v2?".to_owned());
-        assert!(cfg.validate().is_err());
+        assert_matches!(invalid_cfg.validate(), Err(_));
     }
 
     #[test]

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -1319,6 +1319,7 @@ mod tests {
     use kvproto::kvrpcpb::ApiVersion;
     use kvproto::metapb::{Peer, PeerRole, Region};
     use raft::eraftpb::EntryType;
+    use std::assert_matches::assert_matches;
     use tempfile::Builder;
 
     use super::*;
@@ -1629,8 +1630,8 @@ mod tests {
     fn test_scan_mvcc() {
         let debugger = new_debugger();
         // Test scan with bad start, end or limit.
-        assert!(debugger.scan_mvcc(b"z", b"", 0).is_err());
-        assert!(debugger.scan_mvcc(b"z", b"x", 3).is_err());
+        assert_matches!(debugger.scan_mvcc(b"z", b"", 0), Err(_));
+        assert_matches!(debugger.scan_mvcc(b"z", b"x", 3), Err(_));
     }
 
     #[test]
@@ -1938,7 +1939,7 @@ mod tests {
 
         region.set_start_key(b"k".to_vec());
         region.set_end_key(b"z".to_vec());
-        assert!(debugger.recreate_region(region.clone()).is_err());
+        assert_matches!(debugger.recreate_region(region.clone()), Err(_));
 
         remove_region_state(1);
         remove_region_state(2);
@@ -1950,7 +1951,7 @@ mod tests {
 
         region.set_start_key(b"z".to_vec());
         region.set_end_key(b"".to_vec());
-        assert!(debugger.recreate_region(region).is_err());
+        assert_matches!(debugger.recreate_region(region), Err(_));
     }
 
     #[test]

--- a/src/server/resolve.rs
+++ b/src/server/resolve.rs
@@ -189,6 +189,7 @@ impl StoreAddrResolver for PdStoreAddrResolver {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches::assert_matches;
     use std::marker::PhantomData;
     use std::net::SocketAddr;
     use std::ops::Sub;
@@ -270,7 +271,7 @@ mod tests {
     fn test_resolve_store_state_tombstone() {
         let store = new_store(STORE_ADDR, metapb::StoreState::Tombstone);
         let runner = new_runner(store);
-        assert!(runner.get_address(0).is_err());
+        assert_matches!(runner.get_address(0), Err(_));
     }
 
     #[test]

--- a/src/server/status_server/profile.rs
+++ b/src/server/status_server/profile.rs
@@ -333,6 +333,7 @@ mod tests {
     use futures::channel::{mpsc, oneshot};
     use futures::executor::block_on;
     use futures::{SinkExt, TryFutureExt};
+    use std::assert_matches::assert_matches;
     use std::sync::mpsc::sync_channel;
     use std::thread;
     use std::time::Duration;
@@ -385,7 +386,7 @@ mod tests {
         assert_eq!(block_on(res2).unwrap().unwrap_err(), expected);
 
         drop(tx1);
-        assert!(block_on(res1).unwrap().is_err());
+        assert_matches!(block_on(res1).unwrap(), Err(_));
     }
 
     #[test]
@@ -430,7 +431,7 @@ mod tests {
         let (mut tx, rx) = mpsc::channel(1);
         let res = rt.spawn(activate_heap_profile(rx, std::env::temp_dir(), || {}));
         block_on(tx.send(Err("test".to_string()))).unwrap();
-        assert!(block_on(res).unwrap().is_err());
+        assert_matches!(block_on(res).unwrap(), Err(_));
 
         // Test heap profiling can be activated again.
         let (tx, rx) = sync_channel::<i32>(1);

--- a/src/storage/kv/test_engine_builder.rs
+++ b/src/storage/kv/test_engine_builder.rs
@@ -129,6 +129,7 @@ mod tests {
     use crate::storage::{Cursor, CursorBuilder, ScanMode};
     use engine_traits::IterOptions;
     use kvproto::kvrpcpb::Context;
+    use std::assert_matches::assert_matches;
     use tikv_kv::tests::*;
     use txn_types::Key;
     use txn_types::TimeStamp;
@@ -209,7 +210,7 @@ mod tests {
 
         let mut statistics = CfStatistics::default();
         let res = iter.seek(&Key::from_raw(b"foo"), &mut statistics);
-        assert!(res.is_err());
+        assert_matches!(res, Err(_));
         assert!(
             res.unwrap_err()
                 .to_string()

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -2443,6 +2443,7 @@ mod tests {
     use futures::executor::block_on;
     use kvproto::kvrpcpb::{CommandPri, Op};
     use std::{
+        assert_matches::assert_matches,
         sync::{
             atomic::{AtomicBool, Ordering},
             mpsc::{channel, Sender},
@@ -6115,7 +6116,7 @@ mod tests {
             .unwrap();
         rx.recv().unwrap();
         // No wait for msg
-        assert!(msg_rx.try_recv().is_err());
+        assert_matches!(msg_rx.try_recv(), Err(_));
 
         // Meet lock-k.
         storage
@@ -6480,7 +6481,7 @@ mod tests {
             .unwrap();
         rx.recv().unwrap();
         // No msg
-        assert!(msg_rx.try_recv().is_err());
+        assert_matches!(msg_rx.try_recv(), Err(_), Err(_));
 
         // Expired
         storage
@@ -7286,7 +7287,7 @@ mod tests {
             if is_legal {
                 assert!(res.is_ok(), "case {}", i);
             } else {
-                assert!(res.is_err(), "case {}", i);
+                assert_matches!(res, Err(_), "case {}", i);
                 assert_eq!(
                     res.unwrap_err().error_code(),
                     error_code::storage::API_VERSION_NOT_MATCHED,

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -17,6 +17,7 @@ pub use txn_types::{
     SHORT_VALUE_MAX_LEN,
 };
 
+use std::assert_matches::assert_matches;
 use std::error;
 use std::io;
 
@@ -442,7 +443,7 @@ pub mod tests {
         if check_lock(&mut reader, key, ts).is_err() {
             return;
         }
-        assert!(reader.get(key, ts).is_err());
+        assert_matches!(reader.get(key, ts), Err(_));
     }
 
     pub fn must_locked<E: Engine>(engine: &E, key: &[u8], start_ts: impl Into<TimeStamp>) -> Lock {

--- a/src/storage/mvcc/reader/point_getter.rs
+++ b/src/storage/mvcc/reader/point_getter.rs
@@ -351,6 +351,8 @@ mod tests {
 
     use txn_types::SHORT_VALUE_MAX_LEN;
 
+    use std::assert_matches::assert_matches;
+
     use crate::storage::kv::{
         CfStatistics, Engine, PerfStatisticsInstant, RocksEngine, TestEngineBuilder,
     };
@@ -424,7 +426,7 @@ mod tests {
     }
 
     fn must_get_err<S: Snapshot>(point_getter: &mut PointGetter<S>, key: &[u8]) {
-        assert!(point_getter.get(&Key::from_raw(key)).is_err());
+        assert_matches!(point_getter.get(&Key::from_raw(key)), Err(_));
     }
 
     fn assert_seek_next_prev(stat: &CfStatistics, seek: usize, next: usize, prev: usize) {

--- a/src/storage/txn/actions/commit.rs
+++ b/src/storage/txn/actions/commit.rs
@@ -6,6 +6,7 @@ use crate::storage::mvcc::{
     ErrorInner, LockType, MvccTxn, ReleasedLock, Result as MvccResult, SnapshotReader,
 };
 use crate::storage::Snapshot;
+use std::assert_matches::assert_matches;
 use txn_types::{Key, TimeStamp, Write, WriteType};
 
 pub fn commit<S: Snapshot>(
@@ -148,7 +149,10 @@ pub mod tests {
         let cm = ConcurrencyManager::new(start_ts);
         let mut txn = MvccTxn::new(start_ts, cm);
         let mut reader = SnapshotReader::new(start_ts, snapshot, true);
-        assert!(commit(&mut txn, &mut reader, Key::from_raw(key), commit_ts.into()).is_err());
+        assert_matches!(
+            commit(&mut txn, &mut reader, Key::from_raw(key), commit_ts.into()),
+            Err(_)
+        );
     }
 
     #[cfg(test)]

--- a/src/storage/txn/actions/tests.rs
+++ b/src/storage/txn/actions/tests.rs
@@ -10,6 +10,7 @@ use crate::storage::{txn, Engine};
 use concurrency_manager::ConcurrencyManager;
 use kvproto::kvrpcpb::Context;
 use prewrite::{prewrite, CommitKind, TransactionKind, TransactionProperties};
+use std::assert_matches::assert_matches;
 
 pub fn must_prewrite_put_impl<E: Engine>(
     engine: &E,
@@ -459,7 +460,7 @@ pub fn must_prewrite_lock_err<E: Engine>(
     let mut txn = MvccTxn::new(ts, cm);
     let mut reader = SnapshotReader::new(ts, snapshot, true);
 
-    assert!(
+    assert_matches!(
         prewrite(
             &mut txn,
             &mut reader,
@@ -467,8 +468,8 @@ pub fn must_prewrite_lock_err<E: Engine>(
             Mutation::Lock(Key::from_raw(key)),
             &None,
             false,
-        )
-        .is_err()
+        ),
+        Err(_)
     );
 }
 
@@ -512,14 +513,14 @@ pub fn must_rollback_err<E: Engine>(engine: &E, key: &[u8], start_ts: impl Into<
     let cm = ConcurrencyManager::new(start_ts);
     let mut txn = MvccTxn::new(start_ts, cm);
     let mut reader = SnapshotReader::new(start_ts, snapshot, true);
-    assert!(
+    assert_matches!(
         txn::cleanup(
             &mut txn,
             &mut reader,
             Key::from_raw(key),
             TimeStamp::zero(),
             false,
-        )
-        .is_err()
+        ),
+        Err(_)
     );
 }

--- a/src/storage/txn/commands/check_txn_status.rs
+++ b/src/storage/txn/commands/check_txn_status.rs
@@ -148,6 +148,7 @@ pub mod tests {
     use crate::storage::{types::TxnStatus, ProcessResult, TestEngineBuilder};
     use concurrency_manager::ConcurrencyManager;
     use kvproto::kvrpcpb::Context;
+    use std::assert_matches::assert_matches;
     use tikv_util::deadline::Deadline;
     use txn_types::Key;
     use txn_types::WriteType;
@@ -225,19 +226,18 @@ pub mod tests {
             resolving_pessimistic_lock,
             deadline: Deadline::from_now(DEFAULT_EXECUTION_DURATION_LIMIT),
         };
-        assert!(
-            command
-                .process_write(
-                    snapshot,
-                    WriteContext {
-                        lock_mgr: &DummyLockManager,
-                        concurrency_manager: cm,
-                        extra_op: Default::default(),
-                        statistics: &mut Default::default(),
-                        async_apply_prewrite: false,
-                    },
-                )
-                .is_err()
+        assert_matches!(
+            command.process_write(
+                snapshot,
+                WriteContext {
+                    lock_mgr: &DummyLockManager,
+                    concurrency_manager: cm,
+                    extra_op: Default::default(),
+                    statistics: &mut Default::default(),
+                    async_apply_prewrite: false,
+                },
+            ),
+            Err(_)
         );
     }
 

--- a/src/storage/txn/commands/prewrite.rs
+++ b/src/storage/txn/commands/prewrite.rs
@@ -778,6 +778,7 @@ mod tests {
     use concurrency_manager::ConcurrencyManager;
     use engine_traits::CF_WRITE;
     use kvproto::kvrpcpb::{Context, ExtraOp};
+    use std::assert_matches::assert_matches;
     use txn_types::{Key, Mutation, TimeStamp};
 
     fn inner_test_prewrite_skip_constraint_check(pri_key_number: u8, write_num: usize) {
@@ -1883,7 +1884,7 @@ mod tests {
             async_apply_prewrite: false,
         };
         let snap = engine.snapshot(Default::default()).unwrap();
-        assert!(prewrite_cmd.cmd.process_write(snap, context).is_err());
+        assert_matches!(prewrite_cmd.cmd.process_write(snap, context), Err(_));
 
         // Test the pessimistic lock is not found path.
         must_acquire_pessimistic_lock(&engine, k1, v1, 10, 10);
@@ -1903,6 +1904,6 @@ mod tests {
             async_apply_prewrite: false,
         };
         let snap = engine.snapshot(Default::default()).unwrap();
-        assert!(prewrite_cmd.cmd.process_write(snap, context).is_err());
+        assert_matches!(prewrite_cmd.cmd.process_write(snap, context), Err(_));
     }
 }

--- a/src/storage/txn/commands/txn_heart_beat.rs
+++ b/src/storage/txn/commands/txn_heart_beat.rs
@@ -105,6 +105,7 @@ pub mod tests {
     use crate::storage::Engine;
     use concurrency_manager::ConcurrencyManager;
     use kvproto::kvrpcpb::Context;
+    use std::assert_matches::assert_matches;
     use tikv_util::deadline::Deadline;
 
     pub fn must_success<E: Engine>(
@@ -165,19 +166,18 @@ pub mod tests {
             advise_ttl,
             deadline: Deadline::from_now(DEFAULT_EXECUTION_DURATION_LIMIT),
         };
-        assert!(
-            command
-                .process_write(
-                    snapshot,
-                    WriteContext {
-                        lock_mgr: &DummyLockManager,
-                        concurrency_manager: cm,
-                        extra_op: Default::default(),
-                        statistics: &mut Default::default(),
-                        async_apply_prewrite: false,
-                    },
-                )
-                .is_err()
+        assert_matches!(
+            command.process_write(
+                snapshot,
+                WriteContext {
+                    lock_mgr: &DummyLockManager,
+                    concurrency_manager: cm,
+                    extra_op: Default::default(),
+                    statistics: &mut Default::default(),
+                    async_apply_prewrite: false,
+                },
+            ),
+            Err(_)
         );
     }
 

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -636,6 +636,7 @@ mod tests {
     use engine_traits::CfName;
     use engine_traits::{IterOptions, ReadOptions};
     use kvproto::kvrpcpb::Context;
+    use std::assert_matches::assert_matches;
     use std::sync::Arc;
 
     const KEY_PREFIX: &str = "key_prefix";
@@ -967,32 +968,29 @@ mod tests {
                 )
                 .is_ok()
         );
-        assert!(
-            store
-                .scanner(
-                    false,
-                    false,
-                    false,
-                    Some(bound_a.clone()),
-                    Some(bound_c.clone())
-                )
-                .is_err()
+        assert_matches!(
+            store.scanner(
+                false,
+                false,
+                false,
+                Some(bound_a.clone()),
+                Some(bound_c.clone())
+            ),
+            Err(_)
         );
-        assert!(
-            store
-                .scanner(
-                    false,
-                    false,
-                    false,
-                    Some(bound_b.clone()),
-                    Some(bound_d.clone())
-                )
-                .is_err()
+        assert_matches!(
+            store.scanner(
+                false,
+                false,
+                false,
+                Some(bound_b.clone()),
+                Some(bound_d.clone())
+            ),
+            Err(_)
         );
-        assert!(
-            store
-                .scanner(false, false, false, Some(bound_a.clone()), Some(bound_d))
-                .is_err()
+        assert_matches!(
+            store.scanner(false, false, false, Some(bound_a.clone()), Some(bound_d)),
+            Err(_)
         );
 
         // Store with whole range
@@ -1076,7 +1074,7 @@ mod tests {
             store.get(&Key::from_raw(b"ca"), &mut statistics).unwrap(),
             Some(b"hello".to_vec())
         );
-        assert!(store.get(&Key::from_raw(b"bba"), &mut statistics).is_err());
+        assert_matches!(store.get(&Key::from_raw(b"bba"), &mut statistics), Err(_));
         assert_eq!(
             store.get(&Key::from_raw(b"bbaa"), &mut statistics).unwrap(),
             None
@@ -1107,7 +1105,7 @@ mod tests {
             store.get(&Key::from_raw(b"ab"), &mut statistics).unwrap(),
             Some(b"bar".to_vec())
         );
-        assert!(store.get(&Key::from_raw(b"zz"), &mut statistics).is_err());
+        assert_matches!(store.get(&Key::from_raw(b"zz"), &mut statistics), Err(_));
         assert_eq!(
             store.get(&Key::from_raw(b"z"), &mut statistics).unwrap(),
             Some(b"beta".to_vec())
@@ -1139,7 +1137,7 @@ mod tests {
             scanner.next().unwrap(),
             Some((Key::from_raw(b"bb"), b"alphaalpha".to_vec()))
         );
-        assert!(scanner.next().is_err());
+        assert_matches!(scanner.next(), Err(_));
         assert_eq!(
             scanner.next().unwrap(),
             Some((Key::from_raw(b"ca"), b"hello".to_vec()))
@@ -1148,12 +1146,12 @@ mod tests {
             scanner.next().unwrap(),
             Some((Key::from_raw(b"z"), b"beta".to_vec()))
         );
-        assert!(scanner.next().is_err());
+        assert_matches!(scanner.next(), Err(_));
         // note: mvcc impl does not guarantee to work any more after meeting a non lock error
         assert_eq!(scanner.next().unwrap(), None);
 
         let mut scanner = store.scanner(true, false, false, None, None).unwrap();
-        assert!(scanner.next().is_err());
+        assert_matches!(scanner.next(), Err(_));
         // note: mvcc impl does not guarantee to work any more after meeting a non lock error
         assert_eq!(
             scanner.next().unwrap(),
@@ -1163,7 +1161,7 @@ mod tests {
             scanner.next().unwrap(),
             Some((Key::from_raw(b"ca"), b"hello".to_vec()))
         );
-        assert!(scanner.next().is_err());
+        assert_matches!(scanner.next(), Err(_));
         assert_eq!(
             scanner.next().unwrap(),
             Some((Key::from_raw(b"bb"), b"alphaalpha".to_vec()))
@@ -1204,13 +1202,13 @@ mod tests {
             scanner.next().unwrap(),
             Some((Key::from_raw(b"bb"), vec![]))
         );
-        assert!(scanner.next().is_err());
+        assert_matches!(scanner.next(), Err(_));
         assert_eq!(
             scanner.next().unwrap(),
             Some((Key::from_raw(b"ca"), vec![]))
         );
         assert_eq!(scanner.next().unwrap(), Some((Key::from_raw(b"z"), vec![])));
-        assert!(scanner.next().is_err());
+        assert_matches!(scanner.next(), Err(_));
         // note: mvcc impl does not guarantee to work any more after meeting a non lock error
         assert_eq!(scanner.next().unwrap(), None);
 
@@ -1267,7 +1265,7 @@ mod tests {
             scanner.next().unwrap(),
             Some((Key::from_raw(b"bb"), vec![]))
         );
-        assert!(scanner.next().is_err());
+        assert_matches!(scanner.next(), Err(_));
         assert_eq!(scanner.next().unwrap(), None);
 
         let mut scanner = store
@@ -1305,7 +1303,7 @@ mod tests {
                 Some(Key::from_raw(b"bba")),
             )
             .unwrap();
-        assert!(scanner.next().is_err());
+        assert_matches!(scanner.next(), Err(_));
         assert_eq!(
             scanner.next().unwrap(),
             Some((Key::from_raw(b"bb"), vec![]))

--- a/tests/failpoints/cases/test_encryption.rs
+++ b/tests/failpoints/cases/test_encryption.rs
@@ -1,5 +1,7 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::assert_matches::assert_matches;
+
 use encryption::compat;
 use encryption::FileDictionaryFile;
 use kvproto::encryptionpb::{EncryptionMethod, FileInfo};
@@ -23,7 +25,7 @@ fn test_file_dict_file_record_corrupted() {
     fail::remove("file_dict_log_append_incomplete");
     file_dict_file.insert("info2", &info2).unwrap();
     // Intermediate record damage is not allowed.
-    assert!(file_dict_file.recovery().is_err());
+    assert_matches!(file_dict_file.recovery(), Err(_));
 
     let mut file_dict_file = FileDictionaryFile::new(
         tempdir.path(),

--- a/tests/failpoints/cases/test_replica_read.rs
+++ b/tests/failpoints/cases/test_replica_read.rs
@@ -5,6 +5,7 @@ use engine_rocks::{Compat, RocksEngine};
 use engine_traits::{Peekable, RaftEngineReadOnly, CF_RAFT};
 use kvproto::raft_serverpb::{PeerState, RaftMessage, RegionLocalState};
 use raft::eraftpb::MessageType;
+use std::assert_matches::assert_matches;
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -56,7 +57,7 @@ fn test_wait_for_apply_index() {
         .async_command_on_node(3, request, cb)
         .unwrap();
     // Must timeout here
-    assert!(rx.recv_timeout(Duration::from_millis(500)).is_err());
+    assert_matches!(rx.recv_timeout(Duration::from_millis(500)), Err(_));
     fail::remove("on_apply_write_cmd");
 
     // After write cmd applied, the follower read will be executed.

--- a/tests/failpoints/cases/test_transaction.rs
+++ b/tests/failpoints/cases/test_transaction.rs
@@ -2,6 +2,7 @@
 
 use futures::executor::block_on;
 use kvproto::kvrpcpb::Context;
+use std::assert_matches::assert_matches;
 use std::{sync::mpsc::channel, thread, time::Duration};
 use storage::mvcc::tests::must_get;
 use storage::mvcc::{self, tests::must_locked};
@@ -12,7 +13,6 @@ use tikv::storage::txn::tests::{
 };
 use tikv::storage::{self, lock_manager::DummyLockManager, TestEngineBuilder, TestStorageBuilder};
 use txn_types::{Key, Mutation, TimeStamp};
-
 #[test]
 fn test_txn_failpoints() {
     let engine = TestEngineBuilder::new().build().unwrap();
@@ -294,9 +294,9 @@ fn test_max_commit_ts_error() {
         )
         .unwrap();
     thread::sleep(Duration::from_millis(200));
-    assert!(
-        cm.read_key_check(&Key::from_raw(b"k1"), |_| Err(()))
-            .is_err()
+    assert_matches!(
+        cm.read_key_check(&Key::from_raw(b"k1"), |_| Err(())),
+        Err(_)
     );
     cm.update_max_ts(200.into());
 

--- a/tests/failpoints/mod.rs
+++ b/tests/failpoints/mod.rs
@@ -2,6 +2,7 @@
 #![feature(box_patterns)]
 #![feature(test)]
 #![feature(custom_test_frameworks)]
+#![feature(assert_matches)]
 #![test_runner(test_util::run_failpoint_tests)]
 #![recursion_limit = "100"]
 

--- a/tests/integrations/config/dynamic/gc_worker.rs
+++ b/tests/integrations/config/dynamic/gc_worker.rs
@@ -1,6 +1,7 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
 use raftstore::router::RaftStoreBlackHole;
+use std::assert_matches::assert_matches;
 use std::f64::INFINITY;
 use std::sync::mpsc::channel;
 use std::time::Duration;
@@ -19,7 +20,7 @@ fn test_gc_config_validate() {
 
     let mut invalid_cfg = GcConfig::default();
     invalid_cfg.batch_keys = 0;
-    assert!(invalid_cfg.validate().is_err());
+    assert_matches!(invalid_cfg.validate(), Err(_));
 }
 
 fn setup_cfg_controller(

--- a/tests/integrations/config/dynamic/pessimistic_txn.rs
+++ b/tests/integrations/config/dynamic/pessimistic_txn.rs
@@ -1,5 +1,6 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::assert_matches::assert_matches;
 use std::sync::{atomic::Ordering, mpsc, Arc};
 use std::time::Duration;
 
@@ -18,7 +19,7 @@ fn test_config_validate() {
 
     let mut invalid_cfg = Config::default();
     invalid_cfg.wait_for_lock_timeout = ReadableDuration::millis(0);
-    assert!(invalid_cfg.validate().is_err());
+    assert_matches!(invalid_cfg.validate(), Err(_));
 }
 
 #[derive(Clone)]

--- a/tests/integrations/config/test_config_client.rs
+++ b/tests/integrations/config/test_config_client.rs
@@ -2,6 +2,7 @@
 
 use online_config::{ConfigChange, OnlineConfig};
 use raftstore::store::Config as RaftstoreConfig;
+use std::assert_matches::assert_matches;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{Read, Write};
@@ -29,23 +30,23 @@ fn test_update_config() {
 
     // update not support config
     let res = cfg_controller.update(change("server.addr", "localhost:3000"));
-    assert!(res.is_err());
+    assert_matches!(res, Err(_));
     assert_eq!(cfg_controller.get_current(), cfg);
 
     // update to invalid config
     let res = cfg_controller.update(change("raftstore.raft-log-gc-threshold", "0"));
-    assert!(res.is_err());
+    assert_matches!(res, Err(_));
     assert_eq!(cfg_controller.get_current(), cfg);
 
     // bad update request
     let res = cfg_controller.update(change("xxx.yyy", "0"));
-    assert!(res.is_err());
+    assert_matches!(res, Err(_));
     let res = cfg_controller.update(change("raftstore.xxx", "0"));
-    assert!(res.is_err());
+    assert_matches!(res, Err(_));
     let res = cfg_controller.update(change("raftstore.raft-log-gc-threshold", "10MB"));
-    assert!(res.is_err());
+    assert_matches!(res, Err(_));
     let res = cfg_controller.update(change("raft-log-gc-threshold", "10MB"));
-    assert!(res.is_err());
+    assert_matches!(res, Err(_));
     assert_eq!(cfg_controller.get_current(), cfg);
 }
 

--- a/tests/integrations/mod.rs
+++ b/tests/integrations/mod.rs
@@ -3,6 +3,7 @@
 #![feature(test)]
 #![feature(box_patterns)]
 #![feature(custom_test_frameworks)]
+#![feature(assert_matches)]
 #![test_runner(test_util::run_tests)]
 
 extern crate test;

--- a/tests/integrations/pd/test_rpc_client.rs
+++ b/tests/integrations/pd/test_rpc_client.rs
@@ -1,5 +1,6 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::assert_matches::assert_matches;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{mpsc, Arc};
 use std::thread;
@@ -259,7 +260,10 @@ fn test_validate_endpoints() {
 
     let mgr = Arc::new(SecurityManager::new(&SecurityConfig::default()).unwrap());
     let connector = PdConnector::new(env, mgr);
-    assert!(block_on(connector.validate_endpoints(&new_config(eps))).is_err());
+    assert_matches!(
+        block_on(connector.validate_endpoints(&new_config(eps))),
+        Err(_)
+    );
 }
 
 #[test]
@@ -278,7 +282,10 @@ fn test_validate_endpoints_retry() {
     eps.pop();
     let mgr = Arc::new(SecurityManager::new(&SecurityConfig::default()).unwrap());
     let connector = PdConnector::new(env, mgr);
-    assert!(block_on(connector.validate_endpoints(&new_config(eps))).is_err());
+    assert_matches!(
+        block_on(connector.validate_endpoints(&new_config(eps))),
+        Err(_)
+    );
 }
 
 fn test_retry<F: Fn(&RpcClient)>(func: F) {

--- a/tests/integrations/raftstore/test_bootstrap.rs
+++ b/tests/integrations/raftstore/test_bootstrap.rs
@@ -1,5 +1,6 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::assert_matches::assert_matches;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
@@ -169,7 +170,7 @@ fn test_node_switch_api_version() {
     // Should not be able to switch from V1 to V2 now.
     cluster.cfg.storage.api_version = 2;
     cluster.cfg.storage.enable_ttl = true;
-    assert!(cluster.start().is_err());
+    assert_matches!(cluster.start(), Err(_));
     cluster.shutdown();
 
     // Prepare a new storage and switch it to V2.
@@ -185,6 +186,6 @@ fn test_node_switch_api_version() {
     // Should not be able to switch from V2 to V1 now.
     cluster.cfg.storage.api_version = 1;
     cluster.cfg.storage.enable_ttl = false;
-    assert!(cluster.start().is_err());
+    assert_matches!(cluster.start(), Err(_));
     cluster.shutdown();
 }

--- a/tests/integrations/raftstore/test_region_info_accessor.rs
+++ b/tests/integrations/raftstore/test_region_info_accessor.rs
@@ -4,6 +4,7 @@ use kvproto::metapb::Region;
 use raft::StateRole;
 use raftstore::coprocessor::{RangeKey, RegionInfo, RegionInfoAccessor};
 use raftstore::store::util::{find_peer, new_peer};
+use std::assert_matches::assert_matches;
 use std::sync::mpsc::channel;
 use std::sync::Arc;
 use std::thread;
@@ -181,7 +182,7 @@ fn test_node_cluster_region_info_accessor() {
     cluster.run_conf_change();
     let c = rx.recv().unwrap();
     // We only created it on the node whose id == 1 so we shouldn't receive more than one item.
-    assert!(rx.try_recv().is_err());
+    assert_matches!(rx.try_recv(), Err(_));
 
     test_region_info_accessor_impl(&mut cluster, &c);
 

--- a/tests/integrations/server/security.rs
+++ b/tests/integrations/server/security.rs
@@ -4,6 +4,7 @@ use collections::HashSet;
 use grpcio::{ChannelBuilder, Environment};
 use kvproto::kvrpcpb::*;
 use kvproto::tikvpb::TikvClient;
+use std::assert_matches::assert_matches;
 use std::sync::Arc;
 use test_raftstore::new_server_cluster;
 use tikv_util::HandyRwLock;
@@ -45,5 +46,5 @@ fn test_check_cn_fail() {
 
     let client = TikvClient::new(channel);
     let status = client.kv_get(&GetRequest::default());
-    assert!(status.is_err());
+    assert_matches!(status, Err(_));
 }

--- a/tests/integrations/storage/test_raft_storage.rs
+++ b/tests/integrations/storage/test_raft_storage.rs
@@ -1,5 +1,6 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::assert_matches::assert_matches;
 use std::thread;
 use std::time::Duration;
 
@@ -58,14 +59,13 @@ fn test_raft_storage() {
     // Test wrong region id.
     let region_id = ctx.get_region_id();
     ctx.set_region_id(region_id + 1);
-    assert!(storage.get(ctx.clone(), raw_key.clone(), 20).is_err());
-    assert!(
-        storage
-            .batch_get(ctx.clone(), &[raw_key.clone()], 20)
-            .is_err()
+    assert_matches!(storage.get(ctx.clone(), raw_key.clone(), 20), Err(_));
+    assert_matches!(
+        storage.batch_get(ctx.clone(), &[raw_key.clone()], 20),
+        Err(_)
     );
-    assert!(storage.scan(ctx.clone(), key, None, 1, false, 20).is_err());
-    assert!(storage.scan_locks(ctx, 20, None, None, 100).is_err());
+    assert_matches!(storage.scan(ctx.clone(), key, None, 1, false, 20), Err(_));
+    assert_matches!(storage.scan_locks(ctx, 20, None, None, 100), Err(_));
 }
 
 #[test]
@@ -112,7 +112,7 @@ fn test_raft_storage_rollback_before_prewrite() {
         b"key".to_vec(),
         10,
     );
-    assert!(ret.is_err());
+    assert_matches!(ret, Err(_));
     let err = ret.unwrap_err();
     match err {
         StorageError(box StorageErrorInner::Txn(TxnError(box TxnErrorInner::Mvcc(MvccError(
@@ -160,7 +160,7 @@ fn test_raft_storage_store_not_match() {
 
     peer.set_store_id(store_id + 1);
     ctx.set_peer(peer);
-    assert!(storage.get(ctx.clone(), raw_key.clone(), 20).is_err());
+    assert_matches!(storage.get(ctx.clone(), raw_key.clone(), 20), Err(_));
     let res = storage.get(ctx.clone(), raw_key.clone(), 20);
     if let StorageError(box StorageErrorInner::Txn(TxnError(box TxnErrorInner::Engine(KvError(
         box KvErrorInner::Request(ref e),
@@ -170,13 +170,12 @@ fn test_raft_storage_store_not_match() {
     } else {
         panic!("expect store_not_match, but got {:?}", res);
     }
-    assert!(
-        storage
-            .batch_get(ctx.clone(), &[raw_key.clone()], 20)
-            .is_err()
+    assert_matches!(
+        storage.batch_get(ctx.clone(), &[raw_key.clone()], 20),
+        Err(_)
     );
-    assert!(storage.scan(ctx.clone(), key, None, 1, false, 20).is_err());
-    assert!(storage.scan_locks(ctx, 20, None, None, 100).is_err());
+    assert_matches!(storage.scan(ctx.clone(), key, None, 1, false, 20), Err(_));
+    assert_matches!(storage.scan_locks(ctx, 20, None, None, 100), Err(_));
 }
 
 #[test]

--- a/tests/integrations/storage/test_raftkv.rs
+++ b/tests/integrations/storage/test_raftkv.rs
@@ -1,4 +1,5 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
+use std::assert_matches::assert_matches;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::thread;
@@ -545,5 +546,5 @@ fn wrong_context<E: Engine>(ctx: &Context, engine: &E) {
     let region_id = ctx.get_region_id();
     let mut ctx = ctx.to_owned();
     ctx.set_region_id(region_id + 1);
-    assert!(engine.write(&ctx, WriteData::default()).is_err());
+    assert_matches!(engine.write(&ctx, WriteData::default()), Err(_));
 }

--- a/tests/integrations/storage/test_titan.rs
+++ b/tests/integrations/storage/test_titan.rs
@@ -1,5 +1,6 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::assert_matches::assert_matches;
 use std::f64::INFINITY;
 use std::path::Path;
 use std::sync::Arc;
@@ -85,7 +86,7 @@ fn test_turnoff_titan() {
 
     // try reopen db when titan isn't properly turned off.
     configure_for_disable_titan(&mut cluster);
-    assert!(cluster.pre_start_check().is_err());
+    assert_matches!(cluster.pre_start_check(), Err(_));
 
     configure_for_enable_titan(&mut cluster, ReadableSize::kb(0));
     assert!(cluster.pre_start_check().is_ok());


### PR DESCRIPTION
Signed-off-by: Jayice <1185430411@useqq.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: ref https://github.com/tikv/tikv/issues/11435

Problem Summary:
assert! provides too little information when failing

### What is changed and how it works?
use assert_matches!()

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test



### Release note <!-- bugfixes or new feature need a release note -->

```release-note
use assert_matches!()
```