### PR TITLE
storage: fix reverse scan check memory locks

### DIFF
--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -785,8 +785,8 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
     }
 
     /// Scan keys in [`start_key`, `end_key`) up to `limit` keys from the snapshot.
-    ///
-    /// If `end_key` is `None`, it means the upper bound is unbounded.
+    /// If `reverse_scan` is true, it scans [`end_key`, `start_key`) in descending order.
+    /// If `end_key` is `None`, it means the upper bound or the lower bound if reverse scan is unbounded.
     ///
     /// Only writes committed before `start_ts` are visible.
     pub fn scan(
@@ -829,6 +829,10 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
 
                 // TODO: check_api_version
 
+                let (mut start_key, mut end_key) = (Some(start_key), end_key);
+                if reverse_scan {
+                    std::mem::swap(&mut start_key, &mut end_key);
+                }
                 let command_duration = tikv_util::time::Instant::now_coarse();
 
                 let bypass_locks = TsSet::from_u64s(ctx.take_resolved_locks());
@@ -840,7 +844,7 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
                 if ctx.get_isolation_level() == IsolationLevel::Si {
                     let begin_instant = Instant::now();
                     concurrency_manager
-                        .read_range_check(Some(&start_key), end_key.as_ref(), |key, lock| {
+                        .read_range_check(start_key.as_ref(), end_key.as_ref(), |key, lock| {
                             Lock::check_ts_conflict(
                                 Cow::Borrowed(lock),
                                 key,
@@ -868,7 +872,9 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
                 };
                 if need_check_locks_in_replica_read(&ctx) {
                     let mut key_range = KeyRange::default();
-                    key_range.set_start_key(start_key.as_encoded().to_vec());
+                    if let Some(start_key) = &start_key {
+                        key_range.set_start_key(start_key.as_encoded().to_vec());
+                    }
                     if let Some(end_key) = &end_key {
                         key_range.set_end_key(end_key.as_encoded().to_vec());
                     }
@@ -890,14 +896,8 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
                         false,
                     );
 
-                    let mut scanner;
-                    if !reverse_scan {
-                        scanner =
-                            snap_store.scanner(false, key_only, false, Some(start_key), end_key)?;
-                    } else {
-                        scanner =
-                            snap_store.scanner(true, key_only, false, end_key, Some(start_key))?;
-                    };
+                    let mut scanner =
+                        snap_store.scanner(reverse_scan, key_only, false, start_key, end_key)?;
                     let res = scanner.scan(limit, sample_step);
 
                     let statistics = scanner.take_statistics();
@@ -6549,20 +6549,22 @@ mod tests {
         );
         assert_eq!(key_error.get_locked().get_key(), b"key");
 
-        // Test scan
-        let key_error = extract_key_error(
-            &block_on(storage.scan(
+        let scan = |start_key, end_key, reverse| {
+            block_on(storage.scan(
                 ctx.clone(),
-                Key::from_raw(b"a"),
-                None,
+                start_key,
+                end_key,
                 10,
                 0,
                 100.into(),
                 false,
-                false,
+                reverse,
             ))
-            .unwrap_err(),
-        );
+            .unwrap_err()
+        };
+        let key_error = extract_key_error(&scan(Key::from_raw(b"a"), None, false));
+        assert_eq!(key_error.get_locked().get_key(), b"key");
+        let key_error = extract_key_error(&scan(Key::from_raw(b"\xff"), None, true));
         assert_eq!(key_error.get_locked().get_key(), b"key");
 
         // Test batch_get_command


### PR DESCRIPTION
Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number:close #11440 <!-- REMOVE this line if no issue to close -->

Problem Summary:

Reverse scan's start_key is greater than end_key, but storage always uses [start_key, end_key) to check memory locks.

### What is changed and how it works?

What's Changed:

Swap start_key and end_key if is a reverse scan.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix the issue that reverse scan can't detect memory locks and may read stale data.
```