### PR TITLE
raftstore: destroy uninitialized peer can make it possible to recreate old peer

### DIFF
--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -905,7 +905,7 @@ where
         fail_point!("raft_store_skip_destroy_peer", |_| Ok(()));
         let t = TiInstant::now();
 
-        let region = self.region().clone();
+        let mut region = self.region().clone();
         info!(
             "begin to destroy";
             "region_id" => self.region_id,
@@ -916,6 +916,14 @@ where
         let mut kv_wb = engines.kv.write_batch();
         let mut raft_wb = engines.raft.log_batch(1024);
         self.mut_store().clear_meta(&mut kv_wb, &mut raft_wb)?;
+
+        // StoreFsmDelegate::check_msg use both epoch and region peer list to check whether
+        // a message is targing a staled peer.  But for an uninitialized peer, both epoch and
+        // peer list are empty, so a removed peer will be created again.  Saving current peer
+        // into the peer list of region will fix this problem.
+        if !self.get_store().is_initialized() {
+            region.mut_peers().push(self.peer.clone());
+        }
         write_peer_state(
             &mut kv_wb,
             &region,

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -6,13 +6,15 @@ use std::sync::{mpsc, Arc, Mutex, RwLock};
 use std::time::Duration;
 use std::{result, thread};
 
+use crossbeam::channel::TrySendError;
 use futures::executor::block_on;
 use kvproto::errorpb::Error as PbError;
 use kvproto::metapb::{self, PeerRole, RegionEpoch, StoreLabel};
 use kvproto::pdpb;
 use kvproto::raft_cmdpb::*;
 use kvproto::raft_serverpb::{
-    self, RaftApplyState, RaftLocalState, RaftMessage, RaftTruncatedState, RegionLocalState,
+    self, PeerState, RaftApplyState, RaftLocalState, RaftMessage, RaftTruncatedState,
+    RegionLocalState,
 };
 use raft::eraftpb::ConfChangeType;
 use tempfile::TempDir;
@@ -1569,6 +1571,38 @@ impl<T: Simulator> Cluster<T> {
             try_cnt += 1;
             sleep_ms(20);
         }
+    }
+
+    pub fn destroy_peer(
+        &mut self,
+        region_id: u64,
+        node_id: u64,
+        peer: metapb::Peer,
+    ) -> std::result::Result<(), TrySendError<RaftMessage>> {
+        let router = self.sim.rl().get_router(node_id).unwrap();
+
+        let mut message = RaftMessage::default();
+        message.set_region_id(region_id);
+        message.set_from_peer(peer.clone());
+        message.set_to_peer(peer);
+        message.set_region_epoch(self.get_region_epoch(region_id));
+        message.set_is_tombstone(true);
+        router.send_raft_message(message)
+    }
+
+    pub fn must_destroy_peer(&mut self, region_id: u64, node_id: u64, peer: metapb::Peer) {
+        for _ in 0..250 {
+            self.destroy_peer(region_id, node_id, peer.clone()).unwrap();
+            if self.region_local_state(region_id, node_id).get_state() == PeerState::Tombstone {
+                return;
+            }
+            sleep_ms(20);
+        }
+
+        panic!(
+            "destroy peer timeout: region id {}, node id {}, peer {:?}",
+            region_id, node_id, peer
+        );
     }
 }
 

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -1573,7 +1573,7 @@ impl<T: Simulator> Cluster<T> {
         }
     }
 
-    pub fn destroy_peer(
+    pub fn gc_peer(
         &mut self,
         region_id: u64,
         node_id: u64,
@@ -1590,9 +1590,9 @@ impl<T: Simulator> Cluster<T> {
         router.send_raft_message(message)
     }
 
-    pub fn must_destroy_peer(&mut self, region_id: u64, node_id: u64, peer: metapb::Peer) {
+    pub fn must_gc_peer(&mut self, region_id: u64, node_id: u64, peer: metapb::Peer) {
         for _ in 0..250 {
-            self.destroy_peer(region_id, node_id, peer.clone()).unwrap();
+            self.gc_peer(region_id, node_id, peer.clone()).unwrap();
             if self.region_local_state(region_id, node_id).get_state() == PeerState::Tombstone {
                 return;
             }
@@ -1600,7 +1600,7 @@ impl<T: Simulator> Cluster<T> {
         }
 
         panic!(
-            "destroy peer timeout: region id {}, node id {}, peer {:?}",
+            "gc peer timeout: region id {}, node id {}, peer {:?}",
             region_id, node_id, peer
         );
     }

--- a/components/test_raftstore/src/transport_simulate.rs
+++ b/components/test_raftstore/src/transport_simulate.rs
@@ -278,8 +278,14 @@ impl<F: Filter + Clone + 'static> FilterFactory for CloneFilterFactory<F> {
     }
 }
 
-struct PartitionFilter {
+pub struct PartitionFilter {
     node_ids: Vec<u64>,
+}
+
+impl PartitionFilter {
+    pub fn new(node_ids: Vec<u64>) -> PartitionFilter {
+        PartitionFilter { node_ids }
+    }
 }
 
 impl Filter for PartitionFilter {

--- a/components/test_raftstore/src/transport_simulate.rs
+++ b/components/test_raftstore/src/transport_simulate.rs
@@ -278,14 +278,8 @@ impl<F: Filter + Clone + 'static> FilterFactory for CloneFilterFactory<F> {
     }
 }
 
-pub struct PartitionFilter {
+struct PartitionFilter {
     node_ids: Vec<u64>,
-}
-
-impl PartitionFilter {
-    pub fn new(node_ids: Vec<u64>) -> PartitionFilter {
-        PartitionFilter { node_ids }
-    }
 }
 
 impl Filter for PartitionFilter {

--- a/components/test_raftstore/src/util.rs
+++ b/components/test_raftstore/src/util.rs
@@ -308,6 +308,12 @@ pub fn sleep_ms(ms: u64) {
     thread::sleep(Duration::from_millis(ms));
 }
 
+pub fn sleep_until_election_triggered(cfg: &Config) {
+    let election_timeout =
+        cfg.raft_base_tick_interval.as_millis() * cfg.raft_election_timeout_ticks as u64;
+    sleep_ms(3u64 * election_timeout);
+}
+
 pub fn is_error_response(resp: &RaftCmdResponse) -> bool {
     resp.get_header().has_error()
 }

--- a/components/test_raftstore/src/util.rs
+++ b/components/test_raftstore/src/util.rs
@@ -309,8 +309,8 @@ pub fn sleep_ms(ms: u64) {
 }
 
 pub fn sleep_until_election_triggered(cfg: &Config) {
-    let election_timeout =
-        cfg.raft_base_tick_interval.as_millis() * cfg.raft_election_timeout_ticks as u64;
+    let election_timeout = cfg.raft_store.raft_base_tick_interval.as_millis()
+        * cfg.raft_store.raft_election_timeout_ticks as u64;
     sleep_ms(3u64 * election_timeout);
 }
 

--- a/tests/failpoints/cases/test_stale_peer.rs
+++ b/tests/failpoints/cases/test_stale_peer.rs
@@ -213,6 +213,7 @@ fn test_stale_peer_destroy_when_apply_snapshot() {
     must_get_none(&cluster.get_engine(3), b"k1");
 }
 
+/// Test if destroy a uninitialized peer through tombstone msg would allow a staled peer be created again.
 #[test]
 fn test_destroy_uninitialized_peer_when_there_exists_old_peer() {
     // 4 stores cluster.
@@ -273,7 +274,7 @@ fn test_destroy_uninitialized_peer_when_there_exists_old_peer() {
     // Remove and destroy the uninitialized 5
     let peer_5 = new_learner_peer(3, 5);
     pd_client.must_remove_peer(r1, peer_5.clone());
-    cluster.must_destroy_peer(r1, 3, peer_5);
+    cluster.must_gc_peer(r1, 3, peer_5);
 
     let region = block_on(pd_client.get_region_by_id(r1)).unwrap();
     must_region_cleared(&cluster.get_all_engines(3), &region.unwrap());

--- a/tests/failpoints/cases/test_stale_peer.rs
+++ b/tests/failpoints/cases/test_stale_peer.rs
@@ -281,6 +281,7 @@ fn test_destroy_uninitialized_peer_when_there_exists_old_peer() {
 
     // Unisolate 1 and try wakeup 3
     cluster.clear_send_filters();
+    cluster.sim.wl().clear_recv_filters(3);
     cluster.partition(vec![1, 3], vec![2, 4]);
 
     sleep_until_election_triggered(&cluster.cfg);


### PR DESCRIPTION
Signed-off-by: p4tr1ck <patricknicholas@foxmail.com>

### What problem does this PR solve?

Issue Number: close #10533  <!-- REMOVE this line if no issue to close -->

Problem Summary:

For an uninitialized peer, both epoch and peer list are empty, so a message target to a staled peer which override by an uninitialized peer will be create again. 

### What is changed and how it works?

What's Changed:

This PR will save the current peer into peer list if this region is uninitialized.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix the problem that destroying an uninitialized replica may cause a stalled replica be created again.
```