### PR TITLE
raftstore: add pessimistic lock table to peer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3502,6 +3502,7 @@ dependencies = [
  "openssl",
  "ordered-float 2.7.0",
  "panic_hook",
+ "parking_lot",
  "pd_client",
  "prometheus",
  "prometheus-static-metric",

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -1410,7 +1410,6 @@ impl TxnExtraScheduler for CdcTxnExtraScheduler {
 mod tests {
     use std::collections::BTreeMap;
     use std::fmt::Display;
-    use std::sync::atomic::AtomicU64;
     use std::sync::mpsc::{channel, sync_channel, Receiver, RecvTimeoutError, Sender};
 
     use collections::HashSet;
@@ -1519,7 +1518,7 @@ mod tests {
             leader_lease: None,
             last_valid_ts: Timespec::new(0, 0),
             txn_extra_op: Arc::new(AtomicCell::new(TxnExtraOp::default())),
-            max_ts_sync_status: Arc::new(AtomicU64::new(0)),
+            txn_ext: Arc::new(Default::default()),
             track_ver: TrackVer::new(),
             read_progress: Arc::new(RegionReadProgress::new(
                 &Region::default(),

--- a/components/raftstore/Cargo.toml
+++ b/components/raftstore/Cargo.toml
@@ -48,6 +48,7 @@ log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug
 log_wrappers = { path = "../log_wrappers" }
 memory_trace_macros = { path = "../memory_trace_macros" }
 ordered-float = "2.6"
+parking_lot = "0.11"
 pd_client = { path = "../pd_client", default-features = false }
 prometheus = { version = "0.12", features = ["nightly"] }
 prometheus-static-metric = "0.5"

--- a/components/raftstore/src/store/mod.rs
+++ b/components/raftstore/src/store/mod.rs
@@ -22,6 +22,7 @@ mod read_queue;
 mod region_snapshot;
 mod replication_mode;
 mod snap;
+mod txn_ext;
 mod worker;
 
 pub use self::bootstrap::{
@@ -56,6 +57,7 @@ pub use self::snap::{
     Snapshot, SnapshotStatistics,
 };
 pub use self::transport::{CasualRouter, ProposalRouter, StoreRouter, Transport};
+pub use self::txn_ext::{PeerPessimisticLocks, TxnExt};
 pub use self::util::{RegionReadProgress, RegionReadProgressRegistry};
 pub use self::worker::{
     AutoSplitController, FlowStatistics, FlowStatsReporter, PdTask, QueryStats, ReadDelegate,

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -3,7 +3,7 @@
 // #[PerformanceCriticalPath]
 use std::cell::RefCell;
 use std::collections::VecDeque;
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use std::{cmp, mem, u64, usize};
@@ -55,7 +55,7 @@ use crate::store::msg::RaftCommand;
 use crate::store::util::{admin_cmd_epoch_lookup, RegionReadProgress};
 use crate::store::worker::{HeartbeatTask, ReadDelegate, ReadExecutor, ReadProgress, RegionTask};
 use crate::store::{
-    Callback, Config, GlobalReplicationState, PdTask, ReadIndexContext, ReadResponse,
+    Callback, Config, GlobalReplicationState, PdTask, ReadIndexContext, ReadResponse, TxnExt,
 };
 use crate::{Error, Result};
 use collections::{HashMap, HashSet};
@@ -554,15 +554,8 @@ where
 
     pub txn_extra_op: Arc<AtomicCell<TxnExtraOp>>,
 
-    /// The max timestamp recorded in the concurrency manager is only updated at leader.
-    /// So if a peer becomes leader from a follower, the max timestamp can be outdated.
-    /// We need to update the max timestamp with a latest timestamp from PD before this
-    /// peer can work.
-    /// From the least significant to the most, 1 bit marks whether the timestamp is
-    /// updated, 31 bits for the current epoch version, 32 bits for the current term.
-    /// The version and term are stored to prevent stale UpdateMaxTimestamp task from
-    /// marking the lowest bit.
-    pub max_ts_sync_status: Arc<AtomicU64>,
+    /// Transaction extensions related to this peer.
+    pub txn_ext: Arc<TxnExt>,
 
     /// Check whether this proposal can be proposed based on its epoch.
     cmd_epoch_checker: CmdEpochChecker<EK::Snapshot>,
@@ -684,7 +677,7 @@ where
             check_stale_peers: vec![],
             local_first_replicate: false,
             txn_extra_op: Arc::new(AtomicCell::new(TxnExtraOp::Noop)),
-            max_ts_sync_status: Arc::new(AtomicU64::new(0)),
+            txn_ext: Arc::new(TxnExt::default()),
             cmd_epoch_checker: Default::default(),
             disk_full_peers: DiskFullPeers::default(),
             dangerous_majority_set: false,
@@ -3838,7 +3831,7 @@ where
 
         let mut resp = ctx.execute(&req, &Arc::new(region), read_index, None);
         if let Some(snap) = resp.snapshot.as_mut() {
-            snap.max_ts_sync_status = Some(self.max_ts_sync_status.clone());
+            snap.txn_ext = Some(self.txn_ext.clone());
         }
         resp.txn_extra_op = self.txn_extra_op.load();
         cmd_resp::bind_term(&mut resp.response, self.term());
@@ -4359,7 +4352,8 @@ where
         let term_low_bits = self.term() & ((1 << 32) - 1); // 32 bits
         let version_lot_bits = epoch.get_version() & ((1 << 31) - 1); // 31 bits
         let initial_status = (term_low_bits << 32) | (version_lot_bits << 1);
-        self.max_ts_sync_status
+        self.txn_ext
+            .max_ts_sync_status
             .store(initial_status, Ordering::SeqCst);
         info!(
             "require updating max ts";
@@ -4369,7 +4363,7 @@ where
         if let Err(e) = pd_scheduler.schedule(PdTask::UpdateMaxTimestamp {
             region_id: self.region_id,
             initial_status,
-            max_ts_sync_status: self.max_ts_sync_status.clone(),
+            txn_ext: self.txn_ext.clone(),
         }) {
             error!(
                 "failed to update max ts";

--- a/components/raftstore/src/store/txn_ext.rs
+++ b/components/raftstore/src/store/txn_ext.rs
@@ -1,0 +1,68 @@
+// Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::{
+    fmt,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use collections::HashMap;
+use parking_lot::RwLock;
+use txn_types::{Key, PessimisticLock};
+
+/// Transaction extensions related to a peer.
+#[derive(Default)]
+pub struct TxnExt {
+    /// The max timestamp recorded in the concurrency manager is only updated at leader.
+    /// So if a peer becomes leader from a follower, the max timestamp can be outdated.
+    /// We need to update the max timestamp with a latest timestamp from PD before this
+    /// peer can work.
+    /// From the least significant to the most, 1 bit marks whether the timestamp is
+    /// updated, 31 bits for the current epoch version, 32 bits for the current term.
+    /// The version and term are stored to prevent stale UpdateMaxTimestamp task from
+    /// marking the lowest bit.
+    pub max_ts_sync_status: AtomicU64,
+
+    /// The in-memory pessimistic lock table of the peer.
+    pub pessimistic_locks: RwLock<PeerPessimisticLocks>,
+}
+
+impl TxnExt {
+    pub fn is_max_ts_synced(&self) -> bool {
+        self.max_ts_sync_status.load(Ordering::SeqCst) & 1 == 1
+    }
+}
+
+impl fmt::Debug for TxnExt {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut debug_struct = f.debug_struct("TxnExt");
+        debug_struct.field("max_ts_sync_status", &self.max_ts_sync_status);
+        if let Some(pessimistic_locks) = self.pessimistic_locks.try_read() {
+            debug_struct.field("pessimistic_locks", &pessimistic_locks);
+        } else {
+            debug_struct.field("pessimistic_locks", &"(Locked)");
+        }
+        debug_struct.finish()
+    }
+}
+
+/// Pessimistic locks of a region peer.
+#[derive(Default)]
+pub struct PeerPessimisticLocks {
+    pub map: HashMap<Key, PessimisticLock>,
+    /// `epoch` marks the version of the pessimistic lock table. It is increased when the region
+    /// leadership changes or the range changes, to prevent writing locks to the table incorrectly.
+    pub epoch: u64,
+    /// Whether the pessimistic lock map is valid to read or write. If it is invalid,
+    /// the in-memory pessimistic lock feature cannot be used at the moment.
+    pub valid: bool,
+}
+
+impl fmt::Debug for PeerPessimisticLocks {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PeerPessimisticLocks")
+            .field("pessimistic_locks_size", &self.map.len())
+            .field("valid", &self.valid)
+            .field("epoch", &self.epoch)
+            .finish()
+    }
+}

--- a/components/tikv_kv/src/raftstore_impls.rs
+++ b/components/tikv_kv/src/raftstore_impls.rs
@@ -8,7 +8,6 @@ use engine_traits::CfName;
 use engine_traits::{IterOptions, Peekable, ReadOptions, Snapshot};
 use raftstore::store::{RegionIterator, RegionSnapshot};
 use raftstore::Error as RaftServerError;
-use std::sync::atomic::Ordering;
 use txn_types::{Key, Value};
 
 impl From<RaftServerError> for Error {
@@ -74,9 +73,9 @@ impl<S: Snapshot> EngineSnapshot for RegionSnapshot<S> {
     }
 
     fn is_max_ts_synced(&self) -> bool {
-        self.max_ts_sync_status
+        self.txn_ext
             .as_ref()
-            .map(|v| v.load(Ordering::SeqCst) & 1 == 1)
+            .map(|txn_ext| txn_ext.is_max_ts_synced())
             .unwrap_or(false)
     }
 }

--- a/components/txn_types/src/lib.rs
+++ b/components/txn_types/src/lib.rs
@@ -13,7 +13,7 @@ mod write;
 
 use std::io;
 
-pub use lock::{Lock, LockType};
+pub use lock::{Lock, LockType, PessimisticLock};
 pub use timestamp::{TimeStamp, TsSet};
 pub use types::{
     is_short_value, Key, KvPair, Mutation, MutationType, OldValue, OldValues, RawMutation,

--- a/components/txn_types/src/lock.rs
+++ b/components/txn_types/src/lock.rs
@@ -370,6 +370,59 @@ impl Lock {
     }
 }
 
+/// A specialized lock only for pessimistic lock. This saves memory for cases that only
+/// pessimistic locks exist.
+#[derive(Clone, PartialEq, Eq)]
+pub struct PessimisticLock {
+    /// The primary key in raw format.
+    pub primary: Box<[u8]>,
+    pub start_ts: TimeStamp,
+    pub ttl: u64,
+    pub for_update_ts: TimeStamp,
+    pub min_commit_ts: TimeStamp,
+}
+
+impl PessimisticLock {
+    pub fn to_lock(&self) -> Lock {
+        Lock::new(
+            LockType::Pessimistic,
+            self.primary.to_vec(),
+            self.start_ts,
+            self.ttl,
+            None,
+            self.for_update_ts,
+            0,
+            self.min_commit_ts,
+        )
+    }
+
+    // Same with `to_lock` but does not copy the primary key.
+    pub fn into_lock(self) -> Lock {
+        Lock::new(
+            LockType::Pessimistic,
+            Vec::from(self.primary),
+            self.start_ts,
+            self.ttl,
+            None,
+            self.for_update_ts,
+            0,
+            self.min_commit_ts,
+        )
+    }
+}
+
+impl std::fmt::Debug for PessimisticLock {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PessimisticLock")
+            .field("primary_key", &log_wrappers::Value::key(&self.primary))
+            .field("start_ts", &self.start_ts)
+            .field("ttl", &self.ttl)
+            .field("for_update_ts", &self.for_update_ts)
+            .field("min_commit_ts", &self.min_commit_ts)
+            .finish()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -742,6 +795,56 @@ mod tests {
             "Lock { lock_type: Put, primary_key: ?, start_ts: TimeStamp(100), ttl: 3, short_value: ?, \
             for_update_ts: TimeStamp(101), txn_size: 10, min_commit_ts: TimeStamp(127), \
             use_async_commit: true, secondaries: [], rollback_ts: [] }"
+        );
+    }
+
+    #[test]
+    fn test_pessimistic_lock_to_lock() {
+        let pessimistic_lock = PessimisticLock {
+            primary: b"primary".to_vec().into_boxed_slice(),
+            start_ts: 5.into(),
+            ttl: 1000,
+            for_update_ts: 10.into(),
+            min_commit_ts: 20.into(),
+        };
+        let expected_lock = Lock {
+            lock_type: LockType::Pessimistic,
+            primary: b"primary".to_vec(),
+            ts: 5.into(),
+            ttl: 1000,
+            short_value: None,
+            for_update_ts: 10.into(),
+            txn_size: 0,
+            min_commit_ts: 20.into(),
+            use_async_commit: false,
+            secondaries: vec![],
+            rollback_ts: vec![],
+        };
+        assert_eq!(pessimistic_lock.to_lock(), expected_lock);
+        assert_eq!(pessimistic_lock.into_lock(), expected_lock);
+    }
+
+    #[test]
+    fn test_pessimistic_lock_customize_debug() {
+        let pessimistic_lock = PessimisticLock {
+            primary: b"primary".to_vec().into_boxed_slice(),
+            start_ts: 5.into(),
+            ttl: 1000,
+            for_update_ts: 10.into(),
+            min_commit_ts: 20.into(),
+        };
+        assert_eq!(
+            format!("{:?}", pessimistic_lock),
+            "PessimisticLock { primary_key: 7072696D617279, start_ts: TimeStamp(5), ttl: 1000, \
+            for_update_ts: TimeStamp(10), min_commit_ts: TimeStamp(20) }"
+        );
+        log_wrappers::set_redact_info_log(true);
+        let redact_result = format!("{:?}", pessimistic_lock);
+        log_wrappers::set_redact_info_log(false);
+        assert_eq!(
+            redact_result,
+            "PessimisticLock { primary_key: ?, start_ts: TimeStamp(5), ttl: 1000, \
+            for_update_ts: TimeStamp(10), min_commit_ts: TimeStamp(20) }"
         );
     }
 }

--- a/tests/failpoints/cases/test_storage.rs
+++ b/tests/failpoints/cases/test_storage.rs
@@ -478,9 +478,9 @@ fn test_async_commit_prewrite_with_stale_max_ts() {
         ..Default::default()
     };
     let snapshot = engine.snapshot(snap_ctx).unwrap();
-    let max_ts_sync_status = snapshot.max_ts_sync_status.clone().unwrap();
+    let txn_ext = snapshot.txn_ext.clone().unwrap();
     for retry in 0..10 {
-        if max_ts_sync_status.load(Ordering::SeqCst) & 1 == 1 {
+        if txn_ext.is_max_ts_synced() {
             break;
         }
         thread::sleep(Duration::from_millis(1 << retry));

--- a/tests/integrations/raftstore/test_merge.rs
+++ b/tests/integrations/raftstore/test_merge.rs
@@ -1,7 +1,6 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::iter::*;
-use std::sync::atomic::Ordering;
 use std::sync::*;
 use std::thread;
 use std::time::*;
@@ -1173,9 +1172,9 @@ fn test_sync_max_ts_after_region_merge() {
             ..Default::default()
         };
         let snapshot = storage.snapshot(snap_ctx).unwrap();
-        let max_ts_sync_status = snapshot.max_ts_sync_status.clone().unwrap();
+        let txn_ext = snapshot.txn_ext.clone().unwrap();
         for retry in 0..10 {
-            if max_ts_sync_status.load(Ordering::SeqCst) & 1 == 1 {
+            if txn_ext.is_max_ts_synced() {
                 break;
             }
             thread::sleep(Duration::from_millis(1 << retry));

--- a/tests/integrations/raftstore/test_transfer_leader.rs
+++ b/tests/integrations/raftstore/test_transfer_leader.rs
@@ -1,6 +1,5 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
@@ -195,9 +194,9 @@ fn test_sync_max_ts_after_leader_transfer() {
             ..Default::default()
         };
         let snapshot = storage.snapshot(snap_ctx).unwrap();
-        let max_ts_sync_status = snapshot.max_ts_sync_status.clone().unwrap();
+        let txn_ext = snapshot.txn_ext.clone().unwrap();
         for retry in 0..10 {
-            if max_ts_sync_status.load(Ordering::SeqCst) & 1 == 1 {
+            if txn_ext.is_max_ts_synced() {
                 break;
             }
             thread::sleep(Duration::from_millis(1 << retry));


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: #11452

### What is changed and how it works?

This PR adds a region-level pessimistic lock table. And related transaction-related things of a region are refactored into a `TxnExt` struct.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```