### PR TITLE
*: replace snapshot `CbContext` with `SnapshotExt`

### DIFF
--- a/components/raftstore/src/store/region_snapshot.rs
+++ b/components/raftstore/src/store/region_snapshot.rs
@@ -4,8 +4,10 @@
 use engine_traits::{
     IterOptions, KvEngine, Peekable, ReadOptions, Result as EngineResult, Snapshot,
 };
+use kvproto::kvrpcpb::ExtraOp as TxnExtraOp;
 use kvproto::metapb::Region;
 use kvproto::raft_serverpb::RaftApplyState;
+use std::num::NonZeroU64;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
@@ -30,6 +32,8 @@ pub struct RegionSnapshot<S: Snapshot> {
     snap: Arc<S>,
     region: Arc<Region>,
     apply_index: Arc<AtomicU64>,
+    pub term: Option<NonZeroU64>,
+    pub txn_extra_op: TxnExtraOp,
     // `None` means the snapshot does not provide peer related transaction extensions.
     pub txn_ext: Option<Arc<TxnExt>>,
 }
@@ -60,6 +64,8 @@ where
             // Use 0 to indicate that the apply index is missing and we need to KvGet it,
             // since apply index must be >= RAFT_INIT_LOG_INDEX.
             apply_index: Arc::new(AtomicU64::new(0)),
+            term: None,
+            txn_extra_op: TxnExtraOp::Noop,
             txn_ext: None,
         }
     }
@@ -172,6 +178,8 @@ where
             snap: self.snap.clone(),
             region: Arc::clone(&self.region),
             apply_index: Arc::clone(&self.apply_index),
+            term: self.term,
+            txn_extra_op: self.txn_extra_op,
             txn_ext: self.txn_ext.clone(),
         }
     }

--- a/components/tikv_kv/src/btree_engine.rs
+++ b/components/tikv_kv/src/btree_engine.rs
@@ -13,7 +13,7 @@ use kvproto::kvrpcpb::Context;
 use txn_types::{Key, Value};
 
 use crate::{
-    Callback as EngineCallback, CbContext, Engine, Error as EngineError,
+    Callback as EngineCallback, DummySnapshotExt, Engine, Error as EngineError,
     ErrorInner as EngineErrorInner, Iterator, Modify, Result as EngineResult, Snapshot, WriteData,
 };
 
@@ -94,7 +94,7 @@ impl Engine for BTreeEngine {
         if batch.modifies.is_empty() {
             return Err(EngineError::from(EngineErrorInner::EmptyRequest));
         }
-        cb((CbContext::new(), write_modifies(self, batch.modifies)));
+        cb(write_modifies(self, batch.modifies));
 
         Ok(())
     }
@@ -105,7 +105,7 @@ impl Engine for BTreeEngine {
         _ctx: SnapContext<'_>,
         cb: EngineCallback<Self::Snap>,
     ) -> EngineResult<()> {
-        cb((CbContext::new(), Ok(BTreeEngineSnapshot::new(self))));
+        cb(Ok(BTreeEngineSnapshot::new(self)));
         Ok(())
     }
 }
@@ -226,6 +226,7 @@ impl Iterator for BTreeEngineIterator {
 
 impl Snapshot for BTreeEngineSnapshot {
     type Iter = BTreeEngineIterator;
+    type Ext<'a> = DummySnapshotExt;
 
     fn get(&self, key: &Key) -> EngineResult<Option<Value>> {
         self.get_cf(CF_DEFAULT, key)
@@ -249,6 +250,9 @@ impl Snapshot for BTreeEngineSnapshot {
     fn iter_cf(&self, cf: CfName, iter_opt: IterOptions) -> EngineResult<Self::Iter> {
         let tree = self.inner_engine.get_cf(cf);
         Ok(BTreeEngineIterator::new(tree, iter_opt))
+    }
+    fn ext(&self) -> DummySnapshotExt {
+        DummySnapshotExt
     }
 }
 

--- a/components/tikv_kv/src/raftstore_impls.rs
+++ b/components/tikv_kv/src/raftstore_impls.rs
@@ -1,12 +1,16 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::num::NonZeroU64;
+use std::sync::Arc;
+
 use crate::{
     self as kv, Error, Error as KvError, ErrorInner, Iterator as EngineIterator,
-    Snapshot as EngineSnapshot,
+    Snapshot as EngineSnapshot, SnapshotExt,
 };
 use engine_traits::CfName;
 use engine_traits::{IterOptions, Peekable, ReadOptions, Snapshot};
-use raftstore::store::{RegionIterator, RegionSnapshot};
+use kvproto::kvrpcpb::ExtraOp as TxnExtraOp;
+use raftstore::store::{RegionIterator, RegionSnapshot, TxnExt};
 use raftstore::Error as RaftServerError;
 use txn_types::{Key, Value};
 
@@ -16,8 +20,40 @@ impl From<RaftServerError> for Error {
     }
 }
 
+pub struct RegionSnapshotExt<'a, S: Snapshot> {
+    snapshot: &'a RegionSnapshot<S>,
+}
+
+impl<'a, S: Snapshot> SnapshotExt for RegionSnapshotExt<'a, S> {
+    #[inline]
+    fn get_data_version(&self) -> Option<u64> {
+        self.snapshot.get_apply_index().ok()
+    }
+
+    fn is_max_ts_synced(&self) -> bool {
+        self.snapshot
+            .txn_ext
+            .as_ref()
+            .map(|txn_ext| txn_ext.is_max_ts_synced())
+            .unwrap_or(false)
+    }
+
+    fn get_term(&self) -> Option<NonZeroU64> {
+        self.snapshot.term
+    }
+
+    fn get_txn_extra_op(&self) -> TxnExtraOp {
+        self.snapshot.txn_extra_op
+    }
+
+    fn get_txn_ext(&self) -> Option<&Arc<TxnExt>> {
+        self.snapshot.txn_ext.as_ref()
+    }
+}
+
 impl<S: Snapshot> EngineSnapshot for RegionSnapshot<S> {
     type Iter = RegionIterator<S>;
+    type Ext<'a> = RegionSnapshotExt<'a, S>;
 
     fn get(&self, key: &Key) -> kv::Result<Option<Value>> {
         fail_point!("raftkv_snapshot_get", |_| Err(box_err!(
@@ -67,16 +103,8 @@ impl<S: Snapshot> EngineSnapshot for RegionSnapshot<S> {
         Some(self.get_end_key())
     }
 
-    #[inline]
-    fn get_data_version(&self) -> Option<u64> {
-        self.get_apply_index().ok()
-    }
-
-    fn is_max_ts_synced(&self) -> bool {
-        self.txn_ext
-            .as_ref()
-            .map(|txn_ext| txn_ext.is_max_ts_synced())
-            .unwrap_or(false)
+    fn ext(&self) -> RegionSnapshotExt<'_, S> {
+        RegionSnapshotExt { snapshot: self }
     }
 }
 

--- a/src/coprocessor/cache.rs
+++ b/src/coprocessor/cache.rs
@@ -3,6 +3,7 @@
 use async_trait::async_trait;
 use kvproto::coprocessor::Response;
 use tikv_alloc::trace::MemoryTraceGuard;
+use tikv_kv::SnapshotExt;
 
 use crate::coprocessor::RequestHandler;
 use crate::coprocessor::*;
@@ -15,7 +16,7 @@ pub struct CachedRequestHandler {
 impl CachedRequestHandler {
     pub fn new<S: Snapshot>(snap: S) -> Self {
         Self {
-            data_version: snap.get_data_version(),
+            data_version: snap.ext().get_data_version(),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@
 #![feature(drain_filter)]
 #![feature(negative_impls)]
 #![feature(deadline_api)]
+#![feature(generic_associated_types)]
 
 #[macro_use(fail_point)]
 extern crate fail;

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -1115,16 +1115,13 @@ mod tests {
         ) -> EngineResult<()> {
             self.0.async_snapshot(
                 ctx,
-                Box::new(move |(cb_ctx, r)| {
-                    callback((
-                        cb_ctx,
-                        r.map(|snap| {
-                            let mut region = Region::default();
-                            // Add a peer to pass initialized check.
-                            region.mut_peers().push(Peer::default());
-                            RegionSnapshot::from_snapshot(snap, Arc::new(region))
-                        }),
-                    ))
+                Box::new(move |r| {
+                    callback(r.map(|snap| {
+                        let mut region = Region::default();
+                        // Add a peer to pass initialized check.
+                        region.mut_peers().push(Peer::default());
+                        RegionSnapshot::from_snapshot(snap, Arc::new(region))
+                    }))
                 }),
             )
         }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -53,9 +53,9 @@ use self::kv::SnapContext;
 pub use self::{
     errors::{get_error_kind_from_header, get_tag_from_header, Error, ErrorHeaderKind, ErrorInner},
     kv::{
-        CbContext, CfStatistics, Cursor, CursorBuilder, Engine, FlowStatistics, FlowStatsReporter,
-        Iterator, PerfStatisticsDelta, PerfStatisticsInstant, RocksEngine, ScanMode, Snapshot,
-        Statistics, TestEngineBuilder,
+        CfStatistics, Cursor, CursorBuilder, Engine, FlowStatistics, FlowStatsReporter, Iterator,
+        PerfStatisticsDelta, PerfStatisticsInstant, RocksEngine, ScanMode, Snapshot, Statistics,
+        TestEngineBuilder,
     },
     raw::{RawEncodeSnapshot, RawStore},
     read_pool::{build_read_pool, build_read_pool_for_test},
@@ -1177,7 +1177,7 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
         self.engine.async_write(
             &ctx,
             batch,
-            Box::new(|(_, res): (_, kv::Result<_>)| callback(res.map_err(Error::from))),
+            Box::new(|res| callback(res.map_err(Error::from))),
         )?;
         KV_COMMAND_COUNTER_VEC_STATIC.delete_range.inc();
         Ok(())
@@ -1474,7 +1474,7 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
         self.engine.async_write(
             &ctx,
             batch,
-            Box::new(|(_, res): (_, kv::Result<_>)| callback(res.map_err(Error::from))),
+            Box::new(|res| callback(res.map_err(Error::from))),
         )?;
         KV_COMMAND_COUNTER_VEC_STATIC.raw_put.inc();
         Ok(())
@@ -1528,7 +1528,7 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
         self.engine.async_write(
             &ctx,
             batch,
-            Box::new(|(_, res): (_, kv::Result<_>)| callback(res.map_err(Error::from))),
+            Box::new(|res| callback(res.map_err(Error::from))),
         )?;
         KV_COMMAND_COUNTER_VEC_STATIC.raw_batch_put.inc();
         Ok(())
@@ -1555,7 +1555,7 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
         self.engine.async_write(
             &ctx,
             batch,
-            Box::new(|(_, res): (_, kv::Result<_>)| callback(res.map_err(Error::from))),
+            Box::new(|res| callback(res.map_err(Error::from))),
         )?;
         KV_COMMAND_COUNTER_VEC_STATIC.raw_delete.inc();
         Ok(())
@@ -1591,7 +1591,7 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
         self.engine.async_write(
             &ctx,
             batch,
-            Box::new(|(_, res): (_, kv::Result<_>)| callback(res.map_err(Error::from))),
+            Box::new(|res| callback(res.map_err(Error::from))),
         )?;
         KV_COMMAND_COUNTER_VEC_STATIC.raw_delete_range.inc();
         Ok(())
@@ -1621,7 +1621,7 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
         self.engine.async_write(
             &ctx,
             batch,
-            Box::new(|(_, res): (_, kv::Result<_>)| callback(res.map_err(Error::from))),
+            Box::new(|res| callback(res.map_err(Error::from))),
         )?;
         KV_COMMAND_COUNTER_VEC_STATIC.raw_batch_delete.inc();
         Ok(())

--- a/src/storage/raw/encoded.rs
+++ b/src/storage/raw/encoded.rs
@@ -66,6 +66,7 @@ impl<S: Snapshot> RawEncodeSnapshot<S> {
 
 impl<S: Snapshot> Snapshot for RawEncodeSnapshot<S> {
     type Iter = RawEncodeIterator<S::Iter>;
+    type Ext<'a> = S::Ext<'a>;
 
     fn get(&self, key: &Key) -> Result<Option<Value>> {
         self.map_value(self.snap.get(key))
@@ -105,13 +106,8 @@ impl<S: Snapshot> Snapshot for RawEncodeSnapshot<S> {
         self.snap.upper_bound()
     }
 
-    #[inline]
-    fn get_data_version(&self) -> Option<u64> {
-        self.snap.get_data_version()
-    }
-
-    fn is_max_ts_synced(&self) -> bool {
-        self.snap.is_max_ts_synced()
+    fn ext(&self) -> S::Ext<'_> {
+        self.snap.ext()
     }
 }
 

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -631,6 +631,7 @@ mod tests {
     use engine_traits::{IterOptions, ReadOptions};
     use kvproto::kvrpcpb::Context;
     use std::sync::Arc;
+    use tikv_kv::DummySnapshotExt;
 
     const KEY_PREFIX: &str = "key_prefix";
     const START_TS: TimeStamp = TimeStamp::new(10);
@@ -786,6 +787,7 @@ mod tests {
 
     impl Snapshot for MockRangeSnapshot {
         type Iter = MockRangeSnapshotIter;
+        type Ext<'a> = DummySnapshotExt;
 
         fn get(&self, _: &Key) -> EngineResult<Option<Value>> {
             Ok(None)
@@ -807,6 +809,9 @@ mod tests {
         }
         fn upper_bound(&self) -> Option<&[u8]> {
             Some(self.end.as_slice())
+        }
+        fn ext(&self) -> DummySnapshotExt {
+            DummySnapshotExt
         }
     }
 

--- a/tests/benches/hierarchy/mvcc/mod.rs
+++ b/tests/benches/hierarchy/mvcc/mod.rs
@@ -58,7 +58,7 @@ where
         .unwrap();
     }
     let write_data = WriteData::from_modifies(txn.into_modifies());
-    let _ = engine.async_write(&ctx, write_data, Box::new(move |(..)| {}));
+    let _ = engine.async_write(&ctx, write_data, Box::new(move |_| {}));
     let keys: Vec<Key> = kvs.iter().map(|(k, _)| Key::from_raw(k)).collect();
     let snapshot = engine.snapshot(Default::default()).unwrap();
     (snapshot, keys)

--- a/tests/failpoints/cases/test_storage.rs
+++ b/tests/failpoints/cases/test_storage.rs
@@ -20,7 +20,7 @@ use tikv::storage::lock_manager::DummyLockManager;
 use tikv::storage::txn::{commands, Error as TxnError, ErrorInner as TxnErrorInner};
 use tikv::storage::{self, test_util::*, *};
 use tikv::storage::{
-    kv::{Error as KvError, ErrorInner as KvErrorInner, SnapContext},
+    kv::{Error as KvError, ErrorInner as KvErrorInner, SnapContext, SnapshotExt},
     Error as StorageError, ErrorInner as StorageErrorInner,
 };
 use tikv_util::future::paired_future_callback;
@@ -487,7 +487,7 @@ fn test_async_commit_prewrite_with_stale_max_ts() {
         }
         thread::sleep(Duration::from_millis(1 << retry));
     }
-    assert!(snapshot.is_max_ts_synced());
+    assert!(snapshot.ext().is_max_ts_synced());
 
     // should NOT get max timestamp not synced error
     check_max_timestamp_not_synced(false);

--- a/tests/integrations/raftstore/test_merge.rs
+++ b/tests/integrations/raftstore/test_merge.rs
@@ -16,6 +16,7 @@ use engine_traits::{CF_RAFT, CF_WRITE};
 use pd_client::PdClient;
 use test_raftstore::*;
 use tikv::storage::kv::SnapContext;
+use tikv::storage::kv::SnapshotExt;
 use tikv_util::config::*;
 use tikv_util::HandyRwLock;
 
@@ -1179,7 +1180,7 @@ fn test_sync_max_ts_after_region_merge() {
             }
             thread::sleep(Duration::from_millis(1 << retry));
         }
-        assert!(snapshot.is_max_ts_synced());
+        assert!(snapshot.ext().is_max_ts_synced());
     };
 
     wait_for_synced(&mut cluster);

--- a/tests/integrations/raftstore/test_transfer_leader.rs
+++ b/tests/integrations/raftstore/test_transfer_leader.rs
@@ -8,7 +8,7 @@ use kvproto::kvrpcpb::Context;
 use raft::eraftpb::MessageType;
 
 use test_raftstore::*;
-use tikv::storage::kv::SnapContext;
+use tikv::storage::kv::{SnapContext, SnapshotExt};
 use tikv_util::config::*;
 
 fn test_basic_transfer_leader<T: Simulator>(cluster: &mut Cluster<T>) {
@@ -201,7 +201,7 @@ fn test_sync_max_ts_after_leader_transfer() {
             }
             thread::sleep(Duration::from_millis(1 << retry));
         }
-        assert!(snapshot.is_max_ts_synced());
+        assert!(snapshot.ext().is_max_ts_synced());
     };
 
     cluster.must_transfer_leader(1, new_peer(1, 1));


### PR DESCRIPTION
Based on https://github.com/tikv/tikv/pull/11459

### What problem does this PR solve?

Issue Number: #11452

### What is changed and how it works?

This PR is a refactoring about the snapshot interfaces.

It was messy as the raftstore related information is returned in two ways. Some are returned through `CbContext`, such as the term and the `txn_extra_op`. And some are through the `Snapshot` interface directly, like the `data_version` and the sync status.

This PR uniforms the interface returning information specialized for `RaftKv`, through `SnapshotExt`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

Refactoring only.

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```