### PR TITLE
status_server: add glibc, pthread, libgcc to the blocklist (#11205)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.6"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
@@ -84,7 +84,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "398bc55d60097e7b7e9be67d1cb03cb41e5bf4901381607ba0fca8b1328584d6"
 dependencies = [
  "bytes 0.4.12",
- "libc 0.2.86",
+ "libc 0.2.108",
  "serde_json",
 ]
 
@@ -137,7 +137,7 @@ checksum = "a811e6a479f2439f0c04038796b5cfb3d2ad56c230e0f2d3f7b04d68cfee607b"
 dependencies = [
  "concurrent-queue",
  "futures-lite",
- "libc 0.2.86",
+ "libc 0.2.108",
  "log",
  "once_cell",
  "parking",
@@ -264,7 +264,7 @@ version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 dependencies = [
- "libc 0.2.86",
+ "libc 0.2.108",
  "winapi 0.3.9",
 ]
 
@@ -310,7 +310,7 @@ checksum = "5180c5a20655b14a819b652fd2378fa5f1697b6c9ddad3e695c2f9cedf6df4e2"
 dependencies = [
  "backtrace-sys",
  "cfg-if 0.1.10",
- "libc 0.2.86",
+ "libc 0.2.108",
  "rustc-demangle",
 ]
 
@@ -321,7 +321,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
 dependencies = [
  "cc",
- "libc 0.2.86",
+ "libc 0.2.108",
 ]
 
 [[package]]
@@ -397,7 +397,7 @@ dependencies = [
  "bcc-sys",
  "bitflags",
  "byteorder",
- "libc 0.2.86",
+ "libc 0.2.108",
  "regex",
  "thiserror",
 ]
@@ -441,9 +441,9 @@ checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"
@@ -533,7 +533,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
 dependencies = [
  "cc",
- "libc 0.2.86",
+ "libc 0.2.108",
  "pkg-config",
 ]
 
@@ -559,7 +559,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7f788eaf239475a3c1e1acf89951255a46c4b9b46cf3e866fc4d0707b4b9e36"
 dependencies = [
- "libc 0.2.86",
+ "libc 0.2.108",
  "valgrind_request",
 ]
 
@@ -583,9 +583,9 @@ checksum = "926013f2860c46252efceabb19f4a6b308197505082c609025aa6706c011d427"
 
 [[package]]
 name = "cc"
-version = "1.0.66"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
+checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
 dependencies = [
  "jobserver",
 ]
@@ -612,7 +612,7 @@ dependencies = [
  "panic_hook",
  "pd_client",
  "prometheus",
- "prost",
+ "prost 0.7.0",
  "protobuf",
  "raft",
  "raftstore",
@@ -682,7 +682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f54d78e30b388d4815220c8dd03fea5656b6c6d32adb59e89061552a102f8da1"
 dependencies = [
  "glob",
- "libc 0.2.86",
+ "libc 0.2.108",
  "libloading",
 ]
 
@@ -735,7 +735,7 @@ dependencies = [
  "byteorder",
  "bytes 1.0.1",
  "error_code",
- "libc 0.2.86",
+ "libc 0.2.108",
  "panic_hook",
  "protobuf",
  "rand 0.8.3",
@@ -792,7 +792,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
 dependencies = [
  "core-foundation-sys",
- "libc 0.2.86",
+ "libc 0.2.108",
 ]
 
 [[package]]
@@ -855,7 +855,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63aaaf47e457badbcb376c65a49d0f182c317ebd97dc6d1ced94c8e1d09c0f3a"
 dependencies = [
  "criterion",
- "libc 0.2.86",
+ "libc 0.2.108",
 ]
 
 [[package]]
@@ -1155,7 +1155,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
- "libc 0.2.86",
+ "libc 0.2.108",
  "redox_users",
  "winapi 0.3.9",
 ]
@@ -1420,7 +1420,7 @@ dependencies = [
  "grpcio",
  "kvproto",
  "lazy_static",
- "libc 0.2.86",
+ "libc 0.2.108",
  "libloading",
  "matches",
  "nix 0.11.1",
@@ -1485,7 +1485,7 @@ dependencies = [
  "crossbeam-utils 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2",
  "lazy_static",
- "libc 0.2.86",
+ "libc 0.2.108",
  "maligned",
  "nix 0.19.0",
  "online_config",
@@ -1509,8 +1509,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
 dependencies = [
  "cfg-if 1.0.0",
- "libc 0.2.86",
+ "libc 0.2.108",
  "redox_syscall 0.2.6",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc 0.2.108",
  "winapi 0.3.9",
 ]
 
@@ -1521,13 +1533,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
+name = "fixedbitset"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "398ea4fabe40b9b0d885340a2a991a44c8a645624075ad966d21f88688e2b69e"
+
+[[package]]
 name = "flate2"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2adaffba6388640136149e18ed080b77a78611c1e1d6de75aedcdf78df5d4682"
 dependencies = [
  "crc32fast",
- "libc 0.2.86",
+ "libc 0.2.108",
  "libz-sys",
  "miniz-sys",
  "miniz_oxide",
@@ -1570,7 +1588,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 dependencies = [
- "libc 0.2.86",
+ "libc 0.2.108",
  "winapi 0.3.9",
 ]
 
@@ -1596,7 +1614,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0"
 dependencies = [
- "libc 0.2.86",
+ "libc 0.2.108",
 ]
 
 [[package]]
@@ -1804,7 +1822,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cc0b9f53275dc5fada808f1d2f82e3688a6c14d735633d1590b7be8eb2307b5"
 dependencies = [
- "libc 0.2.86",
+ "libc 0.2.108",
  "tempfile",
 ]
 
@@ -1845,7 +1863,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
 dependencies = [
  "cfg-if 0.1.10",
- "libc 0.2.86",
+ "libc 0.2.108",
  "wasi 0.7.0",
 ]
 
@@ -1856,7 +1874,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if 1.0.0",
- "libc 0.2.86",
+ "libc 0.2.108",
  "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
@@ -1911,10 +1929,10 @@ dependencies = [
  "bytes 1.0.1",
  "futures 0.3.15",
  "grpcio-sys",
- "libc 0.2.86",
+ "libc 0.2.108",
  "log",
  "parking_lot",
- "prost",
+ "prost 0.7.0",
  "protobuf",
 ]
 
@@ -1925,9 +1943,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4caa0700833147dcfbe4f0758bd92545cc0f4506ee7fa154e499745a8b24e86c"
 dependencies = [
  "derive-new",
- "prost",
- "prost-build",
- "prost-types",
+ "prost 0.7.0",
+ "prost-build 0.7.0",
+ "prost-types 0.7.0",
  "protobuf",
  "tempfile",
 ]
@@ -1941,7 +1959,7 @@ dependencies = [
  "futures 0.3.15",
  "grpcio",
  "log",
- "prost",
+ "prost 0.7.0",
  "protobuf",
 ]
 
@@ -1955,7 +1973,7 @@ dependencies = [
  "boringssl-src",
  "cc",
  "cmake",
- "libc 0.2.86",
+ "libc 0.2.108",
  "libz-sys",
  "openssl-sys",
  "pkg-config",
@@ -2008,7 +2026,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "307c3c9f937f38e3534b1d6447ecf090cafcc9744e4a6360e8b037b2cf5af120"
 dependencies = [
- "libc 0.2.86",
+ "libc 0.2.108",
 ]
 
 [[package]]
@@ -2186,7 +2204,7 @@ checksum = "4816c66d2c8ae673df83366c18341538f234a26d65a9ecea5c348b453ac1d02f"
 dependencies = [
  "bitflags",
  "inotify-sys",
- "libc 0.2.86",
+ "libc 0.2.108",
 ]
 
 [[package]]
@@ -2195,7 +2213,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
- "libc 0.2.86",
+ "libc 0.2.108",
 ]
 
 [[package]]
@@ -2222,7 +2240,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
- "libc 0.2.86",
+ "libc 0.2.108",
 ]
 
 [[package]]
@@ -2271,7 +2289,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2b1d42ef453b30b7387e113da1c83ab1605d90c5b4e0eb8e96d016ed3b8c160"
 dependencies = [
  "getrandom 0.1.12",
- "libc 0.2.86",
+ "libc 0.2.108",
  "log",
 ]
 
@@ -2324,8 +2342,8 @@ dependencies = [
  "futures 0.3.15",
  "grpcio",
  "lazy_static",
- "prost",
- "prost-derive",
+ "prost 0.7.0",
+ "prost-derive 0.7.0",
  "protobuf",
  "protobuf-build",
  "raft-proto",
@@ -2351,9 +2369,9 @@ checksum = "e32a70cf75e5846d53a673923498228bbec6a8624708a9ea5645f075d6276122"
 
 [[package]]
 name = "libc"
-version = "0.2.86"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
+checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -2393,7 +2411,7 @@ dependencies = [
  "bzip2-sys",
  "cc",
  "cmake",
- "libc 0.2.86",
+ "libc 0.2.108",
  "libtitan_sys",
  "libz-sys",
  "lz4-sys",
@@ -2411,7 +2429,7 @@ dependencies = [
  "bzip2-sys",
  "cc",
  "cmake",
- "libc 0.2.86",
+ "libc 0.2.108",
  "libz-sys",
  "lz4-sys",
  "snappy-sys",
@@ -2425,7 +2443,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
 dependencies = [
  "cc",
- "libc 0.2.86",
+ "libc 0.2.108",
  "pkg-config",
  "vcpkg",
 ]
@@ -2482,7 +2500,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dca79aa95d8b3226213ad454d328369853be3a1382d89532a854f4d69640acae"
 dependencies = [
  "cc",
- "libc 0.2.86",
+ "libc 0.2.108",
 ]
 
 [[package]]
@@ -2523,7 +2541,7 @@ version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 dependencies = [
- "libc 0.2.86",
+ "libc 0.2.108",
 ]
 
 [[package]]
@@ -2532,15 +2550,15 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
 dependencies = [
- "libc 0.2.86",
+ "libc 0.2.108",
  "winapi 0.3.9",
 ]
 
 [[package]]
 name = "memoffset"
-version = "0.6.1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
 dependencies = [
  "autocfg",
 ]
@@ -2575,7 +2593,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9e3ae51cea1576ceba0dde3d484d30e6e5b86dee0b2d412fe3a16a15c98202"
 dependencies = [
  "cc",
- "libc 0.2.86",
+ "libc 0.2.108",
 ]
 
 [[package]]
@@ -2598,7 +2616,7 @@ dependencies = [
  "fuchsia-zircon-sys",
  "iovec",
  "kernel32-sys",
- "libc 0.2.86",
+ "libc 0.2.108",
  "log",
  "miow 0.2.2",
  "net2",
@@ -2612,7 +2630,7 @@ version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf80d3e903b34e0bd7282b218398aec54e082c840d9baf8339e0080a0c542956"
 dependencies = [
- "libc 0.2.86",
+ "libc 0.2.108",
  "log",
  "miow 0.3.7",
  "ntapi",
@@ -2690,7 +2708,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
 dependencies = [
  "lazy_static",
- "libc 0.2.86",
+ "libc 0.2.108",
  "log",
  "openssl",
  "openssl-probe",
@@ -2708,7 +2726,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
 dependencies = [
  "cfg-if 0.1.10",
- "libc 0.2.86",
+ "libc 0.2.108",
  "winapi 0.3.9",
 ]
 
@@ -2721,7 +2739,7 @@ dependencies = [
  "bitflags",
  "cc",
  "cfg-if 0.1.10",
- "libc 0.2.86",
+ "libc 0.2.108",
  "void",
 ]
 
@@ -2734,7 +2752,7 @@ dependencies = [
  "bitflags",
  "cc",
  "cfg-if 0.1.10",
- "libc 0.2.86",
+ "libc 0.2.108",
 ]
 
 [[package]]
@@ -2746,7 +2764,20 @@ dependencies = [
  "bitflags",
  "cc",
  "cfg-if 0.1.10",
- "libc 0.2.86",
+ "libc 0.2.108",
+]
+
+[[package]]
+name = "nix"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f305c2c2e4c39a82f7bf0bf65fb557f9070ce06781d4f2454295cc34b1c43188"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc 0.2.108",
+ "memoffset",
 ]
 
 [[package]]
@@ -2792,7 +2823,7 @@ dependencies = [
  "fsevent",
  "fsevent-sys",
  "inotify",
- "libc 0.2.86",
+ "libc 0.2.108",
  "mio 0.6.23",
  "mio-extras",
  "walkdir",
@@ -2899,7 +2930,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
- "libc 0.2.86",
+ "libc 0.2.108",
 ]
 
 [[package]]
@@ -2949,7 +2980,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "foreign-types",
  "lazy_static",
- "libc 0.2.86",
+ "libc 0.2.108",
  "openssl-sys",
 ]
 
@@ -2976,7 +3007,7 @@ checksum = "921fc71883267538946025deffb622905ecad223c28efbfdef9bb59a0175f3e6"
 dependencies = [
  "autocfg",
  "cc",
- "libc 0.2.86",
+ "libc 0.2.108",
  "openssl-src",
  "pkg-config",
  "vcpkg",
@@ -3006,7 +3037,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebde548fbbf1ea81a99b128872779c437752fb99f217c45245e1a61dcd9edcd"
 dependencies = [
- "libc 0.2.86",
+ "libc 0.2.108",
  "winapi 0.3.9",
 ]
 
@@ -3039,7 +3070,7 @@ checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
 dependencies = [
  "cfg-if 1.0.0",
  "instant",
- "libc 0.2.86",
+ "libc 0.2.108",
  "redox_syscall 0.2.6",
  "smallvec",
  "winapi 0.3.9",
@@ -3134,7 +3165,7 @@ checksum = "88a4decf2d171c232d741ca37d590cd50d35314b7d348198e7e474e0bf34c8b4"
 dependencies = [
  "bitflags",
  "byteorder",
- "libc 0.2.86",
+ "libc 0.2.108",
  "mmap",
  "nom 4.2.3",
  "phf",
@@ -3156,7 +3187,17 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29c127eea4a29ec6c85d153c59dc1213f33ec74cead30fe4730aecc88cc1fd92"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.2.0",
+ "indexmap",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
+dependencies = [
+ "fixedbitset 0.4.0",
  "indexmap",
 ]
 
@@ -3277,7 +3318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d27361d7578b410d0eb5fe815c2b2105b01ab770a7c738cb9a231457a809fcc7"
 dependencies = [
  "ipnetwork",
- "libc 0.2.86",
+ "libc 0.2.108",
  "pnet_base",
  "pnet_sys",
  "winapi 0.2.8",
@@ -3289,7 +3330,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82f881a6d75ac98c5541db6144682d1773bb14c6fc50c6ebac7086c8f7f23c29"
 dependencies = [
- "libc 0.2.86",
+ "libc 0.2.108",
  "winapi 0.2.8",
  "ws2_32-sys",
 ]
@@ -3301,7 +3342,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92341d779fa34ea8437ef4d82d440d5e1ce3f3ff7f824aa64424cd481f9a1f25"
 dependencies = [
  "cfg-if 1.0.0",
- "libc 0.2.86",
+ "libc 0.2.108",
  "log",
  "wepoll-ffi",
  "winapi 0.3.9",
@@ -3309,20 +3350,22 @@ dependencies = [
 
 [[package]]
 name = "pprof"
-version = "0.4.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a066eee7dbaf89a91078ceb15f56642c8d934eb2a639e7f098dd3f365651f55a"
+checksum = "9d47237f290398d4cfcd293fcc9dcc53cdb1f9bde65b78fcbfaafa7f8190d9e9"
 dependencies = [
  "backtrace",
+ "cfg-if 1.0.0",
+ "findshlibs",
  "inferno",
  "lazy_static",
- "libc 0.2.86",
+ "libc 0.2.108",
  "log",
- "nix 0.19.0",
+ "nix 0.23.0",
  "parking_lot",
- "prost",
- "prost-build",
- "prost-derive",
+ "prost 0.9.0",
+ "prost-build 0.9.0",
+ "prost-derive 0.9.0",
  "symbolic-demangle",
  "tempfile",
  "thiserror",
@@ -3391,7 +3434,7 @@ dependencies = [
  "flate2",
  "hex 0.4.2",
  "lazy_static",
- "libc 0.2.86",
+ "libc 0.2.108",
 ]
 
 [[package]]
@@ -3400,7 +3443,7 @@ version = "0.4.2"
 source = "git+https://github.com/tikv/procinfo-rs?rev=5125fc1a69496b73b26b3c08b6e8afc3c665a56e#5125fc1a69496b73b26b3c08b6e8afc3c665a56e"
 dependencies = [
  "byteorder",
- "libc 0.2.86",
+ "libc 0.2.108",
  "nom 2.2.1",
  "rustc_version 0.2.3",
 ]
@@ -3425,7 +3468,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "fnv",
  "lazy_static",
- "libc 0.2.86",
+ "libc 0.2.108",
  "memchr",
  "parking_lot",
  "protobuf",
@@ -3461,7 +3504,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
 dependencies = [
  "bytes 1.0.1",
- "prost-derive",
+ "prost-derive 0.7.0",
+]
+
+[[package]]
+name = "prost"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
+dependencies = [
+ "bytes 1.0.1",
+ "prost-derive 0.9.0",
 ]
 
 [[package]]
@@ -3475,9 +3528,29 @@ dependencies = [
  "itertools 0.9.0",
  "log",
  "multimap",
- "petgraph",
- "prost",
- "prost-types",
+ "petgraph 0.5.0",
+ "prost 0.7.0",
+ "prost-types 0.7.0",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
+dependencies = [
+ "bytes 1.0.1",
+ "heck",
+ "itertools 0.10.0",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph 0.6.0",
+ "prost 0.9.0",
+ "prost-types 0.9.0",
+ "regex",
  "tempfile",
  "which",
 ]
@@ -3496,13 +3569,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
 dependencies = [
  "bytes 1.0.1",
- "prost",
+ "prost 0.7.0",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
+dependencies = [
+ "bytes 1.0.1",
+ "prost 0.9.0",
 ]
 
 [[package]]
@@ -3524,7 +3620,7 @@ dependencies = [
  "bitflags",
  "grpcio-compiler",
  "proc-macro2",
- "prost-build",
+ "prost-build 0.7.0",
  "protobuf",
  "protobuf-codegen",
  "quote",
@@ -3600,7 +3696,7 @@ source = "git+https://github.com/tikv/raft-rs?branch=master#e6d28ef0f509c072e132
 dependencies = [
  "bytes 1.0.1",
  "lazy_static",
- "prost",
+ "prost 0.7.0",
  "protobuf",
  "protobuf-build",
 ]
@@ -3665,7 +3761,7 @@ dependencies = [
  "pd_client",
  "prometheus",
  "prometheus-static-metric",
- "prost",
+ "prost 0.7.0",
  "protobuf",
  "raft",
  "raft-proto",
@@ -3697,7 +3793,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 dependencies = [
  "fuchsia-cprng",
- "libc 0.2.86",
+ "libc 0.2.108",
  "rand_core 0.3.1",
  "rdrand",
  "winapi 0.3.9",
@@ -3710,7 +3806,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom 0.1.12",
- "libc 0.2.86",
+ "libc 0.2.108",
  "rand_chacha 0.2.1",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
@@ -3723,7 +3819,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
 dependencies = [
- "libc 0.2.86",
+ "libc 0.2.108",
  "rand_chacha 0.3.0",
  "rand_core 0.6.2",
  "rand_hc 0.3.0",
@@ -3897,14 +3993,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.2"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-syntax",
- "thread_local",
 ]
 
 [[package]]
@@ -3918,9 +4013,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.21"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "remove_dir_all"
@@ -3985,7 +4080,7 @@ dependencies = [
  "panic_hook",
  "pd_client",
  "prometheus",
- "prost",
+ "prost 0.7.0",
  "protobuf",
  "raft",
  "raftstore",
@@ -4014,7 +4109,7 @@ dependencies = [
  "grpcio",
  "kvproto",
  "lazy_static",
- "libc 0.2.86",
+ "libc 0.2.108",
  "log",
  "online_config",
  "pdqselect",
@@ -4049,7 +4144,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b72b84d47e8ec5a4f2872e8262b8f8256c5be1c938a7d6d3a867a3ba8f722f74"
 dependencies = [
  "cc",
- "libc 0.2.86",
+ "libc 0.2.108",
  "once_cell",
  "spin",
  "untrusted",
@@ -4062,7 +4157,7 @@ name = "rocksdb"
 version = "0.3.0"
 source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-5.2#4e912a8deb720d90d1c528b4d80e0848a2178412"
 dependencies = [
- "libc 0.2.86",
+ "libc 0.2.108",
  "librocksdb_sys",
 ]
 
@@ -4241,7 +4336,7 @@ checksum = "6f0d5e7b0219a3eadd5439498525d4765c59b7c993ef0c12244865cd2d988413"
 dependencies = [
  "cfg-if 0.1.10",
  "dirs-next 1.0.2",
- "libc 0.2.86",
+ "libc 0.2.108",
  "log",
  "memchr",
  "nix 0.18.0",
@@ -4318,7 +4413,7 @@ dependencies = [
  "bitflags",
  "core-foundation",
  "core-foundation-sys",
- "libc 0.2.86",
+ "libc 0.2.108",
  "security-framework-sys",
 ]
 
@@ -4329,7 +4424,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3676258fd3cfe2c9a0ec99ce3038798d847ce3e4bb17746373eb9f0f1ac16339"
 dependencies = [
  "core-foundation-sys",
- "libc 0.2.86",
+ "libc 0.2.108",
 ]
 
 [[package]]
@@ -4481,7 +4576,7 @@ dependencies = [
  "hex 0.4.2",
  "keys",
  "kvproto",
- "libc 0.2.86",
+ "libc 0.2.108",
  "log",
  "log_wrappers",
  "nix 0.11.1",
@@ -4536,7 +4631,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106428d9d96840ecdec5208c13ab8a4e28c38da1e0ccf2909fb44e41b992f897"
 dependencies = [
- "libc 0.2.86",
+ "libc 0.2.108",
  "nix 0.11.1",
 ]
 
@@ -4546,7 +4641,7 @@ version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce32ea0c6c56d5eacaeb814fbed9960547021d3edd010ded1425f180536b20ab"
 dependencies = [
- "libc 0.2.86",
+ "libc 0.2.108",
 ]
 
 [[package]]
@@ -4638,7 +4733,7 @@ version = "0.1.0"
 source = "git+https://github.com/busyjay/rust-snappy.git?branch=static-link#8c12738bad811397600455d6982aff754ea2ac44"
 dependencies = [
  "cmake",
- "libc 0.2.86",
+ "libc 0.2.108",
  "pkg-config",
 ]
 
@@ -4666,7 +4761,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
 dependencies = [
- "libc 0.2.86",
+ "libc 0.2.108",
  "winapi 0.3.9",
 ]
 
@@ -4833,7 +4928,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "core-foundation-sys",
  "doc-comment",
- "libc 0.2.86",
+ "libc 0.2.108",
  "ntapi",
  "once_cell",
  "rayon",
@@ -4916,7 +5011,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
  "cfg-if 1.0.0",
- "libc 0.2.86",
+ "libc 0.2.108",
  "rand 0.8.3",
  "redox_syscall 0.2.6",
  "remove_dir_all",
@@ -5377,7 +5472,7 @@ dependencies = [
  "keys",
  "kvproto",
  "lazy_static",
- "libc 0.2.86",
+ "libc 0.2.108",
  "libloading",
  "log",
  "log_wrappers",
@@ -5402,7 +5497,7 @@ dependencies = [
  "procinfo",
  "prometheus",
  "prometheus-static-metric",
- "prost",
+ "prost 0.7.0",
  "protobuf",
  "raft",
  "raft_log_engine",
@@ -5472,7 +5567,7 @@ dependencies = [
  "hex 0.4.2",
  "keys",
  "kvproto",
- "libc 0.2.86",
+ "libc 0.2.108",
  "log",
  "log_wrappers",
  "nix 0.19.0",
@@ -5507,7 +5602,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28c80e4338857639f443169a601fafe49866aed8d7a8d565c2f5bfb1a021adf"
 dependencies = [
- "libc 0.2.86",
+ "libc 0.2.108",
  "paste 0.1.18",
  "tikv-jemalloc-sys",
 ]
@@ -5520,7 +5615,7 @@ checksum = "8a26331b05179d4cb505c8d6814a7e18d298972f0a551b0e3cefccff927f86d3"
 dependencies = [
  "cc",
  "fs_extra",
- "libc 0.2.86",
+ "libc 0.2.108",
 ]
 
 [[package]]
@@ -5529,7 +5624,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c14a5a604eb8715bc5785018a37d00739b180bcf609916ddf4393d33d49ccdf"
 dependencies = [
- "libc 0.2.86",
+ "libc 0.2.108",
  "tikv-jemalloc-sys",
 ]
 
@@ -5550,7 +5645,7 @@ version = "0.1.0"
 dependencies = [
  "fxhash",
  "lazy_static",
- "libc 0.2.86",
+ "libc 0.2.108",
  "log",
  "mimalloc",
  "snmalloc-rs",
@@ -5616,7 +5711,7 @@ dependencies = [
  "http",
  "kvproto",
  "lazy_static",
- "libc 0.2.86",
+ "libc 0.2.108",
  "log",
  "log_wrappers",
  "nix 0.19.0",
@@ -5659,7 +5754,7 @@ version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 dependencies = [
- "libc 0.2.86",
+ "libc 0.2.108",
  "redox_syscall 0.1.56",
  "winapi 0.3.9",
 ]
@@ -5680,8 +5775,8 @@ version = "0.0.1"
 source = "git+https://github.com/pingcap/tipb.git#dc47a87b52aaa5ff150d179f47ba6c25dc441227"
 dependencies = [
  "lazy_static",
- "prost",
- "prost-derive",
+ "prost 0.7.0",
+ "prost-derive 0.7.0",
  "protobuf",
  "protobuf-build",
 ]
@@ -5703,7 +5798,7 @@ checksum = "01cf844b23c6131f624accf65ce0e4e9956a8bb329400ea5bcc26ae3a5c20b0b"
 dependencies = [
  "autocfg",
  "bytes 1.0.1",
- "libc 0.2.86",
+ "libc 0.2.108",
  "memchr",
  "mio 0.7.11",
  "num_cpus",
@@ -5953,7 +6048,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "055058552ca15c566082fc61da433ae678f78986a6f16957e33162d1b218792a"
 dependencies = [
  "kernel32-sys",
- "libc 0.2.86",
+ "libc 0.2.108",
  "winapi 0.2.8",
 ]
 
@@ -6151,7 +6246,7 @@ version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87c14ef7e1b8b8ecfc75d5eca37949410046e66f15d185c01d70824f1f8111ef"
 dependencies = [
- "libc 0.2.86",
+ "libc 0.2.108",
  "thiserror",
 ]
 
@@ -6283,5 +6378,5 @@ dependencies = [
  "cc",
  "glob",
  "itertools 0.9.0",
- "libc 0.2.86",
+ "libc 0.2.108",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,7 +180,7 @@ pd_client = { path = "components/pd_client", default-features = false }
 pin-project = "1.0"
 pnet_datalink = "0.23"
 prost = "0.7"
-pprof = { version = "^0.4", default-features = false, features = ["flamegraph", "protobuf"] }
+pprof = { version = "^0.6", default-features = false, features = ["flamegraph", "protobuf"] }
 protobuf = "2.8"
 raft = { version = "0.6.0-alpha", default-features = false }
 raftstore = { path = "components/raftstore", default-features = false }

--- a/src/server/status_server/mod.rs
+++ b/src/server/status_server/mod.rs
@@ -319,7 +319,10 @@ where
     }
 
     pub async fn dump_rsprof(seconds: u64, frequency: i32) -> pprof::Result<pprof::Report> {
-        let guard = pprof::ProfilerGuard::new(frequency)?;
+        let guard = pprof::ProfilerGuardBuilder::default()
+            .frequency(frequency)
+            .blocklist(&["libc", "libgcc", "pthread"])
+            .build()?;
         info!(
             "start profiling {} seconds with frequency {} /s",
             seconds, frequency


### PR DESCRIPTION
close #11108

Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What problem does this PR solve?

close #11108 

Problem Summary:

If the `pprof-rs` sample arrives and the current program is fetching a backtrace, the program will panic. The reason is that there is a lock inside the `dl_iterate_phdr`, which is called while unwinding the backtrace.

A more detailed description about this problem can be found in https://github.com/tikv/pprof-rs/pull/85#issuecomment-954446008 . In tikv, when an `Error` is generated, it's likely to get a backtrace and cause this problem.

After adding these libraries to the blocklist, it will also be able to turn on the heap profiling and `pprof-rs` cpu profiling at the same time, but I haven't modified (and tested) it yet.

### What is changed and how it works?

What's Changed:

Skip all samples inside the `glibc`, `pthread` and `libgcc`.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Side effects

The sample in the `libc`, `libgcc` and `pthread` will not be collected in the profiling result.

### Release note 

```release-note
status_server: skip profiling sample in glibc, pthread, libgcc to avoid possible deadlock 
status_server: upgrade pprof-rs to fix memory leak
```