### PR TITLE
*: add configuration for in-memory pessimistic lock

### DIFF
--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -588,7 +588,7 @@ impl<ER: RaftEngine> TiKVServer<ER> {
             .engine
             .set_txn_extra_scheduler(Arc::new(txn_extra_scheduler));
 
-        let lock_mgr = LockManager::new(self.config.pessimistic_txn.pipelined);
+        let lock_mgr = LockManager::new(&self.config.pessimistic_txn);
         cfg_controller.register(
             tikv::config::Module::PessimisticTxn,
             Box::new(lock_mgr.config_manager()),
@@ -642,7 +642,7 @@ impl<ER: RaftEngine> TiKVServer<ER> {
             storage_read_pool_handle,
             lock_mgr.clone(),
             self.concurrency_manager.clone(),
-            lock_mgr.get_pipelined(),
+            lock_mgr.get_storage_dynamic_configs(),
             flow_controller,
             pd_sender.clone(),
         )

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -308,14 +308,14 @@ impl Simulator for ServerCluster {
         let check_leader_runner = CheckLeaderRunner::new(store_meta.clone());
         let check_leader_scheduler = bg_worker.start("check-leader", check_leader_runner);
 
-        let mut lock_mgr = LockManager::new(cfg.pessimistic_txn.pipelined);
+        let mut lock_mgr = LockManager::new(&cfg.pessimistic_txn);
         let store = create_raft_storage(
             engine,
             &cfg.storage,
             storage_read_pool.handle(),
             lock_mgr.clone(),
             concurrency_manager.clone(),
-            lock_mgr.get_pipelined(),
+            lock_mgr.get_storage_dynamic_configs(),
             Arc::new(FlowController::empty()),
             pd_sender,
         )?;

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -1,6 +1,6 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::sync::{atomic::AtomicBool, Arc, Mutex};
+use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 
@@ -12,6 +12,7 @@ use crate::server::lock_manager::LockManager;
 use crate::server::Config as ServerConfig;
 use crate::storage::kv::FlowStatsReporter;
 use crate::storage::txn::flow_controller::FlowController;
+use crate::storage::DynamicConfigs as StorageDynamicConfigs;
 use crate::storage::{config::Config as StorageConfig, Storage};
 use concurrency_manager::ConcurrencyManager;
 use engine_traits::key_prefix::TIDB_RANGES_COMPLEMENT;
@@ -42,7 +43,7 @@ pub fn create_raft_storage<S, EK, R: FlowStatsReporter>(
     read_pool: ReadPoolHandle,
     lock_mgr: LockManager,
     concurrency_manager: ConcurrencyManager,
-    pipelined_pessimistic_lock: Arc<AtomicBool>,
+    dynamic_configs: StorageDynamicConfigs,
     flow_controller: Arc<FlowController>,
     reporter: R,
 ) -> Result<Storage<RaftKv<EK, S>, LockManager>>
@@ -56,7 +57,7 @@ where
         read_pool,
         lock_mgr,
         concurrency_manager,
-        pipelined_pessimistic_lock,
+        dynamic_configs,
         flow_controller,
         reporter,
     )?;

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -57,6 +57,7 @@ use crate::storage::txn::{
     sched_pool::{tls_collect_read_duration, tls_collect_scan_details, SchedPool},
     Error, ProcessResult,
 };
+use crate::storage::DynamicConfigs;
 use crate::storage::{
     get_priority_tag, kv::FlowStatsReporter, types::StorageCallback, Error as StorageError,
     ErrorInner as StorageErrorInner,
@@ -194,6 +195,8 @@ struct SchedulerInner<L: LockManager> {
 
     pipelined_pessimistic_lock: Arc<AtomicBool>,
 
+    in_memory_pessimistic_lock: Arc<AtomicBool>,
+
     enable_async_apply_prewrite: bool,
 }
 
@@ -302,7 +305,7 @@ impl<E: Engine, L: LockManager> Scheduler<E, L> {
         lock_mgr: L,
         concurrency_manager: ConcurrencyManager,
         config: &Config,
-        pipelined_pessimistic_lock: Arc<AtomicBool>,
+        dynamic_configs: DynamicConfigs,
         flow_controller: Arc<FlowController>,
         reporter: R,
     ) -> Self {
@@ -333,7 +336,8 @@ impl<E: Engine, L: LockManager> Scheduler<E, L> {
             control_mutex: Arc::new(tokio::sync::Mutex::new(false)),
             lock_mgr,
             concurrency_manager,
-            pipelined_pessimistic_lock,
+            pipelined_pessimistic_lock: dynamic_configs.pipelined_pessimistic_lock,
+            in_memory_pessimistic_lock: dynamic_configs.in_memory_pessimistic_lock,
             enable_async_apply_prewrite: config.enable_async_apply_prewrite,
             flow_controller,
         });
@@ -722,11 +726,8 @@ impl<E: Engine, L: LockManager> Scheduler<E, L> {
         let priority = task.cmd.priority();
         let ts = task.cmd.ts();
         let scheduler = self.clone();
-        let pipelined_pessimistic_lock = self
-            .inner
-            .pipelined_pessimistic_lock
-            .load(Ordering::Relaxed);
-        let pipelined = pipelined_pessimistic_lock && task.cmd.can_be_pipelined();
+        let pipelined = self.pessimistic_lock_mode() == PessimisticLockMode::Pipelined
+            && task.cmd.can_be_pipelined();
 
         let deadline = task.cmd.deadline();
         let write_result = {
@@ -967,6 +968,34 @@ impl<E: Engine, L: LockManager> Scheduler<E, L> {
             false
         }
     }
+
+    fn pessimistic_lock_mode(&self) -> PessimisticLockMode {
+        let pipelined = self
+            .inner
+            .pipelined_pessimistic_lock
+            .load(Ordering::Relaxed);
+        let in_memory = self
+            .inner
+            .in_memory_pessimistic_lock
+            .load(Ordering::Relaxed);
+        if pipelined && in_memory {
+            PessimisticLockMode::InMemory
+        } else if pipelined {
+            PessimisticLockMode::Pipelined
+        } else {
+            PessimisticLockMode::Sync
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+enum PessimisticLockMode {
+    // Return success only if the pessimistic lock is persisted.
+    Sync,
+    // Return success after the pessimistic lock is proposed successfully.
+    Pipelined,
+    // Try to store pessimistic locks only in the memory.
+    InMemory,
 }
 
 #[cfg(test)]
@@ -1129,7 +1158,10 @@ mod tests {
             DummyLockManager,
             ConcurrencyManager::new(1.into()),
             &config,
-            Arc::new(AtomicBool::new(true)),
+            DynamicConfigs {
+                pipelined_pessimistic_lock: Arc::new(AtomicBool::new(true)),
+                in_memory_pessimistic_lock: Arc::new(AtomicBool::new(false)),
+            },
             Arc::new(FlowController::empty()),
             DummyReporter,
         );
@@ -1181,7 +1213,10 @@ mod tests {
             DummyLockManager,
             ConcurrencyManager::new(1.into()),
             &config,
-            Arc::new(AtomicBool::new(true)),
+            DynamicConfigs {
+                pipelined_pessimistic_lock: Arc::new(AtomicBool::new(true)),
+                in_memory_pessimistic_lock: Arc::new(AtomicBool::new(false)),
+            },
             Arc::new(FlowController::empty()),
             DummyReporter,
         );
@@ -1233,7 +1268,10 @@ mod tests {
             DummyLockManager,
             ConcurrencyManager::new(1.into()),
             &config,
-            Arc::new(AtomicBool::new(true)),
+            DynamicConfigs {
+                pipelined_pessimistic_lock: Arc::new(AtomicBool::new(true)),
+                in_memory_pessimistic_lock: Arc::new(AtomicBool::new(false)),
+            },
             Arc::new(FlowController::empty()),
             DummyReporter,
         );
@@ -1293,7 +1331,10 @@ mod tests {
             DummyLockManager,
             ConcurrencyManager::new(1.into()),
             &config,
-            Arc::new(AtomicBool::new(true)),
+            DynamicConfigs {
+                pipelined_pessimistic_lock: Arc::new(AtomicBool::new(true)),
+                in_memory_pessimistic_lock: Arc::new(AtomicBool::new(false)),
+            },
             Arc::new(FlowController::empty()),
             DummyReporter,
         );
@@ -1327,5 +1368,55 @@ mod tests {
         let (cb, f) = paired_future_callback();
         scheduler.run_cmd(cmd.cmd, StorageCallback::Boolean(cb));
         assert!(block_on(f).is_ok());
+    }
+
+    #[test]
+    fn test_pessimistic_lock_mode() {
+        let engine = TestEngineBuilder::new().build().unwrap();
+        let config = Config {
+            scheduler_concurrency: 1024,
+            scheduler_worker_pool_size: 1,
+            scheduler_pending_write_threshold: ReadableSize(100 * 1024 * 1024),
+            enable_async_apply_prewrite: false,
+            ..Default::default()
+        };
+        let scheduler = Scheduler::new(
+            engine,
+            DummyLockManager,
+            ConcurrencyManager::new(1.into()),
+            &config,
+            DynamicConfigs {
+                pipelined_pessimistic_lock: Arc::new(AtomicBool::new(false)),
+                in_memory_pessimistic_lock: Arc::new(AtomicBool::new(false)),
+            },
+            Arc::new(FlowController::empty()),
+            DummyReporter,
+        );
+        // Use sync mode if pipelined_pessimistic_lock is false.
+        assert_eq!(scheduler.pessimistic_lock_mode(), PessimisticLockMode::Sync);
+        // Use sync mode even when in_memory is true.
+        scheduler
+            .inner
+            .in_memory_pessimistic_lock
+            .store(true, Ordering::SeqCst);
+        assert_eq!(scheduler.pessimistic_lock_mode(), PessimisticLockMode::Sync);
+        // Mode is InMemory when both pipelined and in_memory is true.
+        scheduler
+            .inner
+            .pipelined_pessimistic_lock
+            .store(true, Ordering::SeqCst);
+        assert_eq!(
+            scheduler.pessimistic_lock_mode(),
+            PessimisticLockMode::InMemory
+        );
+        // Mode is Pipelined when only pipelined is true.
+        scheduler
+            .inner
+            .in_memory_pessimistic_lock
+            .store(false, Ordering::SeqCst);
+        assert_eq!(
+            scheduler.pessimistic_lock_mode(),
+            PessimisticLockMode::Pipelined
+        );
     }
 }

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -722,6 +722,7 @@ fn test_serde_custom_tikv_config() {
         wait_for_lock_timeout: ReadableDuration::millis(10),
         wake_up_delay_duration: ReadableDuration::millis(100),
         pipelined: false,
+        in_memory: true,
     };
     value.cdc = CdcConfig {
         min_ts_interval: ReadableDuration::secs(4),

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -608,6 +608,7 @@ enabled = false # test backward compatibility
 wait-for-lock-timeout = "10ms"
 wake-up-delay-duration = 100 # test backward compatibility
 pipelined = false
+in-memory = true
 
 [cdc]
 min-ts-interval = "4s"


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: #11452

### What is changed and how it works?

This PR adds configuration and dynamic switches for the in-memory pessimistic lock feature.

The feature itself is not implemented yet, but it will help us develop the feature without interfere the current implementation by adding the switches first.

### Related changes

Docs are not updated yet. We will update doc after the feature is usable.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```