### PR TITLE
engine: fix backward compatibility issue of raft-engine.recovery-mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5294,6 +5294,7 @@ dependencies = [
  "raftstore",
  "rand 0.7.3",
  "regex",
+ "reqwest",
  "resource_metering",
  "rev_lines",
  "seahash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3435,7 +3435,7 @@ dependencies = [
 [[package]]
 name = "raft-engine"
 version = "0.1.0"
-source = "git+https://github.com/tikv/raft-engine?branch=master#5d2e4fb4af706b3f3cff38145725ca57d6b2cbb9"
+source = "git+https://github.com/tikv/raft-engine?branch=master#a06397be343e3c766568aca5a1f447cf234b4954"
 dependencies = [
  "byteorder",
  "crc32fast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,6 +164,7 @@ seahash = "4.1.0"
 [dev-dependencies]
 example_plugin = { path = "components/test_coprocessor_plugin/example_plugin" } # should be a binary dependency
 panic_hook = { path = "components/panic_hook" }
+reqwest = { version = "0.11", features = ["blocking"] }
 test_sst_importer = { path = "components/test_sst_importer", default-features = false }
 test_util = { path = "components/test_util", default-features = false }
 tokio = { version = "1.5", features = ["macros", "rt-multi-thread", "time"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -4236,6 +4236,23 @@ mod tests {
     }
 
     #[test]
+    fn test_compatibility_with_old_config_template() {
+        let mut buf = Vec::new();
+        let mut resp = reqwest::blocking::get(
+            "https://raw.githubusercontent.com/tikv/tikv/master/etc/config-template.toml",
+        )
+        .expect("failed to download latest config template");
+        std::io::copy(&mut resp, &mut buf).expect("failed to copy content");
+        let template_config = std::str::from_utf8(&buf)
+            .unwrap()
+            .lines()
+            .map(|l| l.strip_prefix('#').unwrap_or(l))
+            .join("\n");
+        println!("{}", template_config);
+        let _: TiKvConfig = toml::from_str(&template_config).unwrap();
+    }
+
+    #[test]
     fn test_cdc() {
         let content = r#"
             [cdc]

--- a/src/config.rs
+++ b/src/config.rs
@@ -4238,18 +4238,27 @@ mod tests {
     #[test]
     fn test_compatibility_with_old_config_template() {
         let mut buf = Vec::new();
-        let mut resp = reqwest::blocking::get(
+        let resp = reqwest::blocking::get(
             "https://raw.githubusercontent.com/tikv/tikv/master/etc/config-template.toml",
-        )
-        .expect("failed to download latest config template");
-        std::io::copy(&mut resp, &mut buf).expect("failed to copy content");
-        let template_config = std::str::from_utf8(&buf)
-            .unwrap()
-            .lines()
-            .map(|l| l.strip_prefix('#').unwrap_or(l))
-            .join("\n");
-        println!("{}", template_config);
-        let _: TiKvConfig = toml::from_str(&template_config).unwrap();
+        );
+        match resp {
+            Ok(mut resp) => {
+                std::io::copy(&mut resp, &mut buf).expect("failed to copy content");
+                let template_config = std::str::from_utf8(&buf)
+                    .unwrap()
+                    .lines()
+                    .map(|l| l.strip_prefix('#').unwrap_or(l))
+                    .join("\n");
+                let _: TiKvConfig = toml::from_str(&template_config).unwrap();
+            }
+            Err(e) => {
+                if e.is_timeout() {
+                    println!("warn: fail to download latest config template due to timeout");
+                } else {
+                    panic!("fail to download latest config template");
+                }
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #11489 

### What is changed and how it works?

What's Changed:

Update raft engine to include https://github.com/tikv/raft-engine/pull/159, also add a test case.

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```