### PR TITLE
raftstore: prevent removing voters directly in 2 replica raft group

### DIFF
--- a/components/cdc/tests/integrations/test_cdc.rs
+++ b/components/cdc/tests/integrations/test_cdc.rs
@@ -11,7 +11,7 @@ use grpcio::WriteFlags;
 use kvproto::cdcpb::*;
 use kvproto::kvrpcpb::*;
 use pd_client::PdClient;
-use raft::eraftpb::MessageType;
+use raft::eraftpb::{ConfChangeType, MessageType};
 use test_raftstore::*;
 use tikv::server::DEFAULT_CLUSTER_ID;
 use tikv_util::HandyRwLock;
@@ -1568,6 +1568,10 @@ fn test_region_created_replicate() {
     suite
         .cluster
         .must_transfer_leader(region.id, new_peer(2, 2));
+    suite.cluster.pd_client.must_joint_confchange(
+        region.id,
+        vec![(ConfChangeType::AddLearnerNode, new_learner_peer(1, 1))],
+    );
     suite
         .cluster
         .pd_client

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -2963,6 +2963,15 @@ where
                         cp
                     ));
                 }
+                (ConfChangeType::RemoveNode, PeerRole::Voter)
+                    if kind == ConfChangeKind::Simple && current_voter.len() == 2 =>
+                {
+                    return Err(box_err!(
+                        "{} unsafe request {:?}, to remove voter directly from a 2 voters raft group, please demoting voter firstly. see issue 10595 for detail",
+                        self.tag,
+                        cp
+                    ));
+                }
                 (ConfChangeType::RemoveNode, _)
                 | (ConfChangeType::AddNode, PeerRole::Voter)
                 | (ConfChangeType::AddLearnerNode, PeerRole::Learner) => {}

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -2967,7 +2967,7 @@ where
                     if kind == ConfChangeKind::Simple && current_voter.len() == 2 =>
                 {
                     return Err(box_err!(
-                        "{} unsafe request {:?}, to remove voter directly from a 2 voters raft group, please demoting voter firstly. see issue 10595 for detail",
+                        "{} removing voter directly from a 2 voters raft group may make region unavailable, please demoting voter firstly, request: {:?}",
                         self.tag,
                         cp
                     ));

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -1210,6 +1210,17 @@ impl<T: Simulator> Cluster<T> {
         }
     }
 
+    pub fn remove_peer(&mut self, region_id: u64, peer: metapb::Peer) -> RaftCmdResponse {
+        let epoch = self.get_region_epoch(region_id);
+        let remove_peer = new_admin_request(
+            region_id,
+            &epoch,
+            new_change_peer_request(ConfChangeType::RemoveNode, peer),
+        );
+        self.call_command_on_leader(remove_peer, Duration::from_secs(5))
+            .unwrap()
+    }
+
     pub fn transfer_leader(&mut self, region_id: u64, leader: metapb::Peer) {
         let epoch = self.get_region_epoch(region_id);
         let transfer_leader = new_admin_request(region_id, &epoch, new_transfer_leader_cmd(leader));

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -1210,17 +1210,6 @@ impl<T: Simulator> Cluster<T> {
         }
     }
 
-    pub fn remove_peer(&mut self, region_id: u64, peer: metapb::Peer) -> RaftCmdResponse {
-        let epoch = self.get_region_epoch(region_id);
-        let remove_peer = new_admin_request(
-            region_id,
-            &epoch,
-            new_change_peer_request(ConfChangeType::RemoveNode, peer),
-        );
-        self.call_command_on_leader(remove_peer, Duration::from_secs(5))
-            .unwrap()
-    }
-
     pub fn transfer_leader(&mut self, region_id: u64, leader: metapb::Peer) {
         let epoch = self.get_region_epoch(region_id);
         let transfer_leader = new_admin_request(region_id, &epoch, new_transfer_leader_cmd(leader));

--- a/tests/failpoints/cases/test_gc_worker.rs
+++ b/tests/failpoints/cases/test_gc_worker.rs
@@ -10,6 +10,7 @@ use engine_traits::Peekable;
 use grpcio::{ChannelBuilder, Environment};
 use keys::data_key;
 use kvproto::{kvrpcpb::*, metapb::Region, tikvpb::TikvClient};
+use raft::eraftpb::ConfChangeType;
 use raftstore::coprocessor::{
     RegionInfo, RegionInfoCallback, RegionInfoProvider, Result as CopResult, SeekRegionCallback,
 };
@@ -277,7 +278,17 @@ fn test_collect_applying_locks() {
     // Transfer the region from store-1 to store-2.
     fail::remove(new_leader_apply_fp);
     cluster.must_transfer_leader(region_id, new_peer);
-    cluster.pd_client.must_remove_peer(region_id, leader);
+    cluster.pd_client.must_joint_confchange(
+        region_id,
+        vec![(
+            ConfChangeType::AddLearnerNode,
+            new_learner_peer(leader.get_store_id(), leader.get_id()),
+        )],
+    );
+    cluster.pd_client.must_remove_peer(
+        region_id,
+        new_learner_peer(leader.get_store_id(), leader.get_id()),
+    );
     // Wait for store-1 desroying the region.
     std::thread::sleep(Duration::from_secs(3));
 


### PR DESCRIPTION
Signed-off-by: p4tr1ck <patricknicholas@foxmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #10595 

Problem Summary:

It may lead to region unavailable when removing a voter from a 2 replica raft group directly.

### What is changed and how it works?


What's Changed:

prevent removing voters directly in 2 replica raft group.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```