### PR TITLE
storage: read and write in-memory pessimistic locks in the scheduler 

### DIFF
--- a/components/tikv_kv/src/btree_engine.rs
+++ b/components/tikv_kv/src/btree_engine.rs
@@ -280,7 +280,11 @@ fn write_modifies(engine: &BTreeEngine, modifies: Vec<Modify>) -> EngineResult<(
                 let cf_tree = engine.get_cf(cf);
                 cf_tree.write().unwrap().insert(k, v);
             }
-
+            Modify::PessimisticLock(k, lock) => {
+                let cf_tree = engine.get_cf(CF_LOCK);
+                let v = lock.into_lock().to_bytes();
+                cf_tree.write().unwrap().insert(k, v);
+            }
             Modify::DeleteRange(_cf, _start_key, _end_key, _notify_only) => unimplemented!(),
         };
     }

--- a/components/tikv_kv/src/lib.rs
+++ b/components/tikv_kv/src/lib.rs
@@ -32,7 +32,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::{error, ptr, result};
 
-use engine_traits::{CfName, CF_DEFAULT};
+use engine_traits::{CfName, CF_DEFAULT, CF_LOCK};
 use engine_traits::{
     IterOptions, KvEngine as LocalEngine, Mutable, MvccProperties, ReadOptions, WriteBatch,
 };
@@ -42,7 +42,7 @@ use kvproto::kvrpcpb::{Context, DiskFullOpt, ExtraOp as TxnExtraOp, KeyRange};
 use raftstore::store::TxnExt;
 use thiserror::Error;
 use tikv_util::{deadline::Deadline, escape};
-use txn_types::{Key, TimeStamp, TxnExtra, Value};
+use txn_types::{Key, PessimisticLock, TimeStamp, TxnExtra, Value};
 
 pub use self::btree_engine::{BTreeEngine, BTreeEngineIterator, BTreeEngineSnapshot};
 pub use self::cursor::{Cursor, CursorBuilder};
@@ -67,6 +67,7 @@ pub type Result<T> = result::Result<T, Error>;
 pub enum Modify {
     Delete(CfName, Key),
     Put(CfName, Key, Value),
+    PessimisticLock(Key, PessimisticLock),
     // cf_name, start_key, end_key, notify_only
     DeleteRange(CfName, Key, Key, bool),
 }
@@ -76,6 +77,7 @@ impl Modify {
         let cf = match self {
             Modify::Delete(cf, _) => cf,
             Modify::Put(cf, ..) => cf,
+            Modify::PessimisticLock(..) => &CF_LOCK,
             Modify::DeleteRange(..) => unreachable!(),
         };
         let cf_size = if cf == &CF_DEFAULT { 0 } else { cf.len() };
@@ -83,6 +85,7 @@ impl Modify {
         match self {
             Modify::Delete(_, k) => cf_size + k.as_encoded().len(),
             Modify::Put(_, k, v) => cf_size + k.as_encoded().len() + v.len(),
+            Modify::PessimisticLock(k, _) => cf_size + k.as_encoded().len(), // FIXME: inaccurate
             Modify::DeleteRange(..) => unreachable!(),
         }
     }
@@ -492,6 +495,11 @@ pub fn write_modifies(kv_engine: &impl LocalEngine, modifies: Vec<Modify>) -> Re
                     trace!("RocksEngine: put_cf"; "cf" => cf, "key" => %k, "value" => escape(&v));
                     wb.put_cf(cf, k.as_encoded(), &v)
                 }
+            }
+            Modify::PessimisticLock(k, lock) => {
+                let v = lock.into_lock().to_bytes();
+                trace!("RocksEngine: put lock"; "key" => %k, "values" => escape(&v));
+                wb.put_cf(CF_LOCK, k.as_encoded(), &v)
             }
             Modify::DeleteRange(cf, start_key, end_key, notify_only) => {
                 trace!(

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -1076,6 +1076,10 @@ mod tests {
                         let bytes = keys::data_key(key.as_encoded());
                         *key = Key::from_encoded(bytes);
                     }
+                    Modify::PessimisticLock(ref mut key, _) => {
+                        let bytes = keys::data_key(key.as_encoded());
+                        *key = Key::from_encoded(bytes);
+                    }
                     Modify::DeleteRange(_, ref mut key1, ref mut key2, _) => {
                         let bytes = keys::data_key(key1.as_encoded());
                         *key1 = Key::from_encoded(bytes);
@@ -1098,6 +1102,9 @@ mod tests {
                     *key = Key::from_encoded(keys::data_key(key.as_encoded()));
                 }
                 Modify::Put(_, ref mut key, _) => {
+                    *key = Key::from_encoded(keys::data_key(key.as_encoded()));
+                }
+                Modify::PessimisticLock(ref mut key, _) => {
                     *key = Key::from_encoded(keys::data_key(key.as_encoded()));
                 }
                 Modify::DeleteRange(_, ref mut start_key, ref mut end_key, _) => {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -93,7 +93,7 @@ use kvproto::kvrpcpb::{
     RawGetRequest,
 };
 use kvproto::pdpb::QueryKind;
-use raftstore::store::util::build_key_range;
+use raftstore::store::{util::build_key_range, TxnExt};
 use raftstore::store::{ReadStats, WriteStats};
 use rand::prelude::*;
 use resource_metering::{FutureExt, ResourceMeteringTag};
@@ -105,6 +105,7 @@ use std::{
         Arc,
     },
 };
+use tikv_kv::SnapshotExt;
 use tikv_util::time::{Instant, ThreadReadId};
 use txn_types::{Key, KvPair, Lock, OldValues, RawMutation, TimeStamp, TsSet, Value};
 
@@ -2183,6 +2184,112 @@ impl TestStorageBuilder<RocksEngine, DummyLockManager> {
 }
 
 #[derive(Clone)]
+pub struct TxnEngine<E: Engine> {
+    engine: E,
+    txn_ext: Arc<TxnExt>,
+}
+
+impl<E: Engine> Engine for TxnEngine<E> {
+    type Snap = TxnSnapshot<E::Snap>;
+    type Local = E::Local;
+
+    fn kv_engine(&self) -> Self::Local {
+        self.engine.kv_engine()
+    }
+
+    fn snapshot_on_kv_engine(
+        &self,
+        start_key: &[u8],
+        end_key: &[u8],
+    ) -> tikv_kv::Result<Self::Snap> {
+        let snapshot = self.engine.snapshot_on_kv_engine(start_key, end_key)?;
+        Ok(TxnSnapshot {
+            snapshot,
+            txn_ext: self.txn_ext.clone(),
+        })
+    }
+
+    fn modify_on_kv_engine(&self, modifies: Vec<Modify>) -> tikv_kv::Result<()> {
+        self.engine.modify_on_kv_engine(modifies)
+    }
+
+    fn async_snapshot(
+        &self,
+        ctx: SnapContext<'_>,
+        cb: tikv_kv::Callback<Self::Snap>,
+    ) -> tikv_kv::Result<()> {
+        let txn_ext = self.txn_ext.clone();
+        self.engine.async_snapshot(
+            ctx,
+            Box::new(
+                move |snapshot| cb(snapshot.map(|snapshot| TxnSnapshot { snapshot, txn_ext })),
+            ),
+        )
+    }
+
+    fn async_write(
+        &self,
+        ctx: &Context,
+        batch: WriteData,
+        write_cb: tikv_kv::Callback<()>,
+    ) -> tikv_kv::Result<()> {
+        self.engine.async_write(ctx, batch, write_cb)
+    }
+}
+
+#[derive(Clone)]
+pub struct TxnSnapshot<S: Snapshot> {
+    snapshot: S,
+    txn_ext: Arc<TxnExt>,
+}
+
+impl<S: Snapshot> Snapshot for TxnSnapshot<S> {
+    type Iter = S::Iter;
+    type Ext<'a> = TxnSnapshotExt<'a>;
+
+    fn get(&self, key: &Key) -> tikv_kv::Result<Option<Value>> {
+        self.snapshot.get(key)
+    }
+
+    fn get_cf(&self, cf: CfName, key: &Key) -> tikv_kv::Result<Option<Value>> {
+        self.snapshot.get_cf(cf, key)
+    }
+
+    fn get_cf_opt(
+        &self,
+        opts: engine_traits::ReadOptions,
+        cf: CfName,
+        key: &Key,
+    ) -> tikv_kv::Result<Option<Value>> {
+        self.snapshot.get_cf_opt(opts, cf, key)
+    }
+
+    fn iter(&self, iter_opt: engine_traits::IterOptions) -> tikv_kv::Result<Self::Iter> {
+        self.snapshot.iter(iter_opt)
+    }
+
+    fn iter_cf(
+        &self,
+        cf: CfName,
+        iter_opt: engine_traits::IterOptions,
+    ) -> tikv_kv::Result<Self::Iter> {
+        self.snapshot.iter_cf(cf, iter_opt)
+    }
+
+    fn ext(&self) -> Self::Ext<'_> {
+        TxnSnapshotExt(&self.txn_ext)
+    }
+}
+
+pub struct TxnSnapshotExt<'a>(&'a Arc<TxnExt>);
+
+impl<'a> SnapshotExt for TxnSnapshotExt<'a> {
+    fn get_txn_ext(&self) -> Option<&Arc<TxnExt>> {
+        Some(self.0)
+    }
+}
+
+#[derive(Clone)]
 struct DummyReporter;
 
 impl FlowStatsReporter for DummyReporter {
@@ -2258,6 +2365,31 @@ impl<E: Engine, L: LockManager> TestStorageBuilder<E, L> {
 
         Storage::from_engine(
             self.engine,
+            &self.config,
+            ReadPool::from(read_pool).handle(),
+            self.lock_mgr,
+            ConcurrencyManager::new(1.into()),
+            DynamicConfigs {
+                pipelined_pessimistic_lock: self.pipelined_pessimistic_lock,
+                in_memory_pessimistic_lock: self.in_memory_pessimistic_lock,
+            },
+            Arc::new(FlowController::empty()),
+            DummyReporter,
+        )
+    }
+
+    pub fn build_for_txn(self, txn_ext: Arc<TxnExt>) -> Result<Storage<TxnEngine<E>, L>> {
+        let engine = TxnEngine {
+            engine: self.engine,
+            txn_ext,
+        };
+        let read_pool = build_read_pool_for_test(
+            &crate::config::StorageReadPoolConfig::default_for_test(),
+            engine.clone(),
+        );
+
+        Storage::from_engine(
+            engine,
             &self.config,
             ReadPool::from(read_pool).handle(),
             self.lock_mgr,
@@ -2505,7 +2637,7 @@ mod tests {
     };
 
     use tikv_util::config::ReadableSize;
-    use txn_types::{Mutation, WriteType};
+    use txn_types::{Mutation, PessimisticLock, WriteType};
 
     #[test]
     fn test_prewrite_blocks_read() {
@@ -7461,5 +7593,127 @@ mod tests {
                 assert!(res.is_ok(), "case {}", i);
             }
         }
+    }
+
+    #[test]
+    fn test_write_in_memory_pessimistic_locks() {
+        let txn_ext = Arc::new(TxnExt::default());
+        let storage = TestStorageBuilder::new(DummyLockManager {}, ApiVersion::V1)
+            .pipelined_pessimistic_lock(true)
+            .in_memory_pessimistic_lock(true)
+            .build_for_txn(txn_ext.clone())
+            .unwrap();
+        let (tx, rx) = channel();
+
+        let k1 = Key::from_raw(b"k1");
+        storage
+            .sched_txn_command(
+                new_acquire_pessimistic_lock_command(vec![(k1.clone(), false)], 10, 10, false),
+                expect_ok_callback(tx, 0),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+
+        {
+            let pessimistic_locks = txn_ext.pessimistic_locks.read();
+            let lock = pessimistic_locks.map.get(&k1).unwrap();
+            assert_eq!(
+                lock,
+                &PessimisticLock {
+                    primary: Box::new(*b"k1"),
+                    start_ts: 10.into(),
+                    ttl: 3000,
+                    for_update_ts: 10.into(),
+                    min_commit_ts: 11.into(),
+                }
+            );
+        }
+
+        let (tx, rx) = channel();
+        // The written in-memory pessimistic lock should be visible, so the new lock request should fail.
+        storage
+            .sched_txn_command(
+                new_acquire_pessimistic_lock_command(vec![(k1.clone(), false)], 20, 20, false),
+                Box::new(move |res| {
+                    tx.send(res).unwrap();
+                }),
+            )
+            .unwrap();
+        // DummyLockManager just drops the callback, so it will fail to receive anything.
+        assert!(rx.recv().is_err());
+
+        let (tx, rx) = channel();
+        storage
+            .sched_txn_command(
+                commands::PrewritePessimistic::new(
+                    vec![(Mutation::Put((k1.clone(), b"v".to_vec())), true)],
+                    b"k1".to_vec(),
+                    10.into(),
+                    3000,
+                    10.into(),
+                    1,
+                    20.into(),
+                    TimeStamp::default(),
+                    None,
+                    false,
+                    Context::default(),
+                ),
+                Box::new(move |res| {
+                    tx.send(res).unwrap();
+                }),
+            )
+            .unwrap();
+        assert!(rx.recv().unwrap().is_ok());
+        // After prewrite, the memory lock should be removed.
+        {
+            let pessimistic_locks = txn_ext.pessimistic_locks.read();
+            assert!(!pessimistic_locks.map.contains_key(&k1));
+        }
+    }
+
+    #[test]
+    fn test_disable_in_memory_pessimistic_locks() {
+        let txn_ext = Arc::new(TxnExt::default());
+        let storage = TestStorageBuilder::new(DummyLockManager {}, ApiVersion::V1)
+            .pipelined_pessimistic_lock(true)
+            .in_memory_pessimistic_lock(false)
+            .build_for_txn(txn_ext.clone())
+            .unwrap();
+        let (tx, rx) = channel();
+
+        let k1 = Key::from_raw(b"k1");
+        storage
+            .sched_txn_command(
+                new_acquire_pessimistic_lock_command(vec![(k1.clone(), false)], 10, 10, false),
+                expect_ok_callback(tx, 0),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+        // When disabling in-memory pessimistic lock, the lock map should remain unchanged.
+        assert!(txn_ext.pessimistic_locks.read().map.is_empty());
+
+        let (tx, rx) = channel();
+        storage
+            .sched_txn_command(
+                commands::PrewritePessimistic::new(
+                    vec![(Mutation::Put((k1, b"v".to_vec())), true)],
+                    b"k1".to_vec(),
+                    10.into(),
+                    3000,
+                    10.into(),
+                    1,
+                    20.into(),
+                    TimeStamp::default(),
+                    None,
+                    false,
+                    Context::default(),
+                ),
+                Box::new(move |res| {
+                    tx.send(res).unwrap();
+                }),
+            )
+            .unwrap();
+        // Prewrite still succeeds
+        assert!(rx.recv().unwrap().is_ok());
     }
 }

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -6,7 +6,7 @@ use crate::storage::kv::Modify;
 use concurrency_manager::{ConcurrencyManager, KeyHandleGuard};
 use engine_traits::{CF_DEFAULT, CF_LOCK, CF_WRITE};
 use std::fmt;
-use txn_types::{Key, Lock, TimeStamp, Value};
+use txn_types::{Key, Lock, PessimisticLock, TimeStamp, Value};
 
 pub const MAX_TXN_WRITE_SIZE: usize = 32 * 1024;
 
@@ -101,6 +101,10 @@ impl MvccTxn {
 
     pub(crate) fn put_locks_for_1pc(&mut self, key: Key, lock: Lock, remove_pessimstic_lock: bool) {
         self.locks_for_1pc.push((key, lock, remove_pessimstic_lock));
+    }
+
+    pub(crate) fn put_pessimistic_lock(&mut self, key: Key, lock: PessimisticLock) {
+        self.modifies.push(Modify::PessimisticLock(key, lock))
     }
 
     pub(crate) fn unlock_key(&mut self, key: Key, pessimistic: bool) -> Option<ReleasedLock> {

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -22,12 +22,13 @@
 //! to the scheduler.
 
 use crossbeam::utils::CachePadded;
+use engine_traits::CF_LOCK;
 use parking_lot::{Mutex, MutexGuard};
 use std::marker::PhantomData;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
-use std::u64;
+use std::{mem, u64};
 
 use collections::HashMap;
 use concurrency_manager::{ConcurrencyManager, KeyHandleGuard};
@@ -35,7 +36,7 @@ use futures::compat::Future01CompatExt;
 use kvproto::kvrpcpb::{CommandPri, DiskFullOpt, ExtraOp};
 use kvproto::pdpb::QueryKind;
 use resource_metering::{FutureExt, ResourceMeteringTag};
-use tikv_kv::{Snapshot, SnapshotExt};
+use tikv_kv::{Modify, Snapshot, SnapshotExt, WriteData};
 use tikv_util::{time::Instant, timer::GLOBAL_TIMER_HANDLE};
 use txn_types::TimeStamp;
 
@@ -726,8 +727,9 @@ impl<E: Engine, L: LockManager> Scheduler<E, L> {
         let priority = task.cmd.priority();
         let ts = task.cmd.ts();
         let scheduler = self.clone();
-        let pipelined = self.pessimistic_lock_mode() == PessimisticLockMode::Pipelined
-            && task.cmd.can_be_pipelined();
+        let pessimistic_lock_mode = self.pessimistic_lock_mode();
+        let pipelined =
+            task.cmd.can_be_pipelined() && pessimistic_lock_mode == PessimisticLockMode::Pipelined;
 
         let deadline = task.cmd.deadline();
         let write_result = {
@@ -740,220 +742,274 @@ impl<E: Engine, L: LockManager> Scheduler<E, L> {
             };
 
             task.cmd
-                .process_write(snapshot, context)
+                .process_write(snapshot.clone(), context)
                 .map_err(StorageError::from)
         };
-        match deadline
+        let WriteResult {
+            ctx,
+            mut to_be_write,
+            rows,
+            pr,
+            lock_info,
+            lock_guards,
+            response_policy,
+        } = match deadline
             .check()
             .map_err(StorageError::from)
             .and(write_result)
         {
-            // Initiates an async write operation on the storage engine, there'll be a `WriteFinished`
-            // message when it finishes.
-            Ok(WriteResult {
-                ctx,
-                mut to_be_write,
-                rows,
-                pr,
-                lock_info,
-                lock_guards,
-                response_policy,
-            }) => {
-                SCHED_STAGE_COUNTER_VEC.get(tag).write.inc();
-
-                if ctx.get_disk_full_opt() == DiskFullOpt::AllowedOnAlmostFull {
-                    to_be_write.disk_full_opt = DiskFullOpt::AllowedOnAlmostFull
-                }
-
-                if let Some(lock_info) = lock_info {
-                    let WriteResultLockInfo {
-                        lock,
-                        key,
-                        is_first_lock,
-                        wait_timeout,
-                    } = lock_info;
-                    let diag_ctx = DiagnosticContext {
-                        key,
-                        resource_group_tag: ctx.get_resource_group_tag().into(),
-                    };
-                    scheduler.on_wait_for_lock(
-                        cid,
-                        ts,
-                        pr,
-                        lock,
-                        is_first_lock,
-                        wait_timeout,
-                        diag_ctx,
-                    );
-                } else if to_be_write.modifies.is_empty() {
-                    scheduler.on_write_finished(
-                        cid,
-                        Some(pr),
-                        Ok(()),
-                        lock_guards,
-                        false,
-                        false,
-                        tag,
-                    );
-                } else {
-                    let mut pr = Some(pr);
-                    let mut is_async_apply_prewrite = false;
-
-                    let (proposed_cb, committed_cb): (Option<ExtCallback>, Option<ExtCallback>) =
-                        match response_policy {
-                            ResponsePolicy::OnApplied => (None, None),
-                            ResponsePolicy::OnCommitted => {
-                                self.inner.store_pr(cid, pr.take().unwrap());
-                                let sched = scheduler.clone();
-                                // Currently, the only case that response is returned after finishing
-                                // commit is async applying prewrites for async commit transactions.
-                                // The committed callback is not guaranteed to be invoked. So store
-                                // the `pr` to the tctx instead of capturing it to the closure.
-                                let committed_cb = Box::new(move || {
-                                    fail_point!("before_async_apply_prewrite_finish", |_| {});
-                                    let (cb, pr) = sched.inner.take_task_cb_and_pr(cid);
-                                    Self::early_response(
-                                        cid,
-                                        cb.unwrap(),
-                                        pr.unwrap(),
-                                        tag,
-                                        metrics::CommandStageKind::async_apply_prewrite,
-                                    );
-                                });
-                                is_async_apply_prewrite = true;
-                                (None, Some(committed_cb))
-                            }
-                            ResponsePolicy::OnProposed => {
-                                if pipelined {
-                                    // The normal write process is respond to clients and release
-                                    // latches after async write finished. If pipelined pessimistic
-                                    // locking is enabled, the process becomes parallel and there are
-                                    // two msgs for one command:
-                                    //   1. Msg::PipelinedWrite: respond to clients
-                                    //   2. Msg::WriteFinished: deque context and release latches
-                                    // The proposed callback is not guaranteed to be invoked. So store
-                                    // the `pr` to the tctx instead of capturing it to the closure.
-                                    self.inner.store_pr(cid, pr.take().unwrap());
-                                    let sched = scheduler.clone();
-                                    // Currently, the only case that response is returned after finishing
-                                    // proposed phase is pipelined pessimistic lock.
-                                    // TODO: Unify the code structure of pipelined pessimistic lock and
-                                    // async apply prewrite.
-                                    let proposed_cb = Box::new(move || {
-                                        fail_point!("before_pipelined_write_finish", |_| {});
-                                        let (cb, pr) = sched.inner.take_task_cb_and_pr(cid);
-                                        Self::early_response(
-                                            cid,
-                                            cb.unwrap(),
-                                            pr.unwrap(),
-                                            tag,
-                                            metrics::CommandStageKind::pipelined_write,
-                                        );
-                                    });
-                                    (Some(proposed_cb), None)
-                                } else {
-                                    (None, None)
-                                }
-                            }
-                        };
-
-                    let sched = scheduler.clone();
-                    let sched_pool = scheduler.get_sched_pool(priority).pool.clone();
-                    let write_size = to_be_write.size();
-                    // The callback to receive async results of write prepare from the storage engine.
-                    let engine_cb = Box::new(move |result: EngineResult<()>| {
-                        sched_pool
-                            .spawn(async move {
-                                fail_point!("scheduler_async_write_finish");
-
-                                let ok = result.is_ok();
-                                sched.on_write_finished(
-                                    cid,
-                                    pr,
-                                    result,
-                                    lock_guards,
-                                    pipelined,
-                                    is_async_apply_prewrite,
-                                    tag,
-                                );
-                                KV_COMMAND_KEYWRITE_HISTOGRAM_VEC
-                                    .get(tag)
-                                    .observe(rows as f64);
-
-                                if !ok {
-                                    // Only consume the quota when write succeeds, otherwise failed write requests may exhaust
-                                    // the quota and other write requests would be in long delay.
-                                    if sched.inner.flow_controller.enabled() {
-                                        sched.inner.flow_controller.unconsume(write_size);
-                                    }
-                                }
-                            })
-                            .unwrap()
-                    });
-
-                    if self.inner.flow_controller.enabled() {
-                        if self.inner.flow_controller.is_unlimited() {
-                            // no need to delay if unthrottled, just call consume to record write flow
-                            let _ = self.inner.flow_controller.consume(write_size);
-                        } else {
-                            let start = Instant::now_coarse();
-                            // Control mutex is used to ensure there is only one request consuming the quota.
-                            // The delay may exceed 1s, and the speed limit is changed every second.
-                            // If the speed of next second is larger than the one of first second,
-                            // without the mutex, the write flow can't throttled strictly.
-                            let control_mutex = self.inner.control_mutex.clone();
-                            let _guard = control_mutex.lock().await;
-                            let delay = self.inner.flow_controller.consume(write_size);
-                            let delay_end = Instant::now_coarse() + delay;
-                            while !self.inner.flow_controller.is_unlimited() {
-                                let now = Instant::now_coarse();
-                                if now >= delay_end {
-                                    break;
-                                }
-                                if now >= deadline.inner() {
-                                    scheduler
-                                        .finish_with_err(cid, StorageErrorInner::DeadlineExceeded);
-                                    self.inner.flow_controller.unconsume(write_size);
-                                    SCHED_THROTTLE_TIME.observe(start.saturating_elapsed_secs());
-                                    return;
-                                }
-                                GLOBAL_TIMER_HANDLE
-                                    .delay(std::time::Instant::now() + Duration::from_millis(1))
-                                    .compat()
-                                    .await
-                                    .unwrap();
-                            }
-                            SCHED_THROTTLE_TIME.observe(start.saturating_elapsed_secs());
-                        }
-                    }
-
-                    to_be_write.deadline = Some(deadline);
-                    // Safety: `self.sched_pool` ensures a TLS engine exists.
-                    unsafe {
-                        with_tls_engine(|engine: &E| {
-                            if let Err(e) = engine.async_write_ext(
-                                &ctx,
-                                to_be_write,
-                                engine_cb,
-                                proposed_cb,
-                                committed_cb,
-                            ) {
-                                SCHED_STAGE_COUNTER_VEC.get(tag).async_write_err.inc();
-
-                                info!("engine async_write failed"; "cid" => cid, "err" => ?e);
-                                scheduler.finish_with_err(cid, e);
-                            }
-                        })
-                    }
-                }
-            }
             // Write prepare failure typically means conflicting transactions are detected. Delivers the
             // error to the callback, and releases the latches.
             Err(err) => {
                 SCHED_STAGE_COUNTER_VEC.get(tag).prepare_write_err.inc();
                 debug!("write command failed at prewrite"; "cid" => cid, "err" => ?err);
                 scheduler.finish_with_err(cid, err);
+                return;
             }
+            // Initiates an async write operation on the storage engine, there'll be a `WriteFinished`
+            // message when it finishes.
+            Ok(res) => res,
+        };
+        SCHED_STAGE_COUNTER_VEC.get(tag).write.inc();
+
+        if let Some(lock_info) = lock_info {
+            let WriteResultLockInfo {
+                lock,
+                key,
+                is_first_lock,
+                wait_timeout,
+            } = lock_info;
+            let diag_ctx = DiagnosticContext {
+                key,
+                resource_group_tag: ctx.get_resource_group_tag().into(),
+            };
+            scheduler.on_wait_for_lock(cid, ts, pr, lock, is_first_lock, wait_timeout, diag_ctx);
+            return;
+        }
+
+        let mut pr = Some(pr);
+        if to_be_write.modifies.is_empty() {
+            scheduler.on_write_finished(cid, pr, Ok(()), lock_guards, false, false, tag);
+            return;
+        }
+
+        if tag == CommandKind::acquire_pessimistic_lock
+            && pessimistic_lock_mode == PessimisticLockMode::InMemory
+            && self.try_write_in_memory_pessimistic_locks(&snapshot, &mut to_be_write)
+        {
+            scheduler.on_write_finished(cid, pr, Ok(()), lock_guards, false, false, tag);
+            return;
+        }
+
+        let mut is_async_apply_prewrite = false;
+        let write_size = to_be_write.size();
+
+        // Mutations on the lock CF should overwrite the memory locks.
+        // These mutations happen on a working leader, so memory pessimistic locks
+        // are only written through the scheduler. Protected by the latches, there will
+        // be no concurrent write on the same keys in the lock table. So, it is safe
+        // for us to only delete keys that are already in the lock table.
+        // This will help us reduce the cost of cloning the keys for the commit command
+        // or when the feature is disabled.
+        let locks_to_be_removed = {
+            match snapshot
+                .ext()
+                .get_txn_ext()
+                .map(|txn_ext| txn_ext.pessimistic_locks.read())
+            {
+                Some(locks) if !locks.map.is_empty() => to_be_write
+                    .modifies
+                    .iter()
+                    .filter_map(|write| match write {
+                        Modify::Put(cf, key, ..) | Modify::Delete(cf, key)
+                            if *cf == CF_LOCK && locks.map.contains_key(key) =>
+                        {
+                            Some(key.clone())
+                        }
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>(),
+                _ => vec![],
+            }
+        };
+
+        if ctx.get_disk_full_opt() == DiskFullOpt::AllowedOnAlmostFull {
+            to_be_write.disk_full_opt = DiskFullOpt::AllowedOnAlmostFull
+        }
+        let (proposed_cb, committed_cb): (Option<ExtCallback>, Option<ExtCallback>) =
+            match response_policy {
+                ResponsePolicy::OnApplied => (None, None),
+                ResponsePolicy::OnCommitted => {
+                    self.inner.store_pr(cid, pr.take().unwrap());
+                    let sched = scheduler.clone();
+                    // Currently, the only case that response is returned after finishing
+                    // commit is async applying prewrites for async commit transactions.
+                    // The committed callback is not guaranteed to be invoked. So store
+                    // the `pr` to the tctx instead of capturing it to the closure.
+                    let committed_cb = Box::new(move || {
+                        fail_point!("before_async_apply_prewrite_finish", |_| {});
+                        let (cb, pr) = sched.inner.take_task_cb_and_pr(cid);
+                        Self::early_response(
+                            cid,
+                            cb.unwrap(),
+                            pr.unwrap(),
+                            tag,
+                            metrics::CommandStageKind::async_apply_prewrite,
+                        );
+                    });
+                    is_async_apply_prewrite = true;
+                    (None, Some(committed_cb))
+                }
+                ResponsePolicy::OnProposed => {
+                    if pipelined {
+                        // The normal write process is respond to clients and release
+                        // latches after async write finished. If pipelined pessimistic
+                        // locking is enabled, the process becomes parallel and there are
+                        // two msgs for one command:
+                        //   1. Msg::PipelinedWrite: respond to clients
+                        //   2. Msg::WriteFinished: deque context and release latches
+                        // The proposed callback is not guaranteed to be invoked. So store
+                        // the `pr` to the tctx instead of capturing it to the closure.
+                        self.inner.store_pr(cid, pr.take().unwrap());
+                        let sched = scheduler.clone();
+                        // Currently, the only case that response is returned after finishing
+                        // proposed phase is pipelined pessimistic lock.
+                        // TODO: Unify the code structure of pipelined pessimistic lock and
+                        // async apply prewrite.
+                        let proposed_cb = Box::new(move || {
+                            fail_point!("before_pipelined_write_finish", |_| {});
+                            let (cb, pr) = sched.inner.take_task_cb_and_pr(cid);
+                            Self::early_response(
+                                cid,
+                                cb.unwrap(),
+                                pr.unwrap(),
+                                tag,
+                                metrics::CommandStageKind::pipelined_write,
+                            );
+                        });
+                        (Some(proposed_cb), None)
+                    } else {
+                        (None, None)
+                    }
+                }
+            };
+
+        let sched = scheduler.clone();
+        let sched_pool = scheduler.get_sched_pool(priority).pool.clone();
+        let txn_ext = snapshot.ext().get_txn_ext().cloned();
+        // The callback to receive async results of write prepare from the storage engine.
+        let engine_cb = Box::new(move |result: EngineResult<()>| {
+            sched_pool
+                .spawn(async move {
+                    fail_point!("scheduler_async_write_finish");
+
+                    let ok = result.is_ok();
+                    if ok {
+                        // Lock CF mutations should overwrite memory pessimistic locks
+                        if let Some(mut pessimistic_locks) = txn_ext
+                            .as_ref()
+                            .map(|txn_ext| txn_ext.pessimistic_locks.write())
+                        {
+                            for key in &locks_to_be_removed {
+                                pessimistic_locks.map.remove(key);
+                            }
+                        }
+                    }
+                    sched.on_write_finished(
+                        cid,
+                        pr,
+                        result,
+                        lock_guards,
+                        pipelined,
+                        is_async_apply_prewrite,
+                        tag,
+                    );
+                    KV_COMMAND_KEYWRITE_HISTOGRAM_VEC
+                        .get(tag)
+                        .observe(rows as f64);
+
+                    if !ok {
+                        // Only consume the quota when write succeeds, otherwise failed write requests may exhaust
+                        // the quota and other write requests would be in long delay.
+                        if sched.inner.flow_controller.enabled() {
+                            sched.inner.flow_controller.unconsume(write_size);
+                        }
+                    }
+                })
+                .unwrap()
+        });
+
+        if self.inner.flow_controller.enabled() {
+            if self.inner.flow_controller.is_unlimited() {
+                // no need to delay if unthrottled, just call consume to record write flow
+                let _ = self.inner.flow_controller.consume(write_size);
+            } else {
+                let start = Instant::now_coarse();
+                // Control mutex is used to ensure there is only one request consuming the quota.
+                // The delay may exceed 1s, and the speed limit is changed every second.
+                // If the speed of next second is larger than the one of first second,
+                // without the mutex, the write flow can't throttled strictly.
+                let control_mutex = self.inner.control_mutex.clone();
+                let _guard = control_mutex.lock().await;
+                let delay = self.inner.flow_controller.consume(write_size);
+                let delay_end = Instant::now_coarse() + delay;
+                while !self.inner.flow_controller.is_unlimited() {
+                    let now = Instant::now_coarse();
+                    if now >= delay_end {
+                        break;
+                    }
+                    if now >= deadline.inner() {
+                        scheduler.finish_with_err(cid, StorageErrorInner::DeadlineExceeded);
+                        self.inner.flow_controller.unconsume(write_size);
+                        SCHED_THROTTLE_TIME.observe(start.saturating_elapsed_secs());
+                        return;
+                    }
+                    GLOBAL_TIMER_HANDLE
+                        .delay(std::time::Instant::now() + Duration::from_millis(1))
+                        .compat()
+                        .await
+                        .unwrap();
+                }
+                SCHED_THROTTLE_TIME.observe(start.saturating_elapsed_secs());
+            }
+        }
+
+        to_be_write.deadline = Some(deadline);
+        // Safety: `self.sched_pool` ensures a TLS engine exists.
+        unsafe {
+            with_tls_engine(|engine: &E| {
+                if let Err(e) =
+                    engine.async_write_ext(&ctx, to_be_write, engine_cb, proposed_cb, committed_cb)
+                {
+                    SCHED_STAGE_COUNTER_VEC.get(tag).async_write_err.inc();
+
+                    info!("engine async_write failed"; "cid" => cid, "err" => ?e);
+                    scheduler.finish_with_err(cid, e);
+                }
+            })
+        }
+    }
+
+    // Returns whether it succeeds to write pessimistic locks to the in-memory lock table
+    fn try_write_in_memory_pessimistic_locks(
+        &self,
+        snapshot: &E::Snap,
+        to_be_write: &mut WriteData,
+    ) -> bool {
+        if let Some(txn_ext) = snapshot.ext().get_txn_ext() {
+            let mut pessimistic_locks = txn_ext.pessimistic_locks.write();
+            // TODO: check `epoch` and `valid`
+            for modify in mem::take(&mut to_be_write.modifies) {
+                match modify {
+                    Modify::PessimisticLock(key, lock) => {
+                        pessimistic_locks.map.insert(key, lock);
+                    }
+                    _ => panic!("all modifies should be PessimisticLock"),
+                }
+            }
+            true
+        } else {
+            false
         }
     }
 

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -904,7 +904,7 @@ impl<E: Engine, L: LockManager> Scheduler<E, L> {
                     fail_point!("scheduler_async_write_finish");
 
                     let ok = result.is_ok();
-                    if ok {
+                    if ok && !locks_to_be_removed.is_empty() {
                         // Lock CF mutations should overwrite memory pessimistic locks
                         if let Some(mut pessimistic_locks) = txn_ext
                             .as_ref()


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

- [x] Based on #11481

### What is changed and how it works?

Ref #11452 

What's Changed:

This PR supports reading and writing pessimistic locks in the transaction layer. 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
