### PR TITLE
tikv_util: reimplement poll_future_notify

### DIFF
--- a/components/tikv_util/src/future.rs
+++ b/components/tikv_util/src/future.rs
@@ -7,7 +7,9 @@ use futures::future::{self, BoxFuture, Future, FutureExt, TryFutureExt};
 use futures::stream::{Stream, StreamExt};
 use futures::task::{self, ArcWake, Context, Poll};
 
-use std::sync::{Arc, Mutex};
+use std::cell::UnsafeCell;
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::Arc;
 
 /// Generates a paired future and callback so that when callback is being called, its result
 /// is automatically passed as a future result.
@@ -72,25 +74,152 @@ where
 /// thread calling `wake()`.
 pub fn poll_future_notify<F: Future<Output = ()> + Send + 'static>(f: F) {
     let f: BoxFuture<'static, ()> = Box::pin(f);
-    let waker = Arc::new(BatchCommandsWaker(Mutex::new(Some(f))));
-    waker.wake();
+    let poller = Arc::new(PollAtWake {
+        f: UnsafeCell::new(Some(f)),
+        state: AtomicU8::new(IDLE),
+    });
+    PollAtWake::poll(&poller)
 }
 
-// BatchCommandsWaker is used to make business pool notifiy completion queues directly.
-struct BatchCommandsWaker(Mutex<Option<BoxFuture<'static, ()>>>);
+/// The future is not processed by any one.
+const IDLE: u8 = 0;
+/// The future is being polled by some thread.
+const POLLING: u8 = 1;
+/// The future is woken when being polled.
+const PENDING: u8 = 2;
 
-impl ArcWake for BatchCommandsWaker {
-    fn wake_by_ref(arc_self: &Arc<Self>) {
-        let mut future_slot = arc_self.0.lock().unwrap();
-        if let Some(mut future) = future_slot.take() {
-            let waker = task::waker_ref(arc_self);
-            let cx = &mut Context::from_waker(&*waker);
-            match future.as_mut().poll(cx) {
-                Poll::Pending => {
-                    *future_slot = Some(future);
+/// A waker that will poll the future immediately when waking up.
+struct PollAtWake {
+    f: UnsafeCell<Option<BoxFuture<'static, ()>>>,
+    state: AtomicU8,
+}
+
+impl PollAtWake {
+    fn poll(arc_self: &Arc<PollAtWake>) {
+        let mut state = arc_self.state.load(Ordering::Relaxed);
+        loop {
+            match state {
+                IDLE => {
+                    match arc_self.state.compare_exchange_weak(
+                        IDLE,
+                        POLLING,
+                        Ordering::SeqCst,
+                        Ordering::SeqCst,
+                    ) {
+                        Ok(_) => break,
+                        Err(s) => state = s,
+                    }
                 }
-                Poll::Ready(()) => {}
+                POLLING => {
+                    match arc_self.state.compare_exchange_weak(
+                        POLLING,
+                        PENDING,
+                        Ordering::SeqCst,
+                        Ordering::SeqCst,
+                    ) {
+                        // The polling thread should poll the future again.
+                        Ok(_) => return,
+                        Err(s) => state = s,
+                    }
+                }
+                PENDING => {
+                    // It will be polled again, so we don't need to do anything here.
+                    return;
+                }
+                _ => panic!("unexpected state {}", state),
             }
         }
+
+        let f = unsafe { &mut *arc_self.f.get() };
+        let fut = match f {
+            Some(f) => f,
+            None => {
+                // It can't be `None` for the moment. But it's not a big mistake, just ignore.
+                return;
+            }
+        };
+
+        let waker = task::waker_ref(arc_self);
+        let cx = &mut Context::from_waker(&*waker);
+        loop {
+            match fut.as_mut().poll(cx) {
+                // Likely pending
+                Poll::Pending => (),
+                Poll::Ready(()) => {
+                    // We skip updating states here as all future wake should be ignored once
+                    // a future is resolved.
+                    f.take();
+                    return;
+                }
+            }
+            match arc_self
+                .state
+                .compare_exchange(POLLING, IDLE, Ordering::SeqCst, Ordering::SeqCst)
+            {
+                Ok(_) => return,
+                Err(s) => {
+                    if s == PENDING {
+                        // Only this thread can change the state from PENDING, so it has to succeed.
+                        match arc_self.state.compare_exchange(
+                            PENDING,
+                            POLLING,
+                            Ordering::SeqCst,
+                            Ordering::SeqCst,
+                        ) {
+                            Ok(_) => continue,
+                            Err(s) => panic!("unexpected state {}", s),
+                        }
+                    } else {
+                        panic!("unexpcted state {}", s);
+                    }
+                }
+            }
+        }
+    }
+}
+
+// `BoxFuture` is Send, so `PollAtWake` is Send and Sync.
+unsafe impl Send for PollAtWake {}
+unsafe impl Sync for PollAtWake {}
+
+impl ArcWake for PollAtWake {
+    #[inline]
+    fn wake_by_ref(arc_self: &Arc<Self>) {
+        PollAtWake::poll(arc_self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::task::Poll;
+    use std::sync::atomic::AtomicUsize;
+
+    #[test]
+    fn test_in_place_wake() {
+        let poll_times = Arc::new(AtomicUsize::new(0));
+        let times = poll_times.clone();
+        let f = futures::future::poll_fn(move |cx| {
+            cx.waker().wake_by_ref();
+            let last_time = times.fetch_add(1, Ordering::SeqCst);
+            if last_time == 0 {
+                Poll::Pending
+            } else {
+                Poll::Ready(())
+            }
+        });
+        poll_future_notify(f);
+        // The future will be woken twice, but only polled twice.
+        // The sequence should be:
+        // 1. future gets polled
+        //   1.1 future gets woken
+        //      1.1.1 future marks PENDING
+        //   1.2 future returns Poll::Pending
+        // 2. future finishes polling, then re-poll
+        //   2.1 future gets woken
+        //     2.1.1 future marks PENDING
+        //   2.2 future returns Poll::Ready
+        // 3. future gets ready, ignore PENDING
+        assert_eq!(poll_times.load(Ordering::SeqCst), 2);
     }
 }

--- a/components/tikv_util/src/future.rs
+++ b/components/tikv_util/src/future.rs
@@ -213,13 +213,13 @@ mod tests {
         // The sequence should be:
         // 1. future gets polled
         //   1.1 future gets woken
-        //      1.1.1 future marks NOTIFIED 
+        //      1.1.1 future marks NOTIFIED
         //   1.2 future returns Poll::Pending
         // 2. future finishes polling, then re-poll
         //   2.1 future gets woken
         //     2.1.1 future marks NOTIFIED
         //   2.2 future returns Poll::Ready
-        // 3. future gets ready, ignore NOTIFIED 
+        // 3. future gets ready, ignore NOTIFIED
         assert_eq!(poll_times.load(Ordering::SeqCst), 2);
     }
 }


### PR DESCRIPTION

### What is changed and how it works?

The current implementation is very easy to get deadlock if the future is
woken immediately during polling. This PR resolves the issue by
maintaining states instead.

Note, if the future is implemented in the wrong way that always
notifying the future without checking if it has readiness, the new
implementation can run into dead loop.

Close #11549.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix deadlock in some rare cases that futures get resolved too fast
```
