### PR TITLE
fix taking rootfs as filesystem by mistake

### DIFF
--- a/src/server/service/diagnostics/sys.rs
+++ b/src/server/service/diagnostics/sys.rs
@@ -362,9 +362,8 @@ fn disk_hardware_info(collector: &mut Vec<ServerInfoItem>) {
     system.refresh_disks();
     let disks = system.get_disks();
     for disk in disks {
-        let file_sys = std::str::from_utf8(disk.get_file_system())
-            .unwrap_or("unknown");
-        if file_sys == "rootfs"{
+        let file_sys = std::str::from_utf8(disk.get_file_system()).unwrap_or("unknown");
+        if file_sys == "rootfs" {
             continue;
         }
         let total = disk.get_total_space();

--- a/src/server/service/diagnostics/sys.rs
+++ b/src/server/service/diagnostics/sys.rs
@@ -362,6 +362,11 @@ fn disk_hardware_info(collector: &mut Vec<ServerInfoItem>) {
     system.refresh_disks();
     let disks = system.get_disks();
     for disk in disks {
+        let file_sys = std::str::from_utf8(disk.get_file_system())
+            .unwrap_or("unknown");
+        if file_sys == "rootfs"{
+            continue;
+        }
         let total = disk.get_total_space();
         let free = disk.get_available_space();
         let used = total - free;
@@ -369,12 +374,7 @@ fn disk_hardware_info(collector: &mut Vec<ServerInfoItem>) {
         let used_pct = (used as f64) / (total as f64);
         let infos = vec![
             ("type", format!("{:?}", disk.get_type())),
-            (
-                "fstype",
-                std::str::from_utf8(disk.get_file_system())
-                    .unwrap_or("unkonwn")
-                    .to_string(),
-            ),
+            ("fstype", file_sys.to_string()),
             (
                 "path",
                 disk.get_mount_point()


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

Close #11552 
What's Changed:
Skip the disk with filesystem as `rootfs` during the diskinfo extracting loop.

### Related changes


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects
### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None.
```
