### PR TITLE
tolerate unmounted cgroup controller

### DIFF
--- a/components/tikv_util/src/sys/cgroup.rs
+++ b/components/tikv_util/src/sys/cgroup.rs
@@ -415,12 +415,12 @@ mod tests {
             let infos = Process::new_with_root(PathBuf::from(dir))
                 .and_then(|x| x.mountinfo())
                 .unwrap();
-            parse_mountinfos_v2(infos)
+            parse_mountinfos_v1(infos)
         };
         let cgroup_sys = CGroupSys {
             cgroups,
             mount_points,
-            is_v2: true,
+            is_v2: false,
         };
 
         assert_eq!(cgroup_sys.cpu_quota(), None);


### PR DESCRIPTION
Signed-off-by: tabokie <xy.tao@outlook.com>

### What is changed and how it works?

Close #11569

What's Changed:

Avoid unwrapping cgroup mountinfo

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix panic when cgroup controller is not mounted
```
