### PR TITLE
*: Fix tikv-ctl region-properties doesn't work on rawkv

### DIFF
--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -905,10 +905,11 @@ fn dump_default_cf_properties(
         .collect::<Vec<_>>()
         .join(", ");
 
-    let mut res = vec![];
-    res.push(("defaultcf.num_entries".to_owned(), num_entries.to_string()));
-    res.push(("defaultcf.num_files".to_owned(), num_files.to_string()));
-    res.push(("defaultcf.sst_files".to_owned(), sst_files));
+    let res = vec![
+        ("defaultcf.num_entries".to_owned(), num_entries.to_string()),
+        ("defaultcf.num_files".to_owned(), num_files.to_string()),
+        ("defaultcf.sst_files".to_owned(), sst_files),
+    ];
     Ok(res)
 }
 

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -841,7 +841,9 @@ impl<ER: RaftEngine> Debugger<ER> {
         let start = keys::enc_start_key(region);
         let end = keys::enc_end_key(region);
 
-        let mut res = dump_mvcc_properties(self.engines.kv.as_inner(), &start, &end)?;
+        let mut res = dump_write_cf_properties(self.engines.kv.as_inner(), &start, &end)?;
+        let mut res1 = dump_default_cf_properties(self.engines.kv.as_inner(), &start, &end)?;
+        res.append(&mut res1);
 
         let middle_key = match box_try!(get_region_approximate_middle(&self.engines.kv, region)) {
             Some(data_key) => keys::origin_key(&data_key).to_vec(),
@@ -862,15 +864,59 @@ impl<ER: RaftEngine> Debugger<ER> {
     }
 
     pub fn get_range_properties(&self, start: &[u8], end: &[u8]) -> Result<Vec<(String, String)>> {
-        dump_mvcc_properties(
+        let mut props = dump_write_cf_properties(
             self.engines.kv.as_inner(),
             &keys::data_key(start),
             &keys::data_end_key(end),
-        )
+        )?;
+        let mut props1 = dump_default_cf_properties(
+            self.engines.kv.as_inner(),
+            &keys::data_key(start),
+            &keys::data_end_key(end),
+        )?;
+        props.append(&mut props1);
+        Ok(props)
     }
 }
 
-fn dump_mvcc_properties(db: &Arc<DB>, start: &[u8], end: &[u8]) -> Result<Vec<(String, String)>> {
+fn dump_default_cf_properties(
+    db: &Arc<DB>,
+    start: &[u8],
+    end: &[u8],
+) -> Result<Vec<(String, String)>> {
+    let mut num_entries = 0; // number of Rocksdb K/V entries.
+
+    let collection = box_try!(db.c().get_range_properties_cf(CF_DEFAULT, start, end));
+    let num_files = collection.len();
+
+    for (_, v) in collection.iter() {
+        num_entries += v.num_entries();
+    }
+
+    let sst_files = collection
+        .iter()
+        .map(|(k, _)| {
+            Path::new(&*k)
+                .file_name()
+                .map(|f| f.to_str().unwrap())
+                .unwrap_or(&*k)
+                .to_string()
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    let mut res = vec![];
+    res.push(("defaultcf.num_entries".to_owned(), num_entries.to_string()));
+    res.push(("defaultcf.num_files".to_owned(), num_files.to_string()));
+    res.push(("defaultcf.sst_files".to_owned(), sst_files));
+    Ok(res)
+}
+
+fn dump_write_cf_properties(
+    db: &Arc<DB>,
+    start: &[u8],
+    end: &[u8],
+) -> Result<Vec<(String, String)>> {
     let mut num_entries = 0; // number of Rocksdb K/V entries.
 
     let collection = box_try!(db.c().get_range_properties_cf(CF_WRITE, start, end));
@@ -896,7 +942,14 @@ fn dump_mvcc_properties(db: &Arc<DB>, start: &[u8], end: &[u8]) -> Result<Vec<(S
         .join(", ");
 
     let mut res: Vec<(String, String)> = [
-        ("mvcc.min_ts", mvcc_properties.min_ts.into_inner()),
+        (
+            "mvcc.min_ts",
+            if mvcc_properties.min_ts == TimeStamp::max() {
+                0
+            } else {
+                mvcc_properties.min_ts.into_inner()
+            },
+        ),
         ("mvcc.max_ts", mvcc_properties.max_ts.into_inner()),
         ("mvcc.num_rows", mvcc_properties.num_rows),
         ("mvcc.num_puts", mvcc_properties.num_puts),
@@ -910,12 +963,12 @@ fn dump_mvcc_properties(db: &Arc<DB>, start: &[u8], end: &[u8]) -> Result<Vec<(S
 
     // Entries and delete marks of RocksDB.
     let num_deletes = num_entries - mvcc_properties.num_versions;
-    res.push(("num_entries".to_owned(), num_entries.to_string()));
-    res.push(("num_deletes".to_owned(), num_deletes.to_string()));
+    res.push(("writecf.num_entries".to_owned(), num_entries.to_string()));
+    res.push(("writecf.num_deletes".to_owned(), num_deletes.to_string()));
 
     // count and list of files.
-    res.push(("num_files".to_owned(), num_files.to_string()));
-    res.push(("sst_files".to_owned(), sst_files));
+    res.push(("writecf.num_files".to_owned(), num_files.to_string()));
+    res.push(("writecf.sst_files".to_owned(), sst_files));
 
     Ok(res)
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1720,7 +1720,7 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
                     metrics::tls_collect_read_flow(ctx.get_region_id(), &statistics);
                     KV_COMMAND_KEYREAD_HISTOGRAM_STATIC
                         .get(CMD)
-                        .observe(statistics.write.flow_stats.read_keys as f64);
+                        .observe(statistics.data.flow_stats.read_keys as f64);
                     metrics::tls_collect_scan_details(CMD, &statistics);
                     SCHED_PROCESSING_READ_HISTOGRAM_STATIC
                         .get(CMD)
@@ -1839,7 +1839,7 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
                     metrics::tls_collect_read_flow(ctx.get_region_id(), &statistics);
                     KV_COMMAND_KEYREAD_HISTOGRAM_STATIC
                         .get(CMD)
-                        .observe(statistics.write.flow_stats.read_keys as f64);
+                        .observe(statistics.data.flow_stats.read_keys as f64);
                     metrics::tls_collect_scan_details(CMD, &statistics);
                     SCHED_PROCESSING_READ_HISTOGRAM_STATIC
                         .get(CMD)


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

Close https://github.com/tikv/tikv/issues/11583  <!-- Associate issue that describes the problem the PR tries to solve. -->

What's Changed: 
- print default cf as well for region-properties
- Fix https://github.com/tikv/tikv/issues/11571 by the way

### Related changes

None

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix tikv-ctl region-properties doesn't work on rawkv
```
