### PR TITLE
metrics: remove coprocessor meet lock alert

### DIFF
--- a/metrics/alertmanager/tikv.rules.yml
+++ b/metrics/alertmanager/tikv.rules.yml
@@ -241,30 +241,6 @@ groups:
       value: '{{ $value }}'
       summary: TiKV scheduler command duration seconds more than 1s
 
-  - alert: TiKV_coprocessor_request_error
-    expr: increase(tikv_coprocessor_request_error{reason!="meet_lock"}[10m]) > 100
-    for: 1m
-    labels:
-      env: ENV_LABELS_ENV
-      level: warning
-      expr:  increase(tikv_coprocessor_request_error{reason!="meet_lock"}[10m]) > 100
-    annotations:
-      description: 'cluster: ENV_LABELS_ENV, reason: {{ $labels.reason }}, instance: {{ $labels.instance }}, values: {{ $value }}'
-      value: '{{ $value }}'
-      summary: TiKV coprocessor request error
-
-  - alert: TiKV_coprocessor_request_lock_error
-    expr: increase(tikv_coprocessor_request_error{reason="meet_lock"}[10m]) > 10000
-    for: 1m
-    labels:
-      env: ENV_LABELS_ENV
-      level: warning
-      expr:  increase(tikv_coprocessor_request_error{reason="meet_lock"}[10m]) > 10000
-    annotations:
-      description: 'cluster: ENV_LABELS_ENV, reason: {{ $labels.reason }}, instance: {{ $labels.instance }}, values: {{ $value }}'
-      value: '{{ $value }}'
-      summary: TiKV coprocessor request lock error
-
   - alert: TiKV_coprocessor_pending_request
     expr: delta( tikv_coprocessor_pending_request[10m]) > 5000
     for: 1m


### PR DESCRIPTION
Signed-off-by: zhangjinpeng1987 <zhangjinpeng@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

Close #11613 <!-- Associate issue that describes the problem the PR tries to solve. -->

What's Changed:

### Related changes
Remove coprocessor meet lock alert because it is normal to meet lock when reading in percolator transaction model.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

- No

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
