### PR TITLE
gc_worker: Add failpoint to unsafe_destroy_range

### DIFF
--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -407,6 +407,8 @@ where
             "start_key" => %start_key, "end_key" => %end_key
         );
 
+        fail_point!("unsafe_destroy_range");
+
         self.flow_info_sender
             .send(FlowInfo::BeforeUnsafeDestroyRange)
             .unwrap();


### PR DESCRIPTION
Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

close #11621

This PR adds a failpoint to unsafe_destroy_range.

This is intended to provide a way for testing the problem fixed by https://github.com/tikv/client-go/pull/270 and https://github.com/tikv/client-go/pull/278 .

What's Changed:

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

Side effects


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
