### PR TITLE
rsmeter: add centralized place to construct protobuf data

### DIFF
--- a/components/resource_metering/src/reporter/data_sink.rs
+++ b/components/resource_metering/src/reporter/data_sink.rs
@@ -1,7 +1,10 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
 use crate::error::Result;
-use crate::model::Records;
+
+use std::sync::Arc;
+
+use kvproto::resource_usage_agent::ResourceUsageRecord;
 
 /// This trait abstracts the interface to communicate with the remote.
 /// We can simply mock this interface to test without RPC.
@@ -10,5 +13,5 @@ pub trait DataSink {
     // by the sink. A deadline can be specified to control how late it should be sent.
     // If the sink is kept full and cannot schedule a send within the specified deadline,
     // or the sink is closed, an error will be returned.
-    fn try_send(&mut self, records: Records) -> Result<()>;
+    fn try_send(&mut self, records: Arc<Vec<ResourceUsageRecord>>) -> Result<()>;
 }


### PR DESCRIPTION
Signed-off-by: Zhenchi <zhongzc_arch@outlook.com>

### What is changed and how it works?

ref #11691 

What's Changed:

Many datasinks will be interested in report data. It's wasted to convert them from the original shape to the protobuf shape multiple times.

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
