### PR TITLE
coprocessor: not return rows when there is no input for simple aggregation

### DIFF
--- a/components/tidb_query_executors/src/simple_aggr_executor.rs
+++ b/components/tidb_query_executors/src/simple_aggr_executor.rs
@@ -105,7 +105,7 @@ impl<Src: BatchExecutor> BatchSimpleAggregationExecutor<Src> {
     ) -> Result<Self> {
         // Empty states is fine because it will be re-initialized later according to the content
         // in entities.
-        let aggr_impl = SimpleAggregationImpl { states: Vec::new() };
+        let aggr_impl = SimpleAggregationImpl { states: Vec::new(), has_input_rows: false };
 
         Ok(Self(AggregationExecutor::new(
             aggr_impl,
@@ -119,6 +119,13 @@ impl<Src: BatchExecutor> BatchSimpleAggregationExecutor<Src> {
 
 pub struct SimpleAggregationImpl {
     states: Vec<Box<dyn AggrFunctionState>>,
+    // To fix https://github.com/pingcap/tidb/issues/30923
+    // for aggregation without group by, it should return at least 1 row even if
+    // there is no input row, however, the aggregation executed in TiKV is always
+    // the first stage agg, so it is safe to not return any thing if no input.
+    // todo should add variable like agg_stage, and if there is no input rows,
+    //  only return 1 row if the aggregation is in the final stage
+    has_input_rows : bool
 }
 
 impl<Src: BatchExecutor> AggregationExecutorImpl<Src> for SimpleAggregationImpl {
@@ -129,6 +136,7 @@ impl<Src: BatchExecutor> AggregationExecutorImpl<Src> for SimpleAggregationImpl 
             .map(|f| f.create_state())
             .collect();
         self.states = states;
+        self.has_input_rows = false
     }
 
     #[inline]
@@ -139,6 +147,7 @@ impl<Src: BatchExecutor> AggregationExecutorImpl<Src> for SimpleAggregationImpl 
         input_logical_rows: &[usize],
     ) -> Result<()> {
         let rows_len = input_logical_rows.len();
+        self.has_input_rows |= rows_len > 0;
 
         assert_eq!(self.states.len(), entities.each_aggr_exprs.len());
 
@@ -203,7 +212,9 @@ impl<Src: BatchExecutor> AggregationExecutorImpl<Src> for SimpleAggregationImpl 
         mut iteratee: impl FnMut(&mut Entities<Src>, &[Box<dyn AggrFunctionState>]) -> Result<()>,
     ) -> Result<Vec<LazyBatchColumn>> {
         assert!(src_is_drained);
-        iteratee(entities, &self.states)?;
+        if self.has_input_rows {
+            iteratee(entities, &self.states)?;
+        }
         Ok(Vec::new())
     }
 
@@ -647,14 +658,12 @@ mod tests {
 
         let r = exec.next_batch(1);
         assert!(r.logical_rows.is_empty());
+        assert_eq!(r.physical_columns.rows_len(), 0);
         assert!(!r.is_drained.unwrap());
 
         let r = exec.next_batch(1);
-        assert_eq!(&r.logical_rows, &[0]);
-        assert_eq!(r.physical_columns.rows_len(), 1);
-        assert_eq!(r.physical_columns.columns_len(), 1);
-        assert!(r.physical_columns[0].is_decoded());
-        assert_eq!(r.physical_columns[0].decoded().to_int_vec(), &[Some(42)]);
+        assert!(r.logical_rows.is_empty());
+        assert_eq!(r.physical_columns.rows_len(), 0);
         assert!(r.is_drained.unwrap());
     }
 }

--- a/components/tidb_query_executors/src/simple_aggr_executor.rs
+++ b/components/tidb_query_executors/src/simple_aggr_executor.rs
@@ -105,7 +105,10 @@ impl<Src: BatchExecutor> BatchSimpleAggregationExecutor<Src> {
     ) -> Result<Self> {
         // Empty states is fine because it will be re-initialized later according to the content
         // in entities.
-        let aggr_impl = SimpleAggregationImpl { states: Vec::new(), has_input_rows: false };
+        let aggr_impl = SimpleAggregationImpl {
+            states: Vec::new(),
+            has_input_rows: false,
+        };
 
         Ok(Self(AggregationExecutor::new(
             aggr_impl,
@@ -125,7 +128,7 @@ pub struct SimpleAggregationImpl {
     // the first stage agg, so it is safe to not return any thing if no input.
     // todo should add variable like agg_stage, and if there is no input rows,
     //  only return 1 row if the aggregation is in the final stage
-    has_input_rows : bool
+    has_input_rows: bool,
 }
 
 impl<Src: BatchExecutor> AggregationExecutorImpl<Src> for SimpleAggregationImpl {
@@ -201,7 +204,7 @@ impl<Src: BatchExecutor> AggregationExecutorImpl<Src> for SimpleAggregationImpl 
 
     #[inline]
     fn groups_len(&self) -> usize {
-        1
+        if self.has_input_rows { 1 } else { 0 }
     }
 
     #[inline]


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

Close #11735, Close pingcap/tidb#30923 <!-- Associate issue that describes the problem the PR tries to solve. -->

What's Changed:
For `SimpleAggregation` does not return row if there is no input rows
### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)


Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix wrong `any_value` result when there are regions returning empty result 
```
