### PR TITLE
metrics: fix the metrics cannot be displayed

### DIFF
--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -734,7 +734,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(process_cpu_seconds_total{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", job=\"tikv\"}[1m])) by (instance)",
+              "expr": "sum(rate(process_cpu_seconds_total{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", job=~\".*tikv\"}[1m])) by (instance)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}}",
@@ -841,7 +841,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(process_resident_memory_bytes{tidb_cluster=\"$tidb_cluster\", job=\"tikv\"}) by (instance)",
+              "expr": "avg(process_resident_memory_bytes{tidb_cluster=\"$tidb_cluster\", job=~\".*tikv\"}) by (instance)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}}",
@@ -1633,7 +1633,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "(time() - process_start_time_seconds{tidb_cluster=\"$tidb_cluster\", job=\"tikv\"})",
+              "expr": "(time() - process_start_time_seconds{tidb_cluster=\"$tidb_cluster\", job=~\".*tikv\"})",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}}",


### PR DESCRIPTION
Signed-off-by: Ryan Leung <rleungx@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

Ref #11662 

What's Changed:

After #11656, some metrics cannot be displayed correctly in K8s environment.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test 

K8s environment:
<img width="1200" alt="Screen Shot 2021-12-23 at 5 14 15 PM" src="https://user-images.githubusercontent.com/35896542/147219636-756077ad-9b46-47bd-90e0-0620f94a28f4.png">
<img width="1200" alt="Screen Shot 2021-12-23 at 5 14 59 PM" src="https://user-images.githubusercontent.com/35896542/147219649-48140a6b-2d80-4d3e-85ac-2f598824a578.png">
<img width="1200" alt="Screen Shot 2021-12-23 at 5 15 25 PM" src="https://user-images.githubusercontent.com/35896542/147219653-419f39a9-0fce-43e1-8abe-ba4a095e0405.png">

TiUP:
<img width="1200" alt="Screen Shot 2021-12-23 at 5 17 56 PM" src="https://user-images.githubusercontent.com/35896542/147219849-b06e4f1f-2637-4d81-b5e7-4e64a005637a.png">
<img width="1200" alt="Screen Shot 2021-12-23 at 5 18 06 PM" src="https://user-images.githubusercontent.com/35896542/147219856-4597e9a8-275b-45ce-92cf-791a26b81cc7.png">
<img width="1200" alt="Screen Shot 2021-12-23 at 5 18 22 PM" src="https://user-images.githubusercontent.com/35896542/147219861-dd5c3fc2-d76a-4f5b-aa07-63c70485e0ca.png">




### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix the metrics in cluster panel cannot be displayed
```
