### PR TITLE
coprocesser: implement upper and lower function on GBK charset

### DIFF
--- a/components/tidb_query_datatype/src/codec/collation/encoding/gbk.rs
+++ b/components/tidb_query_datatype/src/codec/collation/encoding/gbk.rs
@@ -1,6 +1,7 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
 use super::*;
+use crate::codec::data_type::{BytesGuard, BytesWriter};
 use encoding_rs::GBK;
 
 #[derive(Debug)]
@@ -18,5 +19,51 @@ impl Encoding for EncodingGBK {
     #[inline]
     fn encode(data: BytesRef<'_>) -> Result<Bytes> {
         Ok(Bytes::from(GBK.encode(str::from_utf8(data)?).0))
+    }
+
+    #[inline]
+    // GBK lower and upper follows https://dev.mysql.com/worklog/task/?id=4583.
+    fn lower(s: &str, writer: BytesWriter) -> BytesGuard {
+        let res = s.chars().flat_map(|ch| {
+            let c = ch as u32;
+            match c {
+                0x216A..=0x216B => char::from_u32(c),
+                _ => char::from_u32(c).unwrap().to_lowercase().next(),
+            }
+        });
+        writer.write_from_char_iter(res)
+    }
+
+    #[inline]
+    fn upper(s: &str, writer: BytesWriter) -> BytesGuard {
+        let res = s.chars().flat_map(|ch| {
+            let c = ch as u32;
+            match c {
+                0x00E0..=0x00E1
+                | 0x00E8..=0x00EA
+                | 0x00EC..=0x00ED
+                | 0x00F2..=0x00F3
+                | 0x00F9..=0x00FA
+                | 0x00FC
+                | 0x0101
+                | 0x0113
+                | 0x011B
+                | 0x012B
+                | 0x0144
+                | 0x0148
+                | 0x014D
+                | 0x016B
+                | 0x01CE
+                | 0x01D0
+                | 0x01D2
+                | 0x01D4
+                | 0x01D6
+                | 0x01D8
+                | 0x01DA
+                | 0x01DC => char::from_u32(c),
+                _ => char::from_u32(c).unwrap().to_uppercase().next(),
+            }
+        });
+        writer.write_from_char_iter(res)
     }
 }

--- a/components/tidb_query_datatype/src/codec/collation/mod.rs
+++ b/components/tidb_query_datatype/src/codec/collation/mod.rs
@@ -12,7 +12,7 @@ use std::ops::Deref;
 use codec::prelude::*;
 use num::Unsigned;
 
-use crate::codec::data_type::{Bytes, BytesRef};
+use crate::codec::data_type::{Bytes, BytesGuard, BytesRef, BytesWriter};
 use crate::codec::Result;
 
 #[macro_export]
@@ -103,6 +103,18 @@ pub trait Encoding {
     #[inline]
     fn encode(data: BytesRef<'_>) -> Result<Bytes> {
         Ok(Bytes::from(data))
+    }
+
+    #[inline]
+    fn lower(s: &str, writer: BytesWriter) -> BytesGuard {
+        let res = s.chars().flat_map(char::to_lowercase);
+        writer.write_from_char_iter(res)
+    }
+
+    #[inline]
+    fn upper(s: &str, writer: BytesWriter) -> BytesGuard {
+        let res = s.chars().flat_map(char::to_uppercase);
+        writer.write_from_char_iter(res)
     }
 }
 

--- a/components/tidb_query_datatype/src/codec/mysql/charset.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/charset.rs
@@ -10,6 +10,8 @@ pub const CHARSET_UTF8MB4: &str = "utf8mb4";
 pub const CHARSET_ASCII: &str = "ascii";
 /// `CHARSET_LATIN1` is a single byte charset.
 pub const CHARSET_LATIN1: &str = "latin1";
+/// `CHARSET_GBK` is Chinese character set.
+pub const CHARSET_GBK: &str = "gbk";
 
 /// All utf8 charsets.
 pub const UTF8_CHARSETS: &[&str] = &[CHARSET_UTF8, CHARSET_UTF8MB4, CHARSET_ASCII];

--- a/components/tidb_query_expr/src/lib.rs
+++ b/components/tidb_query_expr/src/lib.rs
@@ -312,8 +312,29 @@ fn map_lower_sig(value: ScalarFuncSig, children: &[Expr]) -> Result<RpnFnMeta> {
     if children[0].get_field_type().is_binary_string_like() {
         Ok(lower_fn_meta())
     } else {
-        Ok(lower_utf8_fn_meta())
+        let ret_field_type = children[0].get_field_type();
+        Ok(match_template_charset! {
+            TT, match Charset::from_name(ret_field_type.get_charset()).map_err(tidb_query_datatype::codec::Error::from)? {
+                Charset::TT => lower_utf8_fn_meta::<TT>(),
+            }
+        })
     }
+}
+
+fn map_upper_sig(value: ScalarFuncSig, children: &[Expr]) -> Result<RpnFnMeta> {
+    if children.len() != 1 {
+        return Err(other_err!(
+            "ScalarFunction {:?} (params = {}) is not supported in batch mode",
+            value,
+            children.len()
+        ));
+    }
+    let ret_field_type = children[0].get_field_type();
+    Ok(match_template_charset! {
+     TT, match Charset::from_name(ret_field_type.get_charset()).map_err(tidb_query_datatype::codec::Error::from)? {
+           Charset::TT => upper_utf8_fn_meta::<TT>(),
+        }
+    })
 }
 
 #[rustfmt::skip]
@@ -660,7 +681,7 @@ fn map_expr_node_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
         ScalarFuncSig::Right => right_fn_meta(),
         ScalarFuncSig::Insert => insert_fn_meta(),
         ScalarFuncSig::RightUtf8 => right_utf8_fn_meta(),
-        ScalarFuncSig::UpperUtf8 => upper_utf8_fn_meta(),
+        ScalarFuncSig::UpperUtf8 => map_upper_sig(value, children)?,
         ScalarFuncSig::Upper => upper_fn_meta(),
         ScalarFuncSig::Lower => map_lower_sig(value, children)?,
         ScalarFuncSig::Locate2Args => locate_2_args_fn_meta(),


### PR DESCRIPTION
Signed-off-by: xiongjiwei <xiongjiwei1996@outlook.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

Close https://github.com/tikv/tikv/issues/11757

some characters only have lower or upper case under gbk encoding. if so, we should make its lower or upper eq to itself

see https://github.com/pingcap/tidb/pull/28869 for more details

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
