### PR TITLE
res_meter: ignore the read keys test temporarily

### DIFF
--- a/tests/integrations/resource_metering/test_read_keys.rs
+++ b/tests/integrations/resource_metering/test_read_keys.rs
@@ -29,6 +29,7 @@ use tikv_util::HandyRwLock;
 use tipb::SelectResponse;
 
 #[test]
+#[ignore = "the case is unstable, ref #11765"]
 pub fn test_read_keys() {
     // Create & start receiver server.
     let (tx, rx) = unbounded();
@@ -174,6 +175,7 @@ fn recv_read_keys(rx: &Receiver<Vec<ResourceUsageRecord>>) -> u32 {
 }
 
 #[test]
+#[ignore = "the case is unstable, ref #11765"]
 fn test_read_keys_coprocessor() {
     // Start resource metering.
     let mut cfg = resource_metering::Config::default();


### PR DESCRIPTION
Ignore the read keys test temporarily. The actual optimization of test (with more changes) will be carried out later.

ref #11765

Signed-off-by: mornyx <mornyx.z@gmail.com>

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```