### PR TITLE
UnifiedReadPool: support adjusting the pool size dynamically

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1740,7 +1740,7 @@ impl UnifiedReadPoolConfig {
     }
 }
 
-const UNIFIED_READPOOL_MIN_CONCURRENCY: usize = 4;
+pub const UNIFIED_READPOOL_MIN_CONCURRENCY: usize = 4;
 
 // FIXME: Use macros to generate it if yatp is used elsewhere besides readpool.
 impl Default for UnifiedReadPoolConfig {

--- a/src/read_pool.rs
+++ b/src/read_pool.rs
@@ -18,7 +18,7 @@ use tikv_util::sys::SysQuota;
 use tikv_util::yatp_pool::{self, FuturePool, PoolTicker, YatpPoolBuilder};
 
 use self::metrics::*;
-use crate::config::UnifiedReadPoolConfig;
+use crate::config::{UnifiedReadPoolConfig, UNIFIED_READPOOL_MIN_CONCURRENCY};
 use crate::storage::kv::{destroy_tls_engine, set_tls_engine, Engine, FlowStatsReporter};
 
 pub enum ReadPool {
@@ -251,7 +251,7 @@ pub fn build_yatp_read_pool<E: Engine, R: FlowStatsReporter>(
             config.min_thread_count,
             config.max_thread_count,
             std::cmp::max(
-                config.max_thread_count,
+                UNIFIED_READPOOL_MIN_CONCURRENCY,
                 SysQuota::cpu_cores_quota() as usize,
             ),
         )


### PR DESCRIPTION
close #11781

Signed-off-by: Wenbo Zhang <ethercflow@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

Close #11781 <!-- Associate issue that describes the problem the PR tries to solve. -->

What's Changed:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- None

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
UnifiedReadPool: support adjusting the pool size dynamically
```
