### PR TITLE
config: relax the bounds of online configurable worker number (#11651)

### DIFF
--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -494,12 +494,13 @@ impl Config {
 
         // Since the following configuration supports online update, in order to
         // prevent mistakenly inputting too large values, the max limit is made
-        // according to the cpu quota.
-        let cpu_num = SysQuota::cpu_cores_quota() as usize;
-        if self.apply_batch_system.pool_size == 0 || self.apply_batch_system.pool_size > cpu_num {
+        // according to the cpu quota * 10. Notice 10 is only an estimate, not an
+        // empirical value.
+        let limit = SysQuota::cpu_cores_quota() as usize * 10;
+        if self.apply_batch_system.pool_size == 0 || self.apply_batch_system.pool_size > limit {
             return Err(box_err!(
                 "apply-pool-size should be greater than 0 and less than or equal to: {}",
-                cpu_num
+                limit
             ));
         }
         if let Some(size) = self.apply_batch_system.max_batch_size {
@@ -509,10 +510,10 @@ impl Config {
         } else {
             self.apply_batch_system.max_batch_size = Some(256);
         }
-        if self.store_batch_system.pool_size == 0 || self.store_batch_system.pool_size > cpu_num {
+        if self.store_batch_system.pool_size == 0 || self.store_batch_system.pool_size > limit {
             return Err(box_err!(
                 "store-pool-size should be greater than 0 and less than or equal to: {}",
-                cpu_num
+                limit
             ));
         }
         if self.store_batch_system.low_priority_pool_size > 0 {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1129,19 +1129,20 @@ impl DbConfig {
 
         // Since the following configuration supports online update, in order to
         // prevent mistakenly inputting too large values, the max limit is made
-        // according to the cpu quota.
-        let cpu_num = SysQuota::cpu_cores_quota() as i32;
-        if self.max_background_jobs <= 0 || self.max_background_jobs > cpu_num {
+        // according to the cpu quota * 10. Notice 10 is only an estimate, not an
+        // empirical value.
+        let limit = SysQuota::cpu_cores_quota() as i32 * 10;
+        if self.max_background_jobs <= 0 || self.max_background_jobs > limit {
             return Err(format!(
                 "max_background_jobs should be greater than 0 and less than or equal to {:?}",
-                cpu_num,
+                limit,
             )
             .into());
         }
-        if self.max_background_flushes <= 0 || self.max_background_flushes > cpu_num {
+        if self.max_background_flushes <= 0 || self.max_background_flushes > limit {
             return Err(format!(
                 "max_background_flushes should be greater than 0 and less than or equal to {:?}",
-                cpu_num,
+                limit,
             )
             .into());
         }
@@ -1498,10 +1499,6 @@ impl DBConfigManger {
     }
 
     fn set_max_background_jobs(&self, max_background_jobs: i32) -> Result<(), Box<dyn Error>> {
-        let opt = self.db.as_inner().get_db_options();
-        if max_background_jobs < opt.get_max_background_jobs() {
-            return Err("unable to shrink background jobs while the instance is running".into());
-        }
         self.set_db_config(&[("max_background_jobs", &max_background_jobs.to_string())])?;
         Ok(())
     }
@@ -1510,10 +1507,6 @@ impl DBConfigManger {
         &self,
         max_background_flushes: i32,
     ) -> Result<(), Box<dyn Error>> {
-        let opt = self.db.as_inner().get_db_options();
-        if max_background_flushes < opt.get_max_background_flushes() {
-            return Err("unable to shrink background jobs while the instance is running".into());
-        }
         self.set_db_config(&[(
             "max_background_flushes",
             &max_background_flushes.to_string(),


### PR DESCRIPTION
close #11776

Signed-off-by: Wenbo Zhang <ethercflow@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

Close #11776  <!-- Associate issue that describes the problem the PR tries to solve. -->

What's Changed:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- None

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
