### PR TITLE
txn: Do not check assertion if the mutation is insert or check_not_exist

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -294,7 +294,7 @@ codegen-units = 4
 
 [profile.test]
 opt-level = 0
-debug = 2 # enable line numbers by default for easy test debugging
+debug = 1 # enable line numbers by default for easy test debugging
 codegen-units = 16
 lto = false
 incremental = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -294,7 +294,7 @@ codegen-units = 4
 
 [profile.test]
 opt-level = 0
-debug = 1 # enable line numbers by default for easy test debugging
+debug = 2 # enable line numbers by default for easy test debugging
 codegen-units = 16
 lto = false
 incremental = true

--- a/src/storage/txn/actions/prewrite.rs
+++ b/src/storage/txn/actions/prewrite.rs
@@ -438,6 +438,23 @@ impl<'a> PrewriteMutation<'a> {
         .into())
     }
 
+    /// Check the assertion set on the mutation. A mutation might has assertion (asserts the key
+    /// must already exist / not exist before the current write), and if the assertion is not
+    /// satisfied, it will be regarded as an inconsistent data or corruption.
+    ///
+    /// If `write_loaded` is true, `write` should be the most recent write record on the current
+    /// key, and the check will be made on this record. If the latest write record is not a data
+    /// record (it's neither `Put` nor `Delete`), it will then try to continue finding the most
+    /// recent `Put` or `Delete`.
+    ///
+    /// If `write_loaded` is false, this function will load the recent write by itself.
+    ///
+    /// Returns `(write, reloaded)`, where `reloaded` is a bool indicates whether this function
+    /// tried to load the write record from Write CF (because `write_loaded` is set to false or
+    /// `write` is not `Put` or `Delete`). If `reloaded` is true, `write` will be a write record
+    /// that this function finally found and its commit_ts, if any. If it's needed to read the
+    /// previous value after this function, the returned `write` can be reused to avoid reading
+    /// Write CF again.
     fn check_assertion<S: Snapshot>(
         &self,
         reader: &mut SnapshotReader<S>,
@@ -448,6 +465,11 @@ impl<'a> PrewriteMutation<'a> {
             || self.txn_props.assertion_level == AssertionLevel::Off
         {
             MVCC_PREWRITE_ASSERTION_PERF_COUNTER_VEC.none.inc();
+            return Ok((None, false));
+        }
+
+        // Do nothing if the mutation itself implies an existence check (it's Insert or CheckNotExist).
+        if self.should_not_exist {
             return Ok((None, false));
         }
 
@@ -724,6 +746,26 @@ pub mod tests {
         pk: &[u8],
         ts: impl Into<TimeStamp>,
     ) -> Result<()> {
+        try_prewrite_insert_impl(
+            engine,
+            key,
+            value,
+            pk,
+            ts,
+            Assertion::None,
+            AssertionLevel::Off,
+        )
+    }
+
+    fn try_prewrite_insert_impl<E: Engine>(
+        engine: &E,
+        key: &[u8],
+        value: &[u8],
+        pk: &[u8],
+        ts: impl Into<TimeStamp>,
+        assertion: Assertion,
+        assertion_level: AssertionLevel,
+    ) -> Result<()> {
         let ctx = Context::default();
         let snapshot = engine.snapshot(Default::default()).unwrap();
         let ts = ts.into();
@@ -733,11 +775,12 @@ pub mod tests {
 
         let mut props = optimistic_txn_props(pk, ts);
         props.need_old_value = true;
+        props.assertion_level = assertion_level;
         let (_, old_value) = prewrite(
             &mut txn,
             &mut reader,
             &props,
-            Mutation::make_insert(Key::from_raw(key), value.to_vec()),
+            Mutation::Insert((Key::from_raw(key), value.to_vec()), assertion),
             &None,
             false,
         )?;
@@ -758,17 +801,37 @@ pub mod tests {
         pk: &[u8],
         ts: impl Into<TimeStamp>,
     ) -> Result<()> {
+        try_prewrite_check_not_exists_impl(
+            engine,
+            key,
+            pk,
+            ts,
+            Assertion::None,
+            AssertionLevel::Off,
+        )
+    }
+
+    fn try_prewrite_check_not_exists_impl<E: Engine>(
+        engine: &E,
+        key: &[u8],
+        pk: &[u8],
+        ts: impl Into<TimeStamp>,
+        assertion: Assertion,
+        assertion_level: AssertionLevel,
+    ) -> Result<()> {
         let snapshot = engine.snapshot(Default::default()).unwrap();
         let ts = ts.into();
         let cm = ConcurrencyManager::new(ts);
         let mut txn = MvccTxn::new(ts, cm);
         let mut reader = SnapshotReader::new(ts, snapshot, true);
 
+        let mut props = optimistic_txn_props(pk, ts);
+        props.assertion_level = assertion_level;
         let (_, old_value) = prewrite(
             &mut txn,
             &mut reader,
-            &optimistic_txn_props(pk, ts),
-            Mutation::make_check_not_exists(Key::from_raw(key)),
+            &props,
+            Mutation::CheckNotExists(Key::from_raw(key), assertion),
             &None,
             true,
         )?;
@@ -1746,20 +1809,56 @@ pub mod tests {
             }
         };
 
-        let test = |key_prefix: &[u8], assertion_level, prepare: &dyn for<'a> Fn(&'a [u8])| {
-            let k1 = [key_prefix, b"k1"].concat();
-            let k2 = [key_prefix, b"k2"].concat();
-            let k3 = [key_prefix, b"k3"].concat();
-            let k4 = [key_prefix, b"k4"].concat();
+        let prewrite_insert = |key: &'_ _,
+                               value,
+                               ts: u64,
+                               assertion,
+                               assertion_level,
+                               already_exist| {
+            let res =
+                try_prewrite_insert_impl(&engine, key, value, key, ts, assertion, assertion_level);
+            if already_exist {
+                assert!(matches!(
+                    res,
+                    Err(Error(box ErrorInner::AlreadyExist { .. }))
+                ));
+            } else {
+                res.unwrap();
+            }
+        };
+        let prewrite_check_not_exist =
+            |key: &'_ _, ts: u64, assertion, assertion_level, already_exist| {
+                let res = try_prewrite_check_not_exists_impl(
+                    &engine,
+                    key,
+                    key,
+                    ts,
+                    assertion,
+                    assertion_level,
+                );
+                if already_exist {
+                    assert!(matches!(
+                        res,
+                        Err(Error(box ErrorInner::AlreadyExist { .. }))
+                    ));
+                } else {
+                    res.unwrap();
+                }
+            };
 
-            for k in &[&k1, &k2, &k3, &k4] {
+        let test = |key_prefix: &[u8], assertion_level, prepare: &dyn for<'a> Fn(&'a [u8])| {
+            let keys: Vec<_> = (0..6)
+                .map(|i| [key_prefix, &[b'k', i as u8]].concat())
+                .collect();
+
+            for k in &keys {
                 prepare(k.as_slice());
             }
 
             // Assertion passes (optimistic).
             prewrite_put(
-                &k1,
-                b"v1",
+                &keys[0],
+                b"v0",
                 10,
                 false,
                 0,
@@ -1767,11 +1866,11 @@ pub mod tests {
                 assertion_level,
                 true,
             );
-            must_commit(&engine, &k1, 10, 15);
+            must_commit(&engine, &keys[0], 10, 15);
 
             prewrite_put(
-                &k1,
-                b"v1",
+                &keys[0],
+                b"v0",
                 20,
                 false,
                 0,
@@ -1779,12 +1878,12 @@ pub mod tests {
                 assertion_level,
                 true,
             );
-            must_commit(&engine, &k1, 20, 25);
+            must_commit(&engine, &keys[0], 20, 25);
 
             // Assertion passes (pessimistic).
             prewrite_put(
-                &k2,
-                b"v2",
+                &keys[1],
+                b"v1",
                 10,
                 true,
                 11,
@@ -1792,11 +1891,11 @@ pub mod tests {
                 assertion_level,
                 true,
             );
-            must_commit(&engine, &k2, 10, 15);
+            must_commit(&engine, &keys[1], 10, 15);
 
             prewrite_put(
-                &k2,
-                b"v2",
+                &keys[1],
+                b"v1",
                 20,
                 true,
                 21,
@@ -1804,13 +1903,13 @@ pub mod tests {
                 assertion_level,
                 true,
             );
-            must_commit(&engine, &k2, 20, 25);
+            must_commit(&engine, &keys[1], 20, 25);
 
             // Optimistic transaction assertion fail on fast/strict level.
             let pass = assertion_level == AssertionLevel::Off;
             prewrite_put(
-                &k1,
-                b"v1",
+                &keys[0],
+                b"v0",
                 30,
                 false,
                 0,
@@ -1819,8 +1918,8 @@ pub mod tests {
                 pass,
             );
             prewrite_put(
-                &k3,
-                b"v3",
+                &keys[2],
+                b"v2",
                 30,
                 false,
                 0,
@@ -1828,15 +1927,15 @@ pub mod tests {
                 assertion_level,
                 pass,
             );
-            must_rollback(&engine, &k1, 30, true);
-            must_rollback(&engine, &k3, 30, true);
+            must_rollback(&engine, &keys[0], 30, true);
+            must_rollback(&engine, &keys[2], 30, true);
 
             // Pessimistic transaction assertion fail on fast/strict level if assertion happens
             // during amending pessimistic lock.
             let pass = assertion_level == AssertionLevel::Off;
             prewrite_put(
-                &k2,
-                b"v2",
+                &keys[1],
+                b"v1",
                 30,
                 true,
                 31,
@@ -1845,8 +1944,8 @@ pub mod tests {
                 pass,
             );
             prewrite_put(
-                &k4,
-                b"v4",
+                &keys[3],
+                b"v3",
                 30,
                 true,
                 31,
@@ -1854,14 +1953,14 @@ pub mod tests {
                 assertion_level,
                 pass,
             );
-            must_rollback(&engine, &k2, 30, true);
-            must_rollback(&engine, &k4, 30, true);
+            must_rollback(&engine, &keys[1], 30, true);
+            must_rollback(&engine, &keys[3], 30, true);
 
             // Pessimistic transaction fail on strict level no matter whether `is_pessimistic_lock`.
             let pass = assertion_level != AssertionLevel::Strict;
             prewrite_put(
-                &k1,
-                b"v1",
+                &keys[0],
+                b"v0",
                 40,
                 false,
                 41,
@@ -1870,24 +1969,24 @@ pub mod tests {
                 pass,
             );
             prewrite_put(
-                &k3,
-                b"v3",
-                40,
-                false,
-                41,
-                Assertion::Exist,
-                assertion_level,
-                pass,
-            );
-            must_rollback(&engine, &k1, 40, true);
-            must_rollback(&engine, &k3, 40, true);
-
-            must_acquire_pessimistic_lock(&engine, &k2, &k2, 40, 41);
-            must_acquire_pessimistic_lock(&engine, &k4, &k4, 40, 41);
-            prewrite_put(
-                &k2,
+                &keys[2],
                 b"v2",
                 40,
+                false,
+                41,
+                Assertion::Exist,
+                assertion_level,
+                pass,
+            );
+            must_rollback(&engine, &keys[0], 40, true);
+            must_rollback(&engine, &keys[2], 40, true);
+
+            must_acquire_pessimistic_lock(&engine, &keys[1], &keys[1], 40, 41);
+            must_acquire_pessimistic_lock(&engine, &keys[3], &keys[3], 40, 41);
+            prewrite_put(
+                &keys[1],
+                b"v1",
+                40,
                 true,
                 41,
                 Assertion::NotExist,
@@ -1895,8 +1994,8 @@ pub mod tests {
                 pass,
             );
             prewrite_put(
-                &k4,
-                b"v4",
+                &keys[3],
+                b"v3",
                 40,
                 true,
                 41,
@@ -1904,8 +2003,53 @@ pub mod tests {
                 assertion_level,
                 pass,
             );
-            must_rollback(&engine, &k1, 40, true);
-            must_rollback(&engine, &k3, 40, true);
+            must_rollback(&engine, &keys[1], 40, true);
+            must_rollback(&engine, &keys[3], 40, true);
+
+            // Test insert and check_not_exist.
+            // Insert and check_not_exist are not expected to be combined with Assertion::Exist.
+            // But for completeness, we still test that case. Since we skips checking assertion
+            // for Insert and CheckNotExist, nothing will happen even we assert the key already
+            // exists.
+            prewrite_insert(
+                &keys[4],
+                b"v4",
+                50,
+                Assertion::Exist,
+                assertion_level,
+                false,
+            );
+            prewrite_check_not_exist(&keys[5], 50, Assertion::Exist, assertion_level, false);
+            must_rollback(&engine, &keys[4], 50, false);
+
+            prewrite_insert(
+                &keys[4],
+                b"v4",
+                51,
+                Assertion::NotExist,
+                assertion_level,
+                false,
+            );
+            prewrite_check_not_exist(&keys[5], 51, Assertion::NotExist, assertion_level, false);
+            must_rollback(&engine, &keys[4], 51, false);
+
+            must_prewrite_put(&engine, &keys[4], b"v4", &keys[4], 52);
+            must_prewrite_put(&engine, &keys[5], b"v5", &keys[5], 52);
+            must_commit(&engine, &keys[4], 52, 53);
+            must_commit(&engine, &keys[5], 52, 53);
+
+            prewrite_insert(
+                &keys[4],
+                b"v4",
+                60,
+                Assertion::NotExist,
+                assertion_level,
+                true,
+            );
+            prewrite_check_not_exist(&keys[5], 60, Assertion::NotExist, assertion_level, true);
+
+            prewrite_insert(&keys[4], b"v4", 60, Assertion::Exist, assertion_level, true);
+            prewrite_check_not_exist(&keys[5], 60, Assertion::Exist, assertion_level, true);
         };
 
         let prepare_rollback = |k: &'_ _| must_rollback(&engine, k, 3, true);


### PR DESCRIPTION
Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

Ref #11542

This PR avoids doing any assertion when the mutation is a `Mutation::Insert` or a `Mutation::CheckNotExist`. These two kinds of mutations implies existence check and should not require a key must exist or not exist.

What's Changed:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
