### PR TITLE
verify the meta lock acquire blocked when destroy peer takes much time.

### DIFF
--- a/components/raftstore/src/store/peer_storage.rs
+++ b/components/raftstore/src/store/peer_storage.rs
@@ -1579,6 +1579,8 @@ where
     box_try!(kv_wb.delete_cf(CF_RAFT, &keys::apply_state_key(region_id)));
     box_try!(engines.raft.clean(region_id, raft_state, raft_wb));
 
+    // sleep when triggerred.
+    fail_point!("seek_first_log_index_duration");
     info!(
         "finish clear peer meta";
         "region_id" => region_id,

--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -32,7 +32,7 @@ use tikv_util::codec::number::decode_u64;
 use tikv_util::lru::LruCache;
 use tikv_util::time::monotonic_raw_now;
 use tikv_util::time::{Instant, ThreadReadId};
-use tikv_util::{debug, error};
+use tikv_util::{debug, error, info};
 
 use super::metrics::*;
 use crate::store::fsm::store::StoreMeta;
@@ -443,6 +443,10 @@ where
         cmd.callback.invoke_read(read_resp);
     }
 
+    fn get_must_track_version_changed_failpoint(&self) -> bool {
+        fail_point!("must_track_version_changed", |_| true);
+        false
+    }
     // Ideally `get_delegate` should return `Option<&ReadDelegate>`, but if so the lifetime of
     // the returned `&ReadDelegate` will bind to `self`, and make it impossible to use `&mut self`
     // while the `&ReadDelegate` is alive, a better choice is use `Rc` but `LocalReader: Send` will be
@@ -453,8 +457,18 @@ where
             // The local `ReadDelegate` is up to date
             Some(d) if !d.track_ver.any_new() => Some(Arc::clone(d)),
             _ => {
+                if self.get_must_track_version_changed_failpoint() {
+                    match self.delegates.get(&region_id) {
+                        Some(d) => {
+                            info!("must_track_version_changed: {}", d.track_ver.any_new());
+                        }
+                        _ => {}
+                    }
+                }
                 debug!("update local read delegate"; "region_id" => region_id);
                 self.metrics.rejected_by_cache_miss += 1;
+
+                let t = Instant::now();
 
                 let (meta_len, meta_reader) = {
                     let meta = self.store_meta.lock().unwrap();
@@ -463,6 +477,9 @@ where
                         meta.readers.get(&region_id).cloned().map(Arc::new),
                     )
                 };
+                if self.get_must_track_version_changed_failpoint() {
+                    info!("store meta lock acquire takes {:?}", t.saturating_elapsed());
+                }
 
                 // Remove the stale delegate
                 self.delegates.remove(&region_id);

--- a/tests/failpoints/cases/mod.rs
+++ b/tests/failpoints/cases/mod.rs
@@ -6,6 +6,7 @@ mod test_bootstrap;
 mod test_cmd_epoch_checker;
 mod test_conf_change;
 mod test_coprocessor;
+mod test_destroy_peer;
 mod test_disk_full;
 mod test_early_apply;
 mod test_encryption;

--- a/tests/failpoints/cases/test_destroy_peer.rs
+++ b/tests/failpoints/cases/test_destroy_peer.rs
@@ -1,0 +1,69 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::time::Duration;
+use test_raftstore::*;
+use tikv_util::time::Instant;
+
+/// store meta lock test when destroy peer.
+#[test]
+fn test_meta_lock_when_destroy_peer() {
+    // 3 nodes cluster.
+    let mut cluster = new_node_cluster(0, 3);
+    let pd_client = cluster.pd_client.clone();
+    pd_client.disable_default_operator();
+    let r1 = cluster.run_conf_change();
+    let region_1 = cluster.get_region(b"k1");
+    let peer_1_1 = new_peer(1, 1);
+    pd_client.must_add_peer(r1, new_peer(2, 1002));
+    pd_client.must_add_peer(r1, new_peer(3, 1003));
+
+    cluster.must_transfer_leader(r1, peer_1_1.clone());
+    cluster.must_put(b"k1", b"v1");
+    must_get_equal(&cluster.get_engine(1), b"k1", b"v1");
+    let ch = async_read_on_peer(
+        &mut cluster,
+        peer_1_1.clone(),
+        region_1.clone(),
+        b"k1",
+        true,
+        false,
+    );
+    assert!(ch.recv_timeout(Duration::from_secs(1)).is_ok());
+    fail::cfg("seek_first_log_index_duration", "sleep(10000)").unwrap();
+    cluster.must_transfer_leader(r1, new_peer(2, 1002));
+    let t = Instant::now();
+    pd_client.must_remove_peer(r1, peer_1_1.clone());
+    println!("remove peer takes: {:?}", t.saturating_elapsed());
+    fail::cfg("must_track_version_changed", "return").unwrap();
+
+    let t = Instant::now();
+    let ch = async_read_on_peer(
+        &mut cluster,
+        peer_1_1.clone(),
+        region_1.clone(),
+        b"k1",
+        true,
+        false, // both true or false are tested, and the results are the same.
+    );
+    println!("first async read takes {:?}", t.saturating_elapsed());
+    let t = Instant::now();
+    // assert!(ch.recv_timeout(Duration::from_secs(3)).is_ok());
+    let resp = ch.recv_timeout(Duration::from_secs(3)).unwrap();
+    println!("async read ch recv call takes {:?}", t.saturating_elapsed());
+    println!("async follower read resp is {:?}", resp);
+
+    let t = Instant::now();
+    let ch = async_read_on_peer(
+        &mut cluster,
+        peer_1_1.clone(),
+        region_1.clone(),
+        b"k1",
+        true,
+        false, // both true or false are tested, and the results are the same.
+    );
+    println!("second async read takes {:?}", t.saturating_elapsed());
+    let resp = ch.recv_timeout(Duration::from_secs(3)).unwrap();
+    println!("async follower read resp is {:?}", resp);
+
+    fail::remove("seek_first_log_index_duration");
+}


### PR DESCRIPTION
Signed-off-by: tier-cap <zhengxiaojin@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
1. Set raft log first index seek time duration.
2. Remove leader peer
3. During the destroy peer, send a request on the old leader peer.
4. Verify that the request will be blocked when acquiring the store meta lock.
Close #xxx <!-- Associate issue that describes the problem the PR tries to solve. -->

What's Changed:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.
If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
```
