### PR TITLE
rsmeter: fix perf regression caused by arc swap 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,12 +115,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dabe5a181f83789739c194cbe5a897dde195078fac08568d09221fd6137a7ba8"
 
 [[package]]
-name = "arc-swap"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5d78ce20460b82d3fa150275ed9d55e21064fc7951177baacf86a145c4a4b1f"
-
-[[package]]
 name = "arrayvec"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4083,7 +4077,6 @@ dependencies = [
 name = "resource_metering"
 version = "0.0.1"
 dependencies = [
- "arc-swap 1.5.0",
  "collections",
  "crossbeam",
  "futures 0.3.15",
@@ -4696,7 +4689,7 @@ name = "slog-global"
 version = "0.1.0"
 source = "git+https://github.com/breeswish/slog-global.git?rev=d592f88e4dbba5eb439998463054f1a44fbf17b9#d592f88e4dbba5eb439998463054f1a44fbf17b9"
 dependencies = [
- "arc-swap 0.4.8",
+ "arc-swap",
  "lazy_static",
  "log",
  "slog",

--- a/components/resource_metering/Cargo.toml
+++ b/components/resource_metering/Cargo.toml
@@ -21,7 +21,6 @@ slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debu
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }
 futures = "0.3"
 pdqselect = "0.1"
-arc-swap = "1.5.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "5125fc1a69496b73b26b3c08b6e8afc3c665a56e" }

--- a/components/resource_metering/src/lib.rs
+++ b/components/resource_metering/src/lib.rs
@@ -79,14 +79,18 @@ impl ResourceMeteringTag {
                 }
             }
 
-            assert!(!ls.is_set, "nested attachment is not allowed");
-            ls.attached_tag.swap(Some(self.infos.clone()));
+            // unexpected nested attachment
+            if ls.is_set {
+                debug_assert!(false, "nested attachment is not allowed");
+                return Guard;
+            }
+
+            let prev_tag = ls.attached_tag.swap(Some(self.infos.clone()));
+            debug_assert!(prev_tag.is_none());
             ls.is_set = true;
             ls.summary_cur_record.reset();
 
-            Guard {
-                tag: self.infos.clone(),
-            }
+            Guard
         })
     }
 }
@@ -99,9 +103,7 @@ impl ResourceMeteringTag {
 ///
 /// [ResourceMeteringTag]: crate::ResourceMeteringTag
 /// [ResourceMeteringTag::attach]: crate::ResourceMeteringTag::attach
-pub struct Guard {
-    tag: Arc<TagInfos>,
-}
+pub struct Guard;
 
 // Unlike attached_tag in STORAGE, summary_records will continue to grow as the
 // request arrives. If the recorder thread is not working properly, these maps
@@ -113,15 +115,24 @@ impl Drop for Guard {
         STORAGE.with(|s| {
             let mut ls = s.borrow_mut();
 
-            // If the shared tag is occupied by the recorder thread
-            // with `SharedTagInfos::load_full`, wait for releasing.
-            while ls.attached_tag.swap(None).is_none() {}
-
+            if !ls.is_set {
+                return;
+            }
             ls.is_set = false;
+
+            // If the shared tag is occupied by the recorder thread
+            // with `SharedTagInfos::load_full`, spin wait for releasing.
+            let tag = loop {
+                let tag = ls.attached_tag.swap(None);
+                if let Some(t) = tag {
+                    break t;
+                }
+            };
+
             if !ls.summary_enable.load(SeqCst) {
                 return;
             }
-            if self.tag.extra_attachment.is_empty() {
+            if tag.extra_attachment.is_empty() {
                 return;
             }
             let cur_record = ls.summary_cur_record.take_and_reset();
@@ -129,14 +140,14 @@ impl Drop for Guard {
                 return;
             }
             let mut records = ls.summary_records.lock().unwrap();
-            match records.get(&self.tag) {
+            match records.get(&tag) {
                 Some(record) => {
                     record.merge(&cur_record);
                 }
                 None => {
                     // See MAX_SUMMARY_RECORDS_LEN.
                     if records.len() < MAX_SUMMARY_RECORDS_LEN {
-                        records.insert(self.tag.clone(), cur_record);
+                        records.insert(tag, cur_record);
                     }
                 }
             }
@@ -295,15 +306,13 @@ mod tests {
                 resource_tag_factory,
             };
             {
-                let guard = tag.attach();
-                assert_eq!(guard.tag, tag.infos);
+                let _guard = tag.attach();
                 STORAGE.with(|s| {
                     let ls = s.borrow_mut();
                     let local_tag = ls.attached_tag.swap(None);
                     assert!(local_tag.is_some());
                     let tag_infos = local_tag.unwrap();
                     assert_eq!(tag_infos, tag.infos);
-                    assert_eq!(tag_infos, guard.tag);
                     assert!(ls.attached_tag.swap(Some(tag_infos)).is_none());
                 });
                 // drop here.

--- a/components/resource_metering/src/lib.rs
+++ b/components/resource_metering/src/lib.rs
@@ -80,7 +80,7 @@ impl ResourceMeteringTag {
             }
 
             assert!(!ls.is_set, "nested attachment is not allowed");
-            ls.attached_tag.store(Some(self.infos.clone()));
+            ls.attached_tag.swap(Some(self.infos.clone()));
             ls.is_set = true;
             ls.summary_cur_record.reset();
 
@@ -112,7 +112,7 @@ impl Drop for Guard {
     fn drop(&mut self) {
         STORAGE.with(|s| {
             let mut ls = s.borrow_mut();
-            ls.attached_tag.store(None);
+            while ls.attached_tag.swap(None).is_none() {}
             ls.is_set = false;
             if !ls.summary_enable.load(SeqCst) {
                 return;

--- a/components/resource_metering/src/lib.rs
+++ b/components/resource_metering/src/lib.rs
@@ -112,7 +112,11 @@ impl Drop for Guard {
     fn drop(&mut self) {
         STORAGE.with(|s| {
             let mut ls = s.borrow_mut();
+
+            // If the shared tag is occupied by the recorder thread
+            // with `SharedTagInfos::load_full`, wait for releasing.
             while ls.attached_tag.swap(None).is_none() {}
+
             ls.is_set = false;
             if !ls.summary_enable.load(SeqCst) {
                 return;

--- a/components/resource_metering/src/recorder/localstorage.rs
+++ b/components/resource_metering/src/recorder/localstorage.rs
@@ -4,49 +4,16 @@ use crate::model::SummaryRecord;
 use crate::TagInfos;
 
 use std::cell::RefCell;
-use std::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
+use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
 
 use collections::HashMap;
+use crossbeam::atomic::AtomicCell;
 use tikv_util::sys::thread::Pid;
 
 thread_local! {
     /// `STORAGE` is a thread-localized instance of [LocalStorage].
     pub static STORAGE: RefCell<LocalStorage> = RefCell::new(LocalStorage::default());
-}
-
-/// This is a version of [ResourceMeteringTag] that can be shared across threads.
-///
-/// The typical scenario is that we need to access all threads' tags in the
-/// [Recorder] thread for collection purposes, so we need a non-copy way to pass tags.
-#[derive(Default, Clone)]
-pub struct SharedTagPtr {
-    ptr: Arc<AtomicPtr<TagInfos>>,
-}
-
-impl SharedTagPtr {
-    pub fn new(v: Arc<TagInfos>) -> Self {
-        Self {
-            ptr: Arc::new(AtomicPtr::new(Arc::into_raw(v) as _)),
-        }
-    }
-
-    /// Gets the tag under the pointer and replace the original value with parameter v.
-    pub fn swap(&self, v: Option<Arc<TagInfos>>) -> Option<Arc<TagInfos>> {
-        let ptr = v.map(|v| Arc::into_raw(v)).unwrap_or(std::ptr::null_mut());
-        let prev = self.ptr.swap(ptr as _, Ordering::SeqCst);
-        (!prev.is_null()).then(|| unsafe { Arc::from_raw(prev as _) })
-    }
-
-    /// Gets a clone of the tag under the pointer and put it back.
-    pub fn load_full(&self) -> Option<Arc<TagInfos>> {
-        self.swap(None).map(|req_tag| {
-            let tag = req_tag.clone();
-            // Put it back as quickly as possible.
-            assert!(self.swap(Some(req_tag)).is_none());
-            tag
-        })
-    }
 }
 
 /// `LocalStorage` is a thread-local structure that contains all necessary data of submodules.
@@ -58,7 +25,7 @@ pub struct LocalStorage {
     pub registered: bool,
     pub register_failed_times: u32,
     pub is_set: bool,
-    pub attached_tag: SharedTagPtr,
+    pub attached_tag: SharedTagInfos,
     pub summary_enable: Arc<AtomicBool>,
     pub summary_cur_record: Arc<SummaryRecord>,
     pub summary_records: Arc<Mutex<HashMap<Arc<TagInfos>, SummaryRecord>>>,
@@ -71,4 +38,29 @@ pub struct LocalStorage {
 pub struct LocalStorageRef {
     pub id: Pid,
     pub storage: LocalStorage,
+}
+
+#[derive(Clone, Default)]
+pub struct SharedTagInfos {
+    tag: Arc<AtomicCell<Option<Arc<TagInfos>>>>,
+}
+
+impl SharedTagInfos {
+    pub fn new(tag: Arc<TagInfos>) -> Self {
+        Self {
+            tag: Arc::new(AtomicCell::new(Some(tag))),
+        }
+    }
+
+    pub fn swap(&self, tag: Option<Arc<TagInfos>>) -> Option<Arc<TagInfos>> {
+        self.tag.swap(tag)
+    }
+
+    pub fn load_full(&self) -> Option<Arc<TagInfos>> {
+        self.tag.swap(None).map(|t| {
+            let r = t.clone();
+            assert!(self.tag.swap(Some(t)).is_none());
+            r
+        })
+    }
 }

--- a/components/resource_metering/src/recorder/mod.rs
+++ b/components/resource_metering/src/recorder/mod.rs
@@ -148,7 +148,7 @@ impl Recorder {
             if let Ok(ids) = thread::thread_ids::<HashSet<_>>(thread::process_id()) {
                 self.thread_stores.retain(|k, v| {
                     let retain = ids.contains(&(*k as i32));
-                    assert!(retain || v.attached_tag.swap(None).is_none());
+                    debug_assert!(retain || v.attached_tag.swap(None).is_none());
                     retain
                 });
             }

--- a/components/resource_metering/src/recorder/mod.rs
+++ b/components/resource_metering/src/recorder/mod.rs
@@ -148,7 +148,7 @@ impl Recorder {
             if let Ok(ids) = thread::thread_ids::<HashSet<_>>(thread::process_id()) {
                 self.thread_stores.retain(|k, v| {
                     let retain = ids.contains(&(*k as i32));
-                    assert!(retain || v.attached_tag.load().is_none());
+                    assert!(retain || v.attached_tag.swap(None).is_none());
                     retain
                 });
             }

--- a/components/resource_metering/src/recorder/sub_recorder/cpu.rs
+++ b/components/resource_metering/src/recorder/sub_recorder/cpu.rs
@@ -1,7 +1,7 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
 use crate::metrics::STAT_TASK_COUNT;
-use crate::recorder::localstorage::{LocalStorage, SharedTagPtr};
+use crate::recorder::localstorage::{LocalStorage, SharedTagInfos};
 use crate::recorder::SubRecorder;
 use crate::{RawRecord, RawRecords};
 
@@ -79,7 +79,7 @@ impl SubRecorder for CpuRecorder {
 }
 
 struct ThreadStat {
-    attached_tag: SharedTagPtr,
+    attached_tag: SharedTagInfos,
     stat: thread::ThreadStat,
 }
 
@@ -124,7 +124,7 @@ mod tests {
             extra_attachment: b"abc".to_vec(),
         });
         let mut store = LocalStorage::default();
-        store.attached_tag = SharedTagPtr::new(info);
+        store.attached_tag = SharedTagInfos::new(info);
         let mut recorder = CpuRecorder::default();
         recorder.thread_created(thread::thread_id(), &store);
         let pid = thread::process_id();

--- a/components/resource_metering/src/recorder/sub_recorder/cpu.rs
+++ b/components/resource_metering/src/recorder/sub_recorder/cpu.rs
@@ -1,14 +1,10 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
 use crate::metrics::STAT_TASK_COUNT;
-use crate::recorder::localstorage::LocalStorage;
+use crate::recorder::localstorage::{LocalStorage, SharedTagPtr};
 use crate::recorder::SubRecorder;
-use crate::TagInfos;
 use crate::{RawRecord, RawRecords};
 
-use std::sync::Arc;
-
-use arc_swap::ArcSwapOption;
 use collections::HashMap;
 use tikv_util::sys::thread::{self, Pid};
 
@@ -83,7 +79,7 @@ impl SubRecorder for CpuRecorder {
 }
 
 struct ThreadStat {
-    attached_tag: Arc<ArcSwapOption<TagInfos>>,
+    attached_tag: SharedTagPtr,
     stat: thread::ThreadStat,
 }
 
@@ -106,7 +102,6 @@ mod tests {
 mod tests {
     use super::*;
     use crate::{RawRecords, TagInfos};
-    use arc_swap::ArcSwapOption;
     use std::sync::Arc;
 
     fn heavy_job() -> u64 {
@@ -129,7 +124,7 @@ mod tests {
             extra_attachment: b"abc".to_vec(),
         });
         let mut store = LocalStorage::default();
-        store.attached_tag = Arc::new(ArcSwapOption::new(Some(info)));
+        store.attached_tag = SharedTagPtr::new(info);
         let mut recorder = CpuRecorder::default();
         recorder.thread_created(thread::thread_id(), &store);
         let pid = thread::process_id();


### PR DESCRIPTION
Signed-off-by: Zhenchi <zhongzc_arch@outlook.com>

close #11835

### What is changed and how it works?

arc_swap is optimized for read-heavy situations but our case is write-heavy

What's Changed:

use atomic_cell

#### master
![image](https://user-images.githubusercontent.com/29565014/148769801-92030ad7-5d81-46dd-9b4a-37edf0cadee0.png)

#### this patch
![image](https://user-images.githubusercontent.com/29565014/148769830-83181842-6d70-4bb2-9a54-d04b1602ef04.png)


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
