### PR TITLE
raftstore: Reject transferring leader to store that having log lag after a restart

### DIFF
--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -1500,6 +1500,7 @@ where
         ctx: &mut ApplyContext<EK, W>,
         req: &Request,
     ) -> Result<()> {
+        PEER_WRITE_CMD_COUNTER.put.inc();
         let (key, value) = (req.get_put().get_key(), req.get_put().get_value());
         // region key range has no data prefix, so we must use origin key to check.
         util::check_key_in_region(key, &self.region)?;
@@ -1546,6 +1547,7 @@ where
         ctx: &mut ApplyContext<EK, W>,
         req: &Request,
     ) -> Result<()> {
+        PEER_WRITE_CMD_COUNTER.delete.inc();
         let key = req.get_delete().get_key();
         // region key range has no data prefix, so we must use origin key to check.
         util::check_key_in_region(key, &self.region)?;
@@ -1595,6 +1597,7 @@ where
         ranges: &mut Vec<Range>,
         use_delete_range: bool,
     ) -> Result<()> {
+        PEER_WRITE_CMD_COUNTER.delete_range.inc();
         let s_key = req.get_delete_range().get_start_key();
         let e_key = req.get_delete_range().get_end_key();
         let notify_only = req.get_delete_range().get_notify_only();
@@ -1666,6 +1669,7 @@ where
         req: &Request,
         ssts: &mut Vec<SSTMetaInfo>,
     ) -> Result<()> {
+        PEER_WRITE_CMD_COUNTER.ingest_sst.inc();
         let sst = req.get_ingest_sst().get_sst();
 
         if let Err(e) = check_sst_for_ingestion(sst, &self.region) {

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -3968,7 +3968,7 @@ where
             // use a threshold to not update it too frequently.
             let diff = match (
                 self.fsm.peer.in_store_log_lag.contains(&peer_id),
-                lag >= self.ctx.cfg.leader_transfer_max_log_lag && p.matched > truncated_idx, // p.matched > truncated_idx is to exclude the region needing snapshot
+                lag >= self.ctx.cfg.leader_transfer_max_log_lag && p.matched != 0, // p.matched != 0 is to exclude the peer newly added
             ) {
                 (true, true) => 0,
                 (true, false) => {

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -2235,7 +2235,7 @@ where
             match self
                 .fsm
                 .peer
-                .ready_to_transfer_leader(&mut self.ctx, msg.get_index(), &from)
+                .ready_to_transfer_leader(&mut self.ctx, &msg, &from)
             {
                 Some(reason) => {
                     info!(

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -103,6 +103,7 @@ pub struct StoreMeta {
     pub store_id: Option<u64>,
     /// store_id -> count of region
     pub store_log_lag: HashMap<u64, u64>,
+    pub apply_lag_region: u64,
     /// region_end_key -> region_id
     pub region_ranges: BTreeMap<Vec<u8>, u64>,
     /// region_id -> region
@@ -140,6 +141,7 @@ impl StoreMeta {
         StoreMeta {
             store_id: None,
             store_log_lag: HashMap::default(),
+            apply_lag_region: 0,
             region_ranges: BTreeMap::default(),
             regions: HashMap::default(),
             readers: HashMap::default(),

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -1245,7 +1245,6 @@ where
             split_check_scheduler: self.split_check_scheduler.clone(),
             cleanup_scheduler: self.cleanup_scheduler.clone(),
             raftlog_gc_scheduler: self.raftlog_gc_scheduler.clone(),
-            raftlog_fetch_scheduler: self.raftlog_fetch_scheduler.clone(),
             region_scheduler: self.region_scheduler.clone(),
             apply_router: self.apply_router.clone(),
             router: self.router.clone(),

--- a/components/raftstore/src/store/metrics.rs
+++ b/components/raftstore/src/store/metrics.rs
@@ -26,6 +26,13 @@ make_auto_flush_static_metric! {
         batch,
     }
 
+    pub label_enum WriteCmdType {
+        put,
+        delete,
+        delete_range,
+        ingest_sst,
+    }
+
     pub label_enum AdminCmdType {
         conf_change,
         add_peer,
@@ -177,6 +184,10 @@ make_auto_flush_static_metric! {
     pub struct AdminCmdVec : LocalIntCounter {
         "type" => AdminCmdType,
         "status" => AdminCmdStatus,
+    }
+
+    pub struct WriteCmdVec : LocalIntCounter {
+        "type" => WriteCmdType,
     }
 
     pub struct RaftReadyVec : LocalIntCounter {
@@ -361,6 +372,15 @@ lazy_static! {
     pub static ref PEER_ADMIN_CMD_COUNTER: AdminCmdVec =
         auto_flush_from!(PEER_ADMIN_CMD_COUNTER_VEC, AdminCmdVec);
 
+    pub static ref PEER_WRITE_CMD_COUNTER_VEC: IntCounterVec =
+        register_int_counter_vec!(
+            "tikv_raftstore_write_cmd_total",
+            "Total number of write cmd processed.",
+            &["type"]
+        ).unwrap();
+    pub static ref PEER_WRITE_CMD_COUNTER: WriteCmdVec =
+        auto_flush_from!(PEER_WRITE_CMD_COUNTER_VEC, WriteCmdVec);
+
     pub static ref CHECK_LEADER_DURATION_HISTOGRAM: Histogram =
         register_histogram!(
             "tikv_resolved_ts_check_leader_duration_seconds",
@@ -460,6 +480,11 @@ lazy_static! {
             "tikv_raftstore_log_lag_region_total",
             "Total number of region which has log lag.",
             &["store"]
+        ).unwrap();
+    pub static ref APPLY_LAG_REGION_GAUGE: IntGauge =
+        register_int_gauge!(
+            "tikv_raftstore_apply_lag_region_total",
+            "Total number of region which has apply lag."
         ).unwrap();
     pub static ref REGION_MAX_LOG_LAG: Histogram =
         register_histogram!(

--- a/components/raftstore/src/store/metrics.rs
+++ b/components/raftstore/src/store/metrics.rs
@@ -455,6 +455,12 @@ lazy_static! {
     pub static ref REGION_HASH_COUNTER: RegionHashCounter =
         auto_flush_from!(REGION_HASH_COUNTER_VEC, RegionHashCounter);
 
+    pub static ref LOG_LAG_REGION_GAUGE_VEC: IntGaugeVec =
+        register_int_gauge_vec!(
+            "tikv_raftstore_log_lag_region_total",
+            "Total number of region which has log lag.",
+            &["store"]
+        ).unwrap();
     pub static ref REGION_MAX_LOG_LAG: Histogram =
         register_histogram!(
             "tikv_raftstore_log_lag",

--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -23,6 +23,7 @@ use crate::store::metrics::RaftEventDurationType;
 use crate::store::util::{KeysInfoFormatter, LatencyInspector};
 use crate::store::SnapKey;
 use tikv_util::{deadline::Deadline, escape, memory::HeapSize, time::Instant};
+use time::Timespec;
 
 use super::{AbstractPeer, RegionSnapshot};
 
@@ -572,6 +573,7 @@ where
     Tick(StoreTick),
     Start {
         store: metapb::Store,
+        start_time: Timespec,
     },
 
     /// Asks the store to update replication mode.
@@ -611,7 +613,7 @@ where
                 start_key, end_key
             ),
             StoreMsg::Tick(tick) => write!(fmt, "StoreTick {:?}", tick),
-            StoreMsg::Start { ref store } => write!(fmt, "Start store {:?}", store),
+            StoreMsg::Start { ref store, .. } => write!(fmt, "Start store {:?}", store),
             #[cfg(any(test, feature = "testexport"))]
             StoreMsg::Validate(_) => write!(fmt, "Validate config"),
             StoreMsg::UpdateReplicationMode(_) => write!(fmt, "UpdateReplicationMode"),

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -88,6 +88,7 @@ const SHRINK_CACHE_CAPACITY: usize = 64;
 const MIN_BCAST_WAKE_UP_INTERVAL: u64 = 1_000; // 1s
 const REGION_READ_PROGRESS_CAP: usize = 128;
 const MAX_COMMITTED_SIZE_PER_READY: u64 = 16 * 1024 * 1024;
+const ON_START_MARK: bytes::Bytes = bytes::Bytes::from_static(&[0]);
 
 /// The returned states of the peer after checking whether it is stale
 #[derive(Debug, PartialEq, Eq)]
@@ -2028,6 +2029,31 @@ where
             if self.is_leader() {
                 self.on_leader_commit_idx_changed(pre_commit_index, hs.get_commit());
             }
+
+            let diff = match (
+                self.in_apply_lag,
+                hs.get_commit() - self.get_store().applied_index()
+                    > ctx.cfg.leader_transfer_max_log_lag,
+            ) {
+                (true, false) => {
+                    self.in_apply_lag = false;
+                    -1
+                }
+                (false, true) => {
+                    self.in_apply_lag = true;
+                    1
+                }
+                (..) => 0,
+            };
+            if diff != 0 {
+                let mut meta = ctx.store_meta.lock().unwrap();
+                if diff > 0 {
+                    meta.apply_lag_region += 1;
+                } else {
+                    meta.apply_lag_region -= 1;
+                }
+                APPLY_LAG_REGION_GAUGE.add(diff);
+            }
         }
 
         if !ready.messages().is_empty() {
@@ -2674,10 +2700,16 @@ where
 
         let diff = match (
             self.in_apply_lag,
-            applied_index - self.get_store().commit_index() > ctx.cfg.leader_transfer_max_log_lag,
+            self.get_store().commit_index() - applied_index > ctx.cfg.leader_transfer_max_log_lag,
         ) {
-            (true, false) => -1,
-            (false, true) => 1,
+            (true, false) => {
+                self.in_apply_lag = false;
+                -1
+            }
+            (false, true) => {
+                self.in_apply_lag = true;
+                1
+            }
             (..) => 0,
         };
         if diff != 0 {
@@ -3143,12 +3175,13 @@ where
     pub fn ready_to_transfer_leader<T>(
         &self,
         ctx: &mut PollContext<EK, ER, T>,
-        mut index: u64,
+        msg: &eraftpb::Message,
         peer: &metapb::Peer,
     ) -> Option<&'static str> {
         let peer_id = peer.get_id();
         let status = self.raft_group.status();
         let progress = status.progress.unwrap();
+        let mut index = msg.get_index();
 
         if !progress.conf().voters().contains(peer_id) {
             return Some("non voter");
@@ -3178,10 +3211,12 @@ where
             return Some("log gap");
         }
 
-        let meta = ctx.store_meta.lock().unwrap();
-        if let Some(count) = meta.store_log_lag.get(&peer.get_store_id()) {
-            if *count != 0 {
-                return Some("other peer log gap");
+        if msg.get_context() == &ON_START_MARK {
+            let meta = ctx.store_meta.lock().unwrap();
+            if let Some(count) = meta.store_log_lag.get(&peer.get_store_id()) {
+                if *count != 0 {
+                    return Some("other peer log gap");
+                }
             }
         }
 
@@ -3705,7 +3740,7 @@ where
         if time::get_time() <= ctx.start_time + time::Duration::minutes(10) {
             if ctx.store_meta.lock().unwrap().apply_lag_region != 0 {
                 info!(
-                    "reject tranferring leader due to just after starting";
+                    "reject tranferring leader due to just after starting and have apply lag";
                     "region_id" => self.region_id,
                     "peer_id" => self.peer.get_id(),
                     "from" => msg.get_from(),
@@ -3720,6 +3755,9 @@ where
         msg.set_msg_type(eraftpb::MessageType::MsgTransferLeader);
         msg.set_index(self.get_store().applied_index());
         msg.set_log_term(self.term());
+        if time::get_time() <= ctx.start_time + time::Duration::minutes(10) {
+            msg.set_context(ON_START_MARK);
+        }
         self.raft_group.raft.msgs.push(msg);
     }
 

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -3724,7 +3724,7 @@ where
             // But if the current leader is disk full, and send such request, we should allow it,
             // because it may be a read leader balance request.
             || (!matches!(ctx.self_disk_usage, DiskUsage::Normal) &&
-            matches!(peer_disk_usage,DiskUsage::Normal))
+            matches!(peer_disk_usage, DiskUsage::Normal))
         {
             info!(
                 "reject transferring leader";

--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -28996,7 +28996,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(delta(tikv_engine_ingestion_picked_level_bucket{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (le)",
+              "expr": "sum(delta(tikv_engine_ingestion_picked_level_bucket{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", db=\"$db\"}[1m])) by (le)",
               "format": "heatmap",
               "interval": "",
               "intervalFactor": 2,

--- a/tests/failpoints/cases/test_transfer_leader.rs
+++ b/tests/failpoints/cases/test_transfer_leader.rs
@@ -122,7 +122,7 @@ fn test_transfer_leader_other_region_replicate_log_lag() {
         let bytes = format!("k{:03}", i).into_bytes();
         cluster.must_put(&bytes, &bytes);
     }
-    thread::sleep_ms(10);
+    thread::sleep(Duration::from_millis(10));
     cluster.transfer_leader(r2.get_id(), new_peer(3, 3));
     cluster.must_put(b"k6", b"v6");
     must_get_equal(&cluster.get_engine(1), b"k6", b"v6");
@@ -131,7 +131,7 @@ fn test_transfer_leader_other_region_replicate_log_lag() {
         new_peer(3, 3)
     );
     cluster.clear_send_filters();
-    thread::sleep_ms(10);
+    thread::sleep(Duration::from_millis(10));
     cluster.must_transfer_leader(r2.get_id(), new_peer(3, 3));
     cluster.must_put(b"k7", b"v7");
     must_get_equal(&cluster.get_engine(3), b"k7", b"v7");


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

A part of #11409  <!-- Associate issue that describes the problem the PR tries to solve. -->

What's Changed:
- Collect replicate log lag in `raft_log_gc_tick` and apply log lag in `on_apply_res`
- Reject transfer leader to the store having region with replicate log lag within 10min after the start
- Reject transfer leader to the store having region with apply log lag within 10min after the start

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Reject transferring leader to store that having log lag after a restart
```
