### PR TITLE
server/config: keep compatible using option

### DIFF
--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 use std::{cmp, i32, isize};
+use std::time::Duration;
 
 use super::Result;
 use grpcio::CompressionAlgorithms;
@@ -139,7 +140,7 @@ pub struct Config {
     #[online_config(skip)]
     pub heavy_load_threshold: usize,
     #[online_config(skip)]
-    pub heavy_load_wait_duration: ReadableDuration,
+    pub heavy_load_wait_duration: Option<ReadableDuration>,
     #[online_config(skip)]
     pub enable_request_batch: bool,
     #[online_config(skip)]
@@ -239,7 +240,7 @@ impl Default for Config {
             // 75 means a gRPC thread is under heavy load if its total CPU usage
             // is greater than 75%.
             heavy_load_threshold: 75,
-            heavy_load_wait_duration: ReadableDuration::micros(50),
+            heavy_load_wait_duration: None,
             enable_request_batch: true,
             raft_client_backoff_step: ReadableDuration::secs(1),
             reject_messages_on_memory_ratio: 0.2,
@@ -252,6 +253,11 @@ impl Default for Config {
 }
 
 impl Config {
+    #[inline]
+    pub fn heavy_load_wait_duration(&self) -> Duration {
+        self.heavy_load_wait_duration.unwrap_or(ReadableDuration::micros(50)).0
+    }
+
     /// Validates the configuration and returns an error if it is misconfigured.
     pub fn validate(&mut self) -> Result<()> {
         box_try!(config::check_addr(&self.addr));

--- a/src/server/raft_client.rs
+++ b/src/server/raft_client.rs
@@ -226,9 +226,10 @@ impl Buffer for BatchMessageBuffer {
 
     #[inline]
     fn wait_hint(&mut self) -> Option<Duration> {
-        if !self.cfg.heavy_load_wait_duration.0.is_zero() {
+        let wait_dur = self.cfg.heavy_load_wait_duration();
+        if !wait_dur.is_zero() {
             if self.loads.current_thread_in_heavy_load() {
-                Some(self.cfg.heavy_load_wait_duration.0)
+                Some(wait_dur)
             } else {
                 None
             }

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -107,7 +107,7 @@ fn test_serde_custom_tikv_config() {
         snap_max_total_size: ReadableSize::gb(10),
         stats_concurrency: 10,
         heavy_load_threshold: 25,
-        heavy_load_wait_duration: ReadableDuration::millis(2),
+        heavy_load_wait_duration: Some(ReadableDuration::millis(2)),
         enable_request_batch: false,
         background_thread_count: 999,
         raft_client_backoff_step: ReadableDuration::secs(1),


### PR DESCRIPTION
### What is changed and how it works?

Close #11861.

What's Changed:

Using `Option` for `heavy_load_wait_duration` to keep compatible with
versions prior to v5.3.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test

    Deploy a cluster using this PR, stop TiKV and replace it with v5.2.0, start TiKV.

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
