### PR TITLE
cdc: no more old value cache when all downstream deregistered

### DIFF
--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -2529,7 +2529,7 @@ mod tests {
     }
 
     #[test]
-    fn test_no_more_old_value_cache_when_all_downstream_deregister() {
+    fn test_no_more_old_value_cache_when_all_downstream_deregistered() {
         let mut suite = mock_endpoint(&CdcConfig::default(), None);
         suite.add_region(1, 100);
         let quota = crate::channel::MemoryQuota::new(usize::MAX);
@@ -2567,7 +2567,7 @@ mod tests {
         suite.run(Task::TxnExtra(txn_extra));
         assert_eq!(suite.endpoint.old_value_cache.cache.len(), 1);
 
-        // Unregister all downstreams.
+        // Deregister all downstreams.
         let mut err_header = ErrorHeader::default();
         err_header.set_not_leader(Default::default());
         let deregister = Deregister::Downstream {

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -1435,8 +1435,10 @@ impl<T: 'static + RaftStoreRouter<E>, E: KvEngine> Runnable for Endpoint<T, E> {
                 cb();
             }
             Task::TxnExtra(txn_extra) => {
-                for (k, v) in txn_extra.old_values {
-                    self.old_value_cache.cache.insert(k, v);
+                if !self.capture_regions.is_empty() {
+                    for (k, v) in txn_extra.old_values {
+                        self.old_value_cache.cache.insert(k, v);
+                    }
                 }
             }
             Task::Validate(validate) => match validate {
@@ -1533,6 +1535,7 @@ mod tests {
     use tikv_util::config::{ReadableDuration, ReadableSize};
     use tikv_util::worker::{dummy_scheduler, LazyWorker, ReceiverWrapper};
     use time::Timespec;
+    use txn_types::OldValues;
 
     use super::*;
     use crate::{channel, recv_timeout};
@@ -2523,6 +2526,86 @@ mod tests {
             Ok(other) => panic!("unknown event {:?}", other),
         }
         assert_eq!(suite.endpoint.capture_regions.len(), 1);
+    }
+
+    #[test]
+    fn test_no_more_old_value_cache_when_all_downstream_deregister() {
+        let mut suite = mock_endpoint(&CdcConfig::default(), None);
+        suite.add_region(1, 100);
+        let quota = crate::channel::MemoryQuota::new(usize::MAX);
+        let (tx, mut rx) = channel::channel(1, quota);
+        let mut rx = rx.drain();
+
+        let conn = Conn::new(tx, String::new());
+        let conn_id = conn.get_id();
+        suite.run(Task::OpenConn { conn });
+        let mut req_header = Header::default();
+        req_header.set_cluster_id(0);
+        let mut req = ChangeDataRequest::default();
+        req.set_region_id(1);
+        let region_epoch = req.get_region_epoch().clone();
+        let downstream = Downstream::new("".to_string(), region_epoch, 0, conn_id, true);
+        let downstream_id = downstream.get_id();
+        suite.run(Task::Register {
+            request: req.clone(),
+            downstream,
+            conn_id,
+            version: semver::Version::new(0, 0, 0),
+        });
+        assert_eq!(suite.endpoint.capture_regions.len(), 1);
+
+        // When there is a down stream, it can be cached normally.
+        let mut old_values = OldValues::default();
+        old_values.insert(
+            Key::from_raw(b"1"),
+            (OldValue::value(b"value".to_vec()), None),
+        );
+        let txn_extra = TxnExtra {
+            old_values,
+            one_pc: false,
+        };
+        suite.run(Task::TxnExtra(txn_extra));
+        assert_eq!(suite.endpoint.old_value_cache.cache.len(), 1);
+
+        // Unregister all downstreams.
+        let mut err_header = ErrorHeader::default();
+        err_header.set_not_leader(Default::default());
+        let deregister = Deregister::Downstream {
+            region_id: 1,
+            downstream_id,
+            conn_id,
+            err: Some(Error::request(err_header.clone())),
+        };
+        suite.run(Task::Deregister(deregister));
+        loop {
+            let cdc_event = channel::recv_timeout(&mut rx, Duration::from_millis(500))
+                .unwrap()
+                .unwrap();
+            if let CdcEvent::Event(mut e) = cdc_event.0 {
+                let event = e.event.take().unwrap();
+                match event {
+                    Event_oneof_event::Error(err) => {
+                        assert!(err.has_not_leader());
+                        break;
+                    }
+                    other => panic!("unknown event {:?}", other),
+                }
+            }
+        }
+        assert_eq!(suite.endpoint.capture_regions.len(), 0);
+
+        // No more old value cache.
+        let mut old_values = OldValues::default();
+        old_values.insert(
+            Key::from_raw(b"2"),
+            (OldValue::value(b"value".to_vec()), None),
+        );
+        let txn_extra = TxnExtra {
+            old_values,
+            one_pc: false,
+        };
+        suite.run(Task::TxnExtra(txn_extra));
+        assert_eq!(suite.endpoint.old_value_cache.cache.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
Signed-off-by: hi-rustin <rustin.liu@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

Close https://github.com/tikv/tikv/issues/10091

What's Changed:

### Related changes

None

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- [x] [Manual test](https://github.com/tikv/tikv/pull/11876#issuecomment-1016052750)

Side effects

None

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
