### PR TITLE
server: tikv should panic when read request met engine corruption error

### DIFF
--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -602,11 +602,22 @@ impl<E: Engine> Endpoint<E> {
     }
 }
 
+fn is_engine_corruption_error(e: &Error) -> bool {
+    // Hack! it depend on the error message to identify the engine corruption error
+    let err_msg = format!("{:?}", e).to_lowercase();
+    err_msg.contains("engine") && err_msg.contains("corruption") && err_msg.contains("sst")
+}
+
 fn make_error_response(e: Error) -> coppb::Response {
     warn!(
         "error-response";
         "err" => %e
     );
+
+    if is_engine_corruption_error(&e) {
+        panic!("met engine corruption error: {:?}", e);
+    }
+
     let mut resp = coppb::Response::default();
     let tag;
     match e {

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -605,7 +605,7 @@ impl<E: Engine> Endpoint<E> {
 fn is_engine_corruption_error(e: &Error) -> bool {
     // Hack! it depend on the error message to identify the engine corruption error
     let err_msg = format!("{:?}", e).to_lowercase();
-    err_msg.contains("engine") && err_msg.contains("corruption") && err_msg.contains("sst")
+    err_msg.contains("engine") && err_msg.contains("corruption")
 }
 
 fn make_error_response(e: Error) -> coppb::Response {
@@ -615,6 +615,7 @@ fn make_error_response(e: Error) -> coppb::Response {
     );
 
     if is_engine_corruption_error(&e) {
+        tikv_util::set_panic_mark();
         panic!("met engine corruption error: {:?}", e);
     }
 

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -1291,6 +1291,19 @@ async fn future_handle_empty(
     Ok(res)
 }
 
+fn check_engine_corruption_err<T>(res: &crate::storage::Result<T>) {
+    if let Err(err) = res {
+        if let crate::storage::ErrorInner::Engine(engine_traits::Error::Engine(e)) = err.0.as_ref()
+        {
+            // Hack! it depend on the error message to identify the engine corruption error
+            let err_msg = format!("{}", e).to_lowercase();
+            if err_msg.contains("corruption") && err_msg.contains("sst") {
+                panic!("kv request met engine corruption error: {:?}", e);
+            }
+        }
+    }
+}
+
 fn future_get<E: Engine, L: LockManager>(
     storage: &Storage<E, L>,
     mut req: GetRequest,
@@ -1304,6 +1317,10 @@ fn future_get<E: Engine, L: LockManager>(
 
     async move {
         let v = v.await;
+
+        // Check engine corruption error
+        check_engine_corruption_err(&v);
+
         let duration_ms = duration_to_ms(start.saturating_elapsed());
         let mut resp = GetResponse::default();
         if let Some(err) = extract_region_error(&v) {
@@ -1351,6 +1368,10 @@ fn future_scan<E: Engine, L: LockManager>(
 
     async move {
         let v = v.await;
+
+        // Check engine corruption error
+        check_engine_corruption_err(&v);
+
         let mut resp = ScanResponse::default();
         if let Some(err) = extract_region_error(&v) {
             resp.set_region_error(err);
@@ -1383,6 +1404,10 @@ fn future_batch_get<E: Engine, L: LockManager>(
 
     async move {
         let v = v.await;
+
+        // Check engine corruption error
+        check_engine_corruption_err(&v);
+
         let duration_ms = duration_to_ms(start.saturating_elapsed());
         let mut resp = BatchGetResponse::default();
         if let Some(err) = extract_region_error(&v) {

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -1297,7 +1297,8 @@ fn check_engine_corruption_err<T>(res: &crate::storage::Result<T>) {
         {
             // Hack! it depend on the error message to identify the engine corruption error
             let err_msg = format!("{}", e).to_lowercase();
-            if err_msg.contains("corruption") && err_msg.contains("sst") {
+            if err_msg.contains("corruption") {
+                tikv_util::set_panic_mark();
                 panic!("kv request met engine corruption error: {:?}", e);
             }
         }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

Close #11617 

What's Changed:

Panic when read request met engine corruption error

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
    - Run a read-only workload
    - Corrupt sst files (e.g replace the content with some random bytes)
    - TiKV store, those sst files were corrupted, should panic as read request hit these corrupted sst files
    - Peers on other stores should be elected as the new leader
    - TiDB see a latency spike then become normal as the new leader elected

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
server: tikv should panic when read request met engine corruption error
```
