### PR TITLE
raftstore: move scan delete to raft log gc worker (#11853)

### DIFF
--- a/components/engine_panic/src/raft_engine.rs
+++ b/components/engine_panic/src/raft_engine.rs
@@ -53,6 +53,7 @@ impl RaftEngine for PanicEngine {
     fn clean(
         &self,
         raft_group_id: u64,
+        first_index: u64,
         state: &RaftLocalState,
         batch: &mut Self::LogBatch,
     ) -> Result<()> {

--- a/components/engine_rocks/src/raft_engine.rs
+++ b/components/engine_rocks/src/raft_engine.rs
@@ -133,21 +133,29 @@ impl RaftEngine for RocksEngine {
     fn clean(
         &self,
         raft_group_id: u64,
+        mut first_index: u64,
         state: &RaftLocalState,
         batch: &mut Self::LogBatch,
     ) -> Result<()> {
         batch.delete(&keys::raft_state_key(raft_group_id))?;
-        let seek_key = keys::raft_log_key(raft_group_id, 0);
-        let prefix = keys::raft_log_prefix(raft_group_id);
-        if let Some((key, _)) = self.seek(&seek_key)? {
-            if !key.starts_with(&prefix) {
-                // No raft logs for the raft group.
+        if first_index == 0 {
+            let seek_key = keys::raft_log_key(raft_group_id, 0);
+            let prefix = keys::raft_log_prefix(raft_group_id);
+            fail::fail_point!("engine_rocks_raft_engine_clean_seek", |_| Ok(()));
+            if let Some((key, _)) = self.seek(&seek_key)? {
+                if !key.starts_with(&prefix) {
+                    // No raft logs for the raft group.
+                    return Ok(());
+                }
+                first_index = match keys::raft_log_index(&key) {
+                    Ok(index) => index,
+                    Err(_) => return Ok(()),
+                };
+            } else {
                 return Ok(());
             }
-            let first_index = match keys::raft_log_index(&key) {
-                Ok(index) => index,
-                Err(_) => return Ok(()),
-            };
+        }
+        if first_index <= state.last_index {
             for index in first_index..=state.last_index {
                 let key = keys::raft_log_key(raft_group_id, index);
                 batch.delete(&key)?;

--- a/components/engine_traits/src/raft_engine.rs
+++ b/components/engine_traits/src/raft_engine.rs
@@ -40,6 +40,7 @@ pub trait RaftEngine: Clone + Sync + Send + 'static {
     fn clean(
         &self,
         raft_group_id: u64,
+        first_index: u64,
         state: &RaftLocalState,
         batch: &mut Self::LogBatch,
     ) -> Result<()>;

--- a/components/raft_log_engine/src/engine.rs
+++ b/components/raft_log_engine/src/engine.rs
@@ -127,6 +127,7 @@ impl RaftEngine for RaftLogEngine {
     fn clean(
         &self,
         raft_group_id: u64,
+        _first_index: u64,
         _: &RaftLocalState,
         batch: &mut RaftLogBatch,
     ) -> Result<()> {

--- a/components/raftstore/src/store/bootstrap.rs
+++ b/components/raftstore/src/store/bootstrap.rs
@@ -95,7 +95,7 @@ pub fn clear_prepare_bootstrap_cluster(
     let mut wb = engines.raft.log_batch(1024);
     box_try!(engines
         .raft
-        .clean(region_id, &RaftLocalState::default(), &mut wb));
+        .clean(region_id, 0, &RaftLocalState::default(), &mut wb));
     box_try!(engines.raft.consume(&mut wb, true));
 
     let mut wb = engines.kv.write_batch();

--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -169,6 +169,9 @@ pub struct Config {
     pub dev_assert: bool,
     #[config(hidden)]
     pub apply_yield_duration: ReadableDuration,
+    // Only for tests in v5.0.0.
+    #[serde(skip)]
+    pub raft_log_compact_sync_interval: ReadableDuration,
 
     // Deprecated! These configuration has been moved to Coprocessor.
     // They are preserved for compatibility check.
@@ -253,6 +256,7 @@ impl Default for Config {
             hibernate_regions: true,
             dev_assert: false,
             apply_yield_duration: ReadableDuration::millis(500),
+            raft_log_compact_sync_interval: ReadableDuration::secs(60),
 
             // They are preserved for compatibility check.
             region_max_size: ReadableSize(0),

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -62,6 +62,18 @@ use crate::store::{
 use crate::{Error, Result};
 use keys::{self, enc_end_key, enc_start_key};
 
+#[derive(Clone, Copy, Debug)]
+pub struct DelayDestroy {
+    merged_by_target: bool,
+    reason: DelayReason,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum DelayReason {
+    UnFlushLogGc,
+    Shutdown,
+}
+
 /// Limits the maximum number of regions returned by error.
 ///
 /// Another choice is using coprocessor batch limit, but 10 should be a good fit in most case.
@@ -121,6 +133,13 @@ where
 
     // Batch raft command which has the same header into an entry
     batch_req_builder: BatchRaftCmdRequestBuilder<EK>,
+
+    /// Destroy is delayed because logs clean is flushed asynchronously in Peer.
+    /// Should call `destroy_peer` again after flush is done.
+    delayed_destroy: Option<DelayDestroy>,
+    /// Before actually destroying a peer, ensure all log gc tasks are finished, so we
+    /// can start destroying without seeking.
+    logs_gc_flushed: bool,
 }
 
 pub struct BatchRaftCmdRequestBuilder<E>
@@ -213,6 +232,8 @@ where
                 batch_req_builder: BatchRaftCmdRequestBuilder::new(
                     cfg.raft_entry_max_size.0 as f64,
                 ),
+                delayed_destroy: None,
+                logs_gc_flushed: false,
             }),
         ))
     }
@@ -256,6 +277,8 @@ where
                 batch_req_builder: BatchRaftCmdRequestBuilder::new(
                     cfg.raft_entry_max_size.0 as f64,
                 ),
+                delayed_destroy: None,
+                logs_gc_flushed: false,
             }),
         ))
     }
@@ -877,6 +900,9 @@ where
             } => self.on_capture_change(cmd, region_epoch, callback),
             SignificantMsg::LeaderCallback(cb) => {
                 self.on_leader_callback(cb);
+            }
+            SignificantMsg::RaftLogGcFlushed => {
+                self.on_raft_log_gc_flushed();
             }
         }
     }
@@ -1882,13 +1908,109 @@ where
             false
         } else {
             // Destroy the peer fsm directly
-            self.destroy_peer(false);
-            true
+            self.destroy_peer(false)
         }
     }
 
-    fn destroy_peer(&mut self, merged_by_target: bool) {
+    /// Check if destroy can be executed immediately. If it can't, the reason is returned.
+    fn maybe_delay_destroy(&mut self) -> Option<DelayReason> {
+        if self.fsm.logs_gc_flushed {
+            return None;
+        }
+
+        let start_index = self.fsm.peer.last_compacted_idx;
+        let mut end_index = start_index;
+        if end_index == 0 {
+            // Technically, all logs between first index and last index should be accessible
+            // before being destroyed.
+            end_index = self.fsm.peer.get_store().first_index();
+            self.fsm.peer.last_compacted_idx = end_index;
+        }
+        let region_id = self.region_id();
+        let peer_id = self.fsm.peer.peer_id();
+        let mb = match self.ctx.router.mailbox(region_id) {
+            Some(mb) => mb,
+            None => {
+                if tikv_util::thread_group::is_shutdown(!cfg!(test)) {
+                    // It's shutting down, nothing we can do.
+                    return Some(DelayReason::Shutdown);
+                }
+                panic!("{} failed to get mailbox", self.fsm.peer.tag);
+            }
+        };
+        let task = RaftlogGcTask::gc(
+            self.fsm.peer.get_store().get_region_id(),
+            start_index,
+            end_index,
+        )
+        .flush()
+        .when_done(move || {
+            if let Err(e) = mb.force_send(PeerMsg::SignificantMsg(SignificantMsg::RaftLogGcFlushed))
+            {
+                if tikv_util::thread_group::is_shutdown(!cfg!(test)) {
+                    return;
+                }
+                panic!(
+                    "[region {}] {} failed to respond flush message {:?}",
+                    region_id, peer_id, e
+                );
+            }
+        });
+        if let Err(e) = self.ctx.raftlog_gc_scheduler.schedule(task) {
+            if tikv_util::thread_group::is_shutdown(!cfg!(test)) {
+                // It's shutting down, nothing we can do.
+                return Some(DelayReason::Shutdown);
+            }
+            panic!(
+                "{} failed to schedule raft log task {:?}",
+                self.fsm.peer.tag, e
+            );
+        }
+        // We need to delete all logs entries to avoid introducing race between
+        // new peers and old peers. Flushing gc logs allow last_compact_index be
+        // used directly without seeking.
+        Some(DelayReason::UnFlushLogGc)
+    }
+
+    fn on_raft_log_gc_flushed(&mut self) {
+        self.fsm.logs_gc_flushed = true;
+        let delay = match self.fsm.delayed_destroy {
+            Some(delay) => delay,
+            None => panic!("{} a delayed destroy should not recover", self.fsm.peer.tag),
+        };
+        self.destroy_peer(delay.merged_by_target);
+    }
+
+    fn destroy_peer(&mut self, merged_by_target: bool) -> bool {
         fail_point!("destroy_peer");
+        // Mark itself as pending_remove
+        self.fsm.peer.pending_remove = true;
+
+        if let Some(reason) = self.maybe_delay_destroy() {
+            if self
+                .fsm
+                .delayed_destroy
+                .map_or(false, |delay| delay.reason == reason)
+            {
+                panic!(
+                    "{} destroy peer twice with same delay reason, original {:?}, now {}",
+                    self.fsm.peer.tag, self.fsm.delayed_destroy, merged_by_target
+                );
+            }
+            self.fsm.delayed_destroy = Some(DelayDestroy {
+                merged_by_target,
+                reason,
+            });
+            info!(
+                "delays destroy";
+                "region_id" => self.fsm.region_id(),
+                "peer_id" => self.fsm.peer_id(),
+                "merged_by_target" => merged_by_target,
+                "reason" => ?reason,
+            );
+            return false;
+        }
+
         info!(
             "starts destroy";
             "region_id" => self.fsm.region_id(),
@@ -2012,6 +2134,7 @@ where
             }
         }
         meta.leaders.remove(&region_id);
+        true
     }
 
     // Update some region infos
@@ -2166,21 +2289,9 @@ where
         self.fsm.peer.raft_log_size_hint =
             self.fsm.peer.raft_log_size_hint * remain_cnt / total_cnt;
         let compact_to = state.get_index() + 1;
-        let task = RaftlogGcTask::gc(
-            self.fsm.peer.get_store().get_region_id(),
-            self.fsm.peer.last_compacted_idx,
-            compact_to,
-        );
+        self.fsm.peer.schedule_raftlog_gc(self.ctx, compact_to);
         self.fsm.peer.last_compacted_idx = compact_to;
         self.fsm.peer.mut_store().compact_to(compact_to);
-        if let Err(e) = self.ctx.raftlog_gc_scheduler.schedule(task) {
-            error!(
-                "failed to schedule compact task";
-                "region_id" => self.fsm.region_id(),
-                "peer_id" => self.fsm.peer_id(),
-                "err" => %e,
-            );
-        }
     }
 
     fn on_ready_split_region(
@@ -2917,7 +3028,7 @@ where
                 );
             }
             MergeResultKind::FromTargetSnapshotStep2 => {
-                // `merge_by_target` is true because this region's range already belongs to
+                // `merged_by_target` is true because this region's range already belongs to
                 // its target region so we must not clear data otherwise its target region's
                 // data will corrupt.
                 self.destroy_peer(true);

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -529,7 +529,6 @@ impl<'a, EK: KvEngine + 'static, ER: RaftEngine + 'static, T: Transport>
             StoreTick::CompactCheck => self.on_compact_check_tick(),
             StoreTick::ConsistencyCheck => self.on_consistency_check_tick(),
             StoreTick::CleanupImportSST => self.on_cleanup_import_sst_tick(),
-            StoreTick::RaftEnginePurge => self.on_raft_engine_purge_tick(),
         }
         let elapsed = t.saturating_elapsed();
         RAFT_EVENT_DURATION
@@ -589,7 +588,6 @@ impl<'a, EK: KvEngine + 'static, ER: RaftEngine + 'static, T: Transport>
         self.register_compact_lock_cf_tick();
         self.register_snap_mgr_gc_tick();
         self.register_consistency_check_tick();
-        self.register_raft_engine_purge_tick();
     }
 }
 
@@ -1043,7 +1041,7 @@ impl<EK: KvEngine, ER: RaftEngine, T> RaftPollerBuilder<EK, ER, T> {
             None => return,
             Some(value) => value,
         };
-        peer_storage::clear_meta(&self.engines, kv_wb, raft_wb, rid, &raft_state).unwrap();
+        peer_storage::clear_meta(&self.engines, kv_wb, raft_wb, rid, 0, &raft_state).unwrap();
         let key = keys::region_state_key(rid);
         kv_wb.put_msg_cf(CF_RAFT, &key, origin_state).unwrap();
     }
@@ -1217,7 +1215,10 @@ impl<EK: KvEngine, ER: RaftEngine> RaftBatchSystem<EK, ER> {
             .region_worker
             .start_with_timer("snapshot-worker", region_runner);
 
-        let raftlog_gc_runner = RaftlogGcRunner::new(self.router(), engines.clone());
+        let raftlog_gc_runner = RaftlogGcRunner::new(
+            engines.clone(),
+            cfg.value().raft_log_compact_sync_interval.0,
+        );
         let raftlog_gc_scheduler = workers
             .background_worker
             .start_with_timer("raft-gc-worker", raftlog_gc_runner);
@@ -2380,19 +2381,6 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
         state.set_status(status);
         drop(state);
         self.ctx.router.report_status_update()
-    }
-
-    fn register_raft_engine_purge_tick(&self) {
-        self.ctx.schedule_store_tick(
-            StoreTick::RaftEnginePurge,
-            self.ctx.cfg.raft_engine_purge_interval.0,
-        )
-    }
-
-    fn on_raft_engine_purge_tick(&self) {
-        let scheduler = &self.ctx.raftlog_gc_scheduler;
-        let _ = scheduler.schedule(RaftlogGcTask::Purge);
-        self.register_raft_engine_purge_tick();
     }
 
     fn on_check_leader(&self, leaders: Vec<LeaderInfo>, cb: Box<dyn FnOnce(Vec<u64>) + Send>) {

--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -202,7 +202,6 @@ pub enum StoreTick {
     CompactLockCf,
     ConsistencyCheck,
     CleanupImportSST,
-    RaftEnginePurge,
 }
 
 impl StoreTick {
@@ -215,7 +214,6 @@ impl StoreTick {
             StoreTick::CompactLockCf => RaftEventDurationType::compact_lock_cf,
             StoreTick::ConsistencyCheck => RaftEventDurationType::consistency_check,
             StoreTick::CleanupImportSST => RaftEventDurationType::cleanup_import_sst,
-            StoreTick::RaftEnginePurge => RaftEventDurationType::raft_engine_purge,
         }
     }
 }
@@ -275,6 +273,7 @@ where
         callback: Callback<SK>,
     },
     LeaderCallback(Callback<SK>),
+    RaftLogGcFlushed,
 }
 
 /// Message that will be sent to a peer.

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -43,9 +43,12 @@ use crate::store::fsm::store::PollContext;
 use crate::store::fsm::{apply, Apply, ApplyMetrics, ApplyTask, CollectedReady, Proposal};
 use crate::store::hibernate_state::GroupState;
 use crate::store::msg::RaftCommand;
-use crate::store::worker::{HeartbeatTask, ReadDelegate, ReadExecutor, ReadProgress, RegionTask};
+use crate::store::worker::{
+    HeartbeatTask, RaftlogGcTask, ReadDelegate, ReadExecutor, ReadProgress, RegionTask,
+};
 use crate::store::{
     Callback, Config, GlobalReplicationState, PdTask, ReadIndexContext, ReadResponse,
+    RAFT_INIT_LOG_INDEX,
 };
 use crate::{Error, Result};
 use collections::{HashMap, HashSet};
@@ -790,7 +793,11 @@ where
         // Set Tombstone state explicitly
         let mut kv_wb = ctx.engines.kv.write_batch();
         let mut raft_wb = ctx.engines.raft.log_batch(1024);
-        self.mut_store().clear_meta(&mut kv_wb, &mut raft_wb)?;
+        // Raft log gc should be flushed before being destroyed, so last_compacted_idx has to be
+        // the minimal index that may still have logs.
+        let last_compacted_idx = self.last_compacted_idx;
+        self.mut_store()
+            .clear_meta(last_compacted_idx, &mut kv_wb, &mut raft_wb)?;
         write_peer_state(
             &mut kv_wb,
             &region,
@@ -1579,6 +1586,31 @@ where
             && !self.replication_sync
     }
 
+    pub fn schedule_raftlog_gc<T: Transport>(
+        &mut self,
+        ctx: &mut PollContext<EK, ER, T>,
+        to: u64,
+    ) -> bool {
+        let task = RaftlogGcTask::gc(self.region_id, self.last_compacted_idx, to);
+        debug!(
+            "scheduling raft log gc task";
+            "region_id" => self.region_id,
+            "peer_id" => self.peer_id(),
+            "task" => %task,
+        );
+        if let Err(e) = ctx.raftlog_gc_scheduler.schedule(task) {
+            error!(
+                "failed to schedule raft log gc task";
+                "region_id" => self.region_id,
+                "peer_id" => self.peer_id(),
+                "err" => %e,
+            );
+            false
+        } else {
+            true
+        }
+    }
+
     pub fn handle_raft_ready_append<T: Transport>(
         &mut self,
         ctx: &mut PollContext<EK, ER, T>,
@@ -1765,6 +1797,15 @@ where
         if invoke_ctx.has_snapshot() {
             // When apply snapshot, there is no log applied and not compacted yet.
             self.raft_log_size_hint = 0;
+            let last_first_index = self.get_store().first_index();
+            if self.last_compacted_idx == 0 && last_first_index >= RAFT_INIT_LOG_INDEX {
+                // There may be stale logs in raft engine, so schedule a task to clean it
+                // up. This is a best effort, if TiKV is shutdown before the task is
+                // handled, there can still be stale logs not being deleted until next
+                // log gc command is executed. This will delete range [0, last_first_index).
+                self.schedule_raftlog_gc(ctx, last_first_index);
+                self.last_compacted_idx = last_first_index;
+            }
         }
 
         let apply_snap_result = self.mut_store().post_ready(invoke_ctx);
@@ -1787,9 +1828,7 @@ where
                 );
                 self.peer = peer;
             };
-        }
 
-        if apply_snap_result.is_some() {
             self.activate(ctx);
             let mut meta = ctx.store_meta.lock().unwrap();
             meta.readers

--- a/components/raftstore/src/store/peer_storage.rs
+++ b/components/raftstore/src/store/peer_storage.rs
@@ -1149,7 +1149,18 @@ where
 
         if self.is_initialized() {
             // we can only delete the old data when the peer is initialized.
-            self.clear_meta(kv_wb, raft_wb)?;
+            let first_index = self.first_index();
+            // It's possible that logs between `last_compacted_idx` and `first_index` are
+            // being deleted in raftlog_gc worker. But it's OK as:
+            // 1. If the peer accepts a new snapshot, it must start with an index larger than
+            //    this `first_index`;
+            // 2. If the peer accepts new entries after this snapshot or new snapshot, it must
+            //    start with the new applied index, which is larger than `first_index`.
+            // So new logs won't be deleted by on going raftlog_gc task accidentally.
+            // It's possible that there will be some logs between `last_compacted_idx` and
+            // `first_index` are not deleted. So a cleanup task for the range should be triggered
+            // after applying the snapshot.
+            self.clear_meta(first_index, kv_wb, raft_wb)?;
         }
         // Write its source peers' `RegionLocalState` together with itself for atomicity
         for r in destroy_regions {
@@ -1185,11 +1196,19 @@ where
     /// Delete all meta belong to the region. Results are stored in `wb`.
     pub fn clear_meta(
         &mut self,
+        first_index: u64,
         kv_wb: &mut EK::WriteBatch,
         raft_wb: &mut ER::LogBatch,
     ) -> Result<()> {
         let region_id = self.get_region_id();
-        clear_meta(&self.engines, kv_wb, raft_wb, region_id, &self.raft_state)?;
+        clear_meta(
+            &self.engines,
+            kv_wb,
+            raft_wb,
+            region_id,
+            first_index,
+            &self.raft_state,
+        )?;
         if !self.engines.raft.has_builtin_entry_cache() {
             self.cache = Some(EntryCache::default());
         }
@@ -1513,6 +1532,7 @@ pub fn clear_meta<EK, ER>(
     kv_wb: &mut EK::WriteBatch,
     raft_wb: &mut ER::LogBatch,
     region_id: u64,
+    first_index: u64,
     raft_state: &RaftLocalState,
 ) -> Result<()>
 where
@@ -1522,7 +1542,9 @@ where
     let t = Instant::now();
     box_try!(kv_wb.delete_cf(CF_RAFT, &keys::region_state_key(region_id)));
     box_try!(kv_wb.delete_cf(CF_RAFT, &keys::apply_state_key(region_id)));
-    box_try!(engines.raft.clean(region_id, raft_state, raft_wb));
+    box_try!(engines
+        .raft
+        .clean(region_id, first_index, raft_state, raft_wb));
 
     info!(
         "finish clear peer meta";
@@ -1877,21 +1899,26 @@ mod tests {
 
     #[test]
     fn test_storage_clear_meta() {
-        let td = Builder::new().prefix("tikv-store").tempdir().unwrap();
         let worker = Worker::new("snap-manager").lazy_build("snap-manager");
-        let sched = worker.scheduler();
-        let mut store = new_storage_from_ents(sched, &td, &[new_entry(3, 3), new_entry(4, 4)]);
-        append_ents(&mut store, &[new_entry(5, 5), new_entry(6, 6)]);
+        let cases = vec![(0, 0), (5, 1)];
+        for (first_index, left) in cases {
+            let td = Builder::new().prefix("tikv-store").tempdir().unwrap();
+            let sched = worker.scheduler();
+            let mut store = new_storage_from_ents(sched, &td, &[new_entry(3, 3), new_entry(4, 4)]);
+            append_ents(&mut store, &[new_entry(5, 5), new_entry(6, 6)]);
 
-        assert_eq!(6, get_meta_key_count(&store));
+            assert_eq!(6, get_meta_key_count(&store));
 
-        let mut kv_wb = store.engines.kv.write_batch();
-        let mut raft_wb = store.engines.raft.write_batch();
-        store.clear_meta(&mut kv_wb, &mut raft_wb).unwrap();
-        kv_wb.write().unwrap();
-        raft_wb.write().unwrap();
+            let mut kv_wb = store.engines.kv.write_batch();
+            let mut raft_wb = store.engines.raft.write_batch();
+            store
+                .clear_meta(first_index, &mut kv_wb, &mut raft_wb)
+                .unwrap();
+            kv_wb.write().unwrap();
+            raft_wb.write().unwrap();
 
-        assert_eq!(0, get_meta_key_count(&store));
+            assert_eq!(left, get_meta_key_count(&store));
+        }
     }
 
     #[test]

--- a/components/raftstore/src/store/worker/raftlog_gc.rs
+++ b/components/raftstore/src/store/worker/raftlog_gc.rs
@@ -4,49 +4,53 @@ use std::error;
 use std::fmt::{self, Display, Formatter};
 use std::sync::mpsc::Sender;
 
-use crate::store::{CasualMessage, CasualRouter};
-
 use engine_traits::{Engines, KvEngine, RaftEngine};
 use file_system::{IOType, WithIOType};
 use tikv_util::time::Duration;
 use tikv_util::worker::{Runnable, RunnableWithTimer};
 
 const MAX_GC_REGION_BATCH: usize = 128;
-const COMPACT_LOG_INTERVAL: Duration = Duration::from_secs(60);
 
-pub enum Task {
-    Gc {
-        region_id: u64,
-        start_idx: u64,
-        end_idx: u64,
-    },
-    Purge,
+pub struct Task {
+    region_id: u64,
+    start_idx: u64,
+    end_idx: u64,
+    flush: bool,
+    cb: Option<Box<dyn FnOnce() + Send>>,
 }
 
 impl Task {
     pub fn gc(region_id: u64, start: u64, end: u64) -> Self {
-        Task::Gc {
+        Task {
             region_id,
             start_idx: start,
             end_idx: end,
+            flush: false,
+            cb: None,
         }
+    }
+
+    pub fn flush(mut self) -> Self {
+        self.flush = true;
+        self
+    }
+
+    pub fn when_done(mut self, callback: impl FnOnce() + Send + 'static) -> Self {
+        self.cb = Some(Box::new(callback));
+        self
     }
 }
 
 impl Display for Task {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            Task::Gc {
-                region_id,
-                start_idx,
-                end_idx,
-            } => write!(
-                f,
-                "GC Raft Logs [region: {}, from: {}, to: {}]",
-                region_id, start_idx, end_idx
-            ),
-            Task::Purge => write!(f, "Purge Expired Files",),
-        }
+        write!(
+            f,
+            "GC Raft Logs [region: {}, from: {}, to: {}, has_cb: {}]",
+            self.region_id,
+            self.start_idx,
+            self.end_idx,
+            self.cb.is_some()
+        )
     }
 }
 
@@ -61,20 +65,20 @@ quick_error! {
     }
 }
 
-pub struct Runner<EK: KvEngine, ER: RaftEngine, R: CasualRouter<EK>> {
-    ch: R,
+pub struct Runner<EK: KvEngine, ER: RaftEngine> {
     tasks: Vec<Task>,
     engines: Engines<EK, ER>,
     gc_entries: Option<Sender<usize>>,
+    compact_sync_interval: Duration,
 }
 
-impl<EK: KvEngine, ER: RaftEngine, R: CasualRouter<EK>> Runner<EK, ER, R> {
-    pub fn new(ch: R, engines: Engines<EK, ER>) -> Runner<EK, ER, R> {
+impl<EK: KvEngine, ER: RaftEngine> Runner<EK, ER> {
+    pub fn new(engines: Engines<EK, ER>, compact_log_interval: Duration) -> Runner<EK, ER> {
         Runner {
-            ch,
             engines,
             tasks: vec![],
             gc_entries: None,
+            compact_sync_interval: compact_log_interval,
         }
     }
 
@@ -85,6 +89,13 @@ impl<EK: KvEngine, ER: RaftEngine, R: CasualRouter<EK>> Runner<EK, ER, R> {
         start_idx: u64,
         end_idx: u64,
     ) -> Result<usize, Error> {
+        if start_idx == end_idx {
+            // Flush only.
+            return Ok(0);
+        }
+        fail::fail_point!("worker_gc_raft_log", |s| {
+            Ok(s.and_then(|s| s.parse().ok()).unwrap_or(0))
+        });
         let deleted = box_try!(self.engines.raft.gc(region_id, start_idx, end_idx));
         Ok(deleted)
     }
@@ -102,56 +113,38 @@ impl<EK: KvEngine, ER: RaftEngine, R: CasualRouter<EK>> Runner<EK, ER, R> {
         });
         let tasks = std::mem::replace(&mut self.tasks, vec![]);
         for t in tasks {
-            match t {
-                Task::Gc {
-                    region_id,
-                    start_idx,
-                    end_idx,
-                } => {
-                    debug!("gc raft log"; "region_id" => region_id, "end_index" => end_idx);
-                    match self.gc_raft_log(region_id, start_idx, end_idx) {
-                        Err(e) => {
-                            error!("failed to gc"; "region_id" => region_id, "err" => %e);
-                            self.report_collected(0);
-                        }
-                        Ok(n) => {
-                            debug!("gc log entries"; "region_id" => region_id, "entry_count" => n);
-                            self.report_collected(n);
-                        }
-                    }
+            debug!("gc raft log"; "region_id" => t.region_id, "end_index" => t.end_idx);
+            match self.gc_raft_log(t.region_id, t.start_idx, t.end_idx) {
+                Err(e) => {
+                    error!("failed to gc"; "region_id" => t.region_id, "err" => %e);
+                    self.report_collected(0);
                 }
-                Task::Purge => {
-                    let regions = match self.engines.raft.purge_expired_files() {
-                        Ok(regions) => regions,
-                        Err(e) => {
-                            warn!("purge expired files"; "err" => %e);
-                            return;
-                        }
-                    };
-                    for region_id in regions {
-                        let _ = self.ch.send(region_id, CasualMessage::ForceCompactRaftLogs);
-                    }
+                Ok(n) => {
+                    debug!("gc log entries"; "region_id" => t.region_id, "entry_count" => n);
+                    self.report_collected(n);
                 }
+            }
+            if let Some(cb) = t.cb {
+                cb();
             }
         }
     }
 }
 
-impl<EK, ER, R> Runnable for Runner<EK, ER, R>
+impl<EK, ER> Runnable for Runner<EK, ER>
 where
     EK: KvEngine,
     ER: RaftEngine,
-    R: CasualRouter<EK>,
 {
     type Task = Task;
 
     fn run(&mut self, task: Task) {
         let _io_type_guard = WithIOType::new(IOType::ForegroundWrite);
+        let flush_now = task.flush;
         self.tasks.push(task);
-        if self.tasks.len() < MAX_GC_REGION_BATCH {
-            return;
+        if flush_now || self.tasks.len() >= MAX_GC_REGION_BATCH {
+            self.flush()
         }
-        self.flush();
     }
 
     fn shutdown(&mut self) {
@@ -159,18 +152,17 @@ where
     }
 }
 
-impl<EK, ER, R> RunnableWithTimer for Runner<EK, ER, R>
+impl<EK, ER> RunnableWithTimer for Runner<EK, ER>
 where
     EK: KvEngine,
     ER: RaftEngine,
-    R: CasualRouter<EK>,
 {
     fn on_timeout(&mut self) {
         self.flush();
     }
 
     fn get_interval(&self) -> Duration {
-        COMPACT_LOG_INTERVAL
+        self.compact_sync_interval
     }
 }
 
@@ -195,12 +187,11 @@ mod tests {
         let engines = Engines::new(kv_db, raft_db.clone());
 
         let (tx, rx) = mpsc::channel();
-        let (r, _) = mpsc::sync_channel(1);
         let mut runner = Runner {
             gc_entries: Some(tx),
             engines,
-            ch: r,
             tasks: vec![],
+            compact_sync_interval: Duration::from_secs(5),
         };
 
         // generate raft logs

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -1088,6 +1088,16 @@ impl<T: Simulator> Cluster<T> {
         }
     }
 
+    pub fn get_first_log(&self, region_id: u64, store_id: u64) -> Option<(Vec<u8>, Vec<u8>)> {
+        let raft_engine = self.engines[&store_id].raft.clone();
+        let seek_key = keys::raft_log_key(region_id, 0);
+        let prefix = keys::raft_log_prefix(region_id);
+        match raft_engine.seek(&seek_key).unwrap() {
+            Some((k, v)) if k.starts_with(&prefix) => Some((k, v)),
+            _ => None,
+        }
+    }
+
     pub fn restore_kv_meta(&self, region_id: u64, store_id: u64, snap: &RocksSnapshot) {
         let (meta_start, meta_end) = (
             keys::region_meta_prefix(region_id),

--- a/components/tikv_util/src/yatp_pool/mod.rs
+++ b/components/tikv_util/src/yatp_pool/mod.rs
@@ -248,8 +248,10 @@ impl<T: PoolTicker> YatpPoolBuilder<T> {
     }
 
     fn create_builder(&mut self) -> (yatp::Builder, YatpPoolRunner<T>) {
-        let mut builder =
-            yatp::Builder::new(self.name_prefix.clone().unwrap_or_else(|| "".to_string()));
+        let mut builder = yatp::Builder::new(thd_name!(self
+            .name_prefix
+            .clone()
+            .unwrap_or_else(|| "".to_string())));
         builder
             .stack_size(self.stack_size)
             .min_thread_count(self.min_thread_count)

--- a/tests/failpoints/cases/test_snap.rs
+++ b/tests/failpoints/cases/test_snap.rs
@@ -5,6 +5,7 @@ use std::sync::{mpsc, Arc, Mutex};
 use std::time::Duration;
 use std::{fs, io, mem, thread};
 
+use engine_traits::{Iterable, RaftEngine};
 use raft::eraftpb::MessageType;
 use raftstore::store::*;
 use std::fs::File;
@@ -255,6 +256,13 @@ fn test_destroy_peer_on_pending_snapshot() {
     configure_for_snapshot(&mut cluster);
     let pd_client = Arc::clone(&cluster.pd_client);
     pd_client.disable_default_operator();
+
+    fail::cfg_callback("engine_rocks_raft_engine_clean_seek", move || {
+        if std::thread::current().name().unwrap().contains("raftstore") {
+            panic!("seek should not happen in raftstore threads");
+        }
+    })
+    .unwrap();
 
     let r1 = cluster.run_conf_change();
     pd_client.must_add_peer(r1, new_peer(2, 2));
@@ -582,4 +590,64 @@ fn test_snapshot_gc_after_failed() {
     }
     fail::cfg("get_snapshot_for_gc", "off").unwrap();
     cluster.sim.wl().clear_recv_filters(3);
+}
+
+/// Logs scan are now moved to raftlog gc threads. The case is to test if logs
+/// are still cleaned up when there is stale logs before first index during applying
+/// snapshot. It's expected to schedule a gc task after applying snapshot.
+#[test]
+fn test_snapshot_clean_up_logs_with_unfinished_log_gc() {
+    let mut cluster = new_node_cluster(0, 3);
+    cluster.cfg.raft_store.raft_log_gc_count_limit = 15;
+    cluster.cfg.raft_store.raft_log_gc_threshold = 15;
+    // Speed up log gc.
+    cluster.cfg.raft_store.raft_log_compact_sync_interval = ReadableDuration::millis(1);
+    let pd_client = cluster.pd_client.clone();
+
+    // Disable default max peer number check.
+    pd_client.disable_default_operator();
+    cluster.run();
+    // Simulate raft log gc are pending in queue.
+    let fp = "worker_gc_raft_log";
+    fail::cfg(fp, "return(0)").unwrap();
+
+    let state = cluster.truncated_state(1, 3);
+    for i in 0..30 {
+        let b = format!("k{}", i).into_bytes();
+        cluster.must_put(&b, &b);
+    }
+    must_get_equal(&cluster.get_engine(3), b"k29", b"k29");
+    cluster.wait_log_truncated(1, 3, state.get_index() + 1);
+    cluster.stop_node(3);
+    let truncated_index = cluster.truncated_state(1, 3).get_index();
+    let raft_engine = cluster.engines[&3].raft.clone();
+    // Make sure there are stale logs.
+    raft_engine.get_entry(1, truncated_index).unwrap().unwrap();
+
+    let last_index = cluster.raft_local_state(1, 3).get_last_index();
+    for i in 30..60 {
+        let b = format!("k{}", i).into_bytes();
+        cluster.must_put(&b, &b);
+    }
+    cluster.wait_log_truncated(1, 2, last_index + 1);
+
+    fail::remove(fp);
+    // So peer (3, 3) will accept a snapshot. And all stale logs before first
+    // index should be cleaned up.
+    cluster.run_node(3).unwrap();
+    must_get_equal(&cluster.get_engine(3), b"k59", b"k59");
+    cluster.must_put(b"k60", b"v60");
+    must_get_equal(&cluster.get_engine(3), b"k60", b"v60");
+
+    let truncated_index = cluster.truncated_state(1, 3).get_index();
+    let seek_key = keys::raft_log_key(1, 0);
+    let (key, _) = raft_engine.seek(&seek_key).unwrap().unwrap();
+    let last_truncated_key = keys::raft_log_key(1, truncated_index);
+    // Only previous log should be cleaned up.
+    assert!(
+        key.as_slice() > &last_truncated_key[..],
+        "{:?} > {:?}",
+        key,
+        last_truncated_key
+    );
 }

--- a/tests/failpoints/cases/test_stale_peer.rs
+++ b/tests/failpoints/cases/test_stale_peer.rs
@@ -4,7 +4,7 @@ use std::thread;
 use std::time::Duration;
 
 use engine_rocks::Compat;
-use engine_traits::Peekable;
+use engine_traits::{Peekable, RaftEngine};
 use kvproto::raft_serverpb::RaftLocalState;
 use test_raftstore::*;
 use tikv_util::config::ReadableDuration;
@@ -129,4 +129,47 @@ fn test_stale_learner_restart() {
     fail::remove("on_handle_apply_1003");
     cluster.run_node(2).unwrap();
     must_get_equal(&cluster.get_engine(2), b"k2", b"v2");
+}
+
+/// Logs scan are now moved to raftlog gc threads. The case is to test if logs
+/// are still cleaned up when there is stale logs before first index during destroy.
+#[test]
+fn test_destroy_clean_up_logs_with_unfinished_log_gc() {
+    let mut cluster = new_node_cluster(0, 3);
+    cluster.cfg.raft_store.raft_log_gc_count_limit = 15;
+    cluster.cfg.raft_store.raft_log_gc_threshold = 15;
+    let pd_client = cluster.pd_client.clone();
+
+    // Disable default max peer number check.
+    pd_client.disable_default_operator();
+    cluster.run();
+    // Simulate raft log gc are pending in queue.
+    let fp = "worker_gc_raft_log";
+    fail::cfg(fp, "return(0)").unwrap();
+
+    let state = cluster.truncated_state(1, 3);
+    for i in 0..30 {
+        let b = format!("k{}", i).into_bytes();
+        cluster.must_put(&b, &b);
+    }
+    must_get_equal(&cluster.get_engine(3), b"k29", b"k29");
+    cluster.wait_log_truncated(1, 3, state.get_index() + 1);
+    cluster.stop_node(3);
+    let truncated_index = cluster.truncated_state(1, 3).get_index();
+    let raft_engine = cluster.engines[&3].raft.clone();
+    // Make sure there are stale logs.
+    raft_engine.get_entry(1, truncated_index).unwrap().unwrap();
+
+    pd_client.must_remove_peer(1, new_peer(3, 3));
+    cluster.must_put(b"k30", b"v30");
+    must_get_equal(&cluster.get_engine(1), b"k30", b"v30");
+
+    fail::remove(fp);
+    // So peer (3, 3) will be destroyed by gc message. And all stale logs before first
+    // index should be cleaned up.
+    cluster.run_node(3).unwrap();
+    must_get_none(&cluster.get_engine(3), b"k29");
+
+    // All logs should be deleted.
+    assert_eq!(cluster.get_first_log(1, 3), None);
 }

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -204,6 +204,7 @@ fn test_serde_custom_tikv_config() {
         hibernate_regions: false,
         dev_assert: true,
         apply_yield_duration: ReadableDuration::millis(333),
+        raft_log_compact_sync_interval: ReadableDuration::secs(60),
         perf_level: PerfLevel::EnableTime,
     };
     value.pd = PdConfig::new(vec!["example.com:443".to_owned()]);

--- a/tests/integrations/raftstore/test_snap.rs
+++ b/tests/integrations/raftstore/test_snap.rs
@@ -571,3 +571,33 @@ fn test_correct_snapshot_term() {
     // If peer 4 panicks, it won't be able to apply new writes.
     must_get_equal(&cluster.get_engine(4), b"k1", b"v1");
 }
+
+/// Test when applying a snapshot, old logs should be cleaned up.
+#[test]
+fn test_snapshot_clean_up_logs_with_log_gc() {
+    let mut cluster = new_node_cluster(0, 4);
+    cluster.cfg.raft_store.raft_log_gc_count_limit = 50;
+    cluster.cfg.raft_store.raft_log_gc_threshold = 50;
+    // Speed up log gc.
+    cluster.cfg.raft_store.raft_log_compact_sync_interval = ReadableDuration::millis(1);
+    let pd_client = cluster.pd_client.clone();
+
+    // Disable default max peer number check.
+    pd_client.disable_default_operator();
+    let r = cluster.run_conf_change();
+    pd_client.must_add_peer(r, new_peer(2, 2));
+    pd_client.must_add_peer(r, new_peer(3, 3));
+    cluster.add_send_filter(IsolationFilterFactory::new(2));
+    pd_client.must_add_peer(r, new_peer(4, 4));
+    pd_client.must_remove_peer(r, new_peer(3, 3));
+    cluster.must_transfer_leader(r, new_peer(4, 4));
+    cluster.must_put(b"k1", b"v1");
+    must_get_equal(&cluster.get_engine(4), b"k1", b"v1");
+    cluster.clear_send_filters();
+    cluster.add_send_filter(IsolationFilterFactory::new(1));
+    // Peer (4, 4) must become leader at the end and send snapshot to 2.
+    must_get_equal(&cluster.get_engine(2), b"k1", b"v1");
+
+    // No new log is proposed, so there should be no log at all.
+    assert_eq!(cluster.get_first_log(1, 2), None);
+}

--- a/tests/integrations/raftstore/test_tombstone.rs
+++ b/tests/integrations/raftstore/test_tombstone.rs
@@ -337,3 +337,54 @@ fn test_safe_tombstone_gc() {
     thread::sleep(base_tick_interval * tick as u32 * 3);
     must_get_equal(&cluster.get_engine(5), b"k1", b"v1");
 }
+
+/// Logs scan are now moved to raftlog gc threads. The case is to test if logs
+/// are cleaned up no mater whether log gc task has been executed.
+#[test]
+fn test_destroy_clean_up_logs_with_log_gc() {
+    let mut cluster = new_node_cluster(0, 3);
+    cluster.cfg.raft_store.raft_log_gc_count_limit = 50;
+    cluster.cfg.raft_store.raft_log_gc_threshold = 50;
+    let pd_client = cluster.pd_client.clone();
+
+    // Disable default max peer number check.
+    pd_client.disable_default_operator();
+    cluster.run();
+    cluster.must_put(b"k1", b"v1");
+    cluster.must_put(b"k2", b"v2");
+    must_get_equal(&cluster.get_engine(3), b"k1", b"v1");
+    cluster.get_first_log(1, 3).unwrap();
+
+    pd_client.must_remove_peer(1, new_peer(3, 3));
+    must_get_none(&cluster.get_engine(3), b"k1");
+    // Normally destroy peer should cleanup all logs.
+    assert_eq!(cluster.get_first_log(1, 3), None);
+
+    pd_client.must_add_peer(1, new_peer(3, 4));
+    must_get_equal(&cluster.get_engine(3), b"k1", b"v1");
+    cluster.must_put(b"k3", b"v3");
+    must_get_equal(&cluster.get_engine(3), b"k3", b"v3");
+    cluster.get_first_log(1, 3).unwrap();
+
+    pd_client.must_remove_peer(1, new_peer(3, 4));
+    must_get_none(&cluster.get_engine(3), b"k1");
+    // Peer created by snapshot should also cleanup all logs.
+    assert_eq!(None, cluster.get_first_log(1, 3));
+
+    pd_client.must_add_peer(1, new_peer(3, 5));
+    must_get_equal(&cluster.get_engine(3), b"k1", b"v1");
+    cluster.must_put(b"k4", b"v4");
+    must_get_equal(&cluster.get_engine(3), b"k4", b"v4");
+    cluster.get_first_log(1, 3).unwrap();
+
+    let state = cluster.truncated_state(1, 3);
+    for _ in 0..50 {
+        cluster.must_put(b"k5", b"v5");
+    }
+    cluster.wait_log_truncated(1, 3, state.get_index() + 1);
+
+    pd_client.must_remove_peer(1, new_peer(3, 5));
+    must_get_none(&cluster.get_engine(3), b"k1");
+    // Peer destroy after log gc should also cleanup all logs.
+    assert_eq!(cluster.get_first_log(1, 3), None);
+}


### PR DESCRIPTION
### What is changed and how it works?

When clearing raft metas, raftstore will scan raft logs and delete them
one by one. Seeking can be slow if there are a lot of tombstone keys.
This PR moves the operation to raft log gc worker to reduce the impact.

The final solution should be also moving remaining IO operations to
async write IO threads.

Close #10210.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Avoid destroying a peer blocks raftstore thread
```
