### PR TITLE
gc_worker: fix incorrect scheduled_tasks counting

### DIFF
--- a/components/tikv_util/src/worker/pool.rs
+++ b/components/tikv_util/src/worker/pool.rs
@@ -115,6 +115,14 @@ impl<T: Display + Send> Scheduler<T> {
         if self.counter.load(Ordering::Acquire) >= self.pending_capacity {
             return Err(ScheduleError::Full(task));
         }
+        self.schedule_force(task)
+    }
+
+    /// Schedules a task to run.
+    ///
+    /// Different from the `schedule` function, the task will still be scheduled
+    /// if pending task number exceeds capacity.
+    pub fn schedule_force(&self, task: T) -> Result<(), ScheduleError<T>> {
         self.counter.fetch_add(1, Ordering::SeqCst);
         self.metrics_pending_task_count.inc();
         if let Err(e) = self.sender.unbounded_send(Msg::Task(task)) {

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -676,7 +676,10 @@ fn handle_gc_task_schedule_error(e: ScheduleError<GcTask<impl KvEngine>>) -> Res
         GcTask::PhysicalScanLock { callback, .. } => {
             callback(Err(Error::from(ErrorInner::GcWorkerTooBusy)))
         }
-        _ => {}
+        // Attention: If you are adding a new GcTask, do not forget to call the callback if it has a callback.
+        GcTask::GcKeys { .. } | GcTask::OrphanVersions { .. } => {}
+        #[cfg(any(test, feature = "testexport"))]
+        GcTask::Validate(_) => {}
     }
     res
 }


### PR DESCRIPTION


### What is changed and how it works?

Closes #11903

What's Changed:

1. Callback is always called in `handle_gc_task_schedule_error`, so the `scheduled_tasks` counter is maintained correctly.
2. Allow `unsafe_destroy_range` to schedule even if the worker is full. Then, `unsafe_destroy_range` will still have the chance to execute when the GC worker is busy.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fixes the bug that unsafe_destroy_range does not get executed when GC worker is busy
```
