### PR TITLE
raftstore: Report is apply busy to PD

### DIFF
--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -3272,6 +3272,8 @@ pub struct ApplyMetrics {
     pub written_bytes: u64,
     pub written_keys: u64,
     pub lock_cf_written_bytes: u64,
+
+    pub is_apply_busy: Option<bool>,
 }
 
 #[derive(Debug)]
@@ -3723,6 +3725,7 @@ where
             match msg {
                 Msg::Apply { start, mut apply } => {
                     let apply_wait = start.saturating_elapsed();
+                    self.delegate.metrics.is_apply_busy = Some(apply_wait.as_secs_f64() > 0.2);
                     apply_ctx.apply_wait.observe(apply_wait.as_secs_f64());
                     for tracker in apply
                         .cbs

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -4581,6 +4581,7 @@ where
         self.ctx.store_stat.lock_cf_bytes_written += metrics.lock_cf_written_bytes;
         self.ctx.store_stat.engine_total_bytes_written += metrics.written_bytes;
         self.ctx.store_stat.engine_total_keys_written += metrics.written_keys;
+        self.ctx.store_stat.is_apply_busy = metrics.is_apply_busy;
     }
 
     /// Check if a request is valid if it has valid prepare_merge/commit_merge proposal.

--- a/components/raftstore/src/store/metrics.rs
+++ b/components/raftstore/src/store/metrics.rs
@@ -480,6 +480,13 @@ lazy_static! {
             &["type"]
         ).unwrap();
 
+    pub static ref STORE_RAFT_PROCESS_BUSY_GAUGE_VEC: IntGaugeVec =
+        register_int_gauge_vec!(
+            "tikv_raftstore_raft_process_busy",
+            "Is raft process busy or not",
+            &["type"]
+        ).unwrap();
+
     pub static ref STORE_SNAPSHOT_VALIDATION_FAILURE_COUNTER_VEC: IntCounterVec =
         register_int_counter_vec!(
             "tikv_raftstore_snapshot_validation_failure_total",

--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -36,6 +36,7 @@ use crate::store::{
     worker::{Bucket, BucketRange},
     RaftlogFetchResult, SnapKey,
 };
+use time::Timespec;
 
 #[derive(Debug)]
 pub struct ReadResponse<S: Snapshot> {
@@ -671,6 +672,7 @@ where
     Tick(StoreTick),
     Start {
         store: metapb::Store,
+        start_time: Timespec,
     },
 
     /// Asks the store to update replication mode.
@@ -716,7 +718,7 @@ where
                 start_key, end_key
             ),
             StoreMsg::Tick(tick) => write!(fmt, "StoreTick {:?}", tick),
-            StoreMsg::Start { ref store } => write!(fmt, "Start store {:?}", store),
+            StoreMsg::Start { ref store, .. } => write!(fmt, "Start store {:?}", store),
             #[cfg(any(test, feature = "testexport"))]
             StoreMsg::Validate(_) => write!(fmt, "Validate config"),
             StoreMsg::UpdateReplicationMode(_) => write!(fmt, "UpdateReplicationMode"),


### PR DESCRIPTION
### What is changed and how it works?

Part of #11409  <!-- Associate issue that describes the problem the PR tries to solve. -->

What's Changed:
- Report is apply busy(apply wait duration > 100ms) to PD

### Check List <!--REMOVE the items that are not applicable-->

- Manual test (add detailed scripts or steps below)


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
