### PR TITLE
gc_worker: Limit the key range to scan for GcKeys tasks

### DIFF
--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -358,7 +358,7 @@ where
                 .unwrap()
                 .to_raw()
                 .map_err(|e| EngineError::Codec(e))?;
-            k.push(b'0');
+            k.push(0);
             Key::from_raw(&k).into_encoded()
         };
         let snapshot = self
@@ -1607,16 +1607,16 @@ mod tests {
         let cf = get_cf_handle(&db, CF_WRITE).unwrap();
         // Generate some tombstone
         for i in 10u64..30 {
-            must_rollback(&prefixed_engine, b"k3", i, true);
+            must_rollback(&prefixed_engine, b"k2\x00", i, true);
         }
         db.flush_cf(cf, true).unwrap();
-        must_gc(&prefixed_engine, b"k3", 30);
+        must_gc(&prefixed_engine, b"k2\x00", 30);
 
         // Test tombstone counter works
         assert_eq!(runner.stats.write.seek_tombstone, 0);
         runner
             .gc_keys(
-                vec![Key::from_raw(b"k3")],
+                vec![Key::from_raw(b"k2\x00")],
                 TimeStamp::new(200),
                 Some((1, ri_provider.clone())),
             )


### PR DESCRIPTION
Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

Close #11902
Close #11752
What's Changed: Limits the range to scan when processing `GcKeys` tasks in GC Worker. Hopefully this may reduce unnecessary tombstone scan in GcWorker that slows down GC tasks.


### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

-

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
