### PR TITLE
pprof: ignore cpu profiling on non-x86 arch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,6 @@ pd_client = { path = "components/pd_client", default-features = false }
 case_macros = {path = "components/case_macros"}
 pin-project = "1.0"
 pnet_datalink = "0.23"
-pprof = { version = "^0.6", default-features = false, features = ["flamegraph", "protobuf"] }
 protobuf = { version = "2.8", features = ["bytes"] }
 raft = { version = "0.7.0", default-features = false, features = ["protobuf-codec"] }
 raftstore = { path = "components/raftstore", default-features = false }
@@ -160,6 +159,9 @@ walkdir = "2"
 yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
 resource_metering = { path = "components/resource_metering" }
 seahash = "4.1.0"
+
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+pprof = { version = "^0.6", default-features = false, features = ["flamegraph", "protobuf"] }
 
 [dev-dependencies]
 example_plugin = { path = "components/test_coprocessor_plugin/example_plugin" } # should be a binary dependency


### PR DESCRIPTION
### What is changed and how it works?

ref #10658

Make CPU Profiling only happen on x86_64 to avoid crashes. This is a temporary workaround, we're still working on fixing crashes in libgcc/llvm-libunwind/...

### Release note

```release-note
Prevent TiKV segment fault (but produce an error) when profiling in ARM
```
