### PR TITLE
raftstore: Fix panic on IO delay injected

### DIFF
--- a/components/raftstore/src/store/snap.rs
+++ b/components/raftstore/src/store/snap.rs
@@ -1411,6 +1411,11 @@ impl SnapManager {
 
 impl SnapManagerCore {
     fn get_total_snap_size(&self) -> Result<u64> {
+        fail::fail_point!("get_total_snap_size", |s| s.map_or(
+            Err(Error::from(io::Error::from(io::ErrorKind::Other))),
+            |s| Ok(s.parse().unwrap())
+        ));
+
         let mut total_size = 0;
         for entry in file_system::read_dir(&self.base)? {
             let (entry, metadata) = match entry.and_then(|e| e.metadata().map(|m| (e, m))) {


### PR DESCRIPTION
Signed-off-by: pingyu <yuping@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #11891 

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Fix panic on IO delay injected
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
No.

- PR to update `pingcap/tidb-ansible`:
No.

- Need to cherry-pick to the release branch
No.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects
- No.

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix #11891: one tikv panic when run sysbench insert and inject IO delay fault 
```
