### PR TITLE
raftstore: Introduce force leader state

### DIFF
--- a/components/error_code/src/raftstore.rs
+++ b/components/error_code/src/raftstore.rs
@@ -27,6 +27,7 @@ define_error_codes!(
     SERVER_IS_BUSY => ("ServerIsBusy", "", ""),
     DATA_IS_NOT_READY => ("DataIsNotReady", "", ""),
     DEADLINE_EXCEEDED => ("DeadlineExceeded", "", ""),
+    RECOVERY_IN_PROGRESS => ("RecoveryInProgress", "", ""),
 
     SNAP_ABORT => ("SnapAbort", "", ""),
     SNAP_TOO_MANY => ("SnapTooMany", "", ""),
@@ -59,6 +60,8 @@ impl ErrorCodeExt for errorpb::Error {
             PROPOSAL_IN_MERGING_MODE
         } else if self.has_data_is_not_ready() {
             DATA_IS_NOT_READY
+        } else if self.has_data_is_not_ready() {
+            RECOVERY_IN_PROGRESS
         } else {
             UNKNOWN
         }

--- a/components/raftstore/src/errors.rs
+++ b/components/raftstore/src/errors.rs
@@ -58,6 +58,9 @@ pub enum Error {
     #[error("store ids {0:?}, errmsg {1}")]
     DiskFull(Vec<u64>, String),
 
+    #[error("region {0} is the recovery progress")]
+    RecoveryInProgress(u64),
+
     #[error(
         "key {} is not in region key range [{}, {}) for region {}",
         log_wrappers::Value::key(.0),
@@ -273,6 +276,7 @@ impl ErrorCodeExt for Error {
             Error::RegionNotFound(_) => error_code::raftstore::REGION_NOT_FOUND,
             Error::NotLeader(..) => error_code::raftstore::NOT_LEADER,
             Error::DiskFull(..) => error_code::raftstore::DISK_FULL,
+            Error::RecoveryInProgress(..) => error_code::raftstore::RECOVERY_IN_PROGRESS,
             Error::StaleCommand => error_code::raftstore::STALE_COMMAND,
             Error::RegionNotInitialized(_) => error_code::raftstore::REGION_NOT_INITIALIZED,
             Error::KeyNotInRegion(..) => error_code::raftstore::KEY_NOT_IN_REGION,

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -978,7 +978,7 @@ where
             } => self.on_capture_change(cmd, region_epoch, callback),
             SignificantMsg::LeaderCallback(cb) => {
                 self.on_leader_callback(cb);
-            },
+            }
             SignificantMsg::EnterForceLeaderState => self.on_enter_force_leader(),
             SignificantMsg::ExitForceLeaderState => self.on_exit_force_leader(),
         }
@@ -1000,13 +1000,18 @@ where
         assert!(self.fsm.peer.is_leader());
 
         // forward commit index
-        self.fsm.peer.raft_group.raft.raft_log.committed = self.fsm.peer.raft_group.raft.raft_log.last_index();
+        self.fsm.peer.raft_group.raft.raft_log.committed =
+            self.fsm.peer.raft_group.raft.raft_log.last_index();
         self.fsm.has_ready = true;
     }
 
     fn on_exit_force_leader(&mut self) {
         self.fsm.peer.force_leader = false;
-        self.fsm.peer.raft_group.raft.become_follower(self.fsm.peer.term(), raft::INVALID_ID);
+        self.fsm
+            .peer
+            .raft_group
+            .raft
+            .become_follower(self.fsm.peer.term(), raft::INVALID_ID);
         self.fsm.has_ready = true;
     }
 
@@ -3450,7 +3455,9 @@ where
 
         if self.fsm.peer.force_leader {
             // in force leader state, forbid requests to make the recovery progress less error-prone
-            if !(msg.has_admin_request() && msg.get_admin_request().get_cmd_type() == AdminCmdType::ChangePeer) {
+            if !(msg.has_admin_request()
+                && msg.get_admin_request().get_cmd_type() == AdminCmdType::ChangePeer)
+            {
                 return Err(Error::RecoveryInProgress(self.region_id()));
             }
         }

--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -291,6 +291,8 @@ where
         callback: Callback<SK>,
     },
     LeaderCallback(Callback<SK>),
+    EnterForceLeaderState,
+    ExitForceLeaderState,
 }
 
 /// Message that will be sent to a peer.

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -427,6 +427,8 @@ where
     /// If a snapshot is being applied asynchronously, messages should not be sent.
     pending_messages: Vec<eraftpb::Message>,
 
+    pub force_leader: bool,
+
     /// Record the instants of peers being added into the configuration.
     /// Remove them after they are not pending any more.
     pub peers_start_pending_time: Vec<(u64, Instant)>,
@@ -586,6 +588,7 @@ where
             leader_unreachable: false,
             pending_remove: false,
             should_wake_up: false,
+            force_leader: false,
             pending_merge_state: None,
             want_rollback_merge_peers: HashSet::default(),
             pending_request_snapshot_count: Arc::new(AtomicUsize::new(0)),

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -3071,6 +3071,9 @@ where
             // The message is dropped silently, this usually due to leader absence
             // or transferring leader. Both cases can be considered as NotLeader error.
             return Err(Error::NotLeader(self.region_id, None));
+        } else if self.force_leader {
+            // forward the commit index
+            self.raft_group.raft.raft_log.committed = self.raft_group.raft.raft_log.last_index();
         }
 
         Ok(Either::Left(propose_index))

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -746,10 +746,6 @@ impl<
     }
 }
 
-pub fn integration_on_half_fail_quorum_fn(voters: usize) -> usize {
-    (voters + 1) / 2 + 1
-}
-
 #[derive(PartialEq, Eq, Debug)]
 pub enum ConfChangeKind {
     // Only contains one configuration change
@@ -1892,16 +1888,6 @@ mod tests {
                 check_region_epoch(&req, &region, false).unwrap_err();
                 check_region_epoch(&req, &region, true).unwrap_err();
             }
-        }
-    }
-
-    #[test]
-    fn test_integration_on_half_fail_quorum_fn() {
-        let voters = vec![1, 2, 3, 4, 5, 6, 7];
-        let quorum = vec![2, 2, 3, 3, 4, 4, 5];
-        for (voter_count, expected_quorum) in voters.into_iter().zip(quorum) {
-            let quorum = super::integration_on_half_fail_quorum_fn(voter_count);
-            assert_eq!(quorum, expected_quorum);
         }
     }
 

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -27,11 +27,11 @@ use engine_traits::{
 };
 use file_system::IORateLimiter;
 use pd_client::PdClient;
+use raftstore::router::RaftStoreRouter;
 use raftstore::store::fsm::store::{StoreMeta, PENDING_MSG_CAP};
 use raftstore::store::fsm::{create_raft_batch_system, RaftBatchSystem, RaftRouter};
 use raftstore::store::transport::CasualRouter;
 use raftstore::store::*;
-use raftstore::router::RaftStoreRouter;
 use raftstore::{Error, Result};
 use tikv::config::TiKvConfig;
 use tikv::server::Result as ServerResult;
@@ -1289,20 +1289,16 @@ impl<T: Simulator> Cluster<T> {
 
     pub fn enter_force_leader(&mut self, region_id: u64, store_id: u64) {
         let router = self.sim.rl().get_router(store_id).unwrap();
-        router.significant_send(
-            region_id,
-            SignificantMsg::EnterForceLeaderState,
-        )
-        .unwrap();
+        router
+            .significant_send(region_id, SignificantMsg::EnterForceLeaderState)
+            .unwrap();
     }
 
     pub fn exit_force_leader(&mut self, region_id: u64, store_id: u64) {
         let router = self.sim.rl().get_router(store_id).unwrap();
-        router.significant_send(
-            region_id,
-            SignificantMsg::ExitForceLeaderState,
-        )
-        .unwrap();
+        router
+            .significant_send(region_id, SignificantMsg::ExitForceLeaderState)
+            .unwrap();
     }
 
     pub fn must_split(&mut self, region: &metapb::Region, split_key: &[u8]) {

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -31,6 +31,7 @@ use raftstore::store::fsm::store::{StoreMeta, PENDING_MSG_CAP};
 use raftstore::store::fsm::{create_raft_batch_system, RaftBatchSystem, RaftRouter};
 use raftstore::store::transport::CasualRouter;
 use raftstore::store::*;
+use raftstore::router::RaftStoreRouter;
 use raftstore::{Error, Result};
 use tikv::config::TiKvConfig;
 use tikv::server::Result as ServerResult;
@@ -1282,6 +1283,24 @@ impl<T: Simulator> Cluster<T> {
                 callback: cb,
                 source: "test".into(),
             },
+        )
+        .unwrap();
+    }
+
+    pub fn enter_force_leader(&mut self, region_id: u64, store_id: u64) {
+        let router = self.sim.rl().get_router(store_id).unwrap();
+        router.significant_send(
+            region_id,
+            SignificantMsg::EnterForceLeaderState,
+        )
+        .unwrap();
+    }
+
+    pub fn exit_force_leader(&mut self, region_id: u64, store_id: u64) {
+        let router = self.sim.rl().get_router(store_id).unwrap();
+        router.significant_send(
+            region_id,
+            SignificantMsg::ExitForceLeaderState,
         )
         .unwrap();
     }

--- a/tests/integrations/raftstore/test_hibernate.rs
+++ b/tests/integrations/raftstore/test_hibernate.rs
@@ -27,13 +27,12 @@ fn test_force_leader() {
 
     let put = new_put_cmd(b"k2", b"v2");
     let mut region = cluster.get_region(b"k2");
-    let req = new_request(
-        region.get_id(),
-        region.take_region_epoch(),
-        vec![put],
-        true,
+    let req = new_request(region.get_id(), region.take_region_epoch(), vec![put], true);
+    assert!(
+        cluster
+            .call_command_on_leader(req, Duration::from_millis(10))
+            .is_err()
     );
-    assert!(cluster.call_command_on_leader(req, Duration::from_millis(10)).is_err());
 
     cluster.enter_force_leader(1, 1);
     cluster.pd_client.must_remove_peer(1, new_peer(3, 3));
@@ -41,13 +40,10 @@ fn test_force_leader() {
     cluster.pd_client.must_remove_peer(1, new_peer(5, 5));
     let put = new_put_cmd(b"k3", b"v3");
     let mut region = cluster.get_region(b"k2");
-    let req = new_request(
-        region.get_id(),
-        region.take_region_epoch(),
-        vec![put],
-        true,
-    );
-    let resp = cluster.call_command_on_leader(req, Duration::from_millis(10)).unwrap();
+    let req = new_request(region.get_id(), region.take_region_epoch(), vec![put], true);
+    let resp = cluster
+        .call_command_on_leader(req, Duration::from_millis(10))
+        .unwrap();
     assert!(resp.get_header().has_error());
     cluster.exit_force_leader(1, 1);
 

--- a/tests/integrations/raftstore/test_hibernate.rs
+++ b/tests/integrations/raftstore/test_hibernate.rs
@@ -12,6 +12,24 @@ use test_raftstore::*;
 use tikv_util::time::Instant;
 use tikv_util::HandyRwLock;
 
+fn test_force_leader() {
+    let mut cluster = new_node_cluster(0, 5);
+
+    cluster.run();
+    cluster.must_put(b"k1", b"v1");
+    cluster.must_transfer_leader(1, new_peer(1, 1));
+
+    cluster.stop_node(3);
+    cluster.stop_node(4);
+    cluster.stop_node(5);
+
+    assert!(cluster.put(b"k2", b"v2").is_err());
+    cluster.force_leader();
+
+    cluster.must_put(b"k3", b"v3");
+    cluster.stop_nod
+}
+
 #[test]
 fn test_proposal_prevent_sleep() {
     let mut cluster = new_node_cluster(0, 3);

--- a/tests/integrations/raftstore/test_hibernate.rs
+++ b/tests/integrations/raftstore/test_hibernate.rs
@@ -14,11 +14,12 @@ use tikv_util::HandyRwLock;
 
 #[test]
 fn test_force_leader() {
+    test_util::init_log_for_test();
     let mut cluster = new_node_cluster(0, 5);
 
     cluster.run();
     cluster.must_put(b"k1", b"v1");
-    cluster.must_transfer_leader(1, new_peer(1, 1));
+    cluster.must_transfer_leader(1, new_peer(5, 5));
 
     cluster.stop_node(3);
     cluster.stop_node(4);
@@ -46,7 +47,8 @@ fn test_force_leader() {
         vec![put],
         true,
     );
-    assert!(cluster.call_command_on_leader(req, Duration::from_millis(10)).is_err());
+    let resp = cluster.call_command_on_leader(req, Duration::from_millis(10)).unwrap();
+    assert!(resp.get_header().has_error());
     cluster.exit_force_leader(1, 1);
 
     cluster.must_put(b"k4", b"v4");


### PR DESCRIPTION
### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/tikv/tikv/issues/6107

What's Changed:

Introduce force leader state to advance commit index even if the quorum is not formed. This is used for online unsafe recover.
<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None 
```
