### PR TITLE
Enable full debug info for dev and test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,11 +92,11 @@ Please follow this style to make TiKV easy to review, maintain, and develop.
 
 ### Build issues
 
-To reduce compilation time, TiKV builds do not include full debugging information by default &mdash; `release` and `bench` builds include no debuginfo; `dev` and `test` builds include line numbers only. The easiest way to enable debuginfo is to precede build commands with `RUSTFLAGS=-Cdebuginfo=1` (for line numbers), or `RUSTFLAGS=-Cdebuginfo=2` (for full debuginfo). For example,
+To reduce compilation time, TiKV builds do not include full debugging information by default &mdash; `release` and `bench` builds include no debuginfo; `dev` and `test` builds include full debug. To decrease compilation time with another ~5% (around 10 seconds for a 4 min build time), change the `debug = true` to `debug = 1` in the Cargo.toml file to only include line numbers for `dev` and `test`. Another way to change debuginfo is to precede build commands with `RUSTFLAGS=-Cdebuginfo=1` (for line numbers), or `RUSTFLAGS=-Cdebuginfo=2` (for full debuginfo). For example,
 
 ```bash
-RUSTFLAGS=-Cdebuginfo=2 make dev
-RUSTFLAGS=-Cdebuginfo=2 cargo build
+RUSTFLAGS=-Cdebuginfo=1 make dev
+RUSTFLAGS=-Cdebuginfo=1 cargo build
 ```
 
 When building with make, cargo will automatically use [pipelined][p] compilation to increase the parallelism of the build. To turn on pipelining while using cargo directly, set `CARGO_BUILD_PIPELINING=true`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -267,7 +267,7 @@ default-members = ["cmd/tikv-server", "cmd/tikv-ctl"]
 
 [profile.dev]
 opt-level = 0
-debug = 1 # required for line numbers in tests, see tikv #5049
+debug = true
 codegen-units = 4
 lto = false
 incremental = true
@@ -293,7 +293,7 @@ codegen-units = 4
 
 [profile.test]
 opt-level = 0
-debug = 1 # enable line numbers by default for easy test debugging
+debug = true
 codegen-units = 16
 lto = false
 incremental = true


### PR DESCRIPTION
My testing indicates it takes less than 5% more time
to build, but makes the developer environment better by default,
by showing variables during debugging.

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #5572

What's Changed:
Enable full debug for dev and test targets.

As a newbie I also stumbled upon the issue #5572 which was very confusing and lost a lot of time investigating, since it did not matter which machine or development environment I used.

I think the 5% in longer build time is acceptable for the benefit of being able to use the full power of a debugger. And it is easy to change the settings for power users that want the slight speedup in compiling.

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.


```commit-message
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch
-->

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
- No code

Manual test:
Linux box with 8 cores (3:50 -> 4:00):
```
# Before this PR:
$ make clean
cargo clean
rm -rf bin dist
$ time make build
cargo build --no-default-features --features "jemalloc mem-profiling portable sse test-engines-rocksdb cloud-aws cloud-gcp cloud-azure"
   Compiling libc v0.2.106
...
   Compiling server v0.0.1 (tikv/components/server)
    Finished dev [unoptimized + debuginfo] target(s) in 3m 50s

real	3m50,487s
user	38m11,859s
sys	3m9,540s

# After this PR:
$ git diff
diff --git a/Cargo.toml b/Cargo.toml
index 71f5329d3..67cb9d183 100644
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -267,7 +267,7 @@ default-members = ["cmd/tikv-server", "cmd/tikv-ctl"]
 
 [profile.dev]
 opt-level = 0
-debug = 1 # required for line numbers in tests, see tikv #5049
+debug = true
 codegen-units = 4
 lto = false
 incremental = true
@@ -293,7 +293,7 @@ codegen-units = 4
 
 [profile.test]
 opt-level = 0
-debug = 1 # enable line numbers by default for easy test debugging
+debug = true
 codegen-units = 16
 lto = false
 incremental = true
mattias@msig:~/repos/tikv$ time make clean
cargo clean
rm -rf bin dist

real	0m0,975s
user	0m0,148s
sys	0m0,828s
mattias@msig:~/repos/tikv$ time make build
cargo build --no-default-features --features "jemalloc mem-profiling portable sse test-engines-rocksdb cloud-aws cloud-gcp cloud-azure"
   Compiling libc v0.2.106
...
   Compiling server v0.0.1 (tikv/components/server)
    Finished dev [unoptimized + debuginfo] target(s) in 4m 00s

real	4m0,201s
user	39m45,037s
sys	3m16,397s
```

Macbook Air M1:
```
# Before:
% time make build
cargo build --no-default-features --features " jemalloc test-engines-rocksdb cloud-aws cloud-gcp cloud-azure"
   Compiling libc v0.2.106
....
   Compiling server v0.0.1 (tikv/components/server)
    Finished dev [unoptimized + debuginfo] target(s) in 4m 01s
make build  1107.42s user 116.20s system 506% cpu 4:01.46 total

# After:
% time make build
cargo build --no-default-features --features " jemalloc test-engines-rocksdb cloud-aws cloud-gcp cloud-azure"
   Compiling libc v0.2.106
....
   Compiling server v0.0.1 (tikv/components/server)
    Finished dev [unoptimized + debuginfo] target(s) in 4m 10s
make build  1179.39s user 120.74s system 518% cpu 4:10.98 total
```

Side effects

- Performance regression, Only when building, to the benefit of full debug info by default.


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
