### PR TITLE
copr: support push down mod, sysdate to TiKV

### DIFF
--- a/components/tidb_query_datatype/src/codec/mysql/time/mod.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/time/mod.rs
@@ -2730,7 +2730,7 @@ mod tests {
 
             //2022-02-15 07:45:48.581699 NonFixed(UTC)   c_datetime
             //2022-02-15 07:45:48.581933075 UTC          Utc::now()
-            //We compare length 22 of then; Exceed it my be not equal value ( in milli seconds );
+            //We compare length 22 of then; Exceed it may be not equal ( in milli seconds ).
             let now0 = &c_datetime.to_string()[0..22];
             let now1 = &Utc::now().to_string()[0..22];
             assert_eq!(now0, now1);

--- a/components/tidb_query_datatype/src/codec/mysql/time/mod.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/time/mod.rs
@@ -1343,6 +1343,13 @@ impl Time {
         Time::try_from_chrono_datetime(ctx, time, time_type, duration.fsp() as i8)
     }
 
+    pub fn from_local_time(ctx: &mut EvalContext, time_type: TimeType, fsp: i8) -> Result<Time> {
+        let fsp = check_fsp(fsp)?;
+        let utc = Local::now();
+        let timestamp = ctx.cfg.tz.from_utc_datetime(&utc.naive_utc());
+        Time::try_from_chrono_datetime(ctx, timestamp.naive_local(), time_type, fsp as i8)
+    }
+
     pub fn from_year(
         ctx: &mut EvalContext,
         year: u32,
@@ -2710,6 +2717,20 @@ mod tests {
             assert_eq!(today.hour(), 0);
             assert_eq!(today.minute(), 0);
             assert_eq!(today.second(), 0);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_from_local_time() -> Result<()> {
+        let mut ctx = EvalContext::default();
+        for i in 2..10 {
+            let actual = Time::from_local_time(&mut ctx, TimeType::DateTime, i % MAX_FSP)?;
+            let c_datetime = actual.try_into_chrono_datetime(&mut ctx)?;
+
+            let now0 = &c_datetime.to_string()[0..22]; //2 meas milli_seconds/10 length
+            let now1 = &Utc::now().to_string()[0..22];
+            assert_eq!(now0, now1);
         }
         Ok(())
     }

--- a/components/tidb_query_datatype/src/codec/mysql/time/mod.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/time/mod.rs
@@ -2728,7 +2728,10 @@ mod tests {
             let actual = Time::from_local_time(&mut ctx, TimeType::DateTime, i % MAX_FSP)?;
             let c_datetime = actual.try_into_chrono_datetime(&mut ctx)?;
 
-            let now0 = &c_datetime.to_string()[0..22]; //2 meas milli_seconds/10 length
+            //2022-02-15 07:45:48.581699 NonFixed(UTC)   c_datetime
+            //2022-02-15 07:45:48.581933075 UTC          Utc::now()
+            //We compare length 22 of then; Exceed it my be not equal value ( in milli seconds );
+            let now0 = &c_datetime.to_string()[0..22];
             let now1 = &Utc::now().to_string()[0..22];
             assert_eq!(now0, now1);
         }

--- a/components/tidb_query_expr/src/impl_arithmetic.rs
+++ b/components/tidb_query_expr/src/impl_arithmetic.rs
@@ -237,9 +237,16 @@ impl ArithmeticOp for IntUintMod {
         if *rhs == 0i64 {
             return Ok(None);
         }
-        Ok(Some(
-            ((lhs.overflowing_abs().0 as u64) % (*rhs as u64)) as i64,
-        ))
+
+        if *lhs > 0 {
+            Ok(Some(((*lhs as u64) % (*rhs as u64)) as i64))
+        } else {
+            Ok(Some(
+                (0 as i64)
+                    .overflowing_sub(((lhs.overflowing_abs().0 as u64) % (*rhs as u64)) as i64)
+                    .0,
+            ))
+        }
     }
 }
 

--- a/components/tidb_query_expr/src/impl_arithmetic.rs
+++ b/components/tidb_query_expr/src/impl_arithmetic.rs
@@ -242,8 +242,7 @@ impl ArithmeticOp for IntUintMod {
             Ok(Some(((*lhs as u64) % (*rhs as u64)) as i64))
         } else {
             Ok(Some(
-                (0 as i64)
-                    .overflowing_sub(((lhs.overflowing_abs().0 as u64) % (*rhs as u64)) as i64)
+                0i64.overflowing_sub(((lhs.overflowing_abs().0 as u64) % (*rhs as u64)) as i64)
                     .0,
             ))
         }

--- a/components/tidb_query_expr/src/impl_time.rs
+++ b/components/tidb_query_expr/src/impl_time.rs
@@ -58,6 +58,22 @@ pub fn date(ctx: &mut EvalContext, t: &DateTime) -> Result<Option<DateTime>> {
     Ok(Some(res))
 }
 
+#[rpn_fn(capture = [ctx])]
+#[inline]
+pub fn sysdate_with_fsp(ctx: &mut EvalContext, fsp: &Int) -> Result<Option<DateTime>> {
+    DateTime::from_local_time(ctx, TimeType::DateTime, *fsp as i8)
+        .map(Some)
+        .or_else(|e| ctx.handle_invalid_time_error(e).map(|_| Ok(None))?)
+}
+
+#[rpn_fn(capture = [ctx])]
+#[inline]
+pub fn sysdate_without_fsp(ctx: &mut EvalContext) -> Result<Option<DateTime>> {
+    DateTime::from_local_time(ctx, TimeType::DateTime, 0)
+        .map(Some)
+        .or_else(|e| ctx.handle_invalid_time_error(e).map(|_| Ok(None))?)
+}
+
 #[rpn_fn(nullable, capture = [ctx])]
 #[inline]
 pub fn week_with_mode(

--- a/components/tidb_query_expr/src/lib.rs
+++ b/components/tidb_query_expr/src/lib.rs
@@ -365,6 +365,11 @@ fn map_expr_node_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
         ScalarFuncSig::ModReal => arithmetic_fn_meta::<RealMod>(),
         ScalarFuncSig::ModDecimal => arithmetic_with_ctx_fn_meta::<DecimalMod>(),
         ScalarFuncSig::ModInt => map_int_sig(value, children, mod_mapper)?,
+        ScalarFuncSig::ModIntUnsignedUnsigned => arithmetic_fn_meta::<UintUintMod>(),
+        ScalarFuncSig::ModIntUnsignedSigned => arithmetic_fn_meta::<UintIntMod>(),
+        ScalarFuncSig::ModIntSignedUnsigned => arithmetic_fn_meta::<IntUintMod>(),
+        ScalarFuncSig::ModIntSignedSigned => arithmetic_fn_meta::<IntIntMod>(),
+                
         // impl_cast
         ScalarFuncSig::CastIntAsInt |
         ScalarFuncSig::CastIntAsReal |
@@ -711,6 +716,8 @@ fn map_expr_node_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
         // impl_time
         ScalarFuncSig::DateFormatSig => date_format_fn_meta(),
         ScalarFuncSig::Date => date_fn_meta(),
+        ScalarFuncSig::SysDateWithFsp => sysdate_with_fsp_fn_meta(),
+        ScalarFuncSig::SysDateWithoutFsp => sysdate_without_fsp_fn_meta(),
         ScalarFuncSig::WeekOfYear => week_of_year_fn_meta(),
         ScalarFuncSig::DayOfYear => day_of_year_fn_meta(),
         ScalarFuncSig::DayOfWeek => day_of_week_fn_meta(),


### PR DESCRIPTION
## TiKV coprocessor: support mod、sysdate push down
Issue Number: close #11916

### This PR have Some files and functions update: 
components/tidb_query_datatype/src/codec/mysql/time/mod.rs
components/tidb_query_expr/src/impl_arithmetic.rs
components/tidb_query_expr/src/impl_time.rs
components/tidb_query_expr/src/lib.rs

### Tests: [test reposrt](https://docs.google.com/document/d/1tUy1kcEsuet7Br-xaiNBBq4MHlVAVHPdlyF7BHYbVsQ/edit?usp=sharing)
- Unit test
- [Integration test](https://github.com/tikv/copr-test)
- Manual test

### Side effects
- No side effects.
- Be backward compatibility
- Need TiDB open switch to use this feature.

### Release note
```release-note
Added support for mod, sysdate push down. [tikv#11916]
```