### PR TITLE
stats_monitor: reformat stats_monitor tick

### DIFF
--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -2,7 +2,7 @@
 
 use std::cmp::Ordering as CmpOrdering;
 use std::fmt::{self, Display, Formatter};
-use std::sync::mpsc::{self, Sender};
+use std::sync::mpsc::{self, Sender,Receiver};
 use std::sync::{atomic::Ordering, Arc};
 use std::thread::{Builder, JoinHandle};
 use std::time::{Duration, Instant};
@@ -342,13 +342,15 @@ where
     }
 }
 
-const DEFAULT_QPS_INFO_INTERVAL: Duration = Duration::from_secs(1);
-const DEFAULT_COLLECT_INTERVAL: Duration = Duration::from_secs(1);
+const DEFAULT_LOAD_BASE_SPLIT_INTERVAL: Duration = Duration::from_secs(1);
+const DEFAULT_COLLECT_TICK_INTERVAL: Duration = Duration::from_secs(1);
 
-fn default_collect_interval() -> Duration {
+fn default_collect_tick_interval() -> Duration {
     #[cfg(feature = "failpoints")]
-    fail_point!("mock_collect_interval", |_| { Duration::from_millis(1) });
-    DEFAULT_COLLECT_INTERVAL
+    fail_point!("mock_collect_tick_interval", |_| {
+        Duration::from_millis(1)
+    });
+    DEFAULT_COLLECT_TICK_INTERVAL
 }
 
 #[inline]
@@ -372,9 +374,9 @@ where
     handle: Option<JoinHandle<()>>,
     timer: Option<Sender<bool>>,
     sender: Option<Sender<ReadStats>>,
-    thread_info_interval: Duration,
-    qps_info_interval: Duration,
-    collect_interval: Duration,
+    collect_store_infos_interval: Duration,
+    load_base_split_interval: Duration,
+    collect_tick_interval: Duration,
 }
 
 impl<EK, ER> StatsMonitor<EK, ER>
@@ -388,9 +390,9 @@ where
             handle: None,
             timer: None,
             sender: None,
-            thread_info_interval: interval,
-            qps_info_interval: cmp::min(DEFAULT_QPS_INFO_INTERVAL, interval),
-            collect_interval: cmp::min(DEFAULT_COLLECT_INTERVAL, interval),
+            collect_store_infos_interval: interval,
+            load_base_split_interval: cmp::min(DEFAULT_LOAD_BASE_SPLIT_INTERVAL, interval),
+            collect_tick_interval: cmp::min(DEFAULT_COLLECT_TICK_INTERVAL, interval),
         }
     }
 
@@ -400,22 +402,21 @@ where
         &mut self,
         mut auto_split_controller: AutoSplitController,
     ) -> Result<(), io::Error> {
-        if self.collect_interval < default_collect_interval() {
+        if self.collect_tick_interval < default_collect_tick_interval()
+            || self.collect_store_infos_interval < self.collect_tick_interval
+        {
             info!("it seems we are running tests, skip stats monitoring.");
             return Ok(());
         }
         let mut timer_cnt = 0; // to run functions with different intervals in a loop
-        let collect_interval = self.collect_interval;
-        if self.thread_info_interval < self.collect_interval {
-            info!("running in test mode, skip starting monitor.");
-            return Ok(());
-        }
-        let thread_info_interval = self
-            .thread_info_interval
-            .div_duration_f64(self.collect_interval) as i32;
-        let qps_info_interval = self
-            .qps_info_interval
-            .div_duration_f64(self.collect_interval) as i32;
+        let tick_interval = self.collect_tick_interval;
+        let collect_store_infos_interval = self
+            .collect_store_infos_interval
+            .div_duration_f64(tick_interval) as i32;
+        let load_base_split_interval = self
+            .load_base_split_interval
+            .div_duration_f64(tick_interval) as i32;
+
         let (tx, rx) = mpsc::channel();
         self.timer = Some(tx);
 
@@ -431,60 +432,78 @@ where
                 tikv_util::thread_group::set_properties(props);
                 tikv_alloc::add_thread_memory_accessor();
                 let mut thread_stats = ThreadInfoStatistics::new();
-                while let Err(mpsc::RecvTimeoutError::Timeout) = rx.recv_timeout(collect_interval) {
-                    if timer_cnt % thread_info_interval == 0 {
-                        thread_stats.record();
-                        let cpu_usages = convert_record_pairs(thread_stats.get_cpu_usages());
-                        let read_io_rates = convert_record_pairs(thread_stats.get_read_io_rates());
-                        let write_io_rates =
-                            convert_record_pairs(thread_stats.get_write_io_rates());
-
-                        let task = Task::StoreInfos {
-                            cpu_usages,
-                            read_io_rates,
-                            write_io_rates,
-                        };
-                        if let Err(e) = scheduler.schedule(task) {
-                            error!(
-                                "failed to send store infos to pd worker";
-                                "err" => ?e,
-                            );
-                        }
+                while let Err(mpsc::RecvTimeoutError::Timeout) = rx.recv_timeout(tick_interval) {
+                    if timer_cnt % collect_store_infos_interval == 0 {
+                        StatsMonitor::collect_store_infos(&mut thread_stats, &scheduler);
                     }
-                    if timer_cnt % qps_info_interval == 0 {
-                        let mut others = vec![];
-                        while let Ok(other) = receiver.try_recv() {
-                            others.push(other);
-                        }
-                        let (top, split_infos) = auto_split_controller.flush(others);
-                        auto_split_controller.clear();
-                        let task = Task::AutoSplit { split_infos };
-                        if let Err(e) = scheduler.schedule(task) {
-                            error!(
-                                "failed to send split infos to pd worker";
-                                "err" => ?e,
-                            );
-                        }
-
-                        for i in 0..TOP_N {
-                            if i < top.len() {
-                                READ_QPS_TOPN
-                                    .with_label_values(&[&i.to_string()])
-                                    .set(top[i] as f64);
-                            } else {
-                                READ_QPS_TOPN.with_label_values(&[&i.to_string()]).set(0.0);
-                            }
-                        }
+                    if timer_cnt % load_base_split_interval == 0 {
+                        StatsMonitor::load_base_split(
+                            &mut auto_split_controller,
+                            &receiver,
+                            &scheduler,
+                        );
                     }
                     // modules timer_cnt with the least common multiple of intervals to avoid overflow
-                    timer_cnt = (timer_cnt + 1) % (qps_info_interval * thread_info_interval);
-                    auto_split_controller.refresh_cfg();
+                    timer_cnt =
+                        (timer_cnt + 1) % (load_base_split_interval * collect_store_infos_interval);
                 }
                 tikv_alloc::remove_thread_memory_accessor();
             })?;
 
         self.handle = Some(h);
         Ok(())
+    }
+
+    pub fn collect_store_infos(
+        thread_stats: &mut ThreadInfoStatistics,
+        scheduler: &Scheduler<Task<EK, ER>>,
+    ) {
+        thread_stats.record();
+        let cpu_usages = convert_record_pairs(thread_stats.get_cpu_usages());
+        let read_io_rates = convert_record_pairs(thread_stats.get_read_io_rates());
+        let write_io_rates = convert_record_pairs(thread_stats.get_write_io_rates());
+
+        let task = Task::StoreInfos {
+            cpu_usages,
+            read_io_rates,
+            write_io_rates,
+        };
+        if let Err(e) = scheduler.schedule(task) {
+            error!(
+                "failed to send store infos to pd worker";
+                "err" => ?e,
+            );
+        }
+    }
+
+    pub fn load_base_split(
+        auto_split_controller: &mut AutoSplitController,
+        receiver: &Receiver<ReadStats>,
+        scheduler: &Scheduler<Task<EK, ER>>,
+    ) {
+        auto_split_controller.refresh_cfg();
+        let mut others = vec![];
+        while let Ok(other) = receiver.try_recv() {
+            others.push(other);
+        }
+        let (top, split_infos) = auto_split_controller.flush(others);
+        auto_split_controller.clear();
+        let task = Task::AutoSplit { split_infos };
+        if let Err(e) = scheduler.schedule(task) {
+            error!(
+                "failed to send split infos to pd worker";
+                "err" => ?e,
+            );
+        }
+        for i in 0..TOP_N {
+            if i < top.len() {
+                READ_QPS_TOPN
+                    .with_label_values(&[&i.to_string()])
+                    .set(top[i] as f64);
+            } else {
+                READ_QPS_TOPN.with_label_values(&[&i.to_string()]).set(0.0);
+            }
+        }
     }
 
     pub fn stop(&mut self) {

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -372,7 +372,7 @@ where
 {
     scheduler: Scheduler<Task<EK, ER>>,
     handle: Option<JoinHandle<()>>,
-    ticker: Option<Sender<bool>>,
+    timer: Option<Sender<bool>>,
     read_stats_sender: Option<Sender<ReadStats>>,
     collect_store_infos_interval: Duration,
     load_base_split_check_interval: Duration,
@@ -388,7 +388,7 @@ where
         StatsMonitor {
             scheduler,
             handle: None,
-            ticker: None,
+            timer: None,
             read_stats_sender: None,
             collect_store_infos_interval: interval,
             load_base_split_check_interval: cmp::min(DEFAULT_LOAD_BASE_SPLIT_CHECK_INTERVAL, interval),
@@ -418,7 +418,7 @@ where
             .div_duration_f64(tick_interval) as i32;
 
         let (tx, rx) = mpsc::channel();
-        self.ticker = Some(tx);
+        self.timer = Some(tx);
 
         let (sender, receiver) = mpsc::channel();
         self.read_stats_sender = Some(sender);
@@ -508,7 +508,7 @@ where
 
     pub fn stop(&mut self) {
         if let Some(h) = self.handle.take() {
-            drop(self.ticker.take());
+            drop(self.timer.take());
             drop(self.read_stats_sender.take());
             if let Err(e) = h.join() {
                 error!("join stats collector failed"; "err" => ?e);

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -391,7 +391,10 @@ where
             timer: None,
             read_stats_sender: None,
             collect_store_infos_interval: interval,
-            load_base_split_check_interval: cmp::min(DEFAULT_LOAD_BASE_SPLIT_CHECK_INTERVAL, interval),
+            load_base_split_check_interval: cmp::min(
+                DEFAULT_LOAD_BASE_SPLIT_CHECK_INTERVAL,
+                interval,
+            ),
             collect_tick_interval: cmp::min(DEFAULT_COLLECT_TICK_INTERVAL, interval),
         }
     }
@@ -405,7 +408,9 @@ where
         if self.collect_tick_interval < default_collect_tick_interval()
             || self.collect_store_infos_interval < self.collect_tick_interval
         {
-            info!("interval is too small, skip stats monitoring. If we are running tests, it is normal, otherwise a check is needed.");
+            info!(
+                "interval is too small, skip stats monitoring. If we are running tests, it is normal, otherwise a check is needed."
+            );
             return Ok(());
         }
         let mut timer_cnt = 0; // to run functions with different intervals in a loop
@@ -444,8 +449,8 @@ where
                         );
                     }
                     // modules timer_cnt with the least common multiple of intervals to avoid overflow
-                    timer_cnt =
-                        (timer_cnt + 1) % (load_base_split_check_interval * collect_store_infos_interval);
+                    timer_cnt = (timer_cnt + 1)
+                        % (load_base_split_check_interval * collect_store_infos_interval);
                 }
                 tikv_alloc::remove_thread_memory_accessor();
             })?;

--- a/tests/integrations/raftstore/test_stats.rs
+++ b/tests/integrations/raftstore/test_stats.rs
@@ -362,7 +362,7 @@ fn test_query_stats() {
         });
     fail::cfg("mock_hotspot_threshold", "return(0)").unwrap();
     fail::cfg("mock_tick_interval", "return(0)").unwrap();
-    fail::cfg("mock_collect_interval", "return(0)").unwrap();
+    fail::cfg("mock_collect_tick_interval", "return(0)").unwrap();
     test_query_num(raw_get, true);
     test_query_num(raw_batch_get, true);
     test_query_num(raw_scan, true);
@@ -379,7 +379,7 @@ fn test_query_stats() {
     test_rollback();
     fail::remove("mock_tick_interval");
     fail::remove("mock_hotspot_threshold");
-    fail::remove("mock_collect_interval");
+    fail::remove("mock_collect_tick_interval");
 }
 
 fn raw_put(


### PR DESCRIPTION
Signed-off-by: lhy1024 <admin@liudos.us>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

- rename `collect_interval` to `collect_tick_interval`
- rename `qps_info_interval` to `load_base_split_check_interval`
- rename `thread_info_interval` to `collect_store_infos_interval`
- add two function 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
