### PR TITLE
split_controller: fix the incorrect sampled key ranges number check

### DIFF
--- a/components/raftstore/src/store/worker/split_controller.rs
+++ b/components/raftstore/src/store/worker/split_controller.rs
@@ -632,6 +632,25 @@ mod tests {
     }
 
     #[test]
+    fn test_recorder() {
+        let mut config = SplitConfig::default();
+        config.detect_times = 10;
+        config.sample_threshold = 20;
+
+        let mut recorder = Recorder::new(config.detect_times);
+        for _ in 0..config.detect_times {
+            assert!(!recorder.is_ready());
+            recorder.record(vec![
+                build_key_range(b"a", b"b", false),
+                build_key_range(b"b", b"c", false),
+            ]);
+        }
+        assert!(recorder.is_ready());
+        let key = recorder.collect(&config);
+        assert_eq!(key, b"b");
+    }
+
+    #[test]
     fn test_hub() {
         // raw key mode
         let raw_key_ranges = vec![

--- a/components/raftstore/src/store/worker/split_controller.rs
+++ b/components/raftstore/src/store/worker/split_controller.rs
@@ -247,15 +247,16 @@ impl Recorder {
             |x| x,
         );
         let mut samples = Samples::from(sampled_key_ranges);
+        let recorded_key_ranges: Vec<&KeyRange> = self.key_ranges.iter().flatten().collect();
         // Because we need to observe the number of `no_enough_key` of all the actual keys,
         // so we do this check after the samples are calculated.
-        if (self.key_ranges.len() as u64) < config.sample_threshold {
+        if (recorded_key_ranges.len() as u64) < config.sample_threshold {
             LOAD_BASE_SPLIT_EVENT
                 .with_label_values(&["no_enough_key"])
                 .inc_by(samples.0.len() as u64);
             return vec![];
         }
-        self.key_ranges.iter().flatten().for_each(|key_range| {
+        recorded_key_ranges.into_iter().for_each(|key_range| {
             samples.evaluate(key_range);
         });
         samples.split_key(config.split_balance_score, config.split_contained_score)


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What is changed and how it works?

Issue Number: Close #12012.

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
split_controller: fix the incorrect sampled key ranges number check
```

### Related changes

- Problem cause: https://github.com/tikv/tikv/pull/11986

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None.
```
