### PR TITLE
copr: fix panic during push bit column down

### DIFF
--- a/components/tidb_query_expr/src/impl_cast.rs
+++ b/components/tidb_query_expr/src/impl_cast.rs
@@ -17,7 +17,6 @@ use tidb_query_common::Result;
 use tidb_query_datatype::codec::collation::Encoding;
 use tidb_query_datatype::codec::convert::*;
 use tidb_query_datatype::codec::data_type::*;
-use tidb_query_datatype::codec::datum_codec::DatumPayloadDecoder;
 use tidb_query_datatype::codec::error::{ERR_DATA_OUT_OF_RANGE, ERR_TRUNCATE_WRONG_VALUE};
 use tidb_query_datatype::codec::mysql::time::{MAX_YEAR, MIN_YEAR};
 use tidb_query_datatype::codec::mysql::{binary_literal, Time};


### PR DESCRIPTION
Signed-off-by: yisaer <disxiaofei@163.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref https://github.com/pingcap/tidb/issues/32506 https://github.com/tikv/tikv/pull/12016

What's Changed:
Bit Column should be solved separately according to its flag, otherwise it will cause panic.

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

same in https://github.com/tikv/tikv/pull/12016

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
