### PR TITLE
engine: cut raft-engine to pre-alpha branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3641,7 +3641,7 @@ dependencies = [
 [[package]]
 name = "raft-engine"
 version = "0.1.0"
-source = "git+https://github.com/tikv/raft-engine?branch=master#e478e070aa7e9a1d0a9053a92abd632bf15a986d"
+source = "git+https://github.com/tikv/raft-engine?branch=pre-alpha#48ce04d4d2c9016aa70eaa7850e2fbfb30d184aa"
 dependencies = [
  "byteorder",
  "crc32fast",
@@ -3662,7 +3662,6 @@ dependencies = [
  "prometheus-static-metric",
  "protobuf",
  "rayon",
- "scopeguard",
  "serde",
  "thiserror",
 ]

--- a/components/raft_log_engine/Cargo.toml
+++ b/components/raft_log_engine/Cargo.toml
@@ -19,5 +19,5 @@ serde = "1.0"
 serde_derive = "1.0"
 kvproto = { git = "https://github.com/pingcap/kvproto.git" }
 raft = { version = "0.7.0", default-features = false, features = ["protobuf-codec"] }
-raft-engine = { git = "https://github.com/tikv/raft-engine", branch = "master" }
+raft-engine = { git = "https://github.com/tikv/raft-engine", branch = "pre-alpha" }
 protobuf = "2"


### PR DESCRIPTION
Signed-off-by: tabokie <xy.tao@outlook.com>

### What is changed and how it works?

Issue Number: ref #11119

What's Changed:

Cut to pre-alpha branch, which includes all the major bug fixes but without interface changes in master branch.

Will switch back to master branch by @ztelur as per https://github.com/tikv/raft-engine/issues/165#issuecomment-1042860549.

### Related changes

Mirrors #12029 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
