### PR TITLE
raftstore: check uninitialized destroy for merge

### DIFF
--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -3210,10 +3210,8 @@ where
             .kv
             .get_msg_cf::<RegionLocalState>(CF_RAFT, &state_key)?
         {
-            if util::is_epoch_stale(
-                target_region.get_region_epoch(),
-                target_state.get_region().get_region_epoch(),
-            ) {
+            let state_epoch = target_state.get_region().get_region_epoch();
+            if util::is_epoch_stale(target_region.get_region_epoch(), state_epoch) {
                 return Ok(true);
             }
             // The local target region epoch is staler than target region's.
@@ -3238,6 +3236,10 @@ where
                         );
                     }
                     cmp::Ordering::Greater => {
+                        if state_epoch.get_version() == 0 && state_epoch.get_conf_ver() == 0 {
+                            // There is a new peer and it's destroyed without being initialised.
+                            return Ok(true);
+                        }
                         // The local target peer id is greater than the one in target region, but its epoch
                         // is staler than target_region's. That is contradictory.
                         panic!("{} local target peer id {} is greater than the one in target region {}, but its epoch is staler, local target region {:?},

--- a/components/test_raftstore/src/util.rs
+++ b/components/test_raftstore/src/util.rs
@@ -1290,3 +1290,12 @@ impl PeerClient {
         must_kv_pessimistic_rollback(&self.cli, self.ctx.clone(), key, ts)
     }
 }
+
+pub fn peer_on_store(region: &metapb::Region, store_id: u64) -> metapb::Peer {
+    region
+        .get_peers()
+        .iter()
+        .find(|p| p.get_store_id() == store_id)
+        .unwrap()
+        .clone()
+}

--- a/tests/integrations/raftstore/test_merge.rs
+++ b/tests/integrations/raftstore/test_merge.rs
@@ -1450,3 +1450,66 @@ fn test_merge_pessimistic_locks_repeated_merge() {
         .unwrap();
     assert_eq!(value, lock.into_lock().to_bytes());
 }
+
+/// Check if merge is cleaned up if the merge target is destroyed several times before it's ever
+/// scheduled.
+#[test]
+fn test_node_merge_long_isolated() {
+    let mut cluster = new_node_cluster(0, 3);
+    configure_for_merge(&mut cluster);
+    ignore_merge_target_integrity(&mut cluster);
+    let pd_client = Arc::clone(&cluster.pd_client);
+    pd_client.disable_default_operator();
+
+    cluster.run();
+
+    cluster.must_put(b"k1", b"v1");
+    cluster.must_put(b"k3", b"v3");
+
+    let region = pd_client.get_region(b"k1").unwrap();
+    cluster.must_split(&region, b"k2");
+    let left = pd_client.get_region(b"k1").unwrap();
+    let right = pd_client.get_region(b"k3").unwrap();
+
+    cluster.must_transfer_leader(right.get_id(), new_peer(3, 3));
+    let target_leader = peer_on_store(&left, 3);
+    cluster.must_transfer_leader(left.get_id(), target_leader);
+    must_get_equal(&cluster.get_engine(1), b"k3", b"v3");
+
+    // So cluster becomes:
+    //  left region: 1 I 2 3(leader)
+    // right region: 1 I 2 3(leader)
+    // I means isolation.
+    cluster.add_send_filter(IsolationFilterFactory::new(1));
+    pd_client.must_merge(left.get_id(), right.get_id());
+    pd_client.must_remove_peer(right.get_id(), peer_on_store(&right, 1));
+    // Split to make sure the range of new peer won't overlap with source.
+    let right = pd_client.get_region(b"k1").unwrap();
+    cluster.must_split(&right, b"k2");
+    cluster.must_put(b"k4", b"v4");
+    // Ensure the node is removed, so it will not catch up any logs but just destroy itself.
+    must_get_equal(&cluster.get_engine(3), b"k4", b"v4");
+    must_get_equal(&cluster.get_engine(2), b"k4", b"v4");
+
+    let filter = RegionPacketFilter::new(left.get_id(), 1);
+    cluster.clear_send_filters();
+    // Ensure source region will not take any actions.
+    cluster.add_send_filter(CloneFilterFactory(filter));
+    must_get_none(&cluster.get_engine(1), b"k3");
+    must_get_equal(&cluster.get_engine(1), b"k1", b"v1");
+
+    // So new peer will not apply snapshot.
+    let filter = RegionPacketFilter::new(right.get_id(), 1).msg_type(MessageType::MsgSnapshot);
+    cluster.add_send_filter(CloneFilterFactory(filter));
+    pd_client.must_add_peer(right.get_id(), new_peer(1, 1010));
+    cluster.must_put(b"k5", b"v5");
+    must_get_equal(&cluster.get_engine(2), b"k5", b"v5");
+    must_get_none(&cluster.get_engine(1), b"k3");
+
+    // Now peer(1, 1010) should probably created in memory but not persisted.
+    pd_client.must_remove_peer(right.get_id(), new_peer(1, 1010));
+    cluster.wait_tombstone(right.get_id(), new_peer(1, 1010));
+    cluster.clear_send_filters();
+    // Source peer should discover it's impossible to proceed and cleanup itself.
+    must_get_none(&cluster.get_engine(1), b"k1");
+}


### PR DESCRIPTION

### What is changed and how it works?

Issue Number: Close #12048

What's Changed:

```commit-message
When a peer is destroyed without being initialized, it will store
itself to peer list and the region epoch is missing. In merge if
such state is detected, it should abort merging instead of panicking.
```

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
fix panic when target peer is replaced with an destroyed uninitialized peer during merge
```
