### PR TITLE
rocksdb: use new pipelined-write to replace multibatch-write

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2465,7 +2465,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/Little-Wallace/rust-rocksdb.git?branch=commit-pipeline#de402d5fd33a7e1187569ba2f8dfbc3092ef448d"
+source = "git+https://github.com/tikv/rust-rocksdb.git#296331e0533ee9d7141f03b5f4cc5d7c442600d6"
 dependencies = [
  "bindgen 0.57.0",
  "bzip2-sys",
@@ -2484,7 +2484,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/Little-Wallace/rust-rocksdb.git?branch=commit-pipeline#de402d5fd33a7e1187569ba2f8dfbc3092ef448d"
+source = "git+https://github.com/tikv/rust-rocksdb.git#296331e0533ee9d7141f03b5f4cc5d7c442600d6"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -4097,7 +4097,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/Little-Wallace/rust-rocksdb.git?branch=commit-pipeline#de402d5fd33a7e1187569ba2f8dfbc3092ef448d"
+source = "git+https://github.com/tikv/rust-rocksdb.git#296331e0533ee9d7141f03b5f4cc5d7c442600d6"
 dependencies = [
  "libc 0.2.119",
  "librocksdb_sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2465,7 +2465,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#1494bb51025947bbb4ddc0ce5ea2df7a0a1e8b33"
+source = "git+https://github.com/Little-Wallace/rust-rocksdb.git?branch=commit-pipeline#de402d5fd33a7e1187569ba2f8dfbc3092ef448d"
 dependencies = [
  "bindgen 0.57.0",
  "bzip2-sys",
@@ -2484,7 +2484,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tikv/rust-rocksdb.git#1494bb51025947bbb4ddc0ce5ea2df7a0a1e8b33"
+source = "git+https://github.com/Little-Wallace/rust-rocksdb.git?branch=commit-pipeline#de402d5fd33a7e1187569ba2f8dfbc3092ef448d"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -4097,7 +4097,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#1494bb51025947bbb4ddc0ce5ea2df7a0a1e8b33"
+source = "git+https://github.com/Little-Wallace/rust-rocksdb.git?branch=commit-pipeline#de402d5fd33a7e1187569ba2f8dfbc3092ef448d"
 dependencies = [
  "libc 0.2.119",
  "librocksdb_sys",

--- a/components/engine_panic/src/write_batch.rs
+++ b/components/engine_panic/src/write_batch.rs
@@ -18,11 +18,7 @@ impl WriteBatchExt for PanicEngine {
 
 pub struct PanicWriteBatch;
 
-impl WriteBatch<PanicEngine> for PanicWriteBatch {
-    fn with_capacity(_: &PanicEngine, _: usize) -> Self {
-        panic!()
-    }
-
+impl WriteBatch for PanicWriteBatch {
     fn write_opt(&self, _: &WriteOptions) -> Result<()> {
         panic!()
     }

--- a/components/engine_panic/src/write_batch.rs
+++ b/components/engine_panic/src/write_batch.rs
@@ -5,13 +5,8 @@ use engine_traits::{Mutable, Result, WriteBatch, WriteBatchExt, WriteOptions};
 
 impl WriteBatchExt for PanicEngine {
     type WriteBatch = PanicWriteBatch;
-    type WriteBatchVec = PanicWriteBatch;
 
     const WRITE_BATCH_MAX_KEYS: usize = 1;
-
-    fn support_write_batch_vec(&self) -> bool {
-        panic!()
-    }
 
     fn write_batch(&self) -> Self::WriteBatch {
         panic!()

--- a/components/engine_rocks/Cargo.toml
+++ b/components/engine_rocks/Cargo.toml
@@ -51,8 +51,7 @@ fail = "0.5"
 case_macros = { path = "../case_macros" }
 
 [dependencies.rocksdb]
-git = "https://github.com/Little-Wallace/rust-rocksdb.git"
-branch = "commit-pipeline"
+git = "https://github.com/tikv/rust-rocksdb.git"
 package = "rocksdb"
 features = ["encryption"]
 

--- a/components/engine_rocks/Cargo.toml
+++ b/components/engine_rocks/Cargo.toml
@@ -51,7 +51,8 @@ fail = "0.5"
 case_macros = { path = "../case_macros" }
 
 [dependencies.rocksdb]
-git = "https://github.com/tikv/rust-rocksdb.git"
+git = "https://github.com/Little-Wallace/rust-rocksdb.git"
+branch = "commit-pipeline"
 package = "rocksdb"
 features = ["encryption"]
 

--- a/components/engine_rocks/src/event_listener.rs
+++ b/components/engine_rocks/src/event_listener.rs
@@ -4,7 +4,7 @@ use crate::rocks_metrics::*;
 
 use file_system::{get_io_type, set_io_type, IOType};
 use rocksdb::{
-    CompactionJobInfo, DBBackgroundErrorReason, FlushJobInfo, IngestionInfo, SubcompactionJobInfo,
+    CompactionJobInfo, DBBackgroundErrorReason, MutableStatus, FlushJobInfo, IngestionInfo, SubcompactionJobInfo,
     WriteStallInfo,
 };
 use tikv_util::set_panic_mark;
@@ -95,7 +95,8 @@ impl rocksdb::EventListener for RocksEventListener {
             .observe(info.picked_level() as f64);
     }
 
-    fn on_background_error(&self, reason: DBBackgroundErrorReason, result: Result<(), String>) {
+    fn on_background_error(&self, reason: DBBackgroundErrorReason, status: MutableStatus) {
+        let result = status.result();
         assert!(result.is_err());
         if let Err(err) = result {
             if matches!(

--- a/components/engine_rocks/src/event_listener.rs
+++ b/components/engine_rocks/src/event_listener.rs
@@ -4,8 +4,8 @@ use crate::rocks_metrics::*;
 
 use file_system::{get_io_type, set_io_type, IOType};
 use rocksdb::{
-    CompactionJobInfo, DBBackgroundErrorReason, MutableStatus, FlushJobInfo, IngestionInfo, SubcompactionJobInfo,
-    WriteStallInfo,
+    CompactionJobInfo, DBBackgroundErrorReason, FlushJobInfo, IngestionInfo, MutableStatus,
+    SubcompactionJobInfo, WriteStallInfo,
 };
 use tikv_util::set_panic_mark;
 

--- a/components/engine_rocks/src/raft_engine.rs
+++ b/components/engine_rocks/src/raft_engine.rs
@@ -313,7 +313,7 @@ impl RaftLogBatch for RocksWriteBatch {
     }
 
     fn merge(&mut self, src: Self) {
-        WriteBatch::<RocksEngine>::merge(self, src);
+        WriteBatch::merge(self, src);
     }
 }
 

--- a/components/engine_rocks/src/raft_engine.rs
+++ b/components/engine_rocks/src/raft_engine.rs
@@ -158,7 +158,7 @@ impl RaftEngine for RocksEngine {
     type LogBatch = RocksWriteBatch;
 
     fn log_batch(&self, capacity: usize) -> Self::LogBatch {
-        RocksWriteBatch::with_capacity(self.as_inner().clone(), capacity)
+        RocksWriteBatch::with_capacity(self, capacity)
     }
 
     fn sync(&self) -> Result<()> {
@@ -223,7 +223,7 @@ impl RaftEngine for RocksEngine {
     }
 
     fn append(&self, raft_group_id: u64, entries: Vec<Entry>) -> Result<usize> {
-        let mut wb = RocksWriteBatch::new(self.as_inner().clone());
+        let mut wb = self.write_batch();
         let buf = Vec::with_capacity(1024);
         wb.append_impl(raft_group_id, &entries, buf)?;
         self.consume(&mut wb, false)

--- a/components/engine_rocks/src/write_batch.rs
+++ b/components/engine_rocks/src/write_batch.rs
@@ -5,29 +5,20 @@ use std::sync::Arc;
 use crate::engine::RocksEngine;
 use crate::options::RocksWriteOptions;
 use crate::util::get_cf_handle;
-use engine_traits::{self, Error, Mutable, Result, WriteBatchExt, WriteOptions};
+use engine_traits::{self, Error, Mutable, Result, WriteBatch, WriteBatchExt, WriteOptions};
 use rocksdb::{Writable, WriteBatch as RawWriteBatch, DB};
-
-const WRITE_BATCH_MAX_BATCH: usize = 16;
-const WRITE_BATCH_LIMIT: usize = 16;
 
 impl WriteBatchExt for RocksEngine {
     type WriteBatch = RocksWriteBatch;
-    type WriteBatchVec = RocksWriteBatchVec;
 
     const WRITE_BATCH_MAX_KEYS: usize = 256;
 
-    fn support_write_batch_vec(&self) -> bool {
-        let options = self.as_inner().get_db_options();
-        options.is_enable_multi_batch_write()
+    fn write_batch(&self) -> RocksWriteBatch {
+        RocksWriteBatch::new(self.as_inner().clone())
     }
 
-    fn write_batch(&self) -> Self::WriteBatch {
-        Self::WriteBatch::new(Arc::clone(self.as_inner()))
-    }
-
-    fn write_batch_with_cap(&self, cap: usize) -> Self::WriteBatch {
-        Self::WriteBatch::with_capacity(Arc::clone(self.as_inner()), cap)
+    fn write_batch_with_cap(&self, cap: usize) -> RocksWriteBatch {
+        RocksWriteBatch::with_capacity(self, cap)
     }
 }
 
@@ -38,47 +29,36 @@ pub struct RocksWriteBatch {
 
 impl RocksWriteBatch {
     pub fn new(db: Arc<DB>) -> RocksWriteBatch {
-        RocksWriteBatch {
-            db,
-            wb: RawWriteBatch::default(),
-        }
+        let wb = RawWriteBatch::new();
+        RocksWriteBatch { db, wb }
     }
 
     pub fn as_inner(&self) -> &RawWriteBatch {
         &self.wb
     }
 
-    pub fn with_capacity(db: Arc<DB>, cap: usize) -> RocksWriteBatch {
-        let wb = if cap == 0 {
-            RawWriteBatch::default()
-        } else {
-            RawWriteBatch::with_capacity(cap)
-        };
-        RocksWriteBatch { db, wb }
-    }
-
-    pub fn from_raw(db: Arc<DB>, wb: RawWriteBatch) -> RocksWriteBatch {
-        RocksWriteBatch { db, wb }
+    pub fn as_raw(&self) -> &RawWriteBatch {
+        &self.wb
     }
 
     pub fn get_db(&self) -> &DB {
         self.db.as_ref()
     }
-
-    pub fn merge(&mut self, src: &Self) {
-        self.wb.append(src.wb.data());
-    }
 }
 
 impl engine_traits::WriteBatch<RocksEngine> for RocksWriteBatch {
-    fn with_capacity(e: &RocksEngine, cap: usize) -> RocksWriteBatch {
-        e.write_batch_with_cap(cap)
+    fn with_capacity(engine: &RocksEngine, cap: usize) -> RocksWriteBatch {
+        let wb = RawWriteBatch::with_capacity(cap);
+        RocksWriteBatch {
+            db: engine.as_inner().clone(),
+            wb,
+        }
     }
 
     fn write_opt(&self, opts: &WriteOptions) -> Result<()> {
         let opt: RocksWriteOptions = opts.into();
         self.get_db()
-            .write_opt(self.as_inner(), &opt.into_raw())
+            .write_opt(&self.wb, &opt.into_raw())
             .map_err(Error::Engine)
     }
 
@@ -95,7 +75,7 @@ impl engine_traits::WriteBatch<RocksEngine> for RocksWriteBatch {
     }
 
     fn should_write_to_engine(&self) -> bool {
-        self.wb.count() > RocksEngine::WRITE_BATCH_MAX_KEYS
+        self.count() > RocksEngine::WRITE_BATCH_MAX_KEYS
     }
 
     fn clear(&mut self) {
@@ -114,8 +94,8 @@ impl engine_traits::WriteBatch<RocksEngine> for RocksWriteBatch {
         self.wb.rollback_to_save_point().map_err(Error::Engine)
     }
 
-    fn merge(&mut self, src: Self) {
-        self.wb.append(src.wb.data());
+    fn merge(&mut self, other: Self) {
+        self.wb.append(other.wb.data());
     }
 }
 
@@ -152,180 +132,12 @@ impl Mutable for RocksWriteBatch {
     }
 }
 
-/// `RocksWriteBatchVec` is for method `multi_batch_write` of RocksDB, which splits a large WriteBatch
-/// into many smaller ones and then any thread could help to deal with these small WriteBatch when it
-/// is calling `AwaitState` and wait to become leader of WriteGroup. `multi_batch_write` will perform
-/// much better than traditional `pipelined_write` when TiKV writes very large data into RocksDB. We
-/// will remove this feature when `unordered_write` of RocksDB becomes more stable and becomes compatible
-/// with Titan.
-pub struct RocksWriteBatchVec {
-    db: Arc<DB>,
-    wbs: Vec<RawWriteBatch>,
-    save_points: Vec<usize>,
-    index: usize,
-    cur_batch_size: usize,
-    batch_size_limit: usize,
-}
-
-impl RocksWriteBatchVec {
-    pub fn new(db: Arc<DB>, batch_size_limit: usize, cap: usize) -> RocksWriteBatchVec {
-        let wb = RawWriteBatch::with_capacity(cap);
-        RocksWriteBatchVec {
-            db,
-            wbs: vec![wb],
-            save_points: vec![],
-            index: 0,
-            cur_batch_size: 0,
-            batch_size_limit,
-        }
-    }
-
-    pub fn as_inner(&self) -> &[RawWriteBatch] {
-        &self.wbs[0..=self.index]
-    }
-
-    pub fn as_raw(&self) -> &RawWriteBatch {
-        &self.wbs[0]
-    }
-
-    pub fn get_db(&self) -> &DB {
-        self.db.as_ref()
-    }
-
-    /// `check_switch_batch` will split a large WriteBatch into many smaller ones. This is to avoid
-    /// a large WriteBatch blocking write_thread too long.
-    fn check_switch_batch(&mut self) {
-        if self.batch_size_limit > 0 && self.cur_batch_size >= self.batch_size_limit {
-            self.index += 1;
-            self.cur_batch_size = 0;
-            if self.index >= self.wbs.len() {
-                self.wbs.push(RawWriteBatch::default());
-            }
-        }
-        self.cur_batch_size += 1;
-    }
-}
-
-impl engine_traits::WriteBatch<RocksEngine> for RocksWriteBatchVec {
-    fn with_capacity(e: &RocksEngine, cap: usize) -> RocksWriteBatchVec {
-        RocksWriteBatchVec::new(e.as_inner().clone(), WRITE_BATCH_LIMIT, cap)
-    }
-
-    fn write_opt(&self, opts: &WriteOptions) -> Result<()> {
-        let opt: RocksWriteOptions = opts.into();
-        if self.index > 0 {
-            self.get_db()
-                .multi_batch_write(self.as_inner(), &opt.into_raw())
-                .map_err(Error::Engine)
-        } else {
-            self.get_db()
-                .write_opt(&self.wbs[0], &opt.into_raw())
-                .map_err(Error::Engine)
-        }
-    }
-
-    fn data_size(&self) -> usize {
-        self.wbs.iter().fold(0, |a, b| a + b.data_size())
-    }
-
-    fn count(&self) -> usize {
-        self.cur_batch_size + self.index * self.batch_size_limit
-    }
-
-    fn is_empty(&self) -> bool {
-        self.wbs[0].is_empty()
-    }
-
-    fn should_write_to_engine(&self) -> bool {
-        self.index >= WRITE_BATCH_MAX_BATCH
-    }
-
-    fn clear(&mut self) {
-        for i in 0..=self.index {
-            self.wbs[i].clear();
-        }
-        self.save_points.clear();
-        self.index = 0;
-        self.cur_batch_size = 0;
-    }
-
-    fn set_save_point(&mut self) {
-        self.wbs[self.index].set_save_point();
-        self.save_points.push(self.index);
-    }
-
-    fn pop_save_point(&mut self) -> Result<()> {
-        if let Some(x) = self.save_points.pop() {
-            return self.wbs[x].pop_save_point().map_err(Error::Engine);
-        }
-        Err(Error::Engine("no save point".into()))
-    }
-
-    fn rollback_to_save_point(&mut self) -> Result<()> {
-        if let Some(x) = self.save_points.pop() {
-            for i in x + 1..=self.index {
-                self.wbs[i].clear();
-            }
-            self.index = x;
-            return self.wbs[x].rollback_to_save_point().map_err(Error::Engine);
-        }
-        Err(Error::Engine("no save point".into()))
-    }
-
-    fn merge(&mut self, _: Self) {
-        panic!("merge is not implemented for RocksWriteBatchVec");
-    }
-}
-
-impl Mutable for RocksWriteBatchVec {
-    fn put(&mut self, key: &[u8], value: &[u8]) -> Result<()> {
-        self.check_switch_batch();
-        self.wbs[self.index].put(key, value).map_err(Error::Engine)
-    }
-
-    fn put_cf(&mut self, cf: &str, key: &[u8], value: &[u8]) -> Result<()> {
-        self.check_switch_batch();
-        let handle = get_cf_handle(self.db.as_ref(), cf)?;
-        self.wbs[self.index]
-            .put_cf(handle, key, value)
-            .map_err(Error::Engine)
-    }
-
-    fn delete(&mut self, key: &[u8]) -> Result<()> {
-        self.check_switch_batch();
-        self.wbs[self.index].delete(key).map_err(Error::Engine)
-    }
-
-    fn delete_cf(&mut self, cf: &str, key: &[u8]) -> Result<()> {
-        self.check_switch_batch();
-        let handle = get_cf_handle(self.db.as_ref(), cf)?;
-        self.wbs[self.index]
-            .delete_cf(handle, key)
-            .map_err(Error::Engine)
-    }
-
-    fn delete_range(&mut self, begin_key: &[u8], end_key: &[u8]) -> Result<()> {
-        self.check_switch_batch();
-        self.wbs[self.index]
-            .delete_range(begin_key, end_key)
-            .map_err(Error::Engine)
-    }
-
-    fn delete_range_cf(&mut self, cf: &str, begin_key: &[u8], end_key: &[u8]) -> Result<()> {
-        self.check_switch_batch();
-        let handle = get_cf_handle(self.db.as_ref(), cf)?;
-        self.wbs[self.index]
-            .delete_range_cf(handle, begin_key, end_key)
-            .map_err(Error::Engine)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::super::util::new_engine_opt;
     use super::super::RocksDBOptions;
     use super::*;
-    use engine_traits::WriteBatch;
+    use engine_traits::{Peekable, WriteBatch};
     use rocksdb::DBOptions as RawDBOptions;
     use tempfile::Builder;
 
@@ -336,16 +148,15 @@ mod tests {
             .tempdir()
             .unwrap();
         let opt = RawDBOptions::default();
-        opt.enable_multi_batch_write(true);
         opt.enable_unordered_write(false);
-        opt.enable_pipelined_write(true);
+        opt.enable_pipelined_write(false);
+        opt.enable_pipelined_commit(true);
         let engine = new_engine_opt(
             path.path().join("db").to_str().unwrap(),
             RocksDBOptions::from_raw(opt),
             vec![],
         )
         .unwrap();
-        assert!(engine.support_write_batch_vec());
         let mut wb = engine.write_batch();
         for _i in 0..RocksEngine::WRITE_BATCH_MAX_KEYS {
             wb.put(b"aaa", b"bbb").unwrap();
@@ -353,8 +164,12 @@ mod tests {
         assert!(!wb.should_write_to_engine());
         wb.put(b"aaa", b"bbb").unwrap();
         assert!(wb.should_write_to_engine());
-        let mut wb = RocksWriteBatchVec::with_capacity(&engine, 1024);
-        for _i in 0..WRITE_BATCH_MAX_BATCH * WRITE_BATCH_LIMIT {
+        wb.write().unwrap();
+        let v = engine.get_value(b"aaa").unwrap();
+        assert!(v.is_some());
+        assert_eq!(v.unwrap(), b"bbb");
+        let mut wb = RocksWriteBatch::with_capacity(&engine, 1024);
+        for _i in 0..RocksEngine::WRITE_BATCH_MAX_KEYS {
             wb.put(b"aaa", b"bbb").unwrap();
         }
         assert!(!wb.should_write_to_engine());

--- a/components/engine_rocks/src/write_batch.rs
+++ b/components/engine_rocks/src/write_batch.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use crate::engine::RocksEngine;
 use crate::options::RocksWriteOptions;
 use crate::util::get_cf_handle;
-use engine_traits::{self, Error, Mutable, Result, WriteBatch, WriteBatchExt, WriteOptions};
+use engine_traits::{self, Error, Mutable, Result, WriteBatchExt, WriteOptions};
 use rocksdb::{Writable, WriteBatch as RawWriteBatch, DB};
 
 impl WriteBatchExt for RocksEngine {
@@ -33,6 +33,14 @@ impl RocksWriteBatch {
         RocksWriteBatch { db, wb }
     }
 
+    pub fn with_capacity(engine: &RocksEngine, cap: usize) -> RocksWriteBatch {
+        let wb = RawWriteBatch::with_capacity(cap);
+        RocksWriteBatch {
+            db: engine.as_inner().clone(),
+            wb,
+        }
+    }
+
     pub fn as_inner(&self) -> &RawWriteBatch {
         &self.wb
     }
@@ -46,15 +54,7 @@ impl RocksWriteBatch {
     }
 }
 
-impl engine_traits::WriteBatch<RocksEngine> for RocksWriteBatch {
-    fn with_capacity(engine: &RocksEngine, cap: usize) -> RocksWriteBatch {
-        let wb = RawWriteBatch::with_capacity(cap);
-        RocksWriteBatch {
-            db: engine.as_inner().clone(),
-            wb,
-        }
-    }
-
+impl engine_traits::WriteBatch for RocksWriteBatch {
     fn write_opt(&self, opts: &WriteOptions) -> Result<()> {
         let opt: RocksWriteOptions = opts.into();
         self.get_db()

--- a/components/engine_traits/src/write_batch.rs
+++ b/components/engine_traits/src/write_batch.rs
@@ -6,9 +6,6 @@ use crate::options::WriteOptions;
 /// Engines that can create write batches
 pub trait WriteBatchExt: Sized {
     type WriteBatch: WriteBatch<Self>;
-    /// `WriteBatchVec` is used for `multi_batch_write` of RocksEngine and other Engine could also
-    /// implement another kind of WriteBatch according to their needs.
-    type WriteBatchVec: WriteBatch<Self>;
 
     /// The number of puts/deletes made to a write batch before the batch should
     /// be committed with `write`. More entries than this will cause
@@ -18,12 +15,6 @@ pub trait WriteBatchExt: Sized {
     /// and does not result in an error. It isn't clear the consequence of
     /// exceeding this limit.
     const WRITE_BATCH_MAX_KEYS: usize;
-
-    /// Indicates whether the WriteBatchVec type can be created and works
-    /// as expected.
-    ///
-    /// If this returns false then creating a WriteBatchVec will panic.
-    fn support_write_batch_vec(&self) -> bool;
 
     fn write_batch(&self) -> Self::WriteBatch;
     fn write_batch_with_cap(&self, cap: usize) -> Self::WriteBatch;

--- a/components/engine_traits/src/write_batch.rs
+++ b/components/engine_traits/src/write_batch.rs
@@ -5,7 +5,7 @@ use crate::options::WriteOptions;
 
 /// Engines that can create write batches
 pub trait WriteBatchExt: Sized {
-    type WriteBatch: WriteBatch<Self>;
+    type WriteBatch: WriteBatch;
 
     /// The number of puts/deletes made to a write batch before the batch should
     /// be committed with `write`. More entries than this will cause
@@ -70,10 +70,7 @@ pub trait Mutable: Send {
 /// point can be recorded. Any number of save points can be recorded to a stack.
 /// Calling `rollback_to_save_point` reverts all commands issued since the last
 /// save point, and pops the save point from the stack.
-pub trait WriteBatch<E: WriteBatchExt + Sized>: Mutable {
-    /// Create a WriteBatch with a given command capacity
-    fn with_capacity(e: &E, cap: usize) -> Self;
-
+pub trait WriteBatch: Mutable {
     /// Commit the WriteBatch to disk with the given options
     fn write_opt(&self, opts: &WriteOptions) -> Result<()>;
 

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -5,7 +5,6 @@ use std::borrow::Cow;
 use std::cmp::{Ord, Ordering as CmpOrdering};
 use std::collections::VecDeque;
 use std::fmt::{self, Debug, Formatter};
-use std::marker::PhantomData;
 use std::mem;
 use std::ops::{Deref, DerefMut, Range as StdRange};
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
@@ -26,8 +25,8 @@ use crossbeam::channel::{TryRecvError, TrySendError};
 use engine_traits::PerfContext;
 use engine_traits::PerfContextKind;
 use engine_traits::{
-    DeleteStrategy, KvEngine, RaftEngine, RaftEngineReadOnly, Range as EngineRange, Snapshot,
-    WriteBatch,
+    DeleteStrategy, KvEngine, Mutable, RaftEngine, RaftEngineReadOnly, Range as EngineRange,
+    Snapshot, WriteBatch,
 };
 use engine_traits::{SSTMetaInfo, ALL_CFS, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
 use fail::fail_point;
@@ -346,10 +345,9 @@ pub trait Notifier<EK: KvEngine>: Send {
     fn clone_box(&self) -> Box<dyn Notifier<EK>>;
 }
 
-struct ApplyContext<EK, W>
+struct ApplyContext<EK>
 where
     EK: KvEngine,
-    W: WriteBatch<EK>,
 {
     tag: String,
     timer: Option<Instant>,
@@ -364,7 +362,7 @@ where
     exec_log_index: u64,
     exec_log_term: u64,
 
-    kv_wb: W,
+    kv_wb: EK::WriteBatch,
     kv_wb_last_bytes: u64,
     kv_wb_last_keys: u64,
 
@@ -408,10 +406,9 @@ where
     key_buffer: Vec<u8>,
 }
 
-impl<EK, W> ApplyContext<EK, W>
+impl<EK> ApplyContext<EK>
 where
     EK: KvEngine,
-    W: WriteBatch<EK>,
 {
     pub fn new(
         tag: String,
@@ -425,11 +422,8 @@ where
         store_id: u64,
         pending_create_peers: Arc<Mutex<HashMap<u64, (u64, bool)>>>,
         priority: Priority,
-    ) -> ApplyContext<EK, W> {
-        // If `enable_multi_batch_write` was set true, we create `RocksWriteBatchVec`.
-        // Otherwise create `RocksWriteBatch`.
-        let kv_wb = W::with_capacity(&engine, DEFAULT_APPLY_WB_SIZE);
-
+    ) -> ApplyContext<EK> {
+        let kv_wb = engine.write_batch_with_cap(DEFAULT_APPLY_WB_SIZE);
         ApplyContext {
             tag,
             timer: None,
@@ -525,9 +519,8 @@ where
             self.sync_log_hint = false;
             let data_size = self.kv_wb().data_size();
             if data_size > APPLY_WB_SHRINK_SIZE {
-                // Control the memory usage for the WriteBatch. Whether it's `RocksWriteBatch` or
-                // `RocksWriteBatchVec` depends on the `enable_multi_batch_write` configuration.
-                self.kv_wb = W::with_capacity(&self.engine, DEFAULT_APPLY_WB_SIZE);
+                // Control the memory usage for the WriteBatch.
+                self.kv_wb = self.engine.write_batch_with_cap(DEFAULT_APPLY_WB_SIZE);
             } else {
                 // Clear data, reuse the WriteBatch, this can reduce memory allocations and deallocations.
                 self.kv_wb_mut().clear();
@@ -597,12 +590,12 @@ where
     }
 
     #[inline]
-    pub fn kv_wb(&self) -> &W {
+    pub fn kv_wb(&self) -> &EK::WriteBatch {
         &self.kv_wb
     }
 
     #[inline]
-    pub fn kv_wb_mut(&mut self) -> &mut W {
+    pub fn kv_wb_mut(&mut self) -> &mut EK::WriteBatch {
         &mut self.kv_wb
     }
 
@@ -940,9 +933,9 @@ where
     }
 
     /// Handles all the committed_entries, namely, applies the committed entries.
-    fn handle_raft_committed_entries<W: WriteBatch<EK>>(
+    fn handle_raft_committed_entries(
         &mut self,
-        apply_ctx: &mut ApplyContext<EK, W>,
+        apply_ctx: &mut ApplyContext<EK>,
         mut committed_entries_drainer: Drain<'_, Entry>,
     ) {
         if committed_entries_drainer.len() == 0 {
@@ -1011,12 +1004,12 @@ where
         }
     }
 
-    fn update_metrics<W: WriteBatch<EK>>(&mut self, apply_ctx: &ApplyContext<EK, W>) {
+    fn update_metrics(&mut self, apply_ctx: &ApplyContext<EK>) {
         self.metrics.written_bytes += apply_ctx.delta_bytes();
         self.metrics.written_keys += apply_ctx.delta_keys();
     }
 
-    fn write_apply_state<W: WriteBatch<EK>>(&self, wb: &mut W) {
+    fn write_apply_state(&self, wb: &mut EK::WriteBatch) {
         wb.put_msg_cf(
             CF_RAFT,
             &keys::apply_state_key(self.region.get_id()),
@@ -1030,9 +1023,9 @@ where
         });
     }
 
-    fn handle_raft_entry_normal<W: WriteBatch<EK>>(
+    fn handle_raft_entry_normal(
         &mut self,
-        apply_ctx: &mut ApplyContext<EK, W>,
+        apply_ctx: &mut ApplyContext<EK>,
         entry: &Entry,
     ) -> ApplyResult<EK::Snapshot> {
         fail_point!(
@@ -1093,9 +1086,9 @@ where
         ApplyResult::None
     }
 
-    fn handle_raft_entry_conf_change<W: WriteBatch<EK>>(
+    fn handle_raft_entry_conf_change(
         &mut self,
-        apply_ctx: &mut ApplyContext<EK, W>,
+        apply_ctx: &mut ApplyContext<EK>,
         entry: &Entry,
     ) -> ApplyResult<EK::Snapshot> {
         // Although conf change can't yield in normal case, it is convenient to
@@ -1170,9 +1163,9 @@ where
         None
     }
 
-    fn process_raft_cmd<W: WriteBatch<EK>>(
+    fn process_raft_cmd(
         &mut self,
-        apply_ctx: &mut ApplyContext<EK, W>,
+        apply_ctx: &mut ApplyContext<EK>,
         index: u64,
         term: u64,
         cmd: RaftCmdRequest,
@@ -1219,9 +1212,9 @@ where
     ///   2. it encounters an error that may not occur on all stores, in this case
     /// we should try to apply the entry again or panic. Considering that this
     /// usually due to disk operation fail, which is rare, so just panic is ok.
-    fn apply_raft_cmd<W: WriteBatch<EK>>(
+    fn apply_raft_cmd(
         &mut self,
-        ctx: &mut ApplyContext<EK, W>,
+        ctx: &mut ApplyContext<EK>,
         index: u64,
         term: u64,
         req: &RaftCmdRequest,
@@ -1322,7 +1315,7 @@ where
         (resp, exec_result)
     }
 
-    fn destroy<W: WriteBatch<EK>>(&mut self, apply_ctx: &mut ApplyContext<EK, W>) {
+    fn destroy(&mut self, apply_ctx: &mut ApplyContext<EK>) {
         self.stopped = true;
         apply_ctx.router.close(self.region_id());
         for cmd in self.pending_cmds.normals.drain(..) {
@@ -1365,9 +1358,9 @@ where
     EK: KvEngine,
 {
     // Only errors that will also occur on all other stores should be returned.
-    fn exec_raft_cmd<W: WriteBatch<EK>>(
+    fn exec_raft_cmd(
         &mut self,
-        ctx: &mut ApplyContext<EK, W>,
+        ctx: &mut ApplyContext<EK>,
         req: &RaftCmdRequest,
     ) -> Result<(RaftCmdResponse, ApplyResult<EK::Snapshot>)> {
         // Include region for epoch not match after merge may cause key not in range.
@@ -1381,9 +1374,9 @@ where
         }
     }
 
-    fn exec_admin_cmd<W: WriteBatch<EK>>(
+    fn exec_admin_cmd(
         &mut self,
-        ctx: &mut ApplyContext<EK, W>,
+        ctx: &mut ApplyContext<EK>,
         req: &RaftCmdRequest,
     ) -> Result<(RaftCmdResponse, ApplyResult<EK::Snapshot>)> {
         let request = req.get_admin_request();
@@ -1425,9 +1418,9 @@ where
         Ok((resp, exec_result))
     }
 
-    fn exec_write_cmd<W: WriteBatch<EK>>(
+    fn exec_write_cmd(
         &mut self,
-        ctx: &mut ApplyContext<EK, W>,
+        ctx: &mut ApplyContext<EK>,
         req: &RaftCmdRequest,
     ) -> Result<(RaftCmdResponse, ApplyResult<EK::Snapshot>)> {
         fail_point!(
@@ -1504,11 +1497,7 @@ impl<EK> ApplyDelegate<EK>
 where
     EK: KvEngine,
 {
-    fn handle_put<W: WriteBatch<EK>>(
-        &mut self,
-        ctx: &mut ApplyContext<EK, W>,
-        req: &Request,
-    ) -> Result<()> {
+    fn handle_put(&mut self, ctx: &mut ApplyContext<EK>, req: &Request) -> Result<()> {
         PEER_WRITE_CMD_COUNTER.put.inc();
         let (key, value) = (req.get_put().get_key(), req.get_put().get_value());
         // region key range has no data prefix, so we must use origin key to check.
@@ -1554,11 +1543,7 @@ where
         Ok(())
     }
 
-    fn handle_delete<W: WriteBatch<EK>>(
-        &mut self,
-        ctx: &mut ApplyContext<EK, W>,
-        req: &Request,
-    ) -> Result<()> {
+    fn handle_delete(&mut self, ctx: &mut ApplyContext<EK>, req: &Request) -> Result<()> {
         PEER_WRITE_CMD_COUNTER.delete.inc();
         let key = req.get_delete().get_key();
         // region key range has no data prefix, so we must use origin key to check.
@@ -1678,9 +1663,9 @@ where
         Ok(())
     }
 
-    fn handle_ingest_sst<W: WriteBatch<EK>>(
+    fn handle_ingest_sst(
         &mut self,
-        ctx: &mut ApplyContext<EK, W>,
+        ctx: &mut ApplyContext<EK>,
         req: &Request,
         ssts: &mut Vec<SSTMetaInfo>,
     ) -> Result<()> {
@@ -1744,9 +1729,9 @@ impl<EK> ApplyDelegate<EK>
 where
     EK: KvEngine,
 {
-    fn exec_change_peer<W: WriteBatch<EK>>(
+    fn exec_change_peer(
         &mut self,
-        ctx: &mut ApplyContext<EK, W>,
+        ctx: &mut ApplyContext<EK>,
         request: &AdminRequest,
     ) -> Result<(AdminResponse, ApplyResult<EK::Snapshot>)> {
         assert!(request.has_change_peer());
@@ -1944,9 +1929,9 @@ where
         ))
     }
 
-    fn exec_change_peer_v2<W: WriteBatch<EK>>(
+    fn exec_change_peer_v2(
         &mut self,
-        ctx: &mut ApplyContext<EK, W>,
+        ctx: &mut ApplyContext<EK>,
         request: &AdminRequest,
     ) -> Result<(AdminResponse, ApplyResult<EK::Snapshot>)> {
         assert!(request.has_change_peer_v2());
@@ -2171,9 +2156,9 @@ where
         Ok(region)
     }
 
-    fn exec_split<W: WriteBatch<EK>>(
+    fn exec_split(
         &mut self,
-        ctx: &mut ApplyContext<EK, W>,
+        ctx: &mut ApplyContext<EK>,
         req: &AdminRequest,
     ) -> Result<(AdminResponse, ApplyResult<EK::Snapshot>)> {
         info!(
@@ -2193,9 +2178,9 @@ where
         self.exec_batch_split(ctx, &admin_req)
     }
 
-    fn exec_batch_split<W: WriteBatch<EK>>(
+    fn exec_batch_split(
         &mut self,
-        ctx: &mut ApplyContext<EK, W>,
+        ctx: &mut ApplyContext<EK>,
         req: &AdminRequest,
     ) -> Result<(AdminResponse, ApplyResult<EK::Snapshot>)> {
         fail_point!("apply_before_split");
@@ -2399,9 +2384,9 @@ where
         ))
     }
 
-    fn exec_prepare_merge<W: WriteBatch<EK>>(
+    fn exec_prepare_merge(
         &mut self,
-        ctx: &mut ApplyContext<EK, W>,
+        ctx: &mut ApplyContext<EK>,
         req: &AdminRequest,
     ) -> Result<(AdminResponse, ApplyResult<EK::Snapshot>)> {
         fail_point!("apply_before_prepare_merge");
@@ -2474,9 +2459,9 @@ where
     // 7.   resume `exec_commit_merge` in target apply fsm
     // 8.   `on_ready_commit_merge` in target peer fsm and send `MergeResult` to source peer fsm
     // 9.   `on_merge_result` in source peer fsm (destroy itself)
-    fn exec_commit_merge<W: WriteBatch<EK>>(
+    fn exec_commit_merge(
         &mut self,
-        ctx: &mut ApplyContext<EK, W>,
+        ctx: &mut ApplyContext<EK>,
         req: &AdminRequest,
     ) -> Result<(AdminResponse, ApplyResult<EK::Snapshot>)> {
         {
@@ -2608,9 +2593,9 @@ where
         ))
     }
 
-    fn exec_rollback_merge<W: WriteBatch<EK>>(
+    fn exec_rollback_merge(
         &mut self,
-        ctx: &mut ApplyContext<EK, W>,
+        ctx: &mut ApplyContext<EK>,
         req: &AdminRequest,
     ) -> Result<(AdminResponse, ApplyResult<EK::Snapshot>)> {
         fail_point!("apply_before_rollback_merge");
@@ -2731,9 +2716,9 @@ where
         }
     }
 
-    fn exec_compute_hash<W: WriteBatch<EK>>(
+    fn exec_compute_hash(
         &self,
-        ctx: &ApplyContext<EK, W>,
+        ctx: &ApplyContext<EK>,
         req: &AdminRequest,
     ) -> Result<(AdminResponse, ApplyResult<EK::Snapshot>)> {
         let resp = AdminResponse::default();
@@ -2752,9 +2737,9 @@ where
         ))
     }
 
-    fn exec_verify_hash<W: WriteBatch<EK>>(
+    fn exec_verify_hash(
         &self,
-        _: &ApplyContext<EK, W>,
+        _: &ApplyContext<EK>,
         req: &AdminRequest,
     ) -> Result<(AdminResponse, ApplyResult<EK::Snapshot>)> {
         let verify_req = req.get_verify_hash();
@@ -3264,11 +3249,7 @@ where
     }
 
     /// Handles apply tasks, and uses the apply delegate to handle the committed entries.
-    fn handle_apply<W: WriteBatch<EK>>(
-        &mut self,
-        apply_ctx: &mut ApplyContext<EK, W>,
-        mut apply: Apply<EK::Snapshot>,
-    ) {
+    fn handle_apply(&mut self, apply_ctx: &mut ApplyContext<EK>, mut apply: Apply<EK::Snapshot>) {
         if apply_ctx.timer.is_none() {
             apply_ctx.timer = Some(Instant::now_coarse());
         }
@@ -3371,7 +3352,7 @@ where
         APPLY_PROPOSAL.observe(propose_num as f64);
     }
 
-    fn destroy<W: WriteBatch<EK>>(&mut self, ctx: &mut ApplyContext<EK, W>) {
+    fn destroy(&mut self, ctx: &mut ApplyContext<EK>) {
         let region_id = self.delegate.region_id();
         if ctx.apply_res.iter().any(|res| res.region_id == region_id) {
             // Flush before destroying to avoid reordering messages.
@@ -3391,7 +3372,7 @@ where
     }
 
     /// Handles peer destroy. When a peer is destroyed, the corresponding apply delegate should be removed too.
-    fn handle_destroy<W: WriteBatch<EK>>(&mut self, ctx: &mut ApplyContext<EK, W>, d: Destroy) {
+    fn handle_destroy(&mut self, ctx: &mut ApplyContext<EK>, d: Destroy) {
         assert_eq!(d.region_id, self.delegate.region_id());
         if d.merge_from_snapshot {
             assert_eq!(self.delegate.stopped, false);
@@ -3411,7 +3392,7 @@ where
         }
     }
 
-    fn resume_pending<W: WriteBatch<EK>>(&mut self, ctx: &mut ApplyContext<EK, W>) {
+    fn resume_pending(&mut self, ctx: &mut ApplyContext<EK>) {
         if let Some(ref state) = self.delegate.wait_merge_state {
             let source_region_id = state.logs_up_to_date.load(Ordering::SeqCst);
             if source_region_id == 0 {
@@ -3443,9 +3424,9 @@ where
         }
     }
 
-    fn logs_up_to_date_for_merge<W: WriteBatch<EK>>(
+    fn logs_up_to_date_for_merge(
         &mut self,
-        ctx: &mut ApplyContext<EK, W>,
+        ctx: &mut ApplyContext<EK>,
         catch_up_logs: CatchUpLogs,
     ) {
         fail_point!("after_handle_catch_up_logs_for_merge", |_| {});
@@ -3480,11 +3461,7 @@ where
     }
 
     #[allow(unused_mut, clippy::redundant_closure_call)]
-    fn handle_snapshot<W: WriteBatch<EK>>(
-        &mut self,
-        apply_ctx: &mut ApplyContext<EK, W>,
-        snap_task: GenSnapTask,
-    ) {
+    fn handle_snapshot(&mut self, apply_ctx: &mut ApplyContext<EK>, snap_task: GenSnapTask) {
         if self.delegate.pending_remove || self.delegate.stopped {
             return;
         }
@@ -3533,9 +3510,9 @@ where
         );
     }
 
-    fn handle_change<W: WriteBatch<EK>>(
+    fn handle_change(
         &mut self,
-        apply_ctx: &mut ApplyContext<EK, W>,
+        apply_ctx: &mut ApplyContext<EK>,
         cmd: ChangeObserver,
         region_epoch: RegionEpoch,
         cb: Callback<EK::Snapshot>,
@@ -3617,11 +3594,7 @@ where
         cb.invoke_read(resp);
     }
 
-    fn handle_tasks<W: WriteBatch<EK>>(
-        &mut self,
-        apply_ctx: &mut ApplyContext<EK, W>,
-        msgs: &mut Vec<Msg<EK>>,
-    ) {
+    fn handle_tasks(&mut self, apply_ctx: &mut ApplyContext<EK>, msgs: &mut Vec<Msg<EK>>) {
         let mut drainer = msgs.drain(..);
         let mut batch_apply = None;
         loop {
@@ -3770,23 +3743,21 @@ impl Fsm for ControlFsm {
     }
 }
 
-pub struct ApplyPoller<EK, W>
+pub struct ApplyPoller<EK>
 where
     EK: KvEngine,
-    W: WriteBatch<EK>,
 {
     msg_buf: Vec<Msg<EK>>,
-    apply_ctx: ApplyContext<EK, W>,
+    apply_ctx: ApplyContext<EK>,
     messages_per_tick: usize,
     cfg_tracker: Tracker<Config>,
 
     trace_event: TraceEvent,
 }
 
-impl<EK, W> PollHandler<ApplyFsm<EK>, ControlFsm> for ApplyPoller<EK, W>
+impl<EK> PollHandler<ApplyFsm<EK>, ControlFsm> for ApplyPoller<EK>
 where
     EK: KvEngine,
-    W: WriteBatch<EK> + 'static,
 {
     fn begin<F>(&mut self, _batch_size: usize, update_cfg: F)
     where
@@ -3906,7 +3877,7 @@ where
     }
 }
 
-pub struct Builder<EK: KvEngine, W: WriteBatch<EK>> {
+pub struct Builder<EK: KvEngine> {
     tag: String,
     cfg: Arc<VersionTrack<Config>>,
     coprocessor_host: CoprocessorHost<EK>,
@@ -3915,20 +3886,16 @@ pub struct Builder<EK: KvEngine, W: WriteBatch<EK>> {
     engine: EK,
     sender: Box<dyn Notifier<EK>>,
     router: ApplyRouter<EK>,
-    _phantom: PhantomData<W>,
     store_id: u64,
     pending_create_peers: Arc<Mutex<HashMap<u64, (u64, bool)>>>,
 }
 
-impl<EK: KvEngine, W> Builder<EK, W>
-where
-    W: WriteBatch<EK>,
-{
+impl<EK: KvEngine> Builder<EK> {
     pub fn new<T, ER: RaftEngine>(
         builder: &RaftPollerBuilder<EK, ER, T>,
         sender: Box<dyn Notifier<EK>>,
         router: ApplyRouter<EK>,
-    ) -> Builder<EK, W> {
+    ) -> Builder<EK> {
         Builder {
             tag: format!("[store {}]", builder.store.get_id()),
             cfg: builder.cfg.clone(),
@@ -3936,7 +3903,6 @@ where
             importer: builder.importer.clone(),
             region_scheduler: builder.region_scheduler.clone(),
             engine: builder.engines.kv.clone(),
-            _phantom: PhantomData,
             sender,
             router,
             store_id: builder.store.get_id(),
@@ -3945,14 +3911,13 @@ where
     }
 }
 
-impl<EK, W> HandlerBuilder<ApplyFsm<EK>, ControlFsm> for Builder<EK, W>
+impl<EK> HandlerBuilder<ApplyFsm<EK>, ControlFsm> for Builder<EK>
 where
     EK: KvEngine,
-    W: WriteBatch<EK> + 'static,
 {
-    type Handler = ApplyPoller<EK, W>;
+    type Handler = ApplyPoller<EK>;
 
-    fn build(&mut self, priority: Priority) -> ApplyPoller<EK, W> {
+    fn build(&mut self, priority: Priority) -> ApplyPoller<EK> {
         let cfg = self.cfg.value();
         ApplyPoller {
             msg_buf: Vec::with_capacity(cfg.messages_per_tick),
@@ -3976,10 +3941,9 @@ where
     }
 }
 
-impl<EK, W> Clone for Builder<EK, W>
+impl<EK> Clone for Builder<EK>
 where
     EK: KvEngine,
-    W: WriteBatch<EK>,
 {
     fn clone(&self) -> Self {
         Builder {
@@ -3991,7 +3955,6 @@ where
             engine: self.engine.clone(),
             sender: self.sender.clone_box(),
             router: self.router.clone(),
-            _phantom: self._phantom,
             store_id: self.store_id,
             pending_create_peers: self.pending_create_peers.clone(),
         }
@@ -4261,7 +4224,7 @@ mod tests {
     use crate::store::peer_storage::RAFT_INIT_LOG_INDEX;
     use crate::store::util::{new_learner_peer, new_peer};
     use engine_panic::PanicEngine;
-    use engine_test::kv::{new_engine, KvTestEngine, KvTestSnapshot, KvTestWriteBatch};
+    use engine_test::kv::{new_engine, KvTestEngine, KvTestSnapshot};
     use engine_traits::{Peekable as PeekableTrait, WriteBatchExt};
     use kvproto::kvrpcpb::ApiVersion;
     use kvproto::metapb::{self, RegionEpoch};
@@ -4548,7 +4511,7 @@ mod tests {
         let cfg = Arc::new(VersionTrack::new(Config::default()));
         let (router, mut system) = create_apply_batch_system(&cfg.value());
         let pending_create_peers = Arc::new(Mutex::new(HashMap::default()));
-        let builder = super::Builder::<KvTestEngine, KvTestWriteBatch> {
+        let builder = super::Builder::<KvTestEngine> {
             tag: "test-store".to_owned(),
             cfg,
             coprocessor_host: CoprocessorHost::<KvTestEngine>::default(),
@@ -4557,7 +4520,6 @@ mod tests {
             sender,
             engine,
             router: router.clone(),
-            _phantom: Default::default(),
             store_id: 1,
             pending_create_peers,
         };
@@ -4882,7 +4844,7 @@ mod tests {
         let cfg = Arc::new(VersionTrack::new(Config::default()));
         let (router, mut system) = create_apply_batch_system(&cfg.value());
         let pending_create_peers = Arc::new(Mutex::new(HashMap::default()));
-        let builder = super::Builder::<KvTestEngine, KvTestWriteBatch> {
+        let builder = super::Builder::<KvTestEngine> {
             tag: "test-store".to_owned(),
             cfg,
             sender,
@@ -4891,7 +4853,6 @@ mod tests {
             importer: importer.clone(),
             engine: engine.clone(),
             router: router.clone(),
-            _phantom: Default::default(),
             store_id: 1,
             pending_create_peers,
         };
@@ -5226,7 +5187,7 @@ mod tests {
         };
         let (router, mut system) = create_apply_batch_system(&cfg.value());
         let pending_create_peers = Arc::new(Mutex::new(HashMap::default()));
-        let builder = super::Builder::<KvTestEngine, KvTestWriteBatch> {
+        let builder = super::Builder::<KvTestEngine> {
             tag: "test-store".to_owned(),
             cfg,
             sender,
@@ -5235,7 +5196,6 @@ mod tests {
             importer: importer.clone(),
             engine: engine.clone(),
             router: router.clone(),
-            _phantom: Default::default(),
             store_id: 1,
             pending_create_peers,
         };
@@ -5403,7 +5363,7 @@ mod tests {
         let cfg = Config::default();
         let (router, mut system) = create_apply_batch_system(&cfg);
         let pending_create_peers = Arc::new(Mutex::new(HashMap::default()));
-        let builder = super::Builder::<KvTestEngine, KvTestWriteBatch> {
+        let builder = super::Builder::<KvTestEngine> {
             tag: "test-store".to_owned(),
             cfg: Arc::new(VersionTrack::new(cfg)),
             sender,
@@ -5412,7 +5372,6 @@ mod tests {
             importer,
             engine,
             router: router.clone(),
-            _phantom: Default::default(),
             store_id: 1,
             pending_create_peers,
         };
@@ -5692,7 +5651,7 @@ mod tests {
         let cfg = Arc::new(VersionTrack::new(Config::default()));
         let (router, mut system) = create_apply_batch_system(&cfg.value());
         let pending_create_peers = Arc::new(Mutex::new(HashMap::default()));
-        let builder = super::Builder::<KvTestEngine, KvTestWriteBatch> {
+        let builder = super::Builder::<KvTestEngine> {
             tag: "test-store".to_owned(),
             cfg,
             sender,
@@ -5701,7 +5660,6 @@ mod tests {
             coprocessor_host: host,
             engine: engine.clone(),
             router: router.clone(),
-            _phantom: Default::default(),
             store_id: 2,
             pending_create_peers,
         };

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -16,7 +16,7 @@ use batch_system::{
     HandlerBuilder, PollHandler, Priority,
 };
 use crossbeam::channel::{unbounded, Sender, TryRecvError, TrySendError};
-use engine_traits::{Engines, KvEngine, Mutable, PerfContextKind, WriteBatch, WriteBatchExt};
+use engine_traits::{Engines, KvEngine, Mutable, PerfContextKind, WriteBatch};
 use engine_traits::{CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
 use fail::fail_point;
 use futures::compat::Future01CompatExt;
@@ -1426,36 +1426,21 @@ impl<EK: KvEngine, ER: RaftEngine> RaftBatchSystem<EK, ER> {
             io_reschedule_concurrent_count: Arc::new(AtomicUsize::new(0)),
         };
         let region_peers = builder.init()?;
-        let engine = builder.engines.kv.clone();
-        if engine.support_write_batch_vec() {
-            self.start_system::<T, C, <EK as WriteBatchExt>::WriteBatchVec>(
-                workers,
-                region_peers,
-                builder,
-                auto_split_controller,
-                concurrency_manager,
-                mgr,
-                pd_client,
-                collector_reg_handle,
-                region_read_progress,
-            )?;
-        } else {
-            self.start_system::<T, C, <EK as WriteBatchExt>::WriteBatch>(
-                workers,
-                region_peers,
-                builder,
-                auto_split_controller,
-                concurrency_manager,
-                mgr,
-                pd_client,
-                collector_reg_handle,
-                region_read_progress,
-            )?;
-        }
+        self.start_system::<T, C>(
+            workers,
+            region_peers,
+            builder,
+            auto_split_controller,
+            concurrency_manager,
+            mgr,
+            pd_client,
+            collector_reg_handle,
+            region_read_progress,
+        )?;
         Ok(())
     }
 
-    fn start_system<T: Transport + 'static, C: PdClient + 'static, W: WriteBatch<EK> + 'static>(
+    fn start_system<T: Transport + 'static, C: PdClient + 'static>(
         &mut self,
         mut workers: Workers<EK, ER>,
         region_peers: Vec<SenderFsmPair<EK, ER>>,
@@ -1470,7 +1455,7 @@ impl<EK: KvEngine, ER: RaftEngine> RaftBatchSystem<EK, ER> {
         let cfg = builder.cfg.value().clone();
         let store = builder.store.clone();
 
-        let apply_poller_builder = ApplyPollerBuilder::<EK, W>::new(
+        let apply_poller_builder = ApplyPollerBuilder::<EK>::new(
             &builder,
             Box::new(self.router.clone()),
             self.apply_router.clone(),

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -575,7 +575,8 @@
 # rate-limiter-mode = "write-only"
 # rate-limiter-auto-tuned = true
 
-## Enable or disable the pipelined write.
+## Enable or disable the pipelined write. If set false, RocksDB will use a new write mode port from cockroachdb/pebble.
+## See more deta
 # enable-pipelined-write = false
 
 ## Allows OS to incrementally sync files to disk while they are being written, asynchronously,

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -576,7 +576,6 @@
 # rate-limiter-auto-tuned = true
 
 ## Enable or disable the pipelined write. If set false, RocksDB will use a new write mode port from cockroachdb/pebble.
-## User does not need to configure this option unless TiKV crashes because of the bug of the following PR.
 ## See more details in https://github.com/tikv/rocksdb/pull/267 and https://github.com/tikv/tikv/issues/12059.
 # enable-pipelined-write = false
 

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -576,7 +576,7 @@
 # rate-limiter-auto-tuned = true
 
 ## Enable or disable the pipelined write.
-# enable-pipelined-write = true
+# enable-pipelined-write = false
 
 ## Allows OS to incrementally sync files to disk while they are being written, asynchronously,
 ## in the background.

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -576,7 +576,8 @@
 # rate-limiter-auto-tuned = true
 
 ## Enable or disable the pipelined write. If set false, RocksDB will use a new write mode port from cockroachdb/pebble.
-## See more deta
+## User does not need to configure this option unless TiKV crashes because of the bug of the following PR.
+## See more details in https://github.com/tikv/rocksdb/pull/267 and https://github.com/tikv/tikv/issues/12059.
 # enable-pipelined-write = false
 
 ## Allows OS to incrementally sync files to disk while they are being written, asynchronously,

--- a/src/config.rs
+++ b/src/config.rs
@@ -962,7 +962,9 @@ pub struct DbConfig {
     pub use_direct_io_for_flush_and_compaction: bool,
     #[online_config(skip)]
     pub enable_pipelined_write: bool,
-    // deprecated
+    // deprecated. TiKV will use a new write mode when set `enable_pipelined_write` false and fall
+    // back to write mode in 3.0 when set `enable_pipelined_write` true. The code of multi-batch-write
+    // in RocksDB has been removed.
     #[online_config(skip)]
     pub enable_multi_batch_write: bool,
     #[online_config(skip)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -962,6 +962,7 @@ pub struct DbConfig {
     pub use_direct_io_for_flush_and_compaction: bool,
     #[online_config(skip)]
     pub enable_pipelined_write: bool,
+    // deprecated
     #[online_config(skip)]
     pub enable_multi_batch_write: bool,
     #[online_config(skip)]
@@ -1015,7 +1016,7 @@ impl Default for DbConfig {
             writable_file_max_buffer_size: ReadableSize::mb(1),
             use_direct_io_for_flush_and_compaction: false,
             enable_pipelined_write: false,
-            enable_multi_batch_write: true,
+            enable_multi_batch_write: true, // deprecated
             enable_unordered_write: false,
             defaultcf: DefaultCfConfig::default(),
             writecf: WriteCfConfig::default(),

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -568,7 +568,7 @@ impl<ER: RaftEngine> Debugger<ER> {
             let msg = format!("Store {} in the failed list", store_id);
             return Err(Error::Other(msg.into()));
         }
-        let mut wb = self.engines.kv.write_batch();
+        let mut wb = RocksWriteBatch::new(self.engines.kv.as_inner().clone());
         let store_ids = HashSet::<u64>::from_iter(store_ids);
 
         {
@@ -1001,7 +1001,7 @@ fn recover_mvcc_for_range(
     let wb_limit: usize = 10240;
 
     loop {
-        let mut wb = db.c().write_batch();
+        let mut wb = RocksWriteBatch::new(db.clone());
         mvcc_checker.check_mvcc(&mut wb, Some(wb_limit))?;
 
         let batch_size = wb.count();

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -287,7 +287,7 @@ fn test_serde_custom_tikv_config() {
         writable_file_max_buffer_size: ReadableSize::mb(12),
         use_direct_io_for_flush_and_compaction: true,
         enable_pipelined_write: false,
-        enable_multi_batch_write: false,
+        enable_multi_batch_write: true,
         enable_unordered_write: true,
         defaultcf: DefaultCfConfig {
             block_size: ReadableSize::kb(12),

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -258,7 +258,6 @@ writable-file-max-buffer-size = "12MB"
 use-direct-io-for-flush-and-compaction = true
 enable-pipelined-write = false
 enable-unordered-write = true
-enable-multi-batch-write = false
 
 [rocksdb.titan]
 enabled = true


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/tikv/tikv/issues/12059

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

I refactor the pipelined-write referring the solution of cockroachdb. See the design details in https://github.com/cockroachdb/pebble/blob/master/docs/rocksdb.md#commit-pipeline 

pick https://github.com/tikv/rocksdb/pull/267 to master

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test
- Manual test (add detailed scripts or steps below)

Side effects

- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
* The configure rocksdb.enable-multibatch-write will be discarded.  And if user set both rocksdb.enable-pipelined-write and rocksdb.enable-unordered-write false, TiKV will enable the new pipeline write. Otherwise, TiKV will use either original pipelined-write or unordered-write.
```
