### PR TITLE
config: add check for server.max-grpc-send-msg-len and raftstore.raft-entry-max-size

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -3328,6 +3328,9 @@ mod tests {
 
     #[test]
     fn test_msg_size_check() {
+        let mut cfg = TiKvConfig::default();
+        assert!(cfg.validate().is_ok());
+
         let max_grpc_send_msg_len = cfg.server.max_grpc_send_msg_len;
         cfg.raft_store.raft_entry_max_size.0 = cfg.raft_store.raft_entry_max_size.0 / 2;
         assert!(cfg.validate().is_ok());


### PR DESCRIPTION
Signed-off-by: linning <linningde25@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #11057 

Problem Summary:

See #11057 

### What is changed and how it works?

Proposal: #11057 

What's Changed:

Add a check to the config, if server.max-grpc-send-msg-len < raftstore.raft-entry-max-size set server.max-grpc-send-msg-len = raftstore.raft-entry-max-size + 512KB, the check will be called before TiKV is start

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Check server.max-grpc-send-msg-len >= raftstore.raft-entry-max-size 
```