### PR TITLE
tidb_query_expr: another implementation of truncate_real

### DIFF
--- a/components/tidb_query_expr/src/impl_math.rs
+++ b/components/tidb_query_expr/src/impl_math.rs
@@ -478,7 +478,11 @@ pub fn truncate_real_with_uint(arg0: &Real, arg1: &Int) -> Result<Option<Real>> 
 }
 
 fn truncate_real(x: Real, d: i32) -> Real {
-    let shift = 10_f64.powi(d);
+    let mut shift = 10_f64.powi(d);
+    if shift.is_infinite() {
+        // mysql's behavior
+        shift = 10_f64.powi(15)
+    }
     let tmp = x * shift;
     if *tmp == 0_f64 {
         Real::from(0_f64)

--- a/components/tidb_query_expr/src/impl_math.rs
+++ b/components/tidb_query_expr/src/impl_math.rs
@@ -3,6 +3,7 @@
 use std::cell::RefCell;
 
 use num::traits::Pow;
+use serde_json::de::Read;
 use tidb_query_codegen::rpn_fn;
 
 use tidb_query_common::Result;
@@ -478,18 +479,77 @@ pub fn truncate_real_with_uint(arg0: &Real, arg1: &Int) -> Result<Option<Real>> 
 }
 
 fn truncate_real(x: Real, d: i32) -> Real {
-    let mut shift = 10_f64.powi(d);
-    if shift.is_infinite() {
-        // mysql's behavior
-        shift = 10_f64.powi(15)
-    }
-    let tmp = x * shift;
-    if *tmp == 0_f64 {
-        Real::from(0_f64)
-    } else if tmp.is_infinite() {
+    if *x == 0.00 || x.is_infinite() {
         x
     } else {
-        Real::from(tmp.trunc() / shift)
+        let hole_x = (*x).trunc();
+        let decimal = *x - hole_x;
+        // 0 == trunc function
+        if d == 0 {
+            Real::new(hole_x).unwrap()
+        }
+        // negative trunc hole number
+        else if d < 0 {
+            let d = d as i64;
+            let lg10 = hole_x.abs().log10();
+            if (-d) - 1 > lg10 as i64 {
+                return Real::new(0.0).unwrap();
+            }
+            Real::new((hole_x / 10.0.pow(-d as f64)).trunc() * 10.0.pow(-d as f64)).unwrap()
+        }
+        // positive d trunc decimal
+        else {
+            if decimal == 0.0 {
+                // do nothing
+                return x;
+            }
+            let lg10 = decimal.abs().log10();
+            let lg_floor = lg10.floor();
+            let dd = (1i64 - d as i64) as f64;
+            let floor = 10.0.pow(lg_floor + dd);
+            if floor == 0.0 || floor == f64::INFINITY || floor == f64::NEG_INFINITY {
+                // overflow!
+                return x;
+            }
+            let scale = decimal / floor;
+            let scaletrunc = scale.trunc();
+            let trunced_decimal = scaletrunc * floor;
+            Real::new(hole_x + trunced_decimal).unwrap()
+        }
+    }
+}
+
+#[test]
+fn test() {
+    let test_cases = [
+        f64::INFINITY,
+        f64::NEG_INFINITY,
+        f64::MAX,
+        f64::MIN,
+        -8e307 + 2.0,
+        3.141592653589793,
+        2.0/3.0,
+        1145141919.810,
+        2.0/3.0*1e308
+    ];
+    let truncate_cases = [
+        i32::MAX,
+        i32::MIN,
+        5,
+        2,
+        0,
+        -2,
+        -5,
+        -307,
+    ];
+    for i in 0..test_cases.len() {
+        let x = Real::new(test_cases[i]).unwrap();
+        for j in 0..truncate_cases.len() {
+            let d = truncate_cases[j];
+            print!("test truncate({:+e},{})", *x, d);
+            let y = truncate_real(x, d);
+            println!(" = {:+e}", *y);
+        }
     }
 }
 


### PR DESCRIPTION
Signed-off-by: lemonhx <lemonhx@lemonhx.tech>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
see issue 32623 in tidb
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #12064

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.
If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
```
