### PR TITLE
txn: support read-consistency read with tso checking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,6 +830,7 @@ dependencies = [
  "crossbeam-skiplist",
  "fail",
  "futures 0.3.15",
+ "kvproto",
  "parking_lot 0.12.0",
  "rand 0.8.3",
  "tikv_alloc",

--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -285,6 +285,7 @@ impl BackupRange {
                         key,
                         backup_ts,
                         &Default::default(),
+                        IsolationLevel::Si,
                     )
                 },
             )

--- a/components/concurrency_manager/Cargo.toml
+++ b/components/concurrency_manager/Cargo.toml
@@ -10,6 +10,7 @@ tokio = { version = "1.5", features = ["macros", "sync", "time"] }
 txn_types = { path = "../txn_types", default-features = false }
 tikv_util = { path = "../tikv_util", default-features = false }
 fail = "0.5"
+kvproto = { git = "https://github.com/pingcap/kvproto.git" }
 
 # FIXME: switch to the crates.io version after crossbeam-skiplist is released
 [dependencies.crossbeam-skiplist]

--- a/components/concurrency_manager/benches/lock_table.rs
+++ b/components/concurrency_manager/benches/lock_table.rs
@@ -59,7 +59,13 @@ fn bench_point_check(c: &mut Criterion) {
             thread_rng().fill_bytes(&mut buf[..]);
             let key = Key::from_raw(&buf);
             let _ = cm.read_key_check(&key, |l| {
-                Lock::check_ts_conflict(Cow::Borrowed(l), &key, 1.into(), &ts_set)
+                Lock::check_ts_conflict(
+                    Cow::Borrowed(l),
+                    &key,
+                    1.into(),
+                    &ts_set,
+                    IsolationLevel::Si,
+                )
             });
         })
     });
@@ -85,7 +91,13 @@ fn bench_range_check(c: &mut Criterion) {
             let end_key = Key::from_raw(&[start + 25]);
             // The key range is roughly 1/10 the key space.
             let _ = cm.read_range_check(Some(&start_key), Some(&end_key), |key, l| {
-                Lock::check_ts_conflict(Cow::Borrowed(l), key, 1.into(), &ts_set)
+                Lock::check_ts_conflict(
+                    Cow::Borrowed(l),
+                    key,
+                    1.into(),
+                    &ts_set,
+                    IsolationLevel::Si,
+                )
             });
         })
     });

--- a/components/concurrency_manager/benches/lock_table.rs
+++ b/components/concurrency_manager/benches/lock_table.rs
@@ -6,6 +6,7 @@
 use concurrency_manager::ConcurrencyManager;
 use criterion::*;
 use futures::executor::block_on;
+use kvproto::kvrpcpb::IsolationLevel;
 use rand::prelude::*;
 use std::{borrow::Cow, hint::black_box, mem::forget};
 use txn_types::{Key, Lock, LockType, TsSet};

--- a/components/txn_types/src/lock.rs
+++ b/components/txn_types/src/lock.rs
@@ -4,7 +4,7 @@ use crate::timestamp::{TimeStamp, TsSet};
 use crate::types::{Key, Mutation, Value, SHORT_VALUE_PREFIX};
 use crate::{Error, ErrorInner, Result};
 use byteorder::ReadBytesExt;
-use kvproto::kvrpcpb::{LockInfo, Op};
+use kvproto::kvrpcpb::{IsolationLevel, LockInfo, Op};
 use std::{borrow::Cow, mem::size_of};
 use tikv_util::codec::bytes::{self, BytesEncoder};
 use tikv_util::codec::number::{self, NumberEncoder, MAX_VAR_I64_LEN, MAX_VAR_U64_LEN};
@@ -326,7 +326,7 @@ impl Lock {
     }
 
     /// Checks whether the lock conflicts with the given `ts`. If `ts == TimeStamp::max()`, the primary lock will be ignored.
-    pub fn check_ts_conflict(
+    fn check_ts_conflict_si(
         lock: Cow<'_, Self>,
         key: &Key,
         ts: TimeStamp,
@@ -361,6 +361,49 @@ impl Lock {
         Err(Error::from(ErrorInner::KeyIsLocked(
             lock.into_owned().into_lock_info(raw_key),
         )))
+    }
+
+    // Check if lock could be bypassed for isolation level `RcCheckTs`.
+    fn check_ts_conflict_rc_read(
+        lock: Cow<'_, Self>,
+        key: &Key,
+        ts: TimeStamp,
+        bypass_locks: &TsSet,
+    ) -> Result<()> {
+        if lock.lock_type == LockType::Lock || lock.lock_type == LockType::Pessimistic {
+            // Ignore lock when the lock's type is Lock or Pessimistic.
+            return Ok(());
+        }
+
+        // The lock is resolved already.
+        if bypass_locks.contains(lock.ts) {
+            return Ok(());
+        }
+
+        // Return conflict error.
+        Err(Error::from(ErrorInner::WriteConflict {
+            start_ts: ts,
+            conflict_start_ts: lock.ts,
+            conflict_commit_ts: Default::default(),
+            key: key.to_raw()?,
+            primary: lock.primary.to_vec(),
+        }))
+    }
+
+    pub fn check_ts_conflict(
+        lock: Cow<'_, Self>,
+        key: &Key,
+        ts: TimeStamp,
+        bypass_locks: &TsSet,
+        iso_level: kvproto::kvrpcpb::IsolationLevel,
+    ) -> Result<()> {
+        match iso_level {
+            IsolationLevel::Si => Lock::check_ts_conflict_si(lock, key, ts, bypass_locks),
+            IsolationLevel::RcCheckTs => {
+                Lock::check_ts_conflict_rc_read(lock, key, ts, bypass_locks)
+            }
+            _ => Ok(()),
+        }
     }
 
     pub fn is_pessimistic_txn(&self) -> bool {
@@ -681,10 +724,24 @@ mod tests {
         let empty = Default::default();
 
         // Ignore the lock if read ts is less than the lock version
-        Lock::check_ts_conflict(Cow::Borrowed(&lock), &key, 50.into(), &empty).unwrap();
+        Lock::check_ts_conflict(
+            Cow::Borrowed(&lock),
+            &key,
+            50.into(),
+            &empty,
+            IsolationLevel::Si,
+        )
+        .unwrap();
 
         // Returns the lock if read ts >= lock version
-        Lock::check_ts_conflict(Cow::Borrowed(&lock), &key, 110.into(), &empty).unwrap_err();
+        Lock::check_ts_conflict(
+            Cow::Borrowed(&lock),
+            &key,
+            110.into(),
+            &empty,
+            IsolationLevel::Si,
+        )
+        .unwrap_err();
 
         // Ignore locks that occurs in the `bypass_locks` set.
         Lock::check_ts_conflict(
@@ -692,6 +749,7 @@ mod tests {
             &key,
             110.into(),
             &TsSet::from_u64s(vec![109]),
+            IsolationLevel::Si,
         )
         .unwrap_err();
         Lock::check_ts_conflict(
@@ -699,6 +757,7 @@ mod tests {
             &key,
             110.into(),
             &TsSet::from_u64s(vec![110]),
+            IsolationLevel::Si,
         )
         .unwrap_err();
         Lock::check_ts_conflict(
@@ -706,6 +765,7 @@ mod tests {
             &key,
             110.into(),
             &TsSet::from_u64s(vec![100]),
+            IsolationLevel::Si,
         )
         .unwrap();
         Lock::check_ts_conflict(
@@ -713,14 +773,29 @@ mod tests {
             &key,
             110.into(),
             &TsSet::from_u64s(vec![99, 101, 102, 100, 80]),
+            IsolationLevel::Si,
         )
         .unwrap();
 
         // Ignore the lock if it is Lock or Pessimistic.
         lock.lock_type = LockType::Lock;
-        Lock::check_ts_conflict(Cow::Borrowed(&lock), &key, 110.into(), &empty).unwrap();
+        Lock::check_ts_conflict(
+            Cow::Borrowed(&lock),
+            &key,
+            110.into(),
+            &empty,
+            IsolationLevel::Si,
+        )
+        .unwrap();
         lock.lock_type = LockType::Pessimistic;
-        Lock::check_ts_conflict(Cow::Borrowed(&lock), &key, 110.into(), &empty).unwrap();
+        Lock::check_ts_conflict(
+            Cow::Borrowed(&lock),
+            &key,
+            110.into(),
+            &empty,
+            IsolationLevel::Si,
+        )
+        .unwrap();
 
         // Ignore the primary lock when reading the latest committed version by setting u64::MAX as ts
         lock.lock_type = LockType::Put;
@@ -734,18 +809,47 @@ mod tests {
             &key,
             TimeStamp::max(),
             &empty,
+            IsolationLevel::Si,
         )
         .unwrap_err();
 
         // Should not ignore the secondary lock even though reading the latest version
         lock.primary = b"bar".to_vec();
-        Lock::check_ts_conflict(Cow::Borrowed(&lock), &key, TimeStamp::max(), &empty).unwrap_err();
+        Lock::check_ts_conflict(
+            Cow::Borrowed(&lock),
+            &key,
+            TimeStamp::max(),
+            &empty,
+            IsolationLevel::Si,
+        )
+        .unwrap_err();
 
         // Ignore the lock if read ts is less than min_commit_ts
         lock.min_commit_ts = 150.into();
-        Lock::check_ts_conflict(Cow::Borrowed(&lock), &key, 140.into(), &empty).unwrap();
-        Lock::check_ts_conflict(Cow::Borrowed(&lock), &key, 150.into(), &empty).unwrap_err();
-        Lock::check_ts_conflict(Cow::Borrowed(&lock), &key, 160.into(), &empty).unwrap_err();
+        Lock::check_ts_conflict(
+            Cow::Borrowed(&lock),
+            &key,
+            140.into(),
+            &empty,
+            IsolationLevel::Si,
+        )
+        .unwrap();
+        Lock::check_ts_conflict(
+            Cow::Borrowed(&lock),
+            &key,
+            150.into(),
+            &empty,
+            IsolationLevel::Si,
+        )
+        .unwrap_err();
+        Lock::check_ts_conflict(
+            Cow::Borrowed(&lock),
+            &key,
+            160.into(),
+            &empty,
+            IsolationLevel::Si,
+        )
+        .unwrap_err();
     }
 
     #[test]

--- a/components/txn_types/src/lock.rs
+++ b/components/txn_types/src/lock.rs
@@ -364,7 +364,7 @@ impl Lock {
     }
 
     // Check if lock could be bypassed for isolation level `RcCheckTs`.
-    fn check_ts_conflict_rc_read(
+    fn check_ts_conflict_rc_check_ts(
         lock: Cow<'_, Self>,
         key: &Key,
         ts: TimeStamp,
@@ -400,7 +400,7 @@ impl Lock {
         match iso_level {
             IsolationLevel::Si => Lock::check_ts_conflict_si(lock, key, ts, bypass_locks),
             IsolationLevel::RcCheckTs => {
-                Lock::check_ts_conflict_rc_read(lock, key, ts, bypass_locks)
+                Lock::check_ts_conflict_rc_check_ts(lock, key, ts, bypass_locks)
             }
             _ => Ok(()),
         }

--- a/components/txn_types/src/lock.rs
+++ b/components/txn_types/src/lock.rs
@@ -800,7 +800,14 @@ mod tests {
         // Ignore the primary lock when reading the latest committed version by setting u64::MAX as ts
         lock.lock_type = LockType::Put;
         lock.primary = b"foo".to_vec();
-        Lock::check_ts_conflict(Cow::Borrowed(&lock), &key, TimeStamp::max(), &empty).unwrap();
+        Lock::check_ts_conflict(
+            Cow::Borrowed(&lock),
+            &key,
+            TimeStamp::max(),
+            &empty,
+            IsolationLevel::Si,
+        )
+        .unwrap();
 
         // Should not ignore the primary lock of an async commit transaction even if setting u64::MAX as ts
         let async_commit_lock = lock.clone().use_async_commit(vec![]);

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -11,8 +11,7 @@ use futures::prelude::*;
 use tidb_query_common::execute_stats::ExecSummary;
 use tokio::sync::Semaphore;
 
-use kvproto::kvrpcpb::{self};
-use kvproto::{coprocessor as coppb, errorpb};
+use kvproto::{coprocessor as coppb, errorpb, kvrpcpb};
 use protobuf::CodedInputStream;
 use protobuf::Message;
 use tikv_kv::SnapshotExt;

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -666,6 +666,7 @@ mod tests {
     use std::vec;
 
     use futures::executor::{block_on, block_on_stream};
+    use kvproto::kvrpcpb::IsolationLevel;
 
     use tipb::Executor;
     use tipb::Expr;

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -112,31 +112,35 @@ impl<E: Engine> Endpoint<E> {
         if !req_ctx.context.get_stale_read() {
             self.concurrency_manager.update_max_ts(start_ts);
         }
-        if req_ctx.context.get_isolation_level() == IsolationLevel::Si {
-            let begin_instant = Instant::now();
-            for range in &req_ctx.ranges {
-                let start_key = txn_types::Key::from_raw_maybe_unbounded(range.get_start());
-                let end_key = txn_types::Key::from_raw_maybe_unbounded(range.get_end());
-                self.concurrency_manager
-                    .read_range_check(start_key.as_ref(), end_key.as_ref(), |key, lock| {
-                        Lock::check_ts_conflict(
-                            Cow::Borrowed(lock),
-                            key,
-                            start_ts,
-                            &req_ctx.bypass_locks,
-                        )
-                    })
-                    .map_err(|e| {
-                        MEM_LOCK_CHECK_HISTOGRAM_VEC_STATIC
-                            .locked
-                            .observe(begin_instant.saturating_elapsed().as_secs_f64());
-                        MvccError::from(e)
-                    })?;
+        match req_ctx.context.get_isolation_level() {
+            IsolationLevel::Si | IsolationLevel::RcCheckTs => {
+                let begin_instant = Instant::now();
+                for range in &req_ctx.ranges {
+                    let start_key = txn_types::Key::from_raw_maybe_unbounded(range.get_start());
+                    let end_key = txn_types::Key::from_raw_maybe_unbounded(range.get_end());
+                    self.concurrency_manager
+                        .read_range_check(start_key.as_ref(), end_key.as_ref(), |key, lock| {
+                            Lock::check_ts_conflict(
+                                Cow::Borrowed(lock),
+                                key,
+                                start_ts,
+                                &req_ctx.bypass_locks,
+                                IsolationLevel::Si,
+                            )
+                        })
+                        .map_err(|e| {
+                            MEM_LOCK_CHECK_HISTOGRAM_VEC_STATIC
+                                .locked
+                                .observe(begin_instant.saturating_elapsed().as_secs_f64());
+                            MvccError::from(e)
+                        })?;
+                }
+                MEM_LOCK_CHECK_HISTOGRAM_VEC_STATIC
+                    .unlocked
+                    .observe(begin_instant.saturating_elapsed().as_secs_f64());
             }
-            MEM_LOCK_CHECK_HISTOGRAM_VEC_STATIC
-                .unlocked
-                .observe(begin_instant.saturating_elapsed().as_secs_f64());
-        }
+            IsolationLevel::Rc => {}
+        };
         Ok(())
     }
 

--- a/src/server/raftkv.rs
+++ b/src/server/raftkv.rs
@@ -21,6 +21,7 @@ use engine_traits::{CfName, KvEngine, MvccProperties, Snapshot, CF_DEFAULT, CF_L
 use kvproto::{
     errorpb,
     kvrpcpb::Context,
+    kvrpcpb::IsolationLevel,
     metapb,
     raft_cmdpb::{
         CmdType, DeleteRangeRequest, DeleteRequest, PutRequest, RaftCmdRequest, RaftCmdResponse,
@@ -541,6 +542,7 @@ impl ReadIndexObserver for ReplicaReadLockChecker {
                             key,
                             start_ts,
                             &Default::default(),
+                            IsolationLevel::Si,
                         )
                     },
                 );

--- a/src/server/raftkv.rs
+++ b/src/server/raftkv.rs
@@ -533,6 +533,9 @@ impl ReadIndexObserver for ReplicaReadLockChecker {
                 };
                 let start_key = key_bound(range.take_start_key());
                 let end_key = key_bound(range.take_end_key());
+                // The replica read is not compatible with `RcCheckTs` isolation level yet.
+                // It's ensured in the tidb side when `RcCheckTs` is enabled for read requests,
+                // the replica read would not be enabled at the same time.
                 let res = self.concurrency_manager.read_range_check(
                     start_key.as_ref(),
                     end_key.as_ref(),

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1024,10 +1024,7 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
                 if !ctx.get_stale_read() {
                     concurrency_manager.update_max_ts(start_ts);
                 }
-                if matches!(
-                    ctx.get_isolation_level(),
-                    IsolationLevel::Si | IsolationLevel::RcCheckTs
-                ) {
+                if need_check_locks(ctx.get_isolation_level()) {
                     let begin_instant = Instant::now();
                     concurrency_manager
                         .read_range_check(start_key.as_ref(), end_key.as_ref(), |key, lock| {
@@ -2398,10 +2395,7 @@ fn prepare_snap_ctx<'a>(
     }
     fail_point!("before-storage-check-memory-locks");
     let isolation_level = pb_ctx.get_isolation_level();
-    if matches!(
-        isolation_level,
-        IsolationLevel::Si | IsolationLevel::RcCheckTs
-    ) {
+    if need_check_locks(isolation_level) {
         let begin_instant = Instant::now();
         for key in keys.clone() {
             concurrency_manager
@@ -2446,6 +2440,11 @@ fn prepare_snap_ctx<'a>(
 
 pub fn need_check_locks_in_replica_read(ctx: &Context) -> bool {
     ctx.get_replica_read() && ctx.get_isolation_level() == IsolationLevel::Si
+}
+
+// checks whether the current isolation level needs to check related locks.
+pub fn need_check_locks(iso_level: IsolationLevel) -> bool {
+    matches!(iso_level, IsolationLevel::Si | IsolationLevel::RcCheckTs)
 }
 
 pub fn point_key_range(key: Key) -> KeyRange {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -2395,7 +2395,10 @@ fn prepare_snap_ctx<'a>(
     }
     fail_point!("before-storage-check-memory-locks");
     let isolation_level = pb_ctx.get_isolation_level();
-    if isolation_level == IsolationLevel::Si {
+    if matches!(
+        isolation_level,
+        IsolationLevel::Si | IsolationLevel::RcCheckTs
+    ) {
         let begin_instant = Instant::now();
         for key in keys.clone() {
             concurrency_manager

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1033,6 +1033,7 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
                                 key,
                                 start_ts,
                                 &bypass_locks,
+                                ctx.get_isolation_level(),
                             )
                         })
                         .map_err(|e| {
@@ -2401,7 +2402,13 @@ fn prepare_snap_ctx<'a>(
                 .read_key_check(key, |lock| {
                     // No need to check access_locks because they are committed which means they
                     // can't be in memory lock table.
-                    Lock::check_ts_conflict(Cow::Borrowed(lock), key, start_ts, bypass_locks)
+                    Lock::check_ts_conflict(
+                        Cow::Borrowed(lock),
+                        key,
+                        start_ts,
+                        bypass_locks,
+                        isolation_level,
+                    )
                 })
                 .map_err(|e| {
                     CHECK_MEM_LOCK_DURATION_HISTOGRAM_VEC

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1024,7 +1024,10 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
                 if !ctx.get_stale_read() {
                     concurrency_manager.update_max_ts(start_ts);
                 }
-                if ctx.get_isolation_level() == IsolationLevel::Si {
+                if matches!(
+                    ctx.get_isolation_level(),
+                    IsolationLevel::Si | IsolationLevel::RcCheckTs
+                ) {
                     let begin_instant = Instant::now();
                     concurrency_manager
                         .read_range_check(start_key.as_ref(), end_key.as_ref(), |key, lock| {

--- a/src/storage/mvcc/reader/point_getter.rs
+++ b/src/storage/mvcc/reader/point_getter.rs
@@ -8,6 +8,7 @@ use std::borrow::Cow;
 use txn_types::{Key, Lock, LockType, TimeStamp, TsSet, Value, WriteRef, WriteType};
 
 use crate::storage::kv::{Cursor, CursorBuilder, ScanMode, Snapshot, Statistics};
+use crate::storage::mvcc::ErrorInner::WriteConflict;
 use crate::storage::mvcc::{default_not_found_error, NewerTsCheckState, Result};
 
 /// `PointGetter` factory.
@@ -200,16 +201,13 @@ impl<S: Snapshot> PointGetter<S> {
         }
 
         match self.isolation_level {
-            IsolationLevel::Si => {
-                // Check for locks that signal concurrent writes in Si.
+            IsolationLevel::Si | IsolationLevel::RcCheckTs => {
+                // Check locks that signal concurrent writes for `Si` or more recent writes for `RcCheckTs`.
                 if let Some(lock) = self.load_and_check_lock(user_key)? {
                     return self.load_data_from_lock(user_key, lock);
                 }
             }
             IsolationLevel::Rc => {}
-            IsolationLevel::RcCheckTs => {
-                return Err(box_err!("RcCheckTs is not supported"));
-            }
         }
 
         self.load_data(user_key)
@@ -231,9 +229,13 @@ impl<S: Snapshot> PointGetter<S> {
             if self.met_newer_ts_data == NewerTsCheckState::NotMetYet {
                 self.met_newer_ts_data = NewerTsCheckState::Met;
             }
-            if let Err(e) =
-                Lock::check_ts_conflict(Cow::Borrowed(&lock), user_key, self.ts, &self.bypass_locks)
-            {
+            if let Err(e) = Lock::check_ts_conflict(
+                Cow::Borrowed(&lock),
+                user_key,
+                self.ts,
+                &self.bypass_locks,
+                self.isolation_level,
+            ) {
                 self.statistics.lock.processed_keys += 1;
                 if self.access_locks.contains(lock.ts) {
                     return Ok(Some(lock));
@@ -255,7 +257,9 @@ impl<S: Snapshot> PointGetter<S> {
         let mut use_near_seek = false;
         let mut seek_key = user_key.clone();
 
-        if self.met_newer_ts_data == NewerTsCheckState::NotMetYet {
+        if self.met_newer_ts_data == NewerTsCheckState::NotMetYet
+            || self.isolation_level == IsolationLevel::RcCheckTs
+        {
             seek_key = seek_key.append_ts(TimeStamp::max());
             if !self
                 .write_cursor
@@ -268,8 +272,23 @@ impl<S: Snapshot> PointGetter<S> {
 
             let cursor_key = self.write_cursor.key(&mut self.statistics.write);
             // No need to compare user key because it uses prefix seek.
-            if Key::decode_ts_from(cursor_key)? > self.ts {
-                self.met_newer_ts_data = NewerTsCheckState::Met;
+            let key_commit_ts = Key::decode_ts_from(cursor_key)?;
+            if key_commit_ts > self.ts {
+                if self.met_newer_ts_data == NewerTsCheckState::NotMetYet {
+                    self.met_newer_ts_data = NewerTsCheckState::Met;
+                }
+                if self.isolation_level == IsolationLevel::RcCheckTs {
+                    // TODO: the more write recent version with `LOCK` or `ROLLBACK` write type
+                    //       could be skipped.
+                    return Err(WriteConflict {
+                        start_ts: self.ts,
+                        conflict_start_ts: Default::default(),
+                        conflict_commit_ts: key_commit_ts,
+                        key: cursor_key.into(),
+                        primary: vec![],
+                    }
+                    .into());
+                }
             }
         }
 
@@ -414,17 +433,33 @@ mod tests {
     use kvproto::kvrpcpb::{Assertion, AssertionLevel};
 
     fn new_multi_point_getter<E: Engine>(engine: &E, ts: TimeStamp) -> PointGetter<E::Snap> {
+        new_multi_point_getter_with_iso(engine, ts, IsolationLevel::Si)
+    }
+
+    fn new_multi_point_getter_with_iso<E: Engine>(
+        engine: &E,
+        ts: TimeStamp,
+        iso_level: IsolationLevel,
+    ) -> PointGetter<E::Snap> {
         let snapshot = engine.snapshot(Default::default()).unwrap();
         PointGetterBuilder::new(snapshot, ts)
-            .isolation_level(IsolationLevel::Si)
+            .isolation_level(iso_level)
             .build()
             .unwrap()
     }
 
     fn new_single_point_getter<E: Engine>(engine: &E, ts: TimeStamp) -> PointGetter<E::Snap> {
+        new_single_point_getter_with_iso(engine, ts, IsolationLevel::Si)
+    }
+
+    fn new_single_point_getter_with_iso<E: Engine>(
+        engine: &E,
+        ts: TimeStamp,
+        iso_level: IsolationLevel,
+    ) -> PointGetter<E::Snap> {
         let snapshot = engine.snapshot(Default::default()).unwrap();
         PointGetterBuilder::new(snapshot, ts)
-            .isolation_level(IsolationLevel::Si)
+            .isolation_level(iso_level)
             .multi(false)
             .build()
             .unwrap()
@@ -1233,5 +1268,81 @@ mod tests {
             let value = multi_getter.get(&Key::from_raw(*k)).unwrap();
             assert_eq!(value, v.map(|v| v.to_vec()));
         }
+    }
+
+    #[test]
+    fn test_point_get_check_rc_ts() {
+        let engine = TestEngineBuilder::new().build().unwrap();
+
+        let (key0, val0) = (b"k0", b"v0");
+        must_prewrite_put(&engine, key0, val0, key0, 1);
+        must_commit(&engine, key0, 1, 5);
+
+        let (key1, val1) = (b"k1", b"v1");
+        must_prewrite_put(&engine, key1, val1, key1, 10);
+        must_commit(&engine, key1, 10, 20);
+
+        let (key2, val2, val22) = (b"k2", b"v2", b"v22");
+        must_prewrite_put(&engine, key2, val2, key2, 30);
+        must_commit(&engine, key2, 30, 40);
+        must_prewrite_put(&engine, key2, val22, key2, 41);
+        must_commit(&engine, key2, 41, 42);
+
+        let (key3, val3) = (b"k3", b"v3");
+        must_prewrite_put(&engine, key3, val3, key3, 50);
+
+        let (key4, val4) = (b"k4", b"val4");
+        must_prewrite_put(&engine, key4, val4, key4, 55);
+        must_commit(&engine, key4, 55, 56);
+        must_prewrite_lock(&engine, key4, key4, 60);
+
+        let (key5, val5) = (b"k5", b"val5");
+        must_prewrite_put(&engine, key5, val5, key5, 57);
+        must_commit(&engine, key5, 57, 58);
+        must_acquire_pessimistic_lock(&engine, key5, key5, 65, 65);
+
+        // No more recent version.
+        let mut getter_with_ts_ok =
+            new_single_point_getter_with_iso(&engine, 25.into(), IsolationLevel::RcCheckTs);
+        must_get_value(&mut getter_with_ts_ok, key1, val1);
+
+        // The read_ts is stale error should be reported.
+        let mut getter_not_ok =
+            new_single_point_getter_with_iso(&engine, 35.into(), IsolationLevel::RcCheckTs);
+        must_get_err(&mut getter_not_ok, key2);
+
+        // Though lock.ts > read_ts error should still be reported.
+        let mut getter_not_ok =
+            new_single_point_getter_with_iso(&engine, 45.into(), IsolationLevel::RcCheckTs);
+        must_get_err(&mut getter_not_ok, key3);
+
+        // Error should not be reported if the lock type is rollback or lock.
+        let mut getter_ok =
+            new_single_point_getter_with_iso(&engine, 70.into(), IsolationLevel::RcCheckTs);
+        must_get_value(&mut getter_ok, key4, val4);
+        let mut getter_ok =
+            new_single_point_getter_with_iso(&engine, 70.into(), IsolationLevel::RcCheckTs);
+        must_get_value(&mut getter_ok, key5, val5);
+
+        // Test batch point get. Report error if more recent version is met.
+        let mut batch_getter =
+            new_multi_point_getter_with_iso(&engine, 35.into(), IsolationLevel::RcCheckTs);
+        must_get_value(&mut batch_getter, key0, val0);
+        must_get_value(&mut batch_getter, key1, val1);
+        must_get_err(&mut batch_getter, key2);
+
+        // Test batch point get. Report error if lock is met though lock.ts > read_ts.
+        let mut batch_getter =
+            new_multi_point_getter_with_iso(&engine, 45.into(), IsolationLevel::RcCheckTs);
+        must_get_value(&mut batch_getter, key0, val0);
+        must_get_value(&mut batch_getter, key1, val1);
+        must_get_value(&mut batch_getter, key2, val22);
+        must_get_err(&mut batch_getter, key3);
+
+        // Test batch point get. Error should not be reported if the lock type is rollback or lock.
+        let mut batch_getter_ok =
+            new_multi_point_getter_with_iso(&engine, 70.into(), IsolationLevel::RcCheckTs);
+        must_get_value(&mut batch_getter_ok, key4, val4);
+        must_get_value(&mut batch_getter_ok, key5, val5);
     }
 }

--- a/src/storage/mvcc/reader/scanner/backward.rs
+++ b/src/storage/mvcc/reader/scanner/backward.rs
@@ -9,6 +9,7 @@ use txn_types::{Key, Lock, TimeStamp, Value, Write, WriteRef, WriteType};
 
 use super::ScannerConfig;
 use crate::storage::kv::{Cursor, Snapshot, Statistics, SEEK_BOUND};
+use crate::storage::mvcc::ErrorInner::WriteConflict;
 use crate::storage::mvcc::{Error, NewerTsCheckState, Result};
 
 // When there are many versions for the user key, after several tries,
@@ -153,7 +154,7 @@ impl<S: Snapshot> BackwardKvScanner<S> {
 
             if has_lock {
                 match self.cfg.isolation_level {
-                    IsolationLevel::Si => {
+                    IsolationLevel::Si | IsolationLevel::RcCheckTs => {
                         let lock = {
                             let lock_value = self
                                 .lock_cursor
@@ -170,6 +171,7 @@ impl<S: Snapshot> BackwardKvScanner<S> {
                             &current_user_key,
                             ts,
                             &self.cfg.bypass_locks,
+                            self.cfg.isolation_level,
                         )
                         .map(|_| None)
                         .map_err(Into::into);
@@ -193,9 +195,6 @@ impl<S: Snapshot> BackwardKvScanner<S> {
                         }
                     }
                     IsolationLevel::Rc => {}
-                    IsolationLevel::RcCheckTs => {
-                        return Err(box_err!("RcCheckTs is not supported"));
-                    }
                 }
                 if let Some(lock_cursor) = self.lock_cursor.as_mut() {
                     lock_cursor.prev(&mut self.statistics.lock);
@@ -265,6 +264,18 @@ impl<S: Snapshot> BackwardKvScanner<S> {
                     is_done = true;
                     if self.met_newer_ts_data == NewerTsCheckState::NotMetYet {
                         self.met_newer_ts_data = NewerTsCheckState::Met;
+                    }
+                    if self.cfg.isolation_level == IsolationLevel::RcCheckTs {
+                        // TODO: the more write recent version with `LOCK` or `ROLLBACK` write type
+                        //       could be skipped.
+                        return Err(WriteConflict {
+                            start_ts: self.cfg.ts,
+                            conflict_start_ts: Default::default(),
+                            conflict_commit_ts: last_checked_commit_ts,
+                            key: current_key.into(),
+                            primary: vec![],
+                        }
+                        .into());
                     }
                 }
             }
@@ -480,7 +491,8 @@ mod tests {
     use crate::storage::kv::{Engine, Modify, TestEngineBuilder};
     use crate::storage::mvcc::tests::write;
     use crate::storage::txn::tests::{
-        must_commit, must_gc, must_prewrite_delete, must_prewrite_put, must_rollback,
+        must_acquire_pessimistic_lock, must_commit, must_gc, must_prewrite_delete,
+        must_prewrite_lock, must_prewrite_put, must_rollback,
     };
     use crate::storage::Scanner;
     use engine_traits::{CF_LOCK, CF_WRITE};
@@ -1419,5 +1431,94 @@ mod tests {
             .map(|result| result.unwrap())
             .collect();
         assert_eq!(result, expected_result);
+    }
+
+    #[test]
+    fn test_rc_read_check_ts() {
+        let engine = TestEngineBuilder::new().build().unwrap();
+
+        let (key0, val0) = (b"k0", b"v0");
+        must_prewrite_put(&engine, key0, val0, key0, 60);
+
+        let (key1, val1) = (b"k1", b"v1");
+        must_prewrite_put(&engine, key1, val1, key1, 25);
+        must_commit(&engine, key1, 25, 30);
+
+        let (key2, val2, val22) = (b"k2", b"v2", b"v22");
+        must_prewrite_put(&engine, key2, val2, key2, 6);
+        must_commit(&engine, key2, 6, 9);
+        must_prewrite_put(&engine, key2, val22, key2, 10);
+        must_commit(&engine, key2, 10, 20);
+
+        let (key3, val3) = (b"k3", b"v3");
+        must_prewrite_put(&engine, key3, val3, key3, 5);
+        must_commit(&engine, key3, 5, 6);
+
+        let (key4, val4) = (b"k4", b"val4");
+        must_prewrite_put(&engine, key4, val4, key4, 3);
+        must_commit(&engine, key4, 3, 4);
+        must_prewrite_lock(&engine, key4, key4, 5);
+
+        let (key5, val5) = (b"k5", b"val5");
+        must_prewrite_put(&engine, key5, val5, key5, 1);
+        must_commit(&engine, key5, 1, 2);
+        must_acquire_pessimistic_lock(&engine, key5, key5, 3, 3);
+
+        let snapshot = engine.snapshot(Default::default()).unwrap();
+        let mut scanner = ScannerBuilder::new(snapshot, 29.into())
+            .range(None, None)
+            .desc(true)
+            .isolation_level(IsolationLevel::RcCheckTs)
+            .build()
+            .unwrap();
+
+        // Scanner has met a more recent version.
+        assert_eq!(
+            scanner.next().unwrap(),
+            Some((Key::from_raw(key5), val5.to_vec()))
+        );
+        assert_eq!(
+            scanner.next().unwrap(),
+            Some((Key::from_raw(key4), val4.to_vec()))
+        );
+        assert_eq!(
+            scanner.next().unwrap(),
+            Some((Key::from_raw(key3), val3.to_vec()))
+        );
+        assert_eq!(
+            scanner.next().unwrap(),
+            Some((Key::from_raw(key2), val22.to_vec()))
+        );
+        assert!(scanner.next().is_err());
+
+        // Scanner has met a lock though lock.ts > read_ts.
+        let snapshot = engine.snapshot(Default::default()).unwrap();
+        let mut scanner = ScannerBuilder::new(snapshot, 55.into())
+            .range(None, None)
+            .desc(true)
+            .isolation_level(IsolationLevel::RcCheckTs)
+            .build()
+            .unwrap();
+        assert_eq!(
+            scanner.next().unwrap(),
+            Some((Key::from_raw(key5), val5.to_vec()))
+        );
+        assert_eq!(
+            scanner.next().unwrap(),
+            Some((Key::from_raw(key4), val4.to_vec()))
+        );
+        assert_eq!(
+            scanner.next().unwrap(),
+            Some((Key::from_raw(key3), val3.to_vec()))
+        );
+        assert_eq!(
+            scanner.next().unwrap(),
+            Some((Key::from_raw(key2), val22.to_vec()))
+        );
+        assert_eq!(
+            scanner.next().unwrap(),
+            Some((Key::from_raw(key1), val1.to_vec()))
+        );
+        assert!(scanner.next().is_err());
     }
 }

--- a/src/storage/mvcc/reader/scanner/forward.rs
+++ b/src/storage/mvcc/reader/scanner/forward.rs
@@ -9,6 +9,7 @@ use txn_types::{Key, Lock, LockType, OldValue, TimeStamp, Value, WriteRef, Write
 
 use super::ScannerConfig;
 use crate::storage::kv::SEEK_BOUND;
+use crate::storage::mvcc::ErrorInner::WriteConflict;
 use crate::storage::mvcc::{NewerTsCheckState, Result};
 use crate::storage::txn::{Result as TxnResult, TxnEntry, TxnEntryScanner};
 use crate::storage::{Cursor, Snapshot, Statistics};
@@ -328,12 +329,27 @@ impl<S: Snapshot, P: ScanPolicy<S>> ForwardScanner<S, P> {
                     // Meet another key.
                     return Ok(false);
                 }
-                if Key::decode_ts_from(current_key)? <= self.cfg.ts {
+                let key_commit_ts = Key::decode_ts_from(current_key)?;
+                if key_commit_ts <= self.cfg.ts {
                     // Founded, don't need to seek again.
                     needs_seek = false;
                     break;
                 } else if self.met_newer_ts_data == NewerTsCheckState::NotMetYet {
                     self.met_newer_ts_data = NewerTsCheckState::Met;
+                }
+
+                // Report error if there's a more recent version if the isolation level is RcCheckTs.
+                if self.cfg.isolation_level == IsolationLevel::RcCheckTs {
+                    // TODO: the more write recent version with `LOCK` or `ROLLBACK` write type
+                    //       could be skipped.
+                    return Err(WriteConflict {
+                        start_ts: self.cfg.ts,
+                        conflict_start_ts: Default::default(),
+                        conflict_commit_ts: key_commit_ts,
+                        key: current_key.into(),
+                        primary: vec![],
+                    }
+                    .into());
                 }
             }
         }
@@ -387,6 +403,7 @@ impl<S: Snapshot> ScanPolicy<S> for LatestKvPolicy {
             &current_user_key,
             cfg.ts,
             &cfg.bypass_locks,
+            cfg.isolation_level,
         ) {
             statistics.lock.processed_keys += 1;
             // Skip current_user_key because this key is either blocked or handled.
@@ -617,6 +634,7 @@ fn scan_latest_handle_lock<S: Snapshot, T>(
         &current_user_key,
         cfg.ts,
         &cfg.bypass_locks,
+        cfg.isolation_level,
     )
     .or_else(|e| {
         // Even if there is a lock error, we still need to step the cursor for future
@@ -1466,6 +1484,93 @@ mod latest_kv_tests {
             .map(|result| result.unwrap())
             .collect();
         assert_eq!(result, expected_result);
+    }
+
+    #[test]
+    fn test_rc_read_check_ts() {
+        let engine = TestEngineBuilder::new().build().unwrap();
+
+        let (key0, val0) = (b"k0", b"v0");
+        must_prewrite_put(&engine, key0, val0, key0, 1);
+        must_commit(&engine, key0, 1, 5);
+
+        let (key1, val1) = (b"k1", b"v1");
+        must_prewrite_put(&engine, key1, val1, key1, 10);
+        must_commit(&engine, key1, 10, 20);
+
+        let (key2, val2, val22) = (b"k2", b"v2", b"v22");
+        must_prewrite_put(&engine, key2, val2, key2, 30);
+        must_commit(&engine, key2, 30, 40);
+        must_prewrite_put(&engine, key2, val22, key2, 41);
+        must_commit(&engine, key2, 41, 42);
+
+        let (key3, val3) = (b"k3", b"v3");
+        must_prewrite_put(&engine, key3, val3, key3, 50);
+        must_commit(&engine, key3, 50, 51);
+
+        let (key4, val4) = (b"k4", b"val4");
+        must_prewrite_put(&engine, key4, val4, key4, 55);
+        must_commit(&engine, key4, 55, 56);
+        must_prewrite_lock(&engine, key4, key4, 60);
+
+        let (key5, val5) = (b"k5", b"val5");
+        must_prewrite_put(&engine, key5, val5, key5, 57);
+        must_commit(&engine, key5, 57, 58);
+        must_acquire_pessimistic_lock(&engine, key5, key5, 65, 65);
+
+        let (key6, val6) = (b"k6", b"v6");
+        must_prewrite_put(&engine, key6, val6, key6, 75);
+
+        let snapshot = engine.snapshot(Default::default()).unwrap();
+        let mut scanner = ScannerBuilder::new(snapshot, 35.into())
+            .range(None, None)
+            .isolation_level(IsolationLevel::RcCheckTs)
+            .build()
+            .unwrap();
+
+        // Scanner has met a more recent version.
+        assert_eq!(
+            scanner.next().unwrap(),
+            Some((Key::from_raw(key0), val0.to_vec()))
+        );
+        assert_eq!(
+            scanner.next().unwrap(),
+            Some((Key::from_raw(key1), val1.to_vec()))
+        );
+        assert!(scanner.next().is_err());
+
+        // Scanner has met a lock though lock.ts > read_ts.
+        let snapshot = engine.snapshot(Default::default()).unwrap();
+        let mut scanner = ScannerBuilder::new(snapshot, 70.into())
+            .range(None, None)
+            .isolation_level(IsolationLevel::RcCheckTs)
+            .build()
+            .unwrap();
+        assert_eq!(
+            scanner.next().unwrap(),
+            Some((Key::from_raw(key0), val0.to_vec()))
+        );
+        assert_eq!(
+            scanner.next().unwrap(),
+            Some((Key::from_raw(key1), val1.to_vec()))
+        );
+        assert_eq!(
+            scanner.next().unwrap(),
+            Some((Key::from_raw(key2), val22.to_vec()))
+        );
+        assert_eq!(
+            scanner.next().unwrap(),
+            Some((Key::from_raw(key3), val3.to_vec()))
+        );
+        assert_eq!(
+            scanner.next().unwrap(),
+            Some((Key::from_raw(key4), val4.to_vec()))
+        );
+        assert_eq!(
+            scanner.next().unwrap(),
+            Some((Key::from_raw(key5), val5.to_vec()))
+        );
+        assert!(scanner.next().is_err());
     }
 }
 

--- a/src/storage/mvcc/reader/scanner/mod.rs
+++ b/src/storage/mvcc/reader/scanner/mod.rs
@@ -205,11 +205,10 @@ impl<S: Snapshot> ScannerBuilder<S> {
 
     fn build_lock_cursor(&mut self) -> Result<Option<Cursor<S::Iter>>> {
         Ok(match self.0.isolation_level {
-            IsolationLevel::Si => Some(self.0.create_cf_cursor(CF_LOCK)?),
-            IsolationLevel::Rc => None,
-            IsolationLevel::RcCheckTs => {
-                return Err(box_err!("RcCheckTs is not supported"));
+            IsolationLevel::Si | IsolationLevel::RcCheckTs => {
+                Some(self.0.create_cf_cursor(CF_LOCK)?)
             }
+            IsolationLevel::Rc => None,
         })
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how does it work?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->

Try to support read-consistency read processing with tso checking to optimize the latency.

Ref document: https://github.com/pingcap/tidb/pull/32806
Ref kvproto change: https://github.com/pingcap/kvproto/pull/876

What's Changed:
- If the isolation field in a read request is `RcCheckTs`,  return write conflict error directly to the client. The client may retry the whole SQL statement with a new `for_update_ts` fetched from global tso allocator if no data package has been responsed to the MySQL client.

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->


### Related changes



### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Support read-consistency read with tso checking.
```
