### PR TITLE
copr: extract reschedule to inject a fail point

### DIFF
--- a/components/tidb_query_executors/src/runner.rs
+++ b/components/tidb_query_executors/src/runner.rs
@@ -416,9 +416,8 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
 
         let mut time_slice_start = Instant::now();
         loop {
-            let time_slice_len = time_slice_start.saturating_elapsed();
             // Check whether we should yield from the execution
-            if time_slice_len > MAX_TIME_SLICE {
+            if need_reschedule(time_slice_start) {
                 reschedule().await;
                 time_slice_start = Instant::now();
             }
@@ -639,4 +638,10 @@ fn grow_batch_size(batch_size: &mut usize) {
             *batch_size = BATCH_MAX_SIZE
         }
     }
+}
+
+#[inline]
+fn need_reschedule(time_slice_start: Instant) -> bool {
+    fail_point!("copr_reschedule", |_| true);
+    time_slice_start.saturating_elapsed() > MAX_TIME_SLICE
 }


### PR DESCRIPTION
Signed-off-by: Zhenchi <zhongzc_arch@outlook.com>

### What is changed and how it works?

A tiny refactor to extract a function `reschedule` in order to inject a fail point.

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
