### PR TITLE
*: check memory locks for replica read only on the leader

### DIFF
--- a/components/raftstore/src/coprocessor/dispatcher.rs
+++ b/components/raftstore/src/coprocessor/dispatcher.rs
@@ -526,9 +526,9 @@ impl<E: KvEngine> CoprocessorHost<E> {
         }
     }
 
-    pub fn on_step_read_index(&self, msg: &mut eraftpb::Message) {
+    pub fn on_step_read_index(&self, msg: &mut eraftpb::Message, role: StateRole) {
         for step_ob in &self.registry.read_index_observers {
-            step_ob.observer.inner().on_step(msg);
+            step_ob.observer.inner().on_step(msg, role);
         }
     }
 

--- a/components/raftstore/src/coprocessor/mod.rs
+++ b/components/raftstore/src/coprocessor/mod.rs
@@ -346,7 +346,7 @@ pub trait CmdObserver<E>: Coprocessor {
 
 pub trait ReadIndexObserver: Coprocessor {
     // Hook to call when stepping in raft and the message is a read index message.
-    fn on_step(&self, _msg: &mut eraftpb::Message) {}
+    fn on_step(&self, _msg: &mut eraftpb::Message, _role: StateRole) {}
 }
 
 #[cfg(test)]

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -1335,7 +1335,8 @@ where
         let msg_type = m.get_msg_type();
         if msg_type == MessageType::MsgReadIndex {
             fail_point!("on_step_read_index_msg");
-            ctx.coprocessor_host.on_step_read_index(&mut m);
+            ctx.coprocessor_host
+                .on_step_read_index(&mut m, self.get_role());
             // Must use the commit index of `PeerStorage` instead of the commit index
             // in raft-rs which may be greater than the former one.
             // For more details, see the annotations above `on_leader_commit_idx_changed`.

--- a/src/server/raftkv.rs
+++ b/src/server/raftkv.rs
@@ -13,6 +13,7 @@ use std::{
 };
 
 use raft::eraftpb::{self, MessageType};
+use raft::StateRole;
 use thiserror::Error;
 
 use concurrency_manager::ConcurrencyManager;
@@ -508,8 +509,10 @@ impl ReplicaReadLockChecker {
 impl Coprocessor for ReplicaReadLockChecker {}
 
 impl ReadIndexObserver for ReplicaReadLockChecker {
-    fn on_step(&self, msg: &mut eraftpb::Message) {
-        if msg.get_msg_type() != MessageType::MsgReadIndex {
+    fn on_step(&self, msg: &mut eraftpb::Message, role: StateRole) {
+        // Only check and return result if the current peer is a leader.
+        // If it's not a leader, the read index request will be redirected to the leader later.
+        if msg.get_msg_type() != MessageType::MsgReadIndex || role != StateRole::Leader {
             return;
         }
         assert_eq!(msg.get_entries().len(), 1);
@@ -608,6 +611,7 @@ pub fn modifies_to_requests(modifies: Vec<Modify>) -> Vec<Request> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use kvproto::raft_cmdpb;
     use uuid::Uuid;
 
     // This test ensures `ReplicaReadLockChecker` won't change UUID context of read index.
@@ -622,7 +626,28 @@ mod tests {
         e.set_data(uuid.as_bytes().to_vec().into());
         m.mut_entries().push(e);
 
-        checker.on_step(&mut m);
+        checker.on_step(&mut m, StateRole::Leader);
         assert_eq!(m.get_entries()[0].get_data(), uuid.as_bytes());
+    }
+
+    #[test]
+    fn test_replica_read_lock_check_when_not_leader() {
+        let cm = ConcurrencyManager::new(1.into());
+        let checker = ReplicaReadLockChecker::new(cm);
+        let mut m = eraftpb::Message::default();
+        m.set_msg_type(MessageType::MsgReadIndex);
+        let mut request = raft_cmdpb::ReadIndexRequest::default();
+        request.set_start_ts(100);
+        let rctx = ReadIndexContext {
+            id: Uuid::new_v4(),
+            request: Some(request),
+            locked: None,
+        };
+        let mut e = eraftpb::Entry::default();
+        e.set_data(rctx.to_bytes().into());
+        m.mut_entries().push(e);
+
+        checker.on_step(&mut m, StateRole::Follower);
+        assert_eq!(m.get_entries()[0].get_data(), rctx.to_bytes());
     }
 }

--- a/tests/failpoints/cases/test_replica_read.rs
+++ b/tests/failpoints/cases/test_replica_read.rs
@@ -3,6 +3,7 @@
 use crossbeam::channel;
 use engine_rocks::{Compat, RocksEngine};
 use engine_traits::{Peekable, RaftEngineReadOnly, CF_RAFT};
+use futures::executor::block_on;
 use kvproto::raft_serverpb::{PeerState, RaftMessage, RegionLocalState};
 use raft::eraftpb::MessageType;
 use std::sync::atomic::AtomicBool;
@@ -10,7 +11,9 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 use test_raftstore::*;
+use tikv_util::config::ReadableDuration;
 use tikv_util::HandyRwLock;
+use txn_types::{Key, Lock, LockType};
 
 #[test]
 fn test_wait_for_apply_index() {
@@ -638,4 +641,152 @@ fn test_batch_read_index_after_transfer_leader() {
         // to the current term. So term of `read_index` must equal to the current one.
         assert_eq!(entry.get_term(), term);
     }
+}
+
+#[test]
+fn test_read_index_lock_checking_on_follower() {
+    let mut cluster = new_node_cluster(0, 3);
+
+    let pd_client = Arc::clone(&cluster.pd_client);
+    pd_client.disable_default_operator();
+
+    let rid = cluster.run_conf_change();
+    cluster.must_put(b"k1", b"v1");
+    pd_client.must_add_peer(rid, new_peer(2, 2));
+    must_get_equal(&cluster.get_engine(2), b"k1", b"v1");
+    pd_client.must_add_peer(rid, new_peer(3, 3));
+    must_get_equal(&cluster.get_engine(3), b"k1", b"v1");
+
+    cluster.must_transfer_leader(1, new_peer(1, 1));
+
+    // Pause read_index before transferring leader to peer 3. Then, the read index
+    // message will still be sent to the old leader peer 1.
+    fail::cfg("before_propose_readindex", "1*pause").unwrap();
+    let r1 = cluster.get_region(b"k1");
+    let resp = async_read_index_on_peer(&mut cluster, new_peer(2, 2), r1, b"k1", true);
+    assert!(resp.recv_timeout(Duration::from_millis(500)).is_err());
+
+    // Filter all other responses to peer 2, so the term of peer 2 will not change.
+    // Otherwise, a StaleCommand error will be returned instead.
+    let recv_filter = Box::new(
+        RegionPacketFilter::new(rid, 2)
+            .direction(Direction::Recv)
+            .skip(MessageType::MsgReadIndexResp),
+    );
+    cluster.sim.wl().add_recv_filter(2, recv_filter);
+
+    cluster.must_transfer_leader(1, new_peer(3, 3));
+    // k1 has a memory lock
+    let leader_cm = cluster.sim.rl().get_concurrency_manager(3);
+    let lock = Lock::new(
+        LockType::Put,
+        b"k1".to_vec(),
+        10.into(),
+        20000,
+        None,
+        10.into(),
+        1,
+        20.into(),
+    )
+    .use_async_commit(vec![]);
+    let guard = block_on(leader_cm.lock_key(&Key::from_raw(b"k1")));
+    guard.with_lock(|l| *l = Some(lock.clone()));
+
+    // Now, the leader has been transferred to peer 3. The original read index request
+    // will be first sent to peer 1 and then redirected to peer 3.
+    // We must make sure the lock check is done on peer 3.
+
+    fail::remove("before_propose_readindex");
+    let resp = resp.recv_timeout(Duration::from_millis(2000)).unwrap();
+    assert_eq!(
+        &lock.into_lock_info(b"k1".to_vec()),
+        resp.get_responses()[0].get_read_index().get_locked(),
+        "{:?}",
+        resp
+    );
+}
+
+#[test]
+fn test_read_index_lock_checking_on_false_leader() {
+    let mut cluster = new_node_cluster(0, 5);
+    // Use long election timeout and short lease.
+    configure_for_lease_read(&mut cluster, Some(50), Some(200));
+    cluster.cfg.raft_store.raft_store_max_leader_lease =
+        ReadableDuration(Duration::from_millis(100));
+
+    let pd_client = Arc::clone(&cluster.pd_client);
+    pd_client.disable_default_operator();
+
+    let rid = cluster.run_conf_change();
+    cluster.must_put(b"k1", b"v1");
+    for i in 2..=5 {
+        pd_client.must_add_peer(rid, new_peer(i, i));
+        must_get_equal(&cluster.get_engine(i), b"k1", b"v1");
+    }
+
+    cluster.must_transfer_leader(1, new_peer(1, 1));
+    let r1 = cluster.get_region(b"k1");
+
+    // Let peer 3 become leader, but do not make peer 1 and 2 aware of it.
+    cluster.add_send_filter(PartitionFilterFactory::new(vec![1, 2], vec![3, 4, 5]));
+    let mut raft_msg = RaftMessage::default();
+    raft_msg
+        .mut_message()
+        .set_msg_type(MessageType::MsgTimeoutNow);
+    raft_msg.set_region_id(r1.get_id());
+    raft_msg.set_to_peer(find_peer(&r1, 3).unwrap().to_owned());
+    raft_msg.set_region_epoch(r1.get_region_epoch().to_owned());
+    cluster.send_raft_msg(raft_msg).unwrap();
+
+    for i in 0..10 {
+        thread::sleep(Duration::from_millis(200));
+        cluster.reset_leader_of_region(rid);
+        let leader = cluster.leader_of_region(rid);
+        if let Some(leader) = leader {
+            if leader.get_store_id() == 3 {
+                break;
+            }
+        }
+        if i == 9 {
+            panic!("new leader should be elected");
+        }
+    }
+
+    // k1 has a memory lock on node 3
+    let leader_cm = cluster.sim.rl().get_concurrency_manager(3);
+    let lock = Lock::new(
+        LockType::Put,
+        b"k1".to_vec(),
+        10.into(),
+        20000,
+        None,
+        10.into(),
+        1,
+        20.into(),
+    )
+    .use_async_commit(vec![]);
+    let guard = block_on(leader_cm.lock_key(&Key::from_raw(b"k1")));
+    guard.with_lock(|l| *l = Some(lock.clone()));
+
+    // Read index from peer 2, the read index message will be sent to the old leader peer 1.
+    // But the lease of peer 1 has expired and it cannot get majority of heartbeat.
+    // So, we cannot get the result here.
+    let resp = async_read_index_on_peer(&mut cluster, new_peer(2, 2), r1, b"k1", true);
+    assert!(resp.recv_timeout(Duration::from_millis(300)).is_err());
+
+    // Now, restore the network partition. Peer 1 should now become follower and drop its
+    // pending read index request. Peer 2 cannot get the result now.
+    let recv_filter = Box::new(
+        RegionPacketFilter::new(rid, 2)
+            .direction(Direction::Recv)
+            .skip(MessageType::MsgReadIndexResp),
+    );
+    cluster.sim.wl().add_recv_filter(2, recv_filter);
+    cluster.clear_send_filters();
+    assert!(resp.recv_timeout(Duration::from_millis(300)).is_err());
+
+    // After cleaning all filters, peer 2 will retry and will get error.
+    cluster.sim.wl().clear_recv_filters(2);
+    let resp = resp.recv_timeout(Duration::from_millis(2000)).unwrap();
+    assert!(resp.get_header().has_error());
 }


### PR DESCRIPTION

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #12109

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Consider a reader sends read index to the leader it supposed to be, but when
the leader receives the read index message, it has stepped down to a
follower. Without this commit, a peer will check the locks and re-fill the
read index context with the result no matter what role it is. So, when the
read index request is redirected to the new leader again, it no longer carries
the context of lock checking.

This commmit changes to only do the check when the peer is a leader. Then, the
read index request will remain unchanged before being redirected to the leader.

If the lease of the leader expires, it is still safe to check on the
uncertained leader. If the heartbeat check passes and no new leader is elected,
then the check works fine. If there is a new leader, when the old leader
becomes a follower, it will clear its pending read index. Then, the reader has
to resend the read index again to the correct leader. So, generally it is safe
as long as we guarantee the check only happens on the leader.
```

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix potential linearizability violation in replica reads.
```
