### PR TITLE
*: notify snapshot apply

### DIFF
--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -1029,6 +1029,9 @@ where
                 let raft_msg = self.fsm.peer.build_raft_messages(self.ctx, vec![msg]);
                 self.fsm.peer.send_raft_messages(self.ctx, raft_msg);
             }
+            CasualMessage::SnapshotApplied => {
+                self.fsm.has_ready = true;
+            }
         }
     }
 

--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -389,6 +389,9 @@ pub enum CasualMessage<EK: KvEngine> {
 
     // Try renew leader lease
     RenewLease,
+
+    // Snapshot is applied
+    SnapshotApplied,
 }
 
 impl<EK: KvEngine> fmt::Debug for CasualMessage<EK> {
@@ -446,6 +449,7 @@ impl<EK: KvEngine> fmt::Debug for CasualMessage<EK> {
             }
             CasualMessage::RefreshRegionBuckets { .. } => write!(fmt, "RefreshRegionBuckets"),
             CasualMessage::RenewLease => write!(fmt, "RenewLease"),
+            CasualMessage::SnapshotApplied => write!(fmt, "SnapshotApplied"),
         }
     }
 }

--- a/components/raftstore/src/store/worker/region.rs
+++ b/components/raftstore/src/store/worker/region.rs
@@ -440,9 +440,7 @@ where
         SNAP_HISTOGRAM
             .apply
             .observe(start.saturating_elapsed_secs());
-        let _ = self
-            .router
-            .send(region_id, CasualMessage::SnapshotApplied);
+        let _ = self.router.send(region_id, CasualMessage::SnapshotApplied);
     }
 
     /// Cleans up the data within the range.

--- a/components/raftstore/src/store/worker/region.rs
+++ b/components/raftstore/src/store/worker/region.rs
@@ -440,6 +440,9 @@ where
         SNAP_HISTOGRAM
             .apply
             .observe(start.saturating_elapsed_secs());
+        let _ = self
+            .router
+            .send(region_id, CasualMessage::SnapshotApplied);
     }
 
     /// Cleans up the data within the range.

--- a/components/raftstore/src/store/worker/region.rs
+++ b/components/raftstore/src/store/worker/region.rs
@@ -1065,11 +1065,11 @@ mod tests {
 
         let wait_apply_finish = |ids: &[u64]| {
             for id in ids {
-                match receiver.recv_timeout(Duration::from_secs(3)) {
+                match receiver.recv_timeout(Duration::from_secs(5)) {
                     Ok((region_id, CasualMessage::SnapshotApplied)) => {
                         assert_eq!(region_id, *id);
                     }
-                    msg => panic!("expected SnapshotApplied, but got {:?}", msg),
+                    msg => panic!("expected {} SnapshotApplied, but got {:?}", id, msg),
                 }
                 let region_key = keys::region_state_key(*id);
                 assert_eq!(

--- a/components/raftstore/src/store/worker/region.rs
+++ b/components/raftstore/src/store/worker/region.rs
@@ -1063,20 +1063,24 @@ mod tests {
             v.is_some()
         };
 
-        let wait_apply_finish = |id: u64| {
-            let region_key = keys::region_state_key(id);
-            loop {
-                thread::sleep(Duration::from_millis(100));
-                if engine
-                    .kv
-                    .get_msg_cf::<RegionLocalState>(CF_RAFT, &region_key)
-                    .unwrap()
-                    .unwrap()
-                    .get_state()
-                    == PeerState::Normal
-                {
-                    break;
+        let wait_apply_finish = |ids: &[u64]| {
+            for id in ids {
+                match receiver.recv_timeout(Duration::from_secs(3)) {
+                    Ok((region_id, CasualMessage::SnapshotApplied)) => {
+                        assert_eq!(region_id, *id);
+                    }
+                    msg => panic!("expected SnapshotApplied, but got {:?}", msg),
                 }
+                let region_key = keys::region_state_key(*id);
+                assert_eq!(
+                    engine
+                        .kv
+                        .get_msg_cf::<RegionLocalState>(CF_RAFT, &region_key)
+                        .unwrap()
+                        .unwrap()
+                        .get_state(),
+                    PeerState::Normal
+                )
             }
         };
 
@@ -1102,7 +1106,7 @@ mod tests {
             0
         );
 
-        wait_apply_finish(1);
+        wait_apply_finish(&[1]);
 
         // the pending apply task should be finished and snapshots are ingested.
         // note that when ingest sst, it may flush memtable if overlap,
@@ -1118,7 +1122,7 @@ mod tests {
 
         // no write stall, ingest without delay
         gen_and_apply_snap(2);
-        wait_apply_finish(2);
+        wait_apply_finish(&[2]);
         assert_eq!(
             engine
                 .kv
@@ -1172,7 +1176,7 @@ mod tests {
         );
 
         // make sure have checked pending applies
-        wait_apply_finish(4);
+        wait_apply_finish(&[3, 4]);
 
         // before two pending apply tasks should be finished and snapshots are ingested
         // and one still in pending.
@@ -1195,7 +1199,7 @@ mod tests {
                 .unwrap(),
             0
         );
-        wait_apply_finish(5);
+        wait_apply_finish(&[5]);
 
         // the last one pending task finished
         assert_eq!(

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -1091,13 +1091,13 @@ impl<T: Simulator> Cluster<T> {
         }
     }
 
-    pub fn wait_tombstone(&self, region_id: u64, peer: metapb::Peer) {
+    pub fn wait_tombstone(&self, region_id: u64, peer: metapb::Peer, check_exist: bool) {
         let timer = Instant::now();
         let mut state;
         loop {
             state = self.region_local_state(region_id, peer.get_store_id());
             if state.get_state() == PeerState::Tombstone
-                && state.get_region().get_peers().contains(&peer)
+                && (!check_exist || state.get_region().get_peers().contains(&peer))
             {
                 return;
             }

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -340,9 +340,11 @@ where
         let timer = Instant::now_coarse();
         let import = self.importer.clone();
         let (rx, buf_driver) = create_stream_with_buffer(stream, self.cfg.stream_channel_window);
-        let mut rx = rx.map_err(Error::from);
+        let mut map_rx = rx.map_err(Error::from);
 
         let handle_task = async move {
+            // So stream will not be dropped until response is sent.
+            let rx = &mut map_rx;
             let res = async move {
                 let first_chunk = rx.try_next().await?;
                 let meta = match first_chunk {

--- a/tests/failpoints/cases/test_conf_change.rs
+++ b/tests/failpoints/cases/test_conf_change.rs
@@ -51,7 +51,7 @@ fn test_destroy_local_reader() {
     pd_client.must_remove_peer(r1, new_peer(1, 1));
 
     // Make sure region 1 is removed from store 1.
-    cluster.must_region_not_exist(r1, 1);
+    cluster.wait_tombstone(r1, new_peer(1, 1));
 
     let region = block_on(pd_client.get_region_by_id(r1)).unwrap().unwrap();
 

--- a/tests/failpoints/cases/test_conf_change.rs
+++ b/tests/failpoints/cases/test_conf_change.rs
@@ -51,7 +51,7 @@ fn test_destroy_local_reader() {
     pd_client.must_remove_peer(r1, new_peer(1, 1));
 
     // Make sure region 1 is removed from store 1.
-    cluster.wait_tombstone(r1, new_peer(1, 1));
+    cluster.wait_tombstone(r1, new_peer(1, 1), false);
 
     let region = block_on(pd_client.get_region_by_id(r1)).unwrap().unwrap();
 

--- a/tests/failpoints/cases/test_replica_stale_read.rs
+++ b/tests/failpoints/cases/test_replica_stale_read.rs
@@ -401,11 +401,11 @@ fn test_stale_read_while_region_merge() {
 
     let mut follower_client2 = PeerClient::new(&cluster, target.get_id(), new_peer(2, 2));
     follower_client2.ctx.set_stale_read(true);
+    // We can read `(key5, value1)` with `k1_prewrite_ts`
+    follower_client2.must_kv_read_equal(b"key5".to_vec(), b"value1".to_vec(), k1_prewrite_ts);
     // Can't read `key5` with `k5_commit_ts` because `k1_prewrite_ts` is smaller than `k5_commit_ts`
     let resp = follower_client2.kv_read(b"key5".to_vec(), k5_commit_ts);
     assert!(resp.get_region_error().has_data_is_not_ready());
-    // We can read `(key5, value1)` with `k1_prewrite_ts`
-    follower_client2.must_kv_read_equal(b"key5".to_vec(), b"value1".to_vec(), k1_prewrite_ts);
 
     let target_leader = PeerClient::new(&cluster, target.get_id(), new_peer(1, 1));
     // Commit on `key1`

--- a/tests/failpoints/cases/test_split_region.rs
+++ b/tests/failpoints/cases/test_split_region.rs
@@ -692,7 +692,13 @@ fn test_report_approximate_size_after_split_check() {
         .pd_client
         .get_region_approximate_keys(region_id)
         .unwrap_or_default();
-    assert!(approximate_size == 0 && approximate_keys == 0);
+    // It's either 0 for uninialized or 1 for 0.
+    assert!(
+        approximate_size <= 1 && approximate_keys <= 1,
+        "{} {}",
+        approximate_size,
+        approximate_keys,
+    );
     let (tx, rx) = mpsc::channel();
     let tx = Arc::new(Mutex::new(tx));
 

--- a/tests/integrations/raftstore/test_hibernate.rs
+++ b/tests/integrations/raftstore/test_hibernate.rs
@@ -310,6 +310,8 @@ fn test_inconsistent_configuration() {
     cluster.stop_node(3);
     cluster.run_node(3).unwrap();
     cluster.must_put(b"k2", b"v2");
+    // In case leader changes.
+    cluster.must_transfer_leader(1, new_peer(1, 1));
     must_get_equal(&cluster.get_engine(3), b"k2", b"v2");
     // Wait till leader peer goes to sleep.
     thread::sleep(

--- a/tests/integrations/raftstore/test_merge.rs
+++ b/tests/integrations/raftstore/test_merge.rs
@@ -1508,7 +1508,7 @@ fn test_node_merge_long_isolated() {
 
     // Now peer(1, 1010) should probably created in memory but not persisted.
     pd_client.must_remove_peer(right.get_id(), new_peer(1, 1010));
-    cluster.wait_tombstone(right.get_id(), new_peer(1, 1010));
+    cluster.wait_tombstone(right.get_id(), new_peer(1, 1010), true);
     cluster.clear_send_filters();
     // Source peer should discover it's impossible to proceed and cleanup itself.
     must_get_none(&cluster.get_engine(1), b"k1");


### PR DESCRIPTION

### What is changed and how it works?

Issue Number: Close #12057.

What's Changed:

```commit-message
In the past, it relies on base tick to check if a snapshot is applied.
If the base tick is set to a very large value, it will take a long time
to detect snapshot is finished. This PR adds a casual message to notify
peer actively.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
