### PR TITLE
config: simplify handling of nullable configurations

### DIFF
--- a/components/online_config/online_config_derive/src/lib.rs
+++ b/components/online_config/online_config_derive/src/lib.rs
@@ -224,7 +224,7 @@ fn diff(fields: &Punctuated<Field, Comma>, crate_name: &Ident) -> Result<TokenSt
         } else if is_option_type(&field.ty) {
             quote! {
                 if self.#name != #incoming.#name {
-                    if let Some(v) = #incoming.#name {
+                    if let Some(ref v) = #incoming.#name {
                         #diff_ident.insert(#name_lit.to_owned(), #crate_name::ConfigValue::from(v.clone()));
                     } else {
                         #diff_ident.insert(#name_lit.to_owned(), #crate_name::ConfigValue::None);

--- a/components/online_config/online_config_derive/src/lib.rs
+++ b/components/online_config/online_config_derive/src/lib.rs
@@ -24,7 +24,7 @@ fn generate_token(ast: DeriveInput) -> std::result::Result<TokenStream, Error> {
     let name = &ast.ident;
     check_generics(&ast.generics, name.span())?;
 
-    let creat_name = Ident::new("online_config", Span::call_site());
+    let crate_name = Ident::new("online_config", Span::call_site());
     let encoder_name = Ident::new(
         {
             // Avoid naming conflict
@@ -37,13 +37,13 @@ fn generate_token(ast: DeriveInput) -> std::result::Result<TokenStream, Error> {
     let encoder_lt = Lifetime::new("'lt", Span::call_site());
 
     let fields = get_struct_fields(ast.data, name.span())?;
-    let update_fn = update(&fields, &creat_name)?;
-    let diff_fn = diff(&fields, &creat_name)?;
+    let update_fn = update(&fields, &crate_name)?;
+    let diff_fn = diff(&fields, &crate_name)?;
     let get_encoder_fn = get_encoder(&encoder_name, &encoder_lt);
-    let typed_fn = typed(&fields, &creat_name)?;
+    let typed_fn = typed(&fields, &crate_name)?;
     let encoder_struct = encoder(
         name,
-        &creat_name,
+        &crate_name,
         &encoder_name,
         &encoder_lt,
         ast.attrs,
@@ -51,7 +51,7 @@ fn generate_token(ast: DeriveInput) -> std::result::Result<TokenStream, Error> {
     )?;
 
     Ok(quote! {
-        impl<#encoder_lt> #creat_name::OnlineConfig<#encoder_lt> for #name {
+        impl<#encoder_lt> #crate_name::OnlineConfig<#encoder_lt> for #name {
             type Encoder = #encoder_name<#encoder_lt>;
             #update_fn
             #diff_fn
@@ -92,7 +92,7 @@ fn get_struct_fields(
 
 fn encoder(
     name: &Ident,
-    creat_name: &Ident,
+    crate_name: &Ident,
     encoder_name: &Ident,
     lt: &Lifetime,
     attrs: Vec<Attribute>,
@@ -117,7 +117,7 @@ fn encoder(
         field.ty = {
             let ty = &field.ty;
             if submodule {
-                Type::Verbatim(quote! { <#ty as #creat_name::OnlineConfig<#lt>>::Encoder })
+                Type::Verbatim(quote! { <#ty as #crate_name::OnlineConfig<#lt>>::Encoder })
             } else {
                 Type::Verbatim(quote! { &#lt #ty })
             }
@@ -159,7 +159,7 @@ fn get_encoder(encoder_name: &Ident, lt: &Lifetime) -> TokenStream {
     }
 }
 
-fn update(fields: &Punctuated<Field, Comma>, creat_name: &Ident) -> Result<TokenStream> {
+fn update(fields: &Punctuated<Field, Comma>, crate_name: &Ident) -> Result<TokenStream> {
     let incoming = Ident::new("incoming", Span::call_site());
     let mut update_fields = Vec::with_capacity(fields.len());
     for field in fields {
@@ -171,8 +171,18 @@ fn update(fields: &Punctuated<Field, Comma>, creat_name: &Ident) -> Result<Token
         let name_lit = LitStr::new(&format!("{}", name), name.span());
         let f = if submodule {
             quote! {
-                if let Some(#creat_name::ConfigValue::Module(v)) = #incoming.remove(#name_lit) {
-                    #creat_name::OnlineConfig::update(&mut self.#name, v);
+                if let Some(#crate_name::ConfigValue::Module(v)) = #incoming.remove(#name_lit) {
+                    #crate_name::OnlineConfig::update(&mut self.#name, v);
+                }
+            }
+        } else if is_option_type(&field.ty) {
+            quote! {
+                if let Some(v) = #incoming.remove(#name_lit) {
+                    if #crate_name::ConfigValue::None == v {
+                        self.#name = None;
+                    } else {
+                        self.#name = Some(v.into());
+                    }
                 }
             }
         } else {
@@ -185,13 +195,13 @@ fn update(fields: &Punctuated<Field, Comma>, creat_name: &Ident) -> Result<Token
         update_fields.push(f);
     }
     Ok(quote! {
-        fn update(&mut self, mut #incoming: #creat_name::ConfigChange) {
+        fn update(&mut self, mut #incoming: #crate_name::ConfigChange) {
             #(#update_fields)*
         }
     })
 }
 
-fn diff(fields: &Punctuated<Field, Comma>, creat_name: &Ident) -> Result<TokenStream> {
+fn diff(fields: &Punctuated<Field, Comma>, crate_name: &Ident) -> Result<TokenStream> {
     let diff_ident = Ident::new("diff_ident", Span::call_site());
     let incoming = Ident::new("incoming", Span::call_site());
     let mut diff_fields = Vec::with_capacity(fields.len());
@@ -205,16 +215,26 @@ fn diff(fields: &Punctuated<Field, Comma>, creat_name: &Ident) -> Result<TokenSt
         let f = if submodule {
             quote! {
                 {
-                    let diff = #creat_name::OnlineConfig::diff(&self.#name, &#incoming.#name);
+                    let diff = #crate_name::OnlineConfig::diff(&self.#name, &#incoming.#name);
                     if diff.len() != 0 {
-                        #diff_ident.insert(#name_lit.to_owned(), #creat_name::ConfigValue::from(diff));
+                        #diff_ident.insert(#name_lit.to_owned(), #crate_name::ConfigValue::from(diff));
+                    }
+                }
+            }
+        } else if is_option_type(&field.ty) {
+            quote! {
+                if self.#name != #incoming.#name {
+                    if let Some(v) = #incoming.#name {
+                        #diff_ident.insert(#name_lit.to_owned(), #crate_name::ConfigValue::from(v.clone()));
+                    } else {
+                        #diff_ident.insert(#name_lit.to_owned(), #crate_name::ConfigValue::None);
                     }
                 }
             }
         } else {
             quote! {
                 if self.#name != #incoming.#name {
-                    #diff_ident.insert(#name_lit.to_owned(), #creat_name::ConfigValue::from(#incoming.#name.clone()));
+                    #diff_ident.insert(#name_lit.to_owned(), #crate_name::ConfigValue::from(#incoming.#name.clone()));
                 }
             }
         };
@@ -222,7 +242,7 @@ fn diff(fields: &Punctuated<Field, Comma>, creat_name: &Ident) -> Result<TokenSt
     }
     Ok(quote! {
         #[allow(clippy::float_cmp)]
-        fn diff(&self, mut #incoming: &Self) -> #creat_name::ConfigChange {
+        fn diff(&self, mut #incoming: &Self) -> #crate_name::ConfigChange {
             let mut #diff_ident = std::collections::HashMap::default();
             #(#diff_fields)*
             #diff_ident
@@ -230,7 +250,7 @@ fn diff(fields: &Punctuated<Field, Comma>, creat_name: &Ident) -> Result<TokenSt
     })
 }
 
-fn typed(fields: &Punctuated<Field, Comma>, creat_name: &Ident) -> Result<TokenStream> {
+fn typed(fields: &Punctuated<Field, Comma>, crate_name: &Ident) -> Result<TokenStream> {
     let typed_ident = Ident::new("typed_ident", Span::call_site());
     let mut typed_fields = Vec::with_capacity(fields.len());
     for field in fields {
@@ -243,23 +263,27 @@ fn typed(fields: &Punctuated<Field, Comma>, creat_name: &Ident) -> Result<TokenS
         let f = if submodule {
             quote! {
                 {
-                    let typed = #creat_name::OnlineConfig::typed(&self.#name);
-                    #typed_ident.insert(#name_lit.to_owned(), #creat_name::ConfigValue::from(typed));
+                    let typed = #crate_name::OnlineConfig::typed(&self.#name);
+                    #typed_ident.insert(#name_lit.to_owned(), #crate_name::ConfigValue::from(typed));
                 }
             }
         } else if skip || hidden {
             quote! {
-                #typed_ident.insert(#name_lit.to_owned(), #creat_name::ConfigValue::Skip);
+                #typed_ident.insert(#name_lit.to_owned(), #crate_name::ConfigValue::Skip);
+            }
+        } else if is_option_type(&field.ty) {
+            quote! {
+                #typed_ident.insert(#name_lit.to_owned(), #crate_name::ConfigValue::from(self.#name.clone().unwrap_or_default()));
             }
         } else {
             quote! {
-                #typed_ident.insert(#name_lit.to_owned(), #creat_name::ConfigValue::from(self.#name.clone()));
+                #typed_ident.insert(#name_lit.to_owned(), #crate_name::ConfigValue::from(self.#name.clone()));
             }
         };
         typed_fields.push(f);
     }
     Ok(quote! {
-        fn typed(&self) -> #creat_name::ConfigChange {
+        fn typed(&self) -> #crate_name::ConfigChange {
             let mut #typed_ident = std::collections::HashMap::default();
             #(#typed_fields)*
             #typed_ident
@@ -295,4 +319,35 @@ fn is_attr(name: &str, attr: &Attribute) -> bool {
         }
     }
     false
+}
+
+fn is_option_type(ty: &Type) -> bool {
+    fn extract_type_path(ty: &syn::Type) -> Option<&Path> {
+        match *ty {
+            syn::Type::Path(ref typepath) if typepath.qself.is_none() => Some(&typepath.path),
+            _ => None,
+        }
+    }
+
+    // TODO store (with lazy static) the vec of string
+    // TODO maybe optimization, reverse the order of segments
+    fn extract_option_segment(path: &Path) -> Option<&PathSegment> {
+        let idents_of_path = path
+            .segments
+            .iter()
+            .into_iter()
+            .fold(String::new(), |mut acc, v| {
+                acc.push_str(&v.ident.to_string());
+                acc.push('|');
+                acc
+            });
+        vec!["Option|", "std|option|Option|", "core|option|Option|"]
+            .into_iter()
+            .find(|s| idents_of_path == *s)
+            .and_then(|_| path.segments.last())
+    }
+
+    extract_type_path(ty)
+        .and_then(|path| extract_option_segment(path))
+        .is_some()
 }

--- a/components/online_config/online_config_derive/src/lib.rs
+++ b/components/online_config/online_config_derive/src/lib.rs
@@ -321,6 +321,7 @@ fn is_attr(name: &str, attr: &Attribute) -> bool {
     false
 }
 
+// Copied from https://stackoverflow.com/questions/55271857/how-can-i-get-the-t-from-an-optiont-when-using-syn.
 fn is_option_type(ty: &Type) -> bool {
     fn extract_type_path(ty: &syn::Type) -> Option<&Path> {
         match *ty {

--- a/components/online_config/src/lib.rs
+++ b/components/online_config/src/lib.rs
@@ -142,6 +142,8 @@ mod tests {
     pub struct TestConfig {
         field1: usize,
         field2: String,
+        optional_field1: Option<usize>,
+        optional_field2: Option<String>,
         #[online_config(skip)]
         skip_field: u64,
         #[online_config(submodule)]
@@ -158,21 +160,30 @@ mod tests {
 
     #[test]
     fn test_update_fields() {
-        let mut cfg = TestConfig::default();
+        let mut cfg = TestConfig {
+            optional_field1: Some(1),
+            ..Default::default()
+        };
         let mut updated_cfg = cfg.clone();
         {
-            // update fields
             updated_cfg.field1 = 100;
             updated_cfg.field2 = "1".to_owned();
+            updated_cfg.optional_field1 = None;
+            updated_cfg.optional_field2 = Some("1".to_owned());
             updated_cfg.submodule_field.field1 = 1000;
             updated_cfg.submodule_field.field2 = true;
         }
         let diff = cfg.diff(&updated_cfg);
         {
             let mut diff = diff.clone();
-            assert_eq!(diff.len(), 3);
+            assert_eq!(diff.len(), 5);
             assert_eq!(diff.remove("field1").map(Into::into), Some(100usize));
             assert_eq!(diff.remove("field2").map(Into::into), Some("1".to_owned()));
+            assert_eq!(diff.remove("optional_field1"), Some(ConfigValue::None));
+            assert_eq!(
+                diff.remove("optional_field2").map(Into::into),
+                Some("1".to_owned())
+            );
             // submodule should also be updated
             let sub_m = diff.remove("submodule_field").map(Into::into);
             assert!(sub_m.is_some());

--- a/components/online_config/src/lib.rs
+++ b/components/online_config/src/lib.rs
@@ -20,9 +20,9 @@ pub enum ConfigValue {
     String(String),
     BlobRunMode(String),
     IOPriority(String),
-    OptionSize(Option<u64>),
     Module(ConfigChange),
     Skip,
+    None,
 }
 
 impl Display for ConfigValue {
@@ -30,8 +30,6 @@ impl Display for ConfigValue {
         match self {
             ConfigValue::Duration(v) => write!(f, "{}ms", v),
             ConfigValue::Size(v) => write!(f, "{}b", v),
-            ConfigValue::OptionSize(Some(v)) => write!(f, "{}b", v),
-            ConfigValue::OptionSize(None) => write!(f, ""),
             ConfigValue::U64(v) => write!(f, "{}", v),
             ConfigValue::F64(v) => write!(f, "{}", v),
             ConfigValue::I32(v) => write!(f, "{}", v),
@@ -43,6 +41,7 @@ impl Display for ConfigValue {
             ConfigValue::IOPriority(v) => write!(f, "{}", v),
             ConfigValue::Module(v) => write!(f, "{:?}", v),
             ConfigValue::Skip => write!(f, "ConfigValue::Skip"),
+            ConfigValue::None => write!(f, ""),
         }
     }
 }

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -127,7 +127,7 @@ pub fn run_tikv(config: TiKvConfig) {
             let mut tikv = TiKVServer::<$ER>::init(config);
 
             // Must be called after `TiKVServer::init`.
-            let memory_limit = tikv.config.memory_usage_limit.0.unwrap().0;
+            let memory_limit = tikv.config.memory_usage_limit.unwrap().0;
             let high_water = (tikv.config.memory_usage_high_water * memory_limit as f64) as u64;
             register_memory_usage_high_water(high_water);
 

--- a/components/tikv_util/src/config.rs
+++ b/components/tikv_util/src/config.rs
@@ -60,7 +60,7 @@ pub enum LogFormat {
     Json,
 }
 
-#[derive(Clone, Debug, Copy, PartialEq)]
+#[derive(Clone, Debug, Copy, PartialEq, Default)]
 pub struct ReadableSize(pub u64);
 
 impl From<ReadableSize> for ConfigValue {
@@ -75,42 +75,6 @@ impl From<ConfigValue> for ReadableSize {
             ReadableSize(s)
         } else {
             panic!("expect: ConfigValue::Size, got: {:?}", c);
-        }
-    }
-}
-
-/// This trivial type is needed, because we can't define the `From<Option<ReadableSize>>`
-/// and `Into<Option<ReadableSize>>` trait for `ConfigValue` which is needed to derive
-/// `OnlineConfig` trait for `BlockCacheConfig`
-#[derive(Clone, Debug, Copy, Serialize, Deserialize, PartialEq)]
-#[serde(from = "Option<ReadableSize>")]
-#[serde(into = "Option<ReadableSize>")]
-pub struct OptionReadableSize(pub Option<ReadableSize>);
-
-impl From<Option<ReadableSize>> for OptionReadableSize {
-    fn from(s: Option<ReadableSize>) -> OptionReadableSize {
-        OptionReadableSize(s)
-    }
-}
-
-impl From<OptionReadableSize> for Option<ReadableSize> {
-    fn from(s: OptionReadableSize) -> Option<ReadableSize> {
-        s.0
-    }
-}
-
-impl From<OptionReadableSize> for ConfigValue {
-    fn from(size: OptionReadableSize) -> ConfigValue {
-        ConfigValue::OptionSize(size.0.map(|v| v.0))
-    }
-}
-
-impl From<ConfigValue> for OptionReadableSize {
-    fn from(s: ConfigValue) -> OptionReadableSize {
-        if let ConfigValue::OptionSize(s) = s {
-            OptionReadableSize(s.map(ReadableSize))
-        } else {
-            panic!("expect: ConfigValue::OptionSize, got: {:?}", s);
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,9 +50,7 @@ use raftstore::store::Config as RaftstoreConfig;
 use raftstore::store::{CompactionGuardGeneratorFactory, SplitConfig};
 use resource_metering::Config as ResourceMeteringConfig;
 use security::SecurityConfig;
-use tikv_util::config::{
-    self, LogFormat, OptionReadableSize, ReadableDuration, ReadableSize, TomlWriter, GIB, MIB,
-};
+use tikv_util::config::{self, LogFormat, ReadableDuration, ReadableSize, TomlWriter, GIB, MIB};
 use tikv_util::sys::SysQuota;
 use tikv_util::time::duration_to_sec;
 use tikv_util::yatp_pool;
@@ -1628,10 +1626,6 @@ fn config_value_to_string(config_change: Vec<(String, ConfigValue)>) -> Vec<(Str
                     let s: ReadableSize = s.into();
                     Some(s.0.to_string())
                 }
-                s @ ConfigValue::OptionSize(_) => {
-                    let s: OptionReadableSize = s.into();
-                    s.0.map(|v| v.0.to_string())
-                }
                 ConfigValue::Module(_) => unreachable!(),
                 v => Some(format!("{}", v)),
             };
@@ -2483,7 +2477,7 @@ pub struct TiKvConfig {
 
     #[doc(hidden)]
     #[online_config(skip)]
-    pub memory_usage_limit: OptionReadableSize,
+    pub memory_usage_limit: Option<ReadableSize>,
 
     #[doc(hidden)]
     #[online_config(skip)]
@@ -2568,7 +2562,7 @@ impl Default for TiKvConfig {
             panic_when_unexpected_key_or_data: false,
             enable_io_snoop: true,
             abort_on_panic: false,
-            memory_usage_limit: OptionReadableSize(None),
+            memory_usage_limit: None,
             memory_usage_high_water: 0.9,
             log: LogConfig::default(),
             readpool: ReadPoolConfig::default(),
@@ -2780,7 +2774,7 @@ impl TiKvConfig {
                 .hard_pending_compaction_bytes_limit;
         }
 
-        if let Some(memory_usage_limit) = self.memory_usage_limit.0 {
+        if let Some(memory_usage_limit) = self.memory_usage_limit {
             let total = SysQuota::memory_limit_in_bytes();
             if memory_usage_limit.0 > total {
                 // Explicitly exceeds system memory capacity is not allowed.
@@ -2793,12 +2787,11 @@ impl TiKvConfig {
         } else {
             // Adjust `memory_usage_limit` if necessary.
             if self.storage.block_cache.shared {
-                if let Some(cap) = self.storage.block_cache.capacity.0 {
+                if let Some(cap) = self.storage.block_cache.capacity {
                     let limit = (cap.0 as f64 / BLOCK_CACHE_RATE * MEMORY_USAGE_LIMIT_RATE) as u64;
-                    self.memory_usage_limit.0 = Some(ReadableSize(limit));
+                    self.memory_usage_limit = Some(ReadableSize(limit));
                 } else {
-                    self.memory_usage_limit =
-                        OptionReadableSize(Some(Self::suggested_memory_usage_limit()));
+                    self.memory_usage_limit = Some(Self::suggested_memory_usage_limit());
                 }
             } else {
                 let cap = self.rocksdb.defaultcf.block_cache_size.0
@@ -2806,18 +2799,18 @@ impl TiKvConfig {
                     + self.rocksdb.lockcf.block_cache_size.0
                     + self.raftdb.defaultcf.block_cache_size.0;
                 let limit = (cap as f64 / BLOCK_CACHE_RATE * MEMORY_USAGE_LIMIT_RATE) as u64;
-                self.memory_usage_limit.0 = Some(ReadableSize(limit));
+                self.memory_usage_limit = Some(ReadableSize(limit));
             }
         }
 
-        let mut limit = self.memory_usage_limit.0.unwrap();
+        let mut limit = self.memory_usage_limit.unwrap();
         let total = ReadableSize(SysQuota::memory_limit_in_bytes());
         if limit.0 > total.0 {
             warn!(
                 "memory_usage_limit:{:?} > total:{:?}, fallback to total",
                 limit, total,
             );
-            self.memory_usage_limit.0 = Some(total);
+            self.memory_usage_limit = Some(total);
             limit = total;
         }
 
@@ -2972,8 +2965,8 @@ impl TiKvConfig {
         // block cache sizes. Otherwise use the sum of block cache size of all column families
         // as the shared cache size.
         let cache_cfg = &mut self.storage.block_cache;
-        if cache_cfg.shared && cache_cfg.capacity.0.is_none() {
-            cache_cfg.capacity.0 = Some(ReadableSize(
+        if cache_cfg.shared && cache_cfg.capacity.is_none() {
+            cache_cfg.capacity = Some(ReadableSize(
                 self.rocksdb.defaultcf.block_cache_size.0
                     + self.rocksdb.writecf.block_cache_size.0
                     + self.rocksdb.lockcf.block_cache_size.0
@@ -3311,9 +3304,6 @@ fn to_change_value(v: &str, typed: &ConfigValue) -> CfgResult<ConfigValue> {
     let res = match typed {
         ConfigValue::Duration(_) => ConfigValue::from(v.parse::<ReadableDuration>()?),
         ConfigValue::Size(_) => ConfigValue::from(v.parse::<ReadableSize>()?),
-        ConfigValue::OptionSize(_) => {
-            ConfigValue::from(OptionReadableSize(Some(v.parse::<ReadableSize>()?)))
-        }
         ConfigValue::U64(_) => ConfigValue::from(v.parse::<u64>()?),
         ConfigValue::F64(_) => ConfigValue::from(v.parse::<f64>()?),
         ConfigValue::U32(_) => ConfigValue::from(v.parse::<u32>()?),
@@ -3347,10 +3337,13 @@ fn to_toml_encode(change: HashMap<String, String>) -> CfgResult<HashMap<String, 
                     match c {
                         ConfigValue::Duration(_)
                         | ConfigValue::Size(_)
-                        | ConfigValue::OptionSize(_)
                         | ConfigValue::String(_)
                         | ConfigValue::BlobRunMode(_)
                         | ConfigValue::IOPriority(_) => Ok(true),
+                        ConfigValue::None => Err(Box::new(IoError::new(
+                            ErrorKind::Other,
+                            format!("unexpect none field: {:?}", c),
+                        ))),
                         _ => Ok(false),
                     }
                 }
@@ -4349,21 +4342,21 @@ mod tests {
         );
 
         // Test validating memory_usage_limit when it's greater than max.
-        cfg.memory_usage_limit.0 = Some(ReadableSize(SysQuota::memory_limit_in_bytes() * 2));
+        cfg.memory_usage_limit = Some(ReadableSize(SysQuota::memory_limit_in_bytes() * 2));
         assert!(cfg.validate().is_err());
 
         // Test memory_usage_limit is based on block cache size if it's not configured.
-        cfg.memory_usage_limit = OptionReadableSize(None);
-        cfg.storage.block_cache.capacity.0 = Some(ReadableSize(3 * GIB));
+        cfg.memory_usage_limit = None;
+        cfg.storage.block_cache.capacity = Some(ReadableSize(3 * GIB));
         assert!(cfg.validate().is_ok());
-        assert_eq!(cfg.memory_usage_limit.0.unwrap(), ReadableSize(5 * GIB));
+        assert_eq!(cfg.memory_usage_limit.unwrap(), ReadableSize(5 * GIB));
 
         // Test memory_usage_limit will fallback to system memory capacity with huge block cache.
-        cfg.memory_usage_limit = OptionReadableSize(None);
+        cfg.memory_usage_limit = None;
         let system = SysQuota::memory_limit_in_bytes();
-        cfg.storage.block_cache.capacity.0 = Some(ReadableSize(system * 3 / 4));
+        cfg.storage.block_cache.capacity = Some(ReadableSize(system * 3 / 4));
         assert!(cfg.validate().is_ok());
-        assert_eq!(cfg.memory_usage_limit.0.unwrap(), ReadableSize(system));
+        assert_eq!(cfg.memory_usage_limit.unwrap(), ReadableSize(system));
     }
 
     #[test]
@@ -4602,8 +4595,8 @@ mod tests {
 
         // Other special cases.
         cfg.pd.retry_max_count = default_cfg.pd.retry_max_count; // Both -1 and isize::MAX are the same.
-        cfg.storage.block_cache.capacity = OptionReadableSize(None); // Either `None` and a value is computed or `Some(_)` fixed value.
-        cfg.memory_usage_limit = OptionReadableSize(None);
+        cfg.storage.block_cache.capacity = None; // Either `None` and a value is computed or `Some(_)` fixed value.
+        cfg.memory_usage_limit = None;
         cfg.coprocessor_v2.coprocessor_plugin_directory = None; // Default is `None`, which is represented by not setting the key.
 
         assert_eq!(cfg, default_cfg);

--- a/src/storage/kv/test_engine_builder.rs
+++ b/src/storage/kv/test_engine_builder.rs
@@ -89,7 +89,7 @@ impl TestEngineBuilder {
         let cfs = self.cfs.unwrap_or_else(|| ALL_CFS.to_vec());
         let mut cache_opt = BlockCacheConfig::default();
         if !enable_block_cache {
-            cache_opt.capacity.0 = Some(ReadableSize::kb(0));
+            cache_opt.capacity = Some(ReadableSize::kb(0));
         }
         let cache = cache_opt.build_shared_cache();
         let cfs_opts = cfs

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -31,7 +31,7 @@ use tikv::server::Config as ServerConfig;
 use tikv::storage::config::{
     BlockCacheConfig, Config as StorageConfig, FlowControlConfig, IORateLimitConfig,
 };
-use tikv_util::config::{LogFormat, OptionReadableSize, ReadableDuration, ReadableSize};
+use tikv_util::config::{LogFormat, ReadableDuration, ReadableSize};
 
 mod dynamic;
 mod test_config_client;
@@ -69,7 +69,7 @@ fn test_serde_custom_tikv_config() {
     value.slow_log_file = "slow_foo".to_owned();
     value.slow_log_threshold = ReadableDuration::secs(1);
     value.abort_on_panic = true;
-    value.memory_usage_limit = OptionReadableSize(Some(ReadableSize::gb(10)));
+    value.memory_usage_limit = Some(ReadableSize::gb(10));
     value.memory_usage_high_water = 0.65;
     value.server = ServerConfig {
         cluster_id: 0, // KEEP IT ZERO, it is skipped by serde.
@@ -648,7 +648,7 @@ fn test_serde_custom_tikv_config() {
         },
         block_cache: BlockCacheConfig {
             shared: true,
-            capacity: OptionReadableSize(Some(ReadableSize::gb(40))),
+            capacity: Some(ReadableSize::gb(40)),
             num_shard_bits: 10,
             strict_capacity_limit: true,
             high_pri_pool_ratio: 0.8,
@@ -835,11 +835,11 @@ fn test_block_cache_backward_compatible() {
     let content = read_file_in_project_dir("integrations/config/test-cache-compatible.toml");
     let mut cfg: TiKvConfig = toml::from_str(&content).unwrap();
     assert!(cfg.storage.block_cache.shared);
-    assert!(cfg.storage.block_cache.capacity.0.is_none());
+    assert!(cfg.storage.block_cache.capacity.is_none());
     cfg.compatible_adjust();
-    assert!(cfg.storage.block_cache.capacity.0.is_some());
+    assert!(cfg.storage.block_cache.capacity.is_some());
     assert_eq!(
-        cfg.storage.block_cache.capacity.0.unwrap().0,
+        cfg.storage.block_cache.capacity.unwrap().0,
         cfg.rocksdb.defaultcf.block_cache_size.0
             + cfg.rocksdb.writecf.block_cache_size.0
             + cfg.rocksdb.lockcf.block_cache_size.0


### PR DESCRIPTION
Signed-off-by: tabokie <xy.tao@outlook.com>

### What is changed and how it works?

Issue Number: Ref #11119

What's Changed:

Support deriving `OnlineConfig` on any `Option<T>`. One caveat is such `T` must implement `Default`.

This change is made for #12127.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
