### PR TITLE
config: limit backup workers cap

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2234,8 +2234,9 @@ pub struct BackupConfig {
 
 impl BackupConfig {
     pub fn validate(&self) -> Result<(), Box<dyn Error>> {
-        if self.num_threads == 0 {
-            return Err("backup.num_threads cannot be 0".into());
+        let limit = SysQuota::cpu_cores_quota() as usize;
+        if self.num_threads == 0 || self.num_threads > limit {
+            return Err(format!("backup.num_threads cannot be 0 or larger than {}", limit).into());
         }
         if self.batch_size == 0 {
             return Err("backup.batch_size cannot be 0".into());


### PR DESCRIPTION
Signed-off-by: Wenbo Zhang <ethercflow@gmail.com>

ref #11804  

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->

What's Changed:


<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
config: limit backup workers cap
```

### Related changes

- None

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test,
   - use mysql client to test

Side effects
- None


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None.
```
