### PR TITLE
cmd: link c++ explicitly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5559,6 +5559,7 @@ name = "tikv-ctl"
 version = "0.0.1"
 dependencies = [
  "backup",
+ "cc",
  "cdc",
  "chrono",
  "clap",
@@ -5641,6 +5642,7 @@ dependencies = [
 name = "tikv-server"
 version = "0.0.1"
 dependencies = [
+ "cc",
  "clap",
  "server",
  "tikv",

--- a/cmd/build.rs
+++ b/cmd/build.rs
@@ -1,8 +1,51 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
+fn link_cpp(tool: &cc::Tool) {
+    let stdlib = if tool.is_like_gnu() {
+        "libstdc++.a"
+    } else if tool.is_like_clang() {
+        "libc++.a"
+    } else {
+        // Don't link to c++ statically on windows.
+        return;
+    };
+    link_sys_lib(stdlib, &tool)
+}
+
+fn link_sys_lib(lib: &str, tool: &cc::Tool) {
+    let output = tool
+        .to_command()
+        .arg("--print-file-name")
+        .arg(lib)
+        .output()
+        .unwrap();
+    if !output.status.success() || output.stdout.is_empty() {
+        // fallback to dynamically
+        return;
+    }
+    let path = match std::str::from_utf8(&output.stdout) {
+        Ok(path) => std::path::PathBuf::from(path),
+        Err(_) => return,
+    };
+    if !path.is_absolute() {
+        return;
+    }
+    // remove lib prefix and .a postfix.
+    let libname = &lib[3..lib.len() - 2];
+    println!("cargo:rustc-link-lib=static={}", &libname);
+    println!(
+        "cargo:rustc-link-search=native={}",
+        path.parent().unwrap().display()
+    );
+}
+
 fn main() {
     println!(
         "cargo:rustc-env=TIKV_BUILD_TIME={}",
         time::now_utc().strftime("%Y-%m-%d %H:%M:%S").unwrap()
     );
+
+    let tool = cc::Build::default().get_compiler();
+    link_cpp(&tool);
+    // Maybe we can link more sys libraries.
 }

--- a/cmd/build.rs
+++ b/cmd/build.rs
@@ -9,7 +9,7 @@ fn link_cpp(tool: &cc::Tool) {
         // Don't link to c++ statically on windows.
         return;
     };
-    link_sys_lib(stdlib, &tool)
+    link_sys_lib(stdlib, tool)
 }
 
 fn link_sys_lib(lib: &str, tool: &cc::Tool) {

--- a/cmd/tikv-ctl/Cargo.toml
+++ b/cmd/tikv-ctl/Cargo.toml
@@ -85,6 +85,7 @@ txn_types = { path = "../../components/txn_types", default-features = false }
 
 [build-dependencies]
 time = "0.1"
+cc = "1.0"
 
 [target.'cfg(unix)'.dependencies]
 signal = "0.6"

--- a/cmd/tikv-server/Cargo.toml
+++ b/cmd/tikv-server/Cargo.toml
@@ -30,3 +30,4 @@ toml = "0.5"
 
 [build-dependencies]
 time = "0.1"
+cc = "1.0"

--- a/components/engine_rocks/Cargo.toml
+++ b/components/engine_rocks/Cargo.toml
@@ -53,7 +53,7 @@ case_macros = { path = "../case_macros" }
 [dependencies.rocksdb]
 git = "https://github.com/tikv/rust-rocksdb.git"
 package = "rocksdb"
-features = ["encryption", "static_libcpp"]
+features = ["encryption"]
 
 [dev-dependencies]
 rand = "0.8"


### PR DESCRIPTION

### What is changed and how it works?
Issue Number: Close #12144

What's Changed:

```commit-message
In the past, we rely on librocksdb-sys to include the required stdc++
library. This is not reliable after upgrading grpcio, which also needs
the same library. I suspect it doesn't include all the required symbols.

Anyway, this PR chooses to link to stdc++ explicitly in binary.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
