### PR TITLE
config: enable in-memory pessimistic locks by default

### DIFF
--- a/components/cdc/tests/integrations/test_cdc.rs
+++ b/components/cdc/tests/integrations/test_cdc.rs
@@ -1430,7 +1430,11 @@ fn test_old_value_cache_hit() {
 
 #[test]
 fn test_old_value_cache_hit_pessimistic() {
-    let mut suite = TestSuite::new(1);
+    let mut cluster = new_server_cluster(1, 1);
+    // Increase the Raft tick interval to make this test case running reliably.
+    configure_for_lease_read(&mut cluster, Some(100), None);
+    cluster.cfg.pessimistic_txn.in_memory = false;
+    let mut suite = TestSuiteBuilder::new().cluster(cluster).build();
     let scheduler = suite.endpoints.values().next().unwrap().scheduler();
     let mut req = suite.new_changedata_request(1);
     req.set_extra_op(ExtraOp::ReadOldValue);

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -1095,9 +1095,14 @@
 ## one more likely acquires the lock.
 # wake-up-delay-duration = "20ms"
 
-## Enable pipelined pessimistic lock, only effect when processing perssimistic transactions
-## Enabled this will improve performance, but slightly increase the transcation failure rate
+## Enable pipelined pessimistic lock, only effect when processing perssimistic transactions.
+## Enabling this will improve performance, but slightly increase the transaction failure rate
 # pipelined = true
+
+## Enable in-memory pessimistic lock, only effect when processing perssimistic transactions.
+## Enabling this will improve performance, but slightly increase the transaction failure rate.
+## It only takes effect when `pessimistic-txn.pipelined` is also set to true.
+# in-memory = true
 
 [gc]
 ## The number of keys to GC in one batch.

--- a/src/server/lock_manager/config.rs
+++ b/src/server/lock_manager/config.rs
@@ -55,7 +55,7 @@ impl Default for Config {
             wait_for_lock_timeout: ReadableDuration::millis(1000),
             wake_up_delay_duration: ReadableDuration::millis(20),
             pipelined: true,
-            in_memory: false,
+            in_memory: true,
         }
     }
 }
@@ -126,13 +126,13 @@ mod tests {
         wait-for-lock-timeout = "10ms"
         wake-up-delay-duration = 100
         pipelined = false
-        in-memory = true
+        in-memory = false
         "#;
 
         let config: Config = toml::from_str(conf).unwrap();
         assert_eq!(config.wait_for_lock_timeout.as_millis(), 10);
         assert_eq!(config.wake_up_delay_duration.as_millis(), 100);
         assert_eq!(config.pipelined, false);
-        assert_eq!(config.in_memory, true);
+        assert_eq!(config.in_memory, false);
     }
 }

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -734,7 +734,7 @@ fn test_serde_custom_tikv_config() {
         wait_for_lock_timeout: ReadableDuration::millis(10),
         wake_up_delay_duration: ReadableDuration::millis(100),
         pipelined: false,
-        in_memory: true,
+        in_memory: false,
     };
     value.cdc = CdcConfig {
         min_ts_interval: ReadableDuration::secs(4),

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -624,7 +624,7 @@ enabled = false # test backward compatibility
 wait-for-lock-timeout = "10ms"
 wake-up-delay-duration = 100 # test backward compatibility
 pipelined = false
-in-memory = true
+in-memory = false
 
 [cdc]
 min-ts-interval = "4s"


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #11452

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`: https://github.com/pingcap/docs-cn/pull/8645

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
