### PR TITLE
cdc: don't emit resolved timestamps before scan

### DIFF
--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -67,7 +67,7 @@ impl Default for DownstreamState {
 }
 
 /// Shold only be called when it's uninitialized or stopped. Return false if it's stopped.
-pub fn on_init_downstream(s: &AtomicCell<DownstreamState>) -> bool {
+pub(crate) fn on_init_downstream(s: &AtomicCell<DownstreamState>) -> bool {
     s.compare_exchange(
         DownstreamState::Uninitialized,
         DownstreamState::Initializing,
@@ -76,7 +76,7 @@ pub fn on_init_downstream(s: &AtomicCell<DownstreamState>) -> bool {
 }
 
 /// Shold only be called when it's initializing or stopped. Return false if it's stopped.
-pub fn post_init_downstream(s: &AtomicCell<DownstreamState>) -> bool {
+pub(crate) fn post_init_downstream(s: &AtomicCell<DownstreamState>) -> bool {
     s.compare_exchange(DownstreamState::Initializing, DownstreamState::Normal)
         .is_ok()
 }

--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -50,8 +50,12 @@ impl Default for DownstreamID {
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum DownstreamState {
+    /// It's just created and rejects change events and resolved timestamps.
     Uninitialized,
+    /// It has got a snapshot for incremental scan, and change events will be accepted.
+    /// However it still rejects resolved timestamps.
     Initializing,
+    /// Incremental scan is finished so that resolved timestamps are acceptable now.
     Normal,
     Stopped,
 }
@@ -62,8 +66,23 @@ impl Default for DownstreamState {
     }
 }
 
+/// Shold only be called when it's uninitialized or stopped. Return false if it's stopped.
+pub fn on_init_downstream(s: &AtomicCell<DownstreamState>) -> bool {
+    s.compare_exchange(
+        DownstreamState::Uninitialized,
+        DownstreamState::Initializing,
+    )
+    .is_ok()
+}
+
+/// Shold only be called when it's initializing or stopped. Return false if it's stopped.
+pub fn post_init_downstream(s: &AtomicCell<DownstreamState>) -> bool {
+    s.compare_exchange(DownstreamState::Initializing, DownstreamState::Normal)
+        .is_ok()
+}
+
 impl DownstreamState {
-    pub fn ready_for_changes(&self) -> bool {
+    pub fn ready_for_change_events(&self) -> bool {
         match *self {
             DownstreamState::Uninitialized | DownstreamState::Stopped => false,
             DownstreamState::Initializing | DownstreamState::Normal => true,
@@ -570,7 +589,7 @@ impl Delegate {
             ..Default::default()
         };
         let send = move |downstream: &Downstream| {
-            if !downstream.state.load().ready_for_changes() {
+            if !downstream.state.load().ready_for_change_events() {
                 return Ok(());
             }
             let event = change_data_event.clone();

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -1274,7 +1274,7 @@ impl<E: KvEngine> Initializer<E> {
             // When downstream_state is Stopped, it means the corresponding
             // delegate is stopped. The initialization can be safely canceled.
             if self.downstream_state.load() == DownstreamState::Stopped {
-                on_cancel()?;
+                return on_cancel();
             }
             let cursors = old_value_cursors.as_mut();
             let resolver = resolver.as_mut();
@@ -1289,7 +1289,7 @@ impl<E: KvEngine> Initializer<E> {
         }
 
         if !post_init_downstream(&self.downstream_state) {
-            on_cancel()?;
+            return on_cancel();
         }
         let takes = start.saturating_elapsed();
         info!("cdc async incremental scan finished";

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -156,6 +156,7 @@ pub enum Task {
     // The result of ChangeCmd should be returned from CDC Endpoint to ensure
     // the downstream switches to Normal after the previous commands was sunk.
     InitDownstream {
+        region_id: u64,
         downstream_id: DownstreamID,
         downstream_state: Arc<AtomicCell<DownstreamState>>,
         // `incremental_scan_barrier` will be sent into `sink` to ensure all delta changes
@@ -864,9 +865,7 @@ impl<T: 'static + RaftStoreRouter<E>, E: KvEngine> Endpoint<T, E> {
             resolved_ts.regions = Vec::with_capacity(downstream_regions.len());
             // Only send region ids that are captured by the connection.
             for (region_id, (_, downstream_state)) in conn.get_downstreams() {
-                if regions.contains(region_id)
-                    && matches!(downstream_state.load(), DownstreamState::Normal)
-                {
+                if regions.contains(region_id) && downstream_state.load().ready_for_advancing_ts() {
                     resolved_ts.regions.push(*region_id);
                 }
             }
@@ -1248,16 +1247,25 @@ impl<E: KvEngine> Initializer<E> {
         let conn_id = self.conn_id;
         let mut done = false;
         let start = Instant::now_coarse();
-        while !done {
-            // When downstream_state is Stopped, it means the corresponding
-            // delegate is stopped. The initialization can be safely canceled.
-            if self.downstream_state.load() == DownstreamState::Stopped {
+
+        let curr_state = self.downstream_state.load();
+        assert!([DownstreamState::Initializing, DownstreamState::Stopped].contains(&curr_state));
+        macro_rules! on_cancel {
+            () => {{
                 info!("cdc async incremental scan canceled";
                     "region_id" => region_id,
                     "downstream_id" => ?downstream_id,
                     "observe_id" => ?self.observe_id,
                     "conn_id" => ?conn_id);
                 return Err(box_err!("scan canceled"));
+            }}
+        }
+
+        while !done {
+            // When downstream_state is Stopped, it means the corresponding
+            // delegate is stopped. The initialization can be safely canceled.
+            if self.downstream_state.load() == DownstreamState::Stopped {
+                on_cancel!();
             }
             let cursors = old_value_cursors.as_mut();
             let resolver = resolver.as_mut();
@@ -1271,9 +1279,23 @@ impl<E: KvEngine> Initializer<E> {
             self.sink_scan_events(entries, done).await?;
         }
 
+        if self
+            .downstream_state
+            .compare_exchange(DownstreamState::Initializing, DownstreamState::Normal)
+            .is_err()
+        {
+            on_cancel!();
+        }
         let takes = start.saturating_elapsed();
+        info!("cdc async incremental scan finished";
+            "region_id" => region.get_id(),
+            "conn_id" => ?self.conn_id,
+            "downstream_id" => ?self.downstream_id,
+            "takes" => ?takes,
+        );
+
         if let Some(resolver) = resolver {
-            self.finish_building_resolver(resolver, region, takes);
+            self.finish_building_resolver(resolver, region);
         }
 
         CDC_SCAN_DURATION_HISTOGRAM.observe(takes.as_secs_f64());
@@ -1402,7 +1424,7 @@ impl<E: KvEngine> Initializer<E> {
         Ok(())
     }
 
-    fn finish_building_resolver(&self, mut resolver: Resolver, region: Region, takes: Duration) {
+    fn finish_building_resolver(&self, mut resolver: Resolver, region: Region) {
         let observe_id = self.observe_id;
         let rts = resolver.resolve(TimeStamp::zero());
         info!(
@@ -1413,7 +1435,6 @@ impl<E: KvEngine> Initializer<E> {
             "resolved_ts" => rts,
             "lock_count" => resolver.locks().len(),
             "observe_id" => ?observe_id,
-            "takes" => ?takes,
         );
 
         fail_point!("before_schedule_resolver_ready");
@@ -1538,6 +1559,7 @@ impl<T: 'static + RaftStoreRouter<E>, E: KvEngine> Runnable for Endpoint<T, E> {
             Task::OpenConn { conn } => self.on_open_conn(conn),
             Task::RegisterMinTsEvent => self.register_min_ts_event(),
             Task::InitDownstream {
+                region_id,
                 downstream_id,
                 downstream_state,
                 sink,
@@ -1545,20 +1567,23 @@ impl<T: 'static + RaftStoreRouter<E>, E: KvEngine> Runnable for Endpoint<T, E> {
                 cb,
             } => {
                 if let Err(e) = sink.unbounded_send(incremental_scan_barrier, true) {
-                    error!(
-                        "cdc failed to schedule barrier for delta before delta scan";
-                        "error" => ?e
-                    );
+                    error!("cdc failed to schedule barrier for delta before delta scan";
+                        "region_id" => region_id,
+                        "error" => ?e);
                     return;
                 }
-                match downstream_state
-                    .compare_exchange(DownstreamState::Uninitialized, DownstreamState::Normal)
-                {
+                match downstream_state.compare_exchange(
+                    DownstreamState::Uninitialized,
+                    DownstreamState::Initializing,
+                ) {
                     Ok(_) => {
-                        info!("cdc downstream is initialized"; "downstream_id" => ?downstream_id);
+                        info!("cdc downstream starts to initialize";
+                            "region_id" => region_id,
+                            "downstream_id" => ?downstream_id);
                     }
                     Err(state) => {
                         warn!("cdc downstream fails to initialize";
+                            "region_id" => region_id,
                             "downstream_id" => ?downstream_id,
                             "state" => ?state);
                     }
@@ -1702,7 +1727,7 @@ mod tests {
             .worker_threads(4)
             .build()
             .unwrap();
-        let downstream_state = Arc::new(AtomicCell::new(DownstreamState::Normal));
+        let downstream_state = Arc::new(AtomicCell::new(DownstreamState::Initializing));
         let initializer = Initializer {
             engine: engine.unwrap_or_else(|| {
                 TestEngineBuilder::new()
@@ -1868,10 +1893,16 @@ mod tests {
         block_on(initializer.async_incremental_scan(snap.clone(), region.clone())).unwrap();
         check_result();
 
+        initializer
+            .downstream_state
+            .store(DownstreamState::Initializing);
         initializer.max_scan_batch_bytes = total_bytes;
         block_on(initializer.async_incremental_scan(snap.clone(), region.clone())).unwrap();
         check_result();
 
+        initializer
+            .downstream_state
+            .store(DownstreamState::Initializing);
         initializer.build_resolver = false;
         block_on(initializer.async_incremental_scan(snap.clone(), region.clone())).unwrap();
 
@@ -1902,7 +1933,9 @@ mod tests {
 
         // Disconnect sink by dropping runtime (it also drops drain).
         drop(pool);
-        initializer.downstream_state.store(DownstreamState::Normal);
+        initializer
+            .downstream_state
+            .store(DownstreamState::Initializing);
         block_on(initializer.on_change_cmd_response(resp)).unwrap_err();
 
         worker.stop();

--- a/components/cdc/tests/failpoints/test_endpoint.rs
+++ b/components/cdc/tests/failpoints/test_endpoint.rs
@@ -255,7 +255,6 @@ fn test_no_resolved_ts_before_downstream_initialized() {
     // Create 2 changefeeds and the second will be blocked in initialization.
     let mut req_txs = Vec::with_capacity(2);
     let mut event_feeds = Vec::with_capacity(2);
-    let mut receive_events = Vec::with_capacity(2);
     for i in 0..2 {
         if i == 1 {
             fail::cfg("cdc_incremental_scan_start", "pause").unwrap();


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

Issue Number: Close https://github.com/pingcap/tiflow/issues/4782

CDC shouldn't emit resolved timestamps before incremental scan finished. https://github.com/tikv/tikv/pull/11098 tried to fix the problem but the implementation is wrong. This patch gives a correct solution.

```commit-message
cdc: don't emit resolved timestamps before scan
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
