### PR TITLE
copr: return buckets version for unary call

### DIFF
--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -1641,6 +1641,24 @@ impl<T: Simulator> Cluster<T> {
         ctx.set_region_epoch(epoch);
         ctx
     }
+
+    pub fn refresh_region_bucket_keys(
+        &mut self,
+        region: &metapb::Region,
+        bucket_keys: Vec<Vec<u8>>,
+    ) {
+        let leader = self.leader_of_region(region.get_id()).unwrap();
+        let router = self.sim.rl().get_router(leader.get_store_id()).unwrap();
+        CasualRouter::send(
+            &router,
+            region.get_id(),
+            CasualMessage::RefreshRegionBuckets {
+                region_epoch: region.get_region_epoch().clone(),
+                bucket_keys,
+            },
+        )
+        .unwrap();
+    }
 }
 
 impl<T: Simulator> Drop for Cluster<T> {

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -379,6 +379,7 @@ impl<E: Engine> Endpoint<E> {
         tracker.on_snapshot_finished();
         tracker.req_ctx.deadline.check()?;
         tracker.buckets = snapshot.ext().get_buckets();
+        let buckets_version = tracker.buckets.as_ref().map_or(0, |b| b.version);
 
         let mut handler = if tracker.req_ctx.cache_match_version.is_some()
             && tracker.req_ctx.cache_match_version == snapshot.ext().get_data_version()
@@ -422,6 +423,7 @@ impl<E: Engine> Endpoint<E> {
         };
         resp.set_exec_details(exec_details);
         resp.set_exec_details_v2(exec_details_v2);
+        resp.set_latest_buckets_version(buckets_version);
         Ok(resp)
     }
 


### PR DESCRIPTION
close #12182

Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #12182

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Return the latest buckets version in coprocessor reponses to notify clients to refresh cached buckets information.
```

### Related changes


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
