### PR TITLE
add vdso to the pprof blocklist

### DIFF
--- a/src/server/status_server/profile.rs
+++ b/src/server/status_server/profile.rs
@@ -202,7 +202,7 @@ where
     let on_start = || {
         let guard = pprof::ProfilerGuardBuilder::default()
             .frequency(frequency)
-            .blocklist(&["libc", "libgcc", "pthread"])
+            .blocklist(&["libc", "libgcc", "pthread", "vdso"])
             .build()
             .map_err(|e| format!("pprof::ProfilerGuardBuilder::build fail: {}", e))?;
         Ok(guard)


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What is changed and how it works?

Add `[vdso]` to the `pprof-rs` blocklist, we "guess" the problem would be the dwarf information in vdso is incorrect. This is a PR to test whether it would work well after blocking the `vdso`.

Issue Number: Close https://github.com/tikv/tikv/issues/9765

### Release note 

```release-note
Fix crash when profiling in Ubuntu 18.04.
```