### PR TITLE
security:use clippy to disallow hex_encode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,7 +285,6 @@ pre-clippy: unset-override
 	@rustup component add clippy
 
 clippy: pre-clippy
-	@./scripts/check-redact-log
 	@./scripts/check-docker-build
 	@./scripts/clippy-all
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,3 @@
+disallowed-methods = [
+    { path = "hex::encode_upper", reason = "Keys should not be printed to log. Consider using log_wrapper for logging." },
+]


### PR DESCRIPTION
close https://github.com/tikv/tikv/issues/12061
Signed-off-by: Jayice <1185430411@qq.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/tikv/tikv/issues/12061

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
use clippy to disallow `hex:encode_upper`, replacing grep
```


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


- Manual test (add detailed scripts or steps below)

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
none
```
