### PR TITLE
Transfer the work of callback from on_write_finish which is executed …

### DIFF
--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -638,6 +638,38 @@ impl<E: Engine, L: LockManager> Scheduler<E, L> {
         self.release_lock(&tctx.lock, cid);
     }
 
+    /// Event handler for the success of write.
+    fn on_write_finished_release_latch(
+        &self,
+        cid: u64,
+        lock_guards: Vec<KeyHandleGuard>,
+        pipelined: bool,
+        async_apply_prewrite: bool,
+        tag: metrics::CommandKind,
+        txtc_lock: Lock,
+    ) {
+        // TODO: Does async apply prewrite worth a special metric here?
+        if pipelined {
+            SCHED_STAGE_COUNTER_VEC
+                .get(tag)
+                .pipelined_write_finish
+                .inc();
+        } else if async_apply_prewrite {
+            SCHED_STAGE_COUNTER_VEC
+                .get(tag)
+                .async_apply_prewrite_finish
+                .inc();
+        } else {
+            SCHED_STAGE_COUNTER_VEC.get(tag).write_finish.inc();
+        }
+
+        debug!("write command finished";
+            "cid" => cid, "pipelined" => pipelined, "async_apply_prewrite" => async_apply_prewrite);
+        drop(lock_guards);
+
+        self.release_lock(&txtc_lock, cid);
+    }
+
     /// Event handler for the request of waiting for lock
     fn on_wait_for_lock(
         &self,
@@ -1018,18 +1050,49 @@ impl<E: Engine, L: LockManager> Scheduler<E, L> {
                 }
             }
 
+            let TaskContext {
+                task: _,
+                lock: task_lock,
+                cb: task_cb,
+                pr: task_pr,
+                owned: _,
+                write_bytes: _,
+                tag: _,
+                latch_timer: _,
+                _cmd_timer: _,
+            } = self.inner.dequeue_task_context(cid);
+
+            // If pipelined pessimistic lock or async apply prewrite takes effect, it's not guaranteed
+            // that the proposed or committed callback is surely invoked, which takes and invokes
+            // `tctx.cb(tctx.pr)`.
+            if let Some(cb) = task_cb {
+                let pr = match result {
+                    Ok(()) => pr.or(task_pr).unwrap(),
+                    Err(e) => ProcessResult::Failed {
+                        err: StorageError::from(e),
+                    },
+                };
+                if let ProcessResult::NextCommand { cmd } = pr {
+                    SCHED_STAGE_COUNTER_VEC.get(tag).next_cmd.inc();
+                    self.schedule_command(cmd, cb);
+                } else {
+                    cb.execute(pr);
+                }
+            } else {
+                assert!(pipelined || is_async_apply_prewrite);
+            }
+
             sched_pool
                 .spawn(async move {
                     fail_point!("scheduler_async_write_finish");
 
-                    sched.on_write_finished(
+                    sched.on_write_finished_release_latch(
                         cid,
-                        pr,
-                        result,
                         lock_guards,
                         pipelined,
                         is_async_apply_prewrite,
                         tag,
+                        task_lock,
                     );
                     KV_COMMAND_KEYWRITE_HISTOGRAM_VEC
                         .get(tag)


### PR DESCRIPTION
…in sched worker to apply worker

Signed-off-by:SpadeA <u6748471@anu.edu.au>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #9462

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.
If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
```
