### PR TITLE
Quota limiter: make method to delay cpu more precise

### DIFF
--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -262,6 +262,7 @@ impl<ER: RaftEngine> TiKVServer<ER> {
             config.quota.foreground_cpu_time,
             config.quota.foreground_write_bandwidth,
             config.quota.foreground_read_bandwidth,
+            config.quota.max_delay_duration,
         ));
 
         TiKVServer {

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -348,6 +348,7 @@ impl Simulator for ServerCluster {
             cfg.quota.foreground_cpu_time,
             cfg.quota.foreground_write_bandwidth,
             cfg.quota.foreground_read_bandwidth,
+            cfg.quota.max_delay_duration,
         ));
         let store = create_raft_storage(
             engine,

--- a/components/tikv_util/src/quota_limiter.rs
+++ b/components/tikv_util/src/quota_limiter.rs
@@ -9,13 +9,6 @@ use super::timer::GLOBAL_TIMER_HANDLE;
 use cpu_time::ThreadTime;
 use futures::compat::Future01CompatExt;
 
-// The cpu time is not a real statistics, only part of the processing logic is
-// taken into account, so it needs to be multiplied by a factor.
-// transfer milli cpu to micro cpu
-//
-// TODO: Don't adjusted based on experience.
-const CPU_TIME_FACTOR: f64 = 0.8;
-
 // To avoid long tail latency.
 const MAX_QUOTA_DELAY: Duration = Duration::from_secs(1);
 
@@ -99,7 +92,7 @@ impl QuotaLimiter {
         let cputime_limiter = if cpu_quota == 0 {
             Limiter::new(f64::INFINITY)
         } else {
-            Limiter::new(cpu_quota as f64 * CPU_TIME_FACTOR * 1000_f64)
+            Limiter::new(cpu_quota as f64 * 1000_f64)
         };
 
         let write_bandwidth_limiter = if write_bandwidth.0 == 0 {
@@ -156,12 +149,7 @@ impl QuotaLimiter {
         };
 
         let max_dur = std::cmp::max(cpu_dur, std::cmp::max(w_bw_dur, r_bw_dur));
-        let should_delay = if max_dur > sample.cpu_time {
-            max_dur - sample.cpu_time
-        } else {
-            Duration::ZERO
-        };
-        let exec_delay = std::cmp::min(MAX_QUOTA_DELAY, should_delay);
+        let exec_delay = std::cmp::min(MAX_QUOTA_DELAY, max_dur);
 
         if !exec_delay.is_zero() {
             GLOBAL_TIMER_HANDLE
@@ -182,43 +170,34 @@ mod tests {
 
     #[test]
     fn test_quota_limiter() {
-        // consume write
-        let quota_limiter = QuotaLimiter::new(
-            1250, /*1.1vCPU*/
-            ReadableSize::kb(1),
-            ReadableSize::kb(1),
-        );
+        // refill duration = 100ms
+        // bucket capacity = 100
+        let quota_limiter = QuotaLimiter::new(1000, ReadableSize::kb(1), ReadableSize::kb(1));
 
         let thread_start_time = ThreadTime::now();
 
-        // (1250 * CPU_TIME_FACTOR) * 1 sec = 1000 millis
-        let mut th = quota_limiter.new_sample();
-        th.add_cpu_time(Duration::from_millis(200));
-        let begin_instant = std::time::Instant::now();
-        block_on(quota_limiter.async_consume(th));
-        // 50ms represents fast
-        assert!(begin_instant.elapsed() < Duration::from_millis(50));
+        let mut sample = quota_limiter.new_sample();
+        sample.add_cpu_time(Duration::from_millis(50));
+        let should_delay = block_on(quota_limiter.async_consume(sample));
+        assert_eq!(should_delay, Duration::ZERO);
 
-        // only bytes take effect (1000ms - 300ms used by cpu)
-        // (1250 * CPU_TIME_FACTOR) * 1 sec = 1000 millis
-        let mut th = quota_limiter.new_sample();
-        th.add_cpu_time(Duration::from_millis(300));
-        th.add_write_bytes(ReadableSize::kb(1).0 as usize);
-        let begin_instant = std::time::Instant::now();
-        block_on(quota_limiter.async_consume(th));
-        assert!(begin_instant.elapsed() > Duration::from_millis(700));
-        assert!(begin_instant.elapsed() < Duration::from_millis(800));
+        // after this refill bucket value about 60
+        std::thread::sleep(Duration::from_millis(10));
 
-        // test max delay
-        let mut th = quota_limiter.new_sample();
-        th.add_cpu_time(Duration::from_millis(100));
-        th.add_read_bytes(ReadableSize::kb(100).0 as usize);
-        let begin_instant = std::time::Instant::now();
-        block_on(quota_limiter.async_consume(th));
-        assert!(begin_instant.elapsed() < Duration::from_millis(1100));
-        assert!(begin_instant.elapsed() > Duration::from_millis(1000));
+        let mut sample = quota_limiter.new_sample();
+        sample.add_cpu_time(Duration::from_millis(90));
+        let should_delay = block_on(quota_limiter.async_consume(sample));
+        // bucket value only about 60 but consume 90, delay should be about 130
+        assert!(should_delay <= Duration::from_millis(130));
+        assert!(should_delay > Duration::from_millis(120));
+
+        let mut sample = quota_limiter.new_sample();
+        sample.add_cpu_time(Duration::from_millis(200));
+        sample.add_write_bytes(256);
+        let should_delay = block_on(quota_limiter.async_consume(sample));
+        assert_eq!(should_delay, Duration::from_millis(250));
 
         // ThreadTime elapsed time is not long.
-        assert!(thread_start_time.elapsed() < Duration::from_millis(100));
+        assert!(thread_start_time.elapsed() < Duration::from_millis(50));
     }
 }

--- a/components/tikv_util/src/quota_limiter.rs
+++ b/components/tikv_util/src/quota_limiter.rs
@@ -94,7 +94,7 @@ impl QuotaLimiter {
         let cputime_limiter = if cpu_quota == 0 {
             Limiter::new(f64::INFINITY)
         } else {
-            <Limiter>::builder(cpu_quota as f64 * 1000_f64)
+            Limiter::builder(cpu_quota as f64 * 1000_f64)
                 .refill(CPU_LIMITER_REFILL_DURATION)
                 .build()
         };

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -46,7 +46,7 @@
 ## Quota is use to add some limitation for the read write flow and then
 ## gain predictable stable performance.
 ## CPU quota for these front requests can use, default value is 0, it means unlimited.
-## The unit is millicpu which 1000 means 1vCPU and this config is approximate.
+## The unit is millicpu but for now this config is approximate and soft limit.
 # foreground-cpu-time = 0
 ## Write bandwidth limitation for this TiKV instance, default value is 0 which means unlimited.
 # foreground-write-bandwidth = "0B"

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -50,8 +50,10 @@
 # foreground-cpu-time = 0
 ## Write bandwidth limitation for this TiKV instance, default value is 0 which means unlimited.
 # foreground-write-bandwidth = "0B"
-## Read bandwidth limitation for this TiKV instance, default value is 0 which means unlimited
+## Read bandwidth limitation for this TiKV instance, default value is 0 which means unlimited.
 # foreground-read-bandwidth = "0B"
+## Limitation of max delay duration for each request, default value is 0 which means unlimited.
+# max-delay-duration = "500ms"
 
 [log]
 ## Log levels: debug, info, warn, error, fatal.

--- a/src/config.rs
+++ b/src/config.rs
@@ -2474,6 +2474,7 @@ pub struct QuotaConfig {
     pub foreground_cpu_time: usize,
     pub foreground_write_bandwidth: ReadableSize,
     pub foreground_read_bandwidth: ReadableSize,
+    pub max_delay_duration: ReadableDuration,
 }
 
 impl Default for QuotaConfig {
@@ -2482,6 +2483,7 @@ impl Default for QuotaConfig {
             foreground_cpu_time: 0,
             foreground_write_bandwidth: ReadableSize(0),
             foreground_read_bandwidth: ReadableSize(0),
+            max_delay_duration: ReadableDuration::millis(500),
         }
     }
 }

--- a/tests/integrations/server/kv_service.rs
+++ b/tests/integrations/server/kv_service.rs
@@ -1975,8 +1975,8 @@ fn test_storage_with_quota_limiter_enable() {
     mutation.set_value(v);
     must_kv_prewrite(&client, ctx, vec![mutation], k, prewrite_start_version);
 
-    // 800 only represents quota enabled, no specific significance
-    assert!(begin.elapsed() > Duration::from_millis(800));
+    // 500 only represents quota enabled, no specific significance
+    assert!(begin.elapsed() > Duration::from_millis(500));
 }
 
 #[test]
@@ -2006,5 +2006,5 @@ fn test_storage_with_quota_limiter_disable() {
     mutation.set_value(v);
     must_kv_prewrite(&client, ctx, vec![mutation], k, prewrite_start_version);
 
-    assert!(begin.elapsed() < Duration::from_millis(800));
+    assert!(begin.elapsed() < Duration::from_millis(500));
 }

--- a/tests/integrations/server/kv_service.rs
+++ b/tests/integrations/server/kv_service.rs
@@ -1951,7 +1951,7 @@ fn test_storage_with_quota_limiter_enable() {
         let quota_config = QuotaConfig {
             foreground_cpu_time: 2000,
             foreground_write_bandwidth: ReadableSize(10),
-            foreground_read_bandwidth: ReadableSize(0),
+            ..Default::default()
         };
         cluster.cfg.quota = quota_config;
         cluster.cfg.storage.scheduler_worker_pool_size = 1;
@@ -1983,11 +1983,7 @@ fn test_storage_with_quota_limiter_enable() {
 fn test_storage_with_quota_limiter_disable() {
     let (cluster, leader, ctx) = must_new_and_configure_cluster(|cluster| {
         // all limit set to 0, which means quota limiter not work.
-        let quota_config = QuotaConfig {
-            foreground_cpu_time: 0,
-            foreground_write_bandwidth: ReadableSize(0),
-            foreground_read_bandwidth: ReadableSize(0),
-        };
+        let quota_config = QuotaConfig::default();
         cluster.cfg.quota = quota_config;
         cluster.cfg.storage.scheduler_worker_pool_size = 1;
     });


### PR DESCRIPTION
Signed-off-by: Xintao <hunterlxt@live.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #12218

What's Changed:


<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Use the results returned by the cpu limiter directly without extra processing
```

### Related changes

- Need to cherry-pick to the release 6.0 branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- No

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
