### PR TITLE
copr: limit the number of tasks blocked by the semaphore

### DIFF
--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -67,6 +67,8 @@ pub struct Endpoint<E: Engine> {
     /// The soft time limit of handling Coprocessor requests.
     max_handle_duration: Duration,
 
+    semaphore_waiter_limit: usize,
+
     slow_log_threshold: Duration,
 
     _phantom: PhantomData<E>,
@@ -102,6 +104,7 @@ impl<E: Engine> Endpoint<E> {
             stream_batch_row_limit: cfg.end_point_stream_batch_row_limit,
             stream_channel_size: cfg.end_point_stream_channel_size,
             max_handle_duration: cfg.end_point_request_max_handle_duration.0,
+            semaphore_waiter_limit: cfg.end_point_semaphore_waiter_limit,
             slow_log_threshold: cfg.end_point_slow_log_threshold.0,
             _phantom: Default::default(),
         }
@@ -360,6 +363,7 @@ impl<E: Engine> Endpoint<E> {
     /// `RequestHandler` to process the request and produce a result.
     async fn handle_unary_request_impl(
         semaphore: Option<Arc<Semaphore>>,
+        semaphore_waiter_limit: usize,
         mut tracker: Box<Tracker>,
         handler_builder: RequestHandlerBuilder<E::Snap>,
     ) -> Result<MemoryTraceGuard<coppb::Response>> {
@@ -392,12 +396,27 @@ impl<E: Engine> Endpoint<E> {
         let handle_request_future = check_deadline(handler.handle_request(), deadline);
         let handle_request_future = track(handle_request_future, &mut tracker);
 
-        let deadline_res = if let Some(semaphore) = &semaphore {
-            limit_concurrency(handle_request_future, semaphore, LIGHT_TASK_THRESHOLD).await
+        let result = if let Some(semaphore) = &semaphore {
+            limit_concurrency(
+                handle_request_future,
+                semaphore,
+                semaphore_waiter_limit,
+                LIGHT_TASK_THRESHOLD,
+            )
+            .await
+            .and_then(|deadline_res| deadline_res.map_err(Error::from).and_then(|res| res))
         } else {
-            handle_request_future.await
+            handle_request_future
+                .await
+                .map_err(Error::from)
+                .and_then(|res| res)
         };
-        let result = deadline_res.map_err(Error::from).and_then(|res| res);
+        if matches!(
+            result,
+            Err(Error::DeadlineExceeded | Error::MaxPendingTasksExceeded)
+        ) {
+            tracker.set_abort_error(format!("{}", result.as_ref().unwrap_err()));
+        }
 
         // There might be errors when handling requests. In this case, we still need its
         // execution metrics.
@@ -440,8 +459,13 @@ impl<E: Engine> Endpoint<E> {
         let res = self
             .read_pool
             .spawn_handle(
-                Self::handle_unary_request_impl(self.semaphore.clone(), tracker, handler_builder)
-                    .in_resource_metering_tag(resource_tag),
+                Self::handle_unary_request_impl(
+                    self.semaphore.clone(),
+                    self.semaphore_waiter_limit,
+                    tracker,
+                    handler_builder,
+                )
+                .in_resource_metering_tag(resource_tag),
                 priority,
                 task_id,
             )

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -42,6 +42,8 @@ const DEFAULT_ENDPOINT_STREAM_BATCH_ROW_LIMIT: usize = 128;
 // At least 4 long coprocessor requests are allowed to run concurrently.
 const MIN_ENDPOINT_MAX_CONCURRENCY: usize = 4;
 
+const DEFAULT_ENDPOINT_SEMAPHORE_WAITER_LIMIT: usize = 1024;
+
 const DEFAULT_SNAP_MAX_BYTES_PER_SEC: u64 = 100 * 1024 * 1024;
 
 const DEFAULT_MAX_GRPC_SEND_MSG_LEN: i32 = 10 * 1024 * 1024;
@@ -133,6 +135,8 @@ pub struct Config {
     pub end_point_request_max_handle_duration: ReadableDuration,
     #[online_config(skip)]
     pub end_point_max_concurrency: usize,
+    #[online_config(skip)]
+    pub end_point_semaphore_waiter_limit: usize,
     pub snap_max_write_bytes_per_sec: ReadableSize,
     pub snap_max_total_size: ReadableSize,
     #[online_config(skip)]
@@ -234,6 +238,7 @@ impl Default for Config {
                 DEFAULT_ENDPOINT_REQUEST_MAX_HANDLE_SECS,
             ),
             end_point_max_concurrency: cmp::max(cpu_num as usize, MIN_ENDPOINT_MAX_CONCURRENCY),
+            end_point_semaphore_waiter_limit: DEFAULT_ENDPOINT_SEMAPHORE_WAITER_LIMIT,
             snap_max_write_bytes_per_sec: ReadableSize(DEFAULT_SNAP_MAX_BYTES_PER_SEC),
             snap_max_total_size: ReadableSize(0),
             stats_concurrency: 1,

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -103,6 +103,7 @@ fn test_serde_custom_tikv_config() {
         end_point_enable_batch_if_possible: true,
         end_point_request_max_handle_duration: ReadableDuration::secs(12),
         end_point_max_concurrency: 10,
+        end_point_semaphore_waiter_limit: 300,
         snap_max_write_bytes_per_sec: ReadableSize::mb(10),
         snap_max_total_size: ReadableSize::gb(10),
         stats_concurrency: 10,

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -73,6 +73,7 @@ end-point-stream-batch-row-limit = 4096
 end-point-enable-batch-if-possible = true
 end-point-request-max-handle-duration = "12s"
 end-point-max-concurrency = 10
+end-point-semaphore-waiter-limit = 300
 snap-max-write-bytes-per-sec = "10MB"
 snap-max-total-size = "10GB"
 stats-concurrency = 10


### PR DESCRIPTION
This is only a hotfix PR. 

It adds a config setting the max number of tasks blocked by the semaphore:

```toml
[server]
end-point-semaphore-waiter-limit = 1024
```

Tasks exceeding the limit will be aborted using a `MaxPendingTasksExceeded` error.

Slow log will be printed for all aborted coprocessor requests due to exceeding the deadline or the task number limit.