### PR TITLE
raftstore: validate bucket config only when it's enabled

### DIFF
--- a/components/raftstore/src/coprocessor/config.rs
+++ b/components/raftstore/src/coprocessor/config.rs
@@ -107,22 +107,24 @@ impl Config {
                 self.region_split_keys
             ));
         }
-        if self.region_split_size.0 < self.region_bucket_size.0 {
-            return Err(box_err!(
-                "region split size {} must >= region bucket size {}",
-                self.region_split_size.0,
-                self.region_bucket_size.0
-            ));
-        }
-        if self.region_size_threshold_for_approximate.0 < self.region_bucket_size.0 {
-            return Err(box_err!(
-                "large region threshold size {} must >= region bucket size {}",
-                self.region_size_threshold_for_approximate.0,
-                self.region_bucket_size.0
-            ));
-        }
-        if self.region_bucket_size.0 == 0 {
-            return Err(box_err!("region_bucket size cannot be 0."));
+        if self.enable_region_bucket {
+            if self.region_split_size.0 < self.region_bucket_size.0 {
+                return Err(box_err!(
+                    "region split size {} must >= region bucket size {}",
+                    self.region_split_size.0,
+                    self.region_bucket_size.0
+                ));
+            }
+            if self.region_size_threshold_for_approximate.0 < self.region_bucket_size.0 {
+                return Err(box_err!(
+                    "large region threshold size {} must >= region bucket size {}",
+                    self.region_size_threshold_for_approximate.0,
+                    self.region_bucket_size.0
+                ));
+            }
+            if self.region_bucket_size.0 == 0 {
+                return Err(box_err!("region_bucket size cannot be 0."));
+            }
         }
         Ok(())
     }
@@ -166,5 +168,11 @@ mod tests {
         cfg.region_max_keys = 10;
         cfg.region_split_keys = 20;
         assert!(cfg.validate().is_err());
+
+        cfg = Config::default();
+        cfg.enable_region_bucket = false;
+        cfg.region_split_size = ReadableSize(20);
+        cfg.region_bucket_size = ReadableSize(30);
+        assert!(cfg.validate().is_ok());
     }
 }


### PR DESCRIPTION
Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #12235, #12236

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Shouldn't report config related errors when bucket is disabled.
```

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
