### PR TITLE
res_meter: fix assertion failure

### DIFF
--- a/components/resource_metering/src/reporter/mod.rs
+++ b/components/resource_metering/src/reporter/mod.rs
@@ -129,9 +129,18 @@ impl Reporter {
     }
 
     fn upload(&mut self) {
+        // When either of records.records and records.others is not empty, we
+        // will report it. Only when the cpu_time of all tags is equal, and the
+        // number of tags exceeds the max_resource_group limit, will records.records
+        // be empty and records.others not be empty. This means that we will report
+        // a batch of data that only contains records.others.
+        //
+        // See: https://github.com/tikv/tikv/issues/12234
         if self.records.is_empty() {
+            // This means records.records and records.others are both empty.
             return;
         }
+
         // Whether endpoint exists or not, records should be taken in order to reset.
         let records = std::mem::take(&mut self.records);
         let report_data: Arc<Vec<ResourceUsageRecord>> = Arc::new(records.into());


### PR DESCRIPTION
Issue Number: close #12234

Signed-off-by: mornyx <mornyx.z@gmail.com>

### What's changed

#### Before

In the past, we used assertions to ensure that when tagged `Records.records` was empty, untagged `Records.others` must also be empty:

```rust
pub fn is_empty(&self) -> bool {
    if self.records.is_empty() {
        assert!(self.others.is_empty());
        true
    } else {
        false
    }
}
```

This is reasonable in the general case, but will trigger an assertion failure under some special condition...

In a certain round of collection, when we collect tags that exceed the maximum number limit (`max_resource_group`), and all these tags correspond to equal `cpu_time`, then our `records.top_k()` action will get 0 `top` and many `evicted`:

```rust
fn handle_records(&mut self, records: Arc<RawRecords>) {
    let ts = records.begin_unix_time_secs;
    if self.config.max_resource_groups >= records.records.len() {
        self.records.append(ts, records.records.iter());
        return;
    }
    // Here we got 0 top and many evicted.
    let (top, evicted) = records.top_k(self.config.max_resource_groups);
    self.records.append(ts, top);
    let others = self.records.others.entry(ts).or_default();
    evicted.for_each(|(_, v)| {
        others.merge(v);
    });
}
```

At this point, a scheduled report is triggered and an empty check is performed. So the assertion fails.

#### After

We changed the basis for `Records` to be empty to `Records.records` and `Records.others` are both empty:

```rust
pub fn is_empty(&self) -> bool {
    self.records.is_empty() && self.others.is_empty()
}
```

So when the above scenario occurs, only reporting `Records.others` without `Records.records` is allowed.

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
