### PR TITLE
raftstore: improve force compact strategy

### DIFF
--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -38,8 +38,8 @@ use pd_client::{merge_bucket_stats, new_bucket_stats, BucketMeta, BucketStat};
 use protobuf::Message;
 use raft::eraftpb::{self, ConfChangeType, MessageType};
 use raft::{
-    self, GetEntriesContext, Progress, ProgressState, ReadState, SnapshotStatus, StateRole,
-    INVALID_INDEX, NO_LIMIT,
+    self, GetEntriesContext, Progress, ReadState, SnapshotStatus, StateRole, INVALID_INDEX,
+    NO_LIMIT,
 };
 use smallvec::SmallVec;
 use tikv_alloc::trace::TraceEvent;
@@ -4405,7 +4405,7 @@ where
         let truncated_idx = self.fsm.peer.get_store().truncated_index();
         let last_idx = self.fsm.peer.get_store().last_index();
         let (mut replicated_idx, mut alive_cache_idx) = (last_idx, last_idx);
-        let mut probing = false;
+        let mut disconnected = false;
         for (peer_id, p) in self.fsm.peer.raft_group.raft.prs().iter() {
             if replicated_idx > p.matched {
                 replicated_idx = p.matched;
@@ -4418,8 +4418,8 @@ where
                     alive_cache_idx = p.matched;
                 }
             }
-            if p.state == ProgressState::Probe {
-                probing = true;
+            if !p.recent_active {
+                disconnected = true;
             }
         }
         // When an election happened or a new peer is added, replicated_idx can be 0.
@@ -4447,9 +4447,9 @@ where
 
         let first_idx = self.fsm.peer.get_store().first_index();
 
-        let mut compact_idx = if force_compact && replicated_idx > first_idx && !probing {
+        let mut compact_idx = if force_compact && replicated_idx > first_idx && !disconnected {
             replicated_idx
-        } else if force_compact && probing {
+        } else if force_compact && disconnected {
             std::cmp::max(first_idx + (last_idx - first_idx) / 4, replicated_idx)
         } else if (applied_idx > first_idx
             && applied_idx - first_idx >= self.ctx.cfg.raft_log_gc_count_limit)

--- a/components/raftstore/src/store/local_metrics.rs
+++ b/components/raftstore/src/store/local_metrics.rs
@@ -374,6 +374,7 @@ pub struct RaftLogGcSkippedMetrics {
     pub reserve_log: u64,
     pub threshold_limit: u64,
     pub compact_idx_too_small: u64,
+    pub force_compacted: u64,
 }
 
 impl RaftLogGcSkippedMetrics {
@@ -393,6 +394,12 @@ impl RaftLogGcSkippedMetrics {
                 .compact_idx_too_small
                 .inc_by(self.compact_idx_too_small);
             self.compact_idx_too_small = 0;
+        }
+        if self.force_compacted > 0 {
+            RAFT_LOG_GC_SKIPPED
+                .force_compacted
+                .inc_by(self.force_compacted);
+            self.force_compacted = 0;
         }
     }
 }

--- a/components/raftstore/src/store/metrics.rs
+++ b/components/raftstore/src/store/metrics.rs
@@ -163,6 +163,7 @@ make_auto_flush_static_metric! {
         reserve_log,
         compact_idx_too_small,
         threshold_limit,
+        force_compacted,
     }
 
     pub struct RaftEventDuration : LocalHistogram {

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -1485,7 +1485,6 @@ where
             if p.get_id() == self.peer.get_id() {
                 continue;
             }
-            // TODO
             if let Some(instant) = self.peer_heartbeats.get(&p.get_id()) {
                 let elapsed = instant.saturating_elapsed();
                 if elapsed >= max_duration {


### PR DESCRIPTION
Signed-off-by: tabokie <xy.tao@outlook.com>

### What is changed and how it works?

Issue Number: Close #12255

What's Changed:

When some TiKVs are down, we allow force compacting unreplicated entries to free up log storage. When those nodes recover, we disallow force compacting unreplicated entries to avoid excessive snapshot transfer.

```commit-message
```

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
