### PR TITLE
raftstore: Make unsafe recovery wait apply cover snapshot apply cases ref #10483

### DIFF
--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -1902,6 +1902,7 @@ where
         }
         // After a log has been applied, check if we need to trigger the unsafe recovery reporting procedure.
         if self.fsm.peer.unsafe_recovery_state.is_some() {
+            debug!("unsafe recovery finishes applying an entry");
             self.fsm
                 .peer
                 .unsafe_recovery_maybe_finish_wait_apply(self.ctx, /*force=*/ false);

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -622,9 +622,6 @@ impl<'a, EK: KvEngine + 'static, ER: RaftEngine + 'static, T: Transport>
                     inspector.record_store_wait(send_time.saturating_elapsed());
                     self.ctx.pending_latency_inspect.push(inspector);
                 }
-                StoreMsg::SendDetailedReportForUnsafeRecovery => {
-                    store_heartbeat_pd(self.ctx, /*send_detailed_report=*/ true);
-                }
                 StoreMsg::CreatePeer(region) => self.on_create_peer(region),
             }
         }
@@ -1609,8 +1606,8 @@ enum CheckMsgStatus {
     NewPeerFirst,
 }
 
-fn store_heartbeat_pd<EK: KvEngine, ER: RaftEngine, T: Transport>(
-    ctx: &mut PollContext<EK, ER, T>,
+pub fn store_heartbeat_pd<EK: KvEngine, ER: RaftEngine, T: Transport>(
+    ctx: &PollContext<EK, ER, T>,
     send_detailed_report: bool,
 ) {
     let mut stats = StoreStats::default();

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -1157,7 +1157,7 @@ where
         let mut ctx = PollContext {
             cfg: self.cfg.value().clone(),
             store: self.store.clone(),
-            store_start_time: self.store_start_time.clone(),
+            store_start_time: self.store_start_time,
             pd_scheduler: self.pd_scheduler.clone(),
             consistency_check_scheduler: self.consistency_check_scheduler.clone(),
             split_check_scheduler: self.split_check_scheduler.clone(),
@@ -1225,7 +1225,7 @@ where
         RaftPollerBuilder {
             cfg: self.cfg.clone(),
             store: self.store.clone(),
-            store_start_time: self.store_start_time.clone(),
+            store_start_time: self.store_start_time,
             pd_scheduler: self.pd_scheduler.clone(),
             consistency_check_scheduler: self.consistency_check_scheduler.clone(),
             split_check_scheduler: self.split_check_scheduler.clone(),

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -623,6 +623,9 @@ impl<'a, EK: KvEngine + 'static, ER: RaftEngine + 'static, T: Transport>
                     inspector.record_store_wait(send_time.saturating_elapsed());
                     self.ctx.pending_latency_inspect.push(inspector);
                 }
+                StoreMsg::SendDetailedReportForUnsafeRecovery => {
+                    self.store_heartbeat_pd(/*send_detailed_report=*/ true);
+                }
                 StoreMsg::CreatePeer(region) => self.on_create_peer(region),
             }
         }
@@ -2154,7 +2157,7 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
         }
     }
 
-    fn store_heartbeat_pd(&mut self) {
+    fn store_heartbeat_pd(&mut self, send_detailed_report: bool) {
         let mut stats = StoreStats::default();
 
         stats.set_store_id(self.ctx.store_id());
@@ -2232,7 +2235,7 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
         let task = PdTask::StoreHeartbeat {
             stats,
             store_info,
-            send_detailed_report: false,
+            send_detailed_report,
             dr_autosync_status: self
                 .ctx
                 .global_replication_state
@@ -2249,7 +2252,7 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
     }
 
     fn on_pd_store_heartbeat_tick(&mut self) {
-        self.store_heartbeat_pd();
+        self.store_heartbeat_pd(/*send_detailed_report=*/ false);
         self.register_pd_store_heartbeat_tick();
     }
 

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -358,7 +358,6 @@ where
 {
     pub cfg: Config,
     pub store: metapb::Store,
-    pub store_start_time: Timespec,
     pub pd_scheduler: Scheduler<PdTask<EK, ER>>,
     pub consistency_check_scheduler: Scheduler<ConsistencyCheckTask<EK::Snapshot>>,
     pub split_check_scheduler: Scheduler<SplitCheckTask>,
@@ -515,6 +514,7 @@ struct Store {
     id: u64,
     last_compact_checked_key: Key,
     stopped: bool,
+    start_time: Option<Timespec>,
     consistency_check_time: HashMap<u64, Instant>,
     last_unreachable_report: HashMap<u64, Instant>,
 }
@@ -538,6 +538,7 @@ where
                 id: 0,
                 last_compact_checked_key: keys::DATA_MIN_KEY.to_vec(),
                 stopped: false,
+                start_time: None,
                 consistency_check_time: HashMap::default(),
                 last_unreachable_report: HashMap::default(),
             },
@@ -622,13 +623,21 @@ impl<'a, EK: KvEngine + 'static, ER: RaftEngine + 'static, T: Transport>
                     inspector.record_store_wait(send_time.saturating_elapsed());
                     self.ctx.pending_latency_inspect.push(inspector);
                 }
+                StoreMsg::UnsafeRecoveryReport => self.store_heartbeat_pd(true),
                 StoreMsg::CreatePeer(region) => self.on_create_peer(region),
             }
         }
     }
 
     fn start(&mut self, store: metapb::Store) {
+        if self.fsm.store.start_time.is_some() {
+            panic!(
+                "[store {}] unable to start again with meta {:?}",
+                self.fsm.store.id, store
+            );
+        }
         self.fsm.store.id = store.get_id();
+        self.fsm.store.start_time = Some(time::get_time());
         self.register_cleanup_import_sst_tick();
         self.register_compact_check_tick();
         self.register_pd_store_heartbeat_tick();
@@ -937,7 +946,6 @@ impl<EK: KvEngine, ER: RaftEngine, T: Transport> PollHandler<PeerFsm<EK, ER>, St
 pub struct RaftPollerBuilder<EK: KvEngine, ER: RaftEngine, T> {
     pub cfg: Arc<VersionTrack<Config>>,
     pub store: metapb::Store,
-    store_start_time: Timespec,
     pd_scheduler: Scheduler<PdTask<EK, ER>>,
     consistency_check_scheduler: Scheduler<ConsistencyCheckTask<EK::Snapshot>>,
     split_check_scheduler: Scheduler<SplitCheckTask>,
@@ -1157,7 +1165,6 @@ where
         let mut ctx = PollContext {
             cfg: self.cfg.value().clone(),
             store: self.store.clone(),
-            store_start_time: self.store_start_time,
             pd_scheduler: self.pd_scheduler.clone(),
             consistency_check_scheduler: self.consistency_check_scheduler.clone(),
             split_check_scheduler: self.split_check_scheduler.clone(),
@@ -1225,7 +1232,6 @@ where
         RaftPollerBuilder {
             cfg: self.cfg.clone(),
             store: self.store.clone(),
-            store_start_time: self.store_start_time,
             pd_scheduler: self.pd_scheduler.clone(),
             consistency_check_scheduler: self.consistency_check_scheduler.clone(),
             split_check_scheduler: self.split_check_scheduler.clone(),
@@ -1407,7 +1413,6 @@ impl<EK: KvEngine, ER: RaftEngine> RaftBatchSystem<EK, ER> {
         let mut builder = RaftPollerBuilder {
             cfg,
             store: meta,
-            store_start_time: time::get_time(),
             engines,
             router: self.router.clone(),
             split_check_scheduler,
@@ -1604,91 +1609,6 @@ enum CheckMsgStatus {
     NewPeer,
     // Try to create the peer which is the first one of this region on local store.
     NewPeerFirst,
-}
-
-pub fn store_heartbeat_pd<EK: KvEngine, ER: RaftEngine, T: Transport>(
-    ctx: &PollContext<EK, ER, T>,
-    send_detailed_report: bool,
-) {
-    let mut stats = StoreStats::default();
-
-    stats.set_store_id(ctx.store_id());
-    {
-        let meta = ctx.store_meta.lock().unwrap();
-        stats.set_region_count(meta.regions.len() as u32);
-    }
-
-    let snap_stats = ctx.snap_mgr.stats();
-    stats.set_sending_snap_count(snap_stats.sending_count as u32);
-    stats.set_receiving_snap_count(snap_stats.receiving_count as u32);
-    STORE_SNAPSHOT_TRAFFIC_GAUGE_VEC
-        .with_label_values(&["sending"])
-        .set(snap_stats.sending_count as i64);
-    STORE_SNAPSHOT_TRAFFIC_GAUGE_VEC
-        .with_label_values(&["receiving"])
-        .set(snap_stats.receiving_count as i64);
-
-    stats.set_start_time(ctx.store_start_time.sec as u32);
-
-    // report store write flow to pd
-    stats.set_bytes_written(
-        ctx.global_stat
-            .stat
-            .engine_total_bytes_written
-            .swap(0, Ordering::SeqCst),
-    );
-    stats.set_keys_written(
-        ctx.global_stat
-            .stat
-            .engine_total_keys_written
-            .swap(0, Ordering::SeqCst),
-    );
-
-    stats.set_is_busy(ctx.global_stat.stat.is_busy.swap(false, Ordering::SeqCst));
-
-    let mut query_stats = QueryStats::default();
-    query_stats.set_put(
-        ctx.global_stat
-            .stat
-            .engine_total_query_put
-            .swap(0, Ordering::SeqCst),
-    );
-    query_stats.set_delete(
-        ctx.global_stat
-            .stat
-            .engine_total_query_delete
-            .swap(0, Ordering::SeqCst),
-    );
-    query_stats.set_delete_range(
-        ctx.global_stat
-            .stat
-            .engine_total_query_delete_range
-            .swap(0, Ordering::SeqCst),
-    );
-    stats.set_query_stats(query_stats);
-
-    let store_info = StoreInfo {
-        kv_engine: ctx.engines.kv.clone(),
-        raft_engine: ctx.engines.raft.clone(),
-        capacity: ctx.cfg.capacity.0,
-    };
-
-    let task = PdTask::StoreHeartbeat {
-        stats,
-        store_info,
-        send_detailed_report,
-        dr_autosync_status: ctx
-            .global_replication_state
-            .lock()
-            .unwrap()
-            .store_dr_autosync_status(),
-    };
-    if let Err(e) = ctx.pd_scheduler.schedule(task) {
-        error!("notify pd failed";
-            "store_id" => ctx.store_id(),
-            "err" => ?e
-        );
-    }
 }
 
 impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER, T> {
@@ -2235,8 +2155,102 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
         }
     }
 
+    fn store_heartbeat_pd(&mut self, send_detailed_report: bool) {
+        let mut stats = StoreStats::default();
+
+        stats.set_store_id(self.ctx.store_id());
+        {
+            let meta = self.ctx.store_meta.lock().unwrap();
+            stats.set_region_count(meta.regions.len() as u32);
+        }
+
+        let snap_stats = self.ctx.snap_mgr.stats();
+        stats.set_sending_snap_count(snap_stats.sending_count as u32);
+        stats.set_receiving_snap_count(snap_stats.receiving_count as u32);
+        STORE_SNAPSHOT_TRAFFIC_GAUGE_VEC
+            .with_label_values(&["sending"])
+            .set(snap_stats.sending_count as i64);
+        STORE_SNAPSHOT_TRAFFIC_GAUGE_VEC
+            .with_label_values(&["receiving"])
+            .set(snap_stats.receiving_count as i64);
+
+        stats.set_start_time(self.fsm.store.start_time.unwrap().sec as u32);
+
+        // report store write flow to pd
+        stats.set_bytes_written(
+            self.ctx
+                .global_stat
+                .stat
+                .engine_total_bytes_written
+                .swap(0, Ordering::SeqCst),
+        );
+        stats.set_keys_written(
+            self.ctx
+                .global_stat
+                .stat
+                .engine_total_keys_written
+                .swap(0, Ordering::SeqCst),
+        );
+
+        stats.set_is_busy(
+            self.ctx
+                .global_stat
+                .stat
+                .is_busy
+                .swap(false, Ordering::SeqCst),
+        );
+
+        let mut query_stats = QueryStats::default();
+        query_stats.set_put(
+            self.ctx
+                .global_stat
+                .stat
+                .engine_total_query_put
+                .swap(0, Ordering::SeqCst),
+        );
+        query_stats.set_delete(
+            self.ctx
+                .global_stat
+                .stat
+                .engine_total_query_delete
+                .swap(0, Ordering::SeqCst),
+        );
+        query_stats.set_delete_range(
+            self.ctx
+                .global_stat
+                .stat
+                .engine_total_query_delete_range
+                .swap(0, Ordering::SeqCst),
+        );
+        stats.set_query_stats(query_stats);
+
+        let store_info = StoreInfo {
+            kv_engine: self.ctx.engines.kv.clone(),
+            raft_engine: self.ctx.engines.raft.clone(),
+            capacity: self.ctx.cfg.capacity.0,
+        };
+
+        let task = PdTask::StoreHeartbeat {
+            stats,
+            store_info,
+            send_detailed_report,
+            dr_autosync_status: self
+                .ctx
+                .global_replication_state
+                .lock()
+                .unwrap()
+                .store_dr_autosync_status(),
+        };
+        if let Err(e) = self.ctx.pd_scheduler.schedule(task) {
+            error!("notify pd failed";
+                "store_id" => self.fsm.store.id,
+                "err" => ?e
+            );
+        }
+    }
+
     fn on_pd_store_heartbeat_tick(&mut self) {
-        store_heartbeat_pd(self.ctx, /*send_detailed_report=*/ false);
+        self.store_heartbeat_pd(false);
         self.register_pd_store_heartbeat_tick();
     }
 

--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -648,7 +648,6 @@ where
     #[cfg(any(test, feature = "testexport"))]
     Validate(Box<dyn FnOnce(&crate::store::Config) + Send>),
 
-    SendDetailedReportForUnsafeRecovery,
     CreatePeer(metapb::Region),
 }
 
@@ -678,9 +677,6 @@ where
             StoreMsg::Validate(_) => write!(fmt, "Validate config"),
             StoreMsg::UpdateReplicationMode(_) => write!(fmt, "UpdateReplicationMode"),
             StoreMsg::LatencyInspect { .. } => write!(fmt, "LatencyInspect"),
-            StoreMsg::SendDetailedReportForUnsafeRecovery => {
-                write!(fmt, "Send detailed report for unsafe recovery")
-            }
             StoreMsg::CreatePeer(_) => write!(fmt, "CreatePeer"),
         }
     }

--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -648,6 +648,7 @@ where
     #[cfg(any(test, feature = "testexport"))]
     Validate(Box<dyn FnOnce(&crate::store::Config) + Send>),
 
+    SendDetailedReportForUnsafeRecovery,
     CreatePeer(metapb::Region),
 }
 
@@ -677,6 +678,9 @@ where
             StoreMsg::Validate(_) => write!(fmt, "Validate config"),
             StoreMsg::UpdateReplicationMode(_) => write!(fmt, "UpdateReplicationMode"),
             StoreMsg::LatencyInspect { .. } => write!(fmt, "LatencyInspect"),
+            StoreMsg::SendDetailedReportForUnsafeRecovery => {
+                write!(fmt, "Send detailed report for unsafe recovery")
+            }
             StoreMsg::CreatePeer(_) => write!(fmt, "CreatePeer"),
         }
     }

--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -648,6 +648,7 @@ where
     #[cfg(any(test, feature = "testexport"))]
     Validate(Box<dyn FnOnce(&crate::store::Config) + Send>),
 
+    UnsafeRecoveryReport,
     CreatePeer(metapb::Region),
 }
 
@@ -677,6 +678,7 @@ where
             StoreMsg::Validate(_) => write!(fmt, "Validate config"),
             StoreMsg::UpdateReplicationMode(_) => write!(fmt, "UpdateReplicationMode"),
             StoreMsg::LatencyInspect { .. } => write!(fmt, "LatencyInspect"),
+            StoreMsg::UnsafeRecoveryReport => write!(fmt, "UnsafeRecoveryReport"),
             StoreMsg::CreatePeer(_) => write!(fmt, "CreatePeer"),
         }
     }

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -4516,7 +4516,7 @@ where
                     "force" => force,
                     "counter" =>  task_counter.load(Ordering::SeqCst)
                 );
-                if task_counter.fetch_sub(1, Ordering::Relaxed) == 1 {
+                if task_counter.fetch_sub(1, Ordering::SeqCst) == 1 {
                     if let Err(e) = ctx.router.send_control(StoreMsg::UnsafeRecoveryReport) {
                         error!("fail to send detailed report after recovery tasks finished"; "err" => ?e);
                     }

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -4514,7 +4514,7 @@ where
                     "target_index" => target_index,
                     "applied" =>  self.raft_group.raft.raft_log.applied,
                     "force" => force,
-                    "counter" =>  task_counter.load(Ordering::Relaxed)
+                    "counter" =>  task_counter.load(Ordering::SeqCst)
                 );
                 if task_counter.fetch_sub(1, Ordering::Relaxed) == 1 {
                     if let Err(e) = ctx.router.send_control(StoreMsg::UnsafeRecoveryReport) {

--- a/components/raftstore/src/store/peer_storage.rs
+++ b/components/raftstore/src/store/peer_storage.rs
@@ -1746,6 +1746,9 @@ where
         let mut res = HandleReadyResult::SendIOTask;
         if !ready.snapshot().is_empty() {
             fail_point!("raft_before_apply_snap");
+            fail_point!("raft_before_apply_snap_callback", |_| {
+                Err(box_err!("failpoint early return"))
+            });
             let last_first_index = self.first_index();
             let snap_region =
                 self.apply_snapshot(ready.snapshot(), &mut write_task, &destroy_regions)?;

--- a/components/raftstore/src/store/peer_storage.rs
+++ b/components/raftstore/src/store/peer_storage.rs
@@ -1746,9 +1746,6 @@ where
         let mut res = HandleReadyResult::SendIOTask;
         if !ready.snapshot().is_empty() {
             fail_point!("raft_before_apply_snap");
-            fail_point!("raft_before_apply_snap_callback", |_| {
-                Err(box_err!("failpoint early return"))
-            });
             let last_first_index = self.first_index();
             let snap_region =
                 self.apply_snapshot(ready.snapshot(), &mut write_task, &destroy_regions)?;

--- a/components/raftstore/src/store/worker/raftlog_gc.rs
+++ b/components/raftstore/src/store/worker/raftlog_gc.rs
@@ -89,6 +89,7 @@ impl<EK: KvEngine, ER: RaftEngine> Runner<EK, ER> {
             Ok(s.and_then(|s| s.parse().ok()).unwrap_or(0))
         });
         let deleted = box_try!(self.engines.raft.batch_gc(regions));
+        fail::fail_point!("worker_gc_raft_log_finished", |_| { Ok(deleted) });
         Ok(deleted)
     }
 

--- a/tests/failpoints/cases/test_unsafe_recovery.rs
+++ b/tests/failpoints/cases/test_unsafe_recovery.rs
@@ -121,7 +121,7 @@ fn test_unsafe_recover_wait_for_snapshot_apply() {
     let apply_triggered_pair2 = Arc::clone(&apply_triggered_pair);
     let apply_released_pair = Arc::new((Mutex::new(false), Condvar::new()));
     let apply_released_pair2 = Arc::clone(&apply_released_pair);
-    fail::cfg_callback("raft_before_apply_snap_callback", move || {
+    fail::cfg_callback("region_apply_snap", move || {
         {
             let (lock, cvar) = &*apply_triggered_pair2;
             let mut triggered = lock.lock().unwrap();

--- a/tests/failpoints/cases/test_unsafe_recovery.rs
+++ b/tests/failpoints/cases/test_unsafe_recovery.rs
@@ -10,7 +10,6 @@ use raftstore::store::util::find_peer;
 use test_raftstore::*;
 use tikv_util::{config::ReadableDuration, mpsc};
 
-#[allow(clippy::mutex_atomic)]
 #[test]
 fn test_unsafe_recover_send_report() {
     let mut cluster = new_server_cluster(0, 3);
@@ -73,7 +72,6 @@ fn test_unsafe_recover_send_report() {
     fail::remove("on_handle_apply_store_1");
 }
 
-#[allow(clippy::mutex_atomic)]
 #[test]
 fn test_unsafe_recover_wait_for_snapshot_apply() {
     let mut cluster = new_server_cluster(0, 3);

--- a/tests/failpoints/cases/test_unsafe_recovery.rs
+++ b/tests/failpoints/cases/test_unsafe_recovery.rs
@@ -92,3 +92,81 @@ fn test_unsafe_recover_send_report() {
     assert_eq!(reported, true);
     fail::remove("on_handle_apply_store_1");
 }
+
+#[allow(clippy::mutex_atomic)]
+#[test]
+fn test_unsafe_recover_wait_for_snapshot_apply() {
+    let mut cluster = new_server_cluster(0, 3);
+    cluster.run();
+    let nodes = Vec::from_iter(cluster.get_node_ids());
+    assert_eq!(nodes.len(), 3);
+
+    let pd_client = Arc::clone(&cluster.pd_client);
+    pd_client.disable_default_operator();
+    let region = block_on(pd_client.get_region_by_id(1)).unwrap().unwrap();
+    configure_for_lease_read(&mut cluster, None, None);
+
+    // Makes the leadership definite.
+    let store2_peer = find_peer(&region, nodes[1]).unwrap().to_owned();
+    cluster.must_transfer_leader(region.get_id(), store2_peer);
+    cluster.stop_node(nodes[1]);
+    (0..10).for_each(|_| cluster.must_put(b"random_key1", b"random_val1"));
+    // Sleep for a while to ensure all logs are compacted.
+    sleep_ms(100);
+    // Makes the group lose its quorum.
+    cluster.stop_node(nodes[2]);
+
+    // Blocks the raft snap apply process.
+    let apply_triggered_pair = Arc::new((Mutex::new(false), Condvar::new()));
+    let apply_triggered_pair2 = Arc::clone(&apply_triggered_pair);
+    let apply_released_pair = Arc::new((Mutex::new(false), Condvar::new()));
+    let apply_released_pair2 = Arc::clone(&apply_released_pair);
+    fail::cfg_callback("raft_before_apply_snap_callback", move || {
+        {
+            let (lock, cvar) = &*apply_triggered_pair2;
+            let mut triggered = lock.lock().unwrap();
+            *triggered = true;
+            cvar.notify_one();
+        }
+        {
+            let (lock2, cvar2) = &*apply_released_pair2;
+            let mut released = lock2.lock().unwrap();
+            while !*released {
+                released = cvar2.wait(released).unwrap();
+            }
+        }
+    })
+    .unwrap();
+
+    cluster.run_node(nodes[1]).unwrap();
+
+    // Triggers the unsafe recovery store reporting process.
+    pd_client.must_set_require_report(true);
+    cluster.must_send_store_heartbeat(nodes[1]);
+
+    // No store report is sent, since there are peers have unapplied entries.
+    for _ in 0..20 {
+        assert_eq!(pd_client.must_get_store_reported(&nodes[1]), 0);
+        sleep_ms(100);
+    }
+
+    // Unblocks the snap apply process.
+    {
+        let (lock2, cvar2) = &*apply_released_pair;
+        let mut released = lock2.lock().unwrap();
+        *released = true;
+        cvar2.notify_all();
+    }
+
+    // Store reports are sent once the entries are applied.
+    let mut reported = false;
+    for _ in 0..20 {
+        if pd_client.must_get_store_reported(&nodes[1]) > 0 {
+            reported = true;
+            break;
+        }
+        sleep_ms(100);
+    }
+    assert_eq!(reported, true);
+    fail::remove("raft_before_apply_snap_callback");
+}

--- a/tests/failpoints/cases/test_unsafe_recovery.rs
+++ b/tests/failpoints/cases/test_unsafe_recovery.rs
@@ -91,10 +91,24 @@ fn test_unsafe_recover_wait_for_snapshot_apply() {
     let store2_peer = find_peer(&region, nodes[1]).unwrap().to_owned();
     cluster.must_transfer_leader(region.get_id(), store2_peer);
     cluster.stop_node(nodes[1]);
-    // at least 4m data
+    let (raft_gc_triggered_tx, raft_gc_triggered_rx) = mpsc::bounded::<()>(1);
+    let (raft_gc_finished_tx, raft_gc_finished_rx) = mpsc::bounded::<()>(1);
+    fail::cfg_callback("worker_gc_raft_log", move || {
+        let _ = raft_gc_triggered_rx.recv();
+    })
+    .unwrap();
+    fail::cfg_callback("worker_gc_raft_log_finished", move || {
+        let _ = raft_gc_finished_tx.send(());
+    })
+    .unwrap();
+    // Add at least 4m data
     (0..10).for_each(|_| cluster.must_put(b"random_k", b"random_v"));
-    // Sleep for a while to ensure all logs are compacted.
-    sleep_ms(100);
+    // Unblock raft log GC.
+    drop(raft_gc_triggered_tx);
+    // Wait until logs are GCed.
+    raft_gc_finished_rx
+        .recv_timeout(Duration::from_secs(1))
+        .unwrap();
     // Makes the group lose its quorum.
     cluster.stop_node(nodes[2]);
 
@@ -136,5 +150,7 @@ fn test_unsafe_recover_wait_for_snapshot_apply() {
         sleep_ms(100);
     }
     assert_eq!(reported, true);
+    fail::remove("worker_gc_raft_log");
+    fail::remove("worker_gc_raft_log_finished");
     fail::remove("raft_before_apply_snap_callback");
 }


### PR DESCRIPTION
Signed-off-by: v01dstar <yang.zhang@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #10483

What's Changed:

Raft snapshot apply has a different code path to update the apply index, compare to other types of Raft entry which update apply index in `raftstore/store/fsm/peer.rs:on_apply_res()`. This path was not covered in the initial implementation of "unsafe recovery wait apply", and this PR fixes it.

### Related changes

PR that adds the initial implementation of unsafe recovery wait apply: https://github.com/tikv/tikv/pull/11716

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
