### PR TITLE
Fix test_delegate_subscribe_unsubscribe flaking test

### DIFF
--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -1034,7 +1034,6 @@ mod tests {
             let mut epoch = RegionEpoch::default();
             epoch.set_conf_ver(region_version);
             epoch.set_version(region_version);
-            println!("{:?}", DOWNSTREAM_ID_ALLOC);
             Downstream::new(peer, epoch, id, ConnID::new())
         };
 

--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -1034,6 +1034,7 @@ mod tests {
             let mut epoch = RegionEpoch::default();
             epoch.set_conf_ver(region_version);
             epoch.set_version(region_version);
+            println!("{:?}", DOWNSTREAM_ID_ALLOC);
             Downstream::new(peer, epoch, id, ConnID::new())
         };
 
@@ -1043,14 +1044,18 @@ mod tests {
         assert_eq!(txn_extra_op.load(), TxnExtraOp::Noop);
         assert!(delegate.handle.is_observing());
 
-        // Subscribe once, downstream id will be 0.
-        delegate.subscribe(new_downstream(1, 1)).unwrap();
+        // Subscribe once.
+        let downstream1 = new_downstream(1, 1);
+        let downstream1_id = downstream1.id;
+        delegate.subscribe(downstream1).unwrap();
         assert_eq!(txn_extra_op.load(), TxnExtraOp::ReadOldValue);
         assert!(delegate.handle.is_observing());
 
         // Subscribe twice and then unsubscribe the second downstream.
-        delegate.subscribe(new_downstream(2, 1)).unwrap();
-        assert!(!delegate.unsubscribe(DownstreamID(1), None));
+        let downstream2 = new_downstream(2, 1);
+        let downstream2_id = downstream2.id;
+        delegate.subscribe(downstream2).unwrap();
+        assert!(!delegate.unsubscribe(downstream2_id, None));
         assert_eq!(txn_extra_op.load(), TxnExtraOp::ReadOldValue);
         assert!(delegate.handle.is_observing());
 
@@ -1074,7 +1079,7 @@ mod tests {
         assert_eq!(delegate.downstreams().len(), 1);
 
         // Unsubscribe all downstreams.
-        assert!(delegate.unsubscribe(DownstreamID(0), None));
+        assert!(delegate.unsubscribe(downstream1_id, None));
         assert!(delegate.downstreams().is_empty());
         assert_eq!(txn_extra_op.load(), TxnExtraOp::Noop);
         assert!(!delegate.handle.is_observing());


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/tikv/tikv/issues/12278

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Fix test_delegate_subscribe_unsubscribe flaking test. 
Use the corresponding id, otherwise there will be failures due to concurrent runs of the test. (We will assign downstream ids concurrently).
```

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

None

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
