### PR TITLE
storage: add APIVersion as generic parameter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4627,6 +4627,7 @@ dependencies = [
 name = "server"
 version = "0.0.1"
 dependencies = [
+ "api_version",
  "backup",
  "causal_ts",
  "cdc",
@@ -5164,6 +5165,7 @@ dependencies = [
 name = "test_coprocessor"
 version = "0.0.1"
 dependencies = [
+ "api_version",
  "collections",
  "concurrency_manager",
  "engine_rocks",
@@ -5200,6 +5202,7 @@ dependencies = [
 name = "test_raftstore"
 version = "0.0.1"
 dependencies = [
+ "api_version",
  "backtrace",
  "collections",
  "concurrency_manager",
@@ -5250,6 +5253,7 @@ dependencies = [
 name = "test_storage"
 version = "0.0.1"
 dependencies = [
+ "api_version",
  "collections",
  "futures 0.3.15",
  "kvproto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ cloud-azure = [
   "encryption_export/cloud-azure",
   "sst_importer/cloud-azure",
 ]
-testexport = ["raftstore/testexport"]
+testexport = ["raftstore/testexport", "api_version/testexport"]
 test-engines-rocksdb = [
   "engine_test/test-engines-rocksdb",
 ]

--- a/components/api_version/Cargo.toml
+++ b/components/api_version/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2018"
 publish = false
 
+[features]
+testexport = []
+
 [dependencies]
 bitflags = "1.0.1"
 codec = { path = "../codec", default-features = false }

--- a/components/api_version/src/api_v1.rs
+++ b/components/api_version/src/api_v1.rs
@@ -4,6 +4,7 @@ use super::*;
 
 impl APIVersion for APIV1 {
     const TAG: ApiVersion = ApiVersion::V1;
+    #[cfg(test)]
     const CLIENT_TAG: ApiVersion = ApiVersion::V1;
     const IS_TTL_ENABLED: bool = false;
 

--- a/components/api_version/src/api_v1.rs
+++ b/components/api_version/src/api_v1.rs
@@ -4,6 +4,7 @@ use super::*;
 
 impl APIVersion for APIV1 {
     const TAG: ApiVersion = ApiVersion::V1;
+    const CLIENT_TAG: ApiVersion = ApiVersion::V1;
     const IS_TTL_ENABLED: bool = false;
 
     #[inline]

--- a/components/api_version/src/api_v1.rs
+++ b/components/api_version/src/api_v1.rs
@@ -4,7 +4,6 @@ use super::*;
 
 impl APIVersion for APIV1 {
     const TAG: ApiVersion = ApiVersion::V1;
-    #[cfg(test)]
     const CLIENT_TAG: ApiVersion = ApiVersion::V1;
     const IS_TTL_ENABLED: bool = false;
 

--- a/components/api_version/src/api_v1.rs
+++ b/components/api_version/src/api_v1.rs
@@ -4,6 +4,7 @@ use super::*;
 
 impl APIVersion for APIV1 {
     const TAG: ApiVersion = ApiVersion::V1;
+    #[cfg(any(test, feature = "testexport"))]
     const CLIENT_TAG: ApiVersion = ApiVersion::V1;
     const IS_TTL_ENABLED: bool = false;
 

--- a/components/api_version/src/api_v1ttl.rs
+++ b/components/api_version/src/api_v1ttl.rs
@@ -8,6 +8,7 @@ use super::*;
 
 impl APIVersion for APIV1TTL {
     const TAG: ApiVersion = ApiVersion::V1ttl;
+    const CLIENT_TAG: ApiVersion = ApiVersion::V1;
     const IS_TTL_ENABLED: bool = true;
 
     #[inline]

--- a/components/api_version/src/api_v1ttl.rs
+++ b/components/api_version/src/api_v1ttl.rs
@@ -8,6 +8,7 @@ use super::*;
 
 impl APIVersion for APIV1TTL {
     const TAG: ApiVersion = ApiVersion::V1ttl;
+    #[cfg(any(test, feature = "testexport"))]
     const CLIENT_TAG: ApiVersion = ApiVersion::V1;
     const IS_TTL_ENABLED: bool = true;
 

--- a/components/api_version/src/api_v1ttl.rs
+++ b/components/api_version/src/api_v1ttl.rs
@@ -8,7 +8,6 @@ use super::*;
 
 impl APIVersion for APIV1TTL {
     const TAG: ApiVersion = ApiVersion::V1ttl;
-    #[cfg(test)]
     const CLIENT_TAG: ApiVersion = ApiVersion::V1;
     const IS_TTL_ENABLED: bool = true;
 

--- a/components/api_version/src/api_v1ttl.rs
+++ b/components/api_version/src/api_v1ttl.rs
@@ -8,6 +8,7 @@ use super::*;
 
 impl APIVersion for APIV1TTL {
     const TAG: ApiVersion = ApiVersion::V1ttl;
+    #[cfg(test)]
     const CLIENT_TAG: ApiVersion = ApiVersion::V1;
     const IS_TTL_ENABLED: bool = true;
 

--- a/components/api_version/src/api_v2.rs
+++ b/components/api_version/src/api_v2.rs
@@ -31,6 +31,7 @@ bitflags::bitflags! {
 
 impl APIVersion for APIV2 {
     const TAG: ApiVersion = ApiVersion::V2;
+    const CLIENT_TAG: ApiVersion = ApiVersion::V2;
     const IS_TTL_ENABLED: bool = true;
 
     fn parse_key_mode(key: &[u8]) -> KeyMode {

--- a/components/api_version/src/api_v2.rs
+++ b/components/api_version/src/api_v2.rs
@@ -31,6 +31,7 @@ bitflags::bitflags! {
 
 impl APIVersion for APIV2 {
     const TAG: ApiVersion = ApiVersion::V2;
+    #[cfg(test)]
     const CLIENT_TAG: ApiVersion = ApiVersion::V2;
     const IS_TTL_ENABLED: bool = true;
 

--- a/components/api_version/src/api_v2.rs
+++ b/components/api_version/src/api_v2.rs
@@ -31,7 +31,6 @@ bitflags::bitflags! {
 
 impl APIVersion for APIV2 {
     const TAG: ApiVersion = ApiVersion::V2;
-    #[cfg(test)]
     const CLIENT_TAG: ApiVersion = ApiVersion::V2;
     const IS_TTL_ENABLED: bool = true;
 

--- a/components/api_version/src/api_v2.rs
+++ b/components/api_version/src/api_v2.rs
@@ -31,6 +31,7 @@ bitflags::bitflags! {
 
 impl APIVersion for APIV2 {
     const TAG: ApiVersion = ApiVersion::V2;
+    #[cfg(any(test, feature = "testexport"))]
     const CLIENT_TAG: ApiVersion = ApiVersion::V2;
     const IS_TTL_ENABLED: bool = true;
 

--- a/components/api_version/src/lib.rs
+++ b/components/api_version/src/lib.rs
@@ -14,6 +14,8 @@ use txn_types::{Key, TimeStamp};
 
 pub trait APIVersion: Clone + Copy + 'static + Send + Sync {
     const TAG: ApiVersion;
+    /// Corresponding TAG of client requests.
+    const CLIENT_TAG: ApiVersion;
     const IS_TTL_ENABLED: bool;
 
     /// Parse the key prefix and infer key mode. It's safe to parse either raw key or encoded key.
@@ -86,6 +88,39 @@ macro_rules! match_template_api_version {
             $($tail)*
          }
      }}
+}
+
+/// Dispatch an expression with type `kvproto::kvrpcpb::ApiVersion` to corresponding concrete type of `APIVersion`
+///
+/// For example, the following code
+///
+/// ```ignore
+/// let encoded_key = dispatch_api_version(api_version, API::encode_raw_key(key));
+/// ```
+///
+/// generates
+///
+/// ```ignore
+/// let encoded_key = match api_version {
+///     ApiVersion::V1 => APIV1::encode_raw_key(key),
+///     ApiVersion::V1ttl => APIV1TTL::encode_raw_key(key),
+///     ApiVersion::V2 => APIV2::encode_raw_key(key),
+/// };
+/// ```
+#[macro_export]
+macro_rules! dispatch_api_version {
+    ($api_version:expr, $e:expr) => {{
+        $crate::match_template! {
+            API = [
+                V1 => $crate::APIV1,
+                V1ttl => $crate::APIV1TTL,
+                V2 => $crate::APIV2,
+            ],
+            match $api_version {
+                kvproto::kvrpcpb::ApiVersion::API => $e,
+            }
+        }
+    }};
 }
 
 /// The key mode inferred from the key prefix.

--- a/components/api_version/src/lib.rs
+++ b/components/api_version/src/lib.rs
@@ -15,6 +15,7 @@ use txn_types::{Key, TimeStamp};
 pub trait APIVersion: Clone + Copy + 'static + Send + Sync {
     const TAG: ApiVersion;
     /// Corresponding TAG of client requests. For test only.
+    #[cfg(any(test, feature = "testexport"))]
     const CLIENT_TAG: ApiVersion;
     const IS_TTL_ENABLED: bool;
 

--- a/components/api_version/src/lib.rs
+++ b/components/api_version/src/lib.rs
@@ -76,6 +76,7 @@ pub struct APIV1TTL;
 #[derive(Default, Clone, Copy)]
 pub struct APIV2;
 
+// TODO: move `match_template_api_version!` usage to `dispatch_api_version!`.
 #[macro_export]
 macro_rules! match_template_api_version {
      ($t:tt, $($tail:tt)*) => {{

--- a/components/api_version/src/lib.rs
+++ b/components/api_version/src/lib.rs
@@ -14,8 +14,7 @@ use txn_types::{Key, TimeStamp};
 
 pub trait APIVersion: Clone + Copy + 'static + Send + Sync {
     const TAG: ApiVersion;
-    /// Corresponding TAG of client requests.
-    #[cfg(test)]
+    /// Corresponding TAG of client requests. For test only.
     const CLIENT_TAG: ApiVersion;
     const IS_TTL_ENABLED: bool;
 

--- a/components/api_version/src/lib.rs
+++ b/components/api_version/src/lib.rs
@@ -15,6 +15,7 @@ use txn_types::{Key, TimeStamp};
 pub trait APIVersion: Clone + Copy + 'static + Send + Sync {
     const TAG: ApiVersion;
     /// Corresponding TAG of client requests.
+    #[cfg(test)]
     const CLIENT_TAG: ApiVersion;
     const IS_TTL_ENABLED: bool;
 

--- a/components/server/Cargo.toml
+++ b/components/server/Cargo.toml
@@ -26,6 +26,7 @@ test-engines-panic = [
 nortcheck = ["engine_rocks/nortcheck"]
 
 [dependencies]
+api_version = { path = "../api_version" }
 backup = { path = "../backup", default-features = false }
 cdc = { path = "../cdc", default-features = false }
 chrono = "0.4"

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -160,7 +160,7 @@ pub fn run_tikv(config: TiKvConfig) {
         } else {
             run_impl::<RaftLogEngine, API>(config)
         }
-    }
+    })
 }
 
 const RESERVED_OPEN_FDS: u64 = 1000;

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -25,7 +25,7 @@ use std::{
     u64,
 };
 
-use api_version::{APIVersion, dispatch_api_version};
+use api_version::{dispatch_api_version, APIVersion};
 use cdc::{CdcConfigManager, MemoryQuota};
 use concurrency_manager::ConcurrencyManager;
 use encryption_export::{data_key_manager_from_config, DataKeyManager};

--- a/components/test_coprocessor/Cargo.toml
+++ b/components/test_coprocessor/Cargo.toml
@@ -14,6 +14,7 @@ test-engines-panic = [
 ]
 
 [dependencies]
+api_version = { path = "../api_version" }
 engine_rocks = { path = "../engine_rocks", default-features = false }
 futures = "0.3"
 kvproto = { git = "https://github.com/pingcap/kvproto.git" }

--- a/components/test_coprocessor/src/fixture.rs
+++ b/components/test_coprocessor/src/fixture.rs
@@ -4,6 +4,7 @@ use super::*;
 
 use std::sync::Arc;
 
+use api_version::APIV1;
 use concurrency_manager::ConcurrencyManager;
 use kvproto::kvrpcpb::{ApiVersion, Context};
 
@@ -80,7 +81,7 @@ pub fn init_data_with_details<E: Engine>(
     cfg: &Config,
 ) -> (Store<E>, Endpoint<E>) {
     let storage =
-        TestStorageBuilder::from_engine_and_lock_mgr(engine, DummyLockManager {}, ApiVersion::V1)
+        TestStorageBuilder::<_, _, APIV1>::from_engine_and_lock_mgr(engine, DummyLockManager {})
             .build()
             .unwrap();
     let mut store = Store::from_storage(storage);

--- a/components/test_coprocessor/src/fixture.rs
+++ b/components/test_coprocessor/src/fixture.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use api_version::APIV1;
 use concurrency_manager::ConcurrencyManager;
-use kvproto::kvrpcpb::{ApiVersion, Context};
+use kvproto::kvrpcpb::Context;
 
 use engine_rocks::PerfLevel;
 use resource_metering::ResourceTagFactory;

--- a/components/test_coprocessor/src/fixture.rs
+++ b/components/test_coprocessor/src/fixture.rs
@@ -4,7 +4,6 @@ use super::*;
 
 use std::sync::Arc;
 
-use api_version::APIV1;
 use concurrency_manager::ConcurrencyManager;
 use kvproto::kvrpcpb::Context;
 
@@ -17,7 +16,7 @@ use tikv::read_pool::ReadPool;
 use tikv::server::Config;
 use tikv::storage::kv::RocksEngine;
 use tikv::storage::lock_manager::DummyLockManager;
-use tikv::storage::{Engine, TestEngineBuilder, TestStorageBuilder};
+use tikv::storage::{Engine, TestEngineBuilder, TestStorageBuilderApiV1};
 use tikv_util::quota_limiter::QuotaLimiter;
 use tikv_util::thread_group::GroupProperties;
 
@@ -80,10 +79,9 @@ pub fn init_data_with_details<E: Engine>(
     commit: bool,
     cfg: &Config,
 ) -> (Store<E>, Endpoint<E>) {
-    let storage =
-        TestStorageBuilder::<_, _, APIV1>::from_engine_and_lock_mgr(engine, DummyLockManager {})
-            .build()
-            .unwrap();
+    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager {})
+        .build()
+        .unwrap();
     let mut store = Store::from_storage(storage);
 
     store.begin();

--- a/components/test_coprocessor/src/fixture.rs
+++ b/components/test_coprocessor/src/fixture.rs
@@ -79,7 +79,7 @@ pub fn init_data_with_details<E: Engine>(
     commit: bool,
     cfg: &Config,
 ) -> (Store<E>, Endpoint<E>) {
-    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager {})
+    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager)
         .build()
         .unwrap();
     let mut store = Store::from_storage(storage);

--- a/components/test_coprocessor/src/store.rs
+++ b/components/test_coprocessor/src/store.rs
@@ -4,7 +4,7 @@ use super::*;
 
 use std::collections::BTreeMap;
 
-use kvproto::kvrpcpb::{ApiVersion, Context, IsolationLevel};
+use kvproto::kvrpcpb::{Context, IsolationLevel};
 
 use api_version::APIV1;
 use collections::HashMap;

--- a/components/test_coprocessor/src/store.rs
+++ b/components/test_coprocessor/src/store.rs
@@ -113,7 +113,7 @@ pub struct Store<E: Engine> {
 
 impl Store<RocksEngine> {
     pub fn new() -> Self {
-        let storage = TestStorageBuilderApiV1::new(DummyLockManager {})
+        let storage = TestStorageBuilderApiV1::new(DummyLockManager)
             .build()
             .unwrap();
         Self::from_storage(storage)

--- a/components/test_coprocessor/src/store.rs
+++ b/components/test_coprocessor/src/store.rs
@@ -6,6 +6,7 @@ use std::collections::BTreeMap;
 
 use kvproto::kvrpcpb::{ApiVersion, Context, IsolationLevel};
 
+use api_version::APIV1;
 use collections::HashMap;
 use test_storage::SyncTestStorage;
 use tidb_query_datatype::codec::{datum, table, Datum};
@@ -18,6 +19,8 @@ use tikv::storage::{
     SnapshotStore, Storage, TestStorageBuilder,
 };
 use txn_types::{Key, Mutation, TimeStamp};
+
+type API = APIV1;
 
 pub struct Insert<'a, E: Engine> {
     store: &'a mut Store<E>,
@@ -105,7 +108,7 @@ impl<'a, E: Engine> Delete<'a, E> {
 
 /// A store that operates over MVCC and support transactions.
 pub struct Store<E: Engine> {
-    store: SyncTestStorage<E>,
+    store: SyncTestStorage<E, API>,
     current_ts: TimeStamp,
     last_committed_ts: TimeStamp,
     handles: Vec<Vec<u8>>,
@@ -113,7 +116,7 @@ pub struct Store<E: Engine> {
 
 impl Store<RocksEngine> {
     pub fn new() -> Self {
-        let storage = TestStorageBuilder::new(DummyLockManager {}, ApiVersion::V1)
+        let storage = TestStorageBuilder::<_, _, API>::new(DummyLockManager {})
             .build()
             .unwrap();
         Self::from_storage(storage)
@@ -127,7 +130,7 @@ impl Default for Store<RocksEngine> {
 }
 
 impl<E: Engine> Store<E> {
-    pub fn from_storage(storage: Storage<E, DummyLockManager>) -> Self {
+    pub fn from_storage(storage: Storage<E, DummyLockManager, API>) -> Self {
         Self {
             store: SyncTestStorage::from_storage(storage, GcConfig::default()).unwrap(),
             current_ts: 1.into(),
@@ -194,7 +197,7 @@ impl<E: Engine> Store<E> {
         self.store.get_engine()
     }
 
-    pub fn get_storage(&self) -> SyncTestStorage<E> {
+    pub fn get_storage(&self) -> SyncTestStorage<E, API> {
         self.store.clone()
     }
 

--- a/components/test_raftstore/Cargo.toml
+++ b/components/test_raftstore/Cargo.toml
@@ -17,6 +17,7 @@ test-engines-panic = [
 ]
 
 [dependencies]
+api_version = { path = "../api_version" }
 backtrace = "0.3"
 crossbeam = "0.8"
 engine_traits = { path = "../engine_traits", default-features = false }

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -21,6 +21,7 @@ use tokio::runtime::Builder as TokioBuilder;
 
 use super::*;
 use crate::Config;
+use api_version::{APIVersion, dispatch_api_version};
 use collections::{HashMap, HashSet};
 use concurrency_manager::ConcurrencyManager;
 use encryption_export::DataKeyManager;
@@ -231,10 +232,8 @@ impl ServerCluster {
             }),
         )
     }
-}
 
-impl Simulator for ServerCluster {
-    fn run_node(
+    fn run_node_impl<Api: APIVersion>(
         &mut self,
         node_id: u64,
         mut cfg: Config,
@@ -350,7 +349,7 @@ impl Simulator for ServerCluster {
             cfg.quota.foreground_read_bandwidth,
             cfg.quota.max_delay_duration,
         ));
-        let store = create_raft_storage(
+        let store = create_raft_storage::<_, _, _, Api>(
             engine,
             &cfg.storage,
             storage_read_pool.handle(),
@@ -377,7 +376,7 @@ impl Simulator for ServerCluster {
                     key_manager.clone(),
                     cfg.storage.api_version(),
                 )
-                .unwrap(),
+                    .unwrap(),
             )
         };
         let import_service = ImportSSTService::new(
@@ -464,7 +463,7 @@ impl Simulator for ServerCluster {
                 None,
                 debug_thread_pool.clone(),
             )
-            .unwrap();
+                .unwrap();
             svr.register_service(create_import_sst(import_service.clone()));
             svr.register_service(create_debug(debug_service.clone()));
             svr.register_service(create_deadlock(deadlock_service.clone()));
@@ -558,6 +557,29 @@ impl Simulator for ServerCluster {
             .insert(node_id, concurrency_manager);
 
         Ok(node_id)
+    }
+}
+
+impl Simulator for ServerCluster {
+    fn run_node(
+        &mut self,
+        node_id: u64,
+        mut cfg: Config,
+        engines: Engines<RocksEngine, RocksEngine>,
+        store_meta: Arc<Mutex<StoreMeta>>,
+        key_manager: Option<Arc<DataKeyManager>>,
+        router: RaftRouter<RocksEngine, RocksEngine>,
+        system: RaftBatchSystem<RocksEngine, RocksEngine>,
+    ) -> ServerResult<u64> {
+        dispatch_api_version!(cfg.storage.api_version(), self.run_node_impl::<API>(
+            node_id,
+            cfg,
+            engines,
+            store_meta,
+            key_manager,
+            router,
+            system,
+        ))
     }
 
     fn get_snap_dir(&self, node_id: u64) -> String {

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -21,7 +21,7 @@ use tokio::runtime::Builder as TokioBuilder;
 
 use super::*;
 use crate::Config;
-use api_version::{APIVersion, dispatch_api_version};
+use api_version::{dispatch_api_version, APIVersion};
 use collections::{HashMap, HashSet};
 use concurrency_manager::ConcurrencyManager;
 use encryption_export::DataKeyManager;
@@ -376,7 +376,7 @@ impl ServerCluster {
                     key_manager.clone(),
                     cfg.storage.api_version(),
                 )
-                    .unwrap(),
+                .unwrap(),
             )
         };
         let import_service = ImportSSTService::new(
@@ -463,7 +463,7 @@ impl ServerCluster {
                 None,
                 debug_thread_pool.clone(),
             )
-                .unwrap();
+            .unwrap();
             svr.register_service(create_import_sst(import_service.clone()));
             svr.register_service(create_debug(debug_service.clone()));
             svr.register_service(create_deadlock(deadlock_service.clone()));
@@ -564,22 +564,25 @@ impl Simulator for ServerCluster {
     fn run_node(
         &mut self,
         node_id: u64,
-        mut cfg: Config,
+        cfg: Config,
         engines: Engines<RocksEngine, RocksEngine>,
         store_meta: Arc<Mutex<StoreMeta>>,
         key_manager: Option<Arc<DataKeyManager>>,
         router: RaftRouter<RocksEngine, RocksEngine>,
         system: RaftBatchSystem<RocksEngine, RocksEngine>,
     ) -> ServerResult<u64> {
-        dispatch_api_version!(cfg.storage.api_version(), self.run_node_impl::<API>(
-            node_id,
-            cfg,
-            engines,
-            store_meta,
-            key_manager,
-            router,
-            system,
-        ))
+        dispatch_api_version!(
+            cfg.storage.api_version(),
+            self.run_node_impl::<API>(
+                node_id,
+                cfg,
+                engines,
+                store_meta,
+                key_manager,
+                router,
+                system,
+            )
+        )
     }
 
     fn get_snap_dir(&self, node_id: u64) -> String {

--- a/components/test_storage/Cargo.toml
+++ b/components/test_storage/Cargo.toml
@@ -14,6 +14,7 @@ test-engines-panic = [
 ]
 
 [dependencies]
+api_version = { path = "../api_version" }
 futures = "0.3"
 kvproto = { git = "https://github.com/pingcap/kvproto.git" }
 raftstore = { path = "../raftstore", default-features = false }

--- a/components/test_storage/src/assert_storage.rs
+++ b/components/test_storage/src/assert_storage.rs
@@ -2,6 +2,7 @@
 
 use kvproto::kvrpcpb::{ApiVersion, Context, KeyRange, LockInfo};
 
+use api_version::{APIVersion, APIV1};
 use test_raftstore::{Cluster, ServerCluster, SimulateEngine};
 use tikv::storage::kv::{Error as KvError, ErrorInner as KvErrorInner, RocksEngine};
 use tikv::storage::mvcc::{Error as MvccError, ErrorInner as MvccErrorInner, MAX_TXN_WRITE_SIZE};
@@ -15,12 +16,12 @@ use txn_types::{self, Key, KvPair, Mutation, TimeStamp, Value};
 use super::*;
 
 #[derive(Clone)]
-pub struct AssertionStorage<E: Engine> {
-    pub store: SyncTestStorage<E>,
+pub struct AssertionStorage<E: Engine, Api: APIVersion> {
+    pub store: SyncTestStorage<E, Api>,
     pub ctx: Context,
 }
 
-impl Default for AssertionStorage<RocksEngine> {
+impl Default for AssertionStorage<RocksEngine, APIV1> {
     fn default() -> Self {
         AssertionStorage {
             ctx: Context::default(),
@@ -29,21 +30,21 @@ impl Default for AssertionStorage<RocksEngine> {
     }
 }
 
-impl AssertionStorage<RocksEngine> {
-    pub fn new(api_version: ApiVersion) -> Self {
+impl<Api: APIVersion> AssertionStorage<RocksEngine, Api> {
+    pub fn new() -> Self {
         AssertionStorage {
             ctx: Context::default(),
-            store: SyncTestStorageBuilder::new(api_version).build().unwrap(),
+            store: SyncTestStorageBuilder::new().build().unwrap(),
         }
     }
 }
 
-impl AssertionStorage<SimulateEngine> {
+impl<Api: APIVersion> AssertionStorage<SimulateEngine, Api> {
     pub fn new_raft_storage_with_store_count(
         count: usize,
         key: &str,
     ) -> (Cluster<ServerCluster>, Self) {
-        let (cluster, store, ctx) = new_raft_storage_with_store_count(count, key);
+        let (cluster, store, ctx) = new_raft_storage_with_store_count::<Api>(count, key);
         let storage = Self { store, ctx };
         (cluster, storage)
     }
@@ -226,7 +227,7 @@ impl AssertionStorage<SimulateEngine> {
     }
 }
 
-impl<E: Engine> AssertionStorage<E> {
+impl<E: Engine, Api: APIVersion> AssertionStorage<E, Api> {
     pub fn get_none(&self, key: &[u8], ts: impl Into<TimeStamp>) {
         let key = Key::from_raw(key);
         assert_eq!(

--- a/components/test_storage/src/assert_storage.rs
+++ b/components/test_storage/src/assert_storage.rs
@@ -1,6 +1,6 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
-use kvproto::kvrpcpb::{ApiVersion, Context, KeyRange, LockInfo};
+use kvproto::kvrpcpb::{Context, KeyRange, LockInfo};
 
 use api_version::{APIVersion, APIV1};
 use test_raftstore::{Cluster, ServerCluster, SimulateEngine};

--- a/components/test_storage/src/assert_storage.rs
+++ b/components/test_storage/src/assert_storage.rs
@@ -21,6 +21,8 @@ pub struct AssertionStorage<E: Engine, Api: APIVersion> {
     pub ctx: Context,
 }
 
+pub type AssertionStorageApiV1<E> = AssertionStorage<E, APIV1>;
+
 impl Default for AssertionStorage<RocksEngine, APIV1> {
     fn default() -> Self {
         AssertionStorage {

--- a/components/test_storage/src/sync_storage.rs
+++ b/components/test_storage/src/sync_storage.rs
@@ -1,7 +1,9 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::marker::PhantomData;
 use std::sync::{atomic::AtomicU64, Arc};
 
+use api_version::APIVersion;
 use collections::HashMap;
 use futures::executor::block_on;
 use kvproto::kvrpcpb::{
@@ -23,40 +25,40 @@ use txn_types::{Key, KvPair, Mutation, TimeStamp, Value};
 /// A builder to build a `SyncTestStorage`.
 ///
 /// Only used for test purpose.
-pub struct SyncTestStorageBuilder<E: Engine> {
+pub struct SyncTestStorageBuilder<E: Engine, Api: APIVersion> {
     engine: E,
     config: Option<Config>,
     gc_config: Option<GcConfig>,
-    api_version: ApiVersion,
+    _phantom: PhantomData<Api>,
 }
 
-impl SyncTestStorageBuilder<RocksEngine> {
-    pub fn new(api_version: ApiVersion) -> Self {
+impl<Api: APIVersion> SyncTestStorageBuilder<RocksEngine, Api> {
+    pub fn new() -> Self {
         Self {
             engine: TestEngineBuilder::new()
-                .api_version(api_version)
+                .api_version(Api::TAG)
                 .build()
                 .unwrap(),
             config: None,
             gc_config: None,
-            api_version,
+            _phantom: PhantomData,
         }
     }
 }
 
-impl Default for SyncTestStorageBuilder<RocksEngine> {
+impl Default for SyncTestStorageBuilder<RocksEngine, api_version::APIV1> {
     fn default() -> Self {
-        Self::new(ApiVersion::V1)
+        Self::new()
     }
 }
 
-impl<E: Engine> SyncTestStorageBuilder<E> {
+impl<E: Engine, Api: APIVersion> SyncTestStorageBuilder<E, Api> {
     pub fn from_engine(engine: E) -> Self {
         Self {
             engine,
             config: None,
             gc_config: None,
-            api_version: ApiVersion::V1,
+            _phantom: PhantomData,
         }
     }
 
@@ -72,19 +74,15 @@ impl<E: Engine> SyncTestStorageBuilder<E> {
         self
     }
 
-    pub fn build(mut self) -> Result<SyncTestStorage<E>> {
-        let mut builder = TestStorageBuilder::from_engine_and_lock_mgr(
+    pub fn build(mut self) -> Result<SyncTestStorage<E, Api>> {
+        let mut builder = TestStorageBuilder::<_, _, Api>::from_engine_and_lock_mgr(
             self.engine.clone(),
             DummyLockManager {},
-            self.config
-                .as_ref()
-                .map(|cfg| cfg.api_version())
-                .unwrap_or_default(),
         );
-        if let Some(config) = self.config.take() {
+        if let Some(mut config) = self.config.take() {
+            config.set_api_version(Api::TAG);
             builder = builder.config(config);
         }
-        builder = builder.set_api_version(self.api_version);
         SyncTestStorage::from_storage(builder.build()?, self.gc_config.unwrap_or_default())
     }
 }
@@ -93,13 +91,13 @@ impl<E: Engine> SyncTestStorageBuilder<E> {
 ///
 /// Only used for test purpose.
 #[derive(Clone)]
-pub struct SyncTestStorage<E: Engine> {
+pub struct SyncTestStorage<E: Engine, Api: APIVersion> {
     gc_worker: GcWorker<E, RaftStoreBlackHole>,
-    store: Storage<E, DummyLockManager>,
+    store: Storage<E, DummyLockManager, Api>,
 }
 
-impl<E: Engine> SyncTestStorage<E> {
-    pub fn from_storage(storage: Storage<E, DummyLockManager>, config: GcConfig) -> Result<Self> {
+impl<E: Engine, Api: APIVersion> SyncTestStorage<E, Api> {
+    pub fn from_storage(storage: Storage<E, DummyLockManager, Api>, config: GcConfig) -> Result<Self> {
         let (tx, _rx) = std::sync::mpsc::channel();
         let mut gc_worker = GcWorker::new(
             storage.get_engine(),
@@ -124,7 +122,7 @@ impl<E: Engine> SyncTestStorage<E> {
             .unwrap();
     }
 
-    pub fn get_storage(&self) -> Storage<E, DummyLockManager> {
+    pub fn get_storage(&self) -> Storage<E, DummyLockManager, Api> {
         self.store.clone()
     }
 

--- a/components/test_storage/src/sync_storage.rs
+++ b/components/test_storage/src/sync_storage.rs
@@ -6,9 +6,7 @@ use std::sync::{atomic::AtomicU64, Arc};
 use api_version::APIVersion;
 use collections::HashMap;
 use futures::executor::block_on;
-use kvproto::kvrpcpb::{
-    ApiVersion, ChecksumAlgorithm, Context, GetRequest, KeyRange, LockInfo, RawGetRequest,
-};
+use kvproto::kvrpcpb::{ChecksumAlgorithm, Context, GetRequest, KeyRange, LockInfo, RawGetRequest};
 use raftstore::coprocessor::RegionInfoProvider;
 use raftstore::router::RaftStoreBlackHole;
 use tikv::server::gc_worker::{AutoGcConfig, GcConfig, GcSafePointProvider, GcWorker};
@@ -97,7 +95,10 @@ pub struct SyncTestStorage<E: Engine, Api: APIVersion> {
 }
 
 impl<E: Engine, Api: APIVersion> SyncTestStorage<E, Api> {
-    pub fn from_storage(storage: Storage<E, DummyLockManager, Api>, config: GcConfig) -> Result<Self> {
+    pub fn from_storage(
+        storage: Storage<E, DummyLockManager, Api>,
+        config: GcConfig,
+    ) -> Result<Self> {
         let (tx, _rx) = std::sync::mpsc::channel();
         let mut gc_worker = GcWorker::new(
             storage.get_engine(),

--- a/components/test_storage/src/sync_storage.rs
+++ b/components/test_storage/src/sync_storage.rs
@@ -3,7 +3,7 @@
 use std::marker::PhantomData;
 use std::sync::{atomic::AtomicU64, Arc};
 
-use api_version::APIVersion;
+use api_version::{APIVersion, APIV1};
 use collections::HashMap;
 use futures::executor::block_on;
 use kvproto::kvrpcpb::{ChecksumAlgorithm, Context, GetRequest, KeyRange, LockInfo, RawGetRequest};
@@ -30,6 +30,10 @@ pub struct SyncTestStorageBuilder<E: Engine, Api: APIVersion> {
     _phantom: PhantomData<Api>,
 }
 
+/// SyncTestStorageBuilder for Api V1
+/// To be convenience for test cases unrelated to RawKV.
+pub type SyncTestStorageBuilderApiV1<E> = SyncTestStorageBuilder<E, APIV1>;
+
 impl<Api: APIVersion> SyncTestStorageBuilder<RocksEngine, Api> {
     pub fn new() -> Self {
         Self {
@@ -44,7 +48,7 @@ impl<Api: APIVersion> SyncTestStorageBuilder<RocksEngine, Api> {
     }
 }
 
-impl Default for SyncTestStorageBuilder<RocksEngine, api_version::APIV1> {
+impl Default for SyncTestStorageBuilder<RocksEngine, APIV1> {
     fn default() -> Self {
         Self::new()
     }
@@ -77,10 +81,10 @@ impl<E: Engine, Api: APIVersion> SyncTestStorageBuilder<E, Api> {
             self.engine.clone(),
             DummyLockManager {},
         );
-        if let Some(mut config) = self.config.take() {
-            config.set_api_version(Api::TAG);
+        if let Some(config) = self.config.take() {
             builder = builder.config(config);
         }
+        builder = builder.set_api_version(Api::TAG);
         SyncTestStorage::from_storage(builder.build()?, self.gc_config.unwrap_or_default())
     }
 }
@@ -93,6 +97,10 @@ pub struct SyncTestStorage<E: Engine, Api: APIVersion> {
     gc_worker: GcWorker<E, RaftStoreBlackHole>,
     store: Storage<E, DummyLockManager, Api>,
 }
+
+/// SyncTestStorage for Api V1
+/// To be convenience for test cases unrelated to RawKV.
+pub type SyncTestStorageApiV1<E> = SyncTestStorage<E, APIV1>;
 
 impl<E: Engine, Api: APIVersion> SyncTestStorage<E, Api> {
     pub fn from_storage(

--- a/components/test_storage/src/sync_storage.rs
+++ b/components/test_storage/src/sync_storage.rs
@@ -79,7 +79,7 @@ impl<E: Engine, Api: APIVersion> SyncTestStorageBuilder<E, Api> {
     pub fn build(mut self) -> Result<SyncTestStorage<E, Api>> {
         let mut builder = TestStorageBuilder::<_, _, Api>::from_engine_and_lock_mgr(
             self.engine.clone(),
-            DummyLockManager {},
+            DummyLockManager,
         );
         if let Some(config) = self.config.take() {
             builder = builder.config(config);

--- a/components/test_storage/src/util.rs
+++ b/components/test_storage/src/util.rs
@@ -2,6 +2,7 @@
 
 use kvproto::kvrpcpb::Context;
 
+use api_version::APIVersion;
 use test_raftstore::{new_server_cluster, Cluster, ServerCluster, SimulateEngine};
 use tikv_util::HandyRwLock;
 
@@ -25,12 +26,12 @@ pub fn new_raft_engine(
     (cluster, engine, ctx)
 }
 
-pub fn new_raft_storage_with_store_count(
+pub fn new_raft_storage_with_store_count<Api: APIVersion>(
     count: usize,
     key: &str,
 ) -> (
     Cluster<ServerCluster>,
-    SyncTestStorage<SimulateEngine>,
+    SyncTestStorage<SimulateEngine, Api>,
     Context,
 ) {
     let (cluster, engine, ctx) = new_raft_engine(count, key);

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,7 +16,7 @@ use std::path::Path;
 use std::sync::{Arc, RwLock};
 use std::usize;
 
-use api_version::{APIVersion, match_template_api_version};
+use api_version::{match_template_api_version, APIVersion};
 use causal_ts::Config as CausalTsConfig;
 use encryption_export::DataKeyManager;
 use engine_rocks::config::{self as rocks_config, BlobRunMode, CompressionType, LogLevel};
@@ -3979,13 +3979,11 @@ mod tests {
             Some(cfg.rocksdb.build_opt()),
         )
         .unwrap();
-        let storage = TestStorageBuilder::<_, _, Api>::from_engine_and_lock_mgr(
-            engine,
-            DummyLockManager {},
-        )
-        .config(cfg.storage.clone())
-        .build()
-        .unwrap();
+        let storage =
+            TestStorageBuilder::<_, _, Api>::from_engine_and_lock_mgr(engine, DummyLockManager {})
+                .config(cfg.storage.clone())
+                .build()
+                .unwrap();
         let engine = storage.get_engine().get_rocksdb();
         let (_tx, rx) = std::sync::mpsc::channel();
         let flow_controller = Arc::new(FlowController::new(

--- a/src/config.rs
+++ b/src/config.rs
@@ -3980,7 +3980,7 @@ mod tests {
         )
         .unwrap();
         let storage =
-            TestStorageBuilder::<_, _, Api>::from_engine_and_lock_mgr(engine, DummyLockManager {})
+            TestStorageBuilder::<_, _, Api>::from_engine_and_lock_mgr(engine, DummyLockManager)
                 .config(cfg.storage.clone())
                 .build()
                 .unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,8 +16,7 @@ use std::path::Path;
 use std::sync::{Arc, RwLock};
 use std::usize;
 
-use api_version::match_template_api_version;
-use api_version::APIVersion;
+use api_version::{APIVersion, match_template_api_version};
 use causal_ts::Config as CausalTsConfig;
 use encryption_export::DataKeyManager;
 use engine_rocks::config::{self as rocks_config, BlobRunMode, CompressionType, LogLevel};
@@ -3617,6 +3616,7 @@ mod tests {
     use crate::storage::lock_manager::DummyLockManager;
     use crate::storage::txn::flow_controller::FlowController;
     use crate::storage::{Storage, TestStorageBuilder};
+    use api_version::{APIVersion, APIV1};
     use case_macros::*;
     use engine_traits::{DBOptions as DBOptionsTrait, ALL_CFS};
     use kvproto::kvrpcpb::CommandPri;
@@ -3957,14 +3957,15 @@ mod tests {
         assert_eq!(res.get("raftstore.store-pool-size"), Some(&"17".to_owned()));
     }
 
-    fn new_engines(
+    fn new_engines<Api: APIVersion>(
         cfg: TiKvConfig,
     ) -> (
-        Storage<RocksDBEngine, DummyLockManager>,
+        Storage<RocksDBEngine, DummyLockManager, Api>,
         ConfigController,
         ReceiverWrapper<TTLCheckerTask>,
         Arc<FlowController>,
     ) {
+        assert_eq!(Api::TAG, cfg.storage.api_version());
         let engine = RocksDBEngine::new(
             &cfg.storage.data_dir,
             ALL_CFS,
@@ -3978,10 +3979,9 @@ mod tests {
             Some(cfg.rocksdb.build_opt()),
         )
         .unwrap();
-        let storage = TestStorageBuilder::from_engine_and_lock_mgr(
+        let storage = TestStorageBuilder::<_, _, Api>::from_engine_and_lock_mgr(
             engine,
             DummyLockManager {},
-            ApiVersion::V1,
         )
         .config(cfg.storage.clone())
         .build()
@@ -4018,7 +4018,7 @@ mod tests {
         let (mut cfg, _dir) = TiKvConfig::with_tmp().unwrap();
         cfg.storage.flow_control.l0_files_threshold = 50;
         cfg.validate().unwrap();
-        let (storage, cfg_controller, _, flow_controller) = new_engines(cfg);
+        let (storage, cfg_controller, _, flow_controller) = new_engines::<APIV1>(cfg);
         let db = storage.get_engine().get_rocksdb();
         assert_eq!(
             db.get_options_cf(CF_DEFAULT)
@@ -4147,7 +4147,7 @@ mod tests {
         cfg.rocksdb.rate_limiter_auto_tuned = false;
         cfg.storage.block_cache.shared = false;
         cfg.validate().unwrap();
-        let (storage, cfg_controller, ..) = new_engines(cfg);
+        let (storage, cfg_controller, ..) = new_engines::<APIV1>(cfg);
         let db = storage.get_engine().get_rocksdb();
 
         // update max_background_jobs
@@ -4221,7 +4221,7 @@ mod tests {
         // vanilla limiter does not support dynamically changing auto-tuned mode.
         cfg.rocksdb.rate_limiter_auto_tuned = true;
         cfg.validate().unwrap();
-        let (storage, cfg_controller, ..) = new_engines(cfg);
+        let (storage, cfg_controller, ..) = new_engines::<APIV1>(cfg);
         let db = storage.get_engine().get_rocksdb();
 
         // update rate_limiter_auto_tuned
@@ -4244,7 +4244,7 @@ mod tests {
         let (mut cfg, _dir) = TiKvConfig::with_tmp().unwrap();
         cfg.storage.block_cache.shared = true;
         cfg.validate().unwrap();
-        let (storage, cfg_controller, ..) = new_engines(cfg);
+        let (storage, cfg_controller, ..) = new_engines::<APIV1>(cfg);
         let db = storage.get_engine().get_rocksdb();
 
         // Can not update shared block cache through rocksdb module
@@ -4290,7 +4290,7 @@ mod tests {
         let (mut cfg, _dir) = TiKvConfig::with_tmp().unwrap();
         cfg.storage.block_cache.shared = true;
         cfg.validate().unwrap();
-        let (_, cfg_controller, mut rx, _) = new_engines(cfg);
+        let (_, cfg_controller, mut rx, _) = new_engines::<APIV1>(cfg);
 
         // Can not update shared block cache through rocksdb module
         cfg_controller
@@ -4307,7 +4307,7 @@ mod tests {
         let (mut cfg, _dir) = TiKvConfig::with_tmp().unwrap();
         cfg.storage.scheduler_worker_pool_size = 4;
         cfg.validate().unwrap();
-        let (storage, cfg_controller, ..) = new_engines(cfg);
+        let (storage, cfg_controller, ..) = new_engines::<APIV1>(cfg);
         let scheduler = storage.get_scheduler();
 
         let max_pool_size = std::cmp::max(4, SysQuota::cpu_cores_quota() as usize);

--- a/src/coprocessor_v2/endpoint.rs
+++ b/src/coprocessor_v2/endpoint.rs
@@ -1,11 +1,11 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
+use api_version::APIVersion;
 use coprocessor_plugin_api::*;
 use kvproto::kvrpcpb;
 use semver::VersionReq;
 use std::future::Future;
 use std::sync::Arc;
-use api_version::APIVersion;
 
 use super::config::Config;
 use super::plugin_registry::PluginRegistry;

--- a/src/coprocessor_v2/endpoint.rs
+++ b/src/coprocessor_v2/endpoint.rs
@@ -5,6 +5,7 @@ use kvproto::kvrpcpb;
 use semver::VersionReq;
 use std::future::Future;
 use std::sync::Arc;
+use api_version::APIVersion;
 
 use super::config::Config;
 use super::plugin_registry::PluginRegistry;
@@ -53,9 +54,9 @@ impl Endpoint {
     /// Each request is dispatched to the corresponding coprocessor plugin based on it's `copr_name`
     /// field. A plugin with a matching name must be loaded by TiKV, otherwise an error is returned.
     #[inline]
-    pub fn handle_request<E: Engine, L: LockManager>(
+    pub fn handle_request<E: Engine, L: LockManager, Api: APIVersion>(
         &self,
-        storage: &Storage<E, L>,
+        storage: &Storage<E, L, Api>,
         req: kvrpcpb::RawCoprocessorRequest,
     ) -> impl Future<Output = kvrpcpb::RawCoprocessorResponse> {
         let mut response = kvrpcpb::RawCoprocessorResponse::default();
@@ -72,9 +73,9 @@ impl Endpoint {
     }
 
     #[inline]
-    fn handle_request_impl<E: Engine, L: LockManager>(
+    fn handle_request_impl<E: Engine, L: LockManager, Api: APIVersion>(
         &self,
-        storage: &Storage<E, L>,
+        storage: &Storage<E, L, Api>,
         mut req: kvrpcpb::RawCoprocessorRequest,
     ) -> Result<RawResponse, CoprocessorError> {
         let plugin_registry = self

--- a/src/coprocessor_v2/raw_storage_impl.rs
+++ b/src/coprocessor_v2/raw_storage_impl.rs
@@ -5,6 +5,7 @@ use coprocessor_plugin_api::*;
 use futures::channel::oneshot::Canceled;
 use kvproto::kvrpcpb::Context;
 use std::ops::Range;
+use api_version::APIVersion;
 use tikv_util::future::paired_future_callback;
 
 use crate::storage::errors::extract_kv_pairs;
@@ -16,20 +17,20 @@ use crate::storage::{self, lock_manager::LockManager, Engine, Storage};
 /// It wraps TiKV's [`Storage`] into an API that is exposed to coprocessor plugins.
 /// The `RawStorageImpl` should be constructed for every invocation of a [`CoprocessorPlugin`] as
 /// it wraps a [`Context`] that is unique for every request.
-pub struct RawStorageImpl<'a, E: Engine, L: LockManager> {
+pub struct RawStorageImpl<'a, E: Engine, L: LockManager, Api: APIVersion> {
     context: Context,
-    storage: &'a Storage<E, L>,
+    storage: &'a Storage<E, L, Api>,
 }
 
-impl<'a, E: Engine, L: LockManager> RawStorageImpl<'a, E, L> {
+impl<'a, E: Engine, L: LockManager, Api: APIVersion> RawStorageImpl<'a, E, L, Api> {
     /// Constructs a new `RawStorageImpl` that wraps a given [`Context`] and [`Storage`].
-    pub fn new(context: Context, storage: &'a Storage<E, L>) -> Self {
+    pub fn new(context: Context, storage: &'a Storage<E, L, Api>) -> Self {
         RawStorageImpl { context, storage }
     }
 }
 
 #[async_trait(?Send)]
-impl<E: Engine, L: LockManager> RawStorage for RawStorageImpl<'_, E, L> {
+impl<E: Engine, L: LockManager, Api: APIVersion> RawStorage for RawStorageImpl<'_, E, L, Api> {
     async fn get(&self, key: Key) -> PluginResult<Option<Value>> {
         let ctx = self.context.clone();
 
@@ -204,11 +205,12 @@ impl From<Canceled> for PluginErrorShim {
 mod test {
     use super::*;
     use crate::storage::{lock_manager::DummyLockManager, TestStorageBuilder};
+    use api_version::APIV2;
     use kvproto::kvrpcpb::{ApiVersion, Context};
 
     #[tokio::test]
     async fn test_storage_api() {
-        let storage = TestStorageBuilder::new(DummyLockManager, ApiVersion::V2)
+        let storage = TestStorageBuilder::<_, _, APIV2>::new(DummyLockManager)
             .build()
             .unwrap();
         let ctx = Context {
@@ -244,7 +246,7 @@ mod test {
 
     #[tokio::test]
     async fn test_storage_api_batch() {
-        let storage = TestStorageBuilder::new(DummyLockManager, ApiVersion::V2)
+        let storage = TestStorageBuilder::<_, _, APIV2>::new(DummyLockManager)
             .build()
             .unwrap();
         let ctx = Context {

--- a/src/coprocessor_v2/raw_storage_impl.rs
+++ b/src/coprocessor_v2/raw_storage_impl.rs
@@ -1,11 +1,11 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
+use api_version::APIVersion;
 use async_trait::async_trait;
 use coprocessor_plugin_api::*;
 use futures::channel::oneshot::Canceled;
 use kvproto::kvrpcpb::Context;
 use std::ops::Range;
-use api_version::APIVersion;
 use tikv_util::future::paired_future_callback;
 
 use crate::storage::errors::extract_kv_pairs;

--- a/src/import/duplicate_detect.rs
+++ b/src/import/duplicate_detect.rs
@@ -348,7 +348,7 @@ mod tests {
 
     #[test]
     fn test_duplicate_detect() {
-        let storage = TestStorageBuilderApiV1::new(DummyLockManager {})
+        let storage = TestStorageBuilderApiV1::new(DummyLockManager)
             .build()
             .unwrap();
         let mut data = vec![];
@@ -404,7 +404,7 @@ mod tests {
     // with (108,10).
     #[test]
     fn test_duplicate_detect_incremental() {
-        let storage = TestStorageBuilderApiV1::new(DummyLockManager {})
+        let storage = TestStorageBuilderApiV1::new(DummyLockManager)
             .build()
             .unwrap();
         for &start in &[100, 104, 108, 112] {
@@ -465,7 +465,7 @@ mod tests {
 
     #[test]
     fn test_duplicate_detect_rollback_and_delete() {
-        let storage = TestStorageBuilderApiV1::new(DummyLockManager {})
+        let storage = TestStorageBuilderApiV1::new(DummyLockManager)
             .build()
             .unwrap();
         let data = vec![

--- a/src/import/duplicate_detect.rs
+++ b/src/import/duplicate_detect.rs
@@ -236,9 +236,9 @@ mod tests {
     use crate::storage::lock_manager::{DummyLockManager, LockManager};
     use crate::storage::txn::commands;
     use crate::storage::{Storage, TestStorageBuilder};
-    use kvproto::kvrpcpb::{ApiVersion, Context};
-    use std::sync::mpsc::channel;
     use api_version::{APIVersion, APIV1};
+    use kvproto::kvrpcpb::Context;
+    use std::sync::mpsc::channel;
     use tikv_kv::Engine;
     use txn_types::Mutation;
 

--- a/src/import/duplicate_detect.rs
+++ b/src/import/duplicate_detect.rs
@@ -235,8 +235,8 @@ mod tests {
     use super::*;
     use crate::storage::lock_manager::{DummyLockManager, LockManager};
     use crate::storage::txn::commands;
-    use crate::storage::{Storage, TestStorageBuilder};
-    use api_version::{APIVersion, APIV1};
+    use crate::storage::{Storage, TestStorageBuilderApiV1};
+    use api_version::APIVersion;
     use kvproto::kvrpcpb::Context;
     use std::sync::mpsc::channel;
     use tikv_kv::Engine;
@@ -348,7 +348,7 @@ mod tests {
 
     #[test]
     fn test_duplicate_detect() {
-        let storage = TestStorageBuilder::<_, _, APIV1>::new(DummyLockManager {})
+        let storage = TestStorageBuilderApiV1::new(DummyLockManager {})
             .build()
             .unwrap();
         let mut data = vec![];
@@ -404,7 +404,7 @@ mod tests {
     // with (108,10).
     #[test]
     fn test_duplicate_detect_incremental() {
-        let storage = TestStorageBuilder::<_, _, APIV1>::new(DummyLockManager {})
+        let storage = TestStorageBuilderApiV1::new(DummyLockManager {})
             .build()
             .unwrap();
         for &start in &[100, 104, 108, 112] {
@@ -465,7 +465,7 @@ mod tests {
 
     #[test]
     fn test_duplicate_detect_rollback_and_delete() {
-        let storage = TestStorageBuilder::<_, _, APIV1>::new(DummyLockManager {})
+        let storage = TestStorageBuilderApiV1::new(DummyLockManager {})
             .build()
             .unwrap();
         let data = vec![

--- a/src/import/duplicate_detect.rs
+++ b/src/import/duplicate_detect.rs
@@ -238,11 +238,12 @@ mod tests {
     use crate::storage::{Storage, TestStorageBuilder};
     use kvproto::kvrpcpb::{ApiVersion, Context};
     use std::sync::mpsc::channel;
+    use api_version::{APIVersion, APIV1};
     use tikv_kv::Engine;
     use txn_types::Mutation;
 
-    fn prewrite_data<E: Engine, L: LockManager>(
-        storage: &Storage<E, L>,
+    fn prewrite_data<E: Engine, L: LockManager, Api: APIVersion>(
+        storage: &Storage<E, L, Api>,
         primary: Vec<u8>,
         data: Vec<(Vec<u8>, Vec<u8>)>,
         start_ts: u64,
@@ -273,8 +274,8 @@ mod tests {
         rx.recv().unwrap();
     }
 
-    fn rollback_data<E: Engine, L: LockManager>(
-        storage: &Storage<E, L>,
+    fn rollback_data<E: Engine, L: LockManager, Api: APIVersion>(
+        storage: &Storage<E, L, Api>,
         data: Vec<Vec<u8>>,
         start_ts: u64,
     ) {
@@ -296,8 +297,8 @@ mod tests {
         rx.recv().unwrap();
     }
 
-    fn write_data<E: Engine, L: LockManager>(
-        storage: &Storage<E, L>,
+    fn write_data<E: Engine, L: LockManager, Api: APIVersion>(
+        storage: &Storage<E, L, Api>,
         data: Vec<(Vec<u8>, Vec<u8>)>,
         ts: u64,
     ) {
@@ -347,7 +348,7 @@ mod tests {
 
     #[test]
     fn test_duplicate_detect() {
-        let storage = TestStorageBuilder::new(DummyLockManager {}, ApiVersion::V1)
+        let storage = TestStorageBuilder::<_, _, APIV1>::new(DummyLockManager {})
             .build()
             .unwrap();
         let mut data = vec![];
@@ -403,7 +404,7 @@ mod tests {
     // with (108,10).
     #[test]
     fn test_duplicate_detect_incremental() {
-        let storage = TestStorageBuilder::new(DummyLockManager {}, ApiVersion::V1)
+        let storage = TestStorageBuilder::<_, _, APIV1>::new(DummyLockManager {})
             .build()
             .unwrap();
         for &start in &[100, 104, 108, 112] {
@@ -464,7 +465,7 @@ mod tests {
 
     #[test]
     fn test_duplicate_detect_rollback_and_delete() {
-        let storage = TestStorageBuilder::new(DummyLockManager {}, ApiVersion::V1)
+        let storage = TestStorageBuilder::<_, _, APIV1>::new(DummyLockManager {})
             .build()
             .unwrap();
         let data = vec![

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -1043,6 +1043,7 @@ mod tests {
         must_commit, must_gc, must_prewrite_delete, must_prewrite_put, must_rollback,
     };
     use crate::storage::{txn::commands, Engine, Storage, TestStorageBuilder};
+    use api_version::{APIVersion, APIV1};
     use engine_rocks::{util::get_cf_handle, RocksEngine, RocksSnapshot};
     use engine_traits::KvEngine;
     use futures::executor::block_on;
@@ -1163,8 +1164,8 @@ mod tests {
 
     /// Assert the data in `storage` is the same as `expected_data`. Keys in `expected_data` should
     /// be encoded form without ts.
-    fn check_data<E: Engine>(
-        storage: &Storage<E, DummyLockManager>,
+    fn check_data<E: Engine, Api: APIVersion>(
+        storage: &Storage<E, DummyLockManager, Api>,
         expected_data: &BTreeMap<Vec<u8>, Vec<u8>>,
     ) {
         let scan_res = block_on(storage.scan(
@@ -1197,10 +1198,9 @@ mod tests {
         // Return Result from this function so we can use the `wait_op` macro here.
 
         let engine = TestEngineBuilder::new().build().unwrap();
-        let storage = TestStorageBuilder::from_engine_and_lock_mgr(
+        let storage = TestStorageBuilder::<_, _, APIV1>::from_engine_and_lock_mgr(
             engine.clone(),
             DummyLockManager {},
-            ApiVersion::V1,
         )
         .build()
         .unwrap();
@@ -1362,10 +1362,9 @@ mod tests {
     fn test_physical_scan_lock() {
         let engine = TestEngineBuilder::new().build().unwrap();
         let prefixed_engine = PrefixedEngine(engine);
-        let storage = TestStorageBuilder::<_, DummyLockManager>::from_engine_and_lock_mgr(
+        let storage = TestStorageBuilder::<_, DummyLockManager, APIV1>::from_engine_and_lock_mgr(
             prefixed_engine.clone(),
             DummyLockManager {},
-            ApiVersion::V1,
         )
         .build()
         .unwrap();

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -1047,7 +1047,7 @@ mod tests {
     use engine_rocks::{util::get_cf_handle, RocksEngine, RocksSnapshot};
     use engine_traits::KvEngine;
     use futures::executor::block_on;
-    use kvproto::kvrpcpb::{ApiVersion, Op};
+    use kvproto::kvrpcpb::Op;
     use kvproto::metapb::Peer;
     use raft::StateRole;
     use raftstore::coprocessor::region_info_accessor::RegionInfoAccessor;

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -1042,8 +1042,8 @@ mod tests {
     use crate::storage::txn::tests::{
         must_commit, must_gc, must_prewrite_delete, must_prewrite_put, must_rollback,
     };
-    use crate::storage::{txn::commands, Engine, Storage, TestStorageBuilder};
-    use api_version::{APIVersion, APIV1};
+    use crate::storage::{txn::commands, Engine, Storage, TestStorageBuilderApiV1};
+    use api_version::APIVersion;
     use engine_rocks::{util::get_cf_handle, RocksEngine, RocksSnapshot};
     use engine_traits::KvEngine;
     use futures::executor::block_on;
@@ -1198,12 +1198,10 @@ mod tests {
         // Return Result from this function so we can use the `wait_op` macro here.
 
         let engine = TestEngineBuilder::new().build().unwrap();
-        let storage = TestStorageBuilder::<_, _, APIV1>::from_engine_and_lock_mgr(
-            engine.clone(),
-            DummyLockManager {},
-        )
-        .build()
-        .unwrap();
+        let storage =
+            TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine.clone(), DummyLockManager {})
+                .build()
+                .unwrap();
         let gate = FeatureGate::default();
         gate.set_version("5.0.0").unwrap();
         let (tx, _rx) = mpsc::channel();
@@ -1362,7 +1360,7 @@ mod tests {
     fn test_physical_scan_lock() {
         let engine = TestEngineBuilder::new().build().unwrap();
         let prefixed_engine = PrefixedEngine(engine);
-        let storage = TestStorageBuilder::<_, DummyLockManager, APIV1>::from_engine_and_lock_mgr(
+        let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(
             prefixed_engine.clone(),
             DummyLockManager {},
         )

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -1199,7 +1199,7 @@ mod tests {
 
         let engine = TestEngineBuilder::new().build().unwrap();
         let storage =
-            TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine.clone(), DummyLockManager {})
+            TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine.clone(), DummyLockManager)
                 .build()
                 .unwrap();
         let gate = FeatureGate::default();
@@ -1362,7 +1362,7 @@ mod tests {
         let prefixed_engine = PrefixedEngine(engine);
         let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(
             prefixed_engine.clone(),
-            DummyLockManager {},
+            DummyLockManager,
         )
         .build()
         .unwrap();

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -14,7 +14,7 @@ use crate::storage::kv::FlowStatsReporter;
 use crate::storage::txn::flow_controller::FlowController;
 use crate::storage::DynamicConfigs as StorageDynamicConfigs;
 use crate::storage::{config::Config as StorageConfig, Storage};
-use api_version::api_v2::TIDB_RANGES_COMPLEMENT;
+use api_version::{api_v2::TIDB_RANGES_COMPLEMENT, APIVersion};
 use concurrency_manager::ConcurrencyManager;
 use engine_traits::{Engines, Iterable, KvEngine, RaftEngine, DATA_CFS, DATA_KEY_PREFIX_LEN};
 use kvproto::kvrpcpb::ApiVersion;
@@ -39,7 +39,7 @@ const CHECK_CLUSTER_BOOTSTRAPPED_RETRY_SECONDS: u64 = 3;
 
 /// Creates a new storage engine which is backed by the Raft consensus
 /// protocol.
-pub fn create_raft_storage<S, EK, R: FlowStatsReporter>(
+pub fn create_raft_storage<S, EK, R: FlowStatsReporter, Api: APIVersion>(
     engine: RaftKv<EK, S>,
     cfg: &StorageConfig,
     read_pool: ReadPoolHandle,
@@ -51,7 +51,7 @@ pub fn create_raft_storage<S, EK, R: FlowStatsReporter>(
     resource_tag_factory: ResourceTagFactory,
     quota_limiter: Arc<QuotaLimiter>,
     feature_gate: FeatureGate,
-) -> Result<Storage<RaftKv<EK, S>, LockManager>>
+) -> Result<Storage<RaftKv<EK, S>, LockManager, Api>>
 where
     S: RaftStoreRouter<EK> + LocalReadRouter<EK> + 'static,
     EK: KvEngine,

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -412,8 +412,7 @@ mod tests {
     use crate::coprocessor::{self, readpool_impl};
     use crate::server::TestRaftStoreRouter;
     use crate::storage::lock_manager::DummyLockManager;
-    use crate::storage::TestStorageBuilder;
-    use api_version::APIV1;
+    use crate::storage::TestStorageBuilderApiV1;
     use engine_rocks::{PerfLevel, RocksSnapshot};
     use grpcio::EnvBuilder;
     use kvproto::raft_serverpb::RaftMessage;
@@ -468,7 +467,7 @@ mod tests {
             ..Default::default()
         };
 
-        let storage = TestStorageBuilder::<_, _, APIV1>::new(DummyLockManager {})
+        let storage = TestStorageBuilderApiV1::new(DummyLockManager {})
             .build()
             .unwrap();
 

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -467,7 +467,7 @@ mod tests {
             ..Default::default()
         };
 
-        let storage = TestStorageBuilderApiV1::new(DummyLockManager {})
+        let storage = TestStorageBuilderApiV1::new(DummyLockManager)
             .build()
             .unwrap();
 

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -6,6 +6,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+use api_version::APIVersion;
 use futures::compat::Stream01CompatExt;
 use futures::stream::StreamExt;
 use grpcio::{ChannelBuilder, Environment, ResourceQuota, Server as GrpcServer, ServerBuilder};
@@ -13,7 +14,6 @@ use grpcio_health::{create_health, HealthService, ServingStatus};
 use kvproto::tikvpb::*;
 use tokio::runtime::{Builder as RuntimeBuilder, Handle as RuntimeHandle, Runtime};
 use tokio_timer::timer::Handle;
-use api_version::APIVersion;
 
 use crate::coprocessor::Endpoint;
 use crate::coprocessor_v2;
@@ -414,12 +414,11 @@ mod tests {
     use crate::storage::lock_manager::DummyLockManager;
     use crate::storage::TestStorageBuilder;
     use api_version::APIV1;
+    use engine_rocks::{PerfLevel, RocksSnapshot};
     use grpcio::EnvBuilder;
-    use kvproto::kvrpcpb::ApiVersion;
+    use kvproto::raft_serverpb::RaftMessage;
     use raftstore::store::transport::Transport;
     use raftstore::store::*;
-    use engine_rocks::{PerfLevel, RocksSnapshot};
-    use kvproto::raft_serverpb::RaftMessage;
     use resource_metering::ResourceTagFactory;
     use security::SecurityConfig;
     use tikv_util::quota_limiter::QuotaLimiter;

--- a/src/server/service/batch.rs
+++ b/src/server/service/batch.rs
@@ -13,8 +13,8 @@ use crate::storage::{
     Storage,
 };
 use crate::storage::{ResponseBatchConsumer, Result};
-use kvproto::kvrpcpb::*;
 use api_version::APIVersion;
+use kvproto::kvrpcpb::*;
 use tikv_util::future::poll_future_notify;
 use tikv_util::mpsc::batch::Sender;
 use tikv_util::time::Instant;

--- a/src/server/service/batch.rs
+++ b/src/server/service/batch.rs
@@ -14,6 +14,7 @@ use crate::storage::{
 };
 use crate::storage::{ResponseBatchConsumer, Result};
 use kvproto::kvrpcpb::*;
+use api_version::APIVersion;
 use tikv_util::future::poll_future_notify;
 use tikv_util::mpsc::batch::Sender;
 use tikv_util::time::Instant;
@@ -62,9 +63,9 @@ impl ReqBatcher {
         self.raw_get_ids.push(id);
     }
 
-    pub fn maybe_commit<E: Engine, L: LockManager>(
+    pub fn maybe_commit<E: Engine, L: LockManager, Api: APIVersion>(
         &mut self,
-        storage: &Storage<E, L>,
+        storage: &Storage<E, L, Api>,
         tx: &Sender<MeasuredSingleResponse>,
     ) {
         if self.gets.len() >= self.batch_size {
@@ -80,9 +81,9 @@ impl ReqBatcher {
         }
     }
 
-    pub fn commit<E: Engine, L: LockManager>(
+    pub fn commit<E: Engine, L: LockManager, Api: APIVersion>(
         self,
-        storage: &Storage<E, L>,
+        storage: &Storage<E, L, Api>,
         tx: &Sender<MeasuredSingleResponse>,
     ) {
         if !self.gets.is_empty() {
@@ -203,8 +204,8 @@ impl ResponseBatchConsumer<Option<Vec<u8>>> for GetCommandResponseConsumer {
     }
 }
 
-fn future_batch_get_command<E: Engine, L: LockManager>(
-    storage: &Storage<E, L>,
+fn future_batch_get_command<E: Engine, L: LockManager, Api: APIVersion>(
+    storage: &Storage<E, L, Api>,
     requests: Vec<u64>,
     gets: Vec<GetRequest>,
     tx: Sender<MeasuredSingleResponse>,
@@ -243,8 +244,8 @@ fn future_batch_get_command<E: Engine, L: LockManager>(
     poll_future_notify(f);
 }
 
-fn future_batch_raw_get_command<E: Engine, L: LockManager>(
-    storage: &Storage<E, L>,
+fn future_batch_raw_get_command<E: Engine, L: LockManager, Api: APIVersion>(
+    storage: &Storage<E, L, Api>,
     requests: Vec<u64>,
     gets: Vec<RawGetRequest>,
     tx: Sender<MeasuredSingleResponse>,

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -60,7 +60,12 @@ const GRPC_MSG_MAX_BATCH_SIZE: usize = 128;
 const GRPC_MSG_NOTIFY_SIZE: usize = 8;
 
 /// Service handles the RPC messages for the `Tikv` service.
-pub struct Service<T: RaftStoreRouter<E::Local> + 'static, E: Engine, L: LockManager, Api: APIVersion> {
+pub struct Service<
+    T: RaftStoreRouter<E::Local> + 'static,
+    E: Engine,
+    L: LockManager,
+    Api: APIVersion,
+> {
     store_id: u64,
     /// Used to handle requests related to GC.
     gc_worker: GcWorker<E, T>,
@@ -87,8 +92,12 @@ pub struct Service<T: RaftStoreRouter<E::Local> + 'static, E: Engine, L: LockMan
     reject_messages_on_memory_ratio: f64,
 }
 
-impl<T: RaftStoreRouter<E::Local> + Clone + 'static, E: Engine + Clone, L: LockManager + Clone, Api: APIVersion>
-    Clone for Service<T, E, L, Api>
+impl<
+    T: RaftStoreRouter<E::Local> + Clone + 'static,
+    E: Engine + Clone,
+    L: LockManager + Clone,
+    Api: APIVersion,
+> Clone for Service<T, E, L, Api>
 {
     fn clone(&self) -> Self {
         Service {
@@ -108,7 +117,9 @@ impl<T: RaftStoreRouter<E::Local> + Clone + 'static, E: Engine + Clone, L: LockM
     }
 }
 
-impl<T: RaftStoreRouter<E::Local> + 'static, E: Engine, L: LockManager, Api: APIVersion> Service<T, E, L, Api> {
+impl<T: RaftStoreRouter<E::Local> + 'static, E: Engine, L: LockManager, Api: APIVersion>
+    Service<T, E, L, Api>
+{
     /// Constructs a new `Service` which provides the `Tikv` service.
     pub fn new(
         store_id: u64,
@@ -195,7 +206,9 @@ macro_rules! handle_request {
     }
 }
 
-impl<T: RaftStoreRouter<E::Local> + 'static, E: Engine, L: LockManager, Api: APIVersion> Tikv for Service<T, E, L, Api> {
+impl<T: RaftStoreRouter<E::Local> + 'static, E: Engine, L: LockManager, Api: APIVersion> Tikv
+    for Service<T, E, L, Api>
+{
     handle_request!(kv_get, future_get, GetRequest, GetResponse);
     handle_request!(kv_scan, future_scan, ScanRequest, ScanResponse);
     handle_request!(

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -3128,7 +3128,7 @@ mod tests {
     #[test]
     fn test_prewrite_blocks_read() {
         use kvproto::kvrpcpb::ExtraOp;
-        let storage = TestStorageBuilderApiV1::new(DummyLockManager {})
+        let storage = TestStorageBuilderApiV1::new(DummyLockManager)
             .build()
             .unwrap();
 
@@ -3165,7 +3165,7 @@ mod tests {
 
     #[test]
     fn test_get_put() {
-        let storage = TestStorageBuilderApiV1::new(DummyLockManager {})
+        let storage = TestStorageBuilderApiV1::new(DummyLockManager)
             .build()
             .unwrap();
         let (tx, rx) = channel();
@@ -3223,10 +3223,9 @@ mod tests {
     fn test_cf_error() {
         // New engine lacks normal column families.
         let engine = TestEngineBuilder::new().cfs(["foo"]).build().unwrap();
-        let storage =
-            TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager {})
-                .build()
-                .unwrap();
+        let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager)
+            .build()
+            .unwrap();
         let (tx, rx) = channel();
         storage
             .sched_txn_command(
@@ -3312,7 +3311,7 @@ mod tests {
 
     #[test]
     fn test_scan() {
-        let storage = TestStorageBuilderApiV1::new(DummyLockManager {})
+        let storage = TestStorageBuilderApiV1::new(DummyLockManager)
             .build()
             .unwrap();
         let (tx, rx) = channel();
@@ -3652,10 +3651,9 @@ mod tests {
             )
         }
         .unwrap();
-        let storage =
-            TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager {})
-                .build()
-                .unwrap();
+        let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager)
+            .build()
+            .unwrap();
         let (tx, rx) = channel();
         storage
             .sched_txn_command(
@@ -3882,7 +3880,7 @@ mod tests {
 
     #[test]
     fn test_batch_get() {
-        let storage = TestStorageBuilderApiV1::new(DummyLockManager {})
+        let storage = TestStorageBuilderApiV1::new(DummyLockManager)
             .build()
             .unwrap();
         let (tx, rx) = channel();
@@ -3957,7 +3955,7 @@ mod tests {
 
     #[test]
     fn test_batch_get_command() {
-        let storage = TestStorageBuilderApiV1::new(DummyLockManager {})
+        let storage = TestStorageBuilderApiV1::new(DummyLockManager)
             .build()
             .unwrap();
         let (tx, rx) = channel();
@@ -4043,7 +4041,7 @@ mod tests {
 
     #[test]
     fn test_txn() {
-        let storage = TestStorageBuilderApiV1::new(DummyLockManager {})
+        let storage = TestStorageBuilderApiV1::new(DummyLockManager)
             .build()
             .unwrap();
         let (tx, rx) = channel();
@@ -4129,7 +4127,7 @@ mod tests {
             scheduler_pending_write_threshold: ReadableSize(1),
             ..Default::default()
         };
-        let storage = TestStorageBuilderApiV1::new(DummyLockManager {})
+        let storage = TestStorageBuilderApiV1::new(DummyLockManager)
             .config(config)
             .build()
             .unwrap();
@@ -4172,7 +4170,7 @@ mod tests {
 
     #[test]
     fn test_cleanup() {
-        let storage = TestStorageBuilderApiV1::new(DummyLockManager {})
+        let storage = TestStorageBuilderApiV1::new(DummyLockManager)
             .build()
             .unwrap();
         let cm = storage.concurrency_manager.clone();
@@ -4210,7 +4208,7 @@ mod tests {
 
     #[test]
     fn test_cleanup_check_ttl() {
-        let storage = TestStorageBuilderApiV1::new(DummyLockManager {})
+        let storage = TestStorageBuilderApiV1::new(DummyLockManager)
             .build()
             .unwrap();
         let (tx, rx) = channel();
@@ -4268,7 +4266,7 @@ mod tests {
 
     #[test]
     fn test_high_priority_get_put() {
-        let storage = TestStorageBuilderApiV1::new(DummyLockManager {})
+        let storage = TestStorageBuilderApiV1::new(DummyLockManager)
             .build()
             .unwrap();
         let (tx, rx) = channel();
@@ -4325,7 +4323,7 @@ mod tests {
             scheduler_worker_pool_size: 1,
             ..Default::default()
         };
-        let storage = TestStorageBuilderApiV1::new(DummyLockManager {})
+        let storage = TestStorageBuilderApiV1::new(DummyLockManager)
             .config(config)
             .build()
             .unwrap();
@@ -4379,7 +4377,7 @@ mod tests {
 
     #[test]
     fn test_delete_range() {
-        let storage = TestStorageBuilderApiV1::new(DummyLockManager {})
+        let storage = TestStorageBuilderApiV1::new(DummyLockManager)
             .build()
             .unwrap();
         let (tx, rx) = channel();
@@ -4487,7 +4485,7 @@ mod tests {
     }
 
     fn test_raw_delete_range_impl<Api: APIVersion>() {
-        let storage = TestStorageBuilder::<_, _, Api>::new(DummyLockManager {})
+        let storage = TestStorageBuilder::<_, _, Api>::new(DummyLockManager)
             .build()
             .unwrap();
         let (tx, rx) = channel();
@@ -4600,7 +4598,7 @@ mod tests {
     }
 
     fn test_raw_batch_put_impl<Api: APIVersion>() {
-        let storage = TestStorageBuilder::<_, _, Api>::new(DummyLockManager {})
+        let storage = TestStorageBuilder::<_, _, Api>::new(DummyLockManager)
             .build()
             .unwrap();
         let (tx, rx) = channel();
@@ -4660,7 +4658,7 @@ mod tests {
     }
 
     fn test_raw_batch_get_impl<Api: APIVersion>() {
-        let storage = TestStorageBuilder::<_, _, Api>::new(DummyLockManager {})
+        let storage = TestStorageBuilder::<_, _, Api>::new(DummyLockManager)
             .build()
             .unwrap();
         let (tx, rx) = channel();
@@ -4709,7 +4707,7 @@ mod tests {
     }
 
     fn test_batch_raw_get_impl<Api: APIVersion>() {
-        let storage = TestStorageBuilder::<_, _, Api>::new(DummyLockManager {})
+        let storage = TestStorageBuilder::<_, _, Api>::new(DummyLockManager)
             .build()
             .unwrap();
         let (tx, rx) = channel();
@@ -4772,7 +4770,7 @@ mod tests {
     }
 
     fn test_raw_batch_delete_impl<Api: APIVersion>() {
-        let storage = TestStorageBuilder::<_, _, Api>::new(DummyLockManager {})
+        let storage = TestStorageBuilder::<_, _, Api>::new(DummyLockManager)
             .build()
             .unwrap();
         let (tx, rx) = channel();
@@ -4874,7 +4872,7 @@ mod tests {
             (None, None)
         };
 
-        let storage = TestStorageBuilder::<_, _, Api>::new(DummyLockManager {})
+        let storage = TestStorageBuilder::<_, _, Api>::new(DummyLockManager)
             .build()
             .unwrap();
         let (tx, rx) = channel();
@@ -5274,7 +5272,7 @@ mod tests {
                 .collect()
         };
 
-        let storage = TestStorageBuilder::<_, _, Api>::new(DummyLockManager {})
+        let storage = TestStorageBuilder::<_, _, Api>::new(DummyLockManager)
             .build()
             .unwrap();
         let (tx, rx) = channel();
@@ -5516,7 +5514,7 @@ mod tests {
     }
 
     fn test_raw_get_key_ttl_impl<Api: APIVersion>() {
-        let storage = TestStorageBuilder::<_, _, Api>::new(DummyLockManager {})
+        let storage = TestStorageBuilder::<_, _, Api>::new(DummyLockManager)
             .build()
             .unwrap();
         let (tx, rx) = channel();
@@ -5571,7 +5569,7 @@ mod tests {
 
     #[test]
     fn test_scan_lock() {
-        let storage = TestStorageBuilderApiV1::new(DummyLockManager {})
+        let storage = TestStorageBuilderApiV1::new(DummyLockManager)
             .build()
             .unwrap();
         let (tx, rx) = channel();
@@ -5867,7 +5865,7 @@ mod tests {
     fn test_resolve_lock() {
         use crate::storage::txn::RESOLVE_LOCK_BATCH_SIZE;
 
-        let storage = TestStorageBuilderApiV1::new(DummyLockManager {})
+        let storage = TestStorageBuilderApiV1::new(DummyLockManager)
             .build()
             .unwrap();
         let (tx, rx) = channel();
@@ -5978,7 +5976,7 @@ mod tests {
 
     #[test]
     fn test_resolve_lock_lite() {
-        let storage = TestStorageBuilderApiV1::new(DummyLockManager {})
+        let storage = TestStorageBuilderApiV1::new(DummyLockManager)
             .build()
             .unwrap();
         let (tx, rx) = channel();
@@ -6086,7 +6084,7 @@ mod tests {
 
     #[test]
     fn test_txn_heart_beat() {
-        let storage = TestStorageBuilderApiV1::new(DummyLockManager {})
+        let storage = TestStorageBuilderApiV1::new(DummyLockManager)
             .build()
             .unwrap();
         let (tx, rx) = channel();
@@ -6172,7 +6170,7 @@ mod tests {
 
     #[test]
     fn test_check_txn_status() {
-        let storage = TestStorageBuilderApiV1::new(DummyLockManager {})
+        let storage = TestStorageBuilderApiV1::new(DummyLockManager)
             .build()
             .unwrap();
         let cm = storage.concurrency_manager.clone();
@@ -6379,7 +6377,7 @@ mod tests {
 
     #[test]
     fn test_check_secondary_locks() {
-        let storage = TestStorageBuilderApiV1::new(DummyLockManager {})
+        let storage = TestStorageBuilderApiV1::new(DummyLockManager)
             .build()
             .unwrap();
         let cm = storage.concurrency_manager.clone();
@@ -6497,7 +6495,7 @@ mod tests {
     }
 
     fn test_pessimistic_lock_impl(pipelined_pessimistic_lock: bool) {
-        let storage = TestStorageBuilderApiV1::new(DummyLockManager {})
+        let storage = TestStorageBuilderApiV1::new(DummyLockManager)
             .pipelined_pessimistic_lock(pipelined_pessimistic_lock)
             .build()
             .unwrap();
@@ -7217,7 +7215,7 @@ mod tests {
 
     #[test]
     fn test_check_memory_locks() {
-        let storage = TestStorageBuilderApiV1::new(DummyLockManager {})
+        let storage = TestStorageBuilderApiV1::new(DummyLockManager)
             .build()
             .unwrap();
         let cm = storage.get_concurrency_manager();
@@ -7316,7 +7314,7 @@ mod tests {
 
     #[test]
     fn test_read_access_locks() {
-        let storage = TestStorageBuilderApiV1::new(DummyLockManager {})
+        let storage = TestStorageBuilderApiV1::new(DummyLockManager)
             .build()
             .unwrap();
 
@@ -7395,7 +7393,7 @@ mod tests {
 
     #[test]
     fn test_async_commit_prewrite() {
-        let storage = TestStorageBuilderApiV1::new(DummyLockManager {})
+        let storage = TestStorageBuilderApiV1::new(DummyLockManager)
             .build()
             .unwrap();
         let cm = storage.concurrency_manager.clone();
@@ -7486,7 +7484,7 @@ mod tests {
     fn test_overlapped_ts_rollback_before_prewrite() {
         let engine = TestEngineBuilder::new().build().unwrap();
         let storage =
-            TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine.clone(), DummyLockManager {})
+            TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine.clone(), DummyLockManager)
                 .build()
                 .unwrap();
 
@@ -7654,7 +7652,7 @@ mod tests {
                 }
                 let engine = builder.build();
                 let mut builder =
-                    TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager {});
+                    TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager);
                 builder.config.enable_async_apply_prewrite = true;
                 if self.pipelined_pessimistic_lock {
                     builder
@@ -7794,7 +7792,7 @@ mod tests {
 
     #[test]
     fn test_resolve_commit_pessimistic_locks() {
-        let storage = TestStorageBuilderApiV1::new(DummyLockManager {})
+        let storage = TestStorageBuilderApiV1::new(DummyLockManager)
             .build()
             .unwrap();
         let (tx, rx) = channel();
@@ -8350,7 +8348,7 @@ mod tests {
     #[test]
     fn test_write_in_memory_pessimistic_locks() {
         let txn_ext = Arc::new(TxnExt::default());
-        let storage = TestStorageBuilderApiV1::new(DummyLockManager {})
+        let storage = TestStorageBuilderApiV1::new(DummyLockManager)
             .pipelined_pessimistic_lock(true)
             .in_memory_pessimistic_lock(true)
             .build_for_txn(txn_ext.clone())
@@ -8442,7 +8440,7 @@ mod tests {
     #[test]
     fn test_disable_in_memory_pessimistic_locks() {
         let txn_ext = Arc::new(TxnExt::default());
-        let storage = TestStorageBuilderApiV1::new(DummyLockManager {})
+        let storage = TestStorageBuilderApiV1::new(DummyLockManager)
             .pipelined_pessimistic_lock(true)
             .in_memory_pessimistic_lock(false)
             .build_for_txn(txn_ext.clone())

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -96,6 +96,7 @@ use raftstore::store::{util::build_key_range, TxnExt};
 use raftstore::store::{ReadStats, WriteStats};
 use rand::prelude::*;
 use resource_metering::{FutureExt, ResourceTagFactory};
+use std::marker::PhantomData;
 use std::{
     borrow::Cow,
     iter,
@@ -104,7 +105,6 @@ use std::{
         Arc,
     },
 };
-use std::marker::PhantomData;
 use tikv_kv::SnapshotExt;
 use tikv_util::quota_limiter::QuotaLimiter;
 use tikv_util::time::{duration_to_ms, Instant, ThreadReadId};

--- a/tests/benches/hierarchy/storage/mod.rs
+++ b/tests/benches/hierarchy/storage/mod.rs
@@ -1,10 +1,9 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
 
-use api_version::APIV1;
 use criterion::{black_box, BatchSize, Bencher, Criterion};
 use engine_traits::CF_DEFAULT;
 use kvproto::kvrpcpb::Context;
-use test_storage::SyncTestStorageBuilder;
+use test_storage::SyncTestStorageBuilderApiV1;
 use test_util::KvGenerator;
 use tikv::storage::kv::Engine;
 use txn_types::{Key, Mutation};
@@ -13,7 +12,7 @@ use super::{BenchConfig, EngineFactory, DEFAULT_ITERATIONS};
 
 fn storage_raw_get<E: Engine, F: EngineFactory<E>>(b: &mut Bencher<'_>, config: &BenchConfig<F>) {
     let engine = config.engine_factory.build();
-    let store = SyncTestStorageBuilder::<_, APIV1>::from_engine(engine)
+    let store = SyncTestStorageBuilderApiV1::from_engine(engine)
         .build()
         .unwrap();
     b.iter_batched(
@@ -37,7 +36,7 @@ fn storage_raw_get<E: Engine, F: EngineFactory<E>>(b: &mut Bencher<'_>, config: 
 
 fn storage_prewrite<E: Engine, F: EngineFactory<E>>(b: &mut Bencher<'_>, config: &BenchConfig<F>) {
     let engine = config.engine_factory.build();
-    let store = SyncTestStorageBuilder::<_, APIV1>::from_engine(engine)
+    let store = SyncTestStorageBuilderApiV1::from_engine(engine)
         .build()
         .unwrap();
     b.iter_batched(
@@ -68,7 +67,7 @@ fn storage_prewrite<E: Engine, F: EngineFactory<E>>(b: &mut Bencher<'_>, config:
 
 fn storage_commit<E: Engine, F: EngineFactory<E>>(b: &mut Bencher<'_>, config: &BenchConfig<F>) {
     let engine = config.engine_factory.build();
-    let store = SyncTestStorageBuilder::<_, APIV1>::from_engine(engine)
+    let store = SyncTestStorageBuilderApiV1::from_engine(engine)
         .build()
         .unwrap();
     b.iter_batched(

--- a/tests/benches/hierarchy/storage/mod.rs
+++ b/tests/benches/hierarchy/storage/mod.rs
@@ -13,7 +13,9 @@ use super::{BenchConfig, EngineFactory, DEFAULT_ITERATIONS};
 
 fn storage_raw_get<E: Engine, F: EngineFactory<E>>(b: &mut Bencher<'_>, config: &BenchConfig<F>) {
     let engine = config.engine_factory.build();
-    let store = SyncTestStorageBuilder::<_, APIV1>::from_engine(engine).build().unwrap();
+    let store = SyncTestStorageBuilder::<_, APIV1>::from_engine(engine)
+        .build()
+        .unwrap();
     b.iter_batched(
         || {
             let kvs = KvGenerator::new(config.key_length, config.value_length)
@@ -35,7 +37,9 @@ fn storage_raw_get<E: Engine, F: EngineFactory<E>>(b: &mut Bencher<'_>, config: 
 
 fn storage_prewrite<E: Engine, F: EngineFactory<E>>(b: &mut Bencher<'_>, config: &BenchConfig<F>) {
     let engine = config.engine_factory.build();
-    let store = SyncTestStorageBuilder::<_, APIV1>::from_engine(engine).build().unwrap();
+    let store = SyncTestStorageBuilder::<_, APIV1>::from_engine(engine)
+        .build()
+        .unwrap();
     b.iter_batched(
         || {
             let kvs = KvGenerator::new(config.key_length, config.value_length)
@@ -64,7 +68,9 @@ fn storage_prewrite<E: Engine, F: EngineFactory<E>>(b: &mut Bencher<'_>, config:
 
 fn storage_commit<E: Engine, F: EngineFactory<E>>(b: &mut Bencher<'_>, config: &BenchConfig<F>) {
     let engine = config.engine_factory.build();
-    let store = SyncTestStorageBuilder::<_, APIV1>::from_engine(engine).build().unwrap();
+    let store = SyncTestStorageBuilder::<_, APIV1>::from_engine(engine)
+        .build()
+        .unwrap();
     b.iter_batched(
         || {
             let kvs = KvGenerator::new(config.key_length, config.value_length)

--- a/tests/benches/hierarchy/storage/mod.rs
+++ b/tests/benches/hierarchy/storage/mod.rs
@@ -1,5 +1,6 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
 
+use api_version::APIV1;
 use criterion::{black_box, BatchSize, Bencher, Criterion};
 use engine_traits::CF_DEFAULT;
 use kvproto::kvrpcpb::Context;
@@ -12,7 +13,7 @@ use super::{BenchConfig, EngineFactory, DEFAULT_ITERATIONS};
 
 fn storage_raw_get<E: Engine, F: EngineFactory<E>>(b: &mut Bencher<'_>, config: &BenchConfig<F>) {
     let engine = config.engine_factory.build();
-    let store = SyncTestStorageBuilder::from_engine(engine).build().unwrap();
+    let store = SyncTestStorageBuilder::<_, APIV1>::from_engine(engine).build().unwrap();
     b.iter_batched(
         || {
             let kvs = KvGenerator::new(config.key_length, config.value_length)
@@ -34,7 +35,7 @@ fn storage_raw_get<E: Engine, F: EngineFactory<E>>(b: &mut Bencher<'_>, config: 
 
 fn storage_prewrite<E: Engine, F: EngineFactory<E>>(b: &mut Bencher<'_>, config: &BenchConfig<F>) {
     let engine = config.engine_factory.build();
-    let store = SyncTestStorageBuilder::from_engine(engine).build().unwrap();
+    let store = SyncTestStorageBuilder::<_, APIV1>::from_engine(engine).build().unwrap();
     b.iter_batched(
         || {
             let kvs = KvGenerator::new(config.key_length, config.value_length)
@@ -63,7 +64,7 @@ fn storage_prewrite<E: Engine, F: EngineFactory<E>>(b: &mut Bencher<'_>, config:
 
 fn storage_commit<E: Engine, F: EngineFactory<E>>(b: &mut Bencher<'_>, config: &BenchConfig<F>) {
     let engine = config.engine_factory.build();
-    let store = SyncTestStorageBuilder::from_engine(engine).build().unwrap();
+    let store = SyncTestStorageBuilder::<_, APIV1>::from_engine(engine).build().unwrap();
     b.iter_batched(
         || {
             let kvs = KvGenerator::new(config.key_length, config.value_length)

--- a/tests/benches/misc/storage/mvcc_reader.rs
+++ b/tests/benches/misc/storage/mvcc_reader.rs
@@ -1,13 +1,13 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
 use kvproto::kvrpcpb::Context;
-use test_storage::{SyncTestStorage, SyncTestStorageBuilder};
+use test_storage::{SyncTestStorageApiV1, SyncTestStorageBuilderApiV1};
 use tidb_query_datatype::codec::table;
 use tikv::storage::{kv::RocksEngine, mvcc::SnapshotReader, Engine};
 use txn_types::{Key, Mutation};
 
-fn prepare_mvcc_data(key: &Key, n: u64) -> SyncTestStorage<RocksEngine, api_version::APIV1> {
-    let store = SyncTestStorageBuilder::default().build().unwrap();
+fn prepare_mvcc_data(key: &Key, n: u64) -> SyncTestStorageApiV1<RocksEngine> {
+    let store = SyncTestStorageBuilderApiV1::default().build().unwrap();
     for ts in 1..=n {
         let mutation = Mutation::make_put(key.clone(), b"value".to_vec());
         store

--- a/tests/benches/misc/storage/mvcc_reader.rs
+++ b/tests/benches/misc/storage/mvcc_reader.rs
@@ -6,7 +6,7 @@ use tidb_query_datatype::codec::table;
 use tikv::storage::{kv::RocksEngine, mvcc::SnapshotReader, Engine};
 use txn_types::{Key, Mutation};
 
-fn prepare_mvcc_data(key: &Key, n: u64) -> SyncTestStorage<RocksEngine> {
+fn prepare_mvcc_data(key: &Key, n: u64) -> SyncTestStorage<RocksEngine, api_version::APIV1> {
     let store = SyncTestStorageBuilder::default().build().unwrap();
     for ts in 1..=n {
         let mutation = Mutation::make_put(key.clone(), b"value".to_vec());

--- a/tests/failpoints/cases/test_storage.rs
+++ b/tests/failpoints/cases/test_storage.rs
@@ -7,12 +7,12 @@ use std::time::Duration;
 
 use grpcio::*;
 use kvproto::kvrpcpb::{
-    self, ApiVersion, AssertionLevel, BatchRollbackRequest, CommandPri, CommitRequest, Context,
-    GetRequest, Op, PrewriteRequest, RawPutRequest,
+    self, AssertionLevel, BatchRollbackRequest, CommandPri, CommitRequest, Context, GetRequest, Op,
+    PrewriteRequest, RawPutRequest,
 };
 use kvproto::tikvpb::TikvClient;
 
-use api_version::{APIV1, APIVersion};
+use api_version::{APIVersion, APIV1};
 use collections::HashMap;
 use errors::{extract_key_error, extract_region_error};
 use futures::executor::block_on;

--- a/tests/failpoints/cases/test_storage.rs
+++ b/tests/failpoints/cases/test_storage.rs
@@ -12,7 +12,7 @@ use kvproto::kvrpcpb::{
 };
 use kvproto::tikvpb::TikvClient;
 
-use api_version::{APIVersion, APIV1};
+use api_version::APIVersion;
 use collections::HashMap;
 use errors::{extract_key_error, extract_region_error};
 use futures::executor::block_on;
@@ -43,12 +43,9 @@ fn test_scheduler_leader_change_twice() {
     let peers = region0.get_peers();
     cluster.must_transfer_leader(region0.get_id(), peers[0].clone());
     let engine0 = cluster.sim.rl().storages[&peers[0].get_id()].clone();
-    let storage0 = TestStorageBuilder::<_, DummyLockManager, APIV1>::from_engine_and_lock_mgr(
-        engine0,
-        DummyLockManager {},
-    )
-    .build()
-    .unwrap();
+    let storage0 = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine0, DummyLockManager {})
+        .build()
+        .unwrap();
 
     let mut ctx0 = Context::default();
     ctx0.set_region_id(region0.get_id());
@@ -240,13 +237,10 @@ fn test_scale_scheduler_pool() {
         .get(&1)
         .unwrap()
         .clone();
-    let storage = TestStorageBuilder::<_, DummyLockManager, APIV1>::from_engine_and_lock_mgr(
-        engine,
-        DummyLockManager {},
-    )
-    .config(cluster.cfg.tikv.storage.clone())
-    .build()
-    .unwrap();
+    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager {})
+        .config(cluster.cfg.tikv.storage.clone())
+        .build()
+        .unwrap();
 
     let cfg = new_tikv_config(1);
     let kv_engine = storage.get_engine().kv_engine();
@@ -340,7 +334,7 @@ fn test_pipelined_pessimistic_lock() {
     let before_pipelined_write_finish_fp = "before_pipelined_write_finish";
 
     {
-        let storage = TestStorageBuilder::<_, _, api_version::APIV1>::new(DummyLockManager {})
+        let storage = TestStorageBuilderApiV1::new(DummyLockManager {})
             .pipelined_pessimistic_lock(false)
             .build()
             .unwrap();
@@ -367,7 +361,7 @@ fn test_pipelined_pessimistic_lock() {
         fail::remove(rockskv_write_modifies_fp);
     }
 
-    let storage = TestStorageBuilder::<_, _, api_version::APIV1>::new(DummyLockManager {})
+    let storage = TestStorageBuilderApiV1::new(DummyLockManager {})
         .pipelined_pessimistic_lock(true)
         .build()
         .unwrap();
@@ -511,12 +505,10 @@ fn test_async_commit_prewrite_with_stale_max_ts() {
         .get(&1)
         .unwrap()
         .clone();
-    let storage = TestStorageBuilder::<_, DummyLockManager, APIV1>::from_engine_and_lock_mgr(
-        engine.clone(),
-        DummyLockManager {},
-    )
-    .build()
-    .unwrap();
+    let storage =
+        TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine.clone(), DummyLockManager {})
+            .build()
+            .unwrap();
 
     // Fail to get timestamp from PD at first
     fail::cfg("test_raftstore_get_tso", "pause").unwrap();
@@ -808,13 +800,10 @@ fn test_async_apply_prewrite() {
         .get(&1)
         .unwrap()
         .clone();
-    let storage = TestStorageBuilder::<_, DummyLockManager, APIV1>::from_engine_and_lock_mgr(
-        engine,
-        DummyLockManager {},
-    )
-    .async_apply_prewrite(true)
-    .build()
-    .unwrap();
+    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager {})
+        .async_apply_prewrite(true)
+        .build()
+        .unwrap();
 
     let mut ctx = Context::default();
     ctx.set_region_id(1);
@@ -909,13 +898,10 @@ fn test_async_apply_prewrite_fallback() {
         .get(&1)
         .unwrap()
         .clone();
-    let storage = TestStorageBuilder::<_, DummyLockManager, APIV1>::from_engine_and_lock_mgr(
-        engine,
-        DummyLockManager {},
-    )
-    .async_apply_prewrite(true)
-    .build()
-    .unwrap();
+    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager {})
+        .async_apply_prewrite(true)
+        .build()
+        .unwrap();
 
     let mut ctx = Context::default();
     ctx.set_region_id(1);
@@ -1097,13 +1083,10 @@ fn test_async_apply_prewrite_1pc() {
         .get(&1)
         .unwrap()
         .clone();
-    let storage = TestStorageBuilder::<_, DummyLockManager, APIV1>::from_engine_and_lock_mgr(
-        engine,
-        DummyLockManager {},
-    )
-    .async_apply_prewrite(true)
-    .build()
-    .unwrap();
+    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager {})
+        .async_apply_prewrite(true)
+        .build()
+        .unwrap();
 
     let mut ctx = Context::default();
     ctx.set_region_id(1);
@@ -1127,12 +1110,9 @@ fn test_atomic_cas_lock_by_latch() {
         .get(&1)
         .unwrap()
         .clone();
-    let storage = TestStorageBuilder::<_, DummyLockManager, APIV1>::from_engine_and_lock_mgr(
-        engine,
-        DummyLockManager {},
-    )
-    .build()
-    .unwrap();
+    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager {})
+        .build()
+        .unwrap();
 
     let mut ctx = Context::default();
     ctx.set_region_id(1);
@@ -1216,12 +1196,9 @@ fn test_before_async_write_deadline() {
         .get(&1)
         .unwrap()
         .clone();
-    let storage = TestStorageBuilder::<_, DummyLockManager, APIV1>::from_engine_and_lock_mgr(
-        engine,
-        DummyLockManager {},
-    )
-    .build()
-    .unwrap();
+    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager {})
+        .build()
+        .unwrap();
 
     let mut ctx = Context::default();
     ctx.set_region_id(1);
@@ -1251,12 +1228,9 @@ fn test_before_propose_deadline() {
     cluster.run();
 
     let engine = cluster.sim.read().unwrap().storages[&1].clone();
-    let storage = TestStorageBuilder::<_, DummyLockManager, APIV1>::from_engine_and_lock_mgr(
-        engine,
-        DummyLockManager {},
-    )
-    .build()
-    .unwrap();
+    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager {})
+        .build()
+        .unwrap();
 
     let mut ctx = Context::default();
     ctx.set_region_id(1);
@@ -1287,12 +1261,9 @@ fn test_resolve_lock_deadline() {
     cluster.run();
 
     let engine = cluster.sim.read().unwrap().storages[&1].clone();
-    let storage = TestStorageBuilder::<_, DummyLockManager, APIV1>::from_engine_and_lock_mgr(
-        engine,
-        DummyLockManager {},
-    )
-    .build()
-    .unwrap();
+    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager {})
+        .build()
+        .unwrap();
 
     let mut ctx = Context::default();
     ctx.set_region_id(1);

--- a/tests/failpoints/cases/test_storage.rs
+++ b/tests/failpoints/cases/test_storage.rs
@@ -43,7 +43,7 @@ fn test_scheduler_leader_change_twice() {
     let peers = region0.get_peers();
     cluster.must_transfer_leader(region0.get_id(), peers[0].clone());
     let engine0 = cluster.sim.rl().storages[&peers[0].get_id()].clone();
-    let storage0 = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine0, DummyLockManager {})
+    let storage0 = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine0, DummyLockManager)
         .build()
         .unwrap();
 
@@ -237,7 +237,7 @@ fn test_scale_scheduler_pool() {
         .get(&1)
         .unwrap()
         .clone();
-    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager {})
+    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager)
         .config(cluster.cfg.tikv.storage.clone())
         .build()
         .unwrap();
@@ -334,7 +334,7 @@ fn test_pipelined_pessimistic_lock() {
     let before_pipelined_write_finish_fp = "before_pipelined_write_finish";
 
     {
-        let storage = TestStorageBuilderApiV1::new(DummyLockManager {})
+        let storage = TestStorageBuilderApiV1::new(DummyLockManager)
             .pipelined_pessimistic_lock(false)
             .build()
             .unwrap();
@@ -361,7 +361,7 @@ fn test_pipelined_pessimistic_lock() {
         fail::remove(rockskv_write_modifies_fp);
     }
 
-    let storage = TestStorageBuilderApiV1::new(DummyLockManager {})
+    let storage = TestStorageBuilderApiV1::new(DummyLockManager)
         .pipelined_pessimistic_lock(true)
         .build()
         .unwrap();
@@ -506,7 +506,7 @@ fn test_async_commit_prewrite_with_stale_max_ts() {
         .unwrap()
         .clone();
     let storage =
-        TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine.clone(), DummyLockManager {})
+        TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine.clone(), DummyLockManager)
             .build()
             .unwrap();
 
@@ -800,7 +800,7 @@ fn test_async_apply_prewrite() {
         .get(&1)
         .unwrap()
         .clone();
-    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager {})
+    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager)
         .async_apply_prewrite(true)
         .build()
         .unwrap();
@@ -898,7 +898,7 @@ fn test_async_apply_prewrite_fallback() {
         .get(&1)
         .unwrap()
         .clone();
-    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager {})
+    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager)
         .async_apply_prewrite(true)
         .build()
         .unwrap();
@@ -1083,7 +1083,7 @@ fn test_async_apply_prewrite_1pc() {
         .get(&1)
         .unwrap()
         .clone();
-    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager {})
+    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager)
         .async_apply_prewrite(true)
         .build()
         .unwrap();
@@ -1110,7 +1110,7 @@ fn test_atomic_cas_lock_by_latch() {
         .get(&1)
         .unwrap()
         .clone();
-    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager {})
+    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager)
         .build()
         .unwrap();
 
@@ -1196,7 +1196,7 @@ fn test_before_async_write_deadline() {
         .get(&1)
         .unwrap()
         .clone();
-    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager {})
+    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager)
         .build()
         .unwrap();
 
@@ -1228,7 +1228,7 @@ fn test_before_propose_deadline() {
     cluster.run();
 
     let engine = cluster.sim.read().unwrap().storages[&1].clone();
-    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager {})
+    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager)
         .build()
         .unwrap();
 
@@ -1261,7 +1261,7 @@ fn test_resolve_lock_deadline() {
     cluster.run();
 
     let engine = cluster.sim.read().unwrap().storages[&1].clone();
-    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager {})
+    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager)
         .build()
         .unwrap();
 

--- a/tests/failpoints/cases/test_transaction.rs
+++ b/tests/failpoints/cases/test_transaction.rs
@@ -4,7 +4,7 @@ use api_version::APIV1;
 use futures::executor::block_on;
 use grpcio::{ChannelBuilder, Environment};
 use kvproto::kvrpcpb::{
-    self as pb, ApiVersion, AssertionLevel, Context, Op, PessimisticLockRequest, PrewriteRequest,
+    self as pb, AssertionLevel, Context, Op, PessimisticLockRequest, PrewriteRequest,
 };
 use kvproto::tikvpb::TikvClient;
 use raftstore::store::util::new_peer;
@@ -198,12 +198,13 @@ macro_rules! lock_release_test {
         #[test]
         fn $test_name() {
             let engine = TestEngineBuilder::new().build().unwrap();
-            let storage = TestStorageBuilder::<_, DummyLockManager, APIV1>::from_engine_and_lock_mgr(
-                engine,
-                DummyLockManager {},
-            )
-            .build()
-            .unwrap();
+            let storage =
+                TestStorageBuilder::<_, DummyLockManager, APIV1>::from_engine_and_lock_mgr(
+                    engine,
+                    DummyLockManager {},
+                )
+                .build()
+                .unwrap();
 
             let key = Key::from_raw(b"k");
             let cm = storage.get_concurrency_manager();

--- a/tests/failpoints/cases/test_transaction.rs
+++ b/tests/failpoints/cases/test_transaction.rs
@@ -1,5 +1,6 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
+use api_version::APIV1;
 use futures::executor::block_on;
 use grpcio::{ChannelBuilder, Environment};
 use kvproto::kvrpcpb::{
@@ -54,10 +55,9 @@ fn test_txn_failpoints() {
 #[test]
 fn test_atomic_getting_max_ts_and_storing_memory_lock() {
     let engine = TestEngineBuilder::new().build().unwrap();
-    let storage = TestStorageBuilder::<_, DummyLockManager>::from_engine_and_lock_mgr(
+    let storage = TestStorageBuilder::<_, DummyLockManager, APIV1>::from_engine_and_lock_mgr(
         engine,
         DummyLockManager {},
-        ApiVersion::V1,
     )
     .build()
     .unwrap();
@@ -105,10 +105,9 @@ fn test_atomic_getting_max_ts_and_storing_memory_lock() {
 #[test]
 fn test_snapshot_must_be_later_than_updating_max_ts() {
     let engine = TestEngineBuilder::new().build().unwrap();
-    let storage = TestStorageBuilder::<_, DummyLockManager>::from_engine_and_lock_mgr(
+    let storage = TestStorageBuilder::<_, DummyLockManager, APIV1>::from_engine_and_lock_mgr(
         engine,
         DummyLockManager {},
-        ApiVersion::V1,
     )
     .build()
     .unwrap();
@@ -150,10 +149,9 @@ fn test_snapshot_must_be_later_than_updating_max_ts() {
 #[test]
 fn test_update_max_ts_before_scan_memory_locks() {
     let engine = TestEngineBuilder::new().build().unwrap();
-    let storage = TestStorageBuilder::<_, DummyLockManager>::from_engine_and_lock_mgr(
+    let storage = TestStorageBuilder::<_, DummyLockManager, APIV1>::from_engine_and_lock_mgr(
         engine,
         DummyLockManager {},
-        ApiVersion::V1,
     )
     .build()
     .unwrap();
@@ -200,10 +198,9 @@ macro_rules! lock_release_test {
         #[test]
         fn $test_name() {
             let engine = TestEngineBuilder::new().build().unwrap();
-            let storage = TestStorageBuilder::<_, DummyLockManager>::from_engine_and_lock_mgr(
+            let storage = TestStorageBuilder::<_, DummyLockManager, APIV1>::from_engine_and_lock_mgr(
                 engine,
                 DummyLockManager {},
-                ApiVersion::V1,
             )
             .build()
             .unwrap();
@@ -280,10 +277,9 @@ lock_release_test!(
 #[test]
 fn test_max_commit_ts_error() {
     let engine = TestEngineBuilder::new().build().unwrap();
-    let storage = TestStorageBuilder::<_, DummyLockManager>::from_engine_and_lock_mgr(
+    let storage = TestStorageBuilder::<_, DummyLockManager, APIV1>::from_engine_and_lock_mgr(
         engine,
         DummyLockManager {},
-        ApiVersion::V1,
     )
     .build()
     .unwrap();
@@ -339,10 +335,9 @@ fn test_max_commit_ts_error() {
 #[test]
 fn test_exceed_max_commit_ts_in_the_middle_of_prewrite() {
     let engine = TestEngineBuilder::new().build().unwrap();
-    let storage = TestStorageBuilder::<_, DummyLockManager>::from_engine_and_lock_mgr(
+    let storage = TestStorageBuilder::<_, DummyLockManager, APIV1>::from_engine_and_lock_mgr(
         engine,
         DummyLockManager {},
-        ApiVersion::V1,
     )
     .build()
     .unwrap();

--- a/tests/failpoints/cases/test_transaction.rs
+++ b/tests/failpoints/cases/test_transaction.rs
@@ -1,6 +1,5 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
-use api_version::APIV1;
 use futures::executor::block_on;
 use grpcio::{ChannelBuilder, Environment};
 use kvproto::kvrpcpb::{
@@ -21,7 +20,7 @@ use tikv::storage::txn::tests::{
     must_pessimistic_prewrite_put_err, must_prewrite_put, must_prewrite_put_err,
 };
 use tikv::storage::{
-    self, lock_manager::DummyLockManager, Snapshot, TestEngineBuilder, TestStorageBuilder,
+    self, lock_manager::DummyLockManager, Snapshot, TestEngineBuilder, TestStorageBuilderApiV1,
 };
 use tikv_util::HandyRwLock;
 use txn_types::{Key, Mutation, PessimisticLock, TimeStamp};
@@ -55,12 +54,9 @@ fn test_txn_failpoints() {
 #[test]
 fn test_atomic_getting_max_ts_and_storing_memory_lock() {
     let engine = TestEngineBuilder::new().build().unwrap();
-    let storage = TestStorageBuilder::<_, DummyLockManager, APIV1>::from_engine_and_lock_mgr(
-        engine,
-        DummyLockManager {},
-    )
-    .build()
-    .unwrap();
+    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager {})
+        .build()
+        .unwrap();
 
     let (prewrite_tx, prewrite_rx) = channel();
     // sleep a while between getting max ts and store the lock in memory
@@ -105,12 +101,9 @@ fn test_atomic_getting_max_ts_and_storing_memory_lock() {
 #[test]
 fn test_snapshot_must_be_later_than_updating_max_ts() {
     let engine = TestEngineBuilder::new().build().unwrap();
-    let storage = TestStorageBuilder::<_, DummyLockManager, APIV1>::from_engine_and_lock_mgr(
-        engine,
-        DummyLockManager {},
-    )
-    .build()
-    .unwrap();
+    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager {})
+        .build()
+        .unwrap();
 
     // Suppose snapshot was before updating max_ts, after sleeping for 500ms the following prewrite should complete.
     fail::cfg("after-snapshot", "sleep(500)").unwrap();
@@ -149,12 +142,9 @@ fn test_snapshot_must_be_later_than_updating_max_ts() {
 #[test]
 fn test_update_max_ts_before_scan_memory_locks() {
     let engine = TestEngineBuilder::new().build().unwrap();
-    let storage = TestStorageBuilder::<_, DummyLockManager, APIV1>::from_engine_and_lock_mgr(
-        engine,
-        DummyLockManager {},
-    )
-    .build()
-    .unwrap();
+    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager {})
+        .build()
+        .unwrap();
 
     fail::cfg("before-storage-check-memory-locks", "sleep(500)").unwrap();
     let get_fut = storage.get(Context::default(), Key::from_raw(b"k"), 100.into());
@@ -199,12 +189,9 @@ macro_rules! lock_release_test {
         fn $test_name() {
             let engine = TestEngineBuilder::new().build().unwrap();
             let storage =
-                TestStorageBuilder::<_, DummyLockManager, APIV1>::from_engine_and_lock_mgr(
-                    engine,
-                    DummyLockManager {},
-                )
-                .build()
-                .unwrap();
+                TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager {})
+                    .build()
+                    .unwrap();
 
             let key = Key::from_raw(b"k");
             let cm = storage.get_concurrency_manager();
@@ -278,12 +265,9 @@ lock_release_test!(
 #[test]
 fn test_max_commit_ts_error() {
     let engine = TestEngineBuilder::new().build().unwrap();
-    let storage = TestStorageBuilder::<_, DummyLockManager, APIV1>::from_engine_and_lock_mgr(
-        engine,
-        DummyLockManager {},
-    )
-    .build()
-    .unwrap();
+    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager {})
+        .build()
+        .unwrap();
     let cm = storage.get_concurrency_manager();
 
     fail::cfg("after_prewrite_one_key", "sleep(500)").unwrap();
@@ -336,12 +320,9 @@ fn test_max_commit_ts_error() {
 #[test]
 fn test_exceed_max_commit_ts_in_the_middle_of_prewrite() {
     let engine = TestEngineBuilder::new().build().unwrap();
-    let storage = TestStorageBuilder::<_, DummyLockManager, APIV1>::from_engine_and_lock_mgr(
-        engine,
-        DummyLockManager {},
-    )
-    .build()
-    .unwrap();
+    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager {})
+        .build()
+        .unwrap();
     let cm = storage.get_concurrency_manager();
 
     let (prewrite_tx, prewrite_rx) = channel();

--- a/tests/failpoints/cases/test_transaction.rs
+++ b/tests/failpoints/cases/test_transaction.rs
@@ -54,7 +54,7 @@ fn test_txn_failpoints() {
 #[test]
 fn test_atomic_getting_max_ts_and_storing_memory_lock() {
     let engine = TestEngineBuilder::new().build().unwrap();
-    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager {})
+    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager)
         .build()
         .unwrap();
 
@@ -101,7 +101,7 @@ fn test_atomic_getting_max_ts_and_storing_memory_lock() {
 #[test]
 fn test_snapshot_must_be_later_than_updating_max_ts() {
     let engine = TestEngineBuilder::new().build().unwrap();
-    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager {})
+    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager)
         .build()
         .unwrap();
 
@@ -142,7 +142,7 @@ fn test_snapshot_must_be_later_than_updating_max_ts() {
 #[test]
 fn test_update_max_ts_before_scan_memory_locks() {
     let engine = TestEngineBuilder::new().build().unwrap();
-    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager {})
+    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager)
         .build()
         .unwrap();
 
@@ -189,7 +189,7 @@ macro_rules! lock_release_test {
         fn $test_name() {
             let engine = TestEngineBuilder::new().build().unwrap();
             let storage =
-                TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager {})
+                TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager)
                     .build()
                     .unwrap();
 
@@ -265,7 +265,7 @@ lock_release_test!(
 #[test]
 fn test_max_commit_ts_error() {
     let engine = TestEngineBuilder::new().build().unwrap();
-    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager {})
+    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager)
         .build()
         .unwrap();
     let cm = storage.get_concurrency_manager();
@@ -320,7 +320,7 @@ fn test_max_commit_ts_error() {
 #[test]
 fn test_exceed_max_commit_ts_in_the_middle_of_prewrite() {
     let engine = TestEngineBuilder::new().build().unwrap();
-    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager {})
+    let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager)
         .build()
         .unwrap();
     let cm = storage.get_concurrency_manager();

--- a/tests/failpoints/cases/test_ttl.rs
+++ b/tests/failpoints/cases/test_ttl.rs
@@ -396,7 +396,7 @@ fn test_stoarge_raw_batch_put_ttl() {
 fn test_stoarge_raw_batch_put_ttl_impl<Api: APIVersion>() {
     fail::cfg("ttl_current_ts", "return(100)").unwrap();
 
-    let storage = TestStorageBuilder::<_, _, Api>::new(DummyLockManager {})
+    let storage = TestStorageBuilder::<_, _, Api>::new(DummyLockManager)
         .build()
         .unwrap();
     let (tx, rx) = channel();

--- a/tests/failpoints/cases/test_ttl.rs
+++ b/tests/failpoints/cases/test_ttl.rs
@@ -7,7 +7,7 @@ use engine_rocks::raw::CompactOptions;
 use engine_rocks::util::get_cf_handle;
 use engine_traits::{IterOptions, MiscExt, Peekable, SyncMutable, CF_DEFAULT};
 use futures::executor::block_on;
-use kvproto::kvrpcpb::{ApiVersion, Context};
+use kvproto::kvrpcpb::Context;
 use tikv::config::DbConfig;
 use tikv::server::ttl::check_ttl_and_compact_files;
 use tikv::storage::kv::{SnapContext, TestEngineBuilder};
@@ -396,18 +396,12 @@ fn test_stoarge_raw_batch_put_ttl() {
 fn test_stoarge_raw_batch_put_ttl_impl<Api: APIVersion>() {
     fail::cfg("ttl_current_ts", "return(100)").unwrap();
 
-    let api_version = Api::TAG;
     let storage = TestStorageBuilder::<_, _, Api>::new(DummyLockManager {})
         .build()
         .unwrap();
     let (tx, rx) = channel();
-    let req_api_version = if api_version == ApiVersion::V1ttl {
-        ApiVersion::V1
-    } else {
-        api_version
-    };
     let ctx = Context {
-        api_version: req_api_version,
+        api_version: Api::CLIENT_TAG,
         ..Default::default()
     };
 

--- a/tests/failpoints/cases/test_ttl.rs
+++ b/tests/failpoints/cases/test_ttl.rs
@@ -389,14 +389,15 @@ fn test_ttl_iterator_impl<API: APIVersion>() {
 
 #[test]
 fn test_stoarge_raw_batch_put_ttl() {
-    test_stoarge_raw_batch_put_ttl_impl(ApiVersion::V1ttl);
-    test_stoarge_raw_batch_put_ttl_impl(ApiVersion::V2);
+    test_stoarge_raw_batch_put_ttl_impl::<APIV1TTL>();
+    test_stoarge_raw_batch_put_ttl_impl::<APIV2>();
 }
 
-fn test_stoarge_raw_batch_put_ttl_impl(api_version: ApiVersion) {
+fn test_stoarge_raw_batch_put_ttl_impl<Api: APIVersion>() {
     fail::cfg("ttl_current_ts", "return(100)").unwrap();
 
-    let storage = TestStorageBuilder::new(DummyLockManager {}, api_version)
+    let api_version = Api::TAG;
+    let storage = TestStorageBuilder::<_, _, Api>::new(DummyLockManager {})
         .build()
         .unwrap();
     let (tx, rx) = channel();

--- a/tests/integrations/resource_metering/test_suite/mod.rs
+++ b/tests/integrations/resource_metering/test_suite/mod.rs
@@ -13,7 +13,7 @@ use crossbeam::channel::{unbounded, Receiver, Sender};
 use futures::channel::oneshot;
 use futures::{select, FutureExt};
 use grpcio::{ChannelBuilder, ClientSStreamReceiver, Environment};
-use kvproto::kvrpcpb::{ApiVersion, Context};
+use kvproto::kvrpcpb::Context;
 use kvproto::resource_usage_agent::{
     ResourceMeteringPubSubClient, ResourceMeteringRequest, ResourceUsageRecord,
 };
@@ -84,13 +84,11 @@ impl TestSuite {
         );
 
         let engine = TestEngineBuilder::new().build().unwrap();
-        let storage = TestStorageBuilder::<_, _, API>::from_engine_and_lock_mgr(
-            engine,
-            DummyLockManager {},
-        )
-        .set_resource_tag_factory(resource_tag_factory.clone())
-        .build()
-        .unwrap();
+        let storage =
+            TestStorageBuilder::<_, _, API>::from_engine_and_lock_mgr(engine, DummyLockManager {})
+                .set_resource_tag_factory(resource_tag_factory.clone())
+                .build()
+                .unwrap();
 
         let (tx, rx) = unbounded();
 

--- a/tests/integrations/resource_metering/test_suite/mod.rs
+++ b/tests/integrations/resource_metering/test_suite/mod.rs
@@ -22,17 +22,15 @@ use tempfile::TempDir;
 use test_util::alloc_port;
 use tikv::config::{ConfigController, TiKvConfig};
 use tikv::storage::lock_manager::DummyLockManager;
-use tikv::storage::{RocksEngine, Storage, TestEngineBuilder, TestStorageBuilder};
+use tikv::storage::{RocksEngine, StorageApiV1, TestEngineBuilder, TestStorageBuilderApiV1};
 use tokio::runtime::{self, Runtime};
 use txn_types::{Key, TimeStamp};
-
-type API = api_version::APIV1;
 
 pub struct TestSuite {
     pubsub_server_port: u16,
     receiver_server: Option<MockReceiverServer>,
 
-    storage: Storage<RocksEngine, DummyLockManager, API>,
+    storage: StorageApiV1<RocksEngine, DummyLockManager>,
     cfg_controller: ConfigController,
     resource_tag_factory: ResourceTagFactory,
 
@@ -85,7 +83,7 @@ impl TestSuite {
 
         let engine = TestEngineBuilder::new().build().unwrap();
         let storage =
-            TestStorageBuilder::<_, _, API>::from_engine_and_lock_mgr(engine, DummyLockManager {})
+            TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager {})
                 .set_resource_tag_factory(resource_tag_factory.clone())
                 .build()
                 .unwrap();
@@ -119,7 +117,7 @@ impl TestSuite {
         }
     }
 
-    pub fn get_storage(&self) -> Storage<RocksEngine, DummyLockManager, API> {
+    pub fn get_storage(&self) -> StorageApiV1<RocksEngine, DummyLockManager> {
         self.storage.clone()
     }
 

--- a/tests/integrations/resource_metering/test_suite/mod.rs
+++ b/tests/integrations/resource_metering/test_suite/mod.rs
@@ -26,11 +26,13 @@ use tikv::storage::{RocksEngine, Storage, TestEngineBuilder, TestStorageBuilder}
 use tokio::runtime::{self, Runtime};
 use txn_types::{Key, TimeStamp};
 
+type API = api_version::APIV1;
+
 pub struct TestSuite {
     pubsub_server_port: u16,
     receiver_server: Option<MockReceiverServer>,
 
-    storage: Storage<RocksEngine, DummyLockManager>,
+    storage: Storage<RocksEngine, DummyLockManager, API>,
     cfg_controller: ConfigController,
     resource_tag_factory: ResourceTagFactory,
 
@@ -82,10 +84,9 @@ impl TestSuite {
         );
 
         let engine = TestEngineBuilder::new().build().unwrap();
-        let storage = TestStorageBuilder::from_engine_and_lock_mgr(
+        let storage = TestStorageBuilder::<_, _, API>::from_engine_and_lock_mgr(
             engine,
             DummyLockManager {},
-            ApiVersion::V1,
         )
         .set_resource_tag_factory(resource_tag_factory.clone())
         .build()
@@ -120,7 +121,7 @@ impl TestSuite {
         }
     }
 
-    pub fn get_storage(&self) -> Storage<RocksEngine, DummyLockManager> {
+    pub fn get_storage(&self) -> Storage<RocksEngine, DummyLockManager, API> {
         self.storage.clone()
     }
 

--- a/tests/integrations/resource_metering/test_suite/mod.rs
+++ b/tests/integrations/resource_metering/test_suite/mod.rs
@@ -82,11 +82,10 @@ impl TestSuite {
         );
 
         let engine = TestEngineBuilder::new().build().unwrap();
-        let storage =
-            TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager {})
-                .set_resource_tag_factory(resource_tag_factory.clone())
-                .build()
-                .unwrap();
+        let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, DummyLockManager)
+            .set_resource_tag_factory(resource_tag_factory.clone())
+            .build()
+            .unwrap();
 
         let (tx, rx) = unbounded();
 

--- a/tests/integrations/storage/test_raft_storage.rs
+++ b/tests/integrations/storage/test_raft_storage.rs
@@ -3,7 +3,7 @@
 use std::thread;
 use std::time::Duration;
 
-use api_version::APIVersion;
+use api_version::{APIVersion, APIV1};
 use collections::HashMap;
 use error_code::{raftstore::STALE_COMMAND, ErrorCodeExt};
 use kvproto::kvrpcpb::Context;
@@ -19,14 +19,12 @@ use tikv::storage::{Error as StorageError, ErrorInner as StorageErrorInner};
 use tikv_util::HandyRwLock;
 use txn_types::{Key, Mutation, TimeStamp};
 
-type API = api_version::APIV1;
-
 fn new_raft_storage() -> (
     Cluster<ServerCluster>,
-    SyncTestStorage<SimulateEngine, API>,
+    SyncTestStorageApiV1<SimulateEngine>,
     Context,
 ) {
-    new_raft_storage_with_store_count::<API>(1, "")
+    new_raft_storage_with_store_count::<APIV1>(1, "")
 }
 
 #[test]
@@ -264,7 +262,7 @@ fn check_data<E: Engine, Api: APIVersion>(
 fn test_auto_gc() {
     let count = 3;
     let (mut cluster, first_leader_storage, ctx) =
-        new_raft_storage_with_store_count::<API>(count, "");
+        new_raft_storage_with_store_count::<APIV1>(count, "");
     let pd_client = Arc::clone(&cluster.pd_client);
 
     // Used to wait for all storage's GC to finish
@@ -280,7 +278,7 @@ fn test_auto_gc() {
             let mut config = GcConfig::default();
             // Do not skip GC
             config.ratio_threshold = 0.9;
-            let storage = SyncTestStorageBuilder::<_, API>::from_engine(engine.clone())
+            let storage = SyncTestStorageBuilderApiV1::from_engine(engine.clone())
                 .gc_config(config)
                 .build()
                 .unwrap();

--- a/tests/integrations/storage/test_raft_storage.rs
+++ b/tests/integrations/storage/test_raft_storage.rs
@@ -263,7 +263,8 @@ fn check_data<E: Engine, Api: APIVersion>(
 #[test]
 fn test_auto_gc() {
     let count = 3;
-    let (mut cluster, first_leader_storage, ctx) = new_raft_storage_with_store_count::<API>(count, "");
+    let (mut cluster, first_leader_storage, ctx) =
+        new_raft_storage_with_store_count::<API>(count, "");
     let pd_client = Arc::clone(&cluster.pd_client);
 
     // Used to wait for all storage's GC to finish

--- a/tests/integrations/storage/test_storage.rs
+++ b/tests/integrations/storage/test_storage.rs
@@ -11,7 +11,7 @@ use rand::random;
 
 use kvproto::kvrpcpb::{ApiVersion, Context, KeyRange, LockInfo};
 
-use api_version::APIVersion;
+use api_version::{dispatch_api_version, APIVersion};
 use engine_traits::{CF_DEFAULT, CF_LOCK};
 use test_storage::*;
 use tikv::server::gc_worker::DEFAULT_GC_BATCH_KEYS;
@@ -679,7 +679,8 @@ fn test_store_resolve_with_illegal_tso() {
 fn test_txn_store_gc() {
     let key = "k";
     let store = AssertionStorage::default();
-    let (_cluster, raft_store) = AssertionStorage::<_, API>::new_raft_storage_with_store_count(3, key);
+    let (_cluster, raft_store) =
+        AssertionStorage::<_, API>::new_raft_storage_with_store_count(3, key);
     store.test_txn_store_gc(key);
     raft_store.test_txn_store_gc(key);
 }
@@ -753,7 +754,8 @@ fn test_txn_store_gc3() {
     let key = "k";
     let store = AssertionStorage::default();
     store.test_txn_store_gc3(key.as_bytes()[0]);
-    let (mut cluster, mut raft_store) = AssertionStorage::<_, API>::new_raft_storage_with_store_count(3, key);
+    let (mut cluster, mut raft_store) =
+        AssertionStorage::<_, API>::new_raft_storage_with_store_count(3, key);
     raft_store.test_txn_store_gc3_for_cluster(&mut cluster, key.as_bytes()[0]);
 }
 
@@ -935,38 +937,40 @@ fn test_txn_store_txnkv_api_version() {
     ];
 
     for (storage_api_version, req_api_version, key, is_legal) in test_data.into_iter() {
-        let mut store = AssertionStorage::<_, API>::new();
-        store.ctx.set_api_version(req_api_version);
+        dispatch_api_version!(storage_api_version, {
+            let mut store = AssertionStorage::<_, API>::new();
+            store.ctx.set_api_version(req_api_version);
 
-        let mut end_key = key.to_vec();
-        if let Some(end_key) = end_key.last_mut() {
-            *end_key = 0xff;
-        }
+            let mut end_key = key.to_vec();
+            if let Some(end_key) = end_key.last_mut() {
+                *end_key = 0xff;
+            }
 
-        if is_legal {
-            store.get_none(key, 10);
-            store.put_ok(key, b"x", 5, 10);
-            store.get_none(key, 9);
-            store.get_ok(key, 10, b"x");
+            if is_legal {
+                store.get_none(key, 10);
+                store.put_ok(key, b"x", 5, 10);
+                store.get_none(key, 9);
+                store.get_ok(key, 10, b"x");
 
-            store.batch_get_ok(&[key, key, key], 10, vec![b"x", b"x", b"x"]);
-            store.batch_get_command_ok(&[key, key, key], 10, vec![b"x", b"x", b"x"]);
+                store.batch_get_ok(&[key, key, key], 10, vec![b"x", b"x", b"x"]);
+                store.batch_get_command_ok(&[key, key, key], 10, vec![b"x", b"x", b"x"]);
 
-            store.scan_ok(key, Some(&end_key), 100, 10, vec![Some((key, b"x"))]);
-            store.scan_locks_ok(20, key, &end_key, 10, vec![]);
+                store.scan_ok(key, Some(&end_key), 100, 10, vec![Some((key, b"x"))]);
+                store.scan_locks_ok(20, key, &end_key, 10, vec![]);
 
-            store.delete_range_ok(key, key);
-        } else {
-            store.get_err(key, 10);
-            // check api version at service tier: store.put_err(key, b"x", 5, 10);
-            store.batch_get_err(&[key, key, key], 10);
-            store.batch_get_command_err(&[key, key, key], 10);
+                store.delete_range_ok(key, key);
+            } else {
+                store.get_err(key, 10);
+                // check api version at service tier: store.put_err(key, b"x", 5, 10);
+                store.batch_get_err(&[key, key, key], 10);
+                store.batch_get_command_err(&[key, key, key], 10);
 
-            store.scan_err(key, None, 100, 10);
-            store.scan_locks_err(20, key, &end_key, 10);
+                store.scan_err(key, None, 100, 10);
+                store.scan_locks_err(20, key, &end_key, 10);
 
-            store.delete_range_err(key, key);
-        }
+                store.delete_range_err(key, key);
+            }
+        });
     }
 }
 
@@ -998,134 +1002,142 @@ fn test_txn_store_rawkv_api_version() {
     let cf = "";
 
     for (storage_api_version, req_api_version, key, is_legal) in test_data.into_iter() {
-        let mut store = AssertionStorage::<_, API>::new();
-        store.ctx.set_api_version(req_api_version);
+        dispatch_api_version!(storage_api_version, {
+            let mut store = AssertionStorage::<_, API>::new();
+            store.ctx.set_api_version(req_api_version);
 
-        let mut end_key = key.to_vec();
-        if let Some(end_key) = end_key.last_mut() {
-            *end_key = 0xff;
-        }
-
-        let mut range = KeyRange::default();
-        range.set_start_key(key.to_vec());
-
-        let mut range_bounded = KeyRange::default();
-        range_bounded.set_start_key(key.to_vec());
-        range_bounded.set_end_key(end_key.clone());
-
-        if is_legal {
-            store.raw_get_ok(cf.to_owned(), key.to_vec(), None);
-            store.raw_put_ok(cf.to_owned(), key.to_vec(), b"value".to_vec());
-            store.raw_get_ok(cf.to_owned(), key.to_vec(), Some(b"value".to_vec()));
-            if !matches!(storage_api_version, ApiVersion::V1) {
-                store.raw_get_key_ttl_ok(cf.to_owned(), key.to_vec(), Some(0));
+            let mut end_key = key.to_vec();
+            if let Some(end_key) = end_key.last_mut() {
+                *end_key = 0xff;
             }
 
-            store.raw_batch_get_ok(
-                cf.to_owned(),
-                vec![key.to_vec(), key.to_vec()],
-                vec![(key, b"value"), (key, b"value")],
-            );
-            store.raw_batch_get_command_ok(
-                cf.to_owned(),
-                vec![key.to_vec(), key.to_vec()],
-                vec![b"value", b"value"],
-            );
+            let mut range = KeyRange::default();
+            range.set_start_key(key.to_vec());
 
-            store.raw_delete_ok(cf.to_owned(), key.to_vec());
-            store.raw_delete_range_ok(cf.to_owned(), key.to_vec(), key.to_vec());
-            store.raw_batch_delete_ok(cf.to_owned(), vec![key.to_vec()]);
+            let mut range_bounded = KeyRange::default();
+            range_bounded.set_start_key(key.to_vec());
+            range_bounded.set_end_key(end_key.clone());
 
-            store.raw_batch_put_ok(cf.to_owned(), vec![(key.to_vec(), b"value".to_vec())]);
+            if is_legal {
+                store.raw_get_ok(cf.to_owned(), key.to_vec(), None);
+                store.raw_put_ok(cf.to_owned(), key.to_vec(), b"value".to_vec());
+                store.raw_get_ok(cf.to_owned(), key.to_vec(), Some(b"value".to_vec()));
+                if !matches!(storage_api_version, ApiVersion::V1) {
+                    store.raw_get_key_ttl_ok(cf.to_owned(), key.to_vec(), Some(0));
+                }
 
-            store.raw_scan_ok(
-                cf.to_owned(),
-                key.to_vec(),
-                Some(end_key.clone()),
-                100,
-                vec![(key, b"value")],
-            );
-            store.raw_batch_scan_ok(
-                cf.to_owned(),
-                vec![range_bounded.clone()],
-                100,
-                vec![(key, b"value")],
-            );
-            {
-                // unbounded end key
-                match storage_api_version {
-                    ApiVersion::V1 | ApiVersion::V1ttl => {
-                        store.raw_scan_ok(
-                            cf.to_owned(),
-                            key.to_vec(),
-                            None,
-                            100,
-                            vec![(key, b"value")],
-                        );
-                        store.raw_batch_scan_ok(
-                            cf.to_owned(),
-                            vec![range.clone()],
-                            100,
-                            vec![(key, b"value")],
-                        );
-                    }
-                    ApiVersion::V2 => {
-                        // unbounded key is prohibitted in V2.
-                        store.raw_scan_err(cf.to_owned(), key.to_vec(), None, 100);
-                        store.raw_batch_scan_err(cf.to_owned(), vec![range.clone()], 100);
+                store.raw_batch_get_ok(
+                    cf.to_owned(),
+                    vec![key.to_vec(), key.to_vec()],
+                    vec![(key, b"value"), (key, b"value")],
+                );
+                store.raw_batch_get_command_ok(
+                    cf.to_owned(),
+                    vec![key.to_vec(), key.to_vec()],
+                    vec![b"value", b"value"],
+                );
+
+                store.raw_delete_ok(cf.to_owned(), key.to_vec());
+                store.raw_delete_range_ok(cf.to_owned(), key.to_vec(), key.to_vec());
+                store.raw_batch_delete_ok(cf.to_owned(), vec![key.to_vec()]);
+
+                store.raw_batch_put_ok(cf.to_owned(), vec![(key.to_vec(), b"value".to_vec())]);
+
+                store.raw_scan_ok(
+                    cf.to_owned(),
+                    key.to_vec(),
+                    Some(end_key.clone()),
+                    100,
+                    vec![(key, b"value")],
+                );
+                store.raw_batch_scan_ok(
+                    cf.to_owned(),
+                    vec![range_bounded.clone()],
+                    100,
+                    vec![(key, b"value")],
+                );
+                {
+                    // unbounded end key
+                    match storage_api_version {
+                        ApiVersion::V1 | ApiVersion::V1ttl => {
+                            store.raw_scan_ok(
+                                cf.to_owned(),
+                                key.to_vec(),
+                                None,
+                                100,
+                                vec![(key, b"value")],
+                            );
+                            store.raw_batch_scan_ok(
+                                cf.to_owned(),
+                                vec![range.clone()],
+                                100,
+                                vec![(key, b"value")],
+                            );
+                        }
+                        ApiVersion::V2 => {
+                            // unbounded key is prohibitted in V2.
+                            store.raw_scan_err(cf.to_owned(), key.to_vec(), None, 100);
+                            store.raw_batch_scan_err(cf.to_owned(), vec![range.clone()], 100);
+                        }
                     }
                 }
+
+                store.raw_compare_and_swap_atomic_ok(
+                    cf.to_owned(),
+                    key.to_vec(),
+                    Some(b"value".to_vec()),
+                    b"new_value".to_vec(),
+                    (Some(b"value".to_vec()), true),
+                );
+
+                store.raw_batch_delete_atomic_ok(cf.to_owned(), vec![key.to_vec()]);
+                store.raw_batch_put_atomic_ok(
+                    cf.to_owned(),
+                    vec![(key.to_vec(), b"value".to_vec())],
+                );
+
+                let mut digest = crc64fast::Digest::new();
+                digest.write(key);
+                digest.write(b"value");
+                store.raw_checksum_ok(
+                    vec![range_bounded.clone()],
+                    (digest.sum64(), 1, (key.len() + b"value".len()) as u64),
+                );
+            } else {
+                store.raw_get_err(cf.to_owned(), key.to_vec());
+                if !matches!(storage_api_version, ApiVersion::V1) {
+                    store.raw_get_key_ttl_err(cf.to_owned(), key.to_vec());
+                }
+                store.raw_put_err(cf.to_owned(), key.to_vec(), b"value".to_vec());
+
+                store.raw_batch_get_err(cf.to_owned(), vec![key.to_vec(), key.to_vec()]);
+                store.raw_batch_get_command_err(cf.to_owned(), vec![key.to_vec(), key.to_vec()]);
+
+                store.raw_delete_err(cf.to_owned(), key.to_vec());
+                store.raw_delete_range_err(cf.to_owned(), key.to_vec(), key.to_vec());
+                store.raw_batch_delete_err(cf.to_owned(), vec![key.to_vec()]);
+
+                store.raw_batch_put_err(cf.to_owned(), vec![(key.to_vec(), b"value".to_vec())]);
+
+                store.raw_scan_err(cf.to_owned(), key.to_vec(), Some(end_key.clone()), 100);
+                store.raw_batch_scan_err(cf.to_owned(), vec![range_bounded.clone()], 100);
+
+                store.raw_compare_and_swap_atomic_err(
+                    cf.to_owned(),
+                    key.to_vec(),
+                    None,
+                    b"value".to_vec(),
+                );
+
+                store.raw_batch_delete_atomic_err(cf.to_owned(), vec![key.to_vec()]);
+                store.raw_batch_put_atomic_err(
+                    cf.to_owned(),
+                    vec![(key.to_vec(), b"value".to_vec())],
+                );
+
+                store.raw_checksum_err(vec![range_bounded.clone()]);
             }
-
-            store.raw_compare_and_swap_atomic_ok(
-                cf.to_owned(),
-                key.to_vec(),
-                Some(b"value".to_vec()),
-                b"new_value".to_vec(),
-                (Some(b"value".to_vec()), true),
-            );
-
-            store.raw_batch_delete_atomic_ok(cf.to_owned(), vec![key.to_vec()]);
-            store.raw_batch_put_atomic_ok(cf.to_owned(), vec![(key.to_vec(), b"value".to_vec())]);
-
-            let mut digest = crc64fast::Digest::new();
-            digest.write(key);
-            digest.write(b"value");
-            store.raw_checksum_ok(
-                vec![range_bounded.clone()],
-                (digest.sum64(), 1, (key.len() + b"value".len()) as u64),
-            );
-        } else {
-            store.raw_get_err(cf.to_owned(), key.to_vec());
-            if !matches!(storage_api_version, ApiVersion::V1) {
-                store.raw_get_key_ttl_err(cf.to_owned(), key.to_vec());
-            }
-            store.raw_put_err(cf.to_owned(), key.to_vec(), b"value".to_vec());
-
-            store.raw_batch_get_err(cf.to_owned(), vec![key.to_vec(), key.to_vec()]);
-            store.raw_batch_get_command_err(cf.to_owned(), vec![key.to_vec(), key.to_vec()]);
-
-            store.raw_delete_err(cf.to_owned(), key.to_vec());
-            store.raw_delete_range_err(cf.to_owned(), key.to_vec(), key.to_vec());
-            store.raw_batch_delete_err(cf.to_owned(), vec![key.to_vec()]);
-
-            store.raw_batch_put_err(cf.to_owned(), vec![(key.to_vec(), b"value".to_vec())]);
-
-            store.raw_scan_err(cf.to_owned(), key.to_vec(), Some(end_key.clone()), 100);
-            store.raw_batch_scan_err(cf.to_owned(), vec![range_bounded.clone()], 100);
-
-            store.raw_compare_and_swap_atomic_err(
-                cf.to_owned(),
-                key.to_vec(),
-                None,
-                b"value".to_vec(),
-            );
-
-            store.raw_batch_delete_atomic_err(cf.to_owned(), vec![key.to_vec()]);
-            store.raw_batch_put_atomic_err(cf.to_owned(), vec![(key.to_vec(), b"value".to_vec())]);
-
-            store.raw_checksum_err(vec![range_bounded.clone()]);
-        }
+        });
     }
 }
 
@@ -1147,7 +1159,11 @@ impl Oracle {
 
 const INC_MAX_RETRY: usize = 100;
 
-fn inc<E: Engine, Api: APIVersion>(store: &SyncTestStorage<E, Api>, oracle: &Oracle, key: &[u8]) -> Result<i32, ()> {
+fn inc<E: Engine, Api: APIVersion>(
+    store: &SyncTestStorage<E, Api>,
+    oracle: &Oracle,
+    key: &[u8],
+) -> Result<i32, ()> {
     let key_address = Key::from_raw(key);
     for i in 0..INC_MAX_RETRY {
         let start_ts = oracle.get_ts();
@@ -1228,7 +1244,11 @@ fn format_key(x: usize) -> Vec<u8> {
     format!("k{}", x).into_bytes()
 }
 
-fn inc_multi<E: Engine, Api: APIVersion>(store: &SyncTestStorage<E, Api>, oracle: &Oracle, n: usize) -> bool {
+fn inc_multi<E: Engine, Api: APIVersion>(
+    store: &SyncTestStorage<E, Api>,
+    oracle: &Oracle,
+    n: usize,
+) -> bool {
     'retry: for i in 0..INC_MAX_RETRY {
         let start_ts = oracle.get_ts();
         let keys: Vec<Key> = (0..n).map(format_key).map(|x| Key::from_raw(&x)).collect();

--- a/tests/integrations/storage/test_storage.rs
+++ b/tests/integrations/storage/test_storage.rs
@@ -20,8 +20,6 @@ use tikv::storage::txn::RESOLVE_LOCK_BATCH_SIZE;
 use tikv::storage::Engine;
 use txn_types::{Key, Mutation, TimeStamp};
 
-type API = api_version::APIV1;
-
 #[test]
 fn test_txn_store_get() {
     let store = AssertionStorage::default();
@@ -679,8 +677,7 @@ fn test_store_resolve_with_illegal_tso() {
 fn test_txn_store_gc() {
     let key = "k";
     let store = AssertionStorage::default();
-    let (_cluster, raft_store) =
-        AssertionStorage::<_, API>::new_raft_storage_with_store_count(3, key);
+    let (_cluster, raft_store) = AssertionStorageApiV1::new_raft_storage_with_store_count(3, key);
     store.test_txn_store_gc(key);
     raft_store.test_txn_store_gc(key);
 }
@@ -706,7 +703,7 @@ pub fn test_txn_store_gc_multiple_keys_single_storage(n: usize, prefix: String) 
 
 pub fn test_txn_store_gc_multiple_keys_cluster_storage(n: usize, prefix: String) {
     let (mut cluster, mut store) =
-        AssertionStorage::<_, API>::new_raft_storage_with_store_count(3, prefix.as_str());
+        AssertionStorageApiV1::new_raft_storage_with_store_count(3, prefix.as_str());
     let keys: Vec<String> = (0..n).map(|i| format!("{}{}", prefix, i)).collect();
     if !keys.is_empty() {
         store.batch_put_ok_for_cluster(&mut cluster, &keys, repeat(b"v1" as &[u8]), 5, 10);
@@ -755,7 +752,7 @@ fn test_txn_store_gc3() {
     let store = AssertionStorage::default();
     store.test_txn_store_gc3(key.as_bytes()[0]);
     let (mut cluster, mut raft_store) =
-        AssertionStorage::<_, API>::new_raft_storage_with_store_count(3, key);
+        AssertionStorageApiV1::new_raft_storage_with_store_count(3, key);
     raft_store.test_txn_store_gc3_for_cluster(&mut cluster, key.as_bytes()[0]);
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #11965 #12207

What's Changed:

Add `APIVersion` as generic parameter of `Storage`, to prepare for modifying raw interfaces for API V2.

Refer to RFC:
1. https://github.com/pingyu/tikv-rfcs/blob/rfc_api_v2_pd/text/0069-api-v2.md (https://github.com/tikv/rfcs/pull/79)
2. https://github.com/pingyu/tikv-rfcs/blob/rawkv-cdc/text/0083-rawkv-cross-cluster-replication.md (https://github.com/tikv/rfcs/pull/86)

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Add APIVersion as generic parameter of `Storage`.
```

### Related changes
No.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

No.

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Add APIVersion as generic parameter of `Storage`.
```
