### PR TITLE
raftstore: Wait ticks for hibernated peer when doing force leader

### DIFF
--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -1521,10 +1521,6 @@ where
         }) = &mut self.fsm.peer.force_leader
         {
             *ticks -= 1;
-            debug!(
-                "sub tick";
-                "ticks" => *ticks,
-            );
             if *ticks == 0 {
                 let s = mem::take(failed_stores);
                 self.on_enter_pre_force_leader(s);
@@ -1900,12 +1896,6 @@ where
             }
         }
 
-        debug!(
-            "tick raft group";
-            "region_id" => self.region_id(),
-            "peer_id" => self.fsm.peer_id(),
-            "election_elapsed" => self.fsm.peer.raft_group.raft.election_elapsed,
-        );
         // Tick the raft peer and update some states which can be changed in `tick`.
         if self.fsm.peer.raft_group.tick() {
             self.fsm.has_ready = true;

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -456,9 +456,24 @@ pub struct ReadyResult {
 }
 
 #[derive(Debug)]
+/// ForceLeader process would be:
+/// 1. If it's hibernated, enter wait ticks state, and wake up the peer
+/// 2. Enter pre force leader state, become candidate and send request vote to all peers
+/// 3. Wait for the responses of the request vote, no reject should be received.
+/// 4. Enter force leader state, become leader without leader lease
+/// 5. Execute recovery plan(some remove-peer commands)
+/// 6. After the plan steps are all applied, exit force leader state
 pub enum ForceLeaderState {
-    PreForceLeader { failed_stores: HashSet<u64> },
-    ForceLeader { failed_stores: HashSet<u64> },
+    WaitTicks {
+        failed_stores: HashSet<u64>,
+        ticks: usize,
+    },
+    PreForceLeader {
+        failed_stores: HashSet<u64>,
+    },
+    ForceLeader {
+        failed_stores: HashSet<u64>,
+    },
 }
 
 #[derive(Getters)]
@@ -506,12 +521,7 @@ where
     /// With that, we can further propose remove failed-nodes conf-change, to make
     /// the Raft group forms majority and works normally later on.
     ///
-    /// ForceLeader process would be:
-    /// 1. Enter pre force leader state, become candidate and send request vote to all peers
-    /// 2. Wait for the responses of the request vote, no reject should be received.
-    /// 3. Enter force leader state, become leader without leader lease
-    /// 4. Execute recovery plan(some remove-peer commands)
-    /// 5. After the plan steps are all applied, exit force leader state
+    /// For details, see the comment of `ForceLeaderState`.
     pub force_leader: Option<ForceLeaderState>,
 
     /// Record the instants of peers being added into the configuration.
@@ -1104,6 +1114,10 @@ where
         }
         if self.raft_group.raft.lead_transferee.is_some() {
             res.reason = "transfer leader";
+            return res;
+        }
+        if self.force_leader.is_some() {
+            res.reason = "force leader";
             return res;
         }
         // Unapplied entries can change the configuration of the group.

--- a/tests/integrations/raftstore/test_unsafe_recovery.rs
+++ b/tests/integrations/raftstore/test_unsafe_recovery.rs
@@ -300,6 +300,60 @@ fn test_force_leader_for_learner() {
     cluster.must_transfer_leader(region.get_id(), find_peer(&region, 1).unwrap().clone());
 }
 
+// Test the case that three of five nodes fail and force leader on one of the
+// rest nodes.
+#[test]
+fn test_force_leader_on_hibernated_leader() {
+    test_util::init_log_for_test();
+    let mut cluster = new_node_cluster(0, 5);
+    cluster.pd_client.disable_default_operator();
+
+    cluster.run();
+    cluster.must_put(b"k1", b"v1");
+
+    let region = cluster.get_region(b"k1");
+    cluster.must_split(&region, b"k9");
+    let region = cluster.get_region(b"k2");
+    let peer_on_store1 = find_peer(&region, 1).unwrap();
+    cluster.must_transfer_leader(region.get_id(), peer_on_store1.clone());
+
+    // wait a while to hibernate
+    std::thread::sleep(Duration::from_millis(
+        cluster.cfg.raft_store.raft_election_timeout_ticks as u64
+            * cluster.cfg.raft_store.raft_base_tick_interval.as_millis()
+            * 3,
+    ));
+
+    cluster.stop_node(3);
+    cluster.stop_node(4);
+    cluster.stop_node(5);
+
+    // wait check quorum fail
+    std::thread::sleep(Duration::from_millis(
+        cluster.cfg.raft_store.raft_election_timeout_ticks as u64
+            * cluster.cfg.raft_store.raft_base_tick_interval.as_millis()
+            * 3,
+    ));
+    cluster.enter_force_leader(region.get_id(), 1, HashSet::from_iter(vec![3, 4, 5]));
+    // remove the peers on failed nodes
+    cluster
+        .pd_client
+        .must_remove_peer(region.get_id(), find_peer(&region, 3).unwrap().clone());
+    cluster
+        .pd_client
+        .must_remove_peer(region.get_id(), find_peer(&region, 4).unwrap().clone());
+    cluster
+        .pd_client
+        .must_remove_peer(region.get_id(), find_peer(&region, 5).unwrap().clone());
+    cluster.exit_force_leader(region.get_id(), 1);
+
+    // quorum is formed, can propose command successfully now
+    cluster.must_put(b"k4", b"v4");
+    assert_eq!(cluster.must_get(b"k2"), None);
+    assert_eq!(cluster.must_get(b"k3"), None);
+    assert_eq!(cluster.must_get(b"k4"), Some(b"v4".to_vec()));
+}
+
 // Test the case that three of five nodes fail and force leader on the rest node
 // with triggering snapshot.
 #[test]

--- a/tests/integrations/raftstore/test_unsafe_recovery.rs
+++ b/tests/integrations/raftstore/test_unsafe_recovery.rs
@@ -300,12 +300,12 @@ fn test_force_leader_for_learner() {
     cluster.must_transfer_leader(region.get_id(), find_peer(&region, 1).unwrap().clone());
 }
 
-// Test the case that three of five nodes fail and force leader on one of the
-// rest nodes.
+// Test the case that three of five nodes fail and force leader on one a
+// hibernated previous leader.
 #[test]
 fn test_force_leader_on_hibernated_leader() {
-    test_util::init_log_for_test();
     let mut cluster = new_node_cluster(0, 5);
+    configure_for_hibernate(&mut cluster);
     cluster.pd_client.disable_default_operator();
 
     cluster.run();
@@ -328,12 +328,6 @@ fn test_force_leader_on_hibernated_leader() {
     cluster.stop_node(4);
     cluster.stop_node(5);
 
-    // wait check quorum fail
-    std::thread::sleep(Duration::from_millis(
-        cluster.cfg.raft_store.raft_election_timeout_ticks as u64
-            * cluster.cfg.raft_store.raft_base_tick_interval.as_millis()
-            * 3,
-    ));
     cluster.enter_force_leader(region.get_id(), 1, HashSet::from_iter(vec![3, 4, 5]));
     // remove the peers on failed nodes
     cluster

--- a/tests/integrations/raftstore/test_unsafe_recovery.rs
+++ b/tests/integrations/raftstore/test_unsafe_recovery.rs
@@ -348,6 +348,55 @@ fn test_force_leader_on_hibernated_leader() {
     assert_eq!(cluster.must_get(b"k4"), Some(b"v4".to_vec()));
 }
 
+// Test the case that three of five nodes fail and force leader on a hibernated
+// previous follower.
+#[test]
+fn test_force_leader_on_hibernated_follower() {
+    test_util::init_log_for_test();
+    let mut cluster = new_node_cluster(0, 5);
+    configure_for_hibernate(&mut cluster);
+    cluster.pd_client.disable_default_operator();
+
+    cluster.run();
+    cluster.must_put(b"k1", b"v1");
+
+    let region = cluster.get_region(b"k1");
+    cluster.must_split(&region, b"k9");
+    let region = cluster.get_region(b"k2");
+    let peer_on_store5 = find_peer(&region, 5).unwrap();
+    cluster.must_transfer_leader(region.get_id(), peer_on_store5.clone());
+
+    // wait a while to hibernate
+    std::thread::sleep(Duration::from_millis(
+        cluster.cfg.raft_store.raft_election_timeout_ticks as u64
+            * cluster.cfg.raft_store.raft_base_tick_interval.as_millis()
+            * 3,
+    ));
+
+    cluster.stop_node(3);
+    cluster.stop_node(4);
+    cluster.stop_node(5);
+
+    cluster.enter_force_leader(region.get_id(), 1, HashSet::from_iter(vec![3, 4, 5]));
+    // remove the peers on failed nodes
+    cluster
+        .pd_client
+        .must_remove_peer(region.get_id(), find_peer(&region, 3).unwrap().clone());
+    cluster
+        .pd_client
+        .must_remove_peer(region.get_id(), find_peer(&region, 4).unwrap().clone());
+    cluster
+        .pd_client
+        .must_remove_peer(region.get_id(), find_peer(&region, 5).unwrap().clone());
+    cluster.exit_force_leader(region.get_id(), 1);
+
+    // quorum is formed, can propose command successfully now
+    cluster.must_put(b"k4", b"v4");
+    assert_eq!(cluster.must_get(b"k2"), None);
+    assert_eq!(cluster.must_get(b"k3"), None);
+    assert_eq!(cluster.must_get(b"k4"), Some(b"v4".to_vec()));
+}
+
 // Test the case that three of five nodes fail and force leader on the rest node
 // with triggering snapshot.
 #[test]

--- a/tests/integrations/raftstore/test_unsafe_recovery.rs
+++ b/tests/integrations/raftstore/test_unsafe_recovery.rs
@@ -300,8 +300,8 @@ fn test_force_leader_for_learner() {
     cluster.must_transfer_leader(region.get_id(), find_peer(&region, 1).unwrap().clone());
 }
 
-// Test the case that three of five nodes fail and force leader on one a
-// hibernated previous leader.
+// Test the case that three of five nodes fail and force leader on a hibernated
+// previous leader.
 #[test]
 fn test_force_leader_on_hibernated_leader() {
     let mut cluster = new_node_cluster(0, 5);


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #10483

What's Changed:


<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Force leader is rejected on a peer who is already a leader. For the hibernated leader,
it doesn't step down to follower when quorum is missing due to not ticking election. 
So wait ticks in force leader process for hibernated peers to make sure election ticking
is performed.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
