### PR TITLE
engine_rocks: replace PerfLevel with PerfFlags in raftstore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2528,7 +2528,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#4992ab1233c7593d0277a5cc4a903fc661df81b2"
+source = "git+https://github.com/tikv/rust-rocksdb.git#e97c9b50d388ac00aae538afcdbb6224a2b12fda"
 dependencies = [
  "bindgen 0.57.0",
  "bzip2-sys",
@@ -2547,7 +2547,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tikv/rust-rocksdb.git#4992ab1233c7593d0277a5cc4a903fc661df81b2"
+source = "git+https://github.com/tikv/rust-rocksdb.git#e97c9b50d388ac00aae538afcdbb6224a2b12fda"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -4207,7 +4207,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#4992ab1233c7593d0277a5cc4a903fc661df81b2"
+source = "git+https://github.com/tikv/rust-rocksdb.git#e97c9b50d388ac00aae538afcdbb6224a2b12fda"
 dependencies = [
  "libc 0.2.119",
  "librocksdb_sys",

--- a/components/engine_rocks/src/lib.rs
+++ b/components/engine_rocks/src/lib.rs
@@ -101,9 +101,7 @@ pub mod file_system;
 
 mod raft_engine;
 
-pub use rocksdb::set_perf_level;
-pub use rocksdb::PerfContext;
-pub use rocksdb::PerfLevel;
+pub use rocksdb::{set_perf_flags, set_perf_level, PerfContext, PerfFlag, PerfFlags, PerfLevel};
 
 pub mod flow_control_factors;
 pub use flow_control_factors::*;

--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -344,7 +344,7 @@ impl Default for Config {
             hibernate_regions: true,
             dev_assert: false,
             apply_yield_duration: ReadableDuration::millis(500),
-            perf_level: PerfLevel::EnableTime,
+            perf_level: PerfLevel::Uninitialized,
             evict_cache_on_memory_ratio: 0.0,
             cmd_batch: true,
             cmd_batch_concurrent_ready_max_count: 1,


### PR DESCRIPTION

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #12362

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
PerfFlags provides more fine-grained PerfContext collecting. In this way, we
only collect the duration we really care about. Theoretically, it reduces the
overhead of collecting PerfContext compared to using PerfLevel::EnableTime.

This commit only changes the raftstore part. The read pool part will be done
later.

The default value of raftstore.perf-level is changed to Uninitialized. The
config is not documented before, so I think the change is not so important
to change the default value.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
