### PR TITLE
raftstore: fix race between split check and destroy

### DIFF
--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -3062,6 +3062,7 @@ where
             &self.ctx.engines,
             &mut self.ctx.perf_context,
             merged_by_target,
+            &self.ctx.pending_create_peers,
         ) {
             // If not panic here, the peer will be recreated in the next restart,
             // then it will be gc again. But if some overlap region is created
@@ -3086,21 +3087,6 @@ where
         }
         if meta.regions.remove(&region_id).is_none() && !merged_by_target {
             panic!("{} meta corruption detected", self.fsm.peer.tag)
-        }
-
-        if self.fsm.peer.local_first_replicate {
-            let mut pending_create_peers = self.ctx.pending_create_peers.lock().unwrap();
-            if is_initialized {
-                assert!(pending_create_peers.get(&region_id).is_none());
-            } else {
-                // If this region's data in `pending_create_peers` is not equal to `(peer_id, false)`,
-                // it means this peer will be replaced by the split one.
-                if let Some(status) = pending_create_peers.get(&region_id) {
-                    if *status == (self.fsm.peer_id(), false) {
-                        pending_create_peers.remove(&region_id);
-                    }
-                }
-            }
         }
 
         // Clear merge related structures.
@@ -3138,6 +3124,8 @@ where
                 }
             }
         }
+
+        fail_point!("raft_store_finish_destroy_peer");
 
         true
     }

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -1017,7 +1017,7 @@ where
             if self.get_store().is_initialized() {
                 assert_eq!(pending.get(&region.get_id()), None);
                 (None, true)
-            } else  if let Some(status) = pending.get(&region.get_id()) {
+            } else if let Some(status) = pending.get(&region.get_id()) {
                 if *status == (self.peer.get_id(), false) {
                     pending.remove(&region.get_id());
                     // Hold the lock to avoid apply worker applies split.
@@ -1029,6 +1029,8 @@ where
                     // Peer id can't be different as router should exist all the time, their is no
                     // chance for store to insert a different peer id. And apply worker should skip
                     // split when meeting a different id.
+                    let status = *status;
+                    // Avoid panic with lock.
                     drop(pending);
                     panic!("{} unexpected pending states {:?}", self.tag, status);
                 }

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -1000,6 +1000,7 @@ where
         engines: &Engines<EK, ER>,
         perf_context: &mut EK::PerfContext,
         keep_data: bool,
+        pending_create_peers: &Mutex<HashMap<u64, (u64, bool)>>,
     ) -> Result<()> {
         fail_point!("raft_store_skip_destroy_peer", |_| Ok(()));
         let t = TiInstant::now();
@@ -1011,52 +1012,92 @@ where
             "peer_id" => self.peer.get_id(),
         );
 
-        // Set Tombstone state explicitly
-        let mut kv_wb = engines.kv.write_batch();
-        let mut raft_wb = engines.raft.log_batch(1024);
-        // Raft log gc should be flushed before being destroyed, so last_compacted_idx has to be
-        // the minimal index that may still have logs.
-        let last_compacted_idx = self.last_compacted_idx;
-        self.mut_store()
-            .clear_meta(last_compacted_idx, &mut kv_wb, &mut raft_wb)?;
-
-        // StoreFsmDelegate::check_msg use both epoch and region peer list to check whether
-        // a message is targing a staled peer.  But for an uninitialized peer, both epoch and
-        // peer list are empty, so a removed peer will be created again.  Saving current peer
-        // into the peer list of region will fix this problem.
-        if !self.get_store().is_initialized() {
-            region.mut_peers().push(self.peer.clone());
-        }
-        write_peer_state(
-            &mut kv_wb,
-            &region,
-            PeerState::Tombstone,
-            // Only persist the `merge_state` if the merge is known to be succeeded
-            // which is determined by the `keep_data` flag
-            if keep_data {
-                self.pending_merge_state.clone()
+        let (pending_create_peers, clean) = if self.local_first_replicate {
+            let mut pending = pending_create_peers.lock().unwrap();
+            if self.get_store().is_initialized() {
+                assert_eq!(pending.get(&region.get_id()), None);
+                (None, true)
+            } else  if let Some(status) = pending.get(&region.get_id()) {
+                if *status == (self.peer.get_id(), false) {
+                    pending.remove(&region.get_id());
+                    // Hold the lock to avoid apply worker applies split.
+                    (Some(pending), true)
+                } else if *status == (self.peer.get_id(), true) {
+                    // It's already marked to split by apply worker, skip delete.
+                    (None, false)
+                } else {
+                    // Peer id can't be different as router should exist all the time, their is no
+                    // chance for store to insert a different peer id. And apply worker should skip
+                    // split when meeting a different id.
+                    drop(pending);
+                    panic!("{} unexpected pending states {:?}", self.tag, status);
+                }
             } else {
-                None
-            },
-        )?;
-        // write kv rocksdb first in case of restart happen between two write
-        let mut write_opts = WriteOptions::new();
-        write_opts.set_sync(true);
-        kv_wb.write_opt(&write_opts)?;
+                // The status is inserted when it's created. It will be removed in following cases:
+                // 1. By appy worker as it fails to split due to region state key. This is
+                //    impossible to reach this code path because the delete write batch is not
+                //    persisted yet.
+                // 2. By store fsm as it fails to create peer, which is also invalid obviously.
+                // 3. By peer fsm after persisting snapshot, then it should be initialized.
+                // 4. By peer fsm after split.
+                // 5. By peer fsm when destroy, which should go the above branch instead.
+                (None, false)
+            }
+        } else {
+            (None, true)
+        };
+        if clean {
+            // Set Tombstone state explicitly
+            let mut kv_wb = engines.kv.write_batch();
+            let mut raft_wb = engines.raft.log_batch(1024);
+            // Raft log gc should be flushed before being destroyed, so last_compacted_idx has to be
+            // the minimal index that may still have logs.
+            let last_compacted_idx = self.last_compacted_idx;
+            self.mut_store()
+                .clear_meta(last_compacted_idx, &mut kv_wb, &mut raft_wb)?;
 
-        perf_context.start_observe();
-        engines.raft.consume(&mut raft_wb, true)?;
-        perf_context.report_metrics();
+            // StoreFsmDelegate::check_msg use both epoch and region peer list to check whether
+            // a message is targing a staled peer.  But for an uninitialized peer, both epoch and
+            // peer list are empty, so a removed peer will be created again.  Saving current peer
+            // into the peer list of region will fix this problem.
+            if !self.get_store().is_initialized() {
+                region.mut_peers().push(self.peer.clone());
+            }
 
-        if self.get_store().is_initialized() && !keep_data {
-            // If we meet panic when deleting data and raft log, the dirty data
-            // will be cleared by a newer snapshot applying or restart.
-            if let Err(e) = self.get_store().clear_data() {
-                error!(?e;
-                    "failed to schedule clear data task";
-                    "region_id" => self.region_id,
-                    "peer_id" => self.peer.get_id(),
-                );
+            write_peer_state(
+                &mut kv_wb,
+                &region,
+                PeerState::Tombstone,
+                // Only persist the `merge_state` if the merge is known to be succeeded
+                // which is determined by the `keep_data` flag
+                if keep_data {
+                    self.pending_merge_state.clone()
+                } else {
+                    None
+                },
+            )?;
+
+            // write kv rocksdb first in case of restart happen between two write
+            let mut write_opts = WriteOptions::new();
+            write_opts.set_sync(true);
+            kv_wb.write_opt(&write_opts)?;
+
+            drop(pending_create_peers);
+
+            perf_context.start_observe();
+            engines.raft.consume(&mut raft_wb, true)?;
+            perf_context.report_metrics();
+
+            if self.get_store().is_initialized() && !keep_data {
+                // If we meet panic when deleting data and raft log, the dirty data
+                // will be cleared by a newer snapshot applying or restart.
+                if let Err(e) = self.get_store().clear_data() {
+                    error!(?e;
+                        "failed to schedule clear data task";
+                        "region_id" => self.region_id,
+                        "peer_id" => self.peer.get_id(),
+                    );
+                }
             }
         }
 
@@ -1071,7 +1112,11 @@ where
             "region_id" => self.region_id,
             "peer_id" => self.peer.get_id(),
             "takes" => ?t.saturating_elapsed(),
+            "clean" => clean,
+            "keep_data" => keep_data,
         );
+
+        fail_point!("raft_store_after_destroy_peer");
 
         Ok(())
     }

--- a/tests/failpoints/cases/test_split_region.rs
+++ b/tests/failpoints/cases/test_split_region.rs
@@ -9,7 +9,7 @@ use engine_traits::CF_WRITE;
 use grpcio::{ChannelBuilder, Environment};
 use kvproto::kvrpcpb::{Mutation, Op, PessimisticLockRequest, PrewriteRequest};
 use kvproto::metapb::Region;
-use kvproto::raft_serverpb::{PeerState, RaftMessage};
+use kvproto::raft_serverpb::RaftMessage;
 use kvproto::tikvpb::TikvClient;
 use pd_client::PdClient;
 use raft::eraftpb::MessageType;
@@ -395,10 +395,10 @@ fn test_split_not_to_split_existing_tombstone_region() {
 }
 
 // TiKV uses memory lock to control the order between spliting and creating
-// new peer. This case test if tikv skip split if the peer is destroyed after
-// memory lock check but before state check.
+// new peer. This case test if tikv continues split if the peer is destroyed after
+// memory lock check.
 #[test]
-fn test_not_to_split_tombstone_region_after_mem_check() {
+fn test_split_continue_when_destroy_peer_after_mem_check() {
     let mut cluster = new_node_cluster(0, 3);
     configure_for_merge(&mut cluster);
     cluster.cfg.raft_store.right_derive_when_split = true;
@@ -472,113 +472,13 @@ fn test_not_to_split_tombstone_region_after_mem_check() {
     // If value of `k22` is equal to `v22`, the previous split log must be applied.
     must_get_equal(&cluster.get_engine(2), b"k22", b"v22");
 
-    // If left_peer_2 is created, `must_get_none` will fail.
-    must_get_none(&cluster.get_engine(2), b"k1");
-}
-
-// TiKV uses memory lock to control the order between spliting and creating
-// new peer. This case test if tikv will be able to replace uninitialized peer
-// if the peer is destroyed after the state check.
-#[test]
-fn test_should_split_same_uninitialied_peer_after_state_check() {
-    let mut cluster = new_node_cluster(0, 3);
-    configure_for_merge(&mut cluster);
-    cluster.cfg.raft_store.right_derive_when_split = true;
-    cluster.cfg.raft_store.store_batch_system.max_batch_size = Some(1);
-    cluster.cfg.raft_store.store_batch_system.pool_size = 2;
-    cluster.cfg.raft_store.apply_batch_system.max_batch_size = Some(1);
-    cluster.cfg.raft_store.apply_batch_system.pool_size = 2;
-    let pd_client = Arc::clone(&cluster.pd_client);
-    pd_client.disable_default_operator();
-
-    fail::cfg("on_raft_gc_log_tick", "return()").unwrap();
-    let r1 = cluster.run_conf_change();
-
-    pd_client.must_add_peer(r1, new_peer(3, 3));
-
-    assert_eq!(r1, 1);
-    let before_check_snapshot_1_2_fp = "before_check_snapshot_1_2";
-    fail::cfg(before_check_snapshot_1_2_fp, "pause").unwrap();
-    let before_check_snapshot_1000_2_fp = "before_check_snapshot_1000_2";
-    fail::cfg(before_check_snapshot_1000_2_fp, "pause").unwrap();
-    pd_client.must_add_peer(r1, new_peer(2, 2));
-
-    cluster.must_put(b"k1", b"v1");
-    cluster.must_put(b"k2", b"v2");
-
-    let region = pd_client.get_region(b"k1").unwrap();
-    cluster.must_split(&region, b"k2");
-    cluster.must_put(b"k22", b"v22");
-
-    must_get_none(&cluster.get_engine(2), b"k1");
-
-    let left = pd_client.get_region(b"k1").unwrap();
-    let left_peer_2 = find_peer(&left, 2).cloned().unwrap();
-    pd_client.must_remove_peer(left.get_id(), left_peer_2);
-
-    // Make sure it finish mem check before destorying.
-    let (mem_check_tx, mem_check_rx) = crossbeam::channel::bounded(0);
-    let on_handle_apply_split_2_fp = "on_handle_apply_split_2_after_mem_check";
-    fail::cfg_callback(on_handle_apply_split_2_fp, move || {
-        let _ = mem_check_tx.send(());
-        let _ = mem_check_tx.send(());
-    })
-    .unwrap();
-
-    // So region 1 will start apply snapshot and split.
-    fail::remove(before_check_snapshot_1_2_fp);
-
-    // Wait for split mem check
-    mem_check_rx.recv_timeout(Duration::from_secs(3)).unwrap();
-    let (apply_finish_tx, apply_finish_rx) = crossbeam::channel::bounded(0);
-    let on_handle_post_apply_2_fp = "raft_store_apply_post_write_db";
-    fail::cfg_callback(on_handle_post_apply_2_fp, move || {
-        let _ = apply_finish_tx.send(());
-        let _ = apply_finish_tx.send(());
-    })
-    .unwrap();
-
-    // Resume split in region 1.
-    fail::remove(on_handle_apply_split_2_fp);
-    mem_check_rx.recv_timeout(Duration::from_secs(3)).unwrap();
-
-    // Make sure the state is persisted.
-    apply_finish_rx
-        .recv_timeout(Duration::from_secs(3))
-        .unwrap();
-
-    let (destroy_tx, destroy_rx) = crossbeam::channel::bounded(0);
-    fail::cfg_callback("raft_store_finish_destroy_peer", move || {
-        let _ = destroy_tx.send(());
-    })
-    .unwrap();
-
-    // Resume region 1000 processing and wait till it's destroyed.
-    fail::remove(before_check_snapshot_1000_2_fp);
-    destroy_rx.recv_timeout(Duration::from_secs(3)).unwrap();
-
-    // If left_peer_2 can be created, dropping all msg to make it exist.
-    cluster.add_send_filter(IsolationFilterFactory::new(2));
-    // Also don't send check stale msg to PD
-    let peer_check_stale_state_fp = "peer_check_stale_state";
-    fail::cfg(peer_check_stale_state_fp, "return()").unwrap();
-
-    // Resume apply.
-    fail::remove("raft_store_finish_destroy_peer");
-    fail::remove(on_handle_post_apply_2_fp);
-    apply_finish_rx
-        .recv_timeout(Duration::from_secs(3))
-        .unwrap();
-
-    // If value of `k22` is equal to `v22`, the previous split log must be applied.
-    must_get_equal(&cluster.get_engine(2), b"k22", b"v22");
+    // Once it's marked split in memcheck, destroy should not write tombstone otherwise it will
+    // break the region states. Hence split should continue.
     must_get_equal(&cluster.get_engine(2), b"k1", b"v1");
-    // Its state should not be tombstone.
-    let region_state = cluster.region_local_state(1000, 2);
-    assert_ne!(region_state.get_state(), PeerState::Tombstone);
 
     cluster.clear_send_filters();
-    // The stale peer should be destroy in the end.
+    fail::remove(peer_check_stale_state_fp);
+
     must_get_none(&cluster.get_engine(2), b"k1");
 }
 

--- a/tests/integrations/raftstore/test_split_region.rs
+++ b/tests/integrations/raftstore/test_split_region.rs
@@ -483,7 +483,9 @@ fn test_server_apply_new_version_snapshot() {
     test_apply_new_version_snapshot(&mut cluster);
 }
 
-fn test_split_with_stale_peer<T: Simulator>(cluster: &mut Cluster<T>) {
+#[test]
+fn test_server_split_with_stale_peer() {
+    let mut cluster = new_server_cluster(0, 3);
     // disable raft log gc.
     cluster.cfg.raft_store.raft_log_gc_tick_interval = ReadableDuration::secs(60);
     cluster.cfg.raft_store.peer_stale_state_check_interval = ReadableDuration::millis(500);
@@ -549,18 +551,6 @@ fn test_split_with_stale_peer<T: Simulator>(cluster: &mut Cluster<T>) {
     cluster.must_put(b"k3", b"v3");
     // node 3 must have k3.
     must_get_equal(&engine3, b"k3", b"v3");
-}
-
-#[test]
-fn test_node_split_with_stale_peer() {
-    let mut cluster = new_node_cluster(0, 3);
-    test_split_with_stale_peer(&mut cluster);
-}
-
-#[test]
-fn test_server_split_with_stale_peer() {
-    let mut cluster = new_server_cluster(0, 3);
-    test_split_with_stale_peer(&mut cluster);
 }
 
 fn test_split_region_diff_check<T: Simulator>(cluster: &mut Cluster<T>) {


### PR DESCRIPTION
### What is changed and how it works?
Issue Number: Close #12368

What's Changed:

```commit-message
If an uninitialized peer is destroyed during split check, it can either
panic or create stale peer with corrupted state.
```

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
fix race between split check and destroy
```
