### PR TITLE
copr: return memory locks correctly in replica read

### DIFF
--- a/src/coprocessor/error.rs
+++ b/src/coprocessor/error.rs
@@ -69,6 +69,7 @@ impl From<KvError> for Error {
     fn from(err: KvError) -> Self {
         match err {
             KvError(box KvErrorInner::Request(e)) => Error::Region(e),
+            KvError(box KvErrorInner::KeyIsLocked(lock_info)) => Error::Locked(lock_info),
             e => Error::Other(e.to_string()),
         }
     }

--- a/tests/failpoints/cases/test_coprocessor.rs
+++ b/tests/failpoints/cases/test_coprocessor.rs
@@ -1,14 +1,22 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::sync::Arc;
+
+use futures::executor::block_on;
+use grpcio::{ChannelBuilder, Environment};
 use kvproto::kvrpcpb::{Context, IsolationLevel};
+use kvproto::tikvpb::TikvClient;
 use more_asserts::{assert_ge, assert_le};
 use protobuf::Message;
+use test_raftstore::{must_get_equal, new_peer, new_server_cluster};
+use tikv_util::HandyRwLock;
 use tipb::SelectResponse;
 
 use test_coprocessor::*;
 use test_storage::*;
 use tidb_query_datatype::codec::{datum, Datum};
 use tidb_query_datatype::expr::EvalContext;
+use txn_types::{Key, Lock, LockType};
 
 #[test]
 fn test_deadline() {
@@ -365,4 +373,62 @@ fn test_paging_scan_multi_ranges() {
         assert_eq!(res_start_key, start_key);
         assert_eq!(res_end_key, end_key.get_start(), "{}", desc);
     }
+}
+
+#[test]
+fn test_read_index_lock_checking_on_follower() {
+    let mut cluster = new_server_cluster(0, 2);
+
+    let pd_client = Arc::clone(&cluster.pd_client);
+    pd_client.disable_default_operator();
+
+    let rid = cluster.run_conf_change();
+    cluster.must_put(b"k1", b"v1");
+    pd_client.must_add_peer(rid, new_peer(2, 2));
+    must_get_equal(&cluster.get_engine(2), b"k1", b"v1");
+
+    // Transfer leader to store 1
+    let r1 = cluster.get_region(b"k1");
+    cluster.must_transfer_leader(1, new_peer(1, 1));
+
+    // Connect to store 2, the follower.
+    let env = Arc::new(Environment::new(1));
+    let channel = ChannelBuilder::new(env).connect(&cluster.sim.rl().get_addr(2));
+    let client = TikvClient::new(channel);
+
+    let mut ctx = Context::default();
+    ctx.set_region_id(r1.get_id());
+    ctx.set_region_epoch(r1.get_region_epoch().clone());
+    ctx.set_peer(new_peer(2, 2));
+    ctx.set_replica_read(true);
+
+    let product = ProductTable::new();
+    let mut req = DAGSelect::from(&product).build();
+    req.set_context(ctx);
+    req.set_start_ts(100);
+
+    let leader_cm = cluster.sim.rl().get_concurrency_manager(1);
+    let lock = Lock::new(
+        LockType::Put,
+        b"k1".to_vec(),
+        10.into(),
+        20000,
+        None,
+        10.into(),
+        1,
+        20.into(),
+    )
+    .use_async_commit(vec![]);
+    // Set a memory lock which is in the coprocessor query range on the leader
+    let locked_key = req.get_ranges()[0].get_start();
+    let guard = block_on(leader_cm.lock_key(&Key::from_raw(locked_key)));
+    guard.with_lock(|l| *l = Some(lock.clone()));
+
+    let resp = client.coprocessor(&req).unwrap();
+    assert_eq!(
+        &lock.into_lock_info(locked_key.to_vec()),
+        resp.get_locked(),
+        "{:?}",
+        resp
+    );
 }


### PR DESCRIPTION
Signed-off-by: Yilin Chen <sticnarf@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #12341

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
The memory lock returned from the leader in replica read is a
tikv_kv::ErrorInner::KeyIsLocked. The conversion from this error to
coprocessor::Error is not implemented, so this error is finally turned
to an other error, which cannot be correctly handled in TiDB.

This commit implements the missing conversion. Now, the memory
lock will be correctly set in the `locked` field in the response.
```

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix unhandled KeyIsLocked errors in follower read.
```
