### PR TITLE
raftstore: fix commit state check in apply thread to 5.2

### DIFF
--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -2837,6 +2837,8 @@ where
     pub peer_id: u64,
     pub region_id: u64,
     pub term: u64,
+    pub commit_index: u64,
+    pub commit_term: u64,
     pub entries: CachedEntries,
     pub cbs: Vec<Proposal<S>>,
 }
@@ -2846,6 +2848,8 @@ impl<S: Snapshot> Apply<S> {
         peer_id: u64,
         region_id: u64,
         term: u64,
+        commit_index: u64,
+        commit_term: u64,
         entries: Vec<Entry>,
         cbs: Vec<Proposal<S>>,
     ) -> Apply<S> {
@@ -2854,6 +2858,8 @@ impl<S: Snapshot> Apply<S> {
             peer_id,
             region_id,
             term,
+            commit_index,
+            commit_term,
             entries,
             cbs,
         }
@@ -3228,21 +3234,19 @@ where
 
         self.delegate.metrics = ApplyMetrics::default();
         self.delegate.term = apply.term;
-        if let Some(entry) = entries.last() {
-            let prev_state = (
-                self.delegate.apply_state.get_commit_index(),
-                self.delegate.apply_state.get_commit_term(),
+        let prev_state = (
+            self.delegate.apply_state.get_commit_index(),
+            self.delegate.apply_state.get_commit_term(),
+        );
+        let cur_state = (apply.commit_index, apply.commit_term);
+        if prev_state.0 > cur_state.0 || prev_state.1 > cur_state.1 {
+            panic!(
+                "{} commit state jump backward {:?} -> {:?}",
+                self.delegate.tag, prev_state, cur_state
             );
-            let cur_state = (entry.get_index(), entry.get_term());
-            if prev_state.0 > cur_state.0 || prev_state.1 > cur_state.1 {
-                panic!(
-                    "{} commit state jump backward {:?} -> {:?}",
-                    self.delegate.tag, prev_state, cur_state
-                );
-            }
-            self.delegate.apply_state.set_commit_index(cur_state.0);
-            self.delegate.apply_state.set_commit_term(cur_state.1);
         }
+        self.delegate.apply_state.set_commit_index(cur_state.0);
+        self.delegate.apply_state.set_commit_term(cur_state.1);
 
         self.append_proposal(apply.cbs.drain(..));
         self.delegate
@@ -4378,7 +4382,19 @@ mod tests {
         entries: Vec<Entry>,
         cbs: Vec<Proposal<S>>,
     ) -> Apply<S> {
-        Apply::new(peer_id, region_id, term, entries, cbs)
+        let (commit_index, commit_term) = entries
+            .last()
+            .map(|e| (e.get_index(), e.get_term()))
+            .unwrap();
+        Apply::new(
+            peer_id,
+            region_id,
+            term,
+            commit_index,
+            commit_term,
+            entries,
+            cbs,
+        )
     }
 
     #[test]

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -1991,10 +1991,20 @@ where
             } else {
                 vec![]
             };
+            // Note that the `commit_index` and `commit_term` here may be used to
+            // forward the commit index. So it must be less than or equal to persist
+            // index.
+            let commit_index = cmp::min(
+                self.raft_group.raft.raft_log.committed,
+                self.raft_group.raft.raft_log.persisted,
+            );
+            let commit_term = self.get_store().term(commit_index).unwrap();
             let mut apply = Apply::new(
                 self.peer_id(),
                 self.region_id,
                 self.term(),
+                commit_index,
+                commit_term,
                 committed_entries,
                 cbs,
             );

--- a/tests/failpoints/cases/test_early_apply.rs
+++ b/tests/failpoints/cases/test_early_apply.rs
@@ -77,3 +77,73 @@ fn test_multi_early_apply() {
     fail::remove(store_1_fp);
     must_get_equal(&cluster.get_engine(1), b"k11", b"v22");
 }
+
+/// Test if the commit state check of apply msg is ok.
+/// In the previous implementation, the commit state check uses the state of last
+/// committed entry and it relies on the guarantee that the commit index and term
+/// of the last committed entry must be monotonically increasing even between restarting.
+/// However, this guarantee can be broken by
+///     1. memory limitation of fetching committed entries
+///     2. batching apply msg
+/// Now the commit state uses the minimum of persist index and commit index from the peer
+/// to fix this issue.
+/// For simplicity, this test uses region merge to ensure that the apply state will be written
+/// to kv db before crash.
+#[test]
+fn test_early_apply_yield_followed_with_many_entries() {
+    let mut cluster = new_node_cluster(0, 3);
+    cluster.pd_client.disable_default_operator();
+
+    configure_for_merge(&mut cluster);
+    cluster.run();
+
+    cluster.must_put(b"k1", b"v1");
+
+    let region = cluster.get_region(b"k1");
+    cluster.must_split(&region, b"k2");
+
+    let left = cluster.get_region(b"k1");
+    let right = cluster.get_region(b"k2");
+
+    cluster.must_put(b"k2", b"v2");
+
+    must_get_equal(&cluster.get_engine(3), b"k1", b"v1");
+    must_get_equal(&cluster.get_engine(3), b"k2", b"v2");
+
+    let left_peer_1 = find_peer(&left, 1).unwrap().to_owned();
+    cluster.must_transfer_leader(left.get_id(), left_peer_1);
+
+    let right_peer_2 = find_peer(&right, 2).unwrap().to_owned();
+    cluster.must_transfer_leader(right.get_id(), right_peer_2);
+
+    let before_handle_normal_3_fp = "before_handle_normal_3";
+    fail::cfg(before_handle_normal_3_fp, "pause").unwrap();
+
+    // Put another key before CommitMerge to make write-to-kv-db really happen
+    cluster.must_put(b"k3", b"v3");
+
+    cluster.pd_client.must_merge(left.get_id(), right.get_id());
+
+    let large_val = vec![b'a'; 1024 * 1024];
+    // The size of these entries should be larger than MAX_COMMITTED_SIZE_PER_READY
+    for i in 0..50 {
+        cluster.must_put(format!("k1{}", i).as_bytes(), large_val.as_slice());
+    }
+    cluster.must_put(b"k150", b"v150");
+
+    let after_handle_catch_up_logs_for_merge_1003_fp = "after_handle_catch_up_logs_for_merge_1003";
+    fail::cfg(after_handle_catch_up_logs_for_merge_1003_fp, "return").unwrap();
+
+    fail::remove(before_handle_normal_3_fp);
+
+    // Wait for apply state writting to kv db
+    sleep_ms(200);
+
+    cluster.shutdown();
+
+    fail::remove(after_handle_catch_up_logs_for_merge_1003_fp);
+
+    cluster.start().unwrap();
+
+    must_get_equal(&cluster.get_engine(3), b"k150", b"v150");
+}


### PR DESCRIPTION
Signed-off-by: gengliqi <gengliqiii@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: close #https://github.com/tikv/tikv/issues/11396

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
cherry-pick https://github.com/tikv/tikv/pull/11401 to release-5.2 because the memory limitation of fetching committed entries may cause a panic like https://github.com/tikv/tikv/issues/11396 after upgrading TiKV.

### Related changes

- No

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

Side effects

- No

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
