### PR TITLE
split_controller: fix the bug that may cause the stats_monitor to fall into a dead loop

### DIFF
--- a/components/raftstore/src/lib.rs
+++ b/components/raftstore/src/lib.rs
@@ -6,6 +6,7 @@
 #![feature(min_specialization)]
 #![feature(box_patterns)]
 #![feature(hash_drain_filter)]
+#![feature(vec_retain_mut)]
 #![recursion_limit = "256"]
 
 #[cfg(test)]

--- a/components/raftstore/src/store/worker/split_controller.rs
+++ b/components/raftstore/src/store/worker/split_controller.rs
@@ -369,6 +369,12 @@ impl RegionInfo {
 #[derive(Clone, Debug)]
 pub struct ReadStats {
     // RegionID -> RegionInfo
+    // There're three methods could insert a `RegionInfo` into the map:
+    //   1. add_query_num
+    //   2. add_query_num_batch
+    //   3. add_flow
+    // Among these three methods, `add_flow` will not update `key_ranges` of `RegionInfo`,
+    // and due to this, an `RegionInfo` without `key_ranges` may occur. The caller should be aware of this.
     pub region_infos: HashMap<u64, RegionInfo>,
     pub sample_num: usize,
     pub region_buckets: HashMap<u64, BucketStat>,

--- a/components/raftstore/src/store/worker/split_controller.rs
+++ b/components/raftstore/src/store/worker/split_controller.rs
@@ -525,10 +525,6 @@ impl AutoSplitController {
         let capacity = read_stats_vec.len();
         for read_stats in read_stats_vec {
             for (region_id, region_info) in read_stats.region_infos {
-                // Filter out the region info which has no key ranges to sample later.
-                if region_info.key_ranges.is_empty() {
-                    continue;
-                }
                 let region_infos = region_infos_map
                     .entry(region_id)
                     .or_insert_with(|| Vec::with_capacity(capacity));

--- a/components/raftstore/src/store/worker/split_controller.rs
+++ b/components/raftstore/src/store/worker/split_controller.rs
@@ -638,9 +638,13 @@ impl AutoSplitController {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use rand::Rng;
+
+    use txn_types::Key;
+
     use crate::store::util::build_key_range;
     use crate::store::worker::split_config::DEFAULT_SAMPLE_NUM;
-    use txn_types::Key;
 
     enum Position {
         Left,
@@ -1104,6 +1108,27 @@ mod tests {
         ];
         for sample_num in 0..=DEFAULT_SAMPLE_NUM {
             for test_case in test_cases.iter() {
+                check_sample_length(sample_num, test_case.clone());
+            }
+        }
+    }
+
+    #[test]
+    fn test_sample_length_randomly() {
+        let mut rng = rand::thread_rng();
+        let mut test_case = vec![vec![]; DEFAULT_SAMPLE_NUM / 2];
+        for _ in 0..100 {
+            for key_ranges in test_case.iter_mut() {
+                key_ranges.clear();
+                // Make the empty range more likely to appear.
+                if rng.gen_range(0..=1) == 0 {
+                    continue;
+                }
+                for _ in 0..rng.gen_range(1..=5) as usize {
+                    key_ranges.push(build_key_range(b"a", b"b", false));
+                }
+            }
+            for sample_num in 0..=DEFAULT_SAMPLE_NUM {
                 check_sample_length(sample_num, test_case.clone());
             }
         }

--- a/components/raftstore/src/store/worker/split_controller.rs
+++ b/components/raftstore/src/store/worker/split_controller.rs
@@ -82,13 +82,14 @@ where
 {
     let mut sampled_key_ranges = vec![];
     // Retain the non-empty key ranges.
+    // `key_ranges_provider` may return an empty key ranges vector, which will cause
+    // the later sampling to fall into a dead loop. So we need to filter it out here.
     key_ranges_providers
         .retain_mut(|key_ranges_provider| !key_ranges_getter(key_ranges_provider).is_empty());
     if key_ranges_providers.is_empty() {
         return sampled_key_ranges;
     }
     let prefix_sum = prefix_sum_mut(key_ranges_providers.iter_mut(), |key_ranges_provider| {
-        // NOTICE: `key_ranges_provider` may return an empty key range vector here.
         key_ranges_getter(key_ranges_provider).len()
     });
     // The last sum is the number of all the key ranges.


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What is changed and how it works?

Issue Number: Close #12416

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
split_controller: fix the bug that may cause the stats_monitor to fall into a dead loop
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix a bug that causes the TiKV thread to fall into a dead loop and then lead to OOM.
```
