### PR TITLE
cmd: revert #12400

### DIFF
--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -380,7 +380,6 @@ impl<ER: RaftEngine> TiKvServer<ER> {
         let search_base = env::temp_dir().join(&lock_dir);
         file_system::create_dir_all(&search_base)
             .unwrap_or_else(|_| panic!("create {} failed", search_base.display()));
-        set_path_all_permission(&search_base);
 
         for entry in file_system::read_dir(&search_base).unwrap().flatten() {
             if !entry.file_type().unwrap().is_file() {
@@ -1486,8 +1485,6 @@ fn try_lock_conflict_addr<P: AsRef<Path>>(path: P) -> File {
         )
     });
 
-    set_path_all_permission(&path);
-
     if f.try_lock_exclusive().is_err() {
         fatal!(
             "{} already in use, maybe another instance is binding with this address.",
@@ -1506,18 +1503,6 @@ fn get_lock_dir() -> String {
 fn get_lock_dir() -> String {
     "TIKV_LOCK_FILES".to_owned()
 }
-
-// Make the lock files be accessed by all users. Only support in unix platform.
-#[cfg(unix)]
-fn set_path_all_permission<P: AsRef<Path>>(path: P) {
-    use std::fs::{set_permissions, Permissions};
-    use std::os::unix::fs::PermissionsExt;
-    // this may failed when setting a file created by root.
-    let _ = set_permissions(path, Permissions::from_mode(0o777));
-}
-
-#[cfg(not(unix))]
-fn set_path_all_permission<P: AsRef<Path>>(path: P) {}
 
 /// A small trait for components which can be trivially stopped. Lets us keep
 /// a list of these in `TiKV`, rather than storing each component individually.


### PR DESCRIPTION
This reverts commit 95c4d0ed36369c254b1bee36eb007004ee834948.

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #12399

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
revert #12400. 777 permission is not safe because we cannot assume that all users in the system are trusted.
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
