### PR TITLE
*: introduce general request tracker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6614,6 +6614,7 @@ dependencies = [
  "lazy_static",
  "parking_lot 0.12.0",
  "pin-project",
+ "prometheus",
  "slab",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,6 +1444,7 @@ dependencies = [
  "raft",
  "tikv_alloc",
  "tikv_util",
+ "tracker",
  "txn_types",
 ]
 
@@ -1482,6 +1483,7 @@ dependencies = [
  "tikv_util",
  "time",
  "toml",
+ "tracker",
  "txn_types",
 ]
 
@@ -1541,6 +1543,7 @@ dependencies = [
  "tikv_alloc",
  "tikv_util",
  "toml",
+ "tracker",
  "txn_types",
 ]
 
@@ -5666,6 +5669,7 @@ dependencies = [
  "test_raftstore",
  "tikv",
  "tikv_util",
+ "tracker",
  "txn_types",
 ]
 
@@ -6081,6 +6085,7 @@ dependencies = [
  "tokio-openssl",
  "tokio-timer",
  "toml",
+ "tracker",
  "txn_types",
  "url",
  "uuid",
@@ -6229,6 +6234,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tikv_util",
+ "tracker",
  "txn_types",
 ]
 
@@ -6290,6 +6296,7 @@ dependencies = [
  "tokio-executor",
  "tokio-timer",
  "toml",
+ "tracker",
  "url",
  "utime",
  "yatp",
@@ -6596,6 +6603,18 @@ checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
  "pin-project",
  "tracing",
+]
+
+[[package]]
+name = "tracker"
+version = "0.0.1"
+dependencies = [
+ "collections",
+ "kvproto",
+ "lazy_static",
+ "parking_lot 0.12.0",
+ "pin-project",
+ "slab",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,6 +164,7 @@ tokio = { version = "1.17", features = ["full"] }
 tokio-openssl = "0.6"
 tokio-timer = { git = "https://github.com/tikv/tokio", branch = "tokio-timer-hotfix" }
 toml = "0.5"
+tracker = { path = "components/tracker" }
 txn_types = { path = "components/txn_types", default-features = false }
 url = "2"
 uuid = { version = "0.8.1", features = ["serde", "v4"] }
@@ -268,6 +269,7 @@ members = [
   "components/tikv_alloc",
   "components/tikv_util",
   "components/tipb_helper",
+  "components/tracker",
   "components/txn_types",
   "fuzz",
   "fuzz/fuzzer-afl",

--- a/components/engine_panic/Cargo.toml
+++ b/components/engine_panic/Cargo.toml
@@ -12,4 +12,5 @@ raft = { version = "0.7.0", default-features = false, features = ["protobuf-code
 tikv_alloc = { path = "../tikv_alloc" }
 # FIXME: Remove this dep from the engine_traits interface
 tikv_util = { path = "../tikv_util", default-features = false }
+tracker = { path = "../tracker" }
 txn_types = { path = "../txn_types", default-features = false }

--- a/components/engine_panic/src/perf_context.rs
+++ b/components/engine_panic/src/perf_context.rs
@@ -1,6 +1,7 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
 use engine_traits::{PerfContext, PerfContextExt, PerfContextKind, PerfLevel};
+use tracker::TrackerToken;
 
 use crate::engine::PanicEngine;
 
@@ -19,7 +20,7 @@ impl PerfContext for PanicPerfContext {
         panic!()
     }
 
-    fn report_metrics(&mut self) {
+    fn report_metrics(&mut self, _: &[TrackerToken]) {
         panic!()
     }
 }

--- a/components/engine_rocks/Cargo.toml
+++ b/components/engine_rocks/Cargo.toml
@@ -51,6 +51,7 @@ tempfile = "3.0"
 tikv_alloc = { path = "../tikv_alloc" }
 tikv_util = { path = "../tikv_util", default-features = false }
 time = "0.1"
+tracker = { path = "../tracker" }
 txn_types = { path = "../txn_types", default-features = false }
 
 [dependencies.rocksdb]

--- a/components/engine_rocks/src/perf_context.rs
+++ b/components/engine_rocks/src/perf_context.rs
@@ -1,6 +1,7 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
 use engine_traits::{PerfContext, PerfContextExt, PerfContextKind, PerfLevel};
+use tracker::TrackerToken;
 
 use crate::{engine::RocksEngine, perf_context_impl::PerfContextStatistics};
 
@@ -30,7 +31,7 @@ impl PerfContext for RocksPerfContext {
         self.stats.start()
     }
 
-    fn report_metrics(&mut self) {
-        self.stats.report()
+    fn report_metrics(&mut self, trackers: &[TrackerToken]) {
+        self.stats.report(trackers)
     }
 }

--- a/components/engine_rocks/src/perf_context_metrics.rs
+++ b/components/engine_rocks/src/perf_context_metrics.rs
@@ -36,6 +36,18 @@ lazy_static! {
         exponential_buckets(0.0005, 2.0, 20).unwrap()
     )
     .unwrap();
+    pub static ref STORAGE_ROCKSDB_PERF_COUNTER: IntCounterVec = register_int_counter_vec!(
+        "tikv_storage_rocksdb_perf",
+        "Total number of RocksDB internal operations from PerfContext",
+        &["req", "metric"]
+    )
+    .unwrap();
+    pub static ref COPR_ROCKSDB_PERF_COUNTER: IntCounterVec = register_int_counter_vec!(
+        "tikv_coprocessor_rocksdb_perf",
+        "Total number of RocksDB internal operations from PerfContext",
+        &["req", "metric"]
+    )
+    .unwrap();
     pub static ref APPLY_PERF_CONTEXT_TIME_HISTOGRAM_STATIC: PerfContextTimeDuration =
         auto_flush_from!(APPLY_PERF_CONTEXT_TIME_HISTOGRAM, PerfContextTimeDuration);
     pub static ref STORE_PERF_CONTEXT_TIME_HISTOGRAM_STATIC: PerfContextTimeDuration =

--- a/components/engine_traits/Cargo.toml
+++ b/components/engine_traits/Cargo.toml
@@ -22,6 +22,7 @@ slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global
 thiserror = "1.0"
 tikv_alloc = { path = "../tikv_alloc" }
 tikv_util = { path = "../tikv_util", default-features = false }
+tracker = { path = "../tracker" }
 txn_types = { path = "../txn_types", default-features = false }
 
 [dev-dependencies]

--- a/components/engine_traits/src/perf_context.rs
+++ b/components/engine_traits/src/perf_context.rs
@@ -48,7 +48,9 @@ pub trait PerfContextExt {
 pub enum PerfContextKind {
     RaftstoreApply,
     RaftstoreStore,
+    /// Commands in tikv::storage, the inner str is the command tag.
     Storage(&'static str),
+    /// Coprocessor requests in tikv::coprocessor, the inner str is the request type.
     Coprocessor(&'static str),
 }
 
@@ -60,6 +62,6 @@ pub trait PerfContext: Send {
     /// Reinitializes statistics and the perf level
     fn start_observe(&mut self);
 
-    /// Reports the current collected metrics to prometheus
+    /// Reports the current collected metrics to prometheus and trackers
     fn report_metrics(&mut self, trackers: &[TrackerToken]);
 }

--- a/components/engine_traits/src/perf_context.rs
+++ b/components/engine_traits/src/perf_context.rs
@@ -1,5 +1,6 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 use tikv_util::numeric_enum_serializing_mod;
+use tracker::TrackerToken;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum PerfLevel {
@@ -47,7 +48,8 @@ pub trait PerfContextExt {
 pub enum PerfContextKind {
     RaftstoreApply,
     RaftstoreStore,
-    GenericRead,
+    Storage(&'static str),
+    Coprocessor(&'static str),
 }
 
 /// Reports metrics to prometheus
@@ -59,5 +61,5 @@ pub trait PerfContext: Send {
     fn start_observe(&mut self);
 
     /// Reports the current collected metrics to prometheus
-    fn report_metrics(&mut self);
+    fn report_metrics(&mut self, trackers: &[TrackerToken]);
 }

--- a/components/raftstore/src/store/async_io/write.rs
+++ b/components/raftstore/src/store/async_io/write.rs
@@ -533,7 +533,7 @@ where
                         self.store_id, self.tag, e
                     );
                 });
-            self.perf_context.report_metrics(&[]);
+            self.perf_context.report_metrics(&[]); // TODO: pass in request trackers
             write_raft_time = duration_to_sec(now.saturating_elapsed());
             STORE_WRITE_RAFTDB_DURATION_HISTOGRAM.observe(write_raft_time);
         }

--- a/components/raftstore/src/store/async_io/write.rs
+++ b/components/raftstore/src/store/async_io/write.rs
@@ -533,7 +533,7 @@ where
                         self.store_id, self.tag, e
                     );
                 });
-            self.perf_context.report_metrics();
+            self.perf_context.report_metrics(&[]);
             write_raft_time = duration_to_sec(now.saturating_elapsed());
             STORE_WRITE_RAFTDB_DURATION_HISTOGRAM.observe(write_raft_time);
         }

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -525,7 +525,7 @@ where
             self.kv_wb().write_opt(&write_opts).unwrap_or_else(|e| {
                 panic!("failed to write to engine: {:?}", e);
             });
-            self.perf_context.report_metrics(&[]);
+            self.perf_context.report_metrics(&[]); // TODO: pass in request trackers
             self.sync_log_hint = false;
             let data_size = self.kv_wb().data_size();
             if data_size > APPLY_WB_SHRINK_SIZE {

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -525,7 +525,7 @@ where
             self.kv_wb().write_opt(&write_opts).unwrap_or_else(|e| {
                 panic!("failed to write to engine: {:?}", e);
             });
-            self.perf_context.report_metrics();
+            self.perf_context.report_metrics(&[]);
             self.sync_log_hint = false;
             let data_size = self.kv_wb().data_size();
             if data_size > APPLY_WB_SHRINK_SIZE {

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -1306,7 +1306,7 @@ where
 
             perf_context.start_observe();
             engines.raft.consume(&mut raft_wb, true)?;
-            perf_context.report_metrics();
+            perf_context.report_metrics(&[]);
 
             if self.get_store().is_initialized() && !keep_data {
                 // If we meet panic when deleting data and raft log, the dirty data

--- a/components/test_storage/Cargo.toml
+++ b/components/test_storage/Cargo.toml
@@ -30,4 +30,5 @@ raftstore = { path = "../raftstore", default-features = false }
 test_raftstore = { path = "../test_raftstore", default-features = false }
 tikv = { path = "../../", default-features = false }
 tikv_util = { path = "../tikv_util", default-features = false }
+tracker = { path = "../tracker", default-features = false }
 txn_types = { path = "../txn_types", default-features = false }

--- a/components/test_storage/src/sync_storage.rs
+++ b/components/test_storage/src/sync_storage.rs
@@ -19,6 +19,7 @@ use tikv::{
     },
 };
 use tikv_util::time::Instant;
+use tracker::INVALID_TRACKER_TOKEN;
 use txn_types::{Key, KvPair, Mutation, TimeStamp, Value};
 
 /// A builder to build a `SyncTestStorage`.
@@ -179,10 +180,11 @@ impl<E: Engine, F: KvFormat> SyncTestStorage<E, F> {
                 req
             })
             .collect();
+        let trackers = keys.iter().map(|_| INVALID_TRACKER_TOKEN).collect();
         let p = GetConsumer::new();
         block_on(
             self.store
-                .batch_get_command(requests, ids, p.clone(), Instant::now()),
+                .batch_get_command(requests, ids, trackers, p.clone(), Instant::now()),
         )?;
         let mut values = vec![];
         for value in p.take_data().into_iter() {

--- a/components/tikv_kv/Cargo.toml
+++ b/components/tikv_kv/Cargo.toml
@@ -46,6 +46,7 @@ slog_derive = "0.2"
 tempfile = "3.0"
 thiserror = "1.0"
 tikv_util = { path = "../tikv_util", default-features = false }
+tracker = { path = "../tracker" }
 txn_types = { path = "../txn_types", default-features = false }
 
 [dev-dependencies]

--- a/components/tikv_util/Cargo.toml
+++ b/components/tikv_util/Cargo.toml
@@ -55,6 +55,7 @@ time = "0.1"
 tokio = { version = "1.5", features = ["rt-multi-thread"] }
 tokio-executor = "0.1"
 tokio-timer = { git = "https://github.com/tikv/tokio", branch = "tokio-timer-hotfix" }
+tracker = { path = "../tracker" }
 url = "2"
 yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
 

--- a/components/tikv_util/src/yatp_pool/future_pool.rs
+++ b/components/tikv_util/src/yatp_pool/future_pool.rs
@@ -14,6 +14,7 @@ use std::{
 use fail::fail_point;
 use futures::channel::oneshot::{self, Canceled};
 use prometheus::{IntCounter, IntGauge};
+use tracker::TrackedFuture;
 use yatp::task::future;
 
 pub type ThreadPool = yatp::ThreadPool<future::TaskCell>;
@@ -81,7 +82,7 @@ impl FuturePool {
     where
         F: Future + Send + 'static,
     {
-        self.inner.spawn(future)
+        self.inner.spawn(TrackedFuture::new(future))
     }
 
     /// Spawns a future in the pool and returns a handle to the result of the future.
@@ -95,7 +96,7 @@ impl FuturePool {
         F: Future + Send + 'static,
         F::Output: Send,
     {
-        self.inner.spawn_handle(future)
+        self.inner.spawn_handle(TrackedFuture::new(future))
     }
 }
 

--- a/components/tracker/Cargo.toml
+++ b/components/tracker/Cargo.toml
@@ -10,4 +10,5 @@ kvproto = { git = "https://github.com/pingcap/kvproto.git" }
 lazy_static = "1"
 parking_lot = "0.12"
 pin-project = "1"
+prometheus = "0.13"
 slab = "0.4"

--- a/components/tracker/Cargo.toml
+++ b/components/tracker/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "tracker"
+version = "0.0.1"
+edition = "2018"
+publish = false
+
+[dependencies]
+collections = { path = "../../components/collections" }
+kvproto = { git = "https://github.com/pingcap/kvproto.git" }
+lazy_static = "1"
+parking_lot = "0.12"
+pin-project = "1"
+slab = "0.4"

--- a/components/tracker/src/lib.rs
+++ b/components/tracker/src/lib.rs
@@ -3,6 +3,7 @@
 #![feature(derive_default_enum)]
 #![feature(array_from_fn)]
 
+mod metrics;
 mod slab;
 mod tls;
 

--- a/components/tracker/src/lib.rs
+++ b/components/tracker/src/lib.rs
@@ -1,0 +1,85 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+#![feature(derive_default_enum)]
+#![feature(array_from_fn)]
+
+mod slab;
+mod tls;
+
+use kvproto::kvrpcpb as pb;
+
+pub use self::{
+    slab::{TrackerToken, GLOBAL_TRACKERS, INVALID_TRACKER_TOKEN},
+    tls::*,
+};
+
+#[derive(Debug)]
+pub struct Tracker {
+    pub req_info: RequestInfo,
+    pub metrics: RequestMetrics,
+    // TODO: Add request stage info
+    // pub current_stage: RequestStage,
+}
+
+impl Tracker {
+    pub fn new(req_info: RequestInfo) -> Self {
+        Self {
+            req_info,
+            metrics: Default::default(),
+        }
+    }
+
+    pub fn write_scan_detail(&self, detail_v2: &mut pb::ScanDetailV2) {
+        detail_v2.set_rocksdb_block_read_byte(self.metrics.block_read_byte);
+        detail_v2.set_rocksdb_block_read_count(self.metrics.block_read_count);
+        detail_v2.set_rocksdb_block_cache_hit_count(self.metrics.block_cache_hit_count);
+        detail_v2.set_rocksdb_key_skipped_count(self.metrics.internal_key_skipped_count);
+        detail_v2.set_rocksdb_delete_skipped_count(self.metrics.deleted_key_skipped_count);
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct RequestInfo {
+    pub region_id: u64,
+    pub start_ts: u64,
+    pub task_id: u64,
+    pub resource_group_tag: Vec<u8>,
+    pub request_type: RequestType,
+}
+
+impl RequestInfo {
+    pub fn new(ctx: &pb::Context, request_type: RequestType, start_ts: u64) -> RequestInfo {
+        RequestInfo {
+            region_id: ctx.get_region_id(),
+            start_ts,
+            task_id: ctx.get_task_id(),
+            resource_group_tag: ctx.get_resource_group_tag().to_vec(),
+            request_type,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum RequestType {
+    #[default]
+    Unknown,
+    KvGet,
+    KvBatchGet,
+    KvBatchGetCommand,
+    KvScan,
+    KvScanLock,
+    CoprocessorDag,
+    CoprocessorAnalyze,
+    CoprocessorChecksum,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct RequestMetrics {
+    pub get_snapshot_nanos: u64,
+    pub block_cache_hit_count: u64,
+    pub block_read_count: u64,
+    pub block_read_byte: u64,
+    pub block_read_nanos: u64,
+    pub internal_key_skipped_count: u64,
+    pub deleted_key_skipped_count: u64,
+}

--- a/components/tracker/src/metrics.rs
+++ b/components/tracker/src/metrics.rs
@@ -1,0 +1,12 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+use lazy_static::lazy_static;
+use prometheus::*;
+
+lazy_static! {
+    pub static ref SLAB_FULL_COUNTER: IntCounter = register_int_counter!(
+        "tikv_tracker_slab_full_counter",
+        "Number of tracker slab insert failures because of fullness"
+    )
+    .unwrap();
+}

--- a/components/tracker/src/slab.rs
+++ b/components/tracker/src/slab.rs
@@ -6,7 +6,7 @@ use lazy_static::lazy_static;
 use parking_lot::Mutex;
 use slab::Slab;
 
-use crate::Tracker;
+use crate::{metrics::*, Tracker};
 
 const SLAB_SHARD_BITS: u32 = 6;
 const SLAB_SHARD_COUNT: usize = 1 << SLAB_SHARD_BITS; // 64
@@ -113,6 +113,7 @@ impl TrackerSlab {
             });
             TrackerToken::new(self.shard_id, self.seq, key)
         } else {
+            SLAB_FULL_COUNTER.inc();
             INVALID_TRACKER_TOKEN
         }
     }

--- a/components/tracker/src/slab.rs
+++ b/components/tracker/src/slab.rs
@@ -1,0 +1,268 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::{array, cell::Cell, fmt};
+
+use lazy_static::lazy_static;
+use parking_lot::Mutex;
+use slab::Slab;
+
+use crate::Tracker;
+
+const SLAB_SHARD_BITS: u32 = 6;
+const SLAB_SHARD_COUNT: usize = 1 << SLAB_SHARD_BITS; // 64
+const SLAB_SHARD_INIT_CAPACITY: usize = 256;
+const SLAB_SHARD_MAX_CAPACITY: usize = 4096;
+
+lazy_static! {
+    pub static ref GLOBAL_TRACKERS: ShardedSlab = ShardedSlab::new(SLAB_SHARD_INIT_CAPACITY);
+}
+
+fn next_shard_id() -> usize {
+    thread_local! {
+        static CURRENT_SHARD_ID: Cell<usize> = Cell::new(0);
+    }
+    CURRENT_SHARD_ID.with(|c| {
+        let shard_id = c.get();
+        c.set((shard_id + 1) % SLAB_SHARD_COUNT);
+        shard_id
+    })
+}
+
+pub struct ShardedSlab {
+    shards: [Mutex<TrackerSlab>; SLAB_SHARD_COUNT],
+}
+
+impl ShardedSlab {
+    pub fn new(capacity_per_shard: usize) -> ShardedSlab {
+        let shards = array::from_fn(|shard_id| {
+            Mutex::new(TrackerSlab::with_capacity(
+                shard_id as u32,
+                capacity_per_shard,
+            ))
+        });
+        ShardedSlab { shards }
+    }
+
+    pub fn insert(&self, tracker: Tracker) -> TrackerToken {
+        let shard_id = next_shard_id();
+        self.shards[shard_id].lock().insert(tracker)
+    }
+
+    pub fn remove(&self, token: TrackerToken) -> Option<Tracker> {
+        if token != INVALID_TRACKER_TOKEN {
+            let shard_id = token.shard_id();
+            self.shards[shard_id as usize].lock().remove(token)
+        } else {
+            None
+        }
+    }
+
+    pub fn with_tracker<F, T>(&self, token: TrackerToken, f: F) -> Option<T>
+    where
+        F: FnOnce(&mut Tracker) -> T,
+    {
+        if token != INVALID_TRACKER_TOKEN {
+            let shard_id = token.shard_id();
+            self.shards[shard_id as usize].lock().get_mut(token).map(f)
+        } else {
+            None
+        }
+    }
+
+    pub fn for_each<F>(&self, mut f: F)
+    where
+        F: FnMut(&mut Tracker),
+    {
+        for shard in &self.shards {
+            for (_, tracker) in shard.lock().slab.iter_mut() {
+                f(&mut tracker.tracker)
+            }
+        }
+    }
+}
+
+const SLAB_KEY_BITS: u32 = 32;
+const SHARD_ID_BITS_SHIFT: u32 = 64 - SLAB_SHARD_BITS;
+const SEQ_BITS_MASK: u32 = (1 << (SHARD_ID_BITS_SHIFT - SLAB_KEY_BITS)) - 1;
+
+struct TrackerSlab {
+    slab: Slab<SlabEntry>,
+    shard_id: u32,
+    seq: u32,
+}
+
+impl TrackerSlab {
+    fn with_capacity(shard_id: u32, capacity: usize) -> Self {
+        assert!(capacity < SLAB_SHARD_MAX_CAPACITY);
+        TrackerSlab {
+            slab: Slab::with_capacity(capacity),
+            shard_id,
+            seq: 0,
+        }
+    }
+
+    // Returns the seq and key of the inserted tracker.
+    // If the slab reaches the max capacity, the tracker will be dropped silently
+    // and INVALID_TRACKER_TOKEN will be returned.
+    fn insert(&mut self, tracker: Tracker) -> TrackerToken {
+        if self.slab.len() < SLAB_SHARD_MAX_CAPACITY {
+            self.seq = (self.seq + 1) & SEQ_BITS_MASK;
+            let key = self.slab.insert(SlabEntry {
+                tracker,
+                seq: self.seq,
+            });
+            TrackerToken::new(self.shard_id, self.seq, key)
+        } else {
+            INVALID_TRACKER_TOKEN
+        }
+    }
+
+    pub fn get_mut(&mut self, token: TrackerToken) -> Option<&mut Tracker> {
+        if let Some(entry) = self.slab.get_mut(token.key()) {
+            if entry.seq == token.seq() {
+                return Some(&mut entry.tracker);
+            }
+        }
+        None
+    }
+
+    pub fn remove(&mut self, token: TrackerToken) -> Option<Tracker> {
+        if self.get_mut(token).is_some() {
+            Some(self.slab.remove(token.key()).tracker)
+        } else {
+            None
+        }
+    }
+}
+
+struct SlabEntry {
+    tracker: Tracker,
+    seq: u32,
+}
+
+pub const INVALID_TRACKER_TOKEN: TrackerToken = TrackerToken(u64::MAX);
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct TrackerToken(u64);
+
+impl TrackerToken {
+    fn new(shard_id: u32, seq: u32, key: usize) -> TrackerToken {
+        debug_assert!(shard_id < SLAB_SHARD_COUNT as u32);
+        debug_assert!(seq <= SEQ_BITS_MASK);
+        debug_assert!(key < (1 << SLAB_KEY_BITS));
+        TrackerToken(
+            ((shard_id as u64) << SHARD_ID_BITS_SHIFT)
+                | ((seq as u64) << SLAB_KEY_BITS)
+                | (key as u64),
+        )
+    }
+
+    fn shard_id(&self) -> u32 {
+        (self.0 >> SHARD_ID_BITS_SHIFT) as u32
+    }
+
+    fn seq(&self) -> u32 {
+        (self.0 >> SLAB_KEY_BITS) as u32 & SEQ_BITS_MASK
+    }
+
+    fn key(&self) -> usize {
+        (self.0 & ((1 << SLAB_KEY_BITS) - 1)) as usize
+    }
+}
+
+impl fmt::Debug for TrackerToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TrackerToken")
+            .field("shard_id", &self.shard_id())
+            .field("seq", &self.seq())
+            .field("key", &self.key())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{sync::Arc, thread};
+
+    use super::*;
+    use crate::RequestInfo;
+
+    #[test]
+    fn test_tracker_token() {
+        let shard_id = 47;
+        let seq = SEQ_BITS_MASK - 3;
+        let key = 65535;
+        let token = TrackerToken::new(shard_id, seq, key);
+        assert_eq!(token.shard_id(), shard_id);
+        assert_eq!(token.seq(), seq);
+        assert_eq!(token.key(), key);
+    }
+
+    #[test]
+    fn test_basic() {
+        let slab = ShardedSlab::new(2);
+        // Insert 192 trackers
+        let tokens: Vec<TrackerToken> = (0..192)
+            .map(|i| {
+                let tracker = Tracker::new(RequestInfo {
+                    task_id: i,
+                    ..Default::default()
+                });
+                slab.insert(tracker)
+            })
+            .collect();
+        // Get the tracker with the token and check the content
+        for (i, token) in tokens.iter().enumerate() {
+            slab.with_tracker(*token, |tracker| {
+                assert_eq!(i as u64, tracker.req_info.task_id);
+            });
+        }
+        // Remove 0 ~ 128 trackers
+        for (i, token) in tokens[..128].iter().enumerate() {
+            let tracker = slab.remove(*token).unwrap();
+            assert_eq!(i as u64, tracker.req_info.task_id);
+        }
+        // Insert another 192 trackers
+        for i in 192..384 {
+            let tracker = Tracker::new(RequestInfo {
+                task_id: i,
+                ..Default::default()
+            });
+            slab.insert(tracker);
+        }
+        // Iterate over all trackers in the slab
+        let mut tracker_ids = Vec::new();
+        slab.for_each(|tracker| tracker_ids.push(tracker.req_info.task_id));
+        tracker_ids.sort_unstable();
+        assert_eq!(tracker_ids, (128..384).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn test_shard() {
+        let slab = Arc::new(ShardedSlab::new(4));
+        let threads = [1, 2].map(|i| {
+            let slab = slab.clone();
+            thread::spawn(move || {
+                for _ in 0..SLAB_SHARD_COUNT {
+                    slab.insert(Tracker::new(RequestInfo {
+                        task_id: i,
+                        ..Default::default()
+                    }));
+                }
+            })
+        });
+        for th in threads {
+            th.join().unwrap();
+        }
+        for shard in &slab.shards {
+            let mut v: Vec<_> = shard
+                .lock()
+                .slab
+                .iter()
+                .map(|(_, entry)| entry.tracker.req_info.task_id)
+                .collect();
+            v.sort_unstable();
+            assert_eq!(v, [1, 2]);
+        }
+    }
+}

--- a/components/tracker/src/tls.rs
+++ b/components/tracker/src/tls.rs
@@ -1,0 +1,69 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::{
+    cell::Cell,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use pin_project::pin_project;
+
+use crate::{slab::TrackerToken, Tracker, GLOBAL_TRACKERS, INVALID_TRACKER_TOKEN};
+
+thread_local! {
+    static TLS_TRACKER_TOKEN: Cell<TrackerToken> = Cell::new(INVALID_TRACKER_TOKEN);
+}
+
+pub fn set_tls_tracker(token: TrackerToken) {
+    TLS_TRACKER_TOKEN.with(|c| {
+        c.set(token);
+    })
+}
+
+pub fn clear_tls_tracker() {
+    set_tls_tracker(INVALID_TRACKER_TOKEN);
+}
+
+pub fn get_tls_tracker() -> TrackerToken {
+    TLS_TRACKER_TOKEN.with(|c| c.get())
+}
+
+pub fn with_tls_tracker<F>(mut f: F)
+where
+    F: FnMut(&mut Tracker),
+{
+    TLS_TRACKER_TOKEN.with(|c| {
+        GLOBAL_TRACKERS.with_tracker(c.get(), &mut f);
+    });
+}
+
+#[pin_project]
+pub struct TrackedFuture<F> {
+    #[pin]
+    future: F,
+    tracker: TrackerToken,
+}
+
+impl<F> TrackedFuture<F> {
+    pub fn new(future: F) -> TrackedFuture<F> {
+        TrackedFuture {
+            future,
+            tracker: get_tls_tracker(),
+        }
+    }
+}
+
+impl<F: Future> Future for TrackedFuture<F> {
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        TLS_TRACKER_TOKEN.with(|c| {
+            c.set(*this.tracker);
+            let res = this.future.poll(cx);
+            c.set(INVALID_TRACKER_TOKEN);
+            res
+        })
+    }
+}

--- a/components/tracker/src/tls.rs
+++ b/components/tracker/src/tls.rs
@@ -15,17 +15,17 @@ thread_local! {
     static TLS_TRACKER_TOKEN: Cell<TrackerToken> = Cell::new(INVALID_TRACKER_TOKEN);
 }
 
-pub fn set_tls_tracker(token: TrackerToken) {
+pub fn set_tls_tracker_token(token: TrackerToken) {
     TLS_TRACKER_TOKEN.with(|c| {
         c.set(token);
     })
 }
 
-pub fn clear_tls_tracker() {
-    set_tls_tracker(INVALID_TRACKER_TOKEN);
+pub fn clear_tls_tracker_token() {
+    set_tls_tracker_token(INVALID_TRACKER_TOKEN);
 }
 
-pub fn get_tls_tracker() -> TrackerToken {
+pub fn get_tls_tracker_token() -> TrackerToken {
     TLS_TRACKER_TOKEN.with(|c| c.get())
 }
 
@@ -49,7 +49,7 @@ impl<F> TrackedFuture<F> {
     pub fn new(future: F) -> TrackedFuture<F> {
         TrackedFuture {
             future,
-            tracker: get_tls_tracker(),
+            tracker: get_tls_tracker_token(),
         }
     }
 }

--- a/scripts/check-bins.py
+++ b/scripts/check-bins.py
@@ -14,6 +14,7 @@ WHITE_LIST = {
     "online_config", "online_config_derive", "match_template", "tidb_query_codegen",
     "panic_hook", "fuzz", "fuzzer_afl", "fuzzer_honggfuzz", "fuzzer_libfuzzer",
     "coprocessor_plugin_api", "example_plugin", "memory_trace_macros", "case_macros",
+    "tracker"
 }
 
 JEMALLOC_SYMBOL = ["je_arena_boot", " malloc"]

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -2,7 +2,9 @@
 
 use std::{borrow::Cow, future::Future, marker::PhantomData, sync::Arc, time::Duration};
 
-use ::tracker::{set_tls_tracker, with_tls_tracker, RequestInfo, RequestType, GLOBAL_TRACKERS};
+use ::tracker::{
+    set_tls_tracker_token, with_tls_tracker, RequestInfo, RequestType, GLOBAL_TRACKERS,
+};
 use async_stream::try_stream;
 use concurrency_manager::ConcurrencyManager;
 use engine_traits::PerfLevel;
@@ -488,7 +490,7 @@ impl<E: Engine> Endpoint<E> {
             RequestType::Unknown,
             req.start_ts,
         )));
-        set_tls_tracker(tracker);
+        set_tls_tracker_token(tracker);
         let result_of_future = self
             .parse_request_and_check_memory_locks(req, peer, false)
             .map(|(handler_builder, req_ctx)| self.handle_unary_request(req_ctx, handler_builder));

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -2,6 +2,7 @@
 
 use std::{borrow::Cow, future::Future, marker::PhantomData, sync::Arc, time::Duration};
 
+use ::tracker::{set_tls_tracker, with_tls_tracker, RequestInfo, RequestType, GLOBAL_TRACKERS};
 use async_stream::try_stream;
 use concurrency_manager::ConcurrencyManager;
 use engine_traits::PerfLevel;
@@ -164,6 +165,7 @@ impl<E: Engine> Endpoint<E> {
 
         let mut input = CodedInputStream::from_bytes(&data);
         input.set_recursion_limit(self.recursion_limit);
+
         let req_ctx: ReqContext;
         let builder: RequestHandlerBuilder<E::Snap>;
 
@@ -201,6 +203,10 @@ impl<E: Engine> Endpoint<E> {
                     cache_match_version,
                     self.perf_level,
                 );
+                with_tls_tracker(|tracker| {
+                    tracker.req_info.request_type = RequestType::CoprocessorDag;
+                    tracker.req_info.start_ts = start_ts;
+                });
 
                 self.check_memory_locks(&req_ctx)?;
 
@@ -260,6 +266,10 @@ impl<E: Engine> Endpoint<E> {
                     cache_match_version,
                     self.perf_level,
                 );
+                with_tls_tracker(|tracker| {
+                    tracker.req_info.request_type = RequestType::CoprocessorAnalyze;
+                    tracker.req_info.start_ts = start_ts;
+                });
 
                 self.check_memory_locks(&req_ctx)?;
                 let quota_limiter = self.quota_limiter.clone();
@@ -300,6 +310,10 @@ impl<E: Engine> Endpoint<E> {
                     cache_match_version,
                     self.perf_level,
                 );
+                with_tls_tracker(|tracker| {
+                    tracker.req_info.request_type = RequestType::CoprocessorChecksum;
+                    tracker.req_info.start_ts = start_ts;
+                });
 
                 self.check_memory_locks(&req_ctx)?;
 
@@ -316,6 +330,7 @@ impl<E: Engine> Endpoint<E> {
             }
             tp => return Err(box_err!("unsupported tp {}", tp)),
         };
+
         Ok((builder, req_ctx))
     }
 
@@ -360,7 +375,7 @@ impl<E: Engine> Endpoint<E> {
     /// `RequestHandler` to process the request and produce a result.
     async fn handle_unary_request_impl(
         semaphore: Option<Arc<Semaphore>>,
-        mut tracker: Box<Tracker>,
+        mut tracker: Box<Tracker<E>>,
         handler_builder: RequestHandlerBuilder<E::Snap>,
     ) -> Result<MemoryTraceGuard<coppb::Response>> {
         // When this function is being executed, it may be queued for a long time, so that
@@ -468,17 +483,25 @@ impl<E: Engine> Endpoint<E> {
         req: coppb::Request,
         peer: Option<String>,
     ) -> impl Future<Output = MemoryTraceGuard<coppb::Response>> {
+        let tracker = GLOBAL_TRACKERS.insert(::tracker::Tracker::new(RequestInfo::new(
+            req.get_context(),
+            RequestType::Unknown,
+            req.start_ts,
+        )));
+        set_tls_tracker(tracker);
         let result_of_future = self
             .parse_request_and_check_memory_locks(req, peer, false)
             .map(|(handler_builder, req_ctx)| self.handle_unary_request(req_ctx, handler_builder));
 
         async move {
-            match result_of_future {
+            let res = match result_of_future {
                 Err(e) => make_error_response(e).into(),
                 Ok(handle_fut) => handle_fut
                     .await
                     .unwrap_or_else(|e| make_error_response(e).into()),
-            }
+            };
+            GLOBAL_TRACKERS.remove(tracker);
+            res
         }
     }
 
@@ -489,7 +512,7 @@ impl<E: Engine> Endpoint<E> {
     /// `RequestHandler` multiple times to process the request and produce multiple results.
     fn handle_stream_request_impl(
         semaphore: Option<Arc<Semaphore>>,
-        mut tracker: Box<Tracker>,
+        mut tracker: Box<Tracker<E>>,
         handler_builder: RequestHandlerBuilder<E::Snap>,
     ) -> impl futures::stream::Stream<Item = Result<coppb::Response>> {
         try_stream! {

--- a/src/coprocessor/interceptors/mod.rs
+++ b/src/coprocessor/interceptors/mod.rs
@@ -4,6 +4,4 @@ mod concurrency_limiter;
 mod deadline;
 mod tracker;
 
-pub use concurrency_limiter::limit_concurrency;
-pub use deadline::check_deadline;
-pub use tracker::track;
+pub use self::{concurrency_limiter::limit_concurrency, deadline::check_deadline, tracker::track};

--- a/src/coprocessor/interceptors/tracker.rs
+++ b/src/coprocessor/interceptors/tracker.rs
@@ -7,38 +7,42 @@ use std::{
 };
 
 use pin_project::pin_project;
+use tikv_kv::Engine;
 
 use crate::coprocessor::tracker::Tracker as CopTracker;
 
-pub fn track<'a, F: Future + 'a>(
+pub fn track<'a, F: Future + 'a, E: Engine>(
     fut: F,
-    cop_tracker: &'a mut CopTracker,
+    cop_tracker: &'a mut CopTracker<E>,
 ) -> impl Future<Output = F::Output> + 'a {
     Tracker::new(fut, cop_tracker)
 }
 
 #[pin_project]
-struct Tracker<'a, F>
+struct Tracker<'a, F, E>
 where
     F: Future,
+    E: Engine,
 {
     #[pin]
     fut: F,
-    cop_tracker: &'a mut CopTracker,
+    cop_tracker: &'a mut CopTracker<E>,
 }
 
-impl<'a, F> Tracker<'a, F>
+impl<'a, F, E> Tracker<'a, F, E>
 where
     F: Future,
+    E: Engine,
 {
-    fn new(fut: F, cop_tracker: &'a mut CopTracker) -> Self {
+    fn new(fut: F, cop_tracker: &'a mut CopTracker<E>) -> Self {
         Tracker { fut, cop_tracker }
     }
 }
 
-impl<'a, F: Future> Future for Tracker<'a, F>
+impl<'a, F, E> Future for Tracker<'a, F, E>
 where
     F: Future,
+    E: Engine,
 {
     type Output = F::Output;
 

--- a/src/coprocessor/metrics.rs
+++ b/src/coprocessor/metrics.rs
@@ -3,7 +3,6 @@
 use std::{cell::RefCell, mem, sync::Arc};
 
 use collections::HashMap;
-use engine_rocks::ReadPerfContext;
 use kvproto::{metapb, pdpb::QueryKind};
 use pd_client::BucketMeta;
 use prometheus::*;
@@ -62,57 +61,6 @@ make_auto_flush_static_metric! {
         snapshot,
     }
 
-    pub label_enum PerfMetric {
-        user_key_comparison_count,
-        block_cache_hit_count,
-        block_read_count,
-        block_read_byte,
-        block_read_time,
-        block_cache_index_hit_count,
-        index_block_read_count,
-        block_cache_filter_hit_count,
-        filter_block_read_count,
-        block_checksum_time,
-        block_decompress_time,
-        get_read_bytes,
-        iter_read_bytes,
-        internal_key_skipped_count,
-        internal_delete_skipped_count,
-        internal_recent_skipped_count,
-        get_snapshot_time,
-        get_from_memtable_time,
-        get_from_memtable_count,
-        get_post_process_time,
-        get_from_output_files_time,
-        seek_on_memtable_time,
-        seek_on_memtable_count,
-        next_on_memtable_count,
-        prev_on_memtable_count,
-        seek_child_seek_time,
-        seek_child_seek_count,
-        seek_min_heap_time,
-        seek_max_heap_time,
-        seek_internal_seek_time,
-        db_mutex_lock_nanos,
-        db_condition_wait_nanos,
-        read_index_block_nanos,
-        read_filter_block_nanos,
-        new_table_block_iter_nanos,
-        new_table_iterator_nanos,
-        block_seek_nanos,
-        find_table_nanos,
-        bloom_memtable_hit_count,
-        bloom_memtable_miss_count,
-        bloom_sst_hit_count,
-        bloom_sst_miss_count,
-        get_cpu_nanos,
-        iter_next_cpu_nanos,
-        iter_prev_cpu_nanos,
-        iter_seek_cpu_nanos,
-        encrypt_data_nanos,
-        decrypt_data_nanos,
-    }
-
     pub label_enum MemLockCheckResult {
         unlocked,
         locked,
@@ -125,11 +73,6 @@ make_auto_flush_static_metric! {
     pub struct ReqWaitHistogram: LocalHistogram {
         "req" => ReqTag,
         "type" => WaitType,
-    }
-
-    pub struct PerfCounter: LocalIntCounter {
-        "req" => ReqTag,
-        "metric" => PerfMetric,
     }
 
     pub struct CoprScanKeysHistogram: LocalHistogram {
@@ -208,14 +151,6 @@ lazy_static! {
     .unwrap();
     pub static ref COPR_SCAN_DETAILS_STATIC: CoprScanDetails =
         auto_flush_from!(COPR_SCAN_DETAILS, CoprScanDetails);
-    pub static ref COPR_ROCKSDB_PERF_COUNTER: IntCounterVec = register_int_counter_vec!(
-        "tikv_coprocessor_rocksdb_perf",
-        "Total number of RocksDB internal operations from PerfContext",
-        &["req", "metric"]
-    )
-    .unwrap();
-    pub static ref COPR_ROCKSDB_PERF_COUNTER_STATIC: PerfCounter =
-        auto_flush_from!(COPR_ROCKSDB_PERF_COUNTER, PerfCounter);
     pub static ref COPR_DAG_REQ_COUNT: IntCounterVec = register_int_counter_vec!(
         "tikv_coprocessor_dag_request_count",
         "Total number of DAG requests",
@@ -266,7 +201,6 @@ make_static_metric! {
 pub struct CopLocalMetrics {
     local_scan_details: HashMap<ReqTag, Statistics>,
     local_read_stats: ReadStats,
-    local_perf_stats: HashMap<ReqTag, ReadPerfContext>,
 }
 
 thread_local! {
@@ -274,18 +208,8 @@ thread_local! {
         CopLocalMetrics {
             local_scan_details: HashMap::default(),
             local_read_stats: ReadStats::default(),
-            local_perf_stats: HashMap::default(),
         }
     );
-}
-
-macro_rules! tls_flush_perf_stats {
-    ($tag:ident, $local_stats:ident, $stat:ident) => {
-        COPR_ROCKSDB_PERF_COUNTER_STATIC
-            .get($tag)
-            .$stat
-            .inc_by($local_stats.$stat as u64);
-    };
 }
 
 impl From<GcKeysCF> for CF {
@@ -340,57 +264,6 @@ pub fn tls_flush<R: FlowStatsReporter>(reporter: &R) {
             mem::swap(&mut read_stats, &mut m.local_read_stats);
             reporter.report_read_stats(read_stats);
         }
-
-        for (req_tag, perf_stats) in m.local_perf_stats.drain() {
-            tls_flush_perf_stats!(req_tag, perf_stats, user_key_comparison_count);
-            tls_flush_perf_stats!(req_tag, perf_stats, block_cache_hit_count);
-            tls_flush_perf_stats!(req_tag, perf_stats, block_read_count);
-            tls_flush_perf_stats!(req_tag, perf_stats, block_read_byte);
-            tls_flush_perf_stats!(req_tag, perf_stats, block_read_time);
-            tls_flush_perf_stats!(req_tag, perf_stats, block_cache_index_hit_count);
-            tls_flush_perf_stats!(req_tag, perf_stats, index_block_read_count);
-            tls_flush_perf_stats!(req_tag, perf_stats, block_cache_filter_hit_count);
-            tls_flush_perf_stats!(req_tag, perf_stats, filter_block_read_count);
-            tls_flush_perf_stats!(req_tag, perf_stats, block_checksum_time);
-            tls_flush_perf_stats!(req_tag, perf_stats, block_decompress_time);
-            tls_flush_perf_stats!(req_tag, perf_stats, get_read_bytes);
-            tls_flush_perf_stats!(req_tag, perf_stats, iter_read_bytes);
-            tls_flush_perf_stats!(req_tag, perf_stats, internal_key_skipped_count);
-            tls_flush_perf_stats!(req_tag, perf_stats, internal_delete_skipped_count);
-            tls_flush_perf_stats!(req_tag, perf_stats, internal_recent_skipped_count);
-            tls_flush_perf_stats!(req_tag, perf_stats, get_snapshot_time);
-            tls_flush_perf_stats!(req_tag, perf_stats, get_from_memtable_time);
-            tls_flush_perf_stats!(req_tag, perf_stats, get_from_memtable_count);
-            tls_flush_perf_stats!(req_tag, perf_stats, get_post_process_time);
-            tls_flush_perf_stats!(req_tag, perf_stats, get_from_output_files_time);
-            tls_flush_perf_stats!(req_tag, perf_stats, seek_on_memtable_time);
-            tls_flush_perf_stats!(req_tag, perf_stats, seek_on_memtable_count);
-            tls_flush_perf_stats!(req_tag, perf_stats, next_on_memtable_count);
-            tls_flush_perf_stats!(req_tag, perf_stats, prev_on_memtable_count);
-            tls_flush_perf_stats!(req_tag, perf_stats, seek_child_seek_time);
-            tls_flush_perf_stats!(req_tag, perf_stats, seek_child_seek_count);
-            tls_flush_perf_stats!(req_tag, perf_stats, seek_min_heap_time);
-            tls_flush_perf_stats!(req_tag, perf_stats, seek_max_heap_time);
-            tls_flush_perf_stats!(req_tag, perf_stats, seek_internal_seek_time);
-            tls_flush_perf_stats!(req_tag, perf_stats, db_mutex_lock_nanos);
-            tls_flush_perf_stats!(req_tag, perf_stats, db_condition_wait_nanos);
-            tls_flush_perf_stats!(req_tag, perf_stats, read_index_block_nanos);
-            tls_flush_perf_stats!(req_tag, perf_stats, read_filter_block_nanos);
-            tls_flush_perf_stats!(req_tag, perf_stats, new_table_block_iter_nanos);
-            tls_flush_perf_stats!(req_tag, perf_stats, new_table_iterator_nanos);
-            tls_flush_perf_stats!(req_tag, perf_stats, block_seek_nanos);
-            tls_flush_perf_stats!(req_tag, perf_stats, find_table_nanos);
-            tls_flush_perf_stats!(req_tag, perf_stats, bloom_memtable_hit_count);
-            tls_flush_perf_stats!(req_tag, perf_stats, bloom_memtable_miss_count);
-            tls_flush_perf_stats!(req_tag, perf_stats, bloom_sst_hit_count);
-            tls_flush_perf_stats!(req_tag, perf_stats, bloom_sst_miss_count);
-            tls_flush_perf_stats!(req_tag, perf_stats, get_cpu_nanos);
-            tls_flush_perf_stats!(req_tag, perf_stats, iter_next_cpu_nanos);
-            tls_flush_perf_stats!(req_tag, perf_stats, iter_prev_cpu_nanos);
-            tls_flush_perf_stats!(req_tag, perf_stats, iter_seek_cpu_nanos);
-            tls_flush_perf_stats!(req_tag, perf_stats, encrypt_data_nanos);
-            tls_flush_perf_stats!(req_tag, perf_stats, decrypt_data_nanos);
-        }
     });
 }
 
@@ -436,14 +309,5 @@ pub fn tls_collect_query(
         let key_range = build_key_range(start_key, end_key, reverse_scan);
         m.local_read_stats
             .add_query_num(region_id, peer, key_range, QueryKind::Coprocessor);
-    });
-}
-
-pub fn tls_collect_perf_stats(cmd: ReqTag, perf_stats: &ReadPerfContext) {
-    TLS_COP_METRICS.with(|m| {
-        *(m.borrow_mut()
-            .local_perf_stats
-            .entry(cmd)
-            .or_insert_with(Default::default)) += *perf_stats;
     });
 }

--- a/src/coprocessor/tracker.rs
+++ b/src/coprocessor/tracker.rs
@@ -2,7 +2,7 @@
 
 use std::{cell::RefCell, marker::PhantomData};
 
-use ::tracker::{get_tls_tracker, with_tls_tracker};
+use ::tracker::{get_tls_tracker_token, with_tls_tracker};
 use engine_traits::{PerfContext, PerfContextExt, PerfContextKind};
 use kvproto::{kvrpcpb, kvrpcpb::ScanDetailV2};
 use pd_client::BucketMeta;
@@ -153,7 +153,7 @@ impl<E: Engine> Tracker<E> {
                 self.total_storage_stats.add(&storage_stats);
             }
             self.with_perf_context(|perf_context| {
-                perf_context.report_metrics(&[get_tls_tracker()])
+                perf_context.report_metrics(&[get_tls_tracker_token()])
             });
             self.current_stage = TrackerState::ItemFinished(now);
         } else {

--- a/src/coprocessor/tracker.rs
+++ b/src/coprocessor/tracker.rs
@@ -1,9 +1,12 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_rocks::{ReadPerfContext, RocksPerfContext};
-use engine_traits::{PerfContext, PerfContextKind};
+use std::{cell::RefCell, marker::PhantomData};
+
+use ::tracker::{get_tls_tracker, with_tls_tracker};
+use engine_traits::{PerfContext, PerfContextExt, PerfContextKind};
 use kvproto::{kvrpcpb, kvrpcpb::ScanDetailV2};
 use pd_client::BucketMeta;
+use tikv_kv::{with_tls_engine, Engine};
 use tikv_util::time::{self, Duration, Instant};
 use txn_types::Key;
 
@@ -39,7 +42,7 @@ enum TrackerState {
 
 /// Track coprocessor requests to update statistics and provide slow logs.
 #[derive(Debug)]
-pub struct Tracker {
+pub struct Tracker<E: Engine> {
     request_begin_at: Instant,
 
     // Intermediate results
@@ -60,10 +63,6 @@ pub struct Tracker {
     item_process_time: Duration,
     total_process_time: Duration,
     total_storage_stats: Statistics,
-    // TODO: This leaks the RocksDB engine from abstraction, try to use the PerfContext
-    // in engine_trait instead.
-    perf_context: RocksPerfContext,
-    total_perf_stats: ReadPerfContext, // Accumulated perf statistics
     slow_log_threshold: Duration,
     scan_process_time_ms: u64,
 
@@ -71,13 +70,15 @@ pub struct Tracker {
 
     // Request info, used to print slow log.
     pub req_ctx: ReqContext,
+
+    _phantom: PhantomData<fn() -> E>,
 }
 
-impl Tracker {
+impl<E: Engine> Tracker<E> {
     /// Initialize the tracker. Normally it is called outside future pool's factory context,
     /// because the future pool might be full and we need to wait it. This kind of wait time
     /// has to be recorded.
-    pub fn new(req_ctx: ReqContext, slow_log_threshold: Duration) -> Tracker {
+    pub fn new(req_ctx: ReqContext, slow_log_threshold: Duration) -> Self {
         let now = Instant::now_coarse();
         Tracker {
             request_begin_at: now,
@@ -92,12 +93,11 @@ impl Tracker {
             total_suspend_time: Duration::default(),
             total_process_time: Duration::default(),
             total_storage_stats: Statistics::default(),
-            perf_context: RocksPerfContext::new(req_ctx.perf_level, PerfContextKind::GenericRead),
-            total_perf_stats: ReadPerfContext::default(),
             scan_process_time_ms: 0,
             slow_log_threshold,
             req_ctx,
             buckets: None,
+            _phantom: PhantomData,
         }
     }
 
@@ -140,7 +140,7 @@ impl Tracker {
             _ => unreachable!(),
         }
 
-        self.perf_context.start_observe();
+        self.with_perf_context(|perf_context| perf_context.start_observe());
         self.current_stage = TrackerState::ItemBegan(now);
     }
 
@@ -152,10 +152,9 @@ impl Tracker {
             if let Some(storage_stats) = some_storage_stats {
                 self.total_storage_stats.add(&storage_stats);
             }
-            // Record delta perf statistics
-            self.perf_context.report_metrics();
-            let perf_statistics = self.perf_context.stats.read;
-            self.total_perf_stats += perf_statistics;
+            self.with_perf_context(|perf_context| {
+                perf_context.report_metrics(&[get_tls_tracker()])
+            });
             self.current_stage = TrackerState::ItemFinished(now);
         } else {
             unreachable!()
@@ -212,15 +211,7 @@ impl Tracker {
         detail_v2.set_processed_versions(self.total_storage_stats.write.processed_keys as u64);
         detail_v2.set_processed_versions_size(self.total_storage_stats.processed_size as u64);
         detail_v2.set_total_versions(self.total_storage_stats.write.total_op_count() as u64);
-        detail_v2.set_rocksdb_delete_skipped_count(
-            self.total_perf_stats.internal_delete_skipped_count as u64,
-        );
-        detail_v2
-            .set_rocksdb_key_skipped_count(self.total_perf_stats.internal_key_skipped_count as u64);
-        detail_v2
-            .set_rocksdb_block_cache_hit_count(self.total_perf_stats.block_cache_hit_count as u64);
-        detail_v2.set_rocksdb_block_read_count(self.total_perf_stats.block_read_count as u64);
-        detail_v2.set_rocksdb_block_read_byte(self.total_perf_stats.block_read_byte as u64);
+        with_tls_tracker(|tracker| tracker.write_scan_detail(&mut detail_v2));
         exec_details_v2.set_scan_detail_v2(detail_v2);
 
         (exec_details, exec_details_v2)
@@ -252,33 +243,35 @@ impl Tracker {
                     .unwrap_or_default()
             });
 
-            info!(#"slow_log", "slow-query";
-                "region_id" => &self.req_ctx.context.get_region_id(),
-                "remote_host" => &self.req_ctx.peer,
-                "total_lifetime" => ?self.req_lifetime,
-                "wait_time" => ?self.wait_time,
-                "wait_time.schedule" => ?self.schedule_wait_time,
-                "wait_time.snapshot" => ?self.snapshot_wait_time,
-                "handler_build_time" => ?self.handler_build_time,
-                "total_process_time" => ?self.total_process_time,
-                "total_suspend_time" => ?self.total_suspend_time,
-                "txn_start_ts" => self.req_ctx.txn_start_ts,
-                "table_id" => some_table_id,
-                "tag" => self.req_ctx.tag.get_str(),
-                "scan.is_desc" => self.req_ctx.is_desc_scan,
-                "scan.processed" => total_storage_stats.write.processed_keys,
-                "scan.processed_size" => total_storage_stats.processed_size,
-                "scan.total" => total_storage_stats.write.total_op_count(),
-                "scan.ranges" => self.req_ctx.ranges.len(),
-                "scan.range.first" => ?first_range,
-                "perf_stats.block_cache_hit_count" => self.total_perf_stats.block_cache_hit_count,
-                "perf_stats.block_read_count" => self.total_perf_stats.block_read_count,
-                "perf_stats.block_read_byte" => self.total_perf_stats.block_read_byte,
-                "perf_stats.internal_key_skipped_count"
-                    => self.total_perf_stats.internal_key_skipped_count,
-                "perf_stats.internal_delete_skipped_count"
-                    => self.total_perf_stats.internal_delete_skipped_count,
-            );
+            with_tls_tracker(|tracker| {
+                info!(#"slow_log", "slow-query";
+                    "region_id" => &self.req_ctx.context.get_region_id(),
+                    "remote_host" => &self.req_ctx.peer,
+                    "total_lifetime" => ?self.req_lifetime,
+                    "wait_time" => ?self.wait_time,
+                    "wait_time.schedule" => ?self.schedule_wait_time,
+                    "wait_time.snapshot" => ?self.snapshot_wait_time,
+                    "handler_build_time" => ?self.handler_build_time,
+                    "total_process_time" => ?self.total_process_time,
+                    "total_suspend_time" => ?self.total_suspend_time,
+                    "txn_start_ts" => self.req_ctx.txn_start_ts,
+                    "table_id" => some_table_id,
+                    "tag" => self.req_ctx.tag.get_str(),
+                    "scan.is_desc" => self.req_ctx.is_desc_scan,
+                    "scan.processed" => total_storage_stats.write.processed_keys,
+                    "scan.processed_size" => total_storage_stats.processed_size,
+                    "scan.total" => total_storage_stats.write.total_op_count(),
+                    "scan.ranges" => self.req_ctx.ranges.len(),
+                    "scan.range.first" => ?first_range,
+                    "perf_stats.block_cache_hit_count" => tracker.metrics.block_cache_hit_count,
+                    "perf_stats.block_read_count" => tracker.metrics.block_read_count,
+                    "perf_stats.block_read_byte" => tracker.metrics.block_read_byte,
+                    "perf_stats.internal_key_skipped_count"
+                        => tracker.metrics.internal_key_skipped_count,
+                    "perf_stats.internal_delete_skipped_count"
+                        => tracker.metrics.deleted_key_skipped_count,
+                )
+            });
         }
 
         // req time
@@ -325,7 +318,6 @@ impl Tracker {
             .observe(total_storage_stats.write.processed_keys as f64);
 
         tls_collect_scan_details(self.req_ctx.tag, &total_storage_stats);
-        tls_collect_perf_stats(self.req_ctx.tag, &self.total_perf_stats);
 
         let peer = self.req_ctx.context.get_peer();
         let region_id = self.req_ctx.context.get_region_id();
@@ -353,9 +345,47 @@ impl Tracker {
         );
         self.current_stage = TrackerState::Tracked;
     }
+
+    fn with_perf_context<F, T>(&self, f: F) -> T
+    where
+        F: FnOnce(&mut Box<dyn PerfContext>) -> T,
+    {
+        thread_local! {
+            static SELECT: RefCell<Option<Box<dyn PerfContext>>> = RefCell::new(None);
+            static INDEX: RefCell<Option<Box<dyn PerfContext>>> = RefCell::new(None);
+            static ANALYZE_TABLE: RefCell<Option<Box<dyn PerfContext>>> = RefCell::new(None);
+            static ANALYZE_INDEX: RefCell<Option<Box<dyn PerfContext>>> = RefCell::new(None);
+            static ANALYZE_FULL_SAMPLING: RefCell<Option<Box<dyn PerfContext>>> = RefCell::new(None);
+            static CHECKSUM_TABLE: RefCell<Option<Box<dyn PerfContext>>> = RefCell::new(None);
+            static CHECKSUM_INDEX: RefCell<Option<Box<dyn PerfContext>>> = RefCell::new(None);
+            static TEST: RefCell<Option<Box<dyn PerfContext>>> = RefCell::new(None);
+        }
+        let tls_cell = match self.req_ctx.tag {
+            ReqTag::select => &SELECT,
+            ReqTag::index => &INDEX,
+            ReqTag::analyze_table => &ANALYZE_TABLE,
+            ReqTag::analyze_index => &ANALYZE_INDEX,
+            ReqTag::analyze_full_sampling => &ANALYZE_FULL_SAMPLING,
+            ReqTag::checksum_table => &CHECKSUM_TABLE,
+            ReqTag::checksum_index => &CHECKSUM_INDEX,
+            ReqTag::test => &TEST,
+        };
+        tls_cell.with(|c| {
+            let mut c = c.borrow_mut();
+            let perf_context = c.get_or_insert_with(|| unsafe {
+                with_tls_engine::<E, _, _>(|engine| {
+                    Box::new(engine.kv_engine().get_perf_context(
+                        PerfLevel::Uninitialized,
+                        PerfContextKind::Coprocessor(self.req_ctx.tag.get_str()),
+                    ))
+                })
+            });
+            f(perf_context)
+        })
+    }
 }
 
-impl Drop for Tracker {
+impl<E: Engine> Drop for Tracker<E> {
     /// `Tracker` may be dropped without even calling `on_begin_all_items`. For example, if
     /// get snapshot failed. So we fast-forward if some steps are missing.
     fn drop(&mut self) {

--- a/src/read_pool.rs
+++ b/src/read_pool.rs
@@ -15,6 +15,7 @@ use tikv_util::{
     sys::SysQuota,
     yatp_pool::{self, FuturePool, PoolTicker, YatpPoolBuilder},
 };
+use tracker::TrackedFuture;
 use yatp::{pool::Remote, queue::Extras, task::future::TaskCell};
 
 use self::metrics::*;
@@ -121,10 +122,10 @@ impl ReadPoolHandle {
                 };
                 let extras = Extras::new_multilevel(task_id, fixed_level);
                 let task_cell = TaskCell::new(
-                    async move {
+                    TrackedFuture::new(async move {
                         f.await;
                         running_tasks.dec();
-                    },
+                    }),
                     extras,
                 );
                 remote.spawn(task_cell);

--- a/src/server/service/batch.rs
+++ b/src/server/service/batch.rs
@@ -2,9 +2,9 @@
 
 // #[PerformanceCriticalPath]
 use api_version::KvFormat;
-use engine_rocks::ReadPerfContext;
 use kvproto::kvrpcpb::*;
 use tikv_util::{future::poll_future_notify, mpsc::batch::Sender, time::Instant};
+use tracker::{with_tls_tracker, RequestInfo, RequestType, Tracker, TrackerToken, GLOBAL_TRACKERS};
 
 use crate::{
     server::{
@@ -27,6 +27,7 @@ pub struct ReqBatcher {
     gets: Vec<GetRequest>,
     raw_gets: Vec<RawGetRequest>,
     get_ids: Vec<u64>,
+    get_trackers: Vec<TrackerToken>,
     raw_get_ids: Vec<u64>,
     begin_instant: Instant,
     batch_size: usize,
@@ -39,6 +40,7 @@ impl ReqBatcher {
             gets: vec![],
             raw_gets: vec![],
             get_ids: vec![],
+            get_trackers: vec![],
             raw_get_ids: vec![],
             begin_instant,
             batch_size: std::cmp::min(batch_size, MAX_BATCH_GET_REQUEST_COUNT),
@@ -54,8 +56,14 @@ impl ReqBatcher {
     }
 
     pub fn add_get_request(&mut self, req: GetRequest, id: u64) {
+        let tracker = GLOBAL_TRACKERS.insert(Tracker::new(RequestInfo::new(
+            req.get_context(),
+            RequestType::KvBatchGetCommand,
+            req.get_version(),
+        )));
         self.gets.push(req);
         self.get_ids.push(id);
+        self.get_trackers.push(tracker);
     }
 
     pub fn add_raw_get_request(&mut self, req: RawGetRequest, id: u64) {
@@ -71,7 +79,8 @@ impl ReqBatcher {
         if self.gets.len() >= self.batch_size {
             let gets = std::mem::take(&mut self.gets);
             let ids = std::mem::take(&mut self.get_ids);
-            future_batch_get_command(storage, ids, gets, tx.clone(), self.begin_instant);
+            let trackers = std::mem::take(&mut self.get_trackers);
+            future_batch_get_command(storage, ids, gets, trackers, tx.clone(), self.begin_instant);
         }
 
         if self.raw_gets.len() >= self.batch_size {
@@ -91,6 +100,7 @@ impl ReqBatcher {
                 storage,
                 self.get_ids,
                 self.gets,
+                self.get_trackers,
                 tx.clone(),
                 self.begin_instant,
             );
@@ -141,24 +151,17 @@ pub struct GetCommandResponseConsumer {
     tx: Sender<MeasuredSingleResponse>,
 }
 
-impl ResponseBatchConsumer<(Option<Vec<u8>>, Statistics, ReadPerfContext)>
-    for GetCommandResponseConsumer
-{
-    fn consume(
-        &self,
-        id: u64,
-        res: Result<(Option<Vec<u8>>, Statistics, ReadPerfContext)>,
-        begin: Instant,
-    ) {
+impl ResponseBatchConsumer<(Option<Vec<u8>>, Statistics)> for GetCommandResponseConsumer {
+    fn consume(&self, id: u64, res: Result<(Option<Vec<u8>>, Statistics)>, begin: Instant) {
         let mut resp = GetResponse::default();
         if let Some(err) = extract_region_error(&res) {
             resp.set_region_error(err);
         } else {
             match res {
-                Ok((val, statistics, perf_statistics)) => {
+                Ok((val, statistics)) => {
                     let scan_detail_v2 = resp.mut_exec_details_v2().mut_scan_detail_v2();
                     statistics.write_scan_detail(scan_detail_v2);
-                    perf_statistics.write_scan_detail(scan_detail_v2);
+                    with_tls_tracker(|tracker| tracker.write_scan_detail(scan_detail_v2));
                     match val {
                         Some(val) => resp.set_value(val),
                         None => resp.set_not_found(true),
@@ -208,6 +211,7 @@ fn future_batch_get_command<E: Engine, L: LockManager, F: KvFormat>(
     storage: &Storage<E, L, F>,
     requests: Vec<u64>,
     gets: Vec<GetRequest>,
+    trackers: Vec<TrackerToken>,
     tx: Sender<MeasuredSingleResponse>,
     begin_instant: tikv_util::time::Instant,
 ) {
@@ -218,12 +222,16 @@ fn future_batch_get_command<E: Engine, L: LockManager, F: KvFormat>(
     let res = storage.batch_get_command(
         gets,
         requests,
+        trackers.clone(),
         GetCommandResponseConsumer { tx: tx.clone() },
         begin_instant,
     );
     let f = async move {
         // This error can only cause by readpool busy.
         let res = res.await;
+        for tracker in trackers {
+            GLOBAL_TRACKERS.remove(tracker);
+        }
         if let Some(e) = extract_region_error(&res) {
             let mut resp = GetResponse::default();
             resp.set_region_error(e);

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -43,7 +43,7 @@ use tikv_util::{
     time::{duration_to_ms, duration_to_sec, Instant},
     worker::Scheduler,
 };
-use tracker::{set_tls_tracker, RequestInfo, RequestType, Tracker, GLOBAL_TRACKERS};
+use tracker::{set_tls_tracker_token, RequestInfo, RequestType, Tracker, GLOBAL_TRACKERS};
 use txn_types::{self, Key};
 
 use super::batch::{BatcherBuilder, ReqBatcher};
@@ -1333,7 +1333,7 @@ fn future_get<E: Engine, L: LockManager, F: KvFormat>(
         RequestType::KvGet,
         req.get_version(),
     )));
-    set_tls_tracker(tracker);
+    set_tls_tracker_token(tracker);
     let start = Instant::now();
     let v = storage.get(
         req.take_context(),
@@ -1383,7 +1383,7 @@ fn future_scan<E: Engine, L: LockManager, F: KvFormat>(
         RequestType::KvScan,
         req.get_version(),
     )));
-    set_tls_tracker(tracker);
+    set_tls_tracker_token(tracker);
     let end_key = Key::from_raw_maybe_unbounded(req.get_end_key());
 
     let v = storage.scan(
@@ -1431,7 +1431,7 @@ fn future_batch_get<E: Engine, L: LockManager, F: KvFormat>(
         RequestType::KvBatchGet,
         req.get_version(),
     )));
-    set_tls_tracker(tracker);
+    set_tls_tracker_token(tracker);
     let start = Instant::now();
     let keys = req.get_keys().iter().map(|x| Key::from_raw(x)).collect();
     let v = storage.batch_get(req.take_context(), keys, req.get_version().into());
@@ -1483,7 +1483,7 @@ fn future_scan_lock<E: Engine, L: LockManager, F: KvFormat>(
         RequestType::KvScanLock,
         req.get_max_version(),
     )));
-    set_tls_tracker(tracker);
+    set_tls_tracker_token(tracker);
     let start_key = Key::from_raw_maybe_unbounded(req.get_start_key());
     let end_key = Key::from_raw_maybe_unbounded(req.get_end_key());
 

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -43,6 +43,7 @@ use tikv_util::{
     time::{duration_to_ms, duration_to_sec, Instant},
     worker::Scheduler,
 };
+use tracker::{set_tls_tracker, RequestInfo, RequestType, Tracker, GLOBAL_TRACKERS};
 use txn_types::{self, Key};
 
 use super::batch::{BatcherBuilder, ReqBatcher};
@@ -1327,6 +1328,12 @@ fn future_get<E: Engine, L: LockManager, F: KvFormat>(
     storage: &Storage<E, L, F>,
     mut req: GetRequest,
 ) -> impl Future<Output = ServerResult<GetResponse>> {
+    let tracker = GLOBAL_TRACKERS.insert(Tracker::new(RequestInfo::new(
+        req.get_context(),
+        RequestType::KvGet,
+        req.get_version(),
+    )));
+    set_tls_tracker(tracker);
     let start = Instant::now();
     let v = storage.get(
         req.take_context(),
@@ -1346,7 +1353,9 @@ fn future_get<E: Engine, L: LockManager, F: KvFormat>(
                     let exec_detail_v2 = resp.mut_exec_details_v2();
                     let scan_detail_v2 = exec_detail_v2.mut_scan_detail_v2();
                     stats.stats.write_scan_detail(scan_detail_v2);
-                    stats.perf_stats.write_scan_detail(scan_detail_v2);
+                    GLOBAL_TRACKERS.with_tracker(tracker, |tracker| {
+                        tracker.write_scan_detail(scan_detail_v2);
+                    });
                     let time_detail = exec_detail_v2.mut_time_detail();
                     time_detail.set_kv_read_wall_time_ms(duration_ms as i64);
                     time_detail.set_wait_wall_time_ms(stats.latency_stats.wait_wall_time_ms as i64);
@@ -1360,6 +1369,7 @@ fn future_get<E: Engine, L: LockManager, F: KvFormat>(
                 Err(e) => resp.set_error(extract_key_error(&e)),
             }
         }
+        GLOBAL_TRACKERS.remove(tracker);
         Ok(resp)
     }
 }
@@ -1368,6 +1378,12 @@ fn future_scan<E: Engine, L: LockManager, F: KvFormat>(
     storage: &Storage<E, L, F>,
     mut req: ScanRequest,
 ) -> impl Future<Output = ServerResult<ScanResponse>> {
+    let tracker = GLOBAL_TRACKERS.insert(Tracker::new(RequestInfo::new(
+        req.get_context(),
+        RequestType::KvScan,
+        req.get_version(),
+    )));
+    set_tls_tracker(tracker);
     let end_key = Key::from_raw_maybe_unbounded(req.get_end_key());
 
     let v = storage.scan(
@@ -1401,6 +1417,7 @@ fn future_scan<E: Engine, L: LockManager, F: KvFormat>(
                 }
             }
         }
+        GLOBAL_TRACKERS.remove(tracker);
         Ok(resp)
     }
 }
@@ -1409,6 +1426,12 @@ fn future_batch_get<E: Engine, L: LockManager, F: KvFormat>(
     storage: &Storage<E, L, F>,
     mut req: BatchGetRequest,
 ) -> impl Future<Output = ServerResult<BatchGetResponse>> {
+    let tracker = GLOBAL_TRACKERS.insert(Tracker::new(RequestInfo::new(
+        req.get_context(),
+        RequestType::KvBatchGet,
+        req.get_version(),
+    )));
+    set_tls_tracker(tracker);
     let start = Instant::now();
     let keys = req.get_keys().iter().map(|x| Key::from_raw(x)).collect();
     let v = storage.batch_get(req.take_context(), keys, req.get_version().into());
@@ -1426,7 +1449,9 @@ fn future_batch_get<E: Engine, L: LockManager, F: KvFormat>(
                     let exec_detail_v2 = resp.mut_exec_details_v2();
                     let scan_detail_v2 = exec_detail_v2.mut_scan_detail_v2();
                     stats.stats.write_scan_detail(scan_detail_v2);
-                    stats.perf_stats.write_scan_detail(scan_detail_v2);
+                    GLOBAL_TRACKERS.with_tracker(tracker, |tracker| {
+                        tracker.write_scan_detail(scan_detail_v2);
+                    });
                     let time_detail = exec_detail_v2.mut_time_detail();
                     time_detail.set_kv_read_wall_time_ms(duration_ms as i64);
                     time_detail.set_wait_wall_time_ms(stats.latency_stats.wait_wall_time_ms as i64);
@@ -1444,6 +1469,7 @@ fn future_batch_get<E: Engine, L: LockManager, F: KvFormat>(
                 }
             }
         }
+        GLOBAL_TRACKERS.remove(tracker);
         Ok(resp)
     }
 }
@@ -1452,6 +1478,12 @@ fn future_scan_lock<E: Engine, L: LockManager, F: KvFormat>(
     storage: &Storage<E, L, F>,
     mut req: ScanLockRequest,
 ) -> impl Future<Output = ServerResult<ScanLockResponse>> {
+    let tracker = GLOBAL_TRACKERS.insert(Tracker::new(RequestInfo::new(
+        req.get_context(),
+        RequestType::KvScanLock,
+        req.get_max_version(),
+    )));
+    set_tls_tracker(tracker);
     let start_key = Key::from_raw_maybe_unbounded(req.get_start_key());
     let end_key = Key::from_raw_maybe_unbounded(req.get_end_key());
 
@@ -1474,6 +1506,7 @@ fn future_scan_lock<E: Engine, L: LockManager, F: KvFormat>(
                 Err(e) => resp.set_error(extract_key_error(&e)),
             }
         }
+        GLOBAL_TRACKERS.remove(tracker);
         Ok(resp)
     }
 }

--- a/src/storage/metrics.rs
+++ b/src/storage/metrics.rs
@@ -5,7 +5,6 @@
 use std::{cell::RefCell, mem, sync::Arc};
 
 use collections::HashMap;
-use engine_rocks::ReadPerfContext;
 use kvproto::{kvrpcpb::KeyRange, metapb, pdpb::QueryKind};
 use pd_client::BucketMeta;
 use prometheus::*;
@@ -20,7 +19,6 @@ use crate::{
 struct StorageLocalMetrics {
     local_scan_details: HashMap<CommandKind, Statistics>,
     local_read_stats: ReadStats,
-    local_perf_stats: HashMap<CommandKind, ReadPerfContext>,
 }
 
 thread_local! {
@@ -28,18 +26,8 @@ thread_local! {
         StorageLocalMetrics {
             local_scan_details: HashMap::default(),
             local_read_stats:ReadStats::default(),
-            local_perf_stats: HashMap::default(),
         }
     );
-}
-
-macro_rules! tls_flush_perf_stats {
-    ($tag:ident, $local_stats:ident, $stat:ident) => {
-        STORAGE_ROCKSDB_PERF_COUNTER_STATIC
-            .get($tag)
-            .$stat
-            .inc_by($local_stats.$stat as u64);
-    };
 }
 
 pub fn tls_flush<R: FlowStatsReporter>(reporter: &R) {
@@ -63,57 +51,6 @@ pub fn tls_flush<R: FlowStatsReporter>(reporter: &R) {
             let mut read_stats = ReadStats::default();
             mem::swap(&mut read_stats, &mut m.local_read_stats);
             reporter.report_read_stats(read_stats);
-        }
-
-        for (req_tag, perf_stats) in m.local_perf_stats.drain() {
-            tls_flush_perf_stats!(req_tag, perf_stats, user_key_comparison_count);
-            tls_flush_perf_stats!(req_tag, perf_stats, block_cache_hit_count);
-            tls_flush_perf_stats!(req_tag, perf_stats, block_read_count);
-            tls_flush_perf_stats!(req_tag, perf_stats, block_read_byte);
-            tls_flush_perf_stats!(req_tag, perf_stats, block_read_time);
-            tls_flush_perf_stats!(req_tag, perf_stats, block_cache_index_hit_count);
-            tls_flush_perf_stats!(req_tag, perf_stats, index_block_read_count);
-            tls_flush_perf_stats!(req_tag, perf_stats, block_cache_filter_hit_count);
-            tls_flush_perf_stats!(req_tag, perf_stats, filter_block_read_count);
-            tls_flush_perf_stats!(req_tag, perf_stats, block_checksum_time);
-            tls_flush_perf_stats!(req_tag, perf_stats, block_decompress_time);
-            tls_flush_perf_stats!(req_tag, perf_stats, get_read_bytes);
-            tls_flush_perf_stats!(req_tag, perf_stats, iter_read_bytes);
-            tls_flush_perf_stats!(req_tag, perf_stats, internal_key_skipped_count);
-            tls_flush_perf_stats!(req_tag, perf_stats, internal_delete_skipped_count);
-            tls_flush_perf_stats!(req_tag, perf_stats, internal_recent_skipped_count);
-            tls_flush_perf_stats!(req_tag, perf_stats, get_snapshot_time);
-            tls_flush_perf_stats!(req_tag, perf_stats, get_from_memtable_time);
-            tls_flush_perf_stats!(req_tag, perf_stats, get_from_memtable_count);
-            tls_flush_perf_stats!(req_tag, perf_stats, get_post_process_time);
-            tls_flush_perf_stats!(req_tag, perf_stats, get_from_output_files_time);
-            tls_flush_perf_stats!(req_tag, perf_stats, seek_on_memtable_time);
-            tls_flush_perf_stats!(req_tag, perf_stats, seek_on_memtable_count);
-            tls_flush_perf_stats!(req_tag, perf_stats, next_on_memtable_count);
-            tls_flush_perf_stats!(req_tag, perf_stats, prev_on_memtable_count);
-            tls_flush_perf_stats!(req_tag, perf_stats, seek_child_seek_time);
-            tls_flush_perf_stats!(req_tag, perf_stats, seek_child_seek_count);
-            tls_flush_perf_stats!(req_tag, perf_stats, seek_min_heap_time);
-            tls_flush_perf_stats!(req_tag, perf_stats, seek_max_heap_time);
-            tls_flush_perf_stats!(req_tag, perf_stats, seek_internal_seek_time);
-            tls_flush_perf_stats!(req_tag, perf_stats, db_mutex_lock_nanos);
-            tls_flush_perf_stats!(req_tag, perf_stats, db_condition_wait_nanos);
-            tls_flush_perf_stats!(req_tag, perf_stats, read_index_block_nanos);
-            tls_flush_perf_stats!(req_tag, perf_stats, read_filter_block_nanos);
-            tls_flush_perf_stats!(req_tag, perf_stats, new_table_block_iter_nanos);
-            tls_flush_perf_stats!(req_tag, perf_stats, new_table_iterator_nanos);
-            tls_flush_perf_stats!(req_tag, perf_stats, block_seek_nanos);
-            tls_flush_perf_stats!(req_tag, perf_stats, find_table_nanos);
-            tls_flush_perf_stats!(req_tag, perf_stats, bloom_memtable_hit_count);
-            tls_flush_perf_stats!(req_tag, perf_stats, bloom_memtable_miss_count);
-            tls_flush_perf_stats!(req_tag, perf_stats, bloom_sst_hit_count);
-            tls_flush_perf_stats!(req_tag, perf_stats, bloom_sst_miss_count);
-            tls_flush_perf_stats!(req_tag, perf_stats, get_cpu_nanos);
-            tls_flush_perf_stats!(req_tag, perf_stats, iter_next_cpu_nanos);
-            tls_flush_perf_stats!(req_tag, perf_stats, iter_prev_cpu_nanos);
-            tls_flush_perf_stats!(req_tag, perf_stats, iter_seek_cpu_nanos);
-            tls_flush_perf_stats!(req_tag, perf_stats, encrypt_data_nanos);
-            tls_flush_perf_stats!(req_tag, perf_stats, decrypt_data_nanos);
         }
     });
 }
@@ -175,15 +112,6 @@ pub fn tls_collect_query_batch(
         m.local_read_stats
             .add_query_num_batch(region_id, peer, key_ranges, kind);
     });
-}
-
-pub fn tls_collect_perf_stats(cmd: CommandKind, perf_stats: &ReadPerfContext) {
-    TLS_STORAGE_METRICS.with(|m| {
-        *(m.borrow_mut()
-            .local_perf_stats
-            .entry(cmd)
-            .or_insert_with(Default::default)) += *perf_stats;
-    })
 }
 
 make_auto_flush_static_metric! {
@@ -277,57 +205,6 @@ make_auto_flush_static_metric! {
         unlocked,
     }
 
-    pub label_enum PerfMetric {
-        user_key_comparison_count,
-        block_cache_hit_count,
-        block_read_count,
-        block_read_byte,
-        block_read_time,
-        block_cache_index_hit_count,
-        index_block_read_count,
-        block_cache_filter_hit_count,
-        filter_block_read_count,
-        block_checksum_time,
-        block_decompress_time,
-        get_read_bytes,
-        iter_read_bytes,
-        internal_key_skipped_count,
-        internal_delete_skipped_count,
-        internal_recent_skipped_count,
-        get_snapshot_time,
-        get_from_memtable_time,
-        get_from_memtable_count,
-        get_post_process_time,
-        get_from_output_files_time,
-        seek_on_memtable_time,
-        seek_on_memtable_count,
-        next_on_memtable_count,
-        prev_on_memtable_count,
-        seek_child_seek_time,
-        seek_child_seek_count,
-        seek_min_heap_time,
-        seek_max_heap_time,
-        seek_internal_seek_time,
-        db_mutex_lock_nanos,
-        db_condition_wait_nanos,
-        read_index_block_nanos,
-        read_filter_block_nanos,
-        new_table_block_iter_nanos,
-        new_table_iterator_nanos,
-        block_seek_nanos,
-        find_table_nanos,
-        bloom_memtable_hit_count,
-        bloom_memtable_miss_count,
-        bloom_sst_hit_count,
-        bloom_sst_miss_count,
-        get_cpu_nanos,
-        iter_next_cpu_nanos,
-        iter_prev_cpu_nanos,
-        iter_seek_cpu_nanos,
-        encrypt_data_nanos,
-        decrypt_data_nanos,
-    }
-
     pub label_enum InMemoryPessimisticLockingResult {
         success,
         full,
@@ -379,11 +256,6 @@ make_auto_flush_static_metric! {
     pub struct CheckMemLockHistogramVec: LocalHistogram {
         "type" => CommandKind,
         "result" => CheckMemLockResult,
-    }
-
-    pub struct PerfCounter: LocalIntCounter {
-        "req" => CommandKind,
-        "metric" => PerfMetric,
     }
 
     pub struct TxnCommandThrottleTimeCounterVec: LocalIntCounter {
@@ -619,16 +491,6 @@ lazy_static! {
     .unwrap();
     pub static ref CHECK_MEM_LOCK_DURATION_HISTOGRAM_VEC: CheckMemLockHistogramVec =
         auto_flush_from!(CHECK_MEM_LOCK_DURATION_HISTOGRAM, CheckMemLockHistogramVec);
-
-    pub static ref STORAGE_ROCKSDB_PERF_COUNTER: IntCounterVec = register_int_counter_vec!(
-        "tikv_storage_rocksdb_perf",
-        "Total number of RocksDB internal operations from PerfContext",
-        &["req", "metric"]
-    )
-    .unwrap();
-
-    pub static ref STORAGE_ROCKSDB_PERF_COUNTER_STATIC: PerfCounter =
-        auto_flush_from!(STORAGE_ROCKSDB_PERF_COUNTER, PerfCounter);
 
     pub static ref TXN_COMMAND_THROTTLE_TIME_COUNTER_VEC: IntCounterVec = register_int_counter_vec!(
         "tikv_txn_command_throttle_time_total",

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -52,6 +52,7 @@ mod types;
 
 use std::{
     borrow::Cow,
+    cell::RefCell,
     iter,
     marker::PhantomData,
     sync::{
@@ -62,8 +63,10 @@ use std::{
 
 use api_version::{ApiV1, ApiV2, KeyMode, KvFormat, RawValue};
 use concurrency_manager::ConcurrencyManager;
-use engine_rocks::{ReadPerfContext, ReadPerfInstant};
-use engine_traits::{raw_ttl::ttl_to_expire_ts, CfName, CF_DEFAULT, CF_LOCK, CF_WRITE, DATA_CFS};
+use engine_traits::{
+    raw_ttl::ttl_to_expire_ts, CfName, PerfContext, PerfContextExt, PerfContextKind, PerfLevel,
+    CF_DEFAULT, CF_LOCK, CF_WRITE, DATA_CFS,
+};
 use futures::prelude::*;
 use kvproto::{
     kvrpcpb::{
@@ -81,6 +84,7 @@ use tikv_util::{
     quota_limiter::QuotaLimiter,
     time::{duration_to_ms, Instant, ThreadReadId},
 };
+use tracker::{clear_tls_tracker, get_tls_tracker, set_tls_tracker, TrackedFuture, TrackerToken};
 use txn_types::{Key, KvPair, Lock, OldValues, TimeStamp, TsSet, Value};
 
 pub use self::{
@@ -269,6 +273,42 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
             resource_tag_factory,
             quota_limiter,
             _phantom: PhantomData,
+        })
+    }
+
+    fn with_perf_context<Fn, T>(cmd: CommandKind, f: Fn) -> T
+    where
+        Fn: FnOnce() -> T,
+    {
+        thread_local! {
+            static GET: RefCell<Option<Box<dyn PerfContext>>> = RefCell::new(None);
+            static BATCH_GET: RefCell<Option<Box<dyn PerfContext>>> = RefCell::new(None);
+            static BATCH_GET_COMMAND: RefCell<Option<Box<dyn PerfContext>>> = RefCell::new(None);
+            static SCAN: RefCell<Option<Box<dyn PerfContext>>> = RefCell::new(None);
+            static SCAN_LOCK: RefCell<Option<Box<dyn PerfContext>>> = RefCell::new(None);
+        }
+        let tls_cell = match cmd {
+            CommandKind::get => &GET,
+            CommandKind::batch_get => &BATCH_GET,
+            CommandKind::batch_get_command => &BATCH_GET_COMMAND,
+            CommandKind::scan => &SCAN,
+            CommandKind::scan_lock => &SCAN_LOCK,
+            _ => return f(),
+        };
+        tls_cell.with(|c| {
+            let mut c = c.borrow_mut();
+            let perf_context = c.get_or_insert_with(|| {
+                Self::with_tls_engine(|engine| {
+                    Box::new(engine.kv_engine().get_perf_context(
+                        PerfLevel::Uninitialized,
+                        PerfContextKind::Storage(cmd.get_str()),
+                    ))
+                })
+            });
+            perf_context.start_observe();
+            let res = f();
+            perf_context.report_metrics(&[get_tls_tracker()]);
+            res
         })
     }
 
@@ -597,14 +637,14 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                 )?;
                 let snapshot =
                     Self::with_tls_engine(|engine| Self::snapshot(engine, snap_ctx)).await?;
+
                 {
                     let begin_instant = Instant::now();
                     let stage_snap_recv_ts = begin_instant;
                     let buckets = snapshot.ext().get_buckets();
                     let mut statistics = Statistics::default();
-                    let (result, delta) = {
+                    let result = Self::with_perf_context(CMD, || {
                         let _guard = sample.observe_cpu();
-                        let perf_statistics = ReadPerfInstant::new();
                         let snap_store = SnapshotStore::new(
                             snapshot,
                             start_ts,
@@ -614,18 +654,15 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                             access_locks,
                             false,
                         );
-                        let result = snap_store
+                        snap_store
                         .get(&key, &mut statistics)
                         // map storage::txn::Error -> storage::Error
                         .map_err(Error::from)
                         .map(|r| {
                             KV_COMMAND_KEYREAD_HISTOGRAM_STATIC.get(CMD).observe(1_f64);
                             r
-                        });
-
-                        let delta = perf_statistics.delta();
-                        (result, delta)
-                    };
+                        })
+                    });
                     metrics::tls_collect_scan_details(CMD, &statistics);
                     metrics::tls_collect_read_flow(
                         ctx.get_region_id(),
@@ -634,7 +671,6 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                         &statistics,
                         buckets.as_ref(),
                     );
-                    metrics::tls_collect_perf_stats(CMD, &delta);
                     SCHED_PROCESSING_READ_HISTOGRAM_STATIC
                         .get(CMD)
                         .observe(begin_instant.saturating_elapsed_secs());
@@ -675,7 +711,6 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                         result?,
                         KvGetStatistics {
                             stats: statistics,
-                            perf_stats: delta,
                             latency_stats,
                         },
                     ))
@@ -694,12 +729,11 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
     /// Get values of a set of keys with separate context from a snapshot, return a list of `Result`s.
     ///
     /// Only writes that are committed before their respective `start_ts` are visible.
-    pub fn batch_get_command<
-        P: 'static + ResponseBatchConsumer<(Option<Vec<u8>>, Statistics, ReadPerfContext)>,
-    >(
+    pub fn batch_get_command<P: 'static + ResponseBatchConsumer<(Option<Vec<u8>>, Statistics)>>(
         &self,
         requests: Vec<GetRequest>,
         ids: Vec<u64>,
+        trackers: Vec<TrackerToken>,
         consumer: P,
         begin_instant: tikv_util::time::Instant,
     ) -> impl Future<Output = Result<()>> {
@@ -717,7 +751,8 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         let resource_tag = self
             .resource_tag_factory
             .new_tag_with_key_ranges(rand_ctx, vec![(rand_key.clone(), rand_key)]);
-
+        // Unset the TLS tracker because the future below does not belong to any specific request
+        clear_tls_tracker();
         let res = self.read_pool.spawn_handle(
             async move {
                 KV_COMMAND_COUNTER_VEC_STATIC.get(CMD).inc();
@@ -729,7 +764,8 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                 let mut statistics = Statistics::default();
                 let mut req_snaps = vec![];
 
-                for (mut req, id) in requests.into_iter().zip(ids) {
+                for ((mut req, id), tracker) in requests.into_iter().zip(ids).zip(trackers) {
+                    set_tls_tracker(tracker);
                     let mut ctx = req.take_context();
                     let region_id = ctx.get_region_id();
                     let peer = ctx.get_peer();
@@ -776,7 +812,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
 
                     let snap = Self::with_tls_engine(|engine| Self::snapshot(engine, snap_ctx));
                     req_snaps.push((
-                        snap,
+                        TrackedFuture::new(snap),
                         key,
                         start_ts,
                         isolation_level,
@@ -785,6 +821,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                         access_locks,
                         region_id,
                         id,
+                        tracker,
                     ));
                 }
                 Self::with_tls_engine(|engine| engine.release_snapshot());
@@ -799,9 +836,12 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                         access_locks,
                         region_id,
                         id,
+                        tracker,
                     ) = req_snap;
-                    match snap.await {
-                        Ok(snapshot) => {
+                    let snap_res = snap.await;
+                    set_tls_tracker(tracker);
+                    match snap_res {
+                        Ok(snapshot) => Self::with_perf_context(CMD, || {
                             let buckets = snapshot.ext().get_buckets();
                             match PointGetterBuilder::new(snapshot, start_ts)
                                 .fill_cache(fill_cache)
@@ -811,10 +851,8 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                                 .build()
                             {
                                 Ok(mut point_getter) => {
-                                    let perf_statistics = ReadPerfInstant::new();
                                     let v = point_getter.get(&key);
                                     let stat = point_getter.take_statistics();
-                                    let delta = perf_statistics.delta();
                                     metrics::tls_collect_read_flow(
                                         region_id,
                                         Some(key.as_encoded()),
@@ -822,12 +860,11 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                                         &stat,
                                         buckets.as_ref(),
                                     );
-                                    metrics::tls_collect_perf_stats(CMD, &delta);
                                     statistics.add(&stat);
                                     consumer.consume(
                                         id,
                                         v.map_err(|e| Error::from(txn::Error::from(e)))
-                                            .map(|v| (v, stat, delta)),
+                                            .map(|v| (v, stat)),
                                         begin_instant,
                                     );
                                 }
@@ -839,7 +876,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                                     );
                                 }
                             }
-                        }
+                        }),
                         Err(e) => {
                             consumer.consume(id, Err(e), begin_instant);
                         }
@@ -933,9 +970,8 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                     let stage_snap_recv_ts = begin_instant;
                     let mut statistics = Vec::with_capacity(keys.len());
                     let buckets = snapshot.ext().get_buckets();
-                    let (result, delta, stats) = {
+                    let (result, stats) = Self::with_perf_context(CMD, || {
                         let _guard = sample.observe_cpu();
-                        let perf_statistics = ReadPerfInstant::new();
                         let snap_store = SnapshotStore::new(
                             snapshot,
                             start_ts,
@@ -976,11 +1012,9 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                                     .observe(kv_pairs.len() as f64);
                                 kv_pairs
                             });
-                        let delta = perf_statistics.delta();
-                        (result, delta, stats)
-                    };
+                        (result, stats)
+                    });
                     metrics::tls_collect_scan_details(CMD, &stats);
-                    metrics::tls_collect_perf_stats(CMD, &delta);
                     SCHED_PROCESSING_READ_HISTOGRAM_STATIC
                         .get(CMD)
                         .observe(begin_instant.saturating_elapsed_secs());
@@ -1018,7 +1052,6 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                         result?,
                         KvGetStatistics {
                             stats,
-                            perf_stats: delta,
                             latency_stats,
                         },
                     ))
@@ -1154,9 +1187,8 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
 
                 let snapshot =
                     Self::with_tls_engine(|engine| Self::snapshot(engine, snap_ctx)).await?;
-                {
+                Self::with_perf_context(CMD, || {
                     let begin_instant = Instant::now();
-                    let perf_statistics = ReadPerfInstant::new();
                     let buckets = snapshot.ext().get_buckets();
 
                     let snap_store = SnapshotStore::new(
@@ -1174,7 +1206,6 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                     let res = scanner.scan(limit, sample_step);
 
                     let statistics = scanner.take_statistics();
-                    let delta = perf_statistics.delta();
                     metrics::tls_collect_scan_details(CMD, &statistics);
                     metrics::tls_collect_read_flow(
                         ctx.get_region_id(),
@@ -1183,7 +1214,6 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                         &statistics,
                         buckets.as_ref(),
                     );
-                    metrics::tls_collect_perf_stats(CMD, &delta);
                     SCHED_PROCESSING_READ_HISTOGRAM_STATIC
                         .get(CMD)
                         .observe(begin_instant.saturating_elapsed_secs());
@@ -1200,7 +1230,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                             .map(|x| x.map_err(Error::from))
                             .collect()
                     })
-                }
+                })
             }
             .in_resource_metering_tag(resource_tag),
             priority,
@@ -1304,10 +1334,9 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
 
                 let snapshot =
                     Self::with_tls_engine(|engine| Self::snapshot(engine, snap_ctx)).await?;
-                {
+                Self::with_perf_context(CMD, || {
                     let begin_instant = Instant::now();
                     let mut statistics = Statistics::default();
-                    let perf_statistics = ReadPerfInstant::new();
                     let buckets = snapshot.ext().get_buckets();
                     let mut reader = MvccReader::new(
                         snapshot,
@@ -1331,7 +1360,6 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                         locks.push(lock_info);
                     }
 
-                    let delta = perf_statistics.delta();
                     metrics::tls_collect_scan_details(CMD, &statistics);
                     metrics::tls_collect_read_flow(
                         ctx.get_region_id(),
@@ -1340,7 +1368,6 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                         &statistics,
                         buckets.as_ref(),
                     );
-                    metrics::tls_collect_perf_stats(CMD, &delta);
                     SCHED_PROCESSING_READ_HISTOGRAM_STATIC
                         .get(CMD)
                         .observe(begin_instant.saturating_elapsed_secs());
@@ -1349,7 +1376,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                         .observe(command_duration.saturating_elapsed_secs());
 
                     Ok(locks)
-                }
+                })
             }
             .in_resource_metering_tag(resource_tag),
             priority,
@@ -3029,11 +3056,11 @@ pub mod test_util {
         }
     }
 
-    impl ResponseBatchConsumer<(Option<Vec<u8>>, Statistics, ReadPerfContext)> for GetConsumer {
+    impl ResponseBatchConsumer<(Option<Vec<u8>>, Statistics)> for GetConsumer {
         fn consume(
             &self,
             id: u64,
-            res: Result<(Option<Vec<u8>>, Statistics, ReadPerfContext)>,
+            res: Result<(Option<Vec<u8>>, Statistics)>,
             _: tikv_util::time::Instant,
         ) {
             self.data.lock().unwrap().push(GetResult {
@@ -3060,7 +3087,6 @@ pub mod test_util {
 #[derive(Debug, Default, Clone)]
 pub struct KvGetStatistics {
     pub stats: Statistics,
-    pub perf_stats: ReadPerfContext,
     pub latency_stats: StageLatencyStats,
 }
 
@@ -3085,6 +3111,7 @@ mod tests {
     use futures::executor::block_on;
     use kvproto::kvrpcpb::{AssertionLevel, CommandPri, Op};
     use tikv_util::config::ReadableSize;
+    use tracker::INVALID_TRACKER_TOKEN;
     use txn_types::{Mutation, PessimisticLock, WriteType};
 
     use super::{
@@ -3277,6 +3304,7 @@ mod tests {
         block_on(storage.batch_get_command(
             vec![create_get_request(b"c", 1), create_get_request(b"d", 1)],
             vec![1, 2],
+            vec![INVALID_TRACKER_TOKEN; 2],
             consumer.clone(),
             Instant::now(),
         ))
@@ -3964,6 +3992,7 @@ mod tests {
         block_on(storage.batch_get_command(
             vec![create_get_request(b"c", 2), create_get_request(b"d", 2)],
             vec![1, 2],
+            vec![INVALID_TRACKER_TOKEN; 2],
             consumer.clone(),
             Instant::now(),
         ))
@@ -4004,6 +4033,7 @@ mod tests {
                 create_get_request(b"b", 5),
             ],
             vec![1, 2, 3, 4],
+            vec![INVALID_TRACKER_TOKEN; 4],
             consumer.clone(),
             Instant::now(),
         ))
@@ -7736,6 +7766,7 @@ mod tests {
             block_on(storage.batch_get_command(
                 vec![req1.clone(), req2],
                 vec![1, 2],
+                vec![INVALID_TRACKER_TOKEN; 2],
                 consumer.clone(),
                 Instant::now(),
             ))
@@ -7809,8 +7840,14 @@ mod tests {
         req.set_key(k1.clone());
         req.set_version(110);
         let consumer = GetConsumer::new();
-        block_on(storage.batch_get_command(vec![req], vec![1], consumer.clone(), Instant::now()))
-            .unwrap();
+        block_on(storage.batch_get_command(
+            vec![req],
+            vec![1],
+            vec![INVALID_TRACKER_TOKEN],
+            consumer.clone(),
+            Instant::now(),
+        ))
+        .unwrap();
         let res = consumer.take_data();
         assert_eq!(res.len(), 1);
         assert_eq!(res[0].as_ref().unwrap(), &Some(v1.clone()));


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #12362

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
This commit is a large refactoring that moves collecting engine
PerfContext from storage and coprocessor to engine_rocks and
the tracker.

Now, the storage and coprocessor are mostly decoupled with a
specific engine (engine_rocks).

And it introduces a general trakcer mechanism to collect the metrics
of a request during its whole lifetime. It will help us collect more
performance critical data of a single request more easily.
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM

**I'm still doing benchmarks with this PR. The `HashMap` in the `Tracker` provides flexibility but may bring overhead. If it has much performance impact, we can change it to a pre-defined struct.**

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
