### PR TITLE
log-backup: added quota for initial scanning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,6 +500,7 @@ dependencies = [
  "url",
  "uuid",
  "walkdir",
+ "yatp",
 ]
 
 [[package]]

--- a/components/backup-stream/Cargo.toml
+++ b/components/backup-stream/Cargo.toml
@@ -26,6 +26,7 @@ etcd-client = { version = "0.7", features = ["pub-response-field"] }
 external_storage = { path = "../external_storage", default-features = false }
 external_storage_export = { path = "../external_storage/export", default-features = false }
 fail = "0.5"
+yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
 
 file_system = { path = "../file_system" }
 futures = "0.3"

--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -30,11 +30,11 @@ use tokio_stream::StreamExt;
 use txn_types::TimeStamp;
 use yatp::task::callback::Handle as YatpHandle;
 
-use super::metrics::{HANDLE_EVENT_DURATION_HISTOGRAM, HANDLE_KV_HISTOGRAM};
+use super::metrics::HANDLE_EVENT_DURATION_HISTOGRAM;
 use crate::{
     annotate,
     errors::{Error, Result},
-    event_loader::InitialDataLoader,
+    event_loader::{InitialDataLoader, PendingMemoryQuota},
     metadata::{
         store::{EtcdStore, MetaStore},
         MetadataClient, MetadataEvent, StreamTask,

--- a/components/backup-stream/src/event_loader.rs
+++ b/components/backup-stream/src/event_loader.rs
@@ -1,6 +1,6 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{marker::PhantomData, time::Duration};
+use std::{marker::PhantomData, sync::Arc, time::Duration};
 
 use engine_traits::{KvEngine, CF_DEFAULT, CF_WRITE};
 use futures::executor::block_on;
@@ -17,6 +17,7 @@ use tikv::storage::{
     Snapshot, Statistics,
 };
 use tikv_util::{box_err, time::Instant, warn, worker::Scheduler};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use txn_types::{Key, Lock, TimeStamp};
 
 use crate::{
@@ -32,6 +33,34 @@ use crate::{
 };
 
 const MAX_GET_SNAPSHOT_RETRY: usize = 3;
+
+#[derive(Clone)]
+pub struct PendingMemoryQuota(Arc<Semaphore>);
+
+impl std::fmt::Debug for PendingMemoryQuota {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PendingMemoryQuota")
+            .field("remain", &self.0.available_permits())
+            .field("total", &self.0)
+            .finish()
+    }
+}
+
+pub struct PendingMemory(OwnedSemaphorePermit);
+
+impl PendingMemoryQuota {
+    pub fn new(quota: usize) -> Self {
+        Self(Arc::new(Semaphore::new(quota)))
+    }
+
+    pub fn pending(&self, size: usize) -> PendingMemory {
+        PendingMemory(
+            tokio::runtime::Handle::current()
+                .block_on(self.0.clone().acquire_many_owned(size as _))
+                .expect("BUG: the semaphore is closed unexpectlly."),
+        )
+    }
+}
 
 /// EventLoader transforms data from the snapshot into ApplyEvent.
 pub struct EventLoader<S: Snapshot> {
@@ -132,6 +161,8 @@ pub struct InitialDataLoader<E, R, RT> {
     sink: Router,
     tracing: SubscriptionTracer,
     scheduler: Scheduler<Task>,
+    quota: PendingMemoryQuota,
+    handle: tokio::runtime::Handle,
 
     _engine: PhantomData<E>,
 }
@@ -148,6 +179,8 @@ where
         sink: Router,
         tracing: SubscriptionTracer,
         sched: Scheduler<Task>,
+        quota: PendingMemoryQuota,
+        handle: tokio::runtime::Handle,
     ) -> Self {
         Self {
             router,
@@ -156,6 +189,8 @@ where
             tracing,
             scheduler: sched,
             _engine: PhantomData,
+            quota,
+            handle,
         }
     }
 
@@ -287,14 +322,19 @@ where
                 return Ok(stats.stat);
             }
             stats.add_statistics(&stat);
+            let region_id = region.get_id();
             let sink = self.sink.clone();
             let event_size = events.size();
             let sched = self.scheduler.clone();
+            let permit = self.quota.pending(event_size);
+            debug!("sending events to router"; "size" => %event_size, "region" => %region_id);
             metrics::INCREMENTAL_SCAN_SIZE.observe(event_size as f64);
             metrics::HEAP_MEMORY.add(event_size as _);
             join_handles.push(tokio::spawn(async move {
                 utils::handle_on_event_result(&sched, sink.on_events(events).await);
                 metrics::HEAP_MEMORY.sub(event_size as _);
+                debug!("apply event done"; "size" => %event_size, "region" => %region_id);
+                drop(permit);
             }));
         }
     }
@@ -305,6 +345,7 @@ where
         start_ts: TimeStamp,
         snap: impl Snapshot,
     ) -> Result<Statistics> {
+        let _guard = self.handle.enter();
         // It is ok to sink more data than needed. So scan to +inf TS for convenance.
         let event_loader = EventLoader::load_from(snap, start_ts, TimeStamp::max(), region)?;
         let tr = self.tracing.clone();
@@ -317,7 +358,7 @@ where
         // TODO: use an `WaitGroup` with asynchronous support.
         tokio::spawn(async move {
             for h in join_handles {
-                if let Err(err) = tokio::join!(h).0 {
+                if let Err(err) = h.await {
                     warn!("failed to join task."; "err" => %err);
                 }
             }
@@ -330,7 +371,6 @@ where
                     region_id
                 ));
             }
-            debug!("phase one done."; "region_id" => %region_id);
         });
         stats
     }

--- a/components/backup-stream/src/router.rs
+++ b/components/backup-stream/src/router.rs
@@ -50,7 +50,7 @@ use crate::{
     endpoint::Task,
     errors::{ContextualResultExt, Error},
     metadata::StreamTask,
-    metrics::SKIP_KV_COUNTER,
+    metrics::{HANDLE_KV_HISTOGRAM, SKIP_KV_COUNTER},
     subscription_track::TwoPhaseResolver,
     try_send,
     utils::{self, SegmentMap, Slot, SlotMap, StopWatch},

--- a/components/backup-stream/src/router.rs
+++ b/components/backup-stream/src/router.rs
@@ -431,6 +431,7 @@ impl RouterInner {
 
     pub async fn on_events(&self, kv: ApplyEvents) -> Vec<(String, Result<()>)> {
         use futures::FutureExt;
+        HANDLE_KV_HISTOGRAM.observe(kv.len() as _);
         let partitioned_events = kv.partition_by_range(&self.ranges.rl());
         let tasks = partitioned_events
             .into_iter()

--- a/src/config.rs
+++ b/src/config.rs
@@ -2324,9 +2324,12 @@ impl Default for BackupConfig {
 pub struct BackupStreamConfig {
     pub num_threads: usize,
     #[online_config(skip)]
+    pub io_threads: usize,
+    #[online_config(skip)]
     pub enable: bool,
     pub temp_path: String,
     pub temp_file_size_limit_per_task: ReadableSize,
+    pub initial_scan_pending_memory_quota: ReadableSize,
 }
 
 impl BackupStreamConfig {
@@ -2341,13 +2344,17 @@ impl BackupStreamConfig {
 impl Default for BackupStreamConfig {
     fn default() -> Self {
         let cpu_num = SysQuota::cpu_cores_quota();
+        let total_mem = SysQuota::memory_limit_in_bytes();
+        let quota_size = (total_mem as f64 * 0.1).min(ReadableSize::mb(512).0 as _);
         Self {
             // use at most 50% of vCPU by default
             num_threads: (cpu_num * 0.5).clamp(1.0, 8.0) as usize,
+            io_threads: 2,
             enable: false,
             // TODO: may be use raft store directory
             temp_path: String::new(),
             temp_file_size_limit_per_task: ReadableSize::mb(128),
+            initial_scan_pending_memory_quota: ReadableSize(quota_size as _),
         }
     }
 }
@@ -2650,8 +2657,8 @@ pub struct TiKvConfig {
     pub backup: BackupConfig,
 
     #[online_config(submodule)]
-    // The term "log-backup" and "backup-stream" points to the same object.
-    // But the product name is `log-backup`.
+    // The term "log backup" and "backup stream" are identity.
+    // The "log backup" should be the only product name exposed to the user.
     #[serde(rename = "log-backup")]
     pub backup_stream: BackupStreamConfig,
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #12468 

What's Changed:

Added a `MemoryQuota` for preventing TiKV from OOM when the initial scanning emits events too fast.

This PR also fixed a bug that caused the router and the event loader deadlock if the blocking thread pool of tokio get full. 

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Added quota for initial scanning of log backup.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
I have tested by:
1. Load a TPC-C data set with 200 warehouses and start log backup task.
2. Run the TPC-C workload. 
3. At the same time, pause and wait for 900s then restart the task.

The original version would trigger an OOM, and this PR has a peak memory usage with ~500M.

Side effects

- Performance regression
    - The speed of initial scanning may slow down, but acceptable.

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
