### PR TITLE
raftstore: fix split buckets bug

### DIFF
--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -5176,7 +5176,7 @@ where
             meta.version = gen_bucket_version(self.fsm.peer.term(), current_version);
             region_buckets.meta = Arc::new(meta);
         } else {
-            info!(
+            debug!(
                 "refresh_region_buckets re-generates buckets";
                 "region_id" => self.fsm.region_id(),
             );
@@ -5212,7 +5212,7 @@ where
                 self.fsm.peer.region_buckets.as_ref().unwrap().meta.clone(),
             ));
         }
-        info!(
+        debug!(
             "finished on_refresh_region_buckets";
             "region_id" => self.fsm.region_id(),
             "buckets count" => buckets_count,

--- a/components/raftstore/src/store/worker/split_check.rs
+++ b/components/raftstore/src/store/worker/split_check.rs
@@ -430,6 +430,11 @@ where
                 || bucket_range_list.is_empty() && !skip_check_bucket
             {
                 buckets.push(bucket);
+                 // in case some range's data in bucket_range_list is deleted
+                if buckets.len() < bucket_range_list.len() {
+                    let mut deleted_buckets = vec![Bucket::default(); bucket_range_list.len() - buckets.len()];
+                    buckets.append(&mut deleted_buckets);
+                }
                 if !bucket_range_list.is_empty() {
                     assert_eq!(buckets.len(), bucket_range_list.len());
                 }

--- a/components/raftstore/src/store/worker/split_check.rs
+++ b/components/raftstore/src/store/worker/split_check.rs
@@ -430,9 +430,10 @@ where
                 || bucket_range_list.is_empty() && !skip_check_bucket
             {
                 buckets.push(bucket);
-                 // in case some range's data in bucket_range_list is deleted
+                // in case some range's data in bucket_range_list is deleted
                 if buckets.len() < bucket_range_list.len() {
-                    let mut deleted_buckets = vec![Bucket::default(); bucket_range_list.len() - buckets.len()];
+                    let mut deleted_buckets =
+                        vec![Bucket::default(); bucket_range_list.len() - buckets.len()];
                     buckets.append(&mut deleted_buckets);
                 }
                 if !bucket_range_list.is_empty() {


### PR DESCRIPTION
Signed-off-by: qi.xu <tonxuqi@outlook.com>

### What is changed and how it works?
Issue Number: Close #12467

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```
It's possible that when the split bucket task runs, the data of end ranges in bucket_range_list have been deleted.
As a result, the buckets generated by scan may miss some bucket ranges. The fix is to add the empty Bucket instances.

Also change the log level to debug for some chatty logs.
```

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->
```release-note
None
```