### PR TITLE
kvengine: fix LZ4 compression

### DIFF
--- a/components/kvengine/src/table/sstable/builder.rs
+++ b/components/kvengine/src/table/sstable/builder.rs
@@ -417,8 +417,11 @@ impl BlockBuilder {
         for i in 0..num_entries {
             self.block.build_entry(buf, i, common_prefix_len);
         }
-        if self.compression_tp != NO_COMPRESSION {
-            self.compress();
+        match self.compression_tp {
+            NO_COMPRESSION => (),
+            LZ4_COMPRESSION => self.compress_lz4(),
+            ZSTD_COMPRESSION => self.compress_zstd(),
+            _ => panic!("unexpected compression type {}", self.compression_tp),
         }
         let mut checksum = 0u32;
         if checksum_tp == CRC32_IEEE {
@@ -487,36 +490,38 @@ impl BlockBuilder {
         }
     }
 
-    fn compress(&mut self) {
+    fn compress_lz4(&mut self) {
+        unsafe {
+            self.buf.put_u32_le(self.compression_buf.len() as u32);
+            let buf_len = self.buf.len();
+            let compress_bound = lz4::liblz4::LZ4_compressBound(self.compression_buf.len() as i32);
+            self.buf.reserve(compress_bound as usize);
+            let src = &self.compression_buf;
+            let mut dst = &mut self.buf[buf_len..];
+            let size = lz4::liblz4::LZ4_compress_default(
+                src.as_ptr() as *const libc::c_char,
+                dst.as_mut_ptr() as *mut libc::c_char,
+                src.len() as i32,
+                compress_bound as i32,
+            ) as usize;
+            self.buf.set_len(buf_len + size);
+        }
+    }
+
+    fn compress_zstd(&mut self) {
         unsafe {
             let buf_len = self.buf.len();
-            let compress_bound = if self.compression_tp == LZ4_COMPRESSION {
-                lz4::liblz4::LZ4_compressBound(self.compression_buf.len() as i32) as usize + 4
-            } else {
-                zstd_sys::ZSTD_compressBound(self.compression_buf.len())
-            };
+            let compress_bound = zstd_sys::ZSTD_compressBound(self.compression_buf.len());
             self.buf.reserve(compress_bound);
-            // self.buf.set_len(buf_len + compress_bound);
             let src = &self.compression_buf;
-            let dst = &mut self.buf[buf_len..];
-            let size = if self.compression_tp == LZ4_COMPRESSION {
-                lz4::liblz4::LZ4_compress_default(
-                    src.as_ptr() as *const libc::c_char,
-                    dst.as_mut_ptr() as *mut libc::c_char,
-                    src.len() as i32,
-                    compress_bound as i32,
-                ) as usize
-            } else if self.compression_tp == ZSTD_COMPRESSION {
-                zstd_sys::ZSTD_compress(
-                    dst.as_mut_ptr() as *mut libc::c_void,
-                    compress_bound,
-                    src.as_ptr() as *const libc::c_void,
-                    src.len(),
-                    zstd_sys::ZSTD_defaultCLevel(),
-                )
-            } else {
-                panic!("unexpected compression type {}", self.compression_tp);
-            };
+            let mut dst = &mut self.buf[buf_len..];
+            let size = zstd_sys::ZSTD_compress(
+                dst.as_mut_ptr() as *mut libc::c_void,
+                compress_bound,
+                src.as_ptr() as *const libc::c_void,
+                src.len(),
+                zstd_sys::ZSTD_defaultCLevel(),
+            );
             self.buf.set_len(buf_len + size);
         }
     }

--- a/components/kvengine/src/table/sstable/iterator.rs
+++ b/components/kvengine/src/table/sstable/iterator.rs
@@ -221,13 +221,10 @@ impl TableIterator {
 
     fn set_block(&mut self, b_pos: i32) -> bool {
         self.b_pos = b_pos;
-        let block = match self.t.load_block(self.b_pos as usize, &mut self.block_buf) {
-            Ok(b) => b,
-            Err(e) => {
-                self.err = Some(e);
-                return false;
-            }
-        };
+        let block = self
+            .t
+            .load_block(self.b_pos as usize, &mut self.block_buf)
+            .unwrap();
         self.bi.set_block(block);
         true
     }

--- a/components/kvengine/src/table/sstable/sstable.rs
+++ b/components/kvengine/src/table/sstable/sstable.rs
@@ -547,7 +547,7 @@ pub(crate) fn test_key(prefix: &str, i: usize) -> String {
 mod tests {
     use std::{iter::Iterator as StdIterator, sync::atomic::Ordering};
 
-    use bytes::BytesMut;
+    use bytes::{BufMut, BytesMut};
     use rand::Rng;
 
     use super::*;


### PR DESCRIPTION
Signed-off-by: Evan Zhou <coocood@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
After merge and lz4 update, the compress_to_buffer method is removed, so the length is not included in the compressed data, cause decompression failure, so we manually prepend the length to the buffer.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
  - make sure LZ4 is used in config.
  - load sysbench 1m records and check the table count.

