### PR TITLE
tweaking log backup

### DIFF
--- a/components/backup-stream/src/metrics.rs
+++ b/components/backup-stream/src/metrics.rs
@@ -4,6 +4,12 @@ use lazy_static::lazy_static;
 use prometheus::*;
 
 lazy_static! {
+    pub static ref INITIAL_SCAN_REASON: IntCounterVec = register_int_counter_vec!(
+        "tikv_log_backup_initial_scan_reason",
+        "The reason of doing initial scanning",
+        &["reason"]
+    )
+    .unwrap();
     pub static ref HANDLE_EVENT_DURATION_HISTOGRAM: HistogramVec = register_histogram_vec!(
         "tikv_stream_event_handle_duration_sec",
         "The duration of handling an cmd batch.",

--- a/components/backup-stream/src/router.rs
+++ b/components/backup-stream/src/router.rs
@@ -238,11 +238,17 @@ pub struct Router(Arc<RouterInner>);
 
 impl Router {
     /// Create a new router with the temporary folder.
-    pub fn new(prefix: PathBuf, scheduler: Scheduler<Task>, temp_file_size_limit: u64) -> Self {
+    pub fn new(
+        prefix: PathBuf,
+        scheduler: Scheduler<Task>,
+        temp_file_size_limit: u64,
+        max_flush_interval: Duration,
+    ) -> Self {
         Self(Arc::new(RouterInner::new(
             prefix,
             scheduler,
             temp_file_size_limit,
+            max_flush_interval,
         )))
     }
 }
@@ -278,6 +284,8 @@ pub struct RouterInner {
     scheduler: Scheduler<Task>,
     /// The size limit of temporary file per task.
     temp_file_size_limit: u64,
+    /// The max duration the local data can be pending.
+    max_flush_interval: Duration,
 }
 
 impl std::fmt::Debug for RouterInner {
@@ -291,13 +299,19 @@ impl std::fmt::Debug for RouterInner {
 }
 
 impl RouterInner {
-    pub fn new(prefix: PathBuf, scheduler: Scheduler<Task>, temp_file_size_limit: u64) -> Self {
+    pub fn new(
+        prefix: PathBuf,
+        scheduler: Scheduler<Task>,
+        temp_file_size_limit: u64,
+        max_flush_interval: Duration,
+    ) -> Self {
         RouterInner {
             ranges: SyncRwLock::new(SegmentMap::default()),
             tasks: Mutex::new(HashMap::default()),
             prefix,
             scheduler,
             temp_file_size_limit,
+            max_flush_interval,
         }
     }
 
@@ -350,7 +364,7 @@ impl RouterInner {
 
         // register task info
         let prefix_path = self.prefix.join(&task_name);
-        let stream_task = StreamTaskInfo::new(prefix_path, task).await?;
+        let stream_task = StreamTaskInfo::new(prefix_path, task, self.max_flush_interval).await?;
         self.tasks
             .lock()
             .await
@@ -648,7 +662,11 @@ impl std::fmt::Debug for StreamTaskInfo {
 
 impl StreamTaskInfo {
     /// Create a new temporary file set at the `temp_dir`.
-    pub async fn new(temp_dir: PathBuf, task: StreamTask) -> Result<Self> {
+    pub async fn new(
+        temp_dir: PathBuf,
+        task: StreamTask,
+        flush_interval: Duration,
+    ) -> Result<Self> {
         tokio::fs::create_dir_all(&temp_dir).await?;
         let storage = Arc::from(create_storage(
             task.info.get_storage(),
@@ -662,9 +680,7 @@ impl StreamTaskInfo {
             files: SlotMap::default(),
             flushing_files: RwLock::default(),
             last_flush_time: AtomicPtr::new(Box::into_raw(Box::new(Instant::now()))),
-            // TODO make this config set by config or task?
-            // Keep `0.2 * FLUSH_STORAGE_INTERVAL` for doing flushing.
-            flush_interval: Duration::from_secs((FLUSH_STORAGE_INTERVAL as f64 * 0.8).round() as _),
+            flush_interval,
             total_size: AtomicUsize::new(0),
             flushing: AtomicBool::new(false),
             flush_fail_count: AtomicUsize::new(0),
@@ -765,7 +781,10 @@ impl StreamTaskInfo {
     }
 
     pub fn should_flush(&self) -> bool {
-        self.get_last_flush_time().saturating_elapsed() >= self.flush_interval
+        // When it doesn't flush since 0.8x of auto-flush interval, we get ready to start flushing.
+        // So that we will get a buffer for the cost of actual flushing.
+        self.get_last_flush_time().saturating_elapsed_secs()
+            >= self.flush_interval.as_secs_f64() * 0.8
     }
 
     pub fn is_flushing(&self) -> bool {
@@ -1223,7 +1242,7 @@ mod tests {
     #[test]
     fn test_register() {
         let (tx, _) = dummy_scheduler();
-        let router = RouterInner::new(PathBuf::new(), tx, 1024);
+        let router = RouterInner::new(PathBuf::new(), tx, 1024, Duration::from_secs(300));
         // -----t1.start-----t1.end-----t2.start-----t2.end------
         // --|------------|----------|------------|-----------|--
         // case1        case2      case3        case4       case5
@@ -1309,7 +1328,7 @@ mod tests {
         let tmp = std::env::temp_dir().join(format!("{}", uuid::Uuid::new_v4()));
         tokio::fs::create_dir_all(&tmp).await?;
         let (tx, rx) = dummy_scheduler();
-        let router = RouterInner::new(tmp.clone(), tx, 32);
+        let router = RouterInner::new(tmp.clone(), tx, 32, Duration::from_secs(300));
         let (stream_task, storage_path) = task("dummy".to_owned()).await?;
         must_register_table(&router, stream_task, 1).await;
 
@@ -1465,7 +1484,12 @@ mod tests {
         test_util::init_log_for_test();
         let (tx, _rx) = dummy_scheduler();
         let tmp = std::env::temp_dir().join(format!("{}", uuid::Uuid::new_v4()));
-        let router = Arc::new(RouterInner::new(tmp.clone(), tx, 1));
+        let router = Arc::new(RouterInner::new(
+            tmp.clone(),
+            tx,
+            1,
+            Duration::from_secs(300),
+        ));
         let (task, _path) = task("error_prone".to_owned()).await?;
         must_register_table(router.as_ref(), task, 1).await;
         router
@@ -1492,7 +1516,7 @@ mod tests {
         test_util::init_log_for_test();
         let (tx, _rx) = dummy_scheduler();
         let tmp = std::env::temp_dir().join(format!("{}", uuid::Uuid::new_v4()));
-        let router = RouterInner::new(tmp.clone(), tx, 32);
+        let router = RouterInner::new(tmp.clone(), tx, 32, Duration::from_secs(300));
         let mut stream_task = StreamBackupTaskInfo::default();
         stream_task.set_name("nothing".to_string());
         stream_task.set_storage(create_noop_storage_backend());
@@ -1519,7 +1543,12 @@ mod tests {
         test_util::init_log_for_test();
         let (tx, rx) = dummy_scheduler();
         let tmp = std::env::temp_dir().join(format!("{}", uuid::Uuid::new_v4()));
-        let router = Arc::new(RouterInner::new(tmp.clone(), tx, 1));
+        let router = Arc::new(RouterInner::new(
+            tmp.clone(),
+            tx,
+            1,
+            Duration::from_secs(300),
+        ));
         let (task, _path) = task("flush_failure".to_owned()).await?;
         must_register_table(router.as_ref(), task, 1).await;
         router

--- a/components/backup-stream/src/subscription_track.rs
+++ b/components/backup-stream/src/subscription_track.rs
@@ -58,6 +58,17 @@ impl RegionSubscription {
 }
 
 impl SubscriptionTracer {
+    /// get the current safe point: data before this ts have already be flushed and be able to be GCed.
+    pub fn safepoint(&self) -> TimeStamp {
+        // use the current resolved_ts is safe because it is only advanced when flushing.
+        self.0
+            .iter()
+            .map(|r| r.resolver.resolved_ts())
+            .min()
+            // NOTE: Maybe use the current timestamp?
+            .unwrap_or(TimeStamp::zero())
+    }
+
     /// clear the current `SubscriptionTracer`.
     pub fn clear(&self) {
         self.0.retain(|_, v| {

--- a/components/error_code/src/backup_stream.rs
+++ b/components/error_code/src/backup_stream.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
 define_error_codes! {
-    "KV:StreamBackup:",
+    "KV:LogBackup:",
 
     ETCD => ("ETCD",
         "Error during requesting the meta store(etcd)",

--- a/src/config.rs
+++ b/src/config.rs
@@ -2322,6 +2322,7 @@ impl Default for BackupConfig {
 #[serde(default)]
 #[serde(rename_all = "kebab-case")]
 pub struct BackupStreamConfig {
+    pub max_flush_interval: ReadableDuration,
     pub num_threads: usize,
     #[online_config(skip)]
     pub enable: bool,
@@ -2342,6 +2343,7 @@ impl Default for BackupStreamConfig {
     fn default() -> Self {
         let cpu_num = SysQuota::cpu_cores_quota();
         Self {
+            max_flush_interval: ReadableDuration::minutes(5),
             // use at most 50% of vCPU by default
             num_threads: (cpu_num * 0.5).clamp(1.0, 8.0) as usize,
             enable: false,


### PR DESCRIPTION
Signed-off-by: Yu Juncen <yujuncen@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #12744

What's Changed:
1. added a config for controlling the flush interval
2. enabel a 24 hours service safepoint when meeting fatal error.
3. rename StreamBackup error code to LogBackup

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
tweaking log backup.
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
