### PR TITLE
log-backup: make test more stable, and fix panics

### DIFF
--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -600,11 +600,7 @@ where
         // so simply clear all info would be fine.
         self.observer.ranges.wl().clear();
         self.subs.clear();
-        let info = self
-            .pool
-            .block_on(async move { router.unregister_task(task).await });
-
-        info
+        self.pool.block_on(router.unregister_task(task))
     }
 
     /// try advance the resolved ts by the pd tso.

--- a/components/backup-stream/src/errors.rs
+++ b/components/backup-stream/src/errors.rs
@@ -6,7 +6,7 @@ use std::{
 
 use error_code::ErrorCodeExt;
 use etcd_client::Error as EtcdError;
-use kvproto::errorpb::Error as StoreError;
+use kvproto::{errorpb::Error as StoreError, metapb::*};
 use pd_client::Error as PdError;
 use protobuf::ProtobufError;
 use raftstore::Error as RaftStoreError;
@@ -24,6 +24,8 @@ pub enum Error {
     Protobuf(#[from] ProtobufError),
     #[error("No such task {task_name:?}")]
     NoSuchTask { task_name: String },
+    #[error("Observe have already canceled for region {0} (version = {1:?})")]
+    ObserveCanceled(u64, RegionEpoch),
     #[error("Malformed metadata {0}")]
     MalformedMetadata(String),
     #[error("I/O Error: {0}")]
@@ -63,6 +65,7 @@ impl ErrorCodeExt for Error {
             Error::Contextual { inner_error, .. } => inner_error.error_code(),
             Error::Other(_) => OTHER,
             Error::RaftStore(_) => RAFTSTORE,
+            Error::ObserveCanceled(..) => OBSERVE_CANCELED,
         }
     }
 }

--- a/components/backup-stream/src/event_loader.rs
+++ b/components/backup-stream/src/event_loader.rs
@@ -251,22 +251,42 @@ where
 
     pub fn with_resolver<T: 'static>(
         &self,
-        region_id: u64,
+        region: &Region,
         f: impl FnOnce(&mut TwoPhaseResolver) -> Result<T>,
     ) -> Result<T> {
-        Self::with_resolver_by(&self.tracing, region_id, f)
+        Self::with_resolver_by(&self.tracing, region, f)
     }
 
     pub fn with_resolver_by<T: 'static>(
         tracing: &SubscriptionTracer,
-        region_id: u64,
+        region: &Region,
         f: impl FnOnce(&mut TwoPhaseResolver) -> Result<T>,
     ) -> Result<T> {
-        f(tracing
+        let region_id = region.get_id();
+        let mut v = tracing
             .get_subscription_of(region_id)
-            .ok_or_else(|| Error::Other(box_err!("observer for region {} canceled", region_id)))?
-            .value_mut()
-            .resolver())
+            .ok_or_else(|| Error::Other(box_err!("observer for region {} canceled", region_id)))
+            .and_then(|v| {
+                raftstore::store::util::compare_region_epoch(
+                    region.get_region_epoch(),
+                    &v.value().meta,
+                    // No need for checking conf version because conf change won't cancel the observation.
+                    false,
+                    true,
+                    false,
+                )?;
+                Ok(v)
+            })
+            .map_err(|err| Error::Contextual {
+                // Both when we cannot find the region in the track and
+                // the epoch has changed means that we should cancel the current turn of initial scanning.
+                inner_error: Box::new(Error::ObserveCanceled(
+                    region_id,
+                    region.get_region_epoch().clone(),
+                )),
+                context: format!("{}", err),
+            })?;
+        f(v.value_mut().resolver())
     }
 
     fn scan_and_async_send(
@@ -279,9 +299,8 @@ where
         let start = Instant::now();
         loop {
             let mut events = ApplyEvents::with_capacity(1024, region.id);
-            let stat = self.with_resolver(region.get_id(), |r| {
-                event_loader.scan_batch(1024, &mut events, r)
-            })?;
+            let stat =
+                self.with_resolver(&region, |r| event_loader.scan_batch(1024, &mut events, r))?;
             if events.len() == 0 {
                 metrics::INITIAL_SCAN_DURATION.observe(start.saturating_elapsed_secs());
                 return Ok(stats.stat);
@@ -315,16 +334,18 @@ where
 
         // we should mark phase one as finished whether scan successed.
         // TODO: use an `WaitGroup` with asynchronous support.
+        let r = region.clone();
         tokio::spawn(async move {
             for h in join_handles {
                 if let Err(err) = tokio::join!(h).0 {
                     warn!("failed to join task."; "err" => %err);
                 }
             }
-            if let Err(err) = Self::with_resolver_by(&tr, region_id, |r| {
+            let result = Self::with_resolver_by(&tr, &r, |r| {
                 r.phase_one_done();
                 Ok(())
-            }) {
+            });
+            if let Err(err) = result {
                 err.report(format_args!(
                     "failed to finish phase 1 for region {:?}",
                     region_id

--- a/components/backup-stream/src/event_loader.rs
+++ b/components/backup-stream/src/event_loader.rs
@@ -335,7 +335,7 @@ where
         loop {
             let mut events = ApplyEvents::with_capacity(1024, region.id);
             let stat =
-                self.with_resolver(&region, |r| event_loader.scan_batch(1024, &mut events, r))?;
+                self.with_resolver(region, |r| event_loader.scan_batch(1024, &mut events, r))?;
             if events.len() == 0 {
                 metrics::INITIAL_SCAN_DURATION.observe(start.saturating_elapsed_secs());
                 return Ok(stats.stat);

--- a/components/backup-stream/src/lib.rs
+++ b/components/backup-stream/src/lib.rs
@@ -10,7 +10,7 @@ mod event_loader;
 pub mod metadata;
 mod metrics;
 pub mod observer;
-mod router;
+pub mod router;
 mod subscription_track;
 mod utils;
 

--- a/components/backup-stream/tests/mod.rs
+++ b/components/backup-stream/tests/mod.rs
@@ -5,7 +5,7 @@
 use std::{
     collections::{HashMap, HashSet},
     path::Path,
-    sync::{mpsc::channel, Arc},
+    sync::Arc,
     time::Duration,
 };
 
@@ -434,7 +434,6 @@ impl Suite {
         self.endpoints
             .iter()
             .map({
-                let cond = cond.clone();
                 move |(_, wkr)| {
                     let (tx, rx) = std::sync::mpsc::channel();
                     wkr.scheduler()

--- a/components/error_code/src/backup_stream.rs
+++ b/components/error_code/src/backup_stream.rs
@@ -14,6 +14,11 @@ define_error_codes! {
         "A task not found.",
         "Please check the spell of your task name."
     ),
+    OBSERVE_CANCELED => (
+        "ObserveCancel",
+        "When doing initial scanning, the observe of that region has been canceled",
+        "No need to handle this, this is retryable."
+    ),
     MALFORMED_META => ("MalformedMetadata",
         "Malformed metadata found.",
         "The metadata format is unexpected, please check the compatibility between TiKV / BR."


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #12507 

What's Changed:
- Remove the panic when meet stale `ModifyObserve`: it is possible when pausing the task.
- Make `EventLoader` check the `version` of region and abort if the version don't match.
- Added new message `Sync` for making test more stable.

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
make test more stable, fix panics, give up initial scanning when epoch not match
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
- No code

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
