### PR TITLE
tests: make several txn tests less flaky

### DIFF
--- a/tests/failpoints/cases/test_transaction.rs
+++ b/tests/failpoints/cases/test_transaction.rs
@@ -74,7 +74,6 @@ fn test_atomic_getting_max_ts_and_storing_memory_lock() {
     let (fp_tx, fp_rx) = sync_channel(1);
     // sleep a while between getting max ts and store the lock in memory
     fail::cfg_callback("before-set-lock-in-memory", move || {
-        thread::sleep(Duration::from_millis(200));
         fp_tx.send(()).unwrap();
         thread::sleep(Duration::from_millis(200));
     })

--- a/tests/failpoints/cases/test_transaction.rs
+++ b/tests/failpoints/cases/test_transaction.rs
@@ -1,7 +1,10 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::{
-    sync::{mpsc::channel, Arc},
+    sync::{
+        mpsc::{channel, sync_channel},
+        Arc,
+    },
     thread,
     time::Duration,
 };
@@ -68,8 +71,14 @@ fn test_atomic_getting_max_ts_and_storing_memory_lock() {
         .unwrap();
 
     let (prewrite_tx, prewrite_rx) = channel();
+    let (fp_tx, fp_rx) = sync_channel(1);
     // sleep a while between getting max ts and store the lock in memory
-    fail::cfg("before-set-lock-in-memory", "sleep(500)").unwrap();
+    fail::cfg_callback("before-set-lock-in-memory", move || {
+        thread::sleep(Duration::from_millis(200));
+        fp_tx.send(()).unwrap();
+        thread::sleep(Duration::from_millis(200));
+    })
+    .unwrap();
     storage
         .sched_txn_command(
             commands::Prewrite::new(
@@ -91,8 +100,7 @@ fn test_atomic_getting_max_ts_and_storing_memory_lock() {
             }),
         )
         .unwrap();
-    // sleep a while so prewrite gets max ts before get is triggered
-    thread::sleep(Duration::from_millis(200));
+    fp_rx.recv().unwrap();
     match block_on(storage.get(Context::default(), Key::from_raw(b"k"), 100.into())) {
         // In this case, min_commit_ts is smaller than the start ts, but the lock is visible
         // to the get.
@@ -434,7 +442,11 @@ fn test_pessimistic_lock_check_epoch() {
     ctx.set_peer(leader.clone());
     ctx.set_region_epoch(epoch);
 
-    fail::cfg("acquire_pessimistic_lock", "pause").unwrap();
+    let (fp_tx, fp_rx) = sync_channel(0);
+    fail::cfg_callback("acquire_pessimistic_lock", move || {
+        fp_tx.send(()).unwrap();
+    })
+    .unwrap();
 
     let env = Arc::new(Environment::new(1));
     let channel =
@@ -462,7 +474,7 @@ fn test_pessimistic_lock_check_epoch() {
     // Transfer leader out and back, so the term should have changed.
     cluster.must_transfer_leader(1, new_peer(2, 2));
     cluster.must_transfer_leader(1, new_peer(1, 1));
-    fail::remove("acquire_pessimistic_lock");
+    fp_rx.recv().unwrap();
 
     let resp = lock_resp.join().unwrap();
     // Region leader changes, so we should get a StaleCommand error.


### PR DESCRIPTION

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #12520

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
This commit intends to make test_atomic_getting_max_ts_and_storing_memory_lock
and test_pessimistic_lock_check_epoch less flaky.

Instead of using pause and sleep to control order, this commit uses channels
and fail::callback_cfg to control the order more deterministically.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
