### PR TITLE
add RawKV GC metric versions count

### DIFF
--- a/src/server/gc_worker/rawkv_compaction_filter.rs
+++ b/src/server/gc_worker/rawkv_compaction_filter.rs
@@ -196,6 +196,8 @@ impl RawCompactionFilter {
             if commit_ts.into_inner() >= self.safe_point {
                 return Ok(CompactionFilterDecision::Keep);
             }
+
+            self.versions += 1;
             let raw_value = ApiV2::decode_raw_value(value)?;
             // If it's the latest version, and it's deleted or expired, it needs to be sent to GCWorker to be processed asynchronously.
             if !raw_value.is_valid(self.current_ts) {
@@ -212,6 +214,7 @@ impl RawCompactionFilter {
                 return Ok(CompactionFilterDecision::Keep);
             }
 
+            self.versions += 1;
             self.filtered += 1;
             // If it's ts < safepoint, and it's not the latest version, it's need to be removed.
             Ok(CompactionFilterDecision::Remove)


### PR DESCRIPTION
Signed-off-by: ystaticy <y_static_y@sina.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref https://github.com/tikv/tikv/issues/12535

What's Changed: 

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```release-note 
Fix RawKV Compaction filter report total is aways 0
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

Test steps as follows:
1. To set api version in tikv.toml as follows:
enable-ttl = true
api-version = 2
2. start tikv cluster.
3. write data until trigger compaction.
4. Observation log output ```total``` value is not always 0.


