### PR TITLE
raftstore: misc changes for dynamic regions

### DIFF
--- a/components/raftstore/src/coprocessor/config.rs
+++ b/components/raftstore/src/coprocessor/config.rs
@@ -71,7 +71,7 @@ pub const SPLIT_KEYS: u64 = 960000;
 /// Default batch split limit.
 pub const BATCH_SPLIT_LIMIT: u64 = 10;
 
-pub const DEFAULT_BUCKET_SIZE: ReadableSize = ReadableSize::mb(128);
+pub const DEFAULT_BUCKET_SIZE: ReadableSize = ReadableSize::mb(96);
 
 pub const DEFAULT_REGION_BUCKET_MERGE_SIZE_RATIO: f64 = 0.33;
 

--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -629,7 +629,7 @@ impl Config {
         }
 
         #[cfg(not(any(test, feature = "testexport")))]
-        if self.max_snapshot_file_raw_size.as_mb() < 100 {
+        if self.max_snapshot_file_raw_size.0 != 0 && self.max_snapshot_file_raw_size.as_mb() < 100 {
             return Err(box_err!(
                 "max_snapshot_file_raw_size should be no less than 100MB."
             ));

--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -1476,7 +1476,7 @@
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
           "decimals": 1,
-          "description": "The number of Regions on each TiKV instance",
+          "description": "The number of Regions and Buckets on each TiKV instance",
           "editable": true,
           "error": false,
           "fieldConfig": {
@@ -1531,6 +1531,14 @@
               "intervalFactor": 2,
               "legendFormat": "{{instance}}",
               "refId": "A",
+              "step": 10
+            },
+            {
+              "expr": "sum(tikv_raftstore_region_count{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", type=\"buckets\"}) by (instance)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}} - buckets",
+              "refId": "B",
               "step": 10
             }
           ],

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -238,7 +238,7 @@ impl Default for Config {
             end_point_perf_level: PerfLevel::Uninitialized,
             snap_max_write_bytes_per_sec: ReadableSize(DEFAULT_SNAP_MAX_BYTES_PER_SEC),
             snap_max_total_size: ReadableSize(0),
-            max_snapshot_file_raw_size: ReadableSize::mb(128),
+            max_snapshot_file_raw_size: ReadableSize::mb(0),
             stats_concurrency: 1,
             // 75 means a gRPC thread is under heavy load if its total CPU usage
             // is greater than 75%.

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -238,7 +238,7 @@ impl Default for Config {
             end_point_perf_level: PerfLevel::Uninitialized,
             snap_max_write_bytes_per_sec: ReadableSize(DEFAULT_SNAP_MAX_BYTES_PER_SEC),
             snap_max_total_size: ReadableSize(0),
-            max_snapshot_file_raw_size: ReadableSize(0),
+            max_snapshot_file_raw_size: ReadableSize::mb(128),
             stats_concurrency: 1,
             // 75 means a gRPC thread is under heavy load if its total CPU usage
             // is greater than 75%.

--- a/tests/integrations/raftstore/test_split_region.rs
+++ b/tests/integrations/raftstore/test_split_region.rs
@@ -652,8 +652,8 @@ fn test_node_split_region_after_reboot_with_config_change() {
             break;
         }
         try_cnt += 1;
-        if try_cnt == 50 {
-            panic!("expect get_split_count > 0 after 1s");
+        if try_cnt == 200 {
+            panic!("expect get_split_count > 0 after 4s");
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: qi.xu <tonxuqi@outlook.com>

### What is changed and how it works?
Issue Number: Ref #11966

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
1) update max_snapshot_file_raw_size's validate rule to allow 0
2) update region_bucket_size's default value to 96MB from 128MB
3) add buckets metrics to grafana tikv_details dashboard
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual Test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
