### PR TITLE
file_system: update fs2 fork to use posix_fallocate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1867,7 +1867,7 @@ dependencies = [
 [[package]]
 name = "fs2"
 version = "0.4.3"
-source = "git+https://github.com/tabokie/fs2-rs?branch=tikv#9e17642f4ddec02a8d7733d8c5977cf211de6552"
+source = "git+https://github.com/tabokie/fs2-rs?branch=tikv#cd503764a19a99d74c1ab424dd13d6bcd093fcae"
 dependencies = [
  "libc 0.2.125",
  "winapi 0.3.9",


### PR DESCRIPTION
Signed-off-by: tabokie <xy.tao@outlook.com>

### What is changed and how it works?

Issue Number: Close #12543

What's Changed:

`fallocate` is not as portable as `posix_fallocate`. The change is at https://github.com/tabokie/fs2-rs/commit/cd503764a19a99d74c1ab424dd13d6bcd093fcae.

```commit-message
Use `posix_fallocate` for space reservation.
```

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Use `posix_fallocate` for space reservation.
```
