### PR TITLE
[backup apiv2] fix file range in backup response

### DIFF
--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -1707,6 +1707,111 @@ pub mod tests {
     }
 
     #[test]
+    fn test_handle_backup_raw_non_empty_range() {
+        let cur_api_ver = ApiVersion::V1;
+        let dst_api_ver = ApiVersion::V2;
+        let limiter = Arc::new(IORateLimiter::new_for_test());
+        let stats = limiter.statistics().unwrap();
+        let (tmp, endpoint) = new_endpoint_with_limiter(Some(limiter), cur_api_ver, true);
+        let engine = endpoint.engine.clone();
+
+        let start_key_idx: u64 = 1;
+        let end_key_idx: u64 = 100;
+        endpoint.region_info.set_regions(vec![(
+            generate_test_raw_key(start_key_idx, cur_api_ver).into_bytes(),
+            generate_test_raw_key(end_key_idx, cur_api_ver).into_bytes(),
+            1,
+        )]);
+        let ctx = Context::default();
+        let mut i = start_key_idx;
+        let digest = crc64fast::Digest::new();
+        let mut checksum: u64 = 0;
+        while i < end_key_idx {
+            let key_str = generate_test_raw_key(i, cur_api_ver);
+            let value_str = generate_test_raw_value(i, cur_api_ver);
+            let key = generate_engine_test_key(key_str.clone(), None, cur_api_ver);
+            let value = generate_engine_test_value(value_str.clone(), cur_api_ver);
+            let dst_user_key = convert_test_backup_user_key(key_str, cur_api_ver, dst_api_ver);
+            let dst_value = value_str.as_bytes();
+            checksum = checksum_crc64_xor(
+                checksum,
+                digest.clone(),
+                dst_user_key.as_encoded(),
+                dst_value,
+            );
+            let ret = engine.put(&ctx, key, value);
+            assert!(ret.is_ok());
+            i += 1;
+        }
+        // flush to disk so that read requests can be traced by TiKV limiter.
+        engine
+            .get_rocksdb()
+            .flush_cf(engine_traits::CF_DEFAULT, true /*sync*/)
+            .unwrap();
+
+        // TODO: check key number for each snapshot.
+        stats.reset();
+        let mut req = BackupRequest::default();
+        let backup_start = {
+            let key_str = generate_test_raw_key(start_key_idx, cur_api_ver);
+            generate_engine_test_key(key_str, None, cur_api_ver).into_encoded()
+        };
+        let backup_end = {
+            let key_str = generate_test_raw_key(end_key_idx, cur_api_ver);
+            generate_engine_test_key(key_str, None, cur_api_ver).into_encoded()
+        };
+        let file_start = {
+            let key_str = generate_test_raw_key(start_key_idx, dst_api_ver);
+            generate_engine_test_key(key_str, None, dst_api_ver).into_encoded()
+        };
+        let file_end = {
+            let key_str = generate_test_raw_key(end_key_idx, dst_api_ver);
+            generate_engine_test_key(key_str, None, dst_api_ver).into_encoded()
+        };
+        req.set_start_key(backup_start.clone());
+        req.set_end_key(backup_end.clone());
+        req.set_is_raw_kv(true);
+        req.set_dst_api_version(dst_api_ver);
+        let (tx, rx) = unbounded();
+
+        let limiter = Limiter::new(10.0 * 1024.0 * 1024.0 /* 10 MB/s */);
+        let tmp1 = make_unique_dir(tmp.path());
+        req.set_storage_backend(make_local_backend(&tmp1));
+        req.set_rate_limit(10 * 1024 * 1024);
+        let (mut task, _) = Task::new(req, tx).unwrap();
+        task.request.limiter = limiter;
+        endpoint.handle_backup_task(task);
+        let (resp, rx) = block_on(rx.into_future());
+        let resp = resp.unwrap();
+        assert!(!resp.has_error(), "{:?}", resp);
+        assert_eq!(resp.get_start_key(), backup_start);
+        assert_eq!(resp.get_end_key(), backup_end);
+        let file_len = 1;
+        let files = resp.get_files();
+        info!("{:?}", files);
+        assert_eq!(files.len(), file_len /* default cf*/, "{:?}", resp);
+        assert_eq!(files[0].total_kvs, end_key_idx - start_key_idx);
+        assert_eq!(files[0].crc64xor, checksum);
+        assert_eq!(files[0].get_start_key(), file_start);
+        assert_eq!(files[0].get_end_key(), file_end);
+        let kv_backup_size = {
+            let raw_key_str = generate_test_raw_key(1, cur_api_ver);
+            let raw_value_str = generate_test_raw_value(1, cur_api_ver);
+            let backup_key = convert_test_backup_user_key(raw_key_str, cur_api_ver, dst_api_ver);
+            let backup_value = raw_value_str.as_bytes();
+            backup_key.len() + backup_value.len()
+        } as u64;
+        assert_eq!(
+            files[0].total_bytes,
+            (end_key_idx - start_key_idx) * kv_backup_size
+        );
+        let (none, _rx) = block_on(rx.into_future());
+        assert!(none.is_none(), "{:?}", none);
+        assert_eq!(stats.fetch(IOType::Export, IOOp::Write), 0);
+        assert_ne!(stats.fetch(IOType::Export, IOOp::Read), 0);
+    }
+
+    #[test]
     fn test_scan_error() {
         let (tmp, endpoint) = new_endpoint();
         let engine = endpoint.engine.clone();


### PR DESCRIPTION
Signed-off-by: haojinming <jinming.hao@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #12548 

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
If backup rawkv from apiv1 to rawv2, the range in BackupResponse files field should be encoded with apiv2 format.
1. If the range is empty, the file range should be [r, s)
2. If the range is not empty, the range shoudl be mce padding of [start_key, end_key).

### Related changes


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)

Side effects

- No side effect

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
rawkv apiv2 backup bug fix
```
