### PR TITLE
Rawkv gctask metrics

### DIFF
--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -736,7 +736,6 @@ where
 
         for (cf, details) in stats.details_enum().iter() {
             for (tag, count) in details.iter() {
-                println!("cf:{},tag:{},count:{}", cf, tag, count);
                 GC_KEYS_COUNTER_STATIC
                     .get(*cf)
                     .get(*tag)
@@ -1900,7 +1899,6 @@ mod tests {
         runner
             .raw_gc_keys(to_gc_keys, TimeStamp::new(120), Some((1, ri_provider)))
             .unwrap();
-        runner.update_statistics_metrics();
 
         assert_eq!(7, runner.stats.data.next);
         assert_eq!(2, runner.stats.data.seek);

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -736,6 +736,7 @@ where
 
         for (cf, details) in stats.details_enum().iter() {
             for (tag, count) in details.iter() {
+                println!("cf:{},tag:{},count:{}", cf, tag, count);
                 GC_KEYS_COUNTER_STATIC
                     .get(*cf)
                     .get(*tag)
@@ -1899,6 +1900,7 @@ mod tests {
         runner
             .raw_gc_keys(to_gc_keys, TimeStamp::new(120), Some((1, ri_provider)))
             .unwrap();
+        runner.update_statistics_metrics();
 
         assert_eq!(7, runner.stats.data.next);
         assert_eq!(2, runner.stats.data.seek);


### PR DESCRIPTION
Signed-off-by: ystaticy <y_static_y@sina.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref https://github.com/tikv/tikv/issues/12557

What's Changed: 

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```release-note 
RawKV GCTask return handled and wasted count
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test 
If the data is the latest version is deleted or expired and to Compcation,it will trigger ```GcTask::RawGcKeys```
We can get ```tikv_gc_compaction_filter_mvcc_deletion_handled``` value is not ```0``` in grafana



