### PR TITLE
causal_ts: fix issue #12498

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -726,6 +726,7 @@ dependencies = [
  "engine_rocks",
  "engine_traits",
  "error_code",
+ "fail",
  "futures 0.3.15",
  "kvproto",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,6 +722,7 @@ name = "causal_ts"
 version = "0.0.1"
 dependencies = [
  "api_version",
+ "collections",
  "engine_rocks",
  "engine_traits",
  "error_code",

--- a/components/causal_ts/Cargo.toml
+++ b/components/causal_ts/Cargo.toml
@@ -10,6 +10,7 @@ collections = { path = "../collections" }
 engine_rocks = { path = "../engine_rocks", default-features = false }
 engine_traits = { path = "../engine_traits", default-features = false }
 error_code = { path = "../error_code", default-features = false }
+fail = "0.5"
 futures = { version = "0.3" }
 kvproto = { git = "https://github.com/pingcap/kvproto.git" }
 lazy_static = "1.3"

--- a/components/causal_ts/Cargo.toml
+++ b/components/causal_ts/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [dependencies]
 api_version = { path = "../api_version", default-features = false }
+collections = { path = "../collections" }
 engine_rocks = { path = "../engine_rocks", default-features = false }
 engine_traits = { path = "../engine_traits", default-features = false }
 error_code = { path = "../error_code", default-features = false }

--- a/components/causal_ts/src/observer.rs
+++ b/components/causal_ts/src/observer.rs
@@ -54,18 +54,9 @@ impl<Ts: CausalTsProvider> Clone for CausalObserver<Ts> {
 const CAUSAL_OBSERVER_PRIORITY: u32 = 0;
 
 impl<Ts: CausalTsProvider> CausalObserver<Ts> {
-    #[cfg(not(test))]
-    fn region_is_leader(&self, region_id: u64) -> bool {
-        let region_map = self.region_map.read();
-        region_map
-            .get(&region_id)
-            .unwrap()
-            .is_leader
-            .load(Ordering::Relaxed)
-    }
-
-    #[cfg(test)]
-    // `region_id` not in `region_map` should happen only in test.
+    // Note that `region_id` not in `region_map` would happen in test.
+    // Some test cases do not have coprocessor to deal with "on_region_changed".
+    // TODO: make test cases handle "on_region_changed".
     fn region_is_leader(&self, region_id: u64) -> bool {
         let region_map = self.region_map.read();
         region_map

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -343,8 +343,8 @@ impl ServerCluster {
 
         if ApiVersion::V2 == F::TAG {
             let causal_ts_provider =
-                Arc::new(causal_ts::SimpleTsoProvider::new(self.pd_client.clone()));
-            let causal_ob = causal_ts::CausalObserver::new(causal_ts_provider);
+                block_on(causal_ts::BatchTsoProvider::new(self.pd_client.clone())).unwrap();
+            let causal_ob = causal_ts::CausalObserver::new(Arc::new(causal_ts_provider));
             causal_ob.register_to(&mut coprocessor_host);
         }
 

--- a/tests/failpoints/cases/mod.rs
+++ b/tests/failpoints/cases/mod.rs
@@ -4,6 +4,7 @@ mod test_async_fetch;
 mod test_async_io;
 mod test_backup;
 mod test_bootstrap;
+mod test_causal_ts;
 mod test_cmd_epoch_checker;
 mod test_conf_change;
 mod test_coprocessor;

--- a/tests/failpoints/cases/test_causal_ts.rs
+++ b/tests/failpoints/cases/test_causal_ts.rs
@@ -1,0 +1,128 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::sync::Arc;
+
+use grpcio::{ChannelBuilder, Environment};
+use kvproto::{kvrpcpb::*, tikvpb::TikvClient};
+use test_raftstore::*;
+use tikv_util::HandyRwLock;
+
+fn new_context(cluster: &mut Cluster<ServerCluster>) -> Context {
+    let region_id = 1;
+    let leader = cluster.leader_of_region(region_id).unwrap();
+    let epoch = cluster.get_region_epoch(region_id);
+
+    let mut ctx = Context::default();
+    ctx.set_region_id(region_id);
+    ctx.set_peer(leader);
+    ctx.set_region_epoch(epoch);
+    ctx.set_api_version(ApiVersion::V2);
+    ctx
+}
+
+fn new_client(cluster: &mut Cluster<ServerCluster>) -> TikvClient {
+    let region_id = 1;
+    let leader = cluster.leader_of_region(region_id).unwrap();
+    let addr = cluster.sim.rl().get_addr(leader.store_id);
+    let env = Arc::new(Environment::new(1));
+    let channel = ChannelBuilder::new(env).connect(&addr);
+    TikvClient::new(channel)
+}
+
+fn must_raw_put(cluster: &mut Cluster<ServerCluster>, key: &[u8], value: &[u8]) {
+    let client = new_client(cluster);
+    let ctx = new_context(cluster);
+
+    let mut put_req = RawPutRequest::default();
+    put_req.set_context(ctx);
+    put_req.key = key.to_vec();
+    put_req.value = value.to_vec();
+    let put_resp = client.raw_put(&put_req).unwrap();
+    assert!(!put_resp.has_region_error(), "{:?}", put_resp.region_error);
+    assert!(put_resp.error.is_empty(), "error: {}", put_resp.error);
+}
+
+fn must_raw_get(cluster: &mut Cluster<ServerCluster>, key: &[u8]) -> Option<Vec<u8>> {
+    let client = new_client(cluster);
+    let ctx = new_context(cluster);
+
+    let mut get_req = RawGetRequest::default();
+    get_req.set_context(ctx);
+    get_req.key = key.to_vec();
+    let get_resp = client.raw_get(&get_req).unwrap();
+    assert!(!get_resp.has_region_error(), "{:?}", get_resp.region_error);
+    assert!(get_resp.error.is_empty(), "{}", get_resp.error);
+    if get_resp.not_found {
+        None
+    } else {
+        Some(get_resp.value)
+    }
+}
+
+#[test]
+fn test_causal_ts_issue_12498() {
+    // https://github.com/tikv/tikv/issues/12498
+    let fp_causal_ts_background_renew_interval = "causal_ts_background_renew_interval";
+    let fp_causal_ts_batch_size = "causal_ts_batch_size";
+    let fp_causal_ts_before_on_role_change = "causal_ts_before_on_role_change";
+    let fp_causal_ts_region_is_leader = "causal_ts_region_is_leader";
+    let fp_causal_ts_flush_in_pre_propose = "causal_ts_flush_in_pre_propose";
+
+    // Disable background renew.
+    fail::cfg(fp_causal_ts_background_renew_interval, "return(0)").unwrap();
+    // Make TSO batch easy to be used up.
+    fail::cfg(fp_causal_ts_batch_size, "return(3)").unwrap();
+    // Skip "on_role_change" & set "region_is_leader = false" to simulate scenario in issue that the leader transfer is observed late.
+    fail::cfg(fp_causal_ts_before_on_role_change, "return").unwrap();
+    fail::cfg(fp_causal_ts_region_is_leader, "return(false)").unwrap();
+    // Skip the codes for bug fix to reproduce issue.
+    fail::cfg(fp_causal_ts_flush_in_pre_propose, "return").unwrap();
+
+    let mut cluster = new_server_cluster_with_api_ver(0, 3, ApiVersion::V2);
+    cluster.cfg.raft_store.raft_heartbeat_ticks = 20;
+    cluster.run();
+
+    let pd_client = cluster.pd_client.clone();
+    pd_client.disable_default_operator();
+
+    let region_id = 1;
+    let key1 = b"rk1";
+
+    // Transfer leader to store 1.
+    cluster.must_transfer_leader(region_id, new_peer(1, 1));
+    let origin_leader = cluster.leader_of_region(region_id).unwrap();
+    {
+        must_raw_put(&mut cluster, key1, b"v1");
+        must_raw_put(&mut cluster, key1, b"v2");
+        must_raw_put(&mut cluster, key1, b"v3"); // TSO batch used up
+        must_raw_put(&mut cluster, key1, b"v4"); // Renew and get a ts bigger than other stores.
+        assert_eq!(must_raw_get(&mut cluster, key1), Some(b"v4".to_vec()));
+    }
+
+    // Transfer leader to store 2.
+    cluster.must_transfer_leader(region_id, new_peer(2, 2));
+    let new_leader = cluster.leader_of_region(region_id).unwrap();
+    assert_ne!(origin_leader, new_leader);
+    {
+        // Store 2 has a TSO batch smaller than store 1.
+        must_raw_put(&mut cluster, key1, b"v5");
+        // Reproduce the issue. It's causality violation.
+        assert_eq!(must_raw_get(&mut cluster, key1), Some(b"v4".to_vec()));
+        must_raw_put(&mut cluster, key1, b"v6");
+        assert_eq!(must_raw_get(&mut cluster, key1), Some(b"v4".to_vec()));
+    }
+
+    {
+        // Enable the codes for bug fix.
+        // A flush will be invoked to maintain causality.
+        fail::cfg(fp_causal_ts_flush_in_pre_propose, "off").unwrap();
+        must_raw_put(&mut cluster, key1, b"v7");
+        assert_eq!(must_raw_get(&mut cluster, key1), Some(b"v7".to_vec()));
+    }
+
+    fail::remove(fp_causal_ts_background_renew_interval);
+    fail::remove(fp_causal_ts_batch_size);
+    fail::remove(fp_causal_ts_before_on_role_change);
+    fail::remove(fp_causal_ts_region_is_leader);
+    fail::remove(fp_causal_ts_flush_in_pre_propose);
+}


### PR DESCRIPTION
Issue Number: #12498

Signed-off-by: pingyu <yuping@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #12498

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Fix issue #12498 
```

By logging timestamp of regions, we found that the observing of change from follower to leader by `on_role_change` would be later than the real role change in raft state and adjacent write commands.
When this happen, the adjacent write commands would get unexpected smaller timestamp than the peer transferred from.

The following screenshot shows such a case.
<img width="956" alt="image" src="https://user-images.githubusercontent.com/1907938/168887380-2325a2df-d5f9-4b73-8367-bb0f31a23d36.png">
The "leader transfer" indicates where the leader transfer happen. The log with "pre_propose" is the adjacent write command. "[is_leader=false]" indicates that the change of peer role have not been observed yet. "on_role_change" is the observing of peer role change.
We can see that the `ts` of "pre_propose" is smaller than `ts` of "on_role_change", which is just the violation of causality correctness.

In this PR, we add a `region_map` to store the "observed role" of peer, to help us detect whether the late of role change observing happened.


### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
No.
- Need to cherry-pick to the release branch
No.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
E2E testing, with "shuffle_leader_scheduler".

Side effects
- No.

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix issue #12498.
```
