### PR TITLE
components: handle invalid utf8 characters in `produce_str_with_specified_tp` func

### DIFF
--- a/components/tidb_query_datatype/src/codec/convert.rs
+++ b/components/tidb_query_datatype/src/codec/convert.rs
@@ -708,19 +708,18 @@ pub fn produce_str_with_specified_tp<'a>(
     // flen is the char length, not byte length, for UTF8 charset, we need to calculate the
     // char count and truncate to flen chars if it is too long.
     if chs == charset::CHARSET_UTF8 || chs == charset::CHARSET_UTF8MB4 {
-        let truncate_info = {
+        let (char_count, truncate_pos) = {
             let s = &String::from_utf8_lossy(&s);
             let mut truncate_pos = 0;
-            s.char_indices().take(flen).for_each(|(_, utf8_char)| {
+            s.chars().take(flen).for_each(|utf8_char| {
                 if utf8_char == char::REPLACEMENT_CHARACTER {
                     truncate_pos += 1;
                 } else {
                     truncate_pos += utf8_char.len_utf8();
                 }
             });
-            (s.char_indices().count(), truncate_pos)
+            (s.chars().count(), truncate_pos)
         };
-        let (char_count, truncate_pos) = truncate_info;
         if char_count <= flen {
             return Ok(s);
         }

--- a/components/tidb_query_datatype/src/codec/convert.rs
+++ b/components/tidb_query_datatype/src/codec/convert.rs
@@ -694,10 +694,6 @@ pub fn produce_float_with_specified_tp(
 
 /// `produce_str_with_specified_tp`(`ProduceStrWithSpecifiedTp` in TiDB) produces
 /// a new string according to `flen` and `chs`.
-///
-/// # Panics
-///
-/// The s must represent a valid str, otherwise, panic!
 pub fn produce_str_with_specified_tp<'a>(
     ctx: &mut EvalContext,
     s: Cow<'a, [u8]>,
@@ -713,19 +709,23 @@ pub fn produce_str_with_specified_tp<'a>(
     // char count and truncate to flen chars if it is too long.
     if chs == charset::CHARSET_UTF8 || chs == charset::CHARSET_UTF8MB4 {
         let truncate_info = {
-            // In TiDB's version, the param `s` is a string,
-            // so we can unwrap directly here because we need the `s` represent a valid str
-            let s: &str = std::str::from_utf8(s.as_ref()).unwrap();
-            let mut indices = s.char_indices().skip(flen);
-            indices.next().map(|(truncate_pos, _)| {
-                let char_count = flen + 1 + indices.count();
-                (char_count, truncate_pos)
-            })
+            let s = &String::from_utf8_lossy(&s);
+            let mut truncate_pos = 0 as usize;
+            let mut char_indices = s.char_indices();
+            for _ in 0..flen {
+                let utf8_char = char_indices.next();
+                if utf8_char == None {
+                    break;
+                }
+                if utf8_char.unwrap().1 == char::REPLACEMENT_CHARACTER {
+                    truncate_pos += 1;
+                } else {
+                    truncate_pos += utf8_char.unwrap().1.len_utf8();
+                }
+            }
+            (s.char_indices().count(), truncate_pos)
         };
-        if truncate_info.is_none() {
-            return Ok(s);
-        }
-        let (char_count, truncate_pos) = truncate_info.unwrap();
+        let (char_count, truncate_pos) = truncate_info;
         ctx.handle_truncate_err(Error::data_too_long(format!(
             "Data Too Long, field len {}, data len {}",
             flen, char_count
@@ -2220,6 +2220,26 @@ mod tests {
 
             let p = r.unwrap();
             assert_eq!(p.len(), char_num as usize, "{}, {}, {}", s, char_num, cs);
+        }
+
+        // test with invalid utf8 characters 0x80 and 0x81
+        let test_vec = vec![0xE4, 0xBD, 0xA0, 0x80, 0x81, 0xE4, 0xBD, 0xA0];
+        let cases = vec! [
+            (test_vec.clone(), 1, charset::CHARSET_UTF8, vec![0xE4, 0xBD, 0xA0]),
+            (test_vec.clone(), 2, charset::CHARSET_UTF8, vec![0xE4, 0xBD, 0xA0, 0x80]),
+            (test_vec.clone(), 3, charset::CHARSET_UTF8, vec![0xE4, 0xBD, 0xA0, 0x80, 0x81]),
+            (test_vec.clone(), 4, charset::CHARSET_UTF8, test_vec.clone()),
+            (test_vec.clone(), 5, charset::CHARSET_UTF8, test_vec.clone()),
+        ];
+
+        for (s, char_num, cs, result) in cases {
+            ft.set_charset(cs.to_string());
+            ft.set_flen(char_num);
+            let r = produce_str_with_specified_tp(&mut ctx, Cow::Borrowed(&s), &ft, true);
+            assert!(r.is_ok(), "{:?}, {}, {}, {:?}", &s, char_num, cs, result);
+
+            let p = r.unwrap();
+            assert_eq!(p, result, "{:?}, {}, {}, {:?}", &s, char_num, cs, result);
         }
     }
 

--- a/components/tidb_query_datatype/src/codec/convert.rs
+++ b/components/tidb_query_datatype/src/codec/convert.rs
@@ -711,18 +711,18 @@ pub fn produce_str_with_specified_tp<'a>(
         let truncate_info = {
             let s = &String::from_utf8_lossy(&s);
             let mut truncate_pos = 0;
-            s.char_indices().take(flen).for_each( |(_, utf8_char)|
+            s.char_indices().take(flen).for_each(|(_, utf8_char)| {
                 if utf8_char == char::REPLACEMENT_CHARACTER {
                     truncate_pos += 1;
                 } else {
                     truncate_pos += utf8_char.len_utf8();
                 }
-            );
+            });
             (s.char_indices().count(), truncate_pos)
         };
         let (char_count, truncate_pos) = truncate_info;
         if char_count <= flen {
-            return Ok(s)
+            return Ok(s);
         }
         ctx.handle_truncate_err(Error::data_too_long(format!(
             "Data Too Long, field len {}, data len {}",
@@ -2222,12 +2222,27 @@ mod tests {
 
         // test with invalid utf8 characters 0x80 and 0x81
         let test_vec = vec![0xE4, 0xBD, 0xA0, 0x80, 0x81, 0xE4, 0xBD, 0xA0];
-        let cases = vec! [
-            (test_vec.clone(), 1, charset::CHARSET_UTF8, vec![0xE4, 0xBD, 0xA0]),
-            (test_vec.clone(), 2, charset::CHARSET_UTF8, vec![0xE4, 0xBD, 0xA0, 0x80]),
-            (test_vec.clone(), 3, charset::CHARSET_UTF8, vec![0xE4, 0xBD, 0xA0, 0x80, 0x81]),
+        let cases = vec![
+            (
+                test_vec.clone(),
+                1,
+                charset::CHARSET_UTF8,
+                vec![0xE4, 0xBD, 0xA0],
+            ),
+            (
+                test_vec.clone(),
+                2,
+                charset::CHARSET_UTF8,
+                vec![0xE4, 0xBD, 0xA0, 0x80],
+            ),
+            (
+                test_vec.clone(),
+                3,
+                charset::CHARSET_UTF8,
+                vec![0xE4, 0xBD, 0xA0, 0x80, 0x81],
+            ),
             (test_vec.clone(), 4, charset::CHARSET_UTF8, test_vec.clone()),
-            (test_vec.clone(), 5, charset::CHARSET_UTF8, test_vec.clone()),
+            (test_vec.clone(), 5, charset::CHARSET_UTF8, test_vec),
         ];
 
         for (s, char_num, cs, result) in cases {


### PR DESCRIPTION


<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #12542

What's Changed:


<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
handle invalid utf8 characters in `produce_str_with_specified_tp` func
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
fix panic when `cast` function pushdown to tikv with invalid utf8 characters.
```
