### PR TITLE
Raftstore: reset the bucket after the regions merge

### DIFF
--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -4118,8 +4118,6 @@ where
         source: metapb::Region,
     ) {
         self.register_split_region_check_tick();
-        self.fsm.peer.region_buckets = None;
-        self.fsm.peer.last_region_buckets = None;
         let mut meta = self.ctx.store_meta.lock().unwrap();
 
         let prev = meta.region_ranges.remove(&enc_end_key(&source));
@@ -4165,6 +4163,8 @@ where
         // the reason why follower need to update is that there is a issue that after merge
         // and then transfer leader, the new leader may have stale size and keys.
         self.fsm.peer.size_diff_hint = self.ctx.cfg.region_split_check_diff().0;
+        self.fsm.peer.region_buckets = None;
+        self.fsm.peer.last_region_buckets = None;
         if self.fsm.peer.is_leader() {
             info!(
                 "notify pd with merge";

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -4118,6 +4118,8 @@ where
         source: metapb::Region,
     ) {
         self.register_split_region_check_tick();
+        self.fsm.peer.region_buckets = None;
+        self.fsm.peer.last_region_buckets = None;
         let mut meta = self.ctx.store_meta.lock().unwrap();
 
         let prev = meta.region_ranges.remove(&enc_end_key(&source));

--- a/tests/integrations/raftstore/test_split_region.rs
+++ b/tests/integrations/raftstore/test_split_region.rs
@@ -1150,6 +1150,8 @@ fn test_gen_split_check_bucket_ranges() {
     cluster.cfg.coprocessor.enable_region_bucket = true;
     // disable report buckets; as it will reset the user traffic stats to randmize the test result
     cluster.cfg.raft_store.check_leader_lease_interval = ReadableDuration::secs(5);
+    // Make merge check resume quickly.
+    cluster.cfg.raft_store.merge_check_tick_interval = ReadableDuration::millis(100);
     cluster.run();
     let pd_client = Arc::clone(&cluster.pd_client);
 
@@ -1208,4 +1210,10 @@ fn test_gen_split_check_bucket_ranges() {
         // the bucket_ranges should be None to refresh the bucket
         cluster.send_half_split_region_message(&left, None);
     }
+
+    // merge the region
+    pd_client.must_merge(left.get_id(), right.get_id());
+    let region = pd_client.get_region(b"k10").unwrap();
+    // the bucket_ranges should be None to refresh the bucket
+    cluster.send_half_split_region_message(&region, None);
 }


### PR DESCRIPTION
Signed-off-by: qi.xu <tonxuqi@outlook.com>

### What is changed and how it works?

Issue Number: Ref #12574

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Reset the buckets of target region after the merge, this is to refresh the buckets in-time. 
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
