### PR TITLE
*: avoid mutually exclusive features in pprof

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3785,8 +3785,8 @@ dependencies = [
 
 [[package]]
 name = "pprof"
-version = "0.9.0"
-source = "git+https://github.com/tikv/pprof-rs.git?rev=a5a993a33a23557b27e633f18723366281d3b1c0#a5a993a33a23557b27e633f18723366281d3b1c0"
+version = "0.9.1"
+source = "git+https://github.com/mornyx/pprof-rs.git?branch=optimize-features#764dcefa9f3af82833271c144879330dfc5c99e1"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3786,7 +3786,7 @@ dependencies = [
 [[package]]
 name = "pprof"
 version = "0.9.1"
-source = "git+https://github.com/mornyx/pprof-rs.git?branch=optimize-features#764dcefa9f3af82833271c144879330dfc5c99e1"
+source = "git+https://github.com/tikv/pprof-rs.git?rev=3fed55af8fc6cf69dbd954a0321c799c5a111e4e#3fed55af8fc6cf69dbd954a0321c799c5a111e4e"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ paste = "1.0"
 pd_client = { path = "components/pd_client", default-features = false }
 pin-project = "1.0"
 pnet_datalink = "0.23"
-pprof = { git = "https://github.com/mornyx/pprof-rs.git", branch = "optimize-features", default-features = false, features = ["flamegraph", "protobuf-codec"] }
+pprof = { git = "https://github.com/tikv/pprof-rs.git", rev = "3fed55af8fc6cf69dbd954a0321c799c5a111e4e", default-features = false, features = ["flamegraph", "protobuf-codec"] }
 prometheus = { version = "0.13", features = ["nightly"] }
 prometheus-static-metric = "0.5"
 protobuf = { version = "2.8", features = ["bytes"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 publish = false
 
 [features]
-default = ["test-engine-kv-rocksdb", "test-engine-raft-raft-engine", "cloud-aws", "cloud-gcp", "cloud-azure", "pprof-dwarf"]
+default = ["test-engine-kv-rocksdb", "test-engine-raft-raft-engine", "cloud-aws", "cloud-gcp", "cloud-azure"]
 tcmalloc = ["tikv_alloc/tcmalloc"]
 jemalloc = ["tikv_alloc/jemalloc", "engine_rocks/jemalloc"]
 mimalloc = ["tikv_alloc/mimalloc"]
@@ -53,7 +53,6 @@ test-engines-panic = [
 ]
 cloud-storage-grpc = ["sst_importer/cloud-storage-grpc"]
 cloud-storage-dylib = ["sst_importer/cloud-storage-dylib"]
-pprof-dwarf = ["pprof/backtrace-rs"]
 pprof-fp = ["pprof/frame-pointer"]
 
 # for testing configure propegate to other crates
@@ -125,7 +124,7 @@ paste = "1.0"
 pd_client = { path = "components/pd_client", default-features = false }
 pin-project = "1.0"
 pnet_datalink = "0.23"
-pprof = { git = "https://github.com/tikv/pprof-rs.git", rev = "a5a993a33a23557b27e633f18723366281d3b1c0", default-features = false, features = ["flamegraph", "protobuf-codec"] }
+pprof = { git = "https://github.com/mornyx/pprof-rs.git", branch = "optimize-features", default-features = false, features = ["flamegraph", "protobuf-codec"] }
 prometheus = { version = "0.13", features = ["nightly"] }
 prometheus-static-metric = "0.5"
 protobuf = { version = "2.8", features = ["bytes"] }

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ ifeq ($(TIKV_FRAME_POINTER),1)
 export RUSTFLAGS := $(RUSTFLAGS) -Cforce-frame-pointers=yes
 export CFLAGS := $(CFLAGS) -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer
 export CXXFLAGS := $(CXXFLAGS) -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer
+ENABLE_FEATURES += pprof-fp
 endif
 
 # Pick an allocator
@@ -181,7 +182,6 @@ dev: format clippy
 
 build: export TIKV_PROFILE=debug
 ifeq ($(TIKV_FRAME_POINTER),1)
-build: ENABLE_FEATURES += pprof-fp
 build:
 	rustup component add rust-src
 	cargo build --no-default-features --features "${ENABLE_FEATURES}" \
@@ -190,7 +190,6 @@ build:
 		--target "${TIKV_BUILD_RUSTC_TARGET}" \
 		--out-dir "${CARGO_TARGET_DIR}/debug"
 else
-build: ENABLE_FEATURES += pprof-dwarf
 build:
 	cargo build --no-default-features --features "${ENABLE_FEATURES}"
 endif
@@ -207,7 +206,6 @@ endif
 # enabled (the "sse" option)
 release: export TIKV_PROFILE=release
 ifeq ($(TIKV_FRAME_POINTER),1)
-release: ENABLE_FEATURES += pprof-fp
 release:
 	rustup component add rust-src
 	cargo build --release --no-default-features --features "${ENABLE_FEATURES}" \
@@ -216,7 +214,6 @@ release:
 		--target "${TIKV_BUILD_RUSTC_TARGET}" \
 		--out-dir "${CARGO_TARGET_DIR}/release"
 else
-release: ENABLE_FEATURES += pprof-dwarf
 release:
 	cargo build --release --no-default-features --features "${ENABLE_FEATURES}"
 endif
@@ -410,11 +407,6 @@ endif
 
 export X_CARGO_ARGS:=${CARGO_ARGS}
 
-ifeq ($(TIKV_FRAME_POINTER),1)
-x-build-dist: ENABLE_FEATURES += pprof-fp
-else
-x-build-dist: ENABLE_FEATURES += pprof-dwarf
-endif
 x-build-dist: export X_CARGO_CMD=build
 x-build-dist: export X_CARGO_FEATURES=${ENABLE_FEATURES}
 x-build-dist: export X_CARGO_RELEASE=1

--- a/cmd/tikv-server/Cargo.toml
+++ b/cmd/tikv-server/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 publish = false
 
 [features]
-default = ["test-engine-kv-rocksdb", "test-engine-raft-raft-engine", "cloud-aws", "cloud-gcp", "cloud-azure", "pprof-dwarf"]
+default = ["test-engine-kv-rocksdb", "test-engine-raft-raft-engine", "cloud-aws", "cloud-gcp", "cloud-azure"]
 tcmalloc = ["server/tcmalloc"]
 jemalloc = ["server/jemalloc"]
 mimalloc = ["server/mimalloc"]
@@ -28,7 +28,6 @@ test-engines-panic = ["server/test-engines-panic"]
 
 nortcheck = ["server/nortcheck"]
 
-pprof-dwarf = ["tikv/pprof-dwarf"]
 pprof-fp = ["tikv/pprof-fp"]
 
 [dependencies]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -107,7 +107,7 @@ tidb_query_common = { path = "../components/tidb_query_common", default-features
 tidb_query_datatype = { path = "../components/tidb_query_datatype", default-features = false }
 tidb_query_executors = { path = "../components/tidb_query_executors", default-features = false }
 tidb_query_expr = { path = "../components/tidb_query_expr", default-features = false }
-tikv = { path = "../", features = ["pprof-dwarf"], default-features = false }
+tikv = { path = "../", default-features = false }
 tikv_util = { path = "../components/tikv_util", default-features = false }
 time = "0.1"
 tipb = { git = "https://github.com/pingcap/tipb.git" }


### PR DESCRIPTION
Signed-off-by: mornyx <mornyx.z@gmail.com>

### What's changed

Issue Number: Close #12590

In https://github.com/tikv/tikv/pull/12480, we have introduced two mutually exclusive features, `pprof-dwarf` and `pprof-fp`. One of them must exist, otherwise a compilation error will occur. This introduces stricter requirements for feature usage in some modules.

We need to relax them and keep only one `pprof-fp`, anything else should automatically fallback to DWARF-based.

### Related PR

- https://github.com/tikv/pprof-rs/pull/130

### Release note

```release-note
None
```
