### PR TITLE
fixbug:when enable api v2 , TiDB resolve lock meet error

### DIFF
--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1263,8 +1263,8 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                     .get(priority_tag)
                     .inc();
 
-                // Remove the check_api_version_ranges,
-                // because of resolve locks range from TiDB is invalid key range mode
+                // Do not check_api_version in scan_lock, to be compatible with TiDB gc-worker,
+                // which resolves locks on regions, and boundary of regions will be out of range of TiDB keys.
 
                 let command_duration = tikv_util::time::Instant::now_coarse();
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -485,9 +485,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                         range.0.as_ref().map(AsRef::as_ref),
                         range.1.as_ref().map(AsRef::as_ref),
                     );
-                    if ApiV2::parse_range_mode(range) != KeyMode::TiDB
-                        && cmd != CommandKind::scan_lock
-                    {
+                    if ApiV2::parse_range_mode(range) != KeyMode::TiDB {
                         return Err(ErrorInner::invalid_key_range_mode(
                             cmd,
                             storage_api_version,
@@ -1240,7 +1238,6 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
             )],
         );
         let concurrency_manager = self.concurrency_manager.clone();
-        let api_version = self.api_version;
         // Do not allow replica read for scan_lock.
         ctx.set_replica_read(false);
 
@@ -1265,16 +1262,6 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                 SCHED_COMMANDS_PRI_COUNTER_VEC_STATIC
                     .get(priority_tag)
                     .inc();
-
-                Self::check_api_version_ranges(
-                    api_version,
-                    ctx.api_version,
-                    CMD,
-                    [(
-                        start_key.as_ref().map(Key::as_encoded),
-                        end_key.as_ref().map(Key::as_encoded),
-                    )],
-                )?;
 
                 let command_duration = tikv_util::time::Instant::now_coarse();
 
@@ -6309,7 +6296,7 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_lock_apiv2() {
+    fn test_resolve_lock() {
         test_resolve_lock_impl::<ApiV1>();
         test_resolve_lock_impl::<ApiV2>();
     }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1263,6 +1263,9 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                     .get(priority_tag)
                     .inc();
 
+                // Remove the check_api_version_ranges,
+                // because of resolve locks range from TiDB is invalid key range mode
+
                 let command_duration = tikv_util::time::Instant::now_coarse();
 
                 concurrency_manager.update_max_ts(max_ts);

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -485,7 +485,9 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                         range.0.as_ref().map(AsRef::as_ref),
                         range.1.as_ref().map(AsRef::as_ref),
                     );
-                    if ApiV2::parse_range_mode(range) != KeyMode::TiDB {
+                    if ApiV2::parse_range_mode(range) != KeyMode::TiDB
+                        && cmd != CommandKind::scan_lock
+                    {
                         return Err(ErrorInner::invalid_key_range_mode(
                             cmd,
                             storage_api_version,

--- a/tests/integrations/storage/test_storage.rs
+++ b/tests/integrations/storage/test_storage.rs
@@ -966,7 +966,7 @@ fn test_txn_store_txnkv_api_version() {
                 store.batch_get_command_err(&[key, key, key], 10);
 
                 store.scan_err(key, None, 100, 10);
-                store.scan_locks_err(20, key, &end_key, 10);
+                store.scan_locks_ok(20, key, &end_key, 10, vec![]);
 
                 store.delete_range_err(key, key);
             }

--- a/tests/integrations/storage/test_storage.rs
+++ b/tests/integrations/storage/test_storage.rs
@@ -966,6 +966,8 @@ fn test_txn_store_txnkv_api_version() {
                 store.batch_get_command_err(&[key, key, key], 10);
 
                 store.scan_err(key, None, 100, 10);
+
+                // To compatible with TiDB gc-worker, we remove check_api_version_ranges in scan_lock
                 store.scan_locks_ok(20, key, &end_key, 10, vec![]);
 
                 store.delete_range_err(key, key);


### PR DESCRIPTION
Signed-off-by: ystaticy <y_static_y@sina.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/tikv/tikv/issues/12595

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```
If cmd is scan_lock , it will not execute invalid_key_range_mode check.
```
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
fix:when enable api v2 , TiDB resolve lock meet error
```
