### PR TITLE
Raftstore: fix the config of region_split_check_diff

### DIFF
--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -792,7 +792,11 @@ impl<ER: RaftEngine> TiKvServer<ER> {
 
         self.config
             .raft_store
-            .validate(self.config.coprocessor.region_split_size)
+            .validate(
+                self.config.coprocessor.region_split_size,
+                self.config.coprocessor.enable_region_bucket,
+                self.config.coprocessor.region_bucket_size,
+            )
             .unwrap_or_else(|e| fatal!("failed to validate raftstore config {}", e));
         let raft_store = Arc::new(VersionTrack::new(self.config.raft_store.clone()));
         let health_service = HealthService::default();

--- a/components/test_raftstore/src/node.rs
+++ b/components/test_raftstore/src/node.rs
@@ -231,7 +231,11 @@ impl Simulator for NodeCluster {
         let simulate_trans = SimulateTransport::new(self.trans.clone());
         let mut raft_store = cfg.raft_store.clone();
         raft_store
-            .validate(cfg.coprocessor.region_split_size)
+            .validate(
+                cfg.coprocessor.region_split_size,
+                cfg.coprocessor.enable_region_bucket,
+                cfg.coprocessor.region_bucket_size,
+            )
             .unwrap();
         let bg_worker = WorkerBuilder::new("background").thread_count(2).create();
         let mut node = Node::new(
@@ -330,8 +334,12 @@ impl Simulator for NodeCluster {
         );
 
         let region_split_size = cfg.coprocessor.region_split_size;
+        let enable_region_bucket = cfg.coprocessor.enable_region_bucket;
+        let region_bucket_size = cfg.coprocessor.region_bucket_size;
         let mut raftstore_cfg = cfg.tikv.raft_store;
-        raftstore_cfg.validate(region_split_size).unwrap();
+        raftstore_cfg
+            .validate(region_split_size, enable_region_bucket, region_bucket_size)
+            .unwrap();
         let raft_store = Arc::new(VersionTrack::new(raftstore_cfg));
         cfg_controller.register(
             Module::Raftstore,

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -448,7 +448,11 @@ impl ServerCluster {
         // Create node.
         let mut raft_store = cfg.raft_store.clone();
         raft_store
-            .validate(cfg.coprocessor.region_split_size)
+            .validate(
+                cfg.coprocessor.region_split_size,
+                cfg.coprocessor.enable_region_bucket,
+                cfg.coprocessor.region_bucket_size,
+            )
             .unwrap();
         let health_service = HealthService::default();
         let mut node = Node::new(

--- a/src/config.rs
+++ b/src/config.rs
@@ -2864,8 +2864,11 @@ impl TiKvConfig {
         self.server.validate()?;
         self.pd.validate()?;
         self.coprocessor.validate()?;
-        self.raft_store
-            .validate(self.coprocessor.region_split_size)?;
+        self.raft_store.validate(
+            self.coprocessor.region_split_size,
+            self.coprocessor.enable_region_bucket,
+            self.coprocessor.region_bucket_size,
+        )?;
         self.security.validate()?;
         self.import.validate()?;
         self.backup.validate()?;


### PR DESCRIPTION

Signed-off-by: qi.xu <tonxuqi@outlook.com>

### What is changed and how it works?

Issue Number: Close #12598

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
fix the config of region_split_check_diff with min(region_size/16, bucket_size)
```

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
