### PR TITLE
config: fix startup error when upgrade storage.api-version from 1 to 2

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -3207,10 +3207,14 @@ impl TiKvConfig {
             ));
         }
 
-        if last_cfg.storage.enable_ttl && !self.storage.enable_ttl {
-            return Err("can't disable ttl on a ttl instance".to_owned());
-        } else if !last_cfg.storage.enable_ttl && self.storage.enable_ttl {
-            return Err("can't enable ttl on a non-ttl instance".to_owned());
+        // Check validation of api version change between API V1 and V1ttl only.
+        // Validation between V1/V1ttl and V2 is checked in `Node::check_api_version`.
+        if last_cfg.storage.api_version == 1 && self.storage.api_version == 1 {
+            if last_cfg.storage.enable_ttl && !self.storage.enable_ttl {
+                return Err("can't disable ttl on a ttl instance".to_owned());
+            } else if !last_cfg.storage.enable_ttl && self.storage.enable_ttl {
+                return Err("can't enable ttl on a non-ttl instance".to_owned());
+            }
         }
 
         Ok(())
@@ -3799,6 +3803,30 @@ mod tests {
         last_cfg.raft_store.raftdb_path = "/raft_path".to_owned();
         tikv_cfg.validate().unwrap();
         tikv_cfg.check_critical_cfg_with(&last_cfg).unwrap();
+
+        // Check api version.
+        {
+            let cases = [
+                (ApiVersion::V1, ApiVersion::V1, true),
+                (ApiVersion::V1, ApiVersion::V1ttl, false),
+                (ApiVersion::V1, ApiVersion::V2, true),
+                (ApiVersion::V1ttl, ApiVersion::V1, false),
+                (ApiVersion::V1ttl, ApiVersion::V1ttl, true),
+                (ApiVersion::V1ttl, ApiVersion::V2, true),
+                (ApiVersion::V2, ApiVersion::V1, true),
+                (ApiVersion::V2, ApiVersion::V1ttl, true),
+                (ApiVersion::V2, ApiVersion::V2, true),
+            ];
+            for (from_api, to_api, expected) in cases {
+                last_cfg.storage.set_api_version(from_api);
+                tikv_cfg.storage.set_api_version(to_api);
+                tikv_cfg.validate().unwrap();
+                assert_eq!(
+                    tikv_cfg.check_critical_cfg_with(&last_cfg).is_ok(),
+                    expected
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
Issue Number: #12600

Signed-off-by: pingyu <yuping@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #12600 

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Fix startup error when upgrade storage.api-version from 1 to 2.
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
No.
- Need to cherry-pick to the release branch
v6.1.0

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects
- No.

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix startup error when upgrade storage.api-version from 1 to 2.
```
