### PR TITLE
raftstore: bucket and region split bug fix

### DIFF
--- a/components/raftstore/src/coprocessor/config.rs
+++ b/components/raftstore/src/coprocessor/config.rs
@@ -89,7 +89,7 @@ impl Default for Config {
             perf_level: PerfLevel::Uninitialized,
             enable_region_bucket: false,
             region_bucket_size: DEFAULT_BUCKET_SIZE,
-            region_size_threshold_for_approximate: DEFAULT_BUCKET_SIZE * 4,
+            region_size_threshold_for_approximate: DEFAULT_BUCKET_SIZE * BATCH_SPLIT_LIMIT,
             region_bucket_merge_size_ratio: DEFAULT_REGION_BUCKET_MERGE_SIZE_RATIO,
         }
     }

--- a/components/raftstore/src/coprocessor/config.rs
+++ b/components/raftstore/src/coprocessor/config.rs
@@ -89,7 +89,7 @@ impl Default for Config {
             perf_level: PerfLevel::Uninitialized,
             enable_region_bucket: false,
             region_bucket_size: DEFAULT_BUCKET_SIZE,
-            region_size_threshold_for_approximate: DEFAULT_BUCKET_SIZE * BATCH_SPLIT_LIMIT,
+            region_size_threshold_for_approximate: DEFAULT_BUCKET_SIZE * BATCH_SPLIT_LIMIT / 2 * 3,
             region_bucket_merge_size_ratio: DEFAULT_REGION_BUCKET_MERGE_SIZE_RATIO,
         }
     }

--- a/components/raftstore/src/coprocessor/split_check/keys.rs
+++ b/components/raftstore/src/coprocessor/split_check/keys.rs
@@ -629,7 +629,7 @@ mod tests {
         // it will result in split by keys failed.
         cfg.region_max_size = Some(ReadableSize(region_size * 6 / 5));
         cfg.region_split_size = ReadableSize(region_size * 4 / 5);
-        runnable = SplitCheckRunner::new(engine.clone(), tx.clone(), CoprocessorHost::new(tx, cfg));
+        runnable = SplitCheckRunner::new(engine, tx.clone(), CoprocessorHost::new(tx, cfg));
         runnable.run(SplitCheckTask::split_check(
             region.clone(),
             true,

--- a/components/raftstore/src/coprocessor/split_check/keys.rs
+++ b/components/raftstore/src/coprocessor/split_check/keys.rs
@@ -11,14 +11,13 @@ use kvproto::{metapb::Region, pdpb::CheckPolicy};
 use tikv_util::{box_try, debug, info, warn};
 
 use super::{
-    calc_split_keys_count,
     super::{
         error::Result, metrics::*, Coprocessor, KeyEntry, ObserverContext, SplitCheckObserver,
         SplitChecker,
     },
+    calc_split_keys_count,
     size::get_approximate_split_keys,
     Host,
-
 };
 use crate::store::{CasualMessage, CasualRouter};
 
@@ -97,7 +96,11 @@ where
                 region,
                 self.max_keys_count * self.batch_split_limit,
             )?;
-            let split_keys_count = calc_split_keys_count(region_key_count, self.split_threshold, self.batch_split_limit);
+            let split_keys_count = calc_split_keys_count(
+                region_key_count,
+                self.split_threshold,
+                self.batch_split_limit,
+            );
             if split_keys_count >= 1 {
                 return Ok(box_try!(get_approximate_split_keys(
                     engine,
@@ -434,11 +437,7 @@ mod tests {
             CheckPolicy::Approximate,
             None,
         ));
-        must_split_with(
-            &rx,
-            &region,
-            1,
-        );
+        must_split_with(&rx, &region, 1);
 
         drop(rx);
     }

--- a/components/raftstore/src/coprocessor/split_check/keys.rs
+++ b/components/raftstore/src/coprocessor/split_check/keys.rs
@@ -586,10 +586,12 @@ mod tests {
 
         let (tx, rx) = mpsc::sync_channel(100);
         let cfg = Config {
-            region_max_keys: Some(100),
+            region_max_keys: Some(159),
             region_split_keys: Some(80),
             batch_split_limit: 5,
             enable_region_bucket: true,
+            region_max_size: Some(ReadableSize(301376)),
+            region_split_size: ReadableSize(160616),
             // need check split region buckets, but region size does not exceed the split threshold
             region_bucket_size: ReadableSize(100),
             ..Default::default()

--- a/components/raftstore/src/coprocessor/split_check/mod.rs
+++ b/components/raftstore/src/coprocessor/split_check/mod.rs
@@ -135,7 +135,7 @@ pub fn calc_split_keys_count(
     split_threshold: u64,
     batch_split_limit: u64,
 ) -> u64 {
-    let actual_split_limit = if count_per_region % split_threshold == 0 {
+    let actual_split_limit = if count_per_region % split_threshold < split_threshold / 2 {
         count_per_region / split_threshold
     } else {
         count_per_region / split_threshold + 1

--- a/components/raftstore/src/coprocessor/split_check/mod.rs
+++ b/components/raftstore/src/coprocessor/split_check/mod.rs
@@ -135,11 +135,10 @@ pub fn calc_split_keys_count(
     split_threshold: u64,
     batch_split_limit: u64,
 ) -> u64 {
-    let actual_split_limit = if count_per_region % split_threshold < split_threshold / 2 {
-        count_per_region / split_threshold
-    } else {
-        count_per_region / split_threshold + 1
-    };
     // split keys count is split count - 1
-    std::cmp::min(actual_split_limit.saturating_sub(1), batch_split_limit)
+    // if the count_per_region % split_threshold < split_threshold / 2, then split count is count_per_region/split_threshold
+    std::cmp::min(
+        count_per_region.saturating_sub(split_threshold / 2) / split_threshold,
+        batch_split_limit,
+    )
 }

--- a/components/raftstore/src/coprocessor/split_check/mod.rs
+++ b/components/raftstore/src/coprocessor/split_check/mod.rs
@@ -133,14 +133,24 @@ impl<'a, E> Host<'a, E> {
 pub fn calc_split_keys_count(
     count_per_region: u64,
     split_threshold: u64,
+    max_count_per_region: u64,
     batch_split_limit: u64,
 ) -> u64 {
+    if count_per_region < max_count_per_region {
+        return 0;
+    }
+
     // split keys count is split count - 1
-    // e.g. if split_threshold is 60, count_per_region is 60, return 0
-    //      if split_threshold is 60, count_per_region is 61, return 1
-    //      if split_threshold is 60, count_per_region is 121, return 2
+    // e.g. when split_threshold is 60 & max_count_per_region is 90
+    //      if count_per_region is 60, return 0
+    //      if count_per_region is 90, return 1
+    //      if count_per_region is 121, return 1
+    //      if count_per_region is 183, return 2
     std::cmp::min(
-        ((count_per_region as f64 / split_threshold as f64).ceil() as u64).saturating_sub(1),
+        std::cmp::max(
+            ((count_per_region as f64 / split_threshold as f64 + 0.5) as u64).saturating_sub(1),
+            count_per_region / max_count_per_region,
+        ),
         batch_split_limit,
     )
 }

--- a/components/raftstore/src/coprocessor/split_check/mod.rs
+++ b/components/raftstore/src/coprocessor/split_check/mod.rs
@@ -128,3 +128,15 @@ impl<'a, E> Host<'a, E> {
         self.cfg.region_bucket_size.0
     }
 }
+
+#[inline]
+pub fn calc_split_keys_count(count_per_region: u64, split_threshold: u64, batch_split_limit: u64) -> u64 {
+    let actual_split_limit = if count_per_region % split_threshold == 0 {
+        count_per_region / split_threshold
+    } else {
+        count_per_region / split_threshold + 1
+    };
+    
+    // split keys count is split count - 1
+    std::cmp::min(actual_split_limit - 1, batch_split_limit)
+}

--- a/components/raftstore/src/coprocessor/split_check/mod.rs
+++ b/components/raftstore/src/coprocessor/split_check/mod.rs
@@ -130,13 +130,16 @@ impl<'a, E> Host<'a, E> {
 }
 
 #[inline]
-pub fn calc_split_keys_count(count_per_region: u64, split_threshold: u64, batch_split_limit: u64) -> u64 {
+pub fn calc_split_keys_count(
+    count_per_region: u64,
+    split_threshold: u64,
+    batch_split_limit: u64,
+) -> u64 {
     let actual_split_limit = if count_per_region % split_threshold == 0 {
         count_per_region / split_threshold
     } else {
         count_per_region / split_threshold + 1
     };
-    
     // split keys count is split count - 1
     std::cmp::min(actual_split_limit - 1, batch_split_limit)
 }

--- a/components/raftstore/src/coprocessor/split_check/mod.rs
+++ b/components/raftstore/src/coprocessor/split_check/mod.rs
@@ -136,9 +136,11 @@ pub fn calc_split_keys_count(
     batch_split_limit: u64,
 ) -> u64 {
     // split keys count is split count - 1
-    // if the count_per_region % split_threshold < split_threshold / 2, then split count is count_per_region/split_threshold
+    // e.g. if split_threshold is 60, count_per_region is 60, return 0
+    //      if split_threshold is 60, count_per_region is 61, return 1
+    //      if split_threshold is 60, count_per_region is 121, return 2
     std::cmp::min(
-        count_per_region.saturating_sub(split_threshold / 2) / split_threshold,
+        ((count_per_region as f64 / split_threshold as f64).ceil() as u64).saturating_sub(1),
         batch_split_limit,
     )
 }

--- a/components/raftstore/src/coprocessor/split_check/mod.rs
+++ b/components/raftstore/src/coprocessor/split_check/mod.rs
@@ -141,5 +141,5 @@ pub fn calc_split_keys_count(
         count_per_region / split_threshold + 1
     };
     // split keys count is split count - 1
-    std::cmp::min(actual_split_limit - 1, batch_split_limit)
+    std::cmp::min(actual_split_limit.saturating_sub(1), batch_split_limit)
 }

--- a/components/raftstore/src/coprocessor/split_check/mod.rs
+++ b/components/raftstore/src/coprocessor/split_check/mod.rs
@@ -148,7 +148,7 @@ pub fn calc_split_keys_count(
     //      if count_per_region is 183, return 2
     std::cmp::min(
         std::cmp::max(
-            ((count_per_region as f64 / split_threshold as f64 + 0.5) as u64).saturating_sub(1),
+            ((count_per_region as f64 / split_threshold as f64).round() as u64).saturating_sub(1),
             count_per_region / max_count_per_region,
         ),
         batch_split_limit,

--- a/components/raftstore/src/coprocessor/split_check/size.rs
+++ b/components/raftstore/src/coprocessor/split_check/size.rs
@@ -51,6 +51,10 @@ where
     E: KvEngine,
 {
     fn on_kv(&mut self, _: &mut ObserverContext<'_>, entry: &KeyEntry) -> bool {
+        // If there's no need to check region split, skip it.
+        // Otherwise, the region whose keys > max region keys will not be splitted when batch_split_limit is zero,
+        // because eventually "over_limit && self.current_size + self.split_size >= self.max_size"
+        // will return true.
         if self.batch_split_limit == 0 {
             return false;
         }

--- a/components/raftstore/src/coprocessor/split_check/size.rs
+++ b/components/raftstore/src/coprocessor/split_check/size.rs
@@ -224,7 +224,7 @@ pub fn get_region_approximate_size(
 }
 
 /// Get region approximate split keys based on default, write and lock cf.
-fn get_approximate_split_keys(
+pub fn get_approximate_split_keys(
     db: &impl KvEngine,
     region: &Region,
     batch_split_limit: u64,
@@ -264,7 +264,7 @@ pub mod tests {
         store::{BucketRange, CasualMessage, KeyEntry, SplitCheckRunner, SplitCheckTask},
     };
 
-    fn must_split_at_impl(
+    pub fn must_split_at_impl(
         rx: &mpsc::Receiver<(u64, CasualMessage<KvTestEngine>)>,
         exp_region: &Region,
         exp_split_keys: Vec<Vec<u8>>,

--- a/components/raftstore/src/coprocessor/split_check/size.rs
+++ b/components/raftstore/src/coprocessor/split_check/size.rs
@@ -198,7 +198,7 @@ where
                 "region_id" => region.get_id(),
                 "size" => region_size,
                 "threshold" => host.cfg.region_max_size().0,
-                "policy" => &policy,
+                "policy" => ?policy,
                 "split_check" => batch_split_limit > 0,
             );
             // Need to check size.

--- a/components/raftstore/src/coprocessor/split_check/size.rs
+++ b/components/raftstore/src/coprocessor/split_check/size.rs
@@ -96,8 +96,12 @@ where
                 region,
                 self.max_size * self.batch_split_limit,
             )?;
-            let split_keys_count =
-                calc_split_keys_count(region_size, self.split_size, self.max_size, self.batch_split_limit);
+            let split_keys_count = calc_split_keys_count(
+                region_size,
+                self.split_size,
+                self.max_size,
+                self.batch_split_limit,
+            );
             if split_keys_count >= 1 {
                 return Ok(box_try!(get_approximate_split_keys(
                     engine,

--- a/components/raftstore/src/coprocessor/split_check/size.rs
+++ b/components/raftstore/src/coprocessor/split_check/size.rs
@@ -97,7 +97,7 @@ where
                 self.max_size * self.batch_split_limit,
             )?;
             let split_keys_count =
-                calc_split_keys_count(region_size, self.split_size, self.batch_split_limit);
+                calc_split_keys_count(region_size, self.split_size, self.max_size, self.batch_split_limit);
             if split_keys_count >= 1 {
                 return Ok(box_try!(get_approximate_split_keys(
                     engine,

--- a/components/raftstore/src/coprocessor/split_check/size.rs
+++ b/components/raftstore/src/coprocessor/split_check/size.rs
@@ -51,6 +51,9 @@ where
     E: KvEngine,
 {
     fn on_kv(&mut self, _: &mut ObserverContext<'_>, entry: &KeyEntry) -> bool {
+        if self.batch_split_limit == 0 {
+            return false;
+        }
         let size = entry.entry_size() as u64;
         self.current_size += size;
 

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -4163,6 +4163,8 @@ where
         // the reason why follower need to update is that there is a issue that after merge
         // and then transfer leader, the new leader may have stale size and keys.
         self.fsm.peer.size_diff_hint = self.ctx.cfg.region_split_check_diff().0;
+        self.fsm.peer.region_buckets = None;
+        self.fsm.peer.last_region_buckets = None;
         if self.fsm.peer.is_leader() {
             info!(
                 "notify pd with merge";

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -5221,7 +5221,10 @@ where
                 current_version + 1
             } else {
                 if term > u32::MAX.into() {
-                    error!("unexpected term {} more than u32::MAX. Bucket version will be backward.", term);
+                    error!(
+                        "unexpected term {} more than u32::MAX. Bucket version will be backward.",
+                        term
+                    );
                 }
                 term << 32
             };
@@ -5278,10 +5281,10 @@ where
             let mut i = 0;
             region_buckets = self.fsm.peer.region_buckets.clone().unwrap();
             let mut meta = (*region_buckets.meta).clone();
-            if !buckets.is_empty() { 
+            if !buckets.is_empty() {
                 meta.version = gen_bucket_version(self.fsm.peer.term(), current_version);
             }
-            meta.region_epoch = region_epoch; 
+            meta.region_epoch = region_epoch;
             for (bucket, bucket_range) in buckets.into_iter().zip(bucket_ranges) {
                 while i < meta.keys.len() && meta.keys[i] != bucket_range.0 {
                     i += 1;

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -4163,8 +4163,10 @@ where
         // the reason why follower need to update is that there is a issue that after merge
         // and then transfer leader, the new leader may have stale size and keys.
         self.fsm.peer.size_diff_hint = self.ctx.cfg.region_split_check_diff().0;
-        self.fsm.peer.last_region_buckets = self.fsm.peer.region_buckets.take();
-        self.fsm.peer.region_buckets = None;
+        if self.fsm.peer.region_buckets.is_some() {
+            self.fsm.peer.last_region_buckets = self.fsm.peer.region_buckets.take();
+            self.fsm.peer.region_buckets = None;
+        }
         if self.fsm.peer.is_leader() {
             info!(
                 "notify pd with merge";

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -4163,10 +4163,7 @@ where
         // the reason why follower need to update is that there is a issue that after merge
         // and then transfer leader, the new leader may have stale size and keys.
         self.fsm.peer.size_diff_hint = self.ctx.cfg.region_split_check_diff().0;
-        if self.fsm.peer.region_buckets.is_some() {
-            self.fsm.peer.last_region_buckets = self.fsm.peer.region_buckets.take();
-            self.fsm.peer.region_buckets = None;
-        }
+        self.fsm.peer.reset_region_buckets();
         if self.fsm.peer.is_leader() {
             info!(
                 "notify pd with merge";

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -3165,8 +3165,8 @@ where
         // Reset delete_keys_hint and size_diff_hint.
         self.delete_keys_hint = 0;
         self.size_diff_hint = 0;
+        self.last_region_buckets = self.region_buckets.take();
         self.region_buckets = None;
-        self.last_region_buckets = None;
     }
 
     /// Try to renew leader lease.

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -3165,8 +3165,10 @@ where
         // Reset delete_keys_hint and size_diff_hint.
         self.delete_keys_hint = 0;
         self.size_diff_hint = 0;
-        self.last_region_buckets = self.region_buckets.take();
-        self.region_buckets = None;
+        if self.region_buckets.is_some() {
+            self.last_region_buckets = self.region_buckets.take();
+            self.region_buckets = None;
+        }
     }
 
     /// Try to renew leader lease.

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -3165,6 +3165,10 @@ where
         // Reset delete_keys_hint and size_diff_hint.
         self.delete_keys_hint = 0;
         self.size_diff_hint = 0;
+        self.reset_region_buckets();
+    }
+
+    pub fn reset_region_buckets(&mut self) {
         if self.region_buckets.is_some() {
             self.last_region_buckets = self.region_buckets.take();
             self.region_buckets = None;

--- a/tests/integrations/raftstore/test_split_region.rs
+++ b/tests/integrations/raftstore/test_split_region.rs
@@ -1150,6 +1150,8 @@ fn test_gen_split_check_bucket_ranges() {
     cluster.cfg.coprocessor.enable_region_bucket = true;
     // disable report buckets; as it will reset the user traffic stats to randmize the test result
     cluster.cfg.raft_store.check_leader_lease_interval = ReadableDuration::secs(5);
+    // Make merge check resume quickly.
+    cluster.cfg.raft_store.merge_check_tick_interval = ReadableDuration::millis(100);
     cluster.run();
     let pd_client = Arc::clone(&cluster.pd_client);
 
@@ -1208,4 +1210,10 @@ fn test_gen_split_check_bucket_ranges() {
         // the bucket_ranges should be None to refresh the bucket
         cluster.send_half_split_region_message(&left, None);
     }
+
+    // merge the region
+    pd_client.must_merge(left.get_id(), right.get_id());
+    let region = pd_client.get_region(b"k10").unwrap();
+    // the bucket_ranges should be None to refresh the bucket
+    cluster.send_half_split_region_message(&region, None);
 }

--- a/tests/integrations/raftstore/test_split_region.rs
+++ b/tests/integrations/raftstore/test_split_region.rs
@@ -1180,6 +1180,15 @@ fn test_refresh_region_bucket_keys() {
     let bucket_version7 =
         cluster.refresh_region_bucket_keys(&region, buckets, None, Some(expected_buckets.clone()));
     assert_eq!(bucket_version7, bucket_version6 + 1);
+
+    let bucket_version8 = cluster.refresh_region_bucket_keys(
+        &region,
+        vec![],
+        Some(vec![]),
+        Some(expected_buckets.clone()),
+    );
+    // no change on buckets, the bucket version is not changed.
+    assert_eq!(bucket_version8, bucket_version7)
 }
 
 #[test]

--- a/tests/integrations/raftstore/test_split_region.rs
+++ b/tests/integrations/raftstore/test_split_region.rs
@@ -1134,12 +1134,63 @@ fn test_refresh_region_bucket_keys() {
         ]
         .into(),
     );
-    cluster.refresh_region_bucket_keys(
+    let bucket_version5 = cluster.refresh_region_bucket_keys(
         &region,
         buckets,
         Some(bucket_ranges),
         Some(expected_buckets.clone()),
     );
+
+    assert_eq!(bucket_version5, bucket_version4 + 1);
+
+    {
+        // split the region
+        pd_client.must_split_region(region, pdpb::CheckPolicy::Usekey, vec![b"k11".to_vec()]);
+        // remove k11~k12, k12~k121, k122~[] bucket
+        let mut buckets = vec![Bucket {
+            keys: vec![b"k10".to_vec()],
+            size: 1024 * 1024 * 65, // not small enough to merge with left
+        }];
+
+        expected_buckets.set_keys(vec![vec![], b"k10".to_vec(), b"k11".to_vec()].into());
+
+        let mut region = pd_client.get_region(b"k10").unwrap();
+        let left_id = region.get_id();
+        let right = pd_client.get_region(b"k12").unwrap();
+        if region.get_id() != 1 {
+            region = right.clone();
+            buckets = vec![Bucket {
+                keys: vec![b"k12".to_vec()],
+                size: 1024 * 1024 * 65, // not small enough to merge with left
+            }];
+            expected_buckets.set_keys(vec![b"k11".to_vec(), b"k12".to_vec(), vec![]].into());
+        }
+
+        let bucket_version6 = cluster.refresh_region_bucket_keys(
+            &region,
+            buckets,
+            None,
+            Some(expected_buckets.clone()),
+        );
+        assert_eq!(bucket_version6, bucket_version5 + 1);
+
+        // merge the region
+        pd_client.must_merge(left_id, right.get_id());
+        let region = pd_client.get_region(b"k10").unwrap();
+        let buckets = vec![Bucket {
+            keys: vec![b"k10".to_vec()],
+            size: 1024 * 1024 * 65, // not small enough to merge with left
+        }];
+
+        expected_buckets.set_keys(vec![vec![], b"k10".to_vec(), vec![]].into());
+        let bucket_version7 = cluster.refresh_region_bucket_keys(
+            &region,
+            buckets,
+            None,
+            Some(expected_buckets.clone()),
+        );
+        assert_eq!(bucket_version7, bucket_version6 + 1);
+    }
 }
 
 #[test]


### PR DESCRIPTION

Signed-off-by: qi.xu <tonxuqi@outlook.com>

### What is changed and how it works?

Issue Number: Close #12597

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
1) originally the split by keys only support CheckPolicy::Scan. Add CheckPolicy::Approximate support. 
2) refine the way to use approximate size for split---calculate the actual split count per region size instead of use batch_split_limit
3) refine the bucket_version logic to make it monotonic----basically keep the region_buckets in last_region_buckets on split/merge 
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- None

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
