### PR TITLE
quota-limiter: fix panic when set limiter value to 0

### DIFF
--- a/components/tikv_util/src/quota_limiter.rs
+++ b/components/tikv_util/src/quota_limiter.rs
@@ -136,12 +136,12 @@ impl QuotaLimiter {
 
     pub fn set_write_bandwidth_limit(&self, write_bandwidth: ReadableSize) {
         self.write_bandwidth_limiter
-            .set_speed_limit(write_bandwidth.0 as f64);
+            .set_speed_limit(Self::speed_limit(write_bandwidth.0 as f64));
     }
 
     pub fn set_read_bandwidth_limit(&self, read_bandwidth: ReadableSize) {
         self.read_bandwidth_limiter
-            .set_speed_limit(read_bandwidth.0 as f64);
+            .set_speed_limit(Self::speed_limit(read_bandwidth.0 as f64));
     }
 
     pub fn set_max_delay_duration(&self, duration: ReadableDuration) {
@@ -318,5 +318,32 @@ mod tests {
         sample.add_write_bytes(512);
         let should_delay = block_on(quota_limiter.async_consume(sample));
         check_duration(should_delay, Duration::from_millis(40));
+
+        // test change limiter to 0
+        quota_limiter.set_cpu_time_limit(0);
+        let mut sample = quota_limiter.new_sample();
+        sample.add_cpu_time(Duration::from_millis(100));
+        let should_delay = block_on(quota_limiter.async_consume(sample));
+        check_duration(should_delay, Duration::ZERO);
+
+        quota_limiter.set_write_bandwidth_limit(ReadableSize::kb(0));
+        let mut sample = quota_limiter.new_sample();
+        sample.add_write_bytes(256);
+        let should_delay = block_on(quota_limiter.async_consume(sample));
+        check_duration(should_delay, Duration::ZERO);
+
+        quota_limiter.set_read_bandwidth_limit(ReadableSize::kb(0));
+        let mut sample = quota_limiter.new_sample();
+        sample.add_read_bytes(256);
+        let should_delay = block_on(quota_limiter.async_consume(sample));
+        check_duration(should_delay, Duration::ZERO);
+
+        // set bandwidth back
+        quota_limiter.set_write_bandwidth_limit(ReadableSize::kb(1));
+        quota_limiter.set_max_delay_duration(ReadableDuration::millis(0));
+        let mut sample = quota_limiter.new_sample();
+        sample.add_write_bytes(128);
+        let should_delay = block_on(quota_limiter.async_consume(sample));
+        check_duration(should_delay, Duration::from_millis(125));
     }
 }


### PR DESCRIPTION
Signed-off-by: glorv <glorvs@163.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #12622

What's Changed:

<!--

set limiter to infinity when input is 0

-->
```commit-message
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
