### PR TITLE
tests: try to stablize the deadlock integration test cases

### DIFF
--- a/tests/integrations/server/lock_manager.rs
+++ b/tests/integrations/server/lock_manager.rs
@@ -35,7 +35,7 @@ fn deadlock(client: &TikvClient, ctx: Context, key1: &[u8], ts: u64) -> bool {
         assert!(resp.errors[0].has_locked(), "{:?}", resp.errors[0]);
     });
     // Sleep to make sure txn(ts+1) is waiting for txn(ts)
-    thread::sleep(Duration::from_millis(100));
+    thread::sleep(Duration::from_millis(300));
     let mut ctx2 = ctx.clone();
     ctx2.set_resource_group_tag(b"tag2".to_vec());
     let resp = kv_pessimistic_lock(client, ctx2, vec![key2.clone()], ts, ts, false);
@@ -82,7 +82,7 @@ fn build_leader_client(cluster: &mut Cluster<ServerCluster>, key: &[u8]) -> (Tik
 fn must_detect_deadlock(cluster: &mut Cluster<ServerCluster>, key: &[u8], ts: u64) {
     // Sometimes, deadlocks can't be detected at once due to leader change, but it will be
     // detected.
-    for _ in 0..3 {
+    for _ in 0..5 {
         let (client, ctx) = build_leader_client(cluster, key);
         if deadlock(&client, ctx, key, ts) {
             return;


### PR DESCRIPTION
Signed-off-by: cfzjywxk <lsswxrxr@163.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #12619 

What's Changed:


<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
This commit intends to stabilize the deadlock detection integration test cases. 

Though this might be a temporary solution because using sleep could not control lock orders accurately especially 
if some commands are processed slowly in the CI environment, it introduces low cost. 

Changes:
- The sleep time is increased to 300ms to avoid assertion failures in the issue. 
- The retry limit is increased to 5 to avoid missing expected deadlock results.
```


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test



### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
