### PR TITLE
pd_client: Do not reconnect on store tombstone error

### DIFF
--- a/components/pd_client/src/errors.rs
+++ b/components/pd_client/src/errors.rs
@@ -7,8 +7,6 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("{0}")]
-    Io(#[from] std::io::Error),
     #[error("cluster {0} is already bootstrapped")]
     ClusterBootstrapped(u64),
     #[error("cluster {0} is not bootstrapped")]
@@ -29,10 +27,22 @@ pub enum Error {
 
 pub type Result<T> = result::Result<T, Error>;
 
+impl Error {
+    pub fn retryable(&self) -> bool {
+        match self {
+            Error::Grpc(_) | Error::Other(_) | Error::ClusterNotBootstrapped(_) => true,
+            Error::RegionNotFound(_)
+            | Error::StoreTombstone(_)
+            | Error::GlobalConfigNotFound(_)
+            | Error::ClusterBootstrapped(_)
+            | Error::Incompatible => false,
+        }
+    }
+}
+
 impl ErrorCodeExt for Error {
     fn error_code(&self) -> ErrorCode {
         match self {
-            Error::Io(_) => error_code::pd::IO,
             Error::ClusterBootstrapped(_) => error_code::pd::CLUSTER_BOOTSTRAPPED,
             Error::ClusterNotBootstrapped(_) => error_code::pd::CLUSTER_NOT_BOOTSTRAPPED,
             Error::Incompatible => error_code::pd::INCOMPATIBLE,

--- a/components/pd_client/src/util.rs
+++ b/components/pd_client/src/util.rs
@@ -441,8 +441,13 @@ where
     fn should_not_retry(resp: &Result<Resp>) -> bool {
         match resp {
             Ok(_) => true,
-            // Error::Incompatible is returned by response header from PD, no need to retry
-            Err(Error::Incompatible) => true,
+            // these errors are not caused by network, no need to retry
+            Err(
+                Error::Incompatible
+                | Error::StoreTombstone(..)
+                | Error::RegionNotFound(..)
+                | Error::GlobalConfigNotFound(..),
+            ) => true,
             Err(err) => {
                 error!(?*err; "request failed, retry");
                 false

--- a/components/pd_client/src/util.rs
+++ b/components/pd_client/src/util.rs
@@ -441,16 +441,14 @@ where
     fn should_not_retry(resp: &Result<Resp>) -> bool {
         match resp {
             Ok(_) => true,
-            // these errors are not caused by network, no need to retry
-            Err(
-                Error::Incompatible
-                | Error::StoreTombstone(..)
-                | Error::RegionNotFound(..)
-                | Error::GlobalConfigNotFound(..),
-            ) => true,
             Err(err) => {
-                error!(?*err; "request failed, retry");
-                false
+                // these errors are not caused by network, no need to retry
+                if err.retryable() {
+                    error!(?*err; "request failed, retry");
+                    false
+                } else {
+                    true
+                }
             }
         }
     }

--- a/components/resolved_ts/src/advance.rs
+++ b/components/resolved_ts/src/advance.rs
@@ -31,7 +31,7 @@ use tokio::{
 };
 use txn_types::TimeStamp;
 
-use crate::{endpoint::Task, errors::Result, metrics::*, util};
+use crate::{endpoint::Task, metrics::*, util};
 
 const DEFAULT_CHECK_LEADER_TIMEOUT_MILLISECONDS: u64 = 5_000; // 5s
 
@@ -234,7 +234,10 @@ pub async fn region_resolved_ts_store(
                 let client =
                     get_tikv_client(to_store, pd_client, security_mgr, env, tikv_clients.clone())
                         .await
-                        .map_err(|e| (to_store, true, format!("[get tikv client] {}", e)))?;
+                        .map_err(|e| {
+                            let reconnect = !matches!(e, pd_client::Error::StoreTombstone(..));
+                            (to_store, reconnect, format!("[get tikv client] {}", e))
+                        })?;
 
                 let mut req = CheckLeaderRequest::default();
                 req.set_regions(regions.into());
@@ -363,7 +366,7 @@ async fn get_tikv_client(
     security_mgr: Arc<SecurityManager>,
     env: Arc<Environment>,
     tikv_clients: Arc<Mutex<HashMap<u64, TikvClient>>>,
-) -> Result<TikvClient> {
+) -> pd_client::Result<TikvClient> {
     {
         let clients = tikv_clients.lock().await;
         if let Some(client) = clients.get(&store_id).cloned() {
@@ -371,9 +374,10 @@ async fn get_tikv_client(
         }
     }
     let timeout = Duration::from_millis(DEFAULT_CHECK_LEADER_TIMEOUT_MILLISECONDS);
-    let store = box_try!(box_try!(
-        tokio::time::timeout(timeout, pd_client.get_store_async(store_id)).await
-    ));
+    let store = tokio::time::timeout(timeout, pd_client.get_store_async(store_id))
+        .await
+        .map_err(|e| pd_client::Error::Other(Box::new(e)))
+        .flatten()?;
     let mut clients = tikv_clients.lock().await;
     let start = Instant::now_coarse();
     // hack: so it's different args, grpc will always create a new connection.

--- a/components/resolved_ts/src/advance.rs
+++ b/components/resolved_ts/src/advance.rs
@@ -235,8 +235,7 @@ pub async fn region_resolved_ts_store(
                     get_tikv_client(to_store, pd_client, security_mgr, env, tikv_clients.clone())
                         .await
                         .map_err(|e| {
-                            let reconnect = !matches!(e, pd_client::Error::StoreTombstone(..));
-                            (to_store, reconnect, format!("[get tikv client] {}", e))
+                            (to_store, e.retryable(), format!("[get tikv client] {}", e))
                         })?;
 
                 let mut req = CheckLeaderRequest::default();

--- a/components/resolved_ts/src/lib.rs
+++ b/components/resolved_ts/src/lib.rs
@@ -10,6 +10,7 @@
 //!   3. Resolved TS must be advanced by the region leader after it has applied on its term.
 
 #![feature(box_patterns)]
+#![feature(result_flattening)]
 
 #[macro_use]
 extern crate tikv_util;


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: close #12506 

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
do not reconnect PD on store tombstone error
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix the issue that keep retrying reconnecting PD when encounter store tombstone error
```
