### PR TITLE
expr: fix tikv crash when conv empty string

### DIFF
--- a/components/tidb_query_expr/src/impl_math.rs
+++ b/components/tidb_query_expr/src/impl_math.rs
@@ -616,7 +616,7 @@ fn is_valid_base(base: IntWithSign) -> bool {
 
 fn extract_num_str(s: &str, from_base: IntWithSign) -> Option<(String, bool)> {
     let mut iter = s.chars().peekable();
-    let head = *iter.peek().unwrap();
+    let head = *iter.peek()?;
     let mut is_neg = false;
     if head == '+' || head == '-' {
         is_neg = head == '-';
@@ -1568,6 +1568,7 @@ mod tests {
             ("16九a", 10, 8, "20"),
             ("+", 10, 8, "0"),
             ("-", 10, 8, "0"),
+            ("", 2, 16, "0"),
         ];
         for (n, f, t, e) in tests {
             let n = Some(n.as_bytes().to_vec());


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/tikv/tikv/issues/12673

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Fix tikv crash when conv empty string
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix tikv crash when conv empty string
```
