### PR TITLE
raftstore: use approximate size to generate bucket unless split region check is needed and scan is used for it.

### DIFF
--- a/components/raftstore/src/coprocessor/config.rs
+++ b/components/raftstore/src/coprocessor/config.rs
@@ -50,6 +50,8 @@ pub struct Config {
     pub region_bucket_size: ReadableSize,
     // region size threshold for using approximate size instead of scan
     pub region_size_threshold_for_approximate: ReadableSize,
+    #[online_config(skip)]
+    pub prefer_gen_bucket_by_approximate: bool,
     // ratio of region_bucket_size. (0, 0.5)
     // The region_bucket_merge_size_ratio * region_bucket_size is threshold to merge with its left neighbor bucket
     pub region_bucket_merge_size_ratio: f64,
@@ -91,6 +93,7 @@ impl Default for Config {
             region_bucket_size: DEFAULT_BUCKET_SIZE,
             region_size_threshold_for_approximate: DEFAULT_BUCKET_SIZE * BATCH_SPLIT_LIMIT / 2 * 3,
             region_bucket_merge_size_ratio: DEFAULT_REGION_BUCKET_MERGE_SIZE_RATIO,
+            prefer_gen_bucket_by_approximate: true,
         }
     }
 }

--- a/components/raftstore/src/coprocessor/config.rs
+++ b/components/raftstore/src/coprocessor/config.rs
@@ -51,7 +51,7 @@ pub struct Config {
     // region size threshold for using approximate size instead of scan
     pub region_size_threshold_for_approximate: ReadableSize,
     #[online_config(skip)]
-    pub prefer_gen_bucket_by_approximate: bool,
+    pub prefer_approximate_bucket: bool,
     // ratio of region_bucket_size. (0, 0.5)
     // The region_bucket_merge_size_ratio * region_bucket_size is threshold to merge with its left neighbor bucket
     pub region_bucket_merge_size_ratio: f64,
@@ -93,7 +93,7 @@ impl Default for Config {
             region_bucket_size: DEFAULT_BUCKET_SIZE,
             region_size_threshold_for_approximate: DEFAULT_BUCKET_SIZE * BATCH_SPLIT_LIMIT / 2 * 3,
             region_bucket_merge_size_ratio: DEFAULT_REGION_BUCKET_MERGE_SIZE_RATIO,
-            prefer_gen_bucket_by_approximate: true,
+            prefer_approximate_bucket: true,
         }
     }
 }

--- a/components/raftstore/src/coprocessor/split_check/half.rs
+++ b/components/raftstore/src/coprocessor/split_check/half.rs
@@ -224,7 +224,7 @@ mod tests {
             ..Default::default()
         };
         let cop_host = CoprocessorHost::new(tx.clone(), cfg);
-        let mut runnable = SplitCheckRunner::new(engine.clone(), tx.clone(), cop_host.clone());
+        let mut runnable = SplitCheckRunner::new(engine.clone(), tx, cop_host.clone());
 
         let key_gen = |k: &[u8], i: u64, mvcc: bool| {
             if !mvcc {

--- a/components/raftstore/src/coprocessor/split_check/half.rs
+++ b/components/raftstore/src/coprocessor/split_check/half.rs
@@ -218,7 +218,7 @@ mod tests {
 
         let (tx, rx) = mpsc::sync_channel(100);
         let cfg = Config {
-            region_max_size: Some(ReadableSize(BUCKET_NUMBER_LIMIT as u64)),
+            region_split_size: ReadableSize(130_u64),
             enable_region_bucket: true,
             region_bucket_size: ReadableSize(20_u64), // so that each key below will form a bucket
             ..Default::default()
@@ -345,7 +345,7 @@ mod tests {
 
         let (tx, rx) = mpsc::sync_channel(100);
         let cfg = Config {
-            region_max_size: Some(ReadableSize(BUCKET_NUMBER_LIMIT as u64)),
+            region_split_size: ReadableSize(130_u64),
             enable_region_bucket: true,
             region_bucket_size: ReadableSize(20_u64), // so that each key below will form a bucket
             ..Default::default()

--- a/components/raftstore/src/coprocessor/split_check/half.rs
+++ b/components/raftstore/src/coprocessor/split_check/half.rs
@@ -223,8 +223,8 @@ mod tests {
             region_bucket_size: ReadableSize(20_u64), // so that each key below will form a bucket
             ..Default::default()
         };
-        let mut runnable =
-            SplitCheckRunner::new(engine.clone(), tx.clone(), CoprocessorHost::new(tx, cfg));
+        let cop_host = CoprocessorHost::new(tx.clone(), cfg);
+        let mut runnable = SplitCheckRunner::new(engine.clone(), tx.clone(), cop_host.clone());
 
         let key_gen = |k: &[u8], i: u64, mvcc: bool| {
             if !mvcc {
@@ -276,6 +276,9 @@ mod tests {
             Some(vec![bucket_range]),
         ));
 
+        let host = cop_host.new_split_checker_host(&region, &engine, true, CheckPolicy::Scan);
+        assert_eq!(host.policy(), CheckPolicy::Scan);
+
         must_generate_buckets(&rx, &exp_bucket_keys);
 
         // testing split bucket with end key ""
@@ -299,6 +302,8 @@ mod tests {
             CheckPolicy::Scan,
             Some(vec![bucket_range]),
         ));
+        let host = cop_host.new_split_checker_host(&region, &engine, true, CheckPolicy::Scan);
+        assert_eq!(host.policy(), CheckPolicy::Scan);
 
         must_generate_buckets(&rx, &exp_bucket_keys);
 

--- a/components/raftstore/src/coprocessor/split_check/keys.rs
+++ b/components/raftstore/src/coprocessor/split_check/keys.rs
@@ -186,7 +186,7 @@ where
         // add keys checker as well for free
         // It has the assumption that the size's checker is before the keys's check in the host
         let need_split_region = region_keys >= host.cfg.region_max_keys();
-        if need_split_region || host.get_bucket_scan_checker_added() {
+        if need_split_region {
             info!(
                 "approximate keys over threshold, need to do split check";
                 "region_id" => region.get_id(),
@@ -245,7 +245,7 @@ mod tests {
             calc_split_keys_count,
             size::{
                 get_region_approximate_size,
-                tests::{must_generate_buckets, must_split_at, must_split_with},
+                tests::{must_split_at, must_split_with},
             },
         },
         *,
@@ -696,64 +696,5 @@ mod tests {
         region.set_end_key(b"c".to_vec());
         let range_keys = get_region_approximate_keys(&db, &region, 0).unwrap();
         assert_eq!(range_keys, 1);
-    }
-
-    #[test]
-    fn test_check_region_bucket_split_by_scan_keys() {
-        let path = Builder::new()
-            .prefix("_test_check_region_bucket_split_by_scan_keys")
-            .tempdir()
-            .unwrap();
-        let path_str = path.path().to_str().unwrap();
-        let db_opts = DBOptions::default();
-        let cfs_opts = ALL_CFS
-            .iter()
-            .map(|cf| {
-                let cf_opts = ColumnFamilyOptions::new();
-                CFOptions::new(cf, cf_opts)
-            })
-            .collect();
-        let engine = engine_test::kv::new_engine_opt(path_str, db_opts, cfs_opts).unwrap();
-
-        let mut region = Region::default();
-        region.set_id(1);
-        region.mut_peers().push(Peer::default());
-        region.mut_region_epoch().set_version(2);
-        region.mut_region_epoch().set_conf_ver(5);
-
-        let (tx, rx) = mpsc::sync_channel(100);
-        let cfg = Config {
-            // make sure size based split won't happen
-            region_max_size: Some(ReadableSize(22000_u64)),
-            region_split_size: ReadableSize(15000_u64),
-            region_split_keys: Some(4),
-            region_max_keys: Some(100),
-            enable_region_bucket: true,
-            // so that each key below will form a bucket
-            region_bucket_size: ReadableSize(20_u64),
-            ..Default::default()
-        };
-        let mut runnable =
-            SplitCheckRunner::new(engine.clone(), tx.clone(), CoprocessorHost::new(tx, cfg));
-
-        // so bucket key will be all these keys
-        let mut exp_bucket_keys = vec![];
-        for i in 0..11 {
-            let k = format!("{:04}", i).into_bytes();
-            exp_bucket_keys.push(Key::from_raw(&k).as_encoded().clone());
-            let k = keys::data_key(Key::from_raw(&k).as_encoded());
-            engine.put_cf(CF_WRITE, &k, &k).unwrap();
-        }
-        engine.flush_cf(CF_WRITE, false).unwrap();
-        // the region keys is less than the max region keys,
-        // but we expect keys based split check is triggered even though the approximate keys count is less
-        runnable.run(SplitCheckTask::split_check(
-            region.clone(),
-            true,
-            CheckPolicy::Scan,
-            None,
-        ));
-        must_generate_buckets(&rx, &exp_bucket_keys);
-        must_split_with(&rx, &region, 1);
     }
 }

--- a/components/raftstore/src/coprocessor/split_check/mod.rs
+++ b/components/raftstore/src/coprocessor/split_check/mod.rs
@@ -20,7 +20,6 @@ pub struct Host<'a, E> {
     checkers: Vec<Box<dyn SplitChecker<E>>>,
     auto_split: bool,
     cfg: &'a Config,
-    added_bucket_scan_checker: bool,
 }
 
 impl<'a, E> Host<'a, E> {
@@ -29,7 +28,6 @@ impl<'a, E> Host<'a, E> {
             auto_split,
             checkers: vec![],
             cfg,
-            added_bucket_scan_checker: false,
         }
     }
 
@@ -128,16 +126,6 @@ impl<'a, E> Host<'a, E> {
     #[inline]
     pub fn region_bucket_size(&self) -> u64 {
         self.cfg.region_bucket_size.0
-    }
-
-    #[inline]
-    pub fn set_bucket_scan_checker_added(&mut self, added: bool) {
-        self.added_bucket_scan_checker = added;
-    }
-
-    #[inline]
-    pub fn get_bucket_scan_checker_added(&self) -> bool {
-        self.added_bucket_scan_checker
     }
 }
 

--- a/components/raftstore/src/coprocessor/split_check/mod.rs
+++ b/components/raftstore/src/coprocessor/split_check/mod.rs
@@ -20,7 +20,7 @@ pub struct Host<'a, E> {
     checkers: Vec<Box<dyn SplitChecker<E>>>,
     auto_split: bool,
     cfg: &'a Config,
-    added_bucket_scan_checker: bool, 
+    added_bucket_scan_checker: bool,
 }
 
 impl<'a, E> Host<'a, E> {

--- a/components/raftstore/src/coprocessor/split_check/mod.rs
+++ b/components/raftstore/src/coprocessor/split_check/mod.rs
@@ -20,6 +20,7 @@ pub struct Host<'a, E> {
     checkers: Vec<Box<dyn SplitChecker<E>>>,
     auto_split: bool,
     cfg: &'a Config,
+    added_bucket_scan_checker: bool, 
 }
 
 impl<'a, E> Host<'a, E> {
@@ -28,6 +29,7 @@ impl<'a, E> Host<'a, E> {
             auto_split,
             checkers: vec![],
             cfg,
+            added_bucket_scan_checker: false,
         }
     }
 
@@ -126,6 +128,16 @@ impl<'a, E> Host<'a, E> {
     #[inline]
     pub fn region_bucket_size(&self) -> u64 {
         self.cfg.region_bucket_size.0
+    }
+
+    #[inline]
+    pub fn set_bucket_scan_checker_added(&mut self, added: bool) {
+        self.added_bucket_scan_checker = added;
+    }
+
+    #[inline]
+    pub fn get_bucket_scan_checker_added(&self) -> bool {
+        self.added_bucket_scan_checker
     }
 }
 

--- a/components/raftstore/src/coprocessor/split_check/size.rs
+++ b/components/raftstore/src/coprocessor/split_check/size.rs
@@ -613,7 +613,7 @@ pub mod tests {
             }
         };
         let cop_host = CoprocessorHost::new(tx.clone(), cfg);
-        let mut runnable = SplitCheckRunner::new(engine.clone(), tx.clone(), cop_host.clone());
+        let mut runnable = SplitCheckRunner::new(engine.clone(), tx, cop_host.clone());
         for i in 0..2000 {
             // if not mvcc, kv size is (6+1)*2 = 14, given bucket size is 3000, expect each bucket has about 210 keys
             // if mvcc, kv size is about 18*2 = 36, expect each bucket has about 80 keys

--- a/components/raftstore/src/coprocessor/split_check/size.rs
+++ b/components/raftstore/src/coprocessor/split_check/size.rs
@@ -751,7 +751,7 @@ pub mod tests {
         assert_eq!(host.policy(), CheckPolicy::Scan);
 
         cfg.prefer_gen_bucket_by_approximate = true;
-        let cop_host = CoprocessorHost::new(tx.clone(), cfg);
+        let cop_host = CoprocessorHost::new(tx, cfg);
         let host = cop_host.new_split_checker_host(&region, &engine, true, CheckPolicy::Scan);
         assert_eq!(host.policy(), CheckPolicy::Approximate);
     }

--- a/components/raftstore/src/coprocessor/split_check/size.rs
+++ b/components/raftstore/src/coprocessor/split_check/size.rs
@@ -193,7 +193,7 @@ where
                 if region_size >= host.cfg.region_size_threshold_for_approximate.0 {
                     policy = CheckPolicy::Approximate;
                 }
-            } else if host.cfg.prefer_gen_bucket_by_approximate {
+            } else if host.cfg.prefer_approximate_bucket {
                 // when the check is only for bucket, use approximate anyway
                 policy = CheckPolicy::Approximate;
             }
@@ -731,7 +731,7 @@ pub mod tests {
             region_bucket_size: ReadableSize(1), // minimal bucket size
             region_size_threshold_for_approximate: ReadableSize(500000000),
             // follow split region's check policy, not force to use approximate
-            prefer_gen_bucket_by_approximate: false,
+            prefer_approximate_bucket: false,
             ..Default::default()
         };
         let mut region = Region::default();
@@ -750,7 +750,7 @@ pub mod tests {
         let host = cop_host.new_split_checker_host(&region, &engine, true, CheckPolicy::Scan);
         assert_eq!(host.policy(), CheckPolicy::Scan);
 
-        cfg.prefer_gen_bucket_by_approximate = true;
+        cfg.prefer_approximate_bucket = true;
         let cop_host = CoprocessorHost::new(tx, cfg);
         let host = cop_host.new_split_checker_host(&region, &engine, true, CheckPolicy::Scan);
         assert_eq!(host.policy(), CheckPolicy::Approximate);

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -693,7 +693,7 @@ fn test_serde_custom_tikv_config() {
         enable_region_bucket: true,
         region_bucket_size: ReadableSize::mb(1),
         region_size_threshold_for_approximate: ReadableSize::mb(3),
-        prefer_gen_bucket_by_approximate: false,
+        prefer_approximate_bucket: false,
         region_bucket_merge_size_ratio: 0.4,
     };
     let mut cert_allowed_cn = HashSet::default();

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -693,6 +693,7 @@ fn test_serde_custom_tikv_config() {
         enable_region_bucket: true,
         region_bucket_size: ReadableSize::mb(1),
         region_size_threshold_for_approximate: ReadableSize::mb(3),
+        prefer_gen_bucket_by_approximate: false,
         region_bucket_merge_size_ratio: 0.4,
     };
     let mut cert_allowed_cn = HashSet::default();

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -232,7 +232,7 @@ enable-region-bucket = true
 region-bucket-size = "1MB"
 region-size-threshold-for-approximate = "3MB"
 region-bucket-merge-size-ratio = 0.4
-prefer-gen-bucket-by-approximate = false
+prefer-approximate-bucket = false
 
 [rocksdb]
 wal-recovery-mode = "absolute-consistency"

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -232,6 +232,7 @@ enable-region-bucket = true
 region-bucket-size = "1MB"
 region-size-threshold-for-approximate = "3MB"
 region-bucket-merge-size-ratio = 0.4
+prefer-gen-bucket-by-approximate = false
 
 [rocksdb]
 wal-recovery-mode = "absolute-consistency"


### PR DESCRIPTION
Signed-off-by: qi.xu <tonxuqi@outlook.com>

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #12597

What's Changed:

```commit-message
When bucket is enabled,  using CheckPolicy::Scan would lead to large amount of read IO after tikv restart. Before this PR, the Scan is used unless the region size reaches 1.5G, which is very rare for a 96 ~ 256MB's region-split-size. After this change, generating bucket won't introduce new scan unless the scan is necessary for splitting region. This can significantly reduce the read IO.
Also refine the logic for the fix of 12597. 
```

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
