### PR TITLE
causal_ts: fix issue #12680

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,6 +717,7 @@ dependencies = [
  "futures 0.3.15",
  "kvproto",
  "lazy_static",
+ "log_wrappers",
  "parking_lot 0.12.0",
  "pd_client",
  "prometheus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,6 +714,7 @@ dependencies = [
  "engine_rocks",
  "engine_traits",
  "error_code",
+ "fail",
  "futures 0.3.15",
  "kvproto",
  "lazy_static",

--- a/components/backup-stream/src/observer.rs
+++ b/components/backup-stream/src/observer.rs
@@ -179,7 +179,7 @@ impl RegionChangeObserver for BackupStreamObserver {
                     })
                 );
             }
-            RegionChangeEvent::Update => {
+            RegionChangeEvent::Update(_) => {
                 try_send!(
                     self.scheduler,
                     Task::ModifyObserve(ObserveOp::RefreshResolver {

--- a/components/causal_ts/Cargo.toml
+++ b/components/causal_ts/Cargo.toml
@@ -12,6 +12,7 @@ error_code = { path = "../error_code", default-features = false }
 futures = { version = "0.3" }
 kvproto = { git = "https://github.com/pingcap/kvproto.git" }
 lazy_static = "1.3"
+log_wrappers = { path = "../log_wrappers" }
 parking_lot = "0.12"
 pd_client = { path = "../pd_client", default-features = false }
 prometheus = { version = "0.13", features = ["nightly"] }

--- a/components/causal_ts/Cargo.toml
+++ b/components/causal_ts/Cargo.toml
@@ -9,6 +9,7 @@ api_version = { path = "../api_version", default-features = false }
 engine_rocks = { path = "../engine_rocks", default-features = false }
 engine_traits = { path = "../engine_traits", default-features = false }
 error_code = { path = "../error_code", default-features = false }
+fail = "0.5"
 futures = { version = "0.3" }
 kvproto = { git = "https://github.com/pingcap/kvproto.git" }
 lazy_static = "1.3"

--- a/components/causal_ts/src/observer.rs
+++ b/components/causal_ts/src/observer.rs
@@ -132,7 +132,7 @@ impl<Ts: CausalTsProvider> RegionChangeObserver for CausalObserver<Ts> {
 
         // In the scenario of region merge, the target region would merge some entries from source
         // region with larger timestamps (when leader of source region is in another store with
-        // larger TSO batch than the store where leader of target region exists).
+        // larger TSO batch than the store of target region's leader).
         // So we need a flush after commit merge. See issue #12680.
         // TODO: do not need flush if leaders of source & target region are in the same store.
         if let RegionChangeEvent::Update(RegionChangeReason::CommitMerge) = event {

--- a/components/cdc/tests/integrations/test_cdc.rs
+++ b/components/cdc/tests/integrations/test_cdc.rs
@@ -614,6 +614,7 @@ fn test_cdc_rawkv_scan() {
     let mut suite = TestSuite::new(3, ApiVersion::V2);
 
     suite.set_tso(10);
+    suite.flush_causal_timestamp_for_region(1);
     let (k1, v1) = (b"rkey1".to_vec(), b"value1".to_vec());
     suite.must_kv_put(1, k1, v1);
 
@@ -621,6 +622,7 @@ fn test_cdc_rawkv_scan() {
     suite.must_kv_put(1, k2, v2);
 
     suite.set_tso(1000);
+    suite.flush_causal_timestamp_for_region(1);
     let (k3, v3) = (b"rkey3".to_vec(), b"value3".to_vec());
     suite.must_kv_put(1, k3.clone(), v3.clone());
 

--- a/components/raftstore/src/coprocessor/mod.rs
+++ b/components/raftstore/src/coprocessor/mod.rs
@@ -178,9 +178,18 @@ pub trait RoleObserver: Coprocessor {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
+pub enum RegionChangeReason {
+    ChangePeer,
+    Split,
+    PrepareMerge,
+    CommitMerge,
+    RollbackMerge,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum RegionChangeEvent {
     Create,
-    Update,
+    Update(RegionChangeReason),
     Destroy,
     UpdateBuckets(usize),
 }

--- a/components/raftstore/src/coprocessor/region_info_accessor.rs
+++ b/components/raftstore/src/coprocessor/region_info_accessor.rs
@@ -170,7 +170,7 @@ impl RegionChangeObserver for RegionEventListener {
         let region = context.region().clone();
         let event = match event {
             RegionChangeEvent::Create => RaftStoreEvent::CreateRegion { region, role },
-            RegionChangeEvent::Update => RaftStoreEvent::UpdateRegion { region, role },
+            RegionChangeEvent::Update(_) => RaftStoreEvent::UpdateRegion { region, role },
             RegionChangeEvent::Destroy => RaftStoreEvent::DestroyRegion { region },
             RegionChangeEvent::UpdateBuckets(buckets) => {
                 RaftStoreEvent::UpdateRegionBuckets { region, buckets }

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -63,7 +63,7 @@ use self::memtrace::*;
 #[cfg(any(test, feature = "testexport"))]
 use crate::store::PeerInternalStat;
 use crate::{
-    coprocessor::RegionChangeEvent,
+    coprocessor::{RegionChangeEvent, RegionChangeReason},
     store::{
         cmd_resp::{bind_term, new_error},
         fsm::{
@@ -3364,6 +3364,7 @@ where
                 &self.ctx.coprocessor_host,
                 region.clone(),
                 &mut self.fsm.peer,
+                RegionChangeReason::ChangePeer,
             );
         }
         for peer in region.take_peers().into_iter() {
@@ -3570,7 +3571,12 @@ where
         let estimated_size = self.fsm.peer.approximate_size.map(|v| v / new_region_count);
         let estimated_keys = self.fsm.peer.approximate_keys.map(|v| v / new_region_count);
         let mut meta = self.ctx.store_meta.lock().unwrap();
-        meta.set_region(&self.ctx.coprocessor_host, derived, &mut self.fsm.peer);
+        meta.set_region(
+            &self.ctx.coprocessor_host,
+            derived,
+            &mut self.fsm.peer,
+            RegionChangeReason::Split,
+        );
         self.fsm.peer.post_split();
 
         // It's not correct anymore, so set it to false to schedule a split check task.
@@ -4052,7 +4058,12 @@ where
     fn on_ready_prepare_merge(&mut self, region: metapb::Region, state: MergeState) {
         {
             let mut meta = self.ctx.store_meta.lock().unwrap();
-            meta.set_region(&self.ctx.coprocessor_host, region, &mut self.fsm.peer);
+            meta.set_region(
+                &self.ctx.coprocessor_host,
+                region,
+                &mut self.fsm.peer,
+                RegionChangeReason::PrepareMerge,
+            );
         }
 
         self.fsm.peer.pending_merge_state = Some(state);
@@ -4163,7 +4174,12 @@ where
         meta.region_ranges
             .insert(enc_end_key(&region), region.get_id());
         assert!(meta.regions.remove(&source.get_id()).is_some());
-        meta.set_region(&self.ctx.coprocessor_host, region, &mut self.fsm.peer);
+        meta.set_region(
+            &self.ctx.coprocessor_host,
+            region,
+            &mut self.fsm.peer,
+            RegionChangeReason::CommitMerge,
+        );
         if let Some(d) = meta.readers.get_mut(&source.get_id()) {
             d.mark_pending_remove();
         }
@@ -4246,7 +4262,12 @@ where
 
         if let Some(r) = region {
             let mut meta = self.ctx.store_meta.lock().unwrap();
-            meta.set_region(&self.ctx.coprocessor_host, r, &mut self.fsm.peer);
+            meta.set_region(
+                &self.ctx.coprocessor_host,
+                r,
+                &mut self.fsm.peer,
+                RegionChangeReason::RollbackMerge,
+            );
         }
         if self.fsm.peer.is_leader() {
             info!(

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -68,6 +68,7 @@ use crate::{
     bytes_capacity,
     coprocessor::{
         split_observer::SplitObserver, BoxAdminObserver, CoprocessorHost, RegionChangeEvent,
+        RegionChangeReason,
     },
     store::{
         async_io::write::{StoreWriters, Worker as WriteWorker, WriteMsg},
@@ -173,6 +174,7 @@ impl StoreMeta {
         host: &CoprocessorHost<EK>,
         region: Region,
         peer: &mut crate::store::Peer<EK, ER>,
+        reason: RegionChangeReason,
     ) {
         let prev = self.regions.insert(region.get_id(), region.clone());
         if prev.map_or(true, |r| r.get_id() != region.get_id()) {
@@ -180,7 +182,7 @@ impl StoreMeta {
             panic!("{} region corrupted", peer.tag);
         }
         let reader = self.readers.get_mut(&region.get_id()).unwrap();
-        peer.set_region(host, reader, region);
+        peer.set_region(host, reader, region, reason);
     }
 
     /// Update damaged ranges and return true if overlap exists.

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -82,7 +82,7 @@ use super::{
     DestroyPeerJob,
 };
 use crate::{
-    coprocessor::{CoprocessorHost, RegionChangeEvent, RoleChange},
+    coprocessor::{CoprocessorHost, RegionChangeEvent, RegionChangeReason, RoleChange},
     errors::RAFTSTORE_IS_BUSY,
     store::{
         async_io::{write::WriteMsg, write_router::WriteRouter},
@@ -1462,6 +1462,7 @@ where
         host: &CoprocessorHost<impl KvEngine>,
         reader: &mut ReadDelegate,
         region: metapb::Region,
+        reason: RegionChangeReason,
     ) {
         if self.region().get_region_epoch().get_version() < region.get_region_epoch().get_version()
         {
@@ -1485,7 +1486,11 @@ where
         }
 
         if !self.pending_remove {
-            host.on_region_changed(self.region(), RegionChangeEvent::Update, self.get_role());
+            host.on_region_changed(
+                self.region(),
+                RegionChangeEvent::Update(reason),
+                self.get_role(),
+            );
         }
     }
 

--- a/components/resolved_ts/src/observer.rs
+++ b/components/resolved_ts/src/observer.rs
@@ -110,7 +110,7 @@ impl<E: KvEngine> RegionChangeObserver for Observer<E> {
         }
         match event {
             RegionChangeEvent::Create => {}
-            RegionChangeEvent::Update => {
+            RegionChangeEvent::Update(_) => {
                 if let Err(e) = self
                     .scheduler
                     .schedule(Task::RegionUpdated(ctx.region().clone()))

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use api_version::{dispatch_api_version, KvFormat};
+use causal_ts::CausalTsProvider;
 use collections::{HashMap, HashSet};
 use concurrency_manager::ConcurrencyManager;
 use encryption_export::DataKeyManager;
@@ -147,6 +148,7 @@ pub struct ServerCluster {
     raft_client: RaftClient<AddressMap, RaftStoreBlackHole, RocksEngine>,
     concurrency_managers: HashMap<u64, ConcurrencyManager>,
     env: Arc<Environment>,
+    pub causal_ts_providers: HashMap<u64, Arc<dyn CausalTsProvider>>,
 }
 
 impl ServerCluster {
@@ -188,6 +190,7 @@ impl ServerCluster {
             concurrency_managers: HashMap::default(),
             env,
             txn_extra_schedulers: HashMap::default(),
+            causal_ts_providers: HashMap::default(),
         }
     }
 
@@ -213,6 +216,10 @@ impl ServerCluster {
 
     pub fn get_concurrency_manager(&self, node_id: u64) -> ConcurrencyManager {
         self.concurrency_managers.get(&node_id).unwrap().clone()
+    }
+
+    pub fn get_causal_ts_provider(&self, node_id: u64) -> Option<Arc<dyn CausalTsProvider>> {
+        self.causal_ts_providers.get(&node_id).cloned()
     }
 
     fn init_resource_metering(
@@ -342,8 +349,16 @@ impl ServerCluster {
         };
 
         if ApiVersion::V2 == F::TAG {
-            let causal_ts_provider =
-                Arc::new(causal_ts::SimpleTsoProvider::new(self.pd_client.clone()));
+            let causal_ts_provider = Arc::new(
+                block_on(causal_ts::BatchTsoProvider::new_opt(
+                    self.pd_client.clone(),
+                    cfg.causal_ts.renew_interval.0,
+                    cfg.causal_ts.renew_batch_min_size,
+                ))
+                .unwrap(),
+            );
+            self.causal_ts_providers
+                .insert(node_id, causal_ts_provider.clone());
             let causal_ob = causal_ts::CausalObserver::new(causal_ts_provider);
             causal_ob.register_to(&mut coprocessor_host);
         }

--- a/components/test_raftstore/src/util.rs
+++ b/components/test_raftstore/src/util.rs
@@ -3,6 +3,7 @@
 use std::{
     fmt::Write,
     path::Path,
+    str::FromStr,
     sync::{mpsc, Arc},
     thread,
     time::Duration,
@@ -761,6 +762,16 @@ pub fn configure_for_encryption<T: Simulator>(cluster: &mut Cluster<T>) {
     }
 }
 
+pub fn configure_for_causal_ts<T: Simulator>(
+    cluster: &mut Cluster<T>,
+    renew_interval: &str,
+    renew_batch_min_size: u32,
+) {
+    let cfg = &mut cluster.cfg.causal_ts;
+    cfg.renew_interval = ReadableDuration::from_str(renew_interval).unwrap();
+    cfg.renew_batch_min_size = renew_batch_min_size;
+}
+
 /// Keep putting random kvs until specified size limit is reached.
 pub fn put_till_size<T: Simulator>(
     cluster: &mut Cluster<T>,
@@ -1204,6 +1215,46 @@ pub fn check_compacted(
         }
     }
     true
+}
+
+pub fn must_raw_put(client: &TikvClient, ctx: Context, key: Vec<u8>, value: Vec<u8>) {
+    let mut put_req = RawPutRequest::default();
+    put_req.set_context(ctx);
+    put_req.key = key;
+    put_req.value = value;
+    let put_resp = client.raw_put(&put_req).unwrap();
+    assert!(
+        !put_resp.has_region_error(),
+        "{:?}",
+        put_resp.get_region_error()
+    );
+    assert!(
+        put_resp.get_error().is_empty(),
+        "{:?}",
+        put_resp.get_error()
+    );
+}
+
+pub fn must_raw_get(client: &TikvClient, ctx: Context, key: Vec<u8>) -> Option<Vec<u8>> {
+    let mut get_req = RawGetRequest::default();
+    get_req.set_context(ctx);
+    get_req.key = key;
+    let get_resp = client.raw_get(&get_req).unwrap();
+    assert!(
+        !get_resp.has_region_error(),
+        "{:?}",
+        get_resp.get_region_error()
+    );
+    assert!(
+        get_resp.get_error().is_empty(),
+        "{:?}",
+        get_resp.get_error()
+    );
+    if get_resp.not_found {
+        None
+    } else {
+        Some(get_resp.value)
+    }
 }
 
 // A helpful wrapper to make the test logic clear

--- a/tests/failpoints/cases/mod.rs
+++ b/tests/failpoints/cases/mod.rs
@@ -19,6 +19,7 @@ mod test_merge;
 mod test_metrics_overflow;
 mod test_pd_client;
 mod test_pending_peers;
+mod test_rawkv;
 mod test_replica_read;
 mod test_replica_stale_read;
 mod test_server;

--- a/tests/failpoints/cases/test_rawkv.rs
+++ b/tests/failpoints/cases/test_rawkv.rs
@@ -1,0 +1,135 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::sync::Arc;
+
+use grpcio::{ChannelBuilder, Environment};
+use kvproto::{kvrpcpb::*, tikvpb::TikvClient};
+use test_raftstore::*;
+use tikv_util::HandyRwLock;
+
+struct TestSuite {
+    pub cluster: Cluster<ServerCluster>,
+    pub pd_client: Arc<TestPdClient>,
+    api_version: ApiVersion,
+}
+
+impl TestSuite {
+    pub fn new(count: usize, api_version: ApiVersion) -> Self {
+        let mut cluster = new_server_cluster_with_api_ver(1, count, api_version);
+        // Disable background renew by setting `renew_interval` to 0, to make timestamp allocation predictable.
+        configure_for_causal_ts(&mut cluster, "0s", 100);
+        configure_for_merge(&mut cluster);
+        cluster.run();
+
+        let pd_client = cluster.pd_client.clone();
+        pd_client.disable_default_operator();
+
+        Self {
+            cluster,
+            pd_client,
+            api_version,
+        }
+    }
+
+    pub fn stop(mut self) {
+        self.cluster.shutdown();
+    }
+
+    pub fn get_context(&mut self, region_id: u64) -> Context {
+        let leader = self.cluster.leader_of_region(region_id).unwrap();
+        let epoch = self.cluster.get_region_epoch(region_id);
+
+        let mut ctx = Context::default();
+        ctx.set_region_id(region_id);
+        ctx.set_peer(leader);
+        ctx.set_region_epoch(epoch);
+        ctx.set_api_version(self.api_version);
+        ctx
+    }
+
+    pub fn get_client(&mut self, region_id: u64) -> TikvClient {
+        let leader = self.cluster.leader_of_region(region_id).unwrap();
+        let addr = self.cluster.sim.rl().get_addr(leader.store_id);
+        let env = Arc::new(Environment::new(1));
+        let channel = ChannelBuilder::new(env).connect(&addr);
+        TikvClient::new(channel)
+    }
+
+    pub fn must_raw_put(&mut self, key: &[u8], value: &[u8]) {
+        let region_id = self.cluster.get_region_id(key);
+        let client = self.get_client(region_id);
+        let ctx = self.get_context(region_id);
+        must_raw_put(&client, ctx, key.to_vec(), value.to_vec())
+    }
+
+    pub fn must_raw_get(&mut self, key: &[u8]) -> Option<Vec<u8>> {
+        let region_id = self.cluster.get_region_id(key);
+        let client = self.get_client(region_id);
+        let ctx = self.get_context(region_id);
+        must_raw_get(&client, ctx, key.to_vec())
+    }
+
+    pub fn flush_timestamp(&mut self, node_id: u64) {
+        self.cluster
+            .sim
+            .rl()
+            .get_causal_ts_provider(node_id)
+            .unwrap()
+            .flush()
+            .unwrap();
+    }
+}
+
+const FP_CAUSAL_OBSERVER_FLUSH_TIMESTAMP: &str = "causal_observer_flush_timestamp";
+
+#[test]
+fn test_leader_transfer() {
+    let mut suite = TestSuite::new(3, ApiVersion::V2);
+    let region_id = 1;
+    let key1 = b"rk1";
+
+    // Transfer leader to store 1.
+    let peer1 = new_peer(1, 1);
+    suite.cluster.must_transfer_leader(region_id, peer1.clone());
+    let leader1 = suite.cluster.leader_of_region(region_id).unwrap();
+    {
+        suite.must_raw_put(key1, b"v1");
+        suite.must_raw_put(key1, b"v2");
+        suite.must_raw_put(key1, b"v3");
+        suite.flush_timestamp(leader1.get_store_id()); // Flush to make ts bigger than other stores.
+        suite.must_raw_put(key1, b"v4");
+        assert_eq!(suite.must_raw_get(key1), Some(b"v4".to_vec()));
+    }
+
+    // Disable CausalObserver::flush_timestamp to produce causality issue.
+    fail::cfg(FP_CAUSAL_OBSERVER_FLUSH_TIMESTAMP, "return").unwrap();
+
+    // Transfer leader to store 2.
+    let peer2 = new_peer(2, 2);
+    suite.cluster.must_transfer_leader(region_id, peer2.clone());
+    let leader2 = suite.cluster.leader_of_region(region_id).unwrap();
+    assert_ne!(leader1, leader2);
+    {
+        // Store 2 has a TSO batch smaller than store 1.
+        suite.must_raw_put(key1, b"v5");
+        assert_eq!(suite.must_raw_get(key1), Some(b"v4".to_vec()));
+        suite.must_raw_put(key1, b"v6");
+        assert_eq!(suite.must_raw_get(key1), Some(b"v4".to_vec()));
+    }
+
+    // Enable CausalObserver::flush_timestamp.
+    fail::cfg(FP_CAUSAL_OBSERVER_FLUSH_TIMESTAMP, "off").unwrap();
+    {
+        // Transfer leader again.
+        suite.cluster.must_transfer_leader(region_id, peer1);
+        assert_eq!(suite.cluster.leader_of_region(region_id).unwrap(), leader1);
+        suite.cluster.must_transfer_leader(region_id, peer2);
+        assert_eq!(suite.cluster.leader_of_region(region_id).unwrap(), leader2);
+
+        suite.must_raw_put(key1, b"v7");
+        assert_eq!(suite.must_raw_get(key1), Some(b"v7".to_vec()));
+    }
+
+    fail::remove(FP_CAUSAL_OBSERVER_FLUSH_TIMESTAMP);
+    suite.stop();
+}

--- a/tests/failpoints/cases/test_rawkv.rs
+++ b/tests/failpoints/cases/test_rawkv.rs
@@ -1,15 +1,23 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::sync::Arc;
+use std::{
+    sync::{mpsc, Arc},
+    time::Duration,
+};
 
+use engine_rocks::RocksSnapshot;
 use grpcio::{ChannelBuilder, Environment};
-use kvproto::{kvrpcpb::*, tikvpb::TikvClient};
+use kvproto::{
+    kvrpcpb::*,
+    metapb::{Peer, Region},
+    tikvpb::TikvClient,
+};
+use raftstore::store::{Callback, ReadResponse};
 use test_raftstore::*;
 use tikv_util::HandyRwLock;
 
 struct TestSuite {
     pub cluster: Cluster<ServerCluster>,
-    pub pd_client: Arc<TestPdClient>,
     api_version: ApiVersion,
 }
 
@@ -20,13 +28,10 @@ impl TestSuite {
         configure_for_causal_ts(&mut cluster, "0s", 100);
         configure_for_merge(&mut cluster);
         cluster.run();
-
-        let pd_client = cluster.pd_client.clone();
-        pd_client.disable_default_operator();
+        cluster.pd_client.disable_default_operator();
 
         Self {
             cluster,
-            pd_client,
             api_version,
         }
     }
@@ -49,7 +54,7 @@ impl TestSuite {
 
     pub fn get_client(&mut self, region_id: u64) -> TikvClient {
         let leader = self.cluster.leader_of_region(region_id).unwrap();
-        let addr = self.cluster.sim.rl().get_addr(leader.store_id);
+        let addr = self.cluster.sim.rl().get_addr(leader.get_store_id());
         let env = Arc::new(Environment::new(1));
         let channel = ChannelBuilder::new(env).connect(&addr);
         TikvClient::new(channel)
@@ -78,21 +83,57 @@ impl TestSuite {
             .flush()
             .unwrap();
     }
+
+    pub fn must_merge_region_by_key(&mut self, source_key: &[u8], target_key: &[u8]) {
+        let source = self.cluster.get_region(source_key);
+        let target = self.cluster.get_region(target_key);
+        assert_ne!(source.get_id(), target.get_id());
+
+        let (merge_tx, merge_rx) = mpsc::channel();
+        let cb = Callback::Read(Box::new(move |resp: ReadResponse<RocksSnapshot>| {
+            merge_tx.send(resp.response).unwrap()
+        }));
+        self.cluster
+            .merge_region(source.get_id(), target.get_id(), cb);
+        merge_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+
+        let merged = self.cluster.get_region(source_key);
+        assert_eq!(merged.get_id(), target.get_id());
+        assert_eq!(merged.get_start_key(), source.get_start_key());
+        assert_eq!(merged.get_end_key(), target.get_end_key())
+    }
+
+    pub fn must_transfer_leader(&mut self, region: &Region, store_id: u64) {
+        self.cluster
+            .must_transfer_leader(region.get_id(), peer_on_store(region, store_id));
+    }
+
+    pub fn must_leader_on_store(&mut self, key: &[u8], store_id: u64) -> Peer {
+        let region_id = self.cluster.get_region_id(key);
+        let leader = self.cluster.leader_of_region(region_id).unwrap();
+        assert_eq!(leader.get_store_id(), store_id);
+        leader
+    }
 }
 
 const FP_CAUSAL_OBSERVER_FLUSH_TIMESTAMP: &str = "causal_observer_flush_timestamp";
 
+/// Verify correctness on leader transfer.
+// TODO: simulate and test for the scenario of issue #12498.
 #[test]
 fn test_leader_transfer() {
     let mut suite = TestSuite::new(3, ApiVersion::V2);
-    let region_id = 1;
     let key1 = b"rk1";
+    let region = suite.cluster.get_region(key1);
 
-    // Transfer leader to store 1.
-    let peer1 = new_peer(1, 1);
-    suite.cluster.must_transfer_leader(region_id, peer1.clone());
-    let leader1 = suite.cluster.leader_of_region(region_id).unwrap();
+    // Disable CausalObserver::flush_timestamp to produce causality issue.
+    fail::cfg(FP_CAUSAL_OBSERVER_FLUSH_TIMESTAMP, "return").unwrap();
+
+    // Transfer leader and write to store 1.
     {
+        suite.must_transfer_leader(&region, 1);
+        let leader1 = suite.must_leader_on_store(key1, 1);
+
         suite.must_raw_put(key1, b"v1");
         suite.must_raw_put(key1, b"v2");
         suite.must_raw_put(key1, b"v3");
@@ -101,15 +142,11 @@ fn test_leader_transfer() {
         assert_eq!(suite.must_raw_get(key1), Some(b"v4".to_vec()));
     }
 
-    // Disable CausalObserver::flush_timestamp to produce causality issue.
-    fail::cfg(FP_CAUSAL_OBSERVER_FLUSH_TIMESTAMP, "return").unwrap();
-
-    // Transfer leader to store 2.
-    let peer2 = new_peer(2, 2);
-    suite.cluster.must_transfer_leader(region_id, peer2.clone());
-    let leader2 = suite.cluster.leader_of_region(region_id).unwrap();
-    assert_ne!(leader1, leader2);
+    // Transfer leader and write to store 2.
     {
+        suite.must_transfer_leader(&region, 2);
+        suite.must_leader_on_store(key1, 2);
+
         // Store 2 has a TSO batch smaller than store 1.
         suite.must_raw_put(key1, b"v5");
         assert_eq!(suite.must_raw_get(key1), Some(b"v4".to_vec()));
@@ -117,17 +154,92 @@ fn test_leader_transfer() {
         assert_eq!(suite.must_raw_get(key1), Some(b"v4".to_vec()));
     }
 
+    // Transfer leader back.
+    suite.must_transfer_leader(&region, 1);
+    suite.must_leader_on_store(key1, 1);
     // Enable CausalObserver::flush_timestamp.
     fail::cfg(FP_CAUSAL_OBSERVER_FLUSH_TIMESTAMP, "off").unwrap();
+    // Transfer leader and write to store 2 again.
     {
-        // Transfer leader again.
-        suite.cluster.must_transfer_leader(region_id, peer1);
-        assert_eq!(suite.cluster.leader_of_region(region_id).unwrap(), leader1);
-        suite.cluster.must_transfer_leader(region_id, peer2);
-        assert_eq!(suite.cluster.leader_of_region(region_id).unwrap(), leader2);
+        suite.must_transfer_leader(&region, 2);
+        suite.must_leader_on_store(key1, 2);
 
         suite.must_raw_put(key1, b"v7");
         assert_eq!(suite.must_raw_get(key1), Some(b"v7".to_vec()));
+        suite.must_raw_put(key1, b"v8");
+        assert_eq!(suite.must_raw_get(key1), Some(b"v8".to_vec()));
+    }
+
+    fail::remove(FP_CAUSAL_OBSERVER_FLUSH_TIMESTAMP);
+    suite.stop();
+}
+
+/// Verify correctness on region merge.
+/// See issue #12680.
+#[test]
+fn test_region_merge() {
+    let mut suite = TestSuite::new(3, ApiVersion::V2);
+    let keys = vec![b"rk0", b"rk1", b"rk2", b"rk3", b"rk4", b"rk5"];
+
+    suite.must_raw_put(keys[1], b"v1");
+    suite.must_raw_put(keys[3], b"v3");
+    suite.must_raw_put(keys[5], b"v5");
+
+    // Split to: region1: (-, 2), region3: [2, 4), region5: [4, +)
+    let region1 = suite.cluster.get_region(keys[1]);
+    suite.cluster.must_split(&region1, keys[2]);
+    let region1 = suite.cluster.get_region(keys[1]);
+    let region3 = suite.cluster.get_region(keys[3]);
+    suite.cluster.must_split(&region3, keys[4]);
+    let region3 = suite.cluster.get_region(keys[3]);
+    let region5 = suite.cluster.get_region(keys[5]);
+    assert_eq!(region1.get_end_key(), region3.get_start_key());
+    assert_eq!(region3.get_end_key(), region5.get_start_key());
+
+    // Disable CausalObserver::flush_timestamp to produce causality issue.
+    fail::cfg(FP_CAUSAL_OBSERVER_FLUSH_TIMESTAMP, "return").unwrap();
+
+    // Transfer leaders: region 1 -> store 1, region 3 -> store 2, region 5 -> store 3.
+    suite.must_transfer_leader(&region1, 1);
+    suite.must_transfer_leader(&region3, 2);
+    suite.must_transfer_leader(&region5, 3);
+
+    // Write to region 1.
+    {
+        let leader1 = suite.must_leader_on_store(keys[1], 1);
+
+        suite.must_raw_put(keys[1], b"v2");
+        suite.must_raw_put(keys[1], b"v3");
+        suite.flush_timestamp(leader1.get_store_id()); // Flush to make ts of store 1 larger than others.
+        suite.must_raw_put(keys[1], b"v4");
+        assert_eq!(suite.must_raw_get(keys[1]), Some(b"v4".to_vec()));
+    }
+
+    // Merge region 1 to 3.
+    {
+        suite.must_merge_region_by_key(keys[1], keys[3]);
+        suite.must_leader_on_store(keys[1], 2);
+
+        // Write to store 2. Store 2 has a TSO batch smaller than store 1.
+        suite.must_raw_put(keys[1], b"v5");
+        assert_eq!(suite.must_raw_get(keys[1]), Some(b"v4".to_vec()));
+        suite.must_raw_put(keys[1], b"v6");
+        assert_eq!(suite.must_raw_get(keys[1]), Some(b"v4".to_vec()));
+    }
+
+    // Enable CausalObserver::flush_timestamp.
+    fail::cfg(FP_CAUSAL_OBSERVER_FLUSH_TIMESTAMP, "off").unwrap();
+
+    // Merge region 3 to 5.
+    {
+        suite.must_merge_region_by_key(keys[3], keys[5]);
+        suite.must_leader_on_store(keys[1], 3);
+
+        // Write to store 3.
+        suite.must_raw_put(keys[1], b"v7");
+        assert_eq!(suite.must_raw_get(keys[1]), Some(b"v7".to_vec()));
+        suite.must_raw_put(keys[1], b"v8");
+        assert_eq!(suite.must_raw_get(keys[1]), Some(b"v8".to_vec()));
     }
 
     fail::remove(FP_CAUSAL_OBSERVER_FLUSH_TIMESTAMP);

--- a/tests/integrations/raftstore/test_region_change_observer.rs
+++ b/tests/integrations/raftstore/test_region_change_observer.rs
@@ -14,7 +14,7 @@ use raft::StateRole;
 use raftstore::{
     coprocessor::{
         BoxRegionChangeObserver, Coprocessor, ObserverContext, RegionChangeEvent,
-        RegionChangeObserver,
+        RegionChangeObserver, RegionChangeReason,
     },
     store::util::{find_peer, new_peer},
 };
@@ -79,7 +79,10 @@ fn test_region_change_observer_impl(mut cluster: Cluster<NodeCluster>) {
     pd_client.must_add_peer(r1, new_peer(2, 10));
     let add_peer_event = receiver.recv().unwrap();
     receiver.try_recv().unwrap_err();
-    assert_eq!(add_peer_event.1, RegionChangeEvent::Update);
+    assert_eq!(
+        add_peer_event.1,
+        RegionChangeEvent::Update(RegionChangeReason::ChangePeer)
+    );
     assert_eq!(add_peer_event.0.get_id(), r1);
     assert_eq!(add_peer_event.0.get_peers().len(), 2);
     assert_ne!(
@@ -95,12 +98,15 @@ fn test_region_change_observer_impl(mut cluster: Cluster<NodeCluster>) {
     let mut split_update = receiver.recv().unwrap();
     let mut split_create = receiver.recv().unwrap();
     // We should receive an `Update` and a `Create`. The order of them is not important.
-    if split_update.1 != RegionChangeEvent::Update {
+    if split_update.1 != RegionChangeEvent::Update(RegionChangeReason::Split) {
         mem::swap(&mut split_update, &mut split_create);
     }
     // No more events
     receiver.try_recv().unwrap_err();
-    assert_eq!(split_update.1, RegionChangeEvent::Update);
+    assert_eq!(
+        split_update.1,
+        RegionChangeEvent::Update(RegionChangeReason::Split)
+    );
     assert_eq!(split_update.0.get_id(), r1);
     assert_ne!(
         split_update.0.get_region_epoch(),
@@ -123,16 +129,22 @@ fn test_region_change_observer_impl(mut cluster: Cluster<NodeCluster>) {
     // Merge
     pd_client.must_merge(split_update.0.get_id(), split_create.0.get_id());
     // An `Update` produced by PrepareMerge. Ignore it.
-    assert_eq!(receiver.recv().unwrap().1, RegionChangeEvent::Update);
+    assert_eq!(
+        receiver.recv().unwrap().1,
+        RegionChangeEvent::Update(RegionChangeReason::PrepareMerge)
+    );
     let mut merge_update = receiver.recv().unwrap();
     let mut merge_destroy = receiver.recv().unwrap();
     // We should receive an `Update` and a `Destroy`. The order of them is not important.
-    if merge_update.1 != RegionChangeEvent::Update {
+    if merge_update.1 != RegionChangeEvent::Update(RegionChangeReason::CommitMerge) {
         mem::swap(&mut merge_update, &mut merge_destroy);
     }
     // No more events
     receiver.try_recv().unwrap_err();
-    assert_eq!(merge_update.1, RegionChangeEvent::Update);
+    assert_eq!(
+        merge_update.1,
+        RegionChangeEvent::Update(RegionChangeReason::CommitMerge)
+    );
     assert!(merge_update.0.get_start_key().is_empty());
     assert!(merge_update.0.get_end_key().is_empty());
     assert_eq!(merge_destroy.1, RegionChangeEvent::Destroy);
@@ -160,7 +172,10 @@ fn test_region_change_observer_impl(mut cluster: Cluster<NodeCluster>) {
 
     let remove_peer_update = receiver.recv().unwrap();
     // After being removed from the region's peers, an update is triggered at first.
-    assert_eq!(remove_peer_update.1, RegionChangeEvent::Update);
+    assert_eq!(
+        remove_peer_update.1,
+        RegionChangeEvent::Update(RegionChangeReason::ChangePeer)
+    );
     assert!(find_peer(&remove_peer_update.0, 1).is_none());
 
     let remove_peer_destroy = receiver.recv().unwrap();


### PR DESCRIPTION
Signed-off-by: pingyu yuping@pingcap.com

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #12680

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Fix issue #12680.
```

In the scenario of region merge, the target region would merge some entries from source region with larger timestamps, when leader of source region is in another store with larger TSO batch than the store of target region's leader.
So we need a flush after commit merge.
Also see analysis in #12680.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
No.
- Need to cherry-pick to the release branch
release-6.1

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects
- No.

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix issue #12680.
```
