### PR TITLE
security, server: fix running local test

### DIFF
--- a/components/backup-stream/src/router.rs
+++ b/components/backup-stream/src/router.rs
@@ -1328,7 +1328,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_basic_file() -> Result<()> {
-        test_util::init_log_for_test();
         let tmp = std::env::temp_dir().join(format!("{}", uuid::Uuid::new_v4()));
         tokio::fs::create_dir_all(&tmp).await?;
         let (tx, rx) = dummy_scheduler();
@@ -1485,7 +1484,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_flush_with_error() -> Result<()> {
-        test_util::init_log_for_test();
         let (tx, _rx) = dummy_scheduler();
         let tmp = std::env::temp_dir().join(format!("{}", uuid::Uuid::new_v4()));
         let router = Arc::new(RouterInner::new(
@@ -1517,7 +1515,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_empty_resolved_ts() {
-        test_util::init_log_for_test();
         let (tx, _rx) = dummy_scheduler();
         let tmp = std::env::temp_dir().join(format!("{}", uuid::Uuid::new_v4()));
         let router = RouterInner::new(tmp.clone(), tx, 32, Duration::from_secs(300));
@@ -1544,7 +1541,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_flush_with_pausing_self() -> Result<()> {
-        test_util::init_log_for_test();
         let (tx, rx) = dummy_scheduler();
         let tmp = std::env::temp_dir().join(format!("{}", uuid::Uuid::new_v4()));
         let router = Arc::new(RouterInner::new(
@@ -1585,7 +1581,6 @@ mod tests {
 
     #[test]
     fn test_format_datetime() {
-        test_util::init_log_for_test();
         let s = TempFileKey::format_date_time(431656320867237891);
         let s = s.to_string();
         assert_eq!(s, "20220307");

--- a/components/backup-stream/tests/mod.rs
+++ b/components/backup-stream/tests/mod.rs
@@ -628,25 +628,15 @@ mod test {
                 .global_progress_of_task("test_fatal_error"),
         )
         .unwrap();
-        assert_eq!(safepoints.len(), 4, "{:?}", safepoints);
+
         assert!(
-            safepoints
-                .iter()
-                .take(3)
-                // They are choosing the lock safepoint, it must greater than the global checkpoint.
-                .all(|sp| { sp.safepoint.into_inner() >= checkpoint }),
+            safepoints.iter().any(|sp| {
+                sp.serivce.contains(&format!("{}", victim))
+                    && sp.ttl >= Duration::from_secs(60 * 60 * 24)
+                    && sp.safepoint.into_inner() == checkpoint
+            }),
             "{:?}",
             safepoints
-        );
-
-        let sp = &safepoints[3];
-        assert!(sp.serivce.contains(&format!("{}", victim)), "{:?}", sp);
-        assert!(sp.ttl >= Duration::from_secs(60 * 60 * 24), "{:?}", sp);
-        assert!(
-            sp.safepoint.into_inner() == checkpoint,
-            "{:?} vs {}",
-            sp,
-            checkpoint
         );
     }
 

--- a/components/backup-stream/tests/mod.rs
+++ b/components/backup-stream/tests/mod.rs
@@ -507,7 +507,6 @@ mod test {
 
     #[test]
     fn basic() {
-        // test_util::init_log_for_test();
         let mut suite = super::Suite::new("basic", 4);
 
         run_async_test(async {
@@ -528,7 +527,6 @@ mod test {
 
     #[test]
     fn with_split() {
-        // test_util::init_log_for_test();
         let mut suite = super::Suite::new("with_split", 4);
         run_async_test(async {
             let round1 = suite.write_records(0, 128, 1).await;
@@ -548,7 +546,6 @@ mod test {
     #[test]
     /// This case tests whether the backup can continue when the leader failes.
     fn leader_down() {
-        // test_util::init_log_for_test();
         let mut suite = super::Suite::new("leader_down", 4);
         suite.must_register_task(1, "test_leader_down");
         suite.sync();
@@ -569,7 +566,6 @@ mod test {
     /// This case tests whehter the checkpoint ts (next backup ts) can be advanced correctly
     /// when async commit is enabled.
     fn async_commit() {
-        // test_util::init_log_for_test();
         let mut suite = super::Suite::new("async_commit", 3);
         run_async_test(async {
             suite.must_register_task(1, "test_async_commit");
@@ -600,7 +596,6 @@ mod test {
 
     #[test]
     fn fatal_error() {
-        // test_util::init_log_for_test();
         let mut suite = super::Suite::new("fatal_error", 3);
         suite.must_register_task(1, "test_fatal_error");
         suite.sync();
@@ -657,7 +652,6 @@ mod test {
 
     #[test]
     fn inflight_messages() {
-        test_util::init_log_for_test();
         // We should remove the failpoints when paniked or we may get stucked.
         defer! {{
             fail::remove("delay_on_start_observe");

--- a/components/security/Cargo.toml
+++ b/components/security/Cargo.toml
@@ -15,7 +15,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 tikv_util = { path = "../tikv_util", default-features = false }
-tonic = { version = "0.5", features = ["tls"], optional = true}
+tonic = { version = "0.5", features = ["tls"], optional = true }
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/components/security/Cargo.toml
+++ b/components/security/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.0.1"
 edition = "2018"
 publish = false
 
+[features]
+tonic = ["dep:tonic"]
+
 [dependencies]
 collections = { path = "../collections" }
 encryption = { path = "../encryption", default-features = false }
@@ -12,7 +15,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 tikv_util = { path = "../tikv_util", default-features = false }
-tonic = "0.5"
+tonic = { version = "0.5", features = ["tls"], optional = true}
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/components/security/src/lib.rs
+++ b/components/security/src/lib.rs
@@ -18,6 +18,7 @@ use grpcio::{
     RpcContext, RpcStatus, RpcStatusCode, ServerBuilder, ServerChecker, ServerCredentialsBuilder,
     ServerCredentialsFetcher,
 };
+#[cfg(feature = "tonic")]
 use tonic::transport::{channel::ClientTlsConfig, Certificate, Identity};
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Default)]
@@ -122,6 +123,7 @@ impl SecurityManager {
         })
     }
 
+    #[cfg(feature = "tonic")]
     /// Make a tonic tls config via the config.
     pub fn tonic_tls_config(&self) -> Option<ClientTlsConfig> {
         let (ca, cert, key) = self.cfg.load_certs().unwrap_or_default();

--- a/components/server/Cargo.toml
+++ b/components/server/Cargo.toml
@@ -70,7 +70,7 @@ raftstore = { path = "../raftstore", default-features = false }
 rand = "0.8"
 resolved_ts = { path = "../../components/resolved_ts", default-features = false }
 resource_metering = { path = "../resource_metering" }
-security = { path = "../security", default-features = false }
+security = { path = "../security", default-features = false, features = ["tonic"] }
 serde_json = "1.0"
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }


### PR DESCRIPTION
Signed-off-by: Yu Juncen <yujuncen@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #12711 

What's Changed:
Make `tonic` in `security` crate an optional requirement.

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
Now we can run `cargo test` for raftstore. And there is no need for compiling tonic.

<img width="879" alt="image" src="https://user-images.githubusercontent.com/36239017/171320763-2ba17d92-1fc1-4ff9-bf23-5ed330c0969e.png">


- No code


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
none
```
