### PR TITLE
Reserve key space id encoding in backup convert

### DIFF
--- a/components/api_version/src/api_v1.rs
+++ b/components/api_version/src/api_v1.rs
@@ -1,6 +1,6 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_traits::Error;
+use tikv_util::box_err;
 
 use super::*;
 
@@ -45,9 +45,7 @@ impl KvFormat for ApiV1 {
     ) -> Result<Key> {
         match src_api {
             ApiVersion::V1 | ApiVersion::V1ttl => Ok(Key::from_encoded_slice(key)),
-            ApiVersion::V2 => Err(Error::Engine(String::from(
-                "unsupported conversion from v2 to v1",
-            ))), // reject apiv2 -> apiv1 conversion
+            ApiVersion::V2 => Err(box_err!("unsupported conversion from v2 to v1")), // reject apiv2 -> apiv1 conversion
         }
     }
 
@@ -58,9 +56,7 @@ impl KvFormat for ApiV1 {
     ) -> Result<(Vec<u8>, Vec<u8>)> {
         match src_api {
             ApiVersion::V1 | ApiVersion::V1ttl => Ok((start_key, end_key)),
-            ApiVersion::V2 => Err(Error::Engine(String::from(
-                "unsupported conversion from v2 to v1",
-            ))), // reject apiv2 -> apiv1 conversion
+            ApiVersion::V2 => Err(box_err!("unsupported conversion from v2 to v1")), // reject apiv2 -> apiv1 conversion
         }
     }
 }

--- a/components/api_version/src/api_v1.rs
+++ b/components/api_version/src/api_v1.rs
@@ -1,6 +1,8 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
 use super::*;
+use tikv_util::box_err;
+use engine_traits::Error as EngineError;
 
 impl KvFormat for ApiV1 {
     const TAG: ApiVersion = ApiVersion::V1;
@@ -44,26 +46,20 @@ impl KvFormat for ApiV1 {
         match src_api {
             ApiVersion::V1 | ApiVersion::V1ttl => Ok(Key::from_encoded_slice(key)),
             ApiVersion::V2 => {
-                debug_assert_eq!(ApiV2::parse_key_mode(key), KeyMode::Raw);
-                let (user_key, _) = ApiV2::decode_raw_key(&Key::from_encoded_slice(key), true)?;
-                let raw_key = ApiV2::remove_prefix(user_key)?;
-                Ok(Self::encode_raw_key_owned(raw_key, None))
+                Err(EngineError::Other(box_err!("unsupported conversion")))
             }
         }
     }
 
     fn convert_raw_user_key_range_version_from(
         src_api: ApiVersion,
-        mut start_key: Vec<u8>,
-        mut end_key: Vec<u8>,
+        start_key: Vec<u8>,
+        end_key: Vec<u8>,
     ) -> Result<(Vec<u8>, Vec<u8>)> {
         match src_api {
             ApiVersion::V1 | ApiVersion::V1ttl => Ok((start_key, end_key)),
             ApiVersion::V2 => {
-                // TODO: check raw key range after check_api_version_range is refactored.
-                start_key = ApiV2::remove_prefix(start_key)?;
-                end_key = ApiV2::remove_prefix(end_key)?;
-                Ok((start_key, end_key))
+                Err(EngineError::Other(box_err!("unsupported conversion")))
             }
         }
     }

--- a/components/api_version/src/api_v1.rs
+++ b/components/api_version/src/api_v1.rs
@@ -45,9 +45,9 @@ impl KvFormat for ApiV1 {
             ApiVersion::V1 | ApiVersion::V1ttl => Ok(Key::from_encoded_slice(key)),
             ApiVersion::V2 => {
                 debug_assert_eq!(ApiV2::parse_key_mode(key), KeyMode::Raw);
-                let (mut user_key, _) = ApiV2::decode_raw_key(&Key::from_encoded_slice(key), true)?;
-                user_key.remove(0); // remove first byte `RAW_KEY_PREFIX`
-                Ok(Self::encode_raw_key_owned(user_key, None))
+                let (user_key, _) = ApiV2::decode_raw_key(&Key::from_encoded_slice(key), true)?;
+                let raw_key = ApiV2::remove_prefix(user_key)?;
+                Ok(Self::encode_raw_key_owned(raw_key, None))
             }
         }
     }
@@ -56,14 +56,14 @@ impl KvFormat for ApiV1 {
         src_api: ApiVersion,
         mut start_key: Vec<u8>,
         mut end_key: Vec<u8>,
-    ) -> (Vec<u8>, Vec<u8>) {
+    ) -> Result<(Vec<u8>, Vec<u8>)> {
         match src_api {
-            ApiVersion::V1 | ApiVersion::V1ttl => (start_key, end_key),
+            ApiVersion::V1 | ApiVersion::V1ttl => Ok((start_key, end_key)),
             ApiVersion::V2 => {
                 // TODO: check raw key range after check_api_version_range is refactored.
-                start_key.remove(0);
-                end_key.remove(0);
-                (start_key, end_key)
+                start_key = ApiV2::remove_prefix(start_key)?;
+                end_key = ApiV2::remove_prefix(end_key)?;
+                Ok((start_key, end_key))
             }
         }
     }

--- a/components/api_version/src/api_v1.rs
+++ b/components/api_version/src/api_v1.rs
@@ -1,8 +1,6 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
 use super::*;
-use tikv_util::box_err;
-use engine_traits::Error as EngineError;
 
 impl KvFormat for ApiV1 {
     const TAG: ApiVersion = ApiVersion::V1;
@@ -45,9 +43,7 @@ impl KvFormat for ApiV1 {
     ) -> Result<Key> {
         match src_api {
             ApiVersion::V1 | ApiVersion::V1ttl => Ok(Key::from_encoded_slice(key)),
-            ApiVersion::V2 => {
-                Err(EngineError::Other(box_err!("unsupported conversion")))
-            }
+            ApiVersion::V2 => unreachable!(), // reject apiv2 -> apiv1 conversion
         }
     }
 
@@ -55,12 +51,10 @@ impl KvFormat for ApiV1 {
         src_api: ApiVersion,
         start_key: Vec<u8>,
         end_key: Vec<u8>,
-    ) -> Result<(Vec<u8>, Vec<u8>)> {
+    ) -> (Vec<u8>, Vec<u8>) {
         match src_api {
-            ApiVersion::V1 | ApiVersion::V1ttl => Ok((start_key, end_key)),
-            ApiVersion::V2 => {
-                Err(EngineError::Other(box_err!("unsupported conversion")))
-            }
+            ApiVersion::V1 | ApiVersion::V1ttl => (start_key, end_key),
+            ApiVersion::V2 => unreachable!(), // reject apiv2 -> apiv1 conversion
         }
     }
 }

--- a/components/api_version/src/api_v1.rs
+++ b/components/api_version/src/api_v1.rs
@@ -1,5 +1,7 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
+use engine_traits::Error;
+
 use super::*;
 
 impl KvFormat for ApiV1 {
@@ -43,7 +45,7 @@ impl KvFormat for ApiV1 {
     ) -> Result<Key> {
         match src_api {
             ApiVersion::V1 | ApiVersion::V1ttl => Ok(Key::from_encoded_slice(key)),
-            ApiVersion::V2 => unreachable!(), // reject apiv2 -> apiv1 conversion
+            ApiVersion::V2 => Err(Error::Engine(String::from("unsupported conversion"))), // reject apiv2 -> apiv1 conversion
         }
     }
 
@@ -51,10 +53,10 @@ impl KvFormat for ApiV1 {
         src_api: ApiVersion,
         start_key: Vec<u8>,
         end_key: Vec<u8>,
-    ) -> (Vec<u8>, Vec<u8>) {
+    ) -> Result<(Vec<u8>, Vec<u8>)> {
         match src_api {
-            ApiVersion::V1 | ApiVersion::V1ttl => (start_key, end_key),
-            ApiVersion::V2 => unreachable!(), // reject apiv2 -> apiv1 conversion
+            ApiVersion::V1 | ApiVersion::V1ttl => Ok((start_key, end_key)),
+            ApiVersion::V2 => Err(Error::Engine(String::from("unsupported conversion"))), // reject apiv2 -> apiv1 conversion
         }
     }
 }

--- a/components/api_version/src/api_v1.rs
+++ b/components/api_version/src/api_v1.rs
@@ -45,7 +45,9 @@ impl KvFormat for ApiV1 {
     ) -> Result<Key> {
         match src_api {
             ApiVersion::V1 | ApiVersion::V1ttl => Ok(Key::from_encoded_slice(key)),
-            ApiVersion::V2 => Err(Error::Engine(String::from("unsupported conversion"))), // reject apiv2 -> apiv1 conversion
+            ApiVersion::V2 => Err(Error::Engine(String::from(
+                "unsupported conversion from v2 to v1",
+            ))), // reject apiv2 -> apiv1 conversion
         }
     }
 
@@ -56,7 +58,9 @@ impl KvFormat for ApiV1 {
     ) -> Result<(Vec<u8>, Vec<u8>)> {
         match src_api {
             ApiVersion::V1 | ApiVersion::V1ttl => Ok((start_key, end_key)),
-            ApiVersion::V2 => Err(Error::Engine(String::from("unsupported conversion"))), // reject apiv2 -> apiv1 conversion
+            ApiVersion::V2 => Err(Error::Engine(String::from(
+                "unsupported conversion from v2 to v1",
+            ))), // reject apiv2 -> apiv1 conversion
         }
     }
 }

--- a/components/api_version/src/api_v1ttl.rs
+++ b/components/api_version/src/api_v1ttl.rs
@@ -7,6 +7,8 @@ use tikv_util::codec::{
 };
 
 use super::*;
+use tikv_util::box_err;
+use engine_traits::Error as EngineError;
 
 impl KvFormat for ApiV1Ttl {
     const TAG: ApiVersion = ApiVersion::V1ttl;
@@ -68,26 +70,20 @@ impl KvFormat for ApiV1Ttl {
         match src_api {
             ApiVersion::V1 | ApiVersion::V1ttl => Ok(Key::from_encoded_slice(key)),
             ApiVersion::V2 => {
-                debug_assert_eq!(ApiV2::parse_key_mode(key), KeyMode::Raw);
-                let (user_key, _) = ApiV2::decode_raw_key(&Key::from_encoded_slice(key), true)?;
-                let raw_key = ApiV2::remove_prefix(user_key)?;
-                Ok(Self::encode_raw_key_owned(raw_key, None))
+                Err(EngineError::Other(box_err!("unsupported conversion")))
             }
         }
     }
 
     fn convert_raw_user_key_range_version_from(
         src_api: ApiVersion,
-        mut start_key: Vec<u8>,
-        mut end_key: Vec<u8>,
+        start_key: Vec<u8>,
+        end_key: Vec<u8>,
     ) -> Result<(Vec<u8>, Vec<u8>)> {
         match src_api {
             ApiVersion::V1 | ApiVersion::V1ttl => Ok((start_key, end_key)),
             ApiVersion::V2 => {
-                // TODO: check raw key range after check_api_version_range is refactored.
-                start_key = ApiV2::remove_prefix(start_key)?;
-                end_key = ApiV2::remove_prefix(end_key)?;
-                Ok((start_key, end_key))
+                Err(EngineError::Other(box_err!("unsupported conversion")))
             }
         }
     }

--- a/components/api_version/src/api_v1ttl.rs
+++ b/components/api_version/src/api_v1ttl.rs
@@ -7,8 +7,6 @@ use tikv_util::codec::{
 };
 
 use super::*;
-use tikv_util::box_err;
-use engine_traits::Error as EngineError;
 
 impl KvFormat for ApiV1Ttl {
     const TAG: ApiVersion = ApiVersion::V1ttl;
@@ -69,9 +67,7 @@ impl KvFormat for ApiV1Ttl {
     ) -> Result<Key> {
         match src_api {
             ApiVersion::V1 | ApiVersion::V1ttl => Ok(Key::from_encoded_slice(key)),
-            ApiVersion::V2 => {
-                Err(EngineError::Other(box_err!("unsupported conversion")))
-            }
+            ApiVersion::V2 => unreachable!(), // reject apiv2 -> apiv1ttl conversion
         }
     }
 
@@ -79,12 +75,10 @@ impl KvFormat for ApiV1Ttl {
         src_api: ApiVersion,
         start_key: Vec<u8>,
         end_key: Vec<u8>,
-    ) -> Result<(Vec<u8>, Vec<u8>)> {
+    ) -> (Vec<u8>, Vec<u8>) {
         match src_api {
-            ApiVersion::V1 | ApiVersion::V1ttl => Ok((start_key, end_key)),
-            ApiVersion::V2 => {
-                Err(EngineError::Other(box_err!("unsupported conversion")))
-            }
+            ApiVersion::V1 | ApiVersion::V1ttl => (start_key, end_key),
+            ApiVersion::V2 => unreachable!(), // reject apiv2 -> apiv1ttl conversion
         }
     }
 }

--- a/components/api_version/src/api_v1ttl.rs
+++ b/components/api_version/src/api_v1ttl.rs
@@ -1,6 +1,6 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_traits::Result;
+use engine_traits::{Error as EngineError, Result};
 use tikv_util::codec::{
     number::{self, NumberEncoder},
     Error,
@@ -67,7 +67,7 @@ impl KvFormat for ApiV1Ttl {
     ) -> Result<Key> {
         match src_api {
             ApiVersion::V1 | ApiVersion::V1ttl => Ok(Key::from_encoded_slice(key)),
-            ApiVersion::V2 => unreachable!(), // reject apiv2 -> apiv1ttl conversion
+            ApiVersion::V2 => Err(EngineError::Engine(String::from("unsupported conversion"))), // reject apiv2 -> apiv1ttl conversion
         }
     }
 
@@ -75,10 +75,10 @@ impl KvFormat for ApiV1Ttl {
         src_api: ApiVersion,
         start_key: Vec<u8>,
         end_key: Vec<u8>,
-    ) -> (Vec<u8>, Vec<u8>) {
+    ) -> Result<(Vec<u8>, Vec<u8>)> {
         match src_api {
-            ApiVersion::V1 | ApiVersion::V1ttl => (start_key, end_key),
-            ApiVersion::V2 => unreachable!(), // reject apiv2 -> apiv1ttl conversion
+            ApiVersion::V1 | ApiVersion::V1ttl => Ok((start_key, end_key)),
+            ApiVersion::V2 => Err(EngineError::Engine(String::from("unsupported conversion"))), // reject apiv2 -> apiv1ttl conversion
         }
     }
 }

--- a/components/api_version/src/api_v1ttl.rs
+++ b/components/api_version/src/api_v1ttl.rs
@@ -1,9 +1,12 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_traits::{Error as EngineError, Result};
-use tikv_util::codec::{
-    number::{self, NumberEncoder},
-    Error,
+use engine_traits::Result;
+use tikv_util::{
+    box_err,
+    codec::{
+        number::{self, NumberEncoder},
+        Error,
+    },
 };
 
 use super::*;
@@ -67,9 +70,7 @@ impl KvFormat for ApiV1Ttl {
     ) -> Result<Key> {
         match src_api {
             ApiVersion::V1 | ApiVersion::V1ttl => Ok(Key::from_encoded_slice(key)),
-            ApiVersion::V2 => Err(EngineError::Engine(String::from(
-                "unsupported conversion from v2 to v1ttl",
-            ))), // reject apiv2 -> apiv1ttl conversion
+            ApiVersion::V2 => Err(box_err!("unsupported conversion from v2 to v1ttl")), // reject apiv2 -> apiv1ttl conversion
         }
     }
 
@@ -80,9 +81,7 @@ impl KvFormat for ApiV1Ttl {
     ) -> Result<(Vec<u8>, Vec<u8>)> {
         match src_api {
             ApiVersion::V1 | ApiVersion::V1ttl => Ok((start_key, end_key)),
-            ApiVersion::V2 => Err(EngineError::Engine(String::from(
-                "unsupported conversion from v2 to v1ttl",
-            ))), // reject apiv2 -> apiv1ttl conversion
+            ApiVersion::V2 => Err(box_err!("unsupported conversion from v2 to v1ttl")), // reject apiv2 -> apiv1ttl conversion
         }
     }
 }

--- a/components/api_version/src/api_v1ttl.rs
+++ b/components/api_version/src/api_v1ttl.rs
@@ -67,7 +67,9 @@ impl KvFormat for ApiV1Ttl {
     ) -> Result<Key> {
         match src_api {
             ApiVersion::V1 | ApiVersion::V1ttl => Ok(Key::from_encoded_slice(key)),
-            ApiVersion::V2 => Err(EngineError::Engine(String::from("unsupported conversion"))), // reject apiv2 -> apiv1ttl conversion
+            ApiVersion::V2 => Err(EngineError::Engine(String::from(
+                "unsupported conversion from v2 to v1ttl",
+            ))), // reject apiv2 -> apiv1ttl conversion
         }
     }
 
@@ -78,7 +80,9 @@ impl KvFormat for ApiV1Ttl {
     ) -> Result<(Vec<u8>, Vec<u8>)> {
         match src_api {
             ApiVersion::V1 | ApiVersion::V1ttl => Ok((start_key, end_key)),
-            ApiVersion::V2 => Err(EngineError::Engine(String::from("unsupported conversion"))), // reject apiv2 -> apiv1ttl conversion
+            ApiVersion::V2 => Err(EngineError::Engine(String::from(
+                "unsupported conversion from v2 to v1ttl",
+            ))), // reject apiv2 -> apiv1ttl conversion
         }
     }
 }

--- a/components/api_version/src/api_v2.rs
+++ b/components/api_version/src/api_v2.rs
@@ -17,6 +17,7 @@ pub const TXN_KEY_PREFIX: u8 = b'x';
 pub const TIDB_META_KEY_PREFIX: u8 = b'm';
 pub const TIDB_TABLE_KEY_PREFIX: u8 = b't';
 pub const DEFAULT_KEY_SPACE_ID: [u8; 3] = [0, 0, 0]; // reserve 3 bytes for key space id.
+pub const DEFAULT_KEY_SPACE_ID_END: [u8; 3] = [0, 0, 1];
 
 pub const TIDB_RANGES: &[(&[u8], &[u8])] = &[
     (&[TIDB_META_KEY_PREFIX], &[TIDB_META_KEY_PREFIX + 1]),
@@ -183,7 +184,7 @@ impl KvFormat for ApiV2 {
     ) -> Result<Key> {
         match src_api {
             ApiVersion::V1 | ApiVersion::V1ttl => {
-                let apiv2_key = ApiV2::add_prefix(key);
+                let apiv2_key = ApiV2::add_prefix(key, &DEFAULT_KEY_SPACE_ID);
                 Ok(Self::encode_raw_key_owned(apiv2_key, ts))
             }
             ApiVersion::V2 => Ok(Key::from_encoded_slice(key)),
@@ -197,11 +198,11 @@ impl KvFormat for ApiV2 {
     ) -> (Vec<u8>, Vec<u8>) {
         match src_api {
             ApiVersion::V1 | ApiVersion::V1ttl => {
-                start_key = ApiV2::add_prefix(&start_key);
+                start_key = ApiV2::add_prefix(&start_key, &DEFAULT_KEY_SPACE_ID);
                 if end_key.is_empty() {
-                    end_key.insert(0, RAW_KEY_PREFIX_END);
+                    end_key = ApiV2::add_prefix(&end_key, &DEFAULT_KEY_SPACE_ID_END);
                 } else {
-                    end_key = ApiV2::add_prefix(&end_key);
+                    end_key = ApiV2::add_prefix(&end_key, &DEFAULT_KEY_SPACE_ID);
                 }
                 (start_key, end_key)
             }
@@ -234,12 +235,11 @@ impl ApiV2 {
         Ok(Key::split_on_ts_for(key)?)
     }
 
-    pub fn add_prefix(key: &[u8]) -> Vec<u8> {
-        let mut apiv2_key = Vec::with_capacity(ApiV2::get_encode_len(
-            key.len() + DEFAULT_KEY_SPACE_ID.len() + 1,
-        ));
+    pub fn add_prefix(key: &[u8], key_space: &[u8]) -> Vec<u8> {
+        let mut apiv2_key =
+            Vec::with_capacity(ApiV2::get_encode_len(key.len() + key_space.len() + 1));
         apiv2_key.push(RAW_KEY_PREFIX);
-        apiv2_key.extend(DEFAULT_KEY_SPACE_ID); // Reserved 3 bytes for key space id.
+        apiv2_key.extend(key_space); // Reserved 3 bytes for key space id.
         apiv2_key.extend(key);
         apiv2_key
     }

--- a/components/api_version/src/api_v2.rs
+++ b/components/api_version/src/api_v2.rs
@@ -1,19 +1,14 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
-use codec::{
-    byte::MemComparableByteCodec,
-    number::{NumberCodec, MAX_VARINT64_LENGTH},
-};
-use engine_traits::{Error as EngineError, Result};
-use tikv_util::{
-    box_err,
-    codec::{
-        bytes,
-        number::{self, NumberEncoder},
-        Error,
-    },
+use codec::byte::MemComparableByteCodec;
+use engine_traits::Result;
+use tikv_util::codec::{
+    bytes,
+    number::{self, NumberEncoder},
+    Error,
 };
 use txn_types::{Key, TimeStamp};
+use codec::number::{NumberCodec, MAX_VARINT64_LENGTH};
 
 use super::*;
 
@@ -248,22 +243,6 @@ impl ApiV2 {
         apiv2_key.extend(&tmp_buf[..written]);
         apiv2_key.extend(key);
         apiv2_key
-    }
-
-    pub fn remove_prefix(mut key: Vec<u8>) -> Result<Vec<u8>> {
-        if key.is_empty() {
-            return Err(EngineError::Other(box_err!("key is empty")));
-        }
-        let prefix = key.remove(0);
-        //if prefix is `RAW_KEY_PREFIX_END`, no key space id is encoded.
-        if prefix == RAW_KEY_PREFIX_END {
-            return Ok(key);
-        }
-        if let Ok((_id, len)) = NumberCodec::try_decode_var_u64(key.as_mut_slice()) {
-            Ok(key[len..].to_vec())
-        } else {
-            Err(EngineError::Other(box_err!("fail to decode var uint64")))
-        }
     }
 
     pub const ENCODED_LOGICAL_DELETE: [u8; 1] = [ValueMeta::DELETE_FLAG.bits];

--- a/components/api_version/src/api_v2.rs
+++ b/components/api_version/src/api_v2.rs
@@ -195,7 +195,7 @@ impl KvFormat for ApiV2 {
         src_api: ApiVersion,
         mut start_key: Vec<u8>,
         mut end_key: Vec<u8>,
-    ) -> (Vec<u8>, Vec<u8>) {
+    ) -> Result<(Vec<u8>, Vec<u8>)> {
         match src_api {
             ApiVersion::V1 | ApiVersion::V1ttl => {
                 start_key = ApiV2::add_prefix(&start_key, &DEFAULT_KEY_SPACE_ID);
@@ -204,9 +204,9 @@ impl KvFormat for ApiV2 {
                 } else {
                     end_key = ApiV2::add_prefix(&end_key, &DEFAULT_KEY_SPACE_ID);
                 }
-                (start_key, end_key)
+                Ok((start_key, end_key))
             }
-            ApiVersion::V2 => (start_key, end_key),
+            ApiVersion::V2 => Ok((start_key, end_key)),
         }
     }
 }

--- a/components/api_version/src/api_v2.rs
+++ b/components/api_version/src/api_v2.rs
@@ -1,6 +1,9 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
-use codec::byte::MemComparableByteCodec;
+use codec::{
+    byte::MemComparableByteCodec,
+    number::{NumberCodec, MAX_VARINT64_LENGTH},
+};
 use engine_traits::Result;
 use tikv_util::codec::{
     bytes,
@@ -8,7 +11,6 @@ use tikv_util::codec::{
     Error,
 };
 use txn_types::{Key, TimeStamp};
-use codec::number::{NumberCodec, MAX_VARINT64_LENGTH};
 
 use super::*;
 
@@ -195,7 +197,7 @@ impl KvFormat for ApiV2 {
         src_api: ApiVersion,
         mut start_key: Vec<u8>,
         mut end_key: Vec<u8>,
-    ) -> Result<(Vec<u8>, Vec<u8>)> {
+    ) -> (Vec<u8>, Vec<u8>) {
         match src_api {
             ApiVersion::V1 | ApiVersion::V1ttl => {
                 start_key = ApiV2::add_prefix(&start_key);
@@ -204,9 +206,9 @@ impl KvFormat for ApiV2 {
                 } else {
                     end_key = ApiV2::add_prefix(&end_key);
                 }
-                Ok((start_key, end_key))
+                (start_key, end_key)
             }
-            ApiVersion::V2 => Ok((start_key, end_key)),
+            ApiVersion::V2 => (start_key, end_key),
         }
     }
 }

--- a/components/api_version/src/api_v2.rs
+++ b/components/api_version/src/api_v2.rs
@@ -16,6 +16,7 @@ pub const RAW_KEY_PREFIX_END: u8 = RAW_KEY_PREFIX + 1;
 pub const TXN_KEY_PREFIX: u8 = b'x';
 pub const TIDB_META_KEY_PREFIX: u8 = b'm';
 pub const TIDB_TABLE_KEY_PREFIX: u8 = b't';
+pub const DEFAULT_KEY_SPACE_ID: [u8; 3] = [0, 0, 0]; // reserve 3 bytes for key space id.
 
 pub const TIDB_RANGES: &[(&[u8], &[u8])] = &[
     (&[TIDB_META_KEY_PREFIX], &[TIDB_META_KEY_PREFIX + 1]),
@@ -234,9 +235,11 @@ impl ApiV2 {
     }
 
     pub fn add_prefix(key: &[u8]) -> Vec<u8> {
-        let mut apiv2_key = Vec::with_capacity(ApiV2::get_encode_len(key.len() + 2));
+        let mut apiv2_key = Vec::with_capacity(ApiV2::get_encode_len(
+            key.len() + DEFAULT_KEY_SPACE_ID.len() + 1,
+        ));
         apiv2_key.push(RAW_KEY_PREFIX);
-        apiv2_key.push(0); // 0 is var u64 encoded key space id. Reserved for future use.
+        apiv2_key.extend(DEFAULT_KEY_SPACE_ID); // Reserved 3 bytes for key space id.
         apiv2_key.extend(key);
         apiv2_key
     }

--- a/components/api_version/src/api_v2.rs
+++ b/components/api_version/src/api_v2.rs
@@ -1,9 +1,6 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
-use codec::{
-    byte::MemComparableByteCodec,
-    number::{NumberCodec, MAX_VARINT64_LENGTH},
-};
+use codec::byte::MemComparableByteCodec;
 use engine_traits::Result;
 use tikv_util::codec::{
     bytes,
@@ -19,7 +16,6 @@ pub const RAW_KEY_PREFIX_END: u8 = RAW_KEY_PREFIX + 1;
 pub const TXN_KEY_PREFIX: u8 = b'x';
 pub const TIDB_META_KEY_PREFIX: u8 = b'm';
 pub const TIDB_TABLE_KEY_PREFIX: u8 = b't';
-pub const DEFAULT_KEY_SPACE_ID: u64 = 0;
 
 pub const TIDB_RANGES: &[(&[u8], &[u8])] = &[
     (&[TIDB_META_KEY_PREFIX], &[TIDB_META_KEY_PREFIX + 1]),
@@ -238,11 +234,9 @@ impl ApiV2 {
     }
 
     pub fn add_prefix(key: &[u8]) -> Vec<u8> {
-        let mut tmp_buf = [0; MAX_VARINT64_LENGTH];
-        let written = NumberCodec::encode_var_u64(&mut tmp_buf, DEFAULT_KEY_SPACE_ID);
-        let mut apiv2_key = Vec::with_capacity(ApiV2::get_encode_len(key.len() + written + 1));
+        let mut apiv2_key = Vec::with_capacity(ApiV2::get_encode_len(key.len() + 2));
         apiv2_key.push(RAW_KEY_PREFIX);
-        apiv2_key.extend(&tmp_buf[..written]);
+        apiv2_key.push(0); // 0 is var u64 encoded key space id. Reserved for future use.
         apiv2_key.extend(key);
         apiv2_key
     }

--- a/components/api_version/src/api_v2.rs
+++ b/components/api_version/src/api_v2.rs
@@ -238,10 +238,10 @@ impl ApiV2 {
     }
 
     pub fn add_prefix(key: &[u8]) -> Vec<u8> {
-        let mut apiv2_key = Vec::with_capacity(ApiV2::get_encode_len(key.len() + 2));
-        apiv2_key.push(RAW_KEY_PREFIX);
         let mut tmp_buf = [0; MAX_VARINT64_LENGTH];
         let written = NumberCodec::encode_var_u64(&mut tmp_buf, DEFAULT_KEY_SPACE_ID);
+        let mut apiv2_key = Vec::with_capacity(ApiV2::get_encode_len(key.len() + written + 1));
+        apiv2_key.push(RAW_KEY_PREFIX);
         apiv2_key.extend(&tmp_buf[..written]);
         apiv2_key.extend(key);
         apiv2_key

--- a/components/api_version/src/lib.rs
+++ b/components/api_version/src/lib.rs
@@ -635,8 +635,7 @@ mod tests {
             .clone()
             .into_iter()
             .map(|key| {
-                let mut v2_key = vec![];
-                v2_key.push(RAW_KEY_PREFIX);
+                let mut v2_key = vec![RAW_KEY_PREFIX];
                 let mut tmp_buf = [0; MAX_VARINT64_LENGTH];
                 let written = NumberCodec::encode_var_u64(&mut tmp_buf, 0);
                 v2_key.extend(&tmp_buf[..written]);
@@ -648,8 +647,6 @@ mod tests {
         let test_cases = vec![
             (ApiVersion::V1, ApiVersion::V2, &apiv1_keys, &apiv2_keys),
             (ApiVersion::V1ttl, ApiVersion::V2, &apiv1_keys, &apiv2_keys),
-            (ApiVersion::V2, ApiVersion::V1, &apiv2_keys, &apiv1_keys),
-            (ApiVersion::V2, ApiVersion::V1ttl, &apiv2_keys, &apiv1_keys),
         ];
         for i in 0..apiv1_keys.len() {
             for (src_api_ver, dst_api_ver, src_data, dst_data) in test_cases.clone() {
@@ -767,18 +764,6 @@ mod tests {
                 ApiVersion::V2,
                 &apiv1_key_ranges,
                 &apiv2_key_ranges,
-            ),
-            (
-                ApiVersion::V2,
-                ApiVersion::V1,
-                &apiv2_key_ranges,
-                &apiv1_key_ranges,
-            ),
-            (
-                ApiVersion::V2,
-                ApiVersion::V1ttl,
-                &apiv2_key_ranges,
-                &apiv1_key_ranges,
             ),
         ];
         for (src_api_ver, dst_api_ver, src_data, dst_data) in test_cases {

--- a/components/api_version/src/lib.rs
+++ b/components/api_version/src/lib.rs
@@ -635,7 +635,7 @@ mod tests {
             .map(|key| {
                 let mut v2_key = key;
                 v2_key.insert(0, RAW_KEY_PREFIX);
-                v2_key.insert(1, 0); // 0 is var int encoded key space id
+                v2_key.insert(1, 0); // 0 is var u64 encoded key space id
                 ApiV2::encode_raw_key_owned(v2_key, Some(TimeStamp::from(timestamp))).into_encoded()
             })
             .collect();
@@ -733,12 +733,12 @@ mod tests {
                 let mut v2_start_key = start_key;
                 let mut v2_end_key = end_key;
                 v2_start_key.insert(0, RAW_KEY_PREFIX);
-                v2_start_key.insert(1, 0); // 0 is var int encoded key space id
+                v2_start_key.insert(1, 0); // 0 is var u64 encoded key space id
                 if v2_end_key.is_empty() {
                     v2_end_key.insert(0, RAW_KEY_PREFIX_END);
                 } else {
                     v2_end_key.insert(0, RAW_KEY_PREFIX);
-                    v2_end_key.insert(1, 0); // 0 is var int encoded key space id
+                    v2_end_key.insert(1, 0); // 0 is var u64 encoded key space id
                 }
                 (v2_start_key, v2_end_key)
             })

--- a/components/api_version/src/lib.rs
+++ b/components/api_version/src/lib.rs
@@ -731,7 +731,7 @@ mod tests {
             .map(|(start_key, end_key)| {
                 let mut v2_start_key = vec![RAW_KEY_PREFIX, 0, 0, 0]; // key space takes 3 bytes.
                 let mut v2_end_key = if end_key.is_empty() {
-                    vec![RAW_KEY_PREFIX_END]
+                    vec![RAW_KEY_PREFIX, 0, 0, 1]
                 } else {
                     vec![RAW_KEY_PREFIX, 0, 0, 0] // key space takes 3 bytes.
                 };

--- a/components/api_version/src/lib.rs
+++ b/components/api_version/src/lib.rs
@@ -80,7 +80,7 @@ pub trait KvFormat: Clone + Copy + 'static + Send + Sync {
         src_api: ApiVersion,
         start_key: Vec<u8>,
         end_key: Vec<u8>,
-    ) -> Result<(Vec<u8>, Vec<u8>)>;
+    ) -> (Vec<u8>, Vec<u8>);
 
     /// Convert the encoded value from src_api version to Self::TAG version
     fn convert_raw_encoded_value_version_from(
@@ -253,8 +253,6 @@ impl<T: AsRef<[u8]>> RawValue<T> {
 
 #[cfg(test)]
 mod tests {
-    use codec::number::{NumberCodec, MAX_VARINT64_LENGTH};
-
     use super::*;
     use crate::api_v2::*;
 
@@ -635,11 +633,9 @@ mod tests {
             .clone()
             .into_iter()
             .map(|key| {
-                let mut v2_key = vec![RAW_KEY_PREFIX];
-                let mut tmp_buf = [0; MAX_VARINT64_LENGTH];
-                let written = NumberCodec::encode_var_u64(&mut tmp_buf, 0);
-                v2_key.extend(&tmp_buf[..written]);
-                v2_key.extend(key);
+                let mut v2_key = key;
+                v2_key.insert(0, RAW_KEY_PREFIX);
+                v2_key.insert(1, 0); // 0 is var int encoded key space id
                 ApiV2::encode_raw_key_owned(v2_key, Some(TimeStamp::from(timestamp))).into_encoded()
             })
             .collect();
@@ -734,20 +730,16 @@ mod tests {
             .clone()
             .into_iter()
             .map(|(start_key, end_key)| {
-                let mut tmp_buf = [0; MAX_VARINT64_LENGTH];
-                let written = NumberCodec::encode_var_u64(&mut tmp_buf, 0);
-                let mut v2_start_key = Vec::with_capacity(start_key.len() + 2);
-                let mut v2_end_key = Vec::with_capacity(end_key.len() + 2);
+                let mut v2_start_key = start_key;
+                let mut v2_end_key = end_key;
                 v2_start_key.insert(0, RAW_KEY_PREFIX);
-                v2_start_key.extend(&tmp_buf[0..written]);
-                if end_key.is_empty() {
+                v2_start_key.insert(1, 0); // 0 is var int encoded key space id
+                if v2_end_key.is_empty() {
                     v2_end_key.insert(0, RAW_KEY_PREFIX_END);
                 } else {
                     v2_end_key.insert(0, RAW_KEY_PREFIX);
-                    v2_end_key.extend(&tmp_buf[0..written]);
+                    v2_end_key.insert(1, 0); // 0 is var int encoded key space id
                 }
-                v2_start_key.extend(start_key);
-                v2_end_key.extend(end_key);
                 (v2_start_key, v2_end_key)
             })
             .collect();
@@ -772,7 +764,7 @@ mod tests {
                     let (src_start, src_end) = src_data[i].clone();
                     API::convert_raw_user_key_range_version_from(src_api_ver, src_start, src_end)
                 });
-                assert_eq!(dst_key_range.unwrap(), dst_data[i]);
+                assert_eq!(dst_key_range, dst_data[i]);
             }
         }
     }

--- a/components/api_version/src/lib.rs
+++ b/components/api_version/src/lib.rs
@@ -633,9 +633,8 @@ mod tests {
             .clone()
             .into_iter()
             .map(|key| {
-                let mut v2_key = key;
-                v2_key.insert(0, RAW_KEY_PREFIX);
-                v2_key.insert(1, 0); // 0 is var u64 encoded key space id
+                let mut v2_key = vec![RAW_KEY_PREFIX, 0, 0, 0];
+                v2_key.extend(key);
                 ApiV2::encode_raw_key_owned(v2_key, Some(TimeStamp::from(timestamp))).into_encoded()
             })
             .collect();
@@ -730,16 +729,14 @@ mod tests {
             .clone()
             .into_iter()
             .map(|(start_key, end_key)| {
-                let mut v2_start_key = start_key;
-                let mut v2_end_key = end_key;
-                v2_start_key.insert(0, RAW_KEY_PREFIX);
-                v2_start_key.insert(1, 0); // 0 is var u64 encoded key space id
-                if v2_end_key.is_empty() {
-                    v2_end_key.insert(0, RAW_KEY_PREFIX_END);
+                let mut v2_start_key = vec![RAW_KEY_PREFIX, 0, 0, 0]; // key space takes 3 bytes.
+                let mut v2_end_key = if end_key.is_empty() {
+                    vec![RAW_KEY_PREFIX_END]
                 } else {
-                    v2_end_key.insert(0, RAW_KEY_PREFIX);
-                    v2_end_key.insert(1, 0); // 0 is var u64 encoded key space id
-                }
+                    vec![RAW_KEY_PREFIX, 0, 0, 0] // key space takes 3 bytes.
+                };
+                v2_start_key.extend(start_key);
+                v2_end_key.extend(end_key);
                 (v2_start_key, v2_end_key)
             })
             .collect();

--- a/components/api_version/src/lib.rs
+++ b/components/api_version/src/lib.rs
@@ -80,7 +80,7 @@ pub trait KvFormat: Clone + Copy + 'static + Send + Sync {
         src_api: ApiVersion,
         start_key: Vec<u8>,
         end_key: Vec<u8>,
-    ) -> (Vec<u8>, Vec<u8>);
+    ) -> Result<(Vec<u8>, Vec<u8>)>;
 
     /// Convert the encoded value from src_api version to Self::TAG version
     fn convert_raw_encoded_value_version_from(
@@ -761,7 +761,7 @@ mod tests {
                     let (src_start, src_end) = src_data[i].clone();
                     API::convert_raw_user_key_range_version_from(src_api_ver, src_start, src_end)
                 });
-                assert_eq!(dst_key_range, dst_data[i]);
+                assert_eq!(dst_key_range.unwrap(), dst_data[i]);
             }
         }
     }

--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -206,31 +206,20 @@ async fn save_backup_file_worker(
         let files = if msg.files.need_flush_keys() {
             match msg.files.save(&storage).await {
                 Ok(mut split_files) => {
-                    let mut has_err = false;
                     for file in split_files.iter_mut() {
                         // In the case that backup from v1 and restore to v2,
                         // the file range need be encoded as v2 format.
                         // And range in response keep in v1 format.
-                        let ret = codec.convert_key_range_to_dst_version(
+                        let (start, end) = codec.convert_key_range_to_dst_version(
                             msg.start_key.clone(),
                             msg.end_key.clone(),
                         );
-                        if ret.is_err() {
-                            error_unknown!(?ret; "fail to convert key range to dst version");
-                            has_err = true;
-                            break;
-                        }
-                        let (start, end) = ret.unwrap();
                         file.set_start_key(start);
                         file.set_end_key(end);
                         file.set_start_version(msg.start_version.into_inner());
                         file.set_end_version(msg.end_version.into_inner());
                     }
-                    if has_err {
-                        Err(Error::Other(box_err!("fail to save split files")))
-                    } else {
-                        Ok(split_files)
-                    }
+                    Ok(split_files)
                 }
                 Err(e) => {
                     error_unknown!(?e; "backup save file failed");

--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -1525,7 +1525,7 @@ pub mod tests {
         };
         if api_ver == ApiVersion::V2 {
             key.insert(0, RAW_KEY_PREFIX as char);
-            key.insert(1, 0 as char); // insert 0 as var u64 encoded space id.
+            key.insert_str(1, "000"); // key space id takes 3 bytes.
         }
         key
     }
@@ -1563,7 +1563,7 @@ pub mod tests {
         if (cur_ver == ApiVersion::V1 || cur_ver == ApiVersion::V1ttl) && dst_ver == ApiVersion::V2
         {
             raw_key.insert(0, RAW_KEY_PREFIX as char);
-            raw_key.insert(0, 0 as char); // `0` is var u64 encoded key space id
+            raw_key.insert_str(1, "000"); // key space id takes 3 bytes.
         }
         Key::from_encoded(raw_key.into_bytes())
     }
@@ -1612,7 +1612,7 @@ pub mod tests {
         stats.reset();
         let mut req = BackupRequest::default();
         let backup_start = if cur_api_ver == ApiVersion::V2 {
-            vec![RAW_KEY_PREFIX, 0] // 0 is var u64 encoded key space id
+            vec![RAW_KEY_PREFIX, 0, 0, 0] // key space id takes 3 bytes.
         } else {
             vec![]
         };
@@ -1622,7 +1622,7 @@ pub mod tests {
             vec![]
         };
         let file_start = if dst_api_ver == ApiVersion::V2 {
-            vec![RAW_KEY_PREFIX, 0] // 0 is var u64 encoded key space id
+            vec![RAW_KEY_PREFIX, 0, 0, 0] // key space id takes 3 bytes.
         } else {
             vec![]
         };

--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -1525,7 +1525,7 @@ pub mod tests {
         };
         if api_ver == ApiVersion::V2 {
             key.insert(0, RAW_KEY_PREFIX as char);
-            key.insert(1, 0 as char); // insert 0 as var int encoded space id `0`.
+            key.insert(1, 0 as char); // insert 0 as var u64 encoded space id.
         }
         key
     }
@@ -1563,7 +1563,7 @@ pub mod tests {
         if (cur_ver == ApiVersion::V1 || cur_ver == ApiVersion::V1ttl) && dst_ver == ApiVersion::V2
         {
             raw_key.insert(0, RAW_KEY_PREFIX as char);
-            raw_key.insert(0, 0 as char); // `0` is var int encoded key space id '0'
+            raw_key.insert(0, 0 as char); // `0` is var u64 encoded key space id
         }
         Key::from_encoded(raw_key.into_bytes())
     }
@@ -1612,7 +1612,7 @@ pub mod tests {
         stats.reset();
         let mut req = BackupRequest::default();
         let backup_start = if cur_api_ver == ApiVersion::V2 {
-            vec![RAW_KEY_PREFIX, 0] // 0 is var int encoded key space id `0`
+            vec![RAW_KEY_PREFIX, 0] // 0 is var u64 encoded key space id
         } else {
             vec![]
         };
@@ -1622,7 +1622,7 @@ pub mod tests {
             vec![]
         };
         let file_start = if dst_api_ver == ApiVersion::V2 {
-            vec![RAW_KEY_PREFIX, 0] // 0 is var int encoded key space id `0`
+            vec![RAW_KEY_PREFIX, 0] // 0 is var u64 encoded key space id
         } else {
             vec![]
         };

--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -226,7 +226,7 @@ async fn save_backup_file_worker(
                         file.set_end_version(msg.end_version.into_inner());
                     }
                     if has_err {
-                        Err(Error::Other(box_err!("backup convert key range failed")))
+                        Err(box_err!("backup convert key range failed"))
                     } else {
                         Ok(split_files)
                     }

--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -1524,8 +1524,10 @@ pub mod tests {
             format!("k{:0>10}", idx)
         };
         if api_ver == ApiVersion::V2 {
-            key.insert(0, RAW_KEY_PREFIX as char);
-            key.insert_str(1, "000"); // key space id takes 3 bytes.
+            // [0, 0, 0] is the default key space id.
+            let mut apiv2_key = [RAW_KEY_PREFIX, 0, 0, 0].to_vec();
+            apiv2_key.extend(key.as_bytes());
+            key = String::from_utf8(apiv2_key).unwrap();
         }
         key
     }
@@ -1562,8 +1564,10 @@ pub mod tests {
     ) -> Key {
         if (cur_ver == ApiVersion::V1 || cur_ver == ApiVersion::V1ttl) && dst_ver == ApiVersion::V2
         {
-            raw_key.insert(0, RAW_KEY_PREFIX as char);
-            raw_key.insert_str(1, "000"); // key space id takes 3 bytes.
+            // [0, 0, 0] is the default key space id.
+            let mut apiv2_key = [RAW_KEY_PREFIX, 0, 0, 0].to_vec();
+            apiv2_key.extend(raw_key.as_bytes());
+            raw_key = String::from_utf8(apiv2_key).unwrap();
         }
         Key::from_encoded(raw_key.into_bytes())
     }
@@ -1617,7 +1621,7 @@ pub mod tests {
             vec![]
         };
         let backup_end = if cur_api_ver == ApiVersion::V2 {
-            vec![RAW_KEY_PREFIX + 1]
+            vec![RAW_KEY_PREFIX, 0, 0, 1] // [0, 0, 1] is the end of the file
         } else {
             vec![]
         };
@@ -1627,7 +1631,7 @@ pub mod tests {
             vec![]
         };
         let file_end = if dst_api_ver == ApiVersion::V2 {
-            vec![RAW_KEY_PREFIX + 1]
+            vec![RAW_KEY_PREFIX, 0, 0, 1] // [0, 0, 1] is the end of the file
         } else {
             vec![]
         };

--- a/components/backup/src/utils.rs
+++ b/components/backup/src/utils.rs
@@ -500,14 +500,14 @@ pub mod tests {
             (
                 ApiVersion::V1,
                 ApiVersion::V2,
-                b"abc".to_vec(),
-                ApiV2::encode_raw_key_owned(b"rabc".to_vec(), ts),
+                [61, 62, 63].to_vec(),
+                ApiV2::encode_raw_key_owned([114, 0, 0, 0, 61, 62, 63].to_vec(), ts),
             ),
             (
                 ApiVersion::V1ttl,
                 ApiVersion::V2,
                 b"".to_vec(),
-                ApiV2::encode_raw_key_owned(b"r".to_vec(), ts),
+                ApiV2::encode_raw_key_owned([114, 0, 0, 0].to_vec(), ts),
             ),
         ];
 

--- a/components/backup/src/utils.rs
+++ b/components/backup/src/utils.rs
@@ -240,14 +240,12 @@ impl KeyValueCodec {
         &self,
         start_key: Vec<u8>,
         end_key: Vec<u8>,
-    ) -> Result<(Vec<u8>, Vec<u8>)> {
+    ) -> (Vec<u8>, Vec<u8>) {
         if !self.is_raw_kv {
-            return Ok((start_key, end_key));
+            return (start_key, end_key);
         }
         dispatch_api_version!(self.dst_api_ver, {
-            let (start, end) =
-                API::convert_raw_user_key_range_version_from(self.cur_api_ver, start_key, end_key)?;
-            Ok((start, end))
+            API::convert_raw_user_key_range_version_from(self.cur_api_ver, start_key, end_key)
         })
     }
 }

--- a/components/backup/src/utils.rs
+++ b/components/backup/src/utils.rs
@@ -240,12 +240,14 @@ impl KeyValueCodec {
         &self,
         start_key: Vec<u8>,
         end_key: Vec<u8>,
-    ) -> (Vec<u8>, Vec<u8>) {
+    ) -> Result<(Vec<u8>, Vec<u8>)> {
         if !self.is_raw_kv {
-            return (start_key, end_key);
+            return Ok((start_key, end_key));
         }
         dispatch_api_version!(self.dst_api_ver, {
-            API::convert_raw_user_key_range_version_from(self.cur_api_ver, start_key, end_key)
+            let (start, end) =
+                API::convert_raw_user_key_range_version_from(self.cur_api_ver, start_key, end_key)?;
+            Ok((start, end))
         })
     }
 }

--- a/tests/integrations/backup/mod.rs
+++ b/tests/integrations/backup/mod.rs
@@ -285,8 +285,8 @@ fn test_backup_rawkv_cross_version_impl(cur_api_ver: ApiVersion, dst_api_ver: Ap
     let tmp = Builder::new().tempdir().unwrap();
     let storage_path = make_unique_dir(tmp.path());
     let rx = suite.backup_raw(
-        vec![b'r', b'a'], // start
-        vec![b'r', b'z'], // end
+        vec![b'r'], // start
+        vec![b's'], // end
         cf,
         &storage_path,
         dst_api_ver,
@@ -354,7 +354,9 @@ fn test_backup_rawkv_cross_version_impl(cur_api_ver: ApiVersion, dst_api_ver: Ap
         let key = {
             let mut key = k.into_bytes();
             if cur_api_ver != ApiVersion::V2 && dst_api_ver == ApiVersion::V2 {
-                key.insert(0, b'r')
+                let mut apiv2_key = [b'r', 0, 0, 0].to_vec();
+                apiv2_key.extend(key);
+                key = apiv2_key;
             }
             key
         };
@@ -365,8 +367,8 @@ fn test_backup_rawkv_cross_version_impl(cur_api_ver: ApiVersion, dst_api_ver: Ap
     // Backup file should have same contents.
     // Set non-empty range to check if it's incorrectly encoded.
     let rx = target_suite.backup_raw(
-        vec![b'r', b'a'], // start
-        vec![b'r', b'z'], // end
+        vec![b'r'], // start
+        vec![b's'], // end
         cf,
         &make_unique_dir(tmp.path()),
         dst_api_ver,
@@ -431,8 +433,8 @@ fn test_backup_raw_meta_impl(cur_api_version: ApiVersion, dst_api_version: ApiVe
     let tmp = Builder::new().tempdir().unwrap();
     let storage_path = make_unique_dir(tmp.path());
     let rx = suite.backup_raw(
-        "ra".to_owned().into_bytes(), // start
-        "rz".to_owned().into_bytes(), // end
+        "r".to_owned().into_bytes(), // start
+        "s".to_owned().into_bytes(), // end
         cf,
         &storage_path,
         dst_api_version,

--- a/tests/integrations/backup/mod.rs
+++ b/tests/integrations/backup/mod.rs
@@ -285,8 +285,8 @@ fn test_backup_rawkv_cross_version_impl(cur_api_ver: ApiVersion, dst_api_ver: Ap
     let tmp = Builder::new().tempdir().unwrap();
     let storage_path = make_unique_dir(tmp.path());
     let rx = suite.backup_raw(
-        vec![b'r'], // start
-        vec![b's'], // end
+        vec![b'r', b'a'], // start
+        vec![b'r', b'z'], // end
         cf,
         &storage_path,
         dst_api_ver,
@@ -366,9 +366,17 @@ fn test_backup_rawkv_cross_version_impl(cur_api_ver: ApiVersion, dst_api_ver: Ap
 
     // Backup file should have same contents.
     // Set non-empty range to check if it's incorrectly encoded.
+    let (backup_start, backup_end) = if cur_api_ver != dst_api_ver {
+        (
+            vec![b'r', 0, 0, 0, b'r', b'a'],
+            vec![b'r', 0, 0, 0, b'r', b'z'],
+        )
+    } else {
+        (vec![b'r', b'a'], vec![b'r', b'z'])
+    };
     let rx = target_suite.backup_raw(
-        vec![b'r'], // start
-        vec![b's'], // end
+        backup_start, // start
+        backup_end,   // end
         cf,
         &make_unique_dir(tmp.path()),
         dst_api_ver,
@@ -433,8 +441,8 @@ fn test_backup_raw_meta_impl(cur_api_version: ApiVersion, dst_api_version: ApiVe
     let tmp = Builder::new().tempdir().unwrap();
     let storage_path = make_unique_dir(tmp.path());
     let rx = suite.backup_raw(
-        "r".to_owned().into_bytes(), // start
-        "s".to_owned().into_bytes(), // end
+        "ra".to_owned().into_bytes(), // start
+        "rz".to_owned().into_bytes(), // end
         cf,
         &storage_path,
         dst_api_version,


### PR DESCRIPTION
Signed-off-by: haojinming <jinming.hao@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #12758 

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
Add encoding of key space id in apiv2 key when backup convert.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects


### Release note <!-- bugfixes or new feature need a release note -->

```release-note

Add key space id encoding in apiv2 key when backup convert.
```
