### PR TITLE
config: output warn log when some components config invalid

### DIFF
--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -1542,13 +1542,13 @@ mod tests {
             let mut updated_cfg = cfg.clone();
             {
                 // Update it to be smaller than incremental_scan_threads,
-                // which will be an invalid change and will be lost.
+                // which will be an invalid change and will modified to incremental_scan_threads.
                 updated_cfg.incremental_scan_concurrency = 2;
             }
             let diff = cfg.diff(&updated_cfg);
             ep.run(Task::ChangeConfig(diff));
-            assert_eq!(ep.config.incremental_scan_concurrency, 6);
-            assert_eq!(ep.scan_concurrency_semaphore.available_permits(), 6);
+            assert_eq!(ep.config.incremental_scan_concurrency, 4);
+            assert_eq!(ep.scan_concurrency_semaphore.available_permits(), 4);
 
             {
                 // Correct update.

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -442,12 +442,12 @@ impl<T: 'static + RaftStoreRouter<E>, E: KvEngine> Endpoint<T, E> {
     fn on_change_cfg(&mut self, change: ConfigChange) {
         // Validate first.
         let mut validate_cfg = self.config.clone();
-        validate_cfg.update(change.clone());
+        validate_cfg.update(change);
         if let Err(e) = validate_cfg.validate() {
             warn!("cdc config update failed"; "error" => ?e);
             return;
         }
-
+        let change = self.config.diff(&validate_cfg);
         info!(
             "cdc config updated";
             "current config" => ?self.config,

--- a/components/sst_importer/src/config.rs
+++ b/components/sst_importer/src/config.rs
@@ -27,12 +27,15 @@ impl Default for Config {
 }
 
 impl Config {
-    pub fn validate(&self) -> Result<(), Box<dyn Error>> {
+    pub fn validate(&mut self) -> Result<(), Box<dyn Error>> {
+        let default_cfg = Config::default();
         if self.num_threads == 0 {
-            return Err("import.num_threads can not be 0".into());
+            warn!("import.num_threads can not be 0");
+            self.num_threads = default_cfg.num_threads;
         }
         if self.stream_channel_window == 0 {
-            return Err("import.stream_channel_window can not be 0".into());
+            warn!("import.stream_channel_window can not be 0");
+            self.stream_channel_window = default_cfg.stream_channel_window;
         }
         Ok(())
     }

--- a/components/sst_importer/src/config.rs
+++ b/components/sst_importer/src/config.rs
@@ -30,11 +30,17 @@ impl Config {
     pub fn validate(&mut self) -> Result<(), Box<dyn Error>> {
         let default_cfg = Config::default();
         if self.num_threads == 0 {
-            warn!("import.num_threads can not be 0");
+            warn!(
+                "import.num_threads can not be 0, change it to {}",
+                default_cfg.num_threads
+            );
             self.num_threads = default_cfg.num_threads;
         }
         if self.stream_channel_window == 0 {
-            warn!("import.stream_channel_window can not be 0");
+            warn!(
+                "import.stream_channel_window can not be 0, change it to {}",
+                default_cfg.stream_channel_window
+            );
             self.stream_channel_window = default_cfg.stream_channel_window;
         }
         Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -2320,15 +2320,24 @@ impl BackupConfig {
         let limit = SysQuota::cpu_cores_quota() as usize;
         let default_cfg = BackupConfig::default();
         if self.num_threads == 0 || self.num_threads > limit {
-            warn!("backup.num_threads cannot be 0 or larger than {}", limit);
+            warn!(
+                "backup.num_threads cannot be 0 or larger than {}, change it to {}",
+                limit, default_cfg.num_threads
+            );
             self.num_threads = default_cfg.num_threads;
         }
         if self.batch_size == 0 {
-            warn!("backup.batch_size cannot be 0");
+            warn!(
+                "backup.batch_size cannot be 0, change it to {}",
+                default_cfg.batch_size
+            );
             self.batch_size = default_cfg.batch_size;
         }
         if self.s3_multi_part_size.0 > ReadableSize::gb(5).0 {
-            warn!("backup.s3_multi_part_size cannot larger than 5GB");
+            warn!(
+                "backup.s3_multi_part_size cannot larger than 5GB, change it to {:?}",
+                default_cfg.s3_multi_part_size
+            );
             self.s3_multi_part_size = default_cfg.s3_multi_part_size;
         }
 
@@ -2379,12 +2388,13 @@ pub struct BackupStreamConfig {
 impl BackupStreamConfig {
     pub fn validate(&mut self) -> Result<(), Box<dyn Error>> {
         let limit = SysQuota::cpu_cores_quota() as usize;
+        let default_cfg = BackupStreamConfig::default();
         if self.num_threads == 0 || self.num_threads > limit {
             warn!(
-                "log_backup.num_threads cannot be 0 or larger than {}",
-                limit
+                "log_backup.num_threads cannot be 0 or larger than {}, change it to {}",
+                limit, default_cfg.num_threads
             );
-            self.num_threads = BackupStreamConfig::default().num_threads;
+            self.num_threads = default_cfg.num_threads;
         }
         Ok(())
     }
@@ -2471,23 +2481,35 @@ impl CdcConfig {
     pub fn validate(&mut self) -> Result<(), Box<dyn Error>> {
         let default_cfg = CdcConfig::default();
         if self.min_ts_interval.is_zero() {
-            warn!("cdc.min-ts-interval can't be 0");
+            warn!(
+                "cdc.min-ts-interval can't be 0, change it to {}",
+                default_cfg.min_ts_interval
+            );
             self.min_ts_interval = default_cfg.min_ts_interval;
         }
         if self.incremental_scan_threads == 0 {
-            warn!("cdc.incremental-scan-threads can't be 0");
+            warn!(
+                "cdc.incremental-scan-threads can't be 0, change it to {}",
+                default_cfg.incremental_scan_threads
+            );
             self.incremental_scan_threads = default_cfg.incremental_scan_threads;
         }
         if self.incremental_scan_concurrency < self.incremental_scan_threads {
             warn!(
-                "cdc.incremental-scan-concurrency must be larger than cdc.incremental-scan-threads"
+                "cdc.incremental-scan-concurrency must be larger than cdc.incremental-scan-threads,
+                change it to {}",
+                self.incremental_scan_threads
             );
-            self.incremental_scan_concurrency = self.incremental_scan_threads 
+            self.incremental_scan_concurrency = self.incremental_scan_threads
         }
         if self.incremental_scan_ts_filter_ratio < 0.0
             || self.incremental_scan_ts_filter_ratio > 1.0
         {
-            warn!("cdc.incremental-scan-ts-filter-ratio should be larger than 0 and less than 1");
+            warn!(
+                "cdc.incremental-scan-ts-filter-ratio should be larger than 0 and less than 1,
+                change it to {}",
+                default_cfg.incremental_scan_ts_filter_ratio
+            );
             self.incremental_scan_ts_filter_ratio = default_cfg.incremental_scan_ts_filter_ratio;
         }
         Ok(())


### PR DESCRIPTION
Signed-off-by: 3pointer <luancheng@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/tikv/tikv/issues/12771

What's Changed:
do not return error when validation failed. just change the config value to default instead.

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```config: change the backup/import/cdc config to default value when input config is invalid.
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)

set backup.num-threads to 0
<img width="172" alt="image" src="https://user-images.githubusercontent.com/5906259/172146356-ddfbecd4-f057-49df-9717-a7382fe31ed4.png">

check the log.
<img width="917" alt="image" src="https://user-images.githubusercontent.com/5906259/172146227-71cdf6b9-7b65-4c10-8b41-f50c500bb1dc.png">

check the config in log.
<img width="231" alt="截屏2022-06-06 下午6 44 16" src="https://user-images.githubusercontent.com/5906259/172146390-2b85f10d-34fa-4e50-9e51-f1a3e65e4de5.png">



Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix the issue that tikv refused to start when the config of backup/import/cdc is invalid.

```
