### PR TITLE
engine: deprecate gc-merge-rewrite option

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -822,10 +822,15 @@
 ## default: 0.5
 # discardable-ratio = 0.5
 
-## The mode used to process blob files. In read-only mode Titan
-## stops writing value into blob log. In fallback mode Titan
-## converts blob index into real value on flush and compaction.
-## This option is especially useful for downgrading Titan.
+## The mode used to process blob files. In read-only mode Titan stops writing
+## value into blob log. In fallback mode Titan converts blob index into real
+## value on flush and compaction.
+##
+## This option can be used to disable Titan. More specifically, to disable
+## Titan, set this option to fallback and perform a full compaction using
+## tikv-ctl. Then, monitor the blob file size metrics. After the blob file size
+## decreases to 0, you can set rocksdb.titan.enabled to false and restart TiKV.
+##
 ##   default:   kNormal
 ##   read-only: kReadOnly
 ##   fallback:  kFallback
@@ -843,10 +848,6 @@
 ## Requirement: level_compaction_dynamic_level_base = true
 ## default: false
 # level-merge = false
-
-## Use merge operator to rewrite GC blob index.
-## default: false
-# gc-merge-rewrite = false
 
 ## Options for "Write" Column Family, which stores MVCC commit information
 [rocksdb.writecf]

--- a/src/config.rs
+++ b/src/config.rs
@@ -164,21 +164,6 @@ impl Default for TitanCfConfig {
             gc_merge_rewrite: false,
         }
     }
-
-    fn validate(&self) -> Result<(), Box<dyn Error>> {
-        if self.gc_merge_rewrite {
-            return Err(format!(
-                "gc-merge-rewrite is deprecated. The data produced when this \
-                option is enabled cannot be read by this version. Therefore, if \
-                this option has been applied to an existing node, you must downgrade \
-                it to the previous version and fully clean up the old data. See more \
-                details of how to do that in the documentation for the blob-run-mode \
-                confuguration."
-            )
-            .into());
-        }
-        Ok(())
-    }
 }
 
 impl TitanCfConfig {
@@ -197,6 +182,21 @@ impl TitanCfConfig {
         opts.set_range_merge(self.range_merge);
         opts.set_max_sorted_runs(self.max_sorted_runs);
         opts
+    }
+
+    fn validate(&self) -> Result<(), Box<dyn Error>> {
+        if self.gc_merge_rewrite {
+            return Err(format!(
+                "gc-merge-rewrite is deprecated. The data produced when this \
+                option is enabled cannot be read by this version. Therefore, if \
+                this option has been applied to an existing node, you must downgrade \
+                it to the previous version and fully clean up the old data. See more \
+                details of how to do that in the documentation for the blob-run-mode \
+                confuguration."
+            )
+            .into());
+        }
+        Ok(())
     }
 }
 
@@ -349,6 +349,7 @@ macro_rules! cf_config {
                     )
                     .into());
                 }
+                self.titan.validate()?;
                 Ok(())
             }
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -186,15 +186,15 @@ impl TitanCfConfig {
 
     fn validate(&self) -> Result<(), Box<dyn Error>> {
         if self.gc_merge_rewrite {
-            return Err(format!(
+            return Err(
                 "gc-merge-rewrite is deprecated. The data produced when this \
                 option is enabled cannot be read by this version. Therefore, if \
                 this option has been applied to an existing node, you must downgrade \
                 it to the previous version and fully clean up the old data. See more \
                 details of how to do that in the documentation for the blob-run-mode \
                 confuguration."
-            )
-            .into());
+                    .to_string(),
+            );
         }
         Ok(())
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -139,7 +139,10 @@ pub struct TitanCfConfig {
     pub range_merge: bool,
     #[online_config(skip)]
     pub max_sorted_runs: i32,
+    // deprecated.
     #[online_config(skip)]
+    #[doc(hidden)]
+    #[serde(skip_serializing)]
     pub gc_merge_rewrite: bool,
 }
 
@@ -161,6 +164,21 @@ impl Default for TitanCfConfig {
             gc_merge_rewrite: false,
         }
     }
+
+    fn validate(&self) -> Result<(), Box<dyn Error>> {
+        if self.gc_merge_rewrite {
+            return Err(format!(
+                "gc-merge-rewrite is deprecated. The data produced when this \
+                option is enabled cannot be read by this version. Therefore, if \
+                this option has been applied to an existing node, you must downgrade \
+                it to the previous version and fully clean up the old data. See more \
+                details of how to do that in the documentation for the blob-run-mode \
+                confuguration."
+            )
+            .into());
+        }
+        Ok(())
+    }
 }
 
 impl TitanCfConfig {
@@ -178,7 +196,6 @@ impl TitanCfConfig {
         opts.set_level_merge(self.level_merge);
         opts.set_range_merge(self.range_merge);
         opts.set_max_sorted_runs(self.max_sorted_runs);
-        opts.set_gc_merge_rewrite(self.gc_merge_rewrite);
         opts
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -193,7 +193,7 @@ impl TitanCfConfig {
                 it to the previous version and fully clean up the old data. See more \
                 details of how to do that in the documentation for the blob-run-mode \
                 confuguration."
-                    .to_string(),
+                    .into(),
             );
         }
         Ok(())

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -256,7 +256,7 @@ fn test_serde_custom_tikv_config() {
         level_merge: true,
         range_merge: true,
         max_sorted_runs: 100,
-        gc_merge_rewrite: true,
+        gc_merge_rewrite: false,
     };
     let titan_db_config = TitanDBConfig {
         enabled: true,

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -334,7 +334,6 @@ blob-run-mode = "fallback"
 level-merge = true
 range-merge = true
 max-sorted-runs = 100
-gc-merge-rewrite = true
 
 [rocksdb.writecf]
 block-size = "12KB"
@@ -566,7 +565,6 @@ blob-run-mode = "fallback"
 level-merge = true
 range-merge = true
 max-sorted-runs = 100
-gc-merge-rewrite = true
 
 [raft-engine]
 enable = false


### PR DESCRIPTION
Signed-off-by: tabokie <xy.tao@outlook.com>

### What is changed and how it works?

Issue Number: Close #12797

What's Changed:

```commit-message
Deprecate gc-merge-rewrite option.
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Deprecate gc-merge-rewrite option.
```
