### PR TITLE
pd_client: Do not reconnect for pd unknown error

### DIFF
--- a/components/pd_client/src/errors.rs
+++ b/components/pd_client/src/errors.rs
@@ -30,8 +30,9 @@ pub type Result<T> = result::Result<T, Error>;
 impl Error {
     pub fn retryable(&self) -> bool {
         match self {
-            Error::Grpc(_) | Error::Other(_) | Error::ClusterNotBootstrapped(_) => true,
-            Error::RegionNotFound(_)
+            Error::Grpc(_) | Error::ClusterNotBootstrapped(_) => true,
+            Error::Other(_)
+            | Error::RegionNotFound(_)
             | Error::StoreTombstone(_)
             | Error::GlobalConfigNotFound(_)
             | Error::ClusterBootstrapped(_)

--- a/components/test_pd/src/mocker/retry.rs
+++ b/components/test_pd/src/mocker/retry.rs
@@ -91,7 +91,7 @@ impl PdMocker for NotRetry {
                 "[NotRetry] get_region_by_id returns Ok(_) with header has IncompatibleVersion error"
             );
             let mut err = Error::default();
-            err.set_type(ErrorType::IncompatibleVersion);
+            err.set_type(ErrorType::RegionNotFound);
             let mut resp = GetRegionResponse::default();
             resp.mut_header().set_error(err);
             Some(Ok(resp))
@@ -107,7 +107,7 @@ impl PdMocker for NotRetry {
                 "[NotRetry] get_region_by_id returns Ok(_) with header has IncompatibleVersion error"
             );
             let mut err = Error::default();
-            err.set_type(ErrorType::IncompatibleVersion);
+            err.set_type(ErrorType::Unknown);
             let mut resp = GetStoreResponse::default();
             resp.mut_header().set_error(err);
             Some(Ok(resp))

--- a/components/test_pd/src/mocker/retry.rs
+++ b/components/test_pd/src/mocker/retry.rs
@@ -88,7 +88,7 @@ impl PdMocker for NotRetry {
     fn get_region_by_id(&self, _: &GetRegionByIdRequest) -> Option<Result<GetRegionResponse>> {
         if !self.is_visited.swap(true, Ordering::Relaxed) {
             info!(
-                "[NotRetry] get_region_by_id returns Ok(_) with header has IncompatibleVersion error"
+                "[NotRetry] get_region_by_id returns Ok(_) with header has RegionNotFound error"
             );
             let mut err = Error::default();
             err.set_type(ErrorType::RegionNotFound);
@@ -104,7 +104,7 @@ impl PdMocker for NotRetry {
     fn get_store(&self, _: &GetStoreRequest) -> Option<Result<GetStoreResponse>> {
         if !self.is_visited.swap(true, Ordering::Relaxed) {
             info!(
-                "[NotRetry] get_region_by_id returns Ok(_) with header has IncompatibleVersion error"
+                "[NotRetry] get_region_by_id returns Ok(_) with header has Unknown error"
             );
             let mut err = Error::default();
             err.set_type(ErrorType::Unknown);

--- a/components/test_pd/src/mocker/retry.rs
+++ b/components/test_pd/src/mocker/retry.rs
@@ -87,9 +87,7 @@ impl Default for NotRetry {
 impl PdMocker for NotRetry {
     fn get_region_by_id(&self, _: &GetRegionByIdRequest) -> Option<Result<GetRegionResponse>> {
         if !self.is_visited.swap(true, Ordering::Relaxed) {
-            info!(
-                "[NotRetry] get_region_by_id returns Ok(_) with header has RegionNotFound error"
-            );
+            info!("[NotRetry] get_region_by_id returns Ok(_) with header has RegionNotFound error");
             let mut err = Error::default();
             err.set_type(ErrorType::RegionNotFound);
             let mut resp = GetRegionResponse::default();
@@ -103,9 +101,7 @@ impl PdMocker for NotRetry {
 
     fn get_store(&self, _: &GetStoreRequest) -> Option<Result<GetStoreResponse>> {
         if !self.is_visited.swap(true, Ordering::Relaxed) {
-            info!(
-                "[NotRetry] get_region_by_id returns Ok(_) with header has Unknown error"
-            );
+            info!("[NotRetry] get_region_by_id returns Ok(_) with header has Unknown error");
             let mut err = Error::default();
             err.set_type(ErrorType::Unknown);
             let mut resp = GetStoreResponse::default();


### PR DESCRIPTION
Signed-off-by: Connor1996 <zbk602423539@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #12345

What's Changed:

When encounter error like region not found or invalid region epoch, PD returns error type of unknown. For these errors, we don't need to reconnect pd client.
<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
do not reconnect for pd unknown error
```

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix bug which causes frequent pd client reconnection
```
