### PR TITLE
raftstorev2: add bootstrapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4168,15 +4168,21 @@ version = "0.1.0"
 dependencies = [
  "collections",
  "crossbeam",
+ "engine_test",
  "engine_traits",
  "error_code",
+ "fail",
  "kvproto",
  "pd_client",
  "raft",
  "raft-proto",
  "raftstore",
  "slog",
+ "slog-global",
  "smallvec",
+ "tempfile",
+ "test_pd",
+ "test_util",
  "tikv_util",
 ]
 

--- a/components/engine_panic/src/raft_engine.rs
+++ b/components/engine_panic/src/raft_engine.rs
@@ -29,6 +29,18 @@ impl RaftEngineReadOnly for PanicEngine {
     fn get_all_entries_to(&self, region_id: u64, buf: &mut Vec<Entry>) -> Result<()> {
         panic!()
     }
+
+    fn is_empty(&self) -> Result<bool> {
+        panic!()
+    }
+
+    fn get_store_ident(&self) -> Result<Option<kvproto::raft_serverpb::StoreIdent>> {
+        panic!()
+    }
+
+    fn get_prepare_bootstrap_region(&self) -> Result<Option<kvproto::metapb::Region>> {
+        panic!()
+    }
 }
 
 impl RaftEngineDebug for PanicEngine {
@@ -114,6 +126,10 @@ impl RaftEngine for PanicEngine {
     fn get_engine_size(&self) -> Result<u64> {
         panic!()
     }
+
+    fn put_store_ident(&self, ident: &kvproto::raft_serverpb::StoreIdent) -> Result<()> {
+        panic!()
+    }
 }
 
 impl RaftLogBatch for PanicWriteBatch {
@@ -138,6 +154,34 @@ impl RaftLogBatch for PanicWriteBatch {
     }
 
     fn merge(&mut self, _: Self) -> Result<()> {
+        panic!()
+    }
+
+    fn put_store_ident(&mut self, ident: &kvproto::raft_serverpb::StoreIdent) -> Result<()> {
+        panic!()
+    }
+
+    fn put_prepare_bootstrap_region(&mut self, region: &kvproto::metapb::Region) -> Result<()> {
+        panic!()
+    }
+
+    fn remove_prepare_bootstrap_region(&mut self) -> Result<()> {
+        panic!()
+    }
+
+    fn put_region_state(
+        &mut self,
+        raft_group_id: u64,
+        state: &kvproto::raft_serverpb::RegionLocalState,
+    ) -> Result<()> {
+        panic!()
+    }
+
+    fn put_apply_state(
+        &mut self,
+        raft_group_id: u64,
+        state: &kvproto::raft_serverpb::RaftApplyState,
+    ) -> Result<()> {
         panic!()
     }
 }

--- a/components/engine_panic/src/raft_engine.rs
+++ b/components/engine_panic/src/raft_engine.rs
@@ -1,7 +1,10 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
 use engine_traits::{Error, RaftEngine, RaftEngineDebug, RaftEngineReadOnly, RaftLogBatch, Result};
-use kvproto::raft_serverpb::RaftLocalState;
+use kvproto::{
+    metapb::Region,
+    raft_serverpb::{RaftApplyState, RaftLocalState, RegionLocalState, StoreIdent},
+};
 use raft::eraftpb::Entry;
 
 use crate::{engine::PanicEngine, write_batch::PanicWriteBatch};
@@ -34,11 +37,19 @@ impl RaftEngineReadOnly for PanicEngine {
         panic!()
     }
 
-    fn get_store_ident(&self) -> Result<Option<kvproto::raft_serverpb::StoreIdent>> {
+    fn get_store_ident(&self) -> Result<Option<StoreIdent>> {
         panic!()
     }
 
-    fn get_prepare_bootstrap_region(&self) -> Result<Option<kvproto::metapb::Region>> {
+    fn get_prepare_bootstrap_region(&self) -> Result<Option<Region>> {
+        panic!()
+    }
+
+    fn get_region_state(&self, raft_group_id: u64) -> Result<Option<RegionLocalState>> {
+        panic!()
+    }
+
+    fn get_apply_state(&self, raft_group_id: u64) -> Result<Option<RaftApplyState>> {
         panic!()
     }
 }
@@ -127,7 +138,7 @@ impl RaftEngine for PanicEngine {
         panic!()
     }
 
-    fn put_store_ident(&self, ident: &kvproto::raft_serverpb::StoreIdent) -> Result<()> {
+    fn put_store_ident(&self, ident: &StoreIdent) -> Result<()> {
         panic!()
     }
 }
@@ -157,11 +168,11 @@ impl RaftLogBatch for PanicWriteBatch {
         panic!()
     }
 
-    fn put_store_ident(&mut self, ident: &kvproto::raft_serverpb::StoreIdent) -> Result<()> {
+    fn put_store_ident(&mut self, ident: &StoreIdent) -> Result<()> {
         panic!()
     }
 
-    fn put_prepare_bootstrap_region(&mut self, region: &kvproto::metapb::Region) -> Result<()> {
+    fn put_prepare_bootstrap_region(&mut self, region: &Region) -> Result<()> {
         panic!()
     }
 
@@ -169,19 +180,11 @@ impl RaftLogBatch for PanicWriteBatch {
         panic!()
     }
 
-    fn put_region_state(
-        &mut self,
-        raft_group_id: u64,
-        state: &kvproto::raft_serverpb::RegionLocalState,
-    ) -> Result<()> {
+    fn put_region_state(&mut self, raft_group_id: u64, state: &RegionLocalState) -> Result<()> {
         panic!()
     }
 
-    fn put_apply_state(
-        &mut self,
-        raft_group_id: u64,
-        state: &kvproto::raft_serverpb::RaftApplyState,
-    ) -> Result<()> {
+    fn put_apply_state(&mut self, raft_group_id: u64, state: &RaftApplyState) -> Result<()> {
         panic!()
     }
 }

--- a/components/engine_traits/src/raft_engine.rs
+++ b/components/engine_traits/src/raft_engine.rs
@@ -17,6 +17,8 @@ pub trait RaftEngineReadOnly: Sync + Send + 'static {
     fn get_prepare_bootstrap_region(&self) -> Result<Option<Region>>;
 
     fn get_raft_state(&self, raft_group_id: u64) -> Result<Option<RaftLocalState>>;
+    fn get_region_state(&self, raft_group_id: u64) -> Result<Option<RegionLocalState>>;
+    fn get_apply_state(&self, raft_group_id: u64) -> Result<Option<RaftApplyState>>;
 
     fn get_entry(&self, raft_group_id: u64, index: u64) -> Result<Option<Entry>>;
 

--- a/components/engine_traits/src/raft_engine.rs
+++ b/components/engine_traits/src/raft_engine.rs
@@ -1,6 +1,9 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
-use kvproto::raft_serverpb::RaftLocalState;
+use kvproto::{
+    metapb::Region,
+    raft_serverpb::{RaftApplyState, RaftLocalState, RegionLocalState, StoreIdent},
+};
 use raft::eraftpb::Entry;
 
 use crate::*;
@@ -8,6 +11,11 @@ use crate::*;
 pub const RAFT_LOG_MULTI_GET_CNT: u64 = 8;
 
 pub trait RaftEngineReadOnly: Sync + Send + 'static {
+    fn is_empty(&self) -> Result<bool>;
+
+    fn get_store_ident(&self) -> Result<Option<StoreIdent>>;
+    fn get_prepare_bootstrap_region(&self) -> Result<Option<Region>>;
+
     fn get_raft_state(&self, raft_group_id: u64) -> Result<Option<RaftLocalState>>;
 
     fn get_entry(&self, raft_group_id: u64, index: u64) -> Result<Option<Entry>>;
@@ -89,6 +97,8 @@ pub trait RaftEngine: RaftEngineReadOnly + Clone + Sync + Send + 'static {
     /// Note: `RaftLocalState` won't be updated in this call.
     fn append(&self, raft_group_id: u64, entries: Vec<Entry>) -> Result<usize>;
 
+    fn put_store_ident(&self, ident: &StoreIdent) -> Result<()>;
+
     fn put_raft_state(&self, raft_group_id: u64, state: &RaftLocalState) -> Result<()>;
 
     /// Like `cut_logs` but the range could be very large. Return the deleted count.
@@ -135,7 +145,14 @@ pub trait RaftLogBatch: Send {
     /// Remove Raft logs in [`from`, `to`) which will be overwritten later.
     fn cut_logs(&mut self, raft_group_id: u64, from: u64, to: u64);
 
+    fn put_store_ident(&mut self, ident: &StoreIdent) -> Result<()>;
+
+    fn put_prepare_bootstrap_region(&mut self, region: &Region) -> Result<()>;
+    fn remove_prepare_bootstrap_region(&mut self) -> Result<()>;
+
     fn put_raft_state(&mut self, raft_group_id: u64, state: &RaftLocalState) -> Result<()>;
+    fn put_region_state(&mut self, raft_group_id: u64, state: &RegionLocalState) -> Result<()>;
+    fn put_apply_state(&mut self, raft_group_id: u64, state: &RaftApplyState) -> Result<()>;
 
     /// The data size of this RaftLogBatch.
     fn persist_size(&self) -> usize;

--- a/components/raft_log_engine/src/engine.rs
+++ b/components/raft_log_engine/src/engine.rs
@@ -370,10 +370,7 @@ impl RaftEngineReadOnly for RaftLogEngine {
     }
 
     fn is_empty(&self) -> Result<bool> {
-        self.0
-            .get_message(STORE_REGION_ID, STORE_IDENT_KEY)
-            .map(|a: Option<StoreIdent>| a.is_none())
-            .map_err(transfer_error)
+        self.get_store_ident().map(|i| i.is_none())
     }
 
     fn get_store_ident(&self) -> Result<Option<StoreIdent>> {

--- a/components/raft_log_engine/src/engine.rs
+++ b/components/raft_log_engine/src/engine.rs
@@ -13,7 +13,7 @@ use engine_traits::{
     RaftLogBatch as RaftLogBatchTrait, RaftLogGCTask, Result,
 };
 use file_system::{IOOp, IORateLimiter, IOType};
-use kvproto::raft_serverpb::RaftLocalState;
+use kvproto::raft_serverpb::{RaftApplyState, RaftLocalState, RegionLocalState, StoreIdent};
 use raft::eraftpb::Entry;
 use raft_engine::{
     env::{DefaultFileSystem, FileSystem, Handle, WriteExt},
@@ -21,6 +21,9 @@ use raft_engine::{
 };
 pub use raft_engine::{Config as RaftEngineConfig, ReadableSize, RecoveryMode};
 use tikv_util::Either;
+
+// A special region ID representing global state.
+const STORE_REGION_ID: u64 = 0;
 
 #[derive(Clone)]
 pub struct MessageExtTyped;
@@ -259,6 +262,10 @@ impl RaftLogEngine {
 pub struct RaftLogBatch(LogBatch);
 
 const RAFT_LOG_STATE_KEY: &[u8] = b"R";
+const STORE_IDENT_KEY: &[u8] = &[0x01];
+const PREPARE_BOOTSTRAP_REGION_KEY: &[u8] = &[0x02];
+const REGION_STATE_KEY: &[u8] = &[0x03];
+const APPLY_STATE_KEY: &[u8] = &[0x04];
 
 impl RaftLogBatchTrait for RaftLogBatch {
     fn append(&mut self, raft_group_id: u64, entries: Vec<Entry>) -> Result<()> {
@@ -287,6 +294,40 @@ impl RaftLogBatchTrait for RaftLogBatch {
 
     fn merge(&mut self, mut src: Self) -> Result<()> {
         self.0.merge(&mut src.0).map_err(transfer_error)
+    }
+
+    fn put_store_ident(&mut self, ident: &StoreIdent) -> Result<()> {
+        self.0
+            .put_message(STORE_REGION_ID, STORE_IDENT_KEY.to_vec(), ident)
+            .map_err(transfer_error)
+    }
+
+    fn put_prepare_bootstrap_region(&mut self, region: &kvproto::metapb::Region) -> Result<()> {
+        self.0
+            .put_message(
+                STORE_REGION_ID,
+                PREPARE_BOOTSTRAP_REGION_KEY.to_vec(),
+                region,
+            )
+            .map_err(transfer_error)
+    }
+
+    fn remove_prepare_bootstrap_region(&mut self) -> Result<()> {
+        self.0
+            .delete(STORE_REGION_ID, PREPARE_BOOTSTRAP_REGION_KEY.to_vec());
+        Ok(())
+    }
+
+    fn put_region_state(&mut self, raft_group_id: u64, state: &RegionLocalState) -> Result<()> {
+        self.0
+            .put_message(raft_group_id, REGION_STATE_KEY.to_vec(), state)
+            .map_err(transfer_error)
+    }
+
+    fn put_apply_state(&mut self, raft_group_id: u64, state: &RaftApplyState) -> Result<()> {
+        self.0
+            .put_message(raft_group_id, APPLY_STATE_KEY.to_vec(), state)
+            .map_err(transfer_error)
     }
 }
 
@@ -323,6 +364,25 @@ impl RaftEngineReadOnly for RaftLogEngine {
             self.fetch_entries_to(raft_group_id, first, last + 1, None, buf)?;
         }
         Ok(())
+    }
+
+    fn is_empty(&self) -> Result<bool> {
+        self.0
+            .get_message(STORE_REGION_ID, STORE_IDENT_KEY)
+            .map(|a: Option<StoreIdent>| a.is_none())
+            .map_err(transfer_error)
+    }
+
+    fn get_store_ident(&self) -> Result<Option<StoreIdent>> {
+        self.0
+            .get_message(STORE_REGION_ID, STORE_IDENT_KEY)
+            .map_err(transfer_error)
+    }
+
+    fn get_prepare_bootstrap_region(&self) -> Result<Option<kvproto::metapb::Region>> {
+        self.0
+            .get_message(STORE_REGION_ID, PREPARE_BOOTSTRAP_REGION_KEY)
+            .map_err(transfer_error)
     }
 }
 
@@ -387,6 +447,16 @@ impl RaftEngine for RaftLogEngine {
             .add_entries::<MessageExtTyped>(raft_group_id, &entries)
             .map_err(transfer_error)?;
         self.0.write(&mut batch.0, false).map_err(transfer_error)
+    }
+
+    fn put_store_ident(&self, ident: &StoreIdent) -> Result<()> {
+        let mut batch = Self::LogBatch::default();
+        batch
+            .0
+            .put_message(STORE_REGION_ID, STORE_IDENT_KEY.to_vec(), ident)
+            .map_err(transfer_error)?;
+        self.0.write(&mut batch.0, true).map_err(transfer_error)?;
+        Ok(())
     }
 
     fn put_raft_state(&self, raft_group_id: u64, state: &RaftLocalState) -> Result<()> {

--- a/components/raftstore-v2/Cargo.toml
+++ b/components/raftstore-v2/Cargo.toml
@@ -8,16 +8,20 @@ default = ["test-engine-kv-rocksdb", "test-engine-raft-raft-engine"]
 failpoints = ["raftstore/failpoints"]
 testexport = ["raftstore/testexport"]
 test-engine-kv-rocksdb = [
-  "raftstore/test-engine-kv-rocksdb"
+  "raftstore/test-engine-kv-rocksdb",
+  "engine_test/test-engine-kv-rocksdb",
 ]
 test-engine-raft-raft-engine = [
-  "raftstore/test-engine-raft-raft-engine"
+  "raftstore/test-engine-raft-raft-engine",
+  "engine_test/test-engine-raft-raft-engine",
 ]
 test-engines-rocksdb = [
   "raftstore/test-engines-rocksdb",
+  "engine_test/test-engines-rocksdb",
 ]
 test-engines-panic = [
   "raftstore/test-engines-panic",
+  "engine_test/test-engines-panic",
 ]
 
 cloud-aws = ["raftstore/cloud-aws"]
@@ -29,6 +33,7 @@ collections = { path = "../collections" }
 crossbeam = "0.8"
 engine_traits = { path = "../engine_traits" }
 error_code = { path = "../error_code" }
+fail = "0.5"
 kvproto = { git = "https://github.com/pingcap/kvproto.git" }
 pd_client = { path = "../pd_client" }
 raft = { version = "0.7.0", default-features = false, features = ["protobuf-codec"] }
@@ -37,3 +42,15 @@ raftstore = { path = "../raftstore" }
 slog = "2.3"
 smallvec = "1.4"
 tikv_util = { path = "../tikv_util", default-features = false }
+
+[dev-dependencies]
+engine_test = { path = "../engine_test", default-features = false }
+slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }
+tempfile = "3.0"
+test_pd = { path = "../test_pd" }
+test_util = { path = "../test_util" }
+
+[[test]]
+name = "raftstore-v2-failpoints"
+path = "tests/failpoints/mod.rs"
+required-features = ["failpoints"]

--- a/components/raftstore-v2/src/bootstrap.rs
+++ b/components/raftstore-v2/src/bootstrap.rs
@@ -20,7 +20,7 @@ use crate::{raft::write_initial_states, Result};
 const MAX_CHECK_CLUSTER_BOOTSTRAPPED_RETRY_COUNT: u64 = 60;
 const CHECK_CLUSTER_BOOTSTRAPPED_RETRY_SECONDS: u64 = 3;
 
-/// A struct for bootstraping the store.
+/// A struct for bootstrapping the store.
 ///
 /// A typical bootstrap process should follow following order:
 /// 1. bootstrap the store to get a store ID.
@@ -90,7 +90,7 @@ impl<'a, ER: RaftEngine> Bootstrap<'a, ER> {
 
     /// Bootstrap the store and return the store ID.
     ///
-    /// If store is bootstraped already, return the store ID directly.
+    /// If store is bootstrapped already, return the store ID directly.
     pub fn bootstrap_store(&mut self) -> Result<u64> {
         let store_id = match self.check_store()? {
             Some(id) => id,
@@ -221,7 +221,7 @@ impl<'a, ER: RaftEngine> Bootstrap<'a, ER> {
 
     /// Bootstrap the first region.
     ///
-    /// If the cluster is already bootstraped, `None` is returned.
+    /// If the cluster is already bootstrapped, `None` is returned.
     pub fn bootstrap_first_region(
         &mut self,
         store: &Store,

--- a/components/raftstore-v2/src/bootstrap.rs
+++ b/components/raftstore-v2/src/bootstrap.rs
@@ -18,7 +18,7 @@ use tikv_util::{box_err, box_try};
 use crate::{raft::write_initial_states, Result};
 
 const MAX_CHECK_CLUSTER_BOOTSTRAPPED_RETRY_COUNT: u64 = 60;
-const CHECK_CLUSTER_BOOTSTRAPPED_RETRY_SECONDS: u64 = 3;
+const CHECK_CLUSTER_BOOTSTRAPPED_RETRY_INTERVAL: Duration = Duration::from_secs(3);
 
 /// A struct for bootstrapping the store.
 ///
@@ -135,9 +135,7 @@ impl<'a, ER: RaftEngine> Bootstrap<'a, ER> {
                     warn!(self.logger, "check cluster bootstrapped failed"; "err" => ?e);
                 }
             }
-            thread::sleep(Duration::from_secs(
-                CHECK_CLUSTER_BOOTSTRAPPED_RETRY_SECONDS,
-            ));
+            thread::sleep(CHECK_CLUSTER_BOOTSTRAPPED_RETRY_INTERVAL);
         }
         Err(box_err!("check cluster bootstrapped failed"))
     }
@@ -212,9 +210,7 @@ impl<'a, ER: RaftEngine> Bootstrap<'a, ER> {
                 }
             }
             retry += 1;
-            thread::sleep(Duration::from_secs(
-                CHECK_CLUSTER_BOOTSTRAPPED_RETRY_SECONDS,
-            ));
+            thread::sleep(CHECK_CLUSTER_BOOTSTRAPPED_RETRY_INTERVAL);
         }
         Err(box_err!("bootstrapped cluster failed"))
     }

--- a/components/raftstore-v2/src/bootstrap.rs
+++ b/components/raftstore-v2/src/bootstrap.rs
@@ -1,0 +1,245 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::{thread, time::Duration};
+
+use engine_traits::{RaftEngine, RaftLogBatch};
+use error_code::ErrorCodeExt;
+use fail::fail_point;
+use kvproto::{
+    metapb::{Region, Store},
+    raft_serverpb::{RaftLocalState, RegionLocalState, StoreIdent},
+};
+use pd_client::PdClient;
+use raft::INVALID_ID;
+use raftstore::store::initial_region;
+use slog::{debug, error, info, warn, Logger};
+use tikv_util::{box_err, box_try};
+
+use crate::{raft::write_initial_states, Result};
+
+const MAX_CHECK_CLUSTER_BOOTSTRAPPED_RETRY_COUNT: u64 = 60;
+const CHECK_CLUSTER_BOOTSTRAPPED_RETRY_SECONDS: u64 = 3;
+
+/// A struct for bootstraping the store.
+///
+/// A typical bootstrap process should follow following order:
+/// 1. bootstrap the store to get a store ID.
+/// 2. bootstrap the first region using the last store ID.
+pub struct Bootstrap<'a, ER: RaftEngine> {
+    engine: &'a ER,
+    cluster_id: u64,
+    // It's not performance critical.
+    pd_client: &'a dyn PdClient,
+    logger: Logger,
+}
+
+// Although all methods won't change internal state, but they still receive `&mut self` as it's
+// not thread safe to bootstrap concurrently.
+impl<'a, ER: RaftEngine> Bootstrap<'a, ER> {
+    pub fn new(
+        engine: &'a ER,
+        cluster_id: u64,
+        pd_client: &'a impl PdClient,
+        logger: Logger,
+    ) -> Self {
+        Self {
+            engine,
+            cluster_id,
+            pd_client,
+            logger,
+        }
+    }
+
+    /// check store, return store id for the engine.
+    /// If the store is not bootstrapped, use None.
+    fn check_store(&mut self) -> Result<Option<u64>> {
+        let ident = match self.engine.get_store_ident()? {
+            Some(ident) => ident,
+            None => return Ok(None),
+        };
+        if ident.get_cluster_id() != self.cluster_id {
+            return Err(box_err!(
+                "cluster ID mismatch, local {} != remote {}, \
+                    you are trying to connect to another cluster, please reconnect to the correct PD",
+                ident.get_cluster_id(),
+                self.cluster_id
+            ));
+        }
+        if ident.get_store_id() == INVALID_ID {
+            return Err(box_err!("invalid store ident {:?}", ident));
+        }
+        Ok(Some(ident.get_store_id()))
+    }
+
+    fn inner_bootstrap_store(&mut self) -> Result<u64> {
+        let id = self.pd_client.alloc_id()?;
+        debug!(self.logger, "alloc store id"; "store_id" => id);
+        let mut ident = StoreIdent::default();
+        if !self.engine.is_empty()? {
+            return Err(box_err!("store is not empty and has already had data."));
+        }
+        ident.set_cluster_id(self.cluster_id);
+        ident.set_store_id(id);
+        self.engine.put_store_ident(&ident)?;
+        self.engine.sync()?;
+        fail_point!("node_after_bootstrap_store", |_| Err(box_err!(
+            "injected error: node_after_bootstrap_store"
+        )));
+        Ok(id)
+    }
+
+    /// Bootstrap the store and return the store ID.
+    ///
+    /// If store is bootstraped already, return the store ID directly.
+    pub fn bootstrap_store(&mut self) -> Result<u64> {
+        let store_id = match self.check_store()? {
+            Some(id) => id,
+            None => self.inner_bootstrap_store()?,
+        };
+
+        Ok(store_id)
+    }
+
+    fn prepare_bootstrap_first_region(&mut self, store_id: u64) -> Result<Region> {
+        let region_id = self.pd_client.alloc_id()?;
+        debug!(
+            self.logger,
+            "alloc first region id";
+            "region_id" => region_id,
+            "cluster_id" => self.cluster_id,
+            "store_id" => store_id
+        );
+        let peer_id = self.pd_client.alloc_id()?;
+        debug!(
+            self.logger,
+            "alloc first peer id for first region";
+            "peer_id" => peer_id,
+            "region_id" => region_id,
+        );
+
+        let region = initial_region(store_id, region_id, peer_id);
+
+        let mut wb = self.engine.log_batch(10);
+        wb.put_prepare_bootstrap_region(&region)?;
+        write_initial_states(&mut wb, region.clone())?;
+        box_try!(self.engine.consume(&mut wb, true));
+
+        Ok(region)
+    }
+
+    fn check_first_region_bootstrapped(&mut self) -> Result<bool> {
+        for _ in 0..MAX_CHECK_CLUSTER_BOOTSTRAPPED_RETRY_COUNT {
+            match self.pd_client.is_cluster_bootstrapped() {
+                Ok(b) => return Ok(b),
+                Err(e) => {
+                    warn!(self.logger, "check cluster bootstrapped failed"; "err" => ?e);
+                }
+            }
+            thread::sleep(Duration::from_secs(
+                CHECK_CLUSTER_BOOTSTRAPPED_RETRY_SECONDS,
+            ));
+        }
+        Err(box_err!("check cluster bootstrapped failed"))
+    }
+
+    fn check_or_prepare_bootstrap_first_region(&mut self, store_id: u64) -> Result<Option<Region>> {
+        if let Some(first_region) = self.engine.get_prepare_bootstrap_region()? {
+            // Bootstrap is aborted last time, resume. It may succeed or fail last time, no matter
+            // what, at least we need a way to clean up.
+            Ok(Some(first_region))
+        } else if self.check_first_region_bootstrapped()? {
+            // If other node has bootstrap the cluster, skip to avoid useless ID allocating and
+            // disk writes.
+            Ok(None)
+        } else {
+            // We are probably the first one triggering bootstrap.
+            self.prepare_bootstrap_first_region(store_id).map(Some)
+        }
+    }
+
+    fn clear_prepare_bootstrap(&mut self, first_region_id: Option<u64>) -> Result<()> {
+        let mut wb = self.engine.log_batch(10);
+        wb.remove_prepare_bootstrap_region()?;
+        if let Some(id) = first_region_id {
+            box_try!(
+                self.engine
+                    .clean(id, 0, &RaftLocalState::default(), &mut wb)
+            );
+        }
+        box_try!(self.engine.consume(&mut wb, true));
+        Ok(())
+    }
+
+    fn inner_bootstrap_first_region(
+        &mut self,
+        store: &Store,
+        first_region: &Region,
+    ) -> Result<bool> {
+        let region_id = first_region.get_id();
+        let mut retry = 0;
+        while retry < MAX_CHECK_CLUSTER_BOOTSTRAPPED_RETRY_COUNT {
+            match self
+                .pd_client
+                .bootstrap_cluster(store.clone(), first_region.clone())
+            {
+                Ok(_) => {
+                    info!(self.logger, "bootstrap cluster ok"; "cluster_id" => self.cluster_id);
+                    fail_point!("node_after_bootstrap_cluster", |_| Err(box_err!(
+                        "injected error: node_after_bootstrap_cluster"
+                    )));
+                    self.clear_prepare_bootstrap(None)?;
+                    return Ok(true);
+                }
+                Err(pd_client::Error::ClusterBootstrapped(_)) => {
+                    match self.pd_client.get_region(b"") {
+                        Ok(region) => {
+                            if region == *first_region {
+                                self.clear_prepare_bootstrap(None)?;
+                                return Ok(true);
+                            } else {
+                                info!(self.logger, "cluster is already bootstrapped"; "cluster_id" => self.cluster_id);
+                                self.clear_prepare_bootstrap(Some(region_id))?;
+                                return Ok(false);
+                            }
+                        }
+                        Err(e) => {
+                            warn!(self.logger, "get the first region failed"; "err" => ?e);
+                        }
+                    }
+                }
+                Err(e) => {
+                    error!(self.logger, "bootstrap cluster"; "cluster_id" => self.cluster_id, "err" => ?e, "err_code" => %e.error_code())
+                }
+            }
+            retry += 1;
+            thread::sleep(Duration::from_secs(
+                CHECK_CLUSTER_BOOTSTRAPPED_RETRY_SECONDS,
+            ));
+        }
+        Err(box_err!("bootstrapped cluster failed"))
+    }
+
+    /// Bootstrap the first region.
+    ///
+    /// If the cluster is already bootstraped, `None` is returned.
+    pub fn bootstrap_first_region(
+        &mut self,
+        store: &Store,
+        store_id: u64,
+    ) -> Result<Option<Region>> {
+        let first_region = match self.check_or_prepare_bootstrap_first_region(store_id)? {
+            Some(r) => r,
+            None => return Ok(None),
+        };
+        info!(self.logger, "trying to bootstrap first region"; "store_id" => store_id, "region" => ?first_region);
+        // cluster is not bootstrapped, and we choose first store to bootstrap
+        fail_point!("node_after_prepare_bootstrap_cluster", |_| Err(box_err!(
+            "injected error: node_after_prepare_bootstrap_cluster"
+        )));
+        if self.inner_bootstrap_first_region(store, &first_region)? {
+            Ok(Some(first_region))
+        } else {
+            Ok(None)
+        }
+    }
+}

--- a/components/raftstore-v2/src/fsm/mod.rs
+++ b/components/raftstore-v2/src/fsm/mod.rs
@@ -1,5 +1,10 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
+//! FSM is short for finite state machine. There are three types of FSMs,
+//! - StoreFsm, used for handling control messages and global initialization.
+//! - PeerFsm, used for handling messages specific for one raft peer.
+//! - ApplyFsm, used for handling apply task for one raft peer.
+
 mod apply;
 mod peer;
 mod store;

--- a/components/raftstore-v2/src/fsm/store.rs
+++ b/components/raftstore-v2/src/fsm/store.rs
@@ -1,1 +1,3 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+pub struct StoreFsm {}

--- a/components/raftstore-v2/src/lib.rs
+++ b/components/raftstore-v2/src/lib.rs
@@ -4,16 +4,18 @@
 //!
 //! The thread module of raftstore is batch-system, more check components/batch-system.
 //! All state machines are defined in [`fsm`] module. Everything that wrapping raft is
-//! implemented in [`raft`] module. And the commands are implemented in [`operation`] module.
-//! All state machines are expected to communicate with messages. They are defined in
-//! [`router`] module.
+//! implemented in [`raft`] module. And the commands, including split/merge/confchange/read/write,
+//! are implemented in [`operation`] module. All state machines are expected to communicate with
+//! messages. They are defined in [`router`] module.
 
 #![allow(unused)]
 
+mod bootstrap;
 mod fsm;
 mod operation;
 mod raft;
 mod router;
 
+pub use bootstrap::Bootstrap;
 pub use raftstore::{Error, Result};
 pub use router::{PeerMsg, PeerTick, StoreMsg, StoreTick};

--- a/components/raftstore-v2/src/raft/mod.rs
+++ b/components/raftstore-v2/src/raft/mod.rs
@@ -4,4 +4,4 @@ mod peer;
 mod storage;
 
 pub use peer::Peer;
-pub use storage::Storage;
+pub use storage::{write_initial_states, Storage};

--- a/components/raftstore-v2/src/raft/storage.rs
+++ b/components/raftstore-v2/src/raft/storage.rs
@@ -87,3 +87,50 @@ impl<ER: RaftEngine> raft::Storage for Storage<ER> {
         unimplemented!()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use engine_traits::{RaftEngine, RaftEngineReadOnly, RaftLogBatch};
+    use kvproto::{
+        metapb::{Peer, Region},
+        raft_serverpb::PeerState,
+    };
+    use raftstore::store::{RAFT_INIT_LOG_INDEX, RAFT_INIT_LOG_TERM};
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_write_initial_states() {
+        let mut region = Region::default();
+        region.set_id(4);
+        let mut p = Peer::default();
+        p.set_id(5);
+        p.set_store_id(6);
+        region.mut_peers().push(p);
+        region.mut_region_epoch().set_version(2);
+        region.mut_region_epoch().set_conf_ver(4);
+
+        let path = TempDir::new().unwrap();
+        let engine = engine_test::new_temp_engine(&path);
+        let raft_engine = &engine.raft;
+        let mut wb = raft_engine.log_batch(10);
+        super::write_initial_states(&mut wb, region.clone()).unwrap();
+        assert!(!wb.is_empty());
+        raft_engine.consume(&mut wb, true).unwrap();
+
+        let local_state = raft_engine.get_region_state(4).unwrap().unwrap();
+        assert_eq!(local_state.get_state(), PeerState::Normal);
+        assert_eq!(*local_state.get_region(), region);
+
+        let raft_state = raft_engine.get_raft_state(4).unwrap().unwrap();
+        assert_eq!(raft_state.get_last_index(), RAFT_INIT_LOG_INDEX);
+        let hs = raft_state.get_hard_state();
+        assert_eq!(hs.get_term(), RAFT_INIT_LOG_TERM);
+        assert_eq!(hs.get_commit(), RAFT_INIT_LOG_INDEX);
+
+        let apply_state = raft_engine.get_apply_state(4).unwrap().unwrap();
+        assert_eq!(apply_state.get_applied_index(), RAFT_INIT_LOG_INDEX);
+        let ts = apply_state.get_truncated_state();
+        assert_eq!(ts.get_index(), RAFT_INIT_LOG_INDEX);
+        assert_eq!(ts.get_term(), RAFT_INIT_LOG_TERM);
+    }
+}

--- a/components/raftstore-v2/src/raft/storage.rs
+++ b/components/raftstore-v2/src/raft/storage.rs
@@ -1,11 +1,44 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_traits::RaftEngine;
+use engine_traits::{RaftEngine, RaftLogBatch};
+use kvproto::{
+    metapb::Region,
+    raft_serverpb::{RaftApplyState, RaftLocalState, RegionLocalState},
+};
 use raft::{
     eraftpb::{Entry, Snapshot},
     GetEntriesContext, RaftState,
 };
+use raftstore::store::{RAFT_INIT_LOG_INDEX, RAFT_INIT_LOG_TERM};
 use slog::Logger;
+
+use crate::Result;
+
+pub fn write_initial_states(wb: &mut impl RaftLogBatch, region: Region) -> Result<()> {
+    let region_id = region.get_id();
+
+    let mut state = RegionLocalState::default();
+    state.set_region(region);
+    wb.put_region_state(region_id, &state)?;
+
+    let mut apply_state = RaftApplyState::default();
+    apply_state.set_applied_index(RAFT_INIT_LOG_INDEX);
+    apply_state
+        .mut_truncated_state()
+        .set_index(RAFT_INIT_LOG_INDEX);
+    apply_state
+        .mut_truncated_state()
+        .set_term(RAFT_INIT_LOG_TERM);
+    wb.put_apply_state(region_id, &apply_state)?;
+
+    let mut raft_state = RaftLocalState::default();
+    raft_state.set_last_index(RAFT_INIT_LOG_INDEX);
+    raft_state.mut_hard_state().set_term(RAFT_INIT_LOG_TERM);
+    raft_state.mut_hard_state().set_commit(RAFT_INIT_LOG_INDEX);
+    wb.put_raft_state(region_id, &raft_state)?;
+
+    Ok(())
+}
 
 /// A storage for raft.
 pub struct Storage<ER> {

--- a/components/raftstore-v2/src/router/message.rs
+++ b/components/raftstore-v2/src/router/message.rs
@@ -1,4 +1,4 @@
-// Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
 // #[PerformanceCriticalPath]
 use std::{fmt, marker::PhantomData};

--- a/components/raftstore-v2/tests/failpoints/mod.rs
+++ b/components/raftstore-v2/tests/failpoints/mod.rs
@@ -1,0 +1,8 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+#![feature(test)]
+#![feature(assert_matches)]
+#![feature(custom_test_frameworks)]
+#![test_runner(test_util::run_failpoint_tests)]
+
+mod test_bootstrap;

--- a/components/raftstore-v2/tests/failpoints/test_bootstrap.rs
+++ b/components/raftstore-v2/tests/failpoints/test_bootstrap.rs
@@ -1,0 +1,61 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::assert_matches::assert_matches;
+
+use engine_traits::RaftEngineReadOnly;
+use kvproto::metapb::Store;
+use raftstore_v2::Bootstrap;
+use slog::o;
+use tempfile::TempDir;
+
+#[test]
+fn test_bootstrap_half_way_failure() {
+    let server = test_pd::Server::new(1);
+    let eps = server.bind_addrs();
+    let pd_client = test_pd::util::new_client(eps, None);
+    let path = TempDir::new().unwrap();
+    let engines = engine_test::new_temp_engine(&path);
+    let bootstrap = || {
+        let logger = slog_global::borrow_global().new(o!());
+        let mut bootstrap = Bootstrap::new(&engines.raft, 0, &pd_client, logger);
+        match bootstrap.bootstrap_store() {
+            Ok(store_id) => {
+                let mut store = Store::default();
+                store.set_id(store_id);
+                bootstrap.bootstrap_first_region(&store, store_id)
+            }
+            Err(e) => Err(e),
+        }
+    };
+
+    // Try to start this node, return after persisted some keys.
+    fail::cfg("node_after_bootstrap_store", "return").unwrap();
+    let s = format!("{}", bootstrap().unwrap_err());
+    assert!(s.contains("node_after_bootstrap_store"), "{}", s);
+    assert_matches!(engines.raft.get_prepare_bootstrap_region(), Ok(None));
+
+    let ident = engines.raft.get_store_ident().unwrap().unwrap();
+    assert_ne!(ident.get_store_id(), 0);
+
+    // Check whether it can bootstrap cluster successfully.
+    fail::remove("node_after_bootstrap_store");
+    fail::cfg("node_after_prepare_bootstrap_cluster", "return").unwrap();
+    let s = format!("{}", bootstrap().unwrap_err());
+    assert!(s.contains("node_after_prepare_bootstrap_cluster"), "{}", s);
+    assert_matches!(engines.raft.get_prepare_bootstrap_region(), Ok(Some(_)));
+
+    fail::remove("node_after_prepare_bootstrap_cluster");
+    fail::cfg("node_after_bootstrap_cluster", "return").unwrap();
+    let s = format!("{}", bootstrap().unwrap_err());
+    assert!(s.contains("node_after_bootstrap_cluster"), "{}", s);
+    assert_matches!(engines.raft.get_prepare_bootstrap_region(), Ok(Some(_)));
+
+    // Although aborted by error, rebootstrap should continue.
+    bootstrap().unwrap().unwrap();
+    assert_matches!(engines.raft.get_prepare_bootstrap_region(), Ok(None));
+
+    // Second bootstrap should be noop.
+    assert_eq!(bootstrap().unwrap(), None);
+
+    assert_matches!(engines.raft.get_prepare_bootstrap_region(), Ok(None));
+}

--- a/components/test_pd/src/mocker/service.rs
+++ b/components/test_pd/src/mocker/service.rs
@@ -96,7 +96,7 @@ impl PdMocker for Service {
 
         if self.is_bootstrapped.load(Ordering::SeqCst) {
             let mut err = Error::default();
-            err.set_type(ErrorType::Unknown);
+            err.set_type(ErrorType::AlreadyBootstrapped);
             err.set_message("cluster is already bootstrapped".to_owned());
             header.set_error(err);
             resp.set_header(header);

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -43,7 +43,7 @@ use crate::{
 };
 
 const MAX_CHECK_CLUSTER_BOOTSTRAPPED_RETRY_COUNT: u64 = 60;
-const CHECK_CLUSTER_BOOTSTRAPPED_RETRY_SECONDS: u64 = 3;
+const CHECK_CLUSTER_BOOTSTRAPPED_RETRY_INTERVAL: Duration = Duration::from_secs(3);
 
 /// Creates a new storage engine which is backed by the Raft consensus
 /// protocol.
@@ -436,9 +436,7 @@ where
                 Err(e) => error!(?e; "bootstrap cluster"; "cluster_id" => self.cluster_id,),
             }
             retry += 1;
-            thread::sleep(Duration::from_secs(
-                CHECK_CLUSTER_BOOTSTRAPPED_RETRY_SECONDS,
-            ));
+            thread::sleep(CHECK_CLUSTER_BOOTSTRAPPED_RETRY_INTERVAL);
         }
         Err(box_err!("bootstrapped cluster failed"))
     }
@@ -451,9 +449,7 @@ where
                     warn!("check cluster bootstrapped failed"; "err" => ?e);
                 }
             }
-            thread::sleep(Duration::from_secs(
-                CHECK_CLUSTER_BOOTSTRAPPED_RETRY_SECONDS,
-            ));
+            thread::sleep(CHECK_CLUSTER_BOOTSTRAPPED_RETRY_INTERVAL);
         }
         Err(box_err!("check cluster bootstrapped failed"))
     }


### PR DESCRIPTION

### What is changed and how it works?
Issue Number: Ref #12842

What's Changed:

Different from v1, v2 provides a bootstrap struct that can make bootstrapping easier.

The change may also be friendly for third parties like tiflash to reuse raftstore.

V1 may also adapt similar pattern in the future.

```commit-message
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- 
### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
