### PR TITLE
online_config: allow return error when update config

### DIFF
--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -575,8 +575,7 @@ pub struct ConfigManager(Arc<RwLock<BackupConfig>>);
 
 impl online_config::ConfigManager for ConfigManager {
     fn dispatch(&mut self, change: online_config::ConfigChange) -> online_config::Result<()> {
-        self.0.write().unwrap().update(change);
-        Ok(())
+        self.0.write().unwrap().update(change)
     }
 }
 

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -447,7 +447,10 @@ impl<T: 'static + RaftStoreRouter<E>, E: KvEngine> Endpoint<T, E> {
     fn on_change_cfg(&mut self, change: ConfigChange) {
         // Validate first.
         let mut validate_cfg = self.config.clone();
-        validate_cfg.update(change);
+        if let Err(e) = validate_cfg.update(change) {
+            warn!("cdc config update failed"; "error" => ?e);
+            return;
+        }
         if let Err(e) = validate_cfg.validate() {
             warn!("cdc config update failed"; "error" => ?e);
             return;
@@ -459,7 +462,7 @@ impl<T: 'static + RaftStoreRouter<E>, E: KvEngine> Endpoint<T, E> {
             "change" => ?change
         );
         // Update the config here. The following adjustments will all use the new values.
-        self.config.update(change.clone());
+        self.config.update(change.clone()).unwrap();
 
         // Maybe the cache will be lost due to smaller capacity,
         // but it is acceptable.

--- a/components/engine_rocks/src/config.rs
+++ b/components/engine_rocks/src/config.rs
@@ -1,6 +1,6 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::str::FromStr;
+use std::{convert::TryFrom, str::FromStr};
 
 use online_config::ConfigValue;
 use rocksdb::{
@@ -225,21 +225,17 @@ pub enum BlobRunMode {
 
 impl From<BlobRunMode> for ConfigValue {
     fn from(mode: BlobRunMode) -> ConfigValue {
-        ConfigValue::BlobRunMode(format!("k{:?}", mode))
+        ConfigValue::String(format!("k{:?}", mode))
     }
 }
 
-impl From<ConfigValue> for BlobRunMode {
-    fn from(c: ConfigValue) -> BlobRunMode {
-        if let ConfigValue::BlobRunMode(s) = c {
-            match s.as_str() {
-                "kNormal" => BlobRunMode::Normal,
-                "kReadOnly" => BlobRunMode::ReadOnly,
-                "kFallback" => BlobRunMode::Fallback,
-                m => panic!("expect: kNormal, kReadOnly or kFallback, got: {:?}", m),
-            }
+impl TryFrom<ConfigValue> for BlobRunMode {
+    type Error = String;
+    fn try_from(c: ConfigValue) -> Result<BlobRunMode, Self::Error> {
+        if let ConfigValue::String(s) = c {
+            Self::from_str(&s)
         } else {
-            panic!("expect: ConfigValue::BlobRunMode, got: {:?}", c);
+            panic!("expect: ConfigValue::String, got: {:?}", c);
         }
     }
 }

--- a/components/engine_rocks/src/config.rs
+++ b/components/engine_rocks/src/config.rs
@@ -225,7 +225,12 @@ pub enum BlobRunMode {
 
 impl From<BlobRunMode> for ConfigValue {
     fn from(mode: BlobRunMode) -> ConfigValue {
-        ConfigValue::String(format!("k{:?}", mode))
+        let str_value = match mode {
+            BlobRunMode::Normal => "normal",
+            BlobRunMode::ReadOnly => "read-only",
+            BlobRunMode::Fallback => "fallback",
+        };
+        ConfigValue::String(str_value.into())
     }
 }
 

--- a/components/file_system/src/lib.rs
+++ b/components/file_system/src/lib.rs
@@ -18,11 +18,14 @@ mod metrics;
 mod metrics_manager;
 mod rate_limiter;
 
-pub use std::{convert::TryFrom, fs::{
-    canonicalize, create_dir, create_dir_all, hard_link, metadata, read_dir, read_link, remove_dir,
-    remove_dir_all, remove_file, rename, set_permissions, symlink_metadata, DirBuilder, DirEntry,
-    FileType, Metadata, Permissions, ReadDir,
-}};
+pub use std::{
+    convert::TryFrom,
+    fs::{
+        canonicalize, create_dir, create_dir_all, hard_link, metadata, read_dir, read_link,
+        remove_dir, remove_dir_all, remove_file, rename, set_permissions, symlink_metadata,
+        DirBuilder, DirEntry, FileType, Metadata, Permissions, ReadDir,
+    },
+};
 use std::{
     io::{self, ErrorKind, Read, Write},
     path::Path,

--- a/components/file_system/src/lib.rs
+++ b/components/file_system/src/lib.rs
@@ -18,11 +18,11 @@ mod metrics;
 mod metrics_manager;
 mod rate_limiter;
 
-pub use std::fs::{
+pub use std::{convert::TryFrom, fs::{
     canonicalize, create_dir, create_dir_all, hard_link, metadata, read_dir, read_link, remove_dir,
     remove_dir_all, remove_file, rename, set_permissions, symlink_metadata, DirBuilder, DirEntry,
     FileType, Metadata, Permissions, ReadDir,
-};
+}};
 use std::{
     io::{self, ErrorKind, Read, Write},
     path::Path,
@@ -205,19 +205,17 @@ impl<'de> Deserialize<'de> for IOPriority {
 
 impl From<IOPriority> for ConfigValue {
     fn from(mode: IOPriority) -> ConfigValue {
-        ConfigValue::IOPriority(mode.as_str().to_owned())
+        ConfigValue::String(mode.as_str().to_owned())
     }
 }
 
-impl From<ConfigValue> for IOPriority {
-    fn from(c: ConfigValue) -> IOPriority {
-        if let ConfigValue::IOPriority(s) = c {
-            match IOPriority::from_str(s.as_str()) {
-                Ok(p) => p,
-                _ => panic!("expect: low, medium, high, got: {:?}", s),
-            }
+impl TryFrom<ConfigValue> for IOPriority {
+    type Error = String;
+    fn try_from(c: ConfigValue) -> Result<IOPriority, Self::Error> {
+        if let ConfigValue::String(s) = c {
+            Self::from_str(s.as_str())
         } else {
-            panic!("expect: ConfigValue::IOPriority, got: {:?}", c);
+            panic!("expect: ConfigValue::String, got: {:?}", c);
         }
     }
 }

--- a/components/online_config/online_config_derive/src/lib.rs
+++ b/components/online_config/online_config_derive/src/lib.rs
@@ -172,7 +172,7 @@ fn update(fields: &Punctuated<Field, Comma>, crate_name: &Ident) -> Result<Token
         let f = if submodule {
             quote! {
                 if let Some(#crate_name::ConfigValue::Module(v)) = #incoming.remove(#name_lit) {
-                    #crate_name::OnlineConfig::update(&mut self.#name, v);
+                    #crate_name::OnlineConfig::update(&mut self.#name, v)?;
                 }
             }
         } else if is_option_type(&field.ty) {
@@ -181,22 +181,23 @@ fn update(fields: &Punctuated<Field, Comma>, crate_name: &Ident) -> Result<Token
                     if #crate_name::ConfigValue::None == v {
                         self.#name = None;
                     } else {
-                        self.#name = Some(v.into());
+                        self.#name = Some(std::convert::TryInto::try_into(v)?);
                     }
                 }
             }
         } else {
             quote! {
                 if let Some(v) = #incoming.remove(#name_lit) {
-                    self.#name = v.into();
+                    self.#name = std::convert::TryInto::try_into(v)?;
                 }
             }
         };
         update_fields.push(f);
     }
     Ok(quote! {
-        fn update(&mut self, mut #incoming: #crate_name::ConfigChange) {
+        fn update(&mut self, mut #incoming: #crate_name::ConfigChange) -> std::result::Result<(), Box<dyn std::error::Error>> {
             #(#update_fields)*
+            Ok(())
         }
     })
 }

--- a/components/online_config/src/lib.rs
+++ b/components/online_config/src/lib.rs
@@ -20,8 +20,6 @@ pub enum ConfigValue {
     Usize(usize),
     Bool(bool),
     String(String),
-    BlobRunMode(String),
-    IOPriority(String),
     Module(ConfigChange),
     Skip,
     None,
@@ -39,8 +37,6 @@ impl Display for ConfigValue {
             ConfigValue::Usize(v) => write!(f, "{}", v),
             ConfigValue::Bool(v) => write!(f, "{}", v),
             ConfigValue::String(v) => write!(f, "{}", v),
-            ConfigValue::BlobRunMode(v) => write!(f, "{}", v),
-            ConfigValue::IOPriority(v) => write!(f, "{}", v),
             ConfigValue::Module(v) => write!(f, "{:?}", v),
             ConfigValue::Skip => write!(f, "ConfigValue::Skip"),
             ConfigValue::None => write!(f, ""),
@@ -115,13 +111,13 @@ impl_into!(ConfigChange, Module);
 /// 3. `#[online_config(submodule)]` field, these fields represent the
 /// submodule, and should also derive `OnlineConfig`
 /// 4. normal fields, the type of these fields should be implment
-/// `Into` and `From` for `ConfigValue`
+/// `Into` and `From`/`TryFrom` for `ConfigValue`
 pub trait OnlineConfig<'a> {
     type Encoder: serde::Serialize;
     /// Compare to other config, return the difference
     fn diff(&self, _: &Self) -> ConfigChange;
     /// Update config with difference returned by `diff`
-    fn update(&mut self, _: ConfigChange);
+    fn update(&mut self, _: ConfigChange) -> Result<()>;
     /// Get encoder that can be serialize with `serde::Serializer`
     /// with the disappear of `#[online_config(hidden)]` field
     fn get_encoder(&'a self) -> Self::Encoder;
@@ -137,6 +133,10 @@ pub trait ConfigManager: Send + Sync {
 
 #[cfg(test)]
 mod tests {
+    use std::convert::TryFrom;
+
+    use serde::Serialize;
+
     use super::*;
     use crate as online_config;
 
@@ -194,7 +194,7 @@ mod tests {
             assert_eq!(sub_diff.remove("field1").map(Into::into), Some(1000u64));
             assert_eq!(sub_diff.remove("field2").map(Into::into), Some(true));
         }
-        cfg.update(diff);
+        cfg.update(diff).unwrap();
         assert_eq!(cfg, updated_cfg, "cfg should be updated");
     }
 
@@ -204,7 +204,7 @@ mod tests {
         let diff = cfg.diff(&cfg.clone());
         assert!(diff.is_empty(), "diff should be empty");
 
-        cfg.update(diff);
+        cfg.update(diff).unwrap();
         assert_eq!(cfg, TestConfig::default(), "cfg should not be updated");
     }
 
@@ -218,7 +218,7 @@ mod tests {
 
         let mut diff = HashMap::new();
         diff.insert("skip_field".to_owned(), ConfigValue::U64(123));
-        cfg.update(diff);
+        cfg.update(diff).unwrap();
         assert_eq!(cfg, TestConfig::default(), "cfg should not be updated");
     }
 
@@ -241,7 +241,7 @@ mod tests {
             assert_eq!(sub_diff.remove("field2").map(Into::into), Some(true));
         }
 
-        cfg.update(diff);
+        cfg.update(diff).unwrap();
         assert_eq!(
             cfg.submodule_field, updated_cfg.submodule_field,
             "submodule should be updated"
@@ -294,5 +294,75 @@ mod tests {
             toml::to_string(&cfg.get_encoder()).unwrap(),
             "skip-field = \"\"\n\n[submodule-field]\nrename_field = false\n"
         );
+    }
+
+
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+    pub enum TestEnum {
+        First,
+        Second,
+    }
+
+    impl std::fmt::Display for TestEnum {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::First => f.write_str("first"),
+                Self::Second => f.write_str("second"),
+            }
+        }
+    }
+
+    impl From<TestEnum> for ConfigValue {
+        fn from(v: TestEnum) -> ConfigValue {
+            ConfigValue::String(format!("{}", v))
+        }
+    }
+
+    impl TryFrom<ConfigValue> for TestEnum {
+        type Error = String;
+        fn try_from(v: ConfigValue) -> std::result::Result<Self, Self::Error> {
+            if let ConfigValue::String(s) = v {
+                match s.as_str() {
+                    "first" => Ok(Self::First),
+                    "second" => Ok(Self::Second),
+                    s => Err(format!("invalid config value: {}", s))
+                }
+            } else {
+                panic!("expect ConfigValue::String, got: {:?}", v);
+            }
+        }
+    }
+
+    #[derive(Clone, OnlineConfig, Debug, PartialEq)]
+    pub struct TestEnumConfig {
+        f1: u64,
+        e: TestEnum,
+    }
+
+    impl Default for TestEnumConfig {
+        fn default() -> Self {
+            Self { f1: 0, e: TestEnum::First, }
+        }
+    }
+
+    #[test]
+    fn test_update_enum_config() {
+        let mut config = TestEnumConfig::default();
+
+        let mut diff = HashMap::new();
+        diff.insert("f1".to_owned(), ConfigValue::U64(1));
+        diff.insert("e".to_owned(), ConfigValue::String("second".into()));
+        config.update(diff).unwrap();
+
+        let updated = TestEnumConfig {
+            f1: 1,
+            e: TestEnum::Second,
+        };
+        assert_eq!(config, updated);
+
+        let mut diff = HashMap::new();
+        diff.insert("f1".to_owned(), ConfigValue::String("invalid".into()));
+        assert!(config.update(diff).is_err());
     }
 }

--- a/components/online_config/src/lib.rs
+++ b/components/online_config/src/lib.rs
@@ -363,7 +363,7 @@ mod tests {
         assert_eq!(config, updated);
 
         let mut diff = HashMap::new();
-        diff.insert("f1".to_owned(), ConfigValue::String("invalid".into()));
+        diff.insert("e".to_owned(), ConfigValue::String("invalid".into()));
         assert!(config.update(diff).is_err());
     }
 }

--- a/components/online_config/src/lib.rs
+++ b/components/online_config/src/lib.rs
@@ -296,8 +296,6 @@ mod tests {
         );
     }
 
-
-
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
     pub enum TestEnum {
         First,
@@ -326,7 +324,7 @@ mod tests {
                 match s.as_str() {
                     "first" => Ok(Self::First),
                     "second" => Ok(Self::Second),
-                    s => Err(format!("invalid config value: {}", s))
+                    s => Err(format!("invalid config value: {}", s)),
                 }
             } else {
                 panic!("expect ConfigValue::String, got: {:?}", v);
@@ -342,7 +340,10 @@ mod tests {
 
     impl Default for TestEnumConfig {
         fn default() -> Self {
-            Self { f1: 0, e: TestEnum::First, }
+            Self {
+                f1: 0,
+                e: TestEnum::First,
+            }
         }
     }
 

--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -946,7 +946,8 @@ impl ConfigManager for RaftstoreConfigManager {
     ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         {
             let change = change.clone();
-            self.config.try_update(move |cfg: &mut Config| cfg.update(change))?;
+            self.config
+                .try_update(move |cfg: &mut Config| cfg.update(change))?;
         }
         if let Some(ConfigValue::Module(raft_batch_system_change)) =
             change.get("store_batch_system")

--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -946,8 +946,7 @@ impl ConfigManager for RaftstoreConfigManager {
     ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         {
             let change = change.clone();
-            self.config
-                .update(move |cfg: &mut Config| cfg.update(change));
+            self.config.try_update(move |cfg: &mut Config| cfg.update(change))?;
         }
         if let Some(ConfigValue::Module(raft_batch_system_change)) =
             change.get("store_batch_system")

--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -947,7 +947,7 @@ impl ConfigManager for RaftstoreConfigManager {
         {
             let change = change.clone();
             self.config
-                .try_update(move |cfg: &mut Config| cfg.update(change))?;
+                .update(move |cfg: &mut Config| cfg.update(change))?;
         }
         if let Some(ConfigValue::Module(raft_batch_system_change)) =
             change.get("store_batch_system")

--- a/components/raftstore/src/store/worker/split_check.rs
+++ b/components/raftstore/src/store/worker/split_check.rs
@@ -545,7 +545,7 @@ where
     fn change_cfg(&mut self, change: ConfigChange) {
         if let Err(e) = self.coprocessor.cfg.update(change) {
             error!("update split check config failed"; "err" => ?e);
-            retrun;
+            return;
         };
         info!(
             "split check config updated";

--- a/components/raftstore/src/store/worker/split_check.rs
+++ b/components/raftstore/src/store/worker/split_check.rs
@@ -543,11 +543,14 @@ where
     }
 
     fn change_cfg(&mut self, change: ConfigChange) {
+        if let Err(e) = self.coprocessor.cfg.update(change) {
+            error!("update split check config failed"; "err" => ?e);
+            retrun;
+        };
         info!(
             "split check config updated";
             "change" => ?change
         );
-        self.coprocessor.cfg.update(change).unwrap();
     }
 }
 

--- a/components/raftstore/src/store/worker/split_check.rs
+++ b/components/raftstore/src/store/worker/split_check.rs
@@ -547,7 +547,7 @@ where
             "split check config updated";
             "change" => ?change
         );
-        self.coprocessor.cfg.update(change);
+        self.coprocessor.cfg.update(change).unwrap();
     }
 }
 

--- a/components/raftstore/src/store/worker/split_check.rs
+++ b/components/raftstore/src/store/worker/split_check.rs
@@ -543,7 +543,7 @@ where
     }
 
     fn change_cfg(&mut self, change: ConfigChange) {
-        if let Err(e) = self.coprocessor.cfg.update(change) {
+        if let Err(e) = self.coprocessor.cfg.update(change.clone()) {
             error!("update split check config failed"; "err" => ?e);
             return;
         };

--- a/components/raftstore/src/store/worker/split_config.rs
+++ b/components/raftstore/src/store/worker/split_config.rs
@@ -117,7 +117,7 @@ impl ConfigManager for SplitConfigManager {
         {
             let change = change.clone();
             self.0
-                .update(move |cfg: &mut SplitConfig| cfg.update(change));
+                .try_update(move |cfg: &mut SplitConfig| cfg.update(change))?;
         }
         info!(
             "load base split config changed";

--- a/components/raftstore/src/store/worker/split_config.rs
+++ b/components/raftstore/src/store/worker/split_config.rs
@@ -117,7 +117,7 @@ impl ConfigManager for SplitConfigManager {
         {
             let change = change.clone();
             self.0
-                .try_update(move |cfg: &mut SplitConfig| cfg.update(change))?;
+                .update(move |cfg: &mut SplitConfig| cfg.update(change))?;
         }
         info!(
             "load base split config changed";

--- a/components/resolved_ts/src/endpoint.rs
+++ b/components/resolved_ts/src/endpoint.rs
@@ -579,7 +579,7 @@ where
     fn handle_change_config(&mut self, change: ConfigChange) {
         let prev = format!("{:?}", self.cfg);
         let prev_advance_ts_interval = self.cfg.advance_ts_interval;
-        if let Err(e) = self.cfg.update(change).unwrap() {
+        if let Err(e) = self.cfg.update(change) {
             error!("update resolved-ts config unexpectly failed"; "err" => ?e);
             return;
         }

--- a/components/resolved_ts/src/endpoint.rs
+++ b/components/resolved_ts/src/endpoint.rs
@@ -579,7 +579,10 @@ where
     fn handle_change_config(&mut self, change: ConfigChange) {
         let prev = format!("{:?}", self.cfg);
         let prev_advance_ts_interval = self.cfg.advance_ts_interval;
-        self.cfg.update(change).unwrap();
+        if let Err(e) = self.cfg.update(change).unwrap() {
+            error!("update resolved-ts config unexpectly failed"; "err" => ?e);
+            return;
+        }
         if self.cfg.advance_ts_interval != prev_advance_ts_interval {
             // Increase the `cfg_version` to reject advance event that registered before
             self.cfg_version += 1;

--- a/components/resolved_ts/src/endpoint.rs
+++ b/components/resolved_ts/src/endpoint.rs
@@ -579,7 +579,7 @@ where
     fn handle_change_config(&mut self, change: ConfigChange) {
         let prev = format!("{:?}", self.cfg);
         let prev_advance_ts_interval = self.cfg.advance_ts_interval;
-        self.cfg.update(change);
+        self.cfg.update(change).unwrap();
         if self.cfg.advance_ts_interval != prev_advance_ts_interval {
             // Increase the `cfg_version` to reject advance event that registered before
             self.cfg_version += 1;

--- a/components/resource_metering/src/config.rs
+++ b/components/resource_metering/src/config.rs
@@ -110,7 +110,7 @@ impl ConfigManager {
 impl online_config::ConfigManager for ConfigManager {
     fn dispatch(&mut self, change: ConfigChange) -> Result<(), Box<dyn Error>> {
         let mut new_config = self.current_config.clone();
-        new_config.update(change);
+        new_config.update(change)?;
         new_config.validate()?;
         if self.current_config.receiver_address != new_config.receiver_address {
             self.address_notifier

--- a/components/tikv_util/src/config.rs
+++ b/components/tikv_util/src/config.rs
@@ -1117,6 +1117,15 @@ impl<T> VersionTrack<T> {
         self.version.fetch_add(1, Ordering::Release);
     }
 
+    pub fn try_update<F>(&self, f: F) -> Result<(), Box<dyn std::error::Error>>
+    where 
+        F: FnOnce(&mut T) -> Result<(), Box<dyn std::error::Error>>
+    {
+        f(&mut self.value.write().unwrap())?;
+        self.version.fetch_add(1, Ordering::Release);
+        Ok(())
+    }
+
     pub fn value(&self) -> RwLockReadGuard<'_, T> {
         self.value.read().unwrap()
     }

--- a/components/tikv_util/src/config.rs
+++ b/components/tikv_util/src/config.rs
@@ -1118,8 +1118,8 @@ impl<T> VersionTrack<T> {
     }
 
     pub fn try_update<F>(&self, f: F) -> Result<(), Box<dyn std::error::Error>>
-    where 
-        F: FnOnce(&mut T) -> Result<(), Box<dyn std::error::Error>>
+    where
+        F: FnOnce(&mut T) -> Result<(), Box<dyn std::error::Error>>,
     {
         f(&mut self.value.write().unwrap())?;
         self.version.fetch_add(1, Ordering::Release);

--- a/src/config.rs
+++ b/src/config.rs
@@ -3758,6 +3758,7 @@ impl ConfigController {
                     // dispatched to corresponding config manager, to avoid dispatch change twice
                     if let Some(mgr) = inner.config_mgrs.get_mut(&Module::from(name.as_str())) {
                         if let Err(e) = mgr.dispatch(change.clone()) {
+                            // we already verified the correctness at the beginning of this function.
                             inner.current.update(to_update).unwrap();
                             return Err(e);
                         }
@@ -3770,6 +3771,7 @@ impl ConfigController {
             }
         }
         debug!("all config change had been dispatched"; "change" => ?to_update);
+        // we already verified the correctness at the beginning of this function.
         inner.current.update(to_update).unwrap();
         // Write change to the config file
         if let Some(change) = change {

--- a/src/config.rs
+++ b/src/config.rs
@@ -4518,7 +4518,7 @@ mod tests {
         let diff = config_value_to_string(diff.into_iter().collect());
         assert_eq!(diff.len(), 1);
         assert_eq!(diff[0].0.as_str(), "blob_run_mode");
-        assert_eq!(diff[0].1.as_str(), "kFallback");
+        assert_eq!(diff[0].1.as_str(), "fallback");
     }
 
     #[test]

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -421,7 +421,7 @@ impl ConfigManager for ServerConfigManager {
     fn dispatch(&mut self, c: ConfigChange) -> std::result::Result<(), Box<dyn std::error::Error>> {
         {
             let change = c.clone();
-            self.config.try_update(move |cfg| cfg.update(change))?;
+            self.config.update(move |cfg| cfg.update(change))?;
             if let Some(value) = c.get("grpc_memory_pool_quota") {
                 let mem_quota: ReadableSize = value.clone().into();
                 // the resize is done inplace indeed, but grpc-rs's api need self, so we just

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -421,7 +421,7 @@ impl ConfigManager for ServerConfigManager {
     fn dispatch(&mut self, c: ConfigChange) -> std::result::Result<(), Box<dyn std::error::Error>> {
         {
             let change = c.clone();
-            self.config.update(move |cfg| cfg.update(change));
+            self.config.try_update(move |cfg| cfg.update(change))?;
             if let Some(value) = c.get("grpc_memory_pool_quota") {
                 let mem_quota: ReadableSize = value.clone().into();
                 // the resize is done inplace indeed, but grpc-rs's api need self, so we just

--- a/src/server/gc_worker/config.rs
+++ b/src/server/gc_worker/config.rs
@@ -55,7 +55,7 @@ impl ConfigManager for GcWorkerConfigManager {
         {
             let change = change.clone();
             self.0
-                .try_update(move |cfg: &mut GcConfig| cfg.update(change))?;
+                .update(move |cfg: &mut GcConfig| cfg.update(change))?;
         }
         info!(
             "GC worker config changed";

--- a/src/server/gc_worker/config.rs
+++ b/src/server/gc_worker/config.rs
@@ -54,7 +54,7 @@ impl ConfigManager for GcWorkerConfigManager {
     ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         {
             let change = change.clone();
-            self.0.update(move |cfg: &mut GcConfig| cfg.update(change));
+            self.0.try_update(move |cfg: &mut GcConfig| cfg.update(change))?;
         }
         info!(
             "GC worker config changed";

--- a/src/server/gc_worker/config.rs
+++ b/src/server/gc_worker/config.rs
@@ -54,7 +54,8 @@ impl ConfigManager for GcWorkerConfigManager {
     ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         {
             let change = change.clone();
-            self.0.try_update(move |cfg: &mut GcConfig| cfg.update(change))?;
+            self.0
+                .try_update(move |cfg: &mut GcConfig| cfg.update(change))?;
         }
         info!(
             "GC worker config changed";

--- a/src/server/raft_client.rs
+++ b/src/server/raft_client.rs
@@ -1232,7 +1232,10 @@ mod tests {
         assert!(msg_buf.full());
 
         // update config
-        version_track.update(|cfg| cfg.max_grpc_send_msg_len *= 2);
+        let _ = version_track.update(|cfg| -> Result<(), ()> {
+            cfg.max_grpc_send_msg_len *= 2;
+            Ok(())
+        });
         msg_buf.clear();
 
         let new_max_msg_len =

--- a/src/storage/config_manager.rs
+++ b/src/storage/config_manager.rs
@@ -2,7 +2,7 @@
 
 //! Storage online config manager.
 
-use std::sync::Arc;
+use std::{convert::TryInto, sync::Arc};
 
 use engine_traits::{CFNamesExt, CFOptionsExt, ColumnFamilyOptions, CF_DEFAULT};
 use file_system::{get_io_rate_limiter, IOPriority, IOType};
@@ -110,7 +110,7 @@ impl<EK: Engine, L: LockManager> ConfigManager for StorageConfigManger<EK, L> {
             for t in IOType::iter() {
                 if let Some(priority) = io_rate_limit.remove(&(t.as_str().to_owned() + "_priority"))
                 {
-                    let priority: IOPriority = priority.into();
+                    let priority: IOPriority = priority.try_into()?;
                     limiter.set_io_priority(t, priority);
                 }
             }

--- a/tests/integrations/config/dynamic/gc_worker.rs
+++ b/tests/integrations/config/dynamic/gc_worker.rs
@@ -145,19 +145,28 @@ fn test_change_io_limit_by_debugger() {
     });
 
     // Enable io iolimit
-    config_manager.update(|cfg: &mut GcConfig| cfg.max_write_bytes_per_sec = ReadableSize(1024));
+    let _ = config_manager.update(|cfg: &mut GcConfig| -> Result<(), ()> {
+        cfg.max_write_bytes_per_sec = ReadableSize(1024);
+        Ok(())
+    });
     validate(&scheduler, move |_, limiter: &Limiter| {
         assert_eq!(limiter.speed_limit(), 1024.0);
     });
 
     // Change io iolimit
-    config_manager.update(|cfg: &mut GcConfig| cfg.max_write_bytes_per_sec = ReadableSize(2048));
+    let _ = config_manager.update(|cfg: &mut GcConfig| -> Result<(), ()> {
+        cfg.max_write_bytes_per_sec = ReadableSize(2048);
+        Ok(())
+    });
     validate(&scheduler, move |_, limiter: &Limiter| {
         assert_eq!(limiter.speed_limit(), 2048.0);
     });
 
     // Disable io iolimit
-    config_manager.update(|cfg: &mut GcConfig| cfg.max_write_bytes_per_sec = ReadableSize(0));
+    let _ = config_manager.update(|cfg: &mut GcConfig| -> Result<(), ()> {
+        cfg.max_write_bytes_per_sec = ReadableSize(0);
+        Ok(())
+    });
     validate(&scheduler, move |_, limiter: &Limiter| {
         assert_eq!(limiter.speed_limit(), f64::INFINITY);
     });

--- a/tests/integrations/config/test_config_client.rs
+++ b/tests/integrations/config/test_config_client.rs
@@ -64,8 +64,7 @@ fn test_dispatch_change() {
 
     impl ConfigManager for CfgManager {
         fn dispatch(&mut self, c: ConfigChange) -> Result<(), Box<dyn Error>> {
-            self.0.lock().unwrap().update(c);
-            Ok(())
+            self.0.lock().unwrap().update(c)
         }
     }
 
@@ -198,8 +197,7 @@ fn test_update_from_toml_file() {
 
     impl ConfigManager for CfgManager {
         fn dispatch(&mut self, c: ConfigChange) -> Result<(), Box<dyn Error>> {
-            self.0.lock().unwrap().update(c);
-            Ok(())
+            self.0.lock().unwrap().update(c)
         }
     }
 


### PR DESCRIPTION
Signed-off-by: glorv <glorvs@163.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #12909

What's Changed:
<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```
Replace Into::into with TryInto::try_info to simplify the type conversion of ConfigValue
```

Currently, OnlineConfig depends on `From`/`Into` to convert between `ConfigValue` and the actual config type. For enum types that only accepts some specific string or integer values we have to define a enum variant like `ConfigValue::IOPriority(String)`, `ConfigValue::BlobRunMode(String)`. And the variants count increase linearly with new enum types. 

By changing the type conversion interface from `Into` to `TryInfo`, we can simplify this kind of type into `ConfigValue::String`. 


### Related changes


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
