### PR TITLE
server: support lossy metrics compaction

### DIFF
--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -108,7 +108,7 @@ use tikv_util::{
     check_environment_variables,
     config::{ensure_dir_exist, RaftDataStateMachine, VersionTrack},
     math::MovingAvgU32,
-    metrics::INSTANCE_BACKEND_CPU_QUOTA,
+    metrics::{set_metrics_compact_policy, INSTANCE_BACKEND_CPU_QUOTA},
     quota_limiter::{QuotaLimitConfigManager, QuotaLimiter},
     sys::{cpu_time::ProcessStat, disk, register_memory_usage_high_water, SysQuota},
     thread_group::GroupProperties,
@@ -1004,6 +1004,8 @@ impl<ER: RaftEngine> TiKvServer<ER> {
         }
 
         initial_metric(&self.config.metric);
+        // init metrics glboal variables
+        set_metrics_compact_policy(self.config.server.metrics_compact_policy);
         if self.config.storage.enable_ttl {
             ttl_checker.start_with_timer(TtlChecker::new(
                 self.engines.as_ref().unwrap().engine.kv_engine(),

--- a/components/server/src/signal_handler.rs
+++ b/components/server/src/signal_handler.rs
@@ -22,7 +22,7 @@ mod imp {
                 }
                 SIGUSR1 => {
                     // Use SIGUSR1 to log metrics.
-                    info!("{}", metrics::dump(false));
+                    info!("{}", metrics::dump());
                     if let Some(ref engines) = engines {
                         info!("{:?}", MiscExt::dump_stats(&engines.kv));
                         info!("{:?}", RaftEngine::dump_stats(&engines.raft));

--- a/components/tikv_util/src/metrics/mod.rs
+++ b/components/tikv_util/src/metrics/mod.rs
@@ -1,11 +1,18 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{collections::HashMap, io::Write};
+use std::{
+    collections::HashMap,
+    convert::TryFrom,
+    io::Write,
+    sync::atomic::{AtomicU8, Ordering},
+};
 
 use kvproto::pdpb;
 use lazy_static::lazy_static;
+use online_config::ConfigValue;
 use prometheus::{proto::MetricType, *};
 use prometheus_static_metric::*;
+use serde::{Deserialize, Serialize};
 
 #[cfg(target_os = "linux")]
 mod threads_linux;
@@ -36,16 +43,27 @@ mod metrics_reader;
 
 pub type RecordPairVec = Vec<pdpb::RecordPair>;
 
-pub fn dump(should_simplify: bool) -> String {
+static METRICS_COMPACT_POLICY: AtomicU8 = AtomicU8::new(MetricsCompactPolicy::No as u8);
+
+pub fn set_metrics_compact_policy(p: MetricsCompactPolicy) {
+    METRICS_COMPACT_POLICY.store(p as u8, Ordering::Release);
+}
+
+pub fn get_metrics_compact_policy() -> MetricsCompactPolicy {
+    METRICS_COMPACT_POLICY.load(Ordering::Acquire).into()
+}
+
+pub fn dump() -> String {
     let mut buffer = vec![];
-    dump_to(&mut buffer, should_simplify);
+    dump_to(&mut buffer);
     String::from_utf8(buffer).unwrap()
 }
 
-pub fn dump_to(w: &mut impl Write, should_simplify: bool) {
+pub fn dump_to(w: &mut impl Write) {
+    let compact_policy = get_metrics_compact_policy();
     let encoder = TextEncoder::new();
     let metric_families = prometheus::gather();
-    if !should_simplify {
+    if compact_policy == MetricsCompactPolicy::No {
         if let Err(e) = encoder.encode(&*metric_families, w) {
             warn!("prometheus encoding error"; "err" => ?e);
         }
@@ -59,7 +77,20 @@ pub fn dump_to(w: &mut impl Write, should_simplify: bool) {
             MetricType::COUNTER => {
                 metrics.retain(|m| m.get_counter().get_value() > 0.0);
             }
-            MetricType::HISTOGRAM => metrics.retain(|m| m.get_histogram().get_sample_count() > 0),
+            MetricType::HISTOGRAM => {
+                let threshold = if compact_policy == MetricsCompactPolicy::Lossless {
+                    0
+                } else {
+                    // only retain histogram that the sample count > 0.01 * max_sample_count
+                    metrics
+                        .iter()
+                        .map(|m| m.get_histogram().get_sample_count())
+                        .max()
+                        .unwrap_or(0)
+                        / 100
+                };
+                metrics.retain(|m| m.get_histogram().get_sample_count() > threshold);
+            }
             _ => {}
         }
         if !metrics.is_empty() {
@@ -118,6 +149,77 @@ pub fn convert_record_pairs(m: HashMap<String, u64>) -> RecordPairVec {
         .collect()
 }
 
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Debug)]
+/// MetricsCompactPolicy defines the level of compact metrics sample data, a higher level of
+/// means smaller data size and more information loss.
+#[repr(u8)]
+#[serde(rename_all = "lowercase")]
+pub enum MetricsCompactPolicy {
+    // return full original data, this is the default policy.
+    No = 0,
+    // this level try to compact sample without infromation loss.
+    // currently only filter counter with 0 value and histogram with 0 samples.
+    Lossless = 1,
+    // this level try to reduce the data size as much as possible.
+    // this level also compact histogram vector type by remove histograms which sample count is
+    // smaller than 1% of the max sample count.
+    Lossy = 2,
+}
+
+impl From<u8> for MetricsCompactPolicy {
+    fn from(val: u8) -> Self {
+        match val {
+            0 => Self::No,
+            1 => Self::Lossless,
+            2 => Self::Lossy,
+            // only used in internal logic, so this breanch is unreachable.
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl std::fmt::Display for MetricsCompactPolicy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let str_value = match *self {
+            MetricsCompactPolicy::No => "no",
+            MetricsCompactPolicy::Lossless => "lossless",
+            MetricsCompactPolicy::Lossy => "lossy",
+        };
+        f.write_str(str_value)
+    }
+}
+
+impl From<MetricsCompactPolicy> for ConfigValue {
+    fn from(v: MetricsCompactPolicy) -> Self {
+        Self::String(format!("{v}"))
+    }
+}
+
+impl TryFrom<ConfigValue> for MetricsCompactPolicy {
+    type Error = String;
+    fn try_from(value: ConfigValue) -> std::result::Result<Self, Self::Error> {
+        if let ConfigValue::String(s) = value {
+            match s.as_str() {
+                "no" => Ok(Self::No),
+                "lossless" => Ok(Self::Lossless),
+                "lossy" => Ok(Self::Lossy),
+                v => Err(format!(
+                    "unknown value '{v}', expected one of ['no', 'lossless', 'lossy']"
+                )),
+            }
+        } else {
+            Err(format!("expected ConfigValue::String, got '{:?}'", value))
+        }
+    }
+}
+
+impl TryFrom<&ConfigValue> for MetricsCompactPolicy {
+    type Error = String;
+    fn try_from(c: &ConfigValue) -> std::result::Result<Self, Self::Error> {
+        Self::try_from(c.clone())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
@@ -149,11 +251,13 @@ mod tests {
         }
 
         // test all data is 0.
-        let full_metrics = dump(false);
+        set_metrics_compact_policy(MetricsCompactPolicy::No);
+        let full_metrics = dump();
         assert!(!full_metrics.is_empty());
         check_duplicate(&full_metrics);
 
-        let filtered_metrics = dump(true);
+        set_metrics_compact_policy(MetricsCompactPolicy::Lossless);
+        let filtered_metrics = dump();
         check_duplicate(&full_metrics);
         assert!(full_metrics.len() > filtered_metrics.len());
 
@@ -161,12 +265,14 @@ mod tests {
         histogram.with_label_values(&["test"]).observe(1.0);
         gauge.inc();
 
-        let new_full_metrics = dump(false);
+        set_metrics_compact_policy(MetricsCompactPolicy::No);
+        let new_full_metrics = dump();
         assert!(!new_full_metrics.is_empty());
         check_duplicate(&new_full_metrics);
         assert!(new_full_metrics.len() > full_metrics.len());
 
-        let new_filtered_metrics = dump(true);
+        set_metrics_compact_policy(MetricsCompactPolicy::Lossless);
+        let new_filtered_metrics = dump();
         check_duplicate(&new_filtered_metrics);
         assert!(new_filtered_metrics.len() > filtered_metrics.len());
         assert!(new_full_metrics.len() > new_filtered_metrics.len());

--- a/src/config.rs
+++ b/src/config.rs
@@ -3872,6 +3872,7 @@ mod tests {
     use tikv_kv::RocksEngine as RocksDBEngine;
     use tikv_util::{
         config::VersionTrack,
+        metrics::{get_metrics_compact_policy, MetricsCompactPolicy},
         quota_limiter::{QuotaLimitConfigManager, QuotaLimiter},
         sys::SysQuota,
         worker::{dummy_scheduler, ReceiverWrapper},
@@ -4786,6 +4787,23 @@ mod tests {
         cfg.server.raft_msg_max_batch_size = 32;
         assert_eq!(cfg_controller.get_current(), cfg);
         check_cfg(&cfg);
+
+        cfg_controller
+            .update_config("server.metrics-compact-policy", "lossless")
+            .unwrap();
+        cfg.server.metrics_compact_policy = MetricsCompactPolicy::Lossless;
+        assert_eq!(cfg_controller.get_current(), cfg);
+        assert_eq!(
+            get_metrics_compact_policy(),
+            cfg.server.metrics_compact_policy
+        );
+
+        assert!(
+            cfg_controller
+                .update_config("server.metrics-compact-policy", "invalid-value")
+                .is_err()
+        );
+        assert_eq!(cfg_controller.get_current(), cfg);
     }
 
     #[test]

--- a/src/server/service/debug.rs
+++ b/src/server/service/debug.rs
@@ -360,7 +360,7 @@ impl<ER: RaftEngine, T: RaftStoreRouter<RocksEngine> + 'static> debugpb::Debug f
             .spawn(async move {
                 let mut resp = GetMetricsResponse::default();
                 resp.set_store_id(debugger.get_store_ident()?.store_id);
-                resp.set_prometheus(metrics::dump(false));
+                resp.set_prometheus(metrics::dump());
                 if req.get_all() {
                     let engines = debugger.get_engine();
                     resp.set_rocksdb_kv(box_try!(MiscExt::dump_stats(&engines.kv)));

--- a/src/server/status_server/mod.rs
+++ b/src/server/status_server/mod.rs
@@ -503,19 +503,15 @@ where
         }
     }
 
-    fn handle_get_metrics(
-        req: Request<Body>,
-        mgr: &ConfigController,
-    ) -> hyper::Result<Response<Body>> {
-        let should_simplify = mgr.get_current().server.simplify_metrics;
+    fn handle_get_metrics(req: Request<Body>) -> hyper::Result<Response<Body>> {
         let gz_encoding = client_accept_gzip(&req);
         let metrics = if gz_encoding {
             // gzip can reduce the body size to less than 1/10.
             let mut encoder = GzEncoder::new(vec![], Compression::default());
-            dump_to(&mut encoder, should_simplify);
+            dump_to(&mut encoder);
             encoder.finish().unwrap()
         } else {
-            dump(should_simplify).into_bytes()
+            dump().into_bytes()
         };
         let mut resp = Response::new(metrics.into());
         resp.headers_mut()
@@ -584,9 +580,7 @@ where
                         }
 
                         match (method, path.as_ref()) {
-                            (Method::GET, "/metrics") => {
-                                Self::handle_get_metrics(req, &cfg_controller)
-                            }
+                            (Method::GET, "/metrics") => Self::handle_get_metrics(req),
                             (Method::GET, "/status") => Ok(Response::default()),
                             (Method::GET, "/debug/pprof/heap_list") => Self::list_heap_prof(req),
                             (Method::GET, "/debug/pprof/heap_activate") => {

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -34,7 +34,10 @@ use tikv::{
         BlockCacheConfig, Config as StorageConfig, FlowControlConfig, IORateLimitConfig,
     },
 };
-use tikv_util::config::{LogFormat, ReadableDuration, ReadableSize};
+use tikv_util::{
+    config::{LogFormat, ReadableDuration, ReadableSize},
+    metrics::MetricsCompactPolicy,
+};
 
 mod dynamic;
 mod test_config_client;
@@ -119,6 +122,7 @@ fn test_serde_custom_tikv_config() {
         forward_max_connections_per_address: 5,
         reject_messages_on_memory_ratio: 0.8,
         simplify_metrics: false,
+        metrics_compact_policy: MetricsCompactPolicy::No,
     };
     value.readpool = ReadPoolConfig {
         unified: UnifiedReadPoolConfig {


### PR DESCRIPTION
Signed-off-by: glorv <glorvs@163.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #12355

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```
add a new config to support lossy metrics compaction(reduce histogram size by filter out variants with less than 1% samples), this can further reduce the metrics size by about 10%.
```

This PR is split from #12732 by keeping the `metrics-policy` part:

Add a new config `server.metrics-compact-policy` with three options:
- "no"(default). do nothing, return all the raw metrics data.
- "lossless". As implemented in https://github.com/tikv/tikv/pull/12602, do not return counters with 0 value and histograms will 0 samples as they are the same as the default value, so we reduce the data with no information loss.
- "lossy". Try to reduce the metrics as much as possible. In addition to level LoseLess, this PR will also reduce histogram vector type by filtering all histograms whose sample count < max sample count * 0.01. We may also do further operations(in the future), e.g. we can apply the ideas in https://github.com/tikv/tikv/pull/12417 to compress some data types when we come up with some consensus.

Test Result:
| Metrics Compaction Policy | no | lossless | lossy |
| -- | -- | -- | -- |
| | 1407K | 521K(37.0%) | 400K(28.4%) |
 
### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
