### PR TITLE
[apiv2] encode key range in raw_checksum interface

### DIFF
--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -4582,7 +4582,7 @@ mod tests {
                     expect_ok_callback(tx.clone(), 0),
                 )
                 .unwrap();
-            // start key is set to b"r\0a0", if raw_checksum does not encode the key,
+            // start key is set to b"r\0a\0", if raw_checksum does not encode the key,
             // first key will be included in checksum. This is for testing issue #12950.
             if !is_first {
                 total_kvs += 1;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -4580,8 +4580,7 @@ mod tests {
         range.set_end_key(b"r\0z".to_vec());
         assert_eq!(
             (checksum, total_kvs, total_bytes),
-            block_on(storage.raw_checksum(ctx.clone(), ChecksumAlgorithm::Crc64Xor, vec![range]))
-                .unwrap(),
+            block_on(storage.raw_checksum(ctx, ChecksumAlgorithm::Crc64Xor, vec![range])).unwrap(),
         );
     }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -2461,16 +2461,11 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                         .iter()
                         .map(|range| (Some(range.get_start_key()), Some(range.get_end_key()))),
                 )?;
-                let mut encoded_ranges = Vec::with_capacity(ranges.len());
-                for i in 0..ranges.len() {
-                    let mut new_range = KeyRange::new();
-                    new_range.set_start_key(
-                        F::encode_raw_key_owned(ranges[i].take_start_key(), None).into_encoded(),
-                    );
-                    new_range.set_end_key(
-                        F::encode_raw_key_owned(ranges[i].take_end_key(), None).into_encoded(),
-                    );
-                    encoded_ranges.push(new_range);
+                for range in ranges.iter_mut() {
+                    let start_key = F::encode_raw_key_owned(range.take_start_key(), None);
+                    let end_key = F::encode_raw_key_owned(range.take_end_key(), None);
+                    range.set_start_key(start_key.into_encoded());
+                    range.set_end_key(end_key.into_encoded());
                 }
 
                 let command_duration = tikv_util::time::Instant::now();
@@ -2485,23 +2480,20 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                 let cf = Self::rawkv_cf("", api_version)?;
 
                 let begin_instant = tikv_util::time::Instant::now();
-                let mut stats = Vec::with_capacity(encoded_ranges.len());
+                let mut stats = Vec::with_capacity(ranges.len());
                 let ret = store
-                    .raw_checksum_ranges(cf, &encoded_ranges, &mut stats)
+                    .raw_checksum_ranges(cf, &ranges, &mut stats)
                     .await
                     .map_err(Error::from);
-                stats
-                    .iter()
-                    .zip(encoded_ranges.iter())
-                    .for_each(|(stats, range)| {
-                        tls_collect_read_flow(
-                            ctx.get_region_id(),
-                            Some(range.get_start_key()),
-                            Some(range.get_end_key()),
-                            stats,
-                            buckets.as_ref(),
-                        );
-                    });
+                stats.iter().zip(ranges.iter()).for_each(|(stats, range)| {
+                    tls_collect_read_flow(
+                        ctx.get_region_id(),
+                        Some(range.get_start_key()),
+                        Some(range.get_end_key()),
+                        stats,
+                        buckets.as_ref(),
+                    );
+                });
                 SCHED_PROCESSING_READ_HISTOGRAM_STATIC
                     .get(CMD)
                     .observe(begin_instant.saturating_elapsed().as_secs_f64());
@@ -4576,7 +4568,7 @@ mod tests {
             rx.recv().unwrap();
         }
         let mut range = KeyRange::default();
-        range.set_start_key(b"r\0a0".to_vec());
+        range.set_start_key(b"r\0a\0".to_vec());
         range.set_end_key(b"r\0z".to_vec());
         assert_eq!(
             (checksum, total_kvs, total_bytes),


### PR DESCRIPTION
Signed-off-by: haojinming <jinming.hao@pingcap.com>

encode ranges in raw checksum apiv2

Signed-off-by: haojinming <jinming.hao@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #12950 

What's Changed:

encode key range in raw_checksum interface


### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
