### PR TITLE
br: Adjust the backup organization structure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,6 +395,7 @@ version = "0.0.1"
 dependencies = [
  "api_version",
  "async-channel",
+ "aws",
  "collections",
  "concurrency_manager",
  "crc64fast",

--- a/components/backup/Cargo.toml
+++ b/components/backup/Cargo.toml
@@ -73,6 +73,7 @@ tokio = { version = "1.5", features = ["rt-multi-thread"] }
 tokio-stream = "0.1"
 txn_types = { path = "../txn_types", default-features = false }
 yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
+aws = { path = "../cloud/aws" }
 
 [dev-dependencies]
 rand = "0.8"

--- a/components/backup/Cargo.toml
+++ b/components/backup/Cargo.toml
@@ -35,6 +35,7 @@ failpoints = ["tikv/failpoints"]
 [dependencies]
 api_version = { path = "../api_version", default-features = false }
 async-channel = "1.4"
+aws = { path = "../cloud/aws" }
 collections = { path = "../collections" }
 concurrency_manager = { path = "../concurrency_manager", default-features = false }
 crc64fast = "0.1"
@@ -73,7 +74,6 @@ tokio = { version = "1.5", features = ["rt-multi-thread"] }
 tokio-stream = "0.1"
 txn_types = { path = "../txn_types", default-features = false }
 yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
-aws = { path = "../cloud/aws" }
 
 [dev-dependencies]
 rand = "0.8"

--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use async_channel::SendError;
+use aws::S3Storage;
 use concurrency_manager::ConcurrencyManager;
 use engine_rocks::raw::DB;
 use engine_traits::{name_to_cf, raw_ttl::ttl_current_ts, CfName, SstCompressionType};
@@ -50,8 +51,6 @@ use crate::{
     writer::{BackupWriterBuilder, CfNameWrap},
     Error, *,
 };
-
-use aws::S3Storage;
 
 const BACKUP_BATCH_LIMIT: usize = 1024;
 
@@ -1069,7 +1068,12 @@ fn get_max_start_key(start_key: Option<&Key>, region: &Region) -> Option<Key> {
 /// A name consists with five parts: store id, region_id, a epoch version, the hash of range start key and timestamp.
 /// range start key is used to keep the unique file name for file, to handle different tables exists on the same region.
 /// local unix timestamp is used to keep the unique file name for file, to handle receive the same request after connection reset.
-pub fn backup_file_name(store_id: u64, region: &Region, key: Option<String>, storage_name: &str) -> String {
+pub fn backup_file_name(
+    store_id: u64,
+    region: &Region,
+    key: Option<String>,
+    storage_name: &str,
+) -> String {
     let start = SystemTime::now();
     let since_the_epoch = start
         .duration_since(UNIX_EPOCH)
@@ -1095,7 +1099,7 @@ pub fn backup_file_name(store_id: u64, region: &Region, key: Option<String>, sto
                     since_the_epoch.as_millis()
                 )
             }
-        },
+        }
         None => {
             if storage_name == S3Storage::name() {
                 format!(
@@ -1112,7 +1116,7 @@ pub fn backup_file_name(store_id: u64, region: &Region, key: Option<String>, sto
                     region.get_region_epoch().get_version()
                 )
             }
-        },
+        }
     }
 }
 

--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -2022,14 +2022,15 @@ pub mod tests {
             "1_0_0_000",
         ];
 
+        let delimiter = "_";
         for (storage_name, target) in test_cases.iter().zip(test_target.iter()) {
             let key = Some(String::from("000"));
             let filename = backup_file_name(store_id, &region, key, storage_name);
 
-            let mut prefix_arr: Vec<&str> = filename.split("_").collect();
+            let mut prefix_arr: Vec<&str> = filename.split(delimiter).collect();
             prefix_arr.remove(prefix_arr.len() - 1);
 
-            assert_eq!(target.to_string(), prefix_arr.join("_"));
+            assert_eq!(target.to_string(), prefix_arr.join(delimiter));
         }
     }
 }

--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -9,7 +9,6 @@ use std::{
 };
 
 use async_channel::SendError;
-use aws;
 use causal_ts::CausalTsProvider;
 use concurrency_manager::ConcurrencyManager;
 use engine_rocks::raw::DB;

--- a/components/backup/src/writer.rs
+++ b/components/backup/src/writer.rs
@@ -198,10 +198,10 @@ impl BackupWriterBuilder {
         }
     }
 
-    pub fn build(&self, start_key: Vec<u8>) -> Result<BackupWriter> {
+    pub fn build(&self, start_key: Vec<u8>, storage_name: &str) -> Result<BackupWriter> {
         let key = file_system::sha256(&start_key).ok().map(hex::encode);
         let store_id = self.store_id;
-        let name = backup_file_name(store_id, &self.region, key);
+        let name = backup_file_name(store_id, &self.region, key, storage_name);
         BackupWriter::new(
             self.db.clone(),
             &name,

--- a/components/cloud/aws/src/lib.rs
+++ b/components/cloud/aws/src/lib.rs
@@ -5,6 +5,6 @@ mod kms;
 pub use kms::{AwsKms, ENCRYPTION_VENDOR_NAME_AWS_KMS};
 
 mod s3;
-pub use s3::{Config, S3Storage, STORAGE_VENDOR_NAME_AWS};
+pub use s3::{Config, S3Storage, STORAGE_NAME, STORAGE_VENDOR_NAME_AWS};
 
 mod util;

--- a/components/cloud/aws/src/s3.rs
+++ b/components/cloud/aws/src/s3.rs
@@ -158,6 +158,10 @@ pub struct S3Storage {
 }
 
 impl S3Storage {
+    pub fn name() -> &'static str {
+        STORAGE_NAME
+    }
+
     pub fn from_input(input: InputConfig) -> io::Result<Self> {
         Self::new(Config::from_input(input)?)
     }

--- a/components/cloud/aws/src/s3.rs
+++ b/components/cloud/aws/src/s3.rs
@@ -158,10 +158,6 @@ pub struct S3Storage {
 }
 
 impl S3Storage {
-    pub fn name() -> &'static str {
-        STORAGE_NAME
-    }
-
     pub fn from_input(input: InputConfig) -> io::Result<Self> {
         Self::new(Config::from_input(input)?)
     }
@@ -519,7 +515,7 @@ impl<'client> S3Uploader<'client> {
     }
 }
 
-const STORAGE_NAME: &str = "s3";
+pub const STORAGE_NAME: &str = "s3";
 
 #[async_trait]
 impl BlobStorage for S3Storage {

--- a/components/external_storage/src/lib.rs
+++ b/components/external_storage/src/lib.rs
@@ -30,7 +30,7 @@ use tokio::time::timeout;
 
 mod hdfs;
 pub use hdfs::{HdfsConfig, HdfsStorage};
-mod local;
+pub mod local;
 pub use local::LocalStorage;
 mod noop;
 pub use noop::NoopStorage;

--- a/components/external_storage/src/local.rs
+++ b/components/external_storage/src/local.rs
@@ -54,7 +54,7 @@ fn url_for(base: &Path) -> url::Url {
     u
 }
 
-const STORAGE_NAME: &str = "local";
+pub const STORAGE_NAME: &str = "local";
 
 #[async_trait]
 impl ExternalStorage for LocalStorage {

--- a/tests/integrations/backup/mod.rs
+++ b/tests/integrations/backup/mod.rs
@@ -21,11 +21,11 @@ fn assert_same_file_name(s1: String, s2: String) {
     let tokens1: Vec<&str> = s1.split('_').collect();
     let tokens2: Vec<&str> = s2.split('_').collect();
     assert_eq!(tokens1.len(), tokens2.len());
-    // 2_1_1_e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855_1609407693105_write.sst
-    // 2_1_1_e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855_1609407693199_write.sst
+    // 2/1_1_e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855_1609407693105_write.sst
+    // 2/1_1_e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855_1609407693199_write.sst
     // should be equal
     for i in 0..tokens1.len() {
-        if i != 4 {
+        if i != 3 {
             assert_eq!(tokens1[i], tokens2[i]);
         }
     }


### PR DESCRIPTION
Signed-off-by: Gaoming <zhanggaoming028@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #13063

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Adjust the backup organization structure and add a store_id related prefix under the backup path.
```

### Related changes
None
<!--
- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch
-->

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

#### Manual test
- run `tiup br backup db` to backup the db to S3.
- `drop` the backup db.
- Run `tiup br restore db` to restore the backup on S3.
- Compatibility Test Case 1: Use the pre-modified `br` for backup, and the after-modified `br` for recovery.
- Compatibility Test Case 2: Use the after-modified `br` for backup, and the pre-modified `br` for recovery.

#### Test output
- the directory
![Screenshot from 2022-07-05 15-55-44](https://user-images.githubusercontent.com/32541204/177278798-3339af5d-93df-416a-80e4-0feef0193cdc.png)
- run `tiup br restore db` successfully.
- Compatibility Test Case 1 passed.
- Compatibility Test Case 2 passed.

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
In the new backup organization structure, we will see:

./br backup --pd "127.0.0.1:2379" -s "s3://backup/20220621" 
  - After br command finished, we will have the structure below.
➜  backup tree .
.
└── 20220621
    ├── backupmeta
    ├── store1
    │   └── backup-xxx.sst
    ├── store100
    │   └── backup-yyy.sst
    ├── store2
    │   └── backup-zzz.sst
    ├── store3
    ├── store4
    └── store5
```
