### PR TITLE
Allow undo tombstone, add region force recreation

### DIFF
--- a/cmd/tikv-ctl/src/cmd.rs
+++ b/cmd/tikv-ctl/src/cmd.rs
@@ -337,6 +337,10 @@ pub enum Cmd {
         #[structopt(long)]
         /// force execute without pd
         force: bool,
+
+        #[structopt(long)]
+        /// undo tombstone
+        undo: bool,
     },
     /// Recover mvcc data on one node by deleting corrupted keys
     RecoverMvcc {
@@ -392,6 +396,18 @@ pub enum Cmd {
         #[structopt(short = "r")]
         /// The origin region id
         region: u64,
+
+        #[structopt(long, default_value = "")]
+        /// hex start key
+        start: String,
+
+        #[structopt(long, default_value = "")]
+        /// hex end key
+        end: String,
+
+        #[structopt(long)]
+        /// replace the region range with the start and end key
+        force: bool,
     },
     /// Print the metrics
     Metrics {

--- a/cmd/tikv-ctl/src/main.rs
+++ b/cmd/tikv-ctl/src/main.rs
@@ -334,7 +334,12 @@ fn main() {
                             .compact(host, db_type, &cf, from_key, to_key, threads, bottommost);
                     }
                 }
-                Cmd::Tombstone { regions, pd, force } => {
+                Cmd::Tombstone {
+                    regions,
+                    pd,
+                    force,
+                    undo,
+                } => {
                     if let Some(pd_urls) = pd {
                         let cfg = PdConfig {
                             endpoints: pd_urls,
@@ -346,7 +351,7 @@ fn main() {
                         debug_executor.set_region_tombstone_after_remove_peer(mgr, &cfg, regions);
                     } else {
                         assert!(force);
-                        debug_executor.set_region_tombstone_force(regions);
+                        debug_executor.set_region_tombstone_force(regions, undo);
                     }
                 }
                 Cmd::RecoverMvcc {
@@ -394,13 +399,18 @@ fn main() {
                 },
                 Cmd::RecreateRegion {
                     pd,
-                    region: region_id,
+                    region,
+                    start,
+                    end,
+                    force,
                 } => {
                     let pd_cfg = PdConfig {
                         endpoints: pd,
                         ..Default::default()
                     };
-                    debug_executor.recreate_region(mgr, &pd_cfg, region_id);
+                    let start_key = from_hex(&start).unwrap();
+                    let end_key = from_hex(&end).unwrap();
+                    debug_executor.recreate_region(mgr, &pd_cfg, region, start_key, end_key, force);
                 }
                 Cmd::ConsistencyCheck { region } => {
                     debug_executor.check_region_consistency(region);


### PR DESCRIPTION
Signed-off-by: v01dstar <yang.zhang@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #xxx

What's Changed:
Enrich tikv-ctl, so that we can **undo** a tombstone, or forcibly recreate a region. 

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- N/A

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
