### PR TITLE
tablet: load_tablet should remove the old tablet in the cache.

### DIFF
--- a/src/server/engine_factory_v2.rs
+++ b/src/server/engine_factory_v2.rs
@@ -19,6 +19,17 @@ pub struct KvEngineFactoryV2<ER: RaftEngine> {
     registry: Arc<Mutex<HashMap<(u64, u64), RocksEngine>>>,
 }
 
+// Extract tablet id and tablet suffix from the path.
+fn get_id_and_suffix_from_path(path: &Path) -> (u64, u64) {
+    let (mut tablet_id, mut tablet_suffix) = (0, 1);
+    if let Some(s) = path.file_name().map(|s| s.to_string_lossy()) {
+        let mut split = s.split('_');
+        tablet_id = split.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+        tablet_suffix = split.next().and_then(|s| s.parse().ok()).unwrap_or(1);
+    }
+    (tablet_id, tablet_suffix)
+}
+
 impl<ER: RaftEngine> TabletFactory<RocksEngine> for KvEngineFactoryV2<ER> {
     fn create_tablet(&self, id: u64, suffix: u64) -> Result<RocksEngine> {
         let mut reg = self.registry.lock().unwrap();
@@ -74,12 +85,7 @@ impl<ER: RaftEngine> TabletFactory<RocksEngine> for KvEngineFactoryV2<ER> {
                 path.to_str().unwrap_or_default()
             ));
         }
-        let (mut tablet_id, mut tablet_suffix) = (0, 1);
-        if let Some(s) = path.file_name().map(|s| s.to_string_lossy()) {
-            let mut split = s.split('_');
-            tablet_id = split.next().and_then(|s| s.parse().ok()).unwrap_or(0);
-            tablet_suffix = split.next().and_then(|s| s.parse().ok()).unwrap_or(1);
-        }
+        let (tablet_id, tablet_suffix) = get_id_and_suffix_from_path(path);
         self.create_tablet(tablet_id, tablet_suffix)
     }
 
@@ -132,7 +138,7 @@ impl<ER: RaftEngine> TabletFactory<RocksEngine> for KvEngineFactoryV2<ER> {
     #[inline]
     fn load_tablet(&self, path: &Path, id: u64, suffix: u64) -> Result<RocksEngine> {
         {
-            let reg = self.registry.lock().unwrap();
+            let mut reg = self.registry.lock().unwrap();
             if let Some(db) = reg.get(&(id, suffix)) {
                 return Err(box_err!(
                     "region {} {} already exists",
@@ -140,6 +146,8 @@ impl<ER: RaftEngine> TabletFactory<RocksEngine> for KvEngineFactoryV2<ER> {
                     db.as_inner().path()
                 ));
             }
+            let (old_id, old_suffix) = get_id_and_suffix_from_path(path);
+            reg.remove(&(old_id, old_suffix));
         }
 
         let db_path = self.tablet_path(id, suffix);
@@ -261,6 +269,10 @@ mod tests {
         assert!(!factory.is_tombstoned(1, 10));
         assert!(factory.load_tablet(&tablet_path, 1, 10).is_err());
         assert!(factory.load_tablet(&tablet_path, 1, 20).is_ok());
+        // After we load it as with the new id or suffix, we should be unable to get it with
+        // the old id and suffix in the cache.
+        assert!(factory.open_tablet_cache(1, 10).is_none());
+
         factory.mark_tombstone(1, 20);
         assert!(factory.is_tombstoned(1, 20));
         factory.destroy_tablet(1, 20).unwrap();


### PR DESCRIPTION
Signed-off-by: SpadeA-Tang <u6748471@anu.edu.au>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #xxx

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```
Remove old tablet in the registry in `load_tablet`.
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
