### PR TITLE
BR: flush causal timestamp before backup start for rawkv apiv2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,6 +395,7 @@ version = "0.0.1"
 dependencies = [
  "api_version",
  "async-channel",
+ "causal_ts",
  "collections",
  "concurrency_manager",
  "crc64fast",

--- a/components/backup/Cargo.toml
+++ b/components/backup/Cargo.toml
@@ -35,6 +35,7 @@ failpoints = ["tikv/failpoints"]
 [dependencies]
 api_version = { path = "../api_version", default-features = false }
 async-channel = "1.4"
+causal_ts = { path = "../causal_ts" }
 collections = { path = "../collections" }
 concurrency_manager = { path = "../concurrency_manager", default-features = false }
 crc64fast = "0.1"

--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -966,8 +966,10 @@ impl<E: Engine, R: RegionInfoProvider + Clone + 'static> Endpoint<E, R> {
             }
             return;
         }
-        // CausalTsProvider may cache tso. Flush the cached tso to avoid use them in future data.
-        // BR assume that all data with smaller ts is backup-ed.
+        // Flush causal timestamp to make sure that future writes will have larger timestamps.
+        // And help TiKV-BR acquire a backup-ts with intact data smaller than it.
+        // (Note that intactness is not fully ensured now, until the safe-ts of RawKV is implemented.
+        // TiKV-BR need a workaround by rewinding backup-ts to a small "safe interval").
         if request.is_raw_kv {
             if let Err(e) = self
                 .causal_ts_provider

--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -1763,6 +1763,8 @@ pub mod tests {
         req.set_storage_backend(make_local_backend(&tmp1));
         req.set_start_key(b"r".to_vec());
         req.set_end_key(b"s".to_vec());
+        req.set_is_raw_kv(true);
+        req.set_dst_api_version(ApiVersion::V2);
         let (task, _) = Task::new(req, tx).unwrap();
         endpoint.handle_backup_task(task);
         let end_ts = ts_provider.get_ts().unwrap();

--- a/components/causal_ts/src/lib.rs
+++ b/components/causal_ts/src/lib.rs
@@ -58,6 +58,13 @@ pub mod tests {
         fn get_ts(&self) -> Result<TimeStamp> {
             Ok(self.ts.fetch_add(1, Ordering::Relaxed).into())
         }
+
+        // This is used for unit test. Add 100 from current.
+        // Do not modify this value as several test cases depend on it.
+        fn flush(&self) -> Result<()> {
+            self.ts.fetch_add(100, Ordering::Relaxed);
+            Ok(())
+        }
     }
 
     #[derive(Clone, Default)]

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -414,7 +414,7 @@ pub struct Endpoint<T, E> {
     env: Arc<Environment>,
     security_mgr: Arc<SecurityManager>,
     region_read_progress: RegionReadProgressRegistry,
-    causal_ts_provider: Option<Arc<dyn CausalTsProvider>>,
+    causal_ts_provider: Option<Arc<dyn CausalTsProvider + 'static>>,
 
     // Metrics and logging.
     current_ts: TimeStamp,

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -8,6 +8,7 @@ use std::{
     time::Duration,
 };
 
+use causal_ts::CausalTsProvider;
 use collections::{HashMap, HashMapEntry, HashSet};
 use concurrency_manager::ConcurrencyManager;
 use crossbeam::atomic::AtomicCell;
@@ -413,6 +414,7 @@ pub struct Endpoint<T, E> {
     env: Arc<Environment>,
     security_mgr: Arc<SecurityManager>,
     region_read_progress: RegionReadProgressRegistry,
+    causal_ts_provider: Option<Arc<dyn CausalTsProvider>>,
 
     // Metrics and logging.
     current_ts: TimeStamp,
@@ -438,6 +440,7 @@ impl<T: 'static + RaftStoreRouter<E>, E: KvEngine> Endpoint<T, E> {
         env: Arc<Environment>,
         security_mgr: Arc<SecurityManager>,
         sink_memory_quota: MemoryQuota,
+        causal_ts_provider: Option<Arc<dyn CausalTsProvider>>,
     ) -> Endpoint<T, E> {
         let workers = Builder::new_multi_thread()
             .thread_name("cdcwkr")
@@ -508,6 +511,7 @@ impl<T: 'static + RaftStoreRouter<E>, E: KvEngine> Endpoint<T, E> {
             // Log the first resolved ts warning.
             warn_resolved_ts_repeat_count: WARN_RESOLVED_TS_COUNT_THRESHOLD,
             current_ts: TimeStamp::zero(),
+            causal_ts_provider,
         };
         ep.register_min_ts_event();
         ep
@@ -1111,7 +1115,7 @@ impl<T: 'static + RaftStoreRouter<E>, E: KvEngine> Endpoint<T, E> {
         let tikv_clients = self.tikv_clients.clone();
         let hibernate_regions_compatible = self.config.hibernate_regions_compatible;
         let region_read_progress = self.region_read_progress.clone();
-        let observer = self.observer.clone();
+        let causal_ts_provider = self.causal_ts_provider.clone();
 
         let fut = async move {
             let _ = timeout.compat().await;
@@ -1141,7 +1145,7 @@ impl<T: 'static + RaftStoreRouter<E>, E: KvEngine> Endpoint<T, E> {
 
             // If flush_causal_timestamp fails, cannot schedule MinTS task
             // as new coming raw data may use timestamp smaller than min_ts
-            if let Err(e) = observer.flush_causal_timestamp() {
+            if let Err(e) = causal_ts_provider.map_or(Ok(()), |provider| provider.flush()) {
                 error!("cdc flush causal timestamp failed"; "err" => ?e);
                 return;
             }
@@ -1474,6 +1478,15 @@ mod tests {
         engine: Option<RocksEngine>,
         api_version: ApiVersion,
     ) -> TestEndpointSuite {
+        mock_endpoint_with_ts_provider(cfg, engine, api_version, None)
+    }
+
+    fn mock_endpoint_with_ts_provider(
+        cfg: &CdcConfig,
+        engine: Option<RocksEngine>,
+        api_version: ApiVersion,
+        causal_ts_provider: Option<Arc<dyn CausalTsProvider>>,
+    ) -> TestEndpointSuite {
         let (task_sched, task_rx) = dummy_scheduler();
         let raft_router = MockRaftStoreRouter::new();
         let ep = Endpoint::new(
@@ -1495,6 +1508,7 @@ mod tests {
             Arc::new(Environment::new(1)),
             Arc::new(SecurityManager::default()),
             MemoryQuota::new(usize::MAX),
+            causal_ts_provider,
         );
 
         TestEndpointSuite {
@@ -2224,6 +2238,22 @@ mod tests {
                 .is_none(),
             true
         );
+    }
+
+    #[test]
+    fn test_raw_causal_ts_flush() {
+        let sleep_interval = Duration::from_secs(1);
+        let cfg = CdcConfig {
+            min_ts_interval: ReadableDuration(sleep_interval),
+            ..Default::default()
+        };
+        let ts_provider = Arc::new(causal_ts::tests::TestProvider::default());
+        let start_ts = ts_provider.get_ts().unwrap();
+        let _suite =
+            mock_endpoint_with_ts_provider(&cfg, None, ApiVersion::V2, Some(ts_provider.clone()));
+        std::thread::sleep(sleep_interval * 2);
+        let end_ts = ts_provider.get_ts().unwrap();
+        assert!(end_ts.into_inner() >= start_ts.next().into_inner() + 100); // may trigger more than once.
     }
 
     #[test]

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -2249,9 +2249,14 @@ mod tests {
         };
         let ts_provider = Arc::new(causal_ts::tests::TestProvider::default());
         let start_ts = ts_provider.get_ts().unwrap();
-        let _suite =
+        let mut suite =
             mock_endpoint_with_ts_provider(&cfg, None, ApiVersion::V2, Some(ts_provider.clone()));
-        std::thread::sleep(sleep_interval * 2);
+        suite.run(Task::RegisterMinTsEvent);
+        suite
+            .task_rx
+            .recv_timeout(Duration::from_millis(1500))
+            .unwrap()
+            .unwrap();
         let end_ts = ts_provider.get_ts().unwrap();
         assert!(end_ts.into_inner() >= start_ts.next().into_inner() + 100); // may trigger more than once.
     }

--- a/components/cdc/src/observer.rs
+++ b/components/cdc/src/observer.rs
@@ -2,7 +2,7 @@
 
 use std::sync::{Arc, RwLock};
 
-use causal_ts::{CausalTsProvider, Error as CausalTsError, RawTsTracker, Result as CausalTsResult};
+use causal_ts::{Error as CausalTsError, RawTsTracker, Result as CausalTsResult};
 use collections::HashMap;
 use engine_traits::KvEngine;
 use fail::fail_point;
@@ -30,8 +30,6 @@ pub struct CdcObserver {
     // A shared registry for managing observed regions.
     // TODO: it may become a bottleneck, find a better way to manage the registry.
     observe_regions: Arc<RwLock<HashMap<u64, ObserveID>>>,
-
-    pub causal_ts_provider: Option<Arc<dyn CausalTsProvider>>,
 }
 
 impl CdcObserver {
@@ -43,12 +41,7 @@ impl CdcObserver {
         CdcObserver {
             sched,
             observe_regions: Arc::default(),
-            causal_ts_provider: None,
         }
-    }
-
-    pub fn set_causal_ts_provider(&mut self, provider: Arc<dyn CausalTsProvider>) {
-        self.causal_ts_provider = Some(provider);
     }
 
     pub fn register_to(&self, coprocessor_host: &mut CoprocessorHost<impl KvEngine>) {
@@ -97,12 +90,6 @@ impl CdcObserver {
             .unwrap()
             .get(&region_id)
             .cloned()
-    }
-
-    pub fn flush_causal_timestamp(&self) -> CausalTsResult<()> {
-        self.causal_ts_provider
-            .as_ref()
-            .map_or(Ok(()), |provider| provider.flush())
     }
 }
 

--- a/components/cdc/tests/mod.rs
+++ b/components/cdc/tests/mod.rs
@@ -188,6 +188,7 @@ impl TestSuiteBuilder {
                 env,
                 sim.security_mgr.clone(),
                 MemoryQuota::new(usize::MAX),
+                None,
             );
             let mut updated_cfg = cfg.clone();
             updated_cfg.min_ts_interval = ReadableDuration::millis(100);

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -31,7 +31,7 @@ use backup_stream::{
     metadata::{ConnectionConfig, LazyEtcdClient},
     observer::BackupStreamObserver,
 };
-use causal_ts::CausalTsProvider;
+use causal_ts::{BatchTsoProvider, CausalTsProvider};
 use cdc::{CdcConfigManager, MemoryQuota};
 use concurrency_manager::ConcurrencyManager;
 use encryption_export::{data_key_manager_from_config, DataKeyManager};
@@ -139,7 +139,7 @@ const CPU_QUOTA_ADJUSTMENT_PACE: f64 = 200.0; // 0.2 vcpu
 
 #[inline]
 fn run_impl<CER: ConfiguredRaftEngine, F: KvFormat>(config: TiKvConfig) {
-    let mut tikv = TiKvServer::<CER>::init(config);
+    let mut tikv = TiKvServer::<CER>::init::<F>(config);
 
     // Must be called after `TiKvServer::init`.
     let memory_limit = tikv.config.memory_usage_limit.unwrap().0;
@@ -230,7 +230,7 @@ struct TiKvServer<ER: RaftEngine> {
     background_worker: Worker,
     sst_worker: Option<Box<LazyWorker<String>>>,
     quota_limiter: Arc<QuotaLimiter>,
-    causal_ts_provider: Option<Arc<dyn CausalTsProvider>>, // used for rawkv apiv2
+    causal_ts_provider: Option<Arc<BatchTsoProvider<RpcClient>>>, // used for rawkv apiv2
 }
 
 struct TiKvEngines<EK: KvEngine, ER: RaftEngine> {
@@ -255,7 +255,7 @@ type LocalServer<EK, ER> =
 type LocalRaftKv<EK, ER> = RaftKv<EK, ServerRaftStoreRouter<EK, ER>>;
 
 impl<ER: RaftEngine> TiKvServer<ER> {
-    fn init(mut config: TiKvConfig) -> TiKvServer<ER> {
+    fn init<F: KvFormat>(mut config: TiKvConfig) -> TiKvServer<ER> {
         tikv_util::thread_group::set_properties(Some(GroupProperties::default()));
         // It is okay use pd config and security config before `init_config`,
         // because these configs must be provided by command line, and only
@@ -311,6 +311,20 @@ impl<ER: RaftEngine> TiKvServer<ER> {
             config.quota.enable_auto_tune,
         ));
 
+        let mut causal_ts_provider = None;
+        if let ApiVersion::V2 = F::TAG {
+            let tso = block_on(causal_ts::BatchTsoProvider::new_opt(
+                pd_client.clone(),
+                config.causal_ts.renew_interval.0,
+                config.causal_ts.renew_batch_min_size,
+            ));
+            if let Err(e) = tso {
+                fatal!("Causal timestamp provider initialize failed: {:?}", e);
+            }
+            causal_ts_provider = Some(Arc::new(tso.unwrap()));
+            info!("Causal timestamp provider startup.");
+        }
+
         TiKvServer {
             config,
             cfg_controller: Some(cfg_controller),
@@ -336,7 +350,7 @@ impl<ER: RaftEngine> TiKvServer<ER> {
             flow_info_receiver: None,
             sst_worker: None,
             quota_limiter,
-            causal_ts_provider: None,
+            causal_ts_provider,
         }
     }
 
@@ -807,22 +821,10 @@ impl<ER: RaftEngine> TiKvServer<ER> {
         };
 
         // Register causal observer for RawKV API V2
-        if let ApiVersion::V2 = F::TAG {
-            let tso = block_on(causal_ts::BatchTsoProvider::new_opt(
-                self.pd_client.clone(),
-                self.config.causal_ts.renew_interval.0,
-                self.config.causal_ts.renew_batch_min_size,
-            ));
-            if let Err(e) = tso {
-                fatal!("Causal timestamp provider initialize failed: {:?}", e);
-            }
-            let causal_ts_provider = Arc::new(tso.unwrap());
-            info!("Causal timestamp provider startup.");
-            let causal_ob =
-                causal_ts::CausalObserver::new(causal_ts_provider.clone(), cdc_ob.clone());
+        if let Some(provider) = self.causal_ts_provider.clone() {
+            let causal_ob = causal_ts::CausalObserver::new(provider, cdc_ob.clone());
             causal_ob.register_to(self.coprocessor_host.as_mut().unwrap());
-            self.causal_ts_provider = Some(causal_ts_provider);
-        }
+        };
 
         let check_leader_runner = CheckLeaderRunner::new(engines.store_meta.clone());
         let check_leader_scheduler = self
@@ -1047,7 +1049,9 @@ impl<ER: RaftEngine> TiKvServer<ER> {
             server.env(),
             self.security_mgr.clone(),
             cdc_memory_quota.clone(),
-            self.causal_ts_provider.clone(),
+            self.causal_ts_provider
+                .clone()
+                .map(|provider| provider as Arc<dyn CausalTsProvider>),
         );
         cdc_worker.start_with_timer(cdc_endpoint);
         self.to_stop.push(cdc_worker);
@@ -1181,7 +1185,9 @@ impl<ER: RaftEngine> TiKvServer<ER> {
             self.config.backup.clone(),
             self.concurrency_manager.clone(),
             self.config.storage.api_version(),
-            self.causal_ts_provider.clone(),
+            self.causal_ts_provider
+                .clone()
+                .map(|provider| provider as Arc<dyn CausalTsProvider>),
         );
         self.cfg_controller.as_mut().unwrap().register(
             tikv::config::Module::Backup,

--- a/components/test_backup/src/lib.rs
+++ b/components/test_backup/src/lib.rs
@@ -94,6 +94,7 @@ impl TestSuite {
                 },
                 sim.get_concurrency_manager(*id),
                 api_version,
+                None,
             );
             let mut worker = bg_worker.lazy_build(format!("backup-{}", id));
             worker.start(backup_endpoint);


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #12989 

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

1. Flush causal timestamp before backup start for rawkv apiv2, see issue: https://github.com/tikv/migration/issues/138
2. Address review comments: https://github.com/tikv/tikv/pull/12866#discussion_r904483116
   let cdc::Endpoint hold the causal ts provider instead of cdc::Observer. 


### Related changes


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)

Side effects


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
