### PR TITLE
raftstore: Avoid printing error log in case sending CaptureChange message failed

### DIFF
--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -635,6 +635,17 @@ impl<EK: KvEngine> fmt::Debug for PeerMsg<EK> {
     }
 }
 
+impl<EK: KvEngine> PeerMsg<EK> {
+    /// For some specific kind of messages, it's actually acceptable if failed to send it by
+    /// `significant_send`. This function determine if the current message is acceptable to fail.
+    pub fn is_send_failure_ignorable(&self) -> bool {
+        match self {
+            PeerMsg::SignificantMsg(SignificantMsg::CaptureChange { .. }) => true,
+            _ => false,
+        }
+    }
+}
+
 pub enum StoreMsg<EK>
 where
     EK: KvEngine,

--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -639,10 +639,10 @@ impl<EK: KvEngine> PeerMsg<EK> {
     /// For some specific kind of messages, it's actually acceptable if failed to send it by
     /// `significant_send`. This function determine if the current message is acceptable to fail.
     pub fn is_send_failure_ignorable(&self) -> bool {
-        match self {
-            PeerMsg::SignificantMsg(SignificantMsg::CaptureChange { .. }) => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            PeerMsg::SignificantMsg(SignificantMsg::CaptureChange { .. })
+        )
     }
 }
 

--- a/components/raftstore/src/store/transport.rs
+++ b/components/raftstore/src/store/transport.rs
@@ -6,7 +6,7 @@ use std::sync::mpsc;
 use crossbeam::channel::{SendError, TrySendError};
 use engine_traits::{KvEngine, RaftEngine, Snapshot};
 use kvproto::raft_serverpb::RaftMessage;
-use tikv_util::error;
+use tikv_util::{error, warn};
 
 use crate::{
     store::{CasualMessage, PeerMsg, RaftCommand, RaftRouter, SignificantMsg, StoreMsg},
@@ -90,7 +90,13 @@ where
             .force_send(region_id, PeerMsg::SignificantMsg(msg))
         {
             // TODO: panic here once we can detect system is shutting down reliably.
-            error!("failed to send significant msg"; "msg" => ?msg);
+
+            // Avoid printing error log if it's not a severe error.
+            if msg.is_send_failure_ignorable() {
+                warn!("failed to send significant msg"; "msg" => ?msg);
+            } else {
+                error!("failed to send significant msg"; "msg" => ?msg);
+            }
             return Err(Error::RegionNotFound(region_id));
         }
 

--- a/components/raftstore/src/store/transport.rs
+++ b/components/raftstore/src/store/transport.rs
@@ -91,7 +91,7 @@ where
         {
             // TODO: panic here once we can detect system is shutting down reliably.
 
-            // Avoid printing error log if it's not a severe error.
+            // Avoid printing error log if it's not a severe problem failing to send it.
             if msg.is_send_failure_ignorable() {
                 warn!("failed to send significant msg"; "msg" => ?msg);
             } else {


### PR DESCRIPTION
Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #12996

What's Changed:

Print warning log instead of error log when sending CaptureChange message failed.

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

-

Side effects

-

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
