### PR TITLE
log-backup: store log files by date and hour in sub directory

### DIFF
--- a/components/backup-stream/src/router.rs
+++ b/components/backup-stream/src/router.rs
@@ -605,11 +605,10 @@ impl TempFileKey {
                     .format(&s.unwrap_or_else(|| "%Y%m".to_owned()))
                     .to_string();
             });
-            let s = match t {
+            match t {
                 FormatType::Date => dt.format("%Y%m%d").to_string(),
                 FormatType::Hour => dt.format("%H").to_string(),
-            };
-            return s;
+            }
         }
         #[cfg(not(feature = "failpoints"))]
         match t {
@@ -619,7 +618,7 @@ impl TempFileKey {
     }
 
     /// path_to_log_file specifies the path of record log.
-    /// eg. "v1/20220625/t00000071/434098800931373064-f0251bd5-1441-499a-8f53-adc0d1057a73.log"
+    /// eg. "v1/20220625/03/t00000071/434098800931373064-f0251bd5-1441-499a-8f53-adc0d1057a73.log"
     fn path_to_log_file(&self, min_ts: u64, max_ts: u64) -> String {
         format!(
             "v1/{}/{}/t{:08}/{:012}-{}.log",
@@ -633,7 +632,7 @@ impl TempFileKey {
     }
 
     /// path_to_schema_file specifies the path of schema log.
-    /// eg. "v1/20220625/schema-meta/434055683656384515-cc3cb7a3-e03b-4434-ab6c-907656fddf67.log"
+    /// eg. "v1/20220625/03/schema-meta/434055683656384515-cc3cb7a3-e03b-4434-ab6c-907656fddf67.log"
     fn path_to_schema_file(min_ts: u64, max_ts: u64) -> String {
         format!(
             "v1/{}/{}/schema-meta/{:012}-{}.log",


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/tikv/tikv/issues/12902

What's Changed:
- Store log files by date and hour in sub directory.
- The format changed.
  - The old format: "v1/20220625/t00000071/434098800931373064-f0251bd5-1441-499a-8f53-adc0d1057a73.log"
  - The new format: "v1/20220625/03/t00000071/434098800931373064-f0251bd5-1441-499a-8f53-adc0d1057a73.log"

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

### Manual test
- backup log at up-stream
  - create a task for backup log with the command `br log start...`
  - run ddl and dml to insert records
  - create a full backup with the command `br backup full`
- restore log into down-stream
  - run the PiTR restore with the command `br restore point`
- result
  - the log is stored by `v1/${date}/${hour}/t${tableID}`
  - restore successfully and data is right.

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
```
