### PR TITLE
copr: port pingcap/tidb#17902 to fix pingcap/tidb#32556

### DIFF
--- a/components/tidb_query_datatype/src/codec/convert.rs
+++ b/components/tidb_query_datatype/src/codec/convert.rs
@@ -827,7 +827,11 @@ impl ConvertTo<f64> for Bytes {
     }
 }
 
-pub fn get_valid_int_prefix<'a>(ctx: &mut EvalContext, s: &'a str, is_cast: bool) -> Result<Cow<'a, str>> {
+pub fn get_valid_int_prefix<'a>(
+    ctx: &mut EvalContext,
+    s: &'a str,
+    is_cast: bool,
+) -> Result<Cow<'a, str>> {
     if !is_cast {
         let vs = get_valid_float_prefix(ctx, s, is_cast)?;
         Ok(float_str_to_int_string(ctx, vs))
@@ -854,7 +858,11 @@ pub fn get_valid_int_prefix<'a>(ctx: &mut EvalContext, s: &'a str, is_cast: bool
     }
 }
 
-pub fn get_valid_float_prefix<'a>(ctx: &mut EvalContext, s: &'a str, is_cast: bool) -> Result<&'a str> {
+pub fn get_valid_float_prefix<'a>(
+    ctx: &mut EvalContext,
+    s: &'a str,
+    is_cast: bool,
+) -> Result<&'a str> {
     if is_cast && s.is_empty() {
         return Ok("0");
     }
@@ -2007,7 +2015,10 @@ mod tests {
 
         let mut ctx = EvalContext::new(Arc::new(EvalConfig::default_for_test()));
         for (i, o) in cases {
-            assert_eq!(super::get_valid_float_prefix(&mut ctx, i, false).unwrap(), o);
+            assert_eq!(
+                super::get_valid_float_prefix(&mut ctx, i, false).unwrap(),
+                o
+            );
         }
     }
 

--- a/components/tidb_query_expr/src/impl_cast.rs
+++ b/components/tidb_query_expr/src/impl_cast.rs
@@ -344,7 +344,7 @@ fn cast_string_as_int(
             } else {
                 // FIXME: if the err get_valid_int_prefix returned is overflow err,
                 //  it should be ERR_TRUNCATE_WRONG_VALUE but not others.
-                let valid_int_prefix = get_valid_int_prefix(ctx, val)?;
+                let valid_int_prefix = get_valid_int_prefix(ctx, val, true)?;
                 let parse_res = if !is_str_neg {
                     valid_int_prefix.parse::<u64>().map(|x| x as i64)
                 } else {
@@ -2342,6 +2342,12 @@ mod tests {
                 -9223372036854775808i64,
                 vec![ERR_TRUNCATE_WRONG_VALUE],
                 Cond::Unsigned,
+            ),
+            (
+                "1.0",
+                1i64,
+                vec![ERR_TRUNCATE_WRONG_VALUE],
+                Cond::None,
             ),
         ];
 

--- a/components/tidb_query_expr/src/impl_cast.rs
+++ b/components/tidb_query_expr/src/impl_cast.rs
@@ -2343,12 +2343,7 @@ mod tests {
                 vec![ERR_TRUNCATE_WRONG_VALUE],
                 Cond::Unsigned,
             ),
-            (
-                "1.0",
-                1i64,
-                vec![ERR_TRUNCATE_WRONG_VALUE],
-                Cond::None,
-            ),
+            ("1.0", 1i64, vec![ERR_TRUNCATE_WRONG_VALUE], Cond::None),
         ];
 
         for (input, expected, mut err_code, cond) in cs {


### PR DESCRIPTION
Signed-off-by: zyguan <zhongyangguan@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close pingcap/tidb#32556

What's Changed:
Port pingcap/tidb#17902 to coprocessor

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
The implementation of casting string to int is inconsistent with tidb,
which leads to:
https://github.com/pingcap/tidb/issues/32556#issuecomment-1048657796
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
