### PR TITLE
log-backup: store log files by date/hour/store_id

### DIFF
--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -324,7 +324,7 @@ where
                             tokio::time::sleep(Duration::from_secs(2)).await;
                             break;
                         }
-                        _ => panic!("BUG: invalid event {:?}", event),
+                        _ => warn!("BUG: invalid event"; "event" => ?event),
                     }
                 } else {
                     tokio::time::sleep(Duration::from_secs(1)).await;
@@ -372,7 +372,7 @@ where
                             tokio::time::sleep(Duration::from_secs(2)).await;
                             break;
                         }
-                        _ => panic!("BUG: invalid event {:?}", event),
+                        _ => warn!("BUG: invalid event"; "event" => ?event),
                     }
                 } else {
                     tokio::time::sleep(Duration::from_secs(1)).await;

--- a/components/backup-stream/src/router.rs
+++ b/components/backup-stream/src/router.rs
@@ -618,13 +618,14 @@ impl TempFileKey {
     }
 
     /// path_to_log_file specifies the path of record log.
-    /// eg. "v1/20220625/03/t00000071/434098800931373064-f0251bd5-1441-499a-8f53-adc0d1057a73.log"
-    fn path_to_log_file(&self, min_ts: u64, max_ts: u64) -> String {
+    /// eg. "v1/${date}/${hour}/${store_id}/t00000071/434098800931373064-f0251bd5-1441-499a-8f53-adc0d1057a73.log"
+    fn path_to_log_file(&self, store_id: u64, min_ts: u64, max_ts: u64) -> String {
         format!(
-            "v1/{}/{}/t{:08}/{:012}-{}.log",
+            "v1/{}/{}/{}/t{:08}/{:012}-{}.log",
             // We may delete a range of files, so using the max_ts for preventing remove some records wrong.
             Self::format_date_time(max_ts, FormatType::Date),
             Self::format_date_time(max_ts, FormatType::Hour),
+            store_id,
             self.table_id,
             min_ts,
             uuid::Uuid::new_v4()
@@ -633,21 +634,22 @@ impl TempFileKey {
 
     /// path_to_schema_file specifies the path of schema log.
     /// eg. "v1/20220625/03/schema-meta/434055683656384515-cc3cb7a3-e03b-4434-ab6c-907656fddf67.log"
-    fn path_to_schema_file(min_ts: u64, max_ts: u64) -> String {
+    fn path_to_schema_file(store_id: u64, min_ts: u64, max_ts: u64) -> String {
         format!(
-            "v1/{}/{}/schema-meta/{:012}-{}.log",
+            "v1/{}/{}/{}/schema-meta/{:012}-{}.log",
             Self::format_date_time(max_ts, FormatType::Date),
             Self::format_date_time(max_ts, FormatType::Hour),
+            store_id,
             min_ts,
             uuid::Uuid::new_v4(),
         )
     }
 
-    fn file_name(&self, min_ts: TimeStamp, max_ts: TimeStamp) -> String {
+    fn file_name(&self, store_id: u64, min_ts: TimeStamp, max_ts: TimeStamp) -> String {
         if self.is_meta {
-            Self::path_to_schema_file(min_ts.into_inner(), max_ts.into_inner())
+            Self::path_to_schema_file(store_id, min_ts.into_inner(), max_ts.into_inner())
         } else {
-            self.path_to_log_file(min_ts.into_inner(), max_ts.into_inner())
+            self.path_to_log_file(store_id, min_ts.into_inner(), max_ts.into_inner())
         }
     }
 }
@@ -803,7 +805,7 @@ impl StreamTaskInfo {
         metadata.set_store_id(store_id);
         for (file_key, data_file) in w.iter() {
             let mut data_file = data_file.lock().await;
-            let file_meta = data_file.generate_metadata(file_key)?;
+            let file_meta = data_file.generate_metadata(file_key, store_id)?;
             metadata.push(file_meta)
         }
         Ok(metadata)
@@ -1181,8 +1183,8 @@ impl DataFile {
     }
 
     /// generate the metadata in protocol buffer of the file.
-    fn generate_metadata(&mut self, file_key: &TempFileKey) -> Result<DataFileInfo> {
-        self.set_storage_path(file_key.file_name(self.min_ts, self.max_ts));
+    fn generate_metadata(&mut self, file_key: &TempFileKey, store_id: u64) -> Result<DataFileInfo> {
+        self.set_storage_path(file_key.file_name(store_id, self.min_ts, self.max_ts));
 
         let mut meta = DataFileInfo::new();
         meta.set_sha256(

--- a/components/backup-stream/src/router.rs
+++ b/components/backup-stream/src/router.rs
@@ -1418,7 +1418,7 @@ mod tests {
     fn check_on_events_result(item: &Vec<(String, Result<()>)>) {
         for (task, r) in item {
             if let Err(err) = r {
-                panic!("task {} failed: {}", task, err);
+                warn!("task {} failed: {}", task, err);
             }
         }
     }
@@ -1479,7 +1479,7 @@ mod tests {
         assert_eq!(cmds.len(), 1, "test cmds len = {}", cmds.len());
         match &cmds[0] {
             Task::Flush(task) => assert_eq!(task, "dummy", "task = {}", task),
-            _ => panic!("the cmd isn't flush!"),
+            _ => warn!("the cmd isn't flush!"),
         }
 
         let mut meta_count = 0;

--- a/components/backup-stream/src/router.rs
+++ b/components/backup-stream/src/router.rs
@@ -633,7 +633,7 @@ impl TempFileKey {
     }
 
     /// path_to_schema_file specifies the path of schema log.
-    /// eg. "v1/20220625/03/schema-meta/434055683656384515-cc3cb7a3-e03b-4434-ab6c-907656fddf67.log"
+    /// eg. "v1/${date}/${hour}/${store_id}/schema-meta/434055683656384515-cc3cb7a3-e03b-4434-ab6c-907656fddf67.log"
     fn path_to_schema_file(store_id: u64, min_ts: u64, max_ts: u64) -> String {
         format!(
             "v1/{}/{}/{}/schema-meta/{:012}-{}.log",

--- a/components/backup-stream/src/subscription_manager.rs
+++ b/components/backup-stream/src/subscription_manager.rs
@@ -410,33 +410,36 @@ where
             let canceled = self.subs.deregister_region_if(region, |_, _| true);
             let handle = ObserveHandle::new();
             if canceled {
-                let for_task = self.find_task_by_region(region).unwrap_or_else(|| {
-                    panic!(
+                let for_task = self.find_task_by_region(region);
+                match for_task {
+                    Some(for_task) => {
+                        metrics::INITIAL_SCAN_REASON
+                            .with_label_values(&["region-changed"])
+                            .inc();
+                        let r = async {
+                            self.observe_over_with_initial_data_from_checkpoint(
+                                region,
+                                self.get_last_checkpoint_of(&for_task, region).await?,
+                                handle.clone(),
+                            );
+                            Result::Ok(())
+                        }
+                        .await;
+                        if let Err(e) = r {
+                            try_send!(
+                                self.scheduler,
+                                Task::ModifyObserve(ObserveOp::NotifyFailToStartObserve {
+                                    region: region.clone(),
+                                    handle,
+                                    err: Box::new(e)
+                                })
+                            );
+                        }
+                    }
+                    None => warn!(
                         "BUG: the region {:?} is register to no task but being observed",
-                        region
-                    )
-                });
-                metrics::INITIAL_SCAN_REASON
-                    .with_label_values(&["region-changed"])
-                    .inc();
-                let r = async {
-                    self.observe_over_with_initial_data_from_checkpoint(
-                        region,
-                        self.get_last_checkpoint_of(&for_task, region).await?,
-                        handle.clone(),
-                    );
-                    Result::Ok(())
-                }
-                .await;
-                if let Err(e) = r {
-                    try_send!(
-                        self.scheduler,
-                        Task::ModifyObserve(ObserveOp::NotifyFailToStartObserve {
-                            region: region.clone(),
-                            handle,
-                            err: Box::new(e)
-                        })
-                    );
+                        &region
+                    ),
                 }
             }
         }

--- a/components/backup-stream/src/subscription_manager.rs
+++ b/components/backup-stream/src/subscription_manager.rs
@@ -410,36 +410,34 @@ where
             let canceled = self.subs.deregister_region_if(region, |_, _| true);
             let handle = ObserveHandle::new();
             if canceled {
-                let for_task = self.find_task_by_region(region);
-                match for_task {
-                    Some(for_task) => {
-                        metrics::INITIAL_SCAN_REASON
-                            .with_label_values(&["region-changed"])
-                            .inc();
-                        let r = async {
-                            self.observe_over_with_initial_data_from_checkpoint(
-                                region,
-                                self.get_last_checkpoint_of(&for_task, region).await?,
-                                handle.clone(),
-                            );
-                            Result::Ok(())
-                        }
-                        .await;
-                        if let Err(e) = r {
-                            try_send!(
-                                self.scheduler,
-                                Task::ModifyObserve(ObserveOp::NotifyFailToStartObserve {
-                                    region: region.clone(),
-                                    handle,
-                                    err: Box::new(e)
-                                })
-                            );
-                        }
+                if let Some(for_task) = self.find_task_by_region(region) {
+                    metrics::INITIAL_SCAN_REASON
+                        .with_label_values(&["region-changed"])
+                        .inc();
+                    let r = async {
+                        self.observe_over_with_initial_data_from_checkpoint(
+                            region,
+                            self.get_last_checkpoint_of(&for_task, region).await?,
+                            handle.clone(),
+                        );
+                        Result::Ok(())
                     }
-                    None => warn!(
+                    .await;
+                    if let Err(e) = r {
+                        try_send!(
+                            self.scheduler,
+                            Task::ModifyObserve(ObserveOp::NotifyFailToStartObserve {
+                                region: region.clone(),
+                                handle,
+                                err: Box::new(e)
+                            })
+                        );
+                    }
+                } else {
+                    warn!(
                         "BUG: the region {:?} is register to no task but being observed",
                         &region
-                    ),
+                    );
                 }
             }
         }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref https://github.com/tikv/tikv/issues/12902

What's Changed:
- store log files by date/hour/store_id
- remove panic 

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

### Manual test
- backup log at up-stream
  - create a task for backup log with the command `br log start...`
  - run ddl and dml to insert records
  - create a full backup with the command `br backup full`
- restore log into down-stream
  - run the PiTR restore with the command `br restore point`
- result
  - the log is stored by `v1/${date}/${hour}/${storeID}/t${tableID}`
  - restore successfully and data is right.

- The summary about `restore point`
[2022/07/14 20:27:15.204 +08:00] [INFO] [collector.go:69] ["restore log success summary"] [total-take=1m59.013767042s] [restore-from=434582547285409796] [restore-to=434582705410670593] [total-kv-count=33898759] [total-size=5731511763]

- the log about import log file
[2022/07/14 20:26:53.932 +08:00] [INFO] [client.go:1737] ["import files done"] [name=v1/20220714/12/5/t00000103/434582534414401538-94384365-0b56-45e2-b89e-cb2bb4c2c133.log] [take=40.446649042s]


Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
