### PR TITLE
log-backup: modify the config

### DIFF
--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -114,7 +114,7 @@ where
         concurrency_manager: ConcurrencyManager,
     ) -> Self {
         crate::metrics::STREAM_ENABLED.inc();
-        let pool = create_tokio_runtime(4, "backup-stream")
+        let pool = create_tokio_runtime(config.work_threads, "backup-stream")
             .expect("failed to create tokio runtime for backup stream worker.");
 
         let meta_client = MetadataClient::new(store, store_id);
@@ -162,7 +162,7 @@ where
             observer.clone(),
             meta_client.clone(),
             pd_client.clone(),
-            config.num_threads,
+            config.scan_threads,
         );
         pool.spawn(op_loop);
         Endpoint {

--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -66,6 +66,7 @@ const SLOW_EVENT_THRESHOLD: f64 = 120.0;
 /// CHECKPOINT_SAFEPOINT_TTL_IF_ERROR specifies the safe point TTL(24 hour) if task has fatal error.
 const CHECKPOINT_SAFEPOINT_TTL_IF_ERROR: u64 = 24;
 
+/// CHECKPOINT_ADVANCE_USE_V3 use only the v3 checkpoint advance currenly.
 const CHECKPOINT_ADVANCE_USE_V3: bool = true;
 
 pub struct Endpoint<S, R, E, RT, PDC> {

--- a/components/backup-stream/tests/mod.rs
+++ b/components/backup-stream/tests/mod.rs
@@ -128,8 +128,8 @@ impl SuiteBuilder {
         let Self {
             name: case,
             nodes: n,
-            use_v3: _,
             metastore_error,
+            use_v3: _,
         } = self;
 
         info!("start test"; "case" => %case, "nodes" => %n);

--- a/components/backup-stream/tests/mod.rs
+++ b/components/backup-stream/tests/mod.rs
@@ -256,7 +256,6 @@ impl Suite {
         let regions = sim.region_info_accessors.get(&id).unwrap().clone();
         let mut cfg = BackupStreamConfig::default();
         cfg.enable = true;
-        cfg.use_checkpoint_v3 = use_v3;
         cfg.temp_path = format!("/{}/{}", self.temp_files.path().display(), id);
         let ob = self.obs.get(&id).unwrap().clone();
         let endpoint = Endpoint::new(

--- a/components/backup-stream/tests/mod.rs
+++ b/components/backup-stream/tests/mod.rs
@@ -128,7 +128,7 @@ impl SuiteBuilder {
         let Self {
             name: case,
             nodes: n,
-            use_v3,
+            use_v3: _,
             metastore_error,
         } = self;
 
@@ -156,7 +156,7 @@ impl SuiteBuilder {
         }
         suite.cluster.run();
         for id in 1..=(n as u64) {
-            suite.start_endpoint(id, use_v3);
+            suite.start_endpoint(id);
         }
         // TODO: The current mock metastore (slash_etc) doesn't supports multi-version.
         //       We must wait until the endpoints get ready to watching the metastore, or some modifies may be lost.
@@ -247,7 +247,7 @@ impl Suite {
         worker
     }
 
-    fn start_endpoint(&mut self, id: u64, use_v3: bool) {
+    fn start_endpoint(&mut self, id: u64) {
         let cluster = &mut self.cluster;
         let worker = self.endpoints.get_mut(&id).unwrap();
         let sim = cluster.sim.wl();

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -1188,8 +1188,8 @@
 
 [log-backup] 
 ## Number of threads to perform backup stream tasks.
-## The default value is set to min(CPU_NUM * 0.5, 8).
-# num-threads = 8
+## The default value is CPU_NUM * 0.5, and limited to [2, 4].
+# work-threads = 8
 
 ## enable this feature. TiKV will starts watch related tasks in PD. and backup kv changes to storage accodring to task.
 ## The default value is false.

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -1188,8 +1188,8 @@
 
 [log-backup] 
 ## Number of threads to perform backup stream tasks.
-## The default value is CPU_NUM * 0.5, and limited to [2, 4].
-# work-threads = 8
+## The default value is CPU_NUM * 0.5, and limited to [2, 12].
+# num-threads = 8
 
 ## enable this feature. TiKV will starts watch related tasks in PD. and backup kv changes to storage accodring to task.
 ## The default value is false.

--- a/src/config.rs
+++ b/src/config.rs
@@ -2480,6 +2480,9 @@ pub struct BackupStreamConfig {
     pub initial_scan_pending_memory_quota: ReadableSize,
     #[online_config(skip)]
     pub initial_scan_rate_limit: ReadableSize,
+    #[serde(skip)]
+    #[online_config(skip)]
+    pub use_checkpoint_v3: bool,
 }
 
 impl BackupStreamConfig {
@@ -2510,9 +2513,10 @@ impl Default for BackupStreamConfig {
             enable: false,
             // TODO: may be use raft store directory
             temp_path: String::new(),
-            file_size_limit: ReadableSize::mb(128),
+            file_size_limit: ReadableSize::mb(256),
             initial_scan_pending_memory_quota: ReadableSize(quota_size as _),
             initial_scan_rate_limit: ReadableSize::mb(60),
+            use_checkpoint_v3: true,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2467,19 +2467,15 @@ pub struct BackupStreamConfig {
     #[online_config(skip)]
     pub num_threads: usize,
     #[online_config(skip)]
-    pub io_threads: usize,
-    #[online_config(skip)]
     pub enable: bool,
     #[online_config(skip)]
     pub temp_path: String,
     #[online_config(skip)]
-    pub temp_file_size_limit_per_task: ReadableSize,
+    pub file_size_limit: ReadableSize,
     #[online_config(skip)]
     pub initial_scan_pending_memory_quota: ReadableSize,
     #[online_config(skip)]
     pub initial_scan_rate_limit: ReadableSize,
-    #[online_config(skip)]
-    pub use_checkpoint_v3: bool,
 }
 
 impl BackupStreamConfig {
@@ -2506,14 +2502,12 @@ impl Default for BackupStreamConfig {
             max_flush_interval: ReadableDuration::minutes(5),
             // use at most 50% of vCPU by default
             num_threads: (cpu_num * 0.5).clamp(1.0, 8.0) as usize,
-            io_threads: 2,
             enable: false,
             // TODO: may be use raft store directory
             temp_path: String::new(),
-            temp_file_size_limit_per_task: ReadableSize::mb(128),
+            file_size_limit: ReadableSize::mb(128),
             initial_scan_pending_memory_quota: ReadableSize(quota_size as _),
             initial_scan_rate_limit: ReadableSize::mb(60),
-            use_checkpoint_v3: true,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -5246,6 +5246,7 @@ mod tests {
         cfg.raftdb.max_sub_compactions = default_cfg.raftdb.max_sub_compactions;
         cfg.raftdb.titan.max_background_gc = default_cfg.raftdb.titan.max_background_gc;
         cfg.backup.num_threads = default_cfg.backup.num_threads;
+        cfg.backup_stream.num_threads = default_cfg.backup_stream.num_threads;
 
         // There is another set of config values that we can't directly compare:
         // When the default values are `None`, but are then resolved to `Some(_)` later on.

--- a/src/config.rs
+++ b/src/config.rs
@@ -2467,9 +2467,7 @@ pub struct BackupStreamConfig {
     #[online_config(skip)]
     pub max_flush_interval: ReadableDuration,
     #[online_config(skip)]
-    pub scan_threads: usize,
-    #[online_config(skip)]
-    pub work_threads: usize,
+    pub num_threads: usize,
     #[online_config(skip)]
     pub enable: bool,
     #[online_config(skip)]
@@ -2489,12 +2487,12 @@ impl BackupStreamConfig {
     pub fn validate(&mut self) -> Result<(), Box<dyn Error>> {
         let limit = SysQuota::cpu_cores_quota() as usize;
         let default_cfg = BackupStreamConfig::default();
-        if self.scan_threads == 0 || self.scan_threads > limit {
+        if self.num_threads == 0 || self.num_threads > limit {
             warn!(
                 "log_backup.num_threads cannot be 0 or larger than {}, change it to {}",
-                limit, default_cfg.scan_threads
+                limit, default_cfg.num_threads
             );
-            self.scan_threads = default_cfg.scan_threads;
+            self.num_threads = default_cfg.num_threads;
         }
         Ok(())
     }
@@ -2508,8 +2506,7 @@ impl Default for BackupStreamConfig {
         Self {
             max_flush_interval: ReadableDuration::minutes(5),
             // use at most 50% of vCPU by default
-            scan_threads: (cpu_num * 0.5).clamp(1.0, 8.0) as usize,
-            work_threads: (cpu_num * 0.5).clamp(2.0, 4.0) as usize,
+            num_threads: (cpu_num * 0.5).clamp(2.0, 12.0) as usize,
             enable: false,
             // TODO: may be use raft store directory
             temp_path: String::new(),
@@ -3044,7 +3041,7 @@ impl TiKvConfig {
 
         if self.backup_stream.temp_path.is_empty() {
             self.backup_stream.temp_path =
-                config::canonicalize_sub_path(&self.storage.data_dir, "log-backup-tmp")?;
+                config::canonicalize_sub_path(&self.storage.data_dir, "log-backup-temp")?;
         }
 
         self.rocksdb.validate()?;
@@ -5249,7 +5246,6 @@ mod tests {
         cfg.raftdb.max_sub_compactions = default_cfg.raftdb.max_sub_compactions;
         cfg.raftdb.titan.max_background_gc = default_cfg.raftdb.titan.max_background_gc;
         cfg.backup.num_threads = default_cfg.backup.num_threads;
-        cfg.backup_stream.scan_threads = default_cfg.backup_stream.scan_threads;
 
         // There is another set of config values that we can't directly compare:
         // When the default values are `None`, but are then resolved to `Some(_)` later on.

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -748,7 +748,7 @@ fn test_serde_custom_tikv_config() {
         ..Default::default()
     };
     value.backup_stream = BackupStreamConfig {
-        num_threads: 8,
+        scan_threads: 8,
         ..Default::default()
     };
     value.import = ImportConfig {

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -748,7 +748,7 @@ fn test_serde_custom_tikv_config() {
         ..Default::default()
     };
     value.backup_stream = BackupStreamConfig {
-        num_threads: 8,
+        num_threads: 12,
         ..Default::default()
     };
     value.import = ImportConfig {

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -748,7 +748,7 @@ fn test_serde_custom_tikv_config() {
         ..Default::default()
     };
     value.backup_stream = BackupStreamConfig {
-        scan_threads: 8,
+        num_threads: 8,
         ..Default::default()
     };
     value.import = ImportConfig {


### PR DESCRIPTION
Signed-off-by: joccau <zak.zhao@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref https://github.com/tikv/tikv/issues/12895

What's Changed:
- remove the config field `use_checkpoint_v3` 
- rename the config field `io_threads` to `work_threads`
- rename the config field `num_threads` to `scan_threads`
- rename the config `temp_file_size_limit_per_task` to `file_size_limit`

Above config items all is applied for log-backup(the new feature pitr is planed to release 6.2).

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

### Manual test1
- backup log at up-stream
  - create a task for backup log with the command `br log start...`
  - run ddl and dml to insert records
  - create a full backup with the command `br backup full`
- restore log into down-stream
  - run the PiTR restore with the command `br restore point`
- The summary about `restore point`
[2022/07/14 20:27:15.204 +08:00] [INFO] [collector.go:69] ["restore log success summary"] [total-take=1m59.013767042s] [restore-from=434582547285409796] [restore-to=434582705410670593] [total-kv-count=33898759] [total-size=5731511763]

### Manual test2
- test the config `log-backup.use-v3`is not existed in TiKV.
- test the config `log-backup.num-threads` is dynamic time that can be modified in the cluster.

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
```
