### PR TITLE
log-backup: fixed initial scanning data loss

### DIFF
--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -55,7 +55,7 @@ use crate::{
     metadata::{store::MetaStore, MetadataClient, MetadataEvent, StreamTask},
     metrics::{self, TaskStatus},
     observer::BackupStreamObserver,
-    router::{ApplyEvents, Router},
+    router::{ApplyEvents, Router, TaskSelector},
     subscription_manager::{RegionSubscriptionManager, ResolvedRegions},
     subscription_track::SubscriptionTracer,
     try_send,
@@ -197,45 +197,58 @@ where
         self.meta_client.clone()
     }
 
-    fn on_fatal_error(&self, task: String, err: Box<Error>) {
-        // Let's pause the task first.
-        self.unload_task(&task);
+    fn on_fatal_error(&self, select: TaskSelector, err: Box<Error>) {
         err.report_fatal();
-        metrics::update_task_status(TaskStatus::Error, &task);
+        for task in self
+            .pool
+            .block_on(self.range_router.select_task(select.reference()))
+        {
+            // Let's pause the task first.
+            self.unload_task(&task);
+            metrics::update_task_status(TaskStatus::Error, &task);
 
-        let meta_cli = self.get_meta_client();
-        let pdc = self.pd_client.clone();
-        let store_id = self.store_id;
-        let sched = self.scheduler.clone();
-        let safepoint_name = self.pause_guard_id_for_task(&task);
-        let safepoint_ttl = self.pause_guard_duration();
-        self.pool.block_on(async move {
-            let err_fut = async {
-                let safepoint = meta_cli.global_progress_of_task(&task).await?;
-                pdc.update_service_safe_point(
-                    safepoint_name,
-                    TimeStamp::new(safepoint - 1),
-                    safepoint_ttl,
-                )
-                .await?;
-                meta_cli.pause(&task).await?;
-                let mut last_error = StreamBackupError::new();
-                last_error.set_error_code(err.error_code().code.to_owned());
-                last_error.set_error_message(err.to_string());
-                last_error.set_store_id(store_id);
-                last_error.set_happen_at(TimeStamp::physical_now());
-                meta_cli.report_last_error(&task, last_error).await?;
-                Result::Ok(())
-            };
-            if let Err(err_report) = err_fut.await {
-                err_report.report(format_args!("failed to upload error {}", err_report));
-                // Let's retry reporting after 5s.
-                tokio::task::spawn(async move {
-                    tokio::time::sleep(Duration::from_secs(5)).await;
-                    try_send!(sched, Task::FatalError(task, err));
-                });
-            }
-        })
+            let meta_cli = self.get_meta_client();
+            let pdc = self.pd_client.clone();
+            let store_id = self.store_id;
+            let sched = self.scheduler.clone();
+            let safepoint_name = self.pause_guard_id_for_task(&task);
+            let safepoint_ttl = self.pause_guard_duration();
+            let code = err.error_code().code.to_owned();
+            let msg = err.to_string();
+            self.pool.block_on(async move {
+                let err_fut = async {
+                    let safepoint = meta_cli.global_progress_of_task(&task).await?;
+                    pdc.update_service_safe_point(
+                        safepoint_name,
+                        TimeStamp::new(safepoint - 1),
+                        safepoint_ttl,
+                    )
+                    .await?;
+                    meta_cli.pause(&task).await?;
+                    let mut last_error = StreamBackupError::new();
+                    last_error.set_error_code(code);
+                    last_error.set_error_message(msg.clone());
+                    last_error.set_store_id(store_id);
+                    last_error.set_happen_at(TimeStamp::physical_now());
+                    meta_cli.report_last_error(&task, last_error).await?;
+                    Result::Ok(())
+                };
+                if let Err(err_report) = err_fut.await {
+                    err_report.report(format_args!("failed to upload error {}", err_report));
+                    // Let's retry reporting after 5s.
+                    tokio::task::spawn(async move {
+                        tokio::time::sleep(Duration::from_secs(5)).await;
+                        try_send!(
+                            sched,
+                            Task::FatalError(
+                                TaskSelector::ByName(task.to_owned()),
+                                Box::new(annotate!(err_report, "origin error: {}", msg))
+                            )
+                        );
+                    });
+                }
+            });
+        }
     }
 
     async fn starts_flush_ticks(router: Router) {
@@ -922,7 +935,7 @@ pub enum Task {
     /// Convert status of some task into `flushing` and do flush then.
     ForceFlush(String),
     /// FatalError pauses the task and set the error.
-    FatalError(String, Box<Error>),
+    FatalError(TaskSelector, Box<Error>),
     /// Run the callback when see this message. Only for test usage.
     /// NOTE: Those messages for testing are not guared by `#[cfg(test)]` for now, because
     ///       the integration test would not enable test config when compiling (why?)

--- a/components/backup-stream/src/metrics.rs
+++ b/components/backup-stream/src/metrics.rs
@@ -145,7 +145,7 @@ lazy_static! {
     )
     .unwrap();
     pub static ref PENDING_INITIAL_SCAN_LEN: IntGaugeVec = register_int_gauge_vec!(
-        "pending_initial_scan",
+        "tikv_pending_initial_scan",
         "The pending initial scan",
         &["stage"]
     )

--- a/components/backup-stream/src/subscription_manager.rs
+++ b/components/backup-stream/src/subscription_manager.rs
@@ -11,7 +11,7 @@ use std::{
 use crossbeam::channel::{Receiver as SyncReceiver, Sender as SyncSender};
 use crossbeam_channel::SendError;
 use engine_traits::KvEngine;
-use error_code::{backup_stream::OBSERVE_CANCELED, ErrorCodeExt};
+use error_code::ErrorCodeExt;
 use futures::FutureExt;
 use kvproto::metapb::Region;
 use pd_client::PdClient;
@@ -36,7 +36,7 @@ use crate::{
     metadata::{store::MetaStore, CheckpointProvider, MetadataClient},
     metrics,
     observer::BackupStreamObserver,
-    router::Router,
+    router::{Router, TaskSelector},
     subscription_track::SubscriptionTracer,
     try_send,
     utils::{self, CallbackWaitGroup, Work},
@@ -45,12 +45,14 @@ use crate::{
 
 type ScanPool = yatp::ThreadPool<yatp::task::callback::TaskCell>;
 
+const INITIAL_SCAN_FAILURE_MAX_RETRY_TIME: usize = 10;
+
 /// a request for doing initial scanning.
 struct ScanCmd {
     region: Region,
     handle: ObserveHandle,
     last_checkpoint: TimeStamp,
-    work: Work,
+    _work: Work,
 }
 
 /// The response of requesting resolve the new checkpoint of regions.
@@ -82,6 +84,25 @@ impl ResolvedRegions {
     }
 }
 
+/// returns whether the error should be retried.
+/// for some errors, like `epoch not match` or `not leader`,
+/// implies that the region is drifting, and no more need to be observed by us.
+fn should_retry(err: &Error) -> bool {
+    match err.without_context() {
+        Error::RaftRequest(pbe) => {
+            !(pbe.has_epoch_not_match()
+                || pbe.has_not_leader()
+                || pbe.get_message().contains("stale observe id")
+                || pbe.has_region_not_found())
+        }
+        Error::RaftStore(raftstore::Error::RegionNotFound(_))
+        | Error::RaftStore(raftstore::Error::NotLeader(..))
+        | Error::ObserveCanceled(..)
+        | Error::RaftStore(raftstore::Error::EpochNotMatch(..)) => false,
+        _ => true,
+    }
+}
+
 /// the abstraction over a "DB" which provides the initial scanning.
 trait InitialScan: Clone {
     fn do_initial_scan(
@@ -89,8 +110,9 @@ trait InitialScan: Clone {
         region: &Region,
         start_ts: TimeStamp,
         handle: ObserveHandle,
-        on_finish: impl FnOnce() + Send + 'static,
     ) -> Result<Statistics>;
+
+    fn handle_fatal_error(&self, region: &Region, err: Error);
 }
 
 impl<E, R, RT> InitialScan for InitialDataLoader<E, R, RT>
@@ -104,34 +126,72 @@ where
         region: &Region,
         start_ts: TimeStamp,
         handle: ObserveHandle,
-        on_finish: impl FnOnce() + Send + 'static,
     ) -> Result<Statistics> {
         let region_id = region.get_id();
+        // Note: we have external retry at `ScanCmd::exec_by_with_retry`, should we keep retrying here?
         let snap = self.observe_over_with_retry(region, move || {
             ChangeObserver::from_pitr(region_id, handle.clone())
         })?;
-        let stat = self.do_initial_scan(region, start_ts, snap, on_finish)?;
+        let stat = self.do_initial_scan(region, start_ts, snap)?;
         Ok(stat)
+    }
+
+    fn handle_fatal_error(&self, region: &Region, err: Error) {
+        try_send!(
+            self.scheduler,
+            Task::FatalError(
+                TaskSelector::ByRange(
+                    region.get_start_key().to_owned(),
+                    region.get_end_key().to_owned()
+                ),
+                Box::new(err),
+            )
+        );
     }
 }
 
 impl ScanCmd {
     /// execute the initial scanning via the specificated [`InitialDataLoader`].
-    fn exec_by(self, initial_scan: impl InitialScan) -> Result<()> {
+    fn exec_by(&self, initial_scan: impl InitialScan) -> Result<()> {
         let Self {
             region,
             handle,
             last_checkpoint,
-            work,
+            ..
         } = self;
         let begin = Instant::now_coarse();
-        let stat =
-            initial_scan.do_initial_scan(&region, last_checkpoint, handle, move || drop(work))?;
+        let stat = initial_scan.do_initial_scan(&region, *last_checkpoint, handle.clone())?;
         info!("initial scanning of leader transforming finished!"; "takes" => ?begin.saturating_elapsed(), "region" => %region.get_id(), "from_ts" => %last_checkpoint);
         utils::record_cf_stat("lock", &stat.lock);
         utils::record_cf_stat("write", &stat.write);
         utils::record_cf_stat("default", &stat.data);
         Ok(())
+    }
+
+    /// execute the command, when meeting error, retrying.
+    fn exec_by_with_retry(self, init: impl InitialScan, cancel: &AtomicBool) {
+        let mut retry_time = INITIAL_SCAN_FAILURE_MAX_RETRY_TIME;
+        loop {
+            if cancel.load(Ordering::SeqCst) {
+                return;
+            }
+            match self.exec_by(init.clone()) {
+                Err(err) if should_retry(&err) && retry_time > 0 => {
+                    // NOTE: blocking this thread may stick the process.
+                    // Maybe spawn a task to tokio and reschedule the task then?
+                    std::thread::sleep(Duration::from_millis(500));
+                    warn!("meet retryable error"; "err" => %err, "retry_time" => retry_time);
+                    retry_time -= 1;
+                    continue;
+                }
+                Err(err) if retry_time == 0 => {
+                    init.handle_fatal_error(&self.region, err.context("retry time exceeds"));
+                    break;
+                }
+                // Errors which `should_retry` returns false means they can be ignored.
+                Err(_) | Ok(_) => break,
+            }
+        }
     }
 }
 
@@ -150,15 +210,11 @@ fn scan_executor_loop(
         if canceled.load(Ordering::Acquire) {
             return;
         }
+
         metrics::PENDING_INITIAL_SCAN_LEN
             .with_label_values(&["executing"])
             .inc();
-        let region_id = cmd.region.get_id();
-        if let Err(err) = cmd.exec_by(init.clone()) {
-            if err.error_code() != OBSERVE_CANCELED {
-                err.report(format!("during initial scanning of region {}", region_id));
-            }
-        }
+        cmd.exec_by_with_retry(init.clone(), &canceled);
         metrics::PENDING_INITIAL_SCAN_LEN
             .with_label_values(&["executing"])
             .dec();
@@ -370,13 +426,21 @@ where
                     if err.error_code() == error_code::backup_stream::OBSERVE_CANCELED {
                         return;
                     }
+                    let (start, end) = (
+                        region.get_start_key().to_owned(),
+                        region.get_end_key().to_owned(),
+                    );
                     match self.retry_observe(region, handle).await {
                         Ok(()) => {}
                         Err(e) => {
-                            self.fatal(
-                                e,
-                                format!("While retring to observe region, origin error is {}", err),
+                            let msg = Task::FatalError(
+                                TaskSelector::ByRange(start, end),
+                                Box::new(Error::Contextual {
+                                    context: format!("retry meet error, origin error is {}", err),
+                                    inner_error: Box::new(e),
+                                }),
                             );
+                            try_send!(self.scheduler, msg);
                         }
                     }
                 }
@@ -384,7 +448,7 @@ where
                     let now = Instant::now();
                     let timedout = self.wait(Duration::from_secs(30)).await;
                     if timedout {
-                        warn!("waiting for initial scanning done timed out, forcing progress(with risk of data loss)!"; 
+                        warn!("waiting for initial scanning done timed out, forcing progress!"; 
                             "take" => ?now.saturating_elapsed(), "timedout" => %timedout);
                     }
                     let cps = self.subs.resolve_with(min_ts);
@@ -397,10 +461,6 @@ where
                 }
             }
         }
-    }
-
-    fn fatal(&self, err: Error, message: String) {
-        try_send!(self.scheduler, Task::FatalError(message, Box::new(err)));
     }
 
     async fn refresh_resolver(&self, region: &Region) {
@@ -539,7 +599,7 @@ where
     async fn get_last_checkpoint_of(&self, task: &str, region: &Region) -> Result<TimeStamp> {
         let meta_cli = self.meta_cli.clone();
         let cp = meta_cli.get_region_checkpoint(task, region).await?;
-        info!("got region checkpoint"; "region_id" => %region.get_id(), "checkpoint" => ?cp);
+        debug!("got region checkpoint"; "region_id" => %region.get_id(), "checkpoint" => ?cp);
         if matches!(cp.provider, CheckpointProvider::Global) {
             metrics::STORE_CHECKPOINT_TS
                 .with_label_values(&[task])
@@ -573,7 +633,7 @@ where
             region: region.clone(),
             handle,
             last_checkpoint,
-            work: self.scans.clone().work(),
+            _work: self.scans.clone().work(),
         })
     }
 
@@ -601,9 +661,7 @@ mod test {
             _region: &Region,
             _start_ts: txn_types::TimeStamp,
             _handle: raftstore::coprocessor::ObserveHandle,
-            on_finish: impl FnOnce() + Send + 'static,
         ) -> crate::errors::Result<tikv::storage::Statistics> {
-            on_finish();
             Ok(Statistics::default())
         }
     }
@@ -640,7 +698,7 @@ mod test {
                 handle: Default::default(),
                 last_checkpoint: Default::default(),
                 // Note: Maybe make here a Box<dyn FnOnce()> or some other trait?
-                work: wg.work(),
+                _work: wg.work(),
             })
             .unwrap()
         }


### PR DESCRIPTION
Signed-off-by: Yu Juncen <yujuncen@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #12538 

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Now, initial scanning failure won't just report as a retryable error, but would retry internally and fire a fatal error if retry failed too many times.
This PR also make the report of fatal error can provide a `TaskSelector`, which allows reporting errors in some contexts which cannot access the task name.
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

Side effects

- Performance regression
    - Consumes more CPU

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fixed a bug that may cause data loss when TiKV frequently restarts.
```
