### PR TITLE
[DNM]raftstore: a simple change to enable parallel apply without considering other constraints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -294,12 +294,12 @@ debug = false
 opt-level = 1
 
 [profile.dev.package.tests]
-debug = 1
-opt-level = 1
+debug = true
+opt-level = 0
 
 [profile.dev]
 opt-level = 0
-debug = 0
+debug = true
 codegen-units = 4
 lto = false
 incremental = true
@@ -325,7 +325,7 @@ codegen-units = 4
 
 [profile.test]
 opt-level = 0
-debug = 0
+debug = true
 codegen-units = 16
 lto = false
 incremental = true

--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,6 @@ ifeq ($(TIKV_FRAME_POINTER),1)
 build:
 	rustup component add rust-src
 	cargo build --no-default-features --features "${ENABLE_FEATURES}" \
-		-Z build-std=core,std,alloc,proc_macro,test \
 		-Z unstable-options \
 		--target "${TIKV_BUILD_RUSTC_TARGET}" \
 		--out-dir "${CARGO_TARGET_DIR}/debug"
@@ -209,7 +208,6 @@ ifeq ($(TIKV_FRAME_POINTER),1)
 release:
 	rustup component add rust-src
 	cargo build --release --no-default-features --features "${ENABLE_FEATURES}" \
-		-Z build-std=core,std,alloc,proc_macro,test \
 		-Z unstable-options \
 		--target "${TIKV_BUILD_RUSTC_TARGET}" \
 		--out-dir "${CARGO_TARGET_DIR}/release"

--- a/components/batch-system/src/config.rs
+++ b/components/batch-system/src/config.rs
@@ -25,7 +25,6 @@ impl Config {
 
     pub fn apply_config() -> Self {
         let mut conf = Config::default();
-        conf.parallel_apply = true;
         conf
     }
 }

--- a/components/batch-system/src/config.rs
+++ b/components/batch-system/src/config.rs
@@ -14,12 +14,19 @@ pub struct Config {
     pub reschedule_duration: ReadableDuration,
     #[online_config(skip)]
     pub low_priority_pool_size: usize,
+    pub parallel_apply: bool,
 }
 
 impl Config {
     pub fn max_batch_size(&self) -> usize {
         // `Config::validate` is not called for test so the `max_batch_size` is None.
         self.max_batch_size.unwrap_or(256)
+    }
+
+    pub fn apply_config() -> Self {
+        let mut conf = Config::default();
+        conf.parallel_apply = true;
+        conf
     }
 }
 
@@ -30,6 +37,7 @@ impl Default for Config {
             pool_size: 2,
             reschedule_duration: ReadableDuration::secs(5),
             low_priority_pool_size: 1,
+            parallel_apply: false,
         }
     }
 }

--- a/components/raftstore/src/router.rs
+++ b/components/raftstore/src/router.rs
@@ -7,7 +7,7 @@ use crossbeam::channel::TrySendError;
 use engine_traits::{KvEngine, RaftEngine, Snapshot};
 use kvproto::{raft_cmdpb::RaftCmdRequest, raft_serverpb::RaftMessage};
 use raft::SnapshotStatus;
-use tikv_util::time::ThreadReadId;
+use tikv_util::{info, time::ThreadReadId};
 
 use crate::{
     store::{

--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -337,7 +337,7 @@ impl Default for Config {
             snap_generator_pool_size: 2,
             cleanup_import_sst_interval: ReadableDuration::minutes(10),
             local_read_batch_size: 1024,
-            apply_batch_system: BatchSystemConfig::default(),
+            apply_batch_system: BatchSystemConfig::apply_config(),
             store_batch_system: BatchSystemConfig::default(),
             store_io_pool_size: 0,
             store_io_notify_capacity: 40960,

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -4742,6 +4742,10 @@ where
 
         match util::check_region_epoch(msg, self.fsm.peer.region(), true) {
             Err(Error::EpochNotMatch(m, mut new_regions)) => {
+                warn!("[for debug] check_region_epoch failed";
+                    "msg" => ?&msg,
+                    "peer region" => ?self.fsm.peer.region(),
+                );
                 // Attach the region which might be split from the current region. But it doesn't
                 // matter if the region is not split from the current region. If the region meta
                 // received by the TiKV driver is newer than the meta cached in the driver, the meta is
@@ -4800,7 +4804,7 @@ where
                 return;
             }
             Err(e) => {
-                debug!(
+                info!(
                     "failed to propose";
                     "region_id" => self.region_id(),
                     "peer_id" => self.fsm.peer_id(),

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -87,7 +87,7 @@ use crate::{
     store::{
         async_io::{write::WriteMsg, write_router::WriteRouter},
         fsm::{
-            apply::{self, CatchUpLogs},
+            apply::{self, ApplyFsm, CatchUpLogs},
             store::{PollContext, RaftRouter},
             Apply, ApplyMetrics, ApplyTask, Proposal,
         },
@@ -3763,7 +3763,7 @@ where
         cb: Callback<EK::Snapshot>,
     ) -> bool {
         if let Err(e) = self.pre_read_index() {
-            debug!(
+            info!(
                 "prevents unsafe read index";
                 "region_id" => self.region_id,
                 "peer_id" => self.peer.get_id(),

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -3146,7 +3146,7 @@ where
         }
 
         let applied_index = apply_state.get_applied_index();
-        self.raft_group.advance_apply_to(applied_index);
+        // self.raft_group.advance_apply_to(applied_index);
 
         self.cmd_epoch_checker.advance_apply(
             applied_index,

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -1207,6 +1207,9 @@ impl RegionReadProgressCore {
 
     // Return the `safe_ts` if it is updated
     fn update_applied(&mut self, applied: u64) -> Option<u64> {
+        if applied < self.applied_index {
+            return None;
+        }
         // The apply index should not decrease
         assert!(applied >= self.applied_index);
         self.applied_index = applied;

--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -23,7 +23,7 @@ use kvproto::{
 use pd_client::BucketMeta;
 use tikv_util::{
     codec::number::decode_u64,
-    debug, error,
+    debug, error, info,
     lru::LruCache,
     time::{monotonic_raw_now, Instant, ThreadReadId},
 };

--- a/components/raftstore/src/store/worker/refresh_config.rs
+++ b/components/raftstore/src/store/worker/refresh_config.rs
@@ -64,6 +64,8 @@ where
                 max_batch_size: self.state.max_batch_size,
                 reschedule_duration: self.state.reschedule_duration,
                 joinable_workers: Some(Arc::clone(&self.state.joinable_workers)),
+                parallel_apply: false,
+                name: "".to_string(),
             };
             let props = tikv_util::thread_group::current_properties();
             let t = thread::Builder::new()

--- a/components/resolved_ts/src/endpoint.rs
+++ b/components/resolved_ts/src/endpoint.rs
@@ -134,14 +134,16 @@ impl ObserveRegion {
                                 // One pc command do not contains any lock, so just skip it
                                 ChangeRow::OnePc { .. } => {}
                             });
-                            assert!(
-                                *tracked_index < *index,
-                                "region {}, tracked_index: {}, incoming index: {}",
-                                self.meta.id,
-                                *tracked_index,
-                                *index
-                            );
-                            *tracked_index = *index;
+                            if *tracked_index < *index {
+                                assert!(
+                                    *tracked_index < *index,
+                                    "region {}, tracked_index: {}, incoming index: {}",
+                                    self.meta.id,
+                                    *tracked_index,
+                                    *index
+                                );
+                                *tracked_index = *index;
+                            }
                         }
                     }
                 }

--- a/components/resolved_ts/src/resolver.rs
+++ b/components/resolved_ts/src/resolver.rs
@@ -125,14 +125,16 @@ impl Resolver {
     }
 
     pub fn update_tracked_index(&mut self, index: u64) {
-        assert!(
-            self.tracked_index <= index,
-            "region {}, tracked_index: {}, incoming index: {}",
-            self.region_id,
-            self.tracked_index,
-            index
-        );
-        self.tracked_index = index;
+        if self.tracked_index <= index {
+            assert!(
+                self.tracked_index <= index,
+                "region {}, tracked_index: {}, incoming index: {}",
+                self.region_id,
+                self.tracked_index,
+                index
+            );
+            self.tracked_index = index;
+        }
     }
 
     pub fn track_lock(&mut self, start_ts: TimeStamp, key: Vec<u8>, index: Option<u64>) {

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -463,7 +463,12 @@ impl<T: Simulator> Cluster<T> {
             };
             request.mut_header().set_peer(leader);
             let resp = match self.call_command(request.clone(), timeout) {
-                e @ Err(_) => return e,
+                e @ Err(_) => {
+                    info!("[for debug] call_command returns error";
+                        "err" => ?&e,
+                    );
+                    return e;
+                }
                 Ok(resp) => resp,
             };
             if self.refresh_leader_if_needed(&resp, region_id)

--- a/components/tikv_util/src/mpsc/mod.rs
+++ b/components/tikv_util/src/mpsc/mod.rs
@@ -79,6 +79,7 @@ impl<T> Drop for Sender<T> {
 }
 
 /// The receive end of a channel.
+#[derive(Clone)]
 pub struct Receiver<T> {
     receiver: channel::Receiver<T>,
     state: Arc<State>,


### PR DESCRIPTION
Signed-off-by: cfzjywxk <lsswxrxr@163.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->


What's Changed:

A straightforward example to show the concurrent apply message processing but not considering any other constraints like applied index and admin commands.

1. The client schedules two async put requests.
2. The first request is finished and scheduled to apply worker 1.
3. Apply worker would sleep 1s before end the loop in which the write batch would be flushed to kv db. Note the processed fsm is scheduled again before ending one loop, this allows other apply workers to process messages routed to the same fsm concurrently.
4. The second request is finished and scheduled to apply worker 2. Though the apply loop is ongoing in apply worker 1, the request is being processed by apply worker 2.
5. Apply worker 2 would finish the loop 200ms after apply worker 1, which is correspond to the delay between two client requests.

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
```
