### PR TITLE
log-backup: fix the wrong calculate sha256 in flush retry

### DIFF
--- a/components/backup-stream/src/router.rs
+++ b/components/backup-stream/src/router.rs
@@ -728,7 +728,7 @@ pub struct StreamTaskInfo {
     /// The temporary file index. Both meta (m prefixed keys) and data (t prefixed keys).
     files: SlotMap<TempFileKey, DataFile>,
     /// flushing_files contains files pending flush.
-    flushing_files: RwLock<Vec<(TempFileKey, Slot<DataFile>)>>,
+    flushing_files: RwLock<Vec<(TempFileKey, Slot<DataFile>, DataFileInfo)>>,
     /// last_flush_ts represents last time this task flushed to storage.
     last_flush_time: AtomicPtr<Instant>,
     /// flush_interval represents the tick interval of flush, setting by users.
@@ -753,6 +753,7 @@ impl Drop for StreamTaskInfo {
             .flushing_files
             .get_mut()
             .drain(..)
+            .map(|(a, b, _)| (a, b))
             .chain(self.files.get_mut().drain())
             .map(|(_, f)| f.into_inner().local_path)
             .map(std::fs::remove_file)
@@ -857,7 +858,7 @@ impl StreamTaskInfo {
     pub async fn generate_metadata(&self, store_id: u64) -> Result<MetadataInfo> {
         let w = self.flushing_files.read().await;
         // Let's flush all files first...
-        futures::future::join_all(w.iter().map(|(_, f)| async move {
+        futures::future::join_all(w.iter().map(|(_, f, _)| async move {
             let file = &mut f.lock().await.inner;
             file.flush().await?;
             file.get_ref().sync_all().await?;
@@ -870,10 +871,8 @@ impl StreamTaskInfo {
 
         let mut metadata = MetadataInfo::with_capacity(w.len());
         metadata.set_store_id(store_id);
-        for (file_key, data_file) in w.iter() {
-            let mut data_file = data_file.lock().await;
-            let file_meta = data_file.generate_metadata(file_key, store_id)?;
-            metadata.push(file_meta)
+        for (_, _, file_meta) in w.iter() {
+            metadata.push(file_meta.to_owned())
         }
         Ok(metadata)
     }
@@ -907,22 +906,23 @@ impl StreamTaskInfo {
     }
 
     /// move need-flushing files to flushing_files.
-    pub async fn move_to_flushing_files(&self) -> &Self {
+    pub async fn move_to_flushing_files(&self, store_id: u64) -> Result<&Self> {
         // if flushing_files is not empty, which represents this flush is a retry operation.
         if !self.flushing_files.read().await.is_empty() {
-            return self;
+            return Ok(self);
         }
 
         let mut w = self.files.write().await;
         let mut fw = self.flushing_files.write().await;
         for (k, v) in w.drain() {
-            fw.push((k, v));
+            let file_meta = v.lock().await.generate_metadata(&k, store_id)?;
+            fw.push((k, v, file_meta));
         }
-        self
+        Ok(self)
     }
 
     pub async fn clear_flushing_files(&self) {
-        for (_, v) in self.flushing_files.write().await.drain(..) {
+        for (_, v, _) in self.flushing_files.write().await.drain(..) {
             let data_file = v.lock().await;
             debug!("removing data file"; "size" => %data_file.file_size, "name" => %data_file.local_path.display());
             self.total_size
@@ -977,7 +977,7 @@ impl StreamTaskInfo {
         for batch_files in files.chunks(FLUSH_LOG_CONCURRENT_BATCH_COUNT) {
             let futs = batch_files
                 .iter()
-                .map(|(_, v)| Self::flush_log_file_to(storage.clone(), v));
+                .map(|(_, v, _)| Self::flush_log_file_to(storage.clone(), v));
             futures::future::try_join_all(futs).await?;
         }
 
@@ -1023,8 +1023,8 @@ impl StreamTaskInfo {
 
             // generate meta data and prepare to flush to storage
             let mut metadata_info = self
-                .move_to_flushing_files()
-                .await
+                .move_to_flushing_files(store_id)
+                .await?
                 .generate_metadata(store_id)
                 .await?;
             metadata_info.min_resolved_ts = metadata_info


### PR DESCRIPTION
Signed-off-by: 3pointer <luancheng@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close 

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
```
