### PR TITLE
log-backup: update global-checkpoint to storage periodically

### DIFF
--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -811,14 +811,14 @@ where
                         .update_global_checkpoint(&task, global_checkpoint, self.store_id)
                         .await
                     {
-                        info!("backup stream failed to update global checkpoint.";
+                        warn!("backup stream failed to update global checkpoint.";
                             "task" => ?task,
                             "err" => ?e
                         );
                     }
                 }
                 Err(e) => {
-                    info!("backup stream failed to get global checkpoint.";
+                    warn!("backup stream failed to get global checkpoint.";
                         "task" => ?task,
                         "err" => ?e
                     );

--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -822,7 +822,6 @@ where
                         "task" => ?task,
                         "err" => ?e
                     );
-                    return;
                 }
             }
         });

--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -801,6 +801,33 @@ where
         }));
     }
 
+    fn on_update_global_checkpoint(&self, task: String) {
+        self.pool.block_on(async move {
+            let ts = self.meta_client.global_progress_of_task(&task).await;
+            match ts {
+                Ok(global_checkpoint) => {
+                    if let Err(e) = self
+                        .range_router
+                        .update_global_checkpoint(&task, global_checkpoint, self.store_id)
+                        .await
+                    {
+                        info!("backup stream failed to update global checkpoint.";
+                            "task" => ?task,
+                            "err" => ?e
+                        );
+                    }
+                }
+                Err(e) => {
+                    info!("backup stream failed to get global checkpoint.";
+                        "task" => ?task,
+                        "err" => ?e
+                    );
+                    return;
+                }
+            }
+        });
+    }
+
     /// Modify observe over some region.
     /// This would register the region to the RaftStore.
     pub fn on_modify_observe(&self, op: ObserveOp) {
@@ -839,6 +866,7 @@ where
             Task::MarkFailover(t) => self.failover_time = Some(t),
             Task::FlushWithMinTs(task, min_ts) => self.on_flush_with_min_ts(task, min_ts),
             Task::RegionCheckpointsOp(s) => self.handle_region_checkpoints_op(s),
+            Task::UpdateGlobalCheckpoint(task) => self.on_update_global_checkpoint(task),
         }
     }
 
@@ -958,6 +986,8 @@ pub enum Task {
     FlushWithMinTs(String, TimeStamp),
     /// The command for getting region checkpoints.
     RegionCheckpointsOp(RegionCheckpointOperation),
+    /// update global-checkpoint-ts to storage.
+    UpdateGlobalCheckpoint(String),
 }
 
 #[derive(Debug)]
@@ -1054,6 +1084,9 @@ impl fmt::Debug for Task {
                 .field(arg1)
                 .finish(),
             Self::RegionCheckpointsOp(s) => f.debug_tuple("GetRegionCheckpoints").field(s).finish(),
+            Self::UpdateGlobalCheckpoint(task) => {
+                f.debug_tuple("UpdateGlobalCheckpoint").field(task).finish()
+            }
         }
     }
 }
@@ -1090,6 +1123,7 @@ impl Task {
             Task::MarkFailover(_) => "mark_failover",
             Task::FlushWithMinTs(..) => "flush_with_min_ts",
             Task::RegionCheckpointsOp(..) => "get_checkpoints",
+            Task::UpdateGlobalCheckpoint(..) => "update_global_checkpoint",
         }
     }
 }

--- a/components/backup-stream/src/router.rs
+++ b/components/backup-stream/src/router.rs
@@ -2019,15 +2019,22 @@ mod tests {
         // test no need to update global checkpoint
         let store_id = 3;
         let mut global_checkpoint = 10000;
-        let r = task.update_global_checkpoint(global_checkpoint, store_id).await;
+        let r = task
+            .update_global_checkpoint(global_checkpoint, store_id)
+            .await;
         assert_eq!(r.is_ok(), true);
         assert_eq!(task.global_checkpoint_ts.load(Ordering::SeqCst), 10001);
-        
+
         // test update global checkpoint
         global_checkpoint = 10002;
-        let r = task.update_global_checkpoint(global_checkpoint, store_id).await;
+        let r = task
+            .update_global_checkpoint(global_checkpoint, store_id)
+            .await;
         assert_eq!(r.is_ok(), true);
-        assert_eq!(task.global_checkpoint_ts.load(Ordering::SeqCst), global_checkpoint);
+        assert_eq!(
+            task.global_checkpoint_ts.load(Ordering::SeqCst),
+            global_checkpoint
+        );
 
         let filename = format!("v1/global_checkpoint/{}.ts", store_id);
         let filepath = tmp_dir.as_ref().join(filename);
@@ -2041,5 +2048,4 @@ mod tests {
         let ts = u64::from_le_bytes(ts);
         assert_eq!(ts, global_checkpoint);
     }
-
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref https://github.com/tikv/tikv/issues/12895

What's Changed:
- update global-checkpoint to storage Periodically

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

### Manual test
### manual test
- ./bin/br log status -u "X.X.X.X:2379"
● Total 1 Tasks.
> #1 <
              name: store-by-storeid
            status: ● NORMAL
             start: 2022-07-14 20:08:03.268 +0800 CST
               end: 2090-11-18 22:07:45.624 +0800 CST
           storage: s3://tmp/store-by-storeid/log1
       speed(est.): 0.00 ops/s
checkpoint[global]: 2022-07-17 19:36:27.418 +0800 CST; gap=1m11s
- ./bin/br log metadata -s "XXXX"
[2022/07/17 19:37:38.659 +08:00] [INFO] [collector.go:69] ["log metadata"] [log-min-ts=434582449885806593] [log-min-date="2022-07-14 20:08:03.268 +0800 CST"] [log-max-ts=434649900624904193] [log-max-date="2022-07-17 19:36:27.418 +0800 CST"]


Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
```
