### PR TITLE
log-backup: upload global checkpoint ts to etcd.

### DIFF
--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -817,7 +817,7 @@ where
                                 .set_storage_checkpoint(&task, global_checkpoint)
                                 .await
                             {
-                                warn!("backup stream failed to update global checkpoint.";
+                                warn!("backup stream failed to set global checkpoint.";
                                     "task" => ?task,
                                     "global-checkpoint" => global_checkpoint,
                                     "err" => ?err,

--- a/components/backup-stream/src/metadata/client.rs
+++ b/components/backup-stream/src/metadata/client.rs
@@ -421,6 +421,21 @@ impl<Store: MetaStore> MetadataClient<Store> {
         })
     }
 
+    /// set the storage checkpoint to metadata.
+    pub async fn set_storage_checkpoint(&self, task_name: &str, ts: u64) -> Result<()> {
+        let now = Instant::now();
+        defer! {
+            super::metrics::METADATA_OPERATION_LATENCY.with_label_values(&["task_step"]).observe(now.saturating_elapsed().as_secs_f64())
+        }
+        self.meta_store
+            .set(KeyValue(
+                MetaKey::storage_checkpoint_of(task_name, self.store_id),
+                ts.to_be_bytes().to_vec(),
+            ))
+            .await?;
+        Ok(())
+    }
+
     /// forward the progress of some task.
     pub async fn set_local_task_checkpoint(&self, task_name: &str, ts: u64) -> Result<()> {
         let now = Instant::now();

--- a/components/backup-stream/src/metadata/keys.rs
+++ b/components/backup-stream/src/metadata/keys.rs
@@ -5,6 +5,7 @@ use kvproto::metapb::Region;
 const PREFIX: &str = "/tidb/br-stream";
 const PATH_INFO: &str = "/info";
 const PATH_NEXT_BACKUP_TS: &str = "/checkpoint";
+const PATH_STORAGE_CHECKPOINT: &str = "/storage-checkpoint";
 const PATH_RANGES: &str = "/ranges";
 const PATH_PAUSE: &str = "/pause";
 const PATH_LAST_ERROR: &str = "/last-error";
@@ -23,6 +24,8 @@ const TASKS_PREFIX: &str = "/tidb/br-stream/info/";
 /// <PREFIX>/checkpoint/<task_name>/<store_id(u64,be)>/<region_id(u64,be)> -> <next_backup_ts(u64,be)>
 /// For the status of tasks:
 /// <PREFIX>/pause/<task_name> -> ""
+/// For the global checkpoint ts of tasks:
+/// <PREFIX>/global-checkpoint/<task_name>/<store_id(u64,be)> -> <ts(u64,be)>
 /// ```
 #[derive(Clone)]
 pub struct MetaKey(pub Vec<u8>);
@@ -124,6 +127,17 @@ impl MetaKey {
                 name,
                 region.id,
                 region.get_region_epoch().get_version()
+            )
+            .into_bytes(),
+        )
+    }
+
+    /// defines the key of storage checkpoint-ts of task in a store.
+    pub fn storage_checkpoint_of(name: &str, store_id: u64) -> Self {
+        Self(
+            format!(
+                "{}{}/{}/{}",
+                PREFIX, PATH_STORAGE_CHECKPOINT, name, store_id
             )
             .into_bytes(),
         )

--- a/components/backup-stream/src/metadata/keys.rs
+++ b/components/backup-stream/src/metadata/keys.rs
@@ -25,7 +25,7 @@ const TASKS_PREFIX: &str = "/tidb/br-stream/info/";
 /// For the status of tasks:
 /// <PREFIX>/pause/<task_name> -> ""
 /// For the global checkpoint ts of tasks:
-/// <PREFIX>/global-checkpoint/<task_name>/<store_id(u64,be)> -> <ts(u64,be)>
+/// <PREFIX>/storage-checkpoint/<task_name>/<store_id(u64,be)> -> <ts(u64,be)>
 /// ```
 #[derive(Clone)]
 pub struct MetaKey(pub Vec<u8>);

--- a/components/backup-stream/src/metadata/keys.rs
+++ b/components/backup-stream/src/metadata/keys.rs
@@ -24,7 +24,7 @@ const TASKS_PREFIX: &str = "/tidb/br-stream/info/";
 /// <PREFIX>/checkpoint/<task_name>/<store_id(u64,be)>/<region_id(u64,be)> -> <next_backup_ts(u64,be)>
 /// For the status of tasks:
 /// <PREFIX>/pause/<task_name> -> ""
-/// For the global checkpoint ts of tasks:
+/// For the storage checkpoint ts of tasks:
 /// <PREFIX>/storage-checkpoint/<task_name>/<store_id(u64,be)> -> <ts(u64,be)>
 /// ```
 #[derive(Clone)]

--- a/components/backup-stream/src/metadata/test.rs
+++ b/components/backup-stream/src/metadata/test.rs
@@ -153,6 +153,21 @@ async fn test_progress() -> Result<()> {
 }
 
 #[tokio::test]
+async fn test_storage_checkpoint() -> Result<()> {
+    let cli = test_meta_cli();
+    let task = simple_task("simple_3");
+    let storage_checkpoint_ts: u64 = 12345;
+
+    // set storage checkpoint to metadata
+    cli.set_storage_checkpoint(task.info.get_name(), storage_checkpoint_ts)
+        .await?;
+    // get storage checkpoint from metadata
+    let ts = cli.get_storage_checkpoint(task.info.get_name()).await?;
+    assert_eq!(ts.into_inner(), storage_checkpoint_ts);
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_init() -> Result<()> {
     let cli = test_meta_cli();
     let mut task = simple_task("simple_2");

--- a/components/backup-stream/src/metadata/test.rs
+++ b/components/backup-stream/src/metadata/test.rs
@@ -14,7 +14,7 @@ use kvproto::{
 use tokio_stream::StreamExt;
 use txn_types::TimeStamp;
 
-use super::{MetadataClient, StreamTask};
+use super::{keys::MetaKey, MetadataClient, StreamTask};
 use crate::{
     errors::Result,
     metadata::{
@@ -152,8 +152,19 @@ async fn test_progress() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn test_storage_checkpoint_of() {
+    let task_name = "simple_task";
+    let store_id: u64 = 5;
+    let key = MetaKey::storage_checkpoint_of(task_name, store_id);
+    assert_eq!(
+        &key.0,
+        "/tidb/br-stream/storage-checkpoint/simple_task/5".as_bytes()
+    );
+}
+
 #[tokio::test]
-async fn test_storage_checkpoint() -> Result<()> {
+async fn test_set_storage_checkpoint() -> Result<()> {
     let cli = test_meta_cli();
     let task = simple_task("simple_3");
     let storage_checkpoint_ts: u64 = 12345;

--- a/components/external_storage/src/local.rs
+++ b/components/external_storage/src/local.rs
@@ -214,4 +214,22 @@ mod tests {
     fn test_url_of_backend() {
         assert_eq!(url_for(Path::new("/tmp/a")).to_string(), "local:///tmp/a");
     }
+
+    #[tokio::test]
+    async fn test_write_existed_file() {
+        let temp_dir = Builder::new().tempdir().unwrap();
+        let path = temp_dir.path();
+        let ls = LocalStorage::new(path).unwrap();
+
+        let filename = "existed.file";
+        let buf: &[u8] = b"pingcap";
+        let r = ls
+            .write(filename, UnpinReader(Box::new(buf)), buf.len() as _)
+            .await;
+        assert!(r.is_ok());
+        let r = ls
+            .write(filename, UnpinReader(Box::new(buf)), buf.len() as _)
+            .await;
+        assert!(r.is_ok());
+    }
 }

--- a/components/external_storage/src/local.rs
+++ b/components/external_storage/src/local.rs
@@ -222,14 +222,21 @@ mod tests {
         let ls = LocalStorage::new(path).unwrap();
 
         let filename = "existed.file";
-        let buf: &[u8] = b"pingcap";
+        let buf1: &[u8] = b"pingcap";
+        let buf2: &[u8] = b"tikv";
         let r = ls
-            .write(filename, UnpinReader(Box::new(buf)), buf.len() as _)
+            .write(filename, UnpinReader(Box::new(buf1)), buf1.len() as _)
             .await;
         assert!(r.is_ok());
         let r = ls
-            .write(filename, UnpinReader(Box::new(buf)), buf.len() as _)
+            .write(filename, UnpinReader(Box::new(buf2)), buf2.len() as _)
             .await;
         assert!(r.is_ok());
+
+        let mut read_buff: Vec<u8> = Vec::new();
+        let r = ls.read(filename).read_to_end(&mut read_buff).await;
+        assert!(r.is_ok());
+        assert_eq!(read_buff.len(), 4);
+        assert_eq!(&read_buff, buf2);
     }
 }

--- a/components/external_storage/src/local.rs
+++ b/components/external_storage/src/local.rs
@@ -100,12 +100,11 @@ impl ExternalStorage for LocalStorage {
                     }
                 })?;
         }
-        // Sanitize check, do not save file if it is already exist.
+
+        // Because s3 could support writing(put_object) a existed object.
+        // For the interface consistent with s3, local storage need also support write a existed file.
         if fs::metadata(self.base.join(name)).await.is_ok() {
-            return Err(io::Error::new(
-                io::ErrorKind::AlreadyExists,
-                format!("[{}] is already exists in {}", name, self.base.display()),
-            ));
+            info!("[{}] is already exists in {}", name, self.base.display());
         }
         let tmp_path = self.tmp_path(Path::new(name));
         let mut tmp_f = File::create(&tmp_path).await?;


### PR DESCRIPTION
Signed-off-by: joccau <zak.zhao@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/tikv/tikv/issues/13062


### Problem Summary:
The global checkpoint-ts got by command `br log metadata` from externStorage is smaller than the value got by command `br log status` from PD server in upstream-cluster.

### What is changed and how it works?
- The tikv-server need upload checkpoint-ts(has flushed into externStorage) to pd that can be query by `br log status`.
What's Changed:
<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

### Manual test
- `br log status -u "x.x.x.x:2379"`
● Total 1 Tasks.
> #1 <
              name: store-by-storeid
            status: ● NORMAL
             start: 2022-07-14 20:08:03.268 +0800 CST
               end: 2090-11-18 22:07:45.624 +0800 CST
           storage: s3://tmp/store-by-storeid/log1
       speed(est.): 0.00 ops/s
checkpoint[global]: 2022-07-20 13:03:42.918 +0800 CST; gap=1m42s
- `br log metadata -s "xxxxxx"`
[2022/07/20 13:05:24.908 +08:00] [INFO] [collector.go:69] ["log metadata"] [log-min-ts=434582449885806593] [log-min-date="2022-07-14 20:08:03.268 +0800 CST"] [log-max-ts=434711671057416193] [log-max-date="2022-07-20 13:03:42.918 +0800 CST"]

- Conclusion
 The global checkpoint-ts got by command `br log metadata` from externStorage is smaller than or equal to the value got by command `br log status` from PD server in upstream-cluster.

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
```
