### PR TITLE
server: do not update background cpu limit when auto-tune is off

### DIFF
--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -1292,20 +1292,17 @@ impl<ER: RaftEngine> TiKvServer<ER> {
         };
 
         // Determine the base cpu quota
-        let base_cpu_quota = {
+        let base_cpu_quota =
             // if cpu quota is not specified, start from optimistic case
             if quota_limiter.cputime_limiter(false).is_infinite() {
-                let quota = 1000_f64
+                1000_f64
                     * f64::max(
                         BACKGROUND_REQUEST_CORE_LOWER_BOUND,
                         SysQuota::cpu_cores_quota() * BACKGROUND_REQUEST_CORE_DEFAULT_RATIO,
-                    );
-                quota_limiter.set_cpu_time_limit(quota as usize, false);
-                quota
+                    )
             } else {
                 quota_limiter.cputime_limiter(false) / 1000_f64
-            }
-        };
+            };
 
         // Calculate the celling and floor quota
         let celling_quota = f64::min(
@@ -1322,7 +1319,12 @@ impl<ER: RaftEngine> TiKvServer<ER> {
             DEFAULT_QUOTA_LIMITER_TUNE_INTERVAL,
             move || {
                 if quota_limiter.auto_tune_enabled() {
-                    let old_quota = quota_limiter.cputime_limiter(false) / 1000_f64;
+                    let cputime_limit = quota_limiter.cputime_limiter(false);
+                    let old_quota = if cputime_limit.is_infinite() {
+                        base_cpu_quota
+                    } else {
+                        cputime_limit / 1000_f64
+                    };
                     let cpu_usage = match proc_stats.cpu_usage() {
                         Ok(r) => r,
                         Err(_e) => 0.0,


### PR DESCRIPTION
### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #13055

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
ThreadTime is collected when the cpu limit in the QuotaLimiter
is not infinity.

#12679 updated the background cpu limit even if auto-tune is off,
which is unnecessary. So, that causes additional cost of collecting
thread CPU time in some critical paths.

This commit sets cpu_time_limit of the QuotaLimiter only if auto-tune
is enabled, so we don't waste effort to collect CPU time when
auto-tune is not enabled.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

`ThreadTime` does not appear on the flamegraph now.

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
