### PR TITLE
raftstore: Fix entry cache gc may dropped by mistake when adding new peer 

### DIFF
--- a/components/engine_panic/src/raft_engine.rs
+++ b/components/engine_panic/src/raft_engine.rs
@@ -118,10 +118,6 @@ impl RaftEngine for PanicEngine {
         panic!()
     }
 
-    fn has_builtin_entry_cache(&self) -> bool {
-        panic!()
-    }
-
     fn flush_metrics(&self, instance: &str) {
         panic!()
     }

--- a/components/engine_rocks/src/raft_engine.rs
+++ b/components/engine_rocks/src/raft_engine.rs
@@ -312,10 +312,6 @@ impl RaftEngine for RocksEngine {
         Ok(vec![])
     }
 
-    fn has_builtin_entry_cache(&self) -> bool {
-        false
-    }
-
     fn flush_metrics(&self, instance: &str) {
         KvEngine::flush_metrics(self, instance)
     }

--- a/components/engine_traits/src/raft_engine.rs
+++ b/components/engine_traits/src/raft_engine.rs
@@ -119,14 +119,6 @@ pub trait RaftEngine: RaftEngineReadOnly + PerfContextExt + Clone + Sync + Send 
     /// which needs to be compacted ASAP.
     fn purge_expired_files(&self) -> Result<Vec<u64>>;
 
-    /// The `RaftEngine` has a builtin entry cache or not.
-    fn has_builtin_entry_cache(&self) -> bool {
-        false
-    }
-
-    /// GC the builtin entry cache.
-    fn gc_entry_cache(&self, _raft_group_id: u64, _to: u64) {}
-
     fn flush_metrics(&self, _instance: &str) {}
     fn flush_stats(&self) -> Option<CacheStats> {
         None

--- a/components/raft_log_engine/src/engine.rs
+++ b/components/raft_log_engine/src/engine.rs
@@ -548,12 +548,6 @@ impl RaftEngine for RaftLogEngine {
         self.0.purge_expired_files().map_err(transfer_error)
     }
 
-    fn has_builtin_entry_cache(&self) -> bool {
-        false
-    }
-
-    fn gc_entry_cache(&self, _raft_group_id: u64, _to: u64) {}
-
     /// Flush current cache stats.
     fn flush_stats(&self) -> Option<CacheStats> {
         None

--- a/components/raftstore/src/store/peer_storage.rs
+++ b/components/raftstore/src/store/peer_storage.rs
@@ -1385,16 +1385,11 @@ where
 
     pub fn compact_to(&mut self, idx: u64) {
         self.compact_cache_to(idx);
-
         self.cancel_generating_snap(Some(idx));
     }
 
     pub fn compact_cache_to(&mut self, idx: u64) {
         self.cache.compact_to(idx);
-        let rid = self.get_region_id();
-        if self.engines.raft.has_builtin_entry_cache() {
-            self.engines.raft.gc_entry_cache(rid, idx);
-        }
     }
 
     #[inline]
@@ -1402,31 +1397,9 @@ where
         self.cache.is_empty()
     }
 
-    pub fn maybe_gc_cache(&mut self, replicated_idx: u64, apply_idx: u64) {
-        if self.engines.raft.has_builtin_entry_cache() {
-            let rid = self.get_region_id();
-            self.engines.raft.gc_entry_cache(rid, apply_idx + 1);
-        }
-        if replicated_idx == apply_idx {
-            // The region is inactive, clear the cache immediately.
-            self.cache.compact_to(apply_idx + 1);
-            return;
-        }
-        let cache_first_idx = match self.cache.first_index() {
-            None => return,
-            Some(idx) => idx,
-        };
-        if cache_first_idx > replicated_idx + 1 {
-            // Catching up log requires accessing fs already, let's optimize for
-            // the common case.
-            // Maybe gc to second least replicated_idx is better.
-            self.cache.compact_to(apply_idx + 1);
-        }
-    }
-
     /// Evict entries from the cache.
     pub fn evict_cache(&mut self, half: bool) {
-        if !self.cache.cache.is_empty() {
+        if !self.is_cache_empty() {
             let cache = &mut self.cache;
             let cache_len = cache.cache.len();
             let drain_to = if half { cache_len / 2 } else { cache_len - 1 };
@@ -1436,22 +1409,11 @@ where
         }
     }
 
-    pub fn cache_is_empty(&self) -> bool {
-        self.cache.cache.is_empty()
-    }
-
     #[inline]
     pub fn flush_cache_metrics(&mut self) {
         // NOTE: memory usage of entry cache is flushed realtime.
         self.cache.flush_stats();
         self.raftlog_fetch_stats.flush_stats();
-        if self.engines.raft.has_builtin_entry_cache() {
-            if let Some(stats) = self.engines.raft.flush_stats() {
-                RAFT_ENTRIES_CACHES_GAUGE.set(stats.cache_size as i64);
-                RAFT_ENTRY_FETCHES.hit.inc_by(stats.hit as u64);
-                RAFT_ENTRY_FETCHES.miss.inc_by(stats.miss as u64);
-            }
-        }
     }
 
     // Apply the peer with given snapshot.

--- a/tests/failpoints/cases/test_async_fetch.rs
+++ b/tests/failpoints/cases/test_async_fetch.rs
@@ -234,3 +234,38 @@ fn test_node_async_fetch_leader_change() {
         must_get_equal(&cluster.get_engine(1), &k, &v);
     }
 }
+
+#[test]
+fn test_node_gc_entry_cache() {
+    let count = 5;
+    let mut cluster = new_node_cluster(0, count);
+    cluster.pd_client.disable_default_operator(); 
+
+    cluster.cfg.raft_store.raft_log_gc_tick_interval = ReadableDuration::millis(50);
+    cluster.cfg.raft_store.raft_log_reserve_max_ticks = 2;
+    cluster.run();
+
+    cluster.must_transfer_leader(1, new_peer(1, 1));
+    cluster.must_put(b"k0", b"v0");
+    // change one peer to learner
+    cluster.pd_client.must_remove_peer(1, new_peer(5, 5));
+
+    // pause snapshot applied
+    fail::cfg("before_region_gen_snap", "pause").unwrap();
+    fail::cfg("worker_async_fetch_raft_log", "pause").unwrap();
+    cluster.pd_client.add_peer(1, new_learner_peer(5, 5));
+
+    // cause log lag and pause async fetch to check if entry cache is kept for the learner
+    for i in 1..6 {
+        let k = i.to_string().into_bytes();
+        let v = k.clone();
+        cluster.must_put(&k, &v);
+    }
+    std::thread::sleep(Duration::from_millis(100));
+
+    fail::remove("before_region_gen_snap");
+    cluster.pd_client.must_have_peer(1, new_learner_peer(5, 5));
+
+    // if entry cache is not kept, the learner will not be able to catch up.
+    must_get_equal(&cluster.get_engine(5), b"5", b"5");
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #13077

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
When adding a new peer, `alive_cache_idx` would not consider the new peer still in applying snapshot. Then it may trigger compacting entry cache due to `alive_cache_idx` being equal to `applied_idx`. After the snapshot is applied, the log gap of new peer is not in entry cache, which triggers async fetch to read disk. 

Considering raft engine's read performance is not as good as rocksdb's, once there are a lot of Regions triggering async fetch, the process of replicating log to new peer would be slow. If there is a conf change promoting the learner and demoting  another peer, the commit index can't be advanced in joint state because the to-be-learner peer doesn't catch up logs in time.
```

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test
- Manual test (add detailed scripts or steps below)

before
![origin_img_v2_10002a4c-b966-4881-8f73-3bb01d710deg](https://user-images.githubusercontent.com/13497871/179953163-453cd30b-53ed-4006-88e8-cce7632ad275.jpg)

after
![origin_img_v2_09bb560d-cf36-4bd0-aadf-48369e4eb70g](https://user-images.githubusercontent.com/13497871/179953136-84ca85a3-64ae-4cfb-9261-ded06a9ac94f.jpg)


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix possible QPS drop due to high commit log duration 
```
