### PR TITLE
components, src: avoid cpu quota limitation contamination 

### DIFF
--- a/components/tidb_query_executors/src/runner.rs
+++ b/components/tidb_query_executors/src/runner.rs
@@ -453,7 +453,7 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
 
             let mut chunk = Chunk::default();
 
-            let mut sample = self.quota_limiter.new_sample();
+            let mut sample = self.quota_limiter.new_sample(true);
             let (drained, record_len) = {
                 let _guard = sample.observe_cpu();
                 self.internal_handle_request(

--- a/components/tikv_util/src/quota_limiter.rs
+++ b/components/tikv_util/src/quota_limiter.rs
@@ -234,21 +234,24 @@ impl QuotaLimiter {
     }
 
     // To generate a sampler.
-    pub fn new_sample(&self) -> Sample {
+    pub fn new_sample(&self, is_foreground: bool) -> Sample {
         Sample {
             read_bytes: 0,
             write_bytes: 0,
             cpu_time: Duration::ZERO,
-            enable_cpu_limit: !self
-                .foreground_limiters
-                .cputime_limiter
-                .speed_limit()
-                .is_infinite()
-                || !self
+            enable_cpu_limit: if is_foreground {
+                !self
+                    .foreground_limiters
+                    .cputime_limiter
+                    .speed_limit()
+                    .is_infinite()
+            } else {
+                !self
                     .background_limiters
                     .cputime_limiter
                     .speed_limit()
-                    .is_infinite(),
+                    .is_infinite()
+            },
         }
     }
 
@@ -389,25 +392,25 @@ mod tests {
             );
         };
 
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(true);
         sample.add_cpu_time(Duration::from_millis(60));
         let should_delay = block_on(quota_limiter.consume_sample(sample, true));
         check_duration(should_delay, Duration::ZERO);
 
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(true);
         sample.add_cpu_time(Duration::from_millis(50));
         let should_delay = block_on(quota_limiter.consume_sample(sample, true));
         check_duration(should_delay, Duration::from_millis(110));
 
         std::thread::sleep(Duration::from_millis(10));
 
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(true);
         sample.add_cpu_time(Duration::from_millis(20));
         let should_delay = block_on(quota_limiter.consume_sample(sample, true));
         // should less 60+50+20
         assert!(should_delay < Duration::from_millis(130));
 
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(true);
         sample.add_cpu_time(Duration::from_millis(200));
         sample.add_write_bytes(256);
         let should_delay = block_on(quota_limiter.consume_sample(sample, true));
@@ -417,25 +420,25 @@ mod tests {
         assert!(thread_start_time.elapsed() < Duration::from_millis(50));
 
         quota_limiter.set_cpu_time_limit(2000, true);
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(true);
         sample.add_cpu_time(Duration::from_millis(200));
         let should_delay = block_on(quota_limiter.consume_sample(sample, true));
         check_duration(should_delay, Duration::from_millis(100));
 
         quota_limiter.set_read_bandwidth_limit(ReadableSize(512), true);
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(true);
         sample.add_read_bytes(128);
         let should_delay = block_on(quota_limiter.consume_sample(sample, true));
         check_duration(should_delay, Duration::from_millis(250));
 
         quota_limiter.set_write_bandwidth_limit(ReadableSize::kb(2), true);
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(true);
         sample.add_write_bytes(256);
         let should_delay = block_on(quota_limiter.consume_sample(sample, true));
         check_duration(should_delay, Duration::from_millis(125));
 
         quota_limiter.set_max_delay_duration(ReadableDuration::millis(40));
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(true);
         sample.add_read_bytes(256);
         sample.add_write_bytes(512);
         let should_delay = block_on(quota_limiter.consume_sample(sample, true));
@@ -443,19 +446,19 @@ mod tests {
 
         // test change limiter to 0
         quota_limiter.set_cpu_time_limit(0, true);
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(true);
         sample.add_cpu_time(Duration::from_millis(100));
         let should_delay = block_on(quota_limiter.consume_sample(sample, true));
         check_duration(should_delay, Duration::ZERO);
 
         quota_limiter.set_write_bandwidth_limit(ReadableSize::kb(0), true);
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(true);
         sample.add_write_bytes(256);
         let should_delay = block_on(quota_limiter.consume_sample(sample, true));
         check_duration(should_delay, Duration::ZERO);
 
         quota_limiter.set_read_bandwidth_limit(ReadableSize::kb(0), true);
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(true);
         sample.add_read_bytes(256);
         let should_delay = block_on(quota_limiter.consume_sample(sample, true));
         check_duration(should_delay, Duration::ZERO);
@@ -463,30 +466,30 @@ mod tests {
         // set bandwidth back
         quota_limiter.set_write_bandwidth_limit(ReadableSize::kb(1), true);
         quota_limiter.set_max_delay_duration(ReadableDuration::millis(0));
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(true);
         sample.add_write_bytes(128);
         let should_delay = block_on(quota_limiter.consume_sample(sample, true));
         check_duration(should_delay, Duration::from_millis(125));
 
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(false);
         sample.add_cpu_time(Duration::from_millis(60));
         let should_delay = block_on(quota_limiter.consume_sample(sample, false));
         check_duration(should_delay, Duration::ZERO);
 
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(false);
         sample.add_cpu_time(Duration::from_millis(50));
         let should_delay = block_on(quota_limiter.consume_sample(sample, false));
         check_duration(should_delay, Duration::from_millis(110));
 
         std::thread::sleep(Duration::from_millis(10));
 
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(false);
         sample.add_cpu_time(Duration::from_millis(20));
         let should_delay = block_on(quota_limiter.consume_sample(sample, false));
         // should less 60+50+20
         assert!(should_delay < Duration::from_millis(130));
 
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(false);
         sample.add_cpu_time(Duration::from_millis(200));
         sample.add_write_bytes(256);
         let should_delay = block_on(quota_limiter.consume_sample(sample, false));
@@ -496,25 +499,25 @@ mod tests {
         assert!(thread_start_time.elapsed() < Duration::from_millis(50));
 
         quota_limiter.set_cpu_time_limit(2000, false);
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(false);
         sample.add_cpu_time(Duration::from_millis(200));
         let should_delay = block_on(quota_limiter.consume_sample(sample, false));
         check_duration(should_delay, Duration::from_millis(100));
 
         quota_limiter.set_read_bandwidth_limit(ReadableSize(512), false);
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(false);
         sample.add_read_bytes(128);
         let should_delay = block_on(quota_limiter.consume_sample(sample, false));
         check_duration(should_delay, Duration::from_millis(250));
 
         quota_limiter.set_write_bandwidth_limit(ReadableSize::kb(2), false);
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(false);
         sample.add_write_bytes(256);
         let should_delay = block_on(quota_limiter.consume_sample(sample, false));
         check_duration(should_delay, Duration::from_millis(125));
 
         quota_limiter.set_max_delay_duration(ReadableDuration::millis(40));
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(false);
         sample.add_read_bytes(256);
         sample.add_write_bytes(512);
         let should_delay = block_on(quota_limiter.consume_sample(sample, false));
@@ -522,19 +525,19 @@ mod tests {
 
         // test change limiter to 0
         quota_limiter.set_cpu_time_limit(0, false);
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(false);
         sample.add_cpu_time(Duration::from_millis(100));
         let should_delay = block_on(quota_limiter.consume_sample(sample, false));
         check_duration(should_delay, Duration::ZERO);
 
         quota_limiter.set_write_bandwidth_limit(ReadableSize::kb(0), false);
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(false);
         sample.add_write_bytes(256);
         let should_delay = block_on(quota_limiter.consume_sample(sample, false));
         check_duration(should_delay, Duration::ZERO);
 
         quota_limiter.set_read_bandwidth_limit(ReadableSize::kb(0), false);
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(false);
         sample.add_read_bytes(256);
         let should_delay = block_on(quota_limiter.consume_sample(sample, false));
         check_duration(should_delay, Duration::ZERO);
@@ -542,7 +545,7 @@ mod tests {
         // set bandwidth back
         quota_limiter.set_write_bandwidth_limit(ReadableSize::kb(1), false);
         quota_limiter.set_max_delay_duration(ReadableDuration::millis(0));
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(false);
         sample.add_write_bytes(128);
         let should_delay = block_on(quota_limiter.consume_sample(sample, false));
         check_duration(should_delay, Duration::from_millis(125));

--- a/src/config.rs
+++ b/src/config.rs
@@ -4929,7 +4929,7 @@ mod tests {
         cfg.quota.foreground_write_bandwidth = ReadableSize::mb(256);
         assert_eq!(cfg_controller.get_current(), cfg);
 
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(true);
         sample.add_read_bytes(ReadableSize::mb(32).0 as usize);
         let should_delay = block_on(quota_limiter.consume_sample(sample, true));
         assert_eq!(should_delay, Duration::from_millis(125));
@@ -4939,7 +4939,7 @@ mod tests {
             .unwrap();
         cfg.quota.foreground_read_bandwidth = ReadableSize::mb(512);
         assert_eq!(cfg_controller.get_current(), cfg);
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(true);
         sample.add_write_bytes(ReadableSize::mb(128).0 as usize);
         let should_delay = block_on(quota_limiter.consume_sample(sample, true));
         assert_eq!(should_delay, Duration::from_millis(500));
@@ -4956,7 +4956,7 @@ mod tests {
         cfg.quota.background_write_bandwidth = ReadableSize::mb(256);
         assert_eq!(cfg_controller.get_current(), cfg);
 
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(false);
         sample.add_read_bytes(ReadableSize::mb(32).0 as usize);
         let should_delay = block_on(quota_limiter.consume_sample(sample, false));
         assert_eq!(should_delay, Duration::from_millis(125));
@@ -4966,7 +4966,7 @@ mod tests {
             .unwrap();
         cfg.quota.background_read_bandwidth = ReadableSize::mb(512);
         assert_eq!(cfg_controller.get_current(), cfg);
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(false);
         sample.add_write_bytes(ReadableSize::mb(128).0 as usize);
         let should_delay = block_on(quota_limiter.consume_sample(sample, false));
         assert_eq!(should_delay, Duration::from_millis(500));
@@ -4976,12 +4976,12 @@ mod tests {
             .unwrap();
         cfg.quota.max_delay_duration = ReadableDuration::millis(50);
         assert_eq!(cfg_controller.get_current(), cfg);
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(true);
         sample.add_write_bytes(ReadableSize::mb(128).0 as usize);
         let should_delay = block_on(quota_limiter.consume_sample(sample, true));
         assert_eq!(should_delay, Duration::from_millis(50));
 
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(false);
         sample.add_write_bytes(ReadableSize::mb(128).0 as usize);
         let should_delay = block_on(quota_limiter.consume_sample(sample, false));
         assert_eq!(should_delay, Duration::from_millis(50));

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -325,7 +325,7 @@ struct RowSampleBuilder<S: Snapshot> {
     columns_info: Vec<tipb::ColumnInfo>,
     column_groups: Vec<tipb::AnalyzeColumnGroup>,
     quota_limiter: Arc<QuotaLimiter>,
-    is_quota_auto_tune: bool,
+    is_auto_analyze: bool,
 }
 
 impl<S: Snapshot> RowSampleBuilder<S> {
@@ -359,7 +359,7 @@ impl<S: Snapshot> RowSampleBuilder<S> {
             columns_info,
             column_groups: req.take_column_groups().into(),
             quota_limiter,
-            is_quota_auto_tune,
+            is_auto_analyze: is_quota_auto_tune,
         })
     }
 
@@ -391,7 +391,7 @@ impl<S: Snapshot> RowSampleBuilder<S> {
                 time_slice_start = Instant::now();
             }
 
-            let mut sample = self.quota_limiter.new_sample();
+            let mut sample = self.quota_limiter.new_sample(!self.is_auto_analyze);
             {
                 let _guard = sample.observe_cpu();
                 let result = self.data.next_batch(BATCH_MAX_SIZE);
@@ -446,7 +446,7 @@ impl<S: Snapshot> RowSampleBuilder<S> {
 
             // Don't let analyze bandwidth limit the quota limiter, this is already limited in rate limiter.
             let quota_delay = {
-                if !self.is_quota_auto_tune {
+                if !self.is_auto_analyze {
                     self.quota_limiter.consume_sample(sample, true).await
                 } else {
                     self.quota_limiter.consume_sample(sample, false).await

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -334,7 +334,7 @@ impl<S: Snapshot> RowSampleBuilder<S> {
         storage: TiKvStorage<SnapshotStore<S>>,
         ranges: Vec<KeyRange>,
         quota_limiter: Arc<QuotaLimiter>,
-        is_quota_auto_tune: bool,
+        is_auto_analyze: bool,
     ) -> Result<Self> {
         let columns_info: Vec<_> = req.take_columns_info().into();
         if columns_info.is_empty() {
@@ -359,7 +359,7 @@ impl<S: Snapshot> RowSampleBuilder<S> {
             columns_info,
             column_groups: req.take_column_groups().into(),
             quota_limiter,
-            is_auto_analyze: is_quota_auto_tune,
+            is_auto_analyze,
         })
     }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -569,7 +569,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         let api_version = self.api_version;
 
         let quota_limiter = self.quota_limiter.clone();
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(true);
 
         let res = self.read_pool.spawn_handle(
             async move {
@@ -898,7 +898,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         let concurrency_manager = self.concurrency_manager.clone();
         let api_version = self.api_version;
         let quota_limiter = self.quota_limiter.clone();
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(true);
         let res = self.read_pool.spawn_handle(
             async move {
                 let stage_scheduled_ts = Instant::now();

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -775,7 +775,7 @@ impl<E: Engine, L: LockManager> Scheduler<E, L> {
         let ts = task.cmd.ts();
         let scheduler = self.clone();
         let quota_limiter = self.inner.quota_limiter.clone();
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(true);
         let pessimistic_lock_mode = self.pessimistic_lock_mode();
         let pipelined =
             task.cmd.can_be_pipelined() && pessimistic_lock_mode == PessimisticLockMode::Pipelined;


### PR DESCRIPTION

Signed-off-by: BornChanger <dawn_catcher@126.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #13084 

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```
Sample build didn't check if cpu quota is from foreground or background. 
So, if either cpu quota limit is set, cpu sampling would be conducted for both 
foreground and background.  It's not expected and brought overhead.  We 
need to distinguish the cpu quota limit sources.
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)
Debug to make sure no such contamination any more.

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
