### PR TITLE
*: solve the problem that test_stale_read_while_applying_snapshot is unstable

### DIFF
--- a/components/test_raftstore/src/util.rs
+++ b/components/test_raftstore/src/util.rs
@@ -688,6 +688,7 @@ pub fn configure_for_snapshot<T: Simulator>(cluster: &mut Cluster<T>) {
     cluster.cfg.raft_store.raft_log_gc_count_limit = Some(2);
     cluster.cfg.raft_store.merge_max_log_gap = 1;
     cluster.cfg.raft_store.snap_mgr_gc_tick_interval = ReadableDuration::millis(50);
+    cluster.cfg.rocksdb.writecf.level0_slowdown_writes_trigger = Some(10);
 }
 
 pub fn configure_for_merge<T: Simulator>(cluster: &mut Cluster<T>) {

--- a/components/test_raftstore/src/util.rs
+++ b/components/test_raftstore/src/util.rs
@@ -688,7 +688,6 @@ pub fn configure_for_snapshot<T: Simulator>(cluster: &mut Cluster<T>) {
     cluster.cfg.raft_store.raft_log_gc_count_limit = Some(2);
     cluster.cfg.raft_store.merge_max_log_gap = 1;
     cluster.cfg.raft_store.snap_mgr_gc_tick_interval = ReadableDuration::millis(50);
-    cluster.cfg.rocksdb.writecf.level0_slowdown_writes_trigger = Some(10);
 }
 
 pub fn configure_for_merge<T: Simulator>(cluster: &mut Cluster<T>) {


### PR DESCRIPTION
Signed-off-by: SpadeA-Tang <u6748471@anu.edu.au>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #13057

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
The test `test_stale_read_while_applying_snapshot` is fairly unstable. Althought CI can pass sometimes, In my local environment (ubuntu 20 and mac os), it often fails. This PR solves it.

### Failure reason:
The reason that it fails is that the config variables of `level0_file_num_compaction_trigger` and 
`level0_slowdown_writes_trigger` are both 4 for write cf of the kv db (Default config set None for `level0_slowdown_writes_trigger` and 4 for `level0_slowdown_writes_trigger`. None means `level0_slowdown_writes_trigger` will be set to 0 and then be set to 4 as shown below). 
![image](https://user-images.githubusercontent.com/71589810/180189577-0adb24e7-edde-41fc-b409-6c236e216ee6.png)


Due to snapshot appy, the number of level0 files of write cf can reach at most to 3 in this test which trigers flow control as 3 > 4/2 (the code shown below) and skip `handle_apply`.  
![image](https://user-images.githubusercontent.com/71589810/180176820-19b912a5-8f33-48e3-8c8e-b30c90eeea19.png)

What makes it even worse is that files number 3 will not triger compaction. So it will never call `handle_apply`. It means `safe_ts` will be 0 forever which makes the test fail (`safe_ts` will be 0 when applying snapshot).

So, `level0_slowdown_writes_trigger` / 2 shold be larger or equal to `level0_file_num_compaction_trigger` - 1.

### Solution

To be simple, set an appropriate value for `level0_slowdown_writes_trigger`.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
```
