### PR TITLE
pd-client:  pd client should update if the grpc stream sender failed.

### DIFF
--- a/components/error_code/src/pd.rs
+++ b/components/error_code/src/pd.rs
@@ -8,6 +8,7 @@ define_error_codes!(
     CLUSTER_NOT_BOOTSTRAPPED => ("ClusterNotBootstraped", "", ""),
     INCOMPATIBLE => ("Imcompatible", "", ""),
     GRPC => ("gRPC", "", ""),
+    STREAM_DISCONNECT => ("STREAM_DISCONNECT","",""),
     REGION_NOT_FOUND => ("RegionNotFound", "", ""),
     STORE_TOMBSTONE => ("StoreTombstone", "", ""),
     GLOBAL_CONFIG_NOT_FOUND => ("GlobalConfigNotFound","",""),

--- a/components/error_code/src/pd.rs
+++ b/components/error_code/src/pd.rs
@@ -8,7 +8,7 @@ define_error_codes!(
     CLUSTER_NOT_BOOTSTRAPPED => ("ClusterNotBootstraped", "", ""),
     INCOMPATIBLE => ("Imcompatible", "", ""),
     GRPC => ("gRPC", "", ""),
-    STREAM_DISCONNECT => ("STREAM_DISCONNECT","",""),
+    STREAM_DISCONNECT => ("StreamDisconnect","",""),
     REGION_NOT_FOUND => ("RegionNotFound", "", ""),
     STORE_TOMBSTONE => ("StoreTombstone", "", ""),
     GLOBAL_CONFIG_NOT_FOUND => ("GlobalConfigNotFound","",""),

--- a/components/pd_client/src/client.rs
+++ b/components/pd_client/src/client.rs
@@ -619,7 +619,7 @@ impl PdClient for RpcClient {
                             if last > last_report {
                                 last_report = last - 1;
                             }
-                            fail::fail_point!("region_heartbeat_send_failed", |_|{ 
+                            fail::fail_point!("region_heartbeat_send_failed", |_| {
                                 Err(Error::Grpc(grpcio::Error::RemoteStopped))
                             });
                             Ok((r, WriteFlags::default()))
@@ -646,10 +646,8 @@ impl PdClient for RpcClient {
                 .expect("expect region heartbeat sender");
             let ret = sender
                 .unbounded_send(req)
-                .map_err(|e|{
-                    Error::StreamDisconnect(e.into_send_error())
-                });
-                   
+                .map_err(|e| Error::StreamDisconnect(e.into_send_error()));
+
             Box::pin(future::ready(ret)) as PdFuture<_>
         };
 
@@ -1054,8 +1052,7 @@ impl PdClient for RpcClient {
                 .expect("expect region buckets sender");
             let ret = sender
                 .unbounded_send(req)
-                .map_err(|e|
-                    Error::StreamDisconnect(e.into_send_error()));
+                .map_err(|e| Error::StreamDisconnect(e.into_send_error()));
             Box::pin(future::ready(ret)) as PdFuture<_>
         };
 

--- a/components/pd_client/src/client.rs
+++ b/components/pd_client/src/client.rs
@@ -647,7 +647,7 @@ impl PdClient for RpcClient {
             let ret = sender
                 .unbounded_send(req)
                 .map_err(|e|{
-                    Error::SteamDisconnect(e.into_send_error())
+                    Error::StreamDisconnect(e.into_send_error())
                 });
                    
             Box::pin(future::ready(ret)) as PdFuture<_>
@@ -1055,7 +1055,7 @@ impl PdClient for RpcClient {
             let ret = sender
                 .unbounded_send(req)
                 .map_err(|e|
-                    Error::SteamDisconnect(e.into_send_error()));
+                    Error::StreamDisconnect(e.into_send_error()));
             Box::pin(future::ready(ret)) as PdFuture<_>
         };
 

--- a/components/pd_client/src/errors.rs
+++ b/components/pd_client/src/errors.rs
@@ -3,7 +3,7 @@
 use std::{error, result};
 
 use error_code::{self, ErrorCode, ErrorCodeExt};
-use futures::channel::mpsc::{SendError};
+use futures::channel::mpsc::SendError;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -17,7 +17,7 @@ pub enum Error {
     #[error("{0}")]
     Grpc(#[from] grpcio::Error),
     #[error("{0}")]
-    StreamDisconnect (#[from] SendError),
+    StreamDisconnect(#[from] SendError),
     #[error("unknown error {0:?}")]
     Other(#[from] Box<dyn error::Error + Sync + Send>),
     #[error("region is not found for key {}", log_wrappers::Value::key(.0))]
@@ -33,9 +33,9 @@ pub type Result<T> = result::Result<T, Error>;
 impl Error {
     pub fn retryable(&self) -> bool {
         match self {
-            Error::Grpc(_) | Error::ClusterNotBootstrapped(_)|Error::StreamDisconnect(_) => true,
+            Error::Grpc(_) | Error::ClusterNotBootstrapped(_) | Error::StreamDisconnect(_) => true,
             Error::Other(_)
-            |Error::RegionNotFound(_)
+            | Error::RegionNotFound(_)
             | Error::StoreTombstone(_)
             | Error::GlobalConfigNotFound(_)
             | Error::ClusterBootstrapped(_)

--- a/components/pd_client/src/errors.rs
+++ b/components/pd_client/src/errors.rs
@@ -3,6 +3,7 @@
 use std::{error, result};
 
 use error_code::{self, ErrorCode, ErrorCodeExt};
+use futures::channel::mpsc::{SendError};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -15,6 +16,8 @@ pub enum Error {
     Incompatible,
     #[error("{0}")]
     Grpc(#[from] grpcio::Error),
+    #[error("{0}")]
+    SteamDisconnect(#[from]SendError),
     #[error("unknown error {0:?}")]
     Other(#[from] Box<dyn error::Error + Sync + Send>),
     #[error("region is not found for key {}", log_wrappers::Value::key(.0))]
@@ -30,9 +33,9 @@ pub type Result<T> = result::Result<T, Error>;
 impl Error {
     pub fn retryable(&self) -> bool {
         match self {
-            Error::Grpc(_) | Error::ClusterNotBootstrapped(_) => true,
+            Error::Grpc(_) | Error::ClusterNotBootstrapped(_)|Error::SteamRpcDisconnect(_) => true,
             Error::Other(_)
-            | Error::RegionNotFound(_)
+            |Error::RegionNotFound(_)
             | Error::StoreTombstone(_)
             | Error::GlobalConfigNotFound(_)
             | Error::ClusterBootstrapped(_)
@@ -48,6 +51,7 @@ impl ErrorCodeExt for Error {
             Error::ClusterNotBootstrapped(_) => error_code::pd::CLUSTER_NOT_BOOTSTRAPPED,
             Error::Incompatible => error_code::pd::INCOMPATIBLE,
             Error::Grpc(_) => error_code::pd::GRPC,
+            Error::SteamDisconnect(_) => error_code::pd::STREAM_DISCONNECT,
             Error::RegionNotFound(_) => error_code::pd::REGION_NOT_FOUND,
             Error::StoreTombstone(_) => error_code::pd::STORE_TOMBSTONE,
             Error::GlobalConfigNotFound(_) => error_code::pd::GLOBAL_CONFIG_NOT_FOUND,

--- a/components/pd_client/src/errors.rs
+++ b/components/pd_client/src/errors.rs
@@ -17,7 +17,7 @@ pub enum Error {
     #[error("{0}")]
     Grpc(#[from] grpcio::Error),
     #[error("{0}")]
-    SteamDisconnect(#[from]SendError),
+    StreamDisconnect (#[from] SendError),
     #[error("unknown error {0:?}")]
     Other(#[from] Box<dyn error::Error + Sync + Send>),
     #[error("region is not found for key {}", log_wrappers::Value::key(.0))]
@@ -33,7 +33,7 @@ pub type Result<T> = result::Result<T, Error>;
 impl Error {
     pub fn retryable(&self) -> bool {
         match self {
-            Error::Grpc(_) | Error::ClusterNotBootstrapped(_)|Error::SteamRpcDisconnect(_) => true,
+            Error::Grpc(_) | Error::ClusterNotBootstrapped(_)|Error::StreamDisconnect(_) => true,
             Error::Other(_)
             |Error::RegionNotFound(_)
             | Error::StoreTombstone(_)
@@ -51,7 +51,7 @@ impl ErrorCodeExt for Error {
             Error::ClusterNotBootstrapped(_) => error_code::pd::CLUSTER_NOT_BOOTSTRAPPED,
             Error::Incompatible => error_code::pd::INCOMPATIBLE,
             Error::Grpc(_) => error_code::pd::GRPC,
-            Error::SteamDisconnect(_) => error_code::pd::STREAM_DISCONNECT,
+            Error::StreamDisconnect(_) => error_code::pd::STREAM_DISCONNECT,
             Error::RegionNotFound(_) => error_code::pd::REGION_NOT_FOUND,
             Error::StoreTombstone(_) => error_code::pd::STORE_TOMBSTONE,
             Error::GlobalConfigNotFound(_) => error_code::pd::GLOBAL_CONFIG_NOT_FOUND,

--- a/components/test_pd/src/mocker/service.rs
+++ b/components/test_pd/src/mocker/service.rs
@@ -238,6 +238,7 @@ impl PdMocker for Service {
             .insert(region_id, req.get_leader().clone());
 
         let mut resp = RegionHeartbeatResponse::default();
+        resp.set_region_id(req.get_region().get_id());
         let header = Service::header();
         resp.set_header(header);
         Some(Ok(resp))

--- a/tests/integrations/pd/test_rpc_client.rs
+++ b/tests/integrations/pd/test_rpc_client.rs
@@ -476,6 +476,62 @@ fn test_change_leader_async() {
 }
 
 #[test]
+fn test_pd_client_heartbeat_send_failed(){
+    let pd_client_send_fail_fp = "region_heartbeat_send_failed";
+    fail::cfg(pd_client_send_fail_fp, "return()").unwrap();
+    let server = MockServer::with_case(1,Arc::new(AlreadyBootstrapped));
+    let eps = server.bind_addrs();
+
+    let client = new_client(eps, None);
+    let poller = Builder::new_multi_thread()
+        .thread_name(thd_name!("poller"))
+        .worker_threads(1)
+        .build()
+        .unwrap();
+    let (tx, rx) = mpsc::channel();
+    let f = client.handle_region_heartbeat_response(1, move |resp| {
+        tx.send(resp).unwrap_or_default()
+    });
+    poller.spawn(f);
+
+    let heartbeat_send_fail = |ok| {
+        let mut region = metapb::Region::default();
+        region.set_id(1);
+        let peer = metapb::Peer::default();
+        let stat = RegionStat::default();
+        poller.spawn(client.region_heartbeat(
+            store::RAFT_INIT_LOG_TERM,
+            region.clone(),
+            peer.clone(),
+            stat.clone(),
+            None,
+        ));
+        let rsp=rx.recv_timeout(Duration::from_millis(100));
+        if ok{
+            assert!(rsp.is_ok());
+            assert_eq!(rsp.unwrap().get_region_id(),1);
+        }else{
+            assert!(rsp.is_err());
+        }
+       
+        let region = block_on(client.get_region_by_id(1));
+        if ok{
+            assert!(region.is_ok());
+            let r=region.unwrap();
+            assert!(r.is_some());
+            assert_eq!(1,r.unwrap().get_id());
+        }else{
+            assert!(region.is_err());
+        }
+    };
+    // send fail if network is block.
+    heartbeat_send_fail(false);
+    fail::remove(pd_client_send_fail_fp);
+    // send success after network recovered.
+    heartbeat_send_fail(true);
+}
+
+#[test]
 fn test_region_heartbeat_on_leader_change() {
     let eps_count = 3;
     let server = MockServer::with_case(eps_count, Arc::new(LeaderChange::new()));


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #12934

What's Changed: the error should be  retryable error instead of unkown , this  unkown error will not retry update pd client if the sender failed. 

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test
- Manual test (add detailed scripts or steps below)


Side effects


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
fix the bug that the consume should be refresh if region heartbeat send failed.
```
