### PR TITLE
log-backup: unify namespace for log backup metrics

### DIFF
--- a/components/backup-stream/src/metrics.rs
+++ b/components/backup-stream/src/metrics.rs
@@ -44,31 +44,31 @@ lazy_static! {
     )
     .unwrap();
     pub static ref HANDLE_EVENT_DURATION_HISTOGRAM: HistogramVec = register_histogram_vec!(
-        "tikv_stream_event_handle_duration_sec",
+        "tikv_log_backup_event_handle_duration_sec",
         "The duration of handling an cmd batch.",
         &["stage"],
         exponential_buckets(0.001, 2.0, 16).unwrap()
     )
     .unwrap();
     pub static ref HANDLE_KV_HISTOGRAM: Histogram = register_histogram!(
-        "tikv_stream_handle_kv_batch",
+        "tikv_log_backup_handle_kv_batch",
         "The total kv pair change handle by the stream backup",
         exponential_buckets(1.0, 2.0, 16).unwrap()
     )
     .unwrap();
     pub static ref INCREMENTAL_SCAN_SIZE: Histogram = register_histogram!(
-        "tikv_stream_incremental_scan_bytes",
+        "tikv_log_backup_incremental_scan_bytes",
         "The size of scanning.",
         exponential_buckets(64.0, 2.0, 16).unwrap()
     )
     .unwrap();
     pub static ref SKIP_KV_COUNTER: Counter = register_counter!(
-        "tikv_stream_skip_kv_count",
+        "tikv_log_backup_skip_kv_count",
         "The total kv size skipped by the streaming",
     )
     .unwrap();
     pub static ref STREAM_ERROR: IntCounterVec = register_int_counter_vec!(
-        "tikv_stream_errors",
+        "tikv_log_backup_errors",
         "The errors during stream backup.",
         &["type"]
     )
@@ -80,61 +80,61 @@ lazy_static! {
     )
     .unwrap();
     pub static ref HEAP_MEMORY: IntGauge = register_int_gauge!(
-        "tikv_stream_heap_memory",
+        "tikv_log_backup_heap_memory",
         "The heap memory allocating by stream backup."
     )
     .unwrap();
     pub static ref ON_EVENT_COST_HISTOGRAM: HistogramVec = register_histogram_vec!(
-        "tikv_stream_on_event_duration_seconds",
+        "tikv_log_backup_on_event_duration_seconds",
         "The time cost of handling events.",
         &["stage"],
         exponential_buckets(0.001, 2.0, 16).unwrap()
     )
     .unwrap();
     pub static ref STORE_CHECKPOINT_TS: IntGaugeVec = register_int_gauge_vec!(
-        "tikv_stream_store_checkpoint_ts",
+        "tikv_log_backup_store_checkpoint_ts",
         "The checkpoint ts (next backup ts) of task",
         &["task"],
     )
     .unwrap();
     pub static ref FLUSH_DURATION: HistogramVec = register_histogram_vec!(
-        "tikv_stream_flush_duration_sec",
+        "tikv_log_backup_flush_duration_sec",
         "The time cost of flushing a task.",
         &["stage"],
         exponential_buckets(1.0, 2.0, 16).unwrap()
     )
     .unwrap();
     pub static ref FLUSH_FILE_SIZE: Histogram = register_histogram!(
-        "tikv_stream_flush_file_size",
+        "tikv_log_backup_flush_file_size",
         "Some statistics of flushing of this run.",
         exponential_buckets(1024.0, 2.0, 16).unwrap()
     )
     .unwrap();
     pub static ref INITIAL_SCAN_DURATION: Histogram = register_histogram!(
-        "tikv_stream_initial_scan_duration_sec",
+        "tikv_log_backup_initial_scan_duration_sec",
         "The duration of initial scanning.",
         exponential_buckets(0.001, 2.0, 16).unwrap()
     )
     .unwrap();
     pub static ref SKIP_RETRY: IntCounterVec = register_int_counter_vec!(
-        "tikv_stream_skip_retry_observe",
+        "tikv_log_backup_skip_retry_observe",
         "The reason of giving up observing region when meeting error.",
         &["reason"],
     )
     .unwrap();
     pub static ref INITIAL_SCAN_STAT: IntCounterVec = register_int_counter_vec!(
-        "tikv_stream_initial_scan_operations",
+        "tikv_log_backup_initial_scan_operations",
         "The operations over rocksdb during initial scanning.",
         &["cf", "op"],
     )
     .unwrap();
     pub static ref STREAM_ENABLED: IntCounter = register_int_counter!(
-        "tikv_stream_enabled",
+        "tikv_log_backup_enabled",
         "When gt 0, this node enabled streaming."
     )
     .unwrap();
     pub static ref TRACK_REGION: IntGauge = register_int_gauge!(
-        "tikv_stream_observed_region",
+        "tikv_log_backup_observed_region",
         "the region being observed by the current store.",
     )
     .unwrap();
@@ -145,7 +145,7 @@ lazy_static! {
     )
     .unwrap();
     pub static ref PENDING_INITIAL_SCAN_LEN: IntGaugeVec = register_int_gauge_vec!(
-        "tikv_pending_initial_scan",
+        "tikv_log_backup_pending_initial_scan",
         "The pending initial scan",
         &["stage"]
     )

--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -40199,7 +40199,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "tikv_stream_enabled{instance=~\"$instance\"}",
+              "expr": "tikv_log_backup_enabled{instance=~\"$instance\"}",
               "instant": true,
               "interval": "",
               "legendFormat": "{{ instance }}",
@@ -40261,7 +40261,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(tikv_stream_flush_file_size_sum{instance=~\"$instance\"}[30m]) / on(instance) increase(tikv_stream_flush_duration_sec_count{stage=~\"save_files\",instance=~\"$instance\"}[30m])",
+              "expr": "increase(tikv_log_backup_flush_file_size_sum{instance=~\"$instance\"}[30m]) / on(instance) increase(tikv_log_backup_flush_duration_sec_count{stage=~\"save_files\",instance=~\"$instance\"}[30m])",
               "hide": false,
               "instant": true,
               "interval": "",
@@ -40322,7 +40322,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "round(increase(tikv_stream_flush_file_size_count{instance=~\"$instance\"}[30m]))",
+              "expr": "round(increase(tikv_log_backup_flush_file_size_count{instance=~\"$instance\"}[30m]))",
               "instant": true,
               "interval": "",
               "legendFormat": "{{ instance }}",
@@ -40383,7 +40383,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "round(sum(increase(tikv_stream_flush_duration_sec_count{stage=~\"save_files\",instance=~\"$instance\"}[30m])))",
+              "expr": "round(sum(increase(tikv_log_backup_flush_duration_sec_count{stage=~\"save_files\",instance=~\"$instance\"}[30m])))",
               "hide": false,
               "instant": true,
               "interval": "",
@@ -40444,7 +40444,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(increase(tikv_stream_flush_file_size_sum{instance=~\"$instance\"}[30m]))",
+              "expr": "sum(increase(tikv_log_backup_flush_file_size_sum{instance=~\"$instance\"}[30m]))",
               "hide": false,
               "instant": true,
               "interval": "",
@@ -40663,7 +40663,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "round(sum(increase(tikv_stream_flush_file_size_count{instance=~\"$instance\"}[30m])))",
+              "expr": "round(sum(increase(tikv_log_backup_flush_file_size_count{instance=~\"$instance\"}[30m])))",
               "hide": false,
               "instant": true,
               "interval": "",
@@ -40840,7 +40840,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "rate(tikv_stream_handle_kv_batch_sum{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])",
+              "expr": "rate(tikv_log_backup_handle_kv_batch_sum{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -40941,7 +40941,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "rate(tikv_stream_incremental_scan_bytes_sum{instance=~\"$instance\"}[$__rate_interval])",
+              "expr": "rate(tikv_log_backup_incremental_scan_bytes_sum{instance=~\"$instance\"}[$__rate_interval])",
               "interval": "",
               "intervalFactor": 2,
               "legendFormat": "{{instance}}",
@@ -41193,7 +41193,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "tikv_stream_heap_memory{instance=~\"$instance\"}",
+              "expr": "tikv_log_backup_heap_memory{instance=~\"$instance\"}",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -41298,7 +41298,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "tikv_stream_observed_region{instance=~\"$instance\"}",
+              "expr": "tikv_log_backup_observed_region{instance=~\"$instance\"}",
               "interval": "",
               "intervalFactor": 2,
               "legendFormat": "{{instance}}",
@@ -41307,7 +41307,7 @@
             },
             {
               "exemplar": true,
-              "expr": "sum(tikv_stream_observed_region{instance=~\"$instance\"})",
+              "expr": "sum(tikv_log_backup_observed_region{instance=~\"$instance\"})",
               "hide": false,
               "interval": "",
               "legendFormat": "total",
@@ -41407,7 +41407,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "increase(tikv_stream_errors{instance=~\"$instance\"}[$__interval])",
+              "expr": "increase(tikv_log_backup_errors{instance=~\"$instance\"}[$__interval])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -41418,7 +41418,7 @@
             },
             {
               "exemplar": true,
-              "expr": "tikv_stream_errors{instance=~\"$instance\"}",
+              "expr": "tikv_log_backup_errors{instance=~\"$instance\"}",
               "hide": true,
               "interval": "1m",
               "intervalFactor": 2,
@@ -41752,7 +41752,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(increase(tikv_stream_flush_duration_sec_bucket{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", stage=~\"save_files\"}[$__interval])) by (le)",
+              "expr": "sum(increase(tikv_log_backup_flush_duration_sec_bucket{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", stage=~\"save_files\"}[$__interval])) by (le)",
               "format": "heatmap",
               "instant": false,
               "interval": "",
@@ -41835,7 +41835,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(increase(tikv_stream_initial_scan_duration_sec_bucket{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[$__interval])) by (le)",
+              "expr": "sum(increase(tikv_log_backup_initial_scan_duration_sec_bucket{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[$__interval])) by (le)",
               "format": "heatmap",
               "instant": false,
               "interval": "",
@@ -41918,7 +41918,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(increase(tikv_stream_event_handle_duration_sec_bucket{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", stage=~\"to_stream_event\"}[$__interval])) by (le)",
+              "expr": "sum(increase(tikv_log_backup_event_handle_duration_sec_bucket{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", stage=~\"to_stream_event\"}[$__interval])) by (le)",
               "format": "heatmap",
               "instant": false,
               "interval": "",
@@ -42001,7 +42001,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(increase(tikv_stream_event_handle_duration_sec_bucket{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", stage=~\"get_router_lock\"}[$__interval])) by (le)",
+              "expr": "sum(increase(tikv_log_backup_event_handle_duration_sec_bucket{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", stage=~\"get_router_lock\"}[$__interval])) by (le)",
               "format": "heatmap",
               "instant": false,
               "interval": "",
@@ -42084,7 +42084,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(increase(tikv_stream_handle_kv_batch_bucket{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[$__interval])) by (le)",
+              "expr": "sum(increase(tikv_log_backup_handle_kv_batch_bucket{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[$__interval])) by (le)",
               "format": "heatmap",
               "instant": false,
               "interval": "",
@@ -42167,7 +42167,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(increase(tikv_stream_event_handle_duration_sec_bucket{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", stage=~\"save_to_temp_file\"}[$__interval])) by (le)",
+              "expr": "sum(increase(tikv_log_backup_event_handle_duration_sec_bucket{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", stage=~\"save_to_temp_file\"}[$__interval])) by (le)",
               "format": "heatmap",
               "instant": false,
               "interval": "",
@@ -42250,7 +42250,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(increase(tikv_stream_on_event_duration_seconds_bucket{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", stage=\"write_to_tempfile\"}[$__interval])) by (le)",
+              "expr": "sum(increase(tikv_log_backup_on_event_duration_seconds_bucket{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", stage=\"write_to_tempfile\"}[$__interval])) by (le)",
               "format": "heatmap",
               "instant": false,
               "interval": "",
@@ -42333,7 +42333,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(increase(tikv_stream_on_event_duration_seconds_bucket{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", stage=\"syscall_write\"}[$__interval])) by (le)",
+              "expr": "sum(increase(tikv_log_backup_on_event_duration_seconds_bucket{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", stage=\"syscall_write\"}[$__interval])) by (le)",
               "format": "heatmap",
               "instant": false,
               "interval": "",
@@ -42716,7 +42716,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(rate(tikv_stream_initial_scan_operations{instance=~\"$instance\", op=~\"read_bytes\"}[$__rate_interval])) BY (op, cf)",
+              "expr": "sum(rate(tikv_log_backup_initial_scan_operations{instance=~\"$instance\", op=~\"read_bytes\"}[$__rate_interval])) BY (op, cf)",
               "interval": "",
               "legendFormat": "{{ cf }}",
               "queryType": "randomWalk",
@@ -42815,7 +42815,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(rate(tikv_stream_initial_scan_operations{instance=~\"$instance\", op!~\"read_bytes\"}[$__rate_interval])) BY (op, cf) > 0",
+              "expr": "sum(rate(tikv_log_backup_initial_scan_operations{instance=~\"$instance\", op!~\"read_bytes\"}[$__rate_interval])) BY (op, cf) > 0",
               "interval": "",
               "legendFormat": "{{ cf }}/{{ op }}",
               "queryType": "randomWalk",


### PR DESCRIPTION
Signed-off-by: Yu Juncen <yujuncen@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #12534 

What's Changed:
We have renamed the feature `backup stream` into `log backup`, however some of metrics keep the old name.
This PR has unified all the metrics of `backup-stream` with the namespace `log_bakcup`.

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Renamed metrics in `backup-stream`:
tikv_stream_(.*) => tikv_log_backup_$1
tikv_pending_initial_scan => tikv_log_backup_initial_scan
```

### Related changes

- PR to update `tidb`:
(TBD)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
- No code

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
All log backup related series has the prefix `tikv_log_backup` now.
```
