### PR TITLE
raftstorev2: fix cached tablet bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ dependencies = [
  "codec",
  "engine_traits",
  "kvproto",
- "match_template",
+ "match-template",
  "panic_hook",
  "thiserror",
  "tikv_alloc",
@@ -2852,8 +2852,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e88c3cbe8288f77f293e48a28b3232e3defd203a6d839fa7f68ea4329e83464"
 
 [[package]]
-name = "match_template"
+name = "match-template"
 version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c334ac67725febd94c067736ac46ef1c7cacf1c743ca14b9f917c2df2c20acd8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5827,7 +5829,7 @@ dependencies = [
 name = "tidb_query_aggr"
 version = "0.0.1"
 dependencies = [
- "match_template",
+ "match-template",
  "panic_hook",
  "tidb_query_codegen",
  "tidb_query_common",
@@ -5886,7 +5888,7 @@ dependencies = [
  "kvproto",
  "lazy_static",
  "log_wrappers",
- "match_template",
+ "match-template",
  "nom 5.1.0",
  "num 0.3.0",
  "num-derive",
@@ -5918,7 +5920,7 @@ dependencies = [
  "itertools",
  "kvproto",
  "log_wrappers",
- "match_template",
+ "match-template",
  "protobuf",
  "slog",
  "slog-global",
@@ -5947,7 +5949,7 @@ dependencies = [
  "flate2",
  "hex 0.4.2",
  "log_wrappers",
- "match_template",
+ "match-template",
  "num 0.3.0",
  "num-traits",
  "openssl",
@@ -6024,7 +6026,7 @@ dependencies = [
  "libloading",
  "log",
  "log_wrappers",
- "match_template",
+ "match-template",
  "memory_trace_macros",
  "mime",
  "more-asserts",

--- a/components/raftstore-v2/src/batch/apply.rs
+++ b/components/raftstore-v2/src/batch/apply.rs
@@ -50,15 +50,17 @@ pub struct ApplyPoller {
 
 impl ApplyPoller {
     pub fn new(apply_ctx: ApplyContext, cfg_tracker: Tracker<Config>) -> ApplyPoller {
-        ApplyPoller {
+        let mut poller = ApplyPoller {
             apply_task_buf: Vec::new(),
             pending_latency_inspect: Vec::new(),
             apply_ctx,
             cfg_tracker,
-        }
+        };
+        poller.apply_buf_capacity();
+        poller
     }
 
-    /// Updates the internal buffer to latest capacity.
+    /// Updates the internal buffer to match the latest configuration.
     fn apply_buf_capacity(&mut self) {
         let new_cap = self.messages_per_tick();
         tikv_util::set_vec_capacity(&mut self.apply_task_buf, new_cap);

--- a/components/raftstore-v2/src/batch/apply.rs
+++ b/components/raftstore-v2/src/batch/apply.rs
@@ -50,14 +50,12 @@ pub struct ApplyPoller {
 
 impl ApplyPoller {
     pub fn new(apply_ctx: ApplyContext, cfg_tracker: Tracker<Config>) -> ApplyPoller {
-        let mut poller = ApplyPoller {
+        ApplyPoller {
             apply_task_buf: Vec::new(),
             pending_latency_inspect: Vec::new(),
             apply_ctx,
             cfg_tracker,
-        };
-        poller.apply_buf_capacity();
-        poller
+        }
     }
 
     /// Updates the internal buffer to match the latest configuration.

--- a/components/raftstore-v2/src/batch/apply.rs
+++ b/components/raftstore-v2/src/batch/apply.rs
@@ -50,7 +50,7 @@ pub struct ApplyPoller {
 
 impl ApplyPoller {
     pub fn new(apply_ctx: ApplyContext, cfg_tracker: Tracker<Config>) -> ApplyPoller {
-        ApplyPoller {
+        Self {
             apply_task_buf: Vec::new(),
             pending_latency_inspect: Vec::new(),
             apply_ctx,

--- a/components/raftstore-v2/src/batch/store.rs
+++ b/components/raftstore-v2/src/batch/store.rs
@@ -64,7 +64,7 @@ struct StorePoller<EK: KvEngine, T> {
 
 impl<EK: KvEngine, T> StorePoller<EK, T> {
     pub fn new(poll_ctx: StoreContext<T>, cfg_tracker: Tracker<Config>) -> Self {
-        StorePoller {
+        Self {
             store_msg_buf: Vec::new(),
             peer_msg_buf: Vec::new(),
             poll_ctx,

--- a/components/raftstore-v2/src/batch/store.rs
+++ b/components/raftstore-v2/src/batch/store.rs
@@ -64,16 +64,14 @@ struct StorePoller<EK: KvEngine, T> {
 
 impl<EK: KvEngine, T> StorePoller<EK, T> {
     pub fn new(poll_ctx: StoreContext<T>, cfg_tracker: Tracker<Config>) -> Self {
-        let mut poller = Self {
+        StorePoller {
             store_msg_buf: Vec::new(),
             peer_msg_buf: Vec::new(),
             poll_ctx,
             cfg_tracker,
             last_flush_time: TiInstant::now(),
             need_flush_events: false,
-        };
-        poller.apply_buf_capacity();
-        poller
+        }
     }
 
     /// Updates the internal buffer to match the latest configuration.

--- a/components/raftstore-v2/src/batch/store.rs
+++ b/components/raftstore-v2/src/batch/store.rs
@@ -26,7 +26,7 @@ use crate::{
     Error, PeerMsg, PeerTick, Result, StoreMsg,
 };
 
-/// A per thread context used for handling raft messages.
+/// A per-thread context used for handling raft messages.
 pub struct StoreContext<T> {
     /// A logger without any KV. It's clean for creating new PeerFSM.
     pub logger: Logger,
@@ -76,7 +76,7 @@ impl<EK: KvEngine, T> StorePoller<EK, T> {
         poller
     }
 
-    /// Updates the internal buffer to latest capacity.
+    /// Updates the internal buffer to match the latest configuration.
     fn apply_buf_capacity(&mut self) {
         let new_cap = self.messages_per_tick();
         tikv_util::set_vec_capacity(&mut self.store_msg_buf, new_cap);
@@ -119,6 +119,7 @@ impl<EK: KvEngine, ER: RaftEngine, T: Transport + 'static> PollHandler<PeerFsm<E
     }
 
     fn handle_control(&mut self, store: &mut StoreFsm) -> Option<usize> {
+        debug_assert!(self.store_msg_buf.is_empty());
         let received_cnt = store.recv(&mut self.store_msg_buf);
         let expected_msg_count = if received_cnt == self.messages_per_tick() {
             None
@@ -134,6 +135,7 @@ impl<EK: KvEngine, ER: RaftEngine, T: Transport + 'static> PollHandler<PeerFsm<E
         &mut self,
         peer: &mut impl DerefMut<Target = PeerFsm<EK, ER>>,
     ) -> HandleResult {
+        debug_assert!(self.peer_msg_buf.is_empty());
         let received_cnt = peer.recv(&mut self.peer_msg_buf);
         let handle_result = if received_cnt == self.messages_per_tick() {
             HandleResult::KeepProcessing
@@ -203,7 +205,7 @@ impl<EK: KvEngine, ER: RaftEngine, T> StorePollerBuilder<EK, ER, T> {
         }
     }
 
-    /// Init all the existing raft machine and cleanup stale tablets.
+    /// Initializes all the existing raft machines and cleanup stale tablets.
     fn init(&self) -> Result<HashMap<u64, SenderFsmPair<EK, ER>>> {
         let mut regions = HashMap::default();
         let cfg = self.cfg.value();
@@ -328,7 +330,7 @@ impl<EK: KvEngine, ER: RaftEngine> StoreSystem<EK, ER> {
 
 pub type StoreRouter<EK, ER> = BatchRouter<PeerFsm<EK, ER>, StoreFsm>;
 
-/// Create the batch system for polling raft activities.
+/// Creates the batch system for polling raft activities.
 pub fn create_store_batch_system<EK, ER>(
     cfg: &Config,
     store: Store,

--- a/components/raftstore-v2/src/fsm/apply.rs
+++ b/components/raftstore-v2/src/fsm/apply.rs
@@ -26,7 +26,8 @@ impl<EK: KvEngine> ApplyFsm<EK> {
         )
     }
 
-    /// Fetches tasks to `apply_task_buf`. It will stop when the buffer is full.
+    /// Fetches messages to `apply_task_buf`. It will stop when the buffer
+    /// capacity is reached or there is no more pending messages.
     ///
     /// Returns how many messages are fetched.
     pub fn recv(&mut self, apply_task_buf: &mut Vec<ApplyTask>) -> usize {

--- a/components/raftstore-v2/src/fsm/peer.rs
+++ b/components/raftstore-v2/src/fsm/peer.rs
@@ -47,7 +47,8 @@ impl<EK: KvEngine, ER: RaftEngine> PeerFsm<EK, ER> {
         self.peer.logger()
     }
 
-    /// Fetches messages to `peer_msg_buf`. It will stop when the buffer is full.
+    /// Fetches messages to `peer_msg_buf`. It will stop when the buffer
+    /// capacity is reached or there is no more pending messages.
     ///
     /// Returns how many messages are fetched.
     pub fn recv(&mut self, peer_msg_buf: &mut Vec<PeerMsg<EK>>) -> usize {

--- a/components/raftstore-v2/src/fsm/store.rs
+++ b/components/raftstore-v2/src/fsm/store.rs
@@ -23,7 +23,8 @@ impl StoreFsm {
         (tx, fsm)
     }
 
-    /// Fetches messages to `store_msg_buf`. It will stop when the buffer is full.
+    /// Fetches messages to `store_msg_buf`. It will stop when the buffer
+    /// capacity is reached or there is no more pending messages.
     ///
     /// Returns how many messages are fetched.
     pub fn recv(&self, store_msg_buf: &mut Vec<StoreMsg>) -> usize {

--- a/components/raftstore-v2/src/raft/peer.rs
+++ b/components/raftstore-v2/src/raft/peer.rs
@@ -25,7 +25,7 @@ pub struct Peer<EK: KvEngine, ER: RaftEngine> {
 impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
     /// Creates a new peer.
     ///
-    /// If peer is destroyed, None is returned.
+    /// If peer is destroyed, `None` is returned.
     pub fn new(
         cfg: &Config,
         region_id: u64,

--- a/components/raftstore-v2/src/raft/storage.rs
+++ b/components/raftstore-v2/src/raft/storage.rs
@@ -58,8 +58,8 @@ pub struct Storage<ER> {
 impl<ER: RaftEngine> Storage<ER> {
     /// Creates a new storage.
     ///
-    /// All metadata should be initialized before calling this method. If the region is destroyed
-    /// `None` will be returned.
+    /// All metadata should be initialized before calling this method. If the
+    /// region is destroyed, `None` will be returned.
     pub fn new(
         region_id: u64,
         store_id: u64,

--- a/components/raftstore-v2/src/tablet.rs
+++ b/components/raftstore-v2/src/tablet.rs
@@ -76,14 +76,14 @@ mod tests {
         // Setting tablet will refresh cache immediately.
         cached_tablet.set(2);
         assert_eq!(cached_tablet.cache().cloned(), Some(2));
+
         // Test `latest()` will use cache.
-        {
-            // Unsafe modify the data.
-            *cached_tablet.latest.data.lock().unwrap() = Some(0);
-            assert_eq!(cached_tablet.latest().cloned(), Some(2));
-            // Restore the data.
-            *cached_tablet.latest.data.lock().unwrap() = Some(2);
-        }
+        // Unsafe modify the data.
+        let old_data = *cached_tablet.latest.data.lock().unwrap();
+        *cached_tablet.latest.data.lock().unwrap() = Some(0);
+        assert_eq!(cached_tablet.latest().cloned(), old_data);
+        // Restore the data.
+        *cached_tablet.latest.data.lock().unwrap() = old_data;
 
         let mut cloned = cached_tablet.clone();
         // Clone should reuse cache.

--- a/components/raftstore-v2/src/tablet.rs
+++ b/components/raftstore-v2/src/tablet.rs
@@ -33,12 +33,12 @@ impl<EK: Clone> CachedTablet<EK> {
     }
 
     pub fn set(&mut self, data: EK) {
-        let mut guard = self.latest.data.lock().unwrap();
-        *guard = Some(data.clone());
-        let v = self.latest.version.fetch_add(1, Ordering::Relaxed);
-        drop(guard);
+        self.version = {
+            let mut latest_data = self.latest.data.lock().unwrap();
+            *latest_data = Some(data.clone());
+            self.latest.version.fetch_add(1, Ordering::Relaxed) + 1
+        };
         self.cache = Some(data);
-        self.version = v;
     }
 
     /// Get the tablet from cache without checking if it's up to date.
@@ -51,9 +51,9 @@ impl<EK: Clone> CachedTablet<EK> {
     #[inline]
     pub fn latest(&mut self) -> Option<&EK> {
         if self.latest.version.load(Ordering::Relaxed) > self.version {
-            let guard = self.latest.data.lock().unwrap();
+            let latest_data = self.latest.data.lock().unwrap();
             self.version = self.latest.version.load(Ordering::Relaxed);
-            self.cache = guard.clone();
+            self.cache = latest_data.clone();
         }
         self.cache()
     }
@@ -76,7 +76,14 @@ mod tests {
         // Setting tablet will refresh cache immediately.
         cached_tablet.set(2);
         assert_eq!(cached_tablet.cache().cloned(), Some(2));
-        assert_eq!(cached_tablet.latest().cloned(), Some(2));
+        // Test `latest()` will use cache.
+        {
+            // Unsafe modify the data.
+            *cached_tablet.latest.data.lock().unwrap() = Some(0);
+            assert_eq!(cached_tablet.latest().cloned(), Some(2));
+            // Restore the data.
+            *cached_tablet.latest.data.lock().unwrap() = Some(2);
+        }
 
         let mut cloned = cached_tablet.clone();
         // Clone should reuse cache.

--- a/components/tikv_util/src/lib.rs
+++ b/components/tikv_util/src/lib.rs
@@ -586,6 +586,7 @@ pub fn build_on_master_branch() -> bool {
 }
 
 /// Set the capacity of a vector to the given capacity.
+#[inline]
 pub fn set_vec_capacity<T>(v: &mut Vec<T>, cap: usize) {
     match cap.cmp(&v.capacity()) {
         cmp::Ordering::Less => v.shrink_to(cap),


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Ref #12842

What's Changed:

Some cleaning-ups while reading the code.
- Fix the issue that `CachedTablet::latest()` always acquires lock.
- Initialize buffer capacity when creating a `ApplyPoller`.
- Remove util function `check_or_prepare_bootstrap_first_region` for more clarity.
- Minor improvements to function comments.

```commit-message
None
```

### Related changes


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
