### PR TITLE
txn: add lock wait duration and read exeution duration track for pessimistic lock

### DIFF
--- a/components/tracker/src/lib.rs
+++ b/components/tracker/src/lib.rs
@@ -69,6 +69,11 @@ impl Tracker {
         detail.set_apply_write_wal_nanos(self.metrics.apply_wait_nanos);
         detail.set_apply_write_memtable_nanos(self.metrics.apply_write_memtable_nanos);
     }
+
+    pub fn write_time_detail(&self, detail: &mut pb::TimeDetail) {
+        detail.set_wait_wall_time_ms(self.metrics.wait_wall_time_ms);
+        detail.set_kv_read_wall_time_ms(self.metrics.kv_read_wall_time_ms);
+    }
 }
 
 #[derive(Debug, Default)]
@@ -148,4 +153,8 @@ pub struct RequestMetrics {
     pub apply_thread_wait_nanos: u64,
     pub apply_write_wal_nanos: u64,
     pub apply_write_memtable_nanos: u64,
+
+    // Some execution details about the `TimeDetail` fields in kv request responses.
+    pub wait_wall_time_ms: u64,
+    pub kv_read_wall_time_ms: u64,
 }

--- a/components/tracker/src/slab.rs
+++ b/components/tracker/src/slab.rs
@@ -182,6 +182,12 @@ impl fmt::Debug for TrackerToken {
     }
 }
 
+impl Default for TrackerToken {
+    fn default() -> Self {
+        INVALID_TRACKER_TOKEN
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::{sync::Arc, thread};

--- a/src/server/lock_manager/mod.rs
+++ b/src/server/lock_manager/mod.rs
@@ -315,6 +315,7 @@ mod tests {
     use raftstore::coprocessor::RegionChangeEvent;
     use security::SecurityConfig;
     use tikv_util::config::ReadableDuration;
+    use tracker::TrackerToken;
 
     use self::{deadlock::tests::*, metrics::*, waiter_manager::tests::*};
     use super::*;
@@ -360,6 +361,7 @@ mod tests {
         DiagnosticContext {
             key: key.to_owned(),
             resource_group_tag: resource_group_tag.to_owned(),
+            tracker_token: TrackerToken::default(),
         }
     }
 

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -2086,9 +2086,15 @@ txn_command_future!(future_acquire_pessimistic_lock, PessimisticLockRequest, Pes
             GLOBAL_TRACKERS.with_tracker(tracker, |tracker| {
                 tracker.write_scan_detail(resp.mut_exec_details_v2().mut_scan_detail_v2());
                 tracker.write_write_detail(resp.mut_exec_details_v2().mut_write_detail());
+                tracker.write_time_detail(resp.mut_exec_details_v2().mut_time_detail());
             });
         },
-        Err(e) | Ok(Err(e)) => resp.set_errors(vec![extract_key_error(&e)].into()),
+        Err(e) | Ok(Err(e)) => {
+            GLOBAL_TRACKERS.with_tracker(tracker, |tracker| {
+                tracker.write_time_detail(resp.mut_exec_details_v2().mut_time_detail());
+            });
+            resp.set_errors(vec![extract_key_error(&e)].into())
+        },
     }
 });
 txn_command_future!(future_pessimistic_rollback, PessimisticRollbackRequest, PessimisticRollbackResponse, (v, resp) {

--- a/src/storage/lock_manager.rs
+++ b/src/storage/lock_manager.rs
@@ -2,6 +2,7 @@
 
 use std::time::Duration;
 
+use tracker::TrackerToken;
 use txn_types::TimeStamp;
 
 use crate::{
@@ -23,6 +24,8 @@ pub struct DiagnosticContext {
     /// This tag is used for aggregate related kv requests (eg. generated from same statement)
     /// Currently it is the encoded SQL digest if the client is TiDB
     pub resource_group_tag: Vec<u8>,
+    /// The tracker_token is used to track and collect the lock wait details.
+    pub tracker_token: TrackerToken,
 }
 
 /// Time to wait for lock released when encountering locks.

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -858,6 +858,7 @@ impl<E: Engine, L: LockManager> Scheduler<E, L> {
             let diag_ctx = DiagnosticContext {
                 key,
                 resource_group_tag: ctx.get_resource_group_tag().into(),
+                tracker_token: get_tls_tracker_token(),
             };
             scheduler.on_wait_for_lock(cid, ts, pr, lock, is_first_lock, wait_timeout, diag_ctx);
             return;

--- a/tests/integrations/server/kv_service.rs
+++ b/tests/integrations/server/kv_service.rs
@@ -34,7 +34,6 @@ use raftstore::{
 use resource_metering::CollectorRegHandle;
 use tempfile::Builder;
 use test_raftstore::*;
-use test_util::init_log_for_test;
 use tikv::{
     config::QuotaConfig,
     coprocessor::REQ_TYPE_DAG,

--- a/tests/integrations/server/kv_service.rs
+++ b/tests/integrations/server/kv_service.rs
@@ -34,6 +34,7 @@ use raftstore::{
 use resource_metering::CollectorRegHandle;
 use tempfile::Builder;
 use test_raftstore::*;
+use test_util::init_log_for_test;
 use tikv::{
     config::QuotaConfig,
     coprocessor::REQ_TYPE_DAG,
@@ -2152,4 +2153,39 @@ fn test_rpc_wall_time() {
                 > 0
         );
     }
+}
+
+#[test]
+fn test_pessimistic_lock_execution_tracking() {
+    let (_cluster, client, ctx) = must_new_cluster_and_kv_client();
+    let (k, v) = (b"k1".to_vec(), b"k2".to_vec());
+
+    // Add a prewrite lock.
+    let mut mutation = Mutation::default();
+    mutation.set_op(Op::Put);
+    mutation.set_key(k.clone());
+    mutation.set_value(v.clone());
+    must_kv_prewrite(&client, ctx.clone(), vec![mutation], k.clone(), 10);
+
+    let block_duraion = Duration::from_millis(300);
+    let client_clone = client.clone();
+    let ctx_clone = ctx.clone();
+    let k_clone = k.clone();
+    thread::spawn(move || {
+        thread::sleep(block_duraion);
+        must_kv_commit(&client_clone, ctx_clone, vec![k_clone], 10, 30, 30);
+    });
+
+    let resp = kv_pessimistic_lock(&client, ctx.clone(), vec![k.clone()], 20, 20, false);
+    assert!(
+        resp.get_exec_details_v2()
+            .get_time_detail()
+            .get_wait_wall_time_ms()
+            > 0,
+        "resp wait wall time={:?}, block_duration={:?}",
+        resp.get_exec_details_v2()
+            .get_time_detail()
+            .get_wait_wall_time_ms(),
+        block_duraion
+    );
 }


### PR DESCRIPTION
Signed-off-by: cfzjywxk <lsswxrxr@163.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #12362 

What's Changed:

```commit-message
The transaction command execution contains mainly two parts the read phase and the write phase, some 
commands like `acquire_pessimistic_lock` may have a wait and wakeup phase.
The tracker utility enables us to track the whole path information for a given command, maybe we 
could track more information about:
- The read phase for each transaction command, sometimes slow-read could slow the whole process.
- The in-queue lock wait and wake-up details for pessimistic lock request processing. Especially 
after the optimization of the lock wait/wakeup model which is developed by @MyonKeminta now, 
there would be not much pessimistic retry but the lock wait could become much longer. 

```


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
