### PR TITLE
charset: update the error message about can not convert error

### DIFF
--- a/components/tidb_query_datatype/src/codec/collation/encoding/ascii.rs
+++ b/components/tidb_query_datatype/src/codec/collation/encoding/ascii.rs
@@ -18,8 +18,7 @@ pub struct EncodingAscii;
 impl Encoding for EncodingAscii {
     #[inline]
     fn decode(data: BytesRef<'_>) -> Result<Bytes> {
-        for i in 0..data.len() {
-            let x = data[i];
+        for x in data {
             if !x.is_ascii() {
                 return Err(Error::cannot_convert_string(
                     format_invalid_char(data).as_str(),

--- a/components/tidb_query_datatype/src/codec/collation/encoding/ascii.rs
+++ b/components/tidb_query_datatype/src/codec/collation/encoding/ascii.rs
@@ -18,9 +18,13 @@ pub struct EncodingAscii;
 impl Encoding for EncodingAscii {
     #[inline]
     fn decode(data: BytesRef<'_>) -> Result<Bytes> {
-        for x in data {
+        for i in 0..data.len() {
+            let x = data[i];
             if !x.is_ascii() {
-                return Err(Error::cannot_convert_string("ascii"));
+                return Err(Error::cannot_convert_string(
+                    format_invalid_char(data).as_str(),
+                    "ascii",
+                ));
             }
         }
         Ok(Bytes::from(data))

--- a/components/tidb_query_datatype/src/codec/collation/encoding/gbk.rs
+++ b/components/tidb_query_datatype/src/codec/collation/encoding/gbk.rs
@@ -13,7 +13,10 @@ impl Encoding for EncodingGBK {
     fn decode(data: BytesRef<'_>) -> Result<Bytes> {
         match GBK.decode_without_bom_handling_and_without_replacement(data) {
             Some(v) => Ok(Bytes::from(v.as_bytes())),
-            None => Err(Error::cannot_convert_string("gbk")),
+            None => Err(Error::cannot_convert_string(
+                format_invalid_char(data).as_str(),
+                "gbk",
+            )),
         }
     }
 

--- a/components/tidb_query_datatype/src/codec/collation/encoding/mod.rs
+++ b/components/tidb_query_datatype/src/codec/collation/encoding/mod.rs
@@ -15,3 +15,22 @@ use crate::codec::{
     data_type::{Bytes, BytesRef},
     Error, Result,
 };
+
+fn format_invalid_char(data: BytesRef<'_>) -> String {
+    let mut buf = String::with_capacity(50);
+    const MAX_BYTES_TO_SHOW: usize = 5;
+    buf.push('\'');
+    for i in 0..data.len() {
+        if i > MAX_BYTES_TO_SHOW {
+            buf.push_str("...");
+            break;
+        }
+        if data[i].is_ascii() {
+            buf.push(char::from(data[i]));
+        } else {
+            buf.push_str(format!("\\x{:X}", data[i]).as_str());
+        }
+    }
+    buf.push('\'');
+    buf
+}

--- a/components/tidb_query_datatype/src/codec/collation/encoding/mod.rs
+++ b/components/tidb_query_datatype/src/codec/collation/encoding/mod.rs
@@ -17,7 +17,9 @@ use crate::codec::{
 };
 
 fn format_invalid_char(data: BytesRef<'_>) -> String {
-    let mut buf = String::with_capacity(50);
+    // Max length of the invalid string is '\x00\x00\x00\x00\x00...'(25) we set 32
+    // here.
+    let mut buf = String::with_capacity(32);
     const MAX_BYTES_TO_SHOW: usize = 5;
     buf.push('\'');
     for i in 0..data.len() {

--- a/components/tidb_query_datatype/src/codec/collation/encoding/utf8.rs
+++ b/components/tidb_query_datatype/src/codec/collation/encoding/utf8.rs
@@ -11,7 +11,10 @@ impl<T: Utf8CompatibleEncoding> Encoding for T {
     fn decode(data: BytesRef<'_>) -> Result<Bytes> {
         match str::from_utf8(data) {
             Ok(v) => Ok(Bytes::from(v)),
-            Err(_) => Err(Error::cannot_convert_string(T::NAME)),
+            Err(_) => Err(Error::cannot_convert_string(
+                format_invalid_char(data).as_str(),
+                T::NAME,
+            )),
         }
     }
 }

--- a/components/tidb_query_datatype/src/codec/error.rs
+++ b/components/tidb_query_datatype/src/codec/error.rs
@@ -95,8 +95,8 @@ impl Error {
         }
     }
 
-    pub fn cannot_convert_string(charset: &str) -> Error {
-        let msg = format!("cannot convert string from binary to {}", charset);
+    pub fn cannot_convert_string(s: &str, charset: &str) -> Error {
+        let msg = format!("Cannot convert string {} from binary to {}", s, charset);
         Error::Eval(msg, ERR_CANNOT_CONVERT_STRING)
     }
 


### PR DESCRIPTION
Signed-off-by: xiongjiwei <xiongjiwei1996@outlook.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/tikv/tikv/issues/13156


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
make the error message of convert charset in tikv more clear
```
