### PR TITLE
dr-auto-sync: judge whether `RocksWriteBatchVec` is empty

### DIFF
--- a/src/server/reset_to_version.rs
+++ b/src/server/reset_to_version.rs
@@ -134,8 +134,10 @@ impl ResetToVersionWorker {
             box_try!(wb.delete_cf(CF_WRITE, &key));
             box_try!(wb.delete_cf(CF_DEFAULT, default_key.as_encoded()));
         }
-        wb.write().unwrap();
-        wb.clear();
+        if !wb.is_empty() {
+            wb.write().unwrap();
+            wb.clear();
+        }
         Ok(has_more)
     }
 
@@ -165,7 +167,10 @@ impl ResetToVersionWorker {
                 break;
             }
         }
-        wb.write().unwrap();
+        if !wb.is_empty() {
+            wb.write().unwrap();
+            wb.clear();
+        }
         Ok(has_more)
     }
 }


### PR DESCRIPTION
Signed-off-by: lhy1024 <admin@liudos.us>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #13194

What's Changed:
judge whether `RocksWriteBatchVec` is empty
<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

### Related changes

- Need to cherry-pick to the release branch
6.2  

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
