### PR TITLE
pd-client: tikv should continue if cluster-id is zero.

### DIFF
--- a/components/pd_client/src/util.rs
+++ b/components/pd_client/src/util.rs
@@ -585,6 +585,9 @@ impl PdConnector {
                 .keepalive_timeout(Duration::from_secs(3));
             self.security_mgr.connect(cb, addr_trim)
         };
+        fail_point!("cluster_id_is_not_ready", |_| {
+            Ok((PdClientStub::new(channel.clone()),GetMembersResponse::default()))
+        });
         let client = PdClientStub::new(channel);
         let option = CallOption::default().timeout(Duration::from_secs(REQUEST_TIMEOUT));
         let response = client

--- a/components/pd_client/src/util.rs
+++ b/components/pd_client/src/util.rs
@@ -611,14 +611,14 @@ impl PdConnector {
             for ep in m.get_client_urls() {
                 match self.connect(ep.as_str()).await {
                     Ok((_, r)) => {
-                        let header=r.get_header();
-                        if let Err(e)=check_resp_header(header){
+                        let header = r.get_header();
+                        if let Err(e) = check_resp_header(header) {
                             error!("connect pd failed";"endpoints" => ep, "error" => ?e);
-                        }else{
+                        } else {
                             let new_cluster_id = header.get_cluster_id();
                             if new_cluster_id == cluster_id {
-                                // check whether the response have leader info, otherwise continue to
-                                // loop the rest members
+                                // check whether the response have leader info, otherwise continue
+                                // to loop the rest members
                                 if r.has_leader() {
                                     return Ok(r);
                                 }
@@ -631,7 +631,6 @@ impl PdConnector {
                                 );
                             }
                         }
-                       
                     }
                     Err(e) => {
                         error!("connect failed"; "endpoints" => ep, "error" => ?e);

--- a/components/pd_client/src/util.rs
+++ b/components/pd_client/src/util.rs
@@ -603,11 +603,12 @@ impl PdConnector {
         }
     }
 
-    // load_members returns the pd members by calling getMember, there are three
-    // scene for the reponse: header is error: the pd is not ready to server.
-    // cluster id is different: avoid to connect the different cluster.
-    // cluster id is zero:  etcd start server but the follower did not get cluster
-    // id already. about this case, load_members returns error, so the client
+    // load_members returns the PD members by calling getMember, there are two
+    // abnormal scenes for the reponse:
+    // 1. header is error: the PD is not ready to server.
+    // 2. cluster id is zero: etcd start server but the follower did not get
+    // cluster id yet.
+    // In this case, load_members should return an error, so the client
     // will not update client address.
     pub async fn load_members(&self, previous: &GetMembersResponse) -> Result<GetMembersResponse> {
         let previous_leader = previous.get_leader();

--- a/components/pd_client/src/util.rs
+++ b/components/pd_client/src/util.rs
@@ -586,7 +586,10 @@ impl PdConnector {
             self.security_mgr.connect(cb, addr_trim)
         };
         fail_point!("cluster_id_is_not_ready", |_| {
-            Ok((PdClientStub::new(channel.clone()),GetMembersResponse::default()))
+            Ok((
+                PdClientStub::new(channel.clone()),
+                GetMembersResponse::default(),
+            ))
         });
         let client = PdClientStub::new(channel);
         let option = CallOption::default().timeout(Duration::from_secs(REQUEST_TIMEOUT));

--- a/tests/integrations/pd/test_rpc_client.rs
+++ b/tests/integrations/pd/test_rpc_client.rs
@@ -479,7 +479,7 @@ fn test_change_leader_async() {
 #[test]
 fn test_pd_client_heartbeat_send_failed() {
     let pd_client_send_fail_fp = "region_heartbeat_send_failed";
-    let pd_client_cluster_id_zero ="cluster_id_is_not_ready";
+    let pd_client_cluster_id_zero = "cluster_id_is_not_ready";
     let server = MockServer::with_case(3, Arc::new(AlreadyBootstrapped));
     let eps = server.bind_addrs();
 
@@ -495,7 +495,7 @@ fn test_pd_client_heartbeat_send_failed() {
     poller.spawn(f);
     fail::cfg(pd_client_cluster_id_zero, "return()").unwrap();
     fail::cfg(pd_client_send_fail_fp, "return()").unwrap();
-    
+
     let heartbeat_send_fail = |ok| {
         let mut region = metapb::Region::default();
         region.set_id(1);


### PR DESCRIPTION
close tikv/tikv#13240

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/tikv/tikv/issues/13240,

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
using warn to replace panic.
```

### Related changes


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)


Side effects


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
 None.

```
