### PR TITLE
pd-client:  remove `call_option` to avoid  deadlock(RWR).

### DIFF
--- a/components/pd_client/src/client.rs
+++ b/components/pd_client/src/client.rs
@@ -19,7 +19,7 @@ use futures::{
     sink::SinkExt,
     stream::StreamExt,
 };
-use grpcio::{CallOption, EnvBuilder, Environment, WriteFlags};
+use grpcio::{ EnvBuilder, Environment, WriteFlags};
 use kvproto::{
     metapb,
     pdpb::{self, Member},
@@ -37,7 +37,7 @@ use yatp::{task::future::TaskCell, ThreadPool};
 
 use super::{
     metrics::*,
-    util::{check_resp_header, sync_request, Client, Inner, PdConnector},
+    util::{check_resp_header, sync_request,call_option_inner, Client, PdConnector},
     BucketStat, Config, Error, FeatureGate, PdClient, PdFuture, RegionInfo, RegionStat, Result,
     UnixSecs, REQUEST_TIMEOUT,
 };
@@ -189,20 +189,6 @@ impl RpcClient {
         block_on(self.pd_client.reconnect(true))
     }
 
-    /// Creates a new call option with default request timeout.
-    #[inline]
-    pub fn call_option(client: &Client) -> CallOption {
-        Self::call_option_inner(&client.inner.rl())
-    }
-
-    #[inline]
-    fn call_option_inner(inner: &Inner) -> CallOption {
-        inner
-            .target_info()
-            .call_option()
-            .timeout(Duration::from_secs(REQUEST_TIMEOUT))
-    }
-
     /// Gets given key's Region and Region's leader from PD.
     fn get_region_and_leader(
         &self,
@@ -221,7 +207,7 @@ impl RpcClient {
                 let inner = client.inner.rl();
                 inner
                     .client_stub
-                    .get_region_async_opt(&req, Self::call_option_inner(&inner))
+                    .get_region_async_opt(&req, call_option_inner(&inner))
                     .unwrap_or_else(|e| {
                         panic!("fail to request PD {} err {:?}", "get_region_async_opt", e)
                     })
@@ -261,7 +247,7 @@ impl RpcClient {
                 let inner = client.inner.rl();
                 inner
                     .client_stub
-                    .get_store_async_opt(&req, Self::call_option_inner(&inner))
+                    .get_store_async_opt(&req, call_option_inner(&inner))
                     .unwrap_or_else(|e| {
                         panic!("fail to request PD {} err {:?}", "get_store_async", e)
                     })
@@ -339,7 +325,7 @@ impl PdClient for RpcClient {
     ) -> Result<grpcio::ClientSStreamReceiver<pdpb::WatchGlobalConfigResponse>> {
         use kvproto::pdpb::WatchGlobalConfigRequest;
         let req = WatchGlobalConfigRequest::default();
-        sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client| {
+        sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client,_| {
             client.watch_global_config(&req)
         })
     }
@@ -362,8 +348,8 @@ impl PdClient for RpcClient {
         req.set_store(stores);
         req.set_region(region);
 
-        let mut resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client| {
-            client.bootstrap_opt(&req, Self::call_option(&self.pd_client))
+        let mut resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client,call| {
+            client.bootstrap_opt(&req, call)
         })?;
         check_resp_header(resp.get_header())?;
         Ok(resp.replication_status.take())
@@ -377,8 +363,8 @@ impl PdClient for RpcClient {
         let mut req = pdpb::IsBootstrappedRequest::default();
         req.set_header(self.header());
 
-        let resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client| {
-            client.is_bootstrapped_opt(&req, Self::call_option(&self.pd_client))
+        let resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client,call| {
+            client.is_bootstrapped_opt(&req, call)
         })?;
         check_resp_header(resp.get_header())?;
 
@@ -393,8 +379,8 @@ impl PdClient for RpcClient {
         let mut req = pdpb::AllocIdRequest::default();
         req.set_header(self.header());
 
-        let resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client| {
-            client.alloc_id_opt(&req, Self::call_option(&self.pd_client))
+        let resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client,call| {
+            client.alloc_id_opt(&req, call)
         })?;
         check_resp_header(resp.get_header())?;
 
@@ -414,8 +400,8 @@ impl PdClient for RpcClient {
         req.set_header(self.header());
         req.set_store(store);
 
-        let mut resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client| {
-            client.put_store_opt(&req, Self::call_option(&self.pd_client))
+        let mut resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client,call| {
+            client.put_store_opt(&req, call)
         })?;
         check_resp_header(resp.get_header())?;
 
@@ -431,8 +417,8 @@ impl PdClient for RpcClient {
         req.set_header(self.header());
         req.set_store_id(store_id);
 
-        let mut resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client| {
-            client.get_store_opt(&req, Self::call_option(&self.pd_client))
+        let mut resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client,call| {
+            client.get_store_opt(&req, call)
         })?;
         check_resp_header(resp.get_header())?;
 
@@ -457,8 +443,8 @@ impl PdClient for RpcClient {
         req.set_header(self.header());
         req.set_exclude_tombstone_stores(exclude_tombstone);
 
-        let mut resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client| {
-            client.get_all_stores_opt(&req, Self::call_option(&self.pd_client))
+        let mut resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client,call| {
+            client.get_all_stores_opt(&req, call)
         })?;
         check_resp_header(resp.get_header())?;
 
@@ -473,8 +459,8 @@ impl PdClient for RpcClient {
         let mut req = pdpb::GetClusterConfigRequest::default();
         req.set_header(self.header());
 
-        let mut resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client| {
-            client.get_cluster_config_opt(&req, Self::call_option(&self.pd_client))
+        let mut resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client,call| {
+            client.get_cluster_config_opt(&req, call)
         })?;
         check_resp_header(resp.get_header())?;
 
@@ -511,7 +497,7 @@ impl PdClient for RpcClient {
                 let inner = client.inner.rl();
                 inner
                     .client_stub
-                    .get_region_by_id_async_opt(&req, Self::call_option_inner(&inner))
+                    .get_region_by_id_async_opt(&req, call_option_inner(&inner))
                     .unwrap_or_else(|e| {
                         panic!("fail to request PD {} err {:?}", "get_region_by_id", e);
                     })
@@ -550,7 +536,7 @@ impl PdClient for RpcClient {
                 let inner = client.inner.rl();
                 inner
                     .client_stub
-                    .get_region_by_id_async_opt(&req, Self::call_option_inner(&inner))
+                    .get_region_by_id_async_opt(&req, call_option_inner(&inner))
                     .unwrap_or_else(|e| {
                         panic!("fail to request PD {} err {:?}", "get_region_by_id", e)
                     })
@@ -688,7 +674,7 @@ impl PdClient for RpcClient {
                 let inner = client.inner.rl();
                 inner
                     .client_stub
-                    .ask_split_async_opt(&req, Self::call_option_inner(&inner))
+                    .ask_split_async_opt(&req, call_option_inner(&inner))
                     .unwrap_or_else(|e| panic!("fail to request PD {} err {:?}", "ask_split", e))
             };
 
@@ -724,7 +710,7 @@ impl PdClient for RpcClient {
                 let inner = client.inner.rl();
                 inner
                     .client_stub
-                    .ask_batch_split_async_opt(&req, Self::call_option_inner(&inner))
+                    .ask_batch_split_async_opt(&req, call_option_inner(&inner))
                     .unwrap_or_else(|e| {
                         panic!("fail to request PD {} err {:?}", "ask_batch_split", e)
                     })
@@ -771,7 +757,7 @@ impl PdClient for RpcClient {
                 let inner = client.inner.rl();
                 inner
                     .client_stub
-                    .store_heartbeat_async_opt(&req, Self::call_option_inner(&inner))
+                    .store_heartbeat_async_opt(&req, call_option_inner(&inner))
                     .unwrap_or_else(|e| {
                         panic!("fail to request PD {} err {:?}", "store_heartbeat", e)
                     })
@@ -808,7 +794,7 @@ impl PdClient for RpcClient {
                 let inner = client.inner.rl();
                 inner
                     .client_stub
-                    .report_batch_split_async_opt(&req, Self::call_option_inner(&inner))
+                    .report_batch_split_async_opt(&req, call_option_inner(&inner))
                     .unwrap_or_else(|e| {
                         panic!("fail to request PD {} err {:?}", "report_batch_split", e)
                     })
@@ -841,8 +827,8 @@ impl PdClient for RpcClient {
         }
         req.set_region(region.region);
 
-        let resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client| {
-            client.scatter_region_opt(&req, Self::call_option(&self.pd_client))
+        let resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client,call| {
+            client.scatter_region_opt(&req, call)
         })?;
         check_resp_header(resp.get_header())
     }
@@ -862,7 +848,7 @@ impl PdClient for RpcClient {
                 let inner = client.inner.rl();
                 inner
                     .client_stub
-                    .get_gc_safe_point_async_opt(&req, Self::call_option_inner(&inner))
+                    .get_gc_safe_point_async_opt(&req, call_option_inner(&inner))
                     .unwrap_or_else(|e| {
                         panic!("fail to request PD {} err {:?}", "get_gc_saft_point", e)
                     })
@@ -895,8 +881,8 @@ impl PdClient for RpcClient {
         req.set_header(self.header());
         req.set_region_id(region_id);
 
-        let resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client| {
-            client.get_operator_opt(&req, Self::call_option(&self.pd_client))
+        let resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client,call| {
+            client.get_operator_opt(&req, call)
         })?;
         check_resp_header(resp.get_header())?;
 
@@ -950,7 +936,7 @@ impl PdClient for RpcClient {
                 let inner = client.inner.rl();
                 inner
                     .client_stub
-                    .update_service_gc_safe_point_async_opt(&r, Self::call_option_inner(&inner))
+                    .update_service_gc_safe_point_async_opt(&r, call_option_inner(&inner))
                     .unwrap_or_else(|e| {
                         panic!(
                             "fail to request PD {} err {:?}",
@@ -989,7 +975,7 @@ impl PdClient for RpcClient {
                 let inner = client.inner.rl();
                 inner
                     .client_stub
-                    .report_min_resolved_ts_async_opt(&req, Self::call_option_inner(&inner))
+                    .report_min_resolved_ts_async_opt(&req, call_option_inner(&inner))
                     .unwrap_or_else(|e| {
                         panic!("fail to request PD {} err {:?}", "min_resolved_ts", e)
                     })

--- a/components/pd_client/src/client.rs
+++ b/components/pd_client/src/client.rs
@@ -348,8 +348,8 @@ impl PdClient for RpcClient {
         req.set_store(stores);
         req.set_region(region);
 
-        let mut resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client, call| {
-            client.bootstrap_opt(&req, call)
+        let mut resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client, option| {
+            client.bootstrap_opt(&req, option)
         })?;
         check_resp_header(resp.get_header())?;
         Ok(resp.replication_status.take())
@@ -363,8 +363,8 @@ impl PdClient for RpcClient {
         let mut req = pdpb::IsBootstrappedRequest::default();
         req.set_header(self.header());
 
-        let resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client, call| {
-            client.is_bootstrapped_opt(&req, call)
+        let resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client, option| {
+            client.is_bootstrapped_opt(&req, option)
         })?;
         check_resp_header(resp.get_header())?;
 
@@ -379,8 +379,8 @@ impl PdClient for RpcClient {
         let mut req = pdpb::AllocIdRequest::default();
         req.set_header(self.header());
 
-        let resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client, call| {
-            client.alloc_id_opt(&req, call)
+        let resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client, option| {
+            client.alloc_id_opt(&req, option)
         })?;
         check_resp_header(resp.get_header())?;
 
@@ -400,8 +400,8 @@ impl PdClient for RpcClient {
         req.set_header(self.header());
         req.set_store(store);
 
-        let mut resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client, call| {
-            client.put_store_opt(&req, call)
+        let mut resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client, option| {
+            client.put_store_opt(&req, option)
         })?;
         check_resp_header(resp.get_header())?;
 
@@ -417,8 +417,8 @@ impl PdClient for RpcClient {
         req.set_header(self.header());
         req.set_store_id(store_id);
 
-        let mut resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client, call| {
-            client.get_store_opt(&req, call)
+        let mut resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client, option| {
+            client.get_store_opt(&req, option)
         })?;
         check_resp_header(resp.get_header())?;
 
@@ -443,8 +443,8 @@ impl PdClient for RpcClient {
         req.set_header(self.header());
         req.set_exclude_tombstone_stores(exclude_tombstone);
 
-        let mut resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client, call| {
-            client.get_all_stores_opt(&req, call)
+        let mut resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client, option| {
+            client.get_all_stores_opt(&req, option)
         })?;
         check_resp_header(resp.get_header())?;
 
@@ -459,8 +459,8 @@ impl PdClient for RpcClient {
         let mut req = pdpb::GetClusterConfigRequest::default();
         req.set_header(self.header());
 
-        let mut resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client, call| {
-            client.get_cluster_config_opt(&req, call)
+        let mut resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client, option| {
+            client.get_cluster_config_opt(&req, option)
         })?;
         check_resp_header(resp.get_header())?;
 
@@ -827,8 +827,8 @@ impl PdClient for RpcClient {
         }
         req.set_region(region.region);
 
-        let resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client, call| {
-            client.scatter_region_opt(&req, call)
+        let resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client, option| {
+            client.scatter_region_opt(&req, option)
         })?;
         check_resp_header(resp.get_header())
     }
@@ -881,8 +881,8 @@ impl PdClient for RpcClient {
         req.set_header(self.header());
         req.set_region_id(region_id);
 
-        let resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client, call| {
-            client.get_operator_opt(&req, call)
+        let resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client, option| {
+            client.get_operator_opt(&req, option)
         })?;
         check_resp_header(resp.get_header())?;
 

--- a/components/pd_client/src/client.rs
+++ b/components/pd_client/src/client.rs
@@ -19,7 +19,7 @@ use futures::{
     sink::SinkExt,
     stream::StreamExt,
 };
-use grpcio::{ EnvBuilder, Environment, WriteFlags};
+use grpcio::{EnvBuilder, Environment, WriteFlags};
 use kvproto::{
     metapb,
     pdpb::{self, Member},
@@ -37,7 +37,7 @@ use yatp::{task::future::TaskCell, ThreadPool};
 
 use super::{
     metrics::*,
-    util::{check_resp_header, sync_request,call_option_inner, Client, PdConnector},
+    util::{call_option_inner, check_resp_header, sync_request, Client, PdConnector},
     BucketStat, Config, Error, FeatureGate, PdClient, PdFuture, RegionInfo, RegionStat, Result,
     UnixSecs, REQUEST_TIMEOUT,
 };
@@ -325,7 +325,7 @@ impl PdClient for RpcClient {
     ) -> Result<grpcio::ClientSStreamReceiver<pdpb::WatchGlobalConfigResponse>> {
         use kvproto::pdpb::WatchGlobalConfigRequest;
         let req = WatchGlobalConfigRequest::default();
-        sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client,_| {
+        sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client, _| {
             client.watch_global_config(&req)
         })
     }
@@ -348,7 +348,7 @@ impl PdClient for RpcClient {
         req.set_store(stores);
         req.set_region(region);
 
-        let mut resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client,call| {
+        let mut resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client, call| {
             client.bootstrap_opt(&req, call)
         })?;
         check_resp_header(resp.get_header())?;
@@ -363,7 +363,7 @@ impl PdClient for RpcClient {
         let mut req = pdpb::IsBootstrappedRequest::default();
         req.set_header(self.header());
 
-        let resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client,call| {
+        let resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client, call| {
             client.is_bootstrapped_opt(&req, call)
         })?;
         check_resp_header(resp.get_header())?;
@@ -379,7 +379,7 @@ impl PdClient for RpcClient {
         let mut req = pdpb::AllocIdRequest::default();
         req.set_header(self.header());
 
-        let resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client,call| {
+        let resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client, call| {
             client.alloc_id_opt(&req, call)
         })?;
         check_resp_header(resp.get_header())?;
@@ -400,7 +400,7 @@ impl PdClient for RpcClient {
         req.set_header(self.header());
         req.set_store(store);
 
-        let mut resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client,call| {
+        let mut resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client, call| {
             client.put_store_opt(&req, call)
         })?;
         check_resp_header(resp.get_header())?;
@@ -417,7 +417,7 @@ impl PdClient for RpcClient {
         req.set_header(self.header());
         req.set_store_id(store_id);
 
-        let mut resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client,call| {
+        let mut resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client, call| {
             client.get_store_opt(&req, call)
         })?;
         check_resp_header(resp.get_header())?;
@@ -443,7 +443,7 @@ impl PdClient for RpcClient {
         req.set_header(self.header());
         req.set_exclude_tombstone_stores(exclude_tombstone);
 
-        let mut resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client,call| {
+        let mut resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client, call| {
             client.get_all_stores_opt(&req, call)
         })?;
         check_resp_header(resp.get_header())?;
@@ -459,7 +459,7 @@ impl PdClient for RpcClient {
         let mut req = pdpb::GetClusterConfigRequest::default();
         req.set_header(self.header());
 
-        let mut resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client,call| {
+        let mut resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client, call| {
             client.get_cluster_config_opt(&req, call)
         })?;
         check_resp_header(resp.get_header())?;
@@ -827,7 +827,7 @@ impl PdClient for RpcClient {
         }
         req.set_region(region.region);
 
-        let resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client,call| {
+        let resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client, call| {
             client.scatter_region_opt(&req, call)
         })?;
         check_resp_header(resp.get_header())
@@ -881,7 +881,7 @@ impl PdClient for RpcClient {
         req.set_header(self.header());
         req.set_region_id(region_id);
 
-        let resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client,call| {
+        let resp = sync_request(&self.pd_client, LEADER_CHANGE_RETRY, |client, call| {
             client.get_operator_opt(&req, call)
         })?;
         check_resp_header(resp.get_header())?;

--- a/components/pd_client/src/util.rs
+++ b/components/pd_client/src/util.rs
@@ -490,8 +490,12 @@ where
             // thread which may hold the read lock and wait for PD client thread
             // completing the request and the PD client thread which may block
             // on acquiring the write lock.
-            let inner = client.inner.rl();
-            func(&inner.client_stub, call_option_inner(&inner)).map_err(Error::Grpc)
+            let (client_stub, option) = {
+                let inner = client.inner.rl();
+                (inner.client_stub.clone(), call_option_inner(&inner))
+            };
+
+            func(&client_stub, option).map_err(Error::Grpc)
         };
         match ret {
             Ok(r) => {

--- a/components/pd_client/src/util.rs
+++ b/components/pd_client/src/util.rs
@@ -482,7 +482,7 @@ pub fn call_option_inner(inner: &Inner) -> CallOption {
 /// Do a request in synchronized fashion.
 pub fn sync_request<F, R>(client: &Client, mut retry: usize, func: F) -> Result<R>
 where
-    F: Fn(&PdClientStub,CallOption) -> GrpcResult<R>,
+    F: Fn(&PdClientStub, CallOption) -> GrpcResult<R>,
 {
     loop {
         let ret = {

--- a/components/pd_client/src/util.rs
+++ b/components/pd_client/src/util.rs
@@ -472,10 +472,17 @@ where
     }
 }
 
+pub fn call_option_inner(inner: &Inner) -> CallOption {
+    inner
+        .target_info()
+        .call_option()
+        .timeout(Duration::from_secs(REQUEST_TIMEOUT))
+}
+
 /// Do a request in synchronized fashion.
 pub fn sync_request<F, R>(client: &Client, mut retry: usize, func: F) -> Result<R>
 where
-    F: Fn(&PdClientStub) -> GrpcResult<R>,
+    F: Fn(&PdClientStub,CallOption) -> GrpcResult<R>,
 {
     loop {
         let ret = {
@@ -483,8 +490,8 @@ where
             // thread which may hold the read lock and wait for PD client thread
             // completing the request and the PD client thread which may block
             // on acquiring the write lock.
-            let client_stub = client.inner.rl().client_stub.clone();
-            func(&client_stub).map_err(Error::Grpc)
+            let inner = client.inner.rl();
+            func(&inner.client_stub, call_option_inner(&inner)).map_err(Error::Grpc)
         };
         match ret {
             Ok(r) => {


### PR DESCRIPTION
Signed-off-by: bufferflies <1045931706@qq.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

Issue Number: Close #13191

the RWR should be same in all os after https://github.com/rust-lang/rust/issues/93740， so the RWR deadlock   is not potential case in   linux. 


What's Changed:
Remove `call_option` avoid to read lock double.

```commit-message
```

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
- No code

TCMS Test：
https://tcms.pingcap.net/dashboard/executions/plan/1082168

<img width="1549" alt="image" src="https://user-images.githubusercontent.com/23159587/183820135-db976d04-b392-4cda-a1d8-1c7ca0825e9e.png">

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
remove call_option to avoid  deadlock(RWR).
```
