### PR TITLE
log-backup: add timeout for operations that may stuck

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1620,8 +1620,7 @@ dependencies = [
 [[package]]
 name = "etcd-client"
 version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76b9f5b0b4f53cf836bef05b22cd5239479700bc8d44a04c3c77f1ba6c2c73e9"
+source = "git+https://github.com/yujuncen/etcd-client?rev=e0321a1990ee561cf042973666c0db61c8d82364#e0321a1990ee561cf042973666c0db61c8d82364"
 dependencies = [
  "http",
  "prost",

--- a/components/backup-stream/Cargo.toml
+++ b/components/backup-stream/Cargo.toml
@@ -29,6 +29,8 @@ dashmap = "5"
 engine_rocks = { path = "../engine_rocks", default-features = false }
 engine_traits = { path = "../engine_traits", default-features = false }
 error_code = { path = "../error_code" }
+# We cannot update the etcd-client to latest version because of the cyclic requirement.
+# Also we need wait until https://github.com/etcdv3/etcd-client/pull/43/files to be merged.
 etcd-client = { git = "https://github.com/yujuncen/etcd-client", rev = "e0321a1990ee561cf042973666c0db61c8d82364", features = ["pub-response-field", "tls"] }
 external_storage = { path = "../external_storage", default-features = false }
 external_storage_export = { path = "../external_storage/export", default-features = false }

--- a/components/backup-stream/Cargo.toml
+++ b/components/backup-stream/Cargo.toml
@@ -29,7 +29,7 @@ dashmap = "5"
 engine_rocks = { path = "../engine_rocks", default-features = false }
 engine_traits = { path = "../engine_traits", default-features = false }
 error_code = { path = "../error_code" }
-etcd-client = { version = "0.7", features = ["pub-response-field", "tls"] }
+etcd-client = { git = "https://github.com/yujuncen/etcd-client", rev = "e0321a1990ee561cf042973666c0db61c8d82364", features = ["pub-response-field", "tls"] }
 external_storage = { path = "../external_storage", default-features = false }
 external_storage_export = { path = "../external_storage/export", default-features = false }
 fail = { version = "0.5", optional = true }

--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -864,10 +864,13 @@ where
 
     fn on_update_global_checkpoint(&self, task: String) {
         let _guard = self.pool.handle().enter();
-        self.pool.spawn(tokio::time::timeout(
+        let result = self.pool.block_on(tokio::time::timeout(
             TICK_UPDATE_TIMEOUT,
             self.update_global_checkpoint(task),
         ));
+        if let Err(err) = result {
+            warn!("log backup update global checkpoint timed out"; "err" => %err)
+        }
     }
 
     /// Modify observe over some region.

--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -819,6 +819,15 @@ where
         let router = self.range_router.clone();
         let store_id = self.store_id;
         async move {
+            #[cfg(feature = "failpoints")]
+            {
+                // fail-rs doesn't support async code blocks now.
+                // let's borrow the feature name and do it ourselves :3
+                if std::env::var("LOG_BACKUP_UGC_SLEEP_AND_RETURN").is_ok() {
+                    tokio::time::sleep(Duration::from_secs(100)).await;
+                    return;
+                }
+            }
             let ts = meta_client.global_progress_of_task(&task).await;
             match ts {
                 Ok(global_checkpoint) => {

--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -863,6 +863,7 @@ where
     }
 
     fn on_update_global_checkpoint(&self, task: String) {
+        let _guard = self.pool.handle().enter();
         self.pool.spawn(tokio::time::timeout(
             TICK_UPDATE_TIMEOUT,
             self.update_global_checkpoint(task),

--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -817,12 +817,13 @@ where
     fn update_global_checkpoint(&self, task: String) -> future![()] {
         let meta_client = self.meta_client.clone();
         let router = self.range_router.clone();
+        let store_id = self.store_id;
         async move {
             let ts = meta_client.global_progress_of_task(&task).await;
             match ts {
                 Ok(global_checkpoint) => {
                     let r = router
-                        .update_global_checkpoint(&task, global_checkpoint, self.store_id)
+                        .update_global_checkpoint(&task, global_checkpoint, store_id)
                         .await;
                     match r {
                         Ok(true) => {

--- a/components/backup-stream/src/metadata/store/lazy_etcd.rs
+++ b/components/backup-stream/src/metadata/store/lazy_etcd.rs
@@ -10,6 +10,8 @@ use tokio::sync::OnceCell;
 use super::{etcd::EtcdSnapshot, EtcdStore, MetaStore};
 use crate::errors::{ContextualResultExt, Result};
 
+const RPC_TIMEOUT: Duration = Duration::from_sec(30);
+
 #[derive(Clone)]
 pub struct LazyEtcdClient(Arc<LazyEtcdClientInner>);
 
@@ -28,7 +30,7 @@ impl ConnectionConfig {
         }
         opts = opts
             .with_keep_alive(self.keep_alive_interval, self.keep_alive_timeout)
-            .with_timeout(Duration::from_secs(5))
+            .with_timeout(RPC_TIMEOUT)
             .keep_alive_while_idle(false);
 
         opts

--- a/components/backup-stream/src/metadata/store/lazy_etcd.rs
+++ b/components/backup-stream/src/metadata/store/lazy_etcd.rs
@@ -10,7 +10,7 @@ use tokio::sync::OnceCell;
 use super::{etcd::EtcdSnapshot, EtcdStore, MetaStore};
 use crate::errors::{ContextualResultExt, Result};
 
-const RPC_TIMEOUT: Duration = Duration::from_sec(30);
+const RPC_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Clone)]
 pub struct LazyEtcdClient(Arc<LazyEtcdClientInner>);

--- a/components/backup-stream/src/metadata/store/lazy_etcd.rs
+++ b/components/backup-stream/src/metadata/store/lazy_etcd.rs
@@ -26,7 +26,11 @@ impl ConnectionConfig {
         if let Some(tls) = &self.tls {
             opts = opts.with_tls(tls.clone())
         }
-        opts = opts.with_keep_alive(self.keep_alive_interval, self.keep_alive_timeout);
+        opts = opts
+            .with_keep_alive(self.keep_alive_interval, self.keep_alive_timeout)
+            .with_timeout(Duration::from_secs(5))
+            .keep_alive_while_idle(false);
+
         opts
     }
 }

--- a/components/backup-stream/tests/mod.rs
+++ b/components/backup-stream/tests/mod.rs
@@ -598,7 +598,7 @@ fn run_async_test<T>(test: impl Future<Output = T>) -> T {
 
 #[cfg(test)]
 mod test {
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
 
     use backup_stream::{
         errors::Error, metadata::MetadataClient, router::TaskSelector, GetCheckpointResult,
@@ -871,6 +871,38 @@ mod test {
         suite.check_for_write_records(
             suite.flushed_files.path(),
             keys.union(&keys2).map(|s| s.as_slice()),
+        );
+    }
+
+    #[test]
+    fn upload_checkpoint_exits_in_time() {
+        defer! {{
+            std::env::remove_var("LOG_BACKUP_UGC_SLEEP_AND_RETURN");
+        }}
+        let suite = SuiteBuilder::new_named("upload_checkpoint_exits_in_time")
+            .nodes(1)
+            .build();
+        std::env::set_var("LOG_BACKUP_UGC_SLEEP_AND_RETURN", "meow");
+        let (_, victim) = suite.endpoints.iter().next().unwrap();
+        let sched = victim.scheduler();
+        sched
+            .schedule(Task::UpdateGlobalCheckpoint("greenwoods".to_owned()))
+            .unwrap();
+        let start = Instant::now();
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        sched
+            .schedule(Task::Sync(
+                Box::new(move || {
+                    tx.send(Instant::now()).unwrap();
+                }),
+                Box::new(|_| true),
+            ))
+            .unwrap();
+        let end = run_async_test(rx).unwrap();
+        assert!(
+            end - start < Duration::from_secs(10),
+            "take = {:?}",
+            end - start
         );
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #13251

What's Changed:

This PR added timeout for some operations so we won't get stuck if there are some network issues.

Because we cannot collect enough information when log backup get stuck, we add timeout for two places:
- Every RPC call to etcd.
- The handler `on_update_global_checkpoint`. <del>(This also moved it to background.)</del>

This PR also set the `keep_alive_while_idle` for tonic. So PD won't cut down the connection with error `too many pings`.

For adding timeout for the RPCs, we need to cherry-pick some commits from newer version of the etcd client, and for http2 keep alive while idle config, we need a tiny patch, you can check the diff [here](https://github.com/etcdv3/etcd-client/compare/0.7.2...YuJuncen:etcd-client:v0.7.2-patch-extra-options?expand=1).

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Added a timeout of `30s` for every etcd gRPC request.
Moved `on_update_global_checkpoint` to background.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
