### PR TITLE
tikv: add TsFilter for ResetToVersionWorker

### DIFF
--- a/src/server/reset_to_version.rs
+++ b/src/server/reset_to_version.rs
@@ -487,8 +487,9 @@ mod tests {
     }
 
     fn get_all_keys(engine: &RocksEngine, cf: &str) -> Vec<Vec<u8>> {
-        let readopts = IterOptions::new(None, None, false);
-        let mut iter = engine.iterator_opt(cf, readopts.clone()).unwrap();
+        let mut iter = engine
+            .iterator_opt(cf, IterOptions::new(None, None, false))
+            .unwrap();
         iter.seek_to_first().unwrap();
         let mut keys = vec![];
         while iter.valid().unwrap() {


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What is changed and how it works?

Issue Number: Ref #13276.

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Add `TsFilter` for `ResetToVersionWorker` to filter out the SST that does not have a newer version than the TS to reset in `CF_WRITE`.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None.
```
