### PR TITLE
log-backup: fix early return

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1620,7 +1620,7 @@ dependencies = [
 [[package]]
 name = "etcd-client"
 version = "0.7.2"
-source = "git+https://github.com/yujuncen/etcd-client?rev=e0321a1990ee561cf042973666c0db61c8d82364#e0321a1990ee561cf042973666c0db61c8d82364"
+source = "git+https://github.com/pingcap/etcd-client?rev=e0321a1990ee561cf042973666c0db61c8d82364#e0321a1990ee561cf042973666c0db61c8d82364"
 dependencies = [
  "http",
  "prost",

--- a/components/backup-stream/Cargo.toml
+++ b/components/backup-stream/Cargo.toml
@@ -31,7 +31,7 @@ engine_traits = { path = "../engine_traits", default-features = false }
 error_code = { path = "../error_code" }
 # We cannot update the etcd-client to latest version because of the cyclic requirement.
 # Also we need wait until https://github.com/etcdv3/etcd-client/pull/43/files to be merged.
-etcd-client = { git = "https://github.com/yujuncen/etcd-client", rev = "e0321a1990ee561cf042973666c0db61c8d82364", features = ["pub-response-field", "tls"] }
+etcd-client = { git = "https://github.com/pingcap/etcd-client", rev = "e0321a1990ee561cf042973666c0db61c8d82364", features = ["pub-response-field", "tls"] }
 external_storage = { path = "../external_storage", default-features = false }
 external_storage_export = { path = "../external_storage/export", default-features = false }
 fail = "0.5"

--- a/components/backup-stream/tests/mod.rs
+++ b/components/backup-stream/tests/mod.rs
@@ -159,10 +159,10 @@ impl SuiteBuilder {
         for id in 1..=(n as u64) {
             suite.start_endpoint(id, use_v3);
         }
-        // TODO: The current mock metastore (slash_etc) doesn't supports multi-version.
-        //       We must wait until the endpoints get ready to watching the metastore, or some modifies may be lost.
-        //       Either make Endpoint::with_client wait until watch did start or make slash_etc support multi-version,
-        //       then we can get rid of this sleep.
+        // We must wait until the endpoints get ready to watching the metastore, or some
+        // modifies may be lost. Either make Endpoint::with_client wait until watch did
+        // start or make slash_etc support multi-version, then we can get rid of this
+        // sleep.
         std::thread::sleep(Duration::from_secs(1));
         suite
     }
@@ -666,7 +666,8 @@ mod test {
         suite.cluster.shutdown();
     }
 
-    /// This test tests whether we can handle some weird transactions and their race with initial scanning.
+    /// This test tests whether we can handle some weird transactions and their
+    /// race with initial scanning.
     #[test]
     fn with_split_txn() {
         let mut suite = super::SuiteBuilder::new_named("split_txn").use_v3().build();

--- a/components/backup-stream/tests/mod.rs
+++ b/components/backup-stream/tests/mod.rs
@@ -667,6 +667,14 @@ mod test {
 
     /// This test tests whether we can handle some weird transactions and their
     /// race with initial scanning.
+    /// Generally, those transactions:
+    /// - Has N mutations, which's values are all short enough to be inlined in
+    ///   the `Write` CF. (N > 1024)
+    /// - Commit the latest M mutations first.
+    /// - Before committing remaining mutations, PiTR triggered initial
+    ///   scanning.
+    /// - The remaining mutations are committed before the instant when initial
+    ///   scanning get the snapshot.
     #[test]
     fn with_split_txn() {
         let mut suite = super::SuiteBuilder::new_named("split_txn").use_v3().build();
@@ -679,7 +687,7 @@ mod test {
                     .into_iter()
                     .map(|k| mutation(k, b"hello, world".to_vec()))
                     .collect(),
-                make_record_key(1, 29),
+                make_record_key(1, 1913),
                 start_ts,
             );
             let commit_ts = suite.cluster.pd_client.get_tso().await.unwrap();

--- a/components/backup-stream/tests/mod.rs
+++ b/components/backup-stream/tests/mod.rs
@@ -30,6 +30,7 @@ use pd_client::PdClient;
 use tempdir::TempDir;
 use test_raftstore::{new_server_cluster, Cluster, ServerCluster};
 use test_util::retry;
+use tidb_query_datatype::codec::data_type::ChunkedVec;
 use tikv::config::BackupStreamConfig;
 use tikv_util::{
     codec::{
@@ -159,10 +160,9 @@ impl SuiteBuilder {
             suite.start_endpoint(id, use_v3);
         }
         // TODO: The current mock metastore (slash_etc) doesn't supports multi-version.
-        // We must wait until the endpoints get ready to watching the metastore, or some
-        // modifies may be lost. Either make Endpoint::with_client wait until watch did
-        // start or make slash_etc support multi-version, then we can get rid of this
-        // sleep.
+        //       We must wait until the endpoints get ready to watching the metastore, or some modifies may be lost.
+        //       Either make Endpoint::with_client wait until watch did start or make slash_etc support multi-version,
+        //       then we can get rid of this sleep.
         std::thread::sleep(Duration::from_secs(1));
         suite
     }
@@ -316,6 +316,19 @@ impl Suite {
             ));
         }
         inserted
+    }
+
+    fn commit_keys(&mut self, keys: Vec<Vec<u8>>, start_ts: TimeStamp, commit_ts: TimeStamp) {
+        let mut region_keys = HashMap::<u64, Vec<Vec<u8>>>::new();
+        for k in keys {
+            let enc_key = Key::from_raw(&k).into_encoded();
+            let region = self.cluster.get_region_id(&enc_key);
+            region_keys.entry(region).or_default().push(k);
+        }
+
+        for (region, keys) in region_keys {
+            self.must_kv_commit(region, keys, start_ts, commit_ts);
+        }
     }
 
     fn just_commit_a_key(&mut self, key: Vec<u8>, start_ts: TimeStamp, commit_ts: TimeStamp) {
@@ -604,10 +617,13 @@ mod test {
         errors::Error, metadata::MetadataClient, router::TaskSelector, GetCheckpointResult,
         RegionCheckpointOperation, RegionSet, Task,
     };
+    use pd_client::PdClient;
     use tikv_util::{box_err, defer, info, HandyRwLock};
-    use txn_types::TimeStamp;
+    use txn_types::{Key, TimeStamp};
 
-    use crate::{make_record_key, make_split_key_at_record, run_async_test, SuiteBuilder};
+    use crate::{
+        make_record_key, make_split_key_at_record, mutation, run_async_test, SuiteBuilder,
+    };
 
     #[test]
     fn basic() {
@@ -645,6 +661,44 @@ mod test {
             suite.check_for_write_records(
                 suite.flushed_files.path(),
                 round1.union(&round2).map(Vec::as_slice),
+            );
+        });
+        suite.cluster.shutdown();
+    }
+
+    /// This test tests whether we can handle some weird transactions and their race with initial scanning.
+    #[test]
+    fn with_split_txn() {
+        let mut suite = super::SuiteBuilder::new_named("split_txn").use_v3().build();
+        run_async_test(async {
+            let start_ts = suite.cluster.pd_client.get_tso().await.unwrap();
+            let keys = (1..1960).map(|i| make_record_key(1, i)).collect::<Vec<_>>();
+            suite.must_kv_prewrite(
+                1,
+                keys.clone()
+                    .into_iter()
+                    .map(|k| mutation(k, b"hello, world".to_vec()))
+                    .collect(),
+                make_record_key(1, 29),
+                start_ts,
+            );
+            let commit_ts = suite.cluster.pd_client.get_tso().await.unwrap();
+            suite.commit_keys(keys[1913..].to_vec(), start_ts, commit_ts);
+            suite.must_register_task(1, "test_split_txn");
+            suite.commit_keys(keys[..1913].to_vec(), start_ts, commit_ts);
+            suite.force_flush_files("test_split_txn");
+            suite.wait_for_flush();
+            let keys_encoded = keys
+                .iter()
+                .map(|v| {
+                    Key::from_raw(v.as_slice())
+                        .append_ts(commit_ts)
+                        .into_encoded()
+                })
+                .collect::<Vec<_>>();
+            suite.check_for_write_records(
+                suite.flushed_files.path(),
+                keys_encoded.iter().map(Vec::as_slice),
             );
         });
         suite.cluster.shutdown();

--- a/components/backup-stream/tests/mod.rs
+++ b/components/backup-stream/tests/mod.rs
@@ -670,7 +670,12 @@ mod test {
     /// Generally, those transactions:
     /// - Has N mutations, which's values are all short enough to be inlined in
     ///   the `Write` CF. (N > 1024)
-    /// - Commit the latest M mutations first.
+    /// - Commit the mutation set M first. (for all m in M: Nth-Of-Key(m) >
+    ///   1024)
+    /// ```text
+    /// |--...-----^------*---*-*--*-*-*-> (The line is the Key Space - from "" to inf)
+    ///            +The 1024th key  (* = committed mutation)
+    /// ```
     /// - Before committing remaining mutations, PiTR triggered initial
     ///   scanning.
     /// - The remaining mutations are committed before the instant when initial

--- a/components/backup-stream/tests/mod.rs
+++ b/components/backup-stream/tests/mod.rs
@@ -30,7 +30,6 @@ use pd_client::PdClient;
 use tempdir::TempDir;
 use test_raftstore::{new_server_cluster, Cluster, ServerCluster};
 use test_util::retry;
-use tidb_query_datatype::codec::data_type::ChunkedVec;
 use tikv::config::BackupStreamConfig;
 use tikv_util::{
     codec::{


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #13281 

What's Changed:
This PR fixed a bug that may cause data loss with the satisfaction of these conditions:
- In the initial scanning stage, if...
  - There are more than 1,024 adjacent keys are prewritten but not committed. 
  - The values of these keys are all short enough to be inlined in the `write` CF.
("adjacent" means, the initial scanning cannot get any commit entries interleaving them, the `DeltaScanner` emits a batch with 1,024 `Prewrite`s).
- If there are some keys committed BEFORE the initial scanning but NOT YET have been observed, those key would be lost. (For a detailed case, check the integration test `split_txn`).

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Fixed a bug that may cause data loss in log backup.
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test
- Manual test (add detailed scripts or steps below)
We have tested this with 1,000 tables in `sysbench` `oltp_write_only` prepare phase.
  - with this PR, no data loss observed.
  - without this PR, there would always be data loss for some tables.

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fixed a bug that may cause PiTR losing some data when there are too many adjacent short row putting.
```
