### PR TITLE
copr: use manually written json path parser

### DIFF
--- a/components/tidb_query_datatype/src/codec/mysql/json/path_expr.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/json/path_expr.rs
@@ -25,20 +25,12 @@
 //     select json_extract('{"a": "b", "c": [1, "2"]}', '$.*') -> ["b", [1, "2"]]
 // ```
 
-use std::ops::Index;
-
-use regex::Regex;
+use std::{iter::Peekable, str::CharIndices};
 
 use super::json_unquote::unquote_string;
 use crate::codec::Result;
 
 pub const PATH_EXPR_ASTERISK: &str = "*";
-
-// [a-zA-Z_][a-zA-Z0-9_]* matches any identifier;
-// "[^"\\]*(\\.[^"\\]*)*" matches any string literal which can carry escaped
-// quotes.
-const PATH_EXPR_LEG_RE_STR: &str =
-    r#"(\.\s*([a-zA-Z_][a-zA-Z0-9_]*|\*|"[^"\\]*(\\.[^"\\]*)*")|(\[\s*([0-9]+|\*)\s*\])|\*\*)"#;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum PathLeg {
@@ -73,82 +65,325 @@ impl PathExpression {
     }
 }
 
+// the position is counted from 1
+macro_rules! box_json_path_err {
+    ($e:expr) => {{
+        box_err!(
+            "Invalid JSON path expression. The error is around character position {}.",
+            ($e) + 1
+        )
+    }};
+}
+
+struct PathExpressionTokenizer<'a> {
+    input: &'a str,
+
+    char_iterator: Peekable<CharIndices<'a>>,
+}
+
+struct Position {
+    start: usize,
+    end: usize,
+}
+
+// PathExpressionToken represents a section in path expression and its position
+enum PathExpressionToken {
+    Leg((PathLeg, Position)),
+    // represents the beginning "$" in the expression
+    Start(Position),
+}
+
+impl<'a> Iterator for PathExpressionTokenizer<'a> {
+    type Item = Result<PathExpressionToken>;
+
+    // next will try to parse the next path leg and return
+    // if it returns None, it means the input is over.
+    // if it returns Some(Err(..)), it means the format is error.
+    // if it returns Some(Ok(..)), it means the
+    fn next(&mut self) -> Option<Result<PathExpressionToken>> {
+        self.trim_white_spaces();
+        // trim all spaces at first
+        if self.reached_end() {
+            return None;
+        };
+
+        let (start, ch) = *self.char_iterator.peek().unwrap();
+        match ch {
+            '$' => {
+                self.char_iterator.next();
+                Some(Ok(PathExpressionToken::Start(Position {
+                    start,
+                    end: self.current_index(),
+                })))
+            }
+            '.' => Some(self.next_key()),
+            '[' => Some(self.next_index()),
+            '*' => Some(self.next_double_asterisk()),
+            _ => Some(Err(box_json_path_err!(self.current_index()))),
+        }
+    }
+}
+
+impl<'a> PathExpressionTokenizer<'a> {
+    fn new(input: &'a str) -> PathExpressionTokenizer<'a> {
+        PathExpressionTokenizer {
+            input,
+            char_iterator: input.char_indices().peekable(),
+        }
+    }
+
+    // returns the current index on the slice
+    fn current_index(&mut self) -> usize {
+        match self.char_iterator.peek() {
+            Some((start, _)) => *start,
+            None => self.input.len(),
+        }
+    }
+
+    // trim_while_spaces remove spaces from the position
+    fn trim_white_spaces(&mut self) {
+        while self
+            .char_iterator
+            .next_if(|(_, ch)| ch.is_whitespace())
+            .is_some()
+        {}
+    }
+
+    // returns whether the input has reached the end
+    fn reached_end(&mut self) -> bool {
+        return self.char_iterator.peek().is_none();
+    }
+
+    fn next_key(&mut self) -> Result<PathExpressionToken> {
+        let (start, _) = self.char_iterator.next().unwrap();
+
+        self.trim_white_spaces();
+        if self.reached_end() {
+            return Err(box_json_path_err!(self.current_index()));
+        }
+
+        match *self.char_iterator.peek().unwrap() {
+            (_, '*') => {
+                self.char_iterator.next().unwrap();
+
+                Ok(PathExpressionToken::Leg((
+                    PathLeg::Key(PATH_EXPR_ASTERISK.to_string()),
+                    Position {
+                        start,
+                        end: self.current_index(),
+                    },
+                )))
+            }
+            (mut key_start, '"') => {
+                // skip this '"' character
+                key_start += 1;
+                self.char_iterator.next().unwrap();
+
+                // next until the next '"' character
+                while self.char_iterator.next_if(|(_, ch)| *ch != '"').is_some() {}
+
+                // now, it's a '"' or the end
+                if self.char_iterator.peek().is_none() {
+                    return Err(box_json_path_err!(self.current_index()));
+                }
+
+                // key_end is the index of '"'
+                let key_end = self.current_index();
+                self.char_iterator.next().unwrap();
+
+                Ok(PathExpressionToken::Leg((
+                    PathLeg::Key(unquote_string(&unsafe {
+                        self.input.get_unchecked(key_start..key_end)
+                    })?),
+                    Position {
+                        start,
+                        end: self.current_index(),
+                    },
+                )))
+            }
+            (key_start, _) => {
+                // we have to also check the current value
+                while self
+                    .char_iterator
+                    .next_if(|(_, ch)| {
+                        !(ch.is_whitespace() || *ch == '.' || *ch == '[' || *ch == '*')
+                    })
+                    .is_some()
+                {}
+
+                // now it reaches the end or a whitespace/./[/*
+                let key_end = self.current_index();
+
+                // the start character is not available
+                if key_end == key_start {
+                    return Err(box_json_path_err!(key_start));
+                }
+
+                let key = unsafe { self.input.get_unchecked(key_start..key_end) }.to_string();
+
+                // it's not quoted, we'll have to validate whether it's an available ECMEScript
+                // identifier
+                for (i, c) in key.char_indices() {
+                    if i == 0 && c >= '0' && c <= '9' {
+                        return Err(box_json_path_err!(key_start + i));
+                    }
+                    if !c.is_ascii_alphanumeric() && c != '_' && c != '$' && c.is_ascii() {
+                        return Err(box_json_path_err!(key_start + i));
+                    }
+                }
+
+                Ok(PathExpressionToken::Leg((
+                    PathLeg::Key(key),
+                    Position {
+                        start,
+                        end: key_end,
+                    },
+                )))
+            }
+        }
+    }
+
+    fn next_index(&mut self) -> Result<PathExpressionToken> {
+        let (start, _) = self.char_iterator.next().unwrap();
+
+        self.trim_white_spaces();
+        if self.reached_end() {
+            return Err(box_json_path_err!(self.current_index()));
+        }
+
+        return match self.char_iterator.next().unwrap() {
+            (_, '*') => {
+                // then it's a glob array index
+                self.trim_white_spaces();
+                if self.reached_end() {
+                    return Err(box_json_path_err!(self.current_index()));
+                }
+
+                if self.char_iterator.next_if(|(_, ch)| *ch == ']').is_none() {
+                    return Err(box_json_path_err!(self.current_index()));
+                }
+
+                Ok(PathExpressionToken::Leg((
+                    PathLeg::Index(PATH_EXPR_ARRAY_INDEX_ASTERISK),
+                    Position {
+                        start,
+                        end: self.current_index(),
+                    },
+                )))
+            }
+            (number_start, '0'..='9') => {
+                // then it's a number array index
+                while self
+                    .char_iterator
+                    .next_if(|(_, ch)| ch.is_ascii_digit())
+                    .is_some()
+                {}
+                let number_end = self.current_index();
+
+                self.trim_white_spaces();
+                // now, it reaches the end of input, or reaches a non-digit character
+                match self.char_iterator.peek() {
+                    Some((_, ']')) => {}
+                    Some((pos, _)) => {
+                        return Err(box_json_path_err!(pos));
+                    }
+                    None => {
+                        return Err(box_json_path_err!(self.current_index()));
+                    }
+                }
+                self.char_iterator.next().unwrap();
+
+                let index = self.input[number_start..number_end].parse::<i32>().unwrap();
+                Ok(PathExpressionToken::Leg((
+                    PathLeg::Index(index),
+                    Position {
+                        start,
+                        end: self.current_index(),
+                    },
+                )))
+            }
+            (pos, _) => Err(box_json_path_err!(pos)),
+        };
+    }
+
+    fn next_double_asterisk(&mut self) -> Result<PathExpressionToken> {
+        let (start, _) = self.char_iterator.next().unwrap();
+
+        match self.char_iterator.next() {
+            Some((end, '*')) => {
+                // three or more asterisks are not allowed
+                if let Some((pos, '*')) = self.char_iterator.peek() {
+                    return Err(box_json_path_err!(pos));
+                }
+
+                Ok(PathExpressionToken::Leg((
+                    PathLeg::DoubleAsterisk,
+                    Position { start, end },
+                )))
+            }
+            Some((pos, _)) => {
+                Err(box_json_path_err!(pos))
+            }
+            None => {
+                Err(box_json_path_err!(self.current_index()))
+            }
+        }
+    }
+}
+
 /// Parses a JSON path expression. Returns a `PathExpression`
 /// object which can be used in `JSON_EXTRACT`, `JSON_SET` and so on.
 pub fn parse_json_path_expr(path_expr: &str) -> Result<PathExpression> {
-    // Find the position of first '$'. If any no-blank characters in
-    // path_expr[0: dollarIndex], return an error.
-    let dollar_index = match path_expr.find('$') {
-        Some(i) => i,
-        None => return Err(box_err!("Invalid JSON path: {}", path_expr)),
-    };
-    if path_expr
-        .index(0..dollar_index)
-        .char_indices()
-        .any(|(_, c)| !c.is_ascii_whitespace())
-    {
-        return Err(box_err!("Invalid JSON path: {}", path_expr));
-    }
-
-    let expr = path_expr.index(dollar_index + 1..).trim_start();
-
-    lazy_static::lazy_static! {
-        static ref RE: Regex = Regex::new(PATH_EXPR_LEG_RE_STR).unwrap();
-    }
-    let mut legs = vec![];
+    let mut legs = Vec::new();
+    let tokenizer = PathExpressionTokenizer::new(path_expr);
     let mut flags = PathExpressionFlag::default();
-    let mut last_end = 0;
-    for m in RE.find_iter(expr) {
-        let (start, end) = (m.start(), m.end());
-        // Check all characters between two legs are blank.
-        if expr
-            .index(last_end..start)
-            .char_indices()
-            .any(|(_, c)| !c.is_ascii_whitespace())
-        {
-            return Err(box_err!("Invalid JSON path: {}", path_expr));
-        }
-        last_end = end;
 
-        let next_char = expr.index(start..).chars().next().unwrap();
-        if next_char == '[' {
-            // The leg is an index of a JSON array.
-            let leg = expr[start + 1..end].trim();
-            let index_str = leg[0..leg.len() - 1].trim();
-            let index = if index_str == PATH_EXPR_ASTERISK {
-                flags |= PATH_EXPRESSION_CONTAINS_ASTERISK;
-                PATH_EXPR_ARRAY_INDEX_ASTERISK
-            } else {
-                box_try!(index_str.parse::<i32>())
-            };
-            legs.push(PathLeg::Index(index))
-        } else if next_char == '.' {
-            // The leg is a key of a JSON object.
-            let mut key = expr[start + 1..end].trim().to_owned();
-            if key == PATH_EXPR_ASTERISK {
-                flags |= PATH_EXPRESSION_CONTAINS_ASTERISK;
-            } else if key.starts_with('"') {
-                // We need to unquote the origin string.
-                key = unquote_string(&key[1..key.len() - 1])?;
+    let mut started = false;
+    let mut last_position = Position { start: 0, end: 0 };
+    for (index, token) in tokenizer.enumerate() {
+        let token = token?;
+
+        match token {
+            PathExpressionToken::Leg((leg, position)) => {
+                if !started {
+                    return Err(box_json_path_err!(position.start));
+                }
+
+                match &leg {
+                    PathLeg::Key(key) => {
+                        if key == PATH_EXPR_ASTERISK {
+                            flags |= PATH_EXPRESSION_CONTAINS_ASTERISK
+                        }
+                    }
+                    PathLeg::Index(PATH_EXPR_ARRAY_INDEX_ASTERISK) => {
+                        flags |= PATH_EXPRESSION_CONTAINS_ASTERISK
+                    }
+                    PathLeg::DoubleAsterisk => flags |= PATH_EXPRESSION_CONTAINS_DOUBLE_ASTERISK,
+                    _ => {}
+                }
+
+                legs.push(leg.clone());
+                last_position = position;
             }
-            legs.push(PathLeg::Key(key))
-        } else {
-            // The leg is '**'.
-            flags |= PATH_EXPRESSION_CONTAINS_DOUBLE_ASTERISK;
-            legs.push(PathLeg::DoubleAsterisk);
+            PathExpressionToken::Start(position) => {
+                started = true;
+
+                if index != 0 {
+                    return Err(box_json_path_err!(position.start));
+                }
+            }
         }
     }
-    // Check `!expr.is_empty()` here because "$" is a valid path to specify the
-    // current JSON.
-    if (last_end == 0) && (!expr.is_empty()) {
-        return Err(box_err!("Invalid JSON path: {}", path_expr));
+
+    // there is no available token
+    if !started {
+        return Err(box_json_path_err!(path_expr.len()));
     }
-    if !legs.is_empty() {
-        if let PathLeg::DoubleAsterisk = *legs.last().unwrap() {
-            // The last leg of a path expression cannot be '**'.
-            return Err(box_err!("Invalid JSON path: {}", path_expr));
-        }
+    // the last one cannot be the double asterisk
+    if !legs.is_empty() && legs.last().unwrap() == &PathLeg::DoubleAsterisk {
+        return Err(box_json_path_err!(last_position.end));
     }
+
     Ok(PathExpression { legs, flags })
 }
 
@@ -175,7 +410,7 @@ mod tests {
         let mut test_cases = vec![
             (
                 "$",
-                true,
+                None,
                 Some(PathExpression {
                     legs: vec![],
                     flags: PathExpressionFlag::default(),
@@ -183,7 +418,7 @@ mod tests {
             ),
             (
                 "$.a",
-                true,
+                None,
                 Some(PathExpression {
                     legs: vec![PathLeg::Key(String::from("a"))],
                     flags: PathExpressionFlag::default(),
@@ -191,15 +426,39 @@ mod tests {
             ),
             (
                 "$.\"hello world\"",
-                true,
+                None,
                 Some(PathExpression {
                     legs: vec![PathLeg::Key(String::from("hello world"))],
                     flags: PathExpressionFlag::default(),
                 }),
             ),
             (
-                "$[0]",
-                true,
+                "$.  \"你好 世界\"  ",
+                None,
+                Some(PathExpression {
+                    legs: vec![PathLeg::Key(String::from("你好 世界"))],
+                    flags: PathExpressionFlag::default(),
+                }),
+            ),
+            (
+                "$.   ❤️  ",
+                None,
+                Some(PathExpression {
+                    legs: vec![PathLeg::Key(String::from("❤️"))],
+                    flags: PathExpressionFlag::default(),
+                }),
+            ),
+            (
+                "$.   你好  ",
+                None,
+                Some(PathExpression {
+                    legs: vec![PathLeg::Key(String::from("你好"))],
+                    flags: PathExpressionFlag::default(),
+                }),
+            ),
+            (
+                "$[    0    ]",
+                None,
                 Some(PathExpression {
                     legs: vec![PathLeg::Index(0)],
                     flags: PathExpressionFlag::default(),
@@ -207,33 +466,92 @@ mod tests {
             ),
             (
                 "$**.a",
-                true,
+                None,
                 Some(PathExpression {
                     legs: vec![PathLeg::DoubleAsterisk, PathLeg::Key(String::from("a"))],
                     flags: PATH_EXPRESSION_CONTAINS_DOUBLE_ASTERISK,
                 }),
             ),
+            (
+                "   $  **  . a",
+                None,
+                Some(PathExpression {
+                    legs: vec![PathLeg::DoubleAsterisk, PathLeg::Key(String::from("a"))],
+                    flags: PATH_EXPRESSION_CONTAINS_DOUBLE_ASTERISK,
+                }),
+            ),
+            (
+                "   $  **  . $",
+                None,
+                Some(PathExpression {
+                    legs: vec![PathLeg::DoubleAsterisk, PathLeg::Key(String::from("$"))],
+                    flags: PATH_EXPRESSION_CONTAINS_DOUBLE_ASTERISK,
+                }),
+            ),
             // invalid path expressions
-            (".a", false, None),
-            ("xx$[1]", false, None),
-            ("$.a xx .b", false, None),
-            ("$[a]", false, None),
-            ("$.\"\\u33\"", false, None),
-            ("$**", false, None),
+            (
+                "   $  **  . 5",
+                Some("Invalid JSON path expression. The error is around character position 13."),
+                None,
+            ),
+            (
+                ".a",
+                Some("Invalid JSON path expression. The error is around character position 1."),
+                None,
+            ),
+            (
+                "xx$[1]",
+                Some("Invalid JSON path expression. The error is around character position 1."),
+                None,
+            ),
+            (
+                "$.a xx .b",
+                Some("Invalid JSON path expression. The error is around character position 5."),
+                None,
+            ),
+            (
+                "$[a]",
+                Some("Invalid JSON path expression. The error is around character position 3."),
+                None,
+            ),
+            (
+                "$.\"\\u33\"",
+                // TODO: pass the position in the unquote unicode error
+                Some("Invalid unicode, byte len too short"),
+                None,
+            ),
+            (
+                "$**",
+                Some("Invalid JSON path expression. The error is around character position 3."),
+                None,
+            ),
         ];
-        for (i, (path_expr, no_error, expected)) in test_cases.drain(..).enumerate() {
+        for (i, (path_expr, error_message, expected)) in test_cases.drain(..).enumerate() {
             let r = parse_json_path_expr(path_expr);
-            if no_error {
-                assert!(r.is_ok(), "#{} expect parse ok but got err {:?}", i, r);
-                let got = r.unwrap();
-                let expected = expected.unwrap();
-                assert_eq!(
-                    got, expected,
-                    "#{} expect {:?} but got {:?}",
-                    i, expected, got
-                );
-            } else {
-                assert!(r.is_err(), "#{} expect error but got {:?}", i, r);
+
+            match error_message {
+                Some(error_message) => {
+                    assert!(r.is_err(), "#{} expect error but got {:?}", i, r);
+
+                    let got = r.err().unwrap().to_string();
+                    assert!(
+                        got.contains(error_message),
+                        "#{} error message {} should contain {}",
+                        i,
+                        got,
+                        error_message
+                    )
+                }
+                None => {
+                    assert!(r.is_ok(), "#{} expect parse ok but got err {:?}", i, r);
+                    let got = r.unwrap();
+                    let expected = expected.unwrap();
+                    assert_eq!(
+                        got, expected,
+                        "#{} expect {:?} but got {:?}",
+                        i, expected, got
+                    );
+                }
             }
         }
     }


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What is changed and how it works?

Issue Number: Close #13316

What's Changed:

Use a manually written json path parser to parse the path.

### Check List

Tests

- [x] Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

### Release note

```release-note
Fix the issue that the json path format is incompatible with MySQL
```
