### PR TITLE
br: Adjust the backup organization structure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,11 +370,7 @@ name = "backup"
 version = "0.0.1"
 dependencies = [
  "async-channel",
-<<<<<<< HEAD
-=======
  "aws",
- "causal_ts",
->>>>>>> 82e8f865c... br: Adjust the backup organization structure (#12958)
  "collections",
  "concurrency_manager",
  "crc64fast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,6 +370,11 @@ name = "backup"
 version = "0.0.1"
 dependencies = [
  "async-channel",
+<<<<<<< HEAD
+=======
+ "aws",
+ "causal_ts",
+>>>>>>> 82e8f865c... br: Adjust the backup organization structure (#12958)
  "collections",
  "concurrency_manager",
  "crc64fast",

--- a/components/backup/Cargo.toml
+++ b/components/backup/Cargo.toml
@@ -27,14 +27,7 @@ mem-profiling = ["tikv/mem-profiling"]
 failpoints = ["tikv/failpoints"]
 
 [dependencies]
-<<<<<<< HEAD
-=======
-api_version = { path = "../api_version", default-features = false }
-async-channel = "1.4"
 aws = { path = "../cloud/aws" }
-causal_ts = { path = "../causal_ts" }
-collections = { path = "../collections" }
->>>>>>> 82e8f865c... br: Adjust the backup organization structure (#12958)
 concurrency_manager = { path = "../concurrency_manager", default-features = false }
 online_config = { path = "../online_config" }
 crc64fast = "0.1"

--- a/components/backup/Cargo.toml
+++ b/components/backup/Cargo.toml
@@ -27,6 +27,14 @@ mem-profiling = ["tikv/mem-profiling"]
 failpoints = ["tikv/failpoints"]
 
 [dependencies]
+<<<<<<< HEAD
+=======
+api_version = { path = "../api_version", default-features = false }
+async-channel = "1.4"
+aws = { path = "../cloud/aws" }
+causal_ts = { path = "../causal_ts" }
+collections = { path = "../collections" }
+>>>>>>> 82e8f865c... br: Adjust the backup organization structure (#12958)
 concurrency_manager = { path = "../concurrency_manager", default-features = false }
 online_config = { path = "../online_config" }
 crc64fast = "0.1"

--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -271,6 +271,7 @@ impl BackupRange {
         backup_ts: TimeStamp,
         begin_ts: TimeStamp,
         saver: async_channel::Sender<InMemBackupFiles>,
+        storage_name: &str,
     ) -> Result<Statistics> {
         assert!(!self.is_raw_kv);
 
@@ -339,7 +340,7 @@ impl BackupRange {
             .start_key
             .clone()
             .map_or_else(Vec::new, |k| k.into_raw().unwrap());
-        let mut writer = writer_builder.build(next_file_start_key.clone())?;
+        let mut writer = writer_builder.build(next_file_start_key.clone(), storage_name)?;
         loop {
             if let Err(e) = scanner.scan_entries(&mut batch) {
                 error!(?e; "backup scan entries failed");
@@ -373,7 +374,7 @@ impl BackupRange {
                 send_to_worker_with_metrics(&saver, msg).await?;
                 next_file_start_key = this_end_key;
                 writer = writer_builder
-                    .build(next_file_start_key.clone())
+                    .build(next_file_start_key.clone(), storage_name)
                     .map_err(|e| {
                         error_unknown!(?e; "backup writer failed");
                         e
@@ -859,7 +860,7 @@ impl<E: Engine, R: RegionInfoProvider + Clone + 'static> Endpoint<E, R> {
                         };
                         file_system::sha256(&input).ok().map(hex::encode)
                     });
-                    let name = backup_file_name(store_id, &brange.region, key);
+                    let name = backup_file_name(store_id, &brange.region, key, _backend.name());
                     let ct = to_sst_compression_type(request.compression_type);
 
                     let stat = if is_raw_kv {
@@ -895,6 +896,7 @@ impl<E: Engine, R: RegionInfoProvider + Clone + 'static> Endpoint<E, R> {
                                 backup_ts,
                                 start_ts,
                                 saver_tx.clone(),
+                                _backend.name(),
                             )
                             .await
                     };
@@ -1040,26 +1042,58 @@ fn get_max_start_key(start_key: Option<&Key>, region: &Region) -> Option<Key> {
 /// A name consists with five parts: store id, region_id, a epoch version, the hash of range start key and timestamp.
 /// range start key is used to keep the unique file name for file, to handle different tables exists on the same region.
 /// local unix timestamp is used to keep the unique file name for file, to handle receive the same request after connection reset.
-pub fn backup_file_name(store_id: u64, region: &Region, key: Option<String>) -> String {
+pub fn backup_file_name(
+    store_id: u64,
+    region: &Region,
+    key: Option<String>,
+    storage_name: &str,
+) -> String {
     let start = SystemTime::now();
     let since_the_epoch = start
         .duration_since(UNIX_EPOCH)
         .expect("Time went backwards");
-    match key {
-        Some(k) => format!(
-            "{}_{}_{}_{}_{}",
-            store_id,
-            region.get_id(),
-            region.get_region_epoch().get_version(),
-            k,
-            since_the_epoch.as_millis()
-        ),
-        None => format!(
-            "{}_{}_{}",
-            store_id,
-            region.get_id(),
-            region.get_region_epoch().get_version()
-        ),
+
+    match (key, storage_name) {
+        // See https://github.com/pingcap/tidb/issues/30087
+        // To avoid 503 Slow Down error, if the backup storage is s3,
+        // organize the backup files by store_id (use slash (/) as delimiter).
+        (Some(k), aws::STORAGE_NAME | external_storage::local::STORAGE_NAME) => {
+            format!(
+                "{}/{}_{}_{}_{}",
+                store_id,
+                region.get_id(),
+                region.get_region_epoch().get_version(),
+                k,
+                since_the_epoch.as_millis()
+            )
+        }
+        (Some(k), _) => {
+            format!(
+                "{}_{}_{}_{}_{}",
+                store_id,
+                region.get_id(),
+                region.get_region_epoch().get_version(),
+                k,
+                since_the_epoch.as_millis()
+            )
+        }
+
+        (None, aws::STORAGE_NAME | external_storage::local::STORAGE_NAME) => {
+            format!(
+                "{}/{}_{}",
+                store_id,
+                region.get_id(),
+                region.get_region_epoch().get_version()
+            )
+        }
+        (None, _) => {
+            format!(
+                "{}_{}_{}",
+                store_id,
+                region.get_id(),
+                region.get_region_epoch().get_version()
+            )
+        }
     }
 }
 
@@ -1677,5 +1711,37 @@ pub mod tests {
         pool.adjust_with(2);
         drop(pool);
         std::thread::sleep(Duration::from_millis(150));
+    }
+
+    #[test]
+    fn test_backup_file_name() {
+        let region = metapb::Region::default();
+        let store_id = 1;
+        let test_cases = vec!["s3", "local", "gcs", "azure", "hdfs"];
+        let test_target = vec![
+            "1/0_0_000",
+            "1/0_0_000",
+            "1_0_0_000",
+            "1_0_0_000",
+            "1_0_0_000",
+        ];
+
+        let delimiter = "_";
+        for (storage_name, target) in test_cases.iter().zip(test_target.iter()) {
+            let key = Some(String::from("000"));
+            let filename = backup_file_name(store_id, &region, key, storage_name);
+
+            let mut prefix_arr: Vec<&str> = filename.split(delimiter).collect();
+            prefix_arr.remove(prefix_arr.len() - 1);
+
+            assert_eq!(target.to_string(), prefix_arr.join(delimiter));
+        }
+
+        let test_target = vec!["1/0_0", "1/0_0", "1_0_0", "1_0_0", "1_0_0"];
+        for (storage_name, target) in test_cases.iter().zip(test_target.iter()) {
+            let key = None;
+            let filename = backup_file_name(store_id, &region, key, storage_name);
+            assert_eq!(target.to_string(), filename);
+        }
     }
 }

--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -806,6 +806,7 @@ impl<E: Engine, R: RegionInfoProvider + Clone + 'static> Endpoint<E, R> {
         let limit = self.softlimit.limit();
 
         self.pool.borrow_mut().spawn(async move {
+            let storage_name = backend.name();
             let storage = LimitedStorage {
                 limiter: request.limiter,
                 storage: backend,
@@ -860,7 +861,7 @@ impl<E: Engine, R: RegionInfoProvider + Clone + 'static> Endpoint<E, R> {
                         };
                         file_system::sha256(&input).ok().map(hex::encode)
                     });
-                    let name = backup_file_name(store_id, &brange.region, key, _backend.name());
+                    let name = backup_file_name(store_id, &brange.region, key, storage_name);
                     let ct = to_sst_compression_type(request.compression_type);
 
                     let stat = if is_raw_kv {
@@ -896,7 +897,7 @@ impl<E: Engine, R: RegionInfoProvider + Clone + 'static> Endpoint<E, R> {
                                 backup_ts,
                                 start_ts,
                                 saver_tx.clone(),
-                                _backend.name(),
+                                storage_name,
                             )
                             .await
                     };

--- a/components/backup/src/writer.rs
+++ b/components/backup/src/writer.rs
@@ -199,10 +199,10 @@ impl BackupWriterBuilder {
         }
     }
 
-    pub fn build(&self, start_key: Vec<u8>) -> Result<BackupWriter> {
+    pub fn build(&self, start_key: Vec<u8>, storage_name: &str) -> Result<BackupWriter> {
         let key = file_system::sha256(&start_key).ok().map(hex::encode);
         let store_id = self.store_id;
-        let name = backup_file_name(store_id, &self.region, key);
+        let name = backup_file_name(store_id, &self.region, key, storage_name);
         BackupWriter::new(
             self.db.clone(),
             &name,

--- a/components/cloud/aws/src/lib.rs
+++ b/components/cloud/aws/src/lib.rs
@@ -4,6 +4,6 @@ mod kms;
 pub use kms::{AwsKms, ENCRYPTION_VENDOR_NAME_AWS_KMS};
 
 mod s3;
-pub use s3::{Config, S3Storage, STORAGE_VENDOR_NAME_AWS};
+pub use s3::{Config, S3Storage, STORAGE_NAME, STORAGE_VENDOR_NAME_AWS};
 
 mod util;

--- a/components/cloud/aws/src/s3.rs
+++ b/components/cloud/aws/src/s3.rs
@@ -499,7 +499,7 @@ impl<'client> S3Uploader<'client> {
     }
 }
 
-const STORAGE_NAME: &str = "s3";
+pub const STORAGE_NAME: &str = "s3";
 
 #[async_trait]
 impl BlobStorage for S3Storage {

--- a/components/external_storage/src/lib.rs
+++ b/components/external_storage/src/lib.rs
@@ -24,9 +24,14 @@ use tikv_util::time::{Instant, Limiter};
 use tokio::time::timeout;
 
 mod hdfs;
+<<<<<<< HEAD
 pub use hdfs::HdfsConfig;
 pub use hdfs::HdfsStorage;
 mod local;
+=======
+pub use hdfs::{HdfsConfig, HdfsStorage};
+pub mod local;
+>>>>>>> 82e8f865c... br: Adjust the backup organization structure (#12958)
 pub use local::LocalStorage;
 mod noop;
 pub use noop::NoopStorage;

--- a/components/external_storage/src/lib.rs
+++ b/components/external_storage/src/lib.rs
@@ -24,14 +24,8 @@ use tikv_util::time::{Instant, Limiter};
 use tokio::time::timeout;
 
 mod hdfs;
-<<<<<<< HEAD
-pub use hdfs::HdfsConfig;
-pub use hdfs::HdfsStorage;
-mod local;
-=======
 pub use hdfs::{HdfsConfig, HdfsStorage};
 pub mod local;
->>>>>>> 82e8f865c... br: Adjust the backup organization structure (#12958)
 pub use local::LocalStorage;
 mod noop;
 pub use noop::NoopStorage;

--- a/components/external_storage/src/local.rs
+++ b/components/external_storage/src/local.rs
@@ -66,16 +66,38 @@ impl ExternalStorage for LocalStorage {
     }
 
     async fn write(&self, name: &str, reader: UnpinReader, _content_length: u64) -> io::Result<()> {
-        // Storage does not support dir,
-        // "a/a.sst", "/" and "" will return an error.
-        if Path::new(name)
-            .parent()
-            .map_or(true, |p| p.parent().is_some())
-        {
+        let p = Path::new(name);
+        if p.is_absolute() {
             return Err(io::Error::new(
-                io::ErrorKind::Other,
-                format!("[{}] parent is not allowed in storage", name),
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "the file name (it is {}) should never be absolute path",
+                    p.display()
+                ),
             ));
+        }
+        if name.is_empty() || p.file_name().map(|s| s.is_empty()).unwrap_or(true) {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                format!("the file name (it is {}) should not be empty", p.display()),
+            ));
+        }
+        // create the parent dir if there isn't one.
+        // note: we may write to arbitrary directory here if the path contains things like '../'
+        // but internally the file name should be fully controlled by TiKV, so maybe it is OK?
+        if let Some(parent) = Path::new(name).parent() {
+            fs::create_dir_all(self.base.join(parent))
+                .await
+                // According to the man page mkdir(2), it returns EEXIST if there is already the dir.
+                // (However in practice, it doesn't fail in both Linux(CentOS 7) and macOS(12.2).)
+                // Ignore the `AlreadyExists` anyway for safety.
+                .or_else(|e| {
+                    if e.kind() == io::ErrorKind::AlreadyExists {
+                        Ok(())
+                    } else {
+                        Err(e)
+                    }
+                })?;
         }
         // Sanitize check, do not save file if it is already exist.
         if fs::metadata(self.base.join(name)).await.is_ok() {
@@ -110,6 +132,7 @@ impl ExternalStorage for LocalStorage {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures::AsyncReadExt;
     use std::fs;
     use tempfile::Builder;
 
@@ -151,8 +174,24 @@ mod tests {
             content_length,
         )
         .await
-        .unwrap_err();
-        // Empty name is not allowed.
+        .unwrap();
+        let mut r = ls.read("a/a.log");
+        let mut s = String::new();
+        r.read_to_string(&mut s).await.unwrap();
+        assert_eq!(magic_contents, s.as_bytes());
+
+        ls.write(
+            "a/b.log",
+            UnpinReader(Box::new(magic_contents)),
+            content_length,
+        )
+        .await
+        .unwrap();
+        let mut r = ls.read("a/b.log");
+        let mut s = String::new();
+        r.read_to_string(&mut s).await.unwrap();
+        assert_eq!(magic_contents, s.as_bytes()); // Empty name is not allowed.
+
         ls.write("", UnpinReader(Box::new(magic_contents)), content_length)
             .await
             .unwrap_err();
@@ -160,6 +199,13 @@ mod tests {
         ls.write("/", UnpinReader(Box::new(magic_contents)), content_length)
             .await
             .unwrap_err();
+        ls.write(
+            "/dir/but/nothing/",
+            UnpinReader(Box::new(magic_contents)),
+            content_length,
+        )
+        .await
+        .unwrap_err();
     }
 
     #[test]

--- a/components/external_storage/src/local.rs
+++ b/components/external_storage/src/local.rs
@@ -53,7 +53,7 @@ fn url_for(base: &Path) -> url::Url {
     u
 }
 
-const STORAGE_NAME: &str = "local";
+pub const STORAGE_NAME: &str = "local";
 
 #[async_trait]
 impl ExternalStorage for LocalStorage {

--- a/tests/integrations/backup/mod.rs
+++ b/tests/integrations/backup/mod.rs
@@ -18,11 +18,11 @@ fn assert_same_file_name(s1: String, s2: String) {
     let tokens1: Vec<&str> = s1.split('_').collect();
     let tokens2: Vec<&str> = s2.split('_').collect();
     assert_eq!(tokens1.len(), tokens2.len());
-    // 2_1_1_e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855_1609407693105_write.sst
-    // 2_1_1_e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855_1609407693199_write.sst
+    // 2/1_1_e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855_1609407693105_write.sst
+    // 2/1_1_e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855_1609407693199_write.sst
     // should be equal
     for i in 0..tokens1.len() {
-        if i != 4 {
+        if i != 3 {
             assert_eq!(tokens1[i], tokens2[i]);
         }
     }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
cherry-pick #12958 to release-5.4-20220824 branch.
Issue Number: Close https://github.com/tikv/tikv/issues/13063

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
```
