### PR TITLE
cloud: add retry on web identity credentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,6 +279,7 @@ dependencies = [
  "tikv_util",
  "tokio",
  "url",
+ "uuid",
 ]
 
 [[package]]

--- a/components/cloud/aws/Cargo.toml
+++ b/components/cloud/aws/Cargo.toml
@@ -36,6 +36,7 @@ url = "2.0"
 thiserror = "1.0"
 lazy_static = "1.3"
 prometheus = { version = "0.13", default-features = false, features = ["nightly"] }
+uuid = "0.8"
 
 [dev-dependencies]
 futures = "0.3"

--- a/components/cloud/aws/src/s3.rs
+++ b/components/cloud/aws/src/s3.rs
@@ -17,14 +17,10 @@ use rusoto_core::{request::DispatchSignedRequest, ByteStream, RusotoError};
 use rusoto_credential::{ProvideAwsCredentials, StaticProvider};
 use rusoto_s3::{util::AddressingStyle, *};
 use thiserror::Error;
-use tikv_util::{
-    debug,
-    stream::{error_stream, retry},
-    time::Instant,
-};
+use tikv_util::{debug, stream::error_stream, time::Instant};
 use tokio::time::{sleep, timeout};
 
-use crate::util;
+use crate::util::{self, retry_and_count};
 
 const CONNECTION_TIMEOUT: Duration = Duration::from_secs(900);
 pub const STORAGE_VENDOR_NAME_AWS: &str = "aws";
@@ -311,11 +307,11 @@ impl<'client> S3Uploader<'client> {
             // For short files, execute one put_object to upload the entire thing.
             let mut data = Vec::with_capacity(est_len as usize);
             reader.read_to_end(&mut data).await?;
-            retry(|| self.upload(&data)).await?;
+            retry_and_count(|| self.upload(&data), "upload_small_file").await?;
             Ok(())
         } else {
             // Otherwise, use multipart upload to improve robustness.
-            self.upload_id = retry(|| self.begin()).await?;
+            self.upload_id = retry_and_count(|| self.begin(), "begin_upload").await?;
             let upload_res = async {
                 let mut buf = vec![0; self.multi_part_size];
                 let mut part_number = 1;
@@ -324,7 +320,11 @@ impl<'client> S3Uploader<'client> {
                     if data_size == 0 {
                         break;
                     }
-                    let part = retry(|| self.upload_part(part_number, &buf[..data_size])).await?;
+                    let part = retry_and_count(
+                        || self.upload_part(part_number, &buf[..data_size]),
+                        "upload_part",
+                    )
+                    .await?;
                     self.parts.push(part);
                     part_number += 1;
                 }
@@ -333,9 +333,9 @@ impl<'client> S3Uploader<'client> {
             .await;
 
             if upload_res.is_ok() {
-                retry(|| self.complete()).await?;
+                retry_and_count(|| self.complete(), "complete_upload").await?;
             } else {
-                let _ = retry(|| self.abort()).await;
+                let _ = retry_and_count(|| self.abort(), "abort_upload").await;
             }
             upload_res
         }

--- a/components/cloud/aws/src/util.rs
+++ b/components/cloud/aws/src/util.rs
@@ -3,6 +3,8 @@
 use std::io::{self, Error, ErrorKind};
 
 use async_trait::async_trait;
+use cloud::metrics;
+use futures::{future::TryFutureExt, Future};
 use rusoto_core::{
     region::Region,
     request::{HttpClient, HttpConfig},
@@ -11,9 +13,35 @@ use rusoto_credential::{
     AutoRefreshingProvider, AwsCredentials, ChainProvider, CredentialsError, ProvideAwsCredentials,
 };
 use rusoto_sts::WebIdentityProvider;
+use tikv_util::{
+    stream::{retry_ext, RetryError, RetryExt},
+    warn,
+};
 
 #[allow(dead_code)] // This will be used soon, please remove the allow.
 const READ_BUF_SIZE: usize = 1024 * 1024 * 2;
+
+const AWS_WEB_IDENTITY_TOKEN_FILE: &str = "AWS_WEB_IDENTITY_TOKEN_FILE";
+struct CredentialsErrorWrapper(CredentialsError);
+
+impl From<CredentialsErrorWrapper> for CredentialsError {
+    fn from(c: CredentialsErrorWrapper) -> CredentialsError {
+        c.0
+    }
+}
+
+impl std::fmt::Display for CredentialsErrorWrapper {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0.message)?;
+        Ok(())
+    }
+}
+
+impl RetryError for CredentialsErrorWrapper {
+    fn is_retryable(&self) -> bool {
+        true
+    }
+}
 
 pub fn new_http_client() -> io::Result<HttpClient> {
     let mut http_config = HttpConfig::new();
@@ -47,6 +75,22 @@ pub fn get_region(region: &str, endpoint: &str) -> io::Result<Region> {
     } else {
         Ok(Region::default())
     }
+}
+
+pub async fn retry_and_count<G, T, F, E>(action: G, name: &'static str) -> Result<T, E>
+where
+    G: FnMut() -> F,
+    F: Future<Output = Result<T, E>>,
+    E: RetryError + std::fmt::Display,
+{
+    let id = uuid::Uuid::new_v4();
+    retry_ext(
+        action,
+        RetryExt::default().with_fail_hook(move |err: &E| {
+            warn!("aws request meet error."; "err" => %err, "retry?" => %err.is_retryable(), "context" => %name, "uuid" => %id);
+            metrics::CLOUD_ERROR_VEC.with_label_values(&["aws", name]);
+        }),
+    ).await
 }
 
 pub struct CredentialsProvider(AutoRefreshingProvider<DefaultCredentialsProvider>);
@@ -92,21 +136,81 @@ impl Default for DefaultCredentialsProvider {
 #[async_trait]
 impl ProvideAwsCredentials for DefaultCredentialsProvider {
     async fn credentials(&self) -> Result<AwsCredentials, CredentialsError> {
-        // Prefer the web identity provider first for the kubernetes environment.
-        // Search for both in parallel.
-        let web_creds = self.web_identity_provider.credentials();
-        let def_creds = self.default_provider.credentials();
-        let k8s_error = match web_creds.await {
-            res @ Ok(_) => return res,
-            Err(e) => e,
+        // use web identity provider first for the kubernetes environment.
+        let cred = if std::env::var(AWS_WEB_IDENTITY_TOKEN_FILE).is_ok() {
+            // we need invoke assume_role in web identity provider
+            // this API may failed sometimes.
+            // according to AWS experience, it's better to retry it with 10 times
+            // exponential backoff for every error, because we cannot
+            // distinguish the error type.
+            retry_and_count(
+                || {
+                    #[cfg(test)]
+                    fail::fail_point!("cred_err", |_| {
+                        Box::pin(futures::future::err(CredentialsErrorWrapper(
+                            CredentialsError::new("injected error"),
+                        )))
+                            as std::pin::Pin<Box<dyn futures::Future<Output = _> + Send>>
+                    });
+                    let res = self
+                        .web_identity_provider
+                        .credentials()
+                        .map_err(|e| CredentialsErrorWrapper(e));
+                    #[cfg(test)]
+                    return Box::pin(res);
+                    #[cfg(not(test))]
+                    res
+                },
+                "get_cred_over_the_cloud",
+            )
+            .await
+            .map_err(|e| e.0)
+        } else {
+            // Add exponential backoff for every error, because we cannot
+            // distinguish the error type.
+            retry_and_count(
+                || {
+                    self.default_provider
+                        .credentials()
+                        .map_err(|e| CredentialsErrorWrapper(e))
+                },
+                "get_cred_on_premise",
+            )
+            .await
+            .map_err(|e| e.0)
         };
-        let def_error = match def_creds.await {
-            res @ Ok(_) => return res,
-            Err(e) => e,
-        };
-        Err(CredentialsError::new(format_args!(
-            "Couldn't find AWS credentials in default sources ({}) or k8s environment ({}).",
-            def_error.message, k8s_error.message,
-        )))
+
+        cred.map_err(|e| {
+            CredentialsError::new(format_args!(
+                "Couldn't find AWS credentials in sources ({}).",
+                e.message
+            ))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[allow(unused_imports)]
+    use super::*;
+
+    #[cfg(feature = "failpoints")]
+    #[tokio::test]
+    async fn test_default_provider() {
+        let default_provider = DefaultCredentialsProvider::default();
+        std::env::set_var(AWS_WEB_IDENTITY_TOKEN_FILE, "tmp");
+        // mock k8s env with web_identitiy_provider
+        fail::cfg("cred_err", "return").unwrap();
+        fail::cfg("retry_count", "return(1)").unwrap();
+        let res = default_provider.credentials().await;
+        assert_eq!(res.is_err(), true);
+        assert_eq!(
+            res.err().unwrap().message,
+            "Couldn't find AWS credentials in sources (injected error)."
+        );
+        fail::remove("cred_err");
+        fail::remove("retry_count");
+
+        std::env::remove_var(AWS_WEB_IDENTITY_TOKEN_FILE);
     }
 }

--- a/components/cloud/aws/src/util.rs
+++ b/components/cloud/aws/src/util.rs
@@ -88,7 +88,7 @@ where
         action,
         RetryExt::default().with_fail_hook(move |err: &E| {
             warn!("aws request meet error."; "err" => %err, "retry?" => %err.is_retryable(), "context" => %name, "uuid" => %id);
-            metrics::CLOUD_ERROR_VEC.with_label_values(&["aws", name]);
+            metrics::CLOUD_ERROR_VEC.with_label_values(&["aws", name]).inc();
         }),
     ).await
 }

--- a/components/cloud/src/metrics.rs
+++ b/components/cloud/src/metrics.rs
@@ -10,4 +10,10 @@ lazy_static! {
         &["cloud", "req"]
     )
     .unwrap();
+    pub static ref CLOUD_ERROR_VEC: IntCounterVec = register_int_counter_vec!(
+        "tikv_cloud_error_count",
+        "Total number of credentail errors from EKS env",
+        &["cloud", "error"]
+    )
+    .unwrap();
 }

--- a/components/tikv_util/src/stream.rs
+++ b/components/tikv_util/src/stream.rs
@@ -96,19 +96,69 @@ pub trait RetryError {
 /// <https://cloud.google.com/storage/docs/exponential-backoff>
 /// Since rusoto does not have transparent auto-retry
 /// (<https://github.com/rusoto/rusoto/issues/234>), we need to implement this manually.
-pub async fn retry<G, T, F, E>(mut action: G) -> Result<T, E>
+pub async fn retry<G, T, F, E>(action: G) -> Result<T, E>
+where
+    G: FnMut() -> F,
+    F: Future<Output = Result<T, E>>,
+    E: RetryError,
+{
+    retry_ext(action, RetryExt::default()).await
+}
+
+/// The extra configuration for retry.
+pub struct RetryExt<E> {
+    // NOTE: we can move `MAX_RETRY_DELAY` and `MAX_RETRY_TIMES`
+    // to here, for making the retry more configurable.
+    // However those are constant for now and no place for configure them.
+    on_failure: Option<Box<dyn FnMut(&E) + Send + Sync + 'static>>,
+}
+
+impl<E> RetryExt<E> {
+    /// Attaches the failure hook to the ext.
+    pub fn with_fail_hook<F>(mut self, f: F) -> Self
+    where
+        F: FnMut(&E) + Send + Sync + 'static,
+    {
+        self.on_failure = Some(Box::new(f));
+        self
+    }
+}
+
+// If we use the default derive macro, it would complain that `E` isn't
+// `Default` :(
+impl<E> Default for RetryExt<E> {
+    fn default() -> Self {
+        Self {
+            on_failure: Default::default(),
+        }
+    }
+}
+
+/// Retires a future execution. Comparing to `retry`, this version allows more
+/// configurations.
+pub async fn retry_ext<G, T, F, E>(mut action: G, mut ext: RetryExt<E>) -> Result<T, E>
 where
     G: FnMut() -> F,
     F: Future<Output = Result<T, E>>,
     E: RetryError,
 {
     const MAX_RETRY_DELAY: Duration = Duration::from_secs(32);
-    const MAX_RETRY_TIMES: usize = 4;
+    const MAX_RETRY_TIMES: usize = 14;
+    let max_retry_times = (|| {
+        fail::fail_point!("retry_count", |t| t
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or(MAX_RETRY_TIMES));
+        MAX_RETRY_TIMES
+    })();
+
     let mut retry_wait_dur = Duration::from_secs(1);
 
     let mut final_result = action().await;
-    for _ in 1..MAX_RETRY_TIMES {
+    for _ in 1..max_retry_times {
         if let Err(e) = &final_result {
+            if let Some(ref mut f) = ext.on_failure {
+                f(e);
+            }
             if e.is_retryable() {
                 let backoff = thread_rng().gen_range(0..1000);
                 sleep(retry_wait_dur + Duration::from_millis(backoff)).await;


### PR DESCRIPTION
Signed-off-by: 3pointer <luancheng@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/tikv/tikv/issues/13122

What's Changed:
1. In EKS environment. we shouldn't let the credential fail back. if we detected the credential provider from k8s env. and if we gets error. just retry it.
2. Add retry time to 14(about 5 mins) for all s3 interface and credentials interface. according to experience the jitter of network could be 1 min
<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```cloud: retry on web identity provider credentials
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test
1. create eks cluster.
2. import data.
3. make sure SA with correct role.
![origin_img_v2_51eda314-8a34-4b25-837c-81fb009f00bg](https://user-images.githubusercontent.com/5906259/188551254-074620a4-485e-4de6-8122-12e3ed8ff0ef.png)
4. do backup check the backup succeed
![origin_img_v2_2987666a-5009-44e9-948f-201729a5b4cg](https://user-images.githubusercontent.com/5906259/188551143-c2b456ad-b412-423c-b91a-c7a3cf813c7d.png)
5. bind SA with invalid role
![origin_img_v2_aa63a7e8-28aa-47f6-8b6d-7ee275e0516g](https://user-images.githubusercontent.com/5906259/188551349-580d99f8-40be-4596-942d-bb00fd4c0cbf.png)
6. do backup and check the error message
![origin_img_v2_234ac260-dce1-4d6e-a90f-266e762ac20g](https://user-images.githubusercontent.com/5906259/188551420-a47ebe62-4562-41e0-8c78-d76d0210f1f0.png)

it doesn't fall back to default credentials provider.


Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix the issue that cause permission denied when gets error from web identity provider and fail back to default provider.
```
