### PR TITLE
causal_ts: add benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,6 +722,7 @@ name = "causal_ts"
 version = "0.0.1"
 dependencies = [
  "api_version",
+ "criterion",
  "engine_rocks",
  "engine_traits",
  "error_code",

--- a/components/causal_ts/Cargo.toml
+++ b/components/causal_ts/Cargo.toml
@@ -34,4 +34,10 @@ tokio = { version = "1", features = ["sync"] }
 txn_types = { path = "../txn_types", default-features = false }
 
 [dev-dependencies]
+criterion = "0.3"
 test_raftstore = { path = "../test_raftstore" }
+
+[[bench]]
+name = "tso"
+path = "benches/tso.rs"
+harness = false

--- a/components/causal_ts/benches/tso.rs
+++ b/components/causal_ts/benches/tso.rs
@@ -1,0 +1,123 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::{sync::Arc, time::Duration};
+
+use causal_ts::{BatchTsoProvider, CausalTsProvider, TsoBatchList};
+use criterion::*;
+use futures::executor::block_on;
+use test_raftstore::TestPdClient;
+use txn_types::TimeStamp;
+
+fn bench_batch_tso_list_pop(c: &mut Criterion) {
+    const CAPACITY: u64 = 10_000;
+    let cases = vec![("100", 100), ("10k", 10_000)]; // (id, batch_size)
+
+    let bench_func = |b: &mut Bencher<'_>, batch_size: u64| {
+        let batch_list = TsoBatchList::new(CAPACITY as u32);
+        b.iter_batched(
+            || {
+                batch_list.flush();
+                for i in 0..CAPACITY {
+                    batch_list
+                        .push(
+                            batch_size as u32,
+                            TimeStamp::compose(i as u64, batch_size),
+                            false,
+                        )
+                        .unwrap();
+                }
+            },
+            |_| {
+                black_box(batch_list.pop(None).unwrap());
+            },
+            BatchSize::NumIterations(CAPACITY * batch_size),
+        )
+    };
+
+    let mut group = c.benchmark_group("batch_tso_list_pop");
+    for (id, batch_size) in cases {
+        group.bench_function(id, |b| {
+            bench_func(b, batch_size);
+        });
+    }
+}
+
+fn bench_batch_tso_list_push(c: &mut Criterion) {
+    const BATCH_SIZE: u64 = 8192;
+    let cases = vec![("50", 50), ("1024", 1024)]; // (id, capacity)
+
+    let bench_func = |b: &mut Bencher<'_>, capacity: u64| {
+        let batch_list = TsoBatchList::new(capacity as u32);
+        let mut i = 0;
+        b.iter(|| {
+            i += 1;
+            black_box(
+                batch_list
+                    .push(
+                        BATCH_SIZE as u32,
+                        TimeStamp::compose(i as u64, BATCH_SIZE),
+                        false,
+                    )
+                    .unwrap(),
+            );
+        })
+    };
+
+    let mut group = c.benchmark_group("batch_tso_list_push");
+    for (id, capacity) in cases {
+        group.bench_function(id, |b| {
+            bench_func(b, capacity);
+        });
+    }
+}
+
+fn bench_batch_tso_provider_get_ts(c: &mut Criterion) {
+    let pd_cli = Arc::new(TestPdClient::new(1, false));
+
+    // Disable background renew by setting `renew_interval` to 0 to make test result
+    // stable.
+    let provider = block_on(BatchTsoProvider::new_opt(
+        pd_cli,
+        Duration::ZERO,
+        Duration::from_secs(1), // cache_multiplier = 10
+        100,
+        80000,
+    ))
+    .unwrap();
+
+    c.bench_function("bench_batch_tso_provider_get_ts", |b| {
+        b.iter(|| {
+            black_box(provider.get_ts().unwrap());
+        })
+    });
+}
+
+fn bench_batch_tso_provider_flush(c: &mut Criterion) {
+    let pd_cli = Arc::new(TestPdClient::new(1, false));
+
+    // Disable background renew by setting `renew_interval` to 0 to make test result
+    // stable.
+    let provider = block_on(BatchTsoProvider::new_opt(
+        pd_cli,
+        Duration::ZERO,
+        Duration::from_secs(1), // cache_multiplier = 10
+        100,
+        80000,
+    ))
+    .unwrap();
+
+    c.bench_function("bench_batch_tso_provider_flush", |b| {
+        b.iter(|| {
+            black_box(provider.flush()).unwrap();
+        })
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_batch_tso_list_pop,
+    bench_batch_tso_list_push,
+    bench_batch_tso_provider_get_ts,
+    bench_batch_tso_provider_flush,
+);
+criterion_main!(benches);

--- a/components/causal_ts/src/tso.rs
+++ b/components/causal_ts/src/tso.rs
@@ -140,7 +140,7 @@ impl TsoBatch {
 /// the scenario of leader transfer). Other regions without the requirement can
 /// still use older TSO cache.
 #[derive(Default, Debug)]
-struct TsoBatchList {
+pub struct TsoBatchList {
     inner: RwLock<TsoBatchListInner>,
 
     /// Number of remaining (available) TSO.
@@ -191,7 +191,6 @@ impl TsoBatchList {
         usage
     }
 
-    // TODO: make it async
     fn remove_batch(&self, key: u64) {
         if let Some(batch) = self.inner.write().remove(&key) {
             self.tso_remain
@@ -218,7 +217,9 @@ impl TsoBatchList {
                 self.tso_usage.fetch_add(1, Ordering::Relaxed);
                 self.tso_remain.fetch_sub(1, Ordering::Relaxed);
                 if is_used_up {
-                    // TODO: make it async
+                    // Note: do NOT try to make it async.
+                    // According to benchmark, `remove_batch` can be done in ~50ns, while async
+                    // implemented by `Worker` costs ~1us.
                     self.remove_batch(key);
                 }
                 return Some(ts);
@@ -253,8 +254,10 @@ impl TsoBatchList {
                 .fetch_add(batch_size as i32, Ordering::Relaxed);
         }
 
-        // remove items out of capacity limitation.
-        // TODO: make it async
+        // Remove items out of capacity limitation.
+        // Note: do NOT try to make it async.
+        // According to benchmark, `write().pop_first()` can be done in ~50ns, while
+        // async implemented by `Worker` costs ~1us.
         if self.inner.read().len() > self.capacity as usize {
             if let Some((_, batch)) = self.inner.write().pop_first() {
                 self.tso_remain

--- a/components/txn_types/src/lib.rs
+++ b/components/txn_types/src/lib.rs
@@ -16,7 +16,7 @@ use std::io;
 use error_code::{self, ErrorCode, ErrorCodeExt};
 pub use lock::{Lock, LockType, PessimisticLock};
 use thiserror::Error;
-pub use timestamp::{TimeStamp, TsSet};
+pub use timestamp::{TimeStamp, TsSet, TSO_PHYSICAL_SHIFT_BITS};
 pub use types::{
     is_short_value, Key, KvPair, Mutation, MutationType, OldValue, OldValues, TxnExtra,
     TxnExtraScheduler, Value, WriteBatchFlags, SHORT_VALUE_MAX_LEN,

--- a/components/txn_types/src/timestamp.rs
+++ b/components/txn_types/src/timestamp.rs
@@ -12,7 +12,7 @@ use collections::HashSet;
 #[repr(transparent)]
 pub struct TimeStamp(u64);
 
-const TSO_PHYSICAL_SHIFT_BITS: u64 = 18;
+pub const TSO_PHYSICAL_SHIFT_BITS: u64 = 18;
 
 impl TimeStamp {
     /// Create a time stamp from physical and logical components.


### PR DESCRIPTION
Issue Number: #12794

Signed-off-by: pingyu <yuping@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #12794

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
1. Add benchmark for `causal_ts.BatchTsoProvider`.
2. Change implementation of `TestPdClient.batch_get_tso` to meet interface convention of real PD.
3. Remove "TODO" of making batch removal async for `causal_ts.TsoBatchList`.
```

This is a following PR of #12970. Its original purpose is addressing 2 TODOs ([here](https://github.com/tikv/tikv/blob/90c4a0602040102fabf45ea8e8bfac33f4472d07/components/causal_ts/src/tso.rs#L221) & [here](https://github.com/tikv/tikv/blob/90c4a0602040102fabf45ea8e8bfac33f4472d07/components/causal_ts/src/tso.rs#L257), to make some batch removal operations async and reduce latency.

However, I found that the performance has regressed. See the code [here](https://github.com/tikv/tikv/compare/master...pingyu:tso_batch_list_async), and benchmark result as following. Removing batches with write lock cost `~50ns`, while async implementation by `Worker` cost `> 1us`.
```shell
batch_tso_list_pop/100 sync
                        time:   [48.856 ns 51.229 ns 54.178 ns]
                        change: [-33.633% -18.979% -3.3177%] (p = 0.03 < 0.05)
                        Performance has improved.
batch_tso_list_pop/100 async
                        time:   [1.1562 us 1.3353 us 1.5321 us]
                        change: [-24.163% -5.1578% +20.336%] (p = 0.66 > 0.05)
                        No change in performance detected.
batch_tso_list_pop/10k sync
                        time:   [49.764 ns 51.910 ns 54.444 ns]
                        change: [-28.391% -8.9375% +7.3228%] (p = 0.63 > 0.05)
                        No change in performance detected.
batch_tso_list_pop/10k async
                        time:   [1.1431 us 1.3593 us 1.5998 us]
                        change: [-14.857% +7.3530% +34.254%] (p = 0.54 > 0.05)
                        No change in performance detected.

batch_tso_list_push/sync
                        time:   [173.60 ns 177.21 ns 181.55 ns]
                        change: [-12.558% -9.0807% -5.6845%] (p = 0.00 < 0.05)
                        Performance has improved.
batch_tso_list_push/async
                        time:   [1.2271 us 1.3425 us 1.4572 us]
                        change: [-14.981% -7.4771% +1.1376%] (p = 0.08 > 0.05)
                        No change in performance detected.
```

So the change for making batch removal async is undone, and just add codes of benchmark for future use.

The result of benchmark in this PR:
```shell
❯ cargo criterion -p causal_ts -- tso
...
...
batch_tso_list_pop/100  time:   [51.912 ns 68.496 ns 89.613 ns]
batch_tso_list_pop/10k  time:   [48.877 ns 51.868 ns 55.396 ns]

batch_tso_list_push/50  time:   [152.94 ns 154.12 ns 155.38 ns]
batch_tso_list_push/1024
                        time:   [179.25 ns 181.07 ns 183.03 ns]

bench_batch_tso_provider_get_ts
                        time:   [105.93 ns 106.75 ns 107.65 ns]

bench_batch_tso_provider_flush
                        time:   [6.4969 us 7.1447 us 7.8449 us]
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`: No.
- Need to cherry-pick to the release branch: No.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- No.
- 
### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Add benchmark for causal_ts.BatchTsoProvider.
```
