### PR TITLE
copr: fix wrong json opaque serialization

### DIFF
--- a/components/tidb_query_datatype/src/codec/mysql/json/serde.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/json/serde.rs
@@ -115,7 +115,11 @@ impl<'a> Serialize for JsonRef<'a> {
                     .get_opaque_type()
                     .map_err(|_| SerError::custom("invalid opaque type code"))?;
 
-                let str = format!("base64:type{}:{}", typ, base64::encode(bytes));
+                let str = format!(
+                    "base64:type{}:{}",
+                    typ.to_u8().unwrap(),
+                    base64::encode(bytes)
+                );
                 serializer.serialize_str(&str)
             }
         }
@@ -227,6 +231,7 @@ impl<'de> Deserialize<'de> for Json {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::FieldTypeTp;
 
     #[test]
     fn test_from_str_for_object() {
@@ -274,6 +279,42 @@ mod tests {
         for json_str in illegal_cases {
             let resp = Json::from_str(json_str);
             resp.unwrap_err();
+        }
+    }
+
+    #[test]
+    fn test_to_str() {
+        let legal_cases = vec![
+            (
+                Json::from_kv_pairs(vec![(
+                    b"key",
+                    Json::from_str_val("value").unwrap().as_ref(),
+                )])
+                .unwrap(),
+                r#"{"key": "value"}"#,
+            ),
+            (
+                Json::from_array(vec![
+                    Json::from_str_val("d1").unwrap(),
+                    Json::from_str_val("d2").unwrap(),
+                ])
+                .unwrap(),
+                r#"["d1", "d2"]"#,
+            ),
+            (Json::from_i64(-3).unwrap(), r#"-3"#),
+            (Json::from_i64(3).unwrap(), r#"3"#),
+            (Json::from_f64(3.0).unwrap(), r#"3.0"#),
+            (Json::none().unwrap(), r#"null"#),
+            (Json::from_bool(true).unwrap(), r#"true"#),
+            (Json::from_bool(false).unwrap(), r#"false"#),
+            (
+                Json::from_opaque(FieldTypeTp::VarString, &[0xAB, 0xCD]).unwrap(),
+                r#""base64:type253:q80=""#,
+            ),
+        ];
+
+        for (json, json_str) in legal_cases {
+            assert_eq!(json.to_string(), json_str);
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What is changed and how it works?

Issue Number: Close #13391 

What's Changed:

1. Change the format of json opaque serialization
2. Add more tests about it

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix the issue that the serialization of opaque value is not compatible with MySQL
```
