### PR TITLE
server, raftstore: check resolved ts when prepare the region flashback

### DIFF
--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -1015,7 +1015,7 @@ where
             if version > safe_ts {
                 ch.send(Err(Error::Other(
                     format!(
-                        "region {} safe ts {} is smaller the the flashback version {}",
+                        "region {} safe ts {} is smaller than the flashback version {}",
                         region_id, safe_ts, version
                     )
                     .into(),

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -1008,15 +1008,14 @@ where
             .unwrap();
             return;
         }
-        // Check if the flashback version is greater than the region safe ts, i.e, the
-        // resolved ts.
+        // Check if the flashback version is greater than the region resolved ts.
         let meta = self.ctx.store_meta.lock().unwrap();
-        if let Some(safe_ts) = meta.region_read_progress.get_safe_ts(&region_id) {
-            if version > safe_ts {
+        if let Some(resolved_ts) = meta.region_read_progress.get_resolved_ts(&region_id) {
+            if version > resolved_ts {
                 ch.send(Err(Error::Other(
                     format!(
-                        "region {} safe ts {} is smaller than the flashback version {}",
-                        region_id, safe_ts, version
+                        "region {} resolved ts {} is smaller than the flashback version {}",
+                        region_id, resolved_ts, version
                     )
                     .into(),
                 )))

--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -29,17 +29,20 @@ use tracker::{get_tls_tracker_token, TrackerToken, GLOBAL_TRACKERS, INVALID_TRAC
 use super::{
     local_metrics::TimeTracker, region_meta::RegionMeta, worker::FetchedLogs, RegionSnapshot,
 };
-use crate::store::{
-    fsm::apply::{CatchUpLogs, ChangeObserver, TaskRes as ApplyTaskRes},
-    metrics::RaftEventDurationType,
-    peer::{
-        SnapshotRecoveryWaitApplySyncer, UnsafeRecoveryExecutePlanSyncer,
-        UnsafeRecoveryFillOutReportSyncer, UnsafeRecoveryForceLeaderSyncer,
-        UnsafeRecoveryWaitApplySyncer,
+use crate::{
+    store::{
+        fsm::apply::{CatchUpLogs, ChangeObserver, TaskRes as ApplyTaskRes},
+        metrics::RaftEventDurationType,
+        peer::{
+            SnapshotRecoveryWaitApplySyncer, UnsafeRecoveryExecutePlanSyncer,
+            UnsafeRecoveryFillOutReportSyncer, UnsafeRecoveryForceLeaderSyncer,
+            UnsafeRecoveryWaitApplySyncer,
+        },
+        util::{KeysInfoFormatter, LatencyInspector},
+        worker::{Bucket, BucketRange},
+        SnapKey,
     },
-    util::{KeysInfoFormatter, LatencyInspector},
-    worker::{Bucket, BucketRange},
-    SnapKey,
+    Error,
 };
 
 #[derive(Debug)]
@@ -513,7 +516,11 @@ where
     UnsafeRecoveryWaitApply(UnsafeRecoveryWaitApplySyncer),
     UnsafeRecoveryFillOutReport(UnsafeRecoveryFillOutReportSyncer),
     SnapshotRecoveryWaitApply(SnapshotRecoveryWaitApplySyncer),
-    PrepareFlashback(Sender<bool>),
+    PrepareFlashback(
+        // Version to flashback
+        u64,
+        Sender<Result<(), Error>>,
+    ),
     FinishFlashback,
     CheckPendingAdmin(UnboundedSender<CheckAdminResponse>),
 }

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -766,10 +766,10 @@ pub enum UnsafeRecoveryState {
 // if the latest committed index is met, the syncer will be called to notify the
 // result.
 #[derive(Debug)]
-pub struct FlashbackState(Option<Sender<bool>>);
+pub struct FlashbackState(Option<Sender<Result<()>>>);
 
 impl FlashbackState {
-    pub fn new(ch: Sender<bool>) -> Self {
+    pub fn new(ch: Sender<Result<()>>) -> Self {
         FlashbackState(Some(ch))
     }
 
@@ -778,7 +778,7 @@ impl FlashbackState {
             return;
         }
         let ch = self.0.take().unwrap();
-        match ch.send(true) {
+        match ch.send(Ok(())) {
             Ok(_) => {}
             Err(e) => {
                 error!("Fail to notify flashback state"; "err" => ?e);

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -1424,7 +1424,7 @@ impl<T: Simulator> Cluster<T> {
         let (tx, rx) = oneshot::channel();
 
         router
-            .significant_send(region_id, SignificantMsg::PrepareFlashback(u64::MAX, tx))
+            .significant_send(region_id, SignificantMsg::PrepareFlashback(0, tx))
             .unwrap();
 
         rx.await.unwrap().unwrap();

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -1427,10 +1427,7 @@ impl<T: Simulator> Cluster<T> {
             .significant_send(region_id, SignificantMsg::PrepareFlashback(u64::MAX, tx))
             .unwrap();
 
-        let prepared = rx.await.unwrap();
-        if !prepared {
-            panic!("prepare flashback failed");
-        }
+        rx.await.unwrap().unwrap();
     }
 
     pub fn call_finish_flashback(&mut self, region_id: u64, store_id: u64) {

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -1424,7 +1424,7 @@ impl<T: Simulator> Cluster<T> {
         let (tx, rx) = oneshot::channel();
 
         router
-            .significant_send(region_id, SignificantMsg::PrepareFlashback(tx))
+            .significant_send(region_id, SignificantMsg::PrepareFlashback(u64::MAX, tx))
             .unwrap();
 
         let prepared = rx.await.unwrap();

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -1710,7 +1710,9 @@ fn future_flashback_to_version<
             SignificantMsg::PrepareFlashback(req.get_version(), result_tx),
         )?;
         if let Err(err) = result_rx.await? {
-            return Err(Error::from(err));
+            let mut resp = FlashbackToVersionResponse::default();
+            resp.set_error(format!("failed to prepare the flashback: {}", err));
+            return Ok(resp);
         }
         let (cb, f) = paired_future_callback();
         let res = storage_clone.sched_txn_command(req.into(), cb);

--- a/src/storage/txn/actions/flashback_to_version.rs
+++ b/src/storage/txn/actions/flashback_to_version.rs
@@ -91,7 +91,6 @@ pub fn flashback_to_version<S: Snapshot>(
     // `start_ts` is greater than the specified version, and if it's not a
     // short-value `LockType::Put`, we need to delete the actual data from
     // `CF_DEFAULT` as well.
-    // TODO: `resolved_ts` should be taken into account.
     for (key, lock) in key_locks {
         if txn.write_size() >= MAX_TXN_WRITE_SIZE {
             *next_lock_key = Some(key);

--- a/tests/integrations/raftstore/test_flashback.rs
+++ b/tests/integrations/raftstore/test_flashback.rs
@@ -8,7 +8,7 @@ use test_raftstore::*;
 use txn_types::WriteBatchFlags;
 
 #[test]
-fn test_flahsback_for_applied_index() {
+fn test_flashback_for_applied_index() {
     let mut cluster = new_node_cluster(0, 3);
     cluster.run();
 
@@ -79,7 +79,7 @@ fn test_flashback_for_schedule() {
 }
 
 #[test]
-fn test_flahsback_for_write() {
+fn test_flashback_for_write() {
     let mut cluster = new_node_cluster(0, 3);
     cluster.run();
 
@@ -107,7 +107,7 @@ fn test_flahsback_for_write() {
 }
 
 #[test]
-fn test_flahsback_for_read() {
+fn test_flashback_for_read() {
     let mut cluster = new_node_cluster(0, 3);
     cluster.run();
 
@@ -141,7 +141,7 @@ fn test_flahsback_for_read() {
 // However, when flashback is enabled, it will make the lease None and prevent
 // renew lease.
 #[test]
-fn test_flahsback_for_local_read() {
+fn test_flashback_for_local_read() {
     let mut cluster = new_node_cluster(0, 3);
     let election_timeout = configure_for_lease_read(&mut cluster, Some(50), None);
 
@@ -208,7 +208,7 @@ fn test_flahsback_for_local_read() {
 }
 
 #[test]
-fn test_flahsback_for_status_cmd_as_region_detail() {
+fn test_flashback_for_status_cmd_as_region_detail() {
     let mut cluster = new_node_cluster(0, 3);
     cluster.run();
 

--- a/tests/integrations/server/kv_service.rs
+++ b/tests/integrations/server/kv_service.rs
@@ -599,7 +599,9 @@ fn test_mvcc_resolve_lock_gc_and_delete() {
 
 #[test]
 fn test_mvcc_flashback() {
-    let (_cluster, client, ctx) = must_new_cluster_and_kv_client();
+    let (_cluster, client, ctx) = must_new_and_configure_cluster_and_kv_client(|cluster| {
+        cluster.cfg.resolved_ts.enable = true;
+    });
     let mut ts = 0;
     let k = b"key".to_vec();
     for i in 0..10 {
@@ -679,7 +681,9 @@ fn test_mvcc_flashback() {
 #[test]
 #[cfg(feature = "failpoints")]
 fn test_mvcc_flashback_block_rw() {
-    let (_cluster, client, ctx) = must_new_cluster_and_kv_client();
+    let (_cluster, client, ctx) = must_new_and_configure_cluster_and_kv_client(|cluster| {
+        cluster.cfg.resolved_ts.enable = true;
+    });
     fail::cfg("skip_finish_flashback_to_version", "return").unwrap();
     // Flashback
     let mut flashback_to_version_req = FlashbackToVersionRequest::default();
@@ -728,7 +732,9 @@ fn test_mvcc_flashback_block_rw() {
 #[test]
 #[cfg(feature = "failpoints")]
 fn test_mvcc_flashback_block_scheduling() {
-    let (mut cluster, client, ctx) = must_new_cluster_and_kv_client();
+    let (mut cluster, client, ctx) = must_new_and_configure_cluster_and_kv_client(|cluster| {
+        cluster.cfg.resolved_ts.enable = true;
+    });
     fail::cfg("skip_finish_flashback_to_version", "return").unwrap();
     // Flashback
     let mut flashback_to_version_req = FlashbackToVersionRequest::default();

--- a/tests/integrations/server/kv_service.rs
+++ b/tests/integrations/server/kv_service.rs
@@ -806,7 +806,7 @@ fn test_mvcc_flashback_resolved_ts_check() {
         .unwrap();
     assert!(!flashback_resp.has_region_error());
     assert!(!flashback_resp.get_error().is_empty());
-    must_kv_read_equal(&client, ctx.clone(), k.clone(), v.clone(), ts);
+    must_kv_read_equal(&client, ctx.clone(), k.clone(), v, ts);
     // Flashback with a version that is smaller than the current resolved ts.
     let mut flashback_to_version_req = FlashbackToVersionRequest::default();
     flashback_to_version_req.set_context(ctx.clone());


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #13303.

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Though TiDB will check resolved ts before sending the flashback request to TiKV after https://github.com/pingcap/tidb/pull/37607, 
we still need to perform the check internally in case the upper caller other than TiDB breaks the transaction consistency.
```


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None.
```
