### PR TITLE
raftstore: optimize region destroy (#13384)

### DIFF
--- a/components/engine_rocks/src/misc.rs
+++ b/components/engine_rocks/src/misc.rs
@@ -29,17 +29,6 @@ impl RocksEngine {
     ) -> Result<()> {
         let mut ranges = ranges.to_owned();
         ranges.sort_by(|a, b| a.start_key.cmp(b.start_key));
-        let max_end_key = ranges
-            .iter()
-            .fold(ranges[0].end_key, |x, y| std::cmp::max(x, y.end_key));
-        let start = KeyBuilder::from_slice(ranges[0].start_key, 0, 0);
-        let end = KeyBuilder::from_slice(max_end_key, 0, 0);
-        let mut opts = IterOptions::new(Some(start), Some(end), false);
-        if self.is_titan() {
-            // Cause DeleteFilesInRange may expose old blob index keys, setting key only for Titan
-            // to avoid referring to missing blob files.
-            opts.set_key_only(true);
-        }
 
         let mut writer_wrapper: Option<RocksSstWriter> = None;
         let mut data: Vec<Vec<u8>> = vec![];
@@ -55,7 +44,17 @@ impl RocksEngine {
             }
             last_end_key = Some(r.end_key.to_owned());
 
-            let mut it = self.iterator_cf_opt(cf, opts.clone())?;
+            let mut opts = IterOptions::new(
+                Some(KeyBuilder::from_slice(r.start_key, 0, 0)),
+                Some(KeyBuilder::from_slice(r.end_key, 0, 0)),
+                false,
+            );
+            if self.is_titan() {
+                // Cause DeleteFilesInRange may expose old blob index keys, setting key only for
+                // Titan to avoid referring to missing blob files.
+                opts.set_key_only(true);
+            }
+            let mut it = self.iterator_cf_opt(cf, opts)?;
             let mut it_valid = it.seek(r.start_key.into())?;
             while it_valid {
                 if it.key() >= r.end_key {


### PR DESCRIPTION
cherry-pick #13384 to release-5.4

---

Signed-off-by: tabokie <xy.tao@outlook.com>

### What is changed and how it works?

Issue Number: Close #12421

What's Changed:

Changes are simplified for cherry-pick.

Optimizations:
- Use more accurate bounds to create iterator during `delete_all_in_range_cf_by_ingest`, testing shows it can speed up merge to 10x. (previously we use the max/min of a batch of ranges)
- ~Only call `self.delete_all_in_range` once when cleaning overlap ranges. (previously we delete keys in all overlap ranges, then delete keys in to-apply range)~
- ~When inserting a pending range, only delete files of overlap pending ranges. (previously we also delete keys)~

Refactors:
- ~Change `SnapContext` to a data-only struct `SnapGenContext`. It can be shared by cloning, but fields like `pending_delete_ranges` cannot be shared this way.~

```commit-message
Optimize the performance of merging empty regions
```

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Optimize the performance of merging empty regions
```
