### PR TITLE
test: Separate TestPdClient from test_raftstore component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,7 +743,7 @@ dependencies = [
  "serde_derive",
  "slog",
  "slog-global",
- "test_raftstore",
+ "test_pd_client",
  "thiserror",
  "tikv_alloc",
  "tikv_util",
@@ -795,6 +795,7 @@ dependencies = [
  "slog",
  "slog-global",
  "tempfile",
+ "test_pd_client",
  "test_raftstore",
  "test_util",
  "thiserror",
@@ -5678,6 +5679,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "test_pd_client"
+version = "0.0.1"
+dependencies = [
+ "collections",
+ "fail",
+ "futures 0.3.15",
+ "grpcio",
+ "keys",
+ "kvproto",
+ "log_wrappers",
+ "pd_client",
+ "raft",
+ "raftstore",
+ "slog",
+ "slog-global",
+ "tikv_util",
+ "tokio",
+ "tokio-timer",
+ "txn_types",
+]
+
+[[package]]
 name = "test_raftstore"
 version = "0.0.1"
 dependencies = [
@@ -5713,6 +5736,7 @@ dependencies = [
  "slog",
  "slog-global",
  "tempfile",
+ "test_pd_client",
  "test_util",
  "tikv",
  "tikv_util",
@@ -5828,6 +5852,7 @@ dependencies = [
  "test_backup",
  "test_coprocessor",
  "test_pd",
+ "test_pd_client",
  "test_raftstore",
  "test_sst_importer",
  "test_storage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -265,6 +265,7 @@ members = [
   "components/test_coprocessor",
   "components/test_coprocessor_plugin/example_plugin",
   "components/test_pd",
+  "components/test_pd_client",
   "components/test_raftstore",
   "components/test_sst_importer",
   "components/test_storage",

--- a/components/causal_ts/Cargo.toml
+++ b/components/causal_ts/Cargo.toml
@@ -35,7 +35,7 @@ txn_types = { path = "../txn_types", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3"
-test_raftstore = { path = "../test_raftstore" }
+test_pd_client = { path = "../test_pd_client" }
 
 [[bench]]
 name = "tso"

--- a/components/causal_ts/benches/tso.rs
+++ b/components/causal_ts/benches/tso.rs
@@ -5,7 +5,7 @@ use std::{sync::Arc, time::Duration};
 use causal_ts::{BatchTsoProvider, CausalTsProvider, TsoBatchList};
 use criterion::*;
 use futures::executor::block_on;
-use test_raftstore::TestPdClient;
+use test_pd_client::TestPdClient;
 use txn_types::TimeStamp;
 
 fn bench_batch_tso_list_pop(c: &mut Criterion) {

--- a/components/causal_ts/src/observer.rs
+++ b/components/causal_ts/src/observer.rs
@@ -166,7 +166,7 @@ pub mod tests {
         metapb::Region,
         raft_cmdpb::{RaftCmdRequest, Request as RaftRequest},
     };
-    use test_raftstore::TestPdClient;
+    use test_pd_client::TestPdClient;
     use txn_types::{Key, TimeStamp};
 
     use super::*;

--- a/components/causal_ts/src/tso.rs
+++ b/components/causal_ts/src/tso.rs
@@ -633,7 +633,7 @@ impl CausalTsProvider for SimpleTsoProvider {
 
 #[cfg(test)]
 pub mod tests {
-    use test_raftstore::TestPdClient;
+    use test_pd_client::TestPdClient;
 
     use super::*;
 

--- a/components/cdc/Cargo.toml
+++ b/components/cdc/Cargo.toml
@@ -70,6 +70,7 @@ engine_rocks = { path = "../engine_rocks", default-features = false }
 engine_traits = { path = "../engine_traits", default-features = false }
 raft = { version = "0.7.0", default-features = false, features = ["protobuf-codec"] }
 tempfile = "3.0"
+test_pd_client = { path = "../test_pd_client" }
 test_raftstore = { path = "../test_raftstore", default-features = false }
 test_util = { path = "../test_util", default-features = false }
 

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -1433,7 +1433,8 @@ mod tests {
         errors::{DiscardReason, Error as RaftStoreError},
         store::{msg::CasualMessage, PeerMsg, ReadDelegate},
     };
-    use test_raftstore::{MockRaftStoreRouter, TestPdClient};
+    use test_pd_client::TestPdClient;
+    use test_raftstore::MockRaftStoreRouter;
     use tikv::{
         server::DEFAULT_CLUSTER_ID,
         storage::{kv::Engine, TestEngineBuilder},

--- a/components/cdc/tests/failpoints/test_observe.rs
+++ b/components/cdc/tests/failpoints/test_observe.rs
@@ -14,7 +14,6 @@ use grpcio::WriteFlags;
 use kvproto::{cdcpb::*, kvrpcpb::*, raft_serverpb::RaftMessage};
 use pd_client::PdClient;
 use raft::eraftpb::MessageType;
-use test_raftstore::*;
 use tikv_util::{config::ReadableDuration, HandyRwLock};
 
 use crate::{new_event_feed, TestSuite, TestSuiteBuilder};

--- a/components/cdc/tests/failpoints/test_observe.rs
+++ b/components/cdc/tests/failpoints/test_observe.rs
@@ -14,6 +14,7 @@ use grpcio::WriteFlags;
 use kvproto::{cdcpb::*, kvrpcpb::*, raft_serverpb::RaftMessage};
 use pd_client::PdClient;
 use raft::eraftpb::MessageType;
+use test_raftstore::*;
 use tikv_util::{config::ReadableDuration, HandyRwLock};
 
 use crate::{new_event_feed, TestSuite, TestSuiteBuilder};

--- a/components/test_pd_client/Cargo.toml
+++ b/components/test_pd_client/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "test_pd_client"
+version = "0.0.1"
+edition = "2018"
+publish = false
+
+[dependencies]
+collections = { path = "../collections" }
+fail = "0.5"
+futures = "0.3"
+grpcio = { version = "0.10", default-features = false, features = ["openssl-vendored", "protobuf-codec"] }
+keys = { path = "../keys", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git" }
+log_wrappers = { path = "../log_wrappers" }
+pd_client = { path = "../pd_client", default-features = false }
+raft = { version = "0.7.0", default-features = false, features = ["protobuf-codec"] }
+raftstore = { path = "../raftstore", default-features = false, features = ["testexport"] }
+slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
+slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }
+tikv_util = { path = "../tikv_util", default-features = false }
+tokio = { version = "1.5", features = ["rt-multi-thread"] }
+tokio-timer = { git = "https://github.com/tikv/tokio", branch = "tokio-timer-hotfix" }
+txn_types = { path = "../txn_types", default-features = false }

--- a/components/test_pd_client/src/lib.rs
+++ b/components/test_pd_client/src/lib.rs
@@ -1,0 +1,8 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+#[macro_use]
+extern crate tikv_util;
+
+mod pd;
+
+pub use crate::pd::*;

--- a/components/test_raftstore/Cargo.toml
+++ b/components/test_raftstore/Cargo.toml
@@ -56,6 +56,7 @@ slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debu
 # better to not use slog-global, but pass in the logger
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }
 tempfile = "3.0"
+test_pd_client = { path = "../test_pd_client" }
 test_util = { path = "../test_util", default-features = false }
 tikv = { path = "../../", default-features = false }
 tikv_util = { path = "../tikv_util", default-features = false }

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -46,6 +46,7 @@ use raftstore::{
     Error, Result,
 };
 use tempfile::TempDir;
+use test_pd_client::TestPdClient;
 use tikv::server::Result as ServerResult;
 use tikv_util::{
     thread_group::GroupProperties,

--- a/components/test_raftstore/src/lib.rs
+++ b/components/test_raftstore/src/lib.rs
@@ -8,13 +8,11 @@ extern crate tikv_util;
 mod cluster;
 mod config;
 mod node;
-mod pd;
 mod router;
 mod server;
 mod transport_simulate;
 mod util;
 
 pub use crate::{
-    cluster::*, config::Config, node::*, pd::*, router::*, server::*, transport_simulate::*,
-    util::*,
+    cluster::*, config::Config, node::*, router::*, server::*, transport_simulate::*, util::*,
 };

--- a/components/test_raftstore/src/node.rs
+++ b/components/test_raftstore/src/node.rs
@@ -32,6 +32,7 @@ use raftstore::{
 };
 use resource_metering::CollectorRegHandle;
 use tempfile::TempDir;
+use test_pd_client::TestPdClient;
 use tikv::{
     config::{ConfigController, Module},
     import::SstImporter,

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -45,6 +45,7 @@ use raftstore::{
 use resource_metering::{CollectorRegHandle, ResourceTagFactory};
 use security::SecurityManager;
 use tempfile::TempDir;
+use test_pd_client::TestPdClient;
 use tikv::{
     config::ConfigController,
     coprocessor, coprocessor_v2,

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -144,6 +144,7 @@ sst_importer = { path = "../components/sst_importer", default-features = false }
 test_backup = { path = "../components/test_backup", default-features = false }
 test_coprocessor = { path = "../components/test_coprocessor", default-features = false }
 test_pd = { path = "../components/test_pd", default-features = false }
+test_pd_client = { path = "../components/test_pd_client" }
 test_raftstore = { path = "../components/test_raftstore", default-features = false }
 test_sst_importer = { path = "../components/test_sst_importer", default-features = false }
 test_storage = { path = "../components/test_storage", default-features = false }

--- a/tests/failpoints/cases/test_bootstrap.rs
+++ b/tests/failpoints/cases/test_bootstrap.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, RwLock};
 
 use engine_traits::Peekable;
 use kvproto::{kvrpcpb::ApiVersion, metapb, raft_serverpb};
+use test_pd_client::TestPdClient;
 use test_raftstore::*;
 
 fn test_bootstrap_half_way_failure(fp: &str) {

--- a/tests/failpoints/cases/test_replica_stale_read.rs
+++ b/tests/failpoints/cases/test_replica_stale_read.rs
@@ -5,6 +5,7 @@ use std::{sync::Arc, time::Duration};
 use kvproto::{kvrpcpb::Op, metapb::Peer};
 use pd_client::PdClient;
 use raft::eraftpb::MessageType;
+use test_pd_client::TestPdClient;
 use test_raftstore::*;
 
 fn prepare_for_stale_read(leader: Peer) -> (Cluster<ServerCluster>, Arc<TestPdClient>, PeerClient) {

--- a/tests/failpoints/cases/test_sst_recovery.rs
+++ b/tests/failpoints/cases/test_sst_recovery.rs
@@ -5,6 +5,7 @@ use std::{fmt::Debug, io::Write, path::Path, sync::Arc, time::Duration};
 use engine_rocks::RocksEngine;
 use engine_rocks_helper::sst_recovery::*;
 use engine_traits::{CompactExt, Peekable, CF_DEFAULT};
+use test_pd_client::TestPdClient;
 use test_raftstore::*;
 
 const CHECK_DURATION: Duration = Duration::from_millis(50);

--- a/tests/integrations/config/dynamic/pessimistic_txn.rs
+++ b/tests/integrations/config/dynamic/pessimistic_txn.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use security::SecurityManager;
-use test_raftstore::TestPdClient;
+use test_pd_client::TestPdClient;
 use tikv::{
     config::*,
     server::{

--- a/tests/integrations/config/dynamic/raftstore.rs
+++ b/tests/integrations/config/dynamic/raftstore.rs
@@ -21,7 +21,7 @@ use raftstore::{
 };
 use resource_metering::CollectorRegHandle;
 use tempfile::TempDir;
-use test_raftstore::TestPdClient;
+use test_pd_client::TestPdClient;
 use tikv::{
     config::{ConfigController, Module, TikvConfig},
     import::SstImporter,

--- a/tests/integrations/raftstore/test_bootstrap.rs
+++ b/tests/integrations/raftstore/test_bootstrap.rs
@@ -13,6 +13,7 @@ use raftstore::{
 };
 use resource_metering::CollectorRegHandle;
 use tempfile::Builder;
+use test_pd_client::{bootstrap_with_first_region, TestPdClient};
 use test_raftstore::*;
 use tikv::{import::SstImporter, server::Node};
 use tikv_util::{

--- a/tests/integrations/raftstore/test_conf_change.rs
+++ b/tests/integrations/raftstore/test_conf_change.rs
@@ -19,6 +19,7 @@ use kvproto::{
 use pd_client::PdClient;
 use raft::eraftpb::{ConfChangeType, MessageType};
 use raftstore::{store::util::is_learner, Result};
+use test_pd_client::TestPdClient;
 use test_raftstore::*;
 use tikv_util::{config::ReadableDuration, time::Instant, HandyRwLock};
 


### PR DESCRIPTION
Signed-off-by: haojinming <jinming.hao@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #13452 

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```
`TestPdClient` is in `test_raftstore` component, which may cause circular dependency. For example, `causal_ts` need `TestPdClient`  and `test_raftstore` depend on `causal_ts`. 
Separate `TestPdClient` from `test_raftstore` component to avoid circular dependency.
```

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

Side effects


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
