### PR TITLE
engine_tirocks: port iterator and snapshot

### DIFF
--- a/components/engine_tirocks/Cargo.toml
+++ b/components/engine_tirocks/Cargo.toml
@@ -8,7 +8,9 @@ engine_traits = { path = "../engine_traits" }
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }
 tikv_alloc = { path = "../tikv_alloc" }
+tikv_util = { path = "../tikv_util" }
 tirocks = { git = "https://github.com/busyjay/tirocks.git", branch = "dev" }
 
 [dev-dependencies]
+kvproto = { git = "https://github.com/pingcap/kvproto.git" }
 tempfile = "3.0"

--- a/components/engine_tirocks/src/db_vector.rs
+++ b/components/engine_tirocks/src/db_vector.rs
@@ -1,0 +1,35 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::{
+    fmt::{self, Debug, Formatter},
+    ops::Deref,
+};
+
+use tirocks::PinSlice;
+
+#[derive(Default)]
+pub struct RocksPinSlice(pub(crate) PinSlice);
+
+impl engine_traits::DbVector for RocksPinSlice {}
+
+impl Deref for RocksPinSlice {
+    type Target = [u8];
+
+    #[inline]
+    fn deref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl Debug for RocksPinSlice {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{:?}", &**self)
+    }
+}
+
+impl<'a> PartialEq<&'a [u8]> for RocksPinSlice {
+    #[inline]
+    fn eq(&self, rhs: &&[u8]) -> bool {
+        **rhs == **self
+    }
+}

--- a/components/engine_tirocks/src/engine.rs
+++ b/components/engine_tirocks/src/engine.rs
@@ -3,7 +3,15 @@
 use std::{fs, path::Path, sync::Arc};
 
 use engine_traits::{Code, Error, Result, Status};
-use tirocks::{db::RawCfHandle, Db};
+use tirocks::{
+    db::RawCfHandle,
+    option::{ReadOptions, WriteOptions},
+    Db, Iterator,
+};
+
+use crate::{
+    db_vector::RocksPinSlice, engine_iterator, r2e, util, RocksEngineIterator, RocksSnapshot,
+};
 
 #[derive(Debug)]
 #[repr(transparent)]
@@ -16,8 +24,8 @@ impl RocksEngine {
     }
 
     #[inline]
-    pub fn exists(path: &str) -> Result<bool> {
-        let path = Path::new(path);
+    pub fn exists(path: impl AsRef<Path>) -> Result<bool> {
+        let path = path.as_ref();
         if !path.exists() || !path.is_dir() {
             return Ok(false);
         }
@@ -43,7 +51,250 @@ impl RocksEngine {
     }
 
     #[inline]
-    pub fn cf(&self, name: &str) -> Option<&RawCfHandle> {
-        self.0.cf(name)
+    pub fn cf(&self, name: &str) -> Result<&RawCfHandle> {
+        util::cf_handle(&self.0, name)
+    }
+
+    #[inline]
+    fn get(
+        &self,
+        opts: &engine_traits::ReadOptions,
+        handle: &RawCfHandle,
+        key: &[u8],
+    ) -> Result<Option<RocksPinSlice>> {
+        let mut opt = ReadOptions::default();
+        opt.set_fill_cache(opts.fill_cache());
+        // TODO: reuse slice.
+        let mut slice = RocksPinSlice::default();
+        match self.0.get_pinned(&opt, handle, key, &mut slice.0) {
+            Ok(true) => Ok(Some(slice)),
+            Ok(false) => Ok(None),
+            Err(s) => Err(r2e(s)),
+        }
+    }
+
+    #[inline]
+    fn snapshot(&self) -> RocksSnapshot {
+        RocksSnapshot::new(self.0.clone())
+    }
+}
+
+impl engine_traits::Iterable for RocksEngine {
+    type Iterator = RocksEngineIterator;
+
+    fn iterator_opt(&self, cf: &str, opts: engine_traits::IterOptions) -> Result<Self::Iterator> {
+        let opt = engine_iterator::to_tirocks_opt(opts);
+        let handle = util::cf_handle(&self.0, cf)?;
+        Ok(RocksEngineIterator::from_raw(Iterator::new(
+            self.0.clone(),
+            opt,
+            handle,
+        )))
+    }
+}
+
+impl engine_traits::Peekable for RocksEngine {
+    type DbVector = RocksPinSlice;
+
+    #[inline]
+    fn get_value_opt(
+        &self,
+        opts: &engine_traits::ReadOptions,
+        key: &[u8],
+    ) -> Result<Option<RocksPinSlice>> {
+        self.get(opts, self.0.default_cf(), key)
+    }
+
+    #[inline]
+    fn get_value_cf_opt(
+        &self,
+        opts: &engine_traits::ReadOptions,
+        cf: &str,
+        key: &[u8],
+    ) -> Result<Option<RocksPinSlice>> {
+        let handle = util::cf_handle(&self.0, cf)?;
+        self.get(opts, handle, key)
+    }
+}
+
+impl engine_traits::SyncMutable for RocksEngine {
+    fn put(&self, key: &[u8], value: &[u8]) -> Result<()> {
+        let handle = self.0.default_cf();
+        self.0
+            .put(&WriteOptions::default(), handle, key, value)
+            .map_err(r2e)
+    }
+
+    fn put_cf(&self, cf: &str, key: &[u8], value: &[u8]) -> Result<()> {
+        let handle = util::cf_handle(&self.0, cf)?;
+        self.0
+            .put(&WriteOptions::default(), handle, key, value)
+            .map_err(r2e)
+    }
+
+    fn delete(&self, key: &[u8]) -> Result<()> {
+        let handle = self.0.default_cf();
+        self.0
+            .delete(&WriteOptions::default(), handle, key)
+            .map_err(r2e)
+    }
+
+    fn delete_cf(&self, cf: &str, key: &[u8]) -> Result<()> {
+        let handle = util::cf_handle(&self.0, cf)?;
+        self.0
+            .delete(&WriteOptions::default(), handle, key)
+            .map_err(r2e)
+    }
+
+    fn delete_range(&self, begin_key: &[u8], end_key: &[u8]) -> Result<()> {
+        let handle = self.0.default_cf();
+        self.0
+            .delete_range(&WriteOptions::default(), handle, begin_key, end_key)
+            .map_err(r2e)
+    }
+
+    fn delete_range_cf(&self, cf: &str, begin_key: &[u8], end_key: &[u8]) -> Result<()> {
+        let handle = util::cf_handle(&self.0, cf)?;
+        self.0
+            .delete_range(&WriteOptions::default(), handle, begin_key, end_key)
+            .map_err(r2e)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use engine_traits::{Iterable, Peekable, SyncMutable, CF_DEFAULT};
+    use kvproto::metapb::Region;
+    use tempfile::Builder;
+
+    use crate::util;
+
+    #[test]
+    fn test_base() {
+        let path = Builder::new().prefix("var").tempdir().unwrap();
+        let cf = "cf";
+        let engine = util::new_engine(path.path(), &[CF_DEFAULT, cf]).unwrap();
+
+        let mut r = Region::default();
+        r.set_id(10);
+
+        let key = b"key";
+        engine.put_msg(key, &r).unwrap();
+        engine.put_msg_cf(cf, key, &r).unwrap();
+
+        let snap = engine.snapshot();
+
+        let mut r1: Region = engine.get_msg(key).unwrap().unwrap();
+        assert_eq!(r, r1);
+        let r1_cf: Region = engine.get_msg_cf(cf, key).unwrap().unwrap();
+        assert_eq!(r, r1_cf);
+
+        let mut r2: Region = snap.get_msg(key).unwrap().unwrap();
+        assert_eq!(r, r2);
+        let r2_cf: Region = snap.get_msg_cf(cf, key).unwrap().unwrap();
+        assert_eq!(r, r2_cf);
+
+        r.set_id(11);
+        engine.put_msg(key, &r).unwrap();
+        r1 = engine.get_msg(key).unwrap().unwrap();
+        r2 = snap.get_msg(key).unwrap().unwrap();
+        assert_ne!(r1, r2);
+
+        let b: Option<Region> = engine.get_msg(b"missing_key").unwrap();
+        assert!(b.is_none());
+    }
+
+    #[test]
+    fn test_peekable() {
+        let path = Builder::new().prefix("var").tempdir().unwrap();
+        let cf = "cf";
+        let engine = util::new_engine(path.path(), &[CF_DEFAULT, cf]).unwrap();
+
+        engine.put(b"k1", b"v1").unwrap();
+        engine.put_cf(cf, b"k1", b"v2").unwrap();
+
+        assert_eq!(&*engine.get_value(b"k1").unwrap().unwrap(), b"v1");
+        engine.get_value_cf("foo", b"k1").unwrap_err();
+        assert_eq!(&*engine.get_value_cf(cf, b"k1").unwrap().unwrap(), b"v2");
+    }
+
+    #[test]
+    fn test_scan() {
+        let path = Builder::new().prefix("var").tempdir().unwrap();
+        let cf = "cf";
+        let engine = util::new_engine(path.path(), &[CF_DEFAULT, cf]).unwrap();
+
+        engine.put(b"a1", b"v1").unwrap();
+        engine.put(b"a2", b"v2").unwrap();
+        engine.put_cf(cf, b"a1", b"v1").unwrap();
+        engine.put_cf(cf, b"a2", b"v22").unwrap();
+
+        let mut data = vec![];
+        engine
+            .scan(CF_DEFAULT, b"", &[0xFF, 0xFF], false, |key, value| {
+                data.push((key.to_vec(), value.to_vec()));
+                Ok(true)
+            })
+            .unwrap();
+        assert_eq!(
+            data,
+            vec![
+                (b"a1".to_vec(), b"v1".to_vec()),
+                (b"a2".to_vec(), b"v2".to_vec()),
+            ]
+        );
+        data.clear();
+
+        engine
+            .scan(cf, b"", &[0xFF, 0xFF], false, |key, value| {
+                data.push((key.to_vec(), value.to_vec()));
+                Ok(true)
+            })
+            .unwrap();
+        assert_eq!(
+            data,
+            vec![
+                (b"a1".to_vec(), b"v1".to_vec()),
+                (b"a2".to_vec(), b"v22".to_vec()),
+            ]
+        );
+        data.clear();
+
+        let pair = engine.seek(CF_DEFAULT, b"a1").unwrap().unwrap();
+        assert_eq!(pair, (b"a1".to_vec(), b"v1".to_vec()));
+        assert!(engine.seek(CF_DEFAULT, b"a3").unwrap().is_none());
+        let pair_cf = engine.seek(cf, b"a1").unwrap().unwrap();
+        assert_eq!(pair_cf, (b"a1".to_vec(), b"v1".to_vec()));
+        assert!(engine.seek(cf, b"a3").unwrap().is_none());
+
+        let mut index = 0;
+        engine
+            .scan(CF_DEFAULT, b"", &[0xFF, 0xFF], false, |key, value| {
+                data.push((key.to_vec(), value.to_vec()));
+                index += 1;
+                Ok(index != 1)
+            })
+            .unwrap();
+
+        assert_eq!(data.len(), 1);
+
+        let snap = engine.snapshot();
+
+        engine.put(b"a3", b"v3").unwrap();
+        assert!(engine.seek(CF_DEFAULT, b"a3").unwrap().is_some());
+
+        let pair = snap.seek(CF_DEFAULT, b"a1").unwrap().unwrap();
+        assert_eq!(pair, (b"a1".to_vec(), b"v1".to_vec()));
+        assert!(snap.seek(CF_DEFAULT, b"a3").unwrap().is_none());
+
+        data.clear();
+
+        snap.scan(CF_DEFAULT, b"", &[0xFF, 0xFF], false, |key, value| {
+            data.push((key.to_vec(), value.to_vec()));
+            Ok(true)
+        })
+        .unwrap();
+
+        assert_eq!(data.len(), 2);
     }
 }

--- a/components/engine_tirocks/src/engine.rs
+++ b/components/engine_tirocks/src/engine.rs
@@ -84,7 +84,7 @@ impl engine_traits::Iterable for RocksEngine {
 
     fn iterator_opt(&self, cf: &str, opts: engine_traits::IterOptions) -> Result<Self::Iterator> {
         let opt = engine_iterator::to_tirocks_opt(opts);
-        let handle = util::cf_handle(&self.0, cf)?;
+        let handle = self.cf(cf)?;
         Ok(RocksEngineIterator::from_raw(Iterator::new(
             self.0.clone(),
             opt,
@@ -112,7 +112,7 @@ impl engine_traits::Peekable for RocksEngine {
         cf: &str,
         key: &[u8],
     ) -> Result<Option<RocksPinSlice>> {
-        let handle = util::cf_handle(&self.0, cf)?;
+        let handle = self.cf(cf)?;
         self.get(opts, handle, key)
     }
 }
@@ -126,7 +126,7 @@ impl engine_traits::SyncMutable for RocksEngine {
     }
 
     fn put_cf(&self, cf: &str, key: &[u8], value: &[u8]) -> Result<()> {
-        let handle = util::cf_handle(&self.0, cf)?;
+        let handle = self.cf(cf)?;
         self.0
             .put(&WriteOptions::default(), handle, key, value)
             .map_err(r2e)
@@ -140,7 +140,7 @@ impl engine_traits::SyncMutable for RocksEngine {
     }
 
     fn delete_cf(&self, cf: &str, key: &[u8]) -> Result<()> {
-        let handle = util::cf_handle(&self.0, cf)?;
+        let handle = self.cf(cf)?;
         self.0
             .delete(&WriteOptions::default(), handle, key)
             .map_err(r2e)
@@ -154,7 +154,7 @@ impl engine_traits::SyncMutable for RocksEngine {
     }
 
     fn delete_range_cf(&self, cf: &str, begin_key: &[u8], end_key: &[u8]) -> Result<()> {
-        let handle = util::cf_handle(&self.0, cf)?;
+        let handle = self.cf(cf)?;
         self.0
             .delete_range(&WriteOptions::default(), handle, begin_key, end_key)
             .map_err(r2e)

--- a/components/engine_tirocks/src/engine_iterator.rs
+++ b/components/engine_tirocks/src/engine_iterator.rs
@@ -1,0 +1,188 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::sync::Arc;
+
+use engine_traits::Result;
+use tikv_util::codec::number;
+use tirocks::{
+    option::ReadOptions, properties::table::builtin::TableProperties, table_filter::TableFilter,
+    Db, Iterator, Snapshot,
+};
+
+use crate::r2e;
+
+pub struct RocksIterator<'a, D>(Iterator<'a, D>);
+
+impl<'a, D> RocksIterator<'a, D> {
+    pub fn from_raw(iter: Iterator<'a, D>) -> Self {
+        RocksIterator(iter)
+    }
+
+    pub fn sequence(&self) -> Option<u64> {
+        self.0.sequence_number()
+    }
+}
+
+impl<'a, D: Send> engine_traits::Iterator for RocksIterator<'a, D> {
+    #[inline]
+    fn seek(&mut self, key: &[u8]) -> Result<bool> {
+        self.0.seek(key);
+        self.valid()
+    }
+
+    #[inline]
+    fn seek_for_prev(&mut self, key: &[u8]) -> Result<bool> {
+        self.0.seek_for_prev(key);
+        self.valid()
+    }
+
+    #[inline]
+    fn seek_to_first(&mut self) -> Result<bool> {
+        self.0.seek_to_first();
+        self.valid()
+    }
+
+    #[inline]
+    fn seek_to_last(&mut self) -> Result<bool> {
+        self.0.seek_to_last();
+        self.valid()
+    }
+
+    #[inline]
+    fn prev(&mut self) -> Result<bool> {
+        #[cfg(not(feature = "nortcheck"))]
+        if !self.valid()? {
+            return Err(r2e(tirocks::Status::with_code(
+                tirocks::Code::kInvalidArgument,
+            )));
+        }
+        self.0.prev();
+        self.valid()
+    }
+
+    #[inline]
+    fn next(&mut self) -> Result<bool> {
+        #[cfg(not(feature = "nortcheck"))]
+        if !self.valid()? {
+            return Err(r2e(tirocks::Status::with_code(
+                tirocks::Code::kInvalidArgument,
+            )));
+        }
+        self.0.next();
+        self.valid()
+    }
+
+    #[inline]
+    fn key(&self) -> &[u8] {
+        #[cfg(not(feature = "nortcheck"))]
+        assert!(self.valid().unwrap());
+        self.0.key()
+    }
+
+    #[inline]
+    fn value(&self) -> &[u8] {
+        #[cfg(not(feature = "nortcheck"))]
+        assert!(self.valid().unwrap());
+        self.0.value()
+    }
+
+    #[inline]
+    fn valid(&self) -> Result<bool> {
+        if self.0.valid() {
+            Ok(true)
+        } else {
+            self.0.check().map_err(r2e)?;
+            Ok(false)
+        }
+    }
+}
+
+/// A filter that will only read blocks which have versions overlapping with
+/// [`hint_min_ts, `hint_max_ts`].
+struct TsFilter {
+    hint_min_ts: Option<u64>,
+    hint_max_ts: Option<u64>,
+}
+
+impl TsFilter {
+    fn new(hint_min_ts: Option<u64>, hint_max_ts: Option<u64>) -> TsFilter {
+        TsFilter {
+            hint_min_ts,
+            hint_max_ts,
+        }
+    }
+}
+
+impl TableFilter for TsFilter {
+    fn filter(&self, props: &TableProperties) -> bool {
+        if self.hint_max_ts.is_none() && self.hint_min_ts.is_none() {
+            return true;
+        }
+
+        let user_props = props.user_collected_properties();
+
+        if let Some(hint_min_ts) = self.hint_min_ts {
+            // TODO avoid hard code after refactor MvccProperties from
+            // tikv/src/raftstore/coprocessor/ into some component about engine.
+            if let Some(mut p) = user_props.get("tikv.max_ts") {
+                if let Ok(get_max) = number::decode_u64(&mut p) {
+                    if get_max < hint_min_ts {
+                        return false;
+                    }
+                }
+            }
+        }
+
+        if let Some(hint_max_ts) = self.hint_max_ts {
+            // TODO avoid hard code after refactor MvccProperties from
+            // tikv/src/raftstore/coprocessor/ into some component about engine.
+            if let Some(mut p) = user_props.get("tikv.min_ts") {
+                if let Ok(get_min) = number::decode_u64(&mut p) {
+                    if get_min > hint_max_ts {
+                        return false;
+                    }
+                }
+            }
+        }
+
+        true
+    }
+}
+
+/// Convert an `IterOptions` to rocksdb `ReadOptions`.
+pub fn to_tirocks_opt(iter_opt: engine_traits::IterOptions) -> ReadOptions {
+    let mut opt = ReadOptions::default();
+    opt.set_fill_cache(iter_opt.fill_cache())
+        .set_max_skippable_internal_keys(iter_opt.max_skippable_internal_keys());
+    if iter_opt.key_only() {
+        opt.set_key_only(true);
+    }
+    if iter_opt.total_order_seek_used() {
+        opt.set_total_order_seek(true);
+        // TODO: enable it.
+        opt.set_auto_prefix_mode(false);
+    } else if iter_opt.prefix_same_as_start() {
+        opt.set_prefix_same_as_start(true);
+    }
+    // TODO: enable it.
+    opt.set_adaptive_readahead(false);
+
+    if iter_opt.hint_min_ts().is_some() || iter_opt.hint_max_ts().is_some() {
+        opt.set_table_filter(TsFilter::new(
+            iter_opt.hint_min_ts(),
+            iter_opt.hint_max_ts(),
+        ));
+    }
+
+    let (lower, upper) = iter_opt.build_bounds();
+    if let Some(lower) = lower {
+        opt.set_iterate_lower_bound(lower);
+    }
+    if let Some(upper) = upper {
+        opt.set_iterate_upper_bound(upper);
+    }
+    opt
+}
+
+pub type RocksEngineIterator = RocksIterator<'static, Arc<Db>>;
+pub type RocksSnapIterator = RocksIterator<'static, Arc<Snapshot<'static, Arc<Db>>>>;

--- a/components/engine_tirocks/src/lib.rs
+++ b/components/engine_tirocks/src/lib.rs
@@ -9,10 +9,15 @@ extern crate tikv_alloc as _;
 
 mod cf_options;
 mod db_options;
+mod db_vector;
 mod engine;
+mod engine_iterator;
+mod snapshot;
 mod status;
 mod util;
 
 pub use engine::*;
+pub use engine_iterator::*;
+pub use snapshot::RocksSnapshot;
 pub use status::*;
 pub use util::*;

--- a/components/engine_tirocks/src/snapshot.rs
+++ b/components/engine_tirocks/src/snapshot.rs
@@ -1,0 +1,84 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::{
+    fmt::{self, Debug, Formatter},
+    sync::Arc,
+};
+
+use engine_traits::Result;
+use tirocks::{db::RawCfHandle, option::ReadOptions, Db, Iterator, Snapshot};
+
+use crate::{db_vector::RocksPinSlice, engine_iterator, r2e, util, RocksSnapIterator};
+
+pub struct RocksSnapshot(Arc<Snapshot<'static, Arc<Db>>>);
+
+impl RocksSnapshot {
+    #[inline]
+    pub(crate) fn new(db: Arc<Db>) -> Self {
+        Self(Arc::new(Snapshot::new(db)))
+    }
+
+    #[inline]
+    fn get(
+        &self,
+        opts: &engine_traits::ReadOptions,
+        handle: &RawCfHandle,
+        key: &[u8],
+    ) -> Result<Option<RocksPinSlice>> {
+        let mut opt = ReadOptions::default();
+        opt.set_fill_cache(opts.fill_cache());
+        // TODO: reuse slice.
+        let mut slice = RocksPinSlice::default();
+        match self.0.get_pinned(&mut opt, handle, key, &mut slice.0) {
+            Ok(true) => Ok(Some(slice)),
+            Ok(false) => Ok(None),
+            Err(s) => Err(r2e(s)),
+        }
+    }
+}
+
+impl engine_traits::Snapshot for RocksSnapshot {}
+
+impl Debug for RocksSnapshot {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
+        write!(fmt, "tirocks Snapshot Impl")
+    }
+}
+
+impl engine_traits::Iterable for RocksSnapshot {
+    type Iterator = RocksSnapIterator;
+
+    fn iterator_opt(&self, cf: &str, opts: engine_traits::IterOptions) -> Result<Self::Iterator> {
+        let opt = engine_iterator::to_tirocks_opt(opts);
+        let handle = util::cf_handle(self.0.db(), cf)?;
+        Ok(RocksSnapIterator::from_raw(Iterator::new(
+            self.0.clone(),
+            opt,
+            handle,
+        )))
+    }
+}
+
+impl engine_traits::Peekable for RocksSnapshot {
+    type DbVector = RocksPinSlice;
+
+    #[inline]
+    fn get_value_opt(
+        &self,
+        opts: &engine_traits::ReadOptions,
+        key: &[u8],
+    ) -> Result<Option<Self::DbVector>> {
+        self.get(opts, self.0.db().default_cf(), key)
+    }
+
+    #[inline]
+    fn get_value_cf_opt(
+        &self,
+        opts: &engine_traits::ReadOptions,
+        cf: &str,
+        key: &[u8],
+    ) -> Result<Option<Self::DbVector>> {
+        let handle = util::cf_handle(self.0.db(), cf)?;
+        self.get(opts, handle, key)
+    }
+}


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Ref #13058 

What's Changed:

```commit-message
Everything is almost the same as engine_rocks except engine_tirocks
put snapshot into an `Arc`. The old implementation is not safe as the
snapshot can be released while the iterator is still being used.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
