### PR TITLE
engine: disable raft engine log recycling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4079,8 +4079,7 @@ dependencies = [
 [[package]]
 name = "raft-engine"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b66e735395b7ff12f3ebbb4794006aecb365c4c9a82141279b58b227ac3a8b"
+source = "git+https://github.com/tikv/raft-engine.git#5f718cfe50a28f7fee0282c0959670de5962eec8"
 dependencies = [
  "byteorder",
  "crc32fast",
@@ -4114,8 +4113,7 @@ dependencies = [
 [[package]]
 name = "raft-engine-ctl"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ddbee86249b9d6587e548c05588f6d7cc26d7a99c2d32473fa4c0110361db8"
+source = "git+https://github.com/tikv/raft-engine.git#5f718cfe50a28f7fee0282c0959670de5962eec8"
 dependencies = [
  "clap 3.1.6",
  "env_logger",

--- a/cmd/tikv-ctl/Cargo.toml
+++ b/cmd/tikv-ctl/Cargo.toml
@@ -70,7 +70,7 @@ pd_client = { path = "../../components/pd_client", default-features = false }
 prometheus = { version = "0.13", features = ["nightly"] }
 protobuf = { version = "2.8", features = ["bytes"] }
 raft = { version = "0.7.0", default-features = false, features = ["protobuf-codec"] }
-raft-engine-ctl = "0.3.0"
+raft-engine-ctl = { git = "https://github.com/tikv/raft-engine.git" }
 raft_log_engine = { path = "../../components/raft_log_engine", default-features = false }
 raftstore = { path = "../../components/raftstore", default-features = false }
 rand = "0.8"

--- a/components/raft_log_engine/Cargo.toml
+++ b/components/raft_log_engine/Cargo.toml
@@ -14,7 +14,7 @@ num_cpus = "1"
 online_config = { path = "../online_config" }
 protobuf = "2"
 raft = { version = "0.7.0", default-features = false, features = ["protobuf-codec"] }
-raft-engine = { version = "0.3.0", features = ["swap"] }
+raft-engine = { git = "https://github.com/tikv/raft-engine.git", features = ["swap"] }
 serde = "1.0"
 serde_derive = "1.0"
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -1094,8 +1094,8 @@
 ## Only available for `format-version` >= 2. This option is only
 ## available when TiKV >= 6.3.x.
 ##
-## Default: true.
-# enable-log-recycle = true
+## Default: false.
+# enable-log-recycle = false
 
 [security]
 ## The path for TLS certificates. Empty string means disabling secure connections.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1517,11 +1517,7 @@ impl Default for RaftEngineConfig {
     fn default() -> Self {
         Self {
             enable: true,
-            config: RawRaftEngineConfig {
-                // TODO: remove this when raft-engine is updated.
-                enable_log_recycle: false,
-                ..Default::default()
-            },
+            config: RawRaftEngineConfig::default(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1517,7 +1517,11 @@ impl Default for RaftEngineConfig {
     fn default() -> Self {
         Self {
             enable: true,
-            config: RawRaftEngineConfig::default(),
+            config: RawRaftEngineConfig {
+                // TODO: remove this when raft-engine is updated.
+                enable_log_recycle: false,
+                ..Default::default()
+            },
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: tabokie <xy.tao@outlook.com>

### What is changed and how it works?

Issue Number: Ref #11119
What's Changed:

We observe on physical disk, overwriting existing log files will generate unnecessary read I/Os (1/5 of write throughput), and even though the `fdatasync` latency is reduced, the duration sum of `fdatasync` and `pwrite` has increased.

```commit-message
```

### Related changes

- Update release note: https://github.com/pingcap/docs-cn/pull/11115/files#r973973335
- Still enable it for TiDB cloud: https://github.com/tidbcloud/tidb-configuration/pull/1233#pullrequestreview-1111851032
- Update docs: TBD

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
