### PR TITLE
br: recovering_mark interface block tikv startup when tikv v6.3.0 connect to pd v6.2.0

### DIFF
--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -282,9 +282,16 @@ where
         let pd_client =
             Self::connect_to_pd_cluster(&mut config, env.clone(), Arc::clone(&security_mgr));
         // check if TiKV need to run in snapshot recovery mode
-        let is_recovering_marked = pd_client
-            .is_recovering_marked()
-            .expect("failed to get recovery mode from PD");
+        let is_recovering_marked = match pd_client.is_recovering_marked() {
+            Err(e) => {
+                warn!(
+                    "pd does not support snapshot recovery";
+                    "error" => ?e,
+                );
+                false
+            }
+            Ok(marked) => marked,
+        };
 
         if is_recovering_marked {
             // Run a TiKV server in recovery modeß

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -285,7 +285,7 @@ where
         let is_recovering_marked = match pd_client.is_recovering_marked() {
             Err(e) => {
                 warn!(
-                    "pd does not support snapshot recovery";
+                    "failed to get recovery mode from PD";
                     "error" => ?e,
                 );
                 false


### PR DESCRIPTION
### What is changed and how it works?
only warning in code instead of stop tikv startup.

Issue Number: Close #13497

What's Changed:
when tikv 6.3 connect to pd 6.2, only warning in log instead of block tikv startup.


### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
1. pd 2.0 with tikv fixed branch2. 
2. start pd and then start tikv3. 
3. tikv is able to startup4. 

![r98DewJuDE](https://user-images.githubusercontent.com/85682690/191272089-67bfb1b0-47d4-409b-9de6-23efa8542c96.jpg)

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
```
