### PR TITLE
br: recovering_mark interface block tikv startup when tikv v6.3.0 con…

### DIFF
--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -282,9 +282,16 @@ where
         let pd_client =
             Self::connect_to_pd_cluster(&mut config, env.clone(), Arc::clone(&security_mgr));
         // check if TiKV need to run in snapshot recovery mode
-        let is_recovering_marked = pd_client
-            .is_recovering_marked()
-            .expect("failed to get recovery mode from PD");
+        let is_recovering_marked = match pd_client.is_recovering_marked() {
+            Err(e) => {
+                warn!(
+                    "failed to get recovery mode from PD";
+                    "error" => ?e,
+                );
+                false
+            }
+            Ok(marked) => marked,
+        };
 
         if is_recovering_marked {
             // Run a TiKV server in recovery modeß


### PR DESCRIPTION
cherry-pick https://github.com/tikv/tikv/pull/13498 to release-6.3

close tikv/tikv#13497

Signed-off-by: fengou1 <feng.ou@pingcap.com>
Signed-off-by: fengou1 <85682690+fengou1@users.noreply.github.com>

Co-authored-by: Xinye Tao <xy.tao@outlook.com>

```release-note
None
```
