### PR TITLE
copr: forbid empty pattern for regexp

### DIFF
--- a/components/tidb_query_datatype/src/codec/error.rs
+++ b/components/tidb_query_datatype/src/codec/error.rs
@@ -145,6 +145,10 @@ impl Error {
         );
         Error::Eval(msg, ERR_INCORRECT_PARAMETERS)
     }
+
+    pub fn regexp_error(msg: String) -> Error {
+        Error::Eval(msg, ERR_REGEXP)
+    }
 }
 
 impl From<Error> for tipb::Error {

--- a/components/tidb_query_expr/src/impl_regexp.rs
+++ b/components/tidb_query_expr/src/impl_regexp.rs
@@ -5,7 +5,7 @@ use std::{borrow::Cow, collections::HashSet};
 use regex::Regex;
 use tidb_query_codegen::rpn_fn;
 use tidb_query_common::Result;
-use tidb_query_datatype::codec::{collation::Collator, data_type::*};
+use tidb_query_datatype::codec::{collation::Collator, data_type::*, Error};
 use tipb::{Expr, ExprType};
 
 const PATTERN_IDX: usize = 1;
@@ -13,6 +13,10 @@ const LIKE_MATCH_IDX: usize = 2;
 const SUBSTR_MATCH_IDX: usize = 4;
 const INSTR_MATCH_IDX: usize = 5;
 const REPLACE_MATCH_IDX: usize = 5;
+
+fn invalid_pos_error(pos: i64, count: usize) -> Error {
+    Error::regexp_error(format!("Invalid pos: {} in regexp, count: {}", pos, count))
+}
 
 fn is_valid_match_type(m: char) -> bool {
     matches!(m, 'i' | 'c' | 'm' | 's')
@@ -28,7 +32,8 @@ fn get_match_type<C: Collator>(match_type: &[u8]) -> Result<String> {
 
     for m in match_type.chars() {
         if !is_valid_match_type(m) {
-            return Err(box_err!("invalid match type: {}", m));
+            let err = format!("Invalid match type: {} in regexp", m);
+            return Err(Error::regexp_error(err).into());
         }
         if m == 'c' {
             // re2 is case-sensitive by default, so we only need to delete 'i' flag
@@ -48,6 +53,10 @@ fn get_match_type<C: Collator>(match_type: &[u8]) -> Result<String> {
 }
 
 fn build_regexp<C: Collator>(pattern: &[u8], match_type: &[u8]) -> Result<Regex> {
+    if pattern.is_empty() {
+        return Err(Error::regexp_error("Empty pattern is invalid in regexp".into()).into());
+    }
+
     let match_type = get_match_type::<C>(match_type)?;
 
     let pattern = String::from_utf8(pattern.to_vec())?;
@@ -57,7 +66,8 @@ fn build_regexp<C: Collator>(pattern: &[u8], match_type: &[u8]) -> Result<Regex>
         pattern
     };
 
-    Regex::new(&pattern_with_tp).map_err(|e| box_err!("invalid regex pattern: {:?}", e))
+    Regex::new(&pattern_with_tp)
+        .map_err(|e| Error::regexp_error(format!("Invalid regexp pattern: {:?}", e)).into())
 }
 
 fn build_regexp_from_args<C: Collator>(
@@ -158,18 +168,10 @@ pub fn regexp_substr<C: Collator>(
                 expr = &expr[idx..];
             } else if pos != 1 {
                 // Char count == 0 && pos == 1 is valid.
-                return Err(box_err!(
-                    "invalid regex pos: {}, count: {}",
-                    pos,
-                    expr.chars().count()
-                ));
+                return Err(invalid_pos_error(pos, expr.chars().count()).into());
             }
         } else {
-            return Err(box_err!(
-                "invalid regex pos: {}, count: {}",
-                pos,
-                expr.chars().count()
-            ));
+            return Err(invalid_pos_error(pos, expr.chars().count()).into());
         }
     }
 
@@ -224,18 +226,10 @@ pub fn regexp_instr<C: Collator>(
                 expr = &expr[idx..];
             } else if pos != 1 {
                 // Char count == 0 && pos == 1 is valid.
-                return Err(box_err!(
-                    "invalid regex pos: {}, count: {}",
-                    pos,
-                    expr.chars().count()
-                ));
+                return Err(invalid_pos_error(pos, expr.chars().count()).into());
             }
         } else {
-            return Err(box_err!(
-                "invalid regex pos: {}, count: {}",
-                pos,
-                expr.chars().count()
-            ));
+            return Err(invalid_pos_error(pos, expr.chars().count()).into());
         }
     }
 
@@ -259,7 +253,8 @@ pub fn regexp_instr<C: Collator>(
         };
 
         if return_option != 0 && return_option != 1 {
-            return Err(box_err!("invalid regex return option: {}", return_option));
+            let err = format!("Invalid regexp return option: {}", return_option);
+            return Err(Error::regexp_error(err).into());
         }
     };
 
@@ -314,18 +309,10 @@ pub fn regexp_replace<C: Collator>(
                 trimmed = &expr[idx..];
             } else if pos != 1 {
                 // Char count == 0 && pos == 1 is valid.
-                return Err(box_err!(
-                    "invalid regex pos: {}, count: {}",
-                    pos,
-                    expr.chars().count()
-                ));
+                return Err(invalid_pos_error(pos, expr.chars().count()).into());
             }
         } else {
-            return Err(box_err!(
-                "invalid regex pos: {}, count: {}",
-                pos,
-                expr.chars().count()
-            ));
+            return Err(invalid_pos_error(pos, expr.chars().count()).into());
         }
     }
 
@@ -396,6 +383,8 @@ mod tests {
             ("", "(", None, None),
             ("", "(*", None, None),
             ("", "[a", None, None),
+            ("aa", "", None, None),
+            ("你好", "", None, None),
             // Test case-insensitive
             ("abc", "AbC", Some(""), Some(0)),
             ("abc", "AbC", Some("i"), Some(1)),


### PR DESCRIPTION
Signed-off-by: gengliqi <gengliqiii@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/tikv/tikv/issues/13513

What's Changed:

Forbid empty pattern for regexp and format some error messages.
<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- No

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None.
```
