### PR TITLE
storage: Rollback all locks to prevent from losing the pessimistic lock in flashback

### DIFF
--- a/src/storage/txn/actions/flashback_to_version.rs
+++ b/src/storage/txn/actions/flashback_to_version.rs
@@ -1,6 +1,6 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
-use txn_types::{Key, Lock, LockType, TimeStamp, Write, WriteType};
+use txn_types::{Key, Lock, TimeStamp, Write, WriteType};
 
 use crate::storage::{
     mvcc::{MvccReader, MvccTxn, SnapshotReader, MAX_TXN_WRITE_SIZE},

--- a/src/storage/txn/actions/flashback_to_version.rs
+++ b/src/storage/txn/actions/flashback_to_version.rs
@@ -96,7 +96,6 @@ pub fn flashback_to_version<S: Snapshot>(
             *next_lock_key = Some(key);
             break;
         }
-        
         rollback_lock(
             txn,
             reader,
@@ -105,7 +104,6 @@ pub fn flashback_to_version<S: Snapshot>(
             lock.is_pessimistic_txn(),
             true,
         )?;
-
         rows += 1;
         // If the short value is none and it's a `LockType::Put`, we should delete the
         // corresponding key from `CF_DEFAULT` as well.
@@ -193,7 +191,6 @@ pub mod tests {
             flashback_to_version_read_lock(&mut reader, &Some(key.clone()), &None, &mut statistics)
                 .unwrap();
         assert!(!has_remain_locks);
-
         let (key_old_writes, has_remain_writes) = flashback_to_version_read_write(
             &mut reader,
             0,
@@ -206,7 +203,6 @@ pub mod tests {
         )
         .unwrap();
         assert!(!has_remain_writes);
-
         let cm = ConcurrencyManager::new(TimeStamp::zero());
         let mut txn = MvccTxn::new(start_ts, cm);
         let snapshot = engine.snapshot(Default::default()).unwrap();

--- a/src/storage/txn/actions/flashback_to_version.rs
+++ b/src/storage/txn/actions/flashback_to_version.rs
@@ -96,8 +96,7 @@ pub fn flashback_to_version<S: Snapshot>(
             *next_lock_key = Some(key);
             break;
         }
-        // We need to rollback with lock.ts rather than using version timestamp by
-        // invoking rollback funtion
+        
         rollback_lock(
             txn,
             reader,

--- a/src/storage/txn/actions/flashback_to_version.rs
+++ b/src/storage/txn/actions/flashback_to_version.rs
@@ -2,10 +2,9 @@
 
 use txn_types::{Key, Lock, LockType, TimeStamp, Write, WriteType};
 
-use super::check_txn_status::rollback_lock;
 use crate::storage::{
     mvcc::{MvccReader, MvccTxn, SnapshotReader, MAX_TXN_WRITE_SIZE},
-    txn::{Error, ErrorInner, Result as TxnResult},
+    txn::{actions::check_txn_status::rollback_lock, Error, ErrorInner, Result as TxnResult},
     Snapshot, Statistics,
 };
 
@@ -171,7 +170,7 @@ pub mod tests {
             actions::{
                 acquire_pessimistic_lock::tests::must_pessimistic_locked,
                 commit::tests::must_succeed as must_commit,
-                tests::{must_prewrite_delete, must_prewrite_put,must_rollback},
+                tests::{must_prewrite_delete, must_prewrite_put, must_rollback},
             },
             tests::{must_acquire_pessimistic_lock, must_pessimistic_prewrite_put_err},
         },

--- a/src/storage/txn/actions/flashback_to_version.rs
+++ b/src/storage/txn/actions/flashback_to_version.rs
@@ -331,8 +331,10 @@ pub mod tests {
         must_acquire_pessimistic_lock(&engine, k, k, 30, 30);
         must_pessimistic_locked(&engine, k, 30, 30);
 
-        // Flashback to version 17 with start_ts = 30, commit_ts = 40.
-        assert_eq!(must_flashback_to_version(&engine, k, 17, 30, 40), 2);
+        // Flashback to version 17 with start_ts = 35, commit_ts = 40.
+        // Distinguish from pessimistic start_ts 30 to make sure rollback ts is by lock
+        // ts.
+        assert_eq!(must_flashback_to_version(&engine, k, 17, 35, 40), 2);
 
         // Pessimistic Prewrite Put(k -> v3) with stat_ts = 30 will be error with
         // Rollback.

--- a/src/storage/txn/actions/flashback_to_version.rs
+++ b/src/storage/txn/actions/flashback_to_version.rs
@@ -96,6 +96,8 @@ pub fn flashback_to_version<S: Snapshot>(
             *next_lock_key = Some(key);
             break;
         }
+        // To guarantee rollback with start ts of the locks
+        reader.start_ts = lock.ts;
         rollback_lock(
             txn,
             reader,
@@ -206,7 +208,7 @@ pub mod tests {
         let cm = ConcurrencyManager::new(TimeStamp::zero());
         let mut txn = MvccTxn::new(start_ts, cm);
         let snapshot = engine.snapshot(Default::default()).unwrap();
-        let mut reader = SnapshotReader::new_with_ctx(start_ts, snapshot, &ctx);
+        let mut reader = SnapshotReader::new_with_ctx(version, snapshot, &ctx);
         let rows = flashback_to_version(
             &mut txn,
             &mut reader,

--- a/src/storage/txn/commands/flashback_to_version.rs
+++ b/src/storage/txn/commands/flashback_to_version.rs
@@ -62,7 +62,7 @@ impl CommandExt for FlashbackToVersion {
 
 impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for FlashbackToVersion {
     fn process_write(mut self, snapshot: S, context: WriteContext<'_, L>) -> Result<WriteResult> {
-        let mut reader = SnapshotReader::new_with_ctx(self.start_ts, snapshot, &self.ctx);
+        let mut reader = SnapshotReader::new_with_ctx(self.version, snapshot, &self.ctx);
         let mut txn = MvccTxn::new(TimeStamp::zero(), context.concurrency_manager);
 
         let mut next_lock_key = self.next_lock_key.take();

--- a/src/storage/txn/commands/flashback_to_version.rs
+++ b/src/storage/txn/commands/flashback_to_version.rs
@@ -62,7 +62,7 @@ impl CommandExt for FlashbackToVersion {
 
 impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for FlashbackToVersion {
     fn process_write(mut self, snapshot: S, context: WriteContext<'_, L>) -> Result<WriteResult> {
-        let mut reader = SnapshotReader::new_with_ctx(self.version, snapshot, &self.ctx);
+        let mut reader = SnapshotReader::new_with_ctx(self.start_ts, snapshot, &self.ctx);
         let mut txn = MvccTxn::new(TimeStamp::zero(), context.concurrency_manager);
 
         let mut next_lock_key = self.next_lock_key.take();

--- a/tests/integrations/raftstore/test_flashback.rs
+++ b/tests/integrations/raftstore/test_flashback.rs
@@ -8,7 +8,7 @@ use test_raftstore::*;
 use txn_types::WriteBatchFlags;
 
 #[test]
-fn test_flahsback_for_applied_index() {
+fn test_flashback_for_applied_index() {
     let mut cluster = new_node_cluster(0, 3);
     cluster.run();
 
@@ -79,7 +79,7 @@ fn test_flashback_for_schedule() {
 }
 
 #[test]
-fn test_flahsback_for_write() {
+fn test_flashback_for_write() {
     let mut cluster = new_node_cluster(0, 3);
     cluster.run();
 
@@ -107,7 +107,7 @@ fn test_flahsback_for_write() {
 }
 
 #[test]
-fn test_flahsback_for_read() {
+fn test_flashback_for_read() {
     let mut cluster = new_node_cluster(0, 3);
     cluster.run();
 
@@ -141,7 +141,7 @@ fn test_flahsback_for_read() {
 // However, when flashback is enabled, it will make the lease None and prevent
 // renew lease.
 #[test]
-fn test_flahsback_for_local_read() {
+fn test_flashback_for_local_read() {
     let mut cluster = new_node_cluster(0, 3);
     let election_timeout = configure_for_lease_read(&mut cluster, Some(50), None);
 
@@ -208,7 +208,7 @@ fn test_flahsback_for_local_read() {
 }
 
 #[test]
-fn test_flahsback_for_status_cmd_as_region_detail() {
+fn test_flashback_for_status_cmd_as_region_detail() {
     let mut cluster = new_node_cluster(0, 3);
     cluster.run();
 


### PR DESCRIPTION
Signed-off-by: husharp <jinhao.hu@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #13493 

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Rollback all locks to prevent from losing the pessimistic lock in flashback
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
