### PR TITLE
commands: use ReaderWithStats in flashback_to_version command

### DIFF
--- a/src/storage/txn/actions/cleanup.rs
+++ b/src/storage/txn/actions/cleanup.rs
@@ -39,14 +39,12 @@ pub fn cleanup<S: Snapshot>(
                     ErrorInner::KeyIsLocked(lock.clone().into_lock_info(key.into_raw()?)).into(),
                 );
             }
-
-            let is_pessimistic_txn = !lock.for_update_ts.is_zero();
             rollback_lock(
                 txn,
                 reader,
                 key,
                 lock,
-                is_pessimistic_txn,
+                lock.is_pessimistic_txn(),
                 !protect_rollback,
             )
         }

--- a/src/storage/txn/actions/flashback_to_version.rs
+++ b/src/storage/txn/actions/flashback_to_version.rs
@@ -155,16 +155,10 @@ pub mod tests {
 
     use super::*;
     use crate::storage::{
-        mvcc::{
-            tests::{must_get, must_get_none, write},
-            SnapshotReader,
-        },
-        txn::{
-            actions::{
-                commit::tests::must_succeed as must_commit,
-                tests::{must_prewrite_delete, must_prewrite_put, must_rollback},
-            },
-            commands::ReaderWithStats,
+        mvcc::tests::{must_get, must_get_none, write},
+        txn::actions::{
+            commit::tests::must_succeed as must_commit,
+            tests::{must_prewrite_delete, must_prewrite_put, must_rollback},
         },
         Engine, TestEngineBuilder,
     };
@@ -197,10 +191,7 @@ pub mod tests {
         let cm = ConcurrencyManager::new(TimeStamp::zero());
         let mut txn = MvccTxn::new(start_ts, cm);
         let snapshot = engine.snapshot(Default::default()).unwrap();
-        let mut reader = ReaderWithStats::new(
-            SnapshotReader::new_with_ctx(version, snapshot, &ctx),
-            &mut statistics,
-        );
+        let mut reader = SnapshotReader::new_with_ctx(version, snapshot, &ctx);
         let rows = flashback_to_version(
             &mut txn,
             &mut reader,

--- a/src/storage/txn/commands/mod.rs
+++ b/src/storage/txn/commands/mod.rs
@@ -540,7 +540,7 @@ pub struct ReaderWithStats<'a, S: Snapshot> {
 }
 
 impl<'a, S: Snapshot> ReaderWithStats<'a, S> {
-    fn new(reader: SnapshotReader<S>, statistics: &'a mut Statistics) -> Self {
+    pub fn new(reader: SnapshotReader<S>, statistics: &'a mut Statistics) -> Self {
         Self { reader, statistics }
     }
 }

--- a/src/storage/txn/commands/mod.rs
+++ b/src/storage/txn/commands/mod.rs
@@ -540,7 +540,7 @@ pub struct ReaderWithStats<'a, S: Snapshot> {
 }
 
 impl<'a, S: Snapshot> ReaderWithStats<'a, S> {
-    pub fn new(reader: SnapshotReader<S>, statistics: &'a mut Statistics) -> Self {
+    fn new(reader: SnapshotReader<S>, statistics: &'a mut Statistics) -> Self {
         Self { reader, statistics }
     }
 }


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What is changed and how it works?

Issue Number: ref #13303.

What's Changed:

```commit-message
Use `ReaderWithStats` in `flashback_to_version` command to collect the statistics info as much as possible.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None.
```
