### PR TITLE
engine: batch delete files in ranges

### DIFF
--- a/components/engine_rocks/src/misc.rs
+++ b/components/engine_rocks/src/misc.rs
@@ -154,7 +154,7 @@ impl MiscExt for RocksEngine {
                 let rocks_ranges: Vec<_> = ranges
                     .iter()
                     .filter_map(|r| {
-                        if r.start_key == r.end_key {
+                        if r.start_key >= r.end_key {
                             None
                         } else {
                             Some(RocksRange::new(r.start_key, r.end_key))
@@ -174,7 +174,7 @@ impl MiscExt for RocksEngine {
                     let rocks_ranges: Vec<_> = ranges
                         .iter()
                         .filter_map(|r| {
-                            if r.start_key == r.end_key {
+                            if r.start_key >= r.end_key {
                                 None
                             } else {
                                 Some(RocksRange::new(r.start_key, r.end_key))

--- a/components/engine_rocks/src/misc.rs
+++ b/components/engine_rocks/src/misc.rs
@@ -4,6 +4,7 @@ use engine_traits::{
     CfNamesExt, DeleteStrategy, ImportExt, IterOptions, Iterable, Iterator, MiscExt, Mutable,
     Range, Result, SstWriter, SstWriterBuilder, WriteBatch, WriteBatchExt, ALL_CFS,
 };
+use rocksdb::Range as RocksRange;
 use tikv_util::{box_try, keybuilder::KeyBuilder};
 
 use crate::{
@@ -150,26 +151,42 @@ impl MiscExt for RocksEngine {
         match strategy {
             DeleteStrategy::DeleteFiles => {
                 let handle = util::get_cf_handle(self.as_inner(), cf)?;
-                for r in ranges {
-                    if r.start_key >= r.end_key {
-                        continue;
-                    }
-                    self.as_inner()
-                        .delete_files_in_range_cf(handle, r.start_key, r.end_key, false)
-                        .map_err(r2e)?;
+                let rocks_ranges: Vec<_> = ranges
+                    .iter()
+                    .filter_map(|r| {
+                        if r.start_key == r.end_key {
+                            None
+                        } else {
+                            Some(RocksRange::new(r.start_key, r.end_key))
+                        }
+                    })
+                    .collect();
+                if rocks_ranges.is_empty() {
+                    return Ok(());
                 }
+                self.as_inner()
+                    .delete_files_in_ranges_cf(handle, &rocks_ranges, false)
+                    .map_err(r2e)?;
             }
             DeleteStrategy::DeleteBlobs => {
                 let handle = util::get_cf_handle(self.as_inner(), cf)?;
                 if self.is_titan() {
-                    for r in ranges {
-                        if r.start_key >= r.end_key {
-                            continue;
-                        }
-                        self.as_inner()
-                            .delete_blob_files_in_range_cf(handle, r.start_key, r.end_key, false)
-                            .map_err(r2e)?;
+                    let rocks_ranges: Vec<_> = ranges
+                        .iter()
+                        .filter_map(|r| {
+                            if r.start_key == r.end_key {
+                                None
+                            } else {
+                                Some(RocksRange::new(r.start_key, r.end_key))
+                            }
+                        })
+                        .collect();
+                    if rocks_ranges.is_empty() {
+                        return Ok(());
                     }
+                    self.as_inner()
+                        .delete_blob_files_in_ranges_cf(handle, &rocks_ranges, false)
+                        .map_err(r2e)?;
                 }
             }
             DeleteStrategy::DeleteByRange => {


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Close #13534

What's Changed:

In #13384, the `roughly_cleanup_ranges` is replaced with less optimized `delete_ranges_cfs`, causing drastic regression in TiKV startup time. This PR restores the original implementation, which is deleting files of different ranges in one batch.

```commit-message
```

### Related changes

- Need to update master branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
