### PR TITLE
copr: fix wrong sql mode constants

### DIFF
--- a/components/tidb_query_datatype/src/expr/ctx.rs
+++ b/components/tidb_query_datatype/src/expr/ctx.rs
@@ -11,12 +11,12 @@ use crate::codec::mysql::Tz;
 bitflags! {
     /// Please refer to SQLMode in `mysql/const.go` in repo `pingcap/parser` for details.
     pub struct SqlMode: u64 {
-        const STRICT_TRANS_TABLES = 1 << 22;
-        const STRICT_ALL_TABLES = 1 << 23;
-        const NO_ZERO_IN_DATE = 1 << 24;
-        const NO_ZERO_DATE = 1 << 25;
-        const INVALID_DATES = 1 << 26;
-        const ERROR_FOR_DIVISION_BY_ZERO = 1 << 27;
+        const STRICT_TRANS_TABLES = 1 << 21;
+        const STRICT_ALL_TABLES = 1 << 22;
+        const NO_ZERO_IN_DATE = 1 << 23;
+        const NO_ZERO_DATE = 1 << 24;
+        const INVALID_DATES = 1 << 25;
+        const ERROR_FOR_DIVISION_BY_ZERO = 1 << 26;
     }
 }
 

--- a/components/tidb_query_expr/src/impl_regexp.rs
+++ b/components/tidb_query_expr/src/impl_regexp.rs
@@ -88,7 +88,7 @@ fn build_regexp_from_args<C: Collator>(
         b""
     };
 
-    build_regexp::<C>(pattern, match_type).map(|reg| Some(reg))
+    build_regexp::<C>(pattern, match_type).map(Some)
 }
 
 fn init_regexp_data<C: Collator, const N: usize>(expr: &mut Expr) -> Result<Option<Regex>> {
@@ -111,7 +111,7 @@ fn init_regexp_data<C: Collator, const N: usize>(expr: &mut Expr) -> Result<Opti
         b""
     };
 
-    build_regexp::<C>(pattern, match_type).map(|reg| Some(reg))
+    build_regexp::<C>(pattern, match_type).map(Some)
 }
 
 /// Currently, TiDB only supports regular expressions for utf-8 strings.


### PR DESCRIPTION
Signed-off-by: gengliqi <gengliqiii@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/tikv/tikv/issues/13566.

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None.
```
