### PR TITLE
[Dynamic Region] Fix some large regions can't split

### DIFF
--- a/components/raftstore/src/coprocessor/mod.rs
+++ b/components/raftstore/src/coprocessor/mod.rs
@@ -237,7 +237,7 @@ pub trait SplitCheckObserver<E>: Coprocessor {
     fn add_checker(
         &self,
         _: &mut ObserverContext<'_>,
-        _: &mut SplitCheckerHost<'_, E>,
+        _: &mut SplitCheckerHost<E>,
         _: &E,
         policy: CheckPolicy,
     );

--- a/components/raftstore/src/coprocessor/split_check/half.rs
+++ b/components/raftstore/src/coprocessor/split_check/half.rs
@@ -82,7 +82,7 @@ where
     fn add_checker(
         &self,
         _: &mut ObserverContext<'_>,
-        host: &mut Host<'_, E>,
+        host: &mut Host<E>,
         _: &E,
         policy: CheckPolicy,
     ) {
@@ -123,8 +123,10 @@ pub fn get_region_approximate_middle(
 
 #[cfg(test)]
 mod tests {
-    use std::{iter, sync::mpsc};
-
+    use std::{
+        iter,
+        sync::{mpsc, Arc},
+    };
     use engine_test::ctor::{CfOptions, DbOptions};
     use engine_traits::{MiscExt, SyncMutable, ALL_CFS, CF_DEFAULT, LARGE_CFS};
     use kvproto::{
@@ -132,7 +134,11 @@ mod tests {
         pdpb::CheckPolicy,
     };
     use tempfile::Builder;
-    use tikv_util::{config::ReadableSize, escape, worker::Runnable};
+    use tikv_util::{
+        config::{ReadableSize, VersionTrack},
+        escape,
+        worker::Runnable,
+    };
     use txn_types::Key;
 
     use super::{
@@ -161,6 +167,7 @@ mod tests {
             region_max_size: Some(ReadableSize(BUCKET_NUMBER_LIMIT as u64)),
             ..Default::default()
         };
+        let cfg = Arc::new(VersionTrack::new(cfg));
         let mut runnable =
             SplitCheckRunner::new(engine.clone(), tx.clone(), CoprocessorHost::new(tx, cfg));
 
@@ -206,6 +213,7 @@ mod tests {
             region_max_size: Some(ReadableSize(BUCKET_NUMBER_LIMIT as u64)),
             ..Default::default()
         };
+        let cfg = Arc::new(VersionTrack::new(cfg));
         let mut runnable =
             SplitCheckRunner::new(engine.clone(), tx.clone(), CoprocessorHost::new(tx, cfg));
 
@@ -272,6 +280,7 @@ mod tests {
             region_bucket_size: ReadableSize(20_u64), // so that each key below will form a bucket
             ..Default::default()
         };
+        let cfg = Arc::new(VersionTrack::new(cfg));
         let cop_host = CoprocessorHost::new(tx.clone(), cfg);
         let mut runnable = SplitCheckRunner::new(engine.clone(), tx, cop_host.clone());
 
@@ -396,6 +405,7 @@ mod tests {
             region_bucket_size: ReadableSize(20_u64), // so that each key below will form a bucket
             ..Default::default()
         };
+        let cfg = Arc::new(VersionTrack::new(cfg));
         let mut runnable =
             SplitCheckRunner::new(engine.clone(), tx.clone(), CoprocessorHost::new(tx, cfg));
 

--- a/components/raftstore/src/coprocessor/split_check/mod.rs
+++ b/components/raftstore/src/coprocessor/split_check/mod.rs
@@ -16,14 +16,14 @@ pub use self::{
 };
 use super::{config::Config, error::Result, Bucket, KeyEntry, ObserverContext, SplitChecker};
 
-pub struct Host<'a, E> {
+pub struct Host<E> {
     checkers: Vec<Box<dyn SplitChecker<E>>>,
     auto_split: bool,
-    cfg: &'a Config,
+    cfg: Config,
 }
 
-impl<'a, E> Host<'a, E> {
-    pub fn new(auto_split: bool, cfg: &'a Config) -> Host<'a, E> {
+impl<E> Host<E> {
+    pub fn new(auto_split: bool, cfg: Config) -> Host<E> {
         Host {
             auto_split,
             checkers: vec![],

--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -271,6 +271,7 @@ pub struct Config {
     #[serde(skip_serializing)]
     #[online_config(skip)]
     pub region_split_size: ReadableSize,
+    pub region_split_keys: ReadableSize,
     // Deprecated! The time to clean stale peer safely can be decided based on RocksDB snapshot
     // sequence number.
     #[doc(hidden)]
@@ -399,6 +400,7 @@ impl Default for Config {
             // They are preserved for compatibility check.
             region_max_size: ReadableSize(0),
             region_split_size: ReadableSize(0),
+            region_split_keys: ReadableSize(0),
             clean_stale_peer_delay: ReadableDuration::minutes(0),
             inspect_interval: ReadableDuration::millis(500),
             report_min_resolved_ts_interval: ReadableDuration::secs(1),

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -1152,6 +1152,7 @@ impl<EK: KvEngine, ER: RaftEngine, T> RaftPollerBuilder<EK, ER, T> {
             let (tx, mut peer) = box_try!(PeerFsm::create(
                 store_id,
                 &self.cfg.value(),
+                &self.coprocessor_host.cfg.value(),
                 self.region_scheduler.clone(),
                 self.raftlog_fetch_scheduler.clone(),
                 self.engines.clone(),
@@ -1192,6 +1193,7 @@ impl<EK: KvEngine, ER: RaftEngine, T> RaftPollerBuilder<EK, ER, T> {
             let (tx, mut peer) = PeerFsm::create(
                 store_id,
                 &self.cfg.value(),
+                &self.coprocessor_host.cfg.value(),
                 self.region_scheduler.clone(),
                 self.raftlog_fetch_scheduler.clone(),
                 self.engines.clone(),
@@ -2206,6 +2208,7 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
         let (tx, mut peer) = PeerFsm::replicate(
             self.ctx.store_id(),
             &self.ctx.cfg,
+            &self.ctx.coprocessor_host.cfg.value(),
             self.ctx.region_scheduler.clone(),
             self.ctx.raftlog_fetch_scheduler.clone(),
             self.ctx.engines.clone(),
@@ -2823,6 +2826,7 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
         let (sender, mut peer) = match PeerFsm::create(
             self.ctx.store.get_id(),
             &self.ctx.cfg,
+            &self.ctx.coprocessor_host.cfg.value(),
             self.ctx.region_scheduler.clone(),
             self.ctx.raftlog_fetch_scheduler.clone(),
             self.ctx.engines.clone(),

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -5030,7 +5030,7 @@ where
     }
 
     pub fn maybe_gen_approximate_buckets<T>(&self, ctx: &PollContext<EK, ER, T>) {
-        if ctx.coprocessor_host.cfg.enable_region_bucket && !self.region().get_peers().is_empty() {
+        if ctx.coprocessor_host.cfg.value().enable_region_bucket && !self.region().get_peers().is_empty() {
             if let Err(e) = ctx
                 .split_check_scheduler
                 .schedule(SplitCheckTask::ApproximateBuckets(self.region().clone()))

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -324,7 +324,7 @@ where
 
         let mut coprocessor_host = Some(CoprocessorHost::new(
             router.clone(),
-            config.coprocessor.clone(),
+            Arc::new(VersionTrack::new(config.coprocessor.clone())),
         ));
         let region_info_accessor = RegionInfoAccessor::new(coprocessor_host.as_mut().unwrap());
 
@@ -1004,7 +1004,9 @@ where
             .start("split-check", split_check_runner);
         cfg_controller.register(
             tikv::config::Module::Coprocessor,
-            Box::new(SplitCheckConfigManager(split_check_scheduler.clone())),
+            Box::new(SplitCheckConfigManager::new(
+                self.coprocessor_host.as_ref().unwrap().cfg.clone(),
+            )),
         );
 
         let split_config_manager =

--- a/components/test_raftstore/src/common-test.toml
+++ b/components/test_raftstore/src/common-test.toml
@@ -73,6 +73,9 @@ apply-pool-size = 1
 store-pool-size = 1
 [coprocessor]
 
+region-max-size = "200"
+region-split-size = "100"
+region-split-keys = 100
 [rocksdb]
 max-background-jobs = 1
 max-sub-compactions = 1

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -292,7 +292,8 @@ impl ServerCluster {
         );
 
         // Create coprocessor.
-        let mut coprocessor_host = CoprocessorHost::new(router.clone(), cfg.coprocessor.clone());
+        let cop_cfg = Arc::new(VersionTrack::new(cfg.coprocessor.clone()));
+        let mut coprocessor_host = CoprocessorHost::new(router.clone(), cop_cfg);
         let region_info_accessor = RegionInfoAccessor::new(&mut coprocessor_host);
 
         let raft_router = ServerRaftStoreRouter::new(router.clone(), local_reader);

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -220,6 +220,7 @@ fn test_serde_custom_tikv_config() {
         snap_generator_pool_size: 2,
         cleanup_import_sst_interval: ReadableDuration::minutes(12),
         region_max_size: ReadableSize(0),
+        region_split_keys: ReadableSize(0),
         region_split_size: ReadableSize(0),
         local_read_batch_size: 33,
         apply_batch_system,

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -226,10 +226,6 @@ unreachable-backoff = "111s"
 [coprocessor]
 split-region-on-table = false
 batch-split-limit = 1
-region-max-size = "12MB"
-region-split-size = "12MB"
-region-max-keys = 100000
-region-split-keys = 100000
 consistency-check-method = "raw"
 enable-region-bucket = true
 region-bucket-size = "1MB"

--- a/tests/integrations/raftstore/test_bootstrap.rs
+++ b/tests/integrations/raftstore/test_bootstrap.rs
@@ -90,8 +90,11 @@ fn test_node_bootstrap_with_prepared_data() {
     );
 
     // Create coprocessor.
-    let coprocessor_host = CoprocessorHost::new(node.get_router(), cfg.coprocessor);
-
+    let coprocessor_host = CoprocessorHost::new(
+        node.get_router(),
+        Arc::new(VersionTrack::new(cfg.coprocessor)),
+    );
+    
     let importer = {
         let dir = tmp_path.path().join("import-sst");
         Arc::new(SstImporter::new(&cfg.import, dir, None, cfg.storage.api_version()).unwrap())

--- a/tests/integrations/server/kv_service.rs
+++ b/tests/integrations/server/kv_service.rs
@@ -44,7 +44,7 @@ use tikv::{
     },
 };
 use tikv_util::{
-    config::ReadableSize,
+    config::{ReadableSize, VersionTrack},
     worker::{dummy_scheduler, LazyWorker},
     HandyRwLock,
 };
@@ -1122,7 +1122,10 @@ fn test_double_run_node() {
     let simulate_trans = SimulateTransport::new(ChannelTransport::new());
     let tmp = Builder::new().prefix("test_cluster").tempdir().unwrap();
     let snap_mgr = SnapManager::new(tmp.path().to_str().unwrap());
-    let coprocessor_host = CoprocessorHost::new(router, raftstore::coprocessor::Config::default());
+    let coprocessor_host = CoprocessorHost::new(
+        router,
+        Arc::new(VersionTrack::new(raftstore::coprocessor::Config::default())),
+    );
     let importer = {
         let dir = Path::new(engines.kv.path()).join("import-sst");
         Arc::new(SstImporter::new(&ImportConfig::default(), dir, None, ApiVersion::V1).unwrap())


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #12768

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```
When change split-key/size, trigger split checker to split region.
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
