### PR TITLE
raftstore: run pre_persist when yield

### DIFF
--- a/components/raftstore/src/coprocessor/dispatcher.rs
+++ b/components/raftstore/src/coprocessor/dispatcher.rs
@@ -643,12 +643,13 @@ impl<E: KvEngine> CoprocessorHost<E> {
         &self,
         region: &Region,
         is_finished: bool,
+        is_yield: bool,
         cmd: Option<&RaftCmdRequest>,
     ) -> bool {
         let mut ctx = ObserverContext::new(region);
         for observer in &self.registry.region_change_observers {
             let observer = observer.observer.inner();
-            if !observer.pre_persist(&mut ctx, is_finished, cmd) {
+            if !observer.pre_persist(&mut ctx, is_finished, is_yield, cmd) {
                 return false;
             }
         }

--- a/components/raftstore/src/coprocessor/mod.rs
+++ b/components/raftstore/src/coprocessor/mod.rs
@@ -317,6 +317,7 @@ pub trait RegionChangeObserver: Coprocessor {
         &self,
         _: &mut ObserverContext<'_>,
         _is_finished: bool,
+        _is_yield: bool,
         _cmd: Option<&RaftCmdRequest>,
     ) -> bool {
         true


### PR DESCRIPTION
Signed-off-by: CalvinNeo <calvinneo1995@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #12849

What's Changed:

In #12849, we introduced a observer `pre_persist` which is called before every `write_to_db` which suggests whether should we actually do a persistence or not.
However, we find this observer do not cover when a delegate yields when it is run in another priority. So we need to add this hook.

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
```
