### PR TITLE
Makefile: Default enable SSE instructions in x86 arch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,15 +81,21 @@ ROCKSDB_SYS_PORTABLE=0
 RUST_TEST_THREADS ?= 2
 endif
 
-# Disable SSE on ARM
-ifeq ($(shell uname -p),aarch64)
-ROCKSDB_SYS_SSE=0
+# Enable sse4.2 by default on x86 and x64
+ifeq ($(shell uname -m),x86_64)
+ROCKSDB_SYS_SSE=1
 endif
-ifeq ($(shell uname -p),arm)
-ROCKSDB_SYS_SSE=0
+ifeq ($(shell uname -m),x64)
+ROCKSDB_SYS_SSE=1
 endif
-ifeq ($(shell uname -p),arm64)
-ROCKSDB_SYS_SSE=0
+ifeq ($(shell uname -m),x86)
+ROCKSDB_SYS_SSE=1
+endif
+ifeq ($(shell uname -m),i386)
+ROCKSDB_SYS_SSE=1
+endif
+ifeq ($(shell uname -m),i686)
+ROCKSDB_SYS_SSE=1
 endif
 
 # Build portable binary by default unless disable explicitly
@@ -97,9 +103,8 @@ ifneq ($(ROCKSDB_SYS_PORTABLE),0)
 ENABLE_FEATURES += portable
 endif
 
-# Enable sse4.2 by default unless disable explicitly
 # Note this env var is also tested by scripts/check-sse4_2.sh
-ifneq ($(ROCKSDB_SYS_SSE),0)
+ifeq ($(ROCKSDB_SYS_SSE),1)
 ENABLE_FEATURES += sse
 endif
 
@@ -330,11 +335,11 @@ unset-override:
 
 pre-format: unset-override
 	@rustup component add rustfmt
-	@which cargo-sort &> /dev/null || cargo install -q cargo-sort 
+	@which cargo-sort &> /dev/null || cargo install -q cargo-sort
 
 format: pre-format
 	@cargo fmt
-	@cargo sort -w ./Cargo.toml ./*/Cargo.toml components/*/Cargo.toml cmd/*/Cargo.toml >/dev/null 
+	@cargo sort -w ./Cargo.toml ./*/Cargo.toml components/*/Cargo.toml cmd/*/Cargo.toml >/dev/null
 
 doc:
 	@cargo doc --workspace --document-private-items \


### PR DESCRIPTION
Signed-off-by: Wish <breezewish@outlook.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #13574

What's Changed:

In Debian 11 ARM, TiKV cannot compile, because in a variety of Linux distributions, `uname -p` is assigned to `unknown` ([ref](https://unix.stackexchange.com/questions/307955/uname-p-i-are-unknown)).

This PR changes to use `uname -m`, which should always work.

As there will be never unknowns, the enabling rule is more strict now: SSE is only enabled when arch **is** x86-like. In other arch, it is not enabled.

Additionally, for MacOS in Macbook, `uname -m` outputs:

- Macbook M1: arm64
- Macbook Intel: x86_64

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
