### PR TITLE
causal-ts: rename `available-interval` to `alloc-ahead-buffer`

### DIFF
--- a/components/causal_ts/src/config.rs
+++ b/components/causal_ts/src/config.rs
@@ -28,28 +28,29 @@ pub struct Config {
     /// interval. The 50ms limitation can not be broken through now (see
     /// `tso-update-physical-interval`).
     pub renew_batch_max_size: u32,
-    /// The available interval of BatchTsoProvider.
+    /// The size (in duration) of TSO buffer allocated ahead for
+    /// BatchTsoProvider.
     ///
     /// Default is 3s.
-    /// The longer of the value can provide better "high-availability" against
-    /// PD failure, but more overhead of `TsoBatchList` & pressure to TSO
+    /// The longer of the value will help to improve tolerance against PD
+    /// failure, but more overhead of `TsoBatchList` & pressure to TSO
     /// service.
-    pub available_interval: ReadableDuration,
+    pub alloc_ahead_buffer: ReadableDuration,
 }
 
 impl Config {
     pub fn validate(&self) -> Result<(), Box<dyn Error>> {
         if self.renew_interval.is_zero() {
-            return Err("causal-ts.renew_interval can't be zero".into());
+            return Err("causal-ts.renew-interval can't be zero".into());
         }
         if self.renew_batch_min_size == 0 {
-            return Err("causal-ts.renew_batch_min_size should be greater than 0".into());
+            return Err("causal-ts.renew-batch-min-size should be greater than 0".into());
         }
         if self.renew_batch_max_size == 0 {
-            return Err("causal-ts.renew_batch_max_size should be greater than 0".into());
+            return Err("causal-ts.renew-batch-max-size should be greater than 0".into());
         }
-        if self.available_interval.is_zero() {
-            return Err("causal-ts.available-interval can't be zero".into());
+        if self.alloc_ahead_buffer.is_zero() {
+            return Err("causal-ts.alloc-ahead-buffer can't be zero".into());
         }
         Ok(())
     }
@@ -63,8 +64,8 @@ impl Default for Config {
             ),
             renew_batch_min_size: crate::tso::DEFAULT_TSO_BATCH_MIN_SIZE,
             renew_batch_max_size: crate::tso::DEFAULT_TSO_BATCH_MAX_SIZE,
-            available_interval: ReadableDuration::millis(
-                crate::tso::DEFAULT_TSO_BATCH_AVAILABLE_INTERVAL_MS,
+            alloc_ahead_buffer: ReadableDuration::millis(
+                crate::tso::DEFAULT_TSO_BATCH_ALLOC_AHEAD_BUFFER_MS,
             ),
         }
     }

--- a/components/causal_ts/src/tso.rs
+++ b/components/causal_ts/src/tso.rs
@@ -2,12 +2,12 @@
 
 //! ## The algorithm to make the TSO cache tolerate failure of TSO service
 //!
-//! 1. The scale of High-Available is specified by config item
-//! `causal-ts.available-interval`.
+//! 1. The expected total size (in duration) of TSO cache is specified by
+//! config item `causal-ts.alloc-ahead-buffer`.
 //!
 //! 2. Count usage of TSO on every renew interval.
 //!
-//! 3. Calculate `cache_multiplier` by `causal-ts.available-interval /
+//! 3. Calculate `cache_multiplier` by `causal-ts.alloc-ahead-buffer /
 //! causal-ts.renew-interval`.
 //!
 //! 4. Then `tso_usage x cache_multiplier` is the expected number of TSO should
@@ -67,9 +67,9 @@ pub(crate) const DEFAULT_TSO_BATCH_MAX_SIZE: u32 = 8192;
 /// of PD. The longer of the value can provide better "High-Availability"
 /// against PD failure, but more overhead of `TsoBatchList` & pressure to TSO
 /// service.
-pub(crate) const DEFAULT_TSO_BATCH_AVAILABLE_INTERVAL_MS: u64 = 3000;
+pub(crate) const DEFAULT_TSO_BATCH_ALLOC_AHEAD_BUFFER_MS: u64 = 3000;
 /// Just a limitation for safety, in case user specify a too big
-/// `available_interval`.
+/// `alloc_ahead_buffer`.
 const MAX_TSO_BATCH_LIST_CAPACITY: u32 = 1024;
 
 /// TSO range: [(physical, logical_start), (physical, logical_end))
@@ -326,7 +326,7 @@ impl<C: PdClient + 'static> BatchTsoProvider<C> {
         Self::new_opt(
             pd_client,
             Duration::from_millis(DEFAULT_TSO_BATCH_RENEW_INTERVAL_MS),
-            Duration::from_millis(DEFAULT_TSO_BATCH_AVAILABLE_INTERVAL_MS),
+            Duration::from_millis(DEFAULT_TSO_BATCH_ALLOC_AHEAD_BUFFER_MS),
             DEFAULT_TSO_BATCH_MIN_SIZE,
             DEFAULT_TSO_BATCH_MAX_SIZE,
         )
@@ -334,23 +334,23 @@ impl<C: PdClient + 'static> BatchTsoProvider<C> {
     }
 
     #[allow(unused_mut)]
-    fn calc_cache_multiplier(mut renew_interval: Duration, available_interval: Duration) -> u32 {
+    fn calc_cache_multiplier(mut renew_interval: Duration, alloc_ahead: Duration) -> u32 {
         #[cfg(any(test, feature = "testexport"))]
         if renew_interval.is_zero() {
             // Should happen in test only.
             renew_interval = Duration::from_millis(DEFAULT_TSO_BATCH_RENEW_INTERVAL_MS);
         }
-        available_interval.div_duration_f64(renew_interval).ceil() as u32
+        alloc_ahead.div_duration_f64(renew_interval).ceil() as u32
     }
 
     pub async fn new_opt(
         pd_client: Arc<C>,
         renew_interval: Duration,
-        available_interval: Duration,
+        alloc_ahead: Duration,
         batch_min_size: u32,
         batch_max_size: u32,
     ) -> Result<Self> {
-        let cache_multiplier = Self::calc_cache_multiplier(renew_interval, available_interval);
+        let cache_multiplier = Self::calc_cache_multiplier(renew_interval, alloc_ahead);
         let renew_parameter = RenewParameter {
             batch_min_size,
             batch_max_size,

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -349,7 +349,7 @@ where
             let tso = block_on(causal_ts::BatchTsoProvider::new_opt(
                 pd_client.clone(),
                 config.causal_ts.renew_interval.0,
-                config.causal_ts.available_interval.0,
+                config.causal_ts.alloc_ahead_buffer.0,
                 config.causal_ts.renew_batch_min_size,
                 config.causal_ts.renew_batch_max_size,
             ));

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -374,7 +374,7 @@ impl ServerCluster {
                 block_on(causal_ts::BatchTsoProvider::new_opt(
                     self.pd_client.clone(),
                     cfg.causal_ts.renew_interval.0,
-                    cfg.causal_ts.available_interval.0,
+                    cfg.causal_ts.alloc_ahead_buffer.0,
                     cfg.causal_ts.renew_batch_min_size,
                     cfg.causal_ts.renew_batch_max_size,
                 ))

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -798,7 +798,7 @@ fn test_serde_custom_tikv_config() {
         renew_interval: ReadableDuration::millis(100),
         renew_batch_min_size: 100,
         renew_batch_max_size: 8192,
-        available_interval: ReadableDuration::millis(3000),
+        alloc_ahead_buffer: ReadableDuration::millis(3000),
     };
 
     let custom = read_file_in_project_dir("integrations/config/test-custom.toml");


### PR DESCRIPTION
Issue Number: #13596

Signed-off-by: pingyu <yuping@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #13596 

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Rename `causal-ts.available-interval` to `causal-ts.alloc-ahead-buffer` for more clear meaning.
```

### Related changes

- No

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- No

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Rename `causal-ts.available-interval` to `causal-ts.alloc-ahead-buffer` for more clear meaning.
```
