### PR TITLE
local_reader: solve the race condition when acquiring the snapshot

### DIFF
--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -5359,7 +5359,7 @@ where
         &self.engines.kv
     }
 
-    fn get_snapshot(&mut self) -> Arc<EK::Snapshot> {
+    fn get_snapshot(&self) -> Arc<EK::Snapshot> {
         Arc::new(self.engines.kv.snapshot())
     }
 }

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -59,7 +59,7 @@ use tikv_util::{
     codec::number::decode_u64,
     debug, error, info,
     sys::disk::DiskUsage,
-    time::{duration_to_sec, monotonic_raw_now, Instant as TiInstant, InstantExt, ThreadReadId},
+    time::{duration_to_sec, monotonic_raw_now, Instant as TiInstant, InstantExt},
     warn,
     worker::Scheduler,
     Either,
@@ -4529,7 +4529,7 @@ where
             }
         }
 
-        let mut resp = ctx.execute(&req, &Arc::new(region), read_index, None);
+        let mut resp = ctx.execute(&req, &Arc::new(region), read_index);
         if let Some(snap) = resp.snapshot.as_mut() {
             snap.txn_ext = Some(self.txn_ext.clone());
             snap.bucket_meta = self.region_buckets.as_ref().map(|b| b.meta.clone());
@@ -5303,8 +5303,8 @@ pub trait RequestInspector {
             return Ok(RequestPolicy::ReadIndex);
         }
 
-        // If applied index's term is differ from current raft's term, leader transfer
-        // must happened, if read locally, we may read old value.
+        // If applied index's term differs from current raft's term, leader
+        // transfer must happened, if read locally, we may read old value.
         if !self.has_applied_to_current_term() {
             return Ok(RequestPolicy::ReadIndex);
         }
@@ -5359,7 +5359,7 @@ where
         &self.engines.kv
     }
 
-    fn get_snapshot(&mut self, _: Option<ThreadReadId>) -> Arc<EK::Snapshot> {
+    fn get_snapshot(&mut self) -> Arc<EK::Snapshot> {
         Arc::new(self.engines.kv.snapshot())
     }
 }

--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -44,9 +44,9 @@ use crate::{
 
 pub trait ReadExecutor<E: KvEngine> {
     fn get_engine(&self) -> &E;
-    fn get_snapshot(&mut self) -> Arc<E::Snapshot>;
+    fn get_snapshot(&self) -> Arc<E::Snapshot>;
 
-    fn get_value(&mut self, req: &Request, region: &metapb::Region) -> Result<Response> {
+    fn get_value(&self, req: &Request, region: &metapb::Region) -> Result<Response> {
         let key = req.get_get().get_key();
         // region key range has no data prefix, so we must use origin key to check.
         util::check_key_in_region(key, region)?;
@@ -524,7 +524,7 @@ where
         &self.kv_engine
     }
 
-    fn get_snapshot(&mut self) -> Arc<E::Snapshot> {
+    fn get_snapshot(&self) -> Arc<E::Snapshot> {
         self.snap_cache.snapshot().unwrap()
     }
 }

--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -708,7 +708,7 @@ where
                             fail_point!("localreader_before_redirect", |_| {});
                             // Forward to raftstore.
                             self.redirect(RaftCommand::new(req, cb));
-                            if !read_id_exist {
+                            if self.snap_cache.cached_read_id.is_none() {
                                 self.snap_cache.clear();
                             }
                             return;
@@ -723,7 +723,7 @@ where
                             &mut self.metrics,
                         );
 
-                        if !read_id_exist {
+                        if self.snap_cache.cached_read_id.is_none() {
                             self.snap_cache.clear();
                         }
                         response

--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -696,7 +696,6 @@ where
                 let mut response = match policy {
                     // Leader can read local if and only if it is in lease.
                     RequestPolicy::ReadLocal => {
-                        let read_id_exist = read_id.is_some();
                         snap_updated = self.snap_cache.maybe_update_snapshot(
                             &self.kv_engine,
                             read_id,

--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -5,14 +5,14 @@ use std::{
     cell::Cell,
     fmt::{self, Display, Formatter},
     sync::{
-        atomic::{AtomicU64, Ordering},
+        atomic::{self, AtomicU64, Ordering},
         Arc, Mutex,
     },
     time::Duration,
 };
 
 use crossbeam::{atomic::AtomicCell, channel::TrySendError};
-use engine_traits::{KvEngine, RaftEngine, Snapshot};
+use engine_traits::{KvEngine, Peekable, RaftEngine, Snapshot};
 use fail::fail_point;
 use kvproto::{
     errorpb,
@@ -44,18 +44,18 @@ use crate::{
 
 pub trait ReadExecutor<E: KvEngine> {
     fn get_engine(&self) -> &E;
-    fn get_snapshot(&mut self, ts: Option<ThreadReadId>) -> Arc<E::Snapshot>;
+    fn get_snapshot(&mut self) -> Arc<E::Snapshot>;
 
-    fn get_value(&self, req: &Request, region: &metapb::Region) -> Result<Response> {
+    fn get_value(&mut self, req: &Request, region: &metapb::Region) -> Result<Response> {
         let key = req.get_get().get_key();
         // region key range has no data prefix, so we must use origin key to check.
         util::check_key_in_region(key, region)?;
 
-        let engine = self.get_engine();
         let mut resp = Response::default();
+        let snapshot = self.get_snapshot();
         let res = if !req.get_get().get_cf().is_empty() {
             let cf = req.get_get().get_cf();
-            engine
+            snapshot
                 .get_value_cf(cf, &keys::data_key(key))
                 .unwrap_or_else(|e| {
                     panic!(
@@ -67,14 +67,16 @@ pub trait ReadExecutor<E: KvEngine> {
                     )
                 })
         } else {
-            engine.get_value(&keys::data_key(key)).unwrap_or_else(|e| {
-                panic!(
-                    "[region {}] failed to get {}: {:?}",
-                    region.get_id(),
-                    log_wrappers::Value::key(key),
-                    e
-                )
-            })
+            snapshot
+                .get_value(&keys::data_key(key))
+                .unwrap_or_else(|e| {
+                    panic!(
+                        "[region {}] failed to get {}: {:?}",
+                        region.get_id(),
+                        log_wrappers::Value::key(key),
+                        e
+                    )
+                })
         };
         if let Some(res) = res {
             resp.mut_get().set_value(res.to_vec());
@@ -88,7 +90,6 @@ pub trait ReadExecutor<E: KvEngine> {
         msg: &RaftCmdRequest,
         region: &Arc<metapb::Region>,
         read_index: Option<u64>,
-        mut ts: Option<ThreadReadId>,
     ) -> ReadResponse<E::Snapshot> {
         let requests = msg.get_requests();
         let mut response = ReadResponse {
@@ -113,7 +114,7 @@ pub trait ReadExecutor<E: KvEngine> {
                 },
                 CmdType::Snap => {
                     let snapshot =
-                        RegionSnapshot::from_snapshot(self.get_snapshot(ts.take()), region.clone());
+                        RegionSnapshot::from_snapshot(self.get_snapshot(), region.clone());
                     response.snapshot = Some(snapshot);
                     Response::default()
                 }
@@ -306,6 +307,7 @@ impl ReadDelegate {
             let term = lease.term();
             if term == self.term {
                 if lease.inspect(Some(ts)) == LeaseState::Valid {
+                    fail_point!("after_pass_lease_check");
                     return true;
                 } else {
                     metrics.rejected_by_lease_expire += 1;
@@ -418,6 +420,84 @@ impl Progress {
     }
 }
 
+struct SnapCache<E>
+where
+    E: KvEngine,
+{
+    cached_read_id: Option<ThreadReadId>,
+    snapshot: Option<Arc<E::Snapshot>>,
+    cached_snapshot_ts: Timespec,
+}
+
+impl<E> SnapCache<E>
+where
+    E: KvEngine,
+{
+    fn new() -> Self {
+        SnapCache {
+            cached_read_id: None,
+            snapshot: None,
+            cached_snapshot_ts: Timespec::new(0, 0),
+        }
+    }
+
+    /// Update the snapshot in the `snap_cache` if the read_id is None or does
+    /// not match.
+    fn maybe_update_snapshot(
+        &mut self,
+        engine: &E,
+        read_id: Option<ThreadReadId>,
+        delegate_last_valid_ts: Timespec,
+    ) -> bool {
+        if read_id.is_some() {
+            if self.cached_read_id == read_id
+                && read_id.as_ref().unwrap().create_time >= delegate_last_valid_ts
+            {
+                // Cache hit
+                return false;
+            }
+
+            self.cached_read_id = read_id;
+        }
+
+        self.snapshot = Some(Arc::new(engine.snapshot()));
+
+        // Ensures the snapshot is acquired before getting the time
+        atomic::fence(atomic::Ordering::Release);
+        self.cached_snapshot_ts = monotonic_raw_now();
+
+        true
+    }
+
+    // Note: must be called after `maybe_update_snapshot`
+    fn snapshot_ts(&self) -> Timespec {
+        self.cached_snapshot_ts
+    }
+
+    // Note: must be called after `maybe_update_snapshot`
+    fn snapshot(&self) -> Option<Arc<E::Snapshot>> {
+        self.snapshot.clone()
+    }
+
+    fn clear(&mut self) {
+        self.cached_read_id.take();
+        self.snapshot.take();
+    }
+}
+
+impl<E> Clone for SnapCache<E>
+where
+    E: KvEngine,
+{
+    fn clone(&self) -> Self {
+        Self {
+            cached_read_id: self.cached_read_id.clone(),
+            snapshot: self.snapshot.clone(),
+            cached_snapshot_ts: self.cached_snapshot_ts,
+        }
+    }
+}
+
 pub struct LocalReader<C, E>
 where
     C: ProposalRouter<E::Snapshot> + CasualRouter<E>,
@@ -430,8 +510,7 @@ where
     // region id -> ReadDelegate
     // The use of `Arc` here is a workaround, see the comment at `get_delegate`
     delegates: LruCache<u64, Arc<ReadDelegate>>,
-    snap_cache: Option<Arc<E::Snapshot>>,
-    cache_read_id: ThreadReadId,
+    snap_cache: SnapCache<E>,
     // A channel to raftstore.
     router: C,
 }
@@ -445,21 +524,8 @@ where
         &self.kv_engine
     }
 
-    fn get_snapshot(&mut self, create_time: Option<ThreadReadId>) -> Arc<E::Snapshot> {
-        self.metrics.local_executed_requests += 1;
-        if let Some(ts) = create_time {
-            if ts == self.cache_read_id {
-                if let Some(snap) = self.snap_cache.as_ref() {
-                    self.metrics.local_executed_snapshot_cache_hit += 1;
-                    return snap.clone();
-                }
-            }
-            let snap = Arc::new(self.kv_engine.snapshot());
-            self.cache_read_id = ts;
-            self.snap_cache = Some(snap.clone());
-            return snap;
-        }
-        Arc::new(self.kv_engine.snapshot())
+    fn get_snapshot(&mut self) -> Arc<E::Snapshot> {
+        self.snap_cache.snapshot().unwrap()
     }
 }
 
@@ -469,13 +535,11 @@ where
     E: KvEngine,
 {
     pub fn new(kv_engine: E, store_meta: Arc<Mutex<StoreMeta>>, router: C) -> Self {
-        let cache_read_id = ThreadReadId::new();
         LocalReader {
             store_meta,
             kv_engine,
             router,
-            snap_cache: None,
-            cache_read_id,
+            snap_cache: SnapCache::new(),
             store_id: Cell::new(None),
             metrics: Default::default(),
             delegates: LruCache::with_capacity_and_sample(0, 7),
@@ -621,32 +685,34 @@ where
 
     pub fn propose_raft_command(
         &mut self,
-        mut read_id: Option<ThreadReadId>,
+        read_id: Option<ThreadReadId>,
         req: RaftCmdRequest,
         cb: Callback<E::Snapshot>,
     ) {
         match self.pre_propose_raft_command(&req) {
             Ok(Some((delegate, policy))) => {
+                let snap_updated;
+                let last_valid_ts = delegate.last_valid_ts;
                 let mut response = match policy {
                     // Leader can read local if and only if it is in lease.
                     RequestPolicy::ReadLocal => {
-                        let snapshot_ts = match read_id.as_mut() {
-                            // If this peer became Leader not long ago and just after the cached
-                            // snapshot was created, this snapshot can not see all data of the peer.
-                            Some(id) => {
-                                if id.create_time <= delegate.last_valid_ts {
-                                    id.create_time = monotonic_raw_now();
-                                }
-                                id.create_time
-                            }
-                            None => monotonic_raw_now(),
-                        };
+                        snap_updated = self.snap_cache.maybe_update_snapshot(
+                            &self.kv_engine,
+                            read_id,
+                            last_valid_ts,
+                        );
+
+                        let snapshot_ts = self.snap_cache.snapshot_ts();
                         if !delegate.is_in_leader_lease(snapshot_ts, &mut self.metrics) {
+                            fail_point!("localreader_before_redirect", |_| {});
                             // Forward to raftstore.
                             self.redirect(RaftCommand::new(req, cb));
                             return;
                         }
-                        let response = self.execute(&req, &delegate.region, None, read_id);
+
+                        let region = Arc::clone(&delegate.region);
+                        let response = self.execute(&req, &region, None);
+
                         // Try renew lease in advance
                         delegate.maybe_renew_lease_advance(
                             &self.router,
@@ -666,8 +732,15 @@ where
                             return;
                         }
 
+                        snap_updated = self.snap_cache.maybe_update_snapshot(
+                            &self.kv_engine,
+                            read_id,
+                            last_valid_ts,
+                        );
+
+                        let region = Arc::clone(&delegate.region);
                         // Getting the snapshot
-                        let response = self.execute(&req, &delegate.region, None, read_id);
+                        let response = self.execute(&req, &region, None);
 
                         // Double check in case `safe_ts` change after the first check and before getting snapshot
                         if let Err(resp) =
@@ -681,6 +754,12 @@ where
                     }
                     _ => unreachable!(),
                 };
+
+                self.metrics.local_executed_requests += 1;
+                if !snap_updated {
+                    self.metrics.local_executed_snapshot_cache_hit += 1;
+                }
+
                 cmd_resp::bind_term(&mut response.response, delegate.term);
                 if let Some(snap) = response.snapshot.as_mut() {
                     snap.txn_ext = Some(delegate.txn_ext.clone());
@@ -722,7 +801,7 @@ where
     }
 
     pub fn release_snapshot_cache(&mut self) {
-        self.snap_cache.take();
+        self.snap_cache.clear();
     }
 }
 
@@ -740,7 +819,6 @@ where
             metrics: Default::default(),
             delegates: LruCache::with_capacity_and_sample(0, 7),
             snap_cache: self.snap_cache.clone(),
-            cache_read_id: self.cache_read_id.clone(),
         }
     }
 }
@@ -916,12 +994,12 @@ impl ReadMetrics {
 
 #[cfg(test)]
 mod tests {
-    use std::{sync::mpsc::*, thread};
+    use std::{ops::Add, sync::mpsc::*, thread};
 
     use crossbeam::channel::TrySendError;
     use engine_test::kv::{KvTestEngine, KvTestSnapshot};
-    use engine_traits::ALL_CFS;
-    use kvproto::raft_cmdpb::*;
+    use engine_traits::{Peekable, SyncMutable, ALL_CFS};
+    use kvproto::{metapb::RegionEpoch, raft_cmdpb::*};
     use tempfile::{Builder, TempDir};
     use tikv_util::{codec::number::NumberEncoder, time::monotonic_raw_now};
     use time::Duration;
@@ -1026,7 +1104,16 @@ mod tests {
         rx: &Receiver<RaftCommand<KvTestSnapshot>>,
         task: RaftCommand<KvTestSnapshot>,
     ) {
-        reader.propose_raft_command(None, task.request, task.callback);
+        must_not_redirect_with_read_id(reader, rx, task, None);
+    }
+
+    fn must_not_redirect_with_read_id(
+        reader: &mut LocalReader<MockRouter, KvTestEngine>,
+        rx: &Receiver<RaftCommand<KvTestSnapshot>>,
+        task: RaftCommand<KvTestSnapshot>,
+        read_id: Option<ThreadReadId>,
+    ) {
+        reader.propose_raft_command(read_id, task.request, task.callback);
         assert_eq!(rx.try_recv().unwrap_err(), TryRecvError::Empty);
     }
 
@@ -1383,5 +1470,212 @@ mod tests {
         }
         let d = reader.get_delegate(1).unwrap();
         assert_eq!(d.leader_lease.clone().unwrap().term(), 3);
+    }
+
+    fn prepare_read_delegate(
+        store_id: u64,
+        region_id: u64,
+        term: u64,
+        pr_ids: Vec<u64>,
+        region_epoch: RegionEpoch,
+        store_meta: Arc<Mutex<StoreMeta>>,
+    ) {
+        let mut region = metapb::Region::default();
+        region.set_id(region_id);
+        let prs = new_peers(store_id, pr_ids);
+        region.set_peers(prs.clone().into());
+
+        let leader = prs[0].clone();
+        region.set_region_epoch(region_epoch);
+        let mut lease = Lease::new(Duration::seconds(1), Duration::milliseconds(250)); // 1s is long enough.
+        let read_progress = Arc::new(RegionReadProgress::new(&region, 1, 1, "".to_owned()));
+
+        // Register region
+        lease.renew(monotonic_raw_now());
+        let remote = lease.maybe_new_remote_lease(term).unwrap();
+        // But the applied_term is stale.
+        {
+            let mut meta = store_meta.lock().unwrap();
+            let read_delegate = ReadDelegate {
+                tag: String::new(),
+                region: Arc::new(region.clone()),
+                peer_id: leader.get_id(),
+                term,
+                applied_index_term: term,
+                leader_lease: Some(remote),
+                last_valid_ts: Timespec::new(0, 0),
+                txn_extra_op: Arc::new(AtomicCell::new(TxnExtraOp::default())),
+                txn_ext: Arc::new(TxnExt::default()),
+                read_progress,
+                pending_remove: false,
+                track_ver: TrackVer::new(),
+                bucket_meta: None,
+            };
+            meta.readers.insert(region_id, read_delegate);
+        }
+    }
+
+    #[test]
+    fn test_snap_across_regions() {
+        let store_id = 2;
+        let store_meta = Arc::new(Mutex::new(StoreMeta::new(0)));
+        let (_tmp, mut reader, rx) = new_reader("test-local-reader", store_id, store_meta.clone());
+
+        let epoch13 = {
+            let mut ep = metapb::RegionEpoch::default();
+            ep.set_conf_ver(1);
+            ep.set_version(3);
+            ep
+        };
+        let term6 = 6;
+
+        // Register region1
+        let pr_ids1 = vec![2, 3, 4];
+        let prs1 = new_peers(store_id, pr_ids1.clone());
+        prepare_read_delegate(
+            store_id,
+            1,
+            term6,
+            pr_ids1,
+            epoch13.clone(),
+            store_meta.clone(),
+        );
+        let leader1 = prs1[0].clone();
+
+        // Register region2
+        let pr_ids2 = vec![22, 33, 44];
+        let prs2 = new_peers(store_id, pr_ids2.clone());
+        prepare_read_delegate(store_id, 2, term6, pr_ids2, epoch13.clone(), store_meta);
+        let leader2 = prs2[0].clone();
+
+        let mut cmd = RaftCmdRequest::default();
+        let mut header = RaftRequestHeader::default();
+        header.set_region_id(1);
+        header.set_peer(leader1);
+        header.set_region_epoch(epoch13.clone());
+        header.set_term(term6);
+        cmd.set_header(header);
+        let mut req = Request::default();
+        req.set_cmd_type(CmdType::Snap);
+        cmd.set_requests(vec![req].into());
+
+        let (snap_tx, snap_rx) = channel();
+        let task = RaftCommand::<KvTestSnapshot>::new(
+            cmd.clone(),
+            Callback::Read(Box::new(move |resp: ReadResponse<KvTestSnapshot>| {
+                snap_tx.send(resp.snapshot.unwrap()).unwrap();
+            })),
+        );
+
+        // First request will not hit cache
+        let read_id = Some(ThreadReadId::new());
+        must_not_redirect_with_read_id(&mut reader, &rx, task, read_id.clone());
+        let snap1 = snap_rx.recv().unwrap();
+
+        let mut header = RaftRequestHeader::default();
+        header.set_region_id(2);
+        header.set_peer(leader2);
+        header.set_region_epoch(epoch13);
+        header.set_term(term6);
+        cmd.set_header(header);
+        let (snap_tx, snap_rx) = channel();
+        let task = RaftCommand::<KvTestSnapshot>::new(
+            cmd.clone(),
+            Callback::Read(Box::new(move |resp: ReadResponse<KvTestSnapshot>| {
+                snap_tx.send(resp.snapshot.unwrap()).unwrap();
+            })),
+        );
+        must_not_redirect_with_read_id(&mut reader, &rx, task, read_id);
+        let snap2 = snap_rx.recv().unwrap();
+        assert!(std::ptr::eq(snap1.get_snapshot(), snap2.get_snapshot()));
+
+        // If we use a new read id, the cache will be miss and a new snapshot will be
+        // generated
+        let read_id = Some(ThreadReadId::new());
+        let (snap_tx, snap_rx) = channel();
+        let task = RaftCommand::<KvTestSnapshot>::new(
+            cmd.clone(),
+            Callback::Read(Box::new(move |resp: ReadResponse<KvTestSnapshot>| {
+                snap_tx.send(resp.snapshot.unwrap()).unwrap();
+            })),
+        );
+        must_not_redirect_with_read_id(&mut reader, &rx, task, read_id);
+        let snap2 = snap_rx.recv().unwrap();
+        assert!(!std::ptr::eq(snap1.get_snapshot(), snap2.get_snapshot()));
+    }
+
+    fn create_engine(path: &str) -> KvTestEngine {
+        let path = Builder::new().prefix(path).tempdir().unwrap();
+        engine_test::kv::new_engine(path.path().to_str().unwrap(), None, ALL_CFS, None).unwrap()
+    }
+
+    #[test]
+    fn test_snap_cache() {
+        let db = create_engine("test_snap_cache");
+        let mut snap_cache = SnapCache::new();
+
+        db.put(b"a1", b"val1").unwrap();
+
+        let compare_ts = monotonic_raw_now();
+        // Case 1: None read_id
+        assert!(snap_cache.maybe_update_snapshot(&db, None, Timespec::new(0, 0)));
+        assert!(snap_cache.snapshot_ts() > compare_ts);
+        assert_eq!(
+            snap_cache
+                .snapshot()
+                .unwrap()
+                .get_value(b"a1")
+                .unwrap()
+                .unwrap(),
+            b"val1"
+        );
+
+        let read_id = ThreadReadId::new();
+        let compare_ts = monotonic_raw_now();
+        // Case 2: read_id is not None, snap_cache will reserve it and update snapshot again
+        assert!(snap_cache.maybe_update_snapshot(&db, Some(read_id.clone()), Timespec::new(0, 0)));
+        assert!(snap_cache.snapshot_ts() > compare_ts);
+        let snap_ts = snap_cache.snapshot_ts();
+        assert_eq!(
+            snap_cache
+                .snapshot()
+                .unwrap()
+                .get_value(b"a1")
+                .unwrap()
+                .unwrap(),
+            b"val1"
+        );
+
+        let db2 = create_engine("test_snap_cache_context2");
+        // Case 3: call again with the previous read_id will not update snapshot even pass a new db
+        assert!(!snap_cache.maybe_update_snapshot(
+            &db2,
+            Some(read_id.clone()),
+            Timespec::new(0, 0)
+        ));
+        assert_eq!(snap_cache.snapshot_ts(), snap_ts);
+        assert_eq!(
+            snap_cache
+                .snapshot()
+                .unwrap()
+                .get_value(b"a1")
+                .unwrap()
+                .unwrap(),
+            b"val1"
+        );
+
+        // Case 4: delegate.last_valid_ts is larger than create_time of read_id
+        let mut last_valid_ts = read_id.create_time;
+        last_valid_ts = last_valid_ts.add(Duration::nanoseconds(1));
+        assert!(snap_cache.maybe_update_snapshot(&db2, Some(read_id), last_valid_ts));
+        assert!(snap_cache.snapshot_ts() > snap_ts);
+        assert!(
+            snap_cache
+                .snapshot()
+                .unwrap()
+                .get_value(b"a1")
+                .unwrap()
+                .is_none(),
+        );
     }
 }

--- a/tests/failpoints/cases/mod.rs
+++ b/tests/failpoints/cases/mod.rs
@@ -14,6 +14,7 @@ mod test_gc_worker;
 mod test_hibernate;
 mod test_import_service;
 mod test_kv_service;
+mod test_local_read;
 mod test_memory_usage_limit;
 mod test_merge;
 mod test_metrics_overflow;

--- a/tests/failpoints/cases/test_local_read.rs
+++ b/tests/failpoints/cases/test_local_read.rs
@@ -1,0 +1,81 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::{sync::Arc, thread, time::Duration};
+
+use grpcio::{ChannelBuilder, Environment};
+use kvproto::{
+    kvrpcpb::{Context, RawGetRequest},
+    tikvpb_grpc::TikvClient,
+};
+use test_raftstore::{
+    must_get_equal, must_get_none, must_raw_get, must_raw_put, new_peer, new_server_cluster,
+};
+use tikv_util::HandyRwLock;
+
+// The test mocks the situation that just after passing the lease check, even
+// when lease expires, we can read the correct value.
+#[test]
+fn test_consistency_after_lease_pass() {
+    let mut cluster = new_server_cluster(0, 3);
+    let pd_client = Arc::clone(&cluster.pd_client);
+    pd_client.disable_default_operator();
+    cluster.run();
+    let leader = new_peer(1, 1);
+    cluster.must_transfer_leader(1, leader);
+
+    // Create clients.
+    let env = Arc::new(Environment::new(1));
+    let channel = ChannelBuilder::new(Arc::clone(&env)).connect(&cluster.sim.rl().get_addr(1));
+    let client = TikvClient::new(channel);
+
+    let region = cluster.get_region(&b"key1"[..]);
+    let region_id = region.id;
+    let leader = cluster.leader_of_region(region_id).unwrap();
+
+    let mut ctx = Context::default();
+    ctx.set_region_id(region_id);
+    ctx.set_peer(leader.clone());
+    ctx.set_region_epoch(region.get_region_epoch().clone());
+
+    must_raw_put(&client, ctx.clone(), b"key1".to_vec(), b"value1".to_vec());
+    must_get_equal(&cluster.get_engine(1), b"key1", b"value1");
+
+    // Ensure the request is executed by the local reader
+    fail::cfg("localreader_before_redirect", "panic").unwrap();
+
+    // Lease read works correctly
+    assert_eq!(
+        must_raw_get(&client, ctx.clone(), b"key1".to_vec()).unwrap(),
+        b"value1".to_vec()
+    );
+
+    // we pause just after pass the lease check, and then remove the peer. We can
+    // still read the relevant value as we should have already got the snapshot when
+    // passing the lease check.
+    fail::cfg("after_pass_lease_check", "pause").unwrap();
+
+    let mut get_req = RawGetRequest::default();
+    get_req.set_context(ctx);
+    get_req.key = b"key1".to_vec();
+    let mut receiver = client.raw_get_async(&get_req).unwrap();
+
+    thread::sleep(Duration::from_millis(200));
+
+    let mut peer = leader.clone();
+    cluster.must_transfer_leader(1, new_peer(2, 2));
+    pd_client.must_remove_peer(region_id, leader);
+    peer.id = 1000;
+    // After we pass the lease check, we should have got the snapshot, so the data
+    // that the region contains cannot be deleted.
+    // So we need to add the new peer for this region and stop before applying the
+    // snapshot so that the old data will be deleted and the snapshot data has not
+    // been written.
+    fail::cfg("apply_snap_cleanup_range", "pause").unwrap();
+    pd_client.must_add_peer(region_id, peer);
+
+    // Wait for data to be cleaned
+    must_get_none(&cluster.get_engine(1), b"key1");
+    fail::cfg("after_pass_lease_check", "off").unwrap();
+
+    assert_eq!(b"value1", receiver.receive_sync().unwrap().1.get_value());
+}


### PR DESCRIPTION
Signed-off-by: SpadeA-Tang <u6748471@anu.edu.au>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #https://github.com/tikv/tikv/issues/13553

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
The current code encounters the case that after passing the lease check and before the acquiring the snapshot, the lease expires.
This PR fixes it by implementing SnapCacheContext which ensures the timestamp used for the lease check is generated before the snapshot acquisition.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
```
