### PR TITLE
raftstore: record pending delete ssts in each ApplyDelegate

### DIFF
--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -1382,12 +1382,12 @@ where
             _ => (None, None),
         };
         let old_pending_count = self.pending_delete_ssts.len() as i64;
-        let region_state = RegionState {
-            peer_id: self.id(),
-            pending_remove: self.pending_remove,
-            modified_region,
-        };
         let should_write = {
+            let region_state = RegionState {
+                peer_id: self.id(),
+                pending_remove: self.pending_remove,
+                modified_region,
+            };
             let mut apply_ctx_info = ApplyCtxInfo {
                 pending_handle_ssts: &mut pending_handle_ssts,
                 delete_ssts: &mut ctx.delete_ssts,


### PR DESCRIPTION
Signed-off-by: CalvinNeo <calvinneo1995@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #12849

What's Changed:

This case will not affect current behavior of TiKV, but can happen in TiFlash.

Notice if a delegate is then moved to another apply context, it will result in: 
1. The `delete_ssts` remained in previous apply context. 
2. We may lost track of and not be able to delete previous sst files.


The solution is that we attach `pending_delete_ssts` in each `ApplyDelegate` rather than `ApplyContext`.

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
record pending delete ssts in each ApplyDelegate
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
