### PR TITLE
local_reader: release snapshot properly

### DIFF
--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -1924,7 +1924,12 @@ mod tests {
             Callback::read(Box::new(move |_: ReadResponse<KvTestSnapshot>| {})),
         );
         must_not_redirect_with_read_id(&mut reader, &rx, task, Some(read_id));
-        assert!(reader.snap_cache.snapshot.is_some());
+        assert!(
+            reader
+                .kv_engine
+                .get_oldest_snapshot_sequence_number()
+                .is_some()
+        );
         reader.release_snapshot_cache();
         assert!(
             reader

--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -1910,7 +1910,7 @@ mod tests {
         let mut header = RaftRequestHeader::default();
         header.set_region_id(1);
         header.set_peer(leader1);
-        header.set_region_epoch(epoch13.clone());
+        header.set_region_epoch(epoch13);
         header.set_term(term6);
         cmd.set_header(header.clone());
         let mut req = Request::default();
@@ -1923,7 +1923,7 @@ mod tests {
             cmd.clone(),
             Callback::read(Box::new(move |_: ReadResponse<KvTestSnapshot>| {})),
         );
-        must_not_redirect_with_read_id(&mut reader, &rx, task, Some(read_id.clone()));
+        must_not_redirect_with_read_id(&mut reader, &rx, task, Some(read_id));
         assert!(reader.snap_cache.snapshot.is_some());
         reader.release_snapshot_cache();
         assert!(

--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -1919,7 +1919,7 @@ mod tests {
         cmd.set_requests(vec![req].into());
 
         let task = RaftCommand::<KvTestSnapshot>::new(
-            cmd,
+            cmd.clone(),
             Callback::read(Box::new(move |_: ReadResponse<KvTestSnapshot>| {})),
         );
 

--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -1903,14 +1903,7 @@ mod tests {
         // Register region1
         let pr_ids1 = vec![2, 3, 4];
         let prs1 = new_peers(store_id, pr_ids1.clone());
-        prepare_read_delegate(
-            store_id,
-            1,
-            term6,
-            pr_ids1,
-            epoch13.clone(),
-            store_meta.clone(),
-        );
+        prepare_read_delegate(store_id, 1, term6, pr_ids1, epoch13.clone(), store_meta);
         let leader1 = prs1[0].clone();
 
         // Local read
@@ -1926,7 +1919,7 @@ mod tests {
         cmd.set_requests(vec![req].into());
 
         let task = RaftCommand::<KvTestSnapshot>::new(
-            cmd.clone(),
+            cmd,
             Callback::read(Box::new(move |_: ReadResponse<KvTestSnapshot>| {})),
         );
 

--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -949,8 +949,8 @@ where
                             .maybe_update_snapshot(delegate.get_tablet(), last_valid_ts);
 
                         let region = Arc::clone(&delegate.region);
-                        // Getting the snapshot
-                        let response = delegate.execute(&req, &region, None, Some(local_read_ctx));
+                        // Stale read ignore the read_id
+                        let response = delegate.execute(&req, &region, None, None);
 
                         // Double check in case `safe_ts` change after the first check and before
                         // getting snapshot

--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -943,14 +943,14 @@ where
                             return;
                         }
 
-                        let mut local_read_ctx =
-                            LocalReadContext::new(&mut self.snap_cache, read_id);
+                        // Stale read does not use cache, so we pass None for read_id
+                        let mut local_read_ctx = LocalReadContext::new(&mut self.snap_cache, None);
                         snap_updated = local_read_ctx
                             .maybe_update_snapshot(delegate.get_tablet(), last_valid_ts);
 
                         let region = Arc::clone(&delegate.region);
-                        // Stale read ignore the read_id
-                        let response = delegate.execute(&req, &region, None, None);
+                        // Getting the snapshot
+                        let response = delegate.execute(&req, &region, None, Some(local_read_ctx));
 
                         // Double check in case `safe_ts` change after the first check and before
                         // getting snapshot

--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -1924,6 +1924,7 @@ mod tests {
             Callback::read(Box::new(move |_: ReadResponse<KvTestSnapshot>| {})),
         );
         must_not_redirect_with_read_id(&mut reader, &rx, task, Some(read_id.clone()));
+        assert!(reader.snap_cache.snapshot.is_some());
         reader.release_snapshot_cache();
         assert!(
             reader
@@ -1957,7 +1958,10 @@ mod tests {
             cmd,
             Callback::read(Box::new(move |_: ReadResponse<KvTestSnapshot>| {})),
         );
-        must_not_redirect_with_read_id(&mut reader, &rx, task, None);
+        let read_id = ThreadReadId::new();
+        must_not_redirect_with_read_id(&mut reader, &rx, task, Some(read_id));
+        // Stale read will not use snap cache
+        assert!(reader.snap_cache.snapshot.is_none());
         assert!(
             reader
                 .kv_engine


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #13553

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
When read_id is not set, we should not use `snap_cache` as it may not be released.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
