### PR TITLE
raftstore-v2: support conf change

### DIFF
--- a/components/raftstore-v2/Cargo.toml
+++ b/components/raftstore-v2/Cargo.toml
@@ -62,8 +62,9 @@ test_util = { path = "../test_util" }
 [[test]]
 name = "raftstore-v2-failpoints"
 path = "tests/failpoints/mod.rs"
-required-features = ["failpoints"]
+required-features = ["failpoints", "testexport"]
 
 [[test]]
 name = "raftstore-v2-integrations"
 path = "tests/integrations/mod.rs"
+required-features = ["testexport"]

--- a/components/raftstore-v2/Cargo.toml
+++ b/components/raftstore-v2/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = ["test-engine-kv-rocksdb", "test-engine-raft-raft-engine"]
+default = ["testexport", "test-engine-kv-rocksdb", "test-engine-raft-raft-engine"]
 failpoints = ["raftstore/failpoints"]
 testexport = ["raftstore/testexport"]
 test-engine-kv-rocksdb = [

--- a/components/raftstore-v2/src/fsm/peer.rs
+++ b/components/raftstore-v2/src/fsm/peer.rs
@@ -233,6 +233,8 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> PeerFsmDelegate<'a, EK, ER,
                     self.fsm.peer_mut().on_fetched_logs(fetched_logs)
                 }
                 PeerMsg::QueryDebugInfo(ch) => self.fsm.peer_mut().on_query_debug_info(ch),
+                #[cfg(feature = "testexport")]
+                PeerMsg::WaitFlush(ch) => self.fsm.peer_mut().on_wait_flush(ch),
             }
         }
         // TODO: instead of propose pending commands immediately, we should use timeout.

--- a/components/raftstore-v2/src/operation/command/admin/conf_change.rs
+++ b/components/raftstore-v2/src/operation/command/admin/conf_change.rs
@@ -37,7 +37,7 @@ use crate::{
 
 /// The apply result of conf change.
 #[derive(Default, Debug)]
-pub struct ConfChange {
+pub struct ConfChangeResult {
     pub index: u64,
     // The proposed ConfChangeV2 or (legacy) ConfChange
     // ConfChange (if it is) will convert to ConfChangeV2
@@ -126,7 +126,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         Ok(proposal_index)
     }
 
-    pub fn on_apply_res_conf_change(&mut self, conf_change: ConfChange) {
+    pub fn on_apply_res_conf_change(&mut self, conf_change: ConfChangeResult) {
         // TODO: cancel generating snapshot.
 
         // Snapshot is applied in memory without waiting for all entries being
@@ -265,7 +265,7 @@ impl<EK: KvEngine, R> Apply<EK, R> {
         }
         let mut resp = AdminResponse::default();
         resp.mut_change_peer().set_region(new_region);
-        let mut conf_change = ConfChange {
+        let mut conf_change = ConfChangeResult {
             index,
             conf_change: cc,
             changes: changes.to_vec(),

--- a/components/raftstore-v2/src/operation/command/admin/conf_change.rs
+++ b/components/raftstore-v2/src/operation/command/admin/conf_change.rs
@@ -1,0 +1,509 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+//! This module implements the configuration change command.
+//!
+//! The command will go through the following steps:
+//! - Propose conf change
+//! - Apply after conf change is committed
+//! - Update raft state using the result of conf change
+
+use collections::HashSet;
+use engine_traits::{KvEngine, RaftEngine};
+use kvproto::{
+    metapb::{self, PeerRole},
+    raft_cmdpb::{AdminRequest, AdminResponse, ChangePeerRequest, RaftCmdRequest},
+    raft_serverpb::{PeerState, RegionLocalState},
+};
+use protobuf::Message;
+use raft::prelude::*;
+use raft_proto::ConfChangeI;
+use raftstore::{
+    store::{
+        metrics::{PEER_ADMIN_CMD_COUNTER_VEC, PEER_PROPOSE_LOG_SIZE_HISTOGRAM},
+        util::{self, ChangePeerI, ConfChangeKind},
+        ProposalContext,
+    },
+    Error, Result,
+};
+use slog::{error, info, warn};
+use tikv_util::box_err;
+
+use super::AdminCmdResult;
+use crate::{
+    batch::StoreContext,
+    raft::{Apply, Peer},
+    router::ApplyRes,
+};
+
+/// The apply result of conf change.
+#[derive(Default, Debug)]
+pub struct ConfChange {
+    pub index: u64,
+    // The proposed ConfChangeV2 or (legacy) ConfChange
+    // ConfChange (if it is) will convert to ConfChangeV2
+    pub conf_change: ConfChangeV2,
+    // The change peer requests come along with ConfChangeV2
+    // or (legacy) ConfChange, for ConfChange, it only contains
+    // one element
+    pub changes: Vec<ChangePeerRequest>,
+    pub region_state: RegionLocalState,
+}
+
+impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
+    #[inline]
+    pub fn propose_conf_change<T>(
+        &mut self,
+        ctx: &mut StoreContext<EK, ER, T>,
+        mut req: RaftCmdRequest,
+    ) -> Result<u64> {
+        if self.raft_group().raft.has_pending_conf() {
+            info!(
+                self.logger,
+                "there is a pending conf change, try later";
+            );
+            return Err(box_err!("there is a pending conf change, try later"));
+        }
+        let data = req.write_to_bytes()?;
+        let admin = req.get_admin_request();
+        let leader_role = self.peer().get_role();
+        if admin.has_change_peer() {
+            self.propose_conf_change_imp(ctx, admin.get_change_peer(), data)
+        } else if admin.has_change_peer_v2() {
+            self.propose_conf_change_imp(ctx, admin.get_change_peer_v2(), data)
+        } else {
+            unreachable!()
+        }
+    }
+
+    /// Fails in following cases:
+    ///
+    /// 1. A pending conf change has not been applied yet;
+    /// 2. Removing the leader is not allowed in the configuration;
+    /// 3. The conf change makes the raft group not healthy;
+    /// 4. The conf change is dropped by raft group internally.
+    /// 5. There is a same peer on the same store in history record (TODO).
+    fn propose_conf_change_imp<T>(
+        &mut self,
+        ctx: &mut StoreContext<EK, ER, T>,
+        change_peer: impl ChangePeerI,
+        data: Vec<u8>,
+    ) -> Result<u64> {
+        let data_size = data.len();
+        let cc = change_peer.to_confchange(data);
+        let changes = change_peer.get_change_peers();
+
+        util::check_conf_change(
+            &ctx.cfg,
+            self.raft_group(),
+            self.peer(),
+            changes.as_ref(),
+            &cc,
+            false,
+        )?;
+
+        // TODO: check if the new peer is already in history record.
+
+        ctx.raft_metrics.propose.conf_change.inc();
+        // TODO: use local histogram metrics
+        PEER_PROPOSE_LOG_SIZE_HISTOGRAM.observe(data_size as f64);
+        info!(
+            self.logger,
+            "propose conf change peer";
+            "changes" => ?changes.as_ref(),
+            "kind" => ?ConfChangeKind::confchange_kind(changes.as_ref().len()),
+        );
+
+        let last_index = self.raft_group().raft.raft_log.last_index();
+        self.raft_group_mut()
+            .propose_conf_change(ProposalContext::SYNC_LOG.to_vec(), cc)?;
+        let proposal_index = self.raft_group().raft.raft_log.last_index();
+        if proposal_index == last_index {
+            // The message is dropped silently, this usually due to leader absence
+            // or transferring leader. Both cases can be considered as NotLeader error.
+            return Err(Error::NotLeader(self.region_id(), None));
+        }
+
+        Ok(proposal_index)
+    }
+
+    pub fn on_apply_res_conf_change(&mut self, conf_change: ConfChange) {
+        // TODO: cancel generating snapshot.
+
+        // Snapshot is applied in memory without waiting for all entries being
+        // applied. So it's possible conf_change.index < first_index.
+        if conf_change.index >= self.raft_group().raft.raft_log.first_index() {
+            match self.raft_group_mut().apply_conf_change(&conf_change.conf_change) {
+                Ok(_)
+                // PD could dispatch redundant conf changes.
+                | Err(raft::Error::NotExists { .. }) | Err(raft::Error::Exists { .. }) => (),
+                _ => unreachable!(),
+            }
+        }
+
+        let remove_self = conf_change.region_state.get_state() == PeerState::Tombstone;
+        self.storage_mut()
+            .set_region_state(conf_change.region_state);
+        if self.is_leader() {
+            info!(
+                self.logger,
+                "notify pd with change peer region";
+                "region" => ?self.region(),
+            );
+            let demote_self = tikv_util::store::is_learner(self.peer());
+            if remove_self || demote_self {
+                warn!(self.logger, "removing or demoting leader"; "remove" => remove_self, "demote" => demote_self);
+                let term = self.term();
+                self.raft_group_mut()
+                    .raft
+                    .become_follower(term, raft::INVALID_ID);
+            } else if conf_change.changes.iter().any(|c| {
+                matches!(
+                    c.get_change_type(),
+                    ConfChangeType::AddNode | ConfChangeType::AddLearnerNode
+                )
+            }) {
+                // Speed up snapshot instead of waiting another heartbeat.
+                self.raft_group_mut().ping();
+                self.set_has_ready();
+            }
+        }
+        if remove_self {
+            self.mark_for_destroy(None);
+        }
+    }
+}
+
+impl<EK: KvEngine, R> Apply<EK, R> {
+    #[inline]
+    pub fn apply_conf_change(
+        &mut self,
+        index: u64,
+        req: &AdminRequest,
+        cc: ConfChangeV2,
+    ) -> Result<(AdminResponse, AdminCmdResult)> {
+        assert!(req.has_change_peer());
+        self.apply_conf_change_imp(index, std::slice::from_ref(req.get_change_peer()), cc, true)
+    }
+
+    #[inline]
+    pub fn apply_conf_change_v2(
+        &mut self,
+        index: u64,
+        req: &AdminRequest,
+        cc: ConfChangeV2,
+    ) -> Result<(AdminResponse, AdminCmdResult)> {
+        assert!(req.has_change_peer_v2());
+        self.apply_conf_change_imp(
+            index,
+            req.get_change_peer_v2().get_change_peers(),
+            cc,
+            false,
+        )
+    }
+
+    #[inline]
+    fn apply_conf_change_imp(
+        &mut self,
+        index: u64,
+        changes: &[ChangePeerRequest],
+        cc: ConfChangeV2,
+        legacy: bool,
+    ) -> Result<(AdminResponse, AdminCmdResult)> {
+        let region = self.region_state().get_region();
+        let peer_id = self.peer().get_id();
+        let change_kind = ConfChangeKind::confchange_kind(changes.len());
+        info!(self.logger, "exec ConfChangeV2"; "kind" => ?change_kind, "legacy" => legacy, "epoch" => ?region.get_region_epoch());
+        let mut new_region = region.clone();
+        match change_kind {
+            ConfChangeKind::LeaveJoint => self.apply_leave_joint(&mut new_region),
+            kind => {
+                debug_assert!(!legacy || kind == ConfChangeKind::Simple, "{:?}", kind);
+                debug_assert!(
+                    kind != ConfChangeKind::Simple || changes.len() == 1,
+                    "{:?}",
+                    changes
+                );
+                for cp in changes {
+                    let res = if legacy {
+                        self.apply_single_change_legacy(cp, &mut new_region)
+                    } else {
+                        self.apply_single_change(kind, cp, &mut new_region)
+                    };
+                    if let Err(e) = res {
+                        error!(self.logger, "failed to apply conf change"; 
+                        "changes" => ?changes,
+                        "legacy" => legacy,
+                        "original region" => ?region, "err" => ?e);
+                    }
+                }
+                let conf_ver = region.get_region_epoch().get_conf_ver() + changes.len() as u64;
+                new_region.mut_region_epoch().set_conf_ver(conf_ver);
+            }
+        };
+
+        info!(
+            self.logger,
+            "conf change successfully";
+            "changes" => ?changes,
+            "legacy" => legacy,
+            "original region" => ?region,
+            "current region" => ?new_region,
+        );
+        let my_id = self.peer().get_id();
+        let state = self.region_state_mut();
+        state.set_region(new_region.clone());
+        let new_peer = new_region
+            .get_peers()
+            .iter()
+            .find(|p| p.get_id() == my_id)
+            .cloned();
+        if new_peer.is_none() {
+            // A peer will reject any snapshot that doesn't include itself in the
+            // configuration. So if it disappear from the configuration, it must
+            // be removed by conf change.
+            state.set_state(PeerState::Tombstone);
+        }
+        let mut resp = AdminResponse::default();
+        resp.mut_change_peer().set_region(new_region);
+        let mut conf_change = ConfChange {
+            index,
+            conf_change: cc,
+            changes: changes.to_vec(),
+            region_state: state.clone(),
+        };
+        if state.get_state() == PeerState::Tombstone {
+            self.mark_tombstone();
+        }
+        if let Some(peer) = new_peer {
+            self.set_peer(peer);
+        }
+        Ok((resp, AdminCmdResult::ConfChange(conf_change)))
+    }
+
+    #[inline]
+    fn apply_leave_joint(&self, region: &mut metapb::Region) {
+        let mut change_num = 0;
+        for peer in region.mut_peers().iter_mut() {
+            match peer.get_role() {
+                PeerRole::IncomingVoter => peer.set_role(PeerRole::Voter),
+                PeerRole::DemotingVoter => peer.set_role(PeerRole::Learner),
+                _ => continue,
+            }
+            change_num += 1;
+        }
+        if change_num == 0 {
+            panic!(
+                "{:?} can't leave a non-joint config, region: {:?}",
+                self.logger.list(),
+                self.region_state()
+            );
+        }
+        let conf_ver = region.get_region_epoch().get_conf_ver() + change_num;
+        region.mut_region_epoch().set_conf_ver(conf_ver);
+        info!(self.logger, "leave joint state successfully"; "region" => ?region);
+    }
+
+    /// This is used for conf change v1. Use a standalone function to avoid
+    /// future refactor breaks consistency accidentally.
+    #[inline]
+    fn apply_single_change_legacy(
+        &self,
+        cp: &ChangePeerRequest,
+        region: &mut metapb::Region,
+    ) -> Result<()> {
+        let peer = cp.get_peer();
+        let store_id = peer.get_store_id();
+        let change_type = cp.get_change_type();
+
+        match change_type {
+            ConfChangeType::AddNode => {
+                PEER_ADMIN_CMD_COUNTER_VEC
+                    .with_label_values(&["add_peer", "all"])
+                    .inc();
+
+                let mut exists = false;
+                if let Some(p) = tikv_util::store::find_peer_mut(region, store_id) {
+                    exists = true;
+                    if !tikv_util::store::is_learner(p) || p.get_id() != peer.get_id() {
+                        return Err(box_err!(
+                            "can't add duplicated peer {:?} to region {:?}",
+                            peer,
+                            self.region_state()
+                        ));
+                    } else {
+                        p.set_role(PeerRole::Voter);
+                    }
+                }
+                if !exists {
+                    // TODO: Do we allow adding peer in same node?
+                    region.mut_peers().push(peer.clone());
+                }
+
+                PEER_ADMIN_CMD_COUNTER_VEC
+                    .with_label_values(&["add_peer", "success"])
+                    .inc();
+            }
+            ConfChangeType::RemoveNode => {
+                PEER_ADMIN_CMD_COUNTER_VEC
+                    .with_label_values(&["remove_peer", "all"])
+                    .inc();
+
+                if let Some(p) = tikv_util::store::remove_peer(region, store_id) {
+                    // Considering `is_learner` flag in `Peer` here is by design.
+                    if &p != peer {
+                        return Err(box_err!(
+                            "remove unmatched peer: expect: {:?}, get {:?}, ignore",
+                            peer,
+                            p
+                        ));
+                    }
+                } else {
+                    return Err(box_err!(
+                        "remove missing peer {:?} from region {:?}",
+                        peer,
+                        self.region_state()
+                    ));
+                }
+
+                PEER_ADMIN_CMD_COUNTER_VEC
+                    .with_label_values(&["remove_peer", "success"])
+                    .inc();
+            }
+            ConfChangeType::AddLearnerNode => {
+                PEER_ADMIN_CMD_COUNTER_VEC
+                    .with_label_values(&["add_learner", "all"])
+                    .inc();
+
+                if tikv_util::store::find_peer(region, store_id).is_some() {
+                    return Err(box_err!(
+                        "can't add duplicated learner {:?} to region {:?}",
+                        peer,
+                        self.region_state()
+                    ));
+                }
+                region.mut_peers().push(peer.clone());
+
+                PEER_ADMIN_CMD_COUNTER_VEC
+                    .with_label_values(&["add_learner", "success"])
+                    .inc();
+            }
+        }
+        Ok(())
+    }
+
+    #[inline]
+    fn apply_single_change(
+        &self,
+        kind: ConfChangeKind,
+        cp: &ChangePeerRequest,
+        region: &mut metapb::Region,
+    ) -> Result<()> {
+        let (change_type, peer) = (cp.get_change_type(), cp.get_peer());
+        let store_id = peer.get_store_id();
+
+        let metric = match change_type {
+            ConfChangeType::AddNode => "add_peer",
+            ConfChangeType::RemoveNode => "remove_peer",
+            ConfChangeType::AddLearnerNode => "add_learner",
+        };
+        PEER_ADMIN_CMD_COUNTER_VEC
+            .with_label_values(&[metric, "all"])
+            .inc();
+
+        if let Some(exist_peer) = tikv_util::store::find_peer(region, store_id) {
+            let r = exist_peer.get_role();
+            if r == PeerRole::IncomingVoter || r == PeerRole::DemotingVoter {
+                panic!(
+                    "{:?} can't apply confchange because configuration is still in joint state, confchange: {:?}, region: {:?}",
+                    self.logger.list(),
+                    cp,
+                    self.region_state()
+                );
+            }
+        }
+        match (
+            tikv_util::store::find_peer_mut(region, store_id),
+            change_type,
+        ) {
+            (None, ConfChangeType::AddNode) => {
+                let mut peer = peer.clone();
+                match kind {
+                    ConfChangeKind::Simple => peer.set_role(PeerRole::Voter),
+                    ConfChangeKind::EnterJoint => peer.set_role(PeerRole::IncomingVoter),
+                    _ => unreachable!(),
+                }
+                region.mut_peers().push(peer);
+            }
+            (None, ConfChangeType::AddLearnerNode) => {
+                let mut peer = peer.clone();
+                peer.set_role(PeerRole::Learner);
+                region.mut_peers().push(peer);
+            }
+            (None, ConfChangeType::RemoveNode) => {
+                return Err(box_err!(
+                    "remove missing peer {:?} from region {:?}",
+                    peer,
+                    self.region_state()
+                ));
+            }
+            // Add node
+            (Some(exist_peer), ConfChangeType::AddNode)
+            | (Some(exist_peer), ConfChangeType::AddLearnerNode) => {
+                let (role, exist_id, incoming_id) =
+                    (exist_peer.get_role(), exist_peer.get_id(), peer.get_id());
+
+                if exist_id != incoming_id // Add peer with different id to the same store
+                            // The peer is already the requested role
+                            || (role, change_type) == (PeerRole::Voter, ConfChangeType::AddNode)
+                            || (role, change_type) == (PeerRole::Learner, ConfChangeType::AddLearnerNode)
+                {
+                    return Err(box_err!(
+                        "can't add duplicated peer {:?} to region {:?}, duplicated with exist peer {:?}",
+                        peer,
+                        self.region_state(),
+                        exist_peer
+                    ));
+                }
+                match (role, change_type) {
+                    (PeerRole::Voter, ConfChangeType::AddLearnerNode) => match kind {
+                        ConfChangeKind::Simple => exist_peer.set_role(PeerRole::Learner),
+                        ConfChangeKind::EnterJoint => exist_peer.set_role(PeerRole::DemotingVoter),
+                        _ => unreachable!(),
+                    },
+                    (PeerRole::Learner, ConfChangeType::AddNode) => match kind {
+                        ConfChangeKind::Simple => exist_peer.set_role(PeerRole::Voter),
+                        ConfChangeKind::EnterJoint => exist_peer.set_role(PeerRole::IncomingVoter),
+                        _ => unreachable!(),
+                    },
+                    _ => unreachable!(),
+                }
+            }
+            // Remove node
+            (Some(exist_peer), ConfChangeType::RemoveNode) => {
+                if kind == ConfChangeKind::EnterJoint && exist_peer.get_role() == PeerRole::Voter {
+                    return Err(box_err!(
+                        "can not remove voter {:?} directly from region {:?}",
+                        peer,
+                        self.region_state()
+                    ));
+                }
+                match tikv_util::store::remove_peer(region, store_id) {
+                    Some(p) => {
+                        if &p != peer {
+                            return Err(box_err!(
+                                "remove unmatched peer: expect: {:?}, get {:?}, ignore",
+                                peer,
+                                p
+                            ));
+                        }
+                    }
+                    None => unreachable!(),
+                }
+            }
+        }
+        PEER_ADMIN_CMD_COUNTER_VEC
+            .with_label_values(&[metric, "success"])
+            .inc();
+        Ok(())
+    }
+}

--- a/components/raftstore-v2/src/operation/command/admin/mod.rs
+++ b/components/raftstore-v2/src/operation/command/admin/mod.rs
@@ -21,7 +21,7 @@ use raftstore::{
 use slog::info;
 use tikv_util::box_err;
 
-use self::conf_change::ConfChange;
+use self::conf_change::ConfChangeResult;
 use crate::{
     batch::StoreContext,
     raft::{Apply, Peer},
@@ -30,7 +30,7 @@ use crate::{
 
 #[derive(Debug)]
 pub enum AdminCmdResult {
-    ConfChange(ConfChange),
+    ConfChange(ConfChangeResult),
 }
 
 impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {

--- a/components/raftstore-v2/src/operation/command/admin/mod.rs
+++ b/components/raftstore-v2/src/operation/command/admin/mod.rs
@@ -51,6 +51,9 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             return;
         }
 
+        // The admin request is rejected because it may need to update epoch checker
+        // which introduces an uncertainty and may breaks the correctness of epoch
+        // checker.
         if !self.applied_to_current_term() {
             let e = box_err!(
                 "{:?} peer has not applied to current term, applied_term {}, current_term {}",

--- a/components/raftstore-v2/src/operation/command/admin/mod.rs
+++ b/components/raftstore-v2/src/operation/command/admin/mod.rs
@@ -1,0 +1,84 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+mod conf_change;
+
+use engine_traits::{KvEngine, RaftEngine};
+use kvproto::{
+    raft_cmdpb::{AdminRequest, RaftCmdRequest},
+    raft_serverpb::PeerState,
+};
+use protobuf::Message;
+use raft::prelude::ConfChangeV2;
+use raftstore::{
+    store::{
+        self, cmd_resp,
+        fsm::apply,
+        msg::ErrorCallback,
+        util::{ChangePeerI, ConfChangeKind},
+    },
+    Result,
+};
+use slog::info;
+use tikv_util::box_err;
+
+use self::conf_change::ConfChange;
+use crate::{
+    batch::StoreContext,
+    raft::{Apply, Peer},
+    router::CmdResChannel,
+};
+
+#[derive(Debug)]
+pub enum AdminCmdResult {
+    ConfChange(ConfChange),
+}
+
+impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
+    #[inline]
+    pub fn on_admin_command<T>(
+        &mut self,
+        ctx: &mut StoreContext<EK, ER, T>,
+        mut req: RaftCmdRequest,
+        ch: CmdResChannel,
+    ) {
+        if !self.serving() {
+            apply::notify_req_region_removed(self.region_id(), ch);
+            return;
+        }
+        if let Err(e) = self.validate_command(&req, &mut ctx.raft_metrics) {
+            let resp = cmd_resp::new_error(e);
+            ch.report_error(resp);
+            return;
+        }
+
+        if !self.applied_to_current_term() {
+            let e = box_err!(
+                "{:?} peer has not applied to current term, applied_term {}, current_term {}",
+                self.logger.list(),
+                self.storage().entry_storage().applied_term(),
+                self.term()
+            );
+            let resp = cmd_resp::new_error(e);
+            ch.report_error(resp);
+            return;
+        }
+        // To maintain propose order, we need to make pending proposal first.
+        self.propose_pending_command(ctx);
+        let cmd_type = req.get_admin_request().get_cmd_type();
+        let res = if apply::is_conf_change_cmd(&req) {
+            self.propose_conf_change(ctx, req)
+        } else {
+            // propose other admin command.
+            unimplemented!()
+        };
+        if let Err(e) = &res {
+            info!(
+                self.logger,
+                "failed to propose admin command";
+                "cmd_type" => ?cmd_type,
+                "error" => ?e,
+            );
+        }
+        self.post_propose_write(ctx, res, vec![ch]);
+    }
+}

--- a/components/raftstore-v2/src/operation/command/mod.rs
+++ b/components/raftstore-v2/src/operation/command/mod.rs
@@ -21,16 +21,19 @@ use std::cmp;
 use batch_system::{Fsm, FsmScheduler, Mailbox};
 use engine_traits::{KvEngine, RaftEngine, WriteBatch, WriteOptions};
 use kvproto::{
-    raft_cmdpb::{CmdType, RaftCmdRequest, RaftCmdResponse, RaftRequestHeader},
+    raft_cmdpb::{AdminCmdType, CmdType, RaftCmdRequest, RaftCmdResponse, RaftRequestHeader},
     raft_serverpb::RegionLocalState,
 };
 use protobuf::Message;
-use raft::eraftpb::Entry;
+use raft::eraftpb::{ConfChange, ConfChangeV2, Entry, EntryType};
+use raft_proto::ConfChangeI;
 use raftstore::{
     store::{
         cmd_resp,
         fsm::{
-            apply::{APPLY_WB_SHRINK_SIZE, DEFAULT_APPLY_WB_SIZE, SHRINK_PENDING_CMD_QUEUE_CAP},
+            apply::{
+                self, APPLY_WB_SHRINK_SIZE, DEFAULT_APPLY_WB_SIZE, SHRINK_PENDING_CMD_QUEUE_CAP,
+            },
             Proposal,
         },
         local_metrics::RaftMetrics,
@@ -50,11 +53,27 @@ use crate::{
     router::{ApplyRes, ApplyTask, CmdResChannel, PeerMsg},
 };
 
+mod admin;
 mod write;
 
+pub use admin::AdminCmdResult;
 pub use write::{SimpleWriteDecoder, SimpleWriteEncoder};
 
 use self::write::SimpleWrite;
+
+fn parse_at<M: Message + Default>(logger: &slog::Logger, buf: &[u8], index: u64, term: u64) -> M {
+    let mut m = M::default();
+    match m.merge_from_bytes(buf) {
+        Ok(()) => m,
+        Err(e) => panic!(
+            "{:?} data is corrupted at [{}] {}: {:?}",
+            logger.list(),
+            term,
+            index,
+            e
+        ),
+    }
+}
 
 #[derive(Debug)]
 pub struct CommittedEntries {
@@ -80,7 +99,9 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T> PeerFsmDelegate<'a, EK, ER, T> {
                 .peer_mut()
                 .on_write_command(self.store_ctx, req, ch)
         } else if req.has_admin_request() {
-            // self.on_admin_request(req, ch)
+            self.fsm
+                .peer_mut()
+                .on_admin_command(self.store_ctx, req, ch)
         } else if req.has_status_request() {
             error!(self.fsm.logger(), "status command should be sent by Query");
         }
@@ -99,7 +120,8 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         let mailbox = store_ctx.router.mailbox(self.region_id()).unwrap();
         let tablet = self.tablet().clone();
         let logger = self.logger.clone();
-        let (apply_scheduler, mut apply_fsm) = ApplyFsm::new(region_state, mailbox, tablet, logger);
+        let (apply_scheduler, mut apply_fsm) =
+            ApplyFsm::new(self.peer().clone(), region_state, mailbox, tablet, logger);
         store_ctx
             .apply_pool
             .spawn(async move { apply_fsm.handle_all_tasks().await })
@@ -229,8 +251,16 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         }
         // It must just applied a snapshot.
         if apply_res.applied_index < self.entry_storage().first_index() {
-            // TODO: handle admin side effects like split/merge.
+            // Ignore admin command side effects, otherwise it may split incomplete
+            // region.
             return;
+        }
+        for admin_res in apply_res.admin_result {
+            match admin_res {
+                AdminCmdResult::ConfChange(conf_change) => {
+                    self.on_apply_res_conf_change(conf_change)
+                }
+            }
         }
         self.raft_group_mut()
             .advance_apply_to(apply_res.applied_index);
@@ -254,6 +284,10 @@ impl<EK: KvEngine, R: ApplyResReporter> Apply<EK, R> {
     pub async fn apply_committed_entries(&mut self, ce: CommittedEntries) {
         fail::fail_point!("APPLY_COMMITTED_ENTRIES");
         for (e, ch) in ce.entry_and_proposals {
+            if self.tombstone() {
+                apply::notify_req_region_removed(self.region_state().get_region().get_id(), ch);
+                continue;
+            }
             if !e.get_data().is_empty() {
                 let mut set_save_point = false;
                 if let Some(wb) = self.write_batch_mut() {
@@ -284,62 +318,130 @@ impl<EK: KvEngine, R: ApplyResReporter> Apply<EK, R> {
 
     #[inline]
     async fn apply_entry(&mut self, entry: &Entry) -> Result<RaftCmdResponse> {
-        match SimpleWriteDecoder::new(entry.get_data()) {
-            Ok(decoder) => {
-                util::compare_region_epoch(
-                    decoder.header().get_region_epoch(),
-                    self.region_state().get_region(),
-                    false,
-                    true,
-                    true,
-                )?;
-                let res = Ok(new_response(decoder.header()));
-                for req in decoder {
-                    match req {
-                        SimpleWrite::Put(put) => self.apply_put(put.cf, put.key, put.value)?,
-                        SimpleWrite::Delete(delete) => self.apply_delete(delete.cf, delete.key)?,
-                        SimpleWrite::DeleteRange(dr) => self.apply_delete_range(
-                            dr.cf,
-                            dr.start_key,
-                            dr.end_key,
-                            dr.notify_only,
-                        )?,
-                    }
-                }
-                res
-            }
-            Err(req) => {
-                util::check_region_epoch(&req, self.region_state().get_region(), true)?;
-                if req.has_admin_request() {
-                    // TODO: implement admin request.
-                } else {
-                    for r in req.get_requests() {
-                        match r.get_cmd_type() {
-                            // These three writes should all use the new codec. Keep them here for
-                            // backward compatibility.
-                            CmdType::Put => {
-                                let put = r.get_put();
-                                self.apply_put(put.get_cf(), put.get_key(), put.get_value())?;
+        let mut conf_change = None;
+        let req = match entry.get_entry_type() {
+            EntryType::EntryNormal => match SimpleWriteDecoder::new(
+                &self.logger,
+                entry.get_data(),
+                entry.get_index(),
+                entry.get_term(),
+            ) {
+                Ok(decoder) => {
+                    util::compare_region_epoch(
+                        decoder.header().get_region_epoch(),
+                        self.region_state().get_region(),
+                        false,
+                        true,
+                        true,
+                    )?;
+                    let res = Ok(new_response(decoder.header()));
+                    for req in decoder {
+                        match req {
+                            SimpleWrite::Put(put) => self.apply_put(put.cf, put.key, put.value)?,
+                            SimpleWrite::Delete(delete) => {
+                                self.apply_delete(delete.cf, delete.key)?
                             }
-                            CmdType::Delete => {
-                                let delete = r.get_delete();
-                                self.apply_delete(delete.get_cf(), delete.get_key())?;
-                            }
-                            CmdType::DeleteRange => {
-                                let dr = r.get_delete_range();
-                                self.apply_delete_range(
-                                    dr.get_cf(),
-                                    dr.get_start_key(),
-                                    dr.get_end_key(),
-                                    dr.get_notify_only(),
-                                )?;
-                            }
-                            _ => unimplemented!(),
+                            SimpleWrite::DeleteRange(dr) => self.apply_delete_range(
+                                dr.cf,
+                                dr.start_key,
+                                dr.end_key,
+                                dr.notify_only,
+                            )?,
                         }
                     }
+                    return res;
                 }
-                Ok(new_response(req.get_header()))
+                Err(req) => req,
+            },
+            EntryType::EntryConfChange => {
+                let cc: ConfChange = parse_at(
+                    &self.logger,
+                    entry.get_data(),
+                    entry.get_index(),
+                    entry.get_term(),
+                );
+                let req: RaftCmdRequest = parse_at(
+                    &self.logger,
+                    cc.get_context(),
+                    entry.get_index(),
+                    entry.get_term(),
+                );
+                conf_change = Some(cc.into_v2());
+                req
             }
+            EntryType::EntryConfChangeV2 => {
+                let cc: ConfChangeV2 = parse_at(
+                    &self.logger,
+                    entry.get_data(),
+                    entry.get_index(),
+                    entry.get_term(),
+                );
+                let req: RaftCmdRequest = parse_at(
+                    &self.logger,
+                    cc.get_context(),
+                    entry.get_index(),
+                    entry.get_term(),
+                );
+                conf_change = Some(cc);
+                req
+            }
+        };
+
+        util::check_region_epoch(&req, self.region_state().get_region(), true)?;
+        if req.has_admin_request() {
+            let admin_req = req.get_admin_request();
+            let (admin_resp, admin_result) = match req.get_admin_request().get_cmd_type() {
+                AdminCmdType::CompactLog => unimplemented!(),
+                AdminCmdType::Split => unimplemented!(),
+                AdminCmdType::BatchSplit => unimplemented!(),
+                AdminCmdType::PrepareMerge => unimplemented!(),
+                AdminCmdType::CommitMerge => unimplemented!(),
+                AdminCmdType::RollbackMerge => unimplemented!(),
+                AdminCmdType::TransferLeader => unreachable!(),
+                AdminCmdType::ChangePeer => {
+                    self.apply_conf_change(entry.get_index(), admin_req, conf_change.unwrap())?
+                }
+                AdminCmdType::ChangePeerV2 => {
+                    self.apply_conf_change_v2(entry.get_index(), admin_req, conf_change.unwrap())?
+                }
+                AdminCmdType::ComputeHash => unimplemented!(),
+                AdminCmdType::VerifyHash => unimplemented!(),
+                AdminCmdType::PrepareFlashback => unimplemented!(),
+                AdminCmdType::FinishFlashback => unimplemented!(),
+                AdminCmdType::InvalidAdmin => {
+                    return Err(box_err!("invalid admin command type"));
+                }
+            };
+            self.push_admin_result(admin_result);
+            let mut resp = new_response(req.get_header());
+            resp.set_admin_response(admin_resp);
+            Ok(resp)
+        } else {
+            for r in req.get_requests() {
+                match r.get_cmd_type() {
+                    // These three writes should all use the new codec. Keep them here for
+                    // backward compatibility.
+                    CmdType::Put => {
+                        let put = r.get_put();
+                        self.apply_put(put.get_cf(), put.get_key(), put.get_value())?;
+                    }
+                    CmdType::Delete => {
+                        let delete = r.get_delete();
+                        self.apply_delete(delete.get_cf(), delete.get_key())?;
+                    }
+                    CmdType::DeleteRange => {
+                        let dr = r.get_delete_range();
+                        self.apply_delete_range(
+                            dr.get_cf(),
+                            dr.get_start_key(),
+                            dr.get_end_key(),
+                            dr.get_notify_only(),
+                        )?;
+                    }
+                    _ => unimplemented!(),
+                }
+            }
+            Ok(new_response(req.get_header()))
         }
     }
 
@@ -368,9 +470,7 @@ impl<EK: KvEngine, R: ApplyResReporter> Apply<EK, R> {
         let (index, term) = self.apply_progress();
         apply_res.applied_index = index;
         apply_res.applied_term = term;
-        if self.reset_state_changed() {
-            apply_res.region_state = Some(self.region_state().clone());
-        }
+        apply_res.admin_result = self.take_admin_result();
         self.res_reporter().report(apply_res);
     }
 }

--- a/components/raftstore-v2/src/operation/command/write/mod.rs
+++ b/components/raftstore-v2/src/operation/command/write/mod.rs
@@ -70,7 +70,8 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         }
     }
 
-    fn post_propose_write<T>(
+    #[inline]
+    pub fn post_propose_write<T>(
         &mut self,
         ctx: &mut StoreContext<EK, ER, T>,
         res: Result<u64>,

--- a/components/raftstore-v2/src/operation/mod.rs
+++ b/components/raftstore-v2/src/operation/mod.rs
@@ -5,7 +5,7 @@ mod life;
 mod query;
 mod ready;
 
-pub use command::{CommittedEntries, SimpleWriteDecoder, SimpleWriteEncoder};
+pub use command::{AdminCmdResult, CommittedEntries, SimpleWriteDecoder, SimpleWriteEncoder};
 pub use life::DestroyProgress;
 pub use ready::AsyncWriter;
 

--- a/components/raftstore-v2/src/operation/ready/mod.rs
+++ b/components/raftstore-v2/src/operation/ready/mod.rs
@@ -243,11 +243,15 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
     pub fn handle_raft_ready<T: Transport>(&mut self, ctx: &mut StoreContext<EK, ER, T>) {
         let has_ready = self.reset_has_ready();
         if !has_ready || self.destroy_progress().started() {
+            #[cfg(feature = "testexport")]
+            self.async_writer.notify_flush();
             return;
         }
         ctx.has_ready = true;
 
         if !self.raft_group().has_ready() && (self.serving() || self.postpond_destroy()) {
+            #[cfg(feature = "testexport")]
+            self.async_writer.notify_flush();
             return;
         }
 
@@ -318,6 +322,8 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         }
 
         ctx.raft_metrics.ready.has_ready_region.inc();
+        #[cfg(feature = "testexport")]
+        self.async_writer.notify_flush();
     }
 
     /// Called when an asynchronously write finishes.
@@ -353,6 +359,11 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             // is persisted.
             self.finish_destroy(ctx);
         }
+    }
+
+    #[cfg(feature = "testexport")]
+    pub fn on_wait_flush(&mut self, ch: crate::router::FlushChannel) {
+        self.async_writer.subscirbe_flush(ch);
     }
 }
 

--- a/components/raftstore-v2/src/raft/apply.rs
+++ b/components/raftstore-v2/src/raft/apply.rs
@@ -24,6 +24,8 @@ pub struct Apply<EK: KvEngine, R> {
 
     callbacks: Vec<(Vec<CmdResChannel>, RaftCmdResponse)>,
 
+    /// A flag indicates whether the peer is destroyed by applying admin
+    /// command.
     tombstone: bool,
     applied_index: u64,
     applied_term: u64,

--- a/components/raftstore-v2/src/raft/apply.rs
+++ b/components/raftstore-v2/src/raft/apply.rs
@@ -1,30 +1,35 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::mem;
+
 use engine_traits::{KvEngine, RaftEngine};
-use kvproto::{raft_cmdpb::RaftCmdResponse, raft_serverpb::RegionLocalState};
+use kvproto::{metapb, raft_cmdpb::RaftCmdResponse, raft_serverpb::RegionLocalState};
 use raftstore::store::fsm::apply::DEFAULT_APPLY_WB_SIZE;
 use slog::Logger;
 
 use super::Peer;
 use crate::{
     fsm::ApplyResReporter,
+    operation::AdminCmdResult,
     router::{ApplyRes, CmdResChannel},
     tablet::CachedTablet,
 };
 
 /// Apply applies all the committed commands to kv db.
 pub struct Apply<EK: KvEngine, R> {
+    peer: metapb::Peer,
     remote_tablet: CachedTablet<EK>,
     tablet: EK,
     write_batch: Option<EK::WriteBatch>,
 
     callbacks: Vec<(Vec<CmdResChannel>, RaftCmdResponse)>,
 
+    tombstone: bool,
     applied_index: u64,
     applied_term: u64,
+    admin_cmd_result: Vec<AdminCmdResult>,
 
     region_state: RegionLocalState,
-    state_changed: bool,
 
     res_reporter: R,
     pub(crate) logger: Logger,
@@ -33,20 +38,23 @@ pub struct Apply<EK: KvEngine, R> {
 impl<EK: KvEngine, R> Apply<EK, R> {
     #[inline]
     pub fn new(
+        peer: metapb::Peer,
         region_state: RegionLocalState,
         res_reporter: R,
         mut remote_tablet: CachedTablet<EK>,
         logger: Logger,
     ) -> Self {
         Apply {
+            peer,
             tablet: remote_tablet.latest().unwrap().clone(),
             remote_tablet,
             write_batch: None,
             callbacks: vec![],
+            tombstone: false,
             applied_index: 0,
             applied_term: 0,
+            admin_cmd_result: vec![],
             region_state,
-            state_changed: false,
             res_reporter,
             logger,
         }
@@ -92,8 +100,8 @@ impl<EK: KvEngine, R> Apply<EK, R> {
     }
 
     #[inline]
-    pub fn reset_state_changed(&mut self) -> bool {
-        std::mem::take(&mut self.state_changed)
+    pub fn region_state_mut(&mut self) -> &mut RegionLocalState {
+        &mut self.region_state
     }
 
     /// Publish the tablet so that it can be used by read worker.
@@ -104,5 +112,35 @@ impl<EK: KvEngine, R> Apply<EK, R> {
     pub fn publish_tablet(&mut self, tablet: EK) {
         self.remote_tablet.set(tablet.clone());
         self.tablet = tablet;
+    }
+
+    #[inline]
+    pub fn peer(&self) -> &metapb::Peer {
+        &self.peer
+    }
+
+    #[inline]
+    pub fn set_peer(&mut self, peer: metapb::Peer) {
+        self.peer = peer;
+    }
+
+    #[inline]
+    pub fn mark_tombstone(&mut self) {
+        self.tombstone = true;
+    }
+
+    #[inline]
+    pub fn tombstone(&self) -> bool {
+        self.tombstone
+    }
+
+    #[inline]
+    pub fn push_admin_result(&mut self, admin_result: AdminCmdResult) {
+        self.admin_cmd_result.push(admin_result);
+    }
+
+    #[inline]
+    pub fn take_admin_result(&mut self) -> Vec<AdminCmdResult> {
+        mem::take(&mut self.admin_cmd_result)
     }
 }

--- a/components/raftstore-v2/src/raft/storage.rs
+++ b/components/raftstore-v2/src/raft/storage.rs
@@ -240,6 +240,17 @@ impl<ER: RaftEngine> Storage<ER> {
     pub fn set_ever_persisted(&mut self) {
         self.ever_persisted = true;
     }
+
+    #[inline]
+    pub fn set_region_state(&mut self, state: RegionLocalState) {
+        self.region_state = state;
+        for peer in self.region_state.get_region().get_peers() {
+            if peer.get_id() == self.peer.get_id() {
+                self.peer = peer.clone();
+                break;
+            }
+        }
+    }
 }
 
 impl<ER: RaftEngine> raft::Storage for Storage<ER> {
@@ -295,7 +306,9 @@ impl<ER: RaftEngine> raft::Storage for Storage<ER> {
     }
 
     fn snapshot(&self, request_index: u64, to: u64) -> raft::Result<Snapshot> {
-        unimplemented!()
+        Err(raft::Error::Store(
+            raft::StorageError::SnapshotTemporarilyUnavailable,
+        ))
     }
 }
 

--- a/components/raftstore-v2/src/router/internal_message.rs
+++ b/components/raftstore-v2/src/router/internal_message.rs
@@ -1,8 +1,9 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
 use kvproto::raft_serverpb::RegionLocalState;
+use raftstore::store::fsm::ChangePeer;
 
-use crate::operation::CommittedEntries;
+use crate::operation::{AdminCmdResult, CommittedEntries};
 
 #[derive(Debug)]
 pub enum ApplyTask {
@@ -13,5 +14,5 @@ pub enum ApplyTask {
 pub struct ApplyRes {
     pub applied_index: u64,
     pub applied_term: u64,
-    pub region_state: Option<RegionLocalState>,
+    pub admin_result: Vec<AdminCmdResult>,
 }

--- a/components/raftstore-v2/src/router/message.rs
+++ b/components/raftstore-v2/src/router/message.rs
@@ -134,6 +134,9 @@ pub enum PeerMsg {
         ready_number: u64,
     },
     QueryDebugInfo(DebugInfoChannel),
+    /// A message that used to check if a flush is happened.
+    #[cfg(feature = "testexport")]
+    WaitFlush(super::FlushChannel),
 }
 
 impl PeerMsg {
@@ -172,6 +175,8 @@ impl fmt::Debug for PeerMsg {
             ),
             PeerMsg::FetchedLogs(fetched) => write!(fmt, "FetchedLogs {:?}", fetched),
             PeerMsg::QueryDebugInfo(_) => write!(fmt, "QueryDebugInfo"),
+            #[cfg(feature = "testexport")]
+            PeerMsg::WaitFlush(_) => write!(fmt, "FlushMessages"),
         }
     }
 }

--- a/components/raftstore-v2/src/router/mod.rs
+++ b/components/raftstore-v2/src/router/mod.rs
@@ -6,6 +6,10 @@ pub mod message;
 mod response_channel;
 
 pub(crate) use self::internal_message::ApplyTask;
+#[cfg(feature = "testexport")]
+pub use self::response_channel::FlushChannel;
+#[cfg(feature = "testexport")]
+pub use self::response_channel::FlushSubscriber;
 pub use self::{
     imp::RaftRouter,
     internal_message::ApplyRes,

--- a/components/raftstore-v2/src/router/response_channel.rs
+++ b/components/raftstore-v2/src/router/response_channel.rs
@@ -417,6 +417,11 @@ impl fmt::Debug for QueryResChannel {
 pub type DebugInfoChannel = BaseChannel<RegionMeta>;
 pub type DebugInfoSubscriber = BaseSubscriber<RegionMeta>;
 
+#[cfg(feature = "testexport")]
+pub type FlushChannel = BaseChannel<()>;
+#[cfg(feature = "testexport")]
+pub type FlushSubscriber = BaseSubscriber<()>;
+
 #[cfg(test)]
 mod tests {
     use futures::executor::block_on;

--- a/components/raftstore-v2/tests/failpoints/test_basic_write.rs
+++ b/components/raftstore-v2/tests/failpoints/test_basic_write.rs
@@ -16,12 +16,7 @@ use crate::cluster::Cluster;
 fn test_write_batch_rollback() {
     let cluster = Cluster::default();
     let router = cluster.router(0);
-    let mut req = RaftCmdRequest::default();
-    req.mut_header().set_region_id(2);
-    let epoch = req.mut_header().mut_region_epoch();
-    epoch.set_version(INIT_EPOCH_VER);
-    epoch.set_conf_ver(INIT_EPOCH_CONF_VER);
-    req.mut_header().set_peer(new_peer(1, 3));
+    let mut req = router.new_request_for(2);
     let mut put_req = Request::default();
     put_req.set_cmd_type(CmdType::Put);
     put_req.mut_put().set_key(b"key".to_vec());

--- a/components/raftstore-v2/tests/integrations/cluster.rs
+++ b/components/raftstore-v2/tests/integrations/cluster.rs
@@ -11,7 +11,8 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crossbeam::channel::{self, Receiver, Sender};
+use collections::HashSet;
+use crossbeam::channel::{self, Receiver, Sender, TrySendError};
 use engine_test::{
     ctor::{CfOptions, DbOptions},
     kv::{KvTestEngine, TestTabletFactoryV2},
@@ -28,13 +29,16 @@ use pd_client::RpcClient;
 use raftstore::store::{region_meta::RegionMeta, Config, Transport, RAFT_INIT_LOG_INDEX};
 use raftstore_v2::{
     create_store_batch_system,
-    router::{DebugInfoChannel, PeerMsg, QueryResult, RaftRouter},
+    router::{DebugInfoChannel, FlushChannel, PeerMsg, QueryResult, RaftRouter},
     Bootstrap, StoreMeta, StoreSystem,
 };
-use slog::{o, Logger};
+use slog::{debug, o, Logger};
 use tempfile::TempDir;
 use test_pd::mocker::Service;
-use tikv_util::config::{ReadableDuration, VersionTrack};
+use tikv_util::{
+    config::{ReadableDuration, VersionTrack},
+    store::new_peer,
+};
 
 #[derive(Clone)]
 pub struct TestRouter(RaftRouter<KvTestEngine, RaftTestEngine>);
@@ -81,6 +85,20 @@ impl TestRouter {
         block_on(sub.result())
     }
 
+    pub fn wait_flush(&self, region_id: u64, timeout: Duration) -> bool {
+        let timer = Instant::now();
+        while timer.elapsed() < timeout {
+            let (ch, sub) = FlushChannel::pair();
+            let res = self.send(region_id, PeerMsg::WaitFlush(ch));
+            match res {
+                Ok(_) => return block_on(sub.result()).is_some(),
+                Err(TrySendError::Disconnected(_)) => return false,
+                Err(TrySendError::Full(_)) => thread::sleep(Duration::from_millis(10)),
+            }
+        }
+        panic!("unable to flush {}", region_id);
+    }
+
     pub fn wait_applied_to_current_term(&self, region_id: u64, timeout: Duration) {
         let mut now = Instant::now();
         let deadline = now + timeout;
@@ -104,9 +122,34 @@ impl TestRouter {
             region_id, res
         );
     }
+
+    pub fn new_request_for(&self, region_id: u64) -> RaftCmdRequest {
+        let meta = self
+            .must_query_debug_info(region_id, Duration::from_secs(1))
+            .unwrap();
+        let mut req = RaftCmdRequest::default();
+        req.mut_header().set_region_id(region_id);
+        let epoch = req.mut_header().mut_region_epoch();
+        let epoch_meta = &meta.region_state.epoch;
+        epoch.set_version(epoch_meta.version);
+        epoch.set_conf_ver(epoch_meta.conf_ver);
+        let target_peer = meta
+            .region_state
+            .peers
+            .iter()
+            .find(|p| p.id == meta.raft_status.id)
+            .unwrap()
+            .clone();
+        let mut peer = new_peer(target_peer.store_id, target_peer.id);
+        peer.role = target_peer.role.into();
+        req.mut_header().set_peer(peer);
+        req.mut_header().set_term(meta.raft_status.hard_state.term);
+        req
+    }
 }
 
 pub struct RunningState {
+    store_id: u64,
     pub raft_engine: RaftTestEngine,
     pub factory: Arc<TestTabletFactoryV2>,
     pub system: StoreSystem<KvTestEngine, RaftTestEngine>,
@@ -178,6 +221,7 @@ impl RunningState {
             .unwrap();
 
         let state = Self {
+            store_id,
             raft_engine,
             factory,
             system,
@@ -203,8 +247,7 @@ pub struct TestNode {
 }
 
 impl TestNode {
-    fn with_pd(pd_server: &test_pd::Server<Service>) -> TestNode {
-        let logger = slog_global::borrow_global().new(o!());
+    fn with_pd(pd_server: &test_pd::Server<Service>, logger: Logger) -> TestNode {
         let pd_client = test_pd::util::new_client(pd_server.bind_addrs(), None);
         let path = TempDir::new().unwrap();
 
@@ -244,6 +287,10 @@ impl TestNode {
 
     pub fn running_state(&self) -> Option<&RunningState> {
         self.running_state.as_ref()
+    }
+
+    pub fn id(&self) -> u64 {
+        self.running_state().unwrap().store_id
     }
 }
 
@@ -319,6 +366,7 @@ pub struct Cluster {
     nodes: Vec<TestNode>,
     receivers: Vec<Receiver<RaftMessage>>,
     routers: Vec<TestRouter>,
+    logger: Logger,
 }
 
 impl Default for Cluster {
@@ -330,16 +378,18 @@ impl Default for Cluster {
 impl Cluster {
     pub fn with_node_count(count: usize) -> Self {
         let pd_server = test_pd::Server::new(1);
+        let logger = slog_global::borrow_global().new(o!());
         let mut cluster = Cluster {
             pd_server,
             nodes: vec![],
             receivers: vec![],
             routers: vec![],
+            logger,
         };
         let mut cfg = v2_default_config();
         disable_all_auto_ticks(&mut cfg);
         for _ in 1..=count {
-            let mut node = TestNode::with_pd(&cluster.pd_server);
+            let mut node = TestNode::with_pd(&cluster.pd_server, cluster.logger.clone());
             let (tx, rx) = new_test_transport();
             let router = node.start(Arc::new(VersionTrack::new(cfg.clone())), tx);
             cluster.nodes.push(node);
@@ -360,5 +410,42 @@ impl Cluster {
 
     pub fn router(&self, offset: usize) -> TestRouter {
         self.routers[offset].clone()
+    }
+
+    /// Send messages and wait for side effects are all handled.
+    pub fn dispatch(&self, region_id: u64, mut msgs: Vec<Box<RaftMessage>>) {
+        let mut regions = HashSet::default();
+        regions.insert(region_id);
+        loop {
+            for msg in msgs.drain(..) {
+                let offset = match self
+                    .nodes
+                    .iter()
+                    .position(|n| n.id() == msg.get_to_peer().get_store_id())
+                {
+                    Some(offset) => offset,
+                    None => {
+                        debug!(self.logger, "failed to find node"; "message" => ?msg);
+                        continue;
+                    }
+                };
+                regions.insert(msg.get_region_id());
+                if let Err(e) = self.routers[offset].send_raft_message(msg) {
+                    debug!(self.logger, "failed to send raft message"; "err" => ?e);
+                }
+            }
+            for (router, rx) in self.routers.iter().zip(&self.receivers) {
+                for region_id in &regions {
+                    router.wait_flush(*region_id, Duration::from_secs(3));
+                }
+                while let Ok(msg) = rx.try_recv() {
+                    msgs.push(Box::new(msg));
+                }
+            }
+            regions.clear();
+            if msgs.is_empty() {
+                return;
+            }
+        }
     }
 }

--- a/components/raftstore-v2/tests/integrations/mod.rs
+++ b/components/raftstore-v2/tests/integrations/mod.rs
@@ -7,6 +7,7 @@
 
 mod cluster;
 mod test_basic_write;
+mod test_conf_change;
 mod test_life;
 mod test_read;
 mod test_status;

--- a/components/raftstore-v2/tests/integrations/test_basic_write.rs
+++ b/components/raftstore-v2/tests/integrations/test_basic_write.rs
@@ -19,12 +19,7 @@ use crate::cluster::Cluster;
 fn test_basic_write() {
     let cluster = Cluster::default();
     let router = cluster.router(0);
-    let mut req = RaftCmdRequest::default();
-    req.mut_header().set_region_id(2);
-    let epoch = req.mut_header().mut_region_epoch();
-    epoch.set_version(INIT_EPOCH_VER);
-    epoch.set_conf_ver(INIT_EPOCH_CONF_VER);
-    req.mut_header().set_peer(new_peer(1, 3));
+    let mut req = router.new_request_for(2);
     let mut put_req = Request::default();
     put_req.set_cmd_type(CmdType::Put);
     put_req.mut_put().set_key(b"key".to_vec());
@@ -119,12 +114,7 @@ fn test_basic_write() {
 fn test_put_delete() {
     let cluster = Cluster::default();
     let router = cluster.router(0);
-    let mut req = RaftCmdRequest::default();
-    req.mut_header().set_region_id(2);
-    let epoch = req.mut_header().mut_region_epoch();
-    epoch.set_version(INIT_EPOCH_VER);
-    epoch.set_conf_ver(INIT_EPOCH_CONF_VER);
-    req.mut_header().set_peer(new_peer(1, 3));
+    let mut req = router.new_request_for(2);
     let mut put_req = Request::default();
     put_req.set_cmd_type(CmdType::Put);
     put_req.mut_put().set_key(b"key".to_vec());

--- a/components/raftstore-v2/tests/integrations/test_conf_change.rs
+++ b/components/raftstore-v2/tests/integrations/test_conf_change.rs
@@ -1,0 +1,72 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::time::Duration;
+
+use kvproto::raft_cmdpb::AdminCmdType;
+use raft::prelude::ConfChangeType;
+use tikv_util::store::new_learner_peer;
+
+use crate::cluster::Cluster;
+
+#[test]
+fn test_simple_change() {
+    let cluster = Cluster::with_node_count(2);
+    let router0 = cluster.router(0);
+    let mut req = router0.new_request_for(2);
+    let admin_req = req.mut_admin_request();
+    admin_req.set_cmd_type(AdminCmdType::ChangePeer);
+    admin_req
+        .mut_change_peer()
+        .set_change_type(ConfChangeType::AddLearnerNode);
+    let store_id = cluster.node(1).id();
+    let new_peer = new_learner_peer(store_id, 10);
+    admin_req.mut_change_peer().set_peer(new_peer.clone());
+    let resp = router0.command(2, req.clone()).unwrap();
+    assert!(!resp.get_header().has_error(), "{:?}", resp);
+    let epoch = req.get_header().get_region_epoch();
+    let new_conf_ver = epoch.get_conf_ver() + 1;
+    let leader_peer = req.get_header().get_peer().clone();
+    let meta = router0
+        .must_query_debug_info(2, Duration::from_secs(3))
+        .unwrap();
+    assert_eq!(meta.region_state.epoch.version, epoch.get_version());
+    assert_eq!(meta.region_state.epoch.conf_ver, new_conf_ver);
+    assert_eq!(
+        meta.region_state.peers,
+        vec![leader_peer.clone(), new_peer.clone()]
+    );
+
+    // So heartbeat will create a learner.
+    cluster.send(2, vec![]);
+    let router1 = cluster.router(1);
+    let meta = router1
+        .must_query_debug_info(2, Duration::from_secs(3))
+        .unwrap();
+    assert_eq!(meta.raft_status.id, 10, "{:?}", meta);
+    assert_eq!(meta.region_state.epoch.version, epoch.get_version());
+    assert_eq!(meta.region_state.epoch.conf_ver, new_conf_ver);
+    assert_eq!(
+        meta.raft_status.soft_state.leader_id,
+        req.get_header().get_peer().get_id()
+    );
+
+    req.mut_header()
+        .mut_region_epoch()
+        .set_conf_ver(new_conf_ver);
+    req.mut_admin_request()
+        .mut_change_peer()
+        .set_change_type(ConfChangeType::RemoveNode);
+    let resp = router0.command(2, req.clone()).unwrap();
+    assert!(!resp.get_header().has_error(), "{:?}", resp);
+    let epoch = req.get_header().get_region_epoch();
+    let new_conf_ver = epoch.get_conf_ver() + 1;
+    let leader_peer = req.get_header().get_peer().clone();
+    let meta = router0
+        .must_query_debug_info(2, Duration::from_secs(3))
+        .unwrap();
+    assert_eq!(meta.region_state.epoch.version, epoch.get_version());
+    assert_eq!(meta.region_state.epoch.conf_ver, new_conf_ver);
+    assert_eq!(meta.region_state.peers, vec![leader_peer.clone()]);
+    // TODO: check if the peer is removed once life trace is implemented or
+    // snapshot is implemented.
+}

--- a/components/raftstore-v2/tests/integrations/test_read.rs
+++ b/components/raftstore-v2/tests/integrations/test_read.rs
@@ -13,25 +13,10 @@ fn test_read_index() {
     let router = cluster.router(0);
     std::thread::sleep(std::time::Duration::from_millis(200));
     let region_id = 2;
-    let mut req = RaftCmdRequest::default();
-    req.mut_header().set_peer(new_peer(1, 3));
-    req.mut_status_request()
-        .set_cmd_type(StatusCmdType::RegionDetail);
-    let res = router.query(region_id, req.clone()).unwrap();
-    let status_resp = res.response().unwrap().get_status_response();
-    let detail = status_resp.get_region_detail();
-    let mut region = detail.get_region().clone();
-
-    let read_index_req = ReadIndexRequest::default();
-    let mut req = RaftCmdRequest::default();
-    req.mut_header().set_peer(new_peer(1, 3));
-    req.mut_header().set_term(7);
-    req.mut_header().set_region_id(region_id);
-    req.mut_header()
-        .set_region_epoch(region.take_region_epoch());
+    let mut req = router.new_request_for(region_id);
     let mut request_inner = Request::default();
     request_inner.set_cmd_type(CmdType::Snap);
-    request_inner.set_read_index(read_index_req);
+    request_inner.mut_read_index();
     req.mut_requests().push(request_inner);
     let res = router.query(region_id, req.clone()).unwrap();
     let resp = res.read().unwrap();
@@ -46,21 +31,7 @@ fn test_snap_without_read_index() {
     let router = cluster.router(0);
     std::thread::sleep(std::time::Duration::from_millis(200));
     let region_id = 2;
-    let mut req = RaftCmdRequest::default();
-    req.mut_header().set_peer(new_peer(1, 3));
-    req.mut_status_request()
-        .set_cmd_type(StatusCmdType::RegionDetail);
-    let res = router.query(region_id, req.clone()).unwrap();
-    let status_resp = res.response().unwrap().get_status_response();
-    let detail = status_resp.get_region_detail();
-    let mut region = detail.get_region().clone();
-
-    let mut req = RaftCmdRequest::default();
-    req.mut_header().set_peer(new_peer(1, 3));
-    req.mut_header().set_term(6);
-    req.mut_header().set_region_id(region_id);
-    req.mut_header()
-        .set_region_epoch(region.take_region_epoch());
+    let mut req = router.new_request_for(region_id);
     let mut request_inner = Request::default();
     request_inner.set_cmd_type(CmdType::Snap);
     req.mut_requests().push(request_inner);
@@ -92,21 +63,7 @@ fn test_query_with_write_cmd() {
     let router = cluster.router(0);
     std::thread::sleep(std::time::Duration::from_millis(200));
     let region_id = 2;
-    let mut req = RaftCmdRequest::default();
-    req.mut_header().set_peer(new_peer(1, 3));
-    req.mut_status_request()
-        .set_cmd_type(StatusCmdType::RegionDetail);
-    let res = router.query(region_id, req.clone()).unwrap();
-    let status_resp = res.response().unwrap().get_status_response();
-    let detail = status_resp.get_region_detail();
-    let mut region = detail.get_region().clone();
-
-    let mut req = RaftCmdRequest::default();
-    req.mut_header().set_peer(new_peer(1, 3));
-    req.mut_header().set_term(6);
-    req.mut_header().set_region_id(region_id);
-    req.mut_header()
-        .set_region_epoch(region.take_region_epoch());
+    let mut req = router.new_request_for(2);
 
     for write_cmd in [
         CmdType::Prewrite,
@@ -123,6 +80,7 @@ fn test_query_with_write_cmd() {
         assert!(resp.is_none());
         let error_resp = res.response().unwrap();
         assert!(error_resp.get_header().has_error());
+        req.clear_requests();
     }
 }
 
@@ -132,21 +90,7 @@ fn test_snap_with_invalid_parameter() {
     let router = cluster.router(0);
     std::thread::sleep(std::time::Duration::from_millis(200));
     let region_id = 2;
-    let mut req = RaftCmdRequest::default();
-    req.mut_header().set_peer(new_peer(1, 3));
-    req.mut_status_request()
-        .set_cmd_type(StatusCmdType::RegionDetail);
-    let res = router.query(region_id, req.clone()).unwrap();
-    let status_resp = res.response().unwrap().get_status_response();
-    let detail = status_resp.get_region_detail();
-    let mut region = detail.get_region().clone();
-    let mut region_epoch = region.take_region_epoch();
-
-    let mut req = RaftCmdRequest::default();
-    req.mut_header().set_peer(new_peer(1, 3));
-    req.mut_header().set_term(6);
-    req.mut_header().set_region_id(region_id);
-    req.mut_header().set_region_epoch(region_epoch.clone());
+    let mut req = router.new_request_for(region_id);
     let mut request_inner = Request::default();
     request_inner.set_cmd_type(CmdType::Snap);
     req.mut_requests().push(request_inner);
@@ -198,21 +142,7 @@ fn test_local_read() {
     let mut router = cluster.router(0);
     std::thread::sleep(std::time::Duration::from_millis(200));
     let region_id = 2;
-    let mut req = RaftCmdRequest::default();
-    req.mut_header().set_peer(new_peer(1, 3));
-    req.mut_status_request()
-        .set_cmd_type(StatusCmdType::RegionDetail);
-    let res = router.query(region_id, req.clone()).unwrap();
-    let status_resp = res.response().unwrap().get_status_response();
-    let detail = status_resp.get_region_detail();
-    let mut region = detail.get_region().clone();
-
-    let mut req = RaftCmdRequest::default();
-    req.mut_header().set_peer(new_peer(1, 3));
-    req.mut_header().set_term(6);
-    req.mut_header().set_region_id(region_id);
-    req.mut_header()
-        .set_region_epoch(region.take_region_epoch());
+    let mut req = router.new_request_for(region_id);
     let mut request_inner = Request::default();
     request_inner.set_cmd_type(CmdType::Snap);
     req.mut_requests().push(request_inner);

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -14,6 +14,7 @@ use std::{
     u64,
 };
 
+use collections::HashSet;
 use engine_traits::KvEngine;
 use kvproto::{
     kvrpcpb::{self, KeyRange, LeaderInfo},
@@ -24,14 +25,14 @@ use kvproto::{
 use protobuf::{self, Message};
 use raft::{
     eraftpb::{self, ConfChangeType, ConfState, MessageType},
-    INVALID_INDEX,
+    Changer, RawNode, INVALID_INDEX,
 };
 use raft_proto::ConfChangeI;
 use tikv_util::{box_err, debug, info, store::region, time::monotonic_raw_now, Either};
 use time::{Duration, Timespec};
 use txn_types::{TimeStamp, WriteBatchFlags};
 
-use super::peer_storage;
+use super::{metrics::PEER_ADMIN_CMD_COUNTER_VEC, peer_storage, Config};
 use crate::{coprocessor::CoprocessorHost, Error, Result};
 
 const INVALID_TIMESTAMP: u64 = u64::MAX;
@@ -765,7 +766,7 @@ impl<
     }
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone, Copy)]
 pub enum ConfChangeKind {
     // Only contains one configuration change
     Simple,
@@ -844,6 +845,118 @@ impl<'a> ChangePeerI for &'a ChangePeerV2Request {
         cc.set_changes(changes.into());
         cc.set_context(ctx.into());
         cc
+    }
+}
+
+/// Check if the conf change request is valid.
+///
+/// The function will try to keep operation safe. In some edge cases (or
+/// tests), we may not care about safety. In this case, `ignore_safety`
+/// can be set to true.
+///
+/// Make sure the peer can serve read and write when ignore safety, otherwise
+/// it may produce stale result or cause unavailability.
+pub fn check_conf_change(
+    cfg: &Config,
+    node: &RawNode<impl raft::Storage>,
+    leader: &metapb::Peer,
+    change_peers: &[ChangePeerRequest],
+    cc: &impl ConfChangeI,
+    ignore_safety: bool,
+) -> Result<()> {
+    let current_progress = node.status().progress.unwrap().clone();
+    let mut after_progress = current_progress.clone();
+    let cc_v2 = cc.as_v2();
+    let mut changer = Changer::new(&after_progress);
+    let (conf, changes) = if cc_v2.leave_joint() {
+        changer.leave_joint()?
+    } else if let Some(auto_leave) = cc_v2.enter_joint() {
+        changer.enter_joint(auto_leave, &cc_v2.changes)?
+    } else {
+        changer.simple(&cc_v2.changes)?
+    };
+    after_progress.apply_conf(conf, changes, node.raft.raft_log.last_index());
+
+    // Because the conf change can be applied successfully above, so the current
+    // raft group state must matches the command. For example, won't call leave
+    // joint on a non joint state.
+    let kind = ConfChangeKind::confchange_kind(change_peers.len());
+    if kind == ConfChangeKind::LeaveJoint {
+        if ignore_safety || leader.get_role() != PeerRole::DemotingVoter {
+            return Ok(());
+        }
+        return Err(box_err!("ignore leave joint command that demoting leader"));
+    }
+
+    let mut check_dup = HashSet::default();
+    let mut only_learner_change = true;
+    let current_voter = current_progress.conf().voters().ids();
+    for cp in change_peers {
+        let (change_type, peer) = (cp.get_change_type(), cp.get_peer());
+        match (change_type, peer.get_role()) {
+            (ConfChangeType::RemoveNode, PeerRole::Voter) if kind != ConfChangeKind::Simple => {
+                return Err(box_err!("{:?}: can not remove voter directly", cp));
+            }
+            (ConfChangeType::RemoveNode, _)
+            | (ConfChangeType::AddNode, PeerRole::Voter)
+            | (ConfChangeType::AddLearnerNode, PeerRole::Learner) => {}
+            _ => {
+                return Err(box_err!("{:?}: op not match role", cp));
+            }
+        }
+
+        if !check_dup.insert(peer.get_id()) {
+            return Err(box_err!(
+                "have multiple commands for the same peer {}",
+                peer.get_id()
+            ));
+        }
+
+        if peer.get_id() == leader.get_id()
+            && (change_type == ConfChangeType::RemoveNode
+                // In Joint confchange, the leader is allowed to be DemotingVoter
+                || (kind == ConfChangeKind::Simple
+                && change_type == ConfChangeType::AddLearnerNode))
+            && !cfg.allow_remove_leader()
+        {
+            return Err(box_err!("ignore remove leader or demote leader"));
+        }
+
+        if current_voter.contains(peer.get_id()) || change_type == ConfChangeType::AddNode {
+            only_learner_change = false;
+        }
+    }
+
+    // Multiple changes that only effect learner will not product `IncommingVoter`
+    // or `DemotingVoter` after apply, but raftstore layer and PD rely on these
+    // roles to detect joint state
+    if kind != ConfChangeKind::Simple && only_learner_change {
+        return Err(box_err!("multiple changes that only effect learner"));
+    }
+
+    if !ignore_safety {
+        let promoted_commit_index = after_progress.maximal_committed_index().0;
+        let first_index = node.raft.raft_log.first_index();
+        if current_progress.is_singleton() // It's always safe if there is only one node in the cluster.
+                || promoted_commit_index + 1 >= first_index
+        {
+            return Ok(());
+        }
+
+        PEER_ADMIN_CMD_COUNTER_VEC
+            .with_label_values(&["conf_change", "reject_unsafe"])
+            .inc();
+
+        Err(box_err!(
+            "{:?}: before: {:?}, after: {:?}, first index {}, promoted commit index {}",
+            change_peers,
+            current_progress.conf().to_conf_state(),
+            after_progress.conf().to_conf_state(),
+            first_index,
+            promoted_commit_index
+        ))
+    } else {
+        Ok(())
     }
 }
 

--- a/tests/integrations/raftstore/test_replication_mode.rs
+++ b/tests/integrations/raftstore/test_replication_mode.rs
@@ -189,7 +189,7 @@ fn test_check_conf_change() {
         res.get_header()
             .get_error()
             .get_message()
-            .contains("unsafe to perform conf change"),
+            .contains("promoted commit index"),
         "{:?}",
         res
     );


### PR DESCRIPTION
### What is changed and how it works?
Issue Number: Ref #12842 

What's Changed:

```commit-message
Most workflow is the same as v1 except if apply failed, v2 will not return apply result
back to raftstore. This behavior is a legacy behavior that only works for conf change
before joint consensus and can be removed now.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
