### PR TITLE
raftstore: send heartbeat to pd as soon as it is started

### DIFF
--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -773,6 +773,10 @@ impl<'a, EK: KvEngine + 'static, ER: RaftEngine + 'static, T: Transport>
         self.register_compact_lock_cf_tick();
         self.register_snap_mgr_gc_tick();
         self.register_consistency_check_tick();
+
+        // Send store heartbeat to PD, so that PD knows this store is started.
+        // PD will do some scheduling for this store when it receives this heartbeat.
+        self.store_heartbeat_pd(None);
     }
 }
 


### PR DESCRIPTION
Signed-off-by: cosven <yinshaowen241@gmail.com>

### What is changed and how it works?

Issue Number: Close #13627

What's Changed:


```commit-message
Send first heartbeat to pd as soon as the tikv is started.
```

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
  - case1: tikv can be deployed successfully

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Send heartbeat to PD as soon as a instance is started instead of waiting another 10s
```
