### PR TITLE
log-backup: using `std::fs` for reading local files

### DIFF
--- a/components/backup-stream/src/router.rs
+++ b/components/backup-stream/src/router.rs
@@ -42,7 +42,7 @@ use tikv_util::{
 };
 use tokio::{
     fs::{remove_file, File},
-    io::AsyncWriteExt,
+    io::{AsyncWriteExt, BufReader},
     sync::{Mutex, RwLock},
 };
 use tokio_util::compat::TokioAsyncReadCompatExt;
@@ -1029,7 +1029,7 @@ impl StreamTaskInfo {
                 let compress_length = file.metadata().await?.len();
                 stat_length += compress_length;
                 file_info_clone.set_range_length(compress_length);
-                file
+                BufReader::new(file)
             });
             data_file_infos.push(file_info_clone);
 

--- a/components/backup-stream/src/router.rs
+++ b/components/backup-stream/src/router.rs
@@ -32,16 +32,11 @@ use raftstore::coprocessor::CmdBatch;
 use slog_global::debug;
 use tidb_query_datatype::codec::table::decode_table_id;
 use tikv_util::{
-    box_err,
-    codec::stream_event::EventEncoder,
-    error, info,
-    time::{Instant, Limiter},
-    warn,
-    worker::Scheduler,
-    Either, HandyRwLock,
+    box_err, codec::stream_event::EventEncoder, error, info, time::Instant, warn,
+    worker::Scheduler, Either, HandyRwLock,
 };
 use tokio::{
-    fs::{remove_file, File},
+    fs::remove_file,
     io::{AsyncWriteExt, BufReader},
     sync::{Mutex, RwLock},
 };

--- a/components/backup-stream/src/utils.rs
+++ b/components/backup-stream/src/utils.rs
@@ -601,18 +601,21 @@ pub fn is_overlapping(range: (&[u8], &[u8]), range2: (&[u8], &[u8])) -> bool {
 }
 
 /// read files asynchronously in sequence
-pub struct FilesReader {
-    files: Vec<File>,
+pub struct FilesReader<R> {
+    files: Vec<R>,
     index: usize,
 }
 
-impl FilesReader {
-    pub fn new(files: Vec<File>) -> Self {
+impl<R> FilesReader<R> {
+    pub fn new(files: Vec<R>) -> Self {
         FilesReader { files, index: 0 }
     }
 }
 
-impl AsyncRead for FilesReader {
+impl<R> AsyncRead for FilesReader<R>
+where
+    R: AsyncRead + Unpin,
+{
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: N/A

What's Changed:
This PR make `flush` stage of log backup using the blocking disk I/O for reading local files. This perhaps would help us get rid of the strange low performance of async disk I/O in tokio.

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fixed a bug that may cause log backup checkpoint lag grow too huge in the GCS external storage.
```
