### PR TITLE
mvcc: log the mvcc key if default not found error happens

### DIFF
--- a/src/storage/mvcc/reader/point_getter.rs
+++ b/src/storage/mvcc/reader/point_getter.rs
@@ -347,7 +347,11 @@ impl<S: Snapshot> PointGetter<S> {
             Ok(value)
         } else {
             Err(default_not_found_error(
-                user_key.to_raw()?,
+                user_key
+                    .clone()
+                    .append_ts(write_start_ts)
+                    .as_encoded()
+                    .to_vec(),
                 "load_data_from_default_cf",
             ))
         }

--- a/src/storage/mvcc/reader/point_getter.rs
+++ b/src/storage/mvcc/reader/point_getter.rs
@@ -347,11 +347,7 @@ impl<S: Snapshot> PointGetter<S> {
             Ok(value)
         } else {
             Err(default_not_found_error(
-                user_key
-                    .clone()
-                    .append_ts(write_start_ts)
-                    .as_encoded()
-                    .to_vec(),
+                user_key.clone().append_ts(write_start_ts).into_encoded(),
                 "load_data_from_default_cf",
             ))
         }

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -204,7 +204,7 @@ impl<S: EngineSnapshot> MvccReader<S> {
                 self.statistics.data.processed_keys += 1;
                 Ok(val)
             }
-            None => Err(default_not_found_error(key.to_raw()?, "get")),
+            None => Err(default_not_found_error(k.as_encoded().to_vec(), "get")),
         }
     }
 
@@ -2163,7 +2163,13 @@ pub mod tests {
             },
             Case {
                 // write has no short_value, the reader has a cursor, got nothing
-                expected: Err(default_not_found_error(k.to_vec(), "get")),
+                expected: Err(default_not_found_error(
+                    Key::from_raw(k)
+                        .append_ts(TimeStamp::new(3))
+                        .as_encoded()
+                        .to_vec(),
+                    "get",
+                )),
                 modifies: vec![Modify::Put(
                     CF_WRITE,
                     Key::from_raw(k).append_ts(TimeStamp::new(1)),
@@ -2189,7 +2195,13 @@ pub mod tests {
             },
             Case {
                 // write has no short_value, the reader has no cursor, got nothing
-                expected: Err(default_not_found_error(k.to_vec(), "get")),
+                expected: Err(default_not_found_error(
+                    Key::from_raw(k)
+                        .append_ts(TimeStamp::new(5))
+                        .as_encoded()
+                        .to_vec(),
+                    "get",
+                )),
                 modifies: vec![],
                 scan_mode: None,
                 key: Key::from_raw(k),
@@ -2248,7 +2260,13 @@ pub mod tests {
                 // some write for `key` at `ts` exists, load data return Err
                 // todo: "some write for `key` at `ts` exists" should be checked by `test_get_write`
                 // "load data return Err" is checked by test_load_data
-                expected: Err(default_not_found_error(k.to_vec(), "get")),
+                expected: Err(default_not_found_error(
+                    Key::from_raw(k)
+                        .append_ts(TimeStamp::new(2))
+                        .as_encoded()
+                        .to_vec(),
+                    "get",
+                )),
                 modifies: vec![Modify::Put(
                     CF_WRITE,
                     Key::from_raw(k).append_ts(TimeStamp::new(2)),

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -204,7 +204,7 @@ impl<S: EngineSnapshot> MvccReader<S> {
                 self.statistics.data.processed_keys += 1;
                 Ok(val)
             }
-            None => Err(default_not_found_error(k.as_encoded().to_vec(), "get")),
+            None => Err(default_not_found_error(k.into_encoded(), "get")),
         }
     }
 
@@ -2164,10 +2164,7 @@ pub mod tests {
             Case {
                 // write has no short_value, the reader has a cursor, got nothing
                 expected: Err(default_not_found_error(
-                    Key::from_raw(k)
-                        .append_ts(TimeStamp::new(3))
-                        .as_encoded()
-                        .to_vec(),
+                    Key::from_raw(k).append_ts(TimeStamp::new(3)).into_encoded(),
                     "get",
                 )),
                 modifies: vec![Modify::Put(
@@ -2196,10 +2193,7 @@ pub mod tests {
             Case {
                 // write has no short_value, the reader has no cursor, got nothing
                 expected: Err(default_not_found_error(
-                    Key::from_raw(k)
-                        .append_ts(TimeStamp::new(5))
-                        .as_encoded()
-                        .to_vec(),
+                    Key::from_raw(k).append_ts(TimeStamp::new(5)).into_encoded(),
                     "get",
                 )),
                 modifies: vec![],
@@ -2261,10 +2255,7 @@ pub mod tests {
                 // todo: "some write for `key` at `ts` exists" should be checked by `test_get_write`
                 // "load data return Err" is checked by test_load_data
                 expected: Err(default_not_found_error(
-                    Key::from_raw(k)
-                        .append_ts(TimeStamp::new(2))
-                        .as_encoded()
-                        .to_vec(),
+                    Key::from_raw(k).append_ts(TimeStamp::new(2)).into_encoded(),
                     "get",
                 )),
                 modifies: vec![Modify::Put(

--- a/src/storage/mvcc/reader/scanner/mod.rs
+++ b/src/storage/mvcc/reader/scanner/mod.rs
@@ -366,11 +366,7 @@ where
         || default_cursor.key(&mut statistics.data) != seek_key.as_encoded().as_slice()
     {
         return Err(default_not_found_error(
-            user_key
-                .clone()
-                .append_ts(write_start_ts)
-                .as_encoded()
-                .to_vec(),
+            user_key.clone().append_ts(write_start_ts).into_encoded(),
             "near_load_data_by_write",
         ));
     }
@@ -395,11 +391,7 @@ where
         || default_cursor.key(&mut statistics.data) != seek_key.as_encoded().as_slice()
     {
         return Err(default_not_found_error(
-            user_key
-                .clone()
-                .append_ts(write_start_ts)
-                .as_encoded()
-                .to_vec(),
+            user_key.clone().append_ts(write_start_ts).into_encoded(),
             "near_reverse_load_data_by_write",
         ));
     }

--- a/src/storage/mvcc/reader/scanner/mod.rs
+++ b/src/storage/mvcc/reader/scanner/mod.rs
@@ -366,7 +366,11 @@ where
         || default_cursor.key(&mut statistics.data) != seek_key.as_encoded().as_slice()
     {
         return Err(default_not_found_error(
-            user_key.to_raw()?,
+            user_key
+                .clone()
+                .append_ts(write_start_ts)
+                .as_encoded()
+                .to_vec(),
             "near_load_data_by_write",
         ));
     }
@@ -391,7 +395,11 @@ where
         || default_cursor.key(&mut statistics.data) != seek_key.as_encoded().as_slice()
     {
         return Err(default_not_found_error(
-            user_key.to_raw()?,
+            user_key
+                .clone()
+                .append_ts(write_start_ts)
+                .as_encoded()
+                .to_vec(),
             "near_reverse_load_data_by_write",
         ));
     }


### PR DESCRIPTION
Signed-off-by: cfzjywxk <lsswxrxr@163.com>


### What is changed and how it works?

Issue Number: Close #13655 

What's Changed:

```commit-message
Log the mvcc key if the default not error happens. Usually, the next step is to locate the key region and 
do an unsafe recovery, so mvcc key format logging is more convenient.
```

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
NONE
```
