### PR TITLE
raftstore: make sure PrepareFlashback will get the latest region meta

### DIFF
--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -2825,7 +2825,8 @@ where
         let region_id = self.region_id();
         let region_state_key = keys::region_state_key(region_id);
         let is_in_flashback = req.get_cmd_type() == AdminCmdType::PrepareFlashback;
-        // We need to make sure the `RegionLocalState` read from the engine is latest.
+        // We need to make sure the `RegionLocalState` read from the engine is latest,
+        // so the flush is needed before this function being called.
         let mut old_state = match ctx
             .engine
             .get_msg_cf::<RegionLocalState>(CF_RAFT, &region_state_key)

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -1385,7 +1385,7 @@ where
                 ExecResult::CommitMerge { ref region, .. } => (Some(region.clone()), None),
                 ExecResult::RollbackMerge { ref region, .. } => (Some(region.clone()), None),
                 ExecResult::IngestSst { ref ssts } => (None, Some(ssts.clone())),
-                ExecResult::SetFlashbackState { region } => (Some(region.clone()), None),
+                ExecResult::SetFlashbackState { ref region } => (Some(region.clone()), None),
                 _ => (None, None),
             },
             _ => (None, None),
@@ -2822,39 +2822,27 @@ where
         ctx: &mut ApplyContext<EK>,
         req: &AdminRequest,
     ) -> Result<(AdminResponse, ApplyResult<EK::Snapshot>)> {
-        let region_id = self.region_id();
-        let region_state_key = keys::region_state_key(region_id);
         let is_in_flashback = req.get_cmd_type() == AdminCmdType::PrepareFlashback;
-        // We need to make sure the `RegionLocalState` read from the engine is latest,
-        // so the flush is needed before this function being called.
-        let mut old_state = match ctx
-            .engine
-            .get_msg_cf::<RegionLocalState>(CF_RAFT, &region_state_key)
-        {
-            Ok(Some(s)) => s,
-            _ => {
-                return Err(box_err!(
-                    "failed to get region local state of {}",
-                    region_id
-                ));
-            }
-        };
-        // Modify the `RegionLocalState` persisted in disk.
-        old_state.mut_region().set_is_in_flashback(is_in_flashback);
-        if let Err(e) =
-            ctx.kv_wb_mut()
-                .put_msg_cf(CF_RAFT, &keys::region_state_key(region_id), &old_state)
-        {
-            return Err(box_err!(
-                "failed to change the flashback state to {} for {}: {:?}",
-                is_in_flashback,
-                region_id,
-                e
-            ));
-        }
         // Modify the region meta in memory.
         let mut region = self.region.clone();
         region.set_is_in_flashback(is_in_flashback);
+        // Modify the `RegionLocalState` persisted in disk.
+        write_peer_state(ctx.kv_wb_mut(), &region, PeerState::Normal, None).unwrap_or_else(|e| {
+            panic!(
+                "{} failed to change the flashback state to {} for region {:?}: {:?}",
+                self.tag, is_in_flashback, region, e
+            )
+        });
+
+        match req.get_cmd_type() {
+            AdminCmdType::PrepareFlashback => {
+                PEER_ADMIN_CMD_COUNTER.prepare_flashback.success.inc();
+            }
+            AdminCmdType::FinishFlashback => {
+                PEER_ADMIN_CMD_COUNTER.finish_flashback.success.inc();
+            }
+            _ => unreachable!(),
+        }
         Ok((
             AdminResponse::default(),
             ApplyResult::Res(ExecResult::SetFlashbackState { region }),

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -758,10 +758,7 @@ fn should_write_to_engine(cmd: &RaftCmdRequest) -> bool {
             AdminCmdType::ComputeHash |
             // Merge needs to get the latest apply index.
             AdminCmdType::CommitMerge |
-            AdminCmdType::RollbackMerge |
-            // Flashback needs to get the latest region meta.
-            AdminCmdType::PrepareFlashback |
-            AdminCmdType::FinishFlashback => return true,
+            AdminCmdType::RollbackMerge => return true,
             _ => {}
         }
     }

--- a/components/raftstore/src/store/metrics.rs
+++ b/components/raftstore/src/store/metrics.rs
@@ -33,7 +33,9 @@ make_auto_flush_static_metric! {
         commit_merge,
         rollback_merge,
         compact,
-        transfer_leader
+        transfer_leader,
+        prepare_flashback,
+        finish_flashback
     }
 
     pub label_enum AdminCmdStatus {

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -192,8 +192,10 @@ pub fn admin_cmd_epoch_lookup(admin_cmp_type: AdminCmdType) -> AdminCmdEpochStat
         AdminCmdType::RollbackMerge => AdminCmdEpochState::new(true, true, true, false),
         // Transfer leader
         AdminCmdType::TransferLeader => AdminCmdEpochState::new(true, true, false, false),
-        // PrepareFlashback/FinishFlashback could be committed successfully before a split being
-        // applied, so we need to check the epoch to make sure it's sent to a correct key range.
+        // PrepareFlashback could be committed successfully before a split being applied, so we need
+        // to check the epoch to make sure it's sent to a correct key range.
+        // NOTICE: FinishFlashback will never meet the epoch not match error since any scheduling
+        // before it's forbidden.
         AdminCmdType::PrepareFlashback | AdminCmdType::FinishFlashback => {
             AdminCmdEpochState::new(true, true, false, false)
         }

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -193,7 +193,7 @@ pub fn admin_cmd_epoch_lookup(admin_cmp_type: AdminCmdType) -> AdminCmdEpochStat
         // Transfer leader
         AdminCmdType::TransferLeader => AdminCmdEpochState::new(true, true, false, false),
         AdminCmdType::PrepareFlashback | AdminCmdType::FinishFlashback => {
-            AdminCmdEpochState::new(false, false, false, false)
+            AdminCmdEpochState::new(true, true, false, false)
         }
     }
 }

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -192,6 +192,8 @@ pub fn admin_cmd_epoch_lookup(admin_cmp_type: AdminCmdType) -> AdminCmdEpochStat
         AdminCmdType::RollbackMerge => AdminCmdEpochState::new(true, true, true, false),
         // Transfer leader
         AdminCmdType::TransferLeader => AdminCmdEpochState::new(true, true, false, false),
+        // PrepareFlashback/FinishFlashback could be committed successfully before a split being
+        // applied, so we need to check the epoch to make sure it's sent to a correct key range.
         AdminCmdType::PrepareFlashback | AdminCmdType::FinishFlashback => {
             AdminCmdEpochState::new(true, true, false, false)
         }

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -1476,7 +1476,7 @@ impl<T: Simulator> Cluster<T> {
         }
     }
 
-    fn wait_applied_to_current_term(&mut self, region_id: u64, timeout: Duration) {
+    pub fn wait_applied_to_current_term(&mut self, region_id: u64, timeout: Duration) {
         let mut now = Instant::now();
         let deadline = now + timeout;
         while now < deadline {

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -22,7 +22,7 @@ use file_system::IoRateLimiter;
 use futures::{self, channel::oneshot, executor::block_on};
 use kvproto::{
     errorpb::Error as PbError,
-    kvrpcpb::{ApiVersion, Context},
+    kvrpcpb::{ApiVersion, Context, DiskFullOpt},
     metapb::{self, Buckets, PeerRole, RegionEpoch, StoreLabel},
     pdpb::{self, CheckPolicy, StoreReport},
     raft_cmdpb::*,
@@ -1421,14 +1421,47 @@ impl<T: Simulator> Cluster<T> {
             .unwrap();
     }
 
-    pub fn must_send_flashback_msg(&mut self, region_id: u64, cmd_type: AdminCmdType) {
-        self.wait_applied_to_current_term(region_id, Duration::from_secs(3));
+    pub fn must_send_flashback_msg(
+        &mut self,
+        region_id: u64,
+        cmd_type: AdminCmdType,
+        cb: Callback<RocksSnapshot>,
+    ) {
         let leader = self.leader_of_region(region_id).unwrap();
         let store_id = leader.get_store_id();
         let region_epoch = self.get_region_epoch(region_id);
-        block_on(async move {
-            let (result_tx, result_rx) = oneshot::channel();
-            let cb = Callback::write(Box::new(move |resp| {
+        let mut admin = AdminRequest::default();
+        admin.set_cmd_type(cmd_type);
+        let mut req = RaftCmdRequest::default();
+        req.mut_header().set_region_id(region_id);
+        req.mut_header().set_region_epoch(region_epoch);
+        req.mut_header().set_peer(leader);
+        req.set_admin_request(admin);
+        req.mut_header()
+            .set_flags(WriteBatchFlags::FLASHBACK.bits());
+        let router = self.sim.rl().get_router(store_id).unwrap();
+        if let Err(e) = router.send_command(
+            req,
+            cb,
+            RaftCmdExtraOpts {
+                deadline: None,
+                disk_full_opt: DiskFullOpt::AllowedOnAlmostFull,
+            },
+        ) {
+            panic!(
+                "router send flashback msg {:?} failed, error: {}",
+                cmd_type, e
+            );
+        }
+    }
+
+    pub fn must_send_wait_flashback_msg(&mut self, region_id: u64, cmd_type: AdminCmdType) {
+        self.wait_applied_to_current_term(region_id, Duration::from_secs(3));
+        let (result_tx, result_rx) = oneshot::channel();
+        self.must_send_flashback_msg(
+            region_id,
+            cmd_type,
+            Callback::write(Box::new(move |resp| {
                 if resp.response.get_header().has_error() {
                     result_tx
                         .send(Some(resp.response.get_header().get_error().clone()))
@@ -1436,35 +1469,11 @@ impl<T: Simulator> Cluster<T> {
                     return;
                 }
                 result_tx.send(None).unwrap();
-            }));
-
-            let mut admin = AdminRequest::default();
-            admin.set_cmd_type(cmd_type);
-            let mut req = RaftCmdRequest::default();
-            req.mut_header().set_region_id(region_id);
-            req.mut_header().set_region_epoch(region_epoch);
-            req.mut_header().set_peer(leader);
-            req.set_admin_request(admin);
-            req.mut_header()
-                .set_flags(WriteBatchFlags::FLASHBACK.bits());
-            let router = self.sim.rl().get_router(store_id).unwrap();
-            if let Err(e) = router.send_command(
-                req,
-                cb,
-                RaftCmdExtraOpts {
-                    deadline: None,
-                    disk_full_opt: kvproto::kvrpcpb::DiskFullOpt::AllowedOnAlmostFull,
-                },
-            ) {
-                panic!(
-                    "router send flashback msg {:?} failed, error: {}",
-                    cmd_type, e
-                );
-            }
-            if let Some(e) = result_rx.await.unwrap() {
-                panic!("call flashback msg {:?} failed, error: {:?}", cmd_type, e);
-            }
-        });
+            })),
+        );
+        if let Some(e) = block_on(result_rx).unwrap() {
+            panic!("call flashback msg {:?} failed, error: {:?}", cmd_type, e);
+        }
     }
 
     fn wait_applied_to_current_term(&mut self, region_id: u64, timeout: Duration) {


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What is changed and how it works?

Issue Number: Close #13643.

What's Changed:

```commit-message
* Use `self.region` while executing `PrepareFlashback` command to ensure it gets the latest region meta.
* Check the epoch before executing the `PrepareFlashback`.
```


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None.
```
