### PR TITLE
raft_client: Report store unreachable once until being connected again

### DIFF
--- a/components/batch-system/src/metrics.rs
+++ b/components/batch-system/src/metrics.rs
@@ -10,4 +10,11 @@ lazy_static! {
         &["type"]
     )
     .unwrap();
+
+    pub static ref BROADCAST_NORMAL_DURATION: Histogram =
+    register_histogram!(
+        "tikv_broadcast_normal_duration_seconds",
+        "Duration of broadcasting normals.",
+        exponential_buckets(0.001, 1.59, 20).unwrap() // max 10s
+    ).unwrap();
 }

--- a/components/batch-system/src/router.rs
+++ b/components/batch-system/src/router.rs
@@ -12,12 +12,17 @@ use std::{
 
 use collections::HashMap;
 use crossbeam::channel::{SendError, TrySendError};
-use tikv_util::{debug, info, lru::LruCache, Either};
+use tikv_util::{
+    debug, info,
+    lru::LruCache,
+    time::{duration_to_sec, Instant},
+    Either,
+};
 
 use crate::{
     fsm::{Fsm, FsmScheduler, FsmState},
     mailbox::{BasicMailbox, Mailbox},
-    metrics::CHANNEL_FULL_COUNTER_VEC,
+    metrics::*,
 };
 
 /// A struct that traces the approximate memory usage of router.
@@ -306,10 +311,12 @@ where
 
     /// Try to notify all normal FSMs a message.
     pub fn broadcast_normal(&self, mut msg_gen: impl FnMut() -> N::Message) {
+        let timer = Instant::now_coarse();
         let mailboxes = self.normals.lock().unwrap();
         for mailbox in mailboxes.map.values() {
             let _ = mailbox.force_send(msg_gen(), &self.normal_scheduler);
         }
+        BROADCAST_NORMAL_DURATION.observe(duration_to_sec(timer.saturating_elapsed()) as f64);
     }
 
     /// Try to notify all FSMs that the cluster is being shutdown.

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -55,7 +55,7 @@ use tikv_util::{
     mpsc::{self, LooseBoundedSender, Receiver},
     store::{find_peer, is_learner, region_on_same_stores},
     sys::{disk::DiskUsage, memory_usage_reaches_high_water},
-    time::{monotonic_raw_now, Instant as TiInstant},
+    time::{duration_to_sec, monotonic_raw_now, Instant as TiInstant},
     trace, warn,
     worker::{ScheduleError, Scheduler},
     Either,
@@ -102,7 +102,7 @@ use crate::{
     },
     Error, Result,
 };
-use tikv_util::time::duration_to_sec;
+
 #[derive(Clone, Copy, Debug)]
 pub struct DelayDestroy {
     merged_by_target: bool,

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -684,7 +684,7 @@ impl<'a, EK: KvEngine + 'static, ER: RaftEngine + 'static, T: Transport>
     StoreFsmDelegate<'a, EK, ER, T>
 {
     fn on_tick(&mut self, tick: StoreTick) {
-        let t = TiInstant::now_coarse();
+        let timer = TiInstant::now_coarse();
         match tick {
             StoreTick::PdStoreHeartbeat => self.on_pd_store_heartbeat_tick(),
             StoreTick::SnapGc => self.on_snap_mgr_gc(),
@@ -693,8 +693,10 @@ impl<'a, EK: KvEngine + 'static, ER: RaftEngine + 'static, T: Transport>
             StoreTick::ConsistencyCheck => self.on_consistency_check_tick(),
             StoreTick::CleanupImportSst => self.on_cleanup_import_sst_tick(),
         }
-        let elapsed = t.saturating_elapsed();
-        RAFT_EVENT_DURATION
+        let elapsed = timer.saturating_elapsed();
+        self.ctx
+            .raft_metrics
+            .event_time
             .get(tick.tag())
             .observe(duration_to_sec(elapsed) as f64);
         slow_log!(
@@ -706,6 +708,7 @@ impl<'a, EK: KvEngine + 'static, ER: RaftEngine + 'static, T: Transport>
     }
 
     fn handle_msgs(&mut self, msgs: &mut Vec<StoreMsg<EK>>) {
+        let timer = TiInstant::now_coarse();
         for m in msgs.drain(..) {
             match m {
                 StoreMsg::Tick(tick) => self.on_tick(tick),
@@ -756,6 +759,11 @@ impl<'a, EK: KvEngine + 'static, ER: RaftEngine + 'static, T: Transport>
                 StoreMsg::GcSnapshotFinish => self.register_snap_mgr_gc_tick(),
             }
         }
+        self.ctx
+            .raft_metrics
+            .event_time
+            .store_msg
+            .observe(duration_to_sec(timer.saturating_elapsed()) as f64);
     }
 
     fn start(&mut self, store: metapb::Store) {

--- a/components/raftstore/src/store/local_metrics.rs
+++ b/components/raftstore/src/store/local_metrics.rs
@@ -82,6 +82,8 @@ pub struct RaftMetrics {
     pub store_time: LocalHistogram,
     pub propose_wait_time: LocalHistogram,
     pub process_ready: LocalHistogram,
+    pub event_time: RaftEventDurationVec,
+    pub peer_msg_len: LocalHistogram,
     pub commit_log: LocalHistogram,
     pub write_block_wait: LocalHistogram,
 
@@ -117,6 +119,8 @@ impl RaftMetrics {
             process_ready: PEER_RAFT_PROCESS_DURATION
                 .with_label_values(&["ready"])
                 .local(),
+            event_time: RaftEventDurationVec::from(&RAFT_EVENT_DURATION_VEC),
+            peer_msg_len: PEER_MSG_LEN.local(),
             commit_log: PEER_COMMIT_LOG_HISTOGRAM.local(),
             write_block_wait: STORE_WRITE_MSG_BLOCK_WAIT_DURATION_HISTOGRAM.local(),
             waterfall_metrics,
@@ -149,6 +153,8 @@ impl RaftMetrics {
         self.store_time.flush();
         self.propose_wait_time.flush();
         self.process_ready.flush();
+        self.event_time.flush();
+        self.peer_msg_len.flush();
         self.commit_log.flush();
         self.write_block_wait.flush();
 

--- a/components/raftstore/src/store/metrics.rs
+++ b/components/raftstore/src/store/metrics.rs
@@ -78,26 +78,11 @@ make_auto_flush_static_metric! {
         fetch_unused,
     }
 
-
-    pub label_enum RaftEventDurationType {
-        compact_check,
-        pd_store_heartbeat,
-        snap_gc,
-        compact_lock_cf,
-        consistency_check,
-        cleanup_import_sst,
-        raft_engine_purge,
-    }
-
     pub label_enum CompactionGuardAction {
         init,
         init_failure,
         partition,
         skip_partition,
-    }
-
-    pub struct RaftEventDuration : LocalHistogram {
-        "type" => RaftEventDurationType
     }
 
     pub struct RaftEntryFetches : LocalIntCounter {
@@ -206,6 +191,18 @@ make_static_metric! {
         flashback_not_prepared
     }
 
+    pub label_enum RaftEventDurationType {
+        compact_check,
+        pd_store_heartbeat,
+        snap_gc,
+        compact_lock_cf,
+        consistency_check,
+        cleanup_import_sst,
+        raft_engine_purge,
+        peer_msg,
+        store_msg,
+    }
+
     pub label_enum RaftLogGcSkippedReason {
         reserve_log,
         compact_idx_too_small,
@@ -265,6 +262,10 @@ make_static_metric! {
 
     pub struct RaftInvalidProposalCounterVec : LocalIntCounter {
         "type" => RaftInvalidProposal
+    }
+
+    pub struct RaftEventDurationVec : LocalHistogram {
+        "type" => RaftEventDurationType
     }
 
     pub struct RaftLogGcSkippedCounterVec: LocalIntCounter {
@@ -641,8 +642,13 @@ lazy_static! {
             &["type"],
             exponential_buckets(0.001, 1.59, 20).unwrap() // max 10s
         ).unwrap();
-    pub static ref RAFT_EVENT_DURATION: RaftEventDuration =
-        auto_flush_from!(RAFT_EVENT_DURATION_VEC, RaftEventDuration);
+
+    pub static ref PEER_MSG_LEN: Histogram =
+        register_histogram!(
+            "tikv_raftstore_peer_msg_len",
+            "Length of peer msg.",
+            exponential_buckets(1.0, 2.0, 20).unwrap() // max 1000s
+        ).unwrap();
 
     pub static ref RAFT_READ_INDEX_PENDING_DURATION: Histogram =
         register_histogram!(

--- a/src/server/raft_client.rs
+++ b/src/server/raft_client.rs
@@ -608,7 +608,6 @@ where
                 RaftCallRes::Disconnected(ever_connected)
             };
             let _ = tx.send(res);
-            return;
         }
     }
 }
@@ -873,6 +872,8 @@ async fn start<S, R, E>(
                         .inc_by(1);
                 }
 
+                // broadcast is time consuming operation which would blocks raftstore, so report
+                // unreachable only once until being connected again.
                 if retry_times == 1 || ever_connected {
                     back_end
                         .builder

--- a/tests/integrations/server/raft_client.rs
+++ b/tests/integrations/server/raft_client.rs
@@ -62,7 +62,7 @@ where
 {
     let env = Arc::new(Environment::new(2));
     let cfg = Arc::new(VersionTrack::new(Config::default()));
-    cfg.update(|c| c.raft_client_backoff_step = ReadableDuration::millis(10));
+    cfg.update(|c| Ok(c.raft_client_backoff_step = ReadableDuration::millis(10)));
     let security_mgr = Arc::new(SecurityManager::new(&SecurityConfig::default()).unwrap());
     let worker = LazyWorker::new("test-raftclient");
     let loads = Arc::new(ThreadLoadPool::with_threshold(1000));


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #13676

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Avoid reporting store unreachable again and again as broadcasting is time-consuming and blocks raftstore. Only send store unreachable when the store is ever connected. 
```

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
report store unreachable once until being connected again
```
