### PR TITLE
config: set default cdc.min-ts-interval to 500ms

### DIFF
--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -1538,8 +1538,9 @@ mod tests {
                 updated_cfg.min_ts_interval = ReadableDuration::secs(0);
             }
             let diff = cfg.diff(&updated_cfg);
+            let origin_min_ts_interval = ep.config.min_ts_interval;
             ep.run(Task::ChangeConfig(diff));
-            assert_eq!(ep.config.min_ts_interval, ReadableDuration::secs(1));
+            assert_eq!(ep.config.min_ts_interval, origin_min_ts_interval);
             assert_eq!(ep.config.hibernate_regions_compatible, true);
 
             {

--- a/src/config.rs
+++ b/src/config.rs
@@ -2576,7 +2576,7 @@ pub struct CdcConfig {
 impl Default for CdcConfig {
     fn default() -> Self {
         Self {
-            min_ts_interval: ReadableDuration::secs(1),
+            min_ts_interval: ReadableDuration::millis(500),
             hibernate_regions_compatible: true,
             // 4 threads for incremental scan.
             incremental_scan_threads: 4,


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: ref #13656 ref #13665

What's Changed:

```commit-message
config: set default cdc.min-ts-interval to 500ms 
```

After above two PRs, tso thread CPU usage is reduced about 50%, it's ok to reduce `min-ts-interval` and reduce TiCDC latency.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- Performance regression
    - Consumes more CPU

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
config: set default cdc.min-ts-interval to 500ms  to reduce TiCDC latency
```
