### PR TITLE
debugger: fix compacting raftdb with tikv-ctl

### DIFF
--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -2291,10 +2291,10 @@ mod tests {
 
     #[test]
     fn test_compact() {
-        let bottommest_level_compaction = Some("skip").into();
+        let bottommost_level_compaction = Some("skip").into();
         let debugger = new_debugger();
         let compact =
-            |db, cf| debugger.compact(db, cf, &[0], &[0xFF], 1, bottommest_level_compaction);
+            |db, cf| debugger.compact(db, cf, &[0], &[0xFF], 1, bottommost_level_compaction);
         assert!(compact(DbType::Kv, CF_DEFAULT).is_ok());
         assert!(compact(DbType::Kv, CF_LOCK).is_ok());
         assert!(compact(DbType::Kv, CF_WRITE).is_ok());

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -2291,13 +2291,11 @@ mod tests {
 
     #[test]
     fn test_compact() {
-        let bottommost_level_compaction = Some("skip").into();
         let debugger = new_debugger();
-        let compact =
-            |db, cf| debugger.compact(db, cf, &[0], &[0xFF], 1, bottommost_level_compaction);
-        assert!(compact(DbType::Kv, CF_DEFAULT).is_ok());
-        assert!(compact(DbType::Kv, CF_LOCK).is_ok());
-        assert!(compact(DbType::Kv, CF_WRITE).is_ok());
-        assert!(compact(DbType::Raft, CF_DEFAULT).is_ok());
+        let compact = |db, cf| debugger.compact(db, cf, &[0], &[0xFF], 1, Some("skip").into());
+        compact(DbType::Kv, CF_DEFAULT).unwrap();
+        compact(DbType::Kv, CF_LOCK).unwrap();
+        compact(DbType::Kv, CF_WRITE).unwrap();
+        compact(DbType::Raft, CF_DEFAULT).unwrap();
     }
 }

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -2288,4 +2288,16 @@ mod tests {
                 .get_api_version()
         )
     }
+
+    #[test]
+    fn test_compact() {
+        let bottommest_level_compaction = Some("skip").into();
+        let debugger = new_debugger();
+        let compact =
+            |db, cf| debugger.compact(db, cf, &[0], &[0xFF], 1, bottommest_level_compaction);
+        assert!(compact(DbType::Kv, CF_DEFAULT).is_ok());
+        assert!(compact(DbType::Kv, CF_LOCK).is_ok());
+        assert!(compact(DbType::Kv, CF_WRITE).is_ok());
+        assert!(compact(DbType::Raft, CF_DEFAULT).is_ok());
+    }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #13515

What's Changed:
Moves the function `get_db_from_type` in `Debugger` to a trait, and the tikv instance using Rocksdb as the raftlog backend is specially implemented, so that the compact raft db no longer reports errors.

Maybe I need to explain the following background: In the previous version, according to the description of tikv ctl tool in the official TIDB document, we can manually compact raftdb through the following instructions：
`./tikv-ctl  --host localhost:port compact -d raft`

However, after a version of 5. x, it can no longer be used ,even if we use Rocksdb instead of RaftEngine.
`DebugClient::compact: RpcFailure: 2-UNKNOWN "[src/server/debug.rs:169]: Get raft db is not allowed"`

The reason is that in order to support RaftEngine as an optional raftlog storage engine, the relevant code has a refactor, making this function unavailable at all.
However, the official document always says that it is supported, and we really need to compact raftdb in our actual application scenarios, so I propose this PR for repair.

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
```
