### PR TITLE
storage: fix the flashback dead loop caused by a deleted key

### DIFF
--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -4978,6 +4978,87 @@ mod tests {
     }
 
     #[test]
+    fn test_flashback_to_version_deleted_key() {
+        let storage = TestStorageBuilderApiV1::new(MockLockManager::new())
+            .build()
+            .unwrap();
+        let (tx, rx) = channel();
+        let mut ts = TimeStamp::zero();
+        let (k, v) = (Key::from_raw(b"k"), b"v".to_vec());
+        // Write a key.
+        storage
+            .sched_txn_command(
+                commands::Prewrite::with_defaults(
+                    vec![Mutation::make_put(k.clone(), v.clone())],
+                    k.clone().as_encoded().to_vec(),
+                    *ts.incr(),
+                ),
+                expect_ok_callback(tx.clone(), 0),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+        storage
+            .sched_txn_command(
+                commands::Commit::new(vec![k.clone()], ts, *ts.incr(), Context::default()),
+                expect_value_callback(tx.clone(), 1, TxnStatus::committed(ts)),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+        expect_value(
+            v.clone(),
+            block_on(storage.get(Context::default(), Key::from_raw(b"k"), ts))
+                .unwrap()
+                .0,
+        );
+        // Delete the key.
+        storage
+            .sched_txn_command(
+                commands::Prewrite::with_defaults(
+                    vec![Mutation::make_delete(k.clone())],
+                    k.clone().as_encoded().to_vec(),
+                    *ts.incr(),
+                ),
+                expect_ok_callback(tx.clone(), 2),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+        storage
+            .sched_txn_command(
+                commands::Commit::new(vec![k.clone()], ts, *ts.incr(), Context::default()),
+                expect_value_callback(tx.clone(), 3, TxnStatus::committed(ts)),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+        expect_none(
+            block_on(storage.get(Context::default(), Key::from_raw(b"k"), ts))
+                .unwrap()
+                .0,
+        );
+        // Flashback the key.
+        let flashback_start_ts = *ts.incr();
+        let flashback_commit_ts = *ts.incr();
+        storage
+            .sched_txn_command(
+                new_flashback_to_version_read_phase_cmd(
+                    flashback_start_ts,
+                    flashback_commit_ts,
+                    1.into(),
+                    Key::from_raw(b"k"),
+                    Key::from_raw(b"z"),
+                    Context::default(),
+                ),
+                expect_ok_callback(tx.clone(), 4),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+        expect_none(
+            block_on(storage.get(Context::default(), Key::from_raw(b"k"), flashback_commit_ts))
+                .unwrap()
+                .0,
+        );
+    }
+
+    #[test]
     fn test_high_priority_get_put() {
         let storage = TestStorageBuilderApiV1::new(MockLockManager::new())
             .build()

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -4990,7 +4990,7 @@ mod tests {
             .sched_txn_command(
                 commands::Prewrite::with_defaults(
                     vec![Mutation::make_put(k.clone(), v.clone())],
-                    k.clone().as_encoded().to_vec(),
+                    k.as_encoded().to_vec(),
                     *ts.incr(),
                 ),
                 expect_ok_callback(tx.clone(), 0),
@@ -5005,8 +5005,8 @@ mod tests {
             .unwrap();
         rx.recv().unwrap();
         expect_value(
-            v.clone(),
-            block_on(storage.get(Context::default(), Key::from_raw(b"k"), ts))
+            v,
+            block_on(storage.get(Context::default(), k.clone(), ts))
                 .unwrap()
                 .0,
         );
@@ -5015,7 +5015,7 @@ mod tests {
             .sched_txn_command(
                 commands::Prewrite::with_defaults(
                     vec![Mutation::make_delete(k.clone())],
-                    k.clone().as_encoded().to_vec(),
+                    k.as_encoded().to_vec(),
                     *ts.incr(),
                 ),
                 expect_ok_callback(tx.clone(), 2),
@@ -5047,12 +5047,12 @@ mod tests {
                     Key::from_raw(b"z"),
                     Context::default(),
                 ),
-                expect_ok_callback(tx.clone(), 4),
+                expect_ok_callback(tx, 4),
             )
             .unwrap();
         rx.recv().unwrap();
         expect_none(
-            block_on(storage.get(Context::default(), Key::from_raw(b"k"), flashback_commit_ts))
+            block_on(storage.get(Context::default(), k, flashback_commit_ts))
                 .unwrap()
                 .0,
         );

--- a/src/storage/txn/actions/flashback_to_version.rs
+++ b/src/storage/txn/actions/flashback_to_version.rs
@@ -329,11 +329,11 @@ pub mod tests {
         must_get(&mut engine, k, ts, v);
         must_prewrite_delete(&mut engine, k, k, *ts.incr());
         must_commit(&mut engine, k, ts, *ts.incr());
-        // Since the key has been deleted, flashback to version 1 should not do
-        // anything.
+        // Though the key has been deleted, flashback to version 1 still needs to write
+        // a new `WriteType::Delete` with the flashback `commit_ts`.
         assert_eq!(
             must_flashback_to_version(&mut engine, k, 1, *ts.incr(), *ts.incr()),
-            0
+            1
         );
         must_get_none(&mut engine, k, ts);
     }

--- a/src/storage/txn/actions/flashback_to_version.rs
+++ b/src/storage/txn/actions/flashback_to_version.rs
@@ -167,11 +167,6 @@ pub fn flashback_to_version_write(
         } else {
             // If the old write doesn't exist, we should put a `WriteType::Delete` record to
             // delete the current key when needed.
-            if let Some((_, latest_write)) = reader.seek_write(&key, commit_ts)? {
-                if latest_write.write_type == WriteType::Delete {
-                    continue;
-                }
-            }
             Write::new(WriteType::Delete, start_ts, None)
         };
         txn.put_write(key.clone(), commit_ts, new_write.as_ref().to_bytes());

--- a/src/storage/txn/actions/flashback_to_version.rs
+++ b/src/storage/txn/actions/flashback_to_version.rs
@@ -126,8 +126,7 @@ pub fn flashback_to_version_lock(
 //   - If a key doesn't exist at `self.version`, it will be put a
 //     `WriteType::Delete`.
 //   - If a key exists at `self.version`, it will be put the exact same record
-//     in `CF_WRITE` and `CF_DEFAULT` if needed with `self.commit_ts` and
-//     `self.start_ts`.
+//     in `CF_WRITE` and `CF_DEFAULT` with `self.commit_ts` and `self.start_ts`.
 pub fn flashback_to_version_write(
     txn: &mut MvccTxn,
     reader: &mut SnapshotReader<impl Snapshot>,

--- a/src/storage/txn/commands/flashback_to_version_read_phase.rs
+++ b/src/storage/txn/commands/flashback_to_version_read_phase.rs
@@ -117,7 +117,7 @@ impl<S: Snapshot> ReadCommand<S> for FlashbackToVersionReadPhase {
                     tls_collect_keyread_histogram_vec(tag, key_locks.len() as f64);
                     FlashbackToVersionState::ScanLock {
                         // DO NOT pop the last key as the next key when it's the only key to prevent
-                        // from making flashback fall into an dead loop.
+                        // from making flashback fall into a dead loop.
                         next_lock_key: if key_locks.len() > 1 {
                             key_locks.pop().map(|(key, _)| key).unwrap()
                         } else {


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What is changed and how it works?

Issue Number: Close #13743.

What's Changed:

```commit-message
The original thought is that when a key's latest MVCC record type is DELETE and the corresponding flashback operation is also DELETE, we skip it to avoid duplicated writing.
However, this will cause the flashback to fall into a dead loop since the key doesn't have the written record with the flashback `commit_ts` and the flashback will always try to write it forever.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None.
```
