### PR TITLE
storage: calculate last_change_ts in rollback

### DIFF
--- a/src/storage/txn/commands/check_secondary_locks.rs
+++ b/src/storage/txn/commands/check_secondary_locks.rs
@@ -8,7 +8,9 @@ use crate::storage::{
     lock_manager::LockManager,
     mvcc::{LockType, MvccTxn, SnapshotReader, TimeStamp, TxnCommitRecord},
     txn::{
-        actions::check_txn_status::{collapse_prev_rollback, make_rollback},
+        actions::check_txn_status::{
+            collapse_prev_rollback, make_rollback, update_last_change_for_rollback,
+        },
         commands::{
             Command, CommandExt, ReaderWithStats, ReleasedLocks, ResponsePolicy, TypedCommand,
             WriteCommand, WriteContext, WriteResult,
@@ -119,7 +121,10 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for CheckSecondaryLocks {
                 }
                 // We must protect this rollback in case this rollback is collapsed and a stale
                 // acquire_pessimistic_lock and prewrite succeed again.
-                if let Some(write) = make_rollback(self.start_ts, true, rollback_overlapped_write) {
+                if let Some(mut write) =
+                    make_rollback(self.start_ts, true, rollback_overlapped_write)
+                {
+                    update_last_change_for_rollback(&mut reader, &mut write, &key, self.start_ts)?;
                     txn.put_write(key.clone(), self.start_ts, write.as_ref().to_bytes());
                     collapse_prev_rollback(&mut txn, &mut reader, &key)?;
                 }
@@ -165,14 +170,20 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for CheckSecondaryLocks {
 pub mod tests {
     use concurrency_manager::ConcurrencyManager;
     use kvproto::kvrpcpb::Context;
+    use tikv_kv::Statistics;
     use tikv_util::deadline::Deadline;
+    use txn_types::Mutation;
 
     use super::*;
     use crate::storage::{
         kv::TestEngineBuilder,
         lock_manager::MockLockManager,
         mvcc::tests::*,
-        txn::{commands::WriteCommand, scheduler::DEFAULT_EXECUTION_DURATION_LIMIT, tests::*},
+        txn::{
+            commands::{test_util::prewrite_with_cm, WriteCommand},
+            scheduler::DEFAULT_EXECUTION_DURATION_LIMIT,
+            tests::*,
+        },
         Engine,
     };
 
@@ -342,5 +353,117 @@ pub mod tests {
             res => panic!("unexpected lock status: {:?}", res),
         }
         must_get_overlapped_rollback(&mut engine, b"k1", 15, 13, WriteType::Lock, Some(0));
+    }
+
+    // The main logic is almost identical to
+    // test_rollback_calculate_last_change_info of check_txn_status. But the small
+    // differences about handling lock CF make it difficult to reuse code.
+    #[test]
+    fn test_rollback_calculate_last_change_info() {
+        use pd_client::FeatureGate;
+
+        use crate::storage::txn::sched_pool::set_tls_feature_gate;
+
+        let mut engine = crate::storage::TestEngineBuilder::new().build().unwrap();
+        let cm = ConcurrencyManager::new(1.into());
+        let k = b"k";
+        let mut statistics = Statistics::default();
+
+        must_prewrite_put(&mut engine, k, b"v1", k, 5);
+        must_commit(&mut engine, k, 5, 6);
+        must_prewrite_put(&mut engine, k, b"v2", k, 7);
+        must_commit(&mut engine, k, 7, 8);
+        must_prewrite_put(&mut engine, k, b"v3", k, 30);
+        must_commit(&mut engine, k, 30, 35);
+
+        // TiKV 6.4 should not write last_change_ts.
+        let feature_gate = FeatureGate::default();
+        feature_gate.set_version("6.4.0").unwrap();
+        set_tls_feature_gate(feature_gate);
+        must_success(&mut engine, k, 40, SecondaryLocksStatus::RolledBack);
+        let rollback = must_written(&mut engine, k, 40, 40, WriteType::Rollback);
+        assert!(rollback.last_change_ts.is_zero());
+        assert_eq!(rollback.versions_to_last_change, 0);
+
+        let feature_gate = FeatureGate::default();
+        feature_gate.set_version("6.5.0").unwrap();
+        set_tls_feature_gate(feature_gate);
+
+        must_prewrite_put(&mut engine, k, b"v4", k, 45);
+        must_commit(&mut engine, k, 45, 50);
+
+        // Rollback when there is no lock; prev writes:
+        // - 50: PUT
+        must_success(&mut engine, k, 55, SecondaryLocksStatus::RolledBack);
+        let rollback = must_written(&mut engine, k, 55, 55, WriteType::Rollback);
+        assert_eq!(rollback.last_change_ts, 50.into());
+        assert_eq!(rollback.versions_to_last_change, 1);
+
+        // Write a LOCK; prev writes:
+        // - 55: ROLLBACK
+        // - 50: PUT
+        let res = prewrite_with_cm(
+            &mut engine,
+            cm,
+            &mut statistics,
+            vec![Mutation::make_lock(Key::from_raw(k))],
+            k.to_vec(),
+            60,
+            Some(70),
+        )
+        .unwrap();
+        assert!(!res.one_pc_commit_ts.is_zero());
+        let lock_commit_ts = res.one_pc_commit_ts;
+        let lock = must_written(&mut engine, k, 60, res.one_pc_commit_ts, WriteType::Lock);
+        assert_eq!(lock.last_change_ts, 50.into());
+        assert_eq!(lock.versions_to_last_change, 2);
+
+        // Write another ROLLBACK by rolling back a pessimistic lock; prev writes:
+        // - 61: LOCK
+        // - 55: ROLLBACK
+        // - 50: PUT
+        must_acquire_pessimistic_lock(&mut engine, k, b"pk", 70, 75);
+        must_success(&mut engine, k, 70, SecondaryLocksStatus::RolledBack);
+        let rollback = must_written(&mut engine, k, 70, 70, WriteType::Rollback);
+        assert_eq!(rollback.last_change_ts, 50.into());
+        assert_eq!(rollback.versions_to_last_change, 3);
+
+        // last_change_ts should point to the latest record before start_ts; prev
+        // writes:
+        // - 8: PUT
+        must_acquire_pessimistic_lock(&mut engine, k, k, 10, 75);
+        must_success(&mut engine, k, 10, SecondaryLocksStatus::RolledBack);
+        must_unlocked(&mut engine, k);
+        let rollback = must_written(&mut engine, k, 10, 10, WriteType::Rollback);
+        assert_eq!(rollback.last_change_ts, 8.into());
+        assert_eq!(rollback.versions_to_last_change, 1);
+
+        // Overlapped rollback should not update the last_change_ts of PUT; prev writes:
+        // - 8: PUT <- rollback overlaps
+        // - 6: PUT
+        must_success(&mut engine, k, 8, SecondaryLocksStatus::RolledBack);
+        let put = must_written(&mut engine, k, 7, 8, WriteType::Put);
+        assert!(put.last_change_ts.is_zero());
+        assert_eq!(put.versions_to_last_change, 0);
+        assert!(put.has_overlapped_rollback);
+
+        // Overlapped rollback can update the last_change_ts of LOCK; writes:
+        // - 61: PUT <- rollback overlaps
+        // - 57: ROLLBACK (inserted later)
+        // - 55: ROLLBACK
+        // - 50: PUT
+        must_rollback(&mut engine, k, 57, true);
+        let rollback = must_written(&mut engine, k, 57, 57, WriteType::Rollback);
+        assert_eq!(rollback.last_change_ts, 50.into());
+        assert_eq!(rollback.versions_to_last_change, 2);
+        must_success(
+            &mut engine,
+            k,
+            lock_commit_ts,
+            SecondaryLocksStatus::RolledBack,
+        );
+        let lock = must_written(&mut engine, k, 60, lock_commit_ts, WriteType::Lock);
+        assert_eq!(lock.last_change_ts, 50.into());
+        assert_eq!(lock.versions_to_last_change, 3);
     }
 }

--- a/src/storage/txn/commands/check_txn_status.rs
+++ b/src/storage/txn/commands/check_txn_status.rs
@@ -144,8 +144,9 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for CheckTxnStatus {
 pub mod tests {
     use concurrency_manager::ConcurrencyManager;
     use kvproto::kvrpcpb::{Context, PrewriteRequestPessimisticAction::*};
+    use tikv_kv::Statistics;
     use tikv_util::deadline::Deadline;
-    use txn_types::{Key, WriteType};
+    use txn_types::{Key, Mutation, WriteType};
 
     use super::{TxnStatus::*, *};
     use crate::storage::{
@@ -153,7 +154,9 @@ pub mod tests {
         lock_manager::MockLockManager,
         mvcc::tests::*,
         txn::{
-            commands::{pessimistic_rollback, WriteCommand, WriteContext},
+            commands::{
+                pessimistic_rollback, test_util::prewrite_with_cm, WriteCommand, WriteContext,
+            },
             scheduler::DEFAULT_EXECUTION_DURATION_LIMIT,
             tests::*,
         },
@@ -1162,5 +1165,109 @@ pub mod tests {
         );
         must_unlocked(&mut engine, k);
         must_get_rollback_ts(&mut engine, k, ts(50, 0));
+    }
+
+    #[test]
+    fn test_rollback_calculate_last_change_info() {
+        use pd_client::FeatureGate;
+
+        use crate::storage::txn::sched_pool::set_tls_feature_gate;
+
+        let mut engine = crate::storage::TestEngineBuilder::new().build().unwrap();
+        let cm = ConcurrencyManager::new(1.into());
+        let k = b"k";
+        let mut statistics = Statistics::default();
+
+        must_prewrite_put(&mut engine, k, b"v1", k, 5);
+        must_commit(&mut engine, k, 5, 6);
+        must_prewrite_put(&mut engine, k, b"v2", k, 7);
+        must_commit(&mut engine, k, 7, 8);
+        must_prewrite_put(&mut engine, k, b"v3", k, 30);
+        must_commit(&mut engine, k, 30, 35);
+
+        // TiKV 6.4 should not write last_change_ts.
+        let feature_gate = FeatureGate::default();
+        feature_gate.set_version("6.4.0").unwrap();
+        set_tls_feature_gate(feature_gate);
+        must_rollback(&mut engine, k, 40, true);
+        let rollback = must_written(&mut engine, k, 40, 40, WriteType::Rollback);
+        assert!(rollback.last_change_ts.is_zero());
+        assert_eq!(rollback.versions_to_last_change, 0);
+
+        let feature_gate = FeatureGate::default();
+        feature_gate.set_version("6.5.0").unwrap();
+        set_tls_feature_gate(feature_gate);
+
+        must_prewrite_put(&mut engine, k, b"v4", k, 45);
+        must_commit(&mut engine, k, 45, 50);
+
+        // Rollback when there is no lock; prev writes:
+        // - 50: PUT
+        must_rollback(&mut engine, k, 55, true);
+        let rollback = must_written(&mut engine, k, 55, 55, WriteType::Rollback);
+        assert_eq!(rollback.last_change_ts, 50.into());
+        assert_eq!(rollback.versions_to_last_change, 1);
+
+        // Write a LOCK; prev writes:
+        // - 55: ROLLBACK
+        // - 50: PUT
+        let res = prewrite_with_cm(
+            &mut engine,
+            cm,
+            &mut statistics,
+            vec![Mutation::make_lock(Key::from_raw(k))],
+            k.to_vec(),
+            60,
+            Some(70),
+        )
+        .unwrap();
+        assert!(!res.one_pc_commit_ts.is_zero());
+        let lock_commit_ts = res.one_pc_commit_ts;
+        let lock = must_written(&mut engine, k, 60, res.one_pc_commit_ts, WriteType::Lock);
+        assert_eq!(lock.last_change_ts, 50.into());
+        assert_eq!(lock.versions_to_last_change, 2);
+
+        // Write another ROLLBACK; prev writes:
+        // - 61: LOCK
+        // - 55: ROLLBACK
+        // - 50: PUT
+        must_rollback(&mut engine, k, 70, true);
+        let rollback = must_written(&mut engine, k, 70, 70, WriteType::Rollback);
+        assert_eq!(rollback.last_change_ts, 50.into());
+        assert_eq!(rollback.versions_to_last_change, 3);
+
+        // last_change_ts should point to the latest record before start_ts; prev
+        // writes:
+        // - 8: PUT
+        must_acquire_pessimistic_lock(&mut engine, k, k, 10, 75);
+        must_pessimistic_prewrite_put(&mut engine, k, b"v5", k, 10, 75, DoPessimisticCheck);
+        must_rollback(&mut engine, k, 10, true);
+        must_unlocked(&mut engine, k);
+        let rollback = must_written(&mut engine, k, 10, 10, WriteType::Rollback);
+        assert_eq!(rollback.last_change_ts, 8.into());
+        assert_eq!(rollback.versions_to_last_change, 1);
+
+        // Overlapped rollback should not update the last_change_ts of PUT; prev writes:
+        // - 8: PUT <- rollback overlaps
+        // - 6: PUT
+        must_rollback(&mut engine, k, 8, true);
+        let put = must_written(&mut engine, k, 7, 8, WriteType::Put);
+        assert!(put.last_change_ts.is_zero());
+        assert_eq!(put.versions_to_last_change, 0);
+        assert!(put.has_overlapped_rollback);
+
+        // Overlapped rollback can update the last_change_ts of LOCK; writes:
+        // - 61: PUT <- rollback overlaps
+        // - 57: ROLLBACK (inserted later)
+        // - 55: ROLLBACK
+        // - 50: PUT
+        must_rollback(&mut engine, k, 57, true);
+        let rollback = must_written(&mut engine, k, 57, 57, WriteType::Rollback);
+        assert_eq!(rollback.last_change_ts, 50.into());
+        assert_eq!(rollback.versions_to_last_change, 2);
+        must_rollback(&mut engine, k, lock_commit_ts, true);
+        let lock = must_written(&mut engine, k, 60, lock_commit_ts, WriteType::Lock);
+        assert_eq!(lock.last_change_ts, 50.into());
+        assert_eq!(lock.versions_to_last_change, 3);
     }
 }


### PR DESCRIPTION

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #13694

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
This commit supports calculating last_change_ts when writing a new
Rollback record.

To get the correct last_change_ts, we always call seek_write to find the
last write record before start_ts.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
