### PR TITLE
txn: save last change info in write records

### DIFF
--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -1395,7 +1395,8 @@ pub mod tests {
 
         let (commit_ts, write) = reader.seek_write(&k, 20.into()).unwrap().unwrap();
         assert_eq!(commit_ts, 20.into());
-        assert_eq!(write, Write::new(WriteType::Lock, 10.into(), None));
+        assert_eq!(write.write_type, WriteType::Lock);
+        assert_eq!(write.start_ts, 10.into());
         assert_eq!(reader.statistics.write.seek, 1);
         assert_eq!(reader.statistics.write.next, 1);
 

--- a/src/storage/mvcc/reader/scanner/forward.rs
+++ b/src/storage/mvcc/reader/scanner/forward.rs
@@ -2366,16 +2366,6 @@ mod delta_entry_tests {
 
     #[test]
     fn test_mess() {
-        use pd_client::FeatureGate;
-
-        use crate::storage::txn::sched_pool::set_tls_feature_gate;
-
-        // Set version to 6.5.0 to enable last_change_ts.
-        // TODO: Remove this after TiKV version reaches 6.5
-        let feature_gate = FeatureGate::default();
-        feature_gate.set_version("6.5.0").unwrap();
-        set_tls_feature_gate(feature_gate);
-
         // TODO: non-pessimistic lock should be returned enven if its ts < from_ts.
         // (key, lock, [commit1, commit2, ...])
         // Values ends with 'L' will be made larger than `SHORT_VALUE_MAX_LEN` so it

--- a/src/storage/txn/actions/commit.rs
+++ b/src/storage/txn/actions/commit.rs
@@ -91,7 +91,8 @@ pub fn commit<S: Snapshot>(
         WriteType::from_lock_type(lock.lock_type).unwrap(),
         reader.start_ts,
         lock.short_value.take(),
-    );
+    )
+    .set_last_change(lock.last_change_ts, lock.versions_to_last_change);
 
     for ts in &lock.rollback_ts {
         if *ts == commit_ts {
@@ -319,5 +320,42 @@ pub mod tests {
         must_large_txn_locked(&mut engine, k, ts(60, 0), 100, ts(70, 1), false);
         must_err(&mut engine, k, ts(60, 0), ts(65, 0));
         must_succeed(&mut engine, k, ts(60, 0), ts(80, 0));
+    }
+
+    #[test]
+    fn test_inherit_last_change_info_from_lock() {
+        use pd_client::FeatureGate;
+
+        use crate::storage::txn::sched_pool::set_tls_feature_gate;
+
+        let feature_gate = FeatureGate::default();
+        feature_gate.set_version("6.5.0").unwrap();
+        set_tls_feature_gate(feature_gate);
+
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+
+        let k = b"k";
+        must_prewrite_put(&mut engine, k, b"v1", k, 5);
+        must_succeed(&mut engine, k, 5, 10);
+
+        // WriteType is Lock
+        must_prewrite_lock(&mut engine, k, k, 15);
+        let lock = must_locked(&mut engine, k, 15);
+        assert_eq!(lock.last_change_ts, 10.into());
+        assert_eq!(lock.versions_to_last_change, 1);
+        must_succeed(&mut engine, k, 15, 20);
+        let write = must_written(&mut engine, k, 15, 20, WriteType::Lock);
+        assert_eq!(write.last_change_ts, 10.into());
+        assert_eq!(write.versions_to_last_change, 1);
+
+        // WriteType is Put
+        must_prewrite_put(&mut engine, k, b"v2", k, 25);
+        let lock = must_locked(&mut engine, k, 25);
+        assert!(lock.last_change_ts.is_zero());
+        assert_eq!(lock.versions_to_last_change, 0);
+        must_succeed(&mut engine, k, 25, 30);
+        let write = must_written(&mut engine, k, 25, 30, WriteType::Put);
+        assert!(write.last_change_ts.is_zero());
+        assert_eq!(write.versions_to_last_change, 0);
     }
 }

--- a/src/storage/txn/actions/commit.rs
+++ b/src/storage/txn/actions/commit.rs
@@ -324,14 +324,6 @@ pub mod tests {
 
     #[test]
     fn test_inherit_last_change_info_from_lock() {
-        use pd_client::FeatureGate;
-
-        use crate::storage::txn::sched_pool::set_tls_feature_gate;
-
-        let feature_gate = FeatureGate::default();
-        feature_gate.set_version("6.5.0").unwrap();
-        set_tls_feature_gate(feature_gate);
-
         let mut engine = TestEngineBuilder::new().build().unwrap();
 
         let k = b"k";

--- a/src/storage/txn/actions/prewrite.rs
+++ b/src/storage/txn/actions/prewrite.rs
@@ -2412,13 +2412,6 @@ pub mod tests {
     #[test]
     fn test_inherit_last_change_ts_from_pessimistic_lock() {
         use engine_traits::CF_LOCK;
-        use pd_client::FeatureGate;
-
-        use crate::storage::txn::sched_pool::set_tls_feature_gate;
-
-        let feature_gate = FeatureGate::default();
-        feature_gate.set_version("6.5.0").unwrap();
-        set_tls_feature_gate(feature_gate);
 
         let mut engine = crate::storage::TestEngineBuilder::new().build().unwrap();
         let key = b"k";

--- a/src/storage/txn/commands/prewrite.rs
+++ b/src/storage/txn/commands/prewrite.rs
@@ -2516,10 +2516,6 @@ mod tests {
         let mut engine = TestEngineBuilder::new().build().unwrap();
         let cm = concurrency_manager::ConcurrencyManager::new(1.into());
 
-        let feature_gate = FeatureGate::default();
-        feature_gate.set_version("6.5.0").unwrap();
-        set_tls_feature_gate(feature_gate);
-
         let key = b"k";
         let value = b"v";
         must_prewrite_put(&mut engine, key, value, key, 10);
@@ -2605,10 +2601,6 @@ mod tests {
 
         let mut engine = TestEngineBuilder::new().build().unwrap();
         let cm = concurrency_manager::ConcurrencyManager::new(1.into());
-
-        let feature_gate = FeatureGate::default();
-        feature_gate.set_version("6.5.0").unwrap();
-        set_tls_feature_gate(feature_gate);
 
         let key = b"k";
         let value = b"v";


### PR DESCRIPTION
Signed-off-by: Yilin Chen <sticnarf@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #13694

What's Changed:

Only a one-line change to the code :)

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
In this commit, the commit action will save the last_change_ts and
versions_to_last_change in the lock to the write record.

It is unncessary to check the write type because it is checked during prewrite.
So, among the committable locks, only those of Lock type will have
last_change_ts and versions_to_last_change.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
