### PR TITLE
[WIP] raftstore-v2: stale peer check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2694,7 +2694,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#65d0ae8fa853c1e41b43f329afbf60616bdd4d18"
+source = "git+https://github.com/tonyxuqqi/kvproto?branch=stale_peer#b1e60379b0553ee437e575188450acd9dff0fd0b"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,7 +221,7 @@ procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "6599eb9dca74229
 # kvproto at the same time.
 # After the PR to kvproto is merged, remember to comment this out and run `cargo update -p kvproto`.
 [patch.'https://github.com/pingcap/kvproto']
-# kvproto = { git = "https://github.com/your_github_id/kvproto", branch = "your_branch" }
+kvproto = { git = "https://github.com/tonyxuqqi/kvproto", branch="stale_peer" }
 
 [workspace]
 # See https://github.com/rust-lang/rfcs/blob/master/text/2957-cargo-features2.md

--- a/components/raftstore-v2/Cargo.toml
+++ b/components/raftstore-v2/Cargo.toml
@@ -38,7 +38,7 @@ fail = "0.5"
 file_system = { workspace = true }
 futures = { version = "0.3", features = ["compat"] }
 keys = { workspace = true }
-kvproto = { git = "https://github.com/pingcap/kvproto.git" }
+kvproto = { git = "https://github.com/tonyxuqqi/kvproto", branch="stale_peer" }
 log_wrappers = { workspace = true }
 pd_client = { workspace = true }
 protobuf = { version = "2.8", features = ["bytes"] }

--- a/components/raftstore-v2/src/batch/store.rs
+++ b/components/raftstore-v2/src/batch/store.rs
@@ -71,6 +71,18 @@ pub struct StoreContext<EK: KvEngine, ER: RaftEngine, T> {
     pub read_scheduler: Scheduler<ReadTask<EK>>,
 }
 
+impl<EK, ER, T> StoreContext<EK, ER, T>
+where 
+    EK: KvEngine,
+    ER: RaftEngine
+{
+    pub fn update_ticks_timeout(&mut self) {
+        self.tick_batch[PeerTick::Raft as usize].wait_duration = self.cfg.raft_base_tick_interval.0;
+        self.tick_batch[PeerTick::CheckPeerStaleState as usize].wait_duration =
+            self.cfg.peer_stale_state_check_interval.0;
+    }
+}
+
 /// A [`PollHandler`] that handles updates of [`StoreFsm`]s and [`PeerFsm`]s.
 ///
 /// It is responsible for:
@@ -143,6 +155,7 @@ impl<EK: KvEngine, ER: RaftEngine, T: Transport + 'static> PollHandler<PeerFsm<E
                 self.apply_buf_capacity();
             }
             update_cfg(&self.poll_ctx.cfg.store_batch_system);
+            self.poll_ctx.update_ticks_timeout();
         }
     }
 
@@ -309,7 +322,7 @@ where
 
     fn build(&mut self, priority: batch_system::Priority) -> Self::Handler {
         let cfg = self.cfg.value().clone();
-        let poll_ctx = StoreContext {
+        let mut poll_ctx = StoreContext {
             logger: self.logger.clone(),
             trans: self.trans.clone(),
             current_time: None,
@@ -326,6 +339,7 @@ where
             apply_pool: self.apply_pool.clone(),
             read_scheduler: self.read_scheduler.clone(),
         };
+        poll_ctx.update_ticks_timeout();
         let cfg_tracker = self.cfg.clone().tracker("raftstore".to_string());
         StorePoller::new(poll_ctx, cfg_tracker)
     }

--- a/components/raftstore-v2/src/fsm/peer.rs
+++ b/components/raftstore-v2/src/fsm/peer.rs
@@ -177,6 +177,7 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> PeerFsmDelegate<'a, EK, ER,
 
     fn on_start(&mut self) {
         self.schedule_tick(PeerTick::Raft);
+        self.schedule_tick(PeerTick::StalePeerCheck);
         if self.fsm.peer.storage().is_initialized() {
             self.fsm.peer.schedule_apply_fsm(self.store_ctx);
         }
@@ -203,6 +204,7 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> PeerFsmDelegate<'a, EK, ER,
             PeerTick::ReactivateMemoryLock => unimplemented!(),
             PeerTick::ReportBuckets => unimplemented!(),
             PeerTick::CheckLongUncommitted => unimplemented!(),
+            PeerTick::StalePeerCheck => self.on_stale_peer_check(),
         }
     }
 

--- a/components/raftstore-v2/src/fsm/store.rs
+++ b/components/raftstore-v2/src/fsm/store.rs
@@ -5,7 +5,7 @@ use std::time::SystemTime;
 use batch_system::Fsm;
 use collections::HashMap;
 use engine_traits::{KvEngine, RaftEngine};
-use raftstore::store::{Config, ReadDelegate};
+use raftstore::store::{Config, ReadDelegate, Transport};
 use slog::{o, Logger};
 use tikv_util::mpsc::{self, LooseBoundedSender, Receiver};
 
@@ -122,7 +122,7 @@ pub struct StoreFsmDelegate<'a, EK: KvEngine, ER: RaftEngine, T> {
     store_ctx: &'a mut StoreContext<EK, ER, T>,
 }
 
-impl<'a, EK: KvEngine, ER: RaftEngine, T> StoreFsmDelegate<'a, EK, ER, T> {
+impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER, T> {
     pub fn new(fsm: &'a mut StoreFsm, store_ctx: &'a mut StoreContext<EK, ER, T>) -> Self {
         Self { fsm, store_ctx }
     }

--- a/components/raftstore-v2/src/operation/command/admin/conf_change.rs
+++ b/components/raftstore-v2/src/operation/command/admin/conf_change.rs
@@ -7,6 +7,8 @@
 //! - Apply after conf change is committed
 //! - Update raft state using the result of conf change
 
+use std::ops::DerefMut;
+
 use collections::HashSet;
 use engine_traits::{KvEngine, RaftEngine};
 use kvproto::{
@@ -141,8 +143,29 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         }
 
         let remove_self = conf_change.region_state.get_state() == PeerState::Tombstone;
-        self.storage_mut()
-            .set_region_state(conf_change.region_state);
+        let mut region_state = conf_change.region_state;
+
+        // merge the pending remove peers
+        if !self
+            .storage_mut()
+            .region_state_mut()
+            .pending_remove_peers
+            .is_empty()
+        {
+            loop {
+                let peer = self
+                    .storage_mut()
+                    .region_state_mut()
+                    .pending_remove_peers
+                    .pop();
+                if peer.is_none() {
+                    break;
+                }
+                region_state.pending_remove_peers.push(peer.unwrap());
+            }
+        }
+
+        self.storage_mut().set_region_state(region_state);
         if self.is_leader() {
             info!(
                 self.logger,
@@ -210,6 +233,7 @@ impl<EK: KvEngine, R> Apply<EK, R> {
         legacy: bool,
     ) -> Result<(AdminResponse, AdminCmdResult)> {
         let region = self.region_state().get_region();
+        let mut region_state = self.region_state().clone();
         let peer_id = self.peer().get_id();
         let change_kind = ConfChangeKind::confchange_kind(changes.len());
         info!(self.logger, "exec ConfChangeV2"; "kind" => ?change_kind, "legacy" => legacy, "epoch" => ?region.get_region_epoch());
@@ -225,9 +249,9 @@ impl<EK: KvEngine, R> Apply<EK, R> {
                 );
                 for cp in changes {
                     let res = if legacy {
-                        self.apply_single_change_legacy(cp, &mut new_region)
+                        self.apply_single_change_legacy(cp, &mut new_region, &mut region_state)
                     } else {
-                        self.apply_single_change(kind, cp, &mut new_region)
+                        self.apply_single_change(kind, cp, &mut new_region, &mut region_state)
                     };
                     if let Err(e) = res {
                         error!(self.logger, "failed to apply conf change"; 
@@ -250,8 +274,7 @@ impl<EK: KvEngine, R> Apply<EK, R> {
             "current region" => ?new_region,
         );
         let my_id = self.peer().get_id();
-        let state = self.region_state_mut();
-        state.set_region(new_region.clone());
+        region_state.set_region(new_region.clone());
         let new_peer = new_region
             .get_peers()
             .iter()
@@ -261,7 +284,11 @@ impl<EK: KvEngine, R> Apply<EK, R> {
             // A peer will reject any snapshot that doesn't include itself in the
             // configuration. So if it disappear from the configuration, it must
             // be removed by conf change.
-            state.set_state(PeerState::Tombstone);
+            region_state.set_state(PeerState::Tombstone);
+        }
+        *self.region_state_mut() = region_state.clone();
+        if region_state.get_state() == PeerState::Tombstone {
+            self.mark_tombstone();
         }
         let mut resp = AdminResponse::default();
         resp.mut_change_peer().set_region(new_region);
@@ -269,11 +296,8 @@ impl<EK: KvEngine, R> Apply<EK, R> {
             index,
             conf_change: cc,
             changes: changes.to_vec(),
-            region_state: state.clone(),
+            region_state,
         };
-        if state.get_state() == PeerState::Tombstone {
-            self.mark_tombstone();
-        }
         if let Some(peer) = new_peer {
             self.set_peer(peer);
         }
@@ -310,6 +334,7 @@ impl<EK: KvEngine, R> Apply<EK, R> {
         &self,
         cp: &ChangePeerRequest,
         region: &mut metapb::Region,
+        state: &mut RegionLocalState,
     ) -> Result<()> {
         let peer = cp.get_peer();
         let store_id = peer.get_store_id();
@@ -357,6 +382,7 @@ impl<EK: KvEngine, R> Apply<EK, R> {
                             p
                         ));
                     }
+                    state.mut_pending_remove_peers().push(peer.clone());
                 } else {
                     return Err(box_err!(
                         "remove missing peer {:?} from region {:?}",
@@ -397,6 +423,7 @@ impl<EK: KvEngine, R> Apply<EK, R> {
         kind: ConfChangeKind,
         cp: &ChangePeerRequest,
         region: &mut metapb::Region,
+        state: &mut RegionLocalState,
     ) -> Result<()> {
         let (change_type, peer) = (cp.get_change_type(), cp.get_peer());
         let store_id = peer.get_store_id();
@@ -496,6 +523,7 @@ impl<EK: KvEngine, R> Apply<EK, R> {
                                 p
                             ));
                         }
+                        state.mut_pending_remove_peers().push(peer.clone());
                     }
                     None => unreachable!(),
                 }

--- a/components/raftstore-v2/src/operation/command/mod.rs
+++ b/components/raftstore-v2/src/operation/command/mod.rs
@@ -117,7 +117,9 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
     /// when the old apply scheduler is dropped.
     #[inline]
     pub fn schedule_apply_fsm<T>(&mut self, store_ctx: &mut StoreContext<EK, ER, T>) {
-        let region_state = self.storage().region_state().clone();
+        let mut region_state = self.storage().region_state().clone();
+        // apply fsm will return newly added pending remove peers if any
+        region_state.clear_pending_remove_peers();
         let mailbox = store_ctx.router.mailbox(self.region_id()).unwrap();
         let tablet = self.tablet().clone();
         let logger = self.logger.clone();
@@ -440,6 +442,7 @@ impl<EK: KvEngine, R: ApplyResReporter> Apply<EK, R> {
                 AdminCmdType::InvalidAdmin => {
                     return Err(box_err!("invalid admin command type"));
                 }
+                AdminCmdType::BatchSwitchWitness => unimplemented!(),
             };
 
             self.push_admin_result(admin_result);

--- a/components/raftstore-v2/src/raft/storage.rs
+++ b/components/raftstore-v2/src/raft/storage.rs
@@ -97,6 +97,11 @@ impl<EK: KvEngine, ER> Storage<EK, ER> {
     }
 
     #[inline]
+    pub fn region_state_mut(&mut self) -> &mut RegionLocalState {
+        &mut self.region_state
+    }
+
+    #[inline]
     pub fn region(&self) -> &metapb::Region {
         self.region_state.get_region()
     }

--- a/components/raftstore-v2/src/router/message.rs
+++ b/components/raftstore-v2/src/router/message.rs
@@ -30,6 +30,7 @@ pub enum PeerTick {
     ReactivateMemoryLock = 8,
     ReportBuckets = 9,
     CheckLongUncommitted = 10,
+    StalePeerCheck = 11,
 }
 
 impl PeerTick {
@@ -49,6 +50,7 @@ impl PeerTick {
             PeerTick::ReactivateMemoryLock => "reactivate_memory_lock",
             PeerTick::ReportBuckets => "report_buckets",
             PeerTick::CheckLongUncommitted => "check_long_uncommitted",
+            PeerTick::StalePeerCheck => "stale_peer_check",
         }
     }
 

--- a/components/raftstore-v2/tests/integrations/cluster.rs
+++ b/components/raftstore-v2/tests/integrations/cluster.rs
@@ -326,6 +326,10 @@ impl Transport for TestTransport {
     fn flush(&mut self) {
         self.flush_cnt.fetch_add(1, Ordering::SeqCst);
     }
+
+    fn is_tombstone_store(&self, _store_id: u64) -> bool {
+        false
+    }
 }
 
 // TODO: remove following when we finally integrate it in tikv-server binary.

--- a/components/raftstore/src/store/async_io/write_tests.rs
+++ b/components/raftstore/src/store/async_io/write_tests.rs
@@ -82,6 +82,10 @@ impl Transport for TestTransport {
         false
     }
     fn flush(&mut self) {}
+
+    fn is_tombstone_store(&self, _store_id: u64) -> bool {
+        false
+    }
 }
 
 fn must_have_same_count_msg(msg_count: u32, msg_rx: &Receiver<RaftMessage>) {

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -1586,6 +1586,7 @@ where
                 self.exec_flashback(ctx, request)
             }
             AdminCmdType::InvalidAdmin => Err(box_err!("unsupported admin command type")),
+            AdminCmdType::BatchSwitchWitness => unimplemented!()
         }?;
         response.set_cmd_type(cmd_type);
 

--- a/components/raftstore/src/store/transport.rs
+++ b/components/raftstore/src/store/transport.rs
@@ -25,6 +25,8 @@ pub trait Transport: Send + Clone {
     fn need_flush(&self) -> bool;
 
     fn flush(&mut self);
+
+    fn is_tombstone_store(&self, store_id: u64) -> bool;
 }
 
 /// Routes message to target region.

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -200,6 +200,7 @@ pub fn admin_cmd_epoch_lookup(admin_cmp_type: AdminCmdType) -> AdminCmdEpochStat
         AdminCmdType::PrepareFlashback | AdminCmdType::FinishFlashback => {
             AdminCmdEpochState::new(true, true, false, false)
         }
+        AdminCmdType::BatchSwitchWitness => unimplemented!()
     }
 }
 

--- a/components/test_raftstore/src/node.rs
+++ b/components/test_raftstore/src/node.rs
@@ -145,6 +145,10 @@ impl Transport for ChannelTransport {
     }
 
     fn flush(&mut self) {}
+
+    fn is_tombstone_store(&self, _store_id: u64) -> bool {
+        false
+    }
 }
 
 type SimulateChannelTransport = SimulateTransport<ChannelTransport>;

--- a/components/test_raftstore/src/transport_simulate.rs
+++ b/components/test_raftstore/src/transport_simulate.rs
@@ -212,6 +212,10 @@ impl<C: Transport> Transport for SimulateTransport<C> {
     fn flush(&mut self) {
         self.ch.flush();
     }
+
+    fn is_tombstone_store(&self, _store_id: u64) -> bool {
+        false
+    }
 }
 
 impl<C: RaftStoreRouter<RocksEngine>> StoreRouter<RocksEngine> for SimulateTransport<C> {

--- a/src/server/raft_client.rs
+++ b/src/server/raft_client.rs
@@ -1161,6 +1161,11 @@ where
         let mut p = self.pool.lock().unwrap();
         p.set_store_allowlist(stores);
     }
+
+    pub fn is_tombstone_store(&self, store_id: u64) -> bool {
+        let pool = self.pool.lock().unwrap();
+        pool.tombstone_stores.contains(&store_id) 
+    }
 }
 
 impl<S, R, E> Clone for RaftClient<S, R, E>

--- a/src/server/transport.rs
+++ b/src/server/transport.rs
@@ -70,4 +70,8 @@ where
     fn flush(&mut self) {
         self.raft_client.flush();
     }
+
+    fn is_tombstone_store(&self, store_id: u64) -> bool {
+        self.raft_client.is_tombstone_store(store_id)
+    }
 }


### PR DESCRIPTION
todo:
1) when transfer leader and send snapshot, copy the pending_remove_peers to followers 2) when follower become leader, copy the pending_remove_peers from leader and start the StalePeerCheckTick 3) when follower apply the snapshot, set the pending_remove_peers from snapshot 4) when merge happens, update pending_remove_peers in local state.

Signed-off-by: qi.xu <tonxuqi@outlook.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #xxx

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
```
