### PR TITLE
copr: fix _ pattern in like behavior for old collation

### DIFF
--- a/components/tidb_query_datatype/src/codec/collation/charset.rs
+++ b/components/tidb_query_datatype/src/codec/collation/charset.rs
@@ -22,6 +22,10 @@ impl Charset for CharsetBinary {
             Some((data[0], 1))
         }
     }
+
+    fn charset() -> crate::Charset {
+        crate::Charset::Binary
+    }
 }
 
 pub struct CharsetUtf8mb4;
@@ -47,6 +51,10 @@ impl Charset for CharsetUtf8mb4 {
                 )
             })
         }
+    }
+
+    fn charset() -> crate::Charset {
+        crate::Charset::Utf8Mb4
     }
 }
 

--- a/components/tidb_query_datatype/src/codec/collation/mod.rs
+++ b/components/tidb_query_datatype/src/codec/collation/mod.rs
@@ -42,6 +42,32 @@ macro_rules! match_template_collator {
 }
 
 #[macro_export]
+macro_rules! match_template_multiple_collators {
+    ((), (), $($tail:tt)*) => {
+        $($tail)*
+    };
+    (($first:tt), ($match_exprs:tt), $($tail:tt)*) => {
+        match_template_multiple_collators! {
+            ($first,), ($match_exprs,), $($tail)*
+        }
+    };
+    (($first:tt, $($t:tt)*), ($first_match_expr:tt, $($match_exprs:tt)*), $($tail:tt)*) => {{
+        #[allow(unused_imports)]
+        use $crate::codec::collation::collator::*;
+
+        match_template_collator! {
+            $first, match $first_match_expr {
+                Collation::$first => {
+                    match_template_multiple_collators! {
+                        ($($t)*), ($($match_exprs)*), $($tail)*
+                    }
+                }
+            }
+        }
+    }};
+}
+
+#[macro_export]
 macro_rules! match_template_charset {
      ($t:tt, $($tail:tt)*) => {{
          #[allow(unused_imports)]

--- a/components/tidb_query_datatype/src/codec/collation/mod.rs
+++ b/components/tidb_query_datatype/src/codec/collation/mod.rs
@@ -67,6 +67,8 @@ pub trait Charset {
     fn validate(bstr: &[u8]) -> Result<()>;
 
     fn decode_one(data: &[u8]) -> Option<(Self::Char, usize)>;
+
+    fn charset() -> crate::Charset;
 }
 
 pub trait Collator: 'static + std::marker::Send + std::marker::Sync + std::fmt::Debug {

--- a/components/tidb_query_expr/src/impl_like.rs
+++ b/components/tidb_query_expr/src/impl_like.rs
@@ -332,7 +332,7 @@ mod tests {
                 Collation::Binary,
                 Collation::Utf8Mb4Bin,
                 Collation::Utf8Mb4Bin,
-                Some(0),
+                Some(1),
             ),
         ];
         for (target, pattern, escape, collation, target_collation, pattern_collation, expected) in

--- a/components/tidb_query_expr/src/impl_like.rs
+++ b/components/tidb_query_expr/src/impl_like.rs
@@ -6,17 +6,21 @@ use tidb_query_datatype::codec::{collation::*, data_type::*};
 
 #[rpn_fn]
 #[inline]
-pub fn like<C: Collator>(target: BytesRef, pattern: BytesRef, escape: &i64) -> Result<Option<i64>> {
+pub fn like<C: Collator, CS: Charset>(
+    target: BytesRef,
+    pattern: BytesRef,
+    escape: &i64,
+) -> Result<Option<i64>> {
     let escape = *escape as u32;
     // current search positions in pattern and target.
     let (mut px, mut tx) = (0, 0);
     // positions for backtrace.
     let (mut next_px, mut next_tx) = (0, 0);
     while px < pattern.len() || tx < target.len() {
-        if let Some((c, mut poff)) = C::Charset::decode_one(&pattern[px..]) {
+        if let Some((c, mut poff)) = CS::decode_one(&pattern[px..]) {
             let code: u32 = c.into();
             if code == '_' as u32 {
-                if let Some((_, toff)) = C::Charset::decode_one(&target[tx..]) {
+                if let Some((_, toff)) = CS::decode_one(&target[tx..]) {
                     px += poff;
                     tx += toff;
                     continue;
@@ -26,7 +30,7 @@ pub fn like<C: Collator>(target: BytesRef, pattern: BytesRef, escape: &i64) -> R
                 next_px = px;
                 px += poff;
                 next_tx = tx;
-                next_tx += if let Some((_, toff)) = C::Charset::decode_one(&target[tx..]) {
+                next_tx += if let Some((_, toff)) = CS::decode_one(&target[tx..]) {
                     toff
                 } else {
                     1
@@ -35,13 +39,13 @@ pub fn like<C: Collator>(target: BytesRef, pattern: BytesRef, escape: &i64) -> R
             } else {
                 if code == escape && px + poff < pattern.len() {
                     px += poff;
-                    poff = if let Some((_, off)) = C::Charset::decode_one(&pattern[px..]) {
+                    poff = if let Some((_, off)) = CS::decode_one(&pattern[px..]) {
                         off
                     } else {
                         break;
                     }
                 }
-                if let Some((_, toff)) = C::Charset::decode_one(&target[tx..]) {
+                if let Some((_, toff)) = CS::decode_one(&target[tx..]) {
                     if let Ok(std::cmp::Ordering::Equal) =
                         C::sort_compare(&target[tx..tx + toff], &pattern[px..px + poff])
                     {
@@ -155,20 +159,6 @@ mod tests {
                 Some(0),
             ),
             (
-                r#"夏威夷吉他"#,
-                r#"_____"#,
-                '\\',
-                Collation::Binary,
-                Some(0),
-            ),
-            (
-                r#"🐶🍐🍳➕🥜🎗🐜"#,
-                r#"_______"#,
-                '\\',
-                Collation::Utf8Mb4Bin,
-                Some(1),
-            ),
-            (
                 r#"IpHONE"#,
                 r#"iPhone"#,
                 '\\',
@@ -179,14 +169,6 @@ mod tests {
                 r#"IpHONE xs mAX"#,
                 r#"iPhone XS Max"#,
                 '\\',
-                Collation::Utf8Mb4GeneralCi,
-                Some(1),
-            ),
-            (r#"🕺_"#, r#"🕺🕺🕺_"#, '🕺', Collation::Binary, Some(0)),
-            (
-                r#"🕺_"#,
-                r#"🕺🕺🕺_"#,
-                '🕺',
                 Collation::Utf8Mb4GeneralCi,
                 Some(1),
             ),
@@ -228,6 +210,153 @@ mod tests {
                 )
                 .push_param(target.to_owned().into_bytes())
                 .push_param(pattern.to_owned().into_bytes())
+                .push_param(escape as i64)
+                .evaluate(ScalarFuncSig::LikeSig)
+                .unwrap();
+            assert_eq!(
+                output, expected,
+                "target={}, pattern={}, escape={}",
+                target, pattern, escape
+            );
+        }
+    }
+
+    #[test]
+    fn test_like_wide_character() {
+        let cases = vec![
+            (
+                r#"夏威夷吉他"#,
+                r#"_____"#,
+                '\\',
+                Collation::Binary,
+                Collation::Binary,
+                Collation::Binary,
+                Some(0),
+            ),
+            (
+                r#"🐶🍐🍳➕🥜🎗🐜"#,
+                r#"_______"#,
+                '\\',
+                Collation::Utf8Mb4Bin,
+                Collation::Utf8Mb4Bin,
+                Collation::Utf8Mb4Bin,
+                Some(1),
+            ),
+            (
+                r#"🕺_"#,
+                r#"🕺🕺🕺_"#,
+                '🕺',
+                Collation::Binary,
+                Collation::Binary,
+                Collation::Binary,
+                Some(0),
+            ),
+            (
+                r#"🕺_"#,
+                r#"🕺🕺🕺_"#,
+                '🕺',
+                Collation::Utf8Mb4GeneralCi,
+                Collation::Utf8Mb4GeneralCi,
+                Collation::Utf8Mb4GeneralCi,
+                Some(1),
+            ),
+            // When the new collation framework is not enabled, the collation
+            // will always be binary Some related tests are added here
+            (
+                r#"夏威夷吉他"#,
+                r#"_____"#,
+                '\\',
+                Collation::Binary,
+                Collation::Utf8Mb4Bin,
+                Collation::Utf8Mb4Bin,
+                Some(1),
+            ),
+            (
+                r#"🐶🍐🍳➕🥜🎗🐜"#,
+                r#"_______"#,
+                '\\',
+                Collation::Binary,
+                Collation::Utf8Mb4Bin,
+                Collation::Utf8Mb4Bin,
+                Some(1),
+            ),
+            (
+                r#"🕺_"#,
+                r#"🕺🕺🕺_"#,
+                '🕺',
+                Collation::Binary,
+                Collation::Binary,
+                Collation::Binary,
+                Some(0),
+            ),
+            (
+                r#"🕺_"#,
+                r#"🕺🕺🕺_"#,
+                '🕺',
+                Collation::Binary,
+                Collation::Utf8Mb4Bin,
+                Collation::Utf8Mb4Bin,
+                Some(1),
+            ),
+            // Will not match, because '_' matches only one byte.
+            (
+                r#"测试"#,
+                r#"测_"#,
+                '\\',
+                Collation::Binary,
+                Collation::Utf8Mb4Bin,
+                Collation::Binary,
+                Some(0),
+            ),
+            // Both of them should be decoded with binary charset, so that we'll
+            // compare byte with byte, but not comparing a long character with a
+            // byte.
+            (
+                r#"测试"#,
+                r#"测%"#,
+                '\\',
+                Collation::Binary,
+                Collation::Utf8Mb4Bin,
+                Collation::Binary,
+                Some(1),
+            ),
+            // This can happen when the new collation is not enabled, and TiDB
+            // doesn't push down the collation information. Using binary
+            // comparing order is fine, but we'll need to decode strings with
+            // their own charset (so '_' could match single character, rather
+            // than single byte).
+            (
+                r#"测试"#,
+                r#"测_"#,
+                '\\',
+                Collation::Binary,
+                Collation::Utf8Mb4Bin,
+                Collation::Utf8Mb4Bin,
+                Some(0),
+            ),
+        ];
+        for (target, pattern, escape, collation, target_collation, pattern_collation, expected) in
+            cases
+        {
+            let output = RpnFnScalarEvaluator::new()
+                .return_field_type(
+                    FieldTypeBuilder::new()
+                        .tp(FieldTypeTp::LongLong)
+                        .collation(collation)
+                        .build(),
+                )
+                .push_param_with_field_type(
+                    target.to_owned().into_bytes(),
+                    FieldTypeBuilder::new()
+                        .tp(FieldTypeTp::String)
+                        .collation(target_collation),
+                )
+                .push_param_with_field_type(
+                    pattern.to_owned().into_bytes(),
+                    FieldTypeBuilder::new()
+                        .tp(FieldTypeTp::String)
+                        .collation(pattern_collation),
+                )
                 .push_param(escape as i64)
                 .evaluate(ScalarFuncSig::LikeSig)
                 .unwrap();

--- a/components/tidb_query_expr/src/lib.rs
+++ b/components/tidb_query_expr/src/lib.rs
@@ -44,9 +44,12 @@ pub mod impl_time;
 
 use tidb_query_common::Result;
 use tidb_query_datatype::{
-    codec::{collation::Collator, data_type::*},
-    match_template_charset, match_template_collator, Charset, Collation, FieldTypeAccessor,
-    FieldTypeFlag,
+    codec::{
+        collation::{Charset as _, Collator},
+        data_type::*,
+    },
+    match_template_charset, match_template_collator, match_template_multiple_collators, Charset,
+    Collation, FieldTypeAccessor, FieldTypeFlag,
 };
 use tipb::{Expr, FieldType, ScalarFuncSig};
 
@@ -93,6 +96,10 @@ fn map_compare_in_string_sig(ret_field_type: &FieldType) -> Result<RpnFnMeta> {
 }
 
 fn map_like_sig(ret_field_type: &FieldType, children: &[Expr]) -> Result<RpnFnMeta> {
+    let ret_collation = ret_field_type
+        .as_accessor()
+        .collation()
+        .map_err(tidb_query_datatype::codec::Error::from)?;
     let target_collation = children[0]
         .get_field_type()
         .as_accessor()
@@ -104,39 +111,23 @@ fn map_like_sig(ret_field_type: &FieldType, children: &[Expr]) -> Result<RpnFnMe
         .collation()
         .map_err(tidb_query_datatype::codec::Error::from)?;
 
-    Ok(match_template_collator! {
-        TT, match ret_field_type.as_accessor().collation().map_err(tidb_query_datatype::codec::Error::from)? {
-            Collation::TT =>  match_template_collator!(
-                TC, match target_collation {
-                    Collation::TC => match_template_collator!(
-                        PC, match pattern_collation {
-                            Collation::PC => {
-                                // If the target charset is the same with
-                                // pattern charset, and is Utf8mb4, use their
-                                // charset to decode bytes. If not, use the
-                                // charset pushed down in the ret_field type to
-                                // decode the bytes.
-                                //
-                                // This behavior is for the compatibility and
-                                // correctness: The TiDB doesn't push down the
-                                // collation information when the new collation
-                                // framework is not enabled, and always use the
-                                // binary collation. However, the `_` pattern
-                                // considers not only the order of strings, but
-                                // also the number of characters. Some
-                                // characters more than 1 bytes cannot be
-                                // matched by `_` if the new collation framework
-                                // is not enabled.
-                                if TC::Charset::charset() == PC::Charset::charset() {
-                                    like_fn_meta::<TT, <TC as Collator>::Charset>()
-                                } else {
-                                    like_fn_meta::<TT, <TT as Collator>::Charset>()
-                                }
-                            }
-                        }
-                    )
-                }
-            )
+    // If the target charset is the same with pattern charset, and is Utf8mb4,
+    // use their charset to decode bytes. If not, use the charset pushed down in
+    // the ret_field type to decode the bytes.
+    //
+    // This behavior is for the compatibility and correctness: The TiDB doesn't
+    // push down the collation information when the new collation framework is
+    // not enabled, and always use the binary collation. However, the `_`
+    // pattern considers not only the order of strings, but also the number of
+    // characters. Some characters more than 1 bytes cannot be matched by `_` if
+    // the new collation framework is not enabled.
+    Ok(match_template_multiple_collators! {
+        (TT, TC, PC), (ret_collation, target_collation, pattern_collation), {
+            if <TC as Collator>::Charset::charset() == <PC as Collator>::Charset::charset() {
+                like_fn_meta::<TT, <TC as Collator>::Charset>()
+            } else {
+                like_fn_meta::<TT, <TT as Collator>::Charset>()
+            }
         }
     })
 }

--- a/components/tidb_query_expr/src/lib.rs
+++ b/components/tidb_query_expr/src/lib.rs
@@ -44,8 +44,9 @@ pub mod impl_time;
 
 use tidb_query_common::Result;
 use tidb_query_datatype::{
-    codec::data_type::*, match_template_charset, match_template_collator, Charset, Collation,
-    FieldTypeAccessor, FieldTypeFlag,
+    codec::{collation::Collator, data_type::*},
+    match_template_charset, match_template_collator, Charset, Collation, FieldTypeAccessor,
+    FieldTypeFlag,
 };
 use tipb::{Expr, FieldType, ScalarFuncSig};
 
@@ -91,10 +92,51 @@ fn map_compare_in_string_sig(ret_field_type: &FieldType) -> Result<RpnFnMeta> {
     })
 }
 
-fn map_like_sig(ret_field_type: &FieldType) -> Result<RpnFnMeta> {
+fn map_like_sig(ret_field_type: &FieldType, children: &[Expr]) -> Result<RpnFnMeta> {
+    let target_collation = children[0]
+        .get_field_type()
+        .as_accessor()
+        .collation()
+        .map_err(tidb_query_datatype::codec::Error::from)?;
+    let pattern_collation = children[1]
+        .get_field_type()
+        .as_accessor()
+        .collation()
+        .map_err(tidb_query_datatype::codec::Error::from)?;
+
     Ok(match_template_collator! {
         TT, match ret_field_type.as_accessor().collation().map_err(tidb_query_datatype::codec::Error::from)? {
-            Collation::TT => like_fn_meta::<TT>()
+            Collation::TT =>  match_template_collator!(
+                TC, match target_collation {
+                    Collation::TC => match_template_collator!(
+                        PC, match pattern_collation {
+                            Collation::PC => {
+                                // If the target charset is the same with
+                                // pattern charset, and is Utf8mb4, use their
+                                // charset to decode bytes. If not, use the
+                                // charset pushed down in the ret_field type to
+                                // decode the bytes.
+                                //
+                                // This behavior is for the compatibility and
+                                // correctness: The TiDB doesn't push down the
+                                // collation information when the new collation
+                                // framework is not enabled, and always use the
+                                // binary collation. However, the `_` pattern
+                                // considers not only the order of strings, but
+                                // also the number of characters. Some
+                                // characters more than 1 bytes cannot be
+                                // matched by `_` if the new collation framework
+                                // is not enabled.
+                                if TC::Charset::charset() == PC::Charset::charset() {
+                                    like_fn_meta::<TT, <TC as Collator>::Charset>()
+                                } else {
+                                    like_fn_meta::<TT, <TT as Collator>::Charset>()
+                                }
+                            }
+                        }
+                    )
+                }
+            )
         }
     })
 }
@@ -596,7 +638,7 @@ fn map_expr_node_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
         ScalarFuncSig::JsonKeys2ArgsSig => json_keys_fn_meta(),
         ScalarFuncSig::JsonQuoteSig => json_quote_fn_meta(),
         // impl_like
-        ScalarFuncSig::LikeSig => map_like_sig(ft)?,
+        ScalarFuncSig::LikeSig => map_like_sig(ft, children)?,
         // impl_regexp
         ScalarFuncSig::RegexpSig => map_regexp_like_sig(ft)?,
         ScalarFuncSig::RegexpUtf8Sig => map_regexp_like_sig(ft)?,


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What is changed and how it works?

Issue Number: Close https://github.com/tikv/tikv/issues/13769

This PR is a rework for https://github.com/tikv/tikv/pull/13770. As I have force-pushed the branch, github doesn't allow me to reopen the old one :cry: .

What's Changed:

If the two charset of arguments are equal, use the charset from arguments to decode the bytes.

I have considered the following cases:

| Ret Collation  | First Arg Charset | Second Arg Charset | Description |
| ------------- | ------------- |------------- |------------- |
| binary  | binary  | binary | It works normally |
| binary  | utf8mb4  | binary | It happened when TiDB didn't push down the collation information. Just decode and compare the string byte by byte. A `_` in pattern will only match one byte in the first arg |
| binary  | binary  | utf8mb4 | It happened when TiDB didn't push down the collation information. Just decode and compare the string byte by byte. A `_` in pattern will only match one byte in the first arg |
| binary  | utf8mb4  | utf8mb4 | It happened when TiDB didn't push down the collation information. It'll decode and compare the string character by character. A `_` in pattern will match one unicode character in the first arg. This PR is actually fixing this case |
| utf8mb4_*  | utf8mb4  | binary | will not happen |
| utf8mb4_*  | utf8mb4  | utf8mb4 | It works normally |

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix the issue that `_` pattern in `like` failed to handle non-ascii character without new collation enabled.
```
