### PR TITLE
*: update crossbeam-channel to avoid spin at sending side

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1139,9 +1139,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.1"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils 0.8.8",


### PR DESCRIPTION
### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #13815

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
According to https://github.com/crossbeam-rs/crossbeam/pull/835, spinning at the
sending side is probably a bad idea because of large critical section and it's
fixed in the recent version.

This commit updates crossbeam-channel. It will reduce CPU usage a bit and
improve performance.
```

Spinlock vs mutex is really tricky. Generally, using a mutex is never a bad idea but sometimes spinning improves performance. But in this case, our benchbot doesn't support spinning.

I did A-B-A (where A uses latest crossbeam-channel) tests, the one with latest crossbeam-channel wins consistently.

![image](https://user-images.githubusercontent.com/17217495/202347642-da490cf0-841b-492d-b999-53f00b4909c6.png)


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
