### PR TITLE
txn: make `txn_source` be u64 type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2694,7 +2694,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#29a30c4ef9c52aafb1b1da73dd9df60857068114"
+source = "git+https://github.com/pingcap/kvproto.git#51120697d051df163ec8aa313ee1916a68b07984"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/components/txn_types/src/lock.rs
+++ b/components/txn_types/src/lock.rs
@@ -270,7 +270,7 @@ impl Lock {
             size += 1 + size_of::<u64>() + MAX_VAR_U64_LEN;
         }
         if self.txn_source != 0 {
-            size += 1 + size_of::<u64>() + MAX_VAR_U64_LEN;
+            size += 1 + MAX_VAR_U64_LEN;
         }
         size
     }

--- a/components/txn_types/src/lock.rs
+++ b/components/txn_types/src/lock.rs
@@ -96,7 +96,7 @@ pub struct Lock {
     /// The source of this txn. It is used by ticdc, if the value is 0 ticdc
     /// will sync the kv change event to downstream, if it is not 0, ticdc
     /// may ignore this change event.
-    pub txn_source: u8,
+    pub txn_source: u64,
 }
 
 impl std::fmt::Debug for Lock {
@@ -182,7 +182,7 @@ impl Lock {
 
     #[inline]
     #[must_use]
-    pub fn set_txn_source(mut self, source: u8) -> Self {
+    pub fn set_txn_source(mut self, source: u64) -> Self {
         self.txn_source = source;
         self
     }
@@ -231,7 +231,7 @@ impl Lock {
         }
         if self.txn_source != 0 {
             b.push(TXN_SOURCE_PREFIX);
-            b.push(self.txn_source);
+            b.encode_var_u64(self.txn_source).unwrap();
         }
         b
     }
@@ -266,7 +266,7 @@ impl Lock {
             size += 1 + size_of::<u64>() + MAX_VAR_U64_LEN;
         }
         if self.txn_source != 0 {
-            size += 2;
+            size += 1 + size_of::<u64>() + MAX_VAR_U64_LEN;
         }
         size
     }
@@ -345,7 +345,7 @@ impl Lock {
                     versions_to_last_change = number::decode_var_u64(&mut b)?;
                 }
                 TXN_SOURCE_PREFIX => {
-                    txn_source = b.read_u8()?;
+                    txn_source = number::decode_var_u64(&mut b)?;
                 }
                 _ => {
                     // To support forward compatibility, all fields should be serialized in order

--- a/components/txn_types/src/lock.rs
+++ b/components/txn_types/src/lock.rs
@@ -96,6 +96,10 @@ pub struct Lock {
     /// The source of this txn. It is used by ticdc, if the value is 0 ticdc
     /// will sync the kv change event to downstream, if it is not 0, ticdc
     /// may ignore this change event.
+    ///
+    /// We use `u64` to reserve more space for future use. For now, the upper
+    /// application is limited to setting this value under `0x80`,
+    /// so there will no more cost to change it to `u64`.
     pub txn_source: u64,
 }
 

--- a/components/txn_types/src/write.rs
+++ b/components/txn_types/src/write.rs
@@ -436,7 +436,7 @@ impl WriteRef<'_> {
             size += 1 + size_of::<u64>() + MAX_VAR_U64_LEN;
         }
         if self.txn_source != 0 {
-            size += 1 + size_of::<u64>() + MAX_VAR_U64_LEN;
+            size += 1 + MAX_VAR_U64_LEN;
         }
         size
     }

--- a/components/txn_types/src/write.rs
+++ b/components/txn_types/src/write.rs
@@ -160,7 +160,7 @@ pub struct Write {
     /// to find the latest PUT/DELETE record
     pub versions_to_last_change: u64,
     /// The source of this txn.
-    pub txn_source: u8,
+    pub txn_source: u64,
 }
 
 impl std::fmt::Debug for Write {
@@ -248,7 +248,7 @@ impl Write {
 
     #[inline]
     #[must_use]
-    pub fn set_txn_source(mut self, source: u8) -> Self {
+    pub fn set_txn_source(mut self, source: u64) -> Self {
         self.txn_source = source;
         self
     }
@@ -323,7 +323,7 @@ pub struct WriteRef<'a> {
     /// to find the latest PUT/DELETE record
     pub versions_to_last_change: u64,
     /// The source of this txn.
-    pub txn_source: u8,
+    pub txn_source: u64,
 }
 
 impl WriteRef<'_> {
@@ -373,9 +373,7 @@ impl WriteRef<'_> {
                     versions_to_last_change = number::decode_var_u64(&mut b)?;
                 }
                 TXN_SOURCE_PREFIX => {
-                    txn_source = b
-                        .read_u8()
-                        .map_err(|_| Error::from(ErrorInner::BadFormatWrite))?
+                    txn_source = number::decode_var_u64(&mut b)?;
                 }
                 _ => {
                     // To support forward compatibility, all fields should be serialized in order
@@ -420,7 +418,7 @@ impl WriteRef<'_> {
         }
         if self.txn_source != 0 {
             b.push(TXN_SOURCE_PREFIX);
-            b.push(self.txn_source);
+            b.encode_var_u64(self.txn_source).unwrap();
         }
         b
     }
@@ -438,7 +436,7 @@ impl WriteRef<'_> {
             size += 1 + size_of::<u64>() + MAX_VAR_U64_LEN;
         }
         if self.txn_source != 0 {
-            size += 2;
+            size += 1 + size_of::<u64>() + MAX_VAR_U64_LEN;
         }
         size
     }

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -706,7 +706,7 @@ pub mod tests {
         assert_eq!(ts, commit_ts.into());
     }
 
-    pub fn must_get_txn_source<E: Engine>(engine: &mut E, key: &[u8], ts: u64, txn_source: u8) {
+    pub fn must_get_txn_source<E: Engine>(engine: &mut E, key: &[u8], ts: u64, txn_source: u64) {
         let snapshot = engine.snapshot(Default::default()).unwrap();
         let mut reader = SnapshotReader::new(TimeStamp::from(ts), snapshot, true);
         let write = reader

--- a/src/storage/txn/actions/commit.rs
+++ b/src/storage/txn/actions/commit.rs
@@ -359,7 +359,7 @@ pub mod tests {
 
         let k = b"k";
         // WriteType is Put
-        must_prewrite_put_with_txn_soucre(&mut engine, k, b"v2", k, 25, 1);
+        must_prewrite_put_with_txn_soucre(&mut engine, k, b"v2", k, 25, 0x85);
         let lock = must_locked(&mut engine, k, 25);
         assert_eq!(lock.txn_source, 1);
         must_succeed(&mut engine, k, 25, 30);

--- a/src/storage/txn/actions/commit.rs
+++ b/src/storage/txn/actions/commit.rs
@@ -355,7 +355,7 @@ pub mod tests {
 
     #[test]
     fn test_2pc_with_txn_source() {
-        for source in &[0x1, 0x85] {
+        for source in [0x1, 0x85] {
             let mut engine = TestEngineBuilder::new().build().unwrap();
 
             let k = b"k";

--- a/src/storage/txn/actions/commit.rs
+++ b/src/storage/txn/actions/commit.rs
@@ -355,7 +355,7 @@ pub mod tests {
 
     #[test]
     fn test_2pc_with_txn_source() {
-        for source in vec![0x1, 0x85] {
+        for source in &[0x1, 0x85] {
             let mut engine = TestEngineBuilder::new().build().unwrap();
 
             let k = b"k";

--- a/src/storage/txn/actions/commit.rs
+++ b/src/storage/txn/actions/commit.rs
@@ -5,8 +5,8 @@ use txn_types::{Key, TimeStamp, Write, WriteType};
 
 use crate::storage::{
     mvcc::{
-        ErrorInner,
-        LockType, metrics::{MVCC_CONFLICT_COUNTER, MVCC_DUPLICATE_CMD_COUNTER_VEC}, MvccTxn, ReleasedLock, Result as MvccResult, SnapshotReader,
+        metrics::{MVCC_CONFLICT_COUNTER, MVCC_DUPLICATE_CMD_COUNTER_VEC},
+        ErrorInner, LockType, MvccTxn, ReleasedLock, Result as MvccResult, SnapshotReader,
     },
     Snapshot,
 };
@@ -38,7 +38,7 @@ pub fn commit<S: Snapshot>(
                     key: key.into_raw()?,
                     min_commit_ts: lock.min_commit_ts,
                 }
-                    .into());
+                .into());
             }
 
             // It's an abnormal routine since pessimistic locks shouldn't be committed in
@@ -75,7 +75,7 @@ pub fn commit<S: Snapshot>(
                         commit_ts,
                         key: key.into_raw()?,
                     }
-                        .into())
+                    .into())
                 }
                 // Committed by concurrent transaction.
                 Some((_, WriteType::Put))
@@ -92,8 +92,8 @@ pub fn commit<S: Snapshot>(
         reader.start_ts,
         lock.short_value.take(),
     )
-        .set_last_change(lock.last_change_ts, lock.versions_to_last_change)
-        .set_txn_source(lock.txn_source);
+    .set_last_change(lock.last_change_ts, lock.versions_to_last_change)
+    .set_txn_source(lock.txn_source);
 
     for ts in &lock.rollback_ts {
         if *ts == commit_ts {
@@ -107,30 +107,28 @@ pub fn commit<S: Snapshot>(
 }
 
 pub mod tests {
+    use concurrency_manager::ConcurrencyManager;
     use kvproto::kvrpcpb::Context;
     #[cfg(test)]
     use kvproto::kvrpcpb::PrewriteRequestPessimisticAction::*;
-
-    use concurrency_manager::ConcurrencyManager;
     use tikv_kv::SnapContext;
     use txn_types::TimeStamp;
 
-    #[cfg(test)]
-    use crate::storage::{
-        mvcc::SHORT_VALUE_MAX_LEN, TestEngineBuilder, txn::commands::check_txn_status, TxnStatus,
-    };
-    use crate::storage::{
-        Engine,
-        mvcc::{MvccTxn, tests::*},
-    };
+    use super::*;
     #[cfg(test)]
     use crate::storage::txn::tests::{
         must_acquire_pessimistic_lock_for_large_txn, must_prewrite_delete, must_prewrite_lock,
         must_prewrite_put, must_prewrite_put_for_large_txn, must_prewrite_put_impl,
         must_prewrite_put_with_txn_soucre, must_rollback,
     };
-
-    use super::*;
+    #[cfg(test)]
+    use crate::storage::{
+        mvcc::SHORT_VALUE_MAX_LEN, txn::commands::check_txn_status, TestEngineBuilder, TxnStatus,
+    };
+    use crate::storage::{
+        mvcc::{tests::*, MvccTxn},
+        Engine,
+    };
 
     pub fn must_succeed<E: Engine>(
         engine: &mut E,

--- a/src/storage/txn/actions/prewrite.rs
+++ b/src/storage/txn/actions/prewrite.rs
@@ -172,7 +172,7 @@ pub struct TransactionProperties<'a> {
     pub need_old_value: bool,
     pub is_retry_request: bool,
     pub assertion_level: AssertionLevel,
-    pub txn_source: u8,
+    pub txn_source: u64,
 }
 
 impl<'a> TransactionProperties<'a> {

--- a/src/storage/txn/actions/tests.rs
+++ b/src/storage/txn/actions/tests.rs
@@ -113,7 +113,7 @@ pub fn must_prewrite_put_impl_with_should_not_exist<E: Engine>(
     assertion_level: AssertionLevel,
     should_not_exist: bool,
     region_id: Option<u64>,
-    txn_source: u32,
+    txn_source: u64,
 ) {
     let mut ctx = Context::default();
     ctx.set_txn_source(txn_source);
@@ -158,7 +158,7 @@ pub fn must_prewrite_put_impl_with_should_not_exist<E: Engine>(
             need_old_value: false,
             is_retry_request,
             assertion_level,
-            txn_source: txn_source as u8,
+            txn_source,
         },
         mutation,
         secondary_keys,
@@ -230,7 +230,7 @@ pub fn must_prewrite_put_with_txn_soucre<E: Engine>(
     value: &[u8],
     pk: &[u8],
     ts: impl Into<TimeStamp>,
-    txn_source: u32,
+    txn_source: u64,
 ) {
     must_prewrite_put_impl_with_should_not_exist(
         engine,

--- a/src/storage/txn/commands/prewrite.rs
+++ b/src/storage/txn/commands/prewrite.rs
@@ -511,7 +511,7 @@ impl<K: PrewriteKind> Prewriter<K> {
             need_old_value: extra_op == ExtraOp::ReadOldValue,
             is_retry_request: self.ctx.is_retry_request,
             assertion_level: self.assertion_level,
-            txn_source: self.ctx.get_txn_source() as u8,
+            txn_source: self.ctx.get_txn_source(),
         };
 
         let async_commit_pk = self


### PR DESCRIPTION
Signed-off-by: xiongjiwei <xiongjiwei1996@outlook.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref https://github.com/tikv/tikv/issues/13779

What's Changed:

we use `u64` to reserve more space for future use. For now, the upper application is limited to setting this value under `0x80`, so there will no more cost to change it to `u64`

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
