### PR TITLE
storage: skip accumulated locks on non-existing keys

### DIFF
--- a/components/txn_types/src/write.rs
+++ b/components/txn_types/src/write.rs
@@ -281,11 +281,11 @@ impl Write {
         match self.write_type {
             WriteType::Put | WriteType::Delete => (commit_ts, 1),
             WriteType::Lock | WriteType::Rollback => {
-                // If `last_change_ts` is zero, do not set `last_change_ts` to indicate we don't
-                // know where is the last change.
+                // If neither `last_change_ts` nor `versions_to_last_change` exists, do not
+                // set `last_change_ts` to indicate we don't know where is the last change.
                 // This should not happen if data is written in new version TiKV. If we hope to
                 // support data from old TiKV, consider iterating to the last change to find it.
-                if !self.last_change_ts.is_zero() {
+                if !self.last_change_ts.is_zero() || self.versions_to_last_change != 0 {
                     (self.last_change_ts, self.versions_to_last_change + 1)
                 } else {
                     (TimeStamp::zero(), 0)
@@ -320,7 +320,9 @@ pub struct WriteRef<'a> {
     /// It only exists if this is a LOCK/ROLLBACK record.
     pub last_change_ts: TimeStamp,
     /// The number of versions that need skipping from this record
-    /// to find the latest PUT/DELETE record
+    /// to find the latest PUT/DELETE record.
+    /// If versions_to_last_change > 0 but last_change_ts == 0, the key does not
+    /// have a PUT/DELETE record before this write record.
     pub versions_to_last_change: u64,
     /// The source of this txn.
     pub txn_source: u64,
@@ -411,7 +413,7 @@ impl WriteRef<'_> {
             b.push(GC_FENCE_PREFIX);
             b.encode_u64(ts.into_inner()).unwrap();
         }
-        if !self.last_change_ts.is_zero() {
+        if !self.last_change_ts.is_zero() || self.versions_to_last_change != 0 {
             b.push(LAST_CHANGE_PREFIX);
             b.encode_u64(self.last_change_ts.into_inner()).unwrap();
             b.encode_var_u64(self.versions_to_last_change).unwrap();
@@ -432,7 +434,7 @@ impl WriteRef<'_> {
         if self.gc_fence.is_some() {
             size += 1 + size_of::<u64>();
         }
-        if !self.last_change_ts.is_zero() {
+        if !self.last_change_ts.is_zero() || self.versions_to_last_change != 0 {
             size += 1 + size_of::<u64>() + MAX_VAR_U64_LEN;
         }
         if self.txn_source != 0 {
@@ -547,6 +549,7 @@ mod tests {
             Write::new(WriteType::Put, 456.into(), Some(b"short_value".to_vec()))
                 .set_overlapped_rollback(true, Some(421397468076048385.into())),
             Write::new(WriteType::Lock, 456.into(), None).set_last_change(345.into(), 11),
+            Write::new(WriteType::Lock, 456.into(), None).set_last_change(0.into(), 11),
             Write::new(WriteType::Lock, 456.into(), None).set_txn_source(1),
         ];
         for (i, write) in writes.drain(..).enumerate() {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -9767,7 +9767,7 @@ mod tests {
                         for_update_ts: 10.into(),
                         min_commit_ts: 11.into(),
                         last_change_ts: TimeStamp::zero(),
-                        versions_to_last_change: 0,
+                        versions_to_last_change: 1,
                     },
                     false
                 )

--- a/src/storage/mvcc/reader/point_getter.rs
+++ b/src/storage/mvcc/reader/point_getter.rs
@@ -317,7 +317,8 @@ impl<S: Snapshot> PointGetter<S> {
                 WriteType::Lock | WriteType::Rollback => {
                     if write.versions_to_last_change > 0 && write.last_change_ts.is_zero() {
                         return Ok(None);
-                    } else if write.versions_to_last_change < SEEK_BOUND {
+                    }
+                    if write.versions_to_last_change < SEEK_BOUND {
                         // Continue iterate next `write`.
                     } else {
                         let commit_ts = write.last_change_ts;

--- a/src/storage/mvcc/reader/point_getter.rs
+++ b/src/storage/mvcc/reader/point_getter.rs
@@ -315,8 +315,9 @@ impl<S: Snapshot> PointGetter<S> {
                     return Ok(None);
                 }
                 WriteType::Lock | WriteType::Rollback => {
-                    if write.versions_to_last_change < SEEK_BOUND || write.last_change_ts.is_zero()
-                    {
+                    if write.versions_to_last_change > 0 && write.last_change_ts.is_zero() {
+                        return Ok(None);
+                    } else if write.versions_to_last_change < SEEK_BOUND {
                         // Continue iterate next `write`.
                     } else {
                         let commit_ts = write.last_change_ts;
@@ -1265,5 +1266,26 @@ mod tests {
             new_point_getter_with_iso(&mut engine, 70.into(), IsolationLevel::RcCheckTs);
         must_get_value(&mut batch_getter_ok, key4, val4);
         must_get_value(&mut batch_getter_ok, key5, val5);
+    }
+
+    #[test]
+    fn test_point_get_non_exist_skip_lock() {
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+        let k = b"k";
+
+        // Write enough LOCK recrods
+        for start_ts in (1..30).into_iter().step_by(2) {
+            must_prewrite_lock(&mut engine, k, k, start_ts);
+            must_commit(&mut engine, k, start_ts, start_ts + 1);
+        }
+
+        let mut getter = new_point_getter(&mut engine, 40.into());
+        must_get_none(&mut getter, k);
+        let s = getter.take_statistics();
+        // We can know the key doesn't exist without skipping all these locks according
+        // to last_change_ts and versions_to_last_change.
+        assert_eq!(s.write.seek, 1);
+        assert_eq!(s.write.next, 0);
+        assert_eq!(s.write.get, 0);
     }
 }

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -386,7 +386,8 @@ impl<S: EngineSnapshot> MvccReader<S> {
                         WriteType::Lock | WriteType::Rollback => {
                             if write.versions_to_last_change > 0 && write.last_change_ts.is_zero() {
                                 return Ok(None);
-                            } else if write.versions_to_last_change < SEEK_BOUND {
+                            }
+                            if write.versions_to_last_change < SEEK_BOUND {
                                 ts = commit_ts.prev();
                             } else {
                                 let commit_ts = write.last_change_ts;

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -383,9 +383,9 @@ impl<S: EngineSnapshot> MvccReader<S> {
                             return Ok(None);
                         }
                         WriteType::Lock | WriteType::Rollback => {
-                            if write.versions_to_last_change < SEEK_BOUND
-                                || write.last_change_ts.is_zero()
-                            {
+                            if write.versions_to_last_change > 0 && write.last_change_ts.is_zero() {
+                                return Ok(None);
+                            } else if write.versions_to_last_change < SEEK_BOUND {
                                 ts = commit_ts.prev();
                             } else {
                                 let commit_ts = write.last_change_ts;
@@ -1671,6 +1671,10 @@ pub mod tests {
                     for_update_ts,
                     0,
                     TimeStamp::zero(),
+                )
+                .set_last_change(
+                    TimeStamp::zero(),
+                    (lock_type == LockType::Lock || lock_type == LockType::Pessimistic) as u64,
                 ),
             )
         })
@@ -2567,5 +2571,36 @@ pub mod tests {
         // instead of calling a series of next, so the count of next should be 0 instead
         assert_eq!(reader.statistics.write.next, 0);
         assert_eq!(reader.statistics.write.get, 1);
+    }
+
+    #[test]
+    fn test_get_write_not_exist_skip_lock() {
+        let path = tempfile::Builder::new()
+            .prefix("_test_storage_mvcc_reader_get_write_not_exist_skip_lock")
+            .tempdir()
+            .unwrap();
+        let path = path.path().to_str().unwrap();
+        let region = make_region(1, vec![], vec![]);
+        let db = open_db(path, true);
+        let mut engine = RegionEngine::new(&db, &region);
+        let k = b"k";
+
+        // Write enough LOCK recrods
+        for start_ts in (6..30).into_iter().step_by(2) {
+            engine.lock(k, start_ts, start_ts + 1);
+        }
+
+        let snap = RegionSnapshot::<RocksSnapshot>::from_raw(db, region);
+        let mut reader = MvccReader::new(snap, None, false);
+
+        let res = reader
+            .get_write_with_commit_ts(&Key::from_raw(k), 40.into(), None)
+            .unwrap();
+        // We can know the key doesn't exist without skipping all these locks according
+        // to last_change_ts and versions_to_last_change.
+        assert!(res.is_none());
+        assert_eq!(reader.statistics.write.seek, 1);
+        assert_eq!(reader.statistics.write.next, 0);
+        assert_eq!(reader.statistics.write.get, 0);
     }
 }

--- a/src/storage/mvcc/reader/scanner/forward.rs
+++ b/src/storage/mvcc/reader/scanner/forward.rs
@@ -472,8 +472,9 @@ impl<S: Snapshot> ScanPolicy<S> for LatestKvPolicy {
                 }
                 WriteType::Delete => break None,
                 WriteType::Lock | WriteType::Rollback => {
-                    if write.versions_to_last_change < SEEK_BOUND || write.last_change_ts.is_zero()
-                    {
+                    if write.versions_to_last_change > 0 && write.last_change_ts.is_zero() {
+                        break None;
+                    } else if write.versions_to_last_change < SEEK_BOUND {
                         // Continue iterate next `write`.
                         cursors.write.next(&mut statistics.write);
                     } else {
@@ -1619,14 +1620,16 @@ mod latest_kv_tests {
         must_commit(&mut engine, b"k1", 6, 8);
         must_prewrite_put(&mut engine, b"k2", b"v21", b"k2", 2);
         must_commit(&mut engine, b"k2", 2, 6);
-        must_prewrite_put(&mut engine, b"k3", b"v31", b"k3", 3);
-        must_commit(&mut engine, b"k3", 3, 7);
+        must_prewrite_put(&mut engine, b"k4", b"v41", b"k4", 3);
+        must_commit(&mut engine, b"k4", 3, 7);
 
         for start_ts in (10..30).into_iter().step_by(2) {
             must_prewrite_lock(&mut engine, b"k1", b"k1", start_ts);
             must_commit(&mut engine, b"k1", start_ts, start_ts + 1);
             must_prewrite_lock(&mut engine, b"k3", b"k1", start_ts);
             must_commit(&mut engine, b"k3", start_ts, start_ts + 1);
+            must_prewrite_lock(&mut engine, b"k4", b"k1", start_ts);
+            must_commit(&mut engine, b"k4", start_ts, start_ts + 1);
         }
 
         must_prewrite_put(&mut engine, b"k1", b"v13", b"k1", 40);
@@ -1652,7 +1655,11 @@ mod latest_kv_tests {
         // k3  |     27    |   LOCK   |
         // k3  |    ...    |   LOCK   |
         // k3  |     11    |   LOCK   |
-        // k3  |      7    |   PUT    | v31
+        // k4  |     29    |   LOCK   |
+        // k4  |     27    |   LOCK   |
+        // k4  |    ...    |   LOCK   |
+        // k4  |     11    |   LOCK   |
+        // k4  |      7    |   PUT    | v41
 
         let snapshot = engine.snapshot(Default::default()).unwrap();
         let mut scanner = ScannerBuilder::new(snapshot, 35.into())
@@ -1676,11 +1683,11 @@ mod latest_kv_tests {
 
         assert_eq!(
             scanner.next().unwrap(),
-            Some((Key::from_raw(b"k3"), b"v31".to_vec()))
+            Some((Key::from_raw(b"k4"), b"v41".to_vec()))
         );
         let stats = scanner.take_statistics();
-        assert_le!(stats.write.next, 2); // skip k2@6, k3@47
-        assert_eq!(stats.write.seek, 1); // seek k3@7
+        assert_le!(stats.write.next, 1 + SEEK_BOUND as usize); // skip k2@6, near_seek to k4 (8 times next)
+        assert_eq!(stats.write.seek, 2); // seek k4, k4@7
     }
 }
 

--- a/src/storage/mvcc/reader/scanner/forward.rs
+++ b/src/storage/mvcc/reader/scanner/forward.rs
@@ -474,7 +474,8 @@ impl<S: Snapshot> ScanPolicy<S> for LatestKvPolicy {
                 WriteType::Lock | WriteType::Rollback => {
                     if write.versions_to_last_change > 0 && write.last_change_ts.is_zero() {
                         break None;
-                    } else if write.versions_to_last_change < SEEK_BOUND {
+                    }
+                    if write.versions_to_last_change < SEEK_BOUND {
                         // Continue iterate next `write`.
                         cursors.write.next(&mut statistics.write);
                     } else {

--- a/src/storage/txn/actions/prewrite.rs
+++ b/src/storage/txn/actions/prewrite.rs
@@ -439,6 +439,12 @@ impl<'a> PrewriteMutation<'a> {
 
             return Ok(Some((write, commit_ts)));
         }
+        // If seek_ts is max and it goes here, there is no write record for this key.
+        if seek_ts == TimeStamp::max() {
+            // last_change_ts == 0 && versions_to_last_change > 0 means the key actually
+            // does not exist.
+            (self.last_change_ts, self.versions_to_last_change) = (TimeStamp::zero(), 1);
+        }
         Ok(None)
     }
 
@@ -750,6 +756,10 @@ fn amend_pessimistic_lock<S: Snapshot>(
         }
         (mutation.last_change_ts, mutation.versions_to_last_change) =
             write.next_last_change_info(*commit_ts);
+    } else {
+        // last_change_ts == 0 && versions_to_last_change > 0 means the key actually
+        // does not exist.
+        (mutation.last_change_ts, mutation.versions_to_last_change) = (TimeStamp::zero(), 1);
     }
     // Used pipelined pessimistic lock acquiring in this txn but failed
     // Luckily no other txn modified this lock, amend it by treat it as optimistic
@@ -2240,6 +2250,13 @@ pub mod tests {
 
         let mut engine = crate::storage::TestEngineBuilder::new().build().unwrap();
         let key = b"k";
+
+        // Latest version does not exist
+        prewrite_func(&mut engine, LockType::Lock, 2);
+        let lock = must_locked(&mut engine, key, 2);
+        assert!(lock.last_change_ts.is_zero());
+        assert_eq!(lock.versions_to_last_change, 1);
+        must_rollback(&mut engine, key, 2, false);
 
         // Latest change ts should not be enabled on TiKV 6.4
         let feature_gate = FeatureGate::default();


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #13694

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
For non-existing keys, we will record last_change_ts as 0 and set a non-zero
versions_to_last_change. So, if we encounter such a write record when reading,
we can quickly know this key does not exist.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- TODO

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
