### PR TITLE
engine_rocks: make the db creation more safe 

### DIFF
--- a/components/raftstore-v2/src/raft/peer.rs
+++ b/components/raftstore-v2/src/raft/peer.rs
@@ -106,11 +106,12 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
                     region_id
                 ));
             }
-            // TODO: Perhaps we should stop create the tablet automatically.
+
+            // the tablet must exist.
             Some(tablet_factory.open_tablet(
                 region_id,
                 Some(tablet_index),
-                OpenOptions::default().set_create(true),
+                OpenOptions::default(),
             )?)
         } else {
             None


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #12842

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Make the rocksdb creation more safe. It will first create a db in temp path and then rename it to the target path. 
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- None

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
