### PR TITLE
txn: revert "calculate last_change_ts in rollback"

### DIFF
--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -2541,7 +2541,6 @@ pub mod tests {
         engine.commit(k, 1, 2);
 
         // Write enough ROLLBACK/LOCK recrods
-        engine.rollback(k, 5);
         for start_ts in (6..30).into_iter().step_by(2) {
             engine.lock(k, start_ts, start_ts + 1);
         }

--- a/src/storage/mvcc/reader/scanner/forward.rs
+++ b/src/storage/mvcc/reader/scanner/forward.rs
@@ -1625,7 +1625,8 @@ mod latest_kv_tests {
         for start_ts in (10..30).into_iter().step_by(2) {
             must_prewrite_lock(&mut engine, b"k1", b"k1", start_ts);
             must_commit(&mut engine, b"k1", start_ts, start_ts + 1);
-            must_rollback(&mut engine, b"k3", start_ts + 1, true);
+            must_prewrite_lock(&mut engine, b"k3", b"k1", start_ts);
+            must_commit(&mut engine, b"k3", start_ts, start_ts + 1);
         }
 
         must_prewrite_put(&mut engine, b"k1", b"v13", b"k1", 40);
@@ -1647,10 +1648,10 @@ mod latest_kv_tests {
         // k2  |     46    |   PUT    | v22
         // k2  |      6    |   PUT    | v21
         // k3  |     47    |   PUT    | v32
-        // k3  |     29    | ROLLBACK |
-        // k3  |     27    | ROLLBACK |
-        // k3  |    ...    | ROLLBACK |
-        // k3  |     11    | ROLLBACK |
+        // k3  |     29    |   LOCK   |
+        // k3  |     27    |   LOCK   |
+        // k3  |    ...    |   LOCK   |
+        // k3  |     11    |   LOCK   |
         // k3  |      7    |   PUT    | v31
 
         let snapshot = engine.snapshot(Default::default()).unwrap();

--- a/src/storage/txn/actions/check_txn_status.rs
+++ b/src/storage/txn/actions/check_txn_status.rs
@@ -8,7 +8,6 @@ use crate::storage::{
         metrics::MVCC_CHECK_TXN_STATUS_COUNTER_VEC, reader::OverlappedWrite, ErrorInner, LockType,
         MvccTxn, ReleasedLock, Result, SnapshotReader, TxnCommitRecord,
     },
-    txn::{sched_pool::tls_can_enable, scheduler::LAST_CHANGE_TS},
     Snapshot, TxnStatus,
 };
 
@@ -135,8 +134,7 @@ pub fn check_txn_status_missing_lock(
 
             // Insert a Rollback to Write CF in case that a stale prewrite
             // command is received after a cleanup command.
-            if let Some(mut write) = action.construct_write(ts, overlapped_write) {
-                update_last_change_for_rollback(reader, &mut write, &primary_key, ts)?;
+            if let Some(write) = action.construct_write(ts, overlapped_write) {
                 txn.put_write(primary_key, ts, write.as_ref().to_bytes());
             }
             MVCC_CHECK_TXN_STATUS_COUNTER_VEC.rollback.inc();
@@ -170,8 +168,7 @@ pub fn rollback_lock(
 
     // Only the primary key of a pessimistic transaction needs to be protected.
     let protected: bool = is_pessimistic_txn && key.is_encoded_from(&lock.primary);
-    if let Some(mut write) = make_rollback(reader.start_ts, protected, overlapped_write) {
-        update_last_change_for_rollback(reader, &mut write, &key, lock.ts)?;
+    if let Some(write) = make_rollback(reader.start_ts, protected, overlapped_write) {
         txn.put_write(key.clone(), reader.start_ts, write.as_ref().to_bytes());
     }
 
@@ -190,40 +187,6 @@ pub fn collapse_prev_rollback(
     if let Some((commit_ts, write)) = reader.seek_write(key, reader.start_ts)? {
         if write.write_type == WriteType::Rollback && !write.as_ref().is_protected() {
             txn.delete_write(key.clone(), commit_ts);
-        }
-    }
-    Ok(())
-}
-
-/// Updates the last_change_ts of a new Rollback record.
-///
-/// When writing a new Rollback record, we don't always know about the
-/// information about the last change. So, we will call `seek_write` again to
-/// calculate the last_change_ts.
-///
-/// The `seek_write` here is usually cheap because this functions is typically
-/// called after `get_txn_commit_record` and `get_txn_commit_record` should have
-/// moved the cursor around the record we want.
-pub fn update_last_change_for_rollback(
-    reader: &mut SnapshotReader<impl Snapshot>,
-    write: &mut Write,
-    key: &Key,
-    ts: TimeStamp,
-) -> Result<()> {
-    // Also update the last_change_ts if we are writing an overlapped rollback to a
-    // LOCK record. Actually, because overlapped rollbacks are rare, it does not
-    // solve the inaccuracy caused by inserted rollback (and we don't intend it
-    // because it's uncommon). Just do it when it happens.
-    if tls_can_enable(LAST_CHANGE_TS)
-        && (write.write_type == WriteType::Lock || write.write_type == WriteType::Rollback)
-    {
-        if let Some((commit_ts, w)) = reader.seek_write(key, ts)? {
-            // Even with collapsed rollback, the deleted rollbacks will become tombstones
-            // which we probably need to skip them one by one. That's why we always use
-            // `next_last_change_info` here to calculate and count them in
-            // `versions_to_last_change`.
-            (write.last_change_ts, write.versions_to_last_change) =
-                w.next_last_change_info(commit_ts);
         }
     }
     Ok(())

--- a/src/storage/txn/commands/check_secondary_locks.rs
+++ b/src/storage/txn/commands/check_secondary_locks.rs
@@ -8,9 +8,7 @@ use crate::storage::{
     lock_manager::LockManager,
     mvcc::{LockType, MvccTxn, SnapshotReader, TimeStamp, TxnCommitRecord},
     txn::{
-        actions::check_txn_status::{
-            collapse_prev_rollback, make_rollback, update_last_change_for_rollback,
-        },
+        actions::check_txn_status::{collapse_prev_rollback, make_rollback},
         commands::{
             Command, CommandExt, ReaderWithStats, ReleasedLocks, ResponsePolicy, TypedCommand,
             WriteCommand, WriteContext, WriteResult,
@@ -121,10 +119,7 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for CheckSecondaryLocks {
                 }
                 // We must protect this rollback in case this rollback is collapsed and a stale
                 // acquire_pessimistic_lock and prewrite succeed again.
-                if let Some(mut write) =
-                    make_rollback(self.start_ts, true, rollback_overlapped_write)
-                {
-                    update_last_change_for_rollback(&mut reader, &mut write, &key, self.start_ts)?;
+                if let Some(write) = make_rollback(self.start_ts, true, rollback_overlapped_write) {
                     txn.put_write(key.clone(), self.start_ts, write.as_ref().to_bytes());
                     collapse_prev_rollback(&mut txn, &mut reader, &key)?;
                 }
@@ -170,20 +165,14 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for CheckSecondaryLocks {
 pub mod tests {
     use concurrency_manager::ConcurrencyManager;
     use kvproto::kvrpcpb::Context;
-    use tikv_kv::Statistics;
     use tikv_util::deadline::Deadline;
-    use txn_types::Mutation;
 
     use super::*;
     use crate::storage::{
         kv::TestEngineBuilder,
         lock_manager::MockLockManager,
         mvcc::tests::*,
-        txn::{
-            commands::{test_util::prewrite_with_cm, WriteCommand},
-            scheduler::DEFAULT_EXECUTION_DURATION_LIMIT,
-            tests::*,
-        },
+        txn::{commands::WriteCommand, scheduler::DEFAULT_EXECUTION_DURATION_LIMIT, tests::*},
         Engine,
     };
 
@@ -353,117 +342,5 @@ pub mod tests {
             res => panic!("unexpected lock status: {:?}", res),
         }
         must_get_overlapped_rollback(&mut engine, b"k1", 15, 13, WriteType::Lock, Some(0));
-    }
-
-    // The main logic is almost identical to
-    // test_rollback_calculate_last_change_info of check_txn_status. But the small
-    // differences about handling lock CF make it difficult to reuse code.
-    #[test]
-    fn test_rollback_calculate_last_change_info() {
-        use pd_client::FeatureGate;
-
-        use crate::storage::txn::sched_pool::set_tls_feature_gate;
-
-        let mut engine = crate::storage::TestEngineBuilder::new().build().unwrap();
-        let cm = ConcurrencyManager::new(1.into());
-        let k = b"k";
-        let mut statistics = Statistics::default();
-
-        must_prewrite_put(&mut engine, k, b"v1", k, 5);
-        must_commit(&mut engine, k, 5, 6);
-        must_prewrite_put(&mut engine, k, b"v2", k, 7);
-        must_commit(&mut engine, k, 7, 8);
-        must_prewrite_put(&mut engine, k, b"v3", k, 30);
-        must_commit(&mut engine, k, 30, 35);
-
-        // TiKV 6.4 should not write last_change_ts.
-        let feature_gate = FeatureGate::default();
-        feature_gate.set_version("6.4.0").unwrap();
-        set_tls_feature_gate(feature_gate);
-        must_success(&mut engine, k, 40, SecondaryLocksStatus::RolledBack);
-        let rollback = must_written(&mut engine, k, 40, 40, WriteType::Rollback);
-        assert!(rollback.last_change_ts.is_zero());
-        assert_eq!(rollback.versions_to_last_change, 0);
-
-        let feature_gate = FeatureGate::default();
-        feature_gate.set_version("6.5.0").unwrap();
-        set_tls_feature_gate(feature_gate);
-
-        must_prewrite_put(&mut engine, k, b"v4", k, 45);
-        must_commit(&mut engine, k, 45, 50);
-
-        // Rollback when there is no lock; prev writes:
-        // - 50: PUT
-        must_success(&mut engine, k, 55, SecondaryLocksStatus::RolledBack);
-        let rollback = must_written(&mut engine, k, 55, 55, WriteType::Rollback);
-        assert_eq!(rollback.last_change_ts, 50.into());
-        assert_eq!(rollback.versions_to_last_change, 1);
-
-        // Write a LOCK; prev writes:
-        // - 55: ROLLBACK
-        // - 50: PUT
-        let res = prewrite_with_cm(
-            &mut engine,
-            cm,
-            &mut statistics,
-            vec![Mutation::make_lock(Key::from_raw(k))],
-            k.to_vec(),
-            60,
-            Some(70),
-        )
-        .unwrap();
-        assert!(!res.one_pc_commit_ts.is_zero());
-        let lock_commit_ts = res.one_pc_commit_ts;
-        let lock = must_written(&mut engine, k, 60, res.one_pc_commit_ts, WriteType::Lock);
-        assert_eq!(lock.last_change_ts, 50.into());
-        assert_eq!(lock.versions_to_last_change, 2);
-
-        // Write another ROLLBACK by rolling back a pessimistic lock; prev writes:
-        // - 61: LOCK
-        // - 55: ROLLBACK
-        // - 50: PUT
-        must_acquire_pessimistic_lock(&mut engine, k, b"pk", 70, 75);
-        must_success(&mut engine, k, 70, SecondaryLocksStatus::RolledBack);
-        let rollback = must_written(&mut engine, k, 70, 70, WriteType::Rollback);
-        assert_eq!(rollback.last_change_ts, 50.into());
-        assert_eq!(rollback.versions_to_last_change, 3);
-
-        // last_change_ts should point to the latest record before start_ts; prev
-        // writes:
-        // - 8: PUT
-        must_acquire_pessimistic_lock(&mut engine, k, k, 10, 75);
-        must_success(&mut engine, k, 10, SecondaryLocksStatus::RolledBack);
-        must_unlocked(&mut engine, k);
-        let rollback = must_written(&mut engine, k, 10, 10, WriteType::Rollback);
-        assert_eq!(rollback.last_change_ts, 8.into());
-        assert_eq!(rollback.versions_to_last_change, 1);
-
-        // Overlapped rollback should not update the last_change_ts of PUT; prev writes:
-        // - 8: PUT <- rollback overlaps
-        // - 6: PUT
-        must_success(&mut engine, k, 8, SecondaryLocksStatus::RolledBack);
-        let put = must_written(&mut engine, k, 7, 8, WriteType::Put);
-        assert!(put.last_change_ts.is_zero());
-        assert_eq!(put.versions_to_last_change, 0);
-        assert!(put.has_overlapped_rollback);
-
-        // Overlapped rollback can update the last_change_ts of LOCK; writes:
-        // - 61: PUT <- rollback overlaps
-        // - 57: ROLLBACK (inserted later)
-        // - 55: ROLLBACK
-        // - 50: PUT
-        must_rollback(&mut engine, k, 57, true);
-        let rollback = must_written(&mut engine, k, 57, 57, WriteType::Rollback);
-        assert_eq!(rollback.last_change_ts, 50.into());
-        assert_eq!(rollback.versions_to_last_change, 2);
-        must_success(
-            &mut engine,
-            k,
-            lock_commit_ts,
-            SecondaryLocksStatus::RolledBack,
-        );
-        let lock = must_written(&mut engine, k, 60, lock_commit_ts, WriteType::Lock);
-        assert_eq!(lock.last_change_ts, 50.into());
-        assert_eq!(lock.versions_to_last_change, 3);
     }
 }

--- a/src/storage/txn/commands/check_txn_status.rs
+++ b/src/storage/txn/commands/check_txn_status.rs
@@ -144,9 +144,8 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for CheckTxnStatus {
 pub mod tests {
     use concurrency_manager::ConcurrencyManager;
     use kvproto::kvrpcpb::{Context, PrewriteRequestPessimisticAction::*};
-    use tikv_kv::Statistics;
     use tikv_util::deadline::Deadline;
-    use txn_types::{Key, Mutation, WriteType};
+    use txn_types::{Key, WriteType};
 
     use super::{TxnStatus::*, *};
     use crate::storage::{
@@ -154,9 +153,7 @@ pub mod tests {
         lock_manager::MockLockManager,
         mvcc::tests::*,
         txn::{
-            commands::{
-                pessimistic_rollback, test_util::prewrite_with_cm, WriteCommand, WriteContext,
-            },
+            commands::{pessimistic_rollback, WriteCommand, WriteContext},
             scheduler::DEFAULT_EXECUTION_DURATION_LIMIT,
             tests::*,
         },
@@ -1169,105 +1166,24 @@ pub mod tests {
 
     #[test]
     fn test_rollback_calculate_last_change_info() {
-        use pd_client::FeatureGate;
-
-        use crate::storage::txn::sched_pool::set_tls_feature_gate;
-
         let mut engine = crate::storage::TestEngineBuilder::new().build().unwrap();
-        let cm = ConcurrencyManager::new(1.into());
         let k = b"k";
-        let mut statistics = Statistics::default();
+
+        // Below is a case explaining why we don't calculate last_change_ts for
+        // rollback.
 
         must_prewrite_put(&mut engine, k, b"v1", k, 5);
         must_commit(&mut engine, k, 5, 6);
-        must_prewrite_put(&mut engine, k, b"v2", k, 7);
-        must_commit(&mut engine, k, 7, 8);
-        must_prewrite_put(&mut engine, k, b"v3", k, 30);
-        must_commit(&mut engine, k, 30, 35);
 
-        // TiKV 6.4 should not write last_change_ts.
-        let feature_gate = FeatureGate::default();
-        feature_gate.set_version("6.4.0").unwrap();
-        set_tls_feature_gate(feature_gate);
-        must_rollback(&mut engine, k, 40, true);
-        let rollback = must_written(&mut engine, k, 40, 40, WriteType::Rollback);
+        must_prewrite_put(&mut engine, k, b"v2", k, 7);
+        // When we calculate last_change_ts here, we will get 6.
+        must_rollback(&mut engine, k, 10, true);
+        // But we can still commit with ts 8, then the last_change_ts of the rollback
+        // will be incorrect.
+        must_commit(&mut engine, k, 7, 8);
+
+        let rollback = must_written(&mut engine, k, 10, 10, WriteType::Rollback);
         assert!(rollback.last_change_ts.is_zero());
         assert_eq!(rollback.versions_to_last_change, 0);
-
-        let feature_gate = FeatureGate::default();
-        feature_gate.set_version("6.5.0").unwrap();
-        set_tls_feature_gate(feature_gate);
-
-        must_prewrite_put(&mut engine, k, b"v4", k, 45);
-        must_commit(&mut engine, k, 45, 50);
-
-        // Rollback when there is no lock; prev writes:
-        // - 50: PUT
-        must_rollback(&mut engine, k, 55, true);
-        let rollback = must_written(&mut engine, k, 55, 55, WriteType::Rollback);
-        assert_eq!(rollback.last_change_ts, 50.into());
-        assert_eq!(rollback.versions_to_last_change, 1);
-
-        // Write a LOCK; prev writes:
-        // - 55: ROLLBACK
-        // - 50: PUT
-        let res = prewrite_with_cm(
-            &mut engine,
-            cm,
-            &mut statistics,
-            vec![Mutation::make_lock(Key::from_raw(k))],
-            k.to_vec(),
-            60,
-            Some(70),
-        )
-        .unwrap();
-        assert!(!res.one_pc_commit_ts.is_zero());
-        let lock_commit_ts = res.one_pc_commit_ts;
-        let lock = must_written(&mut engine, k, 60, res.one_pc_commit_ts, WriteType::Lock);
-        assert_eq!(lock.last_change_ts, 50.into());
-        assert_eq!(lock.versions_to_last_change, 2);
-
-        // Write another ROLLBACK; prev writes:
-        // - 61: LOCK
-        // - 55: ROLLBACK
-        // - 50: PUT
-        must_rollback(&mut engine, k, 70, true);
-        let rollback = must_written(&mut engine, k, 70, 70, WriteType::Rollback);
-        assert_eq!(rollback.last_change_ts, 50.into());
-        assert_eq!(rollback.versions_to_last_change, 3);
-
-        // last_change_ts should point to the latest record before start_ts; prev
-        // writes:
-        // - 8: PUT
-        must_acquire_pessimistic_lock(&mut engine, k, k, 10, 75);
-        must_pessimistic_prewrite_put(&mut engine, k, b"v5", k, 10, 75, DoPessimisticCheck);
-        must_rollback(&mut engine, k, 10, true);
-        must_unlocked(&mut engine, k);
-        let rollback = must_written(&mut engine, k, 10, 10, WriteType::Rollback);
-        assert_eq!(rollback.last_change_ts, 8.into());
-        assert_eq!(rollback.versions_to_last_change, 1);
-
-        // Overlapped rollback should not update the last_change_ts of PUT; prev writes:
-        // - 8: PUT <- rollback overlaps
-        // - 6: PUT
-        must_rollback(&mut engine, k, 8, true);
-        let put = must_written(&mut engine, k, 7, 8, WriteType::Put);
-        assert!(put.last_change_ts.is_zero());
-        assert_eq!(put.versions_to_last_change, 0);
-        assert!(put.has_overlapped_rollback);
-
-        // Overlapped rollback can update the last_change_ts of LOCK; writes:
-        // - 61: PUT <- rollback overlaps
-        // - 57: ROLLBACK (inserted later)
-        // - 55: ROLLBACK
-        // - 50: PUT
-        must_rollback(&mut engine, k, 57, true);
-        let rollback = must_written(&mut engine, k, 57, 57, WriteType::Rollback);
-        assert_eq!(rollback.last_change_ts, 50.into());
-        assert_eq!(rollback.versions_to_last_change, 2);
-        must_rollback(&mut engine, k, lock_commit_ts, true);
-        let lock = must_written(&mut engine, k, 60, lock_commit_ts, WriteType::Lock);
-        assert_eq!(lock.last_change_ts, 50.into());
-        assert_eq!(lock.versions_to_last_change, 3);
     }
 }


### PR DESCRIPTION
### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref https://github.com/tikv/tikv/issues/13694

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
This commit reverts #13749 (calculate last_change_ts in rollback).

If we calculate last_change_ts, consider the following case:
Key k has a write record with commit_ts = 5.
1. Prewrite k, start_ts = 10
2. Rollback k, start_ts = 30, last_commit_ts = 5.
3. Commit k, start_ts = 10, commit_ts = 20

Then, read with ts = 40, it will get an incorrect last_commit_ts from
the rollback record.

There is no easy way to handle the rollback case. I choose to give up
calculating it.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
