### PR TITLE
storage: introduce hint_min_ts to speed up the flashback progress

### DIFF
--- a/components/cdc/src/old_value.rs
+++ b/components/cdc/src/old_value.rs
@@ -1,6 +1,6 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::ops::Deref;
+use std::ops::{Bound, Deref};
 
 use engine_traits::{ReadOptions, CF_DEFAULT, CF_WRITE};
 use getset::CopyGetters;
@@ -261,7 +261,7 @@ fn new_write_cursor_on_key<S: EngineSnapshot>(snapshot: &S, key: &Key) -> Cursor
         .range(Some(key.clone()), upper)
         // Use bloom filter to speed up seeking on a given prefix.
         .prefix_seek(true)
-        .hint_max_ts(Some(ts))
+        .hint_max_ts(Some(Bound::Included(ts)))
         .build()
         .unwrap()
 }

--- a/components/tikv_kv/src/cursor.rs
+++ b/components/tikv_kv/src/cursor.rs
@@ -432,10 +432,10 @@ pub struct CursorBuilder<'a, S: Snapshot> {
     prefix_seek: bool,
     upper_bound: Option<Key>,
     lower_bound: Option<Key>,
-    // hint for we will only scan data with commit ts >= hint_min_ts
-    hint_min_ts: Option<TimeStamp>,
-    // hint for we will only scan data with commit ts <= hint_max_ts
-    hint_max_ts: Option<TimeStamp>,
+    // hint for we will only scan data with commit_ts >/>= hint_min_ts
+    hint_min_ts: Option<Bound<TimeStamp>>,
+    // hint for we will only scan data with commit_ts </<= hint_max_ts
+    hint_max_ts: Option<Bound<TimeStamp>>,
     key_only: bool,
     max_skippable_internal_keys: u64,
 }
@@ -506,8 +506,8 @@ impl<'a, S: 'a + Snapshot> CursorBuilder<'a, S> {
     /// Default is empty.
     #[inline]
     #[must_use]
-    pub fn hint_min_ts(mut self, min_ts: Option<TimeStamp>) -> Self {
-        self.hint_min_ts = min_ts;
+    pub fn hint_min_ts(mut self, ts_bound: Option<Bound<TimeStamp>>) -> Self {
+        self.hint_min_ts = ts_bound;
         self
     }
 
@@ -516,8 +516,8 @@ impl<'a, S: 'a + Snapshot> CursorBuilder<'a, S> {
     /// Default is empty.
     #[inline]
     #[must_use]
-    pub fn hint_max_ts(mut self, max_ts: Option<TimeStamp>) -> Self {
-        self.hint_max_ts = max_ts;
+    pub fn hint_max_ts(mut self, ts_bound: Option<Bound<TimeStamp>>) -> Self {
+        self.hint_max_ts = ts_bound;
         self
     }
 
@@ -550,11 +550,11 @@ impl<'a, S: 'a + Snapshot> CursorBuilder<'a, S> {
             None
         };
         let mut iter_opt = IterOptions::new(l_bound, u_bound, self.fill_cache);
-        if let Some(ts) = self.hint_min_ts {
-            iter_opt.set_hint_min_ts(Bound::Included(ts.into_inner()));
+        if let Some(ts_bound) = self.hint_min_ts {
+            iter_opt.set_hint_min_ts(ts_bound.map(TimeStamp::into_inner));
         }
-        if let Some(ts) = self.hint_max_ts {
-            iter_opt.set_hint_max_ts(Bound::Included(ts.into_inner()));
+        if let Some(ts_bound) = self.hint_max_ts {
+            iter_opt.set_hint_max_ts(ts_bound.map(TimeStamp::into_inner));
         }
         iter_opt.set_key_only(self.key_only);
         iter_opt.set_max_skippable_internal_keys(self.max_skippable_internal_keys);

--- a/components/tikv_kv/src/lib.rs
+++ b/components/tikv_kv/src/lib.rs
@@ -5,6 +5,7 @@
 //! [`Server`](crate::server::Server). The [`BTreeEngine`](kv::BTreeEngine) and
 //! [`RocksEngine`](RocksEngine) are used for testing only.
 
+#![feature(bound_map)]
 #![feature(min_specialization)]
 #![feature(type_alias_impl_trait)]
 

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -566,29 +566,23 @@ impl<S: EngineSnapshot> MvccReader<S> {
         Ok((locks, has_remain))
     }
 
-    /// Scan the writes to get all the latest keys with their corresponding
-    /// PUT/DELETE write records at the given version, if the version is not
-    /// specified, it will scan the latest version for each key, if the key
-    /// does not exist or is not visible at that point, an `Option::None` will
-    /// be placed. The return type is:
-    /// * `(Vec<(key, Option<write>)>, has_remain)`.
-    ///   - `key` is the encoded key without commit ts.
-    ///   - `write` is the PUT/DELETE write record at the given version.
-    ///   - `has_remain` indicates whether there MAY be remaining writes that
+    /// Scan the writes to get all the latest user keys. The return type is:
+    /// * `(Vec<key>, has_remain)`.
+    ///   - `key` is the encoded user key without `commit_ts`.
+    ///   - `has_remain` indicates whether there MAY be remaining user keys that
     ///     can be scanned.
     ///
     /// This function is mainly used by
     /// `txn::commands::FlashbackToVersionReadPhase`
     /// and `txn::commands::FlashbackToVersion` to achieve the MVCC
     /// overwriting.
-    pub fn scan_writes<F>(
+    pub fn scan_latest_user_keys<F>(
         &mut self,
         start: Option<&Key>,
         end: Option<&Key>,
-        version: Option<TimeStamp>,
         filter: F,
         limit: usize,
-    ) -> Result<(Vec<(Key, Option<Write>)>, bool)>
+    ) -> Result<(Vec<Key>, bool)>
     where
         F: Fn(&Key /* user key */, TimeStamp /* latest `commit_ts` */) -> bool,
     {
@@ -601,10 +595,8 @@ impl<S: EngineSnapshot> MvccReader<S> {
         if !ok {
             return Ok((vec![], false));
         }
-        // Use the latest version as the default value if the version is not given.
-        let version = version.unwrap_or_else(TimeStamp::max);
-        let mut cur_key = None;
-        let mut key_writes = Vec::with_capacity(limit);
+        let mut cur_user_key = None;
+        let mut keys = Vec::with_capacity(limit);
         let mut has_remain = false;
         while cursor.valid()? {
             let key = Key::from_encoded_slice(cursor.key(&mut self.statistics.write));
@@ -618,62 +610,28 @@ impl<S: EngineSnapshot> MvccReader<S> {
             let user_key = key.truncate_ts()?;
             // To make sure we only check each unique user key once and the filter returns
             // true.
-            let is_same_user_key = cur_key.as_ref() == Some(&user_key);
+            let is_same_user_key = cur_user_key.as_ref() == Some(&user_key);
             if !is_same_user_key {
-                cur_key = Some(user_key.clone());
+                cur_user_key = Some(user_key.clone());
             }
             if is_same_user_key || !filter(&user_key, commit_ts) {
                 cursor.next(&mut self.statistics.write);
                 continue;
             }
-
-            let mut write = None;
-            let version_key = user_key.clone().append_ts(version);
-            // Try to seek to the key with the specified version.
-            if cursor.near_seek(&version_key, &mut self.statistics.write)?
-                && Key::is_user_key_eq(
-                    cursor.key(&mut self.statistics.write),
-                    user_key.as_encoded(),
-                )
-            {
-                while cursor.valid()? {
-                    write =
-                        Some(WriteRef::parse(cursor.value(&mut self.statistics.write))?.to_owned());
-                    // Move to the next key.
-                    cursor.next(&mut self.statistics.write);
-                    match write.as_ref().unwrap().write_type {
-                        WriteType::Put | WriteType::Delete => {
-                            break;
-                        }
-                        WriteType::Lock | WriteType::Rollback => {
-                            // Only return the PUT/DELETE write record.
-                            write = None;
-                            // Reach the end.
-                            if !cursor.valid()? {
-                                break;
-                            }
-                            // Try to find the latest visible version before it.
-                            let key =
-                                Key::from_encoded_slice(cursor.key(&mut self.statistics.write));
-                            // Could not find the visible version, current cursor is on the next
-                            // key, so we set `cur_key` to `None`.
-                            if key.truncate_ts()? != user_key {
-                                cur_key = None;
-                                break;
-                            }
-                        }
-                    }
-                }
-            }
-            key_writes.push((user_key, write));
-            if limit > 0 && key_writes.len() == limit {
+            keys.push(user_key.clone());
+            if limit > 0 && keys.len() == limit {
                 has_remain = true;
                 break;
             }
+            // Seek once to skip all the writes of the same user key.
+            cursor.near_seek(
+                &user_key.append_ts(TimeStamp::zero()),
+                &mut self.statistics.write,
+            )?;
         }
-        self.statistics.write.processed_keys += key_writes.len();
-        resource_metering::record_read_keys(key_writes.len() as u32);
-        Ok((key_writes, has_remain))
+        self.statistics.write.processed_keys += keys.len();
+        resource_metering::record_read_keys(keys.len() as u32);
+        Ok((keys, has_remain))
     }
 
     pub fn scan_keys(
@@ -1774,9 +1732,9 @@ pub mod tests {
     }
 
     #[test]
-    fn test_scan_writes() {
+    fn test_scan_latest_user_keys() {
         let path = tempfile::Builder::new()
-            .prefix("_test_storage_mvcc_reader_scan_writes")
+            .prefix("_test_storage_mvcc_reader_scan_latest_user_keys")
             .tempdir()
             .unwrap();
         let path = path.path().to_str().unwrap();
@@ -1876,256 +1834,55 @@ pub mod tests {
         struct Case {
             start_key: Option<Key>,
             end_key: Option<Key>,
-            version: Option<u64>,
             limit: usize,
-            expect_res: Vec<(Key, Option<Write>)>,
+            expect_res: Vec<Key>,
             expect_is_remain: bool,
         }
 
         let cases = vec![
-            // Get all latest writes with the unspecified version.
-            Case {
-                start_key: None,
-                end_key: None,
-                version: None,
-                limit: 4,
-                expect_res: vec![
-                    (
-                        Key::from_raw(b"k0"),
-                        Some(Write::new(
-                            WriteType::Put,
-                            999.into(),
-                            Some(b"v0@999".to_vec()),
-                        )),
-                    ),
-                    (
-                        Key::from_raw(b"k1"),
-                        Some(Write::new(WriteType::Put, 3.into(), Some(b"v1@3".to_vec()))),
-                    ),
-                    (
-                        Key::from_raw(b"k2"),
-                        Some(Write::new(WriteType::Put, 3.into(), Some(b"v2@3".to_vec()))),
-                    ),
-                    (
-                        Key::from_raw(b"k3"),
-                        Some(Write::new(WriteType::Put, 8.into(), Some(b"v3@8".to_vec()))),
-                    ),
-                ],
-                expect_is_remain: true,
-            },
-            // k0 is invisible at version 9.
-            Case {
-                start_key: None,
-                end_key: None,
-                version: Some(9),
-                limit: 4,
-                expect_res: vec![
-                    (Key::from_raw(b"k0"), None),
-                    (
-                        Key::from_raw(b"k1"),
-                        Some(Write::new(WriteType::Put, 3.into(), Some(b"v1@3".to_vec()))),
-                    ),
-                    (
-                        Key::from_raw(b"k2"),
-                        Some(Write::new(WriteType::Put, 3.into(), Some(b"v2@3".to_vec()))),
-                    ),
-                    (
-                        Key::from_raw(b"k3"),
-                        Some(Write::new(WriteType::Put, 8.into(), Some(b"v3@8".to_vec()))),
-                    ),
-                ],
-                expect_is_remain: true,
-            },
-            // k3 has an old version write at version 8.
-            Case {
-                start_key: None,
-                end_key: None,
-                version: Some(8),
-                limit: 4,
-                expect_res: vec![
-                    (Key::from_raw(b"k0"), None),
-                    (
-                        Key::from_raw(b"k1"),
-                        Some(Write::new(WriteType::Put, 3.into(), Some(b"v1@3".to_vec()))),
-                    ),
-                    (
-                        Key::from_raw(b"k2"),
-                        Some(Write::new(WriteType::Put, 3.into(), Some(b"v2@3".to_vec()))),
-                    ),
-                    (
-                        Key::from_raw(b"k3"),
-                        Some(Write::new(WriteType::Put, 5.into(), Some(b"v3@5".to_vec()))),
-                    ),
-                ],
-                expect_is_remain: true,
-            },
-            Case {
-                start_key: None,
-                end_key: None,
-                version: Some(7),
-                limit: 4,
-                expect_res: vec![
-                    (Key::from_raw(b"k0"), None),
-                    (
-                        Key::from_raw(b"k1"),
-                        Some(Write::new(WriteType::Put, 3.into(), Some(b"v1@3".to_vec()))),
-                    ),
-                    (
-                        Key::from_raw(b"k2"),
-                        Some(Write::new(WriteType::Put, 3.into(), Some(b"v2@3".to_vec()))),
-                    ),
-                    (
-                        Key::from_raw(b"k3"),
-                        Some(Write::new(WriteType::Put, 5.into(), Some(b"v3@5".to_vec()))),
-                    ),
-                ],
-                expect_is_remain: true,
-            },
-            Case {
-                start_key: None,
-                end_key: None,
-                version: Some(6),
-                limit: 4,
-                expect_res: vec![
-                    (Key::from_raw(b"k0"), None),
-                    (
-                        Key::from_raw(b"k1"),
-                        Some(Write::new(WriteType::Put, 3.into(), Some(b"v1@3".to_vec()))),
-                    ),
-                    (
-                        Key::from_raw(b"k2"),
-                        Some(Write::new(WriteType::Put, 3.into(), Some(b"v2@3".to_vec()))),
-                    ),
-                    (
-                        Key::from_raw(b"k3"),
-                        Some(Write::new(WriteType::Put, 5.into(), Some(b"v3@5".to_vec()))),
-                    ),
-                ],
-                expect_is_remain: true,
-            },
-            // k3 doesn't exist at version 5.
-            Case {
-                start_key: None,
-                end_key: None,
-                version: Some(5),
-                limit: 4,
-                expect_res: vec![
-                    (Key::from_raw(b"k0"), None),
-                    (
-                        Key::from_raw(b"k1"),
-                        Some(Write::new(WriteType::Put, 3.into(), Some(b"v1@3".to_vec()))),
-                    ),
-                    (
-                        Key::from_raw(b"k2"),
-                        Some(Write::new(WriteType::Put, 3.into(), Some(b"v2@3".to_vec()))),
-                    ),
-                    (Key::from_raw(b"k3"), None),
-                ],
-                expect_is_remain: true,
-            },
-            Case {
-                start_key: None,
-                end_key: None,
-                version: Some(4),
-                limit: 4,
-                expect_res: vec![
-                    (Key::from_raw(b"k0"), None),
-                    (
-                        Key::from_raw(b"k1"),
-                        Some(Write::new(WriteType::Put, 3.into(), Some(b"v1@3".to_vec()))),
-                    ),
-                    (
-                        Key::from_raw(b"k2"),
-                        Some(Write::new(WriteType::Put, 3.into(), Some(b"v2@3".to_vec()))),
-                    ),
-                    (Key::from_raw(b"k3"), None),
-                ],
-                expect_is_remain: true,
-            },
-            // k1 and k2 have old version writes at version 3.
-            Case {
-                start_key: None,
-                end_key: None,
-                version: Some(3),
-                limit: 4,
-                expect_res: vec![
-                    (Key::from_raw(b"k0"), None),
-                    (
-                        Key::from_raw(b"k1"),
-                        Some(Write::new(WriteType::Put, 1.into(), Some(b"v1@1".to_vec()))),
-                    ),
-                    (
-                        Key::from_raw(b"k2"),
-                        Some(Write::new(WriteType::Put, 1.into(), Some(b"v2@1".to_vec()))),
-                    ),
-                    (Key::from_raw(b"k3"), None),
-                ],
-                expect_is_remain: true,
-            },
-            Case {
-                start_key: None,
-                end_key: None,
-                version: Some(2),
-                limit: 4,
-                expect_res: vec![
-                    (Key::from_raw(b"k0"), None),
-                    (
-                        Key::from_raw(b"k1"),
-                        Some(Write::new(WriteType::Put, 1.into(), Some(b"v1@1".to_vec()))),
-                    ),
-                    (
-                        Key::from_raw(b"k2"),
-                        Some(Write::new(WriteType::Put, 1.into(), Some(b"v2@1".to_vec()))),
-                    ),
-                    (Key::from_raw(b"k3"), None),
-                ],
-                expect_is_remain: true,
-            },
-            // All keys don't exist at version 1.
-            Case {
-                start_key: None,
-                end_key: None,
-                version: Some(1),
-                limit: 4,
-                expect_res: vec![
-                    (Key::from_raw(b"k0"), None),
-                    (Key::from_raw(b"k1"), None),
-                    (Key::from_raw(b"k2"), None),
-                    (Key::from_raw(b"k3"), None),
-                ],
-                expect_is_remain: true,
-            },
             // Test the limit.
             Case {
                 start_key: None,
                 end_key: None,
-                version: Some(0),
                 limit: 1,
-                expect_res: vec![(Key::from_raw(b"k0"), None)],
+                expect_res: vec![Key::from_raw(b"k0")],
                 expect_is_remain: true,
             },
             Case {
                 start_key: None,
                 end_key: None,
-                version: Some(0),
                 limit: 6,
                 expect_res: vec![
-                    (Key::from_raw(b"k0"), None),
-                    (Key::from_raw(b"k1"), None),
-                    (Key::from_raw(b"k2"), None),
-                    (Key::from_raw(b"k3"), None),
-                    (Key::from_raw(b"k4"), None),
+                    Key::from_raw(b"k0"),
+                    Key::from_raw(b"k1"),
+                    Key::from_raw(b"k2"),
+                    Key::from_raw(b"k3"),
+                    Key::from_raw(b"k4"),
                 ],
                 expect_is_remain: false,
             },
-            // Test the invisible record.
+            // Test the start/end key.
             Case {
-                start_key: Some(Key::from_raw(b"k4")),
+                start_key: Some(Key::from_raw(b"k2")),
                 end_key: None,
-                version: Some(10),
-                limit: 1,
-                expect_res: vec![(Key::from_raw(b"k4"), None)],
-                expect_is_remain: true,
+                limit: 4,
+                expect_res: vec![
+                    Key::from_raw(b"k2"),
+                    Key::from_raw(b"k3"),
+                    Key::from_raw(b"k4"),
+                ],
+                expect_is_remain: false,
+            },
+            Case {
+                start_key: None,
+                end_key: Some(Key::from_raw(b"k3")),
+                limit: 4,
+                expect_res: vec![
+                    Key::from_raw(b"k0"),
+                    Key::from_raw(b"k1"),
+                    Key::from_raw(b"k2"),
+                ],
+                expect_is_remain: false,
             },
         ];
 
@@ -2133,10 +1890,9 @@ pub mod tests {
             let snap = RegionSnapshot::<RocksSnapshot>::from_raw(db.clone(), region.clone());
             let mut reader = MvccReader::new(snap, Some(ScanMode::Forward), false);
             let res = reader
-                .scan_writes(
+                .scan_latest_user_keys(
                     case.start_key.as_ref(),
                     case.end_key.as_ref(),
-                    case.version.map(Into::into),
                     |_, _| true,
                     case.limit,
                 )

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -476,7 +476,7 @@ impl<S: EngineSnapshot> MvccReader<S> {
                 .prefix_seek(self.scan_mode.is_none())
                 .scan_mode(self.get_scan_mode(true))
                 .range(self.lower_bound.clone(), self.upper_bound.clone())
-                // `hint_min_ts` is only meaningful when it's the `commit_ts`.
+                // `hint_min_ts` filters data by the `commit_ts`.
                 .hint_min_ts(self.hint_min_ts)
                 .build()?;
             self.write_cursor = Some(cursor);

--- a/src/storage/mvcc/reader/scanner/mod.rs
+++ b/src/storage/mvcc/reader/scanner/mod.rs
@@ -4,6 +4,8 @@
 mod backward;
 mod forward;
 
+use std::ops::Bound;
+
 use engine_traits::{CfName, CF_DEFAULT, CF_LOCK, CF_WRITE};
 use kvproto::kvrpcpb::{ExtraOp, IsolationLevel};
 use txn_types::{
@@ -330,8 +332,8 @@ impl<S: Snapshot> ScannerConfig<S> {
             .range(lower, upper)
             .fill_cache(self.fill_cache)
             .scan_mode(scan_mode)
-            .hint_min_ts(hint_min_ts)
-            .hint_max_ts(hint_max_ts)
+            .hint_min_ts(hint_min_ts.map(|ts| Bound::Included(ts)))
+            .hint_max_ts(hint_max_ts.map(|ts| Bound::Included(ts)))
             .build()?;
         Ok(cursor)
     }

--- a/src/storage/txn/actions/flashback_to_version.rs
+++ b/src/storage/txn/actions/flashback_to_version.rs
@@ -1,5 +1,7 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::ops::Bound;
+
 use txn_types::{Key, Lock, TimeStamp, Write, WriteType};
 
 use crate::storage::{
@@ -35,13 +37,17 @@ pub fn flashback_to_version_read_write<S: Snapshot>(
     flashback_commit_ts: TimeStamp,
     statistics: &mut Statistics,
 ) -> TxnResult<Vec<(Key, Option<Write>)>> {
-    // To flashback the data, we need to get all the latest keys first by scanning
-    // every unique key in `CF_WRITE` and to get its corresponding old MVCC write
-    // record if exists.
-    let result = reader.scan_writes(
+    // Filter out the SST that does not have a newer version than
+    // `flashback_version` in `CF_WRITE`, i.e, whose latest `commit_ts` <=
+    // `flashback_version`. By doing this, we can only flashback those keys that
+    // have version changed since `flashback_version` as much as possible.
+    reader.set_hint_min_ts(Some(Bound::Excluded(flashback_version)));
+    // To flashback the data, we need to get all the latest visible keys first by
+    // scanning every unique key in `CF_WRITE`.
+    let key_writes_result = reader.scan_writes(
         Some(&next_write_key),
         Some(end_key),
-        Some(flashback_version),
+        None,
         |_, latest_commit_ts| {
             // There is no any other write could happen after the flashback begins.
             assert!(latest_commit_ts <= flashback_commit_ts);
@@ -54,8 +60,8 @@ pub fn flashback_to_version_read_write<S: Snapshot>(
         FLASHBACK_BATCH_SIZE,
     );
     statistics.add(&reader.statistics);
-    let (key_old_writes, _) = result?;
-    Ok(key_old_writes)
+    let (key_writes, _) = key_writes_result?;
+    Ok(key_writes)
 }
 
 // To flashback the `CF_LOCK`, we need to delete all locks records whose
@@ -87,20 +93,23 @@ pub fn flashback_to_version_lock(
 }
 
 // To flashback the `CF_WRITE` and `CF_DEFAULT`, we need to write a new MVCC
-// record for each key in `self.keys` with its old value at `self.version`,
-// specifically, the flashback will have the following behavior:
-//   - If a key doesn't exist at `self.version`, it will be put a
+// record for each key in `key_writes` with its old value at
+// `flashback_version`, specifically, the flashback will have the following
+// behavior:
+//   - If a key doesn't exist at `flashback_version`, it will be put a
 //     `WriteType::Delete`.
-//   - If a key exists at `self.version`, it will be put the exact same record
-//     in `CF_WRITE` and `CF_DEFAULT` with `self.commit_ts` and `self.start_ts`.
+//   - If a key exists at `flashback_version`, it will be put the exact same
+//     record in `CF_WRITE` and `CF_DEFAULT` with `self.commit_ts` and
+//     `self.start_ts`.
 pub fn flashback_to_version_write(
     txn: &mut MvccTxn,
     reader: &mut SnapshotReader<impl Snapshot>,
-    key_old_writes: Vec<(Key, Option<Write>)>,
-    start_ts: TimeStamp,
-    commit_ts: TimeStamp,
+    key_writes: Vec<(Key, Option<Write>)>,
+    flashback_version: TimeStamp,
+    flashback_start_ts: TimeStamp,
+    flashback_commit_ts: TimeStamp,
 ) -> TxnResult<Option<Key>> {
-    for (key, old_write) in key_old_writes {
+    for (key, _) in key_writes {
         #[cfg(feature = "failpoints")]
         {
             let should_skip = || {
@@ -114,27 +123,32 @@ pub fn flashback_to_version_write(
         if txn.write_size() >= MAX_TXN_WRITE_SIZE {
             return Ok(Some(key.clone()));
         }
+        let old_write = reader.get_write(&key, flashback_version)?;
         let new_write = if let Some(old_write) = old_write {
             // If it's not a short value and it's a `WriteType::Put`, we should put the old
             // value in `CF_DEFAULT` with `self.start_ts` as well.
             if old_write.short_value.is_none() && old_write.write_type == WriteType::Put {
                 txn.put_value(
                     key.clone(),
-                    start_ts,
+                    flashback_start_ts,
                     reader.load_data(&key, old_write.clone())?,
                 );
             }
             Write::new(
                 old_write.write_type,
-                start_ts,
+                flashback_start_ts,
                 old_write.short_value.clone(),
             )
         } else {
             // If the old write doesn't exist, we should put a `WriteType::Delete` record to
             // delete the current key when needed.
-            Write::new(WriteType::Delete, start_ts, None)
+            Write::new(WriteType::Delete, flashback_start_ts, None)
         };
-        txn.put_write(key.clone(), commit_ts, new_write.as_ref().to_bytes());
+        txn.put_write(
+            key.clone(),
+            flashback_commit_ts,
+            new_write.as_ref().to_bytes(),
+        );
     }
     Ok(None)
 }
@@ -187,7 +201,7 @@ pub mod tests {
         let mut rows = txn.modifies.len();
         write(engine, &ctx, txn.into_modifies());
         // Flashback the writes.
-        let key_old_writes = flashback_to_version_read_write(
+        let key_writes = flashback_to_version_read_write(
             &mut reader,
             key,
             &next_key,
@@ -202,7 +216,8 @@ pub mod tests {
         flashback_to_version_write(
             &mut txn,
             &mut snap_reader,
-            key_old_writes,
+            key_writes,
+            version,
             start_ts,
             commit_ts,
         )

--- a/src/storage/txn/commands/flashback_to_version.rs
+++ b/src/storage/txn/commands/flashback_to_version.rs
@@ -45,9 +45,7 @@ impl CommandExt for FlashbackToVersion {
             FlashbackToVersionState::ScanLock { key_locks, .. } => {
                 latch::Lock::new(key_locks.iter().map(|(key, _)| key))
             }
-            FlashbackToVersionState::ScanWrite { key_writes, .. } => {
-                latch::Lock::new(key_writes.iter().map(|(key, _)| key))
-            }
+            FlashbackToVersionState::ScanWrite { keys, .. } => latch::Lock::new(keys.iter()),
         }
     }
 
@@ -57,10 +55,9 @@ impl CommandExt for FlashbackToVersion {
                 .iter()
                 .map(|(key, _)| key.as_encoded().len())
                 .sum(),
-            FlashbackToVersionState::ScanWrite { key_writes, .. } => key_writes
-                .iter()
-                .map(|(key, _)| key.as_encoded().len())
-                .sum(),
+            FlashbackToVersionState::ScanWrite { keys, .. } => {
+                keys.iter().map(|key| key.as_encoded().len()).sum()
+            }
         }
     }
 }
@@ -86,12 +83,12 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for FlashbackToVersion {
             }
             FlashbackToVersionState::ScanWrite {
                 ref mut next_write_key,
-                ref mut key_writes,
+                ref mut keys,
             } => {
                 if let Some(new_next_write_key) = flashback_to_version_write(
                     &mut txn,
                     &mut reader,
-                    mem::take(key_writes),
+                    mem::take(keys),
                     self.version,
                     self.start_ts,
                     self.commit_ts,


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What is changed and how it works?

Issue Number: ref #13800.

What's Changed:

```commit-message
Introduce `hint_min_ts` during the flashback progress to only flashback those keys that have version changed as much as possible.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None.
```
