### PR TITLE
cop: set the error field properly for the batch cop task response

### DIFF
--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -564,8 +564,12 @@ impl<E: Engine> Endpoint<E> {
                         match res {
                             Ok(mut resp) => {
                                 response.set_data(resp.take_data());
-                                response.set_region_error(resp.take_region_error());
-                                response.set_locked(resp.take_locked());
+                                resp.region_error
+                                    .take()
+                                    .map(|err| response.set_region_error(err));
+                                resp.locked
+                                    .take()
+                                    .map(|lock_info| response.set_locked(lock_info));
                                 response.set_other_error(resp.take_other_error());
                                 GLOBAL_TRACKERS.with_tracker(cur_tracker, |tracker| {
                                     tracker.write_scan_detail(

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -564,12 +564,12 @@ impl<E: Engine> Endpoint<E> {
                         match res {
                             Ok(mut resp) => {
                                 response.set_data(resp.take_data());
-                                resp.region_error
-                                    .take()
-                                    .map(|err| response.set_region_error(err));
-                                resp.locked
-                                    .take()
-                                    .map(|lock_info| response.set_locked(lock_info));
+                                if let Some(err) = resp.region_error.take() {
+                                    response.set_region_error(err);
+                                }
+                                if let Some(lock_info) = resp.locked.take() {
+                                    response.set_locked(lock_info);
+                                }
                                 response.set_other_error(resp.take_other_error());
                                 GLOBAL_TRACKERS.with_tracker(cur_tracker, |tracker| {
                                     tracker.write_scan_detail(

--- a/tests/integrations/coprocessor/test_select.rs
+++ b/tests/integrations/coprocessor/test_select.rs
@@ -2176,14 +2176,23 @@ fn test_batch_request() {
                     row_count += 1;
                 }
                 assert_eq!(row_count, expected_len);
+                assert!(region_err.is_none());
+                assert!(locked.is_none());
+                assert!(other_err.is_empty());
             }
             QueryResult::ErrRegion => {
                 assert!(region_err.is_some());
+                assert!(locked.is_none());
+                assert!(other_err.is_empty());
             }
             QueryResult::ErrLocked => {
+                assert!(region_err.is_none());
                 assert!(locked.is_some());
+                assert!(other_err.is_empty());
             }
             QueryResult::ErrOther => {
+                assert!(region_err.is_none());
+                assert!(locked.is_none());
                 assert!(!other_err.is_empty())
             }
         }


### PR DESCRIPTION
Signed-off-by: cfzjywxk <lsswxrxr@163.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #13856 

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Fill the batch task response error field properly, the error field should be None if no error happens.
```

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects



### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
