### PR TITLE
storage: Unify the flashback reader and fix the start_key bug

### DIFF
--- a/components/cdc/tests/integrations/test_cdc.rs
+++ b/components/cdc/tests/integrations/test_cdc.rs
@@ -2533,7 +2533,7 @@ fn test_flashback() {
     let (start_key, end_key) = (b"key0".to_vec(), b"key2".to_vec());
     // Prepare flashback.
     let flashback_start_ts = block_on(suite.cluster.pd_client.get_tso()).unwrap();
-    suite.must_kv_prepare_flashback(region_id, &start_key, flashback_start_ts);
+    suite.must_kv_prepare_flashback(region_id, &start_key, &end_key, flashback_start_ts);
     // resolved ts should not be advanced anymore.
     let mut counter = 0;
     let mut last_resolved_ts = 0;

--- a/components/cdc/tests/mod.rs
+++ b/components/cdc/tests/mod.rs
@@ -586,11 +586,13 @@ impl TestSuite {
         &mut self,
         region_id: u64,
         start_key: &[u8],
+        end_key: &[u8],
         start_ts: TimeStamp,
     ) {
         let mut prepare_flashback_req = PrepareFlashbackToVersionRequest::default();
         prepare_flashback_req.set_context(self.get_context(region_id));
         prepare_flashback_req.set_start_key(start_key.to_vec());
+        prepare_flashback_req.set_end_key(end_key.to_vec());
         prepare_flashback_req.set_start_ts(start_ts.into_inner());
         let prepare_flashback_resp = self
             .get_tikv_client(region_id)

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -206,7 +206,7 @@ impl<S: EngineSnapshot> MvccReader<S> {
     }
 
     /// load the value associated with `key` and pointed by `write`
-    fn load_data(&mut self, key: &Key, write: Write) -> Result<Value> {
+    pub fn load_data(&mut self, key: &Key, write: Write) -> Result<Value> {
         assert_eq!(write.write_type, WriteType::Put);
         if let Some(val) = write.short_value {
             return Ok(val);

--- a/src/storage/txn/actions/flashback_to_version.rs
+++ b/src/storage/txn/actions/flashback_to_version.rs
@@ -600,6 +600,7 @@ pub mod tests {
             2
         );
         must_get(&mut engine, k, ts, v1);
+        must_get(&mut engine, prewrite_key, ts, prewrite_val);
 
         // case 2: start key is after all keys, prewrite will return None.
         let start_key = b"d";
@@ -611,5 +612,9 @@ pub mod tests {
             must_prewrite_flashback_key(&mut engine, start_key, 4, flashback_start_ts),
             0
         );
+        // case 3: start key is valid, end_key is invalid.
+        let first_key = get_first_user_key(&mut reader, &Key::from_raw(b"a"), &Key::from_raw(b""))
+            .unwrap_or_else(|_| Some(Key::from_raw(b"")));
+        assert_eq!(first_key, None);
     }
 }

--- a/src/storage/txn/commands/flashback_to_version.rs
+++ b/src/storage/txn/commands/flashback_to_version.rs
@@ -3,12 +3,13 @@
 // #[PerformanceCriticalPath]
 use std::mem;
 
+use tikv_kv::ScanMode;
 use txn_types::{Key, TimeStamp};
 
 use crate::storage::{
     kv::WriteData,
     lock_manager::LockManager,
-    mvcc::{MvccTxn, SnapshotReader},
+    mvcc::{MvccReader, MvccTxn},
     txn::{
         actions::flashback_to_version::{
             commit_flashback_key, flashback_to_version_write, prewrite_flashback_key,
@@ -16,8 +17,7 @@ use crate::storage::{
         },
         commands::{
             Command, CommandExt, FlashbackToVersionReadPhase, FlashbackToVersionState,
-            ReaderWithStats, ReleasedLocks, ResponsePolicy, TypedCommand, WriteCommand,
-            WriteContext, WriteResult,
+            ReleasedLocks, ResponsePolicy, TypedCommand, WriteCommand, WriteContext, WriteResult,
         },
         latch, Result,
     },
@@ -71,10 +71,8 @@ impl CommandExt for FlashbackToVersion {
 
 impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for FlashbackToVersion {
     fn process_write(mut self, snapshot: S, context: WriteContext<'_, L>) -> Result<WriteResult> {
-        let mut reader = ReaderWithStats::new(
-            SnapshotReader::new_with_ctx(self.version, snapshot, &self.ctx),
-            context.statistics,
-        );
+        let mut reader =
+            MvccReader::new_with_ctx(snapshot.clone(), Some(ScanMode::Forward), &self.ctx);
         let mut txn = MvccTxn::new(TimeStamp::zero(), context.concurrency_manager);
         match self.state {
             FlashbackToVersionState::RollbackLock {
@@ -82,12 +80,11 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for FlashbackToVersion {
                 ref mut key_locks,
             } => {
                 if let Some(new_next_lock_key) =
-                    rollback_locks(&mut txn, &mut reader, mem::take(key_locks))?
+                    rollback_locks(&mut txn, snapshot, mem::take(key_locks))?
                 {
                     *next_lock_key = new_next_lock_key;
                 }
             }
-            // TODO: add some test cases for the special prewrite key.
             FlashbackToVersionState::Prewrite { ref key_to_lock } => prewrite_flashback_key(
                 &mut txn,
                 &mut reader,

--- a/src/storage/txn/commands/flashback_to_version.rs
+++ b/src/storage/txn/commands/flashback_to_version.rs
@@ -89,6 +89,7 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for FlashbackToVersion {
                 &mut txn,
                 &mut reader,
                 key_to_lock,
+                &self.end_key,
                 self.version,
                 self.start_ts,
             )?,

--- a/src/storage/txn/commands/flashback_to_version.rs
+++ b/src/storage/txn/commands/flashback_to_version.rs
@@ -124,6 +124,7 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for FlashbackToVersion {
         if matches!(self.state, FlashbackToVersionState::FlashbackWrite { .. }) {
             write_data.extra.one_pc = true;
         }
+        context.statistics.add(&reader.statistics);
         Ok(WriteResult {
             ctx: self.ctx.clone(),
             to_be_write: write_data,

--- a/src/storage/txn/commands/flashback_to_version_read_phase.rs
+++ b/src/storage/txn/commands/flashback_to_version_read_phase.rs
@@ -155,15 +155,24 @@ impl<S: Snapshot> ReadCommand<S> for FlashbackToVersionReadPhase {
                     }));
                 }
                 if next_write_key == self.start_key {
-                    // Get real key first.
+                    // The start key from the client is actually a range which is used to limit the
+                    // upper bound of this flashback when scanning data, so it may not be a real
+                    // key. In the Prewrite Phase, we make sure that the start
+                    // key is a real key and take this key as a lock for the
+                    // 2pc. So When overwriting the write, we skip the immediate
+                    // write of this key and instead put it after the completion
+                    // of the 2pc.
                     next_write_key = if let Some(first_key) =
                         get_first_user_key(&mut reader, &self.start_key, &self.end_key)?
                     {
                         first_key
                     } else {
+                        // If the key is None return directly
                         statistics.add(&reader.statistics);
                         return Ok(ProcessResult::Res);
                     };
+                    // Commit key needs to match the Prewrite key, which is set as the first user
+                    // key.
                     start_key = next_write_key.clone();
                     // If the key is not locked, it means that the key has been committed before and
                     // we are in a retry.


### PR DESCRIPTION
Signed-off-by: husharp <jinhao.hu@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #13861  Close https://github.com/pingcap/tiflash/issues/6379 Ref #13800 

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
SnapshotReader typically uses its own start_ts for something. Since it doesn't need the start_ts of SnapshotReader itself,  
we can unify the reader into MvccReader.
And the start key from the client is actually a range, which is used to limit the upper bound of this flashback when scanning data, so it may not be a real key.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
