### PR TITLE
tikv_kv: introduce raft extension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6453,6 +6453,7 @@ dependencies = [
  "pd_client",
  "prometheus",
  "prometheus-static-metric",
+ "raft",
  "raftstore",
  "slog",
  "slog-global",

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -76,8 +76,8 @@ use raftstore::{
             RaftBatchSystem, RaftRouter, StoreMeta, MULTI_FILES_SNAPSHOT_FEATURE, PENDING_MSG_CAP,
         },
         memory::MEMTRACE_ROOT as MEMTRACE_RAFTSTORE,
-        AutoSplitController, CheckLeaderRunner, GlobalReplicationState, LocalReader, SnapManager,
-        SnapManagerBuilder, SplitCheckRunner, SplitConfigManager, StoreMetaDelegate,
+        AutoSplitController, CheckLeaderRunner, LocalReader, SnapManager, SnapManagerBuilder,
+        SplitCheckRunner, SplitConfigManager, StoreMetaDelegate,
     },
     RaftRouterCompactedEventSender,
 };
@@ -221,8 +221,7 @@ struct TikvServer<ER: RaftEngine> {
     flow_info_sender: Option<mpsc::Sender<FlowInfo>>,
     flow_info_receiver: Option<mpsc::Receiver<FlowInfo>>,
     system: Option<RaftBatchSystem<RocksEngine, ER>>,
-    resolver: resolve::PdStoreAddrResolver,
-    state: Arc<Mutex<GlobalReplicationState>>,
+    resolver: Option<resolve::PdStoreAddrResolver>,
     store_path: PathBuf,
     snap_mgr: Option<SnapManager>, // Will be filled in `init_servers`.
     encryption_key_manager: Option<Arc<DataKeyManager>>,
@@ -260,8 +259,7 @@ struct Servers<EK: KvEngine, ER: RaftEngine> {
     backup_stream_scheduler: Option<tikv_util::worker::Scheduler<backup_stream::Task>>,
 }
 
-type LocalServer<EK, ER> =
-    Server<RaftRouter<EK, ER>, resolve::PdStoreAddrResolver, LocalRaftKv<EK, ER>>;
+type LocalServer<EK, ER> = Server<resolve::PdStoreAddrResolver, LocalRaftKv<EK, ER>>;
 type LocalRaftKv<EK, ER> = RaftKv<EK, ServerRaftStoreRouter<EK, ER>>;
 
 impl<ER> TikvServer<ER>
@@ -323,8 +321,6 @@ where
         let background_worker = WorkerBuilder::new("background")
             .thread_count(thread_count)
             .create();
-        let (resolver, state) =
-            resolve::new_resolver(Arc::clone(&pd_client), &background_worker, router.clone());
 
         let mut coprocessor_host = Some(CoprocessorHost::new(
             router.clone(),
@@ -375,8 +371,7 @@ where
             pd_client,
             router,
             system: Some(system),
-            resolver,
-            state,
+            resolver: None,
             store_path,
             snap_mgr: None,
             encryption_key_manager: None,
@@ -655,14 +650,10 @@ where
 
     fn init_gc_worker(
         &mut self,
-    ) -> GcWorker<
-        RaftKv<RocksEngine, ServerRaftStoreRouter<RocksEngine, ER>>,
-        RaftRouter<RocksEngine, ER>,
-    > {
+    ) -> GcWorker<RaftKv<RocksEngine, ServerRaftStoreRouter<RocksEngine, ER>>> {
         let engines = self.engines.as_ref().unwrap();
         let gc_worker = GcWorker::new(
             engines.engine.clone(),
-            self.router.clone(),
             self.flow_info_sender.take().unwrap(),
             self.config.gc.clone(),
             self.pd_client.feature_gate().clone(),
@@ -823,6 +814,13 @@ where
             )),
         );
 
+        let (resolver, state) = resolve::new_resolver(
+            self.pd_client.clone(),
+            &self.background_worker,
+            storage.get_engine().raft_extension().clone(),
+        );
+        self.resolver = Some(resolver);
+
         ReplicaReadLockChecker::new(self.concurrency_manager.clone())
             .register(self.coprocessor_host.as_mut().unwrap());
 
@@ -930,7 +928,7 @@ where
             raft_store.clone(),
             self.config.storage.api_version(),
             self.pd_client.clone(),
-            self.state.clone(),
+            state,
             self.background_worker.clone(),
             Some(health_service.clone()),
             None,
@@ -953,8 +951,7 @@ where
                 Arc::clone(&self.quota_limiter),
             ),
             coprocessor_v2::Endpoint::new(&self.config.coprocessor_v2),
-            self.router.clone(),
-            self.resolver.clone(),
+            self.resolver.clone().unwrap(),
             snap_mgr.clone(),
             gc_worker.clone(),
             check_leader_scheduler,
@@ -1203,7 +1200,7 @@ where
         let debug_service = DebugService::new(
             engines.engines.clone(),
             servers.server.get_debug_thread_pool().clone(),
-            self.router.clone(),
+            engines.engine.raft_extension().clone(),
             self.cfg_controller.as_ref().unwrap().clone(),
         );
         if servers
@@ -1242,7 +1239,7 @@ where
             .start(
                 servers.node.id(),
                 self.pd_client.clone(),
-                self.resolver.clone(),
+                self.resolver.clone().unwrap(),
                 self.security_mgr.clone(),
                 &self.config.pessimistic_txn,
             )

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -33,7 +33,7 @@ use pd_client::PdClient;
 use raftstore::{
     coprocessor::{CoprocessorHost, RegionInfoAccessor},
     errors::Error as RaftError,
-    router::{LocalReadRouter, RaftStoreBlackHole, RaftStoreRouter, ServerRaftStoreRouter},
+    router::{LocalReadRouter, RaftStoreRouter, ServerRaftStoreRouter},
     store::{
         fsm::{store::StoreMeta, ApplyRouter, RaftBatchSystem, RaftRouter},
         msg::RaftCmdExtraOpts,
@@ -64,7 +64,7 @@ use tikv::{
     },
     storage::{
         self,
-        kv::SnapContext,
+        kv::{FakeExtension, SnapContext},
         txn::flow_controller::{EngineFlowController, FlowController},
         Engine,
     },
@@ -84,10 +84,11 @@ use super::*;
 use crate::Config;
 
 type SimulateStoreTransport = SimulateTransport<ServerRaftStoreRouter<RocksEngine, RaftTestEngine>>;
-type SimulateServerTransport =
-    SimulateTransport<ServerTransport<SimulateStoreTransport, PdStoreAddrResolver, RocksEngine>>;
 
 pub type SimulateEngine = RaftKv<RocksEngine, SimulateStoreTransport>;
+type SimulateRaftExtension = <SimulateEngine as Engine>::RaftExtension;
+type SimulateServerTransport =
+    SimulateTransport<ServerTransport<SimulateRaftExtension, PdStoreAddrResolver>>;
 
 #[derive(Default, Clone)]
 pub struct AddressMap {
@@ -125,12 +126,12 @@ impl StoreAddrResolver for AddressMap {
 
 struct ServerMeta {
     node: Node<TestPdClient, RocksEngine, RaftTestEngine>,
-    server: Server<SimulateStoreTransport, PdStoreAddrResolver, SimulateEngine>,
+    server: Server<PdStoreAddrResolver, SimulateEngine>,
     sim_router: SimulateStoreTransport,
     sim_trans: SimulateServerTransport,
     raw_router: RaftRouter<RocksEngine, RaftTestEngine>,
     raw_apply_router: ApplyRouter<RocksEngine>,
-    gc_worker: GcWorker<RaftKv<RocksEngine, SimulateStoreTransport>, SimulateStoreTransport>,
+    gc_worker: GcWorker<RaftKv<RocksEngine, SimulateStoreTransport>>,
     rts_worker: Option<LazyWorker<resolved_ts::Task>>,
     rsmeter_cleanup: Box<dyn FnOnce()>,
 }
@@ -152,7 +153,7 @@ pub struct ServerCluster {
     snap_paths: HashMap<u64, TempDir>,
     snap_mgrs: HashMap<u64, SnapManager>,
     pd_client: Arc<TestPdClient>,
-    raft_client: RaftClient<AddressMap, RaftStoreBlackHole, RocksEngine>,
+    raft_client: RaftClient<AddressMap, FakeExtension>,
     concurrency_managers: HashMap<u64, ConcurrencyManager>,
     env: Arc<Environment>,
     pub causal_ts_providers: HashMap<u64, Arc<CausalTsProviderImpl>>,
@@ -176,7 +177,7 @@ impl ServerCluster {
             Arc::default(),
             security_mgr.clone(),
             map.clone(),
-            RaftStoreBlackHole,
+            FakeExtension,
             worker.scheduler(),
             Arc::new(ThreadLoadPool::with_threshold(usize::MAX)),
         );
@@ -218,7 +219,7 @@ impl ServerCluster {
     pub fn get_gc_worker(
         &self,
         node_id: u64,
-    ) -> &GcWorker<RaftKv<RocksEngine, SimulateStoreTransport>, SimulateStoreTransport> {
+    ) -> &GcWorker<RaftKv<RocksEngine, SimulateStoreTransport>> {
         &self.metas.get(&node_id).unwrap().gc_worker
     }
 
@@ -334,7 +335,6 @@ impl ServerCluster {
         let (tx, _rx) = std::sync::mpsc::channel();
         let mut gc_worker = GcWorker::new(
             engine.clone(),
-            sim_router.clone(),
             tx,
             cfg.gc.clone(),
             Default::default(),
@@ -353,7 +353,7 @@ impl ServerCluster {
             let rts_endpoint = resolved_ts::Endpoint::new(
                 &cfg.resolved_ts,
                 rts_worker.scheduler(),
-                raft_router.clone(),
+                raft_router,
                 store_meta.clone(),
                 self.pd_client.clone(),
                 concurrency_manager.clone(),
@@ -401,6 +401,7 @@ impl ServerCluster {
             cfg.quota.max_delay_duration,
             cfg.quota.enable_auto_tune,
         ));
+        let extension = engine.raft_extension().clone();
         let store = create_raft_storage::<_, _, _, F, _>(
             engine,
             &cfg.storage,
@@ -445,7 +446,7 @@ impl ServerCluster {
 
         // Create pd client, snapshot manager, server.
         let (resolver, state) =
-            resolve::new_resolver(Arc::clone(&self.pd_client), &bg_worker, router.clone());
+            resolve::new_resolver(Arc::clone(&self.pd_client), &bg_worker, extension.clone());
         let snap_mgr = SnapManagerBuilder::default()
             .max_write_bytes_per_sec(cfg.server.snap_max_write_bytes_per_sec.0 as i64)
             .max_total_size(cfg.server.snap_max_total_size.0)
@@ -483,7 +484,7 @@ impl ServerCluster {
         let debug_service = DebugService::new(
             engines.clone(),
             debug_thread_handle,
-            raft_router,
+            extension,
             ConfigController::default(),
         );
 
@@ -520,7 +521,6 @@ impl ServerCluster {
                 store.clone(),
                 copr.clone(),
                 copr_v2.clone(),
-                sim_router.clone(),
                 resolver.clone(),
                 snap_mgr.clone(),
                 gc_worker.clone(),

--- a/components/test_storage/src/sync_storage.rs
+++ b/components/test_storage/src/sync_storage.rs
@@ -12,10 +12,7 @@ use kvproto::{
     kvrpcpb::{ChecksumAlgorithm, Context, GetRequest, KeyRange, LockInfo, RawGetRequest},
     metapb,
 };
-use raftstore::{
-    coprocessor::{region_info_accessor::MockRegionInfoProvider, RegionInfoProvider},
-    router::RaftStoreBlackHole,
-};
+use raftstore::coprocessor::{region_info_accessor::MockRegionInfoProvider, RegionInfoProvider};
 use tikv::{
     server::gc_worker::{AutoGcConfig, GcConfig, GcSafePointProvider, GcWorker},
     storage::{
@@ -106,7 +103,7 @@ impl<E: Engine, F: KvFormat> SyncTestStorageBuilder<E, F> {
 /// Only used for test purpose.
 #[derive(Clone)]
 pub struct SyncTestStorage<E: Engine, F: KvFormat> {
-    gc_worker: GcWorker<E, RaftStoreBlackHole>,
+    gc_worker: GcWorker<E>,
     store: Storage<E, MockLockManager, F>,
 }
 
@@ -123,7 +120,6 @@ impl<E: Engine, F: KvFormat> SyncTestStorage<E, F> {
         let (tx, _rx) = std::sync::mpsc::channel();
         let mut gc_worker = GcWorker::new(
             storage.get_engine(),
-            RaftStoreBlackHole,
             tx,
             config,
             Default::default(),

--- a/components/tikv_kv/Cargo.toml
+++ b/components/tikv_kv/Cargo.toml
@@ -41,6 +41,7 @@ log_wrappers = { workspace = true }
 pd_client = { workspace = true }
 prometheus = { version = "0.13", features = ["nightly"] }
 prometheus-static-metric = "0.5"
+raft = { version = "0.7.0", default-features = false, features = ["protobuf-codec"] }
 raftstore = { workspace = true }
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }

--- a/components/tikv_kv/src/mock_engine.rs
+++ b/components/tikv_kv/src/mock_engine.rs
@@ -153,6 +153,11 @@ impl Engine for MockEngine {
         self.base.kv_engine()
     }
 
+    type RaftExtension = <RocksEngine as Engine>::RaftExtension;
+    fn raft_extension(&self) -> &Self::RaftExtension {
+        self.base.raft_extension()
+    }
+
     fn modify_on_kv_engine(&self, region_modifies: HashMap<u64, Vec<Modify>>) -> Result<()> {
         self.base.modify_on_kv_engine(region_modifies)
     }

--- a/components/tikv_kv/src/raft_extension.rs
+++ b/components/tikv_kv/src/raft_extension.rs
@@ -1,0 +1,69 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+//! TiKV uses raft under the hook to provide consistency between replicas.
+//! Though technically, `Engine` trait should hide the details of raft, but in
+//! some cases it's unavoidable to access raft interface somehow. This module
+//! supports the access pattern via extension.
+
+use futures::future::BoxFuture;
+use kvproto::{
+    metapb::{Region, RegionEpoch},
+    raft_serverpb::RaftMessage,
+};
+use raft::SnapshotStatus;
+use raftstore::store::region_meta::RegionMeta;
+
+use crate::Result;
+
+/// An interface to provide direct access to raftstore layer.
+pub trait RaftExtension: Clone + Send {
+    /// Feed the message to the raft group.
+    ///
+    /// If it's a `key_message` is true, it will log a warning if the message
+    /// failed to send.
+    fn feed(&self, _msg: RaftMessage, _key_message: bool) {}
+
+    /// Retport the message is rejected by the remote peer.
+    fn report_reject_message(&self, _region_id: u64, _from_peer_id: u64) {}
+
+    /// Report the target peer is unreachable.
+    fn report_peer_unreachable(&self, _region_id: u64, _to_peer_id: u64) {}
+
+    /// Report the target store is unreachable.
+    fn report_store_unreachable(&self, _store_id: u64) {}
+
+    /// Report the status of snapshot.
+    fn report_snapshot_status(&self, _region_id: u64, _to_peer_id: u64, _status: SnapshotStatus) {}
+
+    /// Report the address of a store is resolved.
+    fn report_resolved(&self, _store_id: u64, _group_id: u64) {}
+
+    /// Split the region with the given keys.
+    ///
+    /// Use `BoxFuture` for simplicity as it's not performance critical path.
+    fn split(
+        &self,
+        _region_id: u64,
+        _region_epoch: RegionEpoch,
+        _split_keys: Vec<Vec<u8>>,
+        _source: String,
+    ) -> BoxFuture<'static, Result<Vec<Region>>> {
+        Box::pin(async move { Err(box_err!("raft split is not supported")) })
+    }
+
+    /// Get the region meta of the given region.
+    fn query_region(&self, _region_id: u64) -> BoxFuture<'static, Result<RegionMeta>> {
+        Box::pin(async move { Err(box_err!("query region is not supported")) })
+    }
+
+    /// Ask the raft group to do a consistency check.
+    fn check_consistency(&self, _region_id: u64) -> BoxFuture<'static, Result<()>> {
+        Box::pin(async move { Err(box_err!("consistency check is not supported")) })
+    }
+}
+
+/// An extension that does nothing or panic on all operations.
+#[derive(Clone)]
+pub struct FakeExtension;
+
+impl RaftExtension for FakeExtension {}

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -24,7 +24,7 @@ use file_system::{IoType, WithIoType};
 use futures::executor::block_on;
 use kvproto::{kvrpcpb::Context, metapb::Region};
 use pd_client::{FeatureGate, PdClient};
-use raftstore::{coprocessor::RegionInfoProvider, router::RaftStoreRouter, store::msg::StoreMsg};
+use raftstore::coprocessor::RegionInfoProvider;
 use tikv_kv::{CfStatistics, CursorBuilder, Modify, SnapContext};
 use tikv_util::{
     config::{Tracker, VersionTrack},
@@ -174,15 +174,10 @@ where
 }
 
 /// Used to perform GC operations on the engine.
-pub struct GcRunner<E, RR>
-where
-    E: Engine,
-    RR: RaftStoreRouter<E::Local>,
-{
+pub struct GcRunner<E: Engine> {
     store_id: u64,
     engine: E,
 
-    raft_store_router: RR,
     flow_info_sender: Sender<FlowInfo>,
 
     /// Used to limit the write flow of GC.
@@ -283,15 +278,10 @@ fn init_snap_ctx(store_id: u64, region: &Region) -> Context {
     ctx
 }
 
-impl<E, RR> GcRunner<E, RR>
-where
-    E: Engine,
-    RR: RaftStoreRouter<E::Local>,
-{
+impl<E: Engine> GcRunner<E> {
     pub fn new(
         store_id: u64,
         engine: E,
-        raft_store_router: RR,
         flow_info_sender: Sender<FlowInfo>,
         cfg_tracker: Tracker<GcConfig>,
         cfg: GcConfig,
@@ -304,7 +294,6 @@ where
         Self {
             store_id,
             engine,
-            raft_store_router,
             flow_info_sender,
             limiter,
             cfg,
@@ -797,15 +786,10 @@ where
                 .send(FlowInfo::AfterUnsafeDestroyRange(ctx.region_id))
                 .unwrap();
 
-            self.raft_store_router
-            .send_store_msg(StoreMsg::ClearRegionSizeInRange {
-                start_key: start_key.as_encoded().to_vec(),
-                end_key: end_key.as_encoded().to_vec(),
-            })
-            .unwrap_or_else(|e| {
-                // Warn and ignore it.
-                warn!("unsafe destroy range: failed sending ClearRegionSizeInRange"; "err" => ?e);
-            });
+            self.engine.hint_change_in_range(
+                start_key.as_encoded().to_vec(),
+                end_key.as_encoded().to_vec(),
+            );
         } else {
             let cfs = &[CF_LOCK, CF_DEFAULT, CF_WRITE];
             let keys = vec![start_key.clone(), end_key.clone()];
@@ -889,11 +873,7 @@ where
     }
 }
 
-impl<E, RR> Runnable for GcRunner<E, RR>
-where
-    E: Engine,
-    RR: RaftStoreRouter<E::Local>,
-{
+impl<E: Engine> Runnable for GcRunner<E> {
     type Task = GcTask<E::Local>;
 
     #[inline]
@@ -1072,16 +1052,12 @@ pub fn sync_gc(
 }
 
 /// Used to schedule GC operations.
-pub struct GcWorker<E, RR>
+pub struct GcWorker<E>
 where
     E: Engine,
-    RR: RaftStoreRouter<E::Local> + 'static,
 {
     engine: E,
 
-    /// `raft_store_router` is useful to signal raftstore clean region size
-    /// informations.
-    raft_store_router: RR,
     /// Used to signal unsafe destroy range is executed.
     flow_info_sender: Option<Sender<FlowInfo>>,
     region_info_provider: Arc<dyn RegionInfoProvider>,
@@ -1098,18 +1074,13 @@ where
     feature_gate: FeatureGate,
 }
 
-impl<E, RR> Clone for GcWorker<E, RR>
-where
-    E: Engine,
-    RR: RaftStoreRouter<E::Local>,
-{
+impl<E: Engine> Clone for GcWorker<E> {
     #[inline]
     fn clone(&self) -> Self {
         self.refs.fetch_add(1, Ordering::SeqCst);
 
         Self {
             engine: self.engine.clone(),
-            raft_store_router: self.raft_store_router.clone(),
             flow_info_sender: self.flow_info_sender.clone(),
             config_manager: self.config_manager.clone(),
             refs: self.refs.clone(),
@@ -1122,11 +1093,7 @@ where
     }
 }
 
-impl<E, RR> Drop for GcWorker<E, RR>
-where
-    E: Engine,
-    RR: RaftStoreRouter<E::Local> + 'static,
-{
+impl<E: Engine> Drop for GcWorker<E> {
     #[inline]
     fn drop(&mut self) {
         let refs = self.refs.fetch_sub(1, Ordering::SeqCst);
@@ -1142,25 +1109,19 @@ where
     }
 }
 
-impl<E, RR> GcWorker<E, RR>
-where
-    E: Engine,
-    RR: RaftStoreRouter<E::Local>,
-{
+impl<E: Engine> GcWorker<E> {
     pub fn new(
         engine: E,
-        raft_store_router: RR,
         flow_info_sender: Sender<FlowInfo>,
         cfg: GcConfig,
         feature_gate: FeatureGate,
         region_info_provider: Arc<dyn RegionInfoProvider>,
-    ) -> GcWorker<E, RR> {
+    ) -> Self {
         let worker_builder = WorkerBuilder::new("gc-worker").pending_capacity(GC_MAX_PENDING_TASKS);
         let worker = worker_builder.create().lazy_build("gc-worker");
         let worker_scheduler = worker.scheduler();
         GcWorker {
             engine,
-            raft_store_router,
             flow_info_sender: Some(flow_info_sender),
             config_manager: GcWorkerConfigManager(Arc::new(VersionTrack::new(cfg))),
             refs: Arc::new(AtomicUsize::new(1)),
@@ -1211,7 +1172,6 @@ where
         let runner = GcRunner::new(
             store_id,
             self.engine.clone(),
-            self.raft_store_router.clone(),
             self.flow_info_sender.take().unwrap(),
             self.config_manager.0.clone().tracker("gc-woker".to_owned()),
             self.config_manager.value().clone(),
@@ -1468,12 +1428,9 @@ mod tests {
     use futures::executor::block_on;
     use kvproto::{kvrpcpb::ApiVersion, metapb::Peer};
     use raft::StateRole;
-    use raftstore::{
-        coprocessor::{
-            region_info_accessor::{MockRegionInfoProvider, RegionInfoAccessor},
-            CoprocessorHost, RegionChangeEvent,
-        },
-        router::RaftStoreBlackHole,
+    use raftstore::coprocessor::{
+        region_info_accessor::{MockRegionInfoProvider, RegionInfoAccessor},
+        CoprocessorHost, RegionChangeEvent,
     };
     use tempfile::Builder;
     use tikv_kv::Snapshot;
@@ -1620,7 +1577,6 @@ mod tests {
 
         let mut gc_worker = GcWorker::new(
             engine,
-            RaftStoreBlackHole,
             tx,
             GcConfig::default(),
             gate,
@@ -1797,7 +1753,6 @@ mod tests {
 
         let mut gc_worker = GcWorker::new(
             prefixed_engine.clone(),
-            RaftStoreBlackHole,
             tx,
             GcConfig::default(),
             feature_gate,
@@ -1889,7 +1844,6 @@ mod tests {
         let mut runner = GcRunner::new(
             store_id,
             prefixed_engine.clone(),
-            RaftStoreBlackHole,
             tx,
             GcWorkerConfigManager(Arc::new(VersionTrack::new(cfg.clone())))
                 .0
@@ -1952,7 +1906,6 @@ mod tests {
         let mut runner = GcRunner::new(
             store_id,
             prefixed_engine.clone(),
-            RaftStoreBlackHole,
             tx,
             GcWorkerConfigManager(Arc::new(VersionTrack::new(cfg.clone())))
                 .0
@@ -2054,7 +2007,6 @@ mod tests {
         let mut runner = GcRunner::new(
             1,
             prefixed_engine.clone(),
-            RaftStoreBlackHole,
             tx,
             GcWorkerConfigManager(Arc::new(VersionTrack::new(cfg.clone())))
                 .0
@@ -2183,7 +2135,6 @@ mod tests {
 
         let mut gc_worker = GcWorker::new(
             engine.clone(),
-            RaftStoreBlackHole,
             tx,
             GcConfig::default(),
             gate,
@@ -2313,7 +2264,7 @@ mod tests {
     ) -> (
         MultiRocksEngine,
         Arc<MockRegionInfoProvider>,
-        GcRunner<MultiRocksEngine, RaftStoreBlackHole>,
+        GcRunner<MultiRocksEngine>,
         Vec<Region>,
         mpsc::Receiver<FlowInfo>,
     ) {
@@ -2369,7 +2320,6 @@ mod tests {
         let gc_runner = GcRunner::new(
             store_id,
             engine.clone(),
-            RaftStoreBlackHole,
             tx,
             GcWorkerConfigManager(Arc::new(VersionTrack::new(cfg.clone())))
                 .0
@@ -2548,7 +2498,6 @@ mod tests {
         let mut gc_runner = GcRunner::new(
             store_id,
             engine.clone(),
-            RaftStoreBlackHole,
             tx,
             GcWorkerConfigManager(Arc::new(VersionTrack::new(cfg.clone())))
                 .0

--- a/src/server/raftkv/raft_extension.rs
+++ b/src/server/raftkv/raft_extension.rs
@@ -1,0 +1,158 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::marker::PhantomData;
+
+use futures::future::BoxFuture;
+use kvproto::{
+    metapb::{Region, RegionEpoch},
+    raft_cmdpb::{AdminCmdType, RaftCmdRequest},
+    raft_serverpb::RaftMessage,
+};
+use raft::SnapshotStatus;
+use raftstore::{
+    router::RaftStoreRouter,
+    store::{
+        region_meta::{RaftStateRole, RegionMeta},
+        CasualMessage,
+    },
+};
+use tikv_util::future::paired_future_callback;
+
+use crate::storage::kv;
+
+#[derive(Clone)]
+pub struct RaftRouterWrap<S, E> {
+    router: S,
+    _phantom: PhantomData<E>,
+}
+
+impl<S, E> RaftRouterWrap<S, E> {
+    pub fn new(router: S) -> Self {
+        Self {
+            router,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<S, E> tikv_kv::RaftExtension for RaftRouterWrap<S, E>
+where
+    S: RaftStoreRouter<E> + 'static,
+    E: engine_traits::KvEngine,
+{
+    #[inline]
+    fn feed(&self, msg: RaftMessage, key_message: bool) {
+        let region_id = msg.get_region_id();
+        let msg_ty = msg.get_message().get_msg_type();
+        // Channel full and region not found are ignored unless it's a key message.
+        if let Err(e) = self.router.send_raft_msg(msg) && key_message {
+            error!("failed to send raft message"; "region_id" => region_id, "msg_ty" => ?msg_ty, "err" => ?e);
+        }
+    }
+
+    #[inline]
+    fn report_reject_message(&self, region_id: u64, from_peer_id: u64) {
+        let m = CasualMessage::RejectRaftAppend {
+            peer_id: from_peer_id,
+        };
+        let _ = self.router.send_casual_msg(region_id, m);
+    }
+
+    #[inline]
+    fn report_peer_unreachable(&self, region_id: u64, to_peer_id: u64) {
+        let _ = self.router.report_unreachable(region_id, to_peer_id);
+    }
+
+    #[inline]
+    fn report_store_unreachable(&self, store_id: u64) {
+        self.router.broadcast_unreachable(store_id);
+    }
+
+    #[inline]
+    fn report_snapshot_status(&self, region_id: u64, to_peer_id: u64, status: SnapshotStatus) {
+        if let Err(e) = self
+            .router
+            .report_snapshot_status(region_id, to_peer_id, status)
+        {
+            error!(?e;
+                "report snapshot to peer failes";
+                "to_peer_id" => to_peer_id,
+                "status" => ?status,
+                "region_id" => region_id,
+            );
+        }
+    }
+
+    #[inline]
+    fn report_resolved(&self, store_id: u64, group_id: u64) {
+        self.router.report_resolved(store_id, group_id);
+    }
+
+    #[inline]
+    fn split(
+        &self,
+        region_id: u64,
+        region_epoch: RegionEpoch,
+        split_keys: Vec<Vec<u8>>,
+        source: String,
+    ) -> BoxFuture<'static, kv::Result<Vec<Region>>> {
+        let (cb, rx) = paired_future_callback();
+        let req = CasualMessage::SplitRegion {
+            region_epoch,
+            split_keys,
+            callback: raftstore::store::Callback::write(cb),
+            source: source.into(),
+        };
+        let res = self.router.send_casual_msg(region_id, req);
+        Box::pin(async move {
+            res?;
+            let mut admin_resp = box_try!(rx.await);
+            super::check_raft_cmd_response(&mut admin_resp.response)?;
+            let regions = admin_resp
+                .response
+                .mut_admin_response()
+                .mut_splits()
+                .take_regions();
+            Ok(regions.into())
+        })
+    }
+
+    /// Get the region meta of the given region.
+    #[inline]
+    fn query_region(&self, region_id: u64) -> BoxFuture<'static, kv::Result<RegionMeta>> {
+        let (cb, rx) = paired_future_callback();
+        let res = self
+            .router
+            .send_casual_msg(region_id, CasualMessage::AccessPeer(cb));
+        Box::pin(async move {
+            res?;
+            Ok(box_try!(rx.await))
+        })
+    }
+
+    /// Ask the raft group to do a consistency check.
+    fn check_consistency(&self, region_id: u64) -> BoxFuture<'static, kv::Result<()>> {
+        let region = self.query_region(region_id);
+        let router = self.router.clone();
+        Box::pin(async move {
+            let meta: RegionMeta = region.await?;
+            let leader_id = meta.raft_status.soft_state.leader_id;
+            let mut leader = None;
+            for peer in meta.region_state.peers {
+                if peer.id == leader_id {
+                    leader = Some(peer.into());
+                }
+            }
+            if meta.raft_status.soft_state.raft_state != RaftStateRole::Leader {
+                return Err(raftstore::Error::NotLeader(region_id, leader).into());
+            }
+            let mut req = RaftCmdRequest::default();
+            req.mut_header().set_region_id(region_id);
+            req.mut_header().set_peer(leader.unwrap());
+            req.mut_admin_request()
+                .set_cmd_type(AdminCmdType::ComputeHash);
+            let f = super::exec_admin(&router, req);
+            f.await
+        })
+    }
+}

--- a/src/server/raftkv/raft_extension.rs
+++ b/src/server/raftkv/raft_extension.rs
@@ -1,6 +1,9 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::marker::PhantomData;
+use std::{
+    marker::PhantomData,
+    ops::{Deref, DerefMut},
+};
 
 use futures::future::BoxFuture;
 use kvproto::{
@@ -32,6 +35,22 @@ impl<S, E> RaftRouterWrap<S, E> {
             router,
             _phantom: PhantomData,
         }
+    }
+}
+
+impl<S, E> Deref for RaftRouterWrap<S, E> {
+    type Target = S;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.router
+    }
+}
+
+impl<S, E> DerefMut for RaftRouterWrap<S, E> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.router
     }
 }
 

--- a/src/server/service/debug.rs
+++ b/src/server/service/debug.rs
@@ -1,9 +1,8 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
 use engine_rocks::RocksEngine;
-use engine_traits::{Engines, KvEngine, MiscExt, RaftEngine};
+use engine_traits::{Engines, MiscExt, RaftEngine};
 use futures::{
-    channel::oneshot,
     future::{Future, FutureExt, TryFutureExt},
     sink::SinkExt,
     stream::{self, TryStreamExt},
@@ -12,17 +11,8 @@ use grpcio::{
     Error as GrpcError, RpcContext, RpcStatus, RpcStatusCode, ServerStreamingSink, UnarySink,
     WriteFlags,
 };
-use kvproto::{
-    debugpb::{self, *},
-    raft_cmdpb::{
-        AdminCmdType, AdminRequest, RaftCmdRequest, RaftRequestHeader, RegionDetailResponse,
-        StatusCmdType, StatusRequest,
-    },
-};
-use raftstore::{
-    router::RaftStoreRouter,
-    store::msg::{Callback, RaftCmdExtraOpts},
-};
+use kvproto::debugpb::{self, *};
+use tikv_kv::RaftExtension;
 use tikv_util::metrics;
 use tokio::runtime::Handle;
 
@@ -53,28 +43,26 @@ fn error_to_grpc_error(tag: &'static str, e: Error) -> GrpcError {
 
 /// Service handles the RPC messages for the `Debug` service.
 #[derive(Clone)]
-pub struct Service<ER: RaftEngine, EK: KvEngine, T: RaftStoreRouter<EK>> {
+pub struct Service<ER: RaftEngine, T: RaftExtension> {
     pool: Handle,
     debugger: Debugger<ER>,
     raft_router: T,
-    _phantom: std::marker::PhantomData<EK>,
 }
 
-impl<ER: RaftEngine, EK: KvEngine, T: RaftStoreRouter<EK>> Service<ER, EK, T> {
-    /// Constructs a new `Service` with `Engines`, a `RaftStoreRouter` and a
+impl<ER: RaftEngine, T: RaftExtension> Service<ER, T> {
+    /// Constructs a new `Service` with `Engines`, a `RaftExtension` and a
     /// `GcWorker`.
     pub fn new(
         engines: Engines<RocksEngine, ER>,
         pool: Handle,
         raft_router: T,
         cfg_controller: ConfigController,
-    ) -> Service<ER, EK, T> {
+    ) -> Self {
         let debugger = Debugger::new(engines, cfg_controller);
         Service {
             pool,
             debugger,
             raft_router,
-            _phantom: Default::default(),
         }
     }
 
@@ -99,9 +87,7 @@ impl<ER: RaftEngine, EK: KvEngine, T: RaftStoreRouter<EK>> Service<ER, EK, T> {
     }
 }
 
-impl<ER: RaftEngine, EK: KvEngine, T: RaftStoreRouter<EK> + 'static> debugpb::Debug
-    for Service<ER, EK, T>
-{
+impl<ER: RaftEngine, T: RaftExtension + 'static> debugpb::Debug for Service<ER, T> {
     fn get(&mut self, ctx: RpcContext<'_>, mut req: GetRequest, sink: UnarySink<GetResponse>) {
         const TAG: &str = "debug_get";
 
@@ -386,18 +372,14 @@ impl<ER: RaftEngine, EK: KvEngine, T: RaftStoreRouter<EK> + 'static> debugpb::De
         sink: UnarySink<RegionConsistencyCheckResponse>,
     ) {
         let region_id = req.get_region_id();
-        let debugger = self.debugger.clone();
-        let router1 = self.raft_router.clone();
-        let router2 = self.raft_router.clone();
-
-        let consistency_check_task = async move {
-            let store_id = debugger.get_store_ident()?.store_id;
-            let detail = region_detail(router2, region_id, store_id).await?;
-            consistency_check(router1, detail).await
+        let f = self.raft_router.check_consistency(region_id);
+        let task = async move {
+            box_try!(f.await);
+            Ok(())
         };
         let f = self
             .pool
-            .spawn(consistency_check_task)
+            .spawn(task)
             .map(|res| res.unwrap())
             .map_ok(|_| RegionConsistencyCheckResponse::default());
         self.handle_response(ctx, sink, f, "check_region_consistency");
@@ -534,79 +516,6 @@ impl<ER: RaftEngine, EK: KvEngine, T: RaftStoreRouter<EK> + 'static> debugpb::De
     ) {
         self.debugger.reset_to_version(req.get_ts());
         sink.success(ResetToVersionResponse::default());
-    }
-}
-
-fn region_detail<EK: KvEngine, T: RaftStoreRouter<EK>>(
-    raft_router: T,
-    region_id: u64,
-    store_id: u64,
-) -> impl Future<Output = Result<RegionDetailResponse>> {
-    let mut header = RaftRequestHeader::default();
-    header.set_region_id(region_id);
-    header.mut_peer().set_store_id(store_id);
-    let mut status_request = StatusRequest::default();
-    status_request.set_cmd_type(StatusCmdType::RegionDetail);
-    let mut raft_cmd = RaftCmdRequest::default();
-    raft_cmd.set_header(header);
-    raft_cmd.set_status_request(status_request);
-
-    let (tx, rx) = oneshot::channel();
-    let cb = Callback::read(Box::new(|resp| tx.send(resp).unwrap()));
-
-    async move {
-        raft_router
-            .send_command(raft_cmd, cb, RaftCmdExtraOpts::default())
-            .map_err(|e| Error::Other(Box::new(e)))?;
-
-        let mut r = rx.map_err(|e| Error::Other(Box::new(e))).await?;
-
-        if r.response.get_header().has_error() {
-            let e = r.response.get_header().get_error();
-            warn!("region_detail got error"; "err" => ?e);
-            return Err(Error::Other(e.message.clone().into()));
-        }
-
-        let detail = r.response.take_status_response().take_region_detail();
-        debug!("region_detail got region detail"; "detail" => ?detail);
-        let leader_store_id = detail.get_leader().get_store_id();
-        if leader_store_id != store_id {
-            let msg = format!("Leader is on store {}", leader_store_id);
-            return Err(Error::Other(msg.into()));
-        }
-        Ok(detail)
-    }
-}
-
-fn consistency_check<EK: KvEngine, T: RaftStoreRouter<EK>>(
-    raft_router: T,
-    mut detail: RegionDetailResponse,
-) -> impl Future<Output = Result<()>> {
-    let mut header = RaftRequestHeader::default();
-    header.set_region_id(detail.get_region().get_id());
-    header.set_peer(detail.take_leader());
-    let mut admin_request = AdminRequest::default();
-    admin_request.set_cmd_type(AdminCmdType::ComputeHash);
-    let mut raft_cmd = RaftCmdRequest::default();
-    raft_cmd.set_header(header);
-    raft_cmd.set_admin_request(admin_request);
-
-    let (tx, rx) = oneshot::channel();
-    let cb = Callback::read(Box::new(|resp| tx.send(resp).unwrap()));
-
-    async move {
-        raft_router
-            .send_command(raft_cmd, cb, RaftCmdExtraOpts::default())
-            .map_err(|e| Error::Other(Box::new(e)))?;
-
-        let r = rx.map_err(|e| Error::Other(Box::new(e))).await?;
-
-        if r.response.get_header().has_error() {
-            let e = r.response.get_header().get_error();
-            warn!("consistency-check got error"; "err" => ?e);
-            return Err(Error::Other(e.message.clone().into()));
-        }
-        Ok(())
     }
 }
 

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -15,26 +15,19 @@ use grpcio::{
     ClientStreamingSink, DuplexSink, Error as GrpcError, RequestStream, Result as GrpcResult,
     RpcContext, RpcStatus, RpcStatusCode, ServerStreamingSink, UnarySink, WriteFlags,
 };
-use kvproto::{
-    coprocessor::*,
-    errorpb::{Error as RegionError, *},
-    kvrpcpb::*,
-    mpp::*,
-    raft_serverpb::*,
-    tikvpb::*,
-};
+use kvproto::{coprocessor::*, kvrpcpb::*, mpp::*, raft_serverpb::*, tikvpb::*};
 use protobuf::RepeatedField;
 use raft::eraftpb::MessageType;
 use raftstore::{
-    router::RaftStoreRouter,
     store::{
         memory::{MEMTRACE_APPLYS, MEMTRACE_RAFT_ENTRIES, MEMTRACE_RAFT_MESSAGES},
         metrics::RAFT_ENTRIES_CACHES_GAUGE,
-        Callback, CasualMessage, CheckLeaderTask,
+        CheckLeaderTask,
     },
-    DiscardReason, Error as RaftStoreError, Result as RaftStoreResult,
+    Error as RaftStoreError, Result as RaftStoreResult,
 };
 use tikv_alloc::trace::MemoryTraceGuard;
+use tikv_kv::RaftExtension;
 use tikv_util::{
     future::{paired_future_callback, poll_future_notify},
     mpsc::future::{unbounded, BatchReceiver, Sender, WakePolicy},
@@ -69,18 +62,16 @@ const GRPC_MSG_MAX_BATCH_SIZE: usize = 128;
 const GRPC_MSG_NOTIFY_SIZE: usize = 8;
 
 /// Service handles the RPC messages for the `Tikv` service.
-pub struct Service<T: RaftStoreRouter<E::Local> + 'static, E: Engine, L: LockManager, F: KvFormat> {
+pub struct Service<E: Engine, L: LockManager, F: KvFormat> {
     store_id: u64,
     /// Used to handle requests related to GC.
-    gc_worker: GcWorker<E, T>,
+    gc_worker: GcWorker<E>,
     // For handling KV requests.
     storage: Storage<E, L, F>,
     // For handling coprocessor requests.
     copr: Endpoint<E>,
     // For handling corprocessor v2 requests.
     copr_v2: coprocessor_v2::Endpoint,
-    // For handling raft messages.
-    ch: T,
     // For handling snapshot.
     snap_scheduler: Scheduler<SnapTask>,
     // For handling `CheckLeader` request.
@@ -96,13 +87,7 @@ pub struct Service<T: RaftStoreRouter<E::Local> + 'static, E: Engine, L: LockMan
     reject_messages_on_memory_ratio: f64,
 }
 
-impl<
-    T: RaftStoreRouter<E::Local> + Clone + 'static,
-    E: Engine + Clone,
-    L: LockManager + Clone,
-    F: KvFormat,
-> Clone for Service<T, E, L, F>
-{
+impl<E: Engine + Clone, L: LockManager + Clone, F: KvFormat> Clone for Service<E, L, F> {
     fn clone(&self) -> Self {
         Service {
             store_id: self.store_id,
@@ -110,7 +95,6 @@ impl<
             storage: self.storage.clone(),
             copr: self.copr.clone(),
             copr_v2: self.copr_v2.clone(),
-            ch: self.ch.clone(),
             snap_scheduler: self.snap_scheduler.clone(),
             check_leader_scheduler: self.check_leader_scheduler.clone(),
             enable_req_batch: self.enable_req_batch,
@@ -121,17 +105,14 @@ impl<
     }
 }
 
-impl<T: RaftStoreRouter<E::Local> + 'static, E: Engine, L: LockManager, F: KvFormat>
-    Service<T, E, L, F>
-{
+impl<E: Engine, L: LockManager, F: KvFormat> Service<E, L, F> {
     /// Constructs a new `Service` which provides the `Tikv` service.
     pub fn new(
         store_id: u64,
         storage: Storage<E, L, F>,
-        gc_worker: GcWorker<E, T>,
+        gc_worker: GcWorker<E>,
         copr: Endpoint<E>,
         copr_v2: coprocessor_v2::Endpoint,
-        ch: T,
         snap_scheduler: Scheduler<SnapTask>,
         check_leader_scheduler: Scheduler<CheckLeaderTask>,
         grpc_thread_load: Arc<ThreadLoadPool>,
@@ -145,7 +126,6 @@ impl<T: RaftStoreRouter<E::Local> + 'static, E: Engine, L: LockManager, F: KvFor
             storage,
             copr,
             copr_v2,
-            ch,
             snap_scheduler,
             check_leader_scheduler,
             enable_req_batch,
@@ -157,7 +137,7 @@ impl<T: RaftStoreRouter<E::Local> + 'static, E: Engine, L: LockManager, F: KvFor
 
     fn handle_raft_message(
         store_id: u64,
-        ch: &T,
+        ch: &E::RaftExtension,
         msg: RaftMessage,
         reject: bool,
     ) -> RaftStoreResult<()> {
@@ -172,13 +152,11 @@ impl<T: RaftStoreRouter<E::Local> + 'static, E: Engine, L: LockManager, F: KvFor
             RAFT_APPEND_REJECTS.inc();
             let id = msg.get_region_id();
             let peer_id = msg.get_message().get_from();
-            let m = CasualMessage::RejectRaftAppend { peer_id };
-            let _ = ch.send_casual_msg(id, m);
+            ch.report_reject_message(id, peer_id);
             return Ok(());
         }
-        // `send_raft_msg` may return `RaftStoreError::RegionNotFound` or
-        // `RaftStoreError::Transport(DiscardReason::Full)`
-        ch.send_raft_msg(msg)
+        ch.feed(msg, false);
+        Ok(())
     }
 }
 
@@ -228,9 +206,7 @@ macro_rules! set_total_time {
     };
 }
 
-impl<T: RaftStoreRouter<E::Local> + 'static, E: Engine, L: LockManager, F: KvFormat> Tikv
-    for Service<T, E, L, F>
-{
+impl<E: Engine, L: LockManager, F: KvFormat> Tikv for Service<E, L, F> {
     handle_request!(kv_get, future_get, GetRequest, GetResponse, has_time_detail);
     handle_request!(kv_scan, future_scan, ScanRequest, ScanResponse);
     handle_request!(
@@ -614,7 +590,7 @@ impl<T: RaftStoreRouter<E::Local> + 'static, E: Engine, L: LockManager, F: KvFor
         sink: ClientStreamingSink<Done>,
     ) {
         let store_id = self.store_id;
-        let ch = self.ch.clone();
+        let ch = self.storage.get_engine().raft_extension().clone();
         let reject_messages_on_memory_ratio = self.reject_messages_on_memory_ratio;
 
         let res = async move {
@@ -657,7 +633,7 @@ impl<T: RaftStoreRouter<E::Local> + 'static, E: Engine, L: LockManager, F: KvFor
     ) {
         info!("batch_raft RPC is called, new gRPC stream established");
         let store_id = self.store_id;
-        let ch = self.ch.clone();
+        let ch = self.storage.get_engine().raft_extension().clone();
         let reject_messages_on_memory_ratio = self.reject_messages_on_memory_ratio;
 
         let res = async move {
@@ -726,7 +702,6 @@ impl<T: RaftStoreRouter<E::Local> + 'static, E: Engine, L: LockManager, F: KvFor
         let begin_instant = Instant::now();
 
         let region_id = req.get_context().get_region_id();
-        let (cb, f) = paired_future_callback();
         let mut split_keys = if req.is_raw_kv {
             if !req.get_split_key().is_empty() {
                 vec![F::encode_raw_key_owned(req.take_split_key(), None).into_encoded()]
@@ -747,52 +722,45 @@ impl<T: RaftStoreRouter<E::Local> + 'static, E: Engine, L: LockManager, F: KvFor
             }
         };
         split_keys.sort();
-        let req = CasualMessage::SplitRegion {
-            region_epoch: req.take_context().take_region_epoch(),
+        let engine = self.storage.get_engine();
+        let f = engine.raft_extension().split(
+            region_id,
+            req.take_context().take_region_epoch(),
             split_keys,
-            callback: Callback::write(cb),
-            source: ctx.peer().into(),
-        };
-
-        if let Err(e) = self.ch.send_casual_msg(region_id, req) {
-            // Retrun region error instead a gRPC error.
-            let mut resp = SplitRegionResponse::default();
-            resp.set_region_error(raftstore_error_to_region_error(e, region_id));
-            ctx.spawn(
-                async move {
-                    sink.success(resp).await?;
-                    ServerResult::Ok(())
-                }
-                .map_err(|_| ())
-                .map(|_| ()),
-            );
-            return;
-        }
+            ctx.peer(),
+        );
 
         let task = async move {
-            let mut res = f.await?;
+            let res = f.await;
             let mut resp = SplitRegionResponse::default();
-            if res.response.get_header().has_error() {
-                resp.set_region_error(res.response.mut_header().take_error());
-            } else {
-                let admin_resp = res.response.mut_admin_response();
-                let regions: Vec<_> = admin_resp.mut_splits().take_regions().into();
-                if regions.len() < 2 {
-                    error!(
-                        "invalid split response";
-                        "region_id" => region_id,
-                        "resp" => ?admin_resp
-                    );
-                    resp.mut_region_error().set_message(format!(
-                        "Internal Error: invalid response: {:?}",
-                        admin_resp
-                    ));
-                } else {
-                    if regions.len() == 2 {
-                        resp.set_left(regions[0].clone());
-                        resp.set_right(regions[1].clone());
+            match res {
+                Ok(regions) => {
+                    if regions.len() < 2 {
+                        error!(
+                            "invalid split response";
+                            "region_id" => region_id,
+                            "resp" => ?regions
+                        );
+                        resp.mut_region_error().set_message(format!(
+                            "Internal Error: invalid response: {:?}",
+                            regions
+                        ));
+                    } else {
+                        if regions.len() == 2 {
+                            resp.set_left(regions[0].clone());
+                            resp.set_right(regions[1].clone());
+                        }
+                        resp.set_regions(regions.into());
                     }
-                    resp.set_regions(regions.into());
+                }
+                Err(e) => {
+                    let err: crate::storage::Result<()> = Err(e.into());
+                    if let Some(err) = extract_region_error(&err) {
+                        resp.set_region_error(err)
+                    } else {
+                        resp.mut_region_error()
+                            .set_message(format!("failed to split: {:?}", err));
+                    }
                 }
             }
             sink.success(resp).await?;
@@ -2157,20 +2125,6 @@ fn collect_batch_resp(v: &mut MeasuredBatchResponse, mut e: MeasuredSingleRespon
     v.batch_resp.mut_request_ids().push(e.id);
     v.batch_resp.mut_responses().push(e.resp.consume());
     v.measures.push(e.measure);
-}
-
-fn raftstore_error_to_region_error(e: RaftStoreError, region_id: u64) -> RegionError {
-    if let RaftStoreError::Transport(DiscardReason::Disconnected) = e {
-        // `From::from(RaftStoreError) -> RegionError` treats `Disconnected` as `Other`.
-        let mut region_error = RegionError::default();
-        let region_not_found = RegionNotFound {
-            region_id,
-            ..Default::default()
-        };
-        region_error.set_region_not_found(region_not_found);
-        return region_error;
-    }
-    e.into()
 }
 
 fn needs_reject_raft_append(reject_messages_on_memory_ratio: f64) -> bool {

--- a/src/server/snap.rs
+++ b/src/server/snap.rs
@@ -3,7 +3,6 @@
 use std::{
     fmt::{self, Display, Formatter},
     io::{Read, Write},
-    marker::PhantomData,
     pin::Pin,
     sync::{
         atomic::{AtomicUsize, Ordering},
@@ -12,7 +11,6 @@ use std::{
     time::Duration,
 };
 
-use engine_traits::KvEngine;
 use file_system::{IoType, WithIoType};
 use futures::{
     future::{Future, TryFutureExt},
@@ -29,11 +27,9 @@ use kvproto::{
     tikvpb::TikvClient,
 };
 use protobuf::Message;
-use raftstore::{
-    router::RaftStoreRouter,
-    store::{SnapEntry, SnapKey, SnapManager, Snapshot},
-};
+use raftstore::store::{SnapEntry, SnapKey, SnapManager, Snapshot};
 use security::SecurityManager;
+use tikv_kv::RaftExtension;
 use tikv_util::{
     config::{Tracker, VersionTrack},
     time::Instant,
@@ -260,7 +256,7 @@ impl RecvSnapContext {
         })
     }
 
-    fn finish<R: RaftStoreRouter<impl KvEngine>>(self, raft_router: R) -> Result<()> {
+    fn finish<R: RaftExtension>(self, raft_router: R) -> Result<()> {
         let _with_io_type = WithIoType::new(self.io_type);
         let key = self.key;
         if let Some(mut file) = self.file {
@@ -271,15 +267,13 @@ impl RecvSnapContext {
                 return Err(e);
             }
         }
-        if let Err(e) = raft_router.send_raft_msg(self.raft_msg) {
-            return Err(box_err!("{} failed to send snapshot to raft: {}", key, e));
-        }
+        raft_router.feed(self.raft_msg, true);
         info!("saving all snapshot files"; "snap_key" => %key, "takes" => ?self.start.saturating_elapsed());
         Ok(())
     }
 }
 
-fn recv_snap<R: RaftStoreRouter<impl KvEngine> + 'static>(
+fn recv_snap<R: RaftExtension + 'static>(
     stream: RequestStream<SnapshotChunk>,
     sink: ClientStreamingSink<Done>,
     snap_mgr: SnapManager,
@@ -331,11 +325,7 @@ fn recv_snap<R: RaftStoreRouter<impl KvEngine> + 'static>(
     }
 }
 
-pub struct Runner<E, R>
-where
-    E: KvEngine,
-    R: RaftStoreRouter<E> + 'static,
-{
+pub struct Runner<R: RaftExtension> {
     env: Arc<Environment>,
     snap_mgr: SnapManager,
     pool: Runtime,
@@ -345,21 +335,16 @@ where
     cfg: Config,
     sending_count: Arc<AtomicUsize>,
     recving_count: Arc<AtomicUsize>,
-    engine: PhantomData<E>,
 }
 
-impl<E, R> Runner<E, R>
-where
-    E: KvEngine,
-    R: RaftStoreRouter<E> + 'static,
-{
+impl<R: RaftExtension + 'static> Runner<R> {
     pub fn new(
         env: Arc<Environment>,
         snap_mgr: SnapManager,
         r: R,
         security_mgr: Arc<SecurityManager>,
         cfg: Arc<VersionTrack<Config>>,
-    ) -> Runner<E, R> {
+    ) -> Self {
         let cfg_tracker = cfg.clone().tracker("snap-sender".to_owned());
         let snap_worker = Runner {
             env,
@@ -377,7 +362,6 @@ where
             cfg: cfg.value().clone(),
             sending_count: Arc::new(AtomicUsize::new(0)),
             recving_count: Arc::new(AtomicUsize::new(0)),
-            engine: PhantomData,
         };
         snap_worker
     }
@@ -404,11 +388,7 @@ where
     }
 }
 
-impl<E, R> Runnable for Runner<E, R>
-where
-    E: KvEngine,
-    R: RaftStoreRouter<E> + 'static,
-{
+impl<R: RaftExtension + 'static> Runnable for Runner<R> {
     type Task = Task;
 
     fn run(&mut self, task: Task) {

--- a/src/server/transport.rs
+++ b/src/server/transport.rs
@@ -1,56 +1,45 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::marker::PhantomData;
-
-use engine_traits::KvEngine;
 use kvproto::raft_serverpb::RaftMessage;
-use raftstore::{router::RaftStoreRouter, store::Transport, Result as RaftStoreResult};
+use raftstore::{store::Transport, Result as RaftStoreResult};
+use tikv_kv::RaftExtension;
 
 use crate::server::{raft_client::RaftClient, resolve::StoreAddrResolver};
 
-pub struct ServerTransport<T, S, E>
+pub struct ServerTransport<T, S>
 where
-    T: RaftStoreRouter<E> + 'static,
+    T: RaftExtension + 'static,
     S: StoreAddrResolver + 'static,
-    E: KvEngine,
 {
-    raft_client: RaftClient<S, T, E>,
-    engine: PhantomData<E>,
+    raft_client: RaftClient<S, T>,
 }
 
-impl<T, S, E> Clone for ServerTransport<T, S, E>
+impl<T, S> Clone for ServerTransport<T, S>
 where
-    T: RaftStoreRouter<E> + 'static,
+    T: RaftExtension + 'static,
     S: StoreAddrResolver + 'static,
-    E: KvEngine,
 {
     fn clone(&self) -> Self {
         ServerTransport {
             raft_client: self.raft_client.clone(),
-            engine: PhantomData,
         }
     }
 }
 
-impl<T, S, E> ServerTransport<T, S, E>
+impl<T, S> ServerTransport<T, S>
 where
-    E: KvEngine,
-    T: RaftStoreRouter<E> + 'static,
+    T: RaftExtension + 'static,
     S: StoreAddrResolver + 'static,
 {
-    pub fn new(raft_client: RaftClient<S, T, E>) -> ServerTransport<T, S, E> {
-        ServerTransport {
-            raft_client,
-            engine: PhantomData,
-        }
+    pub fn new(raft_client: RaftClient<S, T>) -> Self {
+        ServerTransport { raft_client }
     }
 }
 
-impl<T, S, E> Transport for ServerTransport<T, S, E>
+impl<T, S> Transport for ServerTransport<T, S>
 where
-    T: RaftStoreRouter<E> + Unpin + 'static,
+    T: RaftExtension + Unpin + 'static,
     S: StoreAddrResolver + Unpin + 'static,
-    E: KvEngine,
 {
     fn send(&mut self, msg: RaftMessage) -> RaftStoreResult<()> {
         match self.raft_client.send(msg) {

--- a/tests/failpoints/cases/test_gc_metrics.rs
+++ b/tests/failpoints/cases/test_gc_metrics.rs
@@ -19,7 +19,6 @@ use raftstore::{
     coprocessor::{
         region_info_accessor::MockRegionInfoProvider, CoprocessorHost, RegionChangeEvent,
     },
-    router::RaftStoreBlackHole,
     RegionInfoAccessor,
 };
 use tikv::{
@@ -142,7 +141,6 @@ fn test_txn_gc_keys_handled() {
     feature_gate.set_version("5.0.0").unwrap();
     let mut gc_worker = GcWorker::new(
         prefixed_engine.clone(),
-        RaftStoreBlackHole,
         tx,
         GcConfig::default(),
         feature_gate,
@@ -286,7 +284,6 @@ fn test_raw_gc_keys_handled() {
     let feature_gate = FeatureGate::default();
     let mut gc_worker = GcWorker::new(
         prefixed_engine,
-        RaftStoreBlackHole,
         tx,
         GcConfig::default(),
         feature_gate,

--- a/tests/integrations/config/dynamic/gc_worker.rs
+++ b/tests/integrations/config/dynamic/gc_worker.rs
@@ -5,9 +5,7 @@ use std::{
     time::Duration,
 };
 
-use raftstore::{
-    coprocessor::region_info_accessor::MockRegionInfoProvider, router::RaftStoreBlackHole,
-};
+use raftstore::coprocessor::region_info_accessor::MockRegionInfoProvider;
 use tikv::{
     config::{ConfigController, Module, TikvConfig},
     server::gc_worker::{GcConfig, GcTask, GcWorker},
@@ -27,15 +25,11 @@ fn test_gc_config_validate() {
 
 fn setup_cfg_controller(
     cfg: TikvConfig,
-) -> (
-    GcWorker<tikv::storage::kv::RocksEngine, RaftStoreBlackHole>,
-    ConfigController,
-) {
+) -> (GcWorker<tikv::storage::kv::RocksEngine>, ConfigController) {
     let engine = TestEngineBuilder::new().build().unwrap();
     let (tx, _rx) = std::sync::mpsc::channel();
     let mut gc_worker = GcWorker::new(
         engine,
-        RaftStoreBlackHole,
         tx,
         cfg.gc.clone(),
         Default::default(),

--- a/tests/integrations/config/dynamic/snap.rs
+++ b/tests/integrations/config/dynamic/snap.rs
@@ -15,6 +15,7 @@ use tikv::{
     config::{ConfigController, TikvConfig},
     server::{
         config::{Config as ServerConfig, ServerConfigManager},
+        raftkv::RaftRouterWrap,
         snap::{Runner as SnapHandler, Task as SnapTask},
     },
 };
@@ -60,7 +61,7 @@ fn start_server(
     let snap_runner = SnapHandler::new(
         Arc::clone(&env),
         snap_mgr.clone(),
-        raft_router,
+        RaftRouterWrap::new(raft_router),
         security_mgr,
         Arc::clone(&server_config),
     );

--- a/tests/integrations/server/raft_client.rs
+++ b/tests/integrations/server/raft_client.rs
@@ -9,7 +9,6 @@ use std::{
     time::Duration,
 };
 
-use engine_rocks::RocksEngine;
 use futures::{FutureExt, StreamExt, TryStreamExt};
 use grpcio::{
     ClientStreamingSink, Environment, RequestStream, RpcContext, RpcStatus, RpcStatusCode, Server,
@@ -20,15 +19,12 @@ use kvproto::{
     tikvpb::BatchRaftMessage,
 };
 use raft::eraftpb::Entry;
-use raftstore::{
-    errors::DiscardReason,
-    router::{RaftStoreBlackHole, RaftStoreRouter},
-    store::StoreMsg,
-};
+use raftstore::{errors::DiscardReason, store::StoreMsg};
 use tikv::server::{
-    self, load_statistics::ThreadLoadPool, resolve, resolve::Callback, Config, ConnectionBuilder,
-    RaftClient, StoreAddrResolver, TestRaftStoreRouter,
+    self, load_statistics::ThreadLoadPool, raftkv::RaftRouterWrap, resolve, resolve::Callback,
+    Config, ConnectionBuilder, RaftClient, StoreAddrResolver, TestRaftStoreRouter,
 };
+use tikv_kv::{FakeExtension, RaftExtension};
 use tikv_util::{
     config::{ReadableDuration, VersionTrack},
     worker::{Builder as WorkerBuilder, LazyWorker},
@@ -55,9 +51,9 @@ impl StoreAddrResolver for StaticResolver {
     }
 }
 
-fn get_raft_client<R, T>(router: R, resolver: T) -> RaftClient<T, R, RocksEngine>
+fn get_raft_client<R, T>(router: R, resolver: T) -> RaftClient<T, R>
 where
-    R: RaftStoreRouter<RocksEngine> + Unpin + 'static,
+    R: RaftExtension + Unpin + 'static,
     T: StoreAddrResolver + 'static,
 {
     let env = Arc::new(Environment::new(2));
@@ -80,10 +76,8 @@ where
     RaftClient::new(builder)
 }
 
-fn get_raft_client_by_port(
-    port: u16,
-) -> RaftClient<StaticResolver, RaftStoreBlackHole, RocksEngine> {
-    get_raft_client(RaftStoreBlackHole, StaticResolver::new(port))
+fn get_raft_client_by_port(port: u16) -> RaftClient<StaticResolver, FakeExtension> {
+    get_raft_client(FakeExtension, StaticResolver::new(port))
 }
 
 #[derive(Clone)]
@@ -183,7 +177,8 @@ fn test_raft_client_reconnect() {
     let (tx, rx) = mpsc::channel();
     let (significant_msg_sender, _significant_msg_receiver) = mpsc::channel();
     let router = TestRaftStoreRouter::new(tx, significant_msg_sender);
-    let mut raft_client = get_raft_client(router, StaticResolver::new(port));
+    let wrap = RaftRouterWrap::new(router);
+    let mut raft_client = get_raft_client(wrap, StaticResolver::new(port));
     (0..50).for_each(|_| raft_client.send(RaftMessage::default()).unwrap());
     raft_client.flush();
 
@@ -223,7 +218,8 @@ fn test_raft_client_report_unreachable() {
     let (tx, rx) = mpsc::channel();
     let (significant_msg_sender, _significant_msg_receiver) = mpsc::channel();
     let router = TestRaftStoreRouter::new(tx, significant_msg_sender);
-    let mut raft_client = get_raft_client(router, StaticResolver::new(port));
+    let wrap = RaftRouterWrap::new(router);
+    let mut raft_client = get_raft_client(wrap, StaticResolver::new(port));
 
     // server is disconnected
     mock_server.shutdown();
@@ -386,15 +382,14 @@ fn test_tombstone_block_list() {
     let bg_worker = WorkerBuilder::new(thd_name!("background"))
         .thread_count(2)
         .create();
-    let resolver =
-        resolve::new_resolver::<_, _, RocksEngine>(pd_client, &bg_worker, RaftStoreBlackHole).0;
+    let resolver = resolve::new_resolver(pd_client, &bg_worker, FakeExtension).0;
 
     let msg_count = Arc::new(AtomicUsize::new(0));
     let batch_msg_count = Arc::new(AtomicUsize::new(0));
     let service = MockKvForRaft::new(Arc::clone(&msg_count), Arc::clone(&batch_msg_count), true);
     let (_mock_server, port) = create_mock_server(service, 60200, 60300).unwrap();
 
-    let mut raft_client = get_raft_client(RaftStoreBlackHole, resolver);
+    let mut raft_client = get_raft_client(FakeExtension, resolver);
 
     let mut store1 = metapb::Store::default();
     store1.set_id(1);
@@ -443,9 +438,8 @@ fn test_store_allowlist() {
     let bg_worker = WorkerBuilder::new(thd_name!("background"))
         .thread_count(2)
         .create();
-    let resolver =
-        resolve::new_resolver::<_, _, RocksEngine>(pd_client, &bg_worker, RaftStoreBlackHole).0;
-    let mut raft_client = get_raft_client(RaftStoreBlackHole, resolver);
+    let resolver = resolve::new_resolver(pd_client, &bg_worker, FakeExtension).0;
+    let mut raft_client = get_raft_client(FakeExtension, resolver);
 
     let msg_count1 = Arc::new(AtomicUsize::new(0));
     let batch_msg_count1 = Arc::new(AtomicUsize::new(0));


### PR DESCRIPTION
### What is changed and how it works?
Issue Number: Ref #13827

What's Changed:
```commit-message
So anything related to raft will call raft extension instead of router.
This makes it easier to introduce new raftstore implementations.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
