### PR TITLE
scheduler/lock_manager: Handle the corner case that resumable pessimstic lock request is pushed to queue after cancelling

### DIFF
--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -564,8 +564,12 @@ impl<E: Engine> Endpoint<E> {
                         match res {
                             Ok(mut resp) => {
                                 response.set_data(resp.take_data());
-                                response.set_region_error(resp.take_region_error());
-                                response.set_locked(resp.take_locked());
+                                if let Some(err) = resp.region_error.take() {
+                                    response.set_region_error(err);
+                                }
+                                if let Some(lock_info) = resp.locked.take() {
+                                    response.set_locked(lock_info);
+                                }
                                 response.set_other_error(resp.take_other_error());
                                 GLOBAL_TRACKERS.with_tracker(cur_tracker, |tracker| {
                                     tracker.write_scan_detail(

--- a/src/server/lock_manager/mod.rs
+++ b/src/server/lock_manager/mod.rs
@@ -40,7 +40,7 @@ use crate::{
             CancellationCallback, DiagnosticContext, KeyLockWaitInfo,
             LockManager as LockManagerTrait, LockWaitToken, UpdateWaitForEvent, WaitTimeout,
         },
-        DynamicConfigs as StorageDynamicConfigs, Error as StorageError,
+        DynamicConfigs as StorageDynamicConfigs,
     },
 };
 

--- a/src/server/lock_manager/mod.rs
+++ b/src/server/lock_manager/mod.rs
@@ -37,8 +37,8 @@ use crate::{
     },
     storage::{
         lock_manager::{
-            DiagnosticContext, KeyLockWaitInfo, LockManager as LockManagerTrait, LockWaitToken,
-            UpdateWaitForEvent, WaitTimeout,
+            CancellationCallback, DiagnosticContext, KeyLockWaitInfo,
+            LockManager as LockManagerTrait, LockWaitToken, UpdateWaitForEvent, WaitTimeout,
         },
         DynamicConfigs as StorageDynamicConfigs, Error as StorageError,
     },
@@ -248,7 +248,7 @@ impl LockManagerTrait for LockManager {
         wait_info: KeyLockWaitInfo,
         is_first_lock: bool,
         timeout: Option<WaitTimeout>,
-        cancel_callback: Box<dyn FnOnce(StorageError) + Send>,
+        cancel_callback: CancellationCallback,
         diag_ctx: DiagnosticContext,
     ) {
         let timeout = match timeout {

--- a/src/server/lock_manager/waiter_manager.rs
+++ b/src/server/lock_manager/waiter_manager.rs
@@ -32,8 +32,8 @@ use txn_types::Key;
 use super::{config::Config, deadlock::Scheduler as DetectorScheduler, metrics::*};
 use crate::storage::{
     lock_manager::{
-        DiagnosticContext, KeyLockWaitInfo, LockDigest, LockWaitToken, UpdateWaitForEvent,
-        WaitTimeout,
+        CancellationCallback, DiagnosticContext, KeyLockWaitInfo, LockDigest, LockWaitToken,
+        UpdateWaitForEvent, WaitTimeout,
     },
     mvcc::{Error as MvccError, ErrorInner as MvccErrorInner, TimeStamp},
     txn::Error as TxnError,
@@ -107,9 +107,6 @@ pub type Callback = Box<dyn FnOnce(Vec<WaitForEntry>) + Send>;
 
 #[allow(clippy::large_enum_variant)]
 pub enum Task {
-    SetKeyWakeUpDelayCallback {
-        cb: Box<dyn Fn(&Key, TimeStamp, TimeStamp, Instant) + Send>,
-    },
     WaitFor {
         token: LockWaitToken,
         region_id: u64,
@@ -119,7 +116,7 @@ pub enum Task {
         start_ts: TimeStamp,
         wait_info: KeyLockWaitInfo,
         timeout: WaitTimeout,
-        cancel_callback: Box<dyn FnOnce(StorageError) + Send>,
+        cancel_callback: CancellationCallback,
         diag_ctx: DiagnosticContext,
         start_waiting_time: Instant,
     },
@@ -158,9 +155,6 @@ impl Debug for Task {
 impl Display for Task {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            Task::SetKeyWakeUpDelayCallback { .. } => {
-                write!(f, "setting key wake up delay callback")
-            }
             Task::WaitFor {
                 token,
                 start_ts,
@@ -206,7 +200,7 @@ pub(crate) struct Waiter {
     // term: u64,
     pub(crate) start_ts: TimeStamp,
     pub(crate) wait_info: KeyLockWaitInfo,
-    pub(crate) cancel_callback: Box<dyn FnOnce(StorageError) + Send>,
+    pub(crate) cancel_callback: CancellationCallback,
     pub diag_ctx: DiagnosticContext,
     delay: Delay,
     start_waiting_time: Instant,
@@ -219,7 +213,7 @@ impl Waiter {
         _term: u64,
         start_ts: TimeStamp,
         wait_info: KeyLockWaitInfo,
-        cancel_callback: Box<dyn FnOnce(StorageError) + Send>,
+        cancel_callback: CancellationCallback,
         deadline: Instant,
         diag_ctx: DiagnosticContext,
         start_waiting_time: Instant,
@@ -280,7 +274,7 @@ impl Waiter {
 
     pub(super) fn cancel_no_timeout(
         wait_info: KeyLockWaitInfo,
-        cancel_callback: Box<dyn FnOnce(StorageError)>,
+        cancel_callback: CancellationCallback,
     ) {
         let lock_info = wait_info.lock_info;
         let error = MvccError::from(MvccErrorInner::KeyIsLocked(lock_info));
@@ -311,8 +305,6 @@ struct WaitTable {
     wait_table: HashMap<(u64, TimeStamp), LockWaitToken>,
     waiter_pool: HashMap<LockWaitToken, Waiter>,
     waiter_count: Arc<AtomicUsize>,
-
-    wake_up_key_delay_callback: Option<Box<dyn Fn(&Key, TimeStamp, TimeStamp, Instant) + Send>>,
 }
 
 impl WaitTable {
@@ -321,15 +313,7 @@ impl WaitTable {
             wait_table: HashMap::default(),
             waiter_pool: HashMap::default(),
             waiter_count,
-            wake_up_key_delay_callback: None,
         }
-    }
-
-    fn set_wake_up_key_delay_callback(
-        &mut self,
-        cb: Option<Box<dyn Fn(&Key, TimeStamp, TimeStamp, Instant) + Send>>,
-    ) {
-        self.wake_up_key_delay_callback = cb;
     }
 
     #[cfg(test)]
@@ -430,7 +414,7 @@ impl Scheduler {
         start_ts: TimeStamp,
         wait_info: KeyLockWaitInfo,
         timeout: WaitTimeout,
-        cancel_callback: Box<dyn FnOnce(StorageError) + Send>,
+        cancel_callback: CancellationCallback,
         diag_ctx: DiagnosticContext,
     ) {
         self.notify_scheduler(Task::WaitFor {
@@ -445,13 +429,6 @@ impl Scheduler {
             diag_ctx,
             start_waiting_time: Instant::now(),
         });
-    }
-
-    pub fn set_key_wake_up_delay_callback(
-        &self,
-        cb: Box<dyn Fn(&Key, TimeStamp, TimeStamp, Instant) + Send>,
-    ) {
-        self.notify_scheduler(Task::SetKeyWakeUpDelayCallback { cb });
     }
 
     pub fn remove_lock_wait(&self, token: LockWaitToken) {
@@ -610,11 +587,6 @@ impl WaiterManager {
 impl FutureRunnable<Task> for WaiterManager {
     fn run(&mut self, task: Task) {
         match task {
-            Task::SetKeyWakeUpDelayCallback { cb } => {
-                self.wait_table
-                    .borrow_mut()
-                    .set_wake_up_key_delay_callback(Some(cb));
-            }
             Task::WaitFor {
                 token,
                 region_id,

--- a/src/server/lock_manager/waiter_manager.rs
+++ b/src/server/lock_manager/waiter_manager.rs
@@ -27,7 +27,6 @@ use tikv_util::{
 };
 use tokio::task::spawn_local;
 use tracker::GLOBAL_TRACKERS;
-use txn_types::Key;
 
 use super::{config::Config, deadlock::Scheduler as DetectorScheduler, metrics::*};
 use crate::storage::{

--- a/src/storage/lock_manager/lock_wait_context.rs
+++ b/src/storage/lock_manager/lock_wait_context.rs
@@ -11,20 +11,28 @@
 //! of a single `AcquirePessimisticLock` request, and ensuring the internal
 //! callback for returning response through RPC is called at most only once.
 
-use std::{convert::TryInto, result::Result, sync::Arc};
+use std::{
+    convert::TryInto,
+    result::Result,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc, Arc,
+    },
+};
 
 use parking_lot::Mutex;
 use txn_types::Key;
 
 use crate::storage::{
     errors::SharedError,
-    lock_manager::{
-        lock_waiting_queue::{LockWaitQueues, PessimisticLockKeyCallback},
-        LockManager, LockWaitToken,
-    },
+    lock_manager::{lock_waiting_queue::LockWaitQueues, LockManager, LockWaitToken},
     types::PessimisticLockKeyResult,
     Error as StorageError, PessimisticLockResults, ProcessResult, StorageCallback,
 };
+
+pub type PessimisticLockKeyCallback =
+    Box<dyn FnOnce(Result<PessimisticLockKeyResult, SharedError>, is_canceled) + Send + 'static>;
+pub type CancellationCallback = Box<dyn FnOnce(StorageError) + Send + 'static>;
 
 pub struct LockWaitContextInner {
     /// The callback for finishing the current AcquirePessimisticLock request.
@@ -53,6 +61,108 @@ pub struct LockWaitContextSharedState {
 
     /// The key on which lock waiting occurs.
     key: Key,
+
+    /// When a lock-waiting request (allow_lock_with_conflict == true) is
+    /// resumed, it's theoretically possible that the request meets lock
+    /// again, therefore it may need to be pushed to the lock waiting queue
+    /// again. Since the request is popped out from the queue when resuming
+    /// (which means the lock wait entry doesn't exist in the lock waiting
+    /// queue during the resumed execution), it's possible that timeout or
+    /// deadlock happens from `WaiterManager` during that time, which will
+    /// try to cancel the request. Therefore it leads to such a corner case:
+    ///
+    /// 1. (scheduler) A request enters lock waiting state, so an entry is
+    /// pushed to the `LockWaitQueues`, and a    message is sent to
+    /// `LockManager`. 2. (scheduler) After a while the entry is popped out
+    /// and resumed from the `LockWaitQueues`. 3. (scheduler) The request
+    /// resumes execution but still finds lock on the key.
+    ///     * This is possible to be caused by delayed-waking up or encountering
+    ///       error when writing a lock-releasing command to the engine.
+    /// 4. (lock_manager) At the same time, `LockManager` tries to cancel the
+    /// request due to timeout. But when    calling `finish_request`, the
+    /// entry cannot be found from the `LockWaitQueues`. So it    believes
+    /// that the entry is already popped out and resumed and does nothing.
+    /// 5. (scheduler) An entry is pushed to the `LockWaitQueues` due to
+    /// encountering lock at step 3. 6. Then the request becomes unable to
+    /// be canceled by timeout or other possible errors. In worst
+    ///    cases, the request may stuck in TiKV forever.
+    ///
+    /// To solve this problem, a `is_canceled` flag should be set when
+    /// `LockManager` tries to cancel it, before accessing the
+    /// `LockWaitQueues`; when an entry is pushed to the `LockWaitQueues`,
+    /// check if `is_canceled` is set after locking its inner map (ensures
+    /// exclusive access with `LockManager`), and if it's set, cancel the
+    /// request like how `LockManager` should have done.
+    ///
+    /// The request should be canceled with the error that occurs in
+    /// `LockManager`. `external_error_tx` and `external_error_rx` are used
+    /// to pass this error in this case.
+    ///
+    /// `is_canceled` marks if the request is canceled from outside. Usually
+    /// this is caused by timeout or deadlock detected. When this flag is
+    /// marked true, the request must not be put into the lock waiting queue
+    /// since nobody will wake it up for timeout and it may stuck forever.
+    is_canceled: AtomicBool,
+
+    /// The sender for passing errors in some cancellation cases. See comments
+    /// in [`is_canceled`](LockWaitContextSharedState::is_canceled) for details.
+    /// It's only possible to be used in `LockManager`, so there's no contention
+    /// on the mutex.
+    external_error_tx: Mutex<mpsc::Sender<StorageError>>,
+
+    /// The sender for passing errors in some cancellation cases. See comments
+    /// in [`is_canceled`](LockWaitContextSharedState::is_canceled) for details.
+    /// It's only possible to be used when scheduler tries to push to
+    /// `LockWaitQueues`, so there's no contention on the mutex.
+    external_error_rx: Mutex<mpsc::Receiver<StorageError>>,
+}
+
+impl LockWaitContextSharedState {
+    fn new(lock_wait_token: LockWaitToken, key: Key, cb: StorageCallback) -> Self {
+        let inner = LockWaitContextInner { cb };
+        let (tx, rx) = mpsc::channel();
+        Self {
+            ctx_inner: Mutex::new(Some(inner)),
+            key,
+            lock_wait_token,
+            is_canceled: AtomicBool::new(false),
+            external_error_tx: Mutex::new(tx),
+            external_error_rx: Mutex::new(rx),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn new_dummy(lock_wait_token: LockWaitToken, key: Key) -> Self {
+        let (tx, rx) = mpsc::channel();
+        Self {
+            ctx_inner: Mutex::new(None),
+            key,
+            lock_wait_token,
+            is_canceled: AtomicBool::new(false),
+            external_error_tx: Mutex::new(tx),
+            external_error_rx: Mutex::new(rx),
+        }
+    }
+
+    pub fn is_canceled(&self) -> bool {
+        self.is_canceled.load(Ordering::Acquire)
+    }
+
+    pub(in crate::storage) fn get_external_error(&self) -> StorageError {
+        self.external_error_rx.lock().recv().unwrap()
+    }
+
+    fn put_external_error(&self, error: StorageError) {
+        if let Err(e) = self.external_error_tx.lock().send(error) {
+            debug!("failed to set")
+        }
+    }
+}
+
+enum FinishRequestKind {
+    Executed,
+    Canceled,
+    CanceledBeforeEnqueueing,
 }
 
 #[derive(Clone)]
@@ -70,13 +180,8 @@ impl<L: LockManager> LockWaitContext<L> {
         cb: StorageCallback,
         allow_lock_with_conflict: bool,
     ) -> Self {
-        let inner = LockWaitContextInner { cb };
         Self {
-            shared_states: Arc::new(LockWaitContextSharedState {
-                ctx_inner: Mutex::new(Some(inner)),
-                key,
-                lock_wait_token,
-            }),
+            shared_states: Arc::new(LockWaitContextSharedState::new(lock_wait_token, key, cb)),
             lock_wait_queues,
             allow_lock_with_conflict,
         }
@@ -105,8 +210,13 @@ impl<L: LockManager> LockWaitContext<L> {
     /// key.
     pub fn get_callback_for_blocked_key(&self) -> PessimisticLockKeyCallback {
         let ctx = self.clone();
-        Box::new(move |res| {
-            ctx.finish_request(res, false);
+        Box::new(move |res, is_canceled_before_enqueueing| {
+            let kind = if is_canceled_before_enqueueing {
+                FinishRequestKind::CanceledBeforeEnqueueing
+            } else {
+                FinishRequestKind::Canceled
+            };
+            ctx.finish_request(res, kind);
         })
     }
 
@@ -118,32 +228,48 @@ impl<L: LockManager> LockWaitContext<L> {
     /// This function is assumed to be called when the lock-waiting request is
     /// queueing but canceled outside, so it includes an operation to actively
     /// remove the entry from the lock waiting queue.
-    pub fn get_callback_for_cancellation(&self) -> impl FnOnce(StorageError) {
+    pub fn get_callback_for_cancellation(&self) -> CancellationCallback {
         let ctx = self.clone();
-        move |e| {
-            ctx.finish_request(Err(e.into()), true);
-        }
+        Box::new(move |e| {
+            ctx.finish_request(Err(e.into()), FinishRequestKind::Canceled);
+        })
     }
 
     fn finish_request(
         &self,
-        result: Result<PessimisticLockKeyResult, SharedError>,
-        is_canceling: bool,
+        mut result: Result<PessimisticLockKeyResult, SharedError>,
+        finish_kind: FinishRequestKind,
     ) {
-        if is_canceling {
-            let entry = self
-                .lock_wait_queues
-                .remove_by_token(&self.shared_states.key, self.shared_states.lock_wait_token);
-            if entry.is_none() {
-                // Already popped out from the queue so that it will be woken up normally. Do
-                // nothing.
-                return;
+        match finish_kind {
+            FinishRequestKind::Executed => {
+                self.lock_wait_queues
+                    .get_lock_mgr()
+                    .remove_lock_wait(self.shared_states.lock_wait_token);
             }
-        } else {
-            self.lock_wait_queues
-                .get_lock_mgr()
-                .remove_lock_wait(self.shared_states.lock_wait_token);
+            FinishRequestKind::Canceled => {
+                self.shared_states
+                    .is_canceled
+                    .store(true, Ordering::Release);
+
+                let entry = self
+                    .lock_wait_queues
+                    .remove_by_token(&self.shared_states.key, self.shared_states.lock_wait_token);
+                if entry.is_none() {
+                    // It's absent in the queue infers that it's already popped out from the queue
+                    // so that it will be woken up normally. However
+                    // it may still meet lock and tries to enter waiting state again. In such case,
+                    // the request should be canceled. Store the error here so
+                    // that it can be used for cancellation in that case, where
+                    // there will be a `finish_request(None, false)` invocation).
+                    self.shared_states
+                        .put_external_error(result.unwrap_err().try_into().unwrap());
+                    return;
+                }
+            }
+            FinishRequestKind::CanceledBeforeEnqueueing => {}
         }
+
+        let result = result.unwrap();
 
         // When this is executed, the waiter is either woken up from the queue or
         // canceled and removed from the queue. There should be no chance to try
@@ -270,6 +396,7 @@ mod tests {
                 },
                 should_not_exist: false,
                 lock_wait_token: token,
+                req_states: ctx.get_shared_states().clone(),
                 legacy_wake_up_index: None,
                 key_cb: None,
             }),

--- a/src/storage/lock_manager/lock_wait_context.rs
+++ b/src/storage/lock_manager/lock_wait_context.rs
@@ -131,7 +131,7 @@ impl LockWaitContextSharedState {
             lock_wait_token,
             is_canceled: AtomicBool::new(false),
             external_error_tx: Mutex::new(Some(tx)),
-            external_error_rx: Mutex::new(Soem(rx)),
+            external_error_rx: Mutex::new(Some(rx)),
         }
     }
 

--- a/src/storage/lock_manager/lock_waiting_queue.rs
+++ b/src/storage/lock_manager/lock_waiting_queue.rs
@@ -473,6 +473,8 @@ impl<L: LockManager> LockWaitQueues<L> {
             prev_delay_ms = current_delay_ms;
         }
 
+        fail_point!("lock_waiting_queue_before_delayed_notify_all");
+
         self.delayed_notify_all(&key, notify_id)
     }
 

--- a/src/storage/lock_manager/lock_waiting_queue.rs
+++ b/src/storage/lock_manager/lock_waiting_queue.rs
@@ -56,6 +56,7 @@
 
 use std::{
     future::Future,
+    ops::DerefMut,
     pin::Pin,
     result::Result,
     sync::{
@@ -76,16 +77,16 @@ use txn_types::{Key, TimeStamp};
 
 use crate::storage::{
     errors::SharedError,
-    lock_manager::{LockManager, LockWaitToken},
+    lock_manager::{
+        lock_wait_context::{LockWaitContextSharedState, PessimisticLockKeyCallback},
+        LockManager, LockWaitToken,
+    },
     metrics::*,
     mvcc::{Error as MvccError, ErrorInner as MvccErrorInner},
-    txn::Error as TxnError,
+    txn::{Error as TxnError, ErrorInner as TxnErrorInner},
     types::{PessimisticLockKeyResult, PessimisticLockParameters},
-    Error as StorageError,
+    Error as StorageError, ErrorInner as StorageErrorInner,
 };
-
-pub type CallbackWithSharedError<T> = Box<dyn FnOnce(Result<T, SharedError>) + Send + 'static>;
-pub type PessimisticLockKeyCallback = CallbackWithSharedError<PessimisticLockKeyResult>;
 
 /// Represents an `AcquirePessimisticLock` request that's waiting for a lock,
 /// and contains the request's parameters.
@@ -97,6 +98,7 @@ pub struct LockWaitEntry {
     // Put it in a separated field.
     pub should_not_exist: bool,
     pub lock_wait_token: LockWaitToken,
+    pub req_states: Arc<LockWaitContextSharedState>,
     pub legacy_wake_up_index: Option<usize>,
     pub key_cb: Option<SyncWrapper<PessimisticLockKeyCallback>>,
 }
@@ -248,15 +250,26 @@ impl<L: LockManager> LockWaitQueues<L> {
         current_lock: kvrpcpb::LockInfo,
     ) {
         let mut new_key = false;
-        let mut key_state = self
-            .inner
-            .queue_map
-            .entry(lock_wait_entry.key.clone())
-            .or_insert_with(|| {
-                new_key = true;
-                KeyLockWaitState::new()
-            });
-        key_state.current_lock = current_lock;
+
+        let map_entry = self.inner.queue_map.entry(lock_wait_entry.key.clone());
+
+        // If it's not the first time the request is put into the queue, the request
+        // might be canceled from outside when the entry is temporarily absent
+        // in the queue. In this case, the cancellation operation is not done.
+        // Do it here. For details about this corner case, see document of
+        // `LockWaitContext::is_canceled` field.
+        if lock_wait_entry.req_states.is_canceled() {
+            self.on_push_canceled_entry(lock_wait_entry, map_entry);
+            return;
+        }
+
+        let mut key_state = map_entry.or_insert_with(|| {
+            new_key = true;
+            KeyLockWaitState::new()
+        });
+        if !current_lock.key.is_empty() {
+            key_state.current_lock = current_lock;
+        }
 
         if lock_wait_entry.legacy_wake_up_index.is_none() {
             lock_wait_entry.legacy_wake_up_index = Some(key_state.value().legacy_wake_up_index);
@@ -275,6 +288,31 @@ impl<L: LockManager> LockWaitQueues<L> {
         if new_key {
             LOCK_WAIT_QUEUE_ENTRIES_GAUGE_VEC.keys.inc()
         }
+    }
+
+    fn on_push_canceled_entry(
+        &self,
+        lock_wait_entry: Box<LockWaitEntry>,
+        key_state: dashmap::Entry<'_, Key, KeyLockWaitState, impl std::hash::BuildHasher>,
+    ) {
+        let mut err = lock_wait_entry.req_states.get_external_error();
+
+        if let dashmap::Entry::Occupied(key_state_entry) = key_state {
+            if let StorageError(box StorageErrorInner::Txn(TxnError(box TxnErrorInner::Mvcc(
+                MvccError(box MvccErrorInner::KeyIsLocked(lock_info)),
+            )))) = &mut err
+            {
+                // Update the lock info in the error to the latest if possible.
+                let latest_lock_info = &key_state_entry.get().current_lock;
+                if !latest_lock_info.key.is_empty() {
+                    *lock_info = latest_lock_info.clone();
+                }
+            }
+        }
+
+        // `key_state` is dropped here, so the mutex in the queue map is released.
+
+        (lock_wait_entry.key_cb)(Err(err), true);
     }
 
     /// Dequeues the head of the lock waiting queue of the specified key,
@@ -523,7 +561,7 @@ impl<L: LockManager> LockWaitQueues<L> {
                     reason: kvrpcpb::WriteConflictReason::PessimisticRetry,
                 },
             )));
-            cb(Err(e.into()));
+            cb(Err(e.into()), false);
         }
 
         // Return the item to be woken up in resumable way.
@@ -703,6 +741,7 @@ mod tests {
                 parameters,
                 should_not_exist: false,
                 lock_wait_token: token,
+                req_states: dummy_ctx.get_shared_states().clone(),
                 legacy_wake_up_index: None,
                 key_cb: Some(SyncWrapper::new(Box::new(move |res| tx.send(res).unwrap()))),
             });

--- a/src/storage/lock_manager/mod.rs
+++ b/src/storage/lock_manager/mod.rs
@@ -15,6 +15,7 @@ use parking_lot::Mutex;
 use tracker::TrackerToken;
 use txn_types::{Key, TimeStamp};
 
+pub use crate::storage::lock_manager::lock_wait_context::CancellationCallback;
 use crate::{
     server::lock_manager::{waiter_manager, waiter_manager::Callback},
     storage::{
@@ -147,7 +148,7 @@ pub trait LockManager: Clone + Send + Sync + 'static {
         wait_info: KeyLockWaitInfo,
         is_first_lock: bool,
         timeout: Option<WaitTimeout>,
-        cancel_callback: Box<dyn FnOnce(StorageError) + Send>,
+        cancel_callback: CancellationCallback,
         diag_ctx: DiagnosticContext,
     );
 
@@ -170,8 +171,7 @@ pub trait LockManager: Clone + Send + Sync + 'static {
 #[derive(Clone)]
 pub struct MockLockManager {
     allocated_token: Arc<AtomicU64>,
-    waiters:
-        Arc<Mutex<HashMap<LockWaitToken, (KeyLockWaitInfo, Box<dyn FnOnce(StorageError) + Send>)>>>,
+    waiters: Arc<Mutex<HashMap<LockWaitToken, (KeyLockWaitInfo, CancellationCallback)>>>,
 }
 
 impl MockLockManager {
@@ -205,7 +205,7 @@ impl LockManager for MockLockManager {
         wait_info: KeyLockWaitInfo,
         _is_first_lock: bool,
         _timeout: Option<WaitTimeout>,
-        cancel_callback: Box<dyn FnOnce(StorageError) + Send>,
+        cancel_callback: CancellationCallback,
         _diag_ctx: DiagnosticContext,
     ) {
         self.waiters

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -3560,8 +3560,8 @@ mod tests {
                 Error as KvError, ErrorInner as EngineErrorInner, ExpectedWrite, MockEngineBuilder,
             },
             lock_manager::{
-                DiagnosticContext, KeyLockWaitInfo, LockDigest, LockWaitToken, UpdateWaitForEvent,
-                WaitTimeout,
+                CancellationCallback, DiagnosticContext, KeyLockWaitInfo, LockDigest,
+                LockWaitToken, UpdateWaitForEvent, WaitTimeout,
             },
             mvcc::LockType,
             txn::{
@@ -8762,7 +8762,7 @@ mod tests {
             wait_info: KeyLockWaitInfo,
             is_first_lock: bool,
             timeout: Option<WaitTimeout>,
-            cancel_callback: Box<dyn FnOnce(Error) + Send>,
+            cancel_callback: CancellationCallback,
             diag_ctx: DiagnosticContext,
         ) {
             self.tx

--- a/src/storage/txn/commands/acquire_pessimistic_lock_resumed.rs
+++ b/src/storage/txn/commands/acquire_pessimistic_lock_resumed.rs
@@ -80,6 +80,7 @@ impl CommandExt for AcquirePessimisticLockResumed {
 
 impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for AcquirePessimisticLockResumed {
     fn process_write(self, snapshot: S, context: WriteContext<'_, L>) -> Result<WriteResult> {
+        fail_point!("acquire_pessimistic_lock_resumed_before_process_write");
         let mut modifies = vec![];
         let mut txn = None;
         let mut reader: Option<SnapshotReader<S>> = None;

--- a/src/storage/txn/commands/acquire_pessimistic_lock_resumed.rs
+++ b/src/storage/txn/commands/acquire_pessimistic_lock_resumed.rs
@@ -1,11 +1,16 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::sync::Arc;
+
 // #[PerformanceCriticalPath]
 use kvproto::kvrpcpb::ExtraOp;
 use txn_types::{insert_old_value_if_resolved, Key, OldValues};
 
 use crate::storage::{
-    lock_manager::{lock_waiting_queue::LockWaitEntry, LockManager, LockWaitToken},
+    lock_manager::{
+        lock_wait_context::LockWaitContextSharedState, lock_waiting_queue::LockWaitEntry,
+        LockManager, LockWaitToken,
+    },
     mvcc::{Error as MvccError, ErrorInner as MvccErrorInner, MvccTxn, SnapshotReader},
     txn::{
         acquire_pessimistic_lock,
@@ -27,6 +32,7 @@ pub struct ResumedPessimisticLockItem {
     pub should_not_exist: bool,
     pub params: PessimisticLockParameters,
     pub lock_wait_token: LockWaitToken,
+    pub req_states: Arc<LockWaitContextSharedState>,
 }
 
 command! {
@@ -79,6 +85,7 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for AcquirePessimisticLockR
                 should_not_exist,
                 params,
                 lock_wait_token,
+                req_states,
             } = item;
 
             // TODO: Refine the code for rebuilding txn state.
@@ -136,6 +143,7 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for AcquirePessimisticLockR
                     let mut lock_info =
                         WriteResultLockInfo::new(lock_info, params, key, should_not_exist);
                     lock_info.lock_wait_token = lock_wait_token;
+                    lock_info.req_states = Some(req_states);
                     res.push(PessimisticLockKeyResult::Waiting);
                     encountered_locks.push(lock_info);
                 }
@@ -185,6 +193,7 @@ impl AcquirePessimisticLockResumed {
                     should_not_exist: item.should_not_exist,
                     params: item.parameters,
                     lock_wait_token: item.lock_wait_token,
+                    req_states: item.req_states.unwrap(),
                 }
             })
             .collect();
@@ -207,7 +216,7 @@ mod tests {
 
     use super::*;
     use crate::storage::{
-        lock_manager::{MockLockManager, WaitTimeout},
+        lock_manager::{lock_wait_context::LockWaitContext, MockLockManager, WaitTimeout},
         mvcc::tests::{must_locked, write},
         txn::{
             commands::pessimistic_rollback::tests::must_success as must_pessimistic_rollback,
@@ -304,16 +313,20 @@ mod tests {
 
         let key = Key::from_raw(key);
         let lock_hash = key.gen_hash();
+        let token = LockWaitToken(Some(random()));
+        // The tests in this file doesn't need a valid req_state. Set a dummy value
+        // here.
+        let req_state = Arc::new(LockWaitContextSharedState::new_dummy(token, key.clone()));
         let entry = LockWaitEntry {
             key,
             lock_hash,
             parameters,
             should_not_exist: false,
-            lock_wait_token: LockWaitToken(Some(random())),
+            lock_wait_token: token,
             legacy_wake_up_index: Some(0),
+            req_states,
             key_cb: None,
         };
-
         Box::new(entry)
     }
 

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -68,9 +68,7 @@ use crate::{
         },
         lock_manager::{
             self,
-            lock_wait_context::{
-                CallbackWithSharedError, LockWaitContext, PessimisticLockKeyCallback,
-            },
+            lock_wait_context::{LockWaitContext, PessimisticLockKeyCallback},
             lock_waiting_queue::{DelayedNotifyAllFuture, LockWaitEntry, LockWaitQueues},
             DiagnosticContext, LockManager, LockWaitToken,
         },
@@ -1010,7 +1008,7 @@ impl<E: Engine, L: LockManager> Scheduler<E, L> {
                             reason: kvrpcpb::WriteConflictReason::PessimisticRetry,
                         },
                     )));
-                    cb(Err(e.into()));
+                    cb(Err(e.into()), false);
                 }
 
                 for f in delayed_wake_up_futures {

--- a/tests/integrations/coprocessor/test_select.rs
+++ b/tests/integrations/coprocessor/test_select.rs
@@ -2176,14 +2176,23 @@ fn test_batch_request() {
                     row_count += 1;
                 }
                 assert_eq!(row_count, expected_len);
+                assert!(region_err.is_none());
+                assert!(locked.is_none());
+                assert!(other_err.is_empty());
             }
             QueryResult::ErrRegion => {
                 assert!(region_err.is_some());
+                assert!(locked.is_none());
+                assert!(other_err.is_empty());
             }
             QueryResult::ErrLocked => {
+                assert!(region_err.is_none());
                 assert!(locked.is_some());
+                assert!(other_err.is_empty());
             }
             QueryResult::ErrOther => {
+                assert!(region_err.is_none());
+                assert!(locked.is_none());
                 assert!(!other_err.is_empty())
             }
         }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #13298

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
scheduler/lock_manager: Handle the corner case that resumable pessimstic lock request is pushed to queue after cancelling.

When a lock-waiting request is woken up and continues its execution, in some cases it's possible that it encounters other transaction's lock agian. In this case, the entry will be put to the lock waiting queue again. However, there might be problem when LockManager tries to cancel the request (due to timeout or other possible errors. This PR handles this case.
```

The detailed time-sequence of this corner case is explained in the comments in the code.
There's also some fixes to the previously merged code.

### Related changes

\-

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- Performance regression
    - Consumes more CPU

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
