### PR TITLE
raftstore: allow a read-only flashback request to be propsed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5479,7 +5479,7 @@ dependencies = [
  "log_wrappers",
  "openssl",
  "prometheus",
- "rand 0.8.3",
+ "rand 0.8.5",
  "serde",
  "serde_derive",
  "slog",

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -1588,7 +1588,12 @@ where
         let include_region =
             req.get_header().get_region_epoch().get_version() >= self.last_merge_version;
         check_region_epoch(req, &self.region, include_region)?;
-        check_flashback_state(self.region.get_is_in_flashback(), req, self.region_id())?;
+        check_flashback_state(
+            self.region.get_is_in_flashback(),
+            req,
+            self.region_id(),
+            false,
+        )?;
         if req.has_admin_request() {
             self.exec_admin_cmd(ctx, req)
         } else {

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -6284,7 +6284,7 @@ where
     fn on_set_flashback_state(&mut self, is_in_flashback: bool) {
         // Set flashback memory
         self.fsm.peer.is_in_flashback = (|| {
-            fail_point!("keep_peer_fsm_flashback_state_false", |_| { false });
+            fail_point!("keep_peer_fsm_flashback_state_false", |_| false);
             is_in_flashback
         })();
         // Let the leader lease to None to ensure that local reads are not executed.

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -318,6 +318,7 @@ pub fn check_flashback_state(
     is_in_flashback: bool,
     req: &RaftCmdRequest,
     region_id: u64,
+    skip_not_prepared: bool,
 ) -> Result<()> {
     // The admin flashback cmd could be proposed/applied under any state.
     if req.has_admin_request()
@@ -335,7 +336,7 @@ pub fn check_flashback_state(
     }
     // If the region is not in the flashback state, the flashback request itself
     // should be rejected.
-    if !is_in_flashback && is_flashback_request {
+    if !is_in_flashback && is_flashback_request && !skip_not_prepared {
         return Err(Error::FlashbackNotPrepared(region_id));
     }
     Ok(())

--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -813,7 +813,7 @@ where
         // Check whether the region is in the flashback state and the local read could
         // be performed.
         let is_in_flashback = delegate.region.is_in_flashback;
-        if let Err(e) = util::check_flashback_state(is_in_flashback, req, region_id) {
+        if let Err(e) = util::check_flashback_state(is_in_flashback, req, region_id, false) {
             TLS_LOCAL_READ_METRICS.with(|m| match e {
                 Error::FlashbackNotPrepared(_) => {
                     m.borrow_mut().reject_reason.flashback_not_prepared.inc()

--- a/src/storage/txn/actions/flashback_to_version.rs
+++ b/src/storage/txn/actions/flashback_to_version.rs
@@ -5,8 +5,8 @@ use std::ops::Bound;
 use txn_types::{Key, Lock, LockType, TimeStamp, Write, WriteType};
 
 use crate::storage::{
-    mvcc::{MvccReader, MvccTxn, SnapshotReader, MAX_TXN_WRITE_SIZE},
-    txn::{actions::check_txn_status::rollback_lock, Result as TxnResult},
+    mvcc::{self, MvccReader, MvccTxn, SnapshotReader, MAX_TXN_WRITE_SIZE},
+    txn::{self, actions::check_txn_status::rollback_lock, Result as TxnResult},
     Snapshot,
 };
 
@@ -218,8 +218,29 @@ pub fn commit_flashback_key(
             lock.is_pessimistic_txn(),
             flashback_commit_ts,
         );
+    } else {
+        return Err(txn::Error::from_mvcc(mvcc::ErrorInner::TxnLockNotFound {
+            start_ts: flashback_start_ts,
+            commit_ts: flashback_commit_ts,
+            key: key_to_commit.to_raw()?,
+        }));
     }
     Ok(())
+}
+
+// Check if the flashback has been finished before.
+pub fn check_flashback_commit(
+    reader: &mut MvccReader<impl Snapshot>,
+    key_to_commit: &Key,
+    flashback_start_ts: TimeStamp,
+    flashback_commit_ts: TimeStamp,
+) -> TxnResult<bool> {
+    if let Some(write) = reader.get_write(key_to_commit, flashback_commit_ts, None)? {
+        if write.start_ts == flashback_start_ts {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 pub fn get_first_user_key(

--- a/tests/integrations/server/kv_service.rs
+++ b/tests/integrations/server/kv_service.rs
@@ -781,7 +781,7 @@ fn test_mvcc_flashback_unprepared() {
     req.start_key = b"a".to_vec();
     req.end_key = b"z".to_vec();
     let resp = client.kv_flashback_to_version(&req).unwrap();
-    assert!(resp.get_region_error().has_flashback_not_prepared());
+    assert!(resp.get_error().contains("txn lock not found"));
     must_kv_read_equal(&client, ctx, k, v, 6);
 }
 


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What is changed and how it works?

Issue Number: Close #13870.

What's Changed:

```commit-message
Because the flashback read request must be proposed after the `PrepareFlashback`
and it won't have any side effects, it's safe to allow a read-only flashback request to
be proposed. In this way, we can also fix #13870.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None.
```
