### PR TITLE
raftstore: split raft write batch on failure

### DIFF
--- a/components/engine_panic/src/raft_engine.rs
+++ b/components/engine_panic/src/raft_engine.rs
@@ -209,4 +209,16 @@ impl RaftLogBatch for PanicWriteBatch {
     fn put_apply_state(&mut self, raft_group_id: u64, state: &RaftApplyState) -> Result<()> {
         panic!()
     }
+
+    fn set_save_point(&mut self) {
+        panic!()
+    }
+
+    fn pop_save_point(&mut self) {
+        panic!()
+    }
+
+    fn rollback_to_save_point(&mut self) {
+        panic!()
+    }
 }

--- a/components/engine_rocks/src/raft_engine.rs
+++ b/components/engine_rocks/src/raft_engine.rs
@@ -431,6 +431,18 @@ impl RaftLogBatch for RocksWriteBatchVec {
     fn put_apply_state(&mut self, raft_group_id: u64, state: &RaftApplyState) -> Result<()> {
         self.put_msg(&keys::apply_state_key(raft_group_id), state)
     }
+
+    fn set_save_point(&mut self) {
+        WriteBatch::set_save_point(self);
+    }
+
+    fn pop_save_point(&mut self) {
+        WriteBatch::pop_save_point(self).unwrap();
+    }
+
+    fn rollback_to_save_point(&mut self) {
+        WriteBatch::rollback_to_save_point(self).unwrap();
+    }
 }
 
 impl RocksWriteBatchVec {

--- a/components/engine_traits/src/raft_engine.rs
+++ b/components/engine_traits/src/raft_engine.rs
@@ -183,6 +183,10 @@ pub trait RaftLogBatch: Send {
 
     /// Merge another RaftLogBatch to itself.
     fn merge(&mut self, _: Self) -> Result<()>;
+
+    fn set_save_point(&mut self);
+    fn pop_save_point(&mut self);
+    fn rollback_to_save_point(&mut self);
 }
 
 #[derive(Clone, Copy, Default)]

--- a/components/raft_log_engine/src/engine.rs
+++ b/components/raft_log_engine/src/engine.rs
@@ -412,6 +412,18 @@ impl RaftLogBatchTrait for RaftLogBatch {
             .put_message(raft_group_id, APPLY_STATE_KEY.to_vec(), state)
             .map_err(transfer_error)
     }
+
+    fn set_save_point(&mut self) {
+        unimplemented!()
+    }
+
+    fn pop_save_point(&mut self) {
+        unimplemented!()
+    }
+
+    fn rollback_to_save_point(&mut self) {
+        unimplemented!()
+    }
 }
 
 impl RaftEngineReadOnly for RaftLogEngine {
@@ -540,30 +552,21 @@ impl RaftEngine for RaftLogEngine {
 
     fn append(&self, raft_group_id: u64, entries: Vec<Entry>) -> Result<usize> {
         let mut batch = Self::LogBatch::default();
-        batch
-            .0
-            .add_entries::<MessageExtTyped>(raft_group_id, &entries)
-            .map_err(transfer_error)?;
-        self.0.write(&mut batch.0, false).map_err(transfer_error)
+        batch.append(raft_group_id, entries)?;
+        self.consume(&mut batch, false)
     }
 
     fn put_store_ident(&self, ident: &StoreIdent) -> Result<()> {
         let mut batch = Self::LogBatch::default();
-        batch
-            .0
-            .put_message(STORE_STATE_ID, STORE_IDENT_KEY.to_vec(), ident)
-            .map_err(transfer_error)?;
-        self.0.write(&mut batch.0, true).map_err(transfer_error)?;
+        batch.put_store_ident(ident)?;
+        self.consume(&mut batch, true)?;
         Ok(())
     }
 
     fn put_raft_state(&self, raft_group_id: u64, state: &RaftLocalState) -> Result<()> {
         let mut batch = Self::LogBatch::default();
-        batch
-            .0
-            .put_message(raft_group_id, RAFT_LOG_STATE_KEY.to_vec(), state)
-            .map_err(transfer_error)?;
-        self.0.write(&mut batch.0, false).map_err(transfer_error)?;
+        batch.put_raft_state(raft_group_id, state)?;
+        self.consume(&mut batch, false)?;
         Ok(())
     }
 
@@ -585,7 +588,7 @@ impl RaftEngine for RaftLogEngine {
             old_first_index.push(self.0.first_index(task.raft_group_id));
         }
 
-        self.0.write(&mut batch.0, false).map_err(transfer_error)?;
+        self.consume(&mut batch, false)?;
 
         let mut total = 0;
         for (old_first_index, task) in old_first_index.iter().zip(tasks) {

--- a/components/raftstore/src/store/async_io/write_tests.rs
+++ b/components/raftstore/src/store/async_io/write_tests.rs
@@ -273,7 +273,7 @@ fn test_worker() {
     task_1.raft_state = Some(new_raft_state(5, 123, 6, 8));
     task_1.messages.append(&mut vec![RaftMessage::default()]);
 
-    t.worker.batch.add_write_task(task_1);
+    t.worker.batch.add_write_task(&engines.raft, task_1);
 
     let mut task_2 = WriteTask::<KvTestEngine, RaftTestEngine>::new(region_2, 2, 15);
     init_write_batch(&engines, &mut task_2);
@@ -287,7 +287,7 @@ fn test_worker() {
         .messages
         .append(&mut vec![RaftMessage::default(), RaftMessage::default()]);
 
-    t.worker.batch.add_write_task(task_2);
+    t.worker.batch.add_write_task(&engines.raft, task_2);
 
     let mut task_3 = WriteTask::<KvTestEngine, RaftTestEngine>::new(region_1, 1, 11);
     init_write_batch(&engines, &mut task_3);
@@ -303,7 +303,7 @@ fn test_worker() {
         .messages
         .append(&mut vec![RaftMessage::default(), RaftMessage::default()]);
 
-    t.worker.batch.add_write_task(task_3);
+    t.worker.batch.add_write_task(&engines.raft, task_3);
 
     t.worker.write_to_db(true);
 


### PR DESCRIPTION
Signed-off-by: tabokie <xy.tao@outlook.com>

### What is changed and how it works?

Issue Number: Close #13848

What's Changed:

```commit-message
Fix panic when the size of one single write exceeds 2GiB.
```

[TODO] Test

### Related changes

- Raft Engine:

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix panic when the size of one single write exceeds 2GiB.
```
