### PR TITLE
raftstore: remove is_in_flashback field in peer fsm

### DIFF
--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -1334,7 +1334,7 @@ where
             new_read_index_request(region_id, region_epoch.clone(), self.fsm.peer.peer.clone());
         // Allow to capture change even is in flashback state.
         // TODO: add a test case for this kind of situation.
-        if self.fsm.peer.is_in_flashback {
+        if self.region().is_in_flashback {
             let mut flags = WriteBatchFlags::from_bits_check(msg.get_header().get_flags());
             flags.insert(WriteBatchFlags::FLASHBACK);
             msg.mut_header().set_flags(flags.bits());
@@ -4738,9 +4738,6 @@ where
             "region" => ?region,
         );
 
-        // Update the flashback flag according to the snapshot region meta.
-        self.fsm.peer.is_in_flashback = region.is_in_flashback;
-
         let mut state = self.ctx.global_replication_state.lock().unwrap();
         let gb = state
             .calculate_commit_group(self.fsm.peer.replication_mode_version, region.get_peers());
@@ -4897,9 +4894,7 @@ where
                 }
                 ExecResult::IngestSst { ssts } => self.on_ingest_sst_result(ssts),
                 ExecResult::TransferLeader { term } => self.on_transfer_leader(term),
-                ExecResult::SetFlashbackState { region } => {
-                    self.on_set_flashback_state(region.get_is_in_flashback())
-                }
+                ExecResult::SetFlashbackState { region } => self.on_set_flashback_state(region),
             }
         }
 
@@ -5111,11 +5106,11 @@ where
         };
         // Check whether the region is in the flashback state and the request could be
         // proposed. Skip the not prepared error because the
-        // `self.fsm.peer.is_in_flashback` may not be the latest right after applying
+        // `self.region().is_in_flashback` may not be the latest right after applying
         // the `PrepareFlashback` admin command, we will let it pass here and check in
         // the apply phase.
         if let Err(e) =
-            util::check_flashback_state(self.fsm.peer.is_in_flashback, msg, region_id, true)
+            util::check_flashback_state(self.region().is_in_flashback, msg, region_id, true)
         {
             match e {
                 Error::FlashbackInProgress(_) => self
@@ -6284,12 +6279,13 @@ where
         self.fsm.has_ready = true;
     }
 
-    fn on_set_flashback_state(&mut self, is_in_flashback: bool) {
-        // Set flashback memory
-        self.fsm.peer.is_in_flashback = (|| {
-            fail_point!("keep_peer_fsm_flashback_state_false", |_| false);
-            is_in_flashback
-        })();
+    fn on_set_flashback_state(&mut self, mut region: metapb::Region) {
+        #[cfg(feature = "failpoints")]
+        fail_point!("keep_peer_fsm_flashback_state_false", |_| {
+            region.is_in_flashback = false;
+        });
+        // Update the region meta.
+        self.update_region(region);
         // Let the leader lease to None to ensure that local reads are not executed.
         self.fsm.peer.leader_lease_mut().expire_remote_lease();
     }

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -4738,6 +4738,9 @@ where
             "region" => ?region,
         );
 
+        // Update the flashback flag according to the snapshot region meta.
+        self.fsm.peer.is_in_flashback = region.is_in_flashback;
+
         let mut state = self.ctx.global_replication_state.lock().unwrap();
         let gb = state
             .calculate_commit_group(self.fsm.peer.replication_mode_version, region.get_peers());

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -1030,8 +1030,6 @@ where
     /// lead_transferee if this peer(leader) is in a leadership transferring.
     pub lead_transferee: u64,
     pub unsafe_recovery_state: Option<UnsafeRecoveryState>,
-    // Used as the memory state for Flashback to reject RW/Schedule before proposing.
-    pub is_in_flashback: bool,
     pub snapshot_recovery_state: Option<SnapshotRecoveryState>,
 }
 
@@ -1167,7 +1165,6 @@ where
             last_region_buckets: None,
             lead_transferee: raft::INVALID_ID,
             unsafe_recovery_state: None,
-            is_in_flashback: region.get_is_in_flashback(),
             snapshot_recovery_state: None,
         };
 
@@ -3531,7 +3528,7 @@ where
             self.force_leader.is_some(),
         ) {
             None
-        } else if self.is_in_flashback {
+        } else if self.region().is_in_flashback {
             debug!(
                 "prevents renew lease while in flashback state";
                 "region_id" => self.region_id,

--- a/src/storage/txn/actions/flashback_to_version.rs
+++ b/src/storage/txn/actions/flashback_to_version.rs
@@ -238,8 +238,10 @@ pub fn check_flashback_commit(
         // If the lock doesn't exist and the flashback commit record exists, it means the flashback
         // has been finished.
         None => {
-            if let Some(write) = reader.get_write(key_to_commit, flashback_commit_ts, None)? {
-                if write.start_ts == flashback_start_ts {
+            if let Some((commit_ts, write)) =
+                reader.seek_write(key_to_commit, flashback_commit_ts)?
+            {
+                if commit_ts == flashback_commit_ts && write.start_ts == flashback_start_ts {
                     return Ok(true);
                 }
             }

--- a/src/storage/txn/actions/flashback_to_version.rs
+++ b/src/storage/txn/actions/flashback_to_version.rs
@@ -1,7 +1,5 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::ops::Bound;
-
 use txn_types::{Key, Lock, LockType, TimeStamp, Write, WriteType};
 
 use crate::storage::{
@@ -35,11 +33,6 @@ pub fn flashback_to_version_read_write(
     flashback_version: TimeStamp,
     flashback_commit_ts: TimeStamp,
 ) -> TxnResult<Vec<Key>> {
-    // Filter out the SST that does not have a newer version than
-    // `flashback_version` in `CF_WRITE`, i.e, whose latest `commit_ts` <=
-    // `flashback_version`. By doing this, we can only flashback those keys that
-    // have version changed since `flashback_version` as much as possible.
-    reader.set_hint_min_ts(Some(Bound::Excluded(flashback_version)));
     // To flashback the data, we need to get all the latest visible keys first by
     // scanning every unique key in `CF_WRITE`.
     let keys_result = reader.scan_latest_user_keys(

--- a/src/storage/txn/commands/flashback_to_version_read_phase.rs
+++ b/src/storage/txn/commands/flashback_to_version_read_phase.rs
@@ -145,9 +145,12 @@ impl<S: Snapshot> ReadCommand<S> for FlashbackToVersionReadPhase {
                     //   completion of the 2pc.
                     // - To make sure the key locked in the latch is the same as the actual key
                     //   written, we pass it to the key in `process_write' after getting it.
-                    let key_to_lock = if let Some(first_key) =
-                        get_first_user_key(&mut reader, &self.start_key, &self.end_key)?
-                    {
+                    let key_to_lock = if let Some(first_key) = get_first_user_key(
+                        &mut reader,
+                        &self.start_key,
+                        &self.end_key,
+                        self.version,
+                    )? {
                         first_key
                     } else {
                         // If the key is None return directly
@@ -184,9 +187,12 @@ impl<S: Snapshot> ReadCommand<S> for FlashbackToVersionReadPhase {
                     // 2pc. So When overwriting the write, we skip the immediate
                     // write of this key and instead put it after the completion
                     // of the 2pc.
-                    next_write_key = if let Some(first_key) =
-                        get_first_user_key(&mut reader, &self.start_key, &self.end_key)?
-                    {
+                    next_write_key = if let Some(first_key) = get_first_user_key(
+                        &mut reader,
+                        &self.start_key,
+                        &self.end_key,
+                        self.version,
+                    )? {
                         first_key
                     } else {
                         // If the key is None return directly

--- a/tests/integrations/server/kv_service.rs
+++ b/tests/integrations/server/kv_service.rs
@@ -782,7 +782,32 @@ fn test_mvcc_flashback_unprepared() {
     req.end_key = b"z".to_vec();
     let resp = client.kv_flashback_to_version(&req).unwrap();
     assert!(resp.get_error().contains("txn lock not found"));
-    must_kv_read_equal(&client, ctx, k, v, 6);
+    must_kv_read_equal(&client, ctx.clone(), k.clone(), v, 6);
+    // Flashback with preparing.
+    must_flashback_to_version(&client, ctx.clone(), 0, 6, 7);
+    let mut get_req = GetRequest::default();
+    get_req.set_context(ctx.clone());
+    get_req.key = k;
+    get_req.version = 7;
+    let get_resp = client.kv_get(&get_req).unwrap();
+    assert!(!get_resp.has_region_error());
+    assert!(!get_resp.has_error());
+    assert_eq!(get_resp.value, b"".to_vec());
+    // Mock the flashback retry.
+    let mut req = FlashbackToVersionRequest::default();
+    req.set_context(ctx);
+    req.set_start_ts(6);
+    req.set_commit_ts(7);
+    req.version = 0;
+    req.start_key = b"a".to_vec();
+    req.end_key = b"z".to_vec();
+    let resp = client.kv_flashback_to_version(&req).unwrap();
+    assert!(!resp.has_region_error());
+    assert!(resp.get_error().is_empty());
+    let get_resp = client.kv_get(&get_req).unwrap();
+    assert!(!get_resp.has_region_error());
+    assert!(!get_resp.has_error());
+    assert_eq!(get_resp.value, b"".to_vec());
 }
 
 // raft related RPC is tested as parts of test_snapshot.rs, so skip here.


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What is changed and how it works?

Issue Number: Close #13868.

What's Changed:

```commit-message
- Remove `is_in_flashback` field and use the region meta as the only source of truth in `PeerFSM`.
- Add a corresponding test case.
- Some minor refinement to the code and tests.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None.
```
