### PR TITLE
log-backup: make the safepoint lifetime 2hours

### DIFF
--- a/components/backup-stream/src/checkpoint_manager.rs
+++ b/components/backup-stream/src/checkpoint_manager.rs
@@ -356,9 +356,13 @@ impl<PD: PdClient + 'static> FlushObserver for BasicFlushObserver<PD> {
             .update_service_safe_point(
                 format!("backup-stream-{}-{}", task, self.store_id),
                 TimeStamp::new(rts.saturating_sub(1)),
-                // Add a service safe point for 30 mins (6x the default flush interval).
-                // It would probably be safe.
-                Duration::from_secs(1800),
+                // Add a service safe point for 2 hours (40x the default flush interval).
+                // In some extreme scenario (for example, the external storage is unavailable),
+                // we may keep fail for flushing, we should make sure the safepoint present before
+                // flush errors expires retry count.
+                // TODO: We'd better make the coordinator, who really calculates the checkpoint to
+                // register service safepoint.
+                Duration::from_secs(60 * 60 * 2),
             )
             .await
         {


### PR DESCRIPTION
Signed-off-by: hillium <yu745514916@live.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/pingcap/tidb/issues/39603

What's Changed:
This PR make the lifetime of service points that created by PITR 2 hours, which is longer than `FLUSH_INTERVAL * FLUSH_MAX_RETRY_TIME`

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
- (Almost) No code

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
