### PR TITLE
raftstore-v2: use snapshot to initialize split

### DIFF
--- a/components/raftstore-v2/src/fsm/peer.rs
+++ b/components/raftstore-v2/src/fsm/peer.rs
@@ -221,6 +221,10 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> PeerFsmDelegate<'a, EK, ER,
                 PeerMsg::Tick(tick) => self.on_tick(tick),
                 PeerMsg::ApplyRes(res) => self.fsm.peer.on_apply_res(self.store_ctx, res),
                 PeerMsg::SplitInit(msg) => self.fsm.peer.on_split_init(self.store_ctx, msg),
+                PeerMsg::SplitInitFinish(region_id) => self
+                    .fsm
+                    .peer
+                    .on_split_init_finish(self.store_ctx, region_id),
                 PeerMsg::Start => self.on_start(),
                 PeerMsg::Noop => unimplemented!(),
                 PeerMsg::Persisted {

--- a/components/raftstore-v2/src/operation/command/admin/split.rs
+++ b/components/raftstore-v2/src/operation/command/admin/split.rs
@@ -27,6 +27,7 @@
 
 use std::collections::VecDeque;
 
+use collections::HashSet;
 use crossbeam::channel::{SendError, TrySendError};
 use engine_traits::{
     Checkpointer, DeleteStrategy, KvEngine, OpenOptions, RaftEngine, RaftLogBatch, Range,
@@ -37,17 +38,18 @@ use keys::enc_end_key;
 use kvproto::{
     metapb::{self, Region, RegionEpoch},
     raft_cmdpb::{AdminRequest, AdminResponse, RaftCmdRequest, SplitRequest},
-    raft_serverpb::RegionLocalState,
+    raft_serverpb::{RaftMessage, RaftSnapshotData, RegionLocalState},
 };
 use protobuf::Message;
-use raft::RawNode;
+use raft::{prelude::Snapshot, RawNode, INVALID_ID};
 use raftstore::{
     coprocessor::RegionChangeReason,
     store::{
         fsm::apply::validate_batch_split,
         metrics::PEER_ADMIN_CMD_COUNTER,
+        snap::TABLET_SNAPSHOT_VERSION,
         util::{self, KeysInfoFormatter},
-        PeerPessimisticLocks, PeerStat, ProposalContext, RAFT_INIT_LOG_INDEX,
+        PeerPessimisticLocks, PeerStat, ProposalContext, RAFT_INIT_LOG_INDEX, RAFT_INIT_LOG_TERM,
     },
     Result,
 };
@@ -69,14 +71,35 @@ pub struct SplitResult {
     pub derived_index: usize,
     pub tablet_index: u64,
 }
+
+#[derive(Debug)]
 pub struct SplitInit {
     /// Split region
     pub region: metapb::Region,
     pub check_split: bool,
-    pub parent_is_leader: bool,
+    pub source_leader: bool,
+    pub source_id: u64,
 
     /// In-memory pessimistic locks that should be inherited from parent region
     pub locks: PeerPessimisticLocks,
+}
+
+impl SplitInit {
+    fn to_snapshot(&self) -> Snapshot {
+        let mut snapshot = Snapshot::default();
+        // Set snapshot metadata.
+        snapshot.mut_metadata().set_term(RAFT_INIT_LOG_TERM);
+        snapshot.mut_metadata().set_index(RAFT_INIT_LOG_INDEX);
+        let conf_state = util::conf_state_from_region(&self.region);
+        snapshot.mut_metadata().set_conf_state(conf_state);
+        // Set snapshot data.
+        let mut snap_data = RaftSnapshotData::default();
+        snap_data.set_region(self.region.clone());
+        snap_data.set_version(TABLET_SNAPSHOT_VERSION);
+        snap_data.mut_meta().set_for_balance(false);
+        snapshot.set_data(snap_data.write_to_bytes().unwrap().into());
+        snapshot
+    }
 }
 
 impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
@@ -263,7 +286,7 @@ impl<EK: KvEngine, R: ApplyResReporter> Apply<EK, R> {
 }
 
 impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
-    pub fn on_ready_split_region<T>(
+    pub fn on_apply_res_split<T>(
         &mut self,
         store_ctx: &mut StoreContext<EK, ER, T>,
         derived_index: usize,
@@ -321,15 +344,18 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         }
 
         let last_region_id = regions.last().unwrap().get_id();
+        let mut new_ids = HashSet::default();
         for (new_region, locks) in regions.into_iter().zip(region_locks) {
             let new_region_id = new_region.get_id();
             if new_region_id == region_id {
                 continue;
             }
 
+            new_ids.insert(new_region_id);
             let split_init = PeerMsg::SplitInit(Box::new(SplitInit {
                 region: new_region,
-                parent_is_leader: self.is_leader(),
+                source_leader: self.is_leader(),
+                source_id: region_id,
                 check_split: last_region_id == new_region_id,
                 locks,
             }));
@@ -353,6 +379,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
                 _ => unreachable!(),
             }
         }
+        self.split_trace_mut().push((tablet_index, new_ids));
     }
 
     pub fn on_split_init<T>(
@@ -361,88 +388,52 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         split_init: Box<SplitInit>,
     ) {
         let region_id = split_init.region.id;
-        let replace = split_init.region.get_region_epoch().get_version()
-            > self
-                .storage()
-                .region_state()
-                .get_region()
-                .get_region_epoch()
-                .get_version();
-
-        if !self.storage().is_initialized() || replace {
-            let split_temp_path = store_ctx.tablet_factory.tablet_path_with_prefix(
-                SPLIT_PREFIX,
-                region_id,
-                RAFT_INIT_LOG_INDEX,
-            );
-
-            let tablet = store_ctx
-                .tablet_factory
-                .load_tablet(&split_temp_path, region_id, RAFT_INIT_LOG_INDEX)
-                .unwrap_or_else(|e| {
-                    panic!(
-                        "{:?} fails to load tablet {:?} :{:?}",
-                        self.logger.list(),
-                        split_temp_path,
-                        e
-                    )
-                });
-
-            self.tablet_mut().set(tablet);
-
-            let storage = Storage::with_split(
-                self.peer().get_store_id(),
-                &split_init.region,
-                store_ctx.engine.clone(),
-                store_ctx.read_scheduler.clone(),
-                &store_ctx.logger,
-            )
-            .unwrap_or_else(|e| panic!("fail to create storage: {:?}", e))
-            .unwrap();
-
-            let applied_index = storage.apply_state().get_applied_index();
-            let peer_id = storage.peer().get_id();
-            let raft_cfg = store_ctx.cfg.new_raft_config(peer_id, applied_index);
-
-            let mut raft_group = RawNode::new(&raft_cfg, storage, &self.logger).unwrap();
-            // If this region has only one peer and I am the one, campaign directly.
-            if split_init.region.get_peers().len() == 1 {
-                raft_group.campaign().unwrap();
-                self.set_has_ready();
-            }
-            self.set_raft_group(raft_group);
-        } else {
-            // TODO: when reaching here (peer is initalized before and cannot be replaced),
-            // it is much complexer.
+        if self.storage().is_initialized() || self.raft_group().snap().is_some() {
+            let _ = store_ctx
+                .router
+                .force_send(split_init.source_id, PeerMsg::SplitInitFinish(region_id));
             return;
         }
 
+        let snap = split_init.to_snapshot();
+        let mut msg = raft::eraftpb::Message::default();
+        msg.set_to(self.peer_id());
+        msg.set_from(self.leader_id());
+        msg.set_msg_type(raft::eraftpb::MessageType::MsgSnapshot);
+        msg.set_snapshot(snap);
+        msg.set_term(self.term());
+        let res = self.raft_group_mut().step(msg);
+        let accept_snap = self.raft_group().snap().is_some();
+        if res.is_err() || !accept_snap {
+            panic!(
+                "{:?} failed to accept snapshot {:?} with error {}",
+                self.logger.list(),
+                res,
+                accept_snap
+            );
+        }
+        let prev = self.storage_mut().split_init_mut().replace(split_init);
+        assert!(prev.is_none(), "{:?}", prev);
+        self.set_has_ready();
+    }
+
+    pub fn post_split_init<T>(
+        &mut self,
+        store_ctx: &mut StoreContext<EK, ER, T>,
+        split_init: Box<SplitInit>,
+    ) {
+        if split_init.source_leader && self.leader_id() == INVALID_ID {
+            let _ = self.raft_group_mut().campaign();
+            self.set_has_ready();
+
+            *self.txn_ext().pessimistic_locks.write() = split_init.locks;
+            // The new peer is likely to become leader, send a heartbeat immediately to
+            // reduce client query miss.
+            self.region_heartbeat_pd(store_ctx);
+        }
+        let region_id = self.region_id();
         {
             let mut meta = store_ctx.store_meta.lock().unwrap();
-
-            info!(
-                self.logger,
-                "init split region";
-                "region" => ?split_init.region,
-            );
-
-            // TODO: GlobalReplicationState
-
-            for p in split_init.region.get_peers() {
-                self.insert_peer_cache(p.clone());
-            }
-
-            if split_init.parent_is_leader {
-                if self.maybe_campaign() {
-                    self.set_has_ready();
-                }
-
-                *self.txn_ext().pessimistic_locks.write() = split_init.locks;
-                // The new peer is likely to become leader, send a heartbeat immediately to
-                // reduce client query miss.
-                self.region_heartbeat_pd(store_ctx);
-            }
-
             meta.tablet_caches.insert(region_id, self.tablet().clone());
             meta.readers
                 .insert(region_id, self.generate_read_delegate());
@@ -453,8 +444,28 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         if split_init.check_split {
             // TODO: check if the last region needs to split again
         }
+        let _ = store_ctx
+            .router
+            .force_send(split_init.source_id, PeerMsg::SplitInitFinish(region_id));
+    }
 
-        self.schedule_apply_fsm(store_ctx);
+    pub fn on_split_init_finish<T>(&mut self, ctx: &mut StoreContext<EK, ER, T>, region_id: u64) {
+        let mut found = false;
+        for (tablet_index, ids) in self.split_trace_mut() {
+            if ids.remove(&region_id) {
+                found = true;
+                break;
+            }
+        }
+        assert!(found, "{:?} {}", self.logger.list(), region_id);
+        let split_trace = self.split_trace_mut();
+        if !split_trace.first().unwrap().1.is_empty() {
+            return;
+        }
+        // There should be very few elements in the vector.
+        let tablet_index = split_trace.remove(0).0;
+        // Persist apply index.
+        self.set_has_ready();
     }
 }
 

--- a/components/raftstore-v2/src/operation/command/mod.rs
+++ b/components/raftstore-v2/src/operation/command/mod.rs
@@ -305,7 +305,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
                     regions,
                     derived_index,
                     tablet_index,
-                }) => self.on_ready_split_region(ctx, derived_index, tablet_index, regions),
+                }) => self.on_apply_res_split(ctx, derived_index, tablet_index, regions),
             }
         }
 

--- a/components/raftstore-v2/src/raft/peer.rs
+++ b/components/raftstore-v2/src/raft/peer.rs
@@ -6,7 +6,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use collections::HashMap;
+use collections::{HashMap, HashSet};
 use crossbeam::atomic::AtomicCell;
 use engine_traits::{KvEngine, OpenOptions, RaftEngine, TabletFactory};
 use kvproto::{kvrpcpb::ExtraOp as TxnExtraOp, metapb, pdpb, raft_serverpb::RegionLocalState};
@@ -88,6 +88,9 @@ pub struct Peer<EK: KvEngine, ER: RaftEngine> {
 
     /// Check whether this proposal can be proposed based on its epoch.
     proposal_control: ProposalControl,
+
+    // Trace which peers have not finished split.
+    split_trace: Vec<(u64, HashSet<u64>)>,
 }
 
 impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
@@ -161,6 +164,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             txn_ext: Arc::default(),
             txn_extra_op: Arc::new(AtomicCell::new(TxnExtraOp::Noop)),
             proposal_control: ProposalControl::new(0),
+            split_trace: vec![],
         };
 
         // If this region has only one peer and I am the one, campaign directly.
@@ -599,5 +603,10 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             .store(initial_status, Ordering::SeqCst);
 
         self.update_max_timestamp_pd(ctx, initial_status);
+    }
+
+    #[inline]
+    pub fn split_trace_mut(&mut self) -> &mut Vec<(u64, HashSet<u64>)> {
+        &mut self.split_trace
     }
 }

--- a/components/raftstore-v2/src/router/message.rs
+++ b/components/raftstore-v2/src/router/message.rs
@@ -132,6 +132,7 @@ pub enum PeerMsg {
     Start,
     /// Messages from peer to peer in the same store
     SplitInit(Box<SplitInit>),
+    SplitInitFinish(u64),
     /// A message only used to notify a peer.
     Noop,
     /// A message that indicates an asynchronous write has finished.
@@ -172,6 +173,13 @@ impl fmt::Debug for PeerMsg {
             PeerMsg::Start => write!(fmt, "Startup"),
             PeerMsg::SplitInit(_) => {
                 write!(fmt, "Split initialization")
+            }
+            PeerMsg::SplitInitFinish(region_id) => {
+                write!(
+                    fmt,
+                    "Split initialization finished from region {}",
+                    region_id
+                )
             }
             PeerMsg::Noop => write!(fmt, "Noop"),
             PeerMsg::Persisted {


### PR DESCRIPTION
### What is changed and how it works?
Issue Number: Ref #12842 

What's Changed:

```commit-message
Create a new storage introduces unnecessary complexity and corner cases.
As split is an initialization just like snapshot, this PR reuses snapshot to make
the process a lot simpler and more robust.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
