### PR TITLE
log-backup: remove GC safepoint after task stops

### DIFF
--- a/components/backup-stream/src/checkpoint_manager.rs
+++ b/components/backup-stream/src/checkpoint_manager.rs
@@ -356,9 +356,13 @@ impl<PD: PdClient + 'static> FlushObserver for BasicFlushObserver<PD> {
             .update_service_safe_point(
                 format!("backup-stream-{}-{}", task, self.store_id),
                 TimeStamp::new(rts.saturating_sub(1)),
-                // Add a service safe point for 30 mins (6x the default flush interval).
-                // It would probably be safe.
-                Duration::from_secs(1800),
+                // Add a service safe point for 2 hours (40x the default flush interval).
+                // In some extreme scenario (for example, the external storage is unavailable),
+                // we may keep fail for flushing, we should make sure the safepoint present before
+                // flush errors expires retry count.
+                // TODO: We'd better make the coordinator, who really calculates the checkpoint to
+                // register service safepoint.
+                Duration::from_secs(60 * 60 * 2),
             )
             .await
         {

--- a/components/backup-stream/src/checkpoint_manager.rs
+++ b/components/backup-stream/src/checkpoint_manager.rs
@@ -356,13 +356,13 @@ impl<PD: PdClient + 'static> FlushObserver for BasicFlushObserver<PD> {
             .update_service_safe_point(
                 format!("backup-stream-{}-{}", task, self.store_id),
                 TimeStamp::new(rts.saturating_sub(1)),
-                // Add a service safe point for 2 hours (40x the default flush interval).
-                // In some extreme scenario (for example, the external storage is unavailable),
-                // we may keep fail for flushing, we should make sure the safepoint present before
-                // flush errors expires retry count.
-                // TODO: We'd better make the coordinator, who really calculates the checkpoint to
-                // register service safepoint.
-                Duration::from_secs(60 * 60 * 2),
+                // Add a service safe point for 24 hours. (the same as fatal error.)
+                // We make it the same duration as we meet fatal errors because TiKV may be
+                // SIGKILL'ed after it meets fatal error and before it successfully updated the
+                // fatal error safepoint.
+                // TODO: We'd better make the coordinator, who really
+                // calculates the checkpoint to register service safepoint.
+                Duration::from_secs(60 * 60 * 24),
             )
             .await
         {

--- a/components/backup-stream/tests/mod.rs
+++ b/components/backup-stream/tests/mod.rs
@@ -1293,13 +1293,16 @@ mod test {
 
         suite.must_register_task(1, "safepoint");
         let mut events = suite.flush_stream();
+        // Wait until the subscription has been registered...
+        std::thread::sleep(Duration::from_millis(200));
         suite.sync();
         suite.force_flush_files("safepoint");
         run_async_test(events.next()).expect("failed to wait flush");
         run_async_test(suite.get_meta_cli().remove_task("safepoint"))
             .expect("failed to remove task");
-        suite.sync();
+        // Wait until the event has been observed...
         std::thread::sleep(Duration::from_millis(200));
+        suite.sync();
         let safepoints = suite
             .cluster
             .pd_client

--- a/components/test_pd_client/src/pd.rs
+++ b/components/test_pd_client/src/pd.rs
@@ -1798,13 +1798,11 @@ impl PdClient for TestPdClient {
         safepoint: TimeStamp,
         ttl: Duration,
     ) -> PdFuture<()> {
-        if ttl.as_secs() > 0 {
-            self.gc_safepoints.wl().push(GcSafePoint {
-                serivce: name,
-                ttl,
-                safepoint,
-            });
-        }
+        self.gc_safepoints.wl().push(GcSafePoint {
+            serivce: name,
+            ttl,
+            safepoint,
+        });
         Box::pin(ok(()))
     }
 

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -12,6 +12,7 @@ use collections::HashSet;
 use engine_traits::{KvEngine, CF_DEFAULT, CF_WRITE};
 use file_system::{set_io_type, IoType};
 use futures::{future::join_all, sink::SinkExt, stream::TryStreamExt, TryFutureExt};
+use futures_executor::{ThreadPool, ThreadPoolBuilder};
 use grpcio::{
     ClientStreamingSink, RequestStream, RpcContext, ServerStreamingSink, UnarySink, WriteFlags,
 };
@@ -56,6 +57,12 @@ where
     engine: E,
     router: Router,
     threads: Arc<Runtime>,
+    // For now, PiTR cannot be executed in the tokio runtime because it is synchronous and may
+    // blocks. (tokio is so strict... it panics if we do insane things like blocking in an async
+    // context.)
+    // We need to execute these code in a context which allows blocking.
+    // FIXME: Make PiTR restore asynchronous. Get rid of this pool.
+    block_threads: Arc<ThreadPool>,
     importer: Arc<SstImporter>,
     limiter: Limiter,
     task_slots: Arc<Mutex<HashSet<PathBuf>>>,
@@ -92,6 +99,18 @@ where
             .before_stop_wrapper(move || tikv_alloc::remove_thread_memory_accessor())
             .build()
             .unwrap();
+        let props = tikv_util::thread_group::current_properties();
+        let block_threads = ThreadPoolBuilder::new()
+            .pool_size(cfg.num_threads)
+            .name_prefix("sst-importer")
+            .after_start_wrapper(move || {
+                tikv_util::thread_group::set_properties(props.clone());
+                tikv_alloc::add_thread_memory_accessor();
+                set_io_type(IoType::Import);
+            })
+            .before_stop_wrapper(move || tikv_alloc::remove_thread_memory_accessor())
+            .create()
+            .unwrap();
         importer.start_switch_mode_check(threads.handle(), engine.clone());
         threads.spawn(Self::tick(importer.clone()));
 
@@ -99,6 +118,7 @@ where
             cfg,
             engine,
             threads: Arc::new(threads),
+            block_threads: Arc::new(block_threads),
             router,
             importer,
             limiter: Limiter::new(f64::INFINITY),
@@ -596,7 +616,7 @@ where
             debug!("finished apply kv file with {:?}", resp);
             crate::send_rpc_response!(resp, sink, label, timer);
         };
-        self.threads.spawn(handle_task);
+        self.block_threads.spawn_ok(handle_task);
     }
 
     /// Downloads the file and performs key-rewrite for later ingesting.


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #13889 

What's Changed:

This PR removes GC safepoint after log task stops, so after the task stopped, the GC won't be stuck.

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
