### PR TITLE
backup: allow to backup during the flashback

### DIFF
--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -330,7 +330,7 @@ impl BackupRange {
         assert!(!ctx.get_replica_read());
         let snap_ctx = SnapContext {
             pb_ctx: &ctx,
-            for_flashback: self.region.is_in_flashback,
+            allowed_in_flashback: self.region.is_in_flashback,
             ..Default::default()
         };
 

--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -330,6 +330,7 @@ impl BackupRange {
         assert!(!ctx.get_replica_read());
         let snap_ctx = SnapContext {
             pb_ctx: &ctx,
+            for_flashback: self.region.is_in_flashback,
             ..Default::default()
         };
 

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -5108,7 +5108,9 @@ where
         // proposed. Skip the not prepared error because the
         // `self.region().is_in_flashback` may not be the latest right after applying
         // the `PrepareFlashback` admin command, we will let it pass here and check in
-        // the apply phase.
+        // the apply phase and because a read-only request doesn't need to be applied,
+        // so it will be allowed during the flashback progress, for example, a snapshot
+        // request.
         if let Err(e) =
             util::check_flashback_state(self.region().is_in_flashback, msg, region_id, true)
         {

--- a/components/tikv_kv/src/lib.rs
+++ b/components/tikv_kv/src/lib.rs
@@ -294,8 +294,8 @@ pub struct SnapContext<'a> {
     // `key_ranges` is used in replica read. It will send to
     // the leader via raft "read index" to check memory locks.
     pub key_ranges: Vec<KeyRange>,
-    // Marks that this read is a FlashbackToVersionReadPhase.
-    pub for_flashback: bool,
+    // Marks that this snapshot request is allowed in the flashback state.
+    pub allowed_in_flashback: bool,
 }
 
 /// Engine defines the common behaviour for a storage engine type.

--- a/components/txn_types/src/types.rs
+++ b/components/txn_types/src/types.rs
@@ -532,8 +532,8 @@ pub struct TxnExtra {
     // Marks that this transaction is a 1PC transaction. RaftKv should set this flag
     // in the raft command request.
     pub one_pc: bool,
-    // Marks that this transaction is a flashback transaction.
-    pub for_flashback: bool,
+    // Marks that this transaction is allowed in the flashback state.
+    pub allowed_in_flashback: bool,
 }
 
 impl TxnExtra {

--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -142,6 +142,9 @@ pub struct ReqContext {
 
     /// Perf level
     pub perf_level: PerfLevel,
+
+    /// Whether the request is allowed in the flashback state.
+    pub allowed_in_flashback: bool,
 }
 
 impl ReqContext {
@@ -181,6 +184,7 @@ impl ReqContext {
             lower_bound,
             upper_bound,
             perf_level,
+            allowed_in_flashback: false,
         }
     }
 

--- a/src/server/raftkv/mod.rs
+++ b/src/server/raftkv/mod.rs
@@ -453,7 +453,7 @@ where
         if txn_extra.one_pc {
             flags |= WriteBatchFlags::ONE_PC.bits();
         }
-        if txn_extra.for_flashback {
+        if txn_extra.allowed_in_flashback {
             flags |= WriteBatchFlags::FLASHBACK.bits();
         }
         header.set_flags(flags);
@@ -555,7 +555,7 @@ where
             flags |= WriteBatchFlags::STALE_READ.bits();
             header.set_flag_data(data.into());
         }
-        if ctx.for_flashback {
+        if ctx.allowed_in_flashback {
             flags |= WriteBatchFlags::FLASHBACK.bits();
         }
         header.set_flags(flags);

--- a/src/storage/txn/commands/acquire_pessimistic_lock.rs
+++ b/src/storage/txn/commands/acquire_pessimistic_lock.rs
@@ -191,7 +191,7 @@ pub(super) fn make_write_data(modifies: Vec<Modify>, old_values: OldValues) -> W
             old_values,
             // One pc status is unknown in AcquirePessimisticLock stage.
             one_pc: false,
-            for_flashback: false,
+            allowed_in_flashback: false,
         };
         WriteData::new(modifies, extra)
     } else {

--- a/src/storage/txn/commands/flashback_to_version.rs
+++ b/src/storage/txn/commands/flashback_to_version.rs
@@ -118,7 +118,7 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for FlashbackToVersion {
         let rows = txn.modifies.len();
         let mut write_data = WriteData::from_modifies(txn.into_modifies());
         // To let the flashback modification could be proposed and applied successfully.
-        write_data.extra.for_flashback = true;
+        write_data.extra.allowed_in_flashback = true;
         // To let the CDC treat the flashback modification as an 1PC transaction.
         if matches!(self.state, FlashbackToVersionState::FlashbackWrite { .. }) {
             write_data.extra.one_pc = true;

--- a/src/storage/txn/commands/prewrite.rs
+++ b/src/storage/txn/commands/prewrite.rs
@@ -672,7 +672,7 @@ impl<K: PrewriteKind> Prewriter<K> {
                 old_values: self.old_values,
                 // Set one_pc flag in TxnExtra to let CDC skip handling the resolver.
                 one_pc: self.try_one_pc,
-                for_flashback: false,
+                allowed_in_flashback: false,
             };
             // Here the lock guards are taken and will be released after the write finishes.
             // If an error (KeyIsLocked or WriteConflict) occurs before, these lock guards

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -702,7 +702,7 @@ impl<E: Engine, L: LockManager> Scheduler<E, L> {
                     Command::FlashbackToVersionReadPhase { .. }
                         | Command::FlashbackToVersion { .. }
                 ) {
-                    snap_ctx.for_flashback = true;
+                    snap_ctx.allowed_in_flashback = true;
                 }
                 // The program is currently in scheduler worker threads.
                 // Safety: `self.inner.worker_pool` should ensure that a TLS engine exists.


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What is changed and how it works?

Issue Number: ref #13787, close https://github.com/pingcap/tidb/issues/39639.

What's Changed:

```commit-message
- Allow to backup during the flashback by passing the flashback flag.
- Allow the checksum request to get the snapshot during the flashback progress.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None.
```
