### PR TITLE
*: always share block cache

### DIFF
--- a/components/engine_rocks/src/engine.rs
+++ b/components/engine_rocks/src/engine.rs
@@ -25,7 +25,6 @@ use crate::{
 #[derive(Clone, Debug)]
 pub struct RocksEngine {
     db: Arc<DB>,
-    shared_block_cache: bool,
     support_multi_batch_write: bool,
 }
 
@@ -37,7 +36,6 @@ impl RocksEngine {
     pub fn from_db(db: Arc<DB>) -> Self {
         RocksEngine {
             db: db.clone(),
-            shared_block_cache: false,
             support_multi_batch_write: db.get_db_options().is_enable_multi_batch_write(),
         }
     }
@@ -48,14 +46,6 @@ impl RocksEngine {
 
     pub fn get_sync_db(&self) -> Arc<DB> {
         self.db.clone()
-    }
-
-    pub fn set_shared_block_cache(&mut self, enable: bool) {
-        self.shared_block_cache = enable;
-    }
-
-    pub fn shared_block_cache(&self) -> bool {
-        self.shared_block_cache
     }
 
     pub fn support_multi_batch_write(&self) -> bool {
@@ -95,7 +85,7 @@ impl KvEngine for RocksEngine {
                 }
             }
         }
-        flush_engine_properties(&self.db, instance, self.shared_block_cache);
+        flush_engine_properties(&self.db, instance);
         flush_engine_iostall_properties(&self.db, instance);
     }
 

--- a/components/server/src/raft_engine_switch.rs
+++ b/components/server/src/raft_engine_switch.rs
@@ -237,6 +237,7 @@ mod tests {
         cfg.raft_store.raftdb_path = raftdb_path.to_str().unwrap().to_owned();
         cfg.raftdb.wal_dir = raftdb_wal_path.to_str().unwrap().to_owned();
         cfg.raft_engine.mut_config().dir = raft_engine_path.to_str().unwrap().to_owned();
+        let cache = cfg.storage.block_cache.build_shared_cache();
 
         // Dump logs from RocksEngine to RaftLogEngine.
         let raft_engine = RaftLogEngine::new(
@@ -251,7 +252,7 @@ mod tests {
             let raftdb = engine_rocks::util::new_engine_opt(
                 &cfg.raft_store.raftdb_path,
                 cfg.raftdb.build_opt(),
-                cfg.raftdb.build_cf_opts(&None),
+                cfg.raftdb.build_cf_opts(&cache),
             )
             .unwrap();
             let mut batch = raftdb.log_batch(0);

--- a/components/snap_recovery/src/init_cluster.rs
+++ b/components/snap_recovery/src/init_cluster.rs
@@ -316,13 +316,10 @@ pub fn create_local_engine_service(
     let db_path = config
         .infer_kv_engine_path(None)
         .map_err(|e| format!("infer kvdb path: {}", e))?;
-    let mut kv_db = match new_engine_opt(&db_path, db_opts, cf_opts) {
+    let kv_db = match new_engine_opt(&db_path, db_opts, cf_opts) {
         Ok(db) => db,
         Err(e) => handle_engine_error(e),
     };
-
-    let shared_block_cache = block_cache.is_some();
-    kv_db.set_shared_block_cache(shared_block_cache);
 
     // init raft engine, either is rocksdb or raft engine
     if !config.raft_engine.enable {
@@ -333,12 +330,10 @@ pub fn create_local_engine_service(
         let raft_path = config
             .infer_raft_db_path(None)
             .map_err(|e| format!("infer raftdb path: {}", e))?;
-        let mut raft_db = match new_engine_opt(&raft_path, raft_db_opts, raft_db_cf_opts) {
+        let raft_db = match new_engine_opt(&raft_path, raft_db_opts, raft_db_cf_opts) {
             Ok(db) => db,
             Err(e) => handle_engine_error(e),
         };
-        //       let mut raft_db = RocksEngine::from_db(Arc::new(raft_db));
-        raft_db.set_shared_block_cache(shared_block_cache);
 
         let local_engines = LocalEngines::new(Engines::new(kv_db, raft_db));
         Ok(Box::new(local_engines) as Box<dyn LocalEngineService>)

--- a/components/test_raftstore/src/common-test.toml
+++ b/components/test_raftstore/src/common-test.toml
@@ -34,7 +34,6 @@ scheduler-concurrency = 10
 scheduler-worker-pool-size = 1
 
 [storage.block-cache]
-shared = true
 capacity = "64MB"
 
 [pd]

--- a/components/test_raftstore/src/util.rs
+++ b/components/test_raftstore/src/util.rs
@@ -596,11 +596,8 @@ pub fn create_test_engine(
 
     let raft_engine = RaftTestEngine::build(&cfg, &env, &key_manager, &cache);
 
-    let mut builder =
-        KvEngineFactoryBuilder::new(env, &cfg, dir.path()).sst_recovery_sender(Some(scheduler));
-    if let Some(cache) = cache {
-        builder = builder.block_cache(cache);
-    }
+    let mut builder = KvEngineFactoryBuilder::new(env, &cfg, dir.path(), cache)
+        .sst_recovery_sender(Some(scheduler));
     if let Some(router) = router {
         builder = builder.compaction_event_sender(Arc::new(RaftRouterCompactedEventSender {
             router: Mutex::new(router),

--- a/components/tikv_kv/src/rocksdb_engine.rs
+++ b/components/tikv_kv/src/rocksdb_engine.rs
@@ -114,7 +114,6 @@ impl RocksEngine {
         path: &str,
         db_opts: Option<RocksDbOptions>,
         cfs_opts: Vec<(CfName, RocksCfOptions)>,
-        shared_block_cache: bool,
         io_rate_limiter: Option<Arc<IoRateLimiter>>,
     ) -> Result<RocksEngine> {
         info!("RocksEngine: creating for path"; "path" => path);
@@ -134,11 +133,7 @@ impl RocksEngine {
         let db = engine_rocks::util::new_engine_opt(&path, db_opts, cfs_opts)?;
         // It does not use the raft_engine, so it is ok to fill with the same
         // rocksdb.
-        let mut kv_engine = db.clone();
-        let mut raft_engine = db;
-        kv_engine.set_shared_block_cache(shared_block_cache);
-        raft_engine.set_shared_block_cache(shared_block_cache);
-        let engines = Engines::new(kv_engine, raft_engine);
+        let engines = Engines::new(db.clone(), db);
         let sched = worker.start("engine-rocksdb", Runner(engines.clone()));
         Ok(RocksEngine {
             sched,

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -271,17 +271,11 @@
 ## Set to 0 to disable this feature if you want to panic immediately when encountering such an error.
 # background-error-recovery-window = "1h"
 
-[storage.block-cache]
-## Whether to create a shared block cache for all RocksDB column families.
-##
 ## Block cache is used by RocksDB to cache uncompressed blocks. Big block cache can speed up read.
 ## It is recommended to turn on shared block cache. Since only the total cache size need to be
 ## set, it is easier to config. In most cases it should be able to auto-balance cache usage
 ## between column families with standard LRU algorithm.
-##
-## The rest of config in the storage.block-cache session is effective only when shared block cache
-## is on.
-# shared = true
+[storage.block-cache]
 
 ## Size of the shared block cache. Normally it should be tuned to 30%-50% of system's total memory.
 ## When the config is not set, it is decided by the sum of the following fields or their default

--- a/src/config.rs
+++ b/src/config.rs
@@ -4651,16 +4651,11 @@ mod tests {
             "rocksdb.defaultcf.target-file-size-base".to_owned(),
             "32MB".to_owned(),
         );
-        change.insert(
-            "rocksdb.defaultcf.block-cache-size".to_owned(),
-            "256MB".to_owned(),
-        );
         cfg_controller.update(change).unwrap();
 
         let cf_opts = db.get_options_cf(CF_DEFAULT).unwrap();
         assert_eq!(cf_opts.get_disable_auto_compactions(), true);
         assert_eq!(cf_opts.get_target_file_size_base(), ReadableSize::mb(32).0);
-        assert_eq!(cf_opts.get_block_cache_capacity(), ReadableSize::mb(256).0);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -4641,7 +4641,6 @@ mod tests {
         let cf_opts = db.get_options_cf(CF_DEFAULT).unwrap();
         assert_eq!(cf_opts.get_disable_auto_compactions(), false);
         assert_eq!(cf_opts.get_target_file_size_base(), ReadableSize::mb(64).0);
-        assert_eq!(cf_opts.get_block_cache_capacity(), ReadableSize::mb(8).0);
 
         let mut change = HashMap::new();
         change.insert(

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -193,8 +193,6 @@ impl Default for FlowControlConfig {
 #[serde(default)]
 #[serde(rename_all = "kebab-case")]
 pub struct BlockCacheConfig {
-    #[online_config(skip)]
-    pub shared: bool,
     pub capacity: Option<ReadableSize>,
     #[online_config(skip)]
     pub num_shard_bits: i32,
@@ -209,7 +207,6 @@ pub struct BlockCacheConfig {
 impl Default for BlockCacheConfig {
     fn default() -> BlockCacheConfig {
         BlockCacheConfig {
-            shared: true,
             capacity: None,
             num_shard_bits: 6,
             strict_capacity_limit: false,
@@ -229,10 +226,7 @@ impl BlockCacheConfig {
         }
     }
 
-    pub fn build_shared_cache(&self) -> Option<Cache> {
-        if !self.shared {
-            return None;
-        }
+    pub fn build_shared_cache(&self) -> Cache {
         let capacity = match self.capacity {
             None => {
                 let total_mem = SysQuota::memory_limit_in_bytes();
@@ -248,7 +242,7 @@ impl BlockCacheConfig {
         if let Some(allocator) = self.new_memory_allocator() {
             cache_opts.set_memory_allocator(allocator);
         }
-        Some(Cache::new_lru_cache(cache_opts))
+        Cache::new_lru_cache(cache_opts)
     }
 
     fn new_memory_allocator(&self) -> Option<MemoryAllocator> {

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -193,6 +193,8 @@ impl Default for FlowControlConfig {
 #[serde(default)]
 #[serde(rename_all = "kebab-case")]
 pub struct BlockCacheConfig {
+    #[online_config(skip)]
+    pub shared: Option<bool>,
     pub capacity: Option<ReadableSize>,
     #[online_config(skip)]
     pub num_shard_bits: i32,
@@ -207,6 +209,7 @@ pub struct BlockCacheConfig {
 impl Default for BlockCacheConfig {
     fn default() -> BlockCacheConfig {
         BlockCacheConfig {
+            shared: None,
             capacity: None,
             num_shard_bits: 6,
             strict_capacity_limit: false,
@@ -227,6 +230,9 @@ impl BlockCacheConfig {
     }
 
     pub fn build_shared_cache(&self) -> Cache {
+        if self.shared == Some(false) {
+            warn!("storage.block-cache.shared is deprecated, cache is always shared.");
+        }
         let capacity = match self.capacity {
             None => {
                 let total_mem = SysQuota::memory_limit_in_bytes();

--- a/src/storage/kv/test_engine_builder.rs
+++ b/src/storage/kv/test_engine_builder.rs
@@ -110,8 +110,7 @@ impl TestEngineBuilder {
                 _ => (*cf, RocksCfOptions::default()),
             })
             .collect();
-        let engine =
-            RocksEngine::new(&path, None, cfs_opts, cache.is_some(), self.io_rate_limiter)?;
+        let engine = RocksEngine::new(&path, None, cfs_opts, self.io_rate_limiter)?;
         Ok(engine)
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -4146,11 +4146,7 @@ mod tests {
                 (CF_RAFT, cfg_rocksdb.raftcf.build_opt(&cache)),
             ];
             RocksEngine::new(
-                &path,
-                None,
-                cfs_opts,
-                cache.is_some(),
-                None, // io_rate_limiter
+                &path, None, cfs_opts, None, // io_rate_limiter
             )
         }
         .unwrap();

--- a/tests/failpoints/cases/test_storage.rs
+++ b/tests/failpoints/cases/test_storage.rs
@@ -262,13 +262,12 @@ fn test_scale_scheduler_pool() {
         rx,
     )));
 
-    let cfg_controller = ConfigController::new(cfg.clone());
+    let cfg_controller = ConfigController::new(cfg);
     let (scheduler, _receiver) = dummy_scheduler();
     cfg_controller.register(
         Module::Storage,
         Box::new(StorageConfigManger::new(
             Arc::new(DummyFactory::new(Some(kv_engine), "".to_string())),
-            cfg.storage.block_cache.shared,
             scheduler,
             flow_controller,
             storage.get_scheduler(),

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -684,7 +684,6 @@ fn test_serde_custom_tikv_config() {
             hard_pending_compaction_bytes_limit: ReadableSize(1),
         },
         block_cache: BlockCacheConfig {
-            shared: true,
             capacity: Some(ReadableSize::gb(40)),
             num_shard_bits: 10,
             strict_capacity_limit: true,
@@ -886,7 +885,6 @@ fn test_do_not_use_unified_readpool_with_legacy_config() {
 fn test_block_cache_backward_compatible() {
     let content = read_file_in_project_dir("integrations/config/test-cache-compatible.toml");
     let mut cfg: TikvConfig = toml::from_str(&content).unwrap();
-    assert!(cfg.storage.block_cache.shared);
     assert!(cfg.storage.block_cache.capacity.is_none());
     cfg.compatible_adjust();
     assert!(cfg.storage.block_cache.capacity.is_some());

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -684,6 +684,7 @@ fn test_serde_custom_tikv_config() {
             hard_pending_compaction_bytes_limit: ReadableSize(1),
         },
         block_cache: BlockCacheConfig {
+            shared: None,
             capacity: Some(ReadableSize::gb(40)),
             num_shard_bits: 10,
             strict_capacity_limit: true,

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -102,7 +102,6 @@ enable-ttl = true
 ttl-check-poll-interval = "0s"
 
 [storage.block-cache]
-shared = true
 capacity = "40GB"
 num-shard-bits = 10
 strict-capacity-limit = true


### PR DESCRIPTION

### What is changed and how it works?
Issue Number: Close #12936

What's Changed:

There has been 5 months and nobody objects it so let's always enable share block cache.

```commit-message
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
    https://github.com/pingcap/docs-cn/pull/12241

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- Breaking backward compatibility
    Use separate cache for each CF is not supported anymore.

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
remove the support of specifying separate cache for each CF
```
