### PR TITLE
gc_worker: disable gc if have negative ratio

### DIFF
--- a/src/server/gc_worker/compaction_filter.rs
+++ b/src/server/gc_worker/compaction_filter.rs
@@ -918,8 +918,6 @@ pub mod test_utils {
 
 #[cfg(test)]
 pub mod tests {
-    use std::mem::MaybeUninit;
-
     use engine_traits::{DeleteStrategy, MiscExt, Peekable, Range, SyncMutable, CF_WRITE};
 
     use super::{test_utils::*, *};
@@ -981,6 +979,12 @@ pub mod tests {
         let default_key = Key::from_encoded_slice(b"zkey").append_ts(100.into());
         let default_key = default_key.into_encoded();
         assert!(raw_engine.get_value(&default_key).unwrap().is_none());
+
+        must_prewrite_put(&mut engine, b"zkey", &value, b"zkey", 210);
+        must_commit(&mut engine, b"zkey", 210, 220);
+        gc_runner.ratio_threshold = Some(-1.0);
+        gc_runner.safe_point(256).gc(&raw_engine);
+        must_get(&mut engine, b"zkey", 210, &value);
     }
 
     // Test dirty versions before a deletion mark can be handled correctly.

--- a/src/server/gc_worker/compaction_filter.rs
+++ b/src/server/gc_worker/compaction_filter.rs
@@ -980,6 +980,7 @@ pub mod tests {
         let default_key = default_key.into_encoded();
         assert!(raw_engine.get_value(&default_key).unwrap().is_none());
 
+        // If the ratio threshold is less than 0, GC would be skipped.
         must_prewrite_put(&mut engine, b"zkey", &value, b"zkey", 210);
         must_commit(&mut engine, b"zkey", 210, 220);
         gc_runner.ratio_threshold = Some(-1.0);

--- a/tests/failpoints/cases/test_table_properties.rs
+++ b/tests/failpoints/cases/test_table_properties.rs
@@ -91,7 +91,7 @@ fn test_check_need_gc() {
 
     // Set ratio_threshold, let (props.num_versions as f64 > props.num_rows as
     // f64 * ratio_threshold) return true
-    gc_runner.ratio_threshold = Option::Some(f64::MIN);
+    gc_runner.ratio_threshold = Option::Some(0.0f64);
 
     // is_bottommost_level = false
     do_gc(&raw_engine, 1, &mut gc_runner, &dir);


### PR DESCRIPTION
Signed-off-by: hillium <yu745514916@live.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #13909

What's Changed:
This PR allows GC to be skipped once the `ratio_threshold` is negative or infinity.

Disabling GC is useful in some abnormal scenarios where the transaction model would be break (e.g. writes with higher commit TS would be written BEFORE writes with lower commit TS, or write data with TS lower than current GC safe point).

Mainly, this is for fixing the data inconsistent found at https://github.com/pingcap/tidb/issues/39602: because PITR would apply unordered writes concurrently, once there are some delete records, GC might ripe them and make the write records (which haven't been restored yet) lives.

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
GC would be skipped once the `ratio_threshold` is negative or infinity.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Now, if the config `gc.ratio_threshold` is less than `0`, GC would be disabled.
```
