### PR TITLE
log-backup：Retry to get tasks with etcd-cli from etcd when TiKV starts.

### DIFF
--- a/components/backup-stream/src/checkpoint_manager.rs
+++ b/components/backup-stream/src/checkpoint_manager.rs
@@ -458,7 +458,7 @@ where
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use std::{
         assert_matches,
         collections::HashMap,
@@ -510,7 +510,7 @@ mod tests {
         assert_matches::assert_matches!(r, GetCheckpointResult::Ok{checkpoint, ..} if checkpoint.into_inner() == 24);
     }
 
-    struct MockPdClient {
+    pub struct MockPdClient {
         safepoint: RwLock<HashMap<String, TimeStamp>>,
     }
 

--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -273,33 +273,30 @@ where
         meta_client: MetadataClient<S>,
         scheduler: Scheduler<Task>,
     ) -> Result<()> {
-        let mut revision = 0;
-
+        let mut tasks;
         loop {
-            let tasks = meta_client.get_tasks().await;
-            match  tasks {
-                Err(e) => {
-                    e.report("failed to get backup stream task");
-                    tokio::time::sleep(Duration::from_secs(5)).await;
-                    continue;
-                },
-                Ok(tasks) => {
-                    revision = tasks.revision;
-                    for task in tasks.inner {
-                        info!("backup stream watch task"; "task" => ?task);
-                        if task.is_paused {
-                            continue;
-                        }
-                        // We have meet task upon store start, we must in a failover.
-                        scheduler.schedule(Task::MarkFailover(Instant::now()))?;
-                        // move task to schedule
-                        scheduler.schedule_force(Task::WatchTask(TaskOp::AddTask(task)))?;
-                    }       
-                    break;
-                },
+            tasks = meta_client.get_tasks().await;
+            if let Err(e) = tasks {
+                e.report("failed to get backup stream task");
+                tokio::time::sleep(Duration::from_secs(5)).await;
+            } else {
+                break;
             }
         }
 
+        let tasks = tasks.unwrap();
+        for task in tasks.inner {
+            info!("backup stream watch task"; "task" => ?task);
+            if task.is_paused {
+                continue;
+            }
+            // We have meet task upon store start, we must in a failover.
+            scheduler.schedule(Task::MarkFailover(Instant::now()))?;
+            // move task to schedule
+            scheduler.schedule_force(Task::WatchTask(TaskOp::AddTask(task)))?;
+        }
+
+        let revision = tasks.revision;
         let meta_client_clone = meta_client.clone();
         let scheduler_clone = scheduler.clone();
 

--- a/components/backup-stream/src/metadata/client.rs
+++ b/components/backup-stream/src/metadata/client.rs
@@ -354,7 +354,9 @@ impl<Store: MetaStore> MetadataClient<Store> {
             super::metrics::METADATA_OPERATION_LATENCY.with_label_values(&["task_fetch"]).observe(now.saturating_elapsed().as_secs_f64())
         }
         fail::fail_point!("failed_to_get_tasks", |_| {
-            Err(Error::MalformedMetadata("faild to connect etcd client".to_string()))
+            Err(Error::MalformedMetadata(
+                "faild to connect etcd client".to_string(),
+            ))
         });
         let snap = self.meta_store.snapshot().await?;
         let kvs = snap.get(Keys::Prefix(MetaKey::tasks())).await?;

--- a/components/backup-stream/src/metadata/client.rs
+++ b/components/backup-stream/src/metadata/client.rs
@@ -353,6 +353,9 @@ impl<Store: MetaStore> MetadataClient<Store> {
         defer! {
             super::metrics::METADATA_OPERATION_LATENCY.with_label_values(&["task_fetch"]).observe(now.saturating_elapsed().as_secs_f64())
         }
+        fail::fail_point!("failed_to_get_tasks", |_| {
+            Err(Error::MalformedMetadata("faild to connect etcd client".to_string()))
+        });
         let snap = self.meta_store.snapshot().await?;
         let kvs = snap.get(Keys::Prefix(MetaKey::tasks())).await?;
 

--- a/components/backup-stream/src/metadata/mod.rs
+++ b/components/backup-stream/src/metadata/mod.rs
@@ -4,7 +4,7 @@ mod client;
 pub mod keys;
 mod metrics;
 pub mod store;
-mod test;
+pub mod test;
 
 pub use client::{Checkpoint, CheckpointProvider, MetadataClient, MetadataEvent, StreamTask};
 pub use store::lazy_etcd::{ConnectionConfig, LazyEtcdClient};

--- a/components/backup-stream/src/metadata/store/lazy_etcd.rs
+++ b/components/backup-stream/src/metadata/store/lazy_etcd.rs
@@ -4,6 +4,7 @@ use std::{sync::Arc, time::Duration};
 
 use etcd_client::{ConnectOptions, Error as EtcdError, OpenSslClientConfig};
 use futures::Future;
+use slog_global::info;
 use tikv_util::stream::{RetryError, RetryExt};
 use tokio::sync::OnceCell;
 
@@ -113,7 +114,7 @@ where
     use futures::TryFutureExt;
     let r = tikv_util::stream::retry_ext(
         move || action().err_into::<RetryableEtcdError>(),
-        RetryExt::default().with_fail_hook(|err| println!("meet error {:?}", err)),
+        RetryExt::default().with_fail_hook(|err| info!("retry it"; "err" => ?err)),
     )
     .await;
     r.map_err(|err| err.0.into())

--- a/components/backup-stream/src/metadata/store/lazy_etcd.rs
+++ b/components/backup-stream/src/metadata/store/lazy_etcd.rs
@@ -4,8 +4,10 @@ use std::{sync::Arc, time::Duration};
 
 use etcd_client::{ConnectOptions, Error as EtcdError, OpenSslClientConfig};
 use futures::Future;
-use slog_global::info;
-use tikv_util::stream::{RetryError, RetryExt};
+use tikv_util::{
+    info,
+    stream::{RetryError, RetryExt},
+};
 use tokio::sync::OnceCell;
 
 use super::{etcd::EtcdSnapshot, EtcdStore, MetaStore};

--- a/components/backup-stream/src/metadata/test.rs
+++ b/components/backup-stream/src/metadata/test.rs
@@ -16,11 +16,11 @@ use crate::{
     metadata::{store::SlashEtcStore, MetadataEvent},
 };
 
-fn test_meta_cli() -> MetadataClient<SlashEtcStore> {
+pub fn test_meta_cli() -> MetadataClient<SlashEtcStore> {
     MetadataClient::new(SlashEtcStore::default(), 42)
 }
 
-fn simple_task(name: &str) -> StreamTask {
+pub fn simple_task(name: &str) -> StreamTask {
     let mut task = StreamTask::default();
     task.info.set_name(name.to_owned());
     task.info.set_start_ts(1);

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -1064,7 +1064,7 @@ where
     Box::new(move |k: Vec<u8>, v: Vec<u8>| {
         // Need to skip the empty key/value that could break the transaction or cause
         // data corruption. see details at https://github.com/pingcap/tiflow/issues/5468.
-        if k.is_empty() || v.is_empty() {
+        if k.is_empty() || (!is_delete && v.is_empty()) {
             return;
         }
 


### PR DESCRIPTION
Signed-off-by: joccau <zak.zhao@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/tikv/tikv/issues/13898

What's Changed:
Retry to `get tasks` with `etcd-cli` from `etcd` when TiKV starts on the tokio background thread.

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] - Unit test
- [ ] - Integration test
- [x] - Manual test (add detailed scripts or steps below)
- [ ] - No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Retry to get tasks with etcd-cli from etcd when TiKV starts, which fix issues%13898
```
