### PR TITLE
copr: fix _ pattern in like behavior for old collation (#13785)

### DIFF
--- a/components/tidb_query_datatype/src/codec/collation/charset.rs
+++ b/components/tidb_query_datatype/src/codec/collation/charset.rs
@@ -4,9 +4,15 @@ use std::str;
 
 use super::*;
 
+#[derive(PartialEq)]
+pub enum Charset {
+    Binary,
+    Utf8Mb4,
+}
+
 pub struct CharsetBinary;
 
-impl Charset for CharsetBinary {
+impl super::Charset for CharsetBinary {
     type Char = u8;
 
     #[inline]
@@ -22,11 +28,15 @@ impl Charset for CharsetBinary {
             Some((data[0], 1))
         }
     }
+
+    fn charset() -> Charset {
+        Charset::Binary
+    }
 }
 
 pub struct CharsetUtf8mb4;
 
-impl Charset for CharsetUtf8mb4 {
+impl super::Charset for CharsetUtf8mb4 {
     type Char = char;
 
     #[inline]
@@ -45,5 +55,9 @@ impl Charset for CharsetUtf8mb4 {
                 it.as_slice().as_ptr().offset_from(start) as usize,
             )
         })
+    }
+
+    fn charset() -> Charset {
+        Charset::Utf8Mb4
     }
 }

--- a/components/tidb_query_datatype/src/codec/collation/mod.rs
+++ b/components/tidb_query_datatype/src/codec/collation/mod.rs
@@ -33,12 +33,59 @@ macro_rules! match_template_collator {
      }}
 }
 
+#[macro_export]
+macro_rules! match_template_multiple_collators {
+    ((), (), $($tail:tt)*) => {
+        $($tail)*
+    };
+    (($first:tt), ($match_exprs:tt), $($tail:tt)*) => {
+        match_template_multiple_collators! {
+            ($first,), ($match_exprs,), $($tail)*
+        }
+    };
+    (($first:tt, $($t:tt)*), ($first_match_expr:tt, $($match_exprs:tt)*), $($tail:tt)*) => {{
+        #[allow(unused_imports)]
+        use $crate::codec::collation::collator::*;
+
+        match_template_collator! {
+            $first, match $first_match_expr {
+                Collation::$first => {
+                    match_template_multiple_collators! {
+                        ($($t)*), ($($match_exprs)*), $($tail)*
+                    }
+                }
+            }
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! match_template_charset {
+     ($t:tt, $($tail:tt)*) => {{
+         #[allow(unused_imports)]
+         use $crate::codec::collation::encoding::*;
+
+         match_template::match_template! {
+             $t = [
+                 Utf8 => EncodingUtf8,
+                 Utf8Mb4 => EncodingUtf8Mb4,
+                 Latin1 => EncodingLatin1,
+                 Binary => EncodingBinary,
+                 Ascii => EncodingAscii,
+            ],
+            $($tail)*
+         }
+     }}
+}
+
 pub trait Charset {
     type Char: Copy + Into<u32>;
 
     fn validate(bstr: &[u8]) -> Result<()>;
 
     fn decode_one(data: &[u8]) -> Option<(Self::Char, usize)>;
+
+    fn charset() -> charset::Charset;
 }
 
 pub trait Collator: 'static + std::marker::Send + std::marker::Sync + std::fmt::Debug {

--- a/components/tidb_query_expr/src/impl_like.rs
+++ b/components/tidb_query_expr/src/impl_like.rs
@@ -12,17 +12,21 @@ use tidb_query_datatype::codec::data_type::*;
 
 #[rpn_fn]
 #[inline]
-pub fn like<C: Collator>(target: BytesRef, pattern: BytesRef, escape: &i64) -> Result<Option<i64>> {
+pub fn like<C: Collator, CS: Charset>(
+    target: BytesRef,
+    pattern: BytesRef,
+    escape: &i64,
+) -> Result<Option<i64>> {
     let escape = *escape as u32;
     // current search positions in pattern and target.
     let (mut px, mut tx) = (0, 0);
     // positions for backtrace.
     let (mut next_px, mut next_tx) = (0, 0);
     while px < pattern.len() || tx < target.len() {
-        if let Some((c, mut poff)) = C::Charset::decode_one(&pattern[px..]) {
+        if let Some((c, mut poff)) = CS::decode_one(&pattern[px..]) {
             let code: u32 = c.into();
             if code == '_' as u32 {
-                if let Some((_, toff)) = C::Charset::decode_one(&target[tx..]) {
+                if let Some((_, toff)) = CS::decode_one(&target[tx..]) {
                     px += poff;
                     tx += toff;
                     continue;
@@ -32,7 +36,7 @@ pub fn like<C: Collator>(target: BytesRef, pattern: BytesRef, escape: &i64) -> R
                 next_px = px;
                 px += poff;
                 next_tx = tx;
-                next_tx += if let Some((_, toff)) = C::Charset::decode_one(&target[tx..]) {
+                next_tx += if let Some((_, toff)) = CS::decode_one(&target[tx..]) {
                     toff
                 } else {
                     1
@@ -41,13 +45,13 @@ pub fn like<C: Collator>(target: BytesRef, pattern: BytesRef, escape: &i64) -> R
             } else {
                 if code == escape && px + poff < pattern.len() {
                     px += poff;
-                    poff = if let Some((_, off)) = C::Charset::decode_one(&pattern[px..]) {
+                    poff = if let Some((_, off)) = CS::decode_one(&pattern[px..]) {
                         off
                     } else {
                         break;
                     }
                 }
-                if let Some((_, toff)) = C::Charset::decode_one(&target[tx..]) {
+                if let Some((_, toff)) = CS::decode_one(&target[tx..]) {
                     if let Ok(std::cmp::Ordering::Equal) =
                         C::sort_compare(&target[tx..tx + toff], &pattern[px..px + poff])
                     {
@@ -253,20 +257,6 @@ mod tests {
                 Some(0),
             ),
             (
-                r#"夏威夷吉他"#,
-                r#"_____"#,
-                '\\',
-                Collation::Binary,
-                Some(0),
-            ),
-            (
-                r#"🐶🍐🍳➕🥜🎗🐜"#,
-                r#"_______"#,
-                '\\',
-                Collation::Utf8Mb4Bin,
-                Some(1),
-            ),
-            (
                 r#"IpHONE"#,
                 r#"iPhone"#,
                 '\\',
@@ -277,14 +267,6 @@ mod tests {
                 r#"IpHONE xs mAX"#,
                 r#"iPhone XS Max"#,
                 '\\',
-                Collation::Utf8Mb4GeneralCi,
-                Some(1),
-            ),
-            (r#"🕺_"#, r#"🕺🕺🕺_"#, '🕺', Collation::Binary, Some(0)),
-            (
-                r#"🕺_"#,
-                r#"🕺🕺🕺_"#,
-                '🕺',
                 Collation::Utf8Mb4GeneralCi,
                 Some(1),
             ),
@@ -422,6 +404,153 @@ mod tests {
             let v = val.vector_value().unwrap().as_ref().to_int_vec();
             assert_eq!(v.len(), 1);
             assert_eq!(v[0], expected);
+        }
+    }
+
+    #[test]
+    fn test_like_wide_character() {
+        let cases = vec![
+            (
+                r#"夏威夷吉他"#,
+                r#"_____"#,
+                '\\',
+                Collation::Binary,
+                Collation::Binary,
+                Collation::Binary,
+                Some(0),
+            ),
+            (
+                r#"🐶🍐🍳➕🥜🎗🐜"#,
+                r#"_______"#,
+                '\\',
+                Collation::Utf8Mb4Bin,
+                Collation::Utf8Mb4Bin,
+                Collation::Utf8Mb4Bin,
+                Some(1),
+            ),
+            (
+                r#"🕺_"#,
+                r#"🕺🕺🕺_"#,
+                '🕺',
+                Collation::Binary,
+                Collation::Binary,
+                Collation::Binary,
+                Some(0),
+            ),
+            (
+                r#"🕺_"#,
+                r#"🕺🕺🕺_"#,
+                '🕺',
+                Collation::Utf8Mb4GeneralCi,
+                Collation::Utf8Mb4GeneralCi,
+                Collation::Utf8Mb4GeneralCi,
+                Some(1),
+            ),
+            // When the new collation framework is not enabled, the collation
+            // will always be binary Some related tests are added here
+            (
+                r#"夏威夷吉他"#,
+                r#"_____"#,
+                '\\',
+                Collation::Binary,
+                Collation::Utf8Mb4Bin,
+                Collation::Utf8Mb4Bin,
+                Some(1),
+            ),
+            (
+                r#"🐶🍐🍳➕🥜🎗🐜"#,
+                r#"_______"#,
+                '\\',
+                Collation::Binary,
+                Collation::Utf8Mb4Bin,
+                Collation::Utf8Mb4Bin,
+                Some(1),
+            ),
+            (
+                r#"🕺_"#,
+                r#"🕺🕺🕺_"#,
+                '🕺',
+                Collation::Binary,
+                Collation::Binary,
+                Collation::Binary,
+                Some(0),
+            ),
+            (
+                r#"🕺_"#,
+                r#"🕺🕺🕺_"#,
+                '🕺',
+                Collation::Binary,
+                Collation::Utf8Mb4Bin,
+                Collation::Utf8Mb4Bin,
+                Some(1),
+            ),
+            // Will not match, because '_' matches only one byte.
+            (
+                r#"测试"#,
+                r#"测_"#,
+                '\\',
+                Collation::Binary,
+                Collation::Utf8Mb4Bin,
+                Collation::Binary,
+                Some(0),
+            ),
+            // Both of them should be decoded with binary charset, so that we'll
+            // compare byte with byte, but not comparing a long character with a
+            // byte.
+            (
+                r#"测试"#,
+                r#"测%"#,
+                '\\',
+                Collation::Binary,
+                Collation::Utf8Mb4Bin,
+                Collation::Binary,
+                Some(1),
+            ),
+            // This can happen when the new collation is not enabled, and TiDB
+            // doesn't push down the collation information. Using binary
+            // comparing order is fine, but we'll need to decode strings with
+            // their own charset (so '_' could match single character, rather
+            // than single byte).
+            (
+                r#"测试"#,
+                r#"测_"#,
+                '\\',
+                Collation::Binary,
+                Collation::Utf8Mb4Bin,
+                Collation::Utf8Mb4Bin,
+                Some(1),
+            ),
+        ];
+        for (target, pattern, escape, collation, target_collation, pattern_collation, expected) in
+            cases
+        {
+            let output = RpnFnScalarEvaluator::new()
+                .return_field_type(
+                    FieldTypeBuilder::new()
+                        .tp(FieldTypeTp::LongLong)
+                        .collation(collation)
+                        .build(),
+                )
+                .push_param_with_field_type(
+                    target.to_owned().into_bytes(),
+                    FieldTypeBuilder::new()
+                        .tp(FieldTypeTp::String)
+                        .collation(target_collation),
+                )
+                .push_param_with_field_type(
+                    pattern.to_owned().into_bytes(),
+                    FieldTypeBuilder::new()
+                        .tp(FieldTypeTp::String)
+                        .collation(pattern_collation),
+                )
+                .push_param(escape as i64)
+                .evaluate(ScalarFuncSig::LikeSig)
+                .unwrap();
+            assert_eq!(
+                output, expected,
+                "target={}, pattern={}, escape={}",
+                target, pattern, escape
+            );
         }
     }
 }

--- a/components/tidb_query_expr/src/lib.rs
+++ b/components/tidb_query_expr/src/lib.rs
@@ -44,12 +44,16 @@ pub mod impl_time;
 
 pub use self::types::*;
 
-use tidb_query_datatype::{Collation, FieldTypeAccessor, FieldTypeFlag};
-use tipb::{Expr, FieldType, ScalarFuncSig};
-
 use tidb_query_common::Result;
-use tidb_query_datatype::codec::data_type::*;
-use tidb_query_datatype::match_template_collator;
+use tidb_query_datatype::{
+    codec::{
+        collation::{Charset as _, Collator},
+        data_type::*,
+    },
+    match_template_collator, match_template_multiple_collators, Collation, FieldTypeAccessor,
+    FieldTypeFlag,
+};
+use tipb::{Expr, FieldType, ScalarFuncSig};
 
 use self::impl_arithmetic::*;
 use self::impl_cast::*;
@@ -82,10 +86,39 @@ fn map_compare_in_string_sig(ret_field_type: &FieldType) -> Result<RpnFnMeta> {
     })
 }
 
-fn map_like_sig(ret_field_type: &FieldType) -> Result<RpnFnMeta> {
-    Ok(match_template_collator! {
-        TT, match ret_field_type.as_accessor().collation().map_err(tidb_query_datatype::codec::Error::from)? {
-            Collation::TT => like_fn_meta::<TT>()
+fn map_like_sig(ret_field_type: &FieldType, children: &[Expr]) -> Result<RpnFnMeta> {
+    let ret_collation = ret_field_type
+        .as_accessor()
+        .collation()
+        .map_err(tidb_query_datatype::codec::Error::from)?;
+    let target_collation = children[0]
+        .get_field_type()
+        .as_accessor()
+        .collation()
+        .map_err(tidb_query_datatype::codec::Error::from)?;
+    let pattern_collation = children[1]
+        .get_field_type()
+        .as_accessor()
+        .collation()
+        .map_err(tidb_query_datatype::codec::Error::from)?;
+
+    // If the target charset is the same with pattern charset, and is Utf8mb4,
+    // use their charset to decode bytes. If not, use the charset pushed down in
+    // the ret_field type to decode the bytes.
+    //
+    // This behavior is for the compatibility and correctness: The TiDB doesn't
+    // push down the collation information when the new collation framework is
+    // not enabled, and always use the binary collation. However, the `_`
+    // pattern considers not only the order of strings, but also the number of
+    // characters. Some characters more than 1 bytes cannot be matched by `_` if
+    // the new collation framework is not enabled.
+    Ok(match_template_multiple_collators! {
+        (TT, TC, PC), (ret_collation, target_collation, pattern_collation), {
+            if <TC as Collator>::Charset::charset() == <PC as Collator>::Charset::charset() {
+                like_fn_meta::<TT, <TC as Collator>::Charset>()
+            } else {
+                like_fn_meta::<TT, <TT as Collator>::Charset>()
+            }
         }
     })
 }
@@ -499,7 +532,7 @@ fn map_expr_node_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
         ScalarFuncSig::JsonKeys2ArgsSig => json_keys_fn_meta(),
         ScalarFuncSig::JsonQuoteSig => json_quote_fn_meta(),
         // impl_like
-        ScalarFuncSig::LikeSig => map_like_sig(ft)?,
+        ScalarFuncSig::LikeSig => map_like_sig(ft, children)?,
         ScalarFuncSig::RegexpSig => regexp_fn_meta(),
         ScalarFuncSig::RegexpUtf8Sig => regexp_utf8_fn_meta(),
         // impl_math


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What is changed and how it works?

Issue Number: Close https://github.com/tikv/tikv/issues/13769

This PR is a rework for https://github.com/tikv/tikv/pull/13770. As I have force-pushed the branch, github doesn't allow me to reopen the old one :cry: .

What's Changed:

If the two charset of arguments are equal, use the charset from arguments to decode the bytes.

I have considered the following cases:

| Ret Collation  | First Arg Charset | Second Arg Charset | Description |
| ------------- | ------------- |------------- |------------- |
| binary  | binary  | binary | It works normally |
| binary  | utf8mb4  | binary | It happened when TiDB didn't push down the collation information. Just decode and compare the string byte by byte. A `_` in pattern will only match one byte in the first arg |
| binary  | binary  | utf8mb4 | It happened when TiDB didn't push down the collation information. Just decode and compare the string byte by byte. A `_` in pattern will only match one byte in the first arg |
| binary  | utf8mb4  | utf8mb4 | It happened when TiDB didn't push down the collation information. It'll decode and compare the string character by character. A `_` in pattern will match one unicode character in the first arg. This PR is actually fixing this case |
| utf8mb4_*  | utf8mb4  | binary | will not happen |
| utf8mb4_*  | utf8mb4  | utf8mb4 | It works normally |

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix the issue that `_` pattern in `like` failed to handle non-ascii character without new collation enabled.
```
