### PR TITLE
engine_trait: introduce flush state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4250,6 +4250,7 @@ dependencies = [
 name = "raft_log_engine"
 version = "0.0.1"
 dependencies = [
+ "codec",
  "encryption",
  "engine_traits",
  "file_system",
@@ -4264,6 +4265,7 @@ dependencies = [
  "serde_derive",
  "slog",
  "slog-global",
+ "tempfile",
  "tikv_util",
  "time",
  "tracker",

--- a/components/engine_panic/src/raft_engine.rs
+++ b/components/engine_panic/src/raft_engine.rs
@@ -47,11 +47,23 @@ impl RaftEngineReadOnly for PanicEngine {
         panic!()
     }
 
-    fn get_region_state(&self, raft_group_id: u64) -> Result<Option<RegionLocalState>> {
+    fn get_region_state(
+        &self,
+        raft_group_id: u64,
+        apply_index: u64,
+    ) -> Result<Option<RegionLocalState>> {
         panic!()
     }
 
-    fn get_apply_state(&self, raft_group_id: u64) -> Result<Option<RaftApplyState>> {
+    fn get_apply_state(
+        &self,
+        raft_group_id: u64,
+        apply_index: u64,
+    ) -> Result<Option<RaftApplyState>> {
+        panic!()
+    }
+
+    fn get_flushed_index(&self, raft_group_id: u64, cf: &str) -> Result<Option<u64>> {
         panic!()
     }
 
@@ -186,11 +198,31 @@ impl RaftLogBatch for PanicWriteBatch {
         panic!()
     }
 
-    fn put_region_state(&mut self, raft_group_id: u64, state: &RegionLocalState) -> Result<()> {
+    fn put_region_state(
+        &mut self,
+        raft_group_id: u64,
+        apply_index: u64,
+        state: &RegionLocalState,
+    ) -> Result<()> {
         panic!()
     }
 
-    fn put_apply_state(&mut self, raft_group_id: u64, state: &RaftApplyState) -> Result<()> {
+    fn put_apply_state(
+        &mut self,
+        raft_group_id: u64,
+        apply_index: u64,
+        state: &RaftApplyState,
+    ) -> Result<()> {
+        panic!()
+    }
+
+    fn put_flushed_index(
+        &mut self,
+        raft_group_id: u64,
+        cf: &str,
+        tablet_index: u64,
+        apply_index: u64,
+    ) -> Result<()> {
         panic!()
     }
 

--- a/components/engine_rocks/src/engine.rs
+++ b/components/engine_rocks/src/engine.rs
@@ -2,7 +2,9 @@
 
 use std::{any::Any, sync::Arc};
 
-use engine_traits::{IterOptions, Iterable, KvEngine, Peekable, ReadOptions, Result, SyncMutable};
+use engine_traits::{
+    FlushState, IterOptions, Iterable, KvEngine, Peekable, ReadOptions, Result, SyncMutable,
+};
 use rocksdb::{DBIterator, Writable, DB};
 
 use crate::{
@@ -24,6 +26,7 @@ use crate::{
 pub struct RocksEngine {
     db: Arc<DB>,
     support_multi_batch_write: bool,
+    flush_state: Option<Arc<FlushState>>,
 }
 
 impl RocksEngine {
@@ -35,6 +38,7 @@ impl RocksEngine {
         RocksEngine {
             db: db.clone(),
             support_multi_batch_write: db.get_db_options().is_enable_multi_batch_write(),
+            flush_state: None,
         }
     }
 
@@ -48,6 +52,14 @@ impl RocksEngine {
 
     pub fn support_multi_batch_write(&self) -> bool {
         self.support_multi_batch_write
+    }
+
+    pub fn set_flush_state(&mut self, flush_state: Arc<FlushState>) {
+        self.flush_state = Some(flush_state);
+    }
+
+    pub fn flush_state(&self) -> Option<Arc<FlushState>> {
+        self.flush_state.clone()
     }
 }
 

--- a/components/engine_rocks/src/raft_engine.rs
+++ b/components/engine_rocks/src/raft_engine.rs
@@ -144,14 +144,26 @@ impl RaftEngineReadOnly for RocksEngine {
         self.get_msg_cf(CF_DEFAULT, keys::PREPARE_BOOTSTRAP_KEY)
     }
 
-    fn get_region_state(&self, raft_group_id: u64) -> Result<Option<RegionLocalState>> {
-        let key = keys::region_state_key(raft_group_id);
-        self.get_msg_cf(CF_DEFAULT, &key)
+    // Following methods are used by raftstore v2 only, which always use raft log
+    // engine.
+    fn get_region_state(
+        &self,
+        _raft_group_id: u64,
+        _apply_index: u64,
+    ) -> Result<Option<RegionLocalState>> {
+        panic!()
     }
 
-    fn get_apply_state(&self, raft_group_id: u64) -> Result<Option<RaftApplyState>> {
-        let key = keys::apply_state_key(raft_group_id);
-        self.get_msg_cf(CF_DEFAULT, &key)
+    fn get_apply_state(
+        &self,
+        _raft_group_id: u64,
+        _apply_index: u64,
+    ) -> Result<Option<RaftApplyState>> {
+        panic!()
+    }
+
+    fn get_flushed_index(&self, _raft_group_id: u64, _cf: &str) -> Result<Option<u64>> {
+        panic!()
     }
 
     fn get_recover_state(&self) -> Result<Option<StoreRecoverState>> {
@@ -405,12 +417,34 @@ impl RaftLogBatch for RocksWriteBatchVec {
         self.delete(keys::PREPARE_BOOTSTRAP_KEY)
     }
 
-    fn put_region_state(&mut self, raft_group_id: u64, state: &RegionLocalState) -> Result<()> {
-        self.put_msg(&keys::region_state_key(raft_group_id), state)
+    // Following methods are used by raftstore v2 only, which always use raft log
+    // engine.
+    fn put_region_state(
+        &mut self,
+        _raft_group_id: u64,
+        _apply_index: u64,
+        _state: &RegionLocalState,
+    ) -> Result<()> {
+        panic!()
     }
 
-    fn put_apply_state(&mut self, raft_group_id: u64, state: &RaftApplyState) -> Result<()> {
-        self.put_msg(&keys::apply_state_key(raft_group_id), state)
+    fn put_apply_state(
+        &mut self,
+        _raft_group_id: u64,
+        _apply_index: u64,
+        _state: &RaftApplyState,
+    ) -> Result<()> {
+        panic!()
+    }
+
+    fn put_flushed_index(
+        &mut self,
+        _raft_group_id: u64,
+        _cf: &str,
+        _tablet_index: u64,
+        _apply_index: u64,
+    ) -> Result<()> {
+        panic!()
     }
 
     fn put_recover_state(&mut self, state: &StoreRecoverState) -> Result<()> {

--- a/components/engine_traits/src/flush.rs
+++ b/components/engine_traits/src/flush.rs
@@ -1,0 +1,202 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+//! A helper class to detect flush event and trace apply index.
+//!
+//! The whole idea is when all CFs have flushed to disk, then the apply index
+//! should be able to be advanced to the latest. The implementations depends on
+//! the assumption that memtable/write buffer is frozen one by one and flushed
+//! one by one.
+//!
+//! Because apply index can be arbitrary value after restart, so apply related
+//! states like `RaftApplyState` and `RegionLocalState` are mapped to index.
+//! Once apply index is confirmed, the latest states before apply index should
+//! be used as the start state.
+
+use std::{
+    mem,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, Mutex,
+    },
+};
+
+use kvproto::raft_serverpb::{RaftApplyState, RegionLocalState};
+use tikv_util::Either;
+
+use crate::{RaftEngine, RaftLogBatch};
+
+#[derive(Debug)]
+enum StateChange {
+    ApplyState(RaftApplyState),
+    RegionState(RegionLocalState),
+}
+
+/// States that is related to apply progress.
+#[derive(Default, Debug)]
+struct StateChanges {
+    /// apply index, state change
+    changes: Vec<(u64, StateChange)>,
+}
+
+struct FlushProgress {
+    cf: String,
+    id: u64,
+    apply_index: u64,
+    state_changes: StateChanges,
+}
+
+/// A share state between raftstore and underlying engine.
+///
+/// raftstore will update state changes and corresponding apply index, when
+/// flush, `PersistenceListener` will query states related to the memtable
+/// and persist the relation to raft engine.
+#[derive(Default, Debug)]
+pub struct FlushState {
+    applied_index: AtomicU64,
+    changes: Mutex<StateChanges>,
+}
+
+impl FlushState {
+    /// Set the latest applied index.
+    #[inline]
+    pub fn set_applied_index(&self, index: u64) {
+        self.applied_index.store(index, Ordering::Release);
+    }
+
+    /// Query the applied index.
+    #[inline]
+    pub fn applied_index(&self) -> u64 {
+        self.applied_index.load(Ordering::Acquire)
+    }
+
+    /// Record an apply state change.
+    ///
+    /// This can be triggered by admin command like compact log. General log
+    /// apply will not trigger the change, instead they are recorded by
+    /// `set_applied_index`.
+    #[inline]
+    pub fn update_apply_state(&self, index: u64, state: RaftApplyState) {
+        self.changes
+            .lock()
+            .unwrap()
+            .changes
+            .push((index, StateChange::ApplyState(state)));
+    }
+
+    /// Record a region state change.
+    ///
+    /// This can be triggered by admin command like split/merge.
+    #[inline]
+    pub fn update_region_state(&self, index: u64, state: RegionLocalState) {
+        self.changes
+            .lock()
+            .unwrap()
+            .changes
+            .push((index, StateChange::RegionState(state)));
+    }
+
+    /// Check if there is any state change.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.changes.lock().unwrap().changes.is_empty()
+    }
+
+    /// Get the last changed state.
+    #[inline]
+    pub fn last_state(&self) -> Option<(u64, Either<RaftApplyState, RegionLocalState>)> {
+        let changes = self.changes.lock().unwrap();
+        let (index, state) = changes.changes.last()?;
+        let state = match state {
+            StateChange::ApplyState(state) => Either::Left(state.clone()),
+            StateChange::RegionState(state) => Either::Right(state.clone()),
+        };
+        Some((*index, state))
+    }
+}
+
+/// A flush listener that maps memtable to apply index and persist the relation
+/// to raft engine.
+pub struct PersistenceListener<ER> {
+    region_id: u64,
+    tablet_index: u64,
+    state: Arc<FlushState>,
+    progress: Mutex<Vec<FlushProgress>>,
+    raft: ER,
+}
+
+impl<ER: RaftEngine> PersistenceListener<ER> {
+    pub fn new(region_id: u64, tablet_index: u64, state: Arc<FlushState>, raft: ER) -> Self {
+        Self {
+            region_id,
+            tablet_index,
+            state,
+            progress: Mutex::new(Vec::new()),
+            raft,
+        }
+    }
+}
+
+impl<ER: RaftEngine> PersistenceListener<ER> {
+    pub fn flush_state(&self) -> &Arc<FlushState> {
+        &self.state
+    }
+
+    /// Called when memtable is frozen.
+    ///
+    /// `id` should be unique between memtables, which is used to identify
+    /// memtable in the flushed event.
+    pub fn on_memtable_sealed(&self, cf: String, id: u64) {
+        // The correctness relies on the assumption that there will be only one
+        // thread writting to the DB and increasing apply index.
+        let mut state_changes = self.state.changes.lock().unwrap();
+        // Query within lock so it's correct even in manually flush.
+        let apply_index = self.state.applied_index.load(Ordering::SeqCst);
+        let changes = mem::take(&mut *state_changes);
+        drop(state_changes);
+        self.progress.lock().unwrap().push(FlushProgress {
+            cf,
+            id,
+            apply_index,
+            state_changes: changes,
+        });
+    }
+
+    /// Called a memtable finished flushing.
+    pub fn on_flush_completed(&self, cf: &str, id: u64) {
+        // Maybe we should hook the compaction to avoid the file is compacted before
+        // being recorded.
+        let pr = {
+            let mut prs = self.progress.lock().unwrap();
+            let pos = prs
+                .iter()
+                .position(|pr| pr.cf == cf && pr.id == id)
+                .unwrap();
+            prs.swap_remove(pos)
+        };
+        let mut batch = self.raft.log_batch(1);
+        // TODO: It's possible that flush succeeds but fails to call
+        // `on_flush_completed` before exit. In this case the flushed data will
+        // be replayed again after restarted. To solve the problem, we need to
+        // (1) persist flushed file numbers in `on_flush_begin` and (2) check
+        // the file number in `on_compaction_begin`. After restart, (3) check if the
+        // file exists. If (1) && ((2) || (3)), then we don't need to replay the data.
+        for (index, change) in pr.state_changes.changes {
+            match &change {
+                StateChange::ApplyState(state) => {
+                    batch.put_apply_state(self.region_id, index, state).unwrap();
+                }
+                StateChange::RegionState(state) => {
+                    batch
+                        .put_region_state(self.region_id, index, state)
+                        .unwrap();
+                }
+            }
+        }
+        if pr.apply_index != 0 {
+            batch
+                .put_flushed_index(self.region_id, cf, self.tablet_index, pr.apply_index)
+                .unwrap();
+        }
+        self.raft.consume(&mut batch, true).unwrap();
+    }
+}

--- a/components/engine_traits/src/lib.rs
+++ b/components/engine_traits/src/lib.rs
@@ -277,6 +277,8 @@ mod engine;
 pub use crate::engine::*;
 mod file_system;
 pub use crate::file_system::*;
+mod flush;
+pub use flush::*;
 mod import;
 pub use import::*;
 mod misc;

--- a/components/raft_log_engine/Cargo.toml
+++ b/components/raft_log_engine/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 encryption = { workspace = true }
 engine_traits = { workspace = true }
+codec = { workspace = true }
 file_system = { workspace = true }
 kvproto = { workspace = true }
 lazy_static = "1.4.0"
@@ -22,3 +23,6 @@ slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global
 tikv_util = { workspace = true }
 time = "0.1"
 tracker = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3.0"

--- a/components/raft_log_engine/src/engine.rs
+++ b/components/raft_log_engine/src/engine.rs
@@ -7,11 +7,12 @@ use std::{
     sync::Arc,
 };
 
+use codec::number::NumberCodec;
 use encryption::{DataKeyManager, DecrypterReader, EncrypterWriter};
 use engine_traits::{
     CacheStats, EncryptionKeyManager, EncryptionMethod, PerfContextExt, PerfContextKind, PerfLevel,
     RaftEngine, RaftEngineDebug, RaftEngineReadOnly, RaftLogBatch as RaftLogBatchTrait,
-    RaftLogGcTask, Result,
+    RaftLogGcTask, Result, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE,
 };
 use file_system::{IoOp, IoRateLimiter, IoType};
 use kvproto::{
@@ -290,6 +291,36 @@ impl FileSystem for ManagedFileSystem {
     }
 }
 
+/// Convert a cf to id for encoding.
+fn cf_to_id(cf: &str) -> u8 {
+    match cf {
+        CF_DEFAULT => 0,
+        CF_LOCK => 1,
+        CF_WRITE => 2,
+        CF_RAFT => 3,
+        _ => panic!("unrecognized cf {}", cf),
+    }
+}
+
+/// Encode a key in the format `{prefix}{num}`.
+fn encode_key(prefix: &'static [u8], num: u64) -> [u8; 9] {
+    debug_assert_eq!(prefix.len(), 1);
+    let mut buf = [0; 9];
+    buf[..prefix.len()].copy_from_slice(prefix);
+    NumberCodec::encode_u64(&mut buf[prefix.len()..], num);
+    buf
+}
+
+/// Encode a flush key in the format `{flush key prefix}{cf_id}{tablet_index}`.
+fn encode_flushed_key(cf: &str, tablet_index: u64) -> [u8; 10] {
+    debug_assert_eq!(FLUSH_STATE_KEY.len(), 1);
+    let mut buf = [0; 10];
+    buf[..FLUSH_STATE_KEY.len()].copy_from_slice(FLUSH_STATE_KEY);
+    buf[FLUSH_STATE_KEY.len()] = cf_to_id(cf);
+    NumberCodec::encode_u64(&mut buf[FLUSH_STATE_KEY.len() + 1..], tablet_index);
+    buf
+}
+
 #[derive(Clone)]
 pub struct RaftLogEngine(Arc<RawRaftEngine<ManagedFileSystem>>);
 
@@ -348,6 +379,7 @@ const PREPARE_BOOTSTRAP_REGION_KEY: &[u8] = &[0x02];
 const REGION_STATE_KEY: &[u8] = &[0x03];
 const APPLY_STATE_KEY: &[u8] = &[0x04];
 const RECOVER_STATE_KEY: &[u8] = &[0x05];
+const FLUSH_STATE_KEY: &[u8] = &[0x06];
 
 impl RaftLogBatchTrait for RaftLogBatch {
     fn append(&mut self, raft_group_id: u64, entries: Vec<Entry>) -> Result<()> {
@@ -401,16 +433,42 @@ impl RaftLogBatchTrait for RaftLogBatch {
         Ok(())
     }
 
-    fn put_region_state(&mut self, raft_group_id: u64, state: &RegionLocalState) -> Result<()> {
+    fn put_region_state(
+        &mut self,
+        raft_group_id: u64,
+        apply_index: u64,
+        state: &RegionLocalState,
+    ) -> Result<()> {
+        let key = encode_key(REGION_STATE_KEY, apply_index);
         self.0
-            .put_message(raft_group_id, REGION_STATE_KEY.to_vec(), state)
+            .put_message(raft_group_id, key.to_vec(), state)
             .map_err(transfer_error)
     }
 
-    fn put_apply_state(&mut self, raft_group_id: u64, state: &RaftApplyState) -> Result<()> {
+    fn put_apply_state(
+        &mut self,
+        raft_group_id: u64,
+        apply_index: u64,
+        state: &RaftApplyState,
+    ) -> Result<()> {
+        let key = encode_key(APPLY_STATE_KEY, apply_index);
         self.0
-            .put_message(raft_group_id, APPLY_STATE_KEY.to_vec(), state)
+            .put_message(raft_group_id, key.to_vec(), state)
             .map_err(transfer_error)
+    }
+
+    fn put_flushed_index(
+        &mut self,
+        raft_group_id: u64,
+        cf: &str,
+        tablet_index: u64,
+        apply_index: u64,
+    ) -> Result<()> {
+        let key = encode_flushed_key(cf, tablet_index);
+        let mut value = vec![0; 8];
+        NumberCodec::encode_u64(&mut value, apply_index);
+        self.0.put(raft_group_id, key.to_vec(), value);
+        Ok(())
     }
 
     fn put_recover_state(&mut self, state: &StoreRecoverState) -> Result<()> {
@@ -471,16 +529,72 @@ impl RaftEngineReadOnly for RaftLogEngine {
             .map_err(transfer_error)
     }
 
-    fn get_region_state(&self, raft_group_id: u64) -> Result<Option<RegionLocalState>> {
+    fn get_region_state(
+        &self,
+        raft_group_id: u64,
+        apply_index: u64,
+    ) -> Result<Option<RegionLocalState>> {
+        let mut state = None;
         self.0
-            .get_message(raft_group_id, REGION_STATE_KEY)
-            .map_err(transfer_error)
+            .scan_messages(
+                raft_group_id,
+                Some(REGION_STATE_KEY),
+                Some(APPLY_STATE_KEY),
+                true,
+                |key, value| {
+                    let index = NumberCodec::decode_u64(&key[REGION_STATE_KEY.len()..]);
+                    if index > apply_index {
+                        true
+                    } else {
+                        state = Some(value);
+                        false
+                    }
+                },
+            )
+            .map_err(transfer_error)?;
+        Ok(state)
     }
 
-    fn get_apply_state(&self, raft_group_id: u64) -> Result<Option<RaftApplyState>> {
+    fn get_apply_state(
+        &self,
+        raft_group_id: u64,
+        apply_index: u64,
+    ) -> Result<Option<RaftApplyState>> {
+        let mut state = None;
         self.0
-            .get_message(raft_group_id, APPLY_STATE_KEY)
-            .map_err(transfer_error)
+            .scan_messages(
+                raft_group_id,
+                Some(APPLY_STATE_KEY),
+                Some(RECOVER_STATE_KEY),
+                true,
+                |key, value| {
+                    let index = NumberCodec::decode_u64(&key[REGION_STATE_KEY.len()..]);
+                    if index > apply_index {
+                        true
+                    } else {
+                        state = Some(value);
+                        false
+                    }
+                },
+            )
+            .map_err(transfer_error)?;
+        Ok(state)
+    }
+
+    fn get_flushed_index(&self, raft_group_id: u64, cf: &str) -> Result<Option<u64>> {
+        let mut start = [0; 2];
+        start[..FLUSH_STATE_KEY.len()].copy_from_slice(FLUSH_STATE_KEY);
+        start[FLUSH_STATE_KEY.len()] = cf_to_id(cf);
+        let mut end = start;
+        end[FLUSH_STATE_KEY.len()] += 1;
+        let mut index = None;
+        self.0
+            .scan_raw_messages(raft_group_id, Some(&start), Some(&end), true, |_, v| {
+                index = Some(NumberCodec::decode_u64(v));
+                false
+            })
+            .map_err(transfer_error)?;
+        Ok(index)
     }
 
     fn get_recover_state(&self) -> Result<Option<StoreRecoverState>> {
@@ -621,6 +735,70 @@ fn transfer_error(e: RaftEngineError) -> engine_traits::Error {
         e => {
             let e = box_err!(e);
             engine_traits::Error::Other(e)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::assert_matches::assert_matches;
+
+    use engine_traits::ALL_CFS;
+
+    use super::*;
+
+    #[test]
+    fn test_apply_related_states() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = RaftEngineConfig {
+            dir: dir.path().to_str().unwrap().to_owned(),
+            ..Default::default()
+        };
+        let engine = RaftLogEngine::new(cfg, None, None).unwrap();
+        assert_matches!(engine.get_region_state(2, u64::MAX), Ok(None));
+        assert_matches!(engine.get_apply_state(2, u64::MAX), Ok(None));
+        for cf in ALL_CFS {
+            assert_matches!(engine.get_flushed_index(2, cf), Ok(None));
+        }
+
+        let mut wb = engine.log_batch(10);
+        let mut region_state = RegionLocalState::default();
+        region_state.mut_region().set_id(3);
+        wb.put_region_state(2, 1, &region_state).unwrap();
+        let mut apply_state = RaftApplyState::default();
+        apply_state.set_applied_index(3);
+        wb.put_apply_state(2, 3, &apply_state).unwrap();
+        for cf in ALL_CFS.iter().take(2) {
+            wb.put_flushed_index(2, cf, 5, 4).unwrap();
+        }
+        engine.consume(&mut wb, false).unwrap();
+
+        for cf in ALL_CFS.iter().take(2) {
+            assert_matches!(engine.get_flushed_index(2, cf), Ok(Some(4)));
+        }
+        for cf in ALL_CFS.iter().skip(2) {
+            assert_matches!(engine.get_flushed_index(2, cf), Ok(None));
+        }
+
+        let mut region_state2 = region_state.clone();
+        region_state2.mut_region().set_id(5);
+        wb.put_region_state(2, 4, &region_state2).unwrap();
+        let mut apply_state2 = apply_state.clone();
+        apply_state2.set_applied_index(5);
+        wb.put_apply_state(2, 5, &apply_state2).unwrap();
+        for cf in ALL_CFS {
+            wb.put_flushed_index(2, cf, 6, 5).unwrap();
+        }
+        engine.consume(&mut wb, false).unwrap();
+
+        assert_matches!(engine.get_region_state(2, 0), Ok(None));
+        assert_matches!(engine.get_region_state(2, 1), Ok(Some(s)) if s == region_state);
+        assert_matches!(engine.get_region_state(2, 4), Ok(Some(s)) if s == region_state2);
+        assert_matches!(engine.get_apply_state(2, 0), Ok(None));
+        assert_matches!(engine.get_apply_state(2, 3), Ok(Some(s)) if s == apply_state);
+        assert_matches!(engine.get_apply_state(2, 5), Ok(Some(s)) if s == apply_state2);
+        for cf in ALL_CFS {
+            assert_matches!(engine.get_flushed_index(2, cf), Ok(Some(5)));
         }
     }
 }

--- a/components/raft_log_engine/src/lib.rs
+++ b/components/raft_log_engine/src/lib.rs
@@ -16,6 +16,7 @@
 //! Please read the engine_trait crate docs before hacking.
 
 #![cfg_attr(test, feature(test))]
+#![feature(assert_matches)]
 
 #[macro_use]
 extern crate tikv_util;

--- a/components/raftstore-v2/src/operation/life.rs
+++ b/components/raftstore-v2/src/operation/life.rs
@@ -176,7 +176,7 @@ impl Store {
             return;
         }
         let from_epoch = msg.get_region_epoch();
-        let local_state = match ctx.engine.get_region_state(region_id) {
+        let local_state = match ctx.engine.get_region_state(region_id, 0) {
             Ok(s) => s,
             Err(e) => {
                 error!(self.logger(), "failed to get region state"; "region_id" => region_id, "err" => ?e);

--- a/components/raftstore-v2/src/raft/storage.rs
+++ b/components/raftstore-v2/src/raft/storage.rs
@@ -32,7 +32,7 @@ pub fn write_initial_states(wb: &mut impl RaftLogBatch, region: Region) -> Resul
     let mut state = RegionLocalState::default();
     state.set_region(region);
     state.set_tablet_index(RAFT_INIT_LOG_INDEX);
-    wb.put_region_state(region_id, &state)?;
+    wb.put_region_state(region_id, 0, &state)?;
 
     let mut apply_state = RaftApplyState::default();
     apply_state.set_applied_index(RAFT_INIT_LOG_INDEX);
@@ -42,7 +42,7 @@ pub fn write_initial_states(wb: &mut impl RaftLogBatch, region: Region) -> Resul
     apply_state
         .mut_truncated_state()
         .set_term(RAFT_INIT_LOG_TERM);
-    wb.put_apply_state(region_id, &apply_state)?;
+    wb.put_apply_state(region_id, 0, &apply_state)?;
 
     let mut raft_state = RaftLocalState::default();
     raft_state.set_last_index(RAFT_INIT_LOG_INDEX);
@@ -161,7 +161,7 @@ impl<EK: KvEngine, ER: RaftEngine> Storage<EK, ER> {
         read_scheduler: Scheduler<ReadTask<EK>>,
         logger: &Logger,
     ) -> Result<Option<Storage<EK, ER>>> {
-        let region_state = match engine.get_region_state(region_id) {
+        let region_state = match engine.get_region_state(region_id, 0) {
             Ok(Some(s)) => s,
             res => {
                 return Err(box_err!(
@@ -183,7 +183,7 @@ impl<EK: KvEngine, ER: RaftEngine> Storage<EK, ER> {
             }
         };
 
-        let apply_state = match engine.get_apply_state(region_id) {
+        let apply_state = match engine.get_apply_state(region_id, 0) {
             Ok(Some(s)) => s,
             res => {
                 return Err(box_err!("failed to get apply state: {:?}", res));
@@ -443,7 +443,7 @@ mod tests {
         assert!(!wb.is_empty());
         raft_engine.consume(&mut wb, true).unwrap();
 
-        let local_state = raft_engine.get_region_state(4).unwrap().unwrap();
+        let local_state = raft_engine.get_region_state(4, 0).unwrap().unwrap();
         assert_eq!(local_state.get_state(), PeerState::Normal);
         assert_eq!(*local_state.get_region(), region);
         assert_eq!(local_state.get_tablet_index(), RAFT_INIT_LOG_INDEX);
@@ -454,7 +454,7 @@ mod tests {
         assert_eq!(hs.get_term(), RAFT_INIT_LOG_TERM);
         assert_eq!(hs.get_commit(), RAFT_INIT_LOG_INDEX);
 
-        let apply_state = raft_engine.get_apply_state(4).unwrap().unwrap();
+        let apply_state = raft_engine.get_apply_state(4, 0).unwrap().unwrap();
         assert_eq!(apply_state.get_applied_index(), RAFT_INIT_LOG_INDEX);
         let ts = apply_state.get_truncated_state();
         assert_eq!(ts.get_index(), RAFT_INIT_LOG_INDEX);

--- a/components/raftstore-v2/tests/integrations/test_life.rs
+++ b/components/raftstore-v2/tests/integrations/test_life.rs
@@ -49,8 +49,8 @@ fn assert_tombstone(raft_engine: &impl RaftEngine, region_id: u64, peer: &metapb
     raft_engine.get_all_entries_to(region_id, &mut buf).unwrap();
     assert!(buf.is_empty(), "{:?}", buf);
     assert_matches!(raft_engine.get_raft_state(region_id), Ok(None));
-    assert_matches!(raft_engine.get_apply_state(region_id), Ok(None));
-    let region_state = raft_engine.get_region_state(region_id).unwrap().unwrap();
+    assert_matches!(raft_engine.get_apply_state(region_id, 0), Ok(None));
+    let region_state = raft_engine.get_region_state(region_id, 0).unwrap().unwrap();
     assert_matches!(region_state.get_state(), PeerState::Tombstone);
     assert!(
         region_state.get_region().get_peers().contains(peer),
@@ -121,7 +121,7 @@ fn test_life_by_message() {
     let raft_engine = &cluster.node(0).running_state().unwrap().raft_engine;
     raft_engine.get_raft_state(test_region_id).unwrap().unwrap();
     raft_engine
-        .get_apply_state(test_region_id)
+        .get_apply_state(test_region_id, 0)
         .unwrap()
         .unwrap();
 

--- a/components/raftstore/src/store/async_io/write.rs
+++ b/components/raftstore/src/store/async_io/write.rs
@@ -416,10 +416,11 @@ where
                             )
                             .unwrap();
                     }
-                    wb.put_region_state(region_id, &region_state).unwrap();
+                    wb.put_region_state(region_id, 0, &region_state).unwrap();
                 }
                 if !tombstone {
-                    wb.put_apply_state(region_id, &state.apply_state).unwrap();
+                    wb.put_apply_state(region_id, 0, &state.apply_state)
+                        .unwrap();
                 }
             }
         }

--- a/components/raftstore/src/store/async_io/write_tests.rs
+++ b/components/raftstore/src/store/async_io/write_tests.rs
@@ -431,14 +431,14 @@ fn test_worker_split_raft_wb() {
             ],
         );
         assert_eq!(
-            engines.raft.get_apply_state(region_1).unwrap(),
+            engines.raft.get_apply_state(region_1, 0).unwrap(),
             Some(RaftApplyState {
                 applied_index: 25,
                 ..Default::default()
             })
         );
         assert_eq!(
-            engines.raft.get_apply_state(region_2).unwrap(),
+            engines.raft.get_apply_state(region_2, 0).unwrap(),
             Some(RaftApplyState {
                 applied_index: 16,
                 ..Default::default()
@@ -634,18 +634,18 @@ fn test_basic_flow_with_states() {
         ],
     );
     assert_eq!(
-        engines.raft.get_apply_state(region_1).unwrap().unwrap(),
+        engines.raft.get_apply_state(region_1, 0).unwrap().unwrap(),
         apply_state_3
     );
     assert_eq!(
-        engines.raft.get_apply_state(region_2).unwrap().unwrap(),
+        engines.raft.get_apply_state(region_2, 0).unwrap().unwrap(),
         apply_state_2
     );
     assert_eq!(
-        engines.raft.get_region_state(region_1).unwrap().unwrap(),
+        engines.raft.get_region_state(region_1, 0).unwrap().unwrap(),
         region_state_1
     );
-    assert_eq!(engines.raft.get_region_state(region_2).unwrap(), None);
+    assert_eq!(engines.raft.get_region_state(region_2, 0).unwrap(), None);
 
     must_have_same_count_msg(6, &t.msg_rx);
 


### PR DESCRIPTION
### What is changed and how it works?
Issue Number: Ref #12842 

What's Changed:

```commit-message
Flush state is used to trace persisted apply index. This is the first
PR to remove WAL for raftstore v2.
```

You can checkout the full changes in [here](https://github.com/tikv/tikv/compare/master...BusyJay:tikv:remove-wal-for-v2?expand=1).

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
