### PR TITLE
raftstore-v2: introduce apply trace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -338,7 +338,7 @@ pd_client = { path = "components/pd_client" }
 profiler = { path = "components/profiler" }
 raft_log_engine = { path = "components/raft_log_engine" }
 raftstore = { path = "components/raftstore", default-features = false }
-raftstore_v2 = { path = "components/raftstore-v2", default-features = false }
+raftstore-v2 = { path = "components/raftstore-v2", default-features = false }
 resolved_ts = { path = "components/resolved_ts" }
 resource_metering = { path = "components/resource_metering" }
 security = { path = "components/security" }

--- a/components/engine_panic/src/misc.rs
+++ b/components/engine_panic/src/misc.rs
@@ -5,7 +5,7 @@ use engine_traits::{DeleteStrategy, MiscExt, Range, Result};
 use crate::engine::PanicEngine;
 
 impl MiscExt for PanicEngine {
-    fn flush_cfs(&self, wait: bool) -> Result<()> {
+    fn flush_cfs(&self, cfs: &[&str], wait: bool) -> Result<()> {
         panic!()
     }
 

--- a/components/engine_rocks/src/engine.rs
+++ b/components/engine_rocks/src/engine.rs
@@ -2,9 +2,7 @@
 
 use std::{any::Any, sync::Arc};
 
-use engine_traits::{
-    FlushState, IterOptions, Iterable, KvEngine, Peekable, ReadOptions, Result, SyncMutable,
-};
+use engine_traits::{IterOptions, Iterable, KvEngine, Peekable, ReadOptions, Result, SyncMutable};
 use rocksdb::{DBIterator, Writable, DB};
 
 use crate::{
@@ -26,7 +24,6 @@ use crate::{
 pub struct RocksEngine {
     db: Arc<DB>,
     support_multi_batch_write: bool,
-    flush_state: Option<Arc<FlushState>>,
 }
 
 impl RocksEngine {
@@ -38,7 +35,6 @@ impl RocksEngine {
         RocksEngine {
             db: db.clone(),
             support_multi_batch_write: db.get_db_options().is_enable_multi_batch_write(),
-            flush_state: None,
         }
     }
 
@@ -52,14 +48,6 @@ impl RocksEngine {
 
     pub fn support_multi_batch_write(&self) -> bool {
         self.support_multi_batch_write
-    }
-
-    pub fn set_flush_state(&mut self, flush_state: Arc<FlushState>) {
-        self.flush_state = Some(flush_state);
-    }
-
-    pub fn flush_state(&self) -> Option<Arc<FlushState>> {
-        self.flush_state.clone()
     }
 }
 

--- a/components/engine_rocks/src/event_listener.rs
+++ b/components/engine_rocks/src/event_listener.rs
@@ -1,6 +1,6 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_traits::{PersistenceListener, RaftEngine};
+use engine_traits::PersistenceListener;
 use file_system::{get_io_type, set_io_type, IoType};
 use regex::Regex;
 use rocksdb::{
@@ -179,15 +179,15 @@ fn resolve_sst_filename_from_err(err: &str) -> Option<String> {
     Some(filename)
 }
 
-pub struct RocksPersistenceListener<ER>(PersistenceListener<ER>);
+pub struct RocksPersistenceListener(PersistenceListener);
 
-impl<ER> RocksPersistenceListener<ER> {
-    pub fn new(listener: PersistenceListener<ER>) -> RocksPersistenceListener<ER> {
+impl RocksPersistenceListener {
+    pub fn new(listener: PersistenceListener) -> RocksPersistenceListener {
         RocksPersistenceListener(listener)
     }
 }
 
-impl<ER: RaftEngine> rocksdb::EventListener for RocksPersistenceListener<ER> {
+impl rocksdb::EventListener for RocksPersistenceListener {
     fn on_memtable_sealed(&self, info: &MemTableInfo) {
         self.0
             .on_memtable_sealed(info.cf_name().to_string(), info.first_seqno());

--- a/components/engine_rocks/src/event_listener.rs
+++ b/components/engine_rocks/src/event_listener.rs
@@ -189,13 +189,11 @@ impl RocksPersistenceListener {
 
 impl rocksdb::EventListener for RocksPersistenceListener {
     fn on_memtable_sealed(&self, info: &MemTableInfo) {
-        self.0
-            .on_memtable_sealed(info.cf_name().to_string(), info.first_seqno());
+        self.0.on_memtable_sealed(info.cf_name().to_string());
     }
 
     fn on_flush_completed(&self, job: &FlushJobInfo) {
-        self.0
-            .on_flush_completed(job.cf_name(), job.smallest_seqno());
+        self.0.on_flush_completed(job.cf_name());
     }
 }
 

--- a/components/engine_rocks/src/event_listener.rs
+++ b/components/engine_rocks/src/event_listener.rs
@@ -189,22 +189,170 @@ impl RocksPersistenceListener {
 
 impl rocksdb::EventListener for RocksPersistenceListener {
     fn on_memtable_sealed(&self, info: &MemTableInfo) {
-        self.0.on_memtable_sealed(info.cf_name().to_string());
+        self.0
+            .on_memtable_sealed(info.cf_name().to_string(), info.earliest_seqno());
     }
 
     fn on_flush_completed(&self, job: &FlushJobInfo) {
-        self.0.on_flush_completed(job.cf_name());
+        self.0
+            .on_flush_completed(job.cf_name(), job.largest_seqno());
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{
+        mpsc::{self, Sender},
+        Arc, Mutex,
+    };
+
+    use engine_traits::{
+        FlushProgress, FlushState, MiscExt, StateStorage, SyncMutable, CF_DEFAULT, DATA_CFS,
+    };
+    use tempfile::Builder;
+
     use super::*;
+    use crate::{util, RocksCfOptions, RocksDbOptions};
 
     #[test]
     fn test_resolve_sst_filename() {
         let err = "Corruption: Sst file size mismatch: /qps/data/tikv-10014/db/000398.sst. Size recorded in manifest 6975, actual size 6959";
         let filename = resolve_sst_filename_from_err(err).unwrap();
         assert_eq!(filename, "/000398.sst");
+    }
+
+    type Record = (u64, u64, FlushProgress);
+
+    #[derive(Default)]
+    struct MemStorage {
+        records: Mutex<Vec<Record>>,
+    }
+
+    impl StateStorage for MemStorage {
+        fn persist_progress(&self, region_id: u64, tablet_index: u64, pr: FlushProgress) {
+            self.records
+                .lock()
+                .unwrap()
+                .push((region_id, tablet_index, pr));
+        }
+    }
+
+    struct FlushTrack {
+        sealed: Mutex<Sender<()>>,
+        block_flush: Arc<Mutex<()>>,
+    }
+
+    impl rocksdb::EventListener for FlushTrack {
+        fn on_memtable_sealed(&self, _: &MemTableInfo) {
+            let _ = self.sealed.lock().unwrap().send(());
+        }
+
+        fn on_flush_begin(&self, _: &FlushJobInfo) {
+            drop(self.block_flush.lock().unwrap())
+        }
+    }
+
+    #[test]
+    fn test_persistence_listener() {
+        let temp_dir = Builder::new()
+            .prefix("test_persistence_listener")
+            .tempdir()
+            .unwrap();
+        let (region_id, tablet_index) = (2, 3);
+
+        let storage = Arc::new(MemStorage::default());
+        let state = Arc::new(FlushState::default());
+        let listener =
+            PersistenceListener::new(region_id, tablet_index, state.clone(), storage.clone());
+        let mut db_opt = RocksDbOptions::default();
+        db_opt.add_event_listener(RocksPersistenceListener::new(listener));
+        let (tx, rx) = mpsc::channel();
+        let block_flush = Arc::new(Mutex::new(()));
+        db_opt.add_event_listener(FlushTrack {
+            sealed: Mutex::new(tx),
+            block_flush: block_flush.clone(),
+        });
+
+        let mut cf_opts: Vec<_> = DATA_CFS
+            .iter()
+            .map(|cf| (*cf, RocksCfOptions::default()))
+            .collect();
+        cf_opts[0].1.set_max_write_buffer_number(4);
+        cf_opts[0].1.set_min_write_buffer_number_to_merge(2);
+        cf_opts[0].1.set_write_buffer_size(1024);
+        cf_opts[0].1.set_disable_auto_compactions(true);
+        let db = util::new_engine_opt(temp_dir.path().to_str().unwrap(), db_opt, cf_opts).unwrap();
+        db.flush_cf(CF_DEFAULT, true).unwrap();
+        let sst_count = || {
+            std::fs::read_dir(temp_dir.path())
+                .unwrap()
+                .filter(|p| {
+                    let p = match p {
+                        Ok(p) => p,
+                        Err(_) => return false,
+                    };
+                    p.path().extension().map_or(false, |ext| ext == "sst")
+                })
+                .count()
+        };
+        // Although flush is triggered, but there is nothing to flush.
+        assert_eq!(sst_count(), 0);
+        assert_eq!(storage.records.lock().unwrap().len(), 0);
+
+        // Flush one key should work.
+        state.set_applied_index(2);
+        db.put_cf(CF_DEFAULT, b"k0", b"v0").unwrap();
+        db.flush_cf(CF_DEFAULT, true).unwrap();
+        assert_eq!(sst_count(), 1);
+        let record = storage.records.lock().unwrap().pop().unwrap();
+        assert_eq!(storage.records.lock().unwrap().len(), 0);
+        assert_eq!(record.0, region_id);
+        assert_eq!(record.1, tablet_index);
+        assert_eq!(record.2.applied_index(), 2);
+
+        // When puts and deletes are mixed, the puts may be deleted during flush.
+        state.set_applied_index(3);
+        db.put_cf(CF_DEFAULT, b"k0", b"v0").unwrap();
+        db.delete_cf(CF_DEFAULT, b"k0").unwrap();
+        db.delete_cf(CF_DEFAULT, b"k1").unwrap();
+        db.put_cf(CF_DEFAULT, b"k1", b"v1").unwrap();
+        db.flush_cf(CF_DEFAULT, true).unwrap();
+        assert_eq!(sst_count(), 2);
+        let record = storage.records.lock().unwrap().pop().unwrap();
+        assert_eq!(storage.records.lock().unwrap().len(), 0);
+        assert_eq!(record.0, region_id);
+        assert_eq!(record.1, tablet_index);
+        assert_eq!(record.2.applied_index(), 3);
+        // Detail check of `FlushProgress` will be done in raftstore-v2 tests.
+
+        // Drain all the events.
+        while rx.try_recv().is_ok() {}
+        state.set_applied_index(4);
+        let block = block_flush.lock();
+        // Seal twice to trigger flush. Seal third to make a seqno conflict, in
+        // which case flush largest seqno will be equal to seal earliest seqno.
+        let mut key_count = 2;
+        for i in 0..3 {
+            while rx.try_recv().is_err() {
+                db.put(format!("k{key_count}").as_bytes(), &[0; 512])
+                    .unwrap();
+                key_count += 1;
+            }
+            state.set_applied_index(5 + i);
+        }
+        drop(block);
+        // Memtable is seal before put, so there must be still one KV in memtable.
+        db.flush_cf(CF_DEFAULT, true).unwrap();
+        rx.try_recv().unwrap();
+        // There is 2 sst before this round, and then 4 are merged into 2, so there
+        // should be 4 ssts.
+        assert_eq!(sst_count(), 4);
+        let records = storage.records.lock().unwrap();
+        // Although it seals 4 times, but only create 2 SSTs, so only 2 records.
+        assert_eq!(records.len(), 2);
+        // The indexes of two merged flush state are 4 and 5, so merged value is 5.
+        assert_eq!(records[0].2.applied_index(), 5);
+        // The last two flush state is 6 and 7.
+        assert_eq!(records[1].2.applied_index(), 7);
     }
 }

--- a/components/engine_rocks/src/file_system.rs
+++ b/components/engine_rocks/src/file_system.rs
@@ -82,13 +82,13 @@ mod tests {
         db.put(&data_key(b"a1"), &value).unwrap();
         db.put(&data_key(b"a2"), &value).unwrap();
         assert_eq!(stats.fetch(IoType::Flush, IoOp::Write), 0);
-        db.flush_cfs(true /* wait */).unwrap();
+        db.flush_cfs(&[], true /* wait */).unwrap();
         assert!(stats.fetch(IoType::Flush, IoOp::Write) > value_size * 2);
         assert!(stats.fetch(IoType::Flush, IoOp::Write) < value_size * 2 + amplification_bytes);
         stats.reset();
         db.put(&data_key(b"a2"), &value).unwrap();
         db.put(&data_key(b"a3"), &value).unwrap();
-        db.flush_cfs(true /* wait */).unwrap();
+        db.flush_cfs(&[], true /* wait */).unwrap();
         assert!(stats.fetch(IoType::Flush, IoOp::Write) > value_size * 2);
         assert!(stats.fetch(IoType::Flush, IoOp::Write) < value_size * 2 + amplification_bytes);
         stats.reset();

--- a/components/engine_rocks/src/misc.rs
+++ b/components/engine_rocks/src/misc.rs
@@ -126,10 +126,15 @@ impl RocksEngine {
 }
 
 impl MiscExt for RocksEngine {
-    fn flush_cfs(&self, wait: bool) -> Result<()> {
+    fn flush_cfs(&self, cfs: &[&str], wait: bool) -> Result<()> {
         let mut handles = vec![];
-        for cf in self.cf_names() {
+        for cf in cfs {
             handles.push(util::get_cf_handle(self.as_inner(), cf)?);
+        }
+        if handles.is_empty() {
+            for cf in self.cf_names() {
+                handles.push(util::get_cf_handle(self.as_inner(), cf)?);
+            }
         }
         self.as_inner().flush_cfs(&handles, wait).map_err(r2e)
     }

--- a/components/engine_test/src/lib.rs
+++ b/components/engine_test/src/lib.rs
@@ -119,9 +119,10 @@ pub mod kv {
     }
 
     impl TabletFactory<KvTestEngine> for TestTabletFactory {
-        fn open_tablet(&self, _ctx: TabletContext, path: &Path) -> Result<KvTestEngine> {
-            KvTestEngine::new_kv_engine_opt(
+        fn open_tablet(&self, ctx: TabletContext, path: &Path) -> Result<KvTestEngine> {
+            KvTestEngine::new_tablet(
                 path.to_str().unwrap(),
+                ctx,
                 self.db_opt.clone(),
                 self.cf_opts.clone(),
             )
@@ -155,7 +156,7 @@ pub mod ctor {
     use std::sync::Arc;
 
     use encryption::DataKeyManager;
-    use engine_traits::Result;
+    use engine_traits::{Result, StateStorage, TabletContext};
     use file_system::IoRateLimiter;
 
     /// Kv engine construction
@@ -188,6 +189,14 @@ pub mod ctor {
             db_opt: DbOptions,
             cf_opts: Vec<(&str, CfOptions)>,
         ) -> Result<Self>;
+
+        /// Create a new engine specific for multi rocks.
+        fn new_tablet(
+            path: &str,
+            ctx: TabletContext,
+            db_opt: DbOptions,
+            cf_opts: Vec<(&str, CfOptions)>,
+        ) -> Result<Self>;
     }
 
     /// Raft engine construction
@@ -200,6 +209,7 @@ pub mod ctor {
     pub struct DbOptions {
         key_manager: Option<Arc<DataKeyManager>>,
         rate_limiter: Option<Arc<IoRateLimiter>>,
+        state_storage: Option<Arc<dyn StateStorage>>,
         enable_multi_batch_write: bool,
     }
 
@@ -210,6 +220,10 @@ pub mod ctor {
 
         pub fn set_rate_limiter(&mut self, rate_limiter: Option<Arc<IoRateLimiter>>) {
             self.rate_limiter = rate_limiter;
+        }
+
+        pub fn set_state_storage(&mut self, state_storage: Arc<dyn StateStorage>) {
+            self.state_storage = Some(state_storage);
         }
 
         pub fn set_enable_multi_batch_write(&mut self, enable: bool) {
@@ -329,6 +343,15 @@ pub mod ctor {
             ) -> Result<Self> {
                 Ok(PanicEngine)
             }
+
+            fn new_tablet(
+                _path: &str,
+                _ctx: engine_traits::TabletContext,
+                _db_opt: DbOptions,
+                _cf_opts: Vec<(&str, CfOptions)>,
+            ) -> Result<Self> {
+                Ok(PanicEngine)
+            }
         }
 
         impl RaftEngineConstructorExt for engine_panic::PanicEngine {
@@ -343,9 +366,11 @@ pub mod ctor {
             get_env,
             properties::{MvccPropertiesCollectorFactory, RangePropertiesCollectorFactory},
             util::new_engine_opt as rocks_new_engine_opt,
-            RocksCfOptions, RocksDbOptions,
+            RocksCfOptions, RocksDbOptions, RocksPersistenceListener,
         };
-        use engine_traits::{CfOptions as _, Result, CF_DEFAULT};
+        use engine_traits::{
+            CfOptions as _, PersistenceListener, Result, TabletContext, CF_DEFAULT,
+        };
 
         use super::{
             CfOptions, DbOptions, KvEngineConstructorExt, RaftDbOptions, RaftEngineConstructorExt,
@@ -371,6 +396,36 @@ pub mod ctor {
             ) -> Result<Self> {
                 let rocks_db_opts = get_rocks_db_opts(db_opt)?;
                 let rocks_cfs_opts = cfs_opts
+                    .iter()
+                    .map(|(name, opt)| (*name, get_rocks_cf_opts(opt)))
+                    .collect();
+                rocks_new_engine_opt(path, rocks_db_opts, rocks_cfs_opts)
+            }
+
+            fn new_tablet(
+                path: &str,
+                ctx: TabletContext,
+                db_opt: DbOptions,
+                cf_opts: Vec<(&str, CfOptions)>,
+            ) -> Result<Self> {
+                let mut rocks_db_opts = RocksDbOptions::default();
+                let env = get_env(db_opt.key_manager.clone(), db_opt.rate_limiter)?;
+                rocks_db_opts.set_env(env);
+                rocks_db_opts.enable_unordered_write(false);
+                rocks_db_opts.enable_pipelined_write(false);
+                rocks_db_opts.enable_multi_batch_write(false);
+                rocks_db_opts.allow_concurrent_memtable_write(false);
+                if let Some(storage) = db_opt.state_storage
+                && let Some(flush_state) = ctx.flush_state {
+                    let listener = PersistenceListener::new(
+                        ctx.id,
+                        ctx.suffix.unwrap(),
+                        flush_state,
+                        storage,
+                    );
+                    rocks_db_opts.add_event_listener(RocksPersistenceListener::new(listener));
+                }
+                let rocks_cfs_opts = cf_opts
                     .iter()
                     .map(|(name, opt)| (*name, get_rocks_cf_opts(opt)))
                     .collect();

--- a/components/engine_test/src/lib.rs
+++ b/components/engine_test/src/lib.rs
@@ -416,7 +416,7 @@ pub mod ctor {
                 rocks_db_opts.enable_multi_batch_write(false);
                 rocks_db_opts.allow_concurrent_memtable_write(false);
                 if let Some(storage) = db_opt.state_storage
-                && let Some(flush_state) = ctx.flush_state {
+                    && let Some(flush_state) = ctx.flush_state {
                     let listener = PersistenceListener::new(
                         ctx.id,
                         ctx.suffix.unwrap(),

--- a/components/engine_traits/src/cf_defs.rs
+++ b/components/engine_traits/src/cf_defs.rs
@@ -9,6 +9,7 @@ pub const CF_RAFT: CfName = "raft";
 pub const LARGE_CFS: &[CfName] = &[CF_DEFAULT, CF_LOCK, CF_WRITE];
 pub const ALL_CFS: &[CfName] = &[CF_DEFAULT, CF_LOCK, CF_WRITE, CF_RAFT];
 pub const DATA_CFS: &[CfName] = &[CF_DEFAULT, CF_LOCK, CF_WRITE];
+pub const DATA_CFS_LEN: usize = DATA_CFS.len();
 
 pub fn name_to_cf(name: &str) -> Option<CfName> {
     if name.is_empty() {

--- a/components/engine_traits/src/flush.rs
+++ b/components/engine_traits/src/flush.rs
@@ -58,6 +58,10 @@ impl FlushProgress {
     pub fn applied_index(&self) -> u64 {
         self.apply_index
     }
+
+    pub fn cf(&self) -> &str {
+        &self.cf
+    }
 }
 
 /// A share state between raftstore and underlying engine.
@@ -168,8 +172,7 @@ impl PersistenceListener {
 
     /// Called when memtable is frozen.
     ///
-    /// `id` should be unique between memtables, which is used to identify
-    /// memtable in the flushed event.
+    /// `earliest_seqno` should be the smallest seqno of the memtable.
     pub fn on_memtable_sealed(&self, cf: String, earliest_seqno: u64) {
         // The correctness relies on the assumption that there will be only one
         // thread writting to the DB and increasing apply index.
@@ -187,6 +190,8 @@ impl PersistenceListener {
     }
 
     /// Called a memtable finished flushing.
+    ///
+    /// `largest_seqno` should be the largest seqno of the generated file.
     pub fn on_flush_completed(&self, cf: &str, largest_seqno: u64) {
         // Maybe we should hook the compaction to avoid the file is compacted before
         // being recorded.

--- a/components/engine_traits/src/lib.rs
+++ b/components/engine_traits/src/lib.rs
@@ -251,6 +251,8 @@
 #![cfg_attr(test, feature(test))]
 #![feature(min_specialization)]
 #![feature(assert_matches)]
+#![feature(linked_list_cursors)]
+#![feature(let_chains)]
 
 #[macro_use(fail_point)]
 extern crate fail;

--- a/components/engine_traits/src/misc.rs
+++ b/components/engine_traits/src/misc.rs
@@ -38,7 +38,10 @@ pub enum DeleteStrategy {
 }
 
 pub trait MiscExt: CfNamesExt + FlowControlFactorsExt {
-    fn flush_cfs(&self, wait: bool) -> Result<()>;
+    /// Flush all specified column families at once.
+    ///
+    /// If `cfs` is empty, it will try to flush all available column families.
+    fn flush_cfs(&self, cfs: &[&str], wait: bool) -> Result<()>;
 
     fn flush_cf(&self, cf: &str, wait: bool) -> Result<()>;
 

--- a/components/engine_traits/src/tablet.rs
+++ b/components/engine_traits/src/tablet.rs
@@ -13,7 +13,7 @@ use collections::HashMap;
 use kvproto::metapb::Region;
 use tikv_util::box_err;
 
-use crate::{Error, Result};
+use crate::{Error, FlushState, Result};
 
 #[derive(Debug)]
 struct LatestTablet<EK> {
@@ -91,6 +91,10 @@ pub struct TabletContext {
     /// Any key that is larger than or equal to this key can be considered
     /// obsolete.
     pub end_key: Box<[u8]>,
+    /// The states to be persisted when flush is triggered.
+    ///
+    /// If not set, apply may not be resumed correctly.
+    pub flush_state: Option<Arc<FlushState>>,
 }
 
 impl Debug for TabletContext {
@@ -111,6 +115,7 @@ impl TabletContext {
             suffix,
             start_key: keys::data_key(region.get_start_key()).into_boxed_slice(),
             end_key: keys::data_end_key(region.get_end_key()).into_boxed_slice(),
+            flush_state: None,
         }
     }
 

--- a/components/raftstore-v2/src/bootstrap.rs
+++ b/components/raftstore-v2/src/bootstrap.rs
@@ -15,7 +15,7 @@ use raftstore::store::initial_region;
 use slog::{debug, error, info, warn, Logger};
 use tikv_util::{box_err, box_try};
 
-use crate::{raft::write_initial_states, Result};
+use crate::{operation::write_initial_states, Result};
 
 const MAX_CHECK_CLUSTER_BOOTSTRAPPED_RETRY_COUNT: u64 = 60;
 const CHECK_CLUSTER_BOOTSTRAPPED_RETRY_INTERVAL: Duration = Duration::from_secs(3);

--- a/components/raftstore-v2/src/fsm/apply.rs
+++ b/components/raftstore-v2/src/fsm/apply.rs
@@ -113,7 +113,6 @@ impl<EK: KvEngine, R: ApplyResReporter> ApplyFsm<EK, R> {
                     // TODO: flush by buffer size.
                     ApplyTask::CommittedEntries(ce) => self.apply.apply_committed_entries(ce).await,
                     ApplyTask::Snapshot(snap_task) => self.apply.schedule_gen_snapshot(snap_task),
-                    ApplyTask::ManualFlush { cfs, ch } => self.apply.on_manual_flush(cfs, ch),
                 }
 
                 // TODO: yield after some time.

--- a/components/raftstore-v2/src/fsm/apply.rs
+++ b/components/raftstore-v2/src/fsm/apply.rs
@@ -1,10 +1,13 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::time::{Duration, Instant};
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use batch_system::{Fsm, FsmScheduler, Mailbox};
 use crossbeam::channel::TryRecvError;
-use engine_traits::{KvEngine, TabletRegistry};
+use engine_traits::{FlushState, KvEngine, TabletRegistry};
 use futures::{compat::Future01CompatExt, FutureExt, StreamExt};
 use kvproto::{metapb, raft_serverpb::RegionLocalState};
 use raftstore::store::ReadTask;
@@ -16,6 +19,7 @@ use tikv_util::{
 };
 
 use crate::{
+    operation::DataTrace,
     raft::Apply,
     router::{ApplyRes, ApplyTask, PeerMsg},
 };
@@ -59,6 +63,8 @@ impl<EK: KvEngine, R> ApplyFsm<EK, R> {
         res_reporter: R,
         tablet_registry: TabletRegistry<EK>,
         read_scheduler: Scheduler<ReadTask<EK>>,
+        flush_state: Arc<FlushState>,
+        log_recovery: Option<Box<DataTrace>>,
         logger: Logger,
     ) -> (ApplyScheduler, Self) {
         let (tx, rx) = future::unbounded(WakePolicy::Immediately);
@@ -68,6 +74,8 @@ impl<EK: KvEngine, R> ApplyFsm<EK, R> {
             res_reporter,
             tablet_registry,
             read_scheduler,
+            flush_state,
+            log_recovery,
             logger,
         );
         (
@@ -105,6 +113,7 @@ impl<EK: KvEngine, R: ApplyResReporter> ApplyFsm<EK, R> {
                     // TODO: flush by buffer size.
                     ApplyTask::CommittedEntries(ce) => self.apply.apply_committed_entries(ce).await,
                     ApplyTask::Snapshot(snap_task) => self.apply.schedule_gen_snapshot(snap_task),
+                    ApplyTask::ManualFlush { cfs, ch } => self.apply.on_manual_flush(cfs, ch),
                 }
 
                 // TODO: yield after some time.

--- a/components/raftstore-v2/src/fsm/peer.rs
+++ b/components/raftstore-v2/src/fsm/peer.rs
@@ -254,7 +254,6 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> PeerFsmDelegate<'a, EK, ER,
                     self.fsm.peer_mut().on_snapshot_generated(snap_res)
                 }
                 PeerMsg::QueryDebugInfo(ch) => self.fsm.peer_mut().on_query_debug_info(ch),
-                PeerMsg::ManualFlush { cfs, ch } => self.fsm.peer_mut().on_manual_flush(cfs, ch),
                 PeerMsg::DataFlushed {
                     cf,
                     tablet_index,

--- a/components/raftstore-v2/src/fsm/peer.rs
+++ b/components/raftstore-v2/src/fsm/peer.rs
@@ -254,6 +254,16 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> PeerFsmDelegate<'a, EK, ER,
                     self.fsm.peer_mut().on_snapshot_generated(snap_res)
                 }
                 PeerMsg::QueryDebugInfo(ch) => self.fsm.peer_mut().on_query_debug_info(ch),
+                PeerMsg::ManualFlush { cfs, ch } => self.fsm.peer_mut().on_manual_flush(cfs, ch),
+                PeerMsg::DataFlushed {
+                    cf,
+                    tablet_index,
+                    flushed_index,
+                } => {
+                    self.fsm
+                        .peer_mut()
+                        .on_data_flushed(cf, tablet_index, flushed_index);
+                }
                 #[cfg(feature = "testexport")]
                 PeerMsg::WaitFlush(ch) => self.fsm.peer_mut().on_wait_flush(ch),
             }

--- a/components/raftstore-v2/src/lib.rs
+++ b/components/raftstore-v2/src/lib.rs
@@ -24,6 +24,7 @@
 #![feature(let_chains)]
 #![feature(array_windows)]
 #![feature(div_duration)]
+#![feature(box_into_inner)]
 
 mod batch;
 mod bootstrap;

--- a/components/raftstore-v2/src/lib.rs
+++ b/components/raftstore-v2/src/lib.rs
@@ -37,4 +37,5 @@ pub(crate) use batch::StoreContext;
 pub use batch::{create_store_batch_system, StoreRouter, StoreSystem};
 pub use bootstrap::Bootstrap;
 pub use fsm::StoreMeta;
+pub use operation::StateStorage;
 pub use raftstore::{Error, Result};

--- a/components/raftstore-v2/src/operation/command/admin/split.rs
+++ b/components/raftstore-v2/src/operation/command/admin/split.rs
@@ -473,7 +473,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             assert_ne!(admin_flushed, 0);
             self.storage_mut()
                 .apply_trace_mut()
-                .record_admin_flush(admin_flushed);
+                .on_admin_flush(admin_flushed);
             // Persist admin flushed.
             self.set_has_extra_write();
         }

--- a/components/raftstore-v2/src/operation/command/mod.rs
+++ b/components/raftstore-v2/src/operation/command/mod.rs
@@ -121,6 +121,8 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             mailbox,
             store_ctx.tablet_registry.clone(),
             read_scheduler,
+            self.flush_state().clone(),
+            self.storage().apply_trace().log_recovery(),
             logger,
         );
 
@@ -266,6 +268,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             entry_and_proposals,
         };
         self.apply_scheduler()
+            .unwrap()
             .send(ApplyTask::CommittedEntries(apply));
     }
 
@@ -280,7 +283,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             return;
         }
 
-        for admin_res in apply_res.admin_result {
+        for admin_res in Vec::from(apply_res.admin_result) {
             match admin_res {
                 AdminCmdResult::None => unreachable!(),
                 AdminCmdResult::ConfChange(conf_change) => {
@@ -290,7 +293,12 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
                     regions,
                     derived_index,
                     tablet_index,
-                }) => self.on_apply_res_split(ctx, derived_index, tablet_index, regions),
+                }) => {
+                    self.storage_mut()
+                        .apply_trace_mut()
+                        .record_admin_modify(tablet_index);
+                    self.on_apply_res_split(ctx, derived_index, tablet_index, regions)
+                }
                 AdminCmdResult::TransferLeader(term) => self.on_transfer_leader(ctx, term),
             }
         }
@@ -308,12 +316,24 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         if !is_leader {
             entry_storage.compact_entry_cache(apply_res.applied_index + 1);
         }
+        self.record_data_trace(apply_res.modifications);
         self.handle_read_on_apply(
             ctx,
             apply_res.applied_term,
             apply_res.applied_index,
             progress_to_be_updated,
         );
+    }
+}
+
+impl<EK: KvEngine, R> Apply<EK, R> {
+    #[inline]
+    fn should_skip(&self, off: usize, index: u64) -> bool {
+        let log_recovery = self.log_recovery();
+        if log_recovery.is_none() {
+            return false;
+        }
+        log_recovery.as_ref().unwrap()[off] >= index
     }
 }
 
@@ -357,11 +377,12 @@ impl<EK: KvEngine, R: ApplyResReporter> Apply<EK, R> {
     #[inline]
     async fn apply_entry(&mut self, entry: &Entry) -> Result<RaftCmdResponse> {
         let mut conf_change = None;
+        let log_index = entry.get_index();
         let req = match entry.get_entry_type() {
             EntryType::EntryNormal => match SimpleWriteDecoder::new(
                 &self.logger,
                 entry.get_data(),
-                entry.get_index(),
+                log_index,
                 entry.get_term(),
             ) {
                 Ok(decoder) => {
@@ -375,16 +396,21 @@ impl<EK: KvEngine, R: ApplyResReporter> Apply<EK, R> {
                     let res = Ok(new_response(decoder.header()));
                     for req in decoder {
                         match req {
-                            SimpleWrite::Put(put) => self.apply_put(put.cf, put.key, put.value)?,
-                            SimpleWrite::Delete(delete) => {
-                                self.apply_delete(delete.cf, delete.key)?
+                            SimpleWrite::Put(put) => {
+                                self.apply_put(put.cf, log_index, put.key, put.value)?;
                             }
-                            SimpleWrite::DeleteRange(dr) => self.apply_delete_range(
-                                dr.cf,
-                                dr.start_key,
-                                dr.end_key,
-                                dr.notify_only,
-                            )?,
+                            SimpleWrite::Delete(delete) => {
+                                self.apply_delete(delete.cf, log_index, delete.key)?;
+                            }
+                            SimpleWrite::DeleteRange(dr) => {
+                                self.apply_delete_range(
+                                    dr.cf,
+                                    log_index,
+                                    dr.start_key,
+                                    dr.end_key,
+                                    dr.notify_only,
+                                )?;
+                            }
                         }
                     }
                     return res;
@@ -392,34 +418,18 @@ impl<EK: KvEngine, R: ApplyResReporter> Apply<EK, R> {
                 Err(req) => req,
             },
             EntryType::EntryConfChange => {
-                let cc: ConfChange = parse_at(
-                    &self.logger,
-                    entry.get_data(),
-                    entry.get_index(),
-                    entry.get_term(),
-                );
-                let req: RaftCmdRequest = parse_at(
-                    &self.logger,
-                    cc.get_context(),
-                    entry.get_index(),
-                    entry.get_term(),
-                );
+                let cc: ConfChange =
+                    parse_at(&self.logger, entry.get_data(), log_index, entry.get_term());
+                let req: RaftCmdRequest =
+                    parse_at(&self.logger, cc.get_context(), log_index, entry.get_term());
                 conf_change = Some(cc.into_v2());
                 req
             }
             EntryType::EntryConfChangeV2 => {
-                let cc: ConfChangeV2 = parse_at(
-                    &self.logger,
-                    entry.get_data(),
-                    entry.get_index(),
-                    entry.get_term(),
-                );
-                let req: RaftCmdRequest = parse_at(
-                    &self.logger,
-                    cc.get_context(),
-                    entry.get_index(),
-                    entry.get_term(),
-                );
+                let cc: ConfChangeV2 =
+                    parse_at(&self.logger, entry.get_data(), log_index, entry.get_term());
+                let req: RaftCmdRequest =
+                    parse_at(&self.logger, cc.get_context(), log_index, entry.get_term());
                 conf_change = Some(cc);
                 req
             }
@@ -430,8 +440,8 @@ impl<EK: KvEngine, R: ApplyResReporter> Apply<EK, R> {
             let admin_req = req.get_admin_request();
             let (admin_resp, admin_result) = match req.get_admin_request().get_cmd_type() {
                 AdminCmdType::CompactLog => unimplemented!(),
-                AdminCmdType::Split => self.apply_split(admin_req, entry.index)?,
-                AdminCmdType::BatchSplit => self.apply_batch_split(admin_req, entry.index)?,
+                AdminCmdType::Split => self.apply_split(admin_req, log_index)?,
+                AdminCmdType::BatchSplit => self.apply_batch_split(admin_req, log_index)?,
                 AdminCmdType::PrepareMerge => unimplemented!(),
                 AdminCmdType::CommitMerge => unimplemented!(),
                 AdminCmdType::RollbackMerge => unimplemented!(),
@@ -439,10 +449,10 @@ impl<EK: KvEngine, R: ApplyResReporter> Apply<EK, R> {
                     self.apply_transfer_leader(admin_req, entry.term)?
                 }
                 AdminCmdType::ChangePeer => {
-                    self.apply_conf_change(entry.get_index(), admin_req, conf_change.unwrap())?
+                    self.apply_conf_change(log_index, admin_req, conf_change.unwrap())?
                 }
                 AdminCmdType::ChangePeerV2 => {
-                    self.apply_conf_change_v2(entry.get_index(), admin_req, conf_change.unwrap())?
+                    self.apply_conf_change_v2(log_index, admin_req, conf_change.unwrap())?
                 }
                 AdminCmdType::ComputeHash => unimplemented!(),
                 AdminCmdType::VerifyHash => unimplemented!(),
@@ -468,16 +478,17 @@ impl<EK: KvEngine, R: ApplyResReporter> Apply<EK, R> {
                     // backward compatibility.
                     CmdType::Put => {
                         let put = r.get_put();
-                        self.apply_put(put.get_cf(), put.get_key(), put.get_value())?;
+                        self.apply_put(put.get_cf(), log_index, put.get_key(), put.get_value())?;
                     }
                     CmdType::Delete => {
                         let delete = r.get_delete();
-                        self.apply_delete(delete.get_cf(), delete.get_key())?;
+                        self.apply_delete(delete.get_cf(), log_index, delete.get_key())?;
                     }
                     CmdType::DeleteRange => {
                         let dr = r.get_delete_range();
                         self.apply_delete_range(
                             dr.get_cf(),
+                            log_index,
                             dr.get_start_key(),
                             dr.get_end_key(),
                             dr.get_notify_only(),
@@ -515,7 +526,8 @@ impl<EK: KvEngine, R: ApplyResReporter> Apply<EK, R> {
         let (index, term) = self.apply_progress();
         apply_res.applied_index = index;
         apply_res.applied_term = term;
-        apply_res.admin_result = self.take_admin_result();
+        apply_res.admin_result = self.take_admin_result().into_boxed_slice();
+        apply_res.modifications = *self.modifications_mut();
         self.res_reporter().report(apply_res);
     }
 }

--- a/components/raftstore-v2/src/operation/command/mod.rs
+++ b/components/raftstore-v2/src/operation/command/mod.rs
@@ -316,7 +316,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         if !is_leader {
             entry_storage.compact_entry_cache(apply_res.applied_index + 1);
         }
-        self.record_data_trace(apply_res.modifications);
+        self.on_data_modified(apply_res.modifications);
         self.handle_read_on_apply(
             ctx,
             apply_res.applied_term,

--- a/components/raftstore-v2/src/operation/command/mod.rs
+++ b/components/raftstore-v2/src/operation/command/mod.rs
@@ -296,7 +296,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
                 }) => {
                     self.storage_mut()
                         .apply_trace_mut()
-                        .record_admin_modify(tablet_index);
+                        .on_admin_modify(tablet_index);
                     self.on_apply_res_split(ctx, derived_index, tablet_index, regions)
                 }
                 AdminCmdResult::TransferLeader(term) => self.on_transfer_leader(ctx, term),

--- a/components/raftstore-v2/src/operation/mod.rs
+++ b/components/raftstore-v2/src/operation/mod.rs
@@ -10,6 +10,8 @@ pub use command::{
     AdminCmdResult, CommittedEntries, ProposalControl, SimpleWriteDecoder, SimpleWriteEncoder,
 };
 pub use life::DestroyProgress;
-pub use ready::{AsyncWriter, GenSnapTask, SnapState};
+pub use ready::{
+    cf_offset, write_initial_states, ApplyTrace, AsyncWriter, DataTrace, GenSnapTask, SnapState,
+};
 
 pub(crate) use self::{command::SplitInit, query::LocalReader};

--- a/components/raftstore-v2/src/operation/mod.rs
+++ b/components/raftstore-v2/src/operation/mod.rs
@@ -12,6 +12,7 @@ pub use command::{
 pub use life::DestroyProgress;
 pub use ready::{
     cf_offset, write_initial_states, ApplyTrace, AsyncWriter, DataTrace, GenSnapTask, SnapState,
+    StateStorage,
 };
 
 pub(crate) use self::{command::SplitInit, query::LocalReader};

--- a/components/raftstore-v2/src/operation/ready/apply_trace.rs
+++ b/components/raftstore-v2/src/operation/ready/apply_trace.rs
@@ -1,0 +1,509 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+//! In raftstore v2, WAL is always disabled for tablet. So we need a way to
+//! trace what have been persisted what haven't, and recover those missing
+//! data when restart.
+//!
+//! In summary, we trace the persist progress by recording flushed event.
+//! Because memtable is flushed one by one, so a flushed memtable must contain
+//! all the data within the CF before some certain apply index. So the minimun
+//! flushed apply index + 1 of all data CFs is the recovery start point. In
+//! some cases, a CF may not have any updates at all for a long time. In some
+//! cases, we may still need to recover from smaller index even if flushed
+//! index of all data CFs have advanced. So a special flushed index is
+//! introduced and stored with raft CF (only using the name, raft CF is
+//! dropped). It's the recommended recovery start point. How these two indexes
+//! interact with each other can be found in the `figure_applied_index`.
+//!
+//! All apply related states are associated with an apply index. During
+//! recovery states corresponding to the start index should be used.
+
+use std::cmp;
+
+use engine_traits::{
+    KvEngine, RaftEngine, RaftLogBatch, ALL_CFS, CF_DEFAULT, CF_RAFT, DATA_CFS, DATA_CFS_LEN,
+};
+use kvproto::{
+    metapb::Region,
+    raft_cmdpb::RaftCmdResponse,
+    raft_serverpb::{PeerState, RaftApplyState, RaftLocalState, RegionLocalState},
+};
+use raftstore::store::{cmd_resp, ReadTask, WriteTask, RAFT_INIT_LOG_INDEX, RAFT_INIT_LOG_TERM};
+use slog::Logger;
+use tikv_util::{box_err, worker::Scheduler};
+
+use crate::{
+    fsm::ApplyResReporter,
+    raft::{Apply, Peer, Storage},
+    router::{ApplyTask, CmdResChannel},
+    Result,
+};
+
+/// Write states for the given region. The region is supposed to have all its
+/// data persisted and not governed by any raft group before.
+pub fn write_initial_states(wb: &mut impl RaftLogBatch, region: Region) -> Result<()> {
+    let region_id = region.get_id();
+
+    let mut state = RegionLocalState::default();
+    state.set_region(region);
+    state.set_tablet_index(RAFT_INIT_LOG_INDEX);
+    wb.put_region_state(region_id, RAFT_INIT_LOG_INDEX, &state)?;
+
+    let mut apply_state = RaftApplyState::default();
+    apply_state.set_applied_index(RAFT_INIT_LOG_INDEX);
+    apply_state
+        .mut_truncated_state()
+        .set_index(RAFT_INIT_LOG_INDEX);
+    apply_state
+        .mut_truncated_state()
+        .set_term(RAFT_INIT_LOG_TERM);
+    wb.put_apply_state(region_id, RAFT_INIT_LOG_INDEX, &apply_state)?;
+
+    let mut raft_state = RaftLocalState::default();
+    raft_state.set_last_index(RAFT_INIT_LOG_INDEX);
+    raft_state.mut_hard_state().set_term(RAFT_INIT_LOG_TERM);
+    raft_state.mut_hard_state().set_commit(RAFT_INIT_LOG_INDEX);
+    wb.put_raft_state(region_id, &raft_state)?;
+
+    for cf in ALL_CFS {
+        wb.put_flushed_index(region_id, cf, RAFT_INIT_LOG_INDEX, RAFT_INIT_LOG_INDEX)?;
+    }
+
+    Ok(())
+}
+
+/// An alias of frequent use type that each data cf has a u64.
+pub type DataTrace = [u64; DATA_CFS_LEN];
+
+#[derive(Clone, Copy, Default)]
+struct Progress {
+    flushed: u64,
+    /// The index of last entry that has modification to the CF.
+    ///
+    /// If `flushed` == `last_modified`, then all data in the CF is persisted.
+    last_modified: u64,
+}
+
+pub fn cf_offset(cf: &str) -> usize {
+    let cf = if cf.is_empty() { CF_DEFAULT } else { cf };
+    DATA_CFS.iter().position(|c| *c == cf).expect(cf)
+}
+
+#[derive(Default)]
+pub struct ApplyTrace {
+    data_cfs: Box<[Progress; DATA_CFS_LEN]>,
+    admin: Progress,
+    // Index that is issued to be written. It may not be truely persisted.
+    persisted_applied: u64,
+    try_persist: bool,
+}
+
+impl ApplyTrace {
+    fn recover(region_id: u64, engine: &impl RaftEngine) -> Result<(Self, RegionLocalState)> {
+        let mut trace = ApplyTrace::default();
+        // Get all the recorded apply index from data CFs.
+        for (off, cf) in DATA_CFS.iter().enumerate() {
+            // There should be at least one record.
+            let i = engine.get_flushed_index(region_id, cf)?.unwrap();
+            trace.data_cfs[off].flushed = i;
+            trace.data_cfs[off].last_modified = i;
+        }
+        let i = engine.get_flushed_index(region_id, CF_RAFT)?.unwrap();
+        // Index of raft CF means all data before that must be persisted.
+        trace.admin.flushed = i;
+        trace.admin.last_modified = i;
+        trace.persisted_applied = i;
+        let applied_region_state = engine
+            .get_region_state(region_id, trace.admin.flushed)?
+            .unwrap();
+        let data_index = trace.data_index();
+        // If index is not larger than applied_index, it means some CF doesn't have any
+        // data to flush.
+        if trace.admin.flushed < data_index {
+            let region_state = engine.get_region_state(region_id, data_index)?.unwrap();
+            // If there is no admin change, it means `applied_index` is notadvanced in
+            // time. Otherwise, it may be waiting for flush of other tablets in cases like
+            // split.
+            if applied_region_state
+                .get_region()
+                .get_region_epoch()
+                .get_version()
+                == region_state.get_region().get_region_epoch().get_version()
+            {
+                trace.admin.flushed = data_index;
+                trace.admin.last_modified = data_index;
+            }
+        }
+        Ok((trace, applied_region_state))
+    }
+
+    #[inline]
+    fn data_index(&self) -> u64 {
+        self.data_cfs.iter().map(|p| p.flushed).min().unwrap()
+    }
+
+    fn record_flush(&mut self, cf: &str, index: u64) {
+        let off = cf_offset(cf);
+        // Technically it should always be true.
+        if index > self.data_cfs[off].flushed {
+            self.data_cfs[off].flushed = index;
+        }
+    }
+
+    fn record_modify(&mut self, cf: &str, index: u64) {
+        let off = cf_offset(cf);
+        self.data_cfs[off].last_modified = index;
+    }
+
+    pub fn record_admin_flush(&mut self, index: u64) {
+        if index > self.admin.flushed {
+            self.admin.flushed = index;
+            self.try_persist = true;
+        }
+    }
+
+    pub fn record_admin_modify(&mut self, index: u64) {
+        self.admin.last_modified = index;
+    }
+
+    fn persisted_apply_index(&self) -> u64 {
+        self.admin.flushed
+    }
+
+    fn maybe_advance_admin_flushed(&mut self, mem_index: u64) {
+        if self.admin.flushed < self.admin.last_modified {
+            return;
+        }
+        let mut min_index = u64::MAX;
+        let mut max_modified = 0;
+        let mut all_flushed = true;
+        for pr in self.data_cfs.iter() {
+            if pr.flushed < min_index {
+                min_index = pr.flushed;
+            }
+            // Flush may race with recording modified, using the min index to make
+            // sure admin pr should also record all modification.
+            if pr.last_modified < min_index {
+                min_index = pr.last_modified;
+            }
+            if pr.last_modified >= max_modified {
+                max_modified = pr.last_modified;
+            }
+            all_flushed &= pr.flushed == pr.last_modified;
+        }
+        if min_index > self.admin.flushed {
+            if max_modified > self.admin.flushed {
+                // It means all modification must be received and there is no admin
+                // modification.
+                self.admin.flushed = cmp::min(max_modified, min_index);
+            }
+        } else if all_flushed {
+            // So all are flushed and no blocking admin result, we can advance the
+            // apply index up to memory.
+            self.admin.flushed = mem_index;
+        }
+        // TODO: persist admin.flushed every 10 minutes.
+    }
+
+    #[inline]
+    pub fn log_recovery(&self) -> Option<Box<DataTrace>> {
+        let mut flushed_indexes = [0; DATA_CFS_LEN];
+        for (off, pr) in self.data_cfs.iter().enumerate() {
+            flushed_indexes[off] = pr.flushed;
+        }
+        for i in flushed_indexes {
+            if i > self.admin.flushed {
+                return Some(Box::new(flushed_indexes));
+            }
+        }
+        None
+    }
+
+    #[inline]
+    pub fn should_persist(&self) -> bool {
+        self.try_persist
+    }
+}
+
+impl<EK: KvEngine, ER: RaftEngine> Storage<EK, ER> {
+    /// Creates a new storage with uninit states.
+    ///
+    /// This should only be used for creating new peer from raft message.
+    pub fn uninit(
+        store_id: u64,
+        region: Region,
+        engine: ER,
+        read_scheduler: Scheduler<ReadTask<EK>>,
+        logger: &Logger,
+    ) -> Result<Self> {
+        let mut region_state = RegionLocalState::default();
+        region_state.set_region(region);
+        Self::create(
+            store_id,
+            region_state,
+            RaftLocalState::default(),
+            RaftApplyState::default(),
+            engine,
+            read_scheduler,
+            false,
+            ApplyTrace::default(),
+            logger,
+        )
+    }
+
+    /// Creates a new storage.
+    ///
+    /// All metadata should be initialized before calling this method. If the
+    /// region is destroyed, `None` will be returned.
+    pub fn new(
+        region_id: u64,
+        store_id: u64,
+        engine: ER,
+        read_scheduler: Scheduler<ReadTask<EK>>,
+        logger: &Logger,
+    ) -> Result<Option<Storage<EK, ER>>> {
+        // Check latest region state to determine whether the peer is destroyed.
+        let region_state = match engine.get_region_state(region_id, u64::MAX) {
+            Ok(Some(s)) => s,
+            res => {
+                return Err(box_err!(
+                    "failed to get region state for region {}: {:?}",
+                    region_id,
+                    res
+                ));
+            }
+        };
+
+        if region_state.get_state() == PeerState::Tombstone {
+            return Ok(None);
+        }
+
+        let (trace, region_state) = ApplyTrace::recover(region_id, &engine)?;
+
+        let raft_state = match engine.get_raft_state(region_id) {
+            Ok(Some(s)) => s,
+            res => {
+                return Err(box_err!("failed to get raft state: {:?}", res));
+            }
+        };
+
+        let applied_index = trace.persisted_apply_index();
+        let mut apply_state = match engine.get_apply_state(region_id, applied_index) {
+            Ok(Some(s)) => s,
+            res => {
+                return Err(box_err!("failed to get apply state: {:?}", res));
+            }
+        };
+        apply_state.set_applied_index(applied_index);
+
+        Self::create(
+            store_id,
+            region_state,
+            raft_state,
+            apply_state,
+            engine,
+            read_scheduler,
+            true,
+            trace,
+            logger,
+        )
+        .map(Some)
+    }
+
+    /// Write initial persist trace for uninit peer.
+    pub fn init_apply_trace(&self, write_task: &mut WriteTask<EK, ER>) {
+        let region_id = self.region().get_id();
+        let raft_engine = self.entry_storage().raft_engine();
+        let lb = write_task
+            .extra_write
+            .ensure_v2(|| raft_engine.log_batch(3));
+        lb.put_apply_state(region_id, 0, self.apply_state())
+            .unwrap();
+        lb.put_region_state(region_id, 0, self.region_state())
+            .unwrap();
+        for cf in ALL_CFS {
+            lb.put_flushed_index(region_id, cf, 0, 0).unwrap();
+        }
+    }
+
+    pub fn record_apply_trace(&mut self, write_task: &mut WriteTask<EK, ER>) {
+        let region_id = self.region().get_id();
+        let raft_engine = self.entry_storage().raft_engine();
+        let tablet_index = self.tablet_index();
+        let lb = write_task
+            .extra_write
+            .ensure_v2(|| raft_engine.log_batch(1));
+        let trace = self.apply_trace_mut();
+        lb.put_flushed_index(region_id, CF_RAFT, tablet_index, trace.admin.flushed)
+            .unwrap();
+        trace.try_persist = false;
+        trace.persisted_applied = trace.admin.flushed;
+    }
+}
+
+impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
+    pub fn on_data_flushed(&mut self, cf: &str, tablet_index: u64, index: u64) {
+        if tablet_index < self.storage().tablet_index() {
+            // Stale tablet.
+            return;
+        }
+        let apply_index = self.storage().entry_storage().applied_index();
+        let apply_trace = self.storage_mut().apply_trace_mut();
+        apply_trace.record_flush(cf, index);
+        apply_trace.maybe_advance_admin_flushed(apply_index);
+    }
+
+    pub fn record_data_trace(&mut self, modification: DataTrace) {
+        let apply_index = self.storage().entry_storage().applied_index();
+        let apply_trace = self.storage_mut().apply_trace_mut();
+        for (cf, index) in DATA_CFS.iter().zip(modification) {
+            if index != 0 {
+                apply_trace.record_modify(cf, index);
+            }
+        }
+        apply_trace.maybe_advance_admin_flushed(apply_index);
+    }
+
+    pub fn on_manual_flush(&mut self, cfs: Vec<&'static str>, ch: CmdResChannel) {
+        if let Some(sched) = self.apply_scheduler() {
+            sched.send(ApplyTask::ManualFlush { cfs, ch });
+        }
+    }
+}
+
+impl<EK: KvEngine, R: ApplyResReporter> Apply<EK, R> {
+    pub fn on_manual_flush(&mut self, cfs: Vec<&'static str>, ch: CmdResChannel) {
+        self.flush();
+        // TODO: make it async
+        let res = match self.tablet().flush_cfs(&cfs, true) {
+            Ok(()) => RaftCmdResponse::default(),
+            Err(e) => cmd_resp::new_error(e.into()),
+        };
+        ch.set_result(res);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use engine_traits::RaftEngineReadOnly;
+    use kvproto::metapb::Peer;
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn new_region() -> Region {
+        let mut region = Region::default();
+        region.set_id(4);
+        let mut p = Peer::default();
+        p.set_id(5);
+        p.set_store_id(6);
+        region.mut_peers().push(p);
+        region.mut_region_epoch().set_version(2);
+        region.mut_region_epoch().set_conf_ver(4);
+        region
+    }
+
+    #[test]
+    fn test_write_initial_states() {
+        let region = new_region();
+        let path = TempDir::new().unwrap();
+        let engine = engine_test::new_temp_engine(&path);
+        let raft_engine = &engine.raft;
+        let mut wb = raft_engine.log_batch(10);
+        write_initial_states(&mut wb, region.clone()).unwrap();
+        assert!(!wb.is_empty());
+        raft_engine.consume(&mut wb, true).unwrap();
+
+        let local_state = raft_engine.get_region_state(4, u64::MAX).unwrap().unwrap();
+        assert_eq!(local_state.get_state(), PeerState::Normal);
+        assert_eq!(*local_state.get_region(), region);
+        assert_eq!(local_state.get_tablet_index(), RAFT_INIT_LOG_INDEX);
+        assert_eq!(
+            local_state,
+            raft_engine
+                .get_region_state(4, RAFT_INIT_LOG_INDEX)
+                .unwrap()
+                .unwrap()
+        );
+        assert_eq!(
+            None,
+            raft_engine
+                .get_region_state(4, RAFT_INIT_LOG_INDEX - 1)
+                .unwrap()
+        );
+
+        let raft_state = raft_engine.get_raft_state(4).unwrap().unwrap();
+        assert_eq!(raft_state.get_last_index(), RAFT_INIT_LOG_INDEX);
+        let hs = raft_state.get_hard_state();
+        assert_eq!(hs.get_term(), RAFT_INIT_LOG_TERM);
+        assert_eq!(hs.get_commit(), RAFT_INIT_LOG_INDEX);
+
+        let apply_state = raft_engine.get_apply_state(4, u64::MAX).unwrap().unwrap();
+        assert_eq!(apply_state.get_applied_index(), RAFT_INIT_LOG_INDEX);
+        let ts = apply_state.get_truncated_state();
+        assert_eq!(ts.get_index(), RAFT_INIT_LOG_INDEX);
+        assert_eq!(ts.get_term(), RAFT_INIT_LOG_TERM);
+        assert_eq!(
+            apply_state,
+            raft_engine
+                .get_apply_state(4, RAFT_INIT_LOG_INDEX)
+                .unwrap()
+                .unwrap()
+        );
+        assert_eq!(
+            None,
+            raft_engine
+                .get_apply_state(4, RAFT_INIT_LOG_INDEX - 1)
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_apply_trace() {
+        let mut trace = ApplyTrace::default();
+        assert_eq!(0, trace.persisted_apply_index());
+        // If there is no modifications, index should be advanced anyway.
+        trace.maybe_advance_admin_flushed(2);
+        assert_eq!(2, trace.persisted_apply_index());
+        for cf in DATA_CFS {
+            trace.record_modify(cf, 3);
+        }
+        trace.maybe_advance_admin_flushed(3);
+        // Modification is not flushed.
+        assert_eq!(2, trace.persisted_apply_index());
+        for cf in DATA_CFS {
+            trace.record_flush(cf, 3);
+        }
+        trace.maybe_advance_admin_flushed(3);
+        // No admin is recorded, index should be advanced.
+        assert_eq!(3, trace.persisted_apply_index());
+        trace.record_admin_modify(4);
+        for cf in DATA_CFS {
+            trace.record_flush(cf, 4);
+        }
+        for cf in DATA_CFS {
+            trace.record_modify(cf, 4);
+        }
+        trace.maybe_advance_admin_flushed(4);
+        // Unflushed admin modification should hold index.
+        assert_eq!(3, trace.persisted_apply_index());
+        trace.record_admin_flush(4);
+        trace.maybe_advance_admin_flushed(4);
+        // Admin is flushed, index should be advanced.
+        assert_eq!(4, trace.persisted_apply_index());
+        for cf in DATA_CFS {
+            trace.record_flush(cf, 5);
+        }
+        trace.maybe_advance_admin_flushed(5);
+        // Though all data CFs are flushed, but index should not be
+        // advanced as we don't know whether there is admin modification.
+        assert_eq!(4, trace.persisted_apply_index());
+        for cf in DATA_CFS {
+            trace.record_modify(cf, 5);
+        }
+        trace.maybe_advance_admin_flushed(5);
+        // Because modify is recorded, so we know there should be no admin
+        // modification and index can be advanced.
+        assert_eq!(5, trace.persisted_apply_index());
+    }
+}

--- a/components/raftstore-v2/src/operation/ready/apply_trace.rs
+++ b/components/raftstore-v2/src/operation/ready/apply_trace.rs
@@ -18,7 +18,7 @@
 //!
 //! The correctness of raft cf index relies on the fact that:
 //! - apply is sequential, so if any apply index is updated to apply trace, all
-//!   modification index must be set.
+//!   modification events before that must be processed.
 //! - admin commands that marked by raft cf index must flush all data before
 //!   being executed. Note this contraint is not just for recovery, but also
 //!   necessary to guarantee safety of operations like split init or log gc.

--- a/components/raftstore-v2/src/operation/ready/apply_trace.rs
+++ b/components/raftstore-v2/src/operation/ready/apply_trace.rs
@@ -219,6 +219,21 @@ impl ApplyTrace {
         None
     }
 
+    pub fn reset_snapshot(&mut self, index: u64) {
+        for pr in self.data_cfs.iter_mut() {
+            pr.flushed = index;
+            pr.last_modified = index;
+        }
+        self.admin.flushed = index;
+        self.persisted_applied = index;
+        self.try_persist = false;
+    }
+
+    #[inline]
+    pub fn reset_should_persist(&mut self) {
+        self.try_persist = false;
+    }
+
     #[inline]
     pub fn should_persist(&self) -> bool {
         self.try_persist

--- a/components/raftstore-v2/src/operation/ready/mod.rs
+++ b/components/raftstore-v2/src/operation/ready/mod.rs
@@ -23,7 +23,7 @@ mod snapshot;
 
 use std::{cmp, time::Instant};
 
-pub use apply_trace::{cf_offset, write_initial_states, ApplyTrace, DataTrace};
+pub use apply_trace::{cf_offset, write_initial_states, ApplyTrace, DataTrace, StateStorage};
 use engine_traits::{KvEngine, RaftEngine};
 use error_code::ErrorCodeExt;
 use kvproto::{raft_cmdpb::AdminCmdType, raft_serverpb::RaftMessage};

--- a/components/raftstore-v2/src/operation/ready/mod.rs
+++ b/components/raftstore-v2/src/operation/ready/mod.rs
@@ -562,7 +562,8 @@ impl<EK: KvEngine, ER: RaftEngine> Storage<EK, ER> {
         if !ever_persisted || prev_raft_state != *entry_storage.raft_state() {
             write_task.raft_state = Some(entry_storage.raft_state().clone());
         }
-        if !ever_persisted {
+        // If snapshot initializes the peer, we don't need to write apply trace again.
+        if !self.ever_persisted() {
             self.init_apply_trace(write_task);
             self.set_ever_persisted();
         }

--- a/components/raftstore-v2/src/operation/ready/mod.rs
+++ b/components/raftstore-v2/src/operation/ready/mod.rs
@@ -341,6 +341,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
 
         let ready_number = ready.number();
         let mut write_task = WriteTask::new(self.region_id(), self.peer_id(), ready_number);
+        self.merge_state_changes_to(&mut write_task);
         self.storage_mut()
             .handle_raft_ready(ctx, &mut ready, &mut write_task);
         if !ready.persisted_messages().is_empty() {

--- a/components/raftstore-v2/src/operation/ready/mod.rs
+++ b/components/raftstore-v2/src/operation/ready/mod.rs
@@ -17,12 +17,14 @@
 //!
 //! There two steps can be processed concurrently.
 
+mod apply_trace;
 mod async_writer;
 mod snapshot;
 
 use std::{cmp, time::Instant};
 
-use engine_traits::{KvEngine, RaftEngine, RaftLogBatch};
+pub use apply_trace::{cf_offset, write_initial_states, ApplyTrace, DataTrace};
+use engine_traits::{KvEngine, RaftEngine};
 use error_code::ErrorCodeExt;
 use kvproto::{raft_cmdpb::AdminCmdType, raft_serverpb::RaftMessage};
 use protobuf::Message as _;
@@ -269,6 +271,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
     #[inline]
     pub fn handle_raft_ready<T: Transport>(&mut self, ctx: &mut StoreContext<EK, ER, T>) {
         let has_ready = self.reset_has_ready();
+        let has_extra_write = self.reset_has_extra_write();
         if !has_ready || self.destroy_progress().started() {
             #[cfg(feature = "testexport")]
             self.async_writer.notify_flush();
@@ -276,7 +279,10 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         }
         ctx.has_ready = true;
 
-        if !self.raft_group().has_ready() && (self.serving() || self.postponed_destroy()) {
+        if !has_extra_write
+            && !self.raft_group().has_ready()
+            && (self.serving() || self.postponed_destroy())
+        {
             #[cfg(feature = "testexport")]
             self.async_writer.notify_flush();
             return;
@@ -328,7 +334,9 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         // Always sending snapshot task after apply task, so it gets latest
         // snapshot.
         if let Some(gen_task) = self.storage_mut().take_gen_snap_task() {
-            self.apply_scheduler().send(ApplyTask::Snapshot(gen_task));
+            self.apply_scheduler()
+                .unwrap()
+                .send(ApplyTask::Snapshot(gen_task));
         }
 
         let ready_number = ready.number();
@@ -555,16 +563,11 @@ impl<EK: KvEngine, ER: RaftEngine> Storage<EK, ER> {
             write_task.raft_state = Some(entry_storage.raft_state().clone());
         }
         if !ever_persisted {
-            let region_id = self.region().get_id();
-            let raft_engine = self.entry_storage().raft_engine();
-            let lb = write_task
-                .extra_write
-                .ensure_v2(|| raft_engine.log_batch(3));
-            lb.put_apply_state(region_id, 0, self.apply_state())
-                .unwrap();
-            lb.put_region_state(region_id, 0, self.region_state())
-                .unwrap();
+            self.init_apply_trace(write_task);
             self.set_ever_persisted();
+        }
+        if self.apply_trace().should_persist() {
+            self.record_apply_trace(write_task);
         }
     }
 }

--- a/components/raftstore-v2/src/operation/ready/snapshot.rs
+++ b/components/raftstore-v2/src/operation/ready/snapshot.rs
@@ -121,7 +121,8 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         let first_index = self.storage().entry_storage().first_index();
         if first_index == persisted_index + 1 {
             let region_id = self.region_id();
-            let flush_state = self.reset_flush_state();
+            self.reset_flush_state();
+            let flush_state = self.flush_state().clone();
             let mut tablet_ctx = TabletContext::new(self.region(), Some(persisted_index));
             // Use a new FlushState to avoid conflicts with the old one.
             tablet_ctx.flush_state = Some(flush_state);

--- a/components/raftstore-v2/src/operation/ready/snapshot.rs
+++ b/components/raftstore-v2/src/operation/ready/snapshot.rs
@@ -121,7 +121,10 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         let first_index = self.storage().entry_storage().first_index();
         if first_index == persisted_index + 1 {
             let region_id = self.region_id();
-            let tablet_ctx = TabletContext::new(self.region(), Some(persisted_index));
+            let flush_state = self.reset_flush_state();
+            let mut tablet_ctx = TabletContext::new(self.region(), Some(persisted_index));
+            // Use a new FlushState to avoid conflicts with the old one.
+            tablet_ctx.flush_state = Some(flush_state);
             ctx.tablet_registry.load(tablet_ctx, false).unwrap();
             self.schedule_apply_fsm(ctx);
             self.storage_mut().on_applied_snapshot();

--- a/components/raftstore-v2/src/operation/ready/snapshot.rs
+++ b/components/raftstore-v2/src/operation/ready/snapshot.rs
@@ -27,7 +27,7 @@ use std::{
     },
 };
 
-use engine_traits::{KvEngine, RaftEngine, RaftLogBatch, TabletContext, TabletRegistry, ALL_CFS};
+use engine_traits::{KvEngine, RaftEngine, RaftLogBatch, TabletContext, TabletRegistry, CF_RAFT};
 use kvproto::raft_serverpb::{PeerState, RaftSnapshotData};
 use protobuf::Message;
 use raft::eraftpb::Snapshot;
@@ -406,7 +406,8 @@ impl<EK: KvEngine, ER: RaftEngine> Storage<EK, ER> {
             .unwrap();
         lb.put_region_state(region_id, last_index, self.region_state())
             .unwrap();
-        lb.put_flushed_index(region_id, CF_RAFT, last_index, last_index);
+        lb.put_flushed_index(region_id, CF_RAFT, last_index, last_index)
+            .unwrap();
 
         let (path, clean_split) = match self.split_init_mut() {
             // If index not match, the peer may accept a newer snapshot after split.

--- a/components/raftstore-v2/src/operation/ready/snapshot.rs
+++ b/components/raftstore-v2/src/operation/ready/snapshot.rs
@@ -406,10 +406,7 @@ impl<EK: KvEngine, ER: RaftEngine> Storage<EK, ER> {
             .unwrap();
         lb.put_region_state(region_id, last_index, self.region_state())
             .unwrap();
-        for cf in ALL_CFS {
-            lb.put_flushed_index(region_id, cf, last_index, last_index)
-                .unwrap();
-        }
+        lb.put_flushed_index(region_id, CF_RAFT, last_index, last_index);
 
         let (path, clean_split) = match self.split_init_mut() {
             // If index not match, the peer may accept a newer snapshot after split.

--- a/components/raftstore-v2/src/operation/ready/snapshot.rs
+++ b/components/raftstore-v2/src/operation/ready/snapshot.rs
@@ -27,7 +27,7 @@ use std::{
     },
 };
 
-use engine_traits::{KvEngine, RaftEngine, TabletContext, TabletRegistry};
+use engine_traits::{KvEngine, RaftEngine, RaftLogBatch, TabletContext, TabletRegistry, ALL_CFS};
 use kvproto::raft_serverpb::{PeerState, RaftSnapshotData};
 use protobuf::Message;
 use raft::eraftpb::Snapshot;
@@ -356,7 +356,7 @@ impl<EK: KvEngine, ER: RaftEngine> Storage<EK, ER> {
         let index = entry.truncated_index();
         entry.set_applied_term(term);
         entry.apply_state_mut().set_applied_index(index);
-        self.region_state_mut().set_tablet_index(index);
+        self.apply_trace_mut().reset_snapshot(index);
     }
 
     pub fn apply_snapshot(
@@ -386,14 +386,29 @@ impl<EK: KvEngine, ER: RaftEngine> Storage<EK, ER> {
 
         let last_index = snap.get_metadata().get_index();
         let last_term = snap.get_metadata().get_term();
-        self.region_state_mut().set_state(PeerState::Normal);
-        self.region_state_mut().set_region(region);
-        self.entry_storage_mut()
-            .raft_state_mut()
-            .set_last_index(last_index);
-        self.entry_storage_mut().set_truncated_index(last_index);
-        self.entry_storage_mut().set_truncated_term(last_term);
-        self.entry_storage_mut().set_last_term(last_term);
+        let region_state = self.region_state_mut();
+        region_state.set_state(PeerState::Normal);
+        region_state.set_region(region);
+        region_state.set_tablet_index(last_index);
+        let entry_storage = self.entry_storage_mut();
+        entry_storage.raft_state_mut().set_last_index(last_index);
+        entry_storage.set_truncated_index(last_index);
+        entry_storage.set_truncated_term(last_term);
+        entry_storage.set_last_term(last_term);
+
+        self.apply_trace_mut().reset_should_persist();
+        self.set_ever_persisted();
+        let lb = task
+            .extra_write
+            .ensure_v2(|| self.entry_storage().raft_engine().log_batch(3));
+        lb.put_apply_state(region_id, last_index, self.apply_state())
+            .unwrap();
+        lb.put_region_state(region_id, last_index, self.region_state())
+            .unwrap();
+        for cf in ALL_CFS {
+            lb.put_flushed_index(region_id, cf, last_index, last_index)
+                .unwrap();
+        }
 
         let (path, clean_split) = match self.split_init_mut() {
             // If index not match, the peer may accept a newer snapshot after split.

--- a/components/raftstore-v2/src/raft/apply.rs
+++ b/components/raftstore-v2/src/raft/apply.rs
@@ -31,9 +31,15 @@ pub struct Apply<EK: KvEngine, R> {
     /// command.
     tombstone: bool,
     applied_term: u64,
+    /// The largest index that have modified each column family.
     modifications: DataTrace,
     admin_cmd_result: Vec<AdminCmdResult>,
     flush_state: Arc<FlushState>,
+    /// The flushed indexes of each column family before being restarted.
+    ///
+    /// If an apply index is less than the flushed index, the log can be
+    /// skipped. `None` means logs should apply to all required column
+    /// families.
     log_recovery: Option<Box<DataTrace>>,
 
     region_state: RegionLocalState,

--- a/components/raftstore-v2/src/raft/apply.rs
+++ b/components/raftstore-v2/src/raft/apply.rs
@@ -1,14 +1,17 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::mem;
+use std::{mem, sync::Arc};
 
-use engine_traits::{CachedTablet, KvEngine, TabletRegistry, WriteBatch};
+use engine_traits::{CachedTablet, FlushState, KvEngine, TabletRegistry, WriteBatch, DATA_CFS_LEN};
 use kvproto::{metapb, raft_cmdpb::RaftCmdResponse, raft_serverpb::RegionLocalState};
 use raftstore::store::{fsm::apply::DEFAULT_APPLY_WB_SIZE, ReadTask};
 use slog::Logger;
 use tikv_util::worker::Scheduler;
 
-use crate::{operation::AdminCmdResult, router::CmdResChannel};
+use crate::{
+    operation::{AdminCmdResult, DataTrace},
+    router::CmdResChannel,
+};
 
 /// Apply applies all the committed commands to kv db.
 pub struct Apply<EK: KvEngine, R> {
@@ -27,9 +30,11 @@ pub struct Apply<EK: KvEngine, R> {
     /// A flag indicates whether the peer is destroyed by applying admin
     /// command.
     tombstone: bool,
-    applied_index: u64,
     applied_term: u64,
+    modifications: DataTrace,
     admin_cmd_result: Vec<AdminCmdResult>,
+    flush_state: Arc<FlushState>,
+    log_recovery: Option<Box<DataTrace>>,
 
     region_state: RegionLocalState,
 
@@ -46,6 +51,8 @@ impl<EK: KvEngine, R> Apply<EK, R> {
         res_reporter: R,
         tablet_registry: TabletRegistry<EK>,
         read_scheduler: Scheduler<ReadTask<EK>>,
+        flush_state: Arc<FlushState>,
+        log_recovery: Option<Box<DataTrace>>,
         logger: Logger,
     ) -> Self {
         let mut remote_tablet = tablet_registry
@@ -58,14 +65,16 @@ impl<EK: KvEngine, R> Apply<EK, R> {
             write_batch: None,
             callbacks: vec![],
             tombstone: false,
-            applied_index: 0,
             applied_term: 0,
+            modifications: [0; DATA_CFS_LEN],
             admin_cmd_result: vec![],
             region_state,
             tablet_registry,
             read_scheduler,
             key_buffer: vec![],
             res_reporter,
+            flush_state,
+            log_recovery,
             logger,
         }
     }
@@ -95,13 +104,20 @@ impl<EK: KvEngine, R> Apply<EK, R> {
 
     #[inline]
     pub fn set_apply_progress(&mut self, index: u64, term: u64) {
-        self.applied_index = index;
+        self.flush_state.set_applied_index(index);
         self.applied_term = term;
+        if self.log_recovery.is_none() {
+            return;
+        }
+        let log_recovery = self.log_recovery.as_ref().unwrap();
+        if log_recovery.iter().all(|v| index >= *v) {
+            self.log_recovery.take();
+        }
     }
 
     #[inline]
     pub fn apply_progress(&self) -> (u64, u64) {
-        (self.applied_index, self.applied_term)
+        (self.flush_state.applied_index(), self.applied_term)
     }
 
     #[inline]
@@ -170,5 +186,20 @@ impl<EK: KvEngine, R> Apply<EK, R> {
         if self.write_batch.as_ref().map_or(false, |wb| wb.is_empty()) {
             self.write_batch = None;
         }
+    }
+
+    #[inline]
+    pub fn modifications_mut(&mut self) -> &mut DataTrace {
+        &mut self.modifications
+    }
+
+    #[inline]
+    pub fn flush_state(&self) -> &Arc<FlushState> {
+        &self.flush_state
+    }
+
+    #[inline]
+    pub fn log_recovery(&self) -> &Option<Box<DataTrace>> {
+        &self.log_recovery
     }
 }

--- a/components/raftstore-v2/src/raft/mod.rs
+++ b/components/raftstore-v2/src/raft/mod.rs
@@ -6,4 +6,4 @@ mod storage;
 
 pub use apply::Apply;
 pub use peer::Peer;
-pub use storage::{write_initial_states, Storage};
+pub use storage::Storage;

--- a/components/raftstore-v2/src/raft/peer.rs
+++ b/components/raftstore-v2/src/raft/peer.rs
@@ -658,8 +658,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         &self.flush_state
     }
 
-    pub fn reset_flush_state(&mut self) -> Arc<FlushState> {
+    pub fn reset_flush_state(&mut self) {
         self.flush_state = Arc::default();
-        self.flush_state.clone()
     }
 }

--- a/components/raftstore-v2/src/raft/peer.rs
+++ b/components/raftstore-v2/src/raft/peer.rs
@@ -83,7 +83,7 @@ pub struct Peer<EK: KvEngine, ER: RaftEngine> {
     // Trace which peers have not finished split.
     split_trace: Vec<(u64, HashSet<u64>)>,
 
-    /// Apply ralated State changes that needs to be persisted to raft engine.
+    /// Apply related State changes that needs to be persisted to raft engine.
     ///
     /// To make recovery correct, we need to persist all state changes before
     /// advancing apply index.

--- a/components/raftstore-v2/src/raft/peer.rs
+++ b/components/raftstore-v2/src/raft/peer.rs
@@ -8,7 +8,9 @@ use std::{
 
 use collections::{HashMap, HashSet};
 use crossbeam::atomic::AtomicCell;
-use engine_traits::{CachedTablet, KvEngine, RaftEngine, TabletContext, TabletRegistry};
+use engine_traits::{
+    CachedTablet, FlushState, KvEngine, RaftEngine, TabletContext, TabletRegistry,
+};
 use kvproto::{kvrpcpb::ExtraOp as TxnExtraOp, metapb, pdpb, raft_serverpb::RegionLocalState};
 use pd_client::BucketStat;
 use raft::{RawNode, StateRole};
@@ -53,6 +55,8 @@ pub struct Peer<EK: KvEngine, ER: RaftEngine> {
 
     /// Set to true if any side effect needs to be handled.
     has_ready: bool,
+    /// Sometimes there is no ready at all, but we need to trigger async write.
+    has_extra_write: bool,
     /// Writer for persisting side effects asynchronously.
     pub(crate) async_writer: AsyncWriter<EK, ER>,
 
@@ -78,6 +82,8 @@ pub struct Peer<EK: KvEngine, ER: RaftEngine> {
 
     // Trace which peers have not finished split.
     split_trace: Vec<(u64, HashSet<u64>)>,
+
+    flush_state: Arc<FlushState>,
 }
 
 impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
@@ -102,11 +108,13 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         let region = raft_group.store().region_state().get_region().clone();
 
         let cached_tablet = tablet_registry.get_or_default(region_id);
+        let flush_state: Arc<FlushState> = Arc::default();
         // We can't create tablet if tablet index is 0. It can introduce race when gc
         // old tablet and create new peer. We also can't get the correct range of the
         // region, which is required for kv data gc.
         if tablet_index != 0 {
-            let ctx = TabletContext::new(&region, Some(tablet_index));
+            let mut ctx = TabletContext::new(&region, Some(tablet_index));
+            ctx.flush_state = Some(flush_state.clone());
             // TODO: Perhaps we should stop create the tablet automatically.
             tablet_registry.load(ctx, false)?;
         }
@@ -122,6 +130,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             async_writer: AsyncWriter::new(region_id, peer_id),
             apply_scheduler: None,
             has_ready: false,
+            has_extra_write: false,
             destroy_progress: DestroyProgress::None,
             raft_group,
             logger,
@@ -143,6 +152,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             proposal_control: ProposalControl::new(0),
             pending_ticks: Vec::new(),
             split_trace: vec![],
+            flush_state,
         };
 
         // If this region has only one peer and I am the one, campaign directly.
@@ -335,6 +345,17 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
     }
 
     #[inline]
+    pub fn set_has_extra_write(&mut self) {
+        self.set_has_ready();
+        self.has_extra_write = true;
+    }
+
+    #[inline]
+    pub fn reset_has_extra_write(&mut self) -> bool {
+        mem::take(&mut self.has_extra_write)
+    }
+
+    #[inline]
     pub fn insert_peer_cache(&mut self, peer: metapb::Peer) {
         for p in self.raft_group.store().region().get_peers() {
             if p.get_id() == peer.get_id() {
@@ -499,8 +520,8 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         &self.proposals
     }
 
-    pub fn apply_scheduler(&self) -> &ApplyScheduler {
-        self.apply_scheduler.as_ref().unwrap()
+    pub fn apply_scheduler(&self) -> Option<&ApplyScheduler> {
+        self.apply_scheduler.as_ref()
     }
 
     #[inline]
@@ -630,5 +651,15 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
     #[inline]
     pub fn split_trace_mut(&mut self) -> &mut Vec<(u64, HashSet<u64>)> {
         &mut self.split_trace
+    }
+
+    #[inline]
+    pub fn flush_state(&self) -> &Arc<FlushState> {
+        &self.flush_state
+    }
+
+    pub fn reset_flush_state(&mut self) -> Arc<FlushState> {
+        self.flush_state = Arc::default();
+        self.flush_state.clone()
     }
 }

--- a/components/raftstore-v2/src/raft/storage.rs
+++ b/components/raftstore-v2/src/raft/storage.rs
@@ -382,7 +382,7 @@ mod tests {
         // This index can't be set before load tablet.
         assert_ne!(10, s.entry_storage().applied_index());
         assert_ne!(1, s.entry_storage().applied_term());
-        assert_ne!(10, s.region_state().get_tablet_index());
+        assert_eq!(10, s.region_state().get_tablet_index());
         assert!(task.persisted_cb.is_some());
 
         s.on_applied_snapshot();

--- a/components/raftstore-v2/src/raft/storage.rs
+++ b/components/raftstore-v2/src/raft/storage.rs
@@ -175,6 +175,9 @@ impl<EK: KvEngine, ER: RaftEngine> Storage<EK, ER> {
         self.entry_storage.apply_state()
     }
 
+    /// Check if the storage is initialized.
+    ///
+    /// The storage is considered initialized when data is applied in memory.
     #[inline]
     pub fn is_initialized(&self) -> bool {
         self.region_state.get_tablet_index() != 0

--- a/components/raftstore-v2/src/raft/storage.rs
+++ b/components/raftstore-v2/src/raft/storage.rs
@@ -358,7 +358,7 @@ mod tests {
         let ops = DbOptions::default();
         let cf_opts = DATA_CFS.iter().map(|cf| (*cf, CfOptions::new())).collect();
         let factory = Box::new(TestTabletFactory::new(ops, cf_opts));
-        let reg = TabletRegistry::new(factory, path.path().join("tablet")).unwrap();
+        let reg = TabletRegistry::new(factory, path.path().join("tablets")).unwrap();
         let worker = Worker::new("test-read-worker").lazy_build("test-read-worker");
         let sched = worker.scheduler();
         let logger = slog_global::borrow_global().new(o!());
@@ -405,7 +405,7 @@ mod tests {
         let ops = DbOptions::default();
         let cf_opts = DATA_CFS.iter().map(|cf| (*cf, CfOptions::new())).collect();
         let factory = Box::new(TestTabletFactory::new(ops, cf_opts));
-        let reg = TabletRegistry::new(factory, path.path().join("tablet")).unwrap();
+        let reg = TabletRegistry::new(factory, path.path().join("tablets")).unwrap();
         let tablet_ctx = TabletContext::new(&region, Some(10));
         reg.load(tablet_ctx, true).unwrap();
         // setup read runner worker and peer storage

--- a/components/raftstore-v2/src/raft/storage.rs
+++ b/components/raftstore-v2/src/raft/storage.rs
@@ -5,50 +5,23 @@ use std::{
     fmt::{self, Debug, Formatter},
 };
 
-use engine_traits::{KvEngine, RaftEngine, RaftLogBatch};
+use engine_traits::{KvEngine, RaftEngine};
 use kvproto::{
-    metapb::{self, Region},
+    metapb,
     raft_serverpb::{PeerState, RaftApplyState, RaftLocalState, RegionLocalState},
 };
 use raft::{
     eraftpb::{ConfState, Entry, Snapshot},
     GetEntriesContext, RaftState, INVALID_ID,
 };
-use raftstore::store::{util, EntryStorage, ReadTask, RAFT_INIT_LOG_INDEX, RAFT_INIT_LOG_TERM};
+use raftstore::store::{util, EntryStorage, ReadTask};
 use slog::{o, Logger};
 use tikv_util::{box_err, store::find_peer, worker::Scheduler};
 
 use crate::{
-    operation::{GenSnapTask, SnapState, SplitInit},
+    operation::{ApplyTrace, GenSnapTask, SnapState, SplitInit},
     Result,
 };
-
-pub fn write_initial_states(wb: &mut impl RaftLogBatch, region: Region) -> Result<()> {
-    let region_id = region.get_id();
-
-    let mut state = RegionLocalState::default();
-    state.set_region(region);
-    state.set_tablet_index(RAFT_INIT_LOG_INDEX);
-    wb.put_region_state(region_id, 0, &state)?;
-
-    let mut apply_state = RaftApplyState::default();
-    apply_state.set_applied_index(RAFT_INIT_LOG_INDEX);
-    apply_state
-        .mut_truncated_state()
-        .set_index(RAFT_INIT_LOG_INDEX);
-    apply_state
-        .mut_truncated_state()
-        .set_term(RAFT_INIT_LOG_TERM);
-    wb.put_apply_state(region_id, 0, &apply_state)?;
-
-    let mut raft_state = RaftLocalState::default();
-    raft_state.set_last_index(RAFT_INIT_LOG_INDEX);
-    raft_state.mut_hard_state().set_term(RAFT_INIT_LOG_TERM);
-    raft_state.mut_hard_state().set_commit(RAFT_INIT_LOG_INDEX);
-    wb.put_raft_state(region_id, &raft_state)?;
-
-    Ok(())
-}
 
 /// A storage for raft.
 ///
@@ -67,6 +40,8 @@ pub struct Storage<EK: KvEngine, ER> {
     snap_state: RefCell<SnapState>,
     gen_snap_task: RefCell<Box<Option<GenSnapTask>>>,
     split_init: Option<Box<SplitInit>>,
+    /// The flushed index of all CFs.
+    apply_trace: ApplyTrace,
 }
 
 impl<EK: KvEngine, ER> Debug for Storage<EK, ER> {
@@ -120,87 +95,20 @@ impl<EK: KvEngine, ER> Storage<EK, ER> {
     pub fn gen_snap_task_mut(&self) -> RefMut<'_, Box<Option<GenSnapTask>>> {
         self.gen_snap_task.borrow_mut()
     }
+
+    #[inline]
+    pub fn apply_trace_mut(&mut self) -> &mut ApplyTrace {
+        &mut self.apply_trace
+    }
+
+    #[inline]
+    pub fn apply_trace(&self) -> &ApplyTrace {
+        &self.apply_trace
+    }
 }
 
 impl<EK: KvEngine, ER: RaftEngine> Storage<EK, ER> {
-    /// Creates a new storage with uninit states.
-    ///
-    /// This should only be used for creating new peer from raft message.
-    pub fn uninit(
-        store_id: u64,
-        region: Region,
-        engine: ER,
-        read_scheduler: Scheduler<ReadTask<EK>>,
-        logger: &Logger,
-    ) -> Result<Self> {
-        let mut region_state = RegionLocalState::default();
-        region_state.set_region(region);
-        Self::create(
-            store_id,
-            region_state,
-            RaftLocalState::default(),
-            RaftApplyState::default(),
-            engine,
-            read_scheduler,
-            false,
-            logger,
-        )
-    }
-
-    /// Creates a new storage.
-    ///
-    /// All metadata should be initialized before calling this method. If the
-    /// region is destroyed, `None` will be returned.
-    pub fn new(
-        region_id: u64,
-        store_id: u64,
-        engine: ER,
-        read_scheduler: Scheduler<ReadTask<EK>>,
-        logger: &Logger,
-    ) -> Result<Option<Storage<EK, ER>>> {
-        let region_state = match engine.get_region_state(region_id, u64::MAX) {
-            Ok(Some(s)) => s,
-            res => {
-                return Err(box_err!(
-                    "failed to get region state for region {}: {:?}",
-                    region_id,
-                    res
-                ));
-            }
-        };
-
-        if region_state.get_state() == PeerState::Tombstone {
-            return Ok(None);
-        }
-
-        let raft_state = match engine.get_raft_state(region_id) {
-            Ok(Some(s)) => s,
-            res => {
-                return Err(box_err!("failed to get raft state: {:?}", res));
-            }
-        };
-
-        let apply_state = match engine.get_apply_state(region_id, u64::MAX) {
-            Ok(Some(s)) => s,
-            res => {
-                return Err(box_err!("failed to get apply state: {:?}", res));
-            }
-        };
-
-        Self::create(
-            store_id,
-            region_state,
-            raft_state,
-            apply_state,
-            engine,
-            read_scheduler,
-            true,
-            logger,
-        )
-        .map(Some)
-    }
-
-    fn create(
+    pub(crate) fn create(
         store_id: u64,
         region_state: RegionLocalState,
         raft_state: RaftLocalState,
@@ -208,6 +116,7 @@ impl<EK: KvEngine, ER: RaftEngine> Storage<EK, ER> {
         engine: ER,
         read_scheduler: Scheduler<ReadTask<EK>>,
         persisted: bool,
+        apply_trace: ApplyTrace,
         logger: &Logger,
     ) -> Result<Self> {
         let peer = find_peer(region_state.get_region(), store_id);
@@ -237,6 +146,7 @@ impl<EK: KvEngine, ER: RaftEngine> Storage<EK, ER> {
             snap_state: RefCell::new(SnapState::Relax),
             gen_snap_task: RefCell::new(Box::new(None)),
             split_init: None,
+            apply_trace,
         })
     }
 
@@ -363,7 +273,10 @@ impl<EK: KvEngine, ER: RaftEngine> raft::Storage for Storage<EK, ER> {
 #[cfg(test)]
 mod tests {
     use std::{
-        sync::mpsc::{sync_channel, Receiver, SyncSender},
+        sync::{
+            mpsc::{sync_channel, Receiver, SyncSender},
+            Arc,
+        },
         time::Duration,
     };
 
@@ -371,9 +284,7 @@ mod tests {
         ctor::{CfOptions, DbOptions},
         kv::TestTabletFactory,
     };
-    use engine_traits::{
-        RaftEngine, RaftEngineReadOnly, RaftLogBatch, TabletContext, TabletRegistry, DATA_CFS,
-    };
+    use engine_traits::{RaftEngine, RaftLogBatch, TabletContext, TabletRegistry, DATA_CFS};
     use kvproto::{
         metapb::{Peer, Region},
         raft_serverpb::PeerState,
@@ -381,14 +292,16 @@ mod tests {
     use raft::{Error as RaftError, StorageError};
     use raftstore::store::{
         util::new_empty_snapshot, AsyncReadNotifier, FetchedLogs, GenSnapRes, ReadRunner,
-        TabletSnapKey, TabletSnapManager, WriteTask, RAFT_INIT_LOG_INDEX, RAFT_INIT_LOG_TERM,
+        TabletSnapKey, TabletSnapManager, WriteTask,
     };
     use slog::o;
     use tempfile::TempDir;
     use tikv_util::worker::Worker;
 
     use super::*;
-    use crate::{fsm::ApplyResReporter, raft::Apply, router::ApplyRes};
+    use crate::{
+        fsm::ApplyResReporter, operation::write_initial_states, raft::Apply, router::ApplyRes,
+    };
 
     #[derive(Clone)]
     pub struct TestRouter {
@@ -426,35 +339,6 @@ mod tests {
         region.mut_region_epoch().set_version(2);
         region.mut_region_epoch().set_conf_ver(4);
         region
-    }
-
-    #[test]
-    fn test_write_initial_states() {
-        let region = new_region();
-        let path = TempDir::new().unwrap();
-        let engine = engine_test::new_temp_engine(&path);
-        let raft_engine = &engine.raft;
-        let mut wb = raft_engine.log_batch(10);
-        write_initial_states(&mut wb, region.clone()).unwrap();
-        assert!(!wb.is_empty());
-        raft_engine.consume(&mut wb, true).unwrap();
-
-        let local_state = raft_engine.get_region_state(4, 0).unwrap().unwrap();
-        assert_eq!(local_state.get_state(), PeerState::Normal);
-        assert_eq!(*local_state.get_region(), region);
-        assert_eq!(local_state.get_tablet_index(), RAFT_INIT_LOG_INDEX);
-
-        let raft_state = raft_engine.get_raft_state(4).unwrap().unwrap();
-        assert_eq!(raft_state.get_last_index(), RAFT_INIT_LOG_INDEX);
-        let hs = raft_state.get_hard_state();
-        assert_eq!(hs.get_term(), RAFT_INIT_LOG_TERM);
-        assert_eq!(hs.get_commit(), RAFT_INIT_LOG_INDEX);
-
-        let apply_state = raft_engine.get_apply_state(4, u64::MAX).unwrap().unwrap();
-        assert_eq!(apply_state.get_applied_index(), RAFT_INIT_LOG_INDEX);
-        let ts = apply_state.get_truncated_state();
-        assert_eq!(ts.get_index(), RAFT_INIT_LOG_INDEX);
-        assert_eq!(ts.get_term(), RAFT_INIT_LOG_TERM);
     }
 
     #[test]
@@ -544,6 +428,8 @@ mod tests {
             router,
             reg,
             sched,
+            Arc::default(),
+            None,
             logger,
         );
 

--- a/components/raftstore-v2/src/router/internal_message.rs
+++ b/components/raftstore-v2/src/router/internal_message.rs
@@ -1,16 +1,11 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
-use super::CmdResChannel;
 use crate::operation::{AdminCmdResult, CommittedEntries, DataTrace, GenSnapTask};
 
 #[derive(Debug)]
 pub enum ApplyTask {
     CommittedEntries(CommittedEntries),
     Snapshot(GenSnapTask),
-    ManualFlush {
-        cfs: Vec<&'static str>,
-        ch: CmdResChannel,
-    },
 }
 
 #[derive(Debug, Default)]

--- a/components/raftstore-v2/src/router/internal_message.rs
+++ b/components/raftstore-v2/src/router/internal_message.rs
@@ -1,16 +1,22 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
-use crate::operation::{AdminCmdResult, CommittedEntries, GenSnapTask};
+use super::CmdResChannel;
+use crate::operation::{AdminCmdResult, CommittedEntries, DataTrace, GenSnapTask};
 
 #[derive(Debug)]
 pub enum ApplyTask {
     CommittedEntries(CommittedEntries),
     Snapshot(GenSnapTask),
+    ManualFlush {
+        cfs: Vec<&'static str>,
+        ch: CmdResChannel,
+    },
 }
 
 #[derive(Debug, Default)]
 pub struct ApplyRes {
     pub applied_index: u64,
     pub applied_term: u64,
-    pub admin_result: Vec<AdminCmdResult>,
+    pub admin_result: Box<[AdminCmdResult]>,
+    pub modifications: DataTrace,
 }

--- a/components/raftstore-v2/src/router/message.rs
+++ b/components/raftstore-v2/src/router/message.rs
@@ -139,6 +139,15 @@ pub enum PeerMsg {
         ready_number: u64,
     },
     QueryDebugInfo(DebugInfoChannel),
+    ManualFlush {
+        cfs: Vec<&'static str>,
+        ch: CmdResChannel,
+    },
+    DataFlushed {
+        cf: &'static str,
+        tablet_index: u64,
+        flushed_index: u64,
+    },
     /// A message that used to check if a flush is happened.
     #[cfg(feature = "testexport")]
     WaitFlush(super::FlushChannel),
@@ -191,6 +200,16 @@ impl fmt::Debug for PeerMsg {
             PeerMsg::LogsFetched(fetched) => write!(fmt, "LogsFetched {:?}", fetched),
             PeerMsg::SnapshotGenerated(_) => write!(fmt, "SnapshotGenerated"),
             PeerMsg::QueryDebugInfo(_) => write!(fmt, "QueryDebugInfo"),
+            PeerMsg::ManualFlush { cfs, .. } => write!(fmt, "ManualFlush {:?}", cfs),
+            PeerMsg::DataFlushed {
+                cf,
+                tablet_index,
+                flushed_index,
+            } => write!(
+                fmt,
+                "DataFlushed cf {}, tablet_index {}, flushed_index {}",
+                cf, tablet_index, flushed_index
+            ),
             #[cfg(feature = "testexport")]
             PeerMsg::WaitFlush(_) => write!(fmt, "FlushMessages"),
         }

--- a/components/raftstore-v2/src/router/message.rs
+++ b/components/raftstore-v2/src/router/message.rs
@@ -139,10 +139,6 @@ pub enum PeerMsg {
         ready_number: u64,
     },
     QueryDebugInfo(DebugInfoChannel),
-    ManualFlush {
-        cfs: Vec<&'static str>,
-        ch: CmdResChannel,
-    },
     DataFlushed {
         cf: &'static str,
         tablet_index: u64,
@@ -200,7 +196,6 @@ impl fmt::Debug for PeerMsg {
             PeerMsg::LogsFetched(fetched) => write!(fmt, "LogsFetched {:?}", fetched),
             PeerMsg::SnapshotGenerated(_) => write!(fmt, "SnapshotGenerated"),
             PeerMsg::QueryDebugInfo(_) => write!(fmt, "QueryDebugInfo"),
-            PeerMsg::ManualFlush { cfs, .. } => write!(fmt, "ManualFlush {:?}", cfs),
             PeerMsg::DataFlushed {
                 cf,
                 tablet_index,

--- a/components/raftstore-v2/tests/failpoints/mod.rs
+++ b/components/raftstore-v2/tests/failpoints/mod.rs
@@ -10,3 +10,4 @@
 mod cluster;
 mod test_basic_write;
 mod test_bootstrap;
+mod test_trace_apply;

--- a/components/raftstore-v2/tests/failpoints/test_trace_apply.rs
+++ b/components/raftstore-v2/tests/failpoints/test_trace_apply.rs
@@ -1,0 +1,7 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+// TODO: check if it can recover from:
+// - split not start
+// - split not finish
+// - two pending split the second one finished before the first one
+// - all split finish

--- a/components/raftstore-v2/tests/integrations/cluster.rs
+++ b/components/raftstore-v2/tests/integrations/cluster.rs
@@ -240,7 +240,7 @@ impl RunningState {
         let mut db_opt = DbOptions::default();
         db_opt.set_state_storage(Arc::new(raft_engine.clone()));
         let factory = Box::new(TestTabletFactory::new(db_opt, cf_opts));
-        let registry = TabletRegistry::new(factory, path).unwrap();
+        let registry = TabletRegistry::new(factory, path.join("tablets")).unwrap();
 
         let mut bootstrap = Bootstrap::new(&raft_engine, 0, pd_client.as_ref(), logger.clone());
         let store_id = bootstrap.bootstrap_store().unwrap();
@@ -551,6 +551,15 @@ impl Cluster {
             if msgs.is_empty() {
                 return;
             }
+        }
+    }
+}
+
+impl Drop for Cluster {
+    fn drop(&mut self) {
+        self.routers.clear();
+        for node in &mut self.nodes {
+            node.stop();
         }
     }
 }

--- a/components/raftstore-v2/tests/integrations/mod.rs
+++ b/components/raftstore-v2/tests/integrations/mod.rs
@@ -15,4 +15,5 @@ mod test_pd_heartbeat;
 mod test_read;
 mod test_split;
 mod test_status;
+mod test_trace_apply;
 mod test_transfer_leader;

--- a/components/raftstore-v2/tests/integrations/test_split.rs
+++ b/components/raftstore-v2/tests/integrations/test_split.rs
@@ -181,3 +181,9 @@ fn test_split() {
         false,
     );
 }
+
+// TODO: test split race with
+// - created peer
+// - created peer with pending snapshot
+// - created peer with persisting snapshot
+// - created peer with persisted snapshot

--- a/components/raftstore/src/store/async_io/write.rs
+++ b/components/raftstore/src/store/async_io/write.rs
@@ -152,6 +152,17 @@ impl<W: WriteBatch, L: RaftLogBatch> ExtraWrite<W, L> {
     }
 
     #[inline]
+    pub fn merge_v2(&mut self, log_batch: L) {
+        if let ExtraWrite::None = self {
+            *self = ExtraWrite::V2(log_batch);
+        } else if let ExtraWrite::V1(_) = self {
+            unreachable!("v1 and v2 are mixed used");
+        } else if let ExtraWrite::V2(l) = self {
+            l.merge(log_batch).unwrap();
+        }
+    }
+
+    #[inline]
     pub fn v2_mut(&mut self) -> Option<&mut L> {
         if let ExtraWrite::V2(l) = self {
             Some(l)

--- a/components/raftstore/src/store/compaction_guard.rs
+++ b/components/raftstore/src/store/compaction_guard.rs
@@ -447,14 +447,14 @@ mod tests {
         db.put(b"za1", b"").unwrap();
         db.put(b"zb1", &value).unwrap();
         db.put(b"zc1", &value).unwrap();
-        db.flush_cfs(true /* wait */).unwrap();
+        db.flush_cfs(&[], true /* wait */).unwrap();
         db.put(b"zb2", &value).unwrap();
         db.put(b"zc2", &value).unwrap();
         db.put(b"zc3", &value).unwrap();
         db.put(b"zc4", &value).unwrap();
         db.put(b"zc5", &value).unwrap();
         db.put(b"zc6", &value).unwrap();
-        db.flush_cfs(true /* wait */).unwrap();
+        db.flush_cfs(&[], true /* wait */).unwrap();
         db.compact_range(
             CF_DEFAULT, None,  // start_key
             None,  // end_key

--- a/components/raftstore/src/store/region_snapshot.rs
+++ b/components/raftstore/src/store/region_snapshot.rs
@@ -460,7 +460,7 @@ mod tests {
             let db = &engines.kv;
             for &(ref k, level) in &levels {
                 db.put(&data_key(k), k).unwrap();
-                db.flush_cfs(true).unwrap();
+                db.flush_cfs(&[], true).unwrap();
                 data.push((k.to_vec(), k.to_vec()));
                 db.compact_files_in_range(Some(&data_key(k)), Some(&data_key(k)), Some(level))
                     .unwrap();

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -2109,7 +2109,7 @@ mod test {
         let cache = config.storage.block_cache.build_shared_cache();
 
         let factory = KvEngineFactoryBuilder::new(env, &config, cache).build();
-        let reg = TabletRegistry::new(Box::new(factory), path.path()).unwrap();
+        let reg = TabletRegistry::new(Box::new(factory), path.path().join("tablets")).unwrap();
 
         for i in 1..6 {
             let ctx = TabletContext::with_infinite_region(i, Some(10));

--- a/src/server/engine_factory.rs
+++ b/src/server/engine_factory.rs
@@ -5,10 +5,11 @@ use std::{path::Path, sync::Arc};
 use engine_rocks::{
     raw::{Cache, Env, Statistics},
     CompactedEventSender, CompactionListener, FlowListener, RocksCfOptions, RocksCompactionJobInfo,
-    RocksDbOptions, RocksEngine, RocksEventListener,
+    RocksDbOptions, RocksEngine, RocksEventListener, RocksPersistenceListener,
 };
 use engine_traits::{
-    CompactionJobInfo, MiscExt, Result, TabletContext, TabletFactory, CF_DEFAULT, CF_WRITE,
+    CompactionJobInfo, MiscExt, PersistenceListener, Result, StateStorage, TabletContext,
+    TabletFactory, CF_DEFAULT, CF_WRITE,
 };
 use kvproto::kvrpcpb::ApiVersion;
 use raftstore::RegionInfoAccessor;
@@ -28,6 +29,7 @@ struct FactoryInner {
     flow_listener: Option<engine_rocks::FlowListener>,
     sst_recovery_sender: Option<Scheduler<String>>,
     statistics: Statistics,
+    state_storage: Option<Arc<dyn StateStorage>>,
     lite: bool,
 }
 
@@ -48,6 +50,7 @@ impl KvEngineFactoryBuilder {
                 flow_listener: None,
                 sst_recovery_sender: None,
                 statistics: Statistics::new_titan(),
+                state_storage: None,
                 lite: false,
             },
             compact_event_sender: None,
@@ -82,6 +85,13 @@ impl KvEngineFactoryBuilder {
     /// In lite mode, most listener/filters will not be installed.
     pub fn lite(mut self, lite: bool) -> Self {
         self.inner.lite = lite;
+        self
+    }
+
+    /// A storage for persisting flush states, which is used for recovering when
+    /// disable WAL. Only work for v2.
+    pub fn state_storage(mut self, storage: Arc<dyn StateStorage>) -> Self {
+        self.inner.state_storage = Some(storage);
         self
     }
 
@@ -180,6 +190,16 @@ impl TabletFactory<RocksEngine> for KvEngineFactory {
         let cf_opts = self.cf_opts(EngineType::RaftKv2);
         if let Some(listener) = &self.inner.flow_listener && let Some(suffix) = ctx.suffix {
             db_opts.add_event_listener(listener.clone_with(ctx.id, suffix));
+        }
+        if let Some(storage) = &self.inner.state_storage
+        && let Some(flush_state) = ctx.flush_state {
+            let listener = PersistenceListener::new(
+                ctx.id,
+                ctx.suffix.unwrap(),
+                flush_state,
+                storage.clone(),
+            );
+            db_opts.add_event_listener(RocksPersistenceListener::new(listener));
         }
         let kv_engine =
             engine_rocks::util::new_engine_opt(path.to_str().unwrap(), db_opts, cf_opts);

--- a/src/server/engine_factory.rs
+++ b/src/server/engine_factory.rs
@@ -192,7 +192,7 @@ impl TabletFactory<RocksEngine> for KvEngineFactory {
             db_opts.add_event_listener(listener.clone_with(ctx.id, suffix));
         }
         if let Some(storage) = &self.inner.state_storage
-        && let Some(flush_state) = ctx.flush_state {
+            && let Some(flush_state) = ctx.flush_state {
             let listener = PersistenceListener::new(
                 ctx.id,
                 ctx.suffix.unwrap(),

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -75,7 +75,9 @@ use api_version::{ApiV1, ApiV2, KeyMode, KvFormat, RawValue};
 use causal_ts::{CausalTsProvider, CausalTsProviderImpl};
 use collections::HashMap;
 use concurrency_manager::{ConcurrencyManager, KeyHandleGuard};
-use engine_traits::{raw_ttl::ttl_to_expire_ts, CfName, CF_DEFAULT, CF_LOCK, CF_WRITE, DATA_CFS};
+use engine_traits::{
+    raw_ttl::ttl_to_expire_ts, CfName, CF_DEFAULT, CF_LOCK, CF_WRITE, DATA_CFS, DATA_CFS_LEN,
+};
 use futures::prelude::*;
 use kvproto::{
     kvrpcpb::{
@@ -1538,7 +1540,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
             [(Some(start_key.as_encoded()), Some(end_key.as_encoded()))],
         )?;
 
-        let mut modifies = Vec::with_capacity(DATA_CFS.len());
+        let mut modifies = Vec::with_capacity(DATA_CFS_LEN);
         for cf in DATA_CFS {
             modifies.push(Modify::DeleteRange(
                 cf,

--- a/tests/failpoints/cases/test_table_properties.rs
+++ b/tests/failpoints/cases/test_table_properties.rs
@@ -82,12 +82,12 @@ fn test_check_need_gc() {
     // TEST 2: props.num_versions as f64 > props.num_rows as f64 * ratio_threshold
     // return true.
     do_write(&engine, false, 5);
-    engine.get_rocksdb().flush_cfs(true).unwrap();
+    engine.get_rocksdb().flush_cfs(&[], true).unwrap();
 
     do_gc(&raw_engine, 2, &mut gc_runner, &dir);
 
     do_write(&engine, false, 5);
-    engine.get_rocksdb().flush_cfs(true).unwrap();
+    engine.get_rocksdb().flush_cfs(&[], true).unwrap();
 
     // Set ratio_threshold, let (props.num_versions as f64 > props.num_rows as
     // f64 * ratio_threshold) return true
@@ -185,7 +185,7 @@ fn test_skip_gc_by_check() {
     let mut gc_runner = TestGcRunner::new(0);
 
     do_write(&engine, false, 5);
-    engine.get_rocksdb().flush_cfs(true).unwrap();
+    engine.get_rocksdb().flush_cfs(&[], true).unwrap();
 
     // The min_mvcc_ts ts > gc safepoint, check_need_gc return false, don't call
     // dofilter
@@ -208,12 +208,12 @@ fn test_skip_gc_by_check() {
     // TEST 2:When is_bottommost_level = false,
     // write data to level2
     do_write(&engine, false, 5);
-    engine.get_rocksdb().flush_cfs(true).unwrap();
+    engine.get_rocksdb().flush_cfs(&[], true).unwrap();
 
     do_gc(&raw_engine, 2, &mut gc_runner, &dir);
 
     do_write(&engine, false, 5);
-    engine.get_rocksdb().flush_cfs(true).unwrap();
+    engine.get_rocksdb().flush_cfs(&[], true).unwrap();
 
     // Set ratio_threshold, let (props.num_versions as f64 > props.num_rows as
     // f64 * ratio_threshold) return false

--- a/tests/integrations/raftstore/test_stats.rs
+++ b/tests/integrations/raftstore/test_stats.rs
@@ -27,7 +27,7 @@ fn check_available<T: Simulator>(cluster: &mut Cluster<T>) {
     for i in 0..1000 {
         let last_available = stats.get_available();
         cluster.must_put(format!("k{}", i).as_bytes(), &value);
-        engine.flush_cfs(true).unwrap();
+        engine.flush_cfs(&[], true).unwrap();
         sleep_ms(20);
 
         let stats = pd_client.get_store_stats(1).unwrap();
@@ -58,7 +58,7 @@ fn test_simple_store_stats<T: Simulator>(cluster: &mut Cluster<T>) {
     }
 
     let engine = cluster.get_engine(1);
-    engine.flush_cfs(true).unwrap();
+    engine.flush_cfs(&[], true).unwrap();
     let last_stats = pd_client.get_store_stats(1).unwrap();
     assert_eq!(last_stats.get_region_count(), 1);
 
@@ -67,7 +67,7 @@ fn test_simple_store_stats<T: Simulator>(cluster: &mut Cluster<T>) {
 
     let region = pd_client.get_region(b"").unwrap();
     cluster.must_split(&region, b"k2");
-    engine.flush_cfs(true).unwrap();
+    engine.flush_cfs(&[], true).unwrap();
 
     // wait report region count after split
     for _ in 0..100 {

--- a/tests/integrations/raftstore/test_update_region_size.rs
+++ b/tests/integrations/raftstore/test_update_region_size.rs
@@ -9,7 +9,7 @@ use tikv_util::config::*;
 
 fn flush<T: Simulator>(cluster: &mut Cluster<T>) {
     for engines in cluster.engines.values() {
-        engines.kv.flush_cfs(true).unwrap();
+        engines.kv.flush_cfs(&[], true).unwrap();
     }
 }
 

--- a/tests/integrations/storage/test_titan.rs
+++ b/tests/integrations/storage/test_titan.rs
@@ -211,7 +211,7 @@ fn test_delete_files_in_range_for_titan() {
         .unwrap();
 
     // Flush and compact the kvs into L6.
-    engines.kv.flush_cfs(true).unwrap();
+    engines.kv.flush_cfs(&[], true).unwrap();
     engines.kv.compact_files_in_range(None, None, None).unwrap();
     let db = engines.kv.as_inner();
     let value = db.get_property_int("rocksdb.num-files-at-level0").unwrap();
@@ -254,9 +254,9 @@ fn test_delete_files_in_range_for_titan() {
     // Used to trigger titan gc
     let engine = &engines.kv;
     engine.put(b"1", b"1").unwrap();
-    engine.flush_cfs(true).unwrap();
+    engine.flush_cfs(&[], true).unwrap();
     engine.put(b"2", b"2").unwrap();
-    engine.flush_cfs(true).unwrap();
+    engine.flush_cfs(&[], true).unwrap();
     engine
         .compact_files_in_range(Some(b"0"), Some(b"3"), Some(1))
         .unwrap();


### PR DESCRIPTION

### What is changed and how it works?

Issue Number: Ref #12842 

What's Changed:

```commit-message
raftstore v2 disables WAL for all tablets and store all states to raft
engine. To be able to recover from restart, we need to build some
relations between raft engine and tablets flush. In the previous PR,
flush indexes are stored in raft engine by `PersistenceListener`.


In this PR, ApplyTrace is introduced to anaylze apply index after
restart. And it will trigger persistence for more apply progress like
split.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
