### PR TITLE
log-backup: added a semaphor to limit inflight requests

### DIFF
--- a/components/sst_importer/src/caching/mod.rs
+++ b/components/sst_importer/src/caching/mod.rs
@@ -1,4 +1,5 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
 pub mod cache_map;
+pub mod quota_cache;
 pub mod storage_cache;

--- a/components/sst_importer/src/caching/quota_cache.rs
+++ b/components/sst_importer/src/caching/quota_cache.rs
@@ -1,0 +1,49 @@
+use std::{convert::Infallible, sync::Arc};
+
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+use crate::caching::cache_map::{MakeCache, ShareOwned};
+
+#[derive(Clone)]
+pub struct Quota(Arc<Semaphore>);
+
+impl Quota {
+    fn of(n: usize) -> Self {
+        Self(Arc::new(Semaphore::new(n)))
+    }
+
+    pub async fn require(self, n: u32) -> OwnedSemaphorePermit {
+        self.0
+            .acquire_many_owned(n)
+            .await
+            .expect("this should not be closed")
+    }
+}
+
+impl std::fmt::Debug for Quota {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Quota")
+            .field(&self.0.available_permits())
+            .finish()
+    }
+}
+
+impl ShareOwned for Quota {
+    type Shared = Quota;
+
+    fn share_owned(&self) -> Self::Shared {
+        self.clone()
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct QuotaOf(pub usize);
+
+impl MakeCache for QuotaOf {
+    type Cached = Quota;
+    type Error = Infallible;
+
+    fn make_cache(&self) -> std::result::Result<Self::Cached, Self::Error> {
+        Ok(Quota::of(self.0))
+    }
+}

--- a/components/sst_importer/src/lib.rs
+++ b/components/sst_importer/src/lib.rs
@@ -24,6 +24,10 @@ pub mod metrics;
 pub mod sst_importer;
 
 pub use self::{
+    caching::{
+        cache_map::CacheMap,
+        quota_cache::{Quota, QuotaOf},
+    },
     config::Config,
     errors::{error_inc, Error, Result},
     import_file::sst_meta_to_path,

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -98,7 +98,7 @@ pub struct SstImporter {
     api_version: ApiVersion,
     compression_types: HashMap<CfName, SstCompressionType>,
 
-    cached_storage: CacheMap<StorageBackend>,
+    cached_storage: CacheMap<String, StorageBackend>,
     download_rt: Runtime,
     file_locks: Arc<DashMap<String, (CacheKvFile, Instant)>>,
     mem_use: AtomicU64,


### PR DESCRIPTION
Signed-off-by: hillium <yu745514916@live.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #(TBD)

What's Changed:
This PR did some changes over the `SstService`:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Added a semaphore to SST Service to limit the concurrency of requests for preventing panic.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fixed a bug that may cause TiKV paniking when restoring huge rows by PITR.
```
