### PR TITLE
ratstore-v2: strip ts from split keys before propose

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4359,6 +4359,7 @@ dependencies = [
  "file_system",
  "fs2",
  "futures 0.3.15",
+ "itertools",
  "keys",
  "kvproto",
  "log_wrappers",

--- a/components/raftstore-v2/Cargo.toml
+++ b/components/raftstore-v2/Cargo.toml
@@ -60,6 +60,7 @@ time = "0.1"
 tracker = { workspace = true }
 txn_types = { workspace = true }
 yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
+itertools = "0.10"
 
 [dev-dependencies]
 engine_test = { workspace = true }

--- a/components/raftstore-v2/Cargo.toml
+++ b/components/raftstore-v2/Cargo.toml
@@ -41,6 +41,7 @@ fail = "0.5"
 file_system = { workspace = true }
 fs2 = "0.4"
 futures = { version = "0.3", features = ["compat"] }
+itertools = "0.10"
 keys = { workspace = true }
 kvproto = { workspace = true }
 log_wrappers = { workspace = true }
@@ -60,7 +61,6 @@ time = "0.1"
 tracker = { workspace = true }
 txn_types = { workspace = true }
 yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
-itertools = "0.10"
 
 [dev-dependencies]
 engine_test = { workspace = true }

--- a/components/raftstore-v2/src/operation/command/admin/split.rs
+++ b/components/raftstore-v2/src/operation/command/admin/split.rs
@@ -31,6 +31,7 @@ use collections::HashSet;
 use crossbeam::channel::SendError;
 use engine_traits::{Checkpointer, KvEngine, RaftEngine, TabletContext};
 use fail::fail_point;
+use itertools::Itertools;
 use kvproto::{
     metapb::{self, Region},
     raft_cmdpb::{AdminRequest, AdminResponse, RaftCmdRequest, SplitRequest},
@@ -39,6 +40,7 @@ use kvproto::{
 use protobuf::Message;
 use raft::{prelude::Snapshot, INVALID_ID};
 use raftstore::{
+    coprocessor::split_observer::{is_valid_split_key, strip_timestamp_if_exists},
     store::{
         fsm::apply::validate_batch_split,
         metrics::PEER_ADMIN_CMD_COUNTER,
@@ -48,7 +50,8 @@ use raftstore::{
     },
     Result,
 };
-use slog::info;
+use slog::{error, info, warn, Logger};
+use tikv_util::box_err;
 
 use crate::{
     batch::StoreContext,
@@ -99,13 +102,68 @@ impl SplitInit {
     }
 }
 
+// validate split request and strip ts from split keys if needed
+fn pre_propose_split(logger: &Logger, req: &mut AdminRequest, region: &Region) -> Result<()> {
+    if !req.has_splits() {
+        return Err(box_err!(
+            "cmd_type is BatchSplit but it doesn't have splits request, message maybe \
+             corrupted!"
+                .to_owned()
+        ));
+    }
+
+    let mut requests: Vec<SplitRequest> = req.mut_splits().take_requests().into();
+    let ajusted_splits = std::mem::take(&mut requests)
+        .into_iter()
+        .enumerate()
+        .filter_map(|(i, mut split)| {
+            let key = split.take_split_key();
+            let key = strip_timestamp_if_exists(key);
+            if is_valid_split_key(&key, i, region) {
+                split.split_key = key;
+                Some(split)
+            } else {
+                None
+            }
+        })
+        .coalesce(|prev, curr| {
+            // Make sure that the split keys are sorted and unique.
+            if prev.split_key < curr.split_key {
+                Err((prev, curr))
+            } else {
+                warn!(
+                    logger,
+                    "skip invalid split key: key should not be larger than the previous.";
+                    "region_id" => region.id,
+                    "key" => log_wrappers::Value::key(&curr.split_key),
+                    "previous" => log_wrappers::Value::key(&prev.split_key),
+                );
+                Ok(prev)
+            }
+        })
+        .collect::<Vec<_>>();
+
+    if ajusted_splits.is_empty() {
+        error!(
+            logger,
+            "failed to handle split req, no valid key found for split";
+            "region_id" => region.id,
+        );
+        Err(box_err!("no valid key found for split.".to_owned()))
+    } else {
+        // Rewrite the splits.
+        req.mut_splits().set_requests(ajusted_splits.into());
+        Ok(())
+    }
+}
+
 impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
     pub fn propose_split<T>(
         &mut self,
         store_ctx: &mut StoreContext<EK, ER, T>,
-        req: RaftCmdRequest,
+        mut req: RaftCmdRequest,
     ) -> Result<u64> {
-        validate_batch_split(req.get_admin_request(), self.region())?;
+        pre_propose_split(&self.logger, req.mut_admin_request(), self.region())?;
         // We rely on ConflictChecker to detect conflicts, so no need to set proposal
         // context.
         let data = req.write_to_bytes().unwrap();
@@ -494,6 +552,7 @@ mod test {
         store::{new_learner_peer, new_peer},
         worker::dummy_scheduler,
     };
+    use txn_types::Key;
 
     use super::*;
     use crate::{fsm::ApplyResReporter, raft::Apply, router::ApplyRes};
@@ -595,6 +654,43 @@ mod test {
                 assert!(reg.tablet_factory().exists(&path));
             }
         }
+    }
+
+    #[test]
+    fn test_propose() {
+        let logger = slog_global::borrow_global().new(o!());
+
+        let mut region = Region::default();
+        region.set_end_key(b"k10".to_vec());
+
+        let mut req = AdminRequest::default();
+        let err = pre_propose_split(&logger, &mut req, &region).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("cmd_type is BatchSplit but it doesn't have splits")
+        );
+
+        let mut splits = BatchSplitRequest::default();
+        req.set_splits(splits.clone());
+        let err = pre_propose_split(&logger, &mut req, &region).unwrap_err();
+        assert!(err.to_string().contains("no valid key found"));
+
+        splits.mut_requests().push(new_split_req(b"", 0, vec![]));
+        splits.mut_requests().push(new_split_req(b"k03", 0, vec![]));
+        splits.mut_requests().push(new_split_req(b"k02", 0, vec![]));
+        splits.mut_requests().push(new_split_req(b"k11", 0, vec![]));
+        let split_key = Key::from_raw(b"k06");
+        let split_key_with_ts = split_key.clone().append_ts(10.into());
+        splits
+            .mut_requests()
+            .push(new_split_req(split_key_with_ts.as_encoded(), 0, vec![]));
+
+        req.set_splits(splits);
+        pre_propose_split(&logger, &mut req, &region).unwrap();
+        let split_reqs = req.get_splits().get_requests();
+        assert_eq!(split_reqs.len(), 2);
+        assert_eq!(split_reqs[0].get_split_key(), b"k03");
+        assert_eq!(split_reqs[1].get_split_key(), split_key.as_encoded());
     }
 
     #[test]

--- a/components/raftstore-v2/src/operation/command/admin/split.rs
+++ b/components/raftstore-v2/src/operation/command/admin/split.rs
@@ -134,7 +134,6 @@ fn pre_propose_split(logger: &Logger, req: &mut AdminRequest, region: &Region) -
                 warn!(
                     logger,
                     "skip invalid split key: key should not be larger than the previous.";
-                    "region_id" => region.id,
                     "key" => log_wrappers::Value::key(&curr.split_key),
                     "previous" => log_wrappers::Value::key(&prev.split_key),
                 );
@@ -147,7 +146,6 @@ fn pre_propose_split(logger: &Logger, req: &mut AdminRequest, region: &Region) -
         error!(
             logger,
             "failed to handle split req, no valid key found for split";
-            "region_id" => region.id,
         );
         Err(box_err!("no valid key found for split.".to_owned()))
     } else {


### PR DESCRIPTION
Signed-off-by: SpadeA-Tang <u6748471@anu.edu.au>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #12842

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```
strip ts from split keys before propose
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
