### PR TITLE
br: enlarge the raft client backoff in recovery mode since ebs restore volume very poor during restore

### DIFF
--- a/components/snap_recovery/src/init_cluster.rs
+++ b/components/snap_recovery/src/init_cluster.rs
@@ -92,6 +92,12 @@ pub fn enter_snap_recovery_mode(config: &mut TikvConfig) {
     // disable resolve ts during the recovery
     config.resolved_ts.enable = false;
 
+    // ebs volume has very poor performance during restore, it easy to cause the
+    // raft client timeout, at the same time clean up all message included
+    // significant message. restore is not memory sensetive, we may keep
+    // messages as much as possible during the network disturbing in recovery mode
+    config.server.raft_client_max_backoff = ReadableDuration::secs(20);
+
     // Disable region split during recovering.
     config.coprocessor.region_max_size = Some(ReadableSize::gb(MAX_REGION_SIZE));
     config.coprocessor.region_split_size = ReadableSize::gb(MAX_REGION_SIZE);


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Close #13955

What's Changed:

```commit-message
fix: enlarge the raft client backoff in recovery mode since ebs restore volume very poor during restor
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
1. following the instruction https://docs.pingcap.com/zh/tidb-in-kubernetes/v1.4/backup-to-aws-s3-by-snapshot to create a cluster
2. specify 80 tikv nodes, 3 pd and 3 tidb
3. create backup
4. following https://docs.pingcap.com/zh/tidb-in-kubernetes/v1.4/restore-from-aws-s3-by-snapshot to restore the cluster
5. restore success
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM 
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
```
