### PR TITLE
log-backup: make PITR available when using partial cert chain

### DIFF
--- a/components/backup-stream/src/metadata/store/lazy_etcd.rs
+++ b/components/backup-stream/src/metadata/store/lazy_etcd.rs
@@ -4,6 +4,7 @@ use std::{sync::Arc, time::Duration};
 
 use etcd_client::{ConnectOptions, Error as EtcdError, OpenSslClientConfig};
 use futures::Future;
+use openssl::x509::verify::X509VerifyFlags;
 use tikv_util::{
     info,
     stream::{RetryError, RetryExt},
@@ -33,6 +34,11 @@ impl ConnectionConfig {
             opts = opts.with_openssl_tls(
                 OpenSslClientConfig::default()
                     .ca_cert_pem(&tls.ca)
+                    // Some of users may prefer using multi-level self-signed certs.
+                    // In this scenario, we must set this flag or openssl would probably complain it cannot found the root CA(!).
+                    // We haven't it configurable because it is enabled in gRPC by default too.
+                    // TODO: Perhaps implement grpc-io based etcd client?
+                    .manually(|c| c.cert_store_mut().set_flags(X509VerifyFlags::PARTIAL_CHAIN))
                     .client_cert_pem_and_key(&tls.client_cert, &tls.client_key.0),
             )
         }

--- a/components/backup-stream/src/metadata/store/lazy_etcd.rs
+++ b/components/backup-stream/src/metadata/store/lazy_etcd.rs
@@ -35,9 +35,10 @@ impl ConnectionConfig {
                 OpenSslClientConfig::default()
                     .ca_cert_pem(&tls.ca)
                     // Some of users may prefer using multi-level self-signed certs.
-                    // In this scenario, we must set this flag or openssl would probably complain it cannot found the root CA(!).
-                    // We haven't it configurable because it is enabled in gRPC by default too.
-                    // TODO: Perhaps implement grpc-io based etcd client?
+                    // In this scenario, we must set this flag or openssl would probably complain it cannot found the root CA.
+                    // (Because the flags we provide allows users providing exactly one CA cert.)
+                    // We haven't make it configurable because it is enabled in gRPC by default too.
+                    // TODO: Perhaps implement grpc-io based etcd client, fully remove the difference between gRPC TLS and our custom TLS?
                     .manually(|c| c.cert_store_mut().set_flags(X509VerifyFlags::PARTIAL_CHAIN))
                     .client_cert_pem_and_key(&tls.client_cert, &tls.client_key.0),
             )


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #13959

What's Changed:
This PR sets [`X509_V_FLAG_PARTIAL_CHAIN`](https://man.openbsd.org/X509_VERIFY_PARAM_set_flags.3#VERIFICATION_FLAGS), so we would trust the CA even there isn't a root CA provided.
Given the CA file is provided by the user, I think it should be fully trusted. Also note that the `grpc-io` library sets this flag by default.

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
This PR sets X509_V_FLAG_PARTIAL_CHAIN, so we would trust the CA even there isn't a root CA provided.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
We made a binary for testing this, this is the code snippet:
```rust
    let cfg = Config::parse();
    let security_mgr = Arc::new(
        SecurityManager::new(&cfg.clone().into()).expect("failed to create security manager."),
    );
    println!("using config = {:?}", cfg);
    let ccfg = ConnectionConfig {
        keep_alive_interval: Duration::from_secs(3),
        keep_alive_timeout: Duration::from_secs(10),
        tls: Some(
            security_mgr
                .client_suite()
                .expect("parse client suite failed"),
        ),
    };
    println!("using connection config = {:?}", ccfg);
    let etcd_cli = LazyEtcdClient::new(cfg.endpoints.as_slice(), ccfg);
    let client_id = rand::thread_rng().gen::<u64>();
    println!("using client_id = {}", client_id);
    let t = tokio::runtime::Builder::new_current_thread()
        .enable_all()
        .build()
        .unwrap();
    let kv = KeyValue(
        MetaKey("/hello/world".as_bytes().to_vec()),
        client_id.to_string().into_bytes(),
    );
    println!("setting {:?} to PD", kv);
    t.block_on(etcd_cli.set(kv)).unwrap();
    println!("success!");
```

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fixed a bug that caused PITR cannot work in some special TLS environment.
```
