### PR TITLE
*: support start with raftkv2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5226,6 +5226,7 @@ dependencies = [
  "raft",
  "raft_log_engine",
  "raftstore",
+ "raftstore-v2",
  "rand 0.8.5",
  "resolved_ts",
  "resource_metering",

--- a/cmd/tikv-server/src/main.rs
+++ b/cmd/tikv-server/src/main.rs
@@ -7,7 +7,10 @@ use std::{path::Path, process};
 use clap::{crate_authors, App, Arg};
 use serde_json::{Map, Value};
 use server::setup::{ensure_no_unrecognized_config, validate_and_persist_config};
-use tikv::config::{to_flatten_config_info, TikvConfig};
+use tikv::{
+    config::{to_flatten_config_info, TikvConfig},
+    storage::config::EngineType,
+};
 
 fn main() {
     let build_timestamp = option_env!("TIKV_BUILD_TIME");
@@ -207,5 +210,8 @@ fn main() {
         process::exit(0);
     }
 
-    server::server::run_tikv(config);
+    match config.storage.engine {
+        EngineType::RaftKv => server::server::run_tikv(config),
+        EngineType::RaftKv2 => server::server2::run_tikv(config),
+    }
 }

--- a/cmd/tikv-server/src/main.rs
+++ b/cmd/tikv-server/src/main.rs
@@ -211,7 +211,7 @@ fn main() {
     }
 
     match config.storage.engine {
-        EngineType::RaftKv => server::server_rn::run_tikv(config),
-        EngineType::RaftKv2 => server::server::run_tikv(config),
+        EngineType::RaftKv => server::server::run_tikv(config),
+        EngineType::RaftKv2 => server::server2::run_tikv(config),
     }
 }

--- a/cmd/tikv-server/src/main.rs
+++ b/cmd/tikv-server/src/main.rs
@@ -211,7 +211,7 @@ fn main() {
     }
 
     match config.storage.engine {
-        EngineType::RaftKv => server::server::run_tikv(config),
-        EngineType::RaftKv2 => server::server2::run_tikv(config),
+        EngineType::RaftKv => server::server_rn::run_tikv(config),
+        EngineType::RaftKv2 => server::server::run_tikv(config),
     }
 }

--- a/components/raftstore-v2/src/lib.rs
+++ b/components/raftstore-v2/src/lib.rs
@@ -41,3 +41,4 @@ pub use bootstrap::Bootstrap;
 pub use fsm::StoreMeta;
 pub use operation::{SimpleWriteBinary, SimpleWriteEncoder, StateStorage};
 pub use raftstore::{store::Config, Error, Result};
+pub use worker::pd::{FlowReporter, Task as PdTask};

--- a/components/raftstore-v2/src/worker/pd/mod.rs
+++ b/components/raftstore-v2/src/worker/pd/mod.rs
@@ -11,9 +11,12 @@ use concurrency_manager::ConcurrencyManager;
 use engine_traits::{KvEngine, RaftEngine, TabletRegistry};
 use kvproto::{metapb, pdpb};
 use pd_client::PdClient;
-use raftstore::store::{util::KeysInfoFormatter, TxnExt};
+use raftstore::store::{util::KeysInfoFormatter, FlowStatsReporter, ReadStats, TxnExt, WriteStats};
 use slog::{error, info, Logger};
-use tikv_util::{time::UnixSecs, worker::Runnable};
+use tikv_util::{
+    time::UnixSecs,
+    worker::{Runnable, Scheduler},
+};
 use yatp::{task::future::TaskCell, Remote};
 
 use crate::{
@@ -203,6 +206,29 @@ where
                 info!(self.logger, "remove peer statistic record in pd"; "region_id" => region_id)
             }
         }
+    }
+}
+
+#[derive(Clone)]
+pub struct FlowReporter {
+    _scheduler: Scheduler<Task>,
+}
+
+impl FlowReporter {
+    pub fn new(scheduler: Scheduler<Task>) -> Self {
+        FlowReporter {
+            _scheduler: scheduler,
+        }
+    }
+}
+
+impl FlowStatsReporter for FlowReporter {
+    fn report_read_stats(&self, _read_stats: ReadStats) {
+        // TODO
+    }
+
+    fn report_write_stats(&self, _write_stats: WriteStats) {
+        // TODO
     }
 }
 

--- a/components/raftstore-v2/src/worker/pd/update_max_timestamp.rs
+++ b/components/raftstore-v2/src/worker/pd/update_max_timestamp.rs
@@ -7,7 +7,6 @@ use std::{
 
 use causal_ts::CausalTsProvider;
 use engine_traits::{KvEngine, RaftEngine};
-use fail::fail_point;
 use futures::{compat::Future01CompatExt, FutureExt};
 use pd_client::PdClient;
 use raftstore::{store::TxnExt, Result};
@@ -96,7 +95,7 @@ where
 
         #[cfg(feature = "failpoints")]
         let delay = (|| {
-            fail_point!("delay_update_max_ts", |_| true);
+            fail::fail_point!("delay_update_max_ts", |_| true);
             false
         })();
         #[cfg(not(feature = "failpoints"))]

--- a/components/raftstore-v2/tests/integrations/cluster.rs
+++ b/components/raftstore-v2/tests/integrations/cluster.rs
@@ -47,7 +47,7 @@ use test_pd::mocker::Service;
 use tikv_util::{
     config::{ReadableDuration, VersionTrack},
     store::new_peer,
-    worker::Worker,
+    worker::{LazyWorker, Worker},
 };
 use txn_types::WriteBatchFlags;
 
@@ -286,6 +286,7 @@ impl RunningState {
             raftstore::coprocessor::Config::default(),
         );
         let background = Worker::new("background");
+        let pd_worker = LazyWorker::new("pd-worker");
         system
             .start(
                 store_id,
@@ -301,6 +302,7 @@ impl RunningState {
                 causal_ts_provider,
                 coprocessor_host,
                 background.clone(),
+                pd_worker,
             )
             .unwrap();
 

--- a/components/raftstore/src/store/snap.rs
+++ b/components/raftstore/src/store/snap.rs
@@ -1996,7 +1996,11 @@ impl TabletSnapManager {
 
             let path = entry.path();
             // Generated snapshots are just checkpoints, only counts received snapshots.
-            if !path.starts_with(SNAP_REV_PREFIX) {
+            if !path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .map_or(true, |n| n.starts_with(SNAP_REV_PREFIX))
+            {
                 continue;
             }
             for e in file_system::read_dir(path)? {

--- a/components/server/Cargo.toml
+++ b/components/server/Cargo.toml
@@ -66,6 +66,7 @@ protobuf = { version = "2.8", features = ["bytes"] }
 raft = { version = "0.7.0", default-features = false, features = ["protobuf-codec"] }
 raft_log_engine = { workspace = true }
 raftstore = { workspace = true, features = ["engine_rocks"] }
+raftstore-v2 = { workspace = true }
 rand = "0.8"
 resolved_ts = { workspace = true }
 resource_metering = { workspace = true }

--- a/components/server/src/lib.rs
+++ b/components/server/src/lib.rs
@@ -12,5 +12,5 @@ pub mod setup;
 pub mod memory;
 pub mod raft_engine_switch;
 pub mod server;
-pub mod server_rn;
+pub mod server2;
 pub mod signal_handler;

--- a/components/server/src/lib.rs
+++ b/components/server/src/lib.rs
@@ -12,5 +12,5 @@ pub mod setup;
 pub mod memory;
 pub mod raft_engine_switch;
 pub mod server;
-pub mod server2;
+pub mod server_rn;
 pub mod signal_handler;

--- a/components/server/src/lib.rs
+++ b/components/server/src/lib.rs
@@ -12,4 +12,5 @@ pub mod setup;
 pub mod memory;
 pub mod raft_engine_switch;
 pub mod server;
+pub mod server2;
 pub mod signal_handler;

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
 //! This module startups all the components of a TiKV server.
 //!
@@ -14,39 +14,30 @@
 use std::{
     cmp,
     collections::HashMap,
-    convert::TryFrom,
-    env, fmt,
+    env,
     net::SocketAddr,
     path::{Path, PathBuf},
     str::FromStr,
     sync::{
         atomic::{AtomicU32, AtomicU64, Ordering},
-        mpsc, Arc, Mutex,
+        mpsc, Arc,
     },
     time::Duration,
     u64,
 };
 
 use api_version::{dispatch_api_version, KvFormat};
-use backup_stream::{
-    config::BackupStreamConfigManager,
-    metadata::{ConnectionConfig, LazyEtcdClient},
-    observer::BackupStreamObserver,
-};
 use causal_ts::CausalTsProviderImpl;
-use cdc::{CdcConfigManager, MemoryQuota};
 use concurrency_manager::ConcurrencyManager;
 use encryption_export::{data_key_manager_from_config, DataKeyManager};
 use engine_rocks::{
-    flush_engine_statistics, from_rocks_compression_type,
+    flush_engine_statistics,
     raw::{Cache, Env},
     FlowInfo, RocksEngine, RocksStatistics,
 };
-use engine_rocks_helper::sst_recovery::{RecoveryRunner, DEFAULT_CHECK_INTERVAL};
 use engine_traits::{
     CachedTablet, CfOptions, CfOptionsExt, Engines, FlowControlFactorsExt, KvEngine, MiscExt,
-    RaftEngine, SingletonFactory, StatisticsReporter, TabletContext, TabletRegistry, CF_DEFAULT,
-    CF_LOCK, CF_WRITE,
+    RaftEngine, StatisticsReporter, TabletRegistry, CF_DEFAULT, CF_LOCK, CF_WRITE,
 };
 use error_code::ErrorCodeExt;
 use file_system::{
@@ -56,57 +47,39 @@ use file_system::{
 use futures::executor::block_on;
 use grpcio::{EnvBuilder, Environment};
 use grpcio_health::HealthService;
-use kvproto::{
-    brpb::create_backup, cdcpb::create_change_data, deadlock::create_deadlock,
-    debugpb::create_debug, diagnosticspb::create_diagnostics, import_sstpb::create_import_sst,
-    kvrpcpb::ApiVersion, logbackuppb::create_log_backup, recoverdatapb::create_recover_data,
-    resource_usage_agent::create_resource_metering_pub_sub,
-};
+use kvproto::{deadlock::create_deadlock, diagnosticspb::create_diagnostics, kvrpcpb::ApiVersion};
 use pd_client::{PdClient, RpcClient};
 use raft_log_engine::RaftLogEngine;
 use raftstore::{
     coprocessor::{
-        config::SplitCheckConfigManager, BoxConsistencyCheckObserver, ConsistencyCheckMethod,
-        CoprocessorHost, RawConsistencyCheckObserver, RegionInfoAccessor,
+        BoxConsistencyCheckObserver, ConsistencyCheckMethod, CoprocessorHost,
+        RawConsistencyCheckObserver,
     },
-    router::ServerRaftStoreRouter,
-    store::{
-        config::RaftstoreConfigManager,
-        fsm,
-        fsm::store::{
-            RaftBatchSystem, RaftRouter, StoreMeta, MULTI_FILES_SNAPSHOT_FEATURE, PENDING_MSG_CAP,
-        },
-        memory::MEMTRACE_ROOT as MEMTRACE_RAFTSTORE,
-        AutoSplitController, CheckLeaderRunner, LocalReader, SnapManager, SnapManagerBuilder,
-        SplitCheckRunner, SplitConfigManager, StoreMetaDelegate,
-    },
-    RaftRouterCompactedEventSender,
+    store::{memory::MEMTRACE_ROOT as MEMTRACE_RAFTSTORE, SplitConfigManager, TabletSnapManager},
+    RegionInfoAccessor,
 };
 use security::SecurityManager;
-use snap_recovery::RecoveryService;
 use tikv::{
     config::{ConfigController, DbConfigManger, DbType, LogConfigManager, TikvConfig},
     coprocessor::{self, MEMTRACE_ROOT as MEMTRACE_COPROCESSOR},
     coprocessor_v2,
-    import::{ImportSstService, SstImporter},
-    read_pool::{build_yatp_read_pool, ReadPool, ReadPoolConfigManager},
+    read_pool::{build_yatp_read_pool, ReadPool},
     server::{
         config::{Config as ServerConfig, ServerConfigManager},
         gc_worker::{AutoGcConfig, GcWorker},
         lock_manager::LockManager,
         raftkv::ReplicaReadLockChecker,
         resolve,
-        service::{DebugService, DiagnosticsService},
+        service::DiagnosticsService,
         status_server::StatusServer,
-        ttl::TtlChecker,
-        KvEngineFactoryBuilder, Node, RaftKv, Server, CPU_CORES_QUOTA_GAUGE, DEFAULT_CLUSTER_ID,
+        KvEngineFactoryBuilder, NodeV2, RaftKv2, Server, CPU_CORES_QUOTA_GAUGE, DEFAULT_CLUSTER_ID,
         GRPC_THREAD_PREFIX,
     },
     storage::{
         self,
         config_manager::StorageConfigManger,
         mvcc::MvccConsistencyCheckObserver,
-        txn::flow_controller::{EngineFlowController, FlowController},
+        txn::flow_controller::{FlowController, TabletFlowController},
         Engine, Storage,
     },
 };
@@ -128,7 +101,7 @@ use tikv_util::{
 use tokio::runtime::Builder;
 
 use crate::{
-    memory::*, raft_engine_switch::*, setup::*, signal_handler,
+    memory::*, raft_engine_switch::*, server_rn::Stop, setup::*, signal_handler,
     tikv_util::sys::thread::ThreadBuildWrapper,
 };
 
@@ -160,18 +133,19 @@ fn run_impl<CER: ConfiguredRaftEngine, F: KvFormat>(config: TikvConfig) {
     tikv.init_encryption();
     let fetcher = tikv.init_io_utility();
     let listener = tikv.init_flow_receiver();
-    let (engines, engines_info) = tikv.init_raw_engines(listener);
-    tikv.init_engines(engines.clone());
+    let (raft_engine, engines_info) = tikv.init_raw_engines(listener);
+    tikv.init_engines(raft_engine);
     let server_config = tikv.init_servers::<F>();
     tikv.register_services();
     tikv.init_metrics_flusher(fetcher, engines_info);
-    tikv.init_storage_stats_task(engines);
+    tikv.init_storage_stats_task();
     tikv.run_server(server_config);
     tikv.run_status_server();
     tikv.init_quota_tuning_task(tikv.quota_limiter.clone());
 
+    // TODO: support signal dump stats
     signal_handler::wait_for_signal(
-        Some(tikv.engines.take().unwrap().engines),
+        None as Option<Engines<RocksEngine, CER>>,
         tikv.kv_statistics.clone(),
         tikv.raft_statistics.clone(),
     );
@@ -222,52 +196,41 @@ struct TikvServer<ER: RaftEngine> {
     cfg_controller: Option<ConfigController>,
     security_mgr: Arc<SecurityManager>,
     pd_client: Arc<RpcClient>,
-    router: RaftRouter<RocksEngine, ER>,
     flow_info_sender: Option<mpsc::Sender<FlowInfo>>,
     flow_info_receiver: Option<mpsc::Receiver<FlowInfo>>,
-    system: Option<RaftBatchSystem<RocksEngine, ER>>,
+    node: Option<NodeV2<RpcClient, RocksEngine, ER>>,
     resolver: Option<resolve::PdStoreAddrResolver>,
     store_path: PathBuf,
-    snap_mgr: Option<SnapManager>, // Will be filled in `init_servers`.
+    snap_mgr: Option<TabletSnapManager>, // Will be filled in `init_servers`.
     encryption_key_manager: Option<Arc<DataKeyManager>>,
     engines: Option<TikvEngines<RocksEngine, ER>>,
     kv_statistics: Option<Arc<RocksStatistics>>,
     raft_statistics: Option<Arc<RocksStatistics>>,
     servers: Option<Servers<RocksEngine, ER>>,
-    region_info_accessor: RegionInfoAccessor,
+    region_info_accessor: Option<RegionInfoAccessor>,
     coprocessor_host: Option<CoprocessorHost<RocksEngine>>,
     to_stop: Vec<Box<dyn Stop>>,
     lock_files: Vec<File>,
     concurrency_manager: ConcurrencyManager,
     env: Arc<Environment>,
     background_worker: Worker,
-    check_leader_worker: Worker,
     sst_worker: Option<Box<LazyWorker<String>>>,
     quota_limiter: Arc<QuotaLimiter>,
     causal_ts_provider: Option<Arc<CausalTsProviderImpl>>, // used for rawkv apiv2
     tablet_registry: Option<TabletRegistry<RocksEngine>>,
-    br_snap_recovery_mode: bool, // use for br snapshot recovery
 }
 
 struct TikvEngines<EK: KvEngine, ER: RaftEngine> {
-    engines: Engines<EK, ER>,
-    store_meta: Arc<Mutex<StoreMeta>>,
-    engine: RaftKv<EK, ServerRaftStoreRouter<EK, ER>>,
+    raft_engine: ER,
+    engine: RaftKv2<EK, ER>,
 }
 
 struct Servers<EK: KvEngine, ER: RaftEngine> {
     lock_mgr: LockManager,
     server: LocalServer<EK, ER>,
-    node: Node<RpcClient, EK, ER>,
-    importer: Arc<SstImporter>,
-    cdc_scheduler: tikv_util::worker::Scheduler<cdc::Task>,
-    cdc_memory_quota: MemoryQuota,
-    rsmeter_pubsub_service: resource_metering::PubSubService,
-    backup_stream_scheduler: Option<tikv_util::worker::Scheduler<backup_stream::Task>>,
 }
 
-type LocalServer<EK, ER> = Server<resolve::PdStoreAddrResolver, LocalRaftKv<EK, ER>>;
-type LocalRaftKv<EK, ER> = RaftKv<EK, ServerRaftStoreRouter<EK, ER>>;
+type LocalServer<EK, ER> = Server<resolve::PdStoreAddrResolver, RaftKv2<EK, ER>>;
 
 impl<ER> TikvServer<ER>
 where
@@ -290,30 +253,6 @@ where
         );
         let pd_client =
             Self::connect_to_pd_cluster(&mut config, env.clone(), Arc::clone(&security_mgr));
-        // check if TiKV need to run in snapshot recovery mode
-        let is_recovering_marked = match pd_client.is_recovering_marked() {
-            Err(e) => {
-                warn!(
-                    "failed to get recovery mode from PD";
-                    "error" => ?e,
-                );
-                false
-            }
-            Ok(marked) => marked,
-        };
-
-        if is_recovering_marked {
-            // Run a TiKV server in recovery modeß
-            info!("TiKV running in Snapshot Recovery Mode");
-            snap_recovery::init_cluster::enter_snap_recovery_mode(&mut config);
-            // connect_to_pd_cluster retreived the cluster id from pd
-            let cluster_id = config.server.cluster_id;
-            snap_recovery::init_cluster::start_recovery(
-                config.clone(),
-                cluster_id,
-                pd_client.clone(),
-            );
-        }
 
         // Initialize and check config
         let cfg_controller = Self::init_config(config);
@@ -321,19 +260,10 @@ where
 
         let store_path = Path::new(&config.storage.data_dir).to_owned();
 
-        // Initialize raftstore channels.
-        let (router, system) = fsm::create_raft_batch_system(&config.raft_store);
-
         let thread_count = config.server.background_thread_count;
         let background_worker = WorkerBuilder::new("background")
             .thread_count(thread_count)
             .create();
-
-        let mut coprocessor_host = Some(CoprocessorHost::new(
-            router.clone(),
-            config.coprocessor.clone(),
-        ));
-        let region_info_accessor = RegionInfoAccessor::new(coprocessor_host.as_mut().unwrap());
 
         // Initialize concurrency manager
         let latest_ts = block_on(pd_client.get_tso()).expect("failed to get timestamp from PD");
@@ -367,17 +297,12 @@ where
             info!("Causal timestamp provider startup.");
         }
 
-        // Run check leader in a dedicate thread, because it is time sensitive
-        // and crucial to TiCDC replication lag.
-        let check_leader_worker = WorkerBuilder::new("check_leader").thread_count(1).create();
-
         TikvServer {
             config,
             cfg_controller: Some(cfg_controller),
             security_mgr,
             pd_client,
-            router,
-            system: Some(system),
+            node: None,
             resolver: None,
             store_path,
             snap_mgr: None,
@@ -386,21 +311,19 @@ where
             kv_statistics: None,
             raft_statistics: None,
             servers: None,
-            region_info_accessor,
-            coprocessor_host,
+            region_info_accessor: None,
+            coprocessor_host: None,
             to_stop: vec![],
             lock_files: vec![],
             concurrency_manager,
             env,
             background_worker,
-            check_leader_worker,
             flow_info_sender: None,
             flow_info_receiver: None,
             sst_worker: None,
             quota_limiter,
             causal_ts_provider,
             tablet_registry: None,
-            br_snap_recovery_mode: is_recovering_marked,
         }
     }
 
@@ -635,38 +558,44 @@ where
         engine_rocks::FlowListener::new(tx)
     }
 
-    fn init_engines(&mut self, engines: Engines<RocksEngine, ER>) {
-        let store_meta = Arc::new(Mutex::new(StoreMeta::new(PENDING_MSG_CAP)));
-        let engine = RaftKv::new(
-            ServerRaftStoreRouter::new(
-                self.router.clone(),
-                LocalReader::new(
-                    engines.kv.clone(),
-                    StoreMetaDelegate::new(store_meta.clone(), engines.kv.clone()),
-                    self.router.clone(),
-                ),
-            ),
-            engines.kv.clone(),
-            self.region_info_accessor.region_leaders(),
+    fn init_engines(&mut self, raft_engine: ER) {
+        let tablet_registry = self.tablet_registry.clone().unwrap();
+        let mut node = NodeV2::new(
+            &self.config.server,
+            self.pd_client.clone(),
+            None,
+            tablet_registry,
         );
+        node.try_bootstrap_store(&self.config.raft_store, &raft_engine)
+            .unwrap_or_else(|e| fatal!("failed to bootstrap store: {:?}", e));
+        assert_ne!(node.id(), 0);
+
+        let router = node.router();
+        let mut coprocessor_host: CoprocessorHost<RocksEngine> = CoprocessorHost::new(
+            router.store_router().clone(),
+            self.config.coprocessor.clone(),
+        );
+        let region_info_accessor = RegionInfoAccessor::new(&mut coprocessor_host);
+
+        let engine = RaftKv2::new(router.clone(), region_info_accessor.region_leaders());
 
         self.engines = Some(TikvEngines {
-            engines,
-            store_meta,
+            raft_engine,
             engine,
         });
+        self.node = Some(node);
+        self.coprocessor_host = Some(coprocessor_host);
+        self.region_info_accessor = Some(region_info_accessor);
     }
 
-    fn init_gc_worker(
-        &mut self,
-    ) -> GcWorker<RaftKv<RocksEngine, ServerRaftStoreRouter<RocksEngine, ER>>> {
+    fn init_gc_worker(&mut self) -> GcWorker<RaftKv2<RocksEngine, ER>> {
         let engines = self.engines.as_ref().unwrap();
         let gc_worker = GcWorker::new(
             engines.engine.clone(),
             self.flow_info_sender.take().unwrap(),
             self.config.gc.clone(),
             self.pd_client.feature_gate().clone(),
-            Arc::new(self.region_info_accessor.clone()),
+            Arc::new(self.region_info_accessor.clone().unwrap()),
         );
 
         let cfg_controller = self.cfg_controller.as_mut().unwrap();
@@ -679,13 +608,13 @@ where
     }
 
     fn init_servers<F: KvFormat>(&mut self) -> Arc<VersionTrack<ServerConfig>> {
-        let flow_controller = Arc::new(FlowController::Singleton(EngineFlowController::new(
+        let flow_controller = Arc::new(FlowController::Tablet(TabletFlowController::new(
             &self.config.storage.flow_control,
-            self.engines.as_ref().unwrap().engine.kv_engine().unwrap(),
+            self.tablet_registry.clone().unwrap(),
             self.flow_info_receiver.take().unwrap(),
         )));
         let mut gc_worker = self.init_gc_worker();
-        let mut ttl_checker = Box::new(LazyWorker::new("ttl-checker"));
+        let ttl_checker = Box::new(LazyWorker::new("ttl-checker"));
         let ttl_scheduler = ttl_checker.scheduler();
 
         let cfg_controller = self.cfg_controller.as_mut().unwrap();
@@ -699,17 +628,6 @@ where
 
         cfg_controller.register(tikv::config::Module::Log, Box::new(LogConfigManager));
 
-        // Create cdc.
-        let mut cdc_worker = Box::new(LazyWorker::new("cdc"));
-        let cdc_scheduler = cdc_worker.scheduler();
-        let txn_extra_scheduler = cdc::CdcTxnExtraScheduler::new(cdc_scheduler.clone());
-
-        self.engines
-            .as_mut()
-            .unwrap()
-            .engine
-            .set_txn_extra_scheduler(Arc::new(txn_extra_scheduler));
-
         let lock_mgr = LockManager::new(&self.config.pessimistic_txn);
         cfg_controller.register(
             tikv::config::Module::PessimisticTxn,
@@ -720,17 +638,7 @@ where
         let engines = self.engines.as_ref().unwrap();
 
         let pd_worker = LazyWorker::new("pd-worker");
-        let pd_sender = pd_worker.scheduler();
-
-        if let Some(sst_worker) = &mut self.sst_worker {
-            let sst_runner = RecoveryRunner::new(
-                engines.engines.kv.clone(),
-                engines.store_meta.clone(),
-                self.config.storage.background_error_recovery_window.into(),
-                DEFAULT_CHECK_INTERVAL,
-            );
-            sst_worker.start_with_timer(sst_runner);
-        }
+        let pd_sender = raftstore_v2::FlowReporter::new(pd_worker.scheduler());
 
         let unified_read_pool = if self.config.readpool.is_unified_pool_enabled() {
             Some(build_yatp_read_pool(
@@ -764,16 +672,15 @@ where
         let (reporter_notifier, data_sink_reg_handle, reporter_worker) =
             resource_metering::init_reporter(
                 self.config.resource_metering.clone(),
-                collector_reg_handle.clone(),
+                collector_reg_handle,
             );
         self.to_stop.push(reporter_worker);
         let (address_change_notifier, single_target_worker) = resource_metering::init_single_target(
             self.config.resource_metering.receiver_address.clone(),
             self.env.clone(),
-            data_sink_reg_handle.clone(),
+            data_sink_reg_handle,
         );
         self.to_stop.push(single_target_worker);
-        let rsmeter_pubsub_service = resource_metering::PubSubService::new(data_sink_reg_handle);
 
         let cfg_manager = resource_metering::ConfigManager::new(
             self.config.resource_metering.clone(),
@@ -835,25 +742,12 @@ where
         // Create snapshot manager, server.
         let snap_path = self
             .store_path
-            .join(Path::new("snap"))
+            .join(Path::new("tablet_snap"))
             .to_str()
             .unwrap()
             .to_owned();
 
-        let bps = i64::try_from(self.config.server.snap_max_write_bytes_per_sec.0)
-            .unwrap_or_else(|_| fatal!("snap_max_write_bytes_per_sec > i64::max_value"));
-
-        let snap_mgr = SnapManagerBuilder::default()
-            .max_write_bytes_per_sec(bps)
-            .max_total_size(self.config.server.snap_max_total_size.0)
-            .encryption_key_manager(self.encryption_key_manager.clone())
-            .max_per_file_size(self.config.raft_store.max_snapshot_file_raw_size.0)
-            .enable_multi_snapshot_files(
-                self.pd_client
-                    .feature_gate()
-                    .can_enable(MULTI_FILES_SNAPSHOT_FEATURE),
-            )
-            .build(snap_path);
+        let snap_mgr = TabletSnapManager::new(snap_path);
 
         // Create coprocessor endpoint.
         let cop_read_pool_handle = if self.config.readpool.coprocessor.use_unified_pool() {
@@ -867,57 +761,6 @@ where
             cop_read_pools.handle()
         };
 
-        let mut unified_read_pool_scale_receiver = None;
-        if self.config.readpool.is_unified_pool_enabled() {
-            let (unified_read_pool_scale_notifier, rx) = mpsc::sync_channel(10);
-            cfg_controller.register(
-                tikv::config::Module::Readpool,
-                Box::new(ReadPoolConfigManager::new(
-                    unified_read_pool.as_ref().unwrap().handle(),
-                    unified_read_pool_scale_notifier,
-                    &self.background_worker,
-                    self.config.readpool.unified.max_thread_count,
-                    self.config.readpool.unified.auto_adjust_pool_size,
-                )),
-            );
-            unified_read_pool_scale_receiver = Some(rx);
-        }
-
-        // Register cdc.
-        let cdc_ob = cdc::CdcObserver::new(cdc_scheduler.clone());
-        cdc_ob.register_to(self.coprocessor_host.as_mut().unwrap());
-        // Register cdc config manager.
-        cfg_controller.register(
-            tikv::config::Module::Cdc,
-            Box::new(CdcConfigManager(cdc_worker.scheduler())),
-        );
-
-        // Create resolved ts worker
-        let rts_worker = if self.config.resolved_ts.enable {
-            let worker = Box::new(LazyWorker::new("resolved-ts"));
-            // Register the resolved ts observer
-            let resolved_ts_ob = resolved_ts::Observer::new(worker.scheduler());
-            resolved_ts_ob.register_to(self.coprocessor_host.as_mut().unwrap());
-            // Register config manager for resolved ts worker
-            cfg_controller.register(
-                tikv::config::Module::ResolvedTs,
-                Box::new(resolved_ts::ResolvedTsConfigManager::new(
-                    worker.scheduler(),
-                )),
-            );
-            Some(worker)
-        } else {
-            None
-        };
-
-        let check_leader_runner = CheckLeaderRunner::new(
-            engines.store_meta.clone(),
-            self.coprocessor_host.clone().unwrap(),
-        );
-        let check_leader_scheduler = self
-            .check_leader_worker
-            .start("check-leader", check_leader_runner);
-
         let server_config = Arc::new(VersionTrack::new(self.config.server.clone()));
 
         self.config
@@ -930,19 +773,8 @@ where
             .unwrap_or_else(|e| fatal!("failed to validate raftstore config {}", e));
         let raft_store = Arc::new(VersionTrack::new(self.config.raft_store.clone()));
         let health_service = HealthService::default();
-        let mut node = Node::new(
-            self.system.take().unwrap(),
-            &server_config.value().clone(),
-            raft_store.clone(),
-            self.config.storage.api_version(),
-            self.pd_client.clone(),
-            state,
-            self.background_worker.clone(),
-            Some(health_service.clone()),
-            None,
-        );
-        node.try_bootstrap_store(engines.engines.clone())
-            .unwrap_or_else(|e| fatal!("failed to bootstrap node id: {}", e));
+
+        let node = self.node.as_ref().unwrap();
 
         self.snap_mgr = Some(snap_mgr.clone());
         // Create server
@@ -960,9 +792,9 @@ where
             ),
             coprocessor_v2::Endpoint::new(&self.config.coprocessor_v2),
             self.resolver.clone().unwrap(),
-            Either::Left(snap_mgr.clone()),
+            Either::Right(snap_mgr.clone()),
             gc_worker.clone(),
-            Some(check_leader_scheduler),
+            None,
             self.env.clone(),
             unified_read_pool,
             debug_thread_pool,
@@ -978,101 +810,9 @@ where
             )),
         );
 
-        // Start backup stream
-        let backup_stream_scheduler = if self.config.backup_stream.enable {
-            // Create backup stream.
-            let mut backup_stream_worker = Box::new(LazyWorker::new("backup-stream"));
-            let backup_stream_scheduler = backup_stream_worker.scheduler();
-
-            // Register backup-stream observer.
-            let backup_stream_ob = BackupStreamObserver::new(backup_stream_scheduler.clone());
-            backup_stream_ob.register_to(self.coprocessor_host.as_mut().unwrap());
-            // Register config manager.
-            cfg_controller.register(
-                tikv::config::Module::BackupStream,
-                Box::new(BackupStreamConfigManager(backup_stream_worker.scheduler())),
-            );
-
-            let etcd_cli = LazyEtcdClient::new(
-                self.config.pd.endpoints.as_slice(),
-                ConnectionConfig {
-                    keep_alive_interval: self.config.server.grpc_keepalive_time.0,
-                    keep_alive_timeout: self.config.server.grpc_keepalive_timeout.0,
-                    tls: self
-                        .security_mgr
-                        .client_suite()
-                        .map_err(|err| {
-                            warn!("Failed to load client TLS suite, ignoring TLS config."; "err" => %err);
-                        })
-                        .ok(),
-                },
-            );
-            let backup_stream_endpoint = backup_stream::Endpoint::new(
-                node.id(),
-                etcd_cli,
-                self.config.backup_stream.clone(),
-                backup_stream_scheduler.clone(),
-                backup_stream_ob,
-                self.region_info_accessor.clone(),
-                self.router.clone(),
-                self.pd_client.clone(),
-                self.concurrency_manager.clone(),
-            );
-            backup_stream_worker.start(backup_stream_endpoint);
-            self.to_stop.push(backup_stream_worker);
-            Some(backup_stream_scheduler)
-        } else {
-            None
-        };
-
-        let import_path = self.store_path.join("import");
-        let mut importer = SstImporter::new(
-            &self.config.import,
-            import_path,
-            self.encryption_key_manager.clone(),
-            self.config.storage.api_version(),
-        )
-        .unwrap();
-        for (cf_name, compression_type) in &[
-            (
-                CF_DEFAULT,
-                self.config.rocksdb.defaultcf.bottommost_level_compression,
-            ),
-            (
-                CF_WRITE,
-                self.config.rocksdb.writecf.bottommost_level_compression,
-            ),
-        ] {
-            importer.set_compression_type(cf_name, from_rocks_compression_type(*compression_type));
-        }
-        let importer = Arc::new(importer);
-
-        let split_check_runner = SplitCheckRunner::new(
-            engines.engines.kv.clone(),
-            self.router.clone(),
-            self.coprocessor_host.clone().unwrap(),
-        );
-        let split_check_scheduler = self
-            .background_worker
-            .start("split-check", split_check_runner);
-        cfg_controller.register(
-            tikv::config::Module::Coprocessor,
-            Box::new(SplitCheckConfigManager(split_check_scheduler.clone())),
-        );
-
         let split_config_manager =
             SplitConfigManager::new(Arc::new(VersionTrack::new(self.config.split.clone())));
-        cfg_controller.register(
-            tikv::config::Module::Split,
-            Box::new(split_config_manager.clone()),
-        );
-
-        let auto_split_controller = AutoSplitController::new(
-            split_config_manager,
-            self.config.server.grpc_concurrency,
-            self.config.readpool.unified.max_thread_count,
-            unified_read_pool_scale_receiver,
-        );
+        cfg_controller.register(tikv::config::Module::Split, Box::new(split_config_manager));
 
         // `ConsistencyCheckObserver` must be registered before `Node::start`.
         let safe_point = Arc::new(AtomicU64::new(0));
@@ -1090,142 +830,47 @@ where
             .registry
             .register_consistency_check_observer(100, observer);
 
-        node.start(
-            engines.engines.clone(),
-            server.transport(),
-            snap_mgr,
-            pd_worker,
-            engines.store_meta.clone(),
-            self.coprocessor_host.clone().unwrap(),
-            importer.clone(),
-            split_check_scheduler,
-            auto_split_controller,
-            self.concurrency_manager.clone(),
-            collector_reg_handle,
-            self.causal_ts_provider.clone(),
-        )
-        .unwrap_or_else(|e| fatal!("failed to start node: {}", e));
+        self.node
+            .as_mut()
+            .unwrap()
+            .start(
+                engines.raft_engine.clone(),
+                server.transport(),
+                snap_mgr,
+                self.concurrency_manager.clone(),
+                self.causal_ts_provider.clone(),
+                self.coprocessor_host.clone().unwrap(),
+                self.background_worker.clone(),
+                pd_worker,
+                raft_store,
+                &state,
+            )
+            .unwrap_or_else(|e| fatal!("failed to start node: {}", e));
 
         // Start auto gc. Must after `Node::start` because `node_id` is initialized
         // there.
-        assert!(node.id() > 0); // Node id should never be 0.
+        let store_id = self.node.as_ref().unwrap().id();
         let auto_gc_config = AutoGcConfig::new(
             self.pd_client.clone(),
-            self.region_info_accessor.clone(),
-            node.id(),
+            self.region_info_accessor.clone().unwrap(),
+            store_id,
         );
         gc_worker
-            .start(node.id())
+            .start(store_id)
             .unwrap_or_else(|e| fatal!("failed to start gc worker: {}", e));
         if let Err(e) = gc_worker.start_auto_gc(auto_gc_config, safe_point) {
             fatal!("failed to start auto_gc on storage, error: {}", e);
         }
 
         initial_metric(&self.config.metric);
-        if self.config.storage.enable_ttl {
-            ttl_checker.start_with_timer(TtlChecker::new(
-                self.engines.as_ref().unwrap().engine.kv_engine().unwrap(),
-                self.region_info_accessor.clone(),
-                self.config.storage.ttl_check_poll_interval.into(),
-            ));
-            self.to_stop.push(ttl_checker);
-        }
 
-        // Start CDC.
-        let cdc_memory_quota = MemoryQuota::new(self.config.cdc.sink_memory_quota.0 as _);
-        let cdc_endpoint = cdc::Endpoint::new(
-            self.config.server.cluster_id,
-            &self.config.cdc,
-            self.config.storage.api_version(),
-            self.pd_client.clone(),
-            cdc_scheduler.clone(),
-            self.router.clone(),
-            self.engines.as_ref().unwrap().engines.kv.clone(),
-            cdc_ob,
-            engines.store_meta.clone(),
-            self.concurrency_manager.clone(),
-            server.env(),
-            self.security_mgr.clone(),
-            cdc_memory_quota.clone(),
-            self.causal_ts_provider.clone(),
-        );
-        cdc_worker.start_with_timer(cdc_endpoint);
-        self.to_stop.push(cdc_worker);
-
-        // Start resolved ts
-        if let Some(mut rts_worker) = rts_worker {
-            let rts_endpoint = resolved_ts::Endpoint::new(
-                &self.config.resolved_ts,
-                rts_worker.scheduler(),
-                self.router.clone(),
-                engines.store_meta.clone(),
-                self.pd_client.clone(),
-                self.concurrency_manager.clone(),
-                server.env(),
-                self.security_mgr.clone(),
-            );
-            rts_worker.start_with_timer(rts_endpoint);
-            self.to_stop.push(rts_worker);
-        }
-
-        cfg_controller.register(
-            tikv::config::Module::Raftstore,
-            Box::new(RaftstoreConfigManager::new(
-                node.refresh_config_scheduler(),
-                raft_store,
-            )),
-        );
-
-        self.servers = Some(Servers {
-            lock_mgr,
-            server,
-            node,
-            importer,
-            cdc_scheduler,
-            cdc_memory_quota,
-            rsmeter_pubsub_service,
-            backup_stream_scheduler,
-        });
+        self.servers = Some(Servers { lock_mgr, server });
 
         server_config
     }
 
     fn register_services(&mut self) {
         let servers = self.servers.as_mut().unwrap();
-        let engines = self.engines.as_ref().unwrap();
-
-        // Import SST service.
-        let import_service = ImportSstService::new(
-            self.config.import.clone(),
-            self.config.raft_store.raft_entry_max_size,
-            self.router.clone(),
-            engines.engines.kv.clone(),
-            servers.importer.clone(),
-        );
-        if servers
-            .server
-            .register_service(create_import_sst(import_service))
-            .is_some()
-        {
-            fatal!("failed to register import service");
-        }
-
-        // Debug service.
-        let debug_service = DebugService::new(
-            engines.engines.clone(),
-            self.kv_statistics.clone(),
-            self.raft_statistics.clone(),
-            servers.server.get_debug_thread_pool().clone(),
-            engines.engine.raft_extension(),
-            self.cfg_controller.as_ref().unwrap().clone(),
-        );
-        if servers
-            .server
-            .register_service(create_debug(debug_service))
-            .is_some()
-        {
-            fatal!("failed to register debug service");
-        }
 
         // Create Diagnostics service
         let diag_service = DiagnosticsService::new(
@@ -1253,90 +898,13 @@ where
         servers
             .lock_mgr
             .start(
-                servers.node.id(),
+                self.node.as_ref().unwrap().id(),
                 self.pd_client.clone(),
                 self.resolver.clone().unwrap(),
                 self.security_mgr.clone(),
                 &self.config.pessimistic_txn,
             )
             .unwrap_or_else(|e| fatal!("failed to start lock manager: {}", e));
-
-        // Backup service.
-        let mut backup_worker = Box::new(self.background_worker.lazy_build("backup-endpoint"));
-        let backup_scheduler = backup_worker.scheduler();
-        let backup_service = backup::Service::<RocksEngine, RaftRouter<RocksEngine, ER>>::new(
-            backup_scheduler,
-            self.router.clone(),
-        );
-        if servers
-            .server
-            .register_service(create_backup(backup_service))
-            .is_some()
-        {
-            fatal!("failed to register backup service");
-        }
-
-        let backup_endpoint = backup::Endpoint::new(
-            servers.node.id(),
-            engines.engine.clone(),
-            self.region_info_accessor.clone(),
-            engines.engines.kv.clone(),
-            self.config.backup.clone(),
-            self.concurrency_manager.clone(),
-            self.config.storage.api_version(),
-            self.causal_ts_provider.clone(),
-        );
-        self.cfg_controller.as_mut().unwrap().register(
-            tikv::config::Module::Backup,
-            Box::new(backup_endpoint.get_config_manager()),
-        );
-        backup_worker.start(backup_endpoint);
-
-        let cdc_service = cdc::Service::new(
-            servers.cdc_scheduler.clone(),
-            servers.cdc_memory_quota.clone(),
-        );
-        if servers
-            .server
-            .register_service(create_change_data(cdc_service))
-            .is_some()
-        {
-            fatal!("failed to register cdc service");
-        }
-        if servers
-            .server
-            .register_service(create_resource_metering_pub_sub(
-                servers.rsmeter_pubsub_service.clone(),
-            ))
-            .is_some()
-        {
-            warn!("failed to register resource metering pubsub service");
-        }
-
-        if let Some(sched) = servers.backup_stream_scheduler.take() {
-            let pitr_service = backup_stream::Service::new(sched);
-            if servers
-                .server
-                .register_service(create_log_backup(pitr_service))
-                .is_some()
-            {
-                fatal!("failed to register log backup service");
-            }
-        }
-
-        // the present tikv in recovery mode, start recovery service
-        if self.br_snap_recovery_mode {
-            let recovery_service =
-                RecoveryService::new(engines.engines.clone(), self.router.clone());
-
-            if servers
-                .server
-                .register_service(create_recover_data(recovery_service))
-                .is_some()
-            {
-                fatal!("failed to register recovery service");
-            }
-        }
     }
 
     fn init_io_utility(&mut self) -> BytesFetcher {
@@ -1370,7 +938,7 @@ where
             self.tablet_registry.clone().unwrap(),
             self.kv_statistics.clone(),
             self.config.rocksdb.titan.enabled,
-            self.engines.as_ref().unwrap().engines.raft.clone(),
+            self.engines.as_ref().unwrap().raft_engine.clone(),
             self.raft_statistics.clone(),
         );
         let mut io_metrics = IoMetricsManager::new(fetcher);
@@ -1484,7 +1052,7 @@ where
         );
     }
 
-    fn init_storage_stats_task(&self, engines: Engines<RocksEngine, ER>) {
+    fn init_storage_stats_task(&self) {
         let config_disk_capacity: u64 = self.config.raft_store.capacity.0;
         let data_dir = self.config.storage.data_dir.clone();
         let store_path = self.store_path.clone();
@@ -1495,9 +1063,11 @@ where
             info!("disk space checker not enabled");
             return;
         }
-        let raft_path = engines.raft.get_engine_path().to_string();
+        let raft_engine = self.engines.as_ref().unwrap().raft_engine.clone();
+        let tablet_registry = self.tablet_registry.clone().unwrap();
+        let raft_path = raft_engine.get_engine_path().to_string();
         let separated_raft_mount_path =
-            path_in_diff_mount_point(raft_path.as_str(), engines.kv.path());
+            path_in_diff_mount_point(raft_path.as_str(), tablet_registry.tablet_root());
         let raft_almost_full_threshold = reserve_raft_space;
         let raft_already_full_threshold = reserve_raft_space / 2;
 
@@ -1526,15 +1096,17 @@ where
                     Ok(stats) => stats,
                 };
                 let disk_cap = disk_stats.total_space();
-                let snap_size = snap_mgr.get_total_snap_size().unwrap();
+                let snap_size = snap_mgr.total_snap_size().unwrap();
 
-                let kv_size = engines
-                    .kv
-                    .get_engine_used_size()
-                    .expect("get kv engine size");
+                let mut kv_size = 0;
+                tablet_registry.for_each_opened_tablet(|_, cached| {
+                    if let Some(tablet) = cached.latest() {
+                        kv_size += tablet.get_engine_used_size().unwrap_or(0);
+                    }
+                    true
+                });
 
-                let raft_size = engines
-                    .raft
+                let raft_size = raft_engine
                     .get_engine_size()
                     .expect("get raft engine size");
 
@@ -1668,7 +1240,7 @@ where
         }
     }
 
-    fn stop(self) {
+    fn stop(mut self) {
         tikv_util::thread_group::mark_shutdown();
         let mut servers = self.servers.unwrap();
         servers
@@ -1676,8 +1248,8 @@ where
             .stop()
             .unwrap_or_else(|e| fatal!("failed to stop server: {}", e));
 
-        servers.node.stop();
-        self.region_info_accessor.stop();
+        self.node.as_mut().unwrap().stop();
+        self.region_info_accessor.as_mut().unwrap().stop();
 
         servers.lock_mgr.stop();
 
@@ -1806,7 +1378,7 @@ impl<CER: ConfiguredRaftEngine> TikvServer<CER> {
     fn init_raw_engines(
         &mut self,
         flow_listener: engine_rocks::FlowListener,
-    ) -> (Engines<RocksEngine, CER>, Arc<EnginesResourceInfo>) {
+    ) -> (CER, Arc<EnginesResourceInfo>) {
         let block_cache = self.config.storage.block_cache.build_shared_cache();
         let env = self
             .config
@@ -1824,39 +1396,27 @@ impl<CER: ConfiguredRaftEngine> TikvServer<CER> {
 
         // Create kv engine.
         let builder = KvEngineFactoryBuilder::new(env, &self.config, block_cache)
-            .compaction_event_sender(Arc::new(RaftRouterCompactedEventSender {
-                router: Mutex::new(self.router.clone()),
-            }))
-            .region_info_accessor(self.region_info_accessor.clone())
             .sst_recovery_sender(self.init_sst_recovery_sender())
             .flow_listener(flow_listener);
         let factory = Box::new(builder.build());
-        let kv_engine = factory
-            .create_shared_db(&self.store_path)
-            .unwrap_or_else(|s| fatal!("failed to create kv engine: {}", s));
         self.kv_statistics = Some(factory.rocks_statistics());
-        let engines = Engines::new(kv_engine.clone(), raft_engine);
-
+        let registry = TabletRegistry::new(factory, self.store_path.join("tablets"))
+            .unwrap_or_else(|e| fatal!("failed to create tablet registry {:?}", e));
         let cfg_controller = self.cfg_controller.as_mut().unwrap();
         cfg_controller.register(
             tikv::config::Module::Rocksdb,
-            Box::new(DbConfigManger::new(kv_engine.clone(), DbType::Kv)),
+            Box::new(DbConfigManger::new(registry.clone(), DbType::Kv)),
         );
-        let reg = TabletRegistry::new(Box::new(SingletonFactory::new(kv_engine)), &self.store_path)
-            .unwrap();
-        // It always use the singleton kv_engine, use arbitrary id and suffix.
-        let ctx = TabletContext::with_infinite_region(0, Some(0));
-        reg.load(ctx, false).unwrap();
-        self.tablet_registry = Some(reg.clone());
-        engines.raft.register_config(cfg_controller);
+        self.tablet_registry = Some(registry.clone());
+        raft_engine.register_config(cfg_controller);
 
         let engines_info = Arc::new(EnginesResourceInfo::new(
-            reg,
-            engines.raft.as_rocks_engine().cloned(),
+            registry,
+            raft_engine.as_rocks_engine().cloned(),
             180, // max_samples_to_preserve
         ));
 
-        (engines, engines_info)
+        (raft_engine, engines_info)
     }
 }
 
@@ -1948,33 +1508,6 @@ fn get_lock_dir() -> String {
 #[cfg(not(unix))]
 fn get_lock_dir() -> String {
     "TIKV_LOCK_FILES".to_owned()
-}
-
-/// A small trait for components which can be trivially stopped. Lets us keep
-/// a list of these in `TiKV`, rather than storing each component individually.
-pub(crate) trait Stop {
-    fn stop(self: Box<Self>);
-}
-
-impl<R> Stop for StatusServer<R>
-where
-    R: 'static + Send,
-{
-    fn stop(self: Box<Self>) {
-        (*self).stop()
-    }
-}
-
-impl Stop for Worker {
-    fn stop(self: Box<Self>) {
-        Worker::stop(&self);
-    }
-}
-
-impl<T: fmt::Display + Send + 'static> Stop for LazyWorker<T> {
-    fn stop(self: Box<Self>) {
-        self.stop_worker();
-    }
 }
 
 pub struct EngineMetricsManager<EK: KvEngine, ER: RaftEngine> {

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+// Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
 //! This module startups all the components of a TiKV server.
 //!
@@ -14,30 +14,39 @@
 use std::{
     cmp,
     collections::HashMap,
-    env,
+    convert::TryFrom,
+    env, fmt,
     net::SocketAddr,
     path::{Path, PathBuf},
     str::FromStr,
     sync::{
         atomic::{AtomicU32, AtomicU64, Ordering},
-        mpsc, Arc,
+        mpsc, Arc, Mutex,
     },
     time::Duration,
     u64,
 };
 
 use api_version::{dispatch_api_version, KvFormat};
+use backup_stream::{
+    config::BackupStreamConfigManager,
+    metadata::{ConnectionConfig, LazyEtcdClient},
+    observer::BackupStreamObserver,
+};
 use causal_ts::CausalTsProviderImpl;
+use cdc::{CdcConfigManager, MemoryQuota};
 use concurrency_manager::ConcurrencyManager;
 use encryption_export::{data_key_manager_from_config, DataKeyManager};
 use engine_rocks::{
-    flush_engine_statistics,
+    flush_engine_statistics, from_rocks_compression_type,
     raw::{Cache, Env},
     FlowInfo, RocksEngine, RocksStatistics,
 };
+use engine_rocks_helper::sst_recovery::{RecoveryRunner, DEFAULT_CHECK_INTERVAL};
 use engine_traits::{
     CachedTablet, CfOptions, CfOptionsExt, Engines, FlowControlFactorsExt, KvEngine, MiscExt,
-    RaftEngine, StatisticsReporter, TabletRegistry, CF_DEFAULT, CF_LOCK, CF_WRITE,
+    RaftEngine, SingletonFactory, StatisticsReporter, TabletContext, TabletRegistry, CF_DEFAULT,
+    CF_LOCK, CF_WRITE,
 };
 use error_code::ErrorCodeExt;
 use file_system::{
@@ -47,39 +56,57 @@ use file_system::{
 use futures::executor::block_on;
 use grpcio::{EnvBuilder, Environment};
 use grpcio_health::HealthService;
-use kvproto::{deadlock::create_deadlock, diagnosticspb::create_diagnostics, kvrpcpb::ApiVersion};
+use kvproto::{
+    brpb::create_backup, cdcpb::create_change_data, deadlock::create_deadlock,
+    debugpb::create_debug, diagnosticspb::create_diagnostics, import_sstpb::create_import_sst,
+    kvrpcpb::ApiVersion, logbackuppb::create_log_backup, recoverdatapb::create_recover_data,
+    resource_usage_agent::create_resource_metering_pub_sub,
+};
 use pd_client::{PdClient, RpcClient};
 use raft_log_engine::RaftLogEngine;
 use raftstore::{
     coprocessor::{
-        BoxConsistencyCheckObserver, ConsistencyCheckMethod, CoprocessorHost,
-        RawConsistencyCheckObserver,
+        config::SplitCheckConfigManager, BoxConsistencyCheckObserver, ConsistencyCheckMethod,
+        CoprocessorHost, RawConsistencyCheckObserver, RegionInfoAccessor,
     },
-    store::{memory::MEMTRACE_ROOT as MEMTRACE_RAFTSTORE, SplitConfigManager, TabletSnapManager},
-    RegionInfoAccessor,
+    router::ServerRaftStoreRouter,
+    store::{
+        config::RaftstoreConfigManager,
+        fsm,
+        fsm::store::{
+            RaftBatchSystem, RaftRouter, StoreMeta, MULTI_FILES_SNAPSHOT_FEATURE, PENDING_MSG_CAP,
+        },
+        memory::MEMTRACE_ROOT as MEMTRACE_RAFTSTORE,
+        AutoSplitController, CheckLeaderRunner, LocalReader, SnapManager, SnapManagerBuilder,
+        SplitCheckRunner, SplitConfigManager, StoreMetaDelegate,
+    },
+    RaftRouterCompactedEventSender,
 };
 use security::SecurityManager;
+use snap_recovery::RecoveryService;
 use tikv::{
     config::{ConfigController, DbConfigManger, DbType, LogConfigManager, TikvConfig},
     coprocessor::{self, MEMTRACE_ROOT as MEMTRACE_COPROCESSOR},
     coprocessor_v2,
-    read_pool::{build_yatp_read_pool, ReadPool},
+    import::{ImportSstService, SstImporter},
+    read_pool::{build_yatp_read_pool, ReadPool, ReadPoolConfigManager},
     server::{
         config::{Config as ServerConfig, ServerConfigManager},
         gc_worker::{AutoGcConfig, GcWorker},
         lock_manager::LockManager,
         raftkv::ReplicaReadLockChecker,
         resolve,
-        service::DiagnosticsService,
+        service::{DebugService, DiagnosticsService},
         status_server::StatusServer,
-        KvEngineFactoryBuilder, NodeV2, RaftKv2, Server, CPU_CORES_QUOTA_GAUGE, DEFAULT_CLUSTER_ID,
+        ttl::TtlChecker,
+        KvEngineFactoryBuilder, Node, RaftKv, Server, CPU_CORES_QUOTA_GAUGE, DEFAULT_CLUSTER_ID,
         GRPC_THREAD_PREFIX,
     },
     storage::{
         self,
         config_manager::StorageConfigManger,
         mvcc::MvccConsistencyCheckObserver,
-        txn::flow_controller::{FlowController, TabletFlowController},
+        txn::flow_controller::{EngineFlowController, FlowController},
         Engine, Storage,
     },
 };
@@ -101,7 +128,7 @@ use tikv_util::{
 use tokio::runtime::Builder;
 
 use crate::{
-    memory::*, raft_engine_switch::*, server_rn::Stop, setup::*, signal_handler,
+    memory::*, raft_engine_switch::*, setup::*, signal_handler,
     tikv_util::sys::thread::ThreadBuildWrapper,
 };
 
@@ -133,19 +160,18 @@ fn run_impl<CER: ConfiguredRaftEngine, F: KvFormat>(config: TikvConfig) {
     tikv.init_encryption();
     let fetcher = tikv.init_io_utility();
     let listener = tikv.init_flow_receiver();
-    let (raft_engine, engines_info) = tikv.init_raw_engines(listener);
-    tikv.init_engines(raft_engine);
+    let (engines, engines_info) = tikv.init_raw_engines(listener);
+    tikv.init_engines(engines.clone());
     let server_config = tikv.init_servers::<F>();
     tikv.register_services();
     tikv.init_metrics_flusher(fetcher, engines_info);
-    tikv.init_storage_stats_task();
+    tikv.init_storage_stats_task(engines);
     tikv.run_server(server_config);
     tikv.run_status_server();
     tikv.init_quota_tuning_task(tikv.quota_limiter.clone());
 
-    // TODO: support signal dump stats
     signal_handler::wait_for_signal(
-        None as Option<Engines<RocksEngine, CER>>,
+        Some(tikv.engines.take().unwrap().engines),
         tikv.kv_statistics.clone(),
         tikv.raft_statistics.clone(),
     );
@@ -196,41 +222,52 @@ struct TikvServer<ER: RaftEngine> {
     cfg_controller: Option<ConfigController>,
     security_mgr: Arc<SecurityManager>,
     pd_client: Arc<RpcClient>,
+    router: RaftRouter<RocksEngine, ER>,
     flow_info_sender: Option<mpsc::Sender<FlowInfo>>,
     flow_info_receiver: Option<mpsc::Receiver<FlowInfo>>,
-    node: Option<NodeV2<RpcClient, RocksEngine, ER>>,
+    system: Option<RaftBatchSystem<RocksEngine, ER>>,
     resolver: Option<resolve::PdStoreAddrResolver>,
     store_path: PathBuf,
-    snap_mgr: Option<TabletSnapManager>, // Will be filled in `init_servers`.
+    snap_mgr: Option<SnapManager>, // Will be filled in `init_servers`.
     encryption_key_manager: Option<Arc<DataKeyManager>>,
     engines: Option<TikvEngines<RocksEngine, ER>>,
     kv_statistics: Option<Arc<RocksStatistics>>,
     raft_statistics: Option<Arc<RocksStatistics>>,
     servers: Option<Servers<RocksEngine, ER>>,
-    region_info_accessor: Option<RegionInfoAccessor>,
+    region_info_accessor: RegionInfoAccessor,
     coprocessor_host: Option<CoprocessorHost<RocksEngine>>,
     to_stop: Vec<Box<dyn Stop>>,
     lock_files: Vec<File>,
     concurrency_manager: ConcurrencyManager,
     env: Arc<Environment>,
     background_worker: Worker,
+    check_leader_worker: Worker,
     sst_worker: Option<Box<LazyWorker<String>>>,
     quota_limiter: Arc<QuotaLimiter>,
     causal_ts_provider: Option<Arc<CausalTsProviderImpl>>, // used for rawkv apiv2
     tablet_registry: Option<TabletRegistry<RocksEngine>>,
+    br_snap_recovery_mode: bool, // use for br snapshot recovery
 }
 
 struct TikvEngines<EK: KvEngine, ER: RaftEngine> {
-    raft_engine: ER,
-    engine: RaftKv2<EK, ER>,
+    engines: Engines<EK, ER>,
+    store_meta: Arc<Mutex<StoreMeta>>,
+    engine: RaftKv<EK, ServerRaftStoreRouter<EK, ER>>,
 }
 
 struct Servers<EK: KvEngine, ER: RaftEngine> {
     lock_mgr: LockManager,
     server: LocalServer<EK, ER>,
+    node: Node<RpcClient, EK, ER>,
+    importer: Arc<SstImporter>,
+    cdc_scheduler: tikv_util::worker::Scheduler<cdc::Task>,
+    cdc_memory_quota: MemoryQuota,
+    rsmeter_pubsub_service: resource_metering::PubSubService,
+    backup_stream_scheduler: Option<tikv_util::worker::Scheduler<backup_stream::Task>>,
 }
 
-type LocalServer<EK, ER> = Server<resolve::PdStoreAddrResolver, RaftKv2<EK, ER>>;
+type LocalServer<EK, ER> = Server<resolve::PdStoreAddrResolver, LocalRaftKv<EK, ER>>;
+type LocalRaftKv<EK, ER> = RaftKv<EK, ServerRaftStoreRouter<EK, ER>>;
 
 impl<ER> TikvServer<ER>
 where
@@ -253,6 +290,30 @@ where
         );
         let pd_client =
             Self::connect_to_pd_cluster(&mut config, env.clone(), Arc::clone(&security_mgr));
+        // check if TiKV need to run in snapshot recovery mode
+        let is_recovering_marked = match pd_client.is_recovering_marked() {
+            Err(e) => {
+                warn!(
+                    "failed to get recovery mode from PD";
+                    "error" => ?e,
+                );
+                false
+            }
+            Ok(marked) => marked,
+        };
+
+        if is_recovering_marked {
+            // Run a TiKV server in recovery modeß
+            info!("TiKV running in Snapshot Recovery Mode");
+            snap_recovery::init_cluster::enter_snap_recovery_mode(&mut config);
+            // connect_to_pd_cluster retreived the cluster id from pd
+            let cluster_id = config.server.cluster_id;
+            snap_recovery::init_cluster::start_recovery(
+                config.clone(),
+                cluster_id,
+                pd_client.clone(),
+            );
+        }
 
         // Initialize and check config
         let cfg_controller = Self::init_config(config);
@@ -260,10 +321,19 @@ where
 
         let store_path = Path::new(&config.storage.data_dir).to_owned();
 
+        // Initialize raftstore channels.
+        let (router, system) = fsm::create_raft_batch_system(&config.raft_store);
+
         let thread_count = config.server.background_thread_count;
         let background_worker = WorkerBuilder::new("background")
             .thread_count(thread_count)
             .create();
+
+        let mut coprocessor_host = Some(CoprocessorHost::new(
+            router.clone(),
+            config.coprocessor.clone(),
+        ));
+        let region_info_accessor = RegionInfoAccessor::new(coprocessor_host.as_mut().unwrap());
 
         // Initialize concurrency manager
         let latest_ts = block_on(pd_client.get_tso()).expect("failed to get timestamp from PD");
@@ -297,12 +367,17 @@ where
             info!("Causal timestamp provider startup.");
         }
 
+        // Run check leader in a dedicate thread, because it is time sensitive
+        // and crucial to TiCDC replication lag.
+        let check_leader_worker = WorkerBuilder::new("check_leader").thread_count(1).create();
+
         TikvServer {
             config,
             cfg_controller: Some(cfg_controller),
             security_mgr,
             pd_client,
-            node: None,
+            router,
+            system: Some(system),
             resolver: None,
             store_path,
             snap_mgr: None,
@@ -311,19 +386,21 @@ where
             kv_statistics: None,
             raft_statistics: None,
             servers: None,
-            region_info_accessor: None,
-            coprocessor_host: None,
+            region_info_accessor,
+            coprocessor_host,
             to_stop: vec![],
             lock_files: vec![],
             concurrency_manager,
             env,
             background_worker,
+            check_leader_worker,
             flow_info_sender: None,
             flow_info_receiver: None,
             sst_worker: None,
             quota_limiter,
             causal_ts_provider,
             tablet_registry: None,
+            br_snap_recovery_mode: is_recovering_marked,
         }
     }
 
@@ -558,44 +635,38 @@ where
         engine_rocks::FlowListener::new(tx)
     }
 
-    fn init_engines(&mut self, raft_engine: ER) {
-        let tablet_registry = self.tablet_registry.clone().unwrap();
-        let mut node = NodeV2::new(
-            &self.config.server,
-            self.pd_client.clone(),
-            None,
-            tablet_registry,
+    fn init_engines(&mut self, engines: Engines<RocksEngine, ER>) {
+        let store_meta = Arc::new(Mutex::new(StoreMeta::new(PENDING_MSG_CAP)));
+        let engine = RaftKv::new(
+            ServerRaftStoreRouter::new(
+                self.router.clone(),
+                LocalReader::new(
+                    engines.kv.clone(),
+                    StoreMetaDelegate::new(store_meta.clone(), engines.kv.clone()),
+                    self.router.clone(),
+                ),
+            ),
+            engines.kv.clone(),
+            self.region_info_accessor.region_leaders(),
         );
-        node.try_bootstrap_store(&self.config.raft_store, &raft_engine)
-            .unwrap_or_else(|e| fatal!("failed to bootstrap store: {:?}", e));
-        assert_ne!(node.id(), 0);
-
-        let router = node.router();
-        let mut coprocessor_host: CoprocessorHost<RocksEngine> = CoprocessorHost::new(
-            router.store_router().clone(),
-            self.config.coprocessor.clone(),
-        );
-        let region_info_accessor = RegionInfoAccessor::new(&mut coprocessor_host);
-
-        let engine = RaftKv2::new(router.clone(), region_info_accessor.region_leaders());
 
         self.engines = Some(TikvEngines {
-            raft_engine,
+            engines,
+            store_meta,
             engine,
         });
-        self.node = Some(node);
-        self.coprocessor_host = Some(coprocessor_host);
-        self.region_info_accessor = Some(region_info_accessor);
     }
 
-    fn init_gc_worker(&mut self) -> GcWorker<RaftKv2<RocksEngine, ER>> {
+    fn init_gc_worker(
+        &mut self,
+    ) -> GcWorker<RaftKv<RocksEngine, ServerRaftStoreRouter<RocksEngine, ER>>> {
         let engines = self.engines.as_ref().unwrap();
         let gc_worker = GcWorker::new(
             engines.engine.clone(),
             self.flow_info_sender.take().unwrap(),
             self.config.gc.clone(),
             self.pd_client.feature_gate().clone(),
-            Arc::new(self.region_info_accessor.clone().unwrap()),
+            Arc::new(self.region_info_accessor.clone()),
         );
 
         let cfg_controller = self.cfg_controller.as_mut().unwrap();
@@ -608,13 +679,13 @@ where
     }
 
     fn init_servers<F: KvFormat>(&mut self) -> Arc<VersionTrack<ServerConfig>> {
-        let flow_controller = Arc::new(FlowController::Tablet(TabletFlowController::new(
+        let flow_controller = Arc::new(FlowController::Singleton(EngineFlowController::new(
             &self.config.storage.flow_control,
-            self.tablet_registry.clone().unwrap(),
+            self.engines.as_ref().unwrap().engine.kv_engine().unwrap(),
             self.flow_info_receiver.take().unwrap(),
         )));
         let mut gc_worker = self.init_gc_worker();
-        let ttl_checker = Box::new(LazyWorker::new("ttl-checker"));
+        let mut ttl_checker = Box::new(LazyWorker::new("ttl-checker"));
         let ttl_scheduler = ttl_checker.scheduler();
 
         let cfg_controller = self.cfg_controller.as_mut().unwrap();
@@ -628,6 +699,17 @@ where
 
         cfg_controller.register(tikv::config::Module::Log, Box::new(LogConfigManager));
 
+        // Create cdc.
+        let mut cdc_worker = Box::new(LazyWorker::new("cdc"));
+        let cdc_scheduler = cdc_worker.scheduler();
+        let txn_extra_scheduler = cdc::CdcTxnExtraScheduler::new(cdc_scheduler.clone());
+
+        self.engines
+            .as_mut()
+            .unwrap()
+            .engine
+            .set_txn_extra_scheduler(Arc::new(txn_extra_scheduler));
+
         let lock_mgr = LockManager::new(&self.config.pessimistic_txn);
         cfg_controller.register(
             tikv::config::Module::PessimisticTxn,
@@ -638,7 +720,17 @@ where
         let engines = self.engines.as_ref().unwrap();
 
         let pd_worker = LazyWorker::new("pd-worker");
-        let pd_sender = raftstore_v2::FlowReporter::new(pd_worker.scheduler());
+        let pd_sender = pd_worker.scheduler();
+
+        if let Some(sst_worker) = &mut self.sst_worker {
+            let sst_runner = RecoveryRunner::new(
+                engines.engines.kv.clone(),
+                engines.store_meta.clone(),
+                self.config.storage.background_error_recovery_window.into(),
+                DEFAULT_CHECK_INTERVAL,
+            );
+            sst_worker.start_with_timer(sst_runner);
+        }
 
         let unified_read_pool = if self.config.readpool.is_unified_pool_enabled() {
             Some(build_yatp_read_pool(
@@ -672,15 +764,16 @@ where
         let (reporter_notifier, data_sink_reg_handle, reporter_worker) =
             resource_metering::init_reporter(
                 self.config.resource_metering.clone(),
-                collector_reg_handle,
+                collector_reg_handle.clone(),
             );
         self.to_stop.push(reporter_worker);
         let (address_change_notifier, single_target_worker) = resource_metering::init_single_target(
             self.config.resource_metering.receiver_address.clone(),
             self.env.clone(),
-            data_sink_reg_handle,
+            data_sink_reg_handle.clone(),
         );
         self.to_stop.push(single_target_worker);
+        let rsmeter_pubsub_service = resource_metering::PubSubService::new(data_sink_reg_handle);
 
         let cfg_manager = resource_metering::ConfigManager::new(
             self.config.resource_metering.clone(),
@@ -742,12 +835,25 @@ where
         // Create snapshot manager, server.
         let snap_path = self
             .store_path
-            .join(Path::new("tablet_snap"))
+            .join(Path::new("snap"))
             .to_str()
             .unwrap()
             .to_owned();
 
-        let snap_mgr = TabletSnapManager::new(snap_path);
+        let bps = i64::try_from(self.config.server.snap_max_write_bytes_per_sec.0)
+            .unwrap_or_else(|_| fatal!("snap_max_write_bytes_per_sec > i64::max_value"));
+
+        let snap_mgr = SnapManagerBuilder::default()
+            .max_write_bytes_per_sec(bps)
+            .max_total_size(self.config.server.snap_max_total_size.0)
+            .encryption_key_manager(self.encryption_key_manager.clone())
+            .max_per_file_size(self.config.raft_store.max_snapshot_file_raw_size.0)
+            .enable_multi_snapshot_files(
+                self.pd_client
+                    .feature_gate()
+                    .can_enable(MULTI_FILES_SNAPSHOT_FEATURE),
+            )
+            .build(snap_path);
 
         // Create coprocessor endpoint.
         let cop_read_pool_handle = if self.config.readpool.coprocessor.use_unified_pool() {
@@ -761,6 +867,57 @@ where
             cop_read_pools.handle()
         };
 
+        let mut unified_read_pool_scale_receiver = None;
+        if self.config.readpool.is_unified_pool_enabled() {
+            let (unified_read_pool_scale_notifier, rx) = mpsc::sync_channel(10);
+            cfg_controller.register(
+                tikv::config::Module::Readpool,
+                Box::new(ReadPoolConfigManager::new(
+                    unified_read_pool.as_ref().unwrap().handle(),
+                    unified_read_pool_scale_notifier,
+                    &self.background_worker,
+                    self.config.readpool.unified.max_thread_count,
+                    self.config.readpool.unified.auto_adjust_pool_size,
+                )),
+            );
+            unified_read_pool_scale_receiver = Some(rx);
+        }
+
+        // Register cdc.
+        let cdc_ob = cdc::CdcObserver::new(cdc_scheduler.clone());
+        cdc_ob.register_to(self.coprocessor_host.as_mut().unwrap());
+        // Register cdc config manager.
+        cfg_controller.register(
+            tikv::config::Module::Cdc,
+            Box::new(CdcConfigManager(cdc_worker.scheduler())),
+        );
+
+        // Create resolved ts worker
+        let rts_worker = if self.config.resolved_ts.enable {
+            let worker = Box::new(LazyWorker::new("resolved-ts"));
+            // Register the resolved ts observer
+            let resolved_ts_ob = resolved_ts::Observer::new(worker.scheduler());
+            resolved_ts_ob.register_to(self.coprocessor_host.as_mut().unwrap());
+            // Register config manager for resolved ts worker
+            cfg_controller.register(
+                tikv::config::Module::ResolvedTs,
+                Box::new(resolved_ts::ResolvedTsConfigManager::new(
+                    worker.scheduler(),
+                )),
+            );
+            Some(worker)
+        } else {
+            None
+        };
+
+        let check_leader_runner = CheckLeaderRunner::new(
+            engines.store_meta.clone(),
+            self.coprocessor_host.clone().unwrap(),
+        );
+        let check_leader_scheduler = self
+            .check_leader_worker
+            .start("check-leader", check_leader_runner);
+
         let server_config = Arc::new(VersionTrack::new(self.config.server.clone()));
 
         self.config
@@ -773,8 +930,19 @@ where
             .unwrap_or_else(|e| fatal!("failed to validate raftstore config {}", e));
         let raft_store = Arc::new(VersionTrack::new(self.config.raft_store.clone()));
         let health_service = HealthService::default();
-
-        let node = self.node.as_ref().unwrap();
+        let mut node = Node::new(
+            self.system.take().unwrap(),
+            &server_config.value().clone(),
+            raft_store.clone(),
+            self.config.storage.api_version(),
+            self.pd_client.clone(),
+            state,
+            self.background_worker.clone(),
+            Some(health_service.clone()),
+            None,
+        );
+        node.try_bootstrap_store(engines.engines.clone())
+            .unwrap_or_else(|e| fatal!("failed to bootstrap node id: {}", e));
 
         self.snap_mgr = Some(snap_mgr.clone());
         // Create server
@@ -792,9 +960,9 @@ where
             ),
             coprocessor_v2::Endpoint::new(&self.config.coprocessor_v2),
             self.resolver.clone().unwrap(),
-            Either::Right(snap_mgr.clone()),
+            Either::Left(snap_mgr.clone()),
             gc_worker.clone(),
-            None,
+            Some(check_leader_scheduler),
             self.env.clone(),
             unified_read_pool,
             debug_thread_pool,
@@ -810,9 +978,101 @@ where
             )),
         );
 
+        // Start backup stream
+        let backup_stream_scheduler = if self.config.backup_stream.enable {
+            // Create backup stream.
+            let mut backup_stream_worker = Box::new(LazyWorker::new("backup-stream"));
+            let backup_stream_scheduler = backup_stream_worker.scheduler();
+
+            // Register backup-stream observer.
+            let backup_stream_ob = BackupStreamObserver::new(backup_stream_scheduler.clone());
+            backup_stream_ob.register_to(self.coprocessor_host.as_mut().unwrap());
+            // Register config manager.
+            cfg_controller.register(
+                tikv::config::Module::BackupStream,
+                Box::new(BackupStreamConfigManager(backup_stream_worker.scheduler())),
+            );
+
+            let etcd_cli = LazyEtcdClient::new(
+                self.config.pd.endpoints.as_slice(),
+                ConnectionConfig {
+                    keep_alive_interval: self.config.server.grpc_keepalive_time.0,
+                    keep_alive_timeout: self.config.server.grpc_keepalive_timeout.0,
+                    tls: self
+                        .security_mgr
+                        .client_suite()
+                        .map_err(|err| {
+                            warn!("Failed to load client TLS suite, ignoring TLS config."; "err" => %err);
+                        })
+                        .ok(),
+                },
+            );
+            let backup_stream_endpoint = backup_stream::Endpoint::new(
+                node.id(),
+                etcd_cli,
+                self.config.backup_stream.clone(),
+                backup_stream_scheduler.clone(),
+                backup_stream_ob,
+                self.region_info_accessor.clone(),
+                self.router.clone(),
+                self.pd_client.clone(),
+                self.concurrency_manager.clone(),
+            );
+            backup_stream_worker.start(backup_stream_endpoint);
+            self.to_stop.push(backup_stream_worker);
+            Some(backup_stream_scheduler)
+        } else {
+            None
+        };
+
+        let import_path = self.store_path.join("import");
+        let mut importer = SstImporter::new(
+            &self.config.import,
+            import_path,
+            self.encryption_key_manager.clone(),
+            self.config.storage.api_version(),
+        )
+        .unwrap();
+        for (cf_name, compression_type) in &[
+            (
+                CF_DEFAULT,
+                self.config.rocksdb.defaultcf.bottommost_level_compression,
+            ),
+            (
+                CF_WRITE,
+                self.config.rocksdb.writecf.bottommost_level_compression,
+            ),
+        ] {
+            importer.set_compression_type(cf_name, from_rocks_compression_type(*compression_type));
+        }
+        let importer = Arc::new(importer);
+
+        let split_check_runner = SplitCheckRunner::new(
+            engines.engines.kv.clone(),
+            self.router.clone(),
+            self.coprocessor_host.clone().unwrap(),
+        );
+        let split_check_scheduler = self
+            .background_worker
+            .start("split-check", split_check_runner);
+        cfg_controller.register(
+            tikv::config::Module::Coprocessor,
+            Box::new(SplitCheckConfigManager(split_check_scheduler.clone())),
+        );
+
         let split_config_manager =
             SplitConfigManager::new(Arc::new(VersionTrack::new(self.config.split.clone())));
-        cfg_controller.register(tikv::config::Module::Split, Box::new(split_config_manager));
+        cfg_controller.register(
+            tikv::config::Module::Split,
+            Box::new(split_config_manager.clone()),
+        );
+
+        let auto_split_controller = AutoSplitController::new(
+            split_config_manager,
+            self.config.server.grpc_concurrency,
+            self.config.readpool.unified.max_thread_count,
+            unified_read_pool_scale_receiver,
+        );
 
         // `ConsistencyCheckObserver` must be registered before `Node::start`.
         let safe_point = Arc::new(AtomicU64::new(0));
@@ -830,47 +1090,142 @@ where
             .registry
             .register_consistency_check_observer(100, observer);
 
-        self.node
-            .as_mut()
-            .unwrap()
-            .start(
-                engines.raft_engine.clone(),
-                server.transport(),
-                snap_mgr,
-                self.concurrency_manager.clone(),
-                self.causal_ts_provider.clone(),
-                self.coprocessor_host.clone().unwrap(),
-                self.background_worker.clone(),
-                pd_worker,
-                raft_store,
-                &state,
-            )
-            .unwrap_or_else(|e| fatal!("failed to start node: {}", e));
+        node.start(
+            engines.engines.clone(),
+            server.transport(),
+            snap_mgr,
+            pd_worker,
+            engines.store_meta.clone(),
+            self.coprocessor_host.clone().unwrap(),
+            importer.clone(),
+            split_check_scheduler,
+            auto_split_controller,
+            self.concurrency_manager.clone(),
+            collector_reg_handle,
+            self.causal_ts_provider.clone(),
+        )
+        .unwrap_or_else(|e| fatal!("failed to start node: {}", e));
 
         // Start auto gc. Must after `Node::start` because `node_id` is initialized
         // there.
-        let store_id = self.node.as_ref().unwrap().id();
+        assert!(node.id() > 0); // Node id should never be 0.
         let auto_gc_config = AutoGcConfig::new(
             self.pd_client.clone(),
-            self.region_info_accessor.clone().unwrap(),
-            store_id,
+            self.region_info_accessor.clone(),
+            node.id(),
         );
         gc_worker
-            .start(store_id)
+            .start(node.id())
             .unwrap_or_else(|e| fatal!("failed to start gc worker: {}", e));
         if let Err(e) = gc_worker.start_auto_gc(auto_gc_config, safe_point) {
             fatal!("failed to start auto_gc on storage, error: {}", e);
         }
 
         initial_metric(&self.config.metric);
+        if self.config.storage.enable_ttl {
+            ttl_checker.start_with_timer(TtlChecker::new(
+                self.engines.as_ref().unwrap().engine.kv_engine().unwrap(),
+                self.region_info_accessor.clone(),
+                self.config.storage.ttl_check_poll_interval.into(),
+            ));
+            self.to_stop.push(ttl_checker);
+        }
 
-        self.servers = Some(Servers { lock_mgr, server });
+        // Start CDC.
+        let cdc_memory_quota = MemoryQuota::new(self.config.cdc.sink_memory_quota.0 as _);
+        let cdc_endpoint = cdc::Endpoint::new(
+            self.config.server.cluster_id,
+            &self.config.cdc,
+            self.config.storage.api_version(),
+            self.pd_client.clone(),
+            cdc_scheduler.clone(),
+            self.router.clone(),
+            self.engines.as_ref().unwrap().engines.kv.clone(),
+            cdc_ob,
+            engines.store_meta.clone(),
+            self.concurrency_manager.clone(),
+            server.env(),
+            self.security_mgr.clone(),
+            cdc_memory_quota.clone(),
+            self.causal_ts_provider.clone(),
+        );
+        cdc_worker.start_with_timer(cdc_endpoint);
+        self.to_stop.push(cdc_worker);
+
+        // Start resolved ts
+        if let Some(mut rts_worker) = rts_worker {
+            let rts_endpoint = resolved_ts::Endpoint::new(
+                &self.config.resolved_ts,
+                rts_worker.scheduler(),
+                self.router.clone(),
+                engines.store_meta.clone(),
+                self.pd_client.clone(),
+                self.concurrency_manager.clone(),
+                server.env(),
+                self.security_mgr.clone(),
+            );
+            rts_worker.start_with_timer(rts_endpoint);
+            self.to_stop.push(rts_worker);
+        }
+
+        cfg_controller.register(
+            tikv::config::Module::Raftstore,
+            Box::new(RaftstoreConfigManager::new(
+                node.refresh_config_scheduler(),
+                raft_store,
+            )),
+        );
+
+        self.servers = Some(Servers {
+            lock_mgr,
+            server,
+            node,
+            importer,
+            cdc_scheduler,
+            cdc_memory_quota,
+            rsmeter_pubsub_service,
+            backup_stream_scheduler,
+        });
 
         server_config
     }
 
     fn register_services(&mut self) {
         let servers = self.servers.as_mut().unwrap();
+        let engines = self.engines.as_ref().unwrap();
+
+        // Import SST service.
+        let import_service = ImportSstService::new(
+            self.config.import.clone(),
+            self.config.raft_store.raft_entry_max_size,
+            self.router.clone(),
+            engines.engines.kv.clone(),
+            servers.importer.clone(),
+        );
+        if servers
+            .server
+            .register_service(create_import_sst(import_service))
+            .is_some()
+        {
+            fatal!("failed to register import service");
+        }
+
+        // Debug service.
+        let debug_service = DebugService::new(
+            engines.engines.clone(),
+            self.kv_statistics.clone(),
+            self.raft_statistics.clone(),
+            servers.server.get_debug_thread_pool().clone(),
+            engines.engine.raft_extension(),
+            self.cfg_controller.as_ref().unwrap().clone(),
+        );
+        if servers
+            .server
+            .register_service(create_debug(debug_service))
+            .is_some()
+        {
+            fatal!("failed to register debug service");
+        }
 
         // Create Diagnostics service
         let diag_service = DiagnosticsService::new(
@@ -898,13 +1253,90 @@ where
         servers
             .lock_mgr
             .start(
-                self.node.as_ref().unwrap().id(),
+                servers.node.id(),
                 self.pd_client.clone(),
                 self.resolver.clone().unwrap(),
                 self.security_mgr.clone(),
                 &self.config.pessimistic_txn,
             )
             .unwrap_or_else(|e| fatal!("failed to start lock manager: {}", e));
+
+        // Backup service.
+        let mut backup_worker = Box::new(self.background_worker.lazy_build("backup-endpoint"));
+        let backup_scheduler = backup_worker.scheduler();
+        let backup_service = backup::Service::<RocksEngine, RaftRouter<RocksEngine, ER>>::new(
+            backup_scheduler,
+            self.router.clone(),
+        );
+        if servers
+            .server
+            .register_service(create_backup(backup_service))
+            .is_some()
+        {
+            fatal!("failed to register backup service");
+        }
+
+        let backup_endpoint = backup::Endpoint::new(
+            servers.node.id(),
+            engines.engine.clone(),
+            self.region_info_accessor.clone(),
+            engines.engines.kv.clone(),
+            self.config.backup.clone(),
+            self.concurrency_manager.clone(),
+            self.config.storage.api_version(),
+            self.causal_ts_provider.clone(),
+        );
+        self.cfg_controller.as_mut().unwrap().register(
+            tikv::config::Module::Backup,
+            Box::new(backup_endpoint.get_config_manager()),
+        );
+        backup_worker.start(backup_endpoint);
+
+        let cdc_service = cdc::Service::new(
+            servers.cdc_scheduler.clone(),
+            servers.cdc_memory_quota.clone(),
+        );
+        if servers
+            .server
+            .register_service(create_change_data(cdc_service))
+            .is_some()
+        {
+            fatal!("failed to register cdc service");
+        }
+        if servers
+            .server
+            .register_service(create_resource_metering_pub_sub(
+                servers.rsmeter_pubsub_service.clone(),
+            ))
+            .is_some()
+        {
+            warn!("failed to register resource metering pubsub service");
+        }
+
+        if let Some(sched) = servers.backup_stream_scheduler.take() {
+            let pitr_service = backup_stream::Service::new(sched);
+            if servers
+                .server
+                .register_service(create_log_backup(pitr_service))
+                .is_some()
+            {
+                fatal!("failed to register log backup service");
+            }
+        }
+
+        // the present tikv in recovery mode, start recovery service
+        if self.br_snap_recovery_mode {
+            let recovery_service =
+                RecoveryService::new(engines.engines.clone(), self.router.clone());
+
+            if servers
+                .server
+                .register_service(create_recover_data(recovery_service))
+                .is_some()
+            {
+                fatal!("failed to register recovery service");
+            }
+        }
     }
 
     fn init_io_utility(&mut self) -> BytesFetcher {
@@ -938,7 +1370,7 @@ where
             self.tablet_registry.clone().unwrap(),
             self.kv_statistics.clone(),
             self.config.rocksdb.titan.enabled,
-            self.engines.as_ref().unwrap().raft_engine.clone(),
+            self.engines.as_ref().unwrap().engines.raft.clone(),
             self.raft_statistics.clone(),
         );
         let mut io_metrics = IoMetricsManager::new(fetcher);
@@ -1052,7 +1484,7 @@ where
         );
     }
 
-    fn init_storage_stats_task(&self) {
+    fn init_storage_stats_task(&self, engines: Engines<RocksEngine, ER>) {
         let config_disk_capacity: u64 = self.config.raft_store.capacity.0;
         let data_dir = self.config.storage.data_dir.clone();
         let store_path = self.store_path.clone();
@@ -1063,11 +1495,9 @@ where
             info!("disk space checker not enabled");
             return;
         }
-        let raft_engine = self.engines.as_ref().unwrap().raft_engine.clone();
-        let tablet_registry = self.tablet_registry.clone().unwrap();
-        let raft_path = raft_engine.get_engine_path().to_string();
+        let raft_path = engines.raft.get_engine_path().to_string();
         let separated_raft_mount_path =
-            path_in_diff_mount_point(raft_path.as_str(), tablet_registry.tablet_root());
+            path_in_diff_mount_point(raft_path.as_str(), engines.kv.path());
         let raft_almost_full_threshold = reserve_raft_space;
         let raft_already_full_threshold = reserve_raft_space / 2;
 
@@ -1096,17 +1526,15 @@ where
                     Ok(stats) => stats,
                 };
                 let disk_cap = disk_stats.total_space();
-                let snap_size = snap_mgr.total_snap_size().unwrap();
+                let snap_size = snap_mgr.get_total_snap_size().unwrap();
 
-                let mut kv_size = 0;
-                tablet_registry.for_each_opened_tablet(|_, cached| {
-                    if let Some(tablet) = cached.latest() {
-                        kv_size += tablet.get_engine_used_size().unwrap_or(0);
-                    }
-                    true
-                });
+                let kv_size = engines
+                    .kv
+                    .get_engine_used_size()
+                    .expect("get kv engine size");
 
-                let raft_size = raft_engine
+                let raft_size = engines
+                    .raft
                     .get_engine_size()
                     .expect("get raft engine size");
 
@@ -1240,7 +1668,7 @@ where
         }
     }
 
-    fn stop(mut self) {
+    fn stop(self) {
         tikv_util::thread_group::mark_shutdown();
         let mut servers = self.servers.unwrap();
         servers
@@ -1248,8 +1676,8 @@ where
             .stop()
             .unwrap_or_else(|e| fatal!("failed to stop server: {}", e));
 
-        self.node.as_mut().unwrap().stop();
-        self.region_info_accessor.as_mut().unwrap().stop();
+        servers.node.stop();
+        self.region_info_accessor.stop();
 
         servers.lock_mgr.stop();
 
@@ -1378,7 +1806,7 @@ impl<CER: ConfiguredRaftEngine> TikvServer<CER> {
     fn init_raw_engines(
         &mut self,
         flow_listener: engine_rocks::FlowListener,
-    ) -> (CER, Arc<EnginesResourceInfo>) {
+    ) -> (Engines<RocksEngine, CER>, Arc<EnginesResourceInfo>) {
         let block_cache = self.config.storage.block_cache.build_shared_cache();
         let env = self
             .config
@@ -1396,27 +1824,39 @@ impl<CER: ConfiguredRaftEngine> TikvServer<CER> {
 
         // Create kv engine.
         let builder = KvEngineFactoryBuilder::new(env, &self.config, block_cache)
+            .compaction_event_sender(Arc::new(RaftRouterCompactedEventSender {
+                router: Mutex::new(self.router.clone()),
+            }))
+            .region_info_accessor(self.region_info_accessor.clone())
             .sst_recovery_sender(self.init_sst_recovery_sender())
             .flow_listener(flow_listener);
         let factory = Box::new(builder.build());
+        let kv_engine = factory
+            .create_shared_db(&self.store_path)
+            .unwrap_or_else(|s| fatal!("failed to create kv engine: {}", s));
         self.kv_statistics = Some(factory.rocks_statistics());
-        let registry = TabletRegistry::new(factory, self.store_path.join("tablets"))
-            .unwrap_or_else(|e| fatal!("failed to create tablet registry {:?}", e));
+        let engines = Engines::new(kv_engine.clone(), raft_engine);
+
         let cfg_controller = self.cfg_controller.as_mut().unwrap();
         cfg_controller.register(
             tikv::config::Module::Rocksdb,
-            Box::new(DbConfigManger::new(registry.clone(), DbType::Kv)),
+            Box::new(DbConfigManger::new(kv_engine.clone(), DbType::Kv)),
         );
-        self.tablet_registry = Some(registry.clone());
-        raft_engine.register_config(cfg_controller);
+        let reg = TabletRegistry::new(Box::new(SingletonFactory::new(kv_engine)), &self.store_path)
+            .unwrap();
+        // It always use the singleton kv_engine, use arbitrary id and suffix.
+        let ctx = TabletContext::with_infinite_region(0, Some(0));
+        reg.load(ctx, false).unwrap();
+        self.tablet_registry = Some(reg.clone());
+        engines.raft.register_config(cfg_controller);
 
         let engines_info = Arc::new(EnginesResourceInfo::new(
-            registry,
-            raft_engine.as_rocks_engine().cloned(),
+            reg,
+            engines.raft.as_rocks_engine().cloned(),
             180, // max_samples_to_preserve
         ));
 
-        (raft_engine, engines_info)
+        (engines, engines_info)
     }
 }
 
@@ -1508,6 +1948,33 @@ fn get_lock_dir() -> String {
 #[cfg(not(unix))]
 fn get_lock_dir() -> String {
     "TIKV_LOCK_FILES".to_owned()
+}
+
+/// A small trait for components which can be trivially stopped. Lets us keep
+/// a list of these in `TiKV`, rather than storing each component individually.
+pub(crate) trait Stop {
+    fn stop(self: Box<Self>);
+}
+
+impl<R> Stop for StatusServer<R>
+where
+    R: 'static + Send,
+{
+    fn stop(self: Box<Self>) {
+        (*self).stop()
+    }
+}
+
+impl Stop for Worker {
+    fn stop(self: Box<Self>) {
+        Worker::stop(&self);
+    }
+}
+
+impl<T: fmt::Display + Send + 'static> Stop for LazyWorker<T> {
+    fn stop(self: Box<Self>) {
+        self.stop_worker();
+    }
 }
 
 pub struct EngineMetricsManager<EK: KvEngine, ER: RaftEngine> {

--- a/components/server/src/server2.rs
+++ b/components/server/src/server2.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
 //! This module startups all the components of a TiKV server.
 //!
@@ -14,39 +14,30 @@
 use std::{
     cmp,
     collections::HashMap,
-    convert::TryFrom,
-    env, fmt,
+    env,
     net::SocketAddr,
     path::{Path, PathBuf},
     str::FromStr,
     sync::{
         atomic::{AtomicU32, AtomicU64, Ordering},
-        mpsc, Arc, Mutex,
+        mpsc, Arc,
     },
     time::Duration,
     u64,
 };
 
 use api_version::{dispatch_api_version, KvFormat};
-use backup_stream::{
-    config::BackupStreamConfigManager,
-    metadata::{ConnectionConfig, LazyEtcdClient},
-    observer::BackupStreamObserver,
-};
 use causal_ts::CausalTsProviderImpl;
-use cdc::{CdcConfigManager, MemoryQuota};
 use concurrency_manager::ConcurrencyManager;
 use encryption_export::{data_key_manager_from_config, DataKeyManager};
 use engine_rocks::{
-    flush_engine_statistics, from_rocks_compression_type,
+    flush_engine_statistics,
     raw::{Cache, Env},
     FlowInfo, RocksEngine, RocksStatistics,
 };
-use engine_rocks_helper::sst_recovery::{RecoveryRunner, DEFAULT_CHECK_INTERVAL};
 use engine_traits::{
     CachedTablet, CfOptions, CfOptionsExt, Engines, FlowControlFactorsExt, KvEngine, MiscExt,
-    RaftEngine, SingletonFactory, StatisticsReporter, TabletContext, TabletRegistry, CF_DEFAULT,
-    CF_LOCK, CF_WRITE,
+    RaftEngine, StatisticsReporter, TabletRegistry, CF_DEFAULT, CF_LOCK, CF_WRITE,
 };
 use error_code::ErrorCodeExt;
 use file_system::{
@@ -56,57 +47,39 @@ use file_system::{
 use futures::executor::block_on;
 use grpcio::{EnvBuilder, Environment};
 use grpcio_health::HealthService;
-use kvproto::{
-    brpb::create_backup, cdcpb::create_change_data, deadlock::create_deadlock,
-    debugpb::create_debug, diagnosticspb::create_diagnostics, import_sstpb::create_import_sst,
-    kvrpcpb::ApiVersion, logbackuppb::create_log_backup, recoverdatapb::create_recover_data,
-    resource_usage_agent::create_resource_metering_pub_sub,
-};
+use kvproto::{deadlock::create_deadlock, diagnosticspb::create_diagnostics, kvrpcpb::ApiVersion};
 use pd_client::{PdClient, RpcClient};
 use raft_log_engine::RaftLogEngine;
 use raftstore::{
     coprocessor::{
-        config::SplitCheckConfigManager, BoxConsistencyCheckObserver, ConsistencyCheckMethod,
-        CoprocessorHost, RawConsistencyCheckObserver, RegionInfoAccessor,
+        BoxConsistencyCheckObserver, ConsistencyCheckMethod, CoprocessorHost,
+        RawConsistencyCheckObserver,
     },
-    router::ServerRaftStoreRouter,
-    store::{
-        config::RaftstoreConfigManager,
-        fsm,
-        fsm::store::{
-            RaftBatchSystem, RaftRouter, StoreMeta, MULTI_FILES_SNAPSHOT_FEATURE, PENDING_MSG_CAP,
-        },
-        memory::MEMTRACE_ROOT as MEMTRACE_RAFTSTORE,
-        AutoSplitController, CheckLeaderRunner, LocalReader, SnapManager, SnapManagerBuilder,
-        SplitCheckRunner, SplitConfigManager, StoreMetaDelegate,
-    },
-    RaftRouterCompactedEventSender,
+    store::{memory::MEMTRACE_ROOT as MEMTRACE_RAFTSTORE, SplitConfigManager, TabletSnapManager},
+    RegionInfoAccessor,
 };
 use security::SecurityManager;
-use snap_recovery::RecoveryService;
 use tikv::{
     config::{ConfigController, DbConfigManger, DbType, LogConfigManager, TikvConfig},
     coprocessor::{self, MEMTRACE_ROOT as MEMTRACE_COPROCESSOR},
     coprocessor_v2,
-    import::{ImportSstService, SstImporter},
-    read_pool::{build_yatp_read_pool, ReadPool, ReadPoolConfigManager},
+    read_pool::{build_yatp_read_pool, ReadPool},
     server::{
         config::{Config as ServerConfig, ServerConfigManager},
         gc_worker::{AutoGcConfig, GcWorker},
         lock_manager::LockManager,
         raftkv::ReplicaReadLockChecker,
         resolve,
-        service::{DebugService, DiagnosticsService},
+        service::DiagnosticsService,
         status_server::StatusServer,
-        ttl::TtlChecker,
-        KvEngineFactoryBuilder, Node, RaftKv, Server, CPU_CORES_QUOTA_GAUGE, DEFAULT_CLUSTER_ID,
+        KvEngineFactoryBuilder, NodeV2, RaftKv2, Server, CPU_CORES_QUOTA_GAUGE, DEFAULT_CLUSTER_ID,
         GRPC_THREAD_PREFIX,
     },
     storage::{
         self,
         config_manager::StorageConfigManger,
         mvcc::MvccConsistencyCheckObserver,
-        txn::flow_controller::{EngineFlowController, FlowController},
+        txn::flow_controller::{FlowController, TabletFlowController},
         Engine, Storage,
     },
 };
@@ -128,7 +101,7 @@ use tikv_util::{
 use tokio::runtime::Builder;
 
 use crate::{
-    memory::*, raft_engine_switch::*, setup::*, signal_handler,
+    memory::*, raft_engine_switch::*, server::Stop, setup::*, signal_handler,
     tikv_util::sys::thread::ThreadBuildWrapper,
 };
 
@@ -160,18 +133,19 @@ fn run_impl<CER: ConfiguredRaftEngine, F: KvFormat>(config: TikvConfig) {
     tikv.init_encryption();
     let fetcher = tikv.init_io_utility();
     let listener = tikv.init_flow_receiver();
-    let (engines, engines_info) = tikv.init_raw_engines(listener);
-    tikv.init_engines(engines.clone());
+    let (raft_engine, engines_info) = tikv.init_raw_engines(listener);
+    tikv.init_engines(raft_engine);
     let server_config = tikv.init_servers::<F>();
     tikv.register_services();
     tikv.init_metrics_flusher(fetcher, engines_info);
-    tikv.init_storage_stats_task(engines);
+    tikv.init_storage_stats_task();
     tikv.run_server(server_config);
     tikv.run_status_server();
     tikv.init_quota_tuning_task(tikv.quota_limiter.clone());
 
+    // TODO: support signal dump stats
     signal_handler::wait_for_signal(
-        Some(tikv.engines.take().unwrap().engines),
+        None as Option<Engines<RocksEngine, CER>>,
         tikv.kv_statistics.clone(),
         tikv.raft_statistics.clone(),
     );
@@ -222,52 +196,41 @@ struct TikvServer<ER: RaftEngine> {
     cfg_controller: Option<ConfigController>,
     security_mgr: Arc<SecurityManager>,
     pd_client: Arc<RpcClient>,
-    router: RaftRouter<RocksEngine, ER>,
     flow_info_sender: Option<mpsc::Sender<FlowInfo>>,
     flow_info_receiver: Option<mpsc::Receiver<FlowInfo>>,
-    system: Option<RaftBatchSystem<RocksEngine, ER>>,
+    node: Option<NodeV2<RpcClient, RocksEngine, ER>>,
     resolver: Option<resolve::PdStoreAddrResolver>,
     store_path: PathBuf,
-    snap_mgr: Option<SnapManager>, // Will be filled in `init_servers`.
+    snap_mgr: Option<TabletSnapManager>, // Will be filled in `init_servers`.
     encryption_key_manager: Option<Arc<DataKeyManager>>,
     engines: Option<TikvEngines<RocksEngine, ER>>,
     kv_statistics: Option<Arc<RocksStatistics>>,
     raft_statistics: Option<Arc<RocksStatistics>>,
     servers: Option<Servers<RocksEngine, ER>>,
-    region_info_accessor: RegionInfoAccessor,
+    region_info_accessor: Option<RegionInfoAccessor>,
     coprocessor_host: Option<CoprocessorHost<RocksEngine>>,
     to_stop: Vec<Box<dyn Stop>>,
     lock_files: Vec<File>,
     concurrency_manager: ConcurrencyManager,
     env: Arc<Environment>,
     background_worker: Worker,
-    check_leader_worker: Worker,
     sst_worker: Option<Box<LazyWorker<String>>>,
     quota_limiter: Arc<QuotaLimiter>,
     causal_ts_provider: Option<Arc<CausalTsProviderImpl>>, // used for rawkv apiv2
     tablet_registry: Option<TabletRegistry<RocksEngine>>,
-    br_snap_recovery_mode: bool, // use for br snapshot recovery
 }
 
 struct TikvEngines<EK: KvEngine, ER: RaftEngine> {
-    engines: Engines<EK, ER>,
-    store_meta: Arc<Mutex<StoreMeta>>,
-    engine: RaftKv<EK, ServerRaftStoreRouter<EK, ER>>,
+    raft_engine: ER,
+    engine: RaftKv2<EK, ER>,
 }
 
 struct Servers<EK: KvEngine, ER: RaftEngine> {
     lock_mgr: LockManager,
     server: LocalServer<EK, ER>,
-    node: Node<RpcClient, EK, ER>,
-    importer: Arc<SstImporter>,
-    cdc_scheduler: tikv_util::worker::Scheduler<cdc::Task>,
-    cdc_memory_quota: MemoryQuota,
-    rsmeter_pubsub_service: resource_metering::PubSubService,
-    backup_stream_scheduler: Option<tikv_util::worker::Scheduler<backup_stream::Task>>,
 }
 
-type LocalServer<EK, ER> = Server<resolve::PdStoreAddrResolver, LocalRaftKv<EK, ER>>;
-type LocalRaftKv<EK, ER> = RaftKv<EK, ServerRaftStoreRouter<EK, ER>>;
+type LocalServer<EK, ER> = Server<resolve::PdStoreAddrResolver, RaftKv2<EK, ER>>;
 
 impl<ER> TikvServer<ER>
 where
@@ -290,30 +253,6 @@ where
         );
         let pd_client =
             Self::connect_to_pd_cluster(&mut config, env.clone(), Arc::clone(&security_mgr));
-        // check if TiKV need to run in snapshot recovery mode
-        let is_recovering_marked = match pd_client.is_recovering_marked() {
-            Err(e) => {
-                warn!(
-                    "failed to get recovery mode from PD";
-                    "error" => ?e,
-                );
-                false
-            }
-            Ok(marked) => marked,
-        };
-
-        if is_recovering_marked {
-            // Run a TiKV server in recovery modeß
-            info!("TiKV running in Snapshot Recovery Mode");
-            snap_recovery::init_cluster::enter_snap_recovery_mode(&mut config);
-            // connect_to_pd_cluster retreived the cluster id from pd
-            let cluster_id = config.server.cluster_id;
-            snap_recovery::init_cluster::start_recovery(
-                config.clone(),
-                cluster_id,
-                pd_client.clone(),
-            );
-        }
 
         // Initialize and check config
         let cfg_controller = Self::init_config(config);
@@ -321,19 +260,10 @@ where
 
         let store_path = Path::new(&config.storage.data_dir).to_owned();
 
-        // Initialize raftstore channels.
-        let (router, system) = fsm::create_raft_batch_system(&config.raft_store);
-
         let thread_count = config.server.background_thread_count;
         let background_worker = WorkerBuilder::new("background")
             .thread_count(thread_count)
             .create();
-
-        let mut coprocessor_host = Some(CoprocessorHost::new(
-            router.clone(),
-            config.coprocessor.clone(),
-        ));
-        let region_info_accessor = RegionInfoAccessor::new(coprocessor_host.as_mut().unwrap());
 
         // Initialize concurrency manager
         let latest_ts = block_on(pd_client.get_tso()).expect("failed to get timestamp from PD");
@@ -367,17 +297,12 @@ where
             info!("Causal timestamp provider startup.");
         }
 
-        // Run check leader in a dedicate thread, because it is time sensitive
-        // and crucial to TiCDC replication lag.
-        let check_leader_worker = WorkerBuilder::new("check_leader").thread_count(1).create();
-
         TikvServer {
             config,
             cfg_controller: Some(cfg_controller),
             security_mgr,
             pd_client,
-            router,
-            system: Some(system),
+            node: None,
             resolver: None,
             store_path,
             snap_mgr: None,
@@ -386,21 +311,19 @@ where
             kv_statistics: None,
             raft_statistics: None,
             servers: None,
-            region_info_accessor,
-            coprocessor_host,
+            region_info_accessor: None,
+            coprocessor_host: None,
             to_stop: vec![],
             lock_files: vec![],
             concurrency_manager,
             env,
             background_worker,
-            check_leader_worker,
             flow_info_sender: None,
             flow_info_receiver: None,
             sst_worker: None,
             quota_limiter,
             causal_ts_provider,
             tablet_registry: None,
-            br_snap_recovery_mode: is_recovering_marked,
         }
     }
 
@@ -635,38 +558,44 @@ where
         engine_rocks::FlowListener::new(tx)
     }
 
-    fn init_engines(&mut self, engines: Engines<RocksEngine, ER>) {
-        let store_meta = Arc::new(Mutex::new(StoreMeta::new(PENDING_MSG_CAP)));
-        let engine = RaftKv::new(
-            ServerRaftStoreRouter::new(
-                self.router.clone(),
-                LocalReader::new(
-                    engines.kv.clone(),
-                    StoreMetaDelegate::new(store_meta.clone(), engines.kv.clone()),
-                    self.router.clone(),
-                ),
-            ),
-            engines.kv.clone(),
-            self.region_info_accessor.region_leaders(),
+    fn init_engines(&mut self, raft_engine: ER) {
+        let tablet_registry = self.tablet_registry.clone().unwrap();
+        let mut node = NodeV2::new(
+            &self.config.server,
+            self.pd_client.clone(),
+            None,
+            tablet_registry,
         );
+        node.try_bootstrap_store(&self.config.raft_store, &raft_engine)
+            .unwrap_or_else(|e| fatal!("failed to bootstrap store: {:?}", e));
+        assert_ne!(node.id(), 0);
+
+        let router = node.router();
+        let mut coprocessor_host: CoprocessorHost<RocksEngine> = CoprocessorHost::new(
+            router.store_router().clone(),
+            self.config.coprocessor.clone(),
+        );
+        let region_info_accessor = RegionInfoAccessor::new(&mut coprocessor_host);
+
+        let engine = RaftKv2::new(router.clone(), region_info_accessor.region_leaders());
 
         self.engines = Some(TikvEngines {
-            engines,
-            store_meta,
+            raft_engine,
             engine,
         });
+        self.node = Some(node);
+        self.coprocessor_host = Some(coprocessor_host);
+        self.region_info_accessor = Some(region_info_accessor);
     }
 
-    fn init_gc_worker(
-        &mut self,
-    ) -> GcWorker<RaftKv<RocksEngine, ServerRaftStoreRouter<RocksEngine, ER>>> {
+    fn init_gc_worker(&mut self) -> GcWorker<RaftKv2<RocksEngine, ER>> {
         let engines = self.engines.as_ref().unwrap();
         let gc_worker = GcWorker::new(
             engines.engine.clone(),
             self.flow_info_sender.take().unwrap(),
             self.config.gc.clone(),
             self.pd_client.feature_gate().clone(),
-            Arc::new(self.region_info_accessor.clone()),
+            Arc::new(self.region_info_accessor.clone().unwrap()),
         );
 
         let cfg_controller = self.cfg_controller.as_mut().unwrap();
@@ -679,13 +608,13 @@ where
     }
 
     fn init_servers<F: KvFormat>(&mut self) -> Arc<VersionTrack<ServerConfig>> {
-        let flow_controller = Arc::new(FlowController::Singleton(EngineFlowController::new(
+        let flow_controller = Arc::new(FlowController::Tablet(TabletFlowController::new(
             &self.config.storage.flow_control,
-            self.engines.as_ref().unwrap().engine.kv_engine().unwrap(),
+            self.tablet_registry.clone().unwrap(),
             self.flow_info_receiver.take().unwrap(),
         )));
         let mut gc_worker = self.init_gc_worker();
-        let mut ttl_checker = Box::new(LazyWorker::new("ttl-checker"));
+        let ttl_checker = Box::new(LazyWorker::new("ttl-checker"));
         let ttl_scheduler = ttl_checker.scheduler();
 
         let cfg_controller = self.cfg_controller.as_mut().unwrap();
@@ -699,17 +628,6 @@ where
 
         cfg_controller.register(tikv::config::Module::Log, Box::new(LogConfigManager));
 
-        // Create cdc.
-        let mut cdc_worker = Box::new(LazyWorker::new("cdc"));
-        let cdc_scheduler = cdc_worker.scheduler();
-        let txn_extra_scheduler = cdc::CdcTxnExtraScheduler::new(cdc_scheduler.clone());
-
-        self.engines
-            .as_mut()
-            .unwrap()
-            .engine
-            .set_txn_extra_scheduler(Arc::new(txn_extra_scheduler));
-
         let lock_mgr = LockManager::new(&self.config.pessimistic_txn);
         cfg_controller.register(
             tikv::config::Module::PessimisticTxn,
@@ -720,17 +638,7 @@ where
         let engines = self.engines.as_ref().unwrap();
 
         let pd_worker = LazyWorker::new("pd-worker");
-        let pd_sender = pd_worker.scheduler();
-
-        if let Some(sst_worker) = &mut self.sst_worker {
-            let sst_runner = RecoveryRunner::new(
-                engines.engines.kv.clone(),
-                engines.store_meta.clone(),
-                self.config.storage.background_error_recovery_window.into(),
-                DEFAULT_CHECK_INTERVAL,
-            );
-            sst_worker.start_with_timer(sst_runner);
-        }
+        let pd_sender = raftstore_v2::FlowReporter::new(pd_worker.scheduler());
 
         let unified_read_pool = if self.config.readpool.is_unified_pool_enabled() {
             Some(build_yatp_read_pool(
@@ -764,16 +672,15 @@ where
         let (reporter_notifier, data_sink_reg_handle, reporter_worker) =
             resource_metering::init_reporter(
                 self.config.resource_metering.clone(),
-                collector_reg_handle.clone(),
+                collector_reg_handle,
             );
         self.to_stop.push(reporter_worker);
         let (address_change_notifier, single_target_worker) = resource_metering::init_single_target(
             self.config.resource_metering.receiver_address.clone(),
             self.env.clone(),
-            data_sink_reg_handle.clone(),
+            data_sink_reg_handle,
         );
         self.to_stop.push(single_target_worker);
-        let rsmeter_pubsub_service = resource_metering::PubSubService::new(data_sink_reg_handle);
 
         let cfg_manager = resource_metering::ConfigManager::new(
             self.config.resource_metering.clone(),
@@ -835,25 +742,12 @@ where
         // Create snapshot manager, server.
         let snap_path = self
             .store_path
-            .join(Path::new("snap"))
+            .join(Path::new("tablet_snap"))
             .to_str()
             .unwrap()
             .to_owned();
 
-        let bps = i64::try_from(self.config.server.snap_max_write_bytes_per_sec.0)
-            .unwrap_or_else(|_| fatal!("snap_max_write_bytes_per_sec > i64::max_value"));
-
-        let snap_mgr = SnapManagerBuilder::default()
-            .max_write_bytes_per_sec(bps)
-            .max_total_size(self.config.server.snap_max_total_size.0)
-            .encryption_key_manager(self.encryption_key_manager.clone())
-            .max_per_file_size(self.config.raft_store.max_snapshot_file_raw_size.0)
-            .enable_multi_snapshot_files(
-                self.pd_client
-                    .feature_gate()
-                    .can_enable(MULTI_FILES_SNAPSHOT_FEATURE),
-            )
-            .build(snap_path);
+        let snap_mgr = TabletSnapManager::new(snap_path);
 
         // Create coprocessor endpoint.
         let cop_read_pool_handle = if self.config.readpool.coprocessor.use_unified_pool() {
@@ -867,57 +761,6 @@ where
             cop_read_pools.handle()
         };
 
-        let mut unified_read_pool_scale_receiver = None;
-        if self.config.readpool.is_unified_pool_enabled() {
-            let (unified_read_pool_scale_notifier, rx) = mpsc::sync_channel(10);
-            cfg_controller.register(
-                tikv::config::Module::Readpool,
-                Box::new(ReadPoolConfigManager::new(
-                    unified_read_pool.as_ref().unwrap().handle(),
-                    unified_read_pool_scale_notifier,
-                    &self.background_worker,
-                    self.config.readpool.unified.max_thread_count,
-                    self.config.readpool.unified.auto_adjust_pool_size,
-                )),
-            );
-            unified_read_pool_scale_receiver = Some(rx);
-        }
-
-        // Register cdc.
-        let cdc_ob = cdc::CdcObserver::new(cdc_scheduler.clone());
-        cdc_ob.register_to(self.coprocessor_host.as_mut().unwrap());
-        // Register cdc config manager.
-        cfg_controller.register(
-            tikv::config::Module::Cdc,
-            Box::new(CdcConfigManager(cdc_worker.scheduler())),
-        );
-
-        // Create resolved ts worker
-        let rts_worker = if self.config.resolved_ts.enable {
-            let worker = Box::new(LazyWorker::new("resolved-ts"));
-            // Register the resolved ts observer
-            let resolved_ts_ob = resolved_ts::Observer::new(worker.scheduler());
-            resolved_ts_ob.register_to(self.coprocessor_host.as_mut().unwrap());
-            // Register config manager for resolved ts worker
-            cfg_controller.register(
-                tikv::config::Module::ResolvedTs,
-                Box::new(resolved_ts::ResolvedTsConfigManager::new(
-                    worker.scheduler(),
-                )),
-            );
-            Some(worker)
-        } else {
-            None
-        };
-
-        let check_leader_runner = CheckLeaderRunner::new(
-            engines.store_meta.clone(),
-            self.coprocessor_host.clone().unwrap(),
-        );
-        let check_leader_scheduler = self
-            .check_leader_worker
-            .start("check-leader", check_leader_runner);
-
         let server_config = Arc::new(VersionTrack::new(self.config.server.clone()));
 
         self.config
@@ -930,19 +773,8 @@ where
             .unwrap_or_else(|e| fatal!("failed to validate raftstore config {}", e));
         let raft_store = Arc::new(VersionTrack::new(self.config.raft_store.clone()));
         let health_service = HealthService::default();
-        let mut node = Node::new(
-            self.system.take().unwrap(),
-            &server_config.value().clone(),
-            raft_store.clone(),
-            self.config.storage.api_version(),
-            self.pd_client.clone(),
-            state,
-            self.background_worker.clone(),
-            Some(health_service.clone()),
-            None,
-        );
-        node.try_bootstrap_store(engines.engines.clone())
-            .unwrap_or_else(|e| fatal!("failed to bootstrap node id: {}", e));
+
+        let node = self.node.as_ref().unwrap();
 
         self.snap_mgr = Some(snap_mgr.clone());
         // Create server
@@ -960,9 +792,9 @@ where
             ),
             coprocessor_v2::Endpoint::new(&self.config.coprocessor_v2),
             self.resolver.clone().unwrap(),
-            Either::Left(snap_mgr.clone()),
+            Either::Right(snap_mgr.clone()),
             gc_worker.clone(),
-            Some(check_leader_scheduler),
+            None,
             self.env.clone(),
             unified_read_pool,
             debug_thread_pool,
@@ -978,101 +810,9 @@ where
             )),
         );
 
-        // Start backup stream
-        let backup_stream_scheduler = if self.config.backup_stream.enable {
-            // Create backup stream.
-            let mut backup_stream_worker = Box::new(LazyWorker::new("backup-stream"));
-            let backup_stream_scheduler = backup_stream_worker.scheduler();
-
-            // Register backup-stream observer.
-            let backup_stream_ob = BackupStreamObserver::new(backup_stream_scheduler.clone());
-            backup_stream_ob.register_to(self.coprocessor_host.as_mut().unwrap());
-            // Register config manager.
-            cfg_controller.register(
-                tikv::config::Module::BackupStream,
-                Box::new(BackupStreamConfigManager(backup_stream_worker.scheduler())),
-            );
-
-            let etcd_cli = LazyEtcdClient::new(
-                self.config.pd.endpoints.as_slice(),
-                ConnectionConfig {
-                    keep_alive_interval: self.config.server.grpc_keepalive_time.0,
-                    keep_alive_timeout: self.config.server.grpc_keepalive_timeout.0,
-                    tls: self
-                        .security_mgr
-                        .client_suite()
-                        .map_err(|err| {
-                            warn!("Failed to load client TLS suite, ignoring TLS config."; "err" => %err);
-                        })
-                        .ok(),
-                },
-            );
-            let backup_stream_endpoint = backup_stream::Endpoint::new(
-                node.id(),
-                etcd_cli,
-                self.config.backup_stream.clone(),
-                backup_stream_scheduler.clone(),
-                backup_stream_ob,
-                self.region_info_accessor.clone(),
-                self.router.clone(),
-                self.pd_client.clone(),
-                self.concurrency_manager.clone(),
-            );
-            backup_stream_worker.start(backup_stream_endpoint);
-            self.to_stop.push(backup_stream_worker);
-            Some(backup_stream_scheduler)
-        } else {
-            None
-        };
-
-        let import_path = self.store_path.join("import");
-        let mut importer = SstImporter::new(
-            &self.config.import,
-            import_path,
-            self.encryption_key_manager.clone(),
-            self.config.storage.api_version(),
-        )
-        .unwrap();
-        for (cf_name, compression_type) in &[
-            (
-                CF_DEFAULT,
-                self.config.rocksdb.defaultcf.bottommost_level_compression,
-            ),
-            (
-                CF_WRITE,
-                self.config.rocksdb.writecf.bottommost_level_compression,
-            ),
-        ] {
-            importer.set_compression_type(cf_name, from_rocks_compression_type(*compression_type));
-        }
-        let importer = Arc::new(importer);
-
-        let split_check_runner = SplitCheckRunner::new(
-            engines.engines.kv.clone(),
-            self.router.clone(),
-            self.coprocessor_host.clone().unwrap(),
-        );
-        let split_check_scheduler = self
-            .background_worker
-            .start("split-check", split_check_runner);
-        cfg_controller.register(
-            tikv::config::Module::Coprocessor,
-            Box::new(SplitCheckConfigManager(split_check_scheduler.clone())),
-        );
-
         let split_config_manager =
             SplitConfigManager::new(Arc::new(VersionTrack::new(self.config.split.clone())));
-        cfg_controller.register(
-            tikv::config::Module::Split,
-            Box::new(split_config_manager.clone()),
-        );
-
-        let auto_split_controller = AutoSplitController::new(
-            split_config_manager,
-            self.config.server.grpc_concurrency,
-            self.config.readpool.unified.max_thread_count,
-            unified_read_pool_scale_receiver,
-        );
+        cfg_controller.register(tikv::config::Module::Split, Box::new(split_config_manager));
 
         // `ConsistencyCheckObserver` must be registered before `Node::start`.
         let safe_point = Arc::new(AtomicU64::new(0));
@@ -1090,142 +830,47 @@ where
             .registry
             .register_consistency_check_observer(100, observer);
 
-        node.start(
-            engines.engines.clone(),
-            server.transport(),
-            snap_mgr,
-            pd_worker,
-            engines.store_meta.clone(),
-            self.coprocessor_host.clone().unwrap(),
-            importer.clone(),
-            split_check_scheduler,
-            auto_split_controller,
-            self.concurrency_manager.clone(),
-            collector_reg_handle,
-            self.causal_ts_provider.clone(),
-        )
-        .unwrap_or_else(|e| fatal!("failed to start node: {}", e));
+        self.node
+            .as_mut()
+            .unwrap()
+            .start(
+                engines.raft_engine.clone(),
+                server.transport(),
+                snap_mgr,
+                self.concurrency_manager.clone(),
+                self.causal_ts_provider.clone(),
+                self.coprocessor_host.clone().unwrap(),
+                self.background_worker.clone(),
+                pd_worker,
+                raft_store,
+                &state,
+            )
+            .unwrap_or_else(|e| fatal!("failed to start node: {}", e));
 
         // Start auto gc. Must after `Node::start` because `node_id` is initialized
         // there.
-        assert!(node.id() > 0); // Node id should never be 0.
+        let store_id = self.node.as_ref().unwrap().id();
         let auto_gc_config = AutoGcConfig::new(
             self.pd_client.clone(),
-            self.region_info_accessor.clone(),
-            node.id(),
+            self.region_info_accessor.clone().unwrap(),
+            store_id,
         );
         gc_worker
-            .start(node.id())
+            .start(store_id)
             .unwrap_or_else(|e| fatal!("failed to start gc worker: {}", e));
         if let Err(e) = gc_worker.start_auto_gc(auto_gc_config, safe_point) {
             fatal!("failed to start auto_gc on storage, error: {}", e);
         }
 
         initial_metric(&self.config.metric);
-        if self.config.storage.enable_ttl {
-            ttl_checker.start_with_timer(TtlChecker::new(
-                self.engines.as_ref().unwrap().engine.kv_engine().unwrap(),
-                self.region_info_accessor.clone(),
-                self.config.storage.ttl_check_poll_interval.into(),
-            ));
-            self.to_stop.push(ttl_checker);
-        }
 
-        // Start CDC.
-        let cdc_memory_quota = MemoryQuota::new(self.config.cdc.sink_memory_quota.0 as _);
-        let cdc_endpoint = cdc::Endpoint::new(
-            self.config.server.cluster_id,
-            &self.config.cdc,
-            self.config.storage.api_version(),
-            self.pd_client.clone(),
-            cdc_scheduler.clone(),
-            self.router.clone(),
-            self.engines.as_ref().unwrap().engines.kv.clone(),
-            cdc_ob,
-            engines.store_meta.clone(),
-            self.concurrency_manager.clone(),
-            server.env(),
-            self.security_mgr.clone(),
-            cdc_memory_quota.clone(),
-            self.causal_ts_provider.clone(),
-        );
-        cdc_worker.start_with_timer(cdc_endpoint);
-        self.to_stop.push(cdc_worker);
-
-        // Start resolved ts
-        if let Some(mut rts_worker) = rts_worker {
-            let rts_endpoint = resolved_ts::Endpoint::new(
-                &self.config.resolved_ts,
-                rts_worker.scheduler(),
-                self.router.clone(),
-                engines.store_meta.clone(),
-                self.pd_client.clone(),
-                self.concurrency_manager.clone(),
-                server.env(),
-                self.security_mgr.clone(),
-            );
-            rts_worker.start_with_timer(rts_endpoint);
-            self.to_stop.push(rts_worker);
-        }
-
-        cfg_controller.register(
-            tikv::config::Module::Raftstore,
-            Box::new(RaftstoreConfigManager::new(
-                node.refresh_config_scheduler(),
-                raft_store,
-            )),
-        );
-
-        self.servers = Some(Servers {
-            lock_mgr,
-            server,
-            node,
-            importer,
-            cdc_scheduler,
-            cdc_memory_quota,
-            rsmeter_pubsub_service,
-            backup_stream_scheduler,
-        });
+        self.servers = Some(Servers { lock_mgr, server });
 
         server_config
     }
 
     fn register_services(&mut self) {
         let servers = self.servers.as_mut().unwrap();
-        let engines = self.engines.as_ref().unwrap();
-
-        // Import SST service.
-        let import_service = ImportSstService::new(
-            self.config.import.clone(),
-            self.config.raft_store.raft_entry_max_size,
-            self.router.clone(),
-            engines.engines.kv.clone(),
-            servers.importer.clone(),
-        );
-        if servers
-            .server
-            .register_service(create_import_sst(import_service))
-            .is_some()
-        {
-            fatal!("failed to register import service");
-        }
-
-        // Debug service.
-        let debug_service = DebugService::new(
-            engines.engines.clone(),
-            self.kv_statistics.clone(),
-            self.raft_statistics.clone(),
-            servers.server.get_debug_thread_pool().clone(),
-            engines.engine.raft_extension(),
-            self.cfg_controller.as_ref().unwrap().clone(),
-        );
-        if servers
-            .server
-            .register_service(create_debug(debug_service))
-            .is_some()
-        {
-            fatal!("failed to register debug service");
-        }
 
         // Create Diagnostics service
         let diag_service = DiagnosticsService::new(
@@ -1253,90 +898,13 @@ where
         servers
             .lock_mgr
             .start(
-                servers.node.id(),
+                self.node.as_ref().unwrap().id(),
                 self.pd_client.clone(),
                 self.resolver.clone().unwrap(),
                 self.security_mgr.clone(),
                 &self.config.pessimistic_txn,
             )
             .unwrap_or_else(|e| fatal!("failed to start lock manager: {}", e));
-
-        // Backup service.
-        let mut backup_worker = Box::new(self.background_worker.lazy_build("backup-endpoint"));
-        let backup_scheduler = backup_worker.scheduler();
-        let backup_service = backup::Service::<RocksEngine, RaftRouter<RocksEngine, ER>>::new(
-            backup_scheduler,
-            self.router.clone(),
-        );
-        if servers
-            .server
-            .register_service(create_backup(backup_service))
-            .is_some()
-        {
-            fatal!("failed to register backup service");
-        }
-
-        let backup_endpoint = backup::Endpoint::new(
-            servers.node.id(),
-            engines.engine.clone(),
-            self.region_info_accessor.clone(),
-            engines.engines.kv.clone(),
-            self.config.backup.clone(),
-            self.concurrency_manager.clone(),
-            self.config.storage.api_version(),
-            self.causal_ts_provider.clone(),
-        );
-        self.cfg_controller.as_mut().unwrap().register(
-            tikv::config::Module::Backup,
-            Box::new(backup_endpoint.get_config_manager()),
-        );
-        backup_worker.start(backup_endpoint);
-
-        let cdc_service = cdc::Service::new(
-            servers.cdc_scheduler.clone(),
-            servers.cdc_memory_quota.clone(),
-        );
-        if servers
-            .server
-            .register_service(create_change_data(cdc_service))
-            .is_some()
-        {
-            fatal!("failed to register cdc service");
-        }
-        if servers
-            .server
-            .register_service(create_resource_metering_pub_sub(
-                servers.rsmeter_pubsub_service.clone(),
-            ))
-            .is_some()
-        {
-            warn!("failed to register resource metering pubsub service");
-        }
-
-        if let Some(sched) = servers.backup_stream_scheduler.take() {
-            let pitr_service = backup_stream::Service::new(sched);
-            if servers
-                .server
-                .register_service(create_log_backup(pitr_service))
-                .is_some()
-            {
-                fatal!("failed to register log backup service");
-            }
-        }
-
-        // the present tikv in recovery mode, start recovery service
-        if self.br_snap_recovery_mode {
-            let recovery_service =
-                RecoveryService::new(engines.engines.clone(), self.router.clone());
-
-            if servers
-                .server
-                .register_service(create_recover_data(recovery_service))
-                .is_some()
-            {
-                fatal!("failed to register recovery service");
-            }
-        }
     }
 
     fn init_io_utility(&mut self) -> BytesFetcher {
@@ -1370,7 +938,7 @@ where
             self.tablet_registry.clone().unwrap(),
             self.kv_statistics.clone(),
             self.config.rocksdb.titan.enabled,
-            self.engines.as_ref().unwrap().engines.raft.clone(),
+            self.engines.as_ref().unwrap().raft_engine.clone(),
             self.raft_statistics.clone(),
         );
         let mut io_metrics = IoMetricsManager::new(fetcher);
@@ -1484,7 +1052,7 @@ where
         );
     }
 
-    fn init_storage_stats_task(&self, engines: Engines<RocksEngine, ER>) {
+    fn init_storage_stats_task(&self) {
         let config_disk_capacity: u64 = self.config.raft_store.capacity.0;
         let data_dir = self.config.storage.data_dir.clone();
         let store_path = self.store_path.clone();
@@ -1495,9 +1063,11 @@ where
             info!("disk space checker not enabled");
             return;
         }
-        let raft_path = engines.raft.get_engine_path().to_string();
+        let raft_engine = self.engines.as_ref().unwrap().raft_engine.clone();
+        let tablet_registry = self.tablet_registry.clone().unwrap();
+        let raft_path = raft_engine.get_engine_path().to_string();
         let separated_raft_mount_path =
-            path_in_diff_mount_point(raft_path.as_str(), engines.kv.path());
+            path_in_diff_mount_point(raft_path.as_str(), tablet_registry.tablet_root());
         let raft_almost_full_threshold = reserve_raft_space;
         let raft_already_full_threshold = reserve_raft_space / 2;
 
@@ -1526,15 +1096,17 @@ where
                     Ok(stats) => stats,
                 };
                 let disk_cap = disk_stats.total_space();
-                let snap_size = snap_mgr.get_total_snap_size().unwrap();
+                let snap_size = snap_mgr.total_snap_size().unwrap();
 
-                let kv_size = engines
-                    .kv
-                    .get_engine_used_size()
-                    .expect("get kv engine size");
+                let mut kv_size = 0;
+                tablet_registry.for_each_opened_tablet(|_, cached| {
+                    if let Some(tablet) = cached.latest() {
+                        kv_size += tablet.get_engine_used_size().unwrap_or(0);
+                    }
+                    true
+                });
 
-                let raft_size = engines
-                    .raft
+                let raft_size = raft_engine
                     .get_engine_size()
                     .expect("get raft engine size");
 
@@ -1668,7 +1240,7 @@ where
         }
     }
 
-    fn stop(self) {
+    fn stop(mut self) {
         tikv_util::thread_group::mark_shutdown();
         let mut servers = self.servers.unwrap();
         servers
@@ -1676,8 +1248,8 @@ where
             .stop()
             .unwrap_or_else(|e| fatal!("failed to stop server: {}", e));
 
-        servers.node.stop();
-        self.region_info_accessor.stop();
+        self.node.as_mut().unwrap().stop();
+        self.region_info_accessor.as_mut().unwrap().stop();
 
         servers.lock_mgr.stop();
 
@@ -1806,7 +1378,7 @@ impl<CER: ConfiguredRaftEngine> TikvServer<CER> {
     fn init_raw_engines(
         &mut self,
         flow_listener: engine_rocks::FlowListener,
-    ) -> (Engines<RocksEngine, CER>, Arc<EnginesResourceInfo>) {
+    ) -> (CER, Arc<EnginesResourceInfo>) {
         let block_cache = self.config.storage.block_cache.build_shared_cache();
         let env = self
             .config
@@ -1824,39 +1396,27 @@ impl<CER: ConfiguredRaftEngine> TikvServer<CER> {
 
         // Create kv engine.
         let builder = KvEngineFactoryBuilder::new(env, &self.config, block_cache)
-            .compaction_event_sender(Arc::new(RaftRouterCompactedEventSender {
-                router: Mutex::new(self.router.clone()),
-            }))
-            .region_info_accessor(self.region_info_accessor.clone())
             .sst_recovery_sender(self.init_sst_recovery_sender())
             .flow_listener(flow_listener);
         let factory = Box::new(builder.build());
-        let kv_engine = factory
-            .create_shared_db(&self.store_path)
-            .unwrap_or_else(|s| fatal!("failed to create kv engine: {}", s));
         self.kv_statistics = Some(factory.rocks_statistics());
-        let engines = Engines::new(kv_engine.clone(), raft_engine);
-
+        let registry = TabletRegistry::new(factory, self.store_path.join("tablets"))
+            .unwrap_or_else(|e| fatal!("failed to create tablet registry {:?}", e));
         let cfg_controller = self.cfg_controller.as_mut().unwrap();
         cfg_controller.register(
             tikv::config::Module::Rocksdb,
-            Box::new(DbConfigManger::new(kv_engine.clone(), DbType::Kv)),
+            Box::new(DbConfigManger::new(registry.clone(), DbType::Kv)),
         );
-        let reg = TabletRegistry::new(Box::new(SingletonFactory::new(kv_engine)), &self.store_path)
-            .unwrap();
-        // It always use the singleton kv_engine, use arbitrary id and suffix.
-        let ctx = TabletContext::with_infinite_region(0, Some(0));
-        reg.load(ctx, false).unwrap();
-        self.tablet_registry = Some(reg.clone());
-        engines.raft.register_config(cfg_controller);
+        self.tablet_registry = Some(registry.clone());
+        raft_engine.register_config(cfg_controller);
 
         let engines_info = Arc::new(EnginesResourceInfo::new(
-            reg,
-            engines.raft.as_rocks_engine().cloned(),
+            registry,
+            raft_engine.as_rocks_engine().cloned(),
             180, // max_samples_to_preserve
         ));
 
-        (engines, engines_info)
+        (raft_engine, engines_info)
     }
 }
 
@@ -1948,33 +1508,6 @@ fn get_lock_dir() -> String {
 #[cfg(not(unix))]
 fn get_lock_dir() -> String {
     "TIKV_LOCK_FILES".to_owned()
-}
-
-/// A small trait for components which can be trivially stopped. Lets us keep
-/// a list of these in `TiKV`, rather than storing each component individually.
-pub(crate) trait Stop {
-    fn stop(self: Box<Self>);
-}
-
-impl<R> Stop for StatusServer<R>
-where
-    R: 'static + Send,
-{
-    fn stop(self: Box<Self>) {
-        (*self).stop()
-    }
-}
-
-impl Stop for Worker {
-    fn stop(self: Box<Self>) {
-        Worker::stop(&self);
-    }
-}
-
-impl<T: fmt::Display + Send + 'static> Stop for LazyWorker<T> {
-    fn stop(self: Box<Self>) {
-        self.stop_worker();
-    }
 }
 
 pub struct EngineMetricsManager<EK: KvEngine, ER: RaftEngine> {

--- a/components/server/src/server_rn.rs
+++ b/components/server/src/server_rn.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+// Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
 //! This module startups all the components of a TiKV server.
 //!
@@ -14,30 +14,39 @@
 use std::{
     cmp,
     collections::HashMap,
-    env,
+    convert::TryFrom,
+    env, fmt,
     net::SocketAddr,
     path::{Path, PathBuf},
     str::FromStr,
     sync::{
         atomic::{AtomicU32, AtomicU64, Ordering},
-        mpsc, Arc,
+        mpsc, Arc, Mutex,
     },
     time::Duration,
     u64,
 };
 
 use api_version::{dispatch_api_version, KvFormat};
+use backup_stream::{
+    config::BackupStreamConfigManager,
+    metadata::{ConnectionConfig, LazyEtcdClient},
+    observer::BackupStreamObserver,
+};
 use causal_ts::CausalTsProviderImpl;
+use cdc::{CdcConfigManager, MemoryQuota};
 use concurrency_manager::ConcurrencyManager;
 use encryption_export::{data_key_manager_from_config, DataKeyManager};
 use engine_rocks::{
-    flush_engine_statistics,
+    flush_engine_statistics, from_rocks_compression_type,
     raw::{Cache, Env},
     FlowInfo, RocksEngine, RocksStatistics,
 };
+use engine_rocks_helper::sst_recovery::{RecoveryRunner, DEFAULT_CHECK_INTERVAL};
 use engine_traits::{
     CachedTablet, CfOptions, CfOptionsExt, Engines, FlowControlFactorsExt, KvEngine, MiscExt,
-    RaftEngine, StatisticsReporter, TabletRegistry, CF_DEFAULT, CF_LOCK, CF_WRITE,
+    RaftEngine, SingletonFactory, StatisticsReporter, TabletContext, TabletRegistry, CF_DEFAULT,
+    CF_LOCK, CF_WRITE,
 };
 use error_code::ErrorCodeExt;
 use file_system::{
@@ -47,39 +56,57 @@ use file_system::{
 use futures::executor::block_on;
 use grpcio::{EnvBuilder, Environment};
 use grpcio_health::HealthService;
-use kvproto::{deadlock::create_deadlock, diagnosticspb::create_diagnostics, kvrpcpb::ApiVersion};
+use kvproto::{
+    brpb::create_backup, cdcpb::create_change_data, deadlock::create_deadlock,
+    debugpb::create_debug, diagnosticspb::create_diagnostics, import_sstpb::create_import_sst,
+    kvrpcpb::ApiVersion, logbackuppb::create_log_backup, recoverdatapb::create_recover_data,
+    resource_usage_agent::create_resource_metering_pub_sub,
+};
 use pd_client::{PdClient, RpcClient};
 use raft_log_engine::RaftLogEngine;
 use raftstore::{
     coprocessor::{
-        BoxConsistencyCheckObserver, ConsistencyCheckMethod, CoprocessorHost,
-        RawConsistencyCheckObserver,
+        config::SplitCheckConfigManager, BoxConsistencyCheckObserver, ConsistencyCheckMethod,
+        CoprocessorHost, RawConsistencyCheckObserver, RegionInfoAccessor,
     },
-    store::{memory::MEMTRACE_ROOT as MEMTRACE_RAFTSTORE, SplitConfigManager, TabletSnapManager},
-    RegionInfoAccessor,
+    router::ServerRaftStoreRouter,
+    store::{
+        config::RaftstoreConfigManager,
+        fsm,
+        fsm::store::{
+            RaftBatchSystem, RaftRouter, StoreMeta, MULTI_FILES_SNAPSHOT_FEATURE, PENDING_MSG_CAP,
+        },
+        memory::MEMTRACE_ROOT as MEMTRACE_RAFTSTORE,
+        AutoSplitController, CheckLeaderRunner, LocalReader, SnapManager, SnapManagerBuilder,
+        SplitCheckRunner, SplitConfigManager, StoreMetaDelegate,
+    },
+    RaftRouterCompactedEventSender,
 };
 use security::SecurityManager;
+use snap_recovery::RecoveryService;
 use tikv::{
     config::{ConfigController, DbConfigManger, DbType, LogConfigManager, TikvConfig},
     coprocessor::{self, MEMTRACE_ROOT as MEMTRACE_COPROCESSOR},
     coprocessor_v2,
-    read_pool::{build_yatp_read_pool, ReadPool},
+    import::{ImportSstService, SstImporter},
+    read_pool::{build_yatp_read_pool, ReadPool, ReadPoolConfigManager},
     server::{
         config::{Config as ServerConfig, ServerConfigManager},
         gc_worker::{AutoGcConfig, GcWorker},
         lock_manager::LockManager,
         raftkv::ReplicaReadLockChecker,
         resolve,
-        service::DiagnosticsService,
+        service::{DebugService, DiagnosticsService},
         status_server::StatusServer,
-        KvEngineFactoryBuilder, NodeV2, RaftKv2, Server, CPU_CORES_QUOTA_GAUGE, DEFAULT_CLUSTER_ID,
+        ttl::TtlChecker,
+        KvEngineFactoryBuilder, Node, RaftKv, Server, CPU_CORES_QUOTA_GAUGE, DEFAULT_CLUSTER_ID,
         GRPC_THREAD_PREFIX,
     },
     storage::{
         self,
         config_manager::StorageConfigManger,
         mvcc::MvccConsistencyCheckObserver,
-        txn::flow_controller::{FlowController, TabletFlowController},
+        txn::flow_controller::{EngineFlowController, FlowController},
         Engine, Storage,
     },
 };
@@ -101,7 +128,7 @@ use tikv_util::{
 use tokio::runtime::Builder;
 
 use crate::{
-    memory::*, raft_engine_switch::*, server::Stop, setup::*, signal_handler,
+    memory::*, raft_engine_switch::*, setup::*, signal_handler,
     tikv_util::sys::thread::ThreadBuildWrapper,
 };
 
@@ -133,19 +160,18 @@ fn run_impl<CER: ConfiguredRaftEngine, F: KvFormat>(config: TikvConfig) {
     tikv.init_encryption();
     let fetcher = tikv.init_io_utility();
     let listener = tikv.init_flow_receiver();
-    let (raft_engine, engines_info) = tikv.init_raw_engines(listener);
-    tikv.init_engines(raft_engine);
+    let (engines, engines_info) = tikv.init_raw_engines(listener);
+    tikv.init_engines(engines.clone());
     let server_config = tikv.init_servers::<F>();
     tikv.register_services();
     tikv.init_metrics_flusher(fetcher, engines_info);
-    tikv.init_storage_stats_task();
+    tikv.init_storage_stats_task(engines);
     tikv.run_server(server_config);
     tikv.run_status_server();
     tikv.init_quota_tuning_task(tikv.quota_limiter.clone());
 
-    // TODO: support signal dump stats
     signal_handler::wait_for_signal(
-        None as Option<Engines<RocksEngine, CER>>,
+        Some(tikv.engines.take().unwrap().engines),
         tikv.kv_statistics.clone(),
         tikv.raft_statistics.clone(),
     );
@@ -196,41 +222,52 @@ struct TikvServer<ER: RaftEngine> {
     cfg_controller: Option<ConfigController>,
     security_mgr: Arc<SecurityManager>,
     pd_client: Arc<RpcClient>,
+    router: RaftRouter<RocksEngine, ER>,
     flow_info_sender: Option<mpsc::Sender<FlowInfo>>,
     flow_info_receiver: Option<mpsc::Receiver<FlowInfo>>,
-    node: Option<NodeV2<RpcClient, RocksEngine, ER>>,
+    system: Option<RaftBatchSystem<RocksEngine, ER>>,
     resolver: Option<resolve::PdStoreAddrResolver>,
     store_path: PathBuf,
-    snap_mgr: Option<TabletSnapManager>, // Will be filled in `init_servers`.
+    snap_mgr: Option<SnapManager>, // Will be filled in `init_servers`.
     encryption_key_manager: Option<Arc<DataKeyManager>>,
     engines: Option<TikvEngines<RocksEngine, ER>>,
     kv_statistics: Option<Arc<RocksStatistics>>,
     raft_statistics: Option<Arc<RocksStatistics>>,
     servers: Option<Servers<RocksEngine, ER>>,
-    region_info_accessor: Option<RegionInfoAccessor>,
+    region_info_accessor: RegionInfoAccessor,
     coprocessor_host: Option<CoprocessorHost<RocksEngine>>,
     to_stop: Vec<Box<dyn Stop>>,
     lock_files: Vec<File>,
     concurrency_manager: ConcurrencyManager,
     env: Arc<Environment>,
     background_worker: Worker,
+    check_leader_worker: Worker,
     sst_worker: Option<Box<LazyWorker<String>>>,
     quota_limiter: Arc<QuotaLimiter>,
     causal_ts_provider: Option<Arc<CausalTsProviderImpl>>, // used for rawkv apiv2
     tablet_registry: Option<TabletRegistry<RocksEngine>>,
+    br_snap_recovery_mode: bool, // use for br snapshot recovery
 }
 
 struct TikvEngines<EK: KvEngine, ER: RaftEngine> {
-    raft_engine: ER,
-    engine: RaftKv2<EK, ER>,
+    engines: Engines<EK, ER>,
+    store_meta: Arc<Mutex<StoreMeta>>,
+    engine: RaftKv<EK, ServerRaftStoreRouter<EK, ER>>,
 }
 
 struct Servers<EK: KvEngine, ER: RaftEngine> {
     lock_mgr: LockManager,
     server: LocalServer<EK, ER>,
+    node: Node<RpcClient, EK, ER>,
+    importer: Arc<SstImporter>,
+    cdc_scheduler: tikv_util::worker::Scheduler<cdc::Task>,
+    cdc_memory_quota: MemoryQuota,
+    rsmeter_pubsub_service: resource_metering::PubSubService,
+    backup_stream_scheduler: Option<tikv_util::worker::Scheduler<backup_stream::Task>>,
 }
 
-type LocalServer<EK, ER> = Server<resolve::PdStoreAddrResolver, RaftKv2<EK, ER>>;
+type LocalServer<EK, ER> = Server<resolve::PdStoreAddrResolver, LocalRaftKv<EK, ER>>;
+type LocalRaftKv<EK, ER> = RaftKv<EK, ServerRaftStoreRouter<EK, ER>>;
 
 impl<ER> TikvServer<ER>
 where
@@ -253,6 +290,30 @@ where
         );
         let pd_client =
             Self::connect_to_pd_cluster(&mut config, env.clone(), Arc::clone(&security_mgr));
+        // check if TiKV need to run in snapshot recovery mode
+        let is_recovering_marked = match pd_client.is_recovering_marked() {
+            Err(e) => {
+                warn!(
+                    "failed to get recovery mode from PD";
+                    "error" => ?e,
+                );
+                false
+            }
+            Ok(marked) => marked,
+        };
+
+        if is_recovering_marked {
+            // Run a TiKV server in recovery modeß
+            info!("TiKV running in Snapshot Recovery Mode");
+            snap_recovery::init_cluster::enter_snap_recovery_mode(&mut config);
+            // connect_to_pd_cluster retreived the cluster id from pd
+            let cluster_id = config.server.cluster_id;
+            snap_recovery::init_cluster::start_recovery(
+                config.clone(),
+                cluster_id,
+                pd_client.clone(),
+            );
+        }
 
         // Initialize and check config
         let cfg_controller = Self::init_config(config);
@@ -260,10 +321,19 @@ where
 
         let store_path = Path::new(&config.storage.data_dir).to_owned();
 
+        // Initialize raftstore channels.
+        let (router, system) = fsm::create_raft_batch_system(&config.raft_store);
+
         let thread_count = config.server.background_thread_count;
         let background_worker = WorkerBuilder::new("background")
             .thread_count(thread_count)
             .create();
+
+        let mut coprocessor_host = Some(CoprocessorHost::new(
+            router.clone(),
+            config.coprocessor.clone(),
+        ));
+        let region_info_accessor = RegionInfoAccessor::new(coprocessor_host.as_mut().unwrap());
 
         // Initialize concurrency manager
         let latest_ts = block_on(pd_client.get_tso()).expect("failed to get timestamp from PD");
@@ -297,12 +367,17 @@ where
             info!("Causal timestamp provider startup.");
         }
 
+        // Run check leader in a dedicate thread, because it is time sensitive
+        // and crucial to TiCDC replication lag.
+        let check_leader_worker = WorkerBuilder::new("check_leader").thread_count(1).create();
+
         TikvServer {
             config,
             cfg_controller: Some(cfg_controller),
             security_mgr,
             pd_client,
-            node: None,
+            router,
+            system: Some(system),
             resolver: None,
             store_path,
             snap_mgr: None,
@@ -311,19 +386,21 @@ where
             kv_statistics: None,
             raft_statistics: None,
             servers: None,
-            region_info_accessor: None,
-            coprocessor_host: None,
+            region_info_accessor,
+            coprocessor_host,
             to_stop: vec![],
             lock_files: vec![],
             concurrency_manager,
             env,
             background_worker,
+            check_leader_worker,
             flow_info_sender: None,
             flow_info_receiver: None,
             sst_worker: None,
             quota_limiter,
             causal_ts_provider,
             tablet_registry: None,
+            br_snap_recovery_mode: is_recovering_marked,
         }
     }
 
@@ -558,44 +635,38 @@ where
         engine_rocks::FlowListener::new(tx)
     }
 
-    fn init_engines(&mut self, raft_engine: ER) {
-        let tablet_registry = self.tablet_registry.clone().unwrap();
-        let mut node = NodeV2::new(
-            &self.config.server,
-            self.pd_client.clone(),
-            None,
-            tablet_registry,
+    fn init_engines(&mut self, engines: Engines<RocksEngine, ER>) {
+        let store_meta = Arc::new(Mutex::new(StoreMeta::new(PENDING_MSG_CAP)));
+        let engine = RaftKv::new(
+            ServerRaftStoreRouter::new(
+                self.router.clone(),
+                LocalReader::new(
+                    engines.kv.clone(),
+                    StoreMetaDelegate::new(store_meta.clone(), engines.kv.clone()),
+                    self.router.clone(),
+                ),
+            ),
+            engines.kv.clone(),
+            self.region_info_accessor.region_leaders(),
         );
-        node.try_bootstrap_store(&self.config.raft_store, &raft_engine)
-            .unwrap_or_else(|e| fatal!("failed to bootstrap store: {:?}", e));
-        assert_ne!(node.id(), 0);
-
-        let router = node.router();
-        let mut coprocessor_host: CoprocessorHost<RocksEngine> = CoprocessorHost::new(
-            router.store_router().clone(),
-            self.config.coprocessor.clone(),
-        );
-        let region_info_accessor = RegionInfoAccessor::new(&mut coprocessor_host);
-
-        let engine = RaftKv2::new(router.clone(), region_info_accessor.region_leaders());
 
         self.engines = Some(TikvEngines {
-            raft_engine,
+            engines,
+            store_meta,
             engine,
         });
-        self.node = Some(node);
-        self.coprocessor_host = Some(coprocessor_host);
-        self.region_info_accessor = Some(region_info_accessor);
     }
 
-    fn init_gc_worker(&mut self) -> GcWorker<RaftKv2<RocksEngine, ER>> {
+    fn init_gc_worker(
+        &mut self,
+    ) -> GcWorker<RaftKv<RocksEngine, ServerRaftStoreRouter<RocksEngine, ER>>> {
         let engines = self.engines.as_ref().unwrap();
         let gc_worker = GcWorker::new(
             engines.engine.clone(),
             self.flow_info_sender.take().unwrap(),
             self.config.gc.clone(),
             self.pd_client.feature_gate().clone(),
-            Arc::new(self.region_info_accessor.clone().unwrap()),
+            Arc::new(self.region_info_accessor.clone()),
         );
 
         let cfg_controller = self.cfg_controller.as_mut().unwrap();
@@ -608,13 +679,13 @@ where
     }
 
     fn init_servers<F: KvFormat>(&mut self) -> Arc<VersionTrack<ServerConfig>> {
-        let flow_controller = Arc::new(FlowController::Tablet(TabletFlowController::new(
+        let flow_controller = Arc::new(FlowController::Singleton(EngineFlowController::new(
             &self.config.storage.flow_control,
-            self.tablet_registry.clone().unwrap(),
+            self.engines.as_ref().unwrap().engine.kv_engine().unwrap(),
             self.flow_info_receiver.take().unwrap(),
         )));
         let mut gc_worker = self.init_gc_worker();
-        let ttl_checker = Box::new(LazyWorker::new("ttl-checker"));
+        let mut ttl_checker = Box::new(LazyWorker::new("ttl-checker"));
         let ttl_scheduler = ttl_checker.scheduler();
 
         let cfg_controller = self.cfg_controller.as_mut().unwrap();
@@ -628,6 +699,17 @@ where
 
         cfg_controller.register(tikv::config::Module::Log, Box::new(LogConfigManager));
 
+        // Create cdc.
+        let mut cdc_worker = Box::new(LazyWorker::new("cdc"));
+        let cdc_scheduler = cdc_worker.scheduler();
+        let txn_extra_scheduler = cdc::CdcTxnExtraScheduler::new(cdc_scheduler.clone());
+
+        self.engines
+            .as_mut()
+            .unwrap()
+            .engine
+            .set_txn_extra_scheduler(Arc::new(txn_extra_scheduler));
+
         let lock_mgr = LockManager::new(&self.config.pessimistic_txn);
         cfg_controller.register(
             tikv::config::Module::PessimisticTxn,
@@ -638,7 +720,17 @@ where
         let engines = self.engines.as_ref().unwrap();
 
         let pd_worker = LazyWorker::new("pd-worker");
-        let pd_sender = raftstore_v2::FlowReporter::new(pd_worker.scheduler());
+        let pd_sender = pd_worker.scheduler();
+
+        if let Some(sst_worker) = &mut self.sst_worker {
+            let sst_runner = RecoveryRunner::new(
+                engines.engines.kv.clone(),
+                engines.store_meta.clone(),
+                self.config.storage.background_error_recovery_window.into(),
+                DEFAULT_CHECK_INTERVAL,
+            );
+            sst_worker.start_with_timer(sst_runner);
+        }
 
         let unified_read_pool = if self.config.readpool.is_unified_pool_enabled() {
             Some(build_yatp_read_pool(
@@ -672,15 +764,16 @@ where
         let (reporter_notifier, data_sink_reg_handle, reporter_worker) =
             resource_metering::init_reporter(
                 self.config.resource_metering.clone(),
-                collector_reg_handle,
+                collector_reg_handle.clone(),
             );
         self.to_stop.push(reporter_worker);
         let (address_change_notifier, single_target_worker) = resource_metering::init_single_target(
             self.config.resource_metering.receiver_address.clone(),
             self.env.clone(),
-            data_sink_reg_handle,
+            data_sink_reg_handle.clone(),
         );
         self.to_stop.push(single_target_worker);
+        let rsmeter_pubsub_service = resource_metering::PubSubService::new(data_sink_reg_handle);
 
         let cfg_manager = resource_metering::ConfigManager::new(
             self.config.resource_metering.clone(),
@@ -742,12 +835,25 @@ where
         // Create snapshot manager, server.
         let snap_path = self
             .store_path
-            .join(Path::new("tablet_snap"))
+            .join(Path::new("snap"))
             .to_str()
             .unwrap()
             .to_owned();
 
-        let snap_mgr = TabletSnapManager::new(snap_path);
+        let bps = i64::try_from(self.config.server.snap_max_write_bytes_per_sec.0)
+            .unwrap_or_else(|_| fatal!("snap_max_write_bytes_per_sec > i64::max_value"));
+
+        let snap_mgr = SnapManagerBuilder::default()
+            .max_write_bytes_per_sec(bps)
+            .max_total_size(self.config.server.snap_max_total_size.0)
+            .encryption_key_manager(self.encryption_key_manager.clone())
+            .max_per_file_size(self.config.raft_store.max_snapshot_file_raw_size.0)
+            .enable_multi_snapshot_files(
+                self.pd_client
+                    .feature_gate()
+                    .can_enable(MULTI_FILES_SNAPSHOT_FEATURE),
+            )
+            .build(snap_path);
 
         // Create coprocessor endpoint.
         let cop_read_pool_handle = if self.config.readpool.coprocessor.use_unified_pool() {
@@ -761,6 +867,57 @@ where
             cop_read_pools.handle()
         };
 
+        let mut unified_read_pool_scale_receiver = None;
+        if self.config.readpool.is_unified_pool_enabled() {
+            let (unified_read_pool_scale_notifier, rx) = mpsc::sync_channel(10);
+            cfg_controller.register(
+                tikv::config::Module::Readpool,
+                Box::new(ReadPoolConfigManager::new(
+                    unified_read_pool.as_ref().unwrap().handle(),
+                    unified_read_pool_scale_notifier,
+                    &self.background_worker,
+                    self.config.readpool.unified.max_thread_count,
+                    self.config.readpool.unified.auto_adjust_pool_size,
+                )),
+            );
+            unified_read_pool_scale_receiver = Some(rx);
+        }
+
+        // Register cdc.
+        let cdc_ob = cdc::CdcObserver::new(cdc_scheduler.clone());
+        cdc_ob.register_to(self.coprocessor_host.as_mut().unwrap());
+        // Register cdc config manager.
+        cfg_controller.register(
+            tikv::config::Module::Cdc,
+            Box::new(CdcConfigManager(cdc_worker.scheduler())),
+        );
+
+        // Create resolved ts worker
+        let rts_worker = if self.config.resolved_ts.enable {
+            let worker = Box::new(LazyWorker::new("resolved-ts"));
+            // Register the resolved ts observer
+            let resolved_ts_ob = resolved_ts::Observer::new(worker.scheduler());
+            resolved_ts_ob.register_to(self.coprocessor_host.as_mut().unwrap());
+            // Register config manager for resolved ts worker
+            cfg_controller.register(
+                tikv::config::Module::ResolvedTs,
+                Box::new(resolved_ts::ResolvedTsConfigManager::new(
+                    worker.scheduler(),
+                )),
+            );
+            Some(worker)
+        } else {
+            None
+        };
+
+        let check_leader_runner = CheckLeaderRunner::new(
+            engines.store_meta.clone(),
+            self.coprocessor_host.clone().unwrap(),
+        );
+        let check_leader_scheduler = self
+            .check_leader_worker
+            .start("check-leader", check_leader_runner);
+
         let server_config = Arc::new(VersionTrack::new(self.config.server.clone()));
 
         self.config
@@ -773,8 +930,19 @@ where
             .unwrap_or_else(|e| fatal!("failed to validate raftstore config {}", e));
         let raft_store = Arc::new(VersionTrack::new(self.config.raft_store.clone()));
         let health_service = HealthService::default();
-
-        let node = self.node.as_ref().unwrap();
+        let mut node = Node::new(
+            self.system.take().unwrap(),
+            &server_config.value().clone(),
+            raft_store.clone(),
+            self.config.storage.api_version(),
+            self.pd_client.clone(),
+            state,
+            self.background_worker.clone(),
+            Some(health_service.clone()),
+            None,
+        );
+        node.try_bootstrap_store(engines.engines.clone())
+            .unwrap_or_else(|e| fatal!("failed to bootstrap node id: {}", e));
 
         self.snap_mgr = Some(snap_mgr.clone());
         // Create server
@@ -792,9 +960,9 @@ where
             ),
             coprocessor_v2::Endpoint::new(&self.config.coprocessor_v2),
             self.resolver.clone().unwrap(),
-            Either::Right(snap_mgr.clone()),
+            Either::Left(snap_mgr.clone()),
             gc_worker.clone(),
-            None,
+            Some(check_leader_scheduler),
             self.env.clone(),
             unified_read_pool,
             debug_thread_pool,
@@ -810,9 +978,101 @@ where
             )),
         );
 
+        // Start backup stream
+        let backup_stream_scheduler = if self.config.backup_stream.enable {
+            // Create backup stream.
+            let mut backup_stream_worker = Box::new(LazyWorker::new("backup-stream"));
+            let backup_stream_scheduler = backup_stream_worker.scheduler();
+
+            // Register backup-stream observer.
+            let backup_stream_ob = BackupStreamObserver::new(backup_stream_scheduler.clone());
+            backup_stream_ob.register_to(self.coprocessor_host.as_mut().unwrap());
+            // Register config manager.
+            cfg_controller.register(
+                tikv::config::Module::BackupStream,
+                Box::new(BackupStreamConfigManager(backup_stream_worker.scheduler())),
+            );
+
+            let etcd_cli = LazyEtcdClient::new(
+                self.config.pd.endpoints.as_slice(),
+                ConnectionConfig {
+                    keep_alive_interval: self.config.server.grpc_keepalive_time.0,
+                    keep_alive_timeout: self.config.server.grpc_keepalive_timeout.0,
+                    tls: self
+                        .security_mgr
+                        .client_suite()
+                        .map_err(|err| {
+                            warn!("Failed to load client TLS suite, ignoring TLS config."; "err" => %err);
+                        })
+                        .ok(),
+                },
+            );
+            let backup_stream_endpoint = backup_stream::Endpoint::new(
+                node.id(),
+                etcd_cli,
+                self.config.backup_stream.clone(),
+                backup_stream_scheduler.clone(),
+                backup_stream_ob,
+                self.region_info_accessor.clone(),
+                self.router.clone(),
+                self.pd_client.clone(),
+                self.concurrency_manager.clone(),
+            );
+            backup_stream_worker.start(backup_stream_endpoint);
+            self.to_stop.push(backup_stream_worker);
+            Some(backup_stream_scheduler)
+        } else {
+            None
+        };
+
+        let import_path = self.store_path.join("import");
+        let mut importer = SstImporter::new(
+            &self.config.import,
+            import_path,
+            self.encryption_key_manager.clone(),
+            self.config.storage.api_version(),
+        )
+        .unwrap();
+        for (cf_name, compression_type) in &[
+            (
+                CF_DEFAULT,
+                self.config.rocksdb.defaultcf.bottommost_level_compression,
+            ),
+            (
+                CF_WRITE,
+                self.config.rocksdb.writecf.bottommost_level_compression,
+            ),
+        ] {
+            importer.set_compression_type(cf_name, from_rocks_compression_type(*compression_type));
+        }
+        let importer = Arc::new(importer);
+
+        let split_check_runner = SplitCheckRunner::new(
+            engines.engines.kv.clone(),
+            self.router.clone(),
+            self.coprocessor_host.clone().unwrap(),
+        );
+        let split_check_scheduler = self
+            .background_worker
+            .start("split-check", split_check_runner);
+        cfg_controller.register(
+            tikv::config::Module::Coprocessor,
+            Box::new(SplitCheckConfigManager(split_check_scheduler.clone())),
+        );
+
         let split_config_manager =
             SplitConfigManager::new(Arc::new(VersionTrack::new(self.config.split.clone())));
-        cfg_controller.register(tikv::config::Module::Split, Box::new(split_config_manager));
+        cfg_controller.register(
+            tikv::config::Module::Split,
+            Box::new(split_config_manager.clone()),
+        );
+
+        let auto_split_controller = AutoSplitController::new(
+            split_config_manager,
+            self.config.server.grpc_concurrency,
+            self.config.readpool.unified.max_thread_count,
+            unified_read_pool_scale_receiver,
+        );
 
         // `ConsistencyCheckObserver` must be registered before `Node::start`.
         let safe_point = Arc::new(AtomicU64::new(0));
@@ -830,47 +1090,142 @@ where
             .registry
             .register_consistency_check_observer(100, observer);
 
-        self.node
-            .as_mut()
-            .unwrap()
-            .start(
-                engines.raft_engine.clone(),
-                server.transport(),
-                snap_mgr,
-                self.concurrency_manager.clone(),
-                self.causal_ts_provider.clone(),
-                self.coprocessor_host.clone().unwrap(),
-                self.background_worker.clone(),
-                pd_worker,
-                raft_store,
-                &state,
-            )
-            .unwrap_or_else(|e| fatal!("failed to start node: {}", e));
+        node.start(
+            engines.engines.clone(),
+            server.transport(),
+            snap_mgr,
+            pd_worker,
+            engines.store_meta.clone(),
+            self.coprocessor_host.clone().unwrap(),
+            importer.clone(),
+            split_check_scheduler,
+            auto_split_controller,
+            self.concurrency_manager.clone(),
+            collector_reg_handle,
+            self.causal_ts_provider.clone(),
+        )
+        .unwrap_or_else(|e| fatal!("failed to start node: {}", e));
 
         // Start auto gc. Must after `Node::start` because `node_id` is initialized
         // there.
-        let store_id = self.node.as_ref().unwrap().id();
+        assert!(node.id() > 0); // Node id should never be 0.
         let auto_gc_config = AutoGcConfig::new(
             self.pd_client.clone(),
-            self.region_info_accessor.clone().unwrap(),
-            store_id,
+            self.region_info_accessor.clone(),
+            node.id(),
         );
         gc_worker
-            .start(store_id)
+            .start(node.id())
             .unwrap_or_else(|e| fatal!("failed to start gc worker: {}", e));
         if let Err(e) = gc_worker.start_auto_gc(auto_gc_config, safe_point) {
             fatal!("failed to start auto_gc on storage, error: {}", e);
         }
 
         initial_metric(&self.config.metric);
+        if self.config.storage.enable_ttl {
+            ttl_checker.start_with_timer(TtlChecker::new(
+                self.engines.as_ref().unwrap().engine.kv_engine().unwrap(),
+                self.region_info_accessor.clone(),
+                self.config.storage.ttl_check_poll_interval.into(),
+            ));
+            self.to_stop.push(ttl_checker);
+        }
 
-        self.servers = Some(Servers { lock_mgr, server });
+        // Start CDC.
+        let cdc_memory_quota = MemoryQuota::new(self.config.cdc.sink_memory_quota.0 as _);
+        let cdc_endpoint = cdc::Endpoint::new(
+            self.config.server.cluster_id,
+            &self.config.cdc,
+            self.config.storage.api_version(),
+            self.pd_client.clone(),
+            cdc_scheduler.clone(),
+            self.router.clone(),
+            self.engines.as_ref().unwrap().engines.kv.clone(),
+            cdc_ob,
+            engines.store_meta.clone(),
+            self.concurrency_manager.clone(),
+            server.env(),
+            self.security_mgr.clone(),
+            cdc_memory_quota.clone(),
+            self.causal_ts_provider.clone(),
+        );
+        cdc_worker.start_with_timer(cdc_endpoint);
+        self.to_stop.push(cdc_worker);
+
+        // Start resolved ts
+        if let Some(mut rts_worker) = rts_worker {
+            let rts_endpoint = resolved_ts::Endpoint::new(
+                &self.config.resolved_ts,
+                rts_worker.scheduler(),
+                self.router.clone(),
+                engines.store_meta.clone(),
+                self.pd_client.clone(),
+                self.concurrency_manager.clone(),
+                server.env(),
+                self.security_mgr.clone(),
+            );
+            rts_worker.start_with_timer(rts_endpoint);
+            self.to_stop.push(rts_worker);
+        }
+
+        cfg_controller.register(
+            tikv::config::Module::Raftstore,
+            Box::new(RaftstoreConfigManager::new(
+                node.refresh_config_scheduler(),
+                raft_store,
+            )),
+        );
+
+        self.servers = Some(Servers {
+            lock_mgr,
+            server,
+            node,
+            importer,
+            cdc_scheduler,
+            cdc_memory_quota,
+            rsmeter_pubsub_service,
+            backup_stream_scheduler,
+        });
 
         server_config
     }
 
     fn register_services(&mut self) {
         let servers = self.servers.as_mut().unwrap();
+        let engines = self.engines.as_ref().unwrap();
+
+        // Import SST service.
+        let import_service = ImportSstService::new(
+            self.config.import.clone(),
+            self.config.raft_store.raft_entry_max_size,
+            self.router.clone(),
+            engines.engines.kv.clone(),
+            servers.importer.clone(),
+        );
+        if servers
+            .server
+            .register_service(create_import_sst(import_service))
+            .is_some()
+        {
+            fatal!("failed to register import service");
+        }
+
+        // Debug service.
+        let debug_service = DebugService::new(
+            engines.engines.clone(),
+            self.kv_statistics.clone(),
+            self.raft_statistics.clone(),
+            servers.server.get_debug_thread_pool().clone(),
+            engines.engine.raft_extension(),
+            self.cfg_controller.as_ref().unwrap().clone(),
+        );
+        if servers
+            .server
+            .register_service(create_debug(debug_service))
+            .is_some()
+        {
+            fatal!("failed to register debug service");
+        }
 
         // Create Diagnostics service
         let diag_service = DiagnosticsService::new(
@@ -898,13 +1253,90 @@ where
         servers
             .lock_mgr
             .start(
-                self.node.as_ref().unwrap().id(),
+                servers.node.id(),
                 self.pd_client.clone(),
                 self.resolver.clone().unwrap(),
                 self.security_mgr.clone(),
                 &self.config.pessimistic_txn,
             )
             .unwrap_or_else(|e| fatal!("failed to start lock manager: {}", e));
+
+        // Backup service.
+        let mut backup_worker = Box::new(self.background_worker.lazy_build("backup-endpoint"));
+        let backup_scheduler = backup_worker.scheduler();
+        let backup_service = backup::Service::<RocksEngine, RaftRouter<RocksEngine, ER>>::new(
+            backup_scheduler,
+            self.router.clone(),
+        );
+        if servers
+            .server
+            .register_service(create_backup(backup_service))
+            .is_some()
+        {
+            fatal!("failed to register backup service");
+        }
+
+        let backup_endpoint = backup::Endpoint::new(
+            servers.node.id(),
+            engines.engine.clone(),
+            self.region_info_accessor.clone(),
+            engines.engines.kv.clone(),
+            self.config.backup.clone(),
+            self.concurrency_manager.clone(),
+            self.config.storage.api_version(),
+            self.causal_ts_provider.clone(),
+        );
+        self.cfg_controller.as_mut().unwrap().register(
+            tikv::config::Module::Backup,
+            Box::new(backup_endpoint.get_config_manager()),
+        );
+        backup_worker.start(backup_endpoint);
+
+        let cdc_service = cdc::Service::new(
+            servers.cdc_scheduler.clone(),
+            servers.cdc_memory_quota.clone(),
+        );
+        if servers
+            .server
+            .register_service(create_change_data(cdc_service))
+            .is_some()
+        {
+            fatal!("failed to register cdc service");
+        }
+        if servers
+            .server
+            .register_service(create_resource_metering_pub_sub(
+                servers.rsmeter_pubsub_service.clone(),
+            ))
+            .is_some()
+        {
+            warn!("failed to register resource metering pubsub service");
+        }
+
+        if let Some(sched) = servers.backup_stream_scheduler.take() {
+            let pitr_service = backup_stream::Service::new(sched);
+            if servers
+                .server
+                .register_service(create_log_backup(pitr_service))
+                .is_some()
+            {
+                fatal!("failed to register log backup service");
+            }
+        }
+
+        // the present tikv in recovery mode, start recovery service
+        if self.br_snap_recovery_mode {
+            let recovery_service =
+                RecoveryService::new(engines.engines.clone(), self.router.clone());
+
+            if servers
+                .server
+                .register_service(create_recover_data(recovery_service))
+                .is_some()
+            {
+                fatal!("failed to register recovery service");
+            }
+        }
     }
 
     fn init_io_utility(&mut self) -> BytesFetcher {
@@ -938,7 +1370,7 @@ where
             self.tablet_registry.clone().unwrap(),
             self.kv_statistics.clone(),
             self.config.rocksdb.titan.enabled,
-            self.engines.as_ref().unwrap().raft_engine.clone(),
+            self.engines.as_ref().unwrap().engines.raft.clone(),
             self.raft_statistics.clone(),
         );
         let mut io_metrics = IoMetricsManager::new(fetcher);
@@ -1052,7 +1484,7 @@ where
         );
     }
 
-    fn init_storage_stats_task(&self) {
+    fn init_storage_stats_task(&self, engines: Engines<RocksEngine, ER>) {
         let config_disk_capacity: u64 = self.config.raft_store.capacity.0;
         let data_dir = self.config.storage.data_dir.clone();
         let store_path = self.store_path.clone();
@@ -1063,11 +1495,9 @@ where
             info!("disk space checker not enabled");
             return;
         }
-        let raft_engine = self.engines.as_ref().unwrap().raft_engine.clone();
-        let tablet_registry = self.tablet_registry.clone().unwrap();
-        let raft_path = raft_engine.get_engine_path().to_string();
+        let raft_path = engines.raft.get_engine_path().to_string();
         let separated_raft_mount_path =
-            path_in_diff_mount_point(raft_path.as_str(), tablet_registry.tablet_root());
+            path_in_diff_mount_point(raft_path.as_str(), engines.kv.path());
         let raft_almost_full_threshold = reserve_raft_space;
         let raft_already_full_threshold = reserve_raft_space / 2;
 
@@ -1096,17 +1526,15 @@ where
                     Ok(stats) => stats,
                 };
                 let disk_cap = disk_stats.total_space();
-                let snap_size = snap_mgr.total_snap_size().unwrap();
+                let snap_size = snap_mgr.get_total_snap_size().unwrap();
 
-                let mut kv_size = 0;
-                tablet_registry.for_each_opened_tablet(|_, cached| {
-                    if let Some(tablet) = cached.latest() {
-                        kv_size += tablet.get_engine_used_size().unwrap_or(0);
-                    }
-                    true
-                });
+                let kv_size = engines
+                    .kv
+                    .get_engine_used_size()
+                    .expect("get kv engine size");
 
-                let raft_size = raft_engine
+                let raft_size = engines
+                    .raft
                     .get_engine_size()
                     .expect("get raft engine size");
 
@@ -1240,7 +1668,7 @@ where
         }
     }
 
-    fn stop(mut self) {
+    fn stop(self) {
         tikv_util::thread_group::mark_shutdown();
         let mut servers = self.servers.unwrap();
         servers
@@ -1248,8 +1676,8 @@ where
             .stop()
             .unwrap_or_else(|e| fatal!("failed to stop server: {}", e));
 
-        self.node.as_mut().unwrap().stop();
-        self.region_info_accessor.as_mut().unwrap().stop();
+        servers.node.stop();
+        self.region_info_accessor.stop();
 
         servers.lock_mgr.stop();
 
@@ -1378,7 +1806,7 @@ impl<CER: ConfiguredRaftEngine> TikvServer<CER> {
     fn init_raw_engines(
         &mut self,
         flow_listener: engine_rocks::FlowListener,
-    ) -> (CER, Arc<EnginesResourceInfo>) {
+    ) -> (Engines<RocksEngine, CER>, Arc<EnginesResourceInfo>) {
         let block_cache = self.config.storage.block_cache.build_shared_cache();
         let env = self
             .config
@@ -1396,27 +1824,39 @@ impl<CER: ConfiguredRaftEngine> TikvServer<CER> {
 
         // Create kv engine.
         let builder = KvEngineFactoryBuilder::new(env, &self.config, block_cache)
+            .compaction_event_sender(Arc::new(RaftRouterCompactedEventSender {
+                router: Mutex::new(self.router.clone()),
+            }))
+            .region_info_accessor(self.region_info_accessor.clone())
             .sst_recovery_sender(self.init_sst_recovery_sender())
             .flow_listener(flow_listener);
         let factory = Box::new(builder.build());
+        let kv_engine = factory
+            .create_shared_db(&self.store_path)
+            .unwrap_or_else(|s| fatal!("failed to create kv engine: {}", s));
         self.kv_statistics = Some(factory.rocks_statistics());
-        let registry = TabletRegistry::new(factory, self.store_path.join("tablets"))
-            .unwrap_or_else(|e| fatal!("failed to create tablet registry {:?}", e));
+        let engines = Engines::new(kv_engine.clone(), raft_engine);
+
         let cfg_controller = self.cfg_controller.as_mut().unwrap();
         cfg_controller.register(
             tikv::config::Module::Rocksdb,
-            Box::new(DbConfigManger::new(registry.clone(), DbType::Kv)),
+            Box::new(DbConfigManger::new(kv_engine.clone(), DbType::Kv)),
         );
-        self.tablet_registry = Some(registry.clone());
-        raft_engine.register_config(cfg_controller);
+        let reg = TabletRegistry::new(Box::new(SingletonFactory::new(kv_engine)), &self.store_path)
+            .unwrap();
+        // It always use the singleton kv_engine, use arbitrary id and suffix.
+        let ctx = TabletContext::with_infinite_region(0, Some(0));
+        reg.load(ctx, false).unwrap();
+        self.tablet_registry = Some(reg.clone());
+        engines.raft.register_config(cfg_controller);
 
         let engines_info = Arc::new(EnginesResourceInfo::new(
-            registry,
-            raft_engine.as_rocks_engine().cloned(),
+            reg,
+            engines.raft.as_rocks_engine().cloned(),
             180, // max_samples_to_preserve
         ));
 
-        (raft_engine, engines_info)
+        (engines, engines_info)
     }
 }
 
@@ -1508,6 +1948,33 @@ fn get_lock_dir() -> String {
 #[cfg(not(unix))]
 fn get_lock_dir() -> String {
     "TIKV_LOCK_FILES".to_owned()
+}
+
+/// A small trait for components which can be trivially stopped. Lets us keep
+/// a list of these in `TiKV`, rather than storing each component individually.
+pub(crate) trait Stop {
+    fn stop(self: Box<Self>);
+}
+
+impl<R> Stop for StatusServer<R>
+where
+    R: 'static + Send,
+{
+    fn stop(self: Box<Self>) {
+        (*self).stop()
+    }
+}
+
+impl Stop for Worker {
+    fn stop(self: Box<Self>) {
+        Worker::stop(&self);
+    }
+}
+
+impl<T: fmt::Display + Send + 'static> Stop for LazyWorker<T> {
+    fn stop(self: Box<Self>) {
+        self.stop_worker();
+    }
 }
 
 pub struct EngineMetricsManager<EK: KvEngine, ER: RaftEngine> {

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -523,9 +523,9 @@ impl ServerCluster {
                 copr.clone(),
                 copr_v2.clone(),
                 resolver.clone(),
-                snap_mgr.clone(),
+                tikv_util::Either::Left(snap_mgr.clone()),
                 gc_worker.clone(),
-                check_leader_scheduler.clone(),
+                Some(check_leader_scheduler.clone()),
                 self.env.clone(),
                 None,
                 debug_thread_pool.clone(),
@@ -794,6 +794,10 @@ impl Cluster<ServerCluster> {
             thread::sleep(Duration::from_millis(200));
         }
         panic!("failed to get snapshot of region {}", region_id);
+    }
+
+    pub fn raft_extension(&self, node_id: u64) -> SimulateRaftExtension {
+        self.sim.rl().storages[&node_id].raft_extension()
     }
 }
 

--- a/components/tikv_util/src/sys/mod.rs
+++ b/components/tikv_util/src/sys/mod.rs
@@ -165,7 +165,8 @@ pub fn cache_line_size(level: usize) -> Option<u64> {
 #[cfg(target_os = "linux")]
 pub fn path_in_diff_mount_point(path1: impl AsRef<Path>, path2: impl AsRef<Path>) -> bool {
     let (path1, path2) = (path1.as_ref(), path2.as_ref());
-    if path1.is_empty() || path2.is_empty() {
+    let empty_path = |p: &Path| p.to_str().map_or(false, |s| s.is_empty());
+    if empty_path(path1) || empty_path(path2) {
         return false;
     }
     match (get_mount(&path1), get_mount(&path2)) {

--- a/components/tikv_util/src/sys/mod.rs
+++ b/components/tikv_util/src/sys/mod.rs
@@ -9,9 +9,10 @@ pub mod ioload;
 pub mod thread;
 
 // re-export some traits for ease of use
-#[cfg(target_os = "linux")]
-use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::{
+    path::Path,
+    sync::atomic::{AtomicU64, Ordering},
+};
 
 use fail::fail_point;
 #[cfg(target_os = "linux")]
@@ -162,12 +163,11 @@ pub fn cache_line_size(level: usize) -> Option<u64> {
 }
 
 #[cfg(target_os = "linux")]
-pub fn path_in_diff_mount_point(path1: &str, path2: &str) -> bool {
+pub fn path_in_diff_mount_point(path1: impl AsRef<Path>, path2: impl AsRef<Path>) -> bool {
+    let (path1, path2) = (path1.as_ref(), path2.as_ref());
     if path1.is_empty() || path2.is_empty() {
         return false;
     }
-    let path1 = PathBuf::from(path1);
-    let path2 = PathBuf::from(path2);
     match (get_mount(&path1), get_mount(&path2)) {
         (Err(e1), _) => {
             warn!("Get mount point error for path {}, {}", path1.display(), e1);
@@ -190,7 +190,7 @@ pub fn path_in_diff_mount_point(path1: &str, path2: &str) -> bool {
 }
 
 #[cfg(not(target_os = "linux"))]
-pub fn path_in_diff_mount_point(_path1: &str, _path2: &str) -> bool {
+pub fn path_in_diff_mount_point(_path1: impl AsRef<Path>, _path2: impl AsRef<Path>) -> bool {
     false
 }
 

--- a/components/tikv_util/src/sys/mod.rs
+++ b/components/tikv_util/src/sys/mod.rs
@@ -169,7 +169,7 @@ pub fn path_in_diff_mount_point(path1: impl AsRef<Path>, path2: impl AsRef<Path>
     if empty_path(path1) || empty_path(path2) {
         return false;
     }
-    match (get_mount(&path1), get_mount(&path2)) {
+    match (get_mount(path1), get_mount(path2)) {
         (Err(e1), _) => {
             warn!("Get mount point error for path {}, {}", path1.display(), e1);
             false

--- a/src/server/raftkv2/node.rs
+++ b/src/server/raftkv2/node.rs
@@ -11,9 +11,12 @@ use raftstore::{
     coprocessor::CoprocessorHost,
     store::{GlobalReplicationState, TabletSnapManager, Transport, RAFT_INIT_LOG_INDEX},
 };
-use raftstore_v2::{router::RaftRouter, Bootstrap, StoreSystem};
+use raftstore_v2::{router::RaftRouter, Bootstrap, PdTask, StoreSystem};
 use slog::{info, o, Logger};
-use tikv_util::{config::VersionTrack, worker::Worker};
+use tikv_util::{
+    config::VersionTrack,
+    worker::{LazyWorker, Worker},
+};
 
 use crate::server::{node::init_store, Result};
 
@@ -21,13 +24,10 @@ use crate::server::{node::init_store, Result};
 pub struct NodeV2<C: PdClient + 'static, EK: KvEngine, ER: RaftEngine> {
     cluster_id: u64,
     store: metapb::Store,
-    store_cfg: Arc<VersionTrack<raftstore_v2::Config>>,
-    system: StoreSystem<EK, ER>,
+    system: Option<(RaftRouter<EK, ER>, StoreSystem<EK, ER>)>,
     has_started: bool,
 
     pd_client: Arc<C>,
-    state: Arc<Mutex<GlobalReplicationState>>,
-    bg_worker: Worker,
     registry: TabletRegistry<EK>,
     logger: Logger,
 }
@@ -40,12 +40,8 @@ where
 {
     /// Creates a new Node.
     pub fn new(
-        system: StoreSystem<EK, ER>,
         cfg: &crate::server::Config,
-        store_cfg: Arc<VersionTrack<raftstore_v2::Config>>,
         pd_client: Arc<C>,
-        state: Arc<Mutex<GlobalReplicationState>>,
-        bg_worker: Worker,
         store: Option<metapb::Store>,
         registry: TabletRegistry<EK>,
     ) -> NodeV2<C, EK, ER> {
@@ -54,18 +50,19 @@ where
         NodeV2 {
             cluster_id: cfg.cluster_id,
             store,
-            store_cfg,
             pd_client,
-            system,
+            system: None,
             has_started: false,
-            state,
-            bg_worker,
             registry,
             logger: slog_global::borrow_global().new(o!()),
         }
     }
 
-    pub fn try_bootstrap_store(&mut self, raft_engine: &ER) -> Result<()> {
+    pub fn try_bootstrap_store(
+        &mut self,
+        cfg: &raftstore_v2::Config,
+        raft_engine: &ER,
+    ) -> Result<()> {
         let store_id = Bootstrap::new(
             raft_engine,
             self.cluster_id,
@@ -74,7 +71,17 @@ where
         )
         .bootstrap_store()?;
         self.store.set_id(store_id);
+        let (router, system) =
+            raftstore_v2::create_store_batch_system(cfg, store_id, self.logger.clone());
+        self.system = Some((
+            RaftRouter::new(store_id, self.registry.clone(), router),
+            system,
+        ));
         Ok(())
+    }
+
+    pub fn router(&self) -> &RaftRouter<EK, ER> {
+        &self.system.as_ref().unwrap().0
     }
 
     /// Starts the Node. It tries to bootstrap cluster if the cluster is not
@@ -84,19 +91,21 @@ where
         &mut self,
         raft_engine: ER,
         trans: T,
-        router: &RaftRouter<EK, ER>,
         snap_mgr: TabletSnapManager,
         concurrency_manager: ConcurrencyManager,
         causal_ts_provider: Option<Arc<CausalTsProviderImpl>>, // used for rawkv apiv2
         coprocessor_host: CoprocessorHost<EK>,
         background: Worker,
+        pd_worker: LazyWorker<PdTask>,
+        store_cfg: Arc<VersionTrack<raftstore_v2::Config>>,
+        state: &Mutex<GlobalReplicationState>,
     ) -> Result<()>
     where
         T: Transport + 'static,
     {
         let store_id = self.id();
         {
-            let mut meta = router.store_meta().lock().unwrap();
+            let mut meta = self.router().store_meta().lock().unwrap();
             meta.store_id = Some(store_id);
         }
         if let Some(region) = Bootstrap::new(
@@ -121,17 +130,18 @@ where
         // Put store only if the cluster is bootstrapped.
         info!(self.logger, "put store to PD"; "store" => ?&self.store);
         let status = self.pd_client.put_store(self.store.clone())?;
-        self.load_all_stores(status);
+        self.load_all_stores(state, status);
 
         self.start_store(
             raft_engine,
             trans,
-            router,
             snap_mgr,
             concurrency_manager,
             causal_ts_provider,
             coprocessor_host,
             background,
+            pd_worker,
+            store_cfg,
         )?;
 
         Ok(())
@@ -140,6 +150,10 @@ where
     /// Gets the store id.
     pub fn id(&self) -> u64 {
         self.store.get_id()
+    }
+
+    pub fn logger(&self) -> Logger {
+        self.logger.clone()
     }
 
     /// Gets a copy of Store which is registered to Pd.
@@ -153,13 +167,17 @@ where
     // Do we really need to do the check giving we don't consider support upgrade
     // ATM?
 
-    fn load_all_stores(&mut self, status: Option<ReplicationStatus>) {
+    fn load_all_stores(
+        &mut self,
+        state: &Mutex<GlobalReplicationState>,
+        status: Option<ReplicationStatus>,
+    ) {
         info!(self.logger, "initializing replication mode"; "status" => ?status, "store_id" => self.store.id);
         let stores = match self.pd_client.get_all_stores(false) {
             Ok(stores) => stores,
             Err(e) => panic!("failed to load all stores: {:?}", e),
         };
-        let mut state = self.state.lock().unwrap();
+        let mut state = state.lock().unwrap();
         if let Some(s) = status {
             state.set_status(s);
         }
@@ -174,12 +192,13 @@ where
         &mut self,
         raft_engine: ER,
         trans: T,
-        router: &RaftRouter<EK, ER>,
         snap_mgr: TabletSnapManager,
         concurrency_manager: ConcurrencyManager,
         causal_ts_provider: Option<Arc<CausalTsProviderImpl>>, // used for rawkv apiv2
         coprocessor_host: CoprocessorHost<EK>,
         background: Worker,
+        pd_worker: LazyWorker<PdTask>,
+        store_cfg: Arc<VersionTrack<raftstore_v2::Config>>,
     ) -> Result<()>
     where
         T: Transport + 'static,
@@ -191,11 +210,12 @@ where
             return Err(box_err!("{} is already started", store_id));
         }
         self.has_started = true;
-        let cfg = self.store_cfg.clone();
 
-        self.system.start(
+        let (router, system) = self.system.as_mut().unwrap();
+
+        system.start(
             store_id,
-            cfg,
+            store_cfg,
             raft_engine,
             self.registry.clone(),
             trans,
@@ -207,6 +227,7 @@ where
             causal_ts_provider,
             coprocessor_host,
             background,
+            pd_worker,
         )?;
         Ok(())
     }
@@ -214,8 +235,8 @@ where
     /// Stops the Node.
     pub fn stop(&mut self) {
         let store_id = self.store.get_id();
+        let Some((_, mut system)) = self.system.take() else { return };
         info!(self.logger, "stop raft store thread"; "store_id" => store_id);
-        self.system.shutdown();
-        self.bg_worker.stop();
+        system.shutdown();
     }
 }

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -13,7 +13,7 @@ use futures::{compat::Stream01CompatExt, stream::StreamExt};
 use grpcio::{ChannelBuilder, Environment, ResourceQuota, Server as GrpcServer, ServerBuilder};
 use grpcio_health::{create_health, HealthService, ServingStatus};
 use kvproto::tikvpb::*;
-use raftstore::store::{CheckLeaderTask, SnapManager};
+use raftstore::store::{CheckLeaderTask, SnapManager, TabletSnapManager};
 use security::SecurityManager;
 use tikv_util::{
     config::VersionTrack,
@@ -39,7 +39,7 @@ use crate::{
     coprocessor::Endpoint,
     coprocessor_v2,
     read_pool::ReadPool,
-    server::{gc_worker::GcWorker, Proxy},
+    server::{gc_worker::GcWorker, tablet_snap::TabletRunner, Proxy},
     storage::{lock_manager::LockManager, Engine, Storage},
     tikv_util::sys::thread::ThreadBuildWrapper,
 };
@@ -67,7 +67,7 @@ pub struct Server<S: StoreAddrResolver + 'static, E: Engine> {
     trans: ServerTransport<E::RaftExtension, S>,
     raft_router: E::RaftExtension,
     // For sending/receiving snapshots.
-    snap_mgr: SnapManager,
+    snap_mgr: Either<SnapManager, TabletSnapManager>,
     snap_worker: LazyWorker<SnapTask>,
 
     // Currently load statistics is done in the thread.
@@ -94,9 +94,9 @@ where
         copr: Endpoint<E>,
         copr_v2: coprocessor_v2::Endpoint,
         resolver: S,
-        snap_mgr: SnapManager,
+        snap_mgr: Either<SnapManager, TabletSnapManager>,
         gc_worker: GcWorker<E>,
-        check_leader_scheduler: Scheduler<CheckLeaderTask>,
+        check_leader_scheduler: Option<Scheduler<CheckLeaderTask>>,
         env: Arc<Environment>,
         yatp_read_pool: Option<ReadPool>,
         debug_thread_pool: Arc<Runtime>,
@@ -252,14 +252,28 @@ where
         cfg: Arc<VersionTrack<Config>>,
         security_mgr: Arc<SecurityManager>,
     ) -> Result<()> {
-        let snap_runner = SnapHandler::new(
-            Arc::clone(&self.env),
-            self.snap_mgr.clone(),
-            self.raft_router.clone(),
-            security_mgr,
-            Arc::clone(&cfg),
-        );
-        self.snap_worker.start(snap_runner);
+        match self.snap_mgr.clone() {
+            Either::Left(mgr) => {
+                let snap_runner = SnapHandler::new(
+                    self.env.clone(),
+                    mgr,
+                    self.raft_router.clone(),
+                    security_mgr,
+                    cfg,
+                );
+                self.snap_worker.start(snap_runner);
+            }
+            Either::Right(mgr) => {
+                let snap_runner = TabletRunner::new(
+                    self.env.clone(),
+                    mgr,
+                    self.raft_router.clone(),
+                    security_mgr,
+                    cfg,
+                );
+                self.snap_worker.start(snap_runner);
+            }
+        }
 
         let mut grpc_server = self.builder_or_server.take().unwrap().right().unwrap();
         info!("listening on addr"; "addr" => &self.local_addr);
@@ -564,9 +578,9 @@ mod tests {
                 quick_fail: Arc::clone(&quick_fail),
                 addr: Arc::clone(&addr),
             },
-            SnapManager::new(""),
+            Either::Left(SnapManager::new("")),
             gc_worker,
-            check_leader_scheduler,
+            Some(check_leader_scheduler),
             env,
             None,
             debug_thread_pool,

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -65,6 +65,7 @@ const GRPC_MSG_NOTIFY_SIZE: usize = 8;
 pub struct Service<E: Engine, L: LockManager, F: KvFormat> {
     store_id: u64,
     /// Used to handle requests related to GC.
+    // TODO: make it Some after GC is supported for v2.
     gc_worker: GcWorker<E>,
     // For handling KV requests.
     storage: Storage<E, L, F>,
@@ -75,7 +76,7 @@ pub struct Service<E: Engine, L: LockManager, F: KvFormat> {
     // For handling snapshot.
     snap_scheduler: Scheduler<SnapTask>,
     // For handling `CheckLeader` request.
-    check_leader_scheduler: Scheduler<CheckLeaderTask>,
+    check_leader_scheduler: Option<Scheduler<CheckLeaderTask>>,
 
     enable_req_batch: bool,
 
@@ -114,7 +115,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Service<E, L, F> {
         copr: Endpoint<E>,
         copr_v2: coprocessor_v2::Endpoint,
         snap_scheduler: Scheduler<SnapTask>,
-        check_leader_scheduler: Scheduler<CheckLeaderTask>,
+        check_leader_scheduler: Option<Scheduler<CheckLeaderTask>>,
         grpc_thread_load: Arc<ThreadLoadPool>,
         enable_req_batch: bool,
         proxy: Proxy,
@@ -908,6 +909,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Tikv for Service<E, L, F> {
         let (cb, resp) = paired_future_callback();
         let check_leader_scheduler = self.check_leader_scheduler.clone();
         let task = async move {
+            let Some(check_leader_scheduler) = check_leader_scheduler else { return Err(box_err!("check leader is not supported")) };
             check_leader_scheduler
                 .schedule(CheckLeaderTask::CheckLeader { leaders, cb })
                 .map_err(|e| Error::Other(format!("{}", e).into()))?;
@@ -945,6 +947,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Tikv for Service<E, L, F> {
         let (cb, resp) = paired_future_callback();
         let check_leader_scheduler = self.check_leader_scheduler.clone();
         let task = async move {
+            let Some(check_leader_scheduler) = check_leader_scheduler else { return Err(box_err!("check leader is not supported")) };
             check_leader_scheduler
                 .schedule(CheckLeaderTask::GetStoreTs { key_range, cb })
                 .map_err(|e| Error::Other(format!("{}", e).into()))?;

--- a/tests/integrations/server/status_server.rs
+++ b/tests/integrations/server/status_server.rs
@@ -5,9 +5,8 @@ use std::{error::Error, net::SocketAddr, sync::Arc};
 use hyper::{body, Client, StatusCode, Uri};
 use raftstore::store::region_meta::RegionMeta;
 use security::SecurityConfig;
-use test_raftstore::{new_server_cluster, Simulator};
+use test_raftstore::new_server_cluster;
 use tikv::{config::ConfigController, server::status_server::StatusServer};
-use tikv_util::HandyRwLock;
 
 async fn check(authority: SocketAddr, region_id: u64) -> Result<(), Box<dyn Error>> {
     let client = Client::new();
@@ -39,13 +38,12 @@ fn test_region_meta_endpoint() {
     let peer = region.get_peers().get(0);
     assert!(peer.is_some());
     let store_id = peer.unwrap().get_store_id();
-    let router = cluster.sim.rl().get_router(store_id);
-    assert!(router.is_some());
+    let router = cluster.raft_extension(store_id);
     let mut status_server = StatusServer::new(
         1,
         ConfigController::default(),
         Arc::new(SecurityConfig::default()),
-        router.unwrap(),
+        router,
         std::env::temp_dir(),
     )
     .unwrap();


### PR DESCRIPTION
### What is changed and how it works?
Issue Number: Ref #12842 

What's Changed:

This PR enables start raftkv2 by introducing a new module named server2.rs.
server2.rs is just copied and adjusted from server.rs. For now, I avoid
edit server.rs in place in case introducing bad problems. In the long term,
perhaps next month, I will merge server.rs with server2.rs.

To make review easier, I rename server.rs to server_rn.rs, and server2.rs to server.rs.
So github can display what's missing and changed in server2. I will revert the naming
before merging.

```commit-message
Not all functionality are supported, this is just a naive pure
KV system with transaction support.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
