### PR TITLE
v2: fix several panics

### DIFF
--- a/components/cdc/src/observer.rs
+++ b/components/cdc/src/observer.rs
@@ -272,6 +272,7 @@ mod tests {
                 leader_id: 2,
                 prev_lead_transferee: raft::INVALID_ID,
                 vote: raft::INVALID_ID,
+                initialized: true,
             },
         );
         match rx.recv_timeout(Duration::from_millis(10)).unwrap().unwrap() {
@@ -299,6 +300,7 @@ mod tests {
                 leader_id: raft::INVALID_ID,
                 prev_lead_transferee: 3,
                 vote: 3,
+                initialized: true,
             },
         );
         match rx.recv_timeout(Duration::from_millis(10)).unwrap().unwrap() {

--- a/components/raftstore-v2/src/fsm/peer.rs
+++ b/components/raftstore-v2/src/fsm/peer.rs
@@ -188,6 +188,7 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> PeerFsmDelegate<'a, EK, ER,
 
     fn on_start(&mut self) {
         self.schedule_tick(PeerTick::Raft);
+        self.schedule_tick(PeerTick::SplitRegionCheck);
         if self.fsm.peer.storage().is_initialized() {
             self.fsm.peer.schedule_apply_fsm(self.store_ctx);
         }

--- a/components/raftstore-v2/src/operation/ready/mod.rs
+++ b/components/raftstore-v2/src/operation/ready/mod.rs
@@ -533,6 +533,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
                     leader_id: ss.leader_id,
                     prev_lead_transferee: target,
                     vote: self.raft_group().raft.vote,
+                    initialized: self.storage().is_initialized(),
                 },
             );
             self.proposal_control_mut().maybe_update_term(term);

--- a/components/raftstore-v2/src/raft/storage.rs
+++ b/components/raftstore-v2/src/raft/storage.rs
@@ -348,8 +348,7 @@ mod tests {
     fn test_apply_snapshot() {
         let region = new_region();
         let path = TempDir::new().unwrap();
-        let mgr = TabletSnapManager::new(path.path().join("snap_dir").to_str().unwrap());
-        mgr.init().unwrap();
+        let mgr = TabletSnapManager::new(path.path().join("snap_dir").to_str().unwrap()).unwrap();
         let raft_engine =
             engine_test::raft::new_engine(&format!("{}", path.path().join("raft").display()), None)
                 .unwrap();
@@ -402,8 +401,7 @@ mod tests {
         write_initial_states(&mut wb, region.clone()).unwrap();
         assert!(!wb.is_empty());
         raft_engine.consume(&mut wb, true).unwrap();
-        let mgr = TabletSnapManager::new(path.path().join("snap_dir").to_str().unwrap());
-        mgr.init().unwrap();
+        let mgr = TabletSnapManager::new(path.path().join("snap_dir").to_str().unwrap()).unwrap();
         // building a tablet factory
         let ops = DbOptions::default();
         let cf_opts = DATA_CFS.iter().map(|cf| (*cf, CfOptions::new())).collect();

--- a/components/raftstore-v2/tests/integrations/cluster.rs
+++ b/components/raftstore-v2/tests/integrations/cluster.rs
@@ -278,8 +278,7 @@ impl RunningState {
 
         let router = RaftRouter::new(store_id, registry.clone(), router);
         let store_meta = router.store_meta().clone();
-        let snap_mgr = TabletSnapManager::new(path.join("tablets_snap").to_str().unwrap());
-        snap_mgr.init().unwrap();
+        let snap_mgr = TabletSnapManager::new(path.join("tablets_snap").to_str().unwrap()).unwrap();
 
         let coprocessor_host = CoprocessorHost::new(
             router.store_router().clone(),

--- a/components/raftstore/src/coprocessor/mod.rs
+++ b/components/raftstore/src/coprocessor/mod.rs
@@ -268,15 +268,18 @@ pub struct RoleChange {
     pub prev_lead_transferee: u64,
     /// Which peer is voted by itself.
     pub vote: u64,
+    pub initialized: bool,
 }
 
 impl RoleChange {
+    #[cfg(feature = "testexport")]
     pub fn new(state: StateRole) -> Self {
         RoleChange {
             state,
             leader_id: raft::INVALID_ID,
             prev_lead_transferee: raft::INVALID_ID,
             vote: raft::INVALID_ID,
+            initialized: true,
         }
     }
 }

--- a/components/raftstore/src/coprocessor/region_info_accessor.rs
+++ b/components/raftstore/src/coprocessor/region_info_accessor.rs
@@ -46,11 +46,26 @@ use super::{
 /// `RaftStoreEvent` Represents events dispatched from raftstore coprocessor.
 #[derive(Debug)]
 pub enum RaftStoreEvent {
-    CreateRegion { region: Region, role: StateRole },
-    UpdateRegion { region: Region, role: StateRole },
-    DestroyRegion { region: Region },
-    RoleChange { region: Region, role: StateRole },
-    UpdateRegionBuckets { region: Region, buckets: usize },
+    CreateRegion {
+        region: Region,
+        role: StateRole,
+    },
+    UpdateRegion {
+        region: Region,
+        role: StateRole,
+    },
+    DestroyRegion {
+        region: Region,
+    },
+    RoleChange {
+        region: Region,
+        role: StateRole,
+        initialized: bool,
+    },
+    UpdateRegionBuckets {
+        region: Region,
+        buckets: usize,
+    },
 }
 
 impl RaftStoreEvent {
@@ -191,7 +206,11 @@ impl RoleObserver for RegionEventListener {
     fn on_role_change(&self, context: &mut ObserverContext<'_>, role_change: &RoleChange) {
         let region = context.region().clone();
         let role = role_change.state;
-        let event = RaftStoreEvent::RoleChange { region, role };
+        let event = RaftStoreEvent::RoleChange {
+            region,
+            role,
+            initialized: role_change.initialized,
+        };
         self.scheduler
             .schedule(RegionInfoQuery::RaftStoreEvent(event))
             .unwrap();
@@ -426,7 +445,10 @@ impl RegionCollector {
             // They are impossible to equal, or they cannot overlap.
             assert_ne!(
                 region.get_region_epoch().get_version(),
-                current_region.get_region_epoch().get_version()
+                current_region.get_region_epoch().get_version(),
+                "{:?} vs {:?}",
+                region,
+                current_region,
             );
             // Remove it since it's a out-of-date region info.
             if clear_regions_in_range {
@@ -492,6 +514,10 @@ impl RegionCollector {
                 // epoch is properly set and an Update message was sent.
                 return;
             }
+            if let RaftStoreEvent::RoleChange { initialized, .. } = &event && !initialized {
+                // Ignore uninitialized peers.
+                return;
+            }
             if !self.check_region_range(region, true) {
                 debug!(
                     "Received stale event";
@@ -511,7 +537,7 @@ impl RegionCollector {
             RaftStoreEvent::DestroyRegion { region } => {
                 self.handle_destroy_region(region);
             }
-            RaftStoreEvent::RoleChange { region, role } => {
+            RaftStoreEvent::RoleChange { region, role, .. } => {
                 self.handle_role_change(region, role);
             }
             RaftStoreEvent::UpdateRegionBuckets { region, buckets } => {
@@ -988,10 +1014,16 @@ mod tests {
         }
     }
 
-    fn must_change_role(c: &mut RegionCollector, region: &Region, role: StateRole) {
+    fn must_change_role(
+        c: &mut RegionCollector,
+        region: &Region,
+        role: StateRole,
+        initialized: bool,
+    ) {
         c.handle_raftstore_event(RaftStoreEvent::RoleChange {
             region: region.clone(),
             role,
+            initialized,
         });
 
         if let Some(r) = c.regions.get(&region.get_id()) {
@@ -1037,6 +1069,12 @@ mod tests {
         c.handle_raftstore_event(RaftStoreEvent::RoleChange {
             region: new_region(1, b"k1", b"k2", 0),
             role: StateRole::Leader,
+            initialized: true,
+        });
+        c.handle_raftstore_event(RaftStoreEvent::RoleChange {
+            region: new_region(1, b"", b"", 3),
+            role: StateRole::Leader,
+            initialized: false,
         });
 
         check_collection(&c, &[]);
@@ -1198,9 +1236,15 @@ mod tests {
             &mut c,
             &new_region(1, b"k0", b"k1", 2),
             StateRole::Candidate,
+            true,
         );
         must_create_region(&mut c, &new_region(5, b"k99", b"", 2), StateRole::Follower);
-        must_change_role(&mut c, &new_region(2, b"k2", b"k8", 2), StateRole::Leader);
+        must_change_role(
+            &mut c,
+            &new_region(2, b"k2", b"k8", 2),
+            StateRole::Leader,
+            true,
+        );
         must_update_region(&mut c, &new_region(2, b"k3", b"k7", 3), StateRole::Leader);
         // test region buckets update
         must_update_region_buckets(&mut c, &new_region(2, b"k3", b"k7", 3), 4);
@@ -1343,7 +1387,12 @@ mod tests {
         // which haven't been handled.
         must_create_region(&mut c, &new_region(4, b"k5", b"k9", 2), StateRole::Follower);
         must_update_region(&mut c, &new_region(2, b"k1", b"k9", 1), StateRole::Follower);
-        must_change_role(&mut c, &new_region(2, b"k1", b"k9", 1), StateRole::Leader);
+        must_change_role(
+            &mut c,
+            &new_region(2, b"k1", b"k9", 1),
+            StateRole::Leader,
+            true,
+        );
         must_update_region(&mut c, &new_region(2, b"k1", b"k5", 2), StateRole::Leader);
         // TODO: In fact, region 2's role should be follower. However because it's
         // previous state was removed while creating updating region 4, it can't be
@@ -1364,7 +1413,12 @@ mod tests {
         // handled.
         must_update_region(&mut c, &new_region(2, b"k1", b"k9", 3), StateRole::Leader);
         must_update_region(&mut c, &new_region(4, b"k5", b"k9", 2), StateRole::Follower);
-        must_change_role(&mut c, &new_region(4, b"k5", b"k9", 2), StateRole::Leader);
+        must_change_role(
+            &mut c,
+            &new_region(4, b"k5", b"k9", 2),
+            StateRole::Leader,
+            true,
+        );
         must_destroy_region(&mut c, new_region(4, b"k5", b"k9", 2));
         check_collection(
             &c,

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -2282,6 +2282,7 @@ where
                     leader_id: ss.leader_id,
                     prev_lead_transferee: self.lead_transferee,
                     vote: self.raft_group.raft.vote,
+                    initialized: self.is_initialized(),
                 },
             );
             self.cmd_epoch_checker.maybe_update_term(self.term());

--- a/components/raftstore/src/store/snap.rs
+++ b/components/raftstore/src/store/snap.rs
@@ -1932,20 +1932,15 @@ impl Display for TabletSnapKey {
 #[derive(Clone)]
 pub struct TabletSnapManager {
     // directory to store snapfile.
-    base: String,
+    base: PathBuf,
 }
 
 impl TabletSnapManager {
-    pub fn new<T: Into<String>>(path: T) -> Self {
-        Self { base: path.into() }
-    }
-
-    pub fn init(&self) -> io::Result<()> {
+    pub fn new<T: Into<PathBuf>>(path: T) -> io::Result<Self> {
         // Initialize the directory if it doesn't exist.
-        let path = Path::new(&self.base);
+        let path = path.into();
         if !path.exists() {
-            file_system::create_dir_all(path)?;
-            return Ok(());
+            file_system::create_dir_all(&path)?;
         }
         if !path.is_dir() {
             return Err(io::Error::new(
@@ -1953,7 +1948,7 @@ impl TabletSnapManager {
                 format!("{} should be a directory", path.display()),
             ));
         }
-        Ok(())
+        Ok(Self { base: path })
     }
 
     pub fn tablet_gen_path(&self, key: &TabletSnapKey) -> PathBuf {

--- a/components/server/src/server2.rs
+++ b/components/server/src/server2.rs
@@ -1542,18 +1542,14 @@ impl<EK: KvEngine, ER: RaftEngine> EngineMetricsManager<EK, ER> {
 
     pub fn flush(&mut self, now: Instant) {
         let mut reporter = EK::StatisticsReporter::new("kv");
-        let mut collected = false;
         self.tablet_registry
             .for_each_opened_tablet(|_, db: &mut CachedTablet<EK>| {
                 if let Some(db) = db.latest() {
                     reporter.collect(db);
-                    collected = true;
                 }
                 true
             });
-        if collected {
-            reporter.flush();
-        }
+        reporter.flush();
         self.raft_engine.flush_metrics("raft");
 
         if let Some(s) = self.kv_statistics.as_ref() {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2988,6 +2988,10 @@ impl TikvConfig {
                 .to_owned();
         }
 
+        if self.storage.engine == EngineType::RaftKv2 {
+            self.raft_store.store_io_pool_size = cmp::max(self.raft_store.store_io_pool_size, 1);
+        }
+
         self.raft_store.raftdb_path = self.infer_raft_db_path(None)?;
         self.raft_engine.config.dir = self.infer_raft_engine_path(None)?;
 

--- a/src/server/tablet_snap.rs
+++ b/src/server/tablet_snap.rs
@@ -493,7 +493,7 @@ mod tests {
         msg.mut_message().mut_snapshot().mut_metadata().set_term(1);
         let send_path = TempDir::new().unwrap();
         let send_snap_mgr =
-            TabletSnapManager::new(send_path.path().join("snap_dir").to_str().unwrap());
+            TabletSnapManager::new(send_path.path().join("snap_dir").to_str().unwrap()).unwrap();
         let snap_path = send_snap_mgr.tablet_gen_path(&snap_key);
         create_dir_all(snap_path.as_path()).unwrap();
         // send file should skip directory
@@ -512,7 +512,7 @@ mod tests {
 
         let recv_path = TempDir::new().unwrap();
         let recv_snap_manager =
-            TabletSnapManager::new(recv_path.path().join("snap_dir").to_str().unwrap());
+            TabletSnapManager::new(recv_path.path().join("snap_dir").to_str().unwrap()).unwrap();
         let (tx, rx) = mpsc::unbounded();
         let sink = tx.sink_map_err(Error::from);
         block_on(send_snap_files(


### PR DESCRIPTION
### What is changed and how it works?
Issue Number: Ref #12842 

What's Changed:

```commit-message
Perf context is disabled for now as we don't have shared kv engine.
And fix region info access panic by filter out uninitialized role change.
There are also several other fixes.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test
    tiup playground

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
