### PR TITLE
raftstore-v2: add flush tick to propose pending write

### DIFF
--- a/components/raftstore-v2/src/operation/pd.rs
+++ b/components/raftstore-v2/src/operation/pd.rs
@@ -72,6 +72,13 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> PeerFsmDelegate<'a, EK, ER,
         // TODO: hibernate region
         self.schedule_tick(PeerTick::PdHeartbeat);
     }
+
+    #[inline]
+    pub fn on_propose_pending_write(&mut self) {
+        if let Some(write) = self.fsm.peer.simple_write_encoder_mut()&& write.need_schedule() {
+            self.fsm.peer.propose_pending_writes(self.store_ctx);
+        }
+    }
 }
 
 impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {

--- a/components/raftstore-v2/src/operation/pd.rs
+++ b/components/raftstore-v2/src/operation/pd.rs
@@ -72,13 +72,6 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> PeerFsmDelegate<'a, EK, ER,
         // TODO: hibernate region
         self.schedule_tick(PeerTick::PdHeartbeat);
     }
-
-    #[inline]
-    pub fn on_propose_pending_write(&mut self) {
-        if let Some(write) = self.fsm.peer.simple_write_encoder_mut()&& write.need_schedule() {
-            self.fsm.peer.propose_pending_writes(self.store_ctx);
-        }
-    }
 }
 
 impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {

--- a/components/raftstore-v2/src/operation/ready/mod.rs
+++ b/components/raftstore-v2/src/operation/ready/mod.rs
@@ -73,6 +73,13 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> PeerFsmDelegate<'a, EK, ER,
         }
         self.schedule_tick(PeerTick::Raft);
     }
+
+    pub fn on_propose_pending_write(&mut self) {
+        let peer = self.fsm.peer_mut();
+        if peer.simple_write_encoder().is_some() {
+            peer.propose_pending_writes(self.store_ctx);
+        }
+    }
 }
 
 impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {

--- a/components/raftstore-v2/src/router/message.rs
+++ b/components/raftstore-v2/src/router/message.rs
@@ -32,6 +32,7 @@ pub enum PeerTick {
     ReactivateMemoryLock = 8,
     ReportBuckets = 9,
     CheckLongUncommitted = 10,
+    ProposePendingWrite = 11,
 }
 
 impl PeerTick {
@@ -51,6 +52,7 @@ impl PeerTick {
             PeerTick::ReactivateMemoryLock => "reactivate_memory_lock",
             PeerTick::ReportBuckets => "report_buckets",
             PeerTick::CheckLongUncommitted => "check_long_uncommitted",
+            PeerTick::ProposePendingWrite => "propose_pending_write",
         }
     }
 
@@ -67,6 +69,7 @@ impl PeerTick {
             PeerTick::ReactivateMemoryLock,
             PeerTick::ReportBuckets,
             PeerTick::CheckLongUncommitted,
+            PeerTick::ProposePendingWrite,
         ];
         TICKS
     }

--- a/components/raftstore-v2/src/router/message.rs
+++ b/components/raftstore-v2/src/router/message.rs
@@ -32,7 +32,7 @@ pub enum PeerTick {
     ReactivateMemoryLock = 8,
     ReportBuckets = 9,
     CheckLongUncommitted = 10,
-    ProposePendingWrite = 11,
+    FlushPendingWrite = 11,
 }
 
 impl PeerTick {
@@ -52,7 +52,7 @@ impl PeerTick {
             PeerTick::ReactivateMemoryLock => "reactivate_memory_lock",
             PeerTick::ReportBuckets => "report_buckets",
             PeerTick::CheckLongUncommitted => "check_long_uncommitted",
-            PeerTick::ProposePendingWrite => "propose_pending_write",
+            PeerTick::FlushPendingWrite => "flush_pending_write",
         }
     }
 
@@ -69,7 +69,7 @@ impl PeerTick {
             PeerTick::ReactivateMemoryLock,
             PeerTick::ReportBuckets,
             PeerTick::CheckLongUncommitted,
-            PeerTick::ProposePendingWrite,
+            PeerTick::FlushPendingWrite,
         ];
         TICKS
     }

--- a/components/raftstore-v2/tests/integrations/cluster.rs
+++ b/components/raftstore-v2/tests/integrations/cluster.rs
@@ -38,7 +38,7 @@ use raftstore::{
 };
 use raftstore_v2::{
     create_store_batch_system,
-    router::{DebugInfoChannel, FlushChannel, PeerMsg, QueryResult, RaftRouter},
+    router::{DebugInfoChannel, FlushChannel, PeerMsg, PeerTick, QueryResult, RaftRouter},
     Bootstrap, SimpleWriteEncoder, StateStorage, StoreSystem,
 };
 use slog::{debug, o, Logger};
@@ -109,6 +109,8 @@ impl TestRouter {
     ) -> Option<RaftCmdResponse> {
         let (msg, sub) = PeerMsg::simple_write(header, write.encode());
         self.send(region_id, msg).unwrap();
+        self.send(region_id, PeerMsg::Tick(PeerTick::FlushPendingWrite))
+            .unwrap();
         block_on(sub.result())
     }
 

--- a/components/raftstore-v2/tests/integrations/test_basic_write.rs
+++ b/components/raftstore-v2/tests/integrations/test_basic_write.rs
@@ -3,37 +3,47 @@
 use std::{assert_matches::assert_matches, time::Duration};
 
 use engine_traits::{Peekable, CF_DEFAULT};
-use futures::executor::block_on;
 use kvproto::raft_serverpb::RaftMessage;
 use raftstore::store::{INIT_EPOCH_CONF_VER, INIT_EPOCH_VER};
 use raftstore_v2::{router::PeerMsg, SimpleWriteEncoder};
-use tikv_util::store::new_peer;
+use tikv_util::{config::ReadableSize, store::new_peer};
 
-use crate::cluster::{check_skip_wal, Cluster};
+use crate::cluster::{check_skip_wal, v2_default_config, Cluster};
 
 /// Test basic write flow.
 #[test]
 fn test_basic_write() {
-    let cluster = Cluster::default();
-    let router = &cluster.routers[0];
+    let mut config = v2_default_config();
+    config.raft_entry_max_size = ReadableSize::kb(1);
+    let mut cluster = Cluster::with_config(config);
+    let router = &mut cluster.routers[0];
+    let region_id = 2;
     let header = Box::new(router.new_request_for(2).take_header());
     let mut put = SimpleWriteEncoder::with_capacity(64);
     put.put(CF_DEFAULT, b"key", b"value");
 
-    router.wait_applied_to_current_term(2, Duration::from_secs(3));
+    router.wait_applied_to_current_term(region_id, Duration::from_secs(3));
+    // it will propose this batch write util the buffer size is bigger than the
+    // raft_entry_max_size.
+    for _ in 0..35 {
+        let (msg, _) = PeerMsg::simple_write(header.clone(), put.clone().encode());
+        router.send(region_id, msg).unwrap();
+    }
 
-    // Good proposal should be committed.
-    let (msg, mut sub) = PeerMsg::simple_write(header.clone(), put.clone().encode());
-    router.send(2, msg).unwrap();
-    assert!(block_on(sub.wait_proposed()));
-    assert!(block_on(sub.wait_committed()));
-    let resp = block_on(sub.result()).unwrap();
+    let snap = router.stale_snapshot(region_id);
+    assert_eq!(snap.get_value(b"key").unwrap().unwrap(), b"value");
+
+    let resp = router
+        .simple_write(region_id, header.clone(), put.clone())
+        .unwrap();
     assert!(!resp.get_header().has_error(), "{:?}", resp);
 
     // Store id should be checked.
     let mut invalid_header = header.clone();
     invalid_header.set_peer(new_peer(3, 3));
-    let resp = router.simple_write(2, invalid_header, put.clone()).unwrap();
+    let resp = router
+        .simple_write(region_id, invalid_header, put.clone())
+        .unwrap();
     assert!(
         resp.get_header().get_error().has_store_not_match(),
         "{:?}",
@@ -71,7 +81,9 @@ fn test_basic_write() {
     // Too large message can cause regression and should be rejected.
     let mut invalid_put = SimpleWriteEncoder::with_capacity(9 * 1024 * 1024);
     invalid_put.put(CF_DEFAULT, b"key", &vec![0; 8 * 1024 * 1024]);
-    let resp = router.simple_write(2, header.clone(), invalid_put).unwrap();
+    let resp = router
+        .simple_write(region_id, header.clone(), invalid_put)
+        .unwrap();
     assert!(
         resp.get_header().get_error().has_raft_entry_too_large(),
         "{:?}",
@@ -89,7 +101,7 @@ fn test_basic_write() {
     raft_message.set_from(4);
     raft_message.set_term(8);
     router.send_raft_message(msg).unwrap();
-    let resp = router.simple_write(2, header, put).unwrap();
+    let resp = router.simple_write(region_id, header, put).unwrap();
     assert!(resp.get_header().get_error().has_not_leader(), "{:?}", resp);
 }
 
@@ -105,22 +117,14 @@ fn test_put_delete() {
 
     let snap = router.stale_snapshot(2);
     assert!(snap.get_value(b"key").unwrap().is_none());
-    let (msg, mut sub) = PeerMsg::simple_write(header.clone(), put.encode());
-    router.send(2, msg).unwrap();
-    assert!(block_on(sub.wait_proposed()));
-    assert!(block_on(sub.wait_committed()));
-    let resp = block_on(sub.result()).unwrap();
+    let resp = router.simple_write(2, header.clone(), put.clone()).unwrap();
     assert!(!resp.get_header().has_error(), "{:?}", resp);
     let snap = router.stale_snapshot(2);
     assert_eq!(snap.get_value(b"key").unwrap().unwrap(), b"value");
 
     let mut delete = SimpleWriteEncoder::with_capacity(64);
     delete.delete(CF_DEFAULT, b"key");
-    let (msg, mut sub) = PeerMsg::simple_write(header, delete.encode());
-    router.send(2, msg).unwrap();
-    assert!(block_on(sub.wait_proposed()));
-    assert!(block_on(sub.wait_committed()));
-    let resp = block_on(sub.result()).unwrap();
+    let resp = router.simple_write(2, header, delete.clone()).unwrap();
     assert!(!resp.get_header().has_error(), "{:?}", resp);
     let snap = router.stale_snapshot(2);
     assert_matches!(snap.get_value(b"key"), Ok(None));

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -1193,6 +1193,7 @@ where
             PeerTick::ReportBuckets => self.on_report_region_buckets_tick(),
             PeerTick::CheckLongUncommitted => self.on_check_long_uncommitted_tick(),
             PeerTick::CheckPeersAvailability => self.on_check_peers_availability(),
+            PeerTick::FlushPendingWrite => unimplemented!(),
         }
     }
 

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -558,6 +558,8 @@ where
             self.cfg.check_long_uncommitted_interval.0;
         self.tick_batch[PeerTick::CheckPeersAvailability as usize].wait_duration =
             self.cfg.check_peers_availability_interval.0;
+        self.tick_batch[PeerTick::ProposePendingWrite as usize].wait_duration =
+            Duration::from_millis(1);
     }
 }
 

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -558,8 +558,8 @@ where
             self.cfg.check_long_uncommitted_interval.0;
         self.tick_batch[PeerTick::CheckPeersAvailability as usize].wait_duration =
             self.cfg.check_peers_availability_interval.0;
-        self.tick_batch[PeerTick::ProposePendingWrite as usize].wait_duration =
-            Duration::from_millis(1);
+        self.tick_batch[PeerTick::FlushPendingWrite as usize].wait_duration =
+            Duration::from_millis(10);
     }
 }
 

--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -375,6 +375,7 @@ pub enum PeerTick {
     ReportBuckets = 9,
     CheckLongUncommitted = 10,
     CheckPeersAvailability = 11,
+    FlushPendingWrite = 12,
 }
 
 impl PeerTick {
@@ -395,6 +396,7 @@ impl PeerTick {
             PeerTick::ReportBuckets => "report_buckets",
             PeerTick::CheckLongUncommitted => "check_long_uncommitted",
             PeerTick::CheckPeersAvailability => "check_peers_availability",
+            PeerTick::FlushPendingWrite => "flush_pending_write",
         }
     }
 
@@ -412,6 +414,7 @@ impl PeerTick {
             PeerTick::ReportBuckets,
             PeerTick::CheckLongUncommitted,
             PeerTick::CheckPeersAvailability,
+            PeerTick::FlushPendingWrite,
         ];
         TICKS
     }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref https://github.com/tikv/tikv/issues/12842

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Add new tick to flash propose pending writes instead of propose them every batch 

```

### Related changes



### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test


Side effects



### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
