### PR TITLE
raftstore-v2: avoid ticking when there are many unapplied logs

### DIFF
--- a/components/engine_rocks/src/event_listener.rs
+++ b/components/engine_rocks/src/event_listener.rs
@@ -261,7 +261,7 @@ mod tests {
         let (region_id, tablet_index) = (2, 3);
 
         let storage = Arc::new(MemStorage::default());
-        let state = Arc::new(FlushState::default());
+        let state = Arc::new(FlushState::new(0));
         let listener =
             PersistenceListener::new(region_id, tablet_index, state.clone(), storage.clone());
         let mut db_opt = RocksDbOptions::default();

--- a/components/engine_traits/src/flush.rs
+++ b/components/engine_traits/src/flush.rs
@@ -50,12 +50,18 @@ impl FlushProgress {
 /// raftstore will update state changes and corresponding apply index, when
 /// flush, `PersistenceListener` will query states related to the memtable
 /// and persist the relation to raft engine.
-#[derive(Default, Debug)]
+#[derive(Debug)]
 pub struct FlushState {
     applied_index: AtomicU64,
 }
 
 impl FlushState {
+    pub fn new(applied_index: u64) -> Self {
+        Self {
+            applied_index: AtomicU64::new(applied_index),
+        }
+    }
+
     /// Set the latest applied index.
     #[inline]
     pub fn set_applied_index(&self, index: u64) {

--- a/components/engine_traits/src/tablet.rs
+++ b/components/engine_traits/src/tablet.rs
@@ -222,18 +222,27 @@ impl<EK> TabletRegistry<EK> {
         })
     }
 
+    /// Format the name as {prefix}_{id}_{suffix}. If prefix is empty, it will
+    /// be format as {id}_{suffix}.
     pub fn tablet_name(&self, prefix: &str, id: u64, suffix: u64) -> String {
-        format!("{}{}_{}", prefix, id, suffix)
+        format!(
+            "{}{:_<width$}{}_{}",
+            prefix,
+            "",
+            id,
+            suffix,
+            width = !prefix.is_empty() as usize
+        )
     }
 
+    /// Returns the prefix, id and suffix of the tablet name.
     pub fn parse_tablet_name<'a>(&self, path: &'a Path) -> Option<(&'a str, u64, u64)> {
         let name = path.file_name().unwrap().to_str().unwrap();
-        let (rest, suffix) = name.rsplit_once('_')?;
-        let (prefix, id) = match rest.rfind('_') {
-            Some(idx) => unsafe { (rest.get_unchecked(..=idx), rest.get_unchecked(idx + 1..)) },
-            None => ("", rest),
-        };
-        Some((prefix, id.parse().ok()?, suffix.parse().ok()?))
+        let mut parts = name.rsplit('_');
+        let suffix = parts.next()?.parse().ok()?;
+        let id = parts.next()?.parse().ok()?;
+        let prefix = parts.as_str();
+        Some((prefix, id, suffix))
     }
 
     pub fn tablet_root(&self) -> &Path {
@@ -464,7 +473,7 @@ mod tests {
         });
         assert_eq!(count, 1);
 
-        let name = registry.tablet_name("prefix_", 12, 30);
+        let name = registry.tablet_name("prefix", 12, 30);
         assert_eq!(name, "prefix_12_30");
         let normal_name = registry.tablet_name("", 20, 15);
         let normal_tablet_path = registry.tablet_path(20, 15);
@@ -472,7 +481,7 @@ mod tests {
 
         let full_prefix_path = registry.tablet_root().join(name);
         let res = registry.parse_tablet_name(&full_prefix_path);
-        assert_eq!(res, Some(("prefix_", 12, 30)));
+        assert_eq!(res, Some(("prefix", 12, 30)));
         let res = registry.parse_tablet_name(&normal_tablet_path);
         assert_eq!(res, Some(("", 20, 15)));
         let invalid_path = registry.tablet_root().join("invalid_12");

--- a/components/raftstore-v2/src/fsm/apply.rs
+++ b/components/raftstore-v2/src/fsm/apply.rs
@@ -65,6 +65,8 @@ impl<EK: KvEngine, R> ApplyFsm<EK, R> {
         read_scheduler: Scheduler<ReadTask<EK>>,
         flush_state: Arc<FlushState>,
         log_recovery: Option<Box<DataTrace>>,
+        applied_index: u64,
+        applied_term: u64,
         logger: Logger,
     ) -> (ApplyScheduler, Self) {
         let (tx, rx) = future::unbounded(WakePolicy::Immediately);
@@ -76,6 +78,8 @@ impl<EK: KvEngine, R> ApplyFsm<EK, R> {
             read_scheduler,
             flush_state,
             log_recovery,
+            applied_index,
+            applied_term,
             logger,
         );
         (

--- a/components/raftstore-v2/src/fsm/apply.rs
+++ b/components/raftstore-v2/src/fsm/apply.rs
@@ -114,6 +114,7 @@ impl<EK: KvEngine, R: ApplyResReporter> ApplyFsm<EK, R> {
                     ApplyTask::CommittedEntries(ce) => self.apply.apply_committed_entries(ce).await,
                     ApplyTask::Snapshot(snap_task) => self.apply.schedule_gen_snapshot(snap_task),
                     ApplyTask::UnsafeWrite(raw_write) => self.apply.apply_unsafe_write(raw_write),
+                    ApplyTask::ManualFlush => self.apply.on_manual_flush(),
                 }
 
                 // TODO: yield after some time.

--- a/components/raftstore-v2/src/fsm/apply.rs
+++ b/components/raftstore-v2/src/fsm/apply.rs
@@ -65,7 +65,6 @@ impl<EK: KvEngine, R> ApplyFsm<EK, R> {
         read_scheduler: Scheduler<ReadTask<EK>>,
         flush_state: Arc<FlushState>,
         log_recovery: Option<Box<DataTrace>>,
-        applied_index: u64,
         applied_term: u64,
         logger: Logger,
     ) -> (ApplyScheduler, Self) {
@@ -78,7 +77,6 @@ impl<EK: KvEngine, R> ApplyFsm<EK, R> {
             read_scheduler,
             flush_state,
             log_recovery,
-            applied_index,
             applied_term,
             logger,
         );

--- a/components/raftstore-v2/src/fsm/peer.rs
+++ b/components/raftstore-v2/src/fsm/peer.rs
@@ -187,20 +187,17 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> PeerFsmDelegate<'a, EK, ER,
     }
 
     fn on_start(&mut self) {
-        self.schedule_tick(PeerTick::Raft);
+        if !self.fsm.peer.maybe_pause_for_recovery() {
+            self.schedule_tick(PeerTick::Raft);
+        }
         self.schedule_tick(PeerTick::SplitRegionCheck);
         self.schedule_tick(PeerTick::PdHeartbeat);
         self.schedule_tick(PeerTick::CompactLog);
         if self.fsm.peer.storage().is_initialized() {
             self.fsm.peer.schedule_apply_fsm(self.store_ctx);
         }
-        // Unlike v1, it's a must to set ready when there are pending entries. Otherwise
-        // it may block for ever when there is unapplied conf change.
-        let entry_storage = self.fsm.peer.storage().entry_storage();
-        if entry_storage.commit_index() > entry_storage.applied_index()
-            // Speed up setup if there is only one peer.
-            || self.fsm.peer.is_leader()
-        {
+        // Speed up setup if there is only one peer.
+        if self.fsm.peer.is_leader() {
             self.fsm.peer.set_has_ready();
         }
     }

--- a/components/raftstore-v2/src/fsm/peer.rs
+++ b/components/raftstore-v2/src/fsm/peer.rs
@@ -43,7 +43,11 @@ impl<EK: KvEngine, ER: RaftEngine> PeerFsm<EK, ER> {
         storage: Storage<EK, ER>,
     ) -> Result<SenderFsmPair<EK, ER>> {
         let peer = Peer::new(cfg, tablet_registry, snap_mgr, storage)?;
-        info!(peer.logger, "create peer");
+        info!(peer.logger, "create peer";
+            "raft_state" => ?peer.storage().raft_state(),
+            "apply_state" => ?peer.storage().apply_state(),
+            "region_state" => ?peer.storage().region_state()
+        );
         let (tx, rx) = mpsc::loose_bounded(cfg.notify_capacity);
         let fsm = Box::new(PeerFsm {
             peer,

--- a/components/raftstore-v2/src/operation/command/admin/compact_log.rs
+++ b/components/raftstore-v2/src/operation/command/admin/compact_log.rs
@@ -300,10 +300,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
 
     fn compact_log_from_engine<T>(&mut self, store_ctx: &mut StoreContext<EK, ER, T>) {
         let truncated = self.entry_storage().truncated_index() + 1;
-        let persisted_applied = self
-            .storage()
-            .apply_trace()
-            .persisted_apply_index();
+        let persisted_applied = self.storage().apply_trace().persisted_apply_index();
         let compact_index = std::cmp::min(truncated, persisted_applied);
         // Raft Engine doesn't care about first index.
         if let Err(e) =

--- a/components/raftstore-v2/src/operation/command/admin/compact_log.rs
+++ b/components/raftstore-v2/src/operation/command/admin/compact_log.rs
@@ -317,7 +317,10 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             error!(self.logger, "failed to compact raft logs"; "err" => ?e);
         } else {
             // TODO: make this debug when stable.
-            info!(self.logger, "compact log"; "index" => compact_index);
+            info!(self.logger, "compact log";
+                "index" => compact_index,
+                "apply_trace" => ?self.storage().apply_trace(),
+                "truncated" => ?self.entry_storage().apply_state());
             self.set_has_extra_write();
         }
     }

--- a/components/raftstore-v2/src/operation/command/admin/compact_log.rs
+++ b/components/raftstore-v2/src/operation/command/admin/compact_log.rs
@@ -21,7 +21,7 @@ use raftstore::{
     Result,
 };
 use slog::{debug, error, info};
-use tikv_util::{box_err, Either};
+use tikv_util::box_err;
 
 use crate::{
     batch::StoreContext,
@@ -255,7 +255,15 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             .unwrap();
         self.set_has_extra_write();
 
-        self.maybe_compact_log_from_engine(store_ctx, Either::Right(old_truncated));
+        // All logs < perssited_apply will be deleted, so should check with +1.
+        if old_truncated + 1 < self.storage().apply_trace().persisted_apply_index() {
+            self.maybe_compact_log_from_engine(store_ctx);
+        }
+
+        let applied = *self.last_applying_index_mut();
+        let total_cnt = applied - old_truncated;
+        let remain_cnt = applied - res.compact_index;
+        self.update_approximate_raft_log_size(|s| s * remain_cnt / total_cnt);
     }
 
     #[inline]
@@ -278,7 +286,9 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             } else {
                 self.set_has_extra_write();
             }
-            self.maybe_compact_log_from_engine(store_ctx, Either::Left(old_persisted));
+            if old_persisted < self.entry_storage().truncated_index() + 1 {
+                self.maybe_compact_log_from_engine(store_ctx);
+            }
             if self.remove_tombstone_tablets_before(new_persisted) {
                 let sched = store_ctx.schedulers.tablet_gc.clone();
                 task.persisted_cbs.push(Box::new(move || {
@@ -288,19 +298,16 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         }
     }
 
-    pub fn maybe_compact_log_from_engine<T>(
-        &mut self,
-        store_ctx: &mut StoreContext<EK, ER, T>,
-        old_index: Either<u64, u64>,
-    ) {
+    fn maybe_compact_log_from_engine<T>(&mut self, store_ctx: &mut StoreContext<EK, ER, T>) {
         let truncated = self.entry_storage().truncated_index();
-        let persisted = self.storage().apply_trace().persisted_apply_index();
-        match old_index {
-            Either::Left(old_persisted) if old_persisted >= truncated => return,
-            Either::Right(old_truncated) if old_truncated >= persisted => return,
-            _ => {}
-        }
-        let compact_index = std::cmp::min(truncated, persisted);
+        // We need to keep at lease one log at apply index.
+        let persisted_applied = self
+            .storage()
+            .apply_trace()
+            .persisted_apply_index()
+            .checked_sub(1)
+            .unwrap();
+        let compact_index = std::cmp::min(truncated, persisted_applied);
         // Raft Engine doesn't care about first index.
         if let Err(e) =
             store_ctx
@@ -309,11 +316,8 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         {
             error!(self.logger, "failed to compact raft logs"; "err" => ?e);
         } else {
+            debug!(self.logger, "compact log"; "index" => compact_index);
             self.set_has_extra_write();
-            let applied = self.storage().apply_state().get_applied_index();
-            let total_cnt = applied - self.storage().entry_storage().first_index() + 1;
-            let remain_cnt = applied - compact_index;
-            self.update_approximate_raft_log_size(|s| s * remain_cnt / total_cnt);
         }
     }
 }

--- a/components/raftstore-v2/src/operation/command/admin/compact_log.rs
+++ b/components/raftstore-v2/src/operation/command/admin/compact_log.rs
@@ -299,14 +299,11 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
     }
 
     fn compact_log_from_engine<T>(&mut self, store_ctx: &mut StoreContext<EK, ER, T>) {
-        let truncated = self.entry_storage().truncated_index();
-        // We need to keep at lease one log at apply index.
+        let truncated = self.entry_storage().truncated_index() + 1;
         let persisted_applied = self
             .storage()
             .apply_trace()
-            .persisted_apply_index()
-            .checked_sub(1)
-            .unwrap();
+            .persisted_apply_index();
         let compact_index = std::cmp::min(truncated, persisted_applied);
         // Raft Engine doesn't care about first index.
         if let Err(e) =

--- a/components/raftstore-v2/src/operation/command/admin/conf_change.rs
+++ b/components/raftstore-v2/src/operation/command/admin/conf_change.rs
@@ -232,7 +232,7 @@ impl<EK: KvEngine, R> Apply<EK, R> {
     ) -> Result<(AdminResponse, AdminCmdResult)> {
         let region = self.region_state().get_region();
         let change_kind = ConfChangeKind::confchange_kind(changes.len());
-        info!(self.logger, "exec ConfChangeV2"; "kind" => ?change_kind, "legacy" => legacy, "epoch" => ?region.get_region_epoch());
+        info!(self.logger, "exec ConfChangeV2"; "kind" => ?change_kind, "legacy" => legacy, "epoch" => ?region.get_region_epoch(), "index" => index);
         let mut new_region = region.clone();
         match change_kind {
             ConfChangeKind::LeaveJoint => self.apply_leave_joint(&mut new_region),

--- a/components/raftstore-v2/src/operation/command/admin/mod.rs
+++ b/components/raftstore-v2/src/operation/command/admin/mod.rs
@@ -113,7 +113,9 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             Ok(index) => {
                 self.proposal_control_mut()
                     .record_proposed_admin(cmd_type, *index);
-                self.raft_group_mut().skip_bcast_commit(true);
+                if self.proposal_control_mut().has_uncommitted_admin() {
+                    self.raft_group_mut().skip_bcast_commit(false);
+                }
             }
             Err(e) => {
                 info!(

--- a/components/raftstore-v2/src/operation/command/admin/mod.rs
+++ b/components/raftstore-v2/src/operation/command/admin/mod.rs
@@ -110,9 +110,11 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             }
         };
         match &res {
-            Ok(index) => self
-                .proposal_control_mut()
-                .record_proposed_admin(cmd_type, *index),
+            Ok(index) => {
+                self.proposal_control_mut()
+                    .record_proposed_admin(cmd_type, *index);
+                self.raft_group_mut().skip_bcast_commit(true);
+            }
             Err(e) => {
                 info!(
                     self.logger,

--- a/components/raftstore-v2/src/operation/command/admin/split.rs
+++ b/components/raftstore-v2/src/operation/command/admin/split.rs
@@ -789,6 +789,8 @@ mod test {
             read_scheduler,
             Arc::default(),
             None,
+            0,
+            0,
             logger.clone(),
         );
 

--- a/components/raftstore-v2/src/operation/command/admin/split.rs
+++ b/components/raftstore-v2/src/operation/command/admin/split.rs
@@ -793,9 +793,9 @@ mod test {
             reporter,
             reg,
             read_scheduler,
-            Arc::new(FlushState::new(0)),
+            Arc::new(FlushState::new(5)),
             None,
-            0,
+            5,
             logger.clone(),
         );
 
@@ -810,7 +810,7 @@ mod test {
 
         splits.mut_requests().clear();
         req.set_splits(splits.clone());
-        let err = apply.apply_batch_split(&req, 0).unwrap_err();
+        let err = apply.apply_batch_split(&req, 6).unwrap_err();
         // Empty requests should be rejected.
         assert!(err.to_string().contains("missing split requests"));
 
@@ -831,7 +831,7 @@ mod test {
             .mut_requests()
             .push(new_split_req(b"", 1, vec![11, 12, 13]));
         req.set_splits(splits.clone());
-        let err = apply.apply_batch_split(&req, 0).unwrap_err();
+        let err = apply.apply_batch_split(&req, 7).unwrap_err();
         // Empty key will not in any region exclusively.
         assert!(err.to_string().contains("missing split key"), "{:?}", err);
 
@@ -843,7 +843,7 @@ mod test {
             .mut_requests()
             .push(new_split_req(b"k1", 1, vec![11, 12, 13]));
         req.set_splits(splits.clone());
-        let err = apply.apply_batch_split(&req, 0).unwrap_err();
+        let err = apply.apply_batch_split(&req, 8).unwrap_err();
         // keys should be in ascend order.
         assert!(
             err.to_string().contains("invalid split request"),
@@ -859,7 +859,7 @@ mod test {
             .mut_requests()
             .push(new_split_req(b"k2", 1, vec![11, 12]));
         req.set_splits(splits.clone());
-        let err = apply.apply_batch_split(&req, 0).unwrap_err();
+        let err = apply.apply_batch_split(&req, 9).unwrap_err();
         // All requests should be checked.
         assert!(err.to_string().contains("id count"), "{:?}", err);
 

--- a/components/raftstore-v2/src/operation/command/admin/split.rs
+++ b/components/raftstore-v2/src/operation/command/admin/split.rs
@@ -65,7 +65,7 @@ use crate::{
     Error,
 };
 
-pub const SPLIT_PREFIX: &str = "split_";
+pub const SPLIT_PREFIX: &str = "split";
 
 #[derive(Debug)]
 pub struct SplitResult {

--- a/components/raftstore-v2/src/operation/command/admin/split.rs
+++ b/components/raftstore-v2/src/operation/command/admin/split.rs
@@ -630,7 +630,7 @@ mod test {
         kv::TestTabletFactory,
     };
     use engine_traits::{
-        Peekable, TabletContext, TabletRegistry, WriteBatch, CF_DEFAULT, DATA_CFS,
+        FlushState, Peekable, TabletContext, TabletRegistry, WriteBatch, CF_DEFAULT, DATA_CFS,
     };
     use kvproto::{
         metapb::RegionEpoch,
@@ -788,9 +788,8 @@ mod test {
             reporter,
             reg,
             read_scheduler,
-            Arc::default(),
+            Arc::new(FlushState::new(0)),
             None,
-            0,
             0,
             logger.clone(),
         );

--- a/components/raftstore-v2/src/operation/command/admin/split.rs
+++ b/components/raftstore-v2/src/operation/command/admin/split.rs
@@ -265,6 +265,7 @@ impl<EK: KvEngine, R: ApplyResReporter> Apply<EK, R> {
             self.logger,
             "split region";
             "region" => ?region,
+            "index" => log_index,
             "boundaries" => %KeysInfoFormatter(boundaries.iter()),
         );
 

--- a/components/raftstore-v2/src/operation/command/control.rs
+++ b/components/raftstore-v2/src/operation/command/control.rs
@@ -181,6 +181,11 @@ impl ProposalControl {
         }
     }
 
+    #[inline]
+    pub fn has_uncommitted_admin(&self) -> bool {
+        !self.proposed_admin_cmd.is_empty() && !self.proposed_admin_cmd.back().unwrap().committed
+    }
+
     pub fn advance_apply(&mut self, index: u64, term: u64, region: &metapb::Region) {
         while !self.proposed_admin_cmd.is_empty() {
             let cmd = self.proposed_admin_cmd.front_mut().unwrap();

--- a/components/raftstore-v2/src/operation/command/mod.rs
+++ b/components/raftstore-v2/src/operation/command/mod.rs
@@ -112,7 +112,6 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             read_scheduler,
             self.flush_state().clone(),
             self.storage().apply_trace().log_recovery(),
-            self.entry_storage().applied_index(),
             self.entry_storage().applied_term(),
             logger,
         );

--- a/components/raftstore-v2/src/operation/command/mod.rs
+++ b/components/raftstore-v2/src/operation/command/mod.rs
@@ -312,6 +312,11 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             }
             self.add_pending_tick(PeerTick::Raft);
         }
+        if !self.pause_for_recovery() && self.storage_mut().apply_trace_mut().should_flush() {
+            if let Some(scheduler) = self.apply_scheduler() {
+                scheduler.send(ApplyTask::ManualFlush);
+            }
+        }
     }
 }
 

--- a/components/raftstore-v2/src/operation/command/mod.rs
+++ b/components/raftstore-v2/src/operation/command/mod.rs
@@ -38,7 +38,7 @@ use raftstore::{
     },
     Error, Result,
 };
-use slog::warn;
+use slog::{info, warn};
 use tikv_util::{box_err, time::monotonic_raw_now};
 
 use crate::{
@@ -311,6 +311,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         if self.pause_for_recovery()
             && self.storage().entry_storage().commit_index() <= apply_res.applied_index
         {
+            info!(self.logger, "recovery completed"; "apply_index" => apply_res.applied_index);
             self.set_pause_for_recovery(false);
             // Flush to avoid recover again and again.
             if let Some(scheduler) = self.apply_scheduler() {

--- a/components/raftstore-v2/src/operation/command/mod.rs
+++ b/components/raftstore-v2/src/operation/command/mod.rs
@@ -112,6 +112,8 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             read_scheduler,
             self.flush_state().clone(),
             self.storage().apply_trace().log_recovery(),
+            self.entry_storage().applied_index(),
+            self.entry_storage().applied_term(),
             logger,
         );
 

--- a/components/raftstore-v2/src/operation/ready/apply_trace.rs
+++ b/components/raftstore-v2/src/operation/ready/apply_trace.rs
@@ -168,8 +168,9 @@ pub struct ApplyTrace {
     admin: Progress,
     /// Index that is issued to be written. It may not be truely persisted.
     persisted_applied: u64,
-    /// Flush will be triggered explicitly when there are too many pending writes.
-    /// It marks the last index that is flushed to avoid too many flushes.
+    /// Flush will be triggered explicitly when there are too many pending
+    /// writes. It marks the last index that is flushed to avoid too many
+    /// flushes.
     last_flush_trigger: u64,
     /// `true` means the raft cf record should be persisted in next ready.
     try_persist: bool,
@@ -230,13 +231,17 @@ impl ApplyTrace {
             // It's waiting for other peers, flush will not help.
             return false;
         }
-        let last_modified = self.data_cfs.iter().filter_map(|pr| {
-            if pr.last_modified != pr.flushed {
-                Some(pr.last_modified)
-            } else {
-                None
-            }
-        }).max();
+        let last_modified = self
+            .data_cfs
+            .iter()
+            .filter_map(|pr| {
+                if pr.last_modified != pr.flushed {
+                    Some(pr.last_modified)
+                } else {
+                    None
+                }
+            })
+            .max();
         if let Some(m) = last_modified && m >= self.admin.flushed + 512 && m >= self.last_flush_trigger + 512 {
             self.last_flush_trigger = m;
             true

--- a/components/raftstore-v2/src/operation/ready/apply_trace.rs
+++ b/components/raftstore-v2/src/operation/ready/apply_trace.rs
@@ -242,7 +242,7 @@ impl ApplyTrace {
                 }
             })
             .max();
-        if let Some(m) = last_modified && m >= self.admin.flushed + 512 && m >= self.last_flush_trigger + 512 {
+        if let Some(m) = last_modified && m >= self.admin.flushed + 4096 && m >= self.last_flush_trigger + 4096 {
             self.last_flush_trigger = m;
             true
         } else {

--- a/components/raftstore-v2/src/operation/ready/mod.rs
+++ b/components/raftstore-v2/src/operation/ready/mod.rs
@@ -32,7 +32,7 @@ use raftstore::{
     coprocessor::{RegionChangeEvent, RoleChange},
     store::{needs_evict_entry_cache, util, FetchedLogs, ReadProgress, Transport, WriteTask},
 };
-use slog::{debug, error, trace, warn};
+use slog::{debug, error, info, trace, warn};
 use tikv_util::{
     store::find_peer,
     time::{duration_to_sec, monotonic_raw_now},
@@ -88,6 +88,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         if committed_index > applied_index + 128 {
             // If there are too many pending entries, pause  to avoid
             // too much memory usage.
+            info!(self.logger, "pause for recovery"; "applied" => applied_index, "committed" => committed_index);
             self.set_pause_for_recovery(true);
             true
         } else {

--- a/components/raftstore-v2/src/operation/ready/mod.rs
+++ b/components/raftstore-v2/src/operation/ready/mod.rs
@@ -548,6 +548,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
 
                     self.region_heartbeat_pd(ctx);
                     self.add_pending_tick(PeerTick::CompactLog);
+                    self.add_pending_tick(PeerTick::SplitRegionCheck);
                 }
                 StateRole::Follower => {
                     self.leader_lease_mut().expire();

--- a/components/raftstore-v2/src/operation/ready/mod.rs
+++ b/components/raftstore-v2/src/operation/ready/mod.rs
@@ -296,31 +296,44 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
     ) {
         // TODO: skip handling committed entries if a snapshot is being applied
         // asynchronously.
-        if self.is_leader() {
+        let mut update_lease = self.is_leader();
+        if update_lease {
             for entry in committed_entries.iter().rev() {
                 self.update_approximate_raft_log_size(|s| s + entry.get_data().len() as u64);
-                let propose_time = self
-                    .proposals()
-                    .find_propose_time(entry.get_term(), entry.get_index());
-                if let Some(propose_time) = propose_time {
-                    // We must renew current_time because this value may be created a long time ago.
-                    // If we do not renew it, this time may be smaller than propose_time of a
-                    // command, which was proposed in another thread while this thread receives its
-                    // AppendEntriesResponse and is ready to calculate its commit-log-duration.
-                    ctx.current_time.replace(monotonic_raw_now());
-                    ctx.raft_metrics.commit_log.observe(duration_to_sec(
-                        (ctx.current_time.unwrap() - propose_time).to_std().unwrap(),
-                    ));
-                    self.maybe_renew_leader_lease(propose_time, &ctx.store_meta, None);
-                    break;
+                if update_lease {
+                    let propose_time = self
+                        .proposals()
+                        .find_propose_time(entry.get_term(), entry.get_index());
+                    if let Some(propose_time) = propose_time {
+                        // We must renew current_time because this value may be created a long time
+                        // ago. If we do not renew it, this time may be
+                        // smaller than propose_time of a command, which was
+                        // proposed in another thread while this thread receives its
+                        // AppendEntriesResponse and is ready to calculate its commit-log-duration.
+                        ctx.current_time.replace(monotonic_raw_now());
+                        ctx.raft_metrics.commit_log.observe(duration_to_sec(
+                            (ctx.current_time.unwrap() - propose_time).to_std().unwrap(),
+                        ));
+                        self.maybe_renew_leader_lease(propose_time, &ctx.store_meta, None);
+                        update_lease = false;
+                    }
                 }
             }
         }
+        let applying_index = committed_entries.last().unwrap().index;
+        let commit_to_current_term = committed_entries.last().unwrap().term == self.term();
+        *self.last_applying_index_mut() = applying_index;
         if needs_evict_entry_cache(ctx.cfg.evict_cache_on_memory_ratio) {
             // Compact all cached entries instead of half evict.
             self.entry_storage_mut().evict_entry_cache(false);
         }
         self.schedule_apply_committed_entries(committed_entries);
+        if self.is_leader()
+            && commit_to_current_term
+            && !self.proposal_control().has_uncommitted_admin()
+        {
+            self.raft_group_mut().skip_bcast_commit(true);
+        }
     }
 
     /// Processing the ready of raft. A detail description of how it's handled

--- a/components/raftstore-v2/src/operation/ready/mod.rs
+++ b/components/raftstore-v2/src/operation/ready/mod.rs
@@ -101,7 +101,10 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
 
     #[inline]
     fn tick(&mut self) -> bool {
-        self.raft_group_mut().tick()
+        // When it's handling snapshot, it's pointless to tick as all the side
+        // affects have to wait till snapshot is applied. On the other hand, ticking
+        // will bring other corner cases like elections.
+        !self.is_handling_snapshot() && self.raft_group_mut().tick()
     }
 
     pub fn on_peer_unreachable(&mut self, to_peer_id: u64) {

--- a/components/raftstore-v2/src/operation/ready/snapshot.rs
+++ b/components/raftstore-v2/src/operation/ready/snapshot.rs
@@ -201,7 +201,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         let first_index = self.entry_storage().first_index();
         if first_index == persisted_index + 1 {
             let region_id = self.region_id();
-            self.reset_flush_state();
+            self.reset_flush_state(persisted_index);
             let flush_state = self.flush_state().clone();
             let mut tablet_ctx = TabletContext::new(self.region(), Some(persisted_index));
             // Use a new FlushState to avoid conflicts with the old one.

--- a/components/raftstore-v2/src/operation/ready/snapshot.rs
+++ b/components/raftstore-v2/src/operation/ready/snapshot.rs
@@ -509,6 +509,7 @@ impl<EK: KvEngine, ER: RaftEngine> Storage<EK, ER> {
             // All states are rewritten in the following blocks. Stale states will be
             // cleaned up by compact worker.
             task.cut_logs = Some((0, old_last_index));
+            self.entry_storage_mut().clear();
         }
 
         let last_index = snap.get_metadata().get_index();

--- a/components/raftstore-v2/src/operation/ready/snapshot.rs
+++ b/components/raftstore-v2/src/operation/ready/snapshot.rs
@@ -508,7 +508,7 @@ impl<EK: KvEngine, ER: RaftEngine> Storage<EK, ER> {
         if self.entry_storage().first_index() <= old_last_index {
             // All states are rewritten in the following blocks. Stale states will be
             // cleaned up by compact worker.
-            task.cut_logs = Some((0, old_last_index));
+            task.cut_logs = Some((0, old_last_index + 1));
             self.entry_storage_mut().clear();
         }
 

--- a/components/raftstore-v2/src/operation/ready/snapshot.rs
+++ b/components/raftstore-v2/src/operation/ready/snapshot.rs
@@ -197,7 +197,8 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             StateRole::Follower,
         );
         let persisted_index = self.persisted_index();
-        let first_index = self.storage().entry_storage().first_index();
+        *self.last_applying_index_mut() = persisted_index;
+        let first_index = self.entry_storage().first_index();
         if first_index == persisted_index + 1 {
             let region_id = self.region_id();
             self.reset_flush_state();

--- a/components/raftstore-v2/src/operation/ready/snapshot.rs
+++ b/components/raftstore-v2/src/operation/ready/snapshot.rs
@@ -37,7 +37,7 @@ use raftstore::{
     coprocessor::RegionChangeEvent,
     store::{
         metrics::STORE_SNAPSHOT_VALIDATION_FAILURE_COUNTER, GenSnapRes, ReadTask, TabletSnapKey,
-        TabletSnapManager, Transport, WriteTask, RAFT_INIT_LOG_INDEX,
+        TabletSnapManager, Transport, WriteTask, RAFT_INIT_LOG_INDEX, RAFT_INIT_LOG_TERM,
     },
 };
 use slog::{error, info, warn};
@@ -199,22 +199,23 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         let persisted_index = self.persisted_index();
         *self.last_applying_index_mut() = persisted_index;
         let first_index = self.entry_storage().first_index();
+        assert!(first_index > RAFT_INIT_LOG_INDEX, "{:?}", self.logger);
         // If leader sends a message append to the follower while it's applying
         // snapshot (via split init for example), the persisted_index may be larger
         // than the first index. But as long as first index is not larger, the
         // latest snapshot should be applied.
         if first_index <= persisted_index + 1 {
+            let snapshot_index = first_index - 1;
             let region_id = self.region_id();
-            self.reset_flush_state(persisted_index);
+            self.reset_flush_state(snapshot_index);
             let flush_state = self.flush_state().clone();
-            let mut tablet_ctx = TabletContext::new(self.region(), Some(persisted_index));
+            let mut tablet_ctx = TabletContext::new(self.region(), Some(snapshot_index));
             // Use a new FlushState to avoid conflicts with the old one.
             tablet_ctx.flush_state = Some(flush_state);
             ctx.tablet_registry.load(tablet_ctx, false).unwrap();
-            self.record_tablet_as_tombstone_and_refresh(persisted_index, ctx);
-            self.schedule_apply_fsm(ctx);
+            self.record_tablet_as_tombstone_and_refresh(snapshot_index, ctx);
             self.storage_mut().on_applied_snapshot();
-            self.raft_group_mut().advance_apply_to(persisted_index);
+            self.raft_group_mut().advance_apply_to(snapshot_index);
             {
                 let mut meta = ctx.store_meta.lock().unwrap();
                 meta.set_region(self.region(), true, &self.logger);
@@ -223,18 +224,18 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
                 meta.region_read_progress
                     .insert(region_id, self.read_progress().clone());
             }
-            self.read_progress_mut()
-                .update_applied_core(persisted_index);
+            self.read_progress_mut().update_applied_core(snapshot_index);
             let split = self.storage_mut().split_init_mut().take();
             if split.as_ref().map_or(true, |s| {
-                !s.scheduled || persisted_index != RAFT_INIT_LOG_INDEX
+                !s.scheduled || snapshot_index != RAFT_INIT_LOG_INDEX
             }) {
                 info!(self.logger, "apply tablet snapshot completely");
             }
             if let Some(init) = split {
-                info!(self.logger, "init with snapshot finished");
+                info!(self.logger, "init split with snapshot finished");
                 self.post_split_init(ctx, init);
             }
+            self.schedule_apply_fsm(ctx);
         }
     }
 }
@@ -348,6 +349,15 @@ impl<EK: KvEngine, ER: RaftEngine> Storage<EK, ER> {
     /// Validate the snapshot. Returns true if it's valid.
     fn validate_snap(&self, snap: &Snapshot, request_index: u64) -> bool {
         let idx = snap.get_metadata().get_index();
+        if idx < RAFT_INIT_LOG_INDEX || snap.get_metadata().get_term() < RAFT_INIT_LOG_TERM {
+            info!(
+                self.logger(),
+                "corrupted snapshot detected, generate again";
+                "snap" => ?snap,
+                "request_index" => request_index,
+            );
+            return false;
+        }
         // TODO(nolouch): check tuncated index
         if idx < request_index {
             // stale snapshot, should generate again.
@@ -494,8 +504,20 @@ impl<EK: KvEngine, ER: RaftEngine> Storage<EK, ER> {
             ));
         }
 
+        let old_last_index = self.entry_storage().last_index();
+        if self.entry_storage().first_index() <= old_last_index {
+            // All states are rewritten in the following blocks. Stale states will be
+            // cleaned up by compact worker.
+            task.cut_logs = Some((0, old_last_index));
+        }
+
         let last_index = snap.get_metadata().get_index();
         let last_term = snap.get_metadata().get_term();
+        assert!(
+            last_index >= RAFT_INIT_LOG_INDEX && last_term >= RAFT_INIT_LOG_TERM,
+            "{:?}",
+            self.logger().list()
+        );
         let region_state = self.region_state_mut();
         region_state.set_state(PeerState::Normal);
         region_state.set_region(region);

--- a/components/raftstore-v2/src/raft/apply.rs
+++ b/components/raftstore-v2/src/raft/apply.rs
@@ -64,6 +64,8 @@ impl<EK: KvEngine, R> Apply<EK, R> {
         read_scheduler: Scheduler<ReadTask<EK>>,
         flush_state: Arc<FlushState>,
         log_recovery: Option<Box<DataTrace>>,
+        applied_index: u64,
+        applied_term: u64,
         logger: Logger,
     ) -> Self {
         let mut remote_tablet = tablet_registry
@@ -76,8 +78,8 @@ impl<EK: KvEngine, R> Apply<EK, R> {
             write_batch: None,
             callbacks: vec![],
             tombstone: false,
-            applied_term: 0,
-            applied_index: flush_state.applied_index(),
+            applied_term,
+            applied_index,
             modifications: [0; DATA_CFS_LEN],
             admin_cmd_result: vec![],
             region_state,

--- a/components/raftstore-v2/src/raft/apply.rs
+++ b/components/raftstore-v2/src/raft/apply.rs
@@ -73,6 +73,9 @@ impl<EK: KvEngine, R> Apply<EK, R> {
         let mut remote_tablet = tablet_registry
             .get(region_state.get_region().get_id())
             .unwrap();
+        assert_ne!(applied_term, 0, "{:?}", logger.list());
+        let applied_index = flush_state.applied_index();
+        assert_ne!(applied_index, 0, "{:?}", logger.list());
         Apply {
             peer,
             tablet: remote_tablet.latest().unwrap().clone(),

--- a/components/raftstore-v2/src/raft/apply.rs
+++ b/components/raftstore-v2/src/raft/apply.rs
@@ -125,9 +125,6 @@ impl<EK: KvEngine, R> Apply<EK, R> {
         let log_recovery = self.log_recovery.as_ref().unwrap();
         if log_recovery.iter().all(|v| index >= *v) {
             self.log_recovery.take();
-            // Now all logs are recovered, flush them to avoid recover again
-            // and again.
-            let _ = self.tablet.flush_cfs(&[], false);
         }
     }
 

--- a/components/raftstore-v2/src/raft/peer.rs
+++ b/components/raftstore-v2/src/raft/peer.rs
@@ -135,7 +135,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         let raft_group = RawNode::new(&raft_cfg, storage, &logger)?;
         let region = raft_group.store().region_state().get_region().clone();
 
-        let flush_state: Arc<FlushState> = Arc::default();
+        let flush_state: Arc<FlushState> = Arc::new(FlushState::new(applied_index));
         // We can't create tablet if tablet index is 0. It can introduce race when gc
         // old tablet and create new peer. We also can't get the correct range of the
         // region, which is required for kv data gc.
@@ -795,8 +795,8 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         &self.flush_state
     }
 
-    pub fn reset_flush_state(&mut self) {
-        self.flush_state = Arc::default();
+    pub fn reset_flush_state(&mut self, index: u64) {
+        self.flush_state = Arc::new(FlushState::new(index));
     }
 
     // Note: Call `set_has_extra_write` after adding new state changes.

--- a/components/raftstore-v2/src/raft/peer.rs
+++ b/components/raftstore-v2/src/raft/peer.rs
@@ -73,6 +73,7 @@ pub struct Peer<EK: KvEngine, ER: RaftEngine> {
     has_ready: bool,
     /// Sometimes there is no ready at all, but we need to trigger async write.
     has_extra_write: bool,
+    pause_for_recovery: bool,
     /// Writer for persisting side effects asynchronously.
     pub(crate) async_writer: AsyncWriter<EK, ER>,
 
@@ -161,6 +162,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             apply_scheduler: None,
             has_ready: false,
             has_extra_write: false,
+            pause_for_recovery: false,
             destroy_progress: DestroyProgress::None,
             raft_group,
             logger,
@@ -429,6 +431,16 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
     #[inline]
     pub fn reset_has_extra_write(&mut self) -> bool {
         mem::take(&mut self.has_extra_write)
+    }
+
+    #[inline]
+    pub fn set_pause_for_recovery(&mut self, pause: bool) {
+        self.pause_for_recovery = pause;
+    }
+
+    #[inline]
+    pub fn pause_for_recovery(&self) -> bool {
+        self.pause_for_recovery
     }
 
     #[inline]

--- a/components/raftstore-v2/src/raft/peer.rs
+++ b/components/raftstore-v2/src/raft/peer.rs
@@ -675,8 +675,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
     /// See the comments of `check_snap_status` for more details.
     #[inline]
     pub fn is_handling_snapshot(&self) -> bool {
-        // todo: This method may be unnecessary now?
-        false
+        self.persisted_index() < self.entry_storage().truncated_index()
     }
 
     /// Returns `true` if the raft group has replicated a snapshot but not

--- a/components/raftstore-v2/src/raft/peer.rs
+++ b/components/raftstore-v2/src/raft/peer.rs
@@ -370,14 +370,17 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
     /// Returns if there's any tombstone being removed.
     #[inline]
     pub fn remove_tombstone_tablets_before(&mut self, persisted: u64) -> bool {
-        let mut removed = 0;
-        while let Some(i) = self.pending_tombstone_tablets.first()
-            && *i <= persisted
-        {
-            removed += 1;
+        let removed = self
+            .pending_tombstone_tablets
+            .iter()
+            .take_while(|i| **i <= persisted)
+            .count();
+        if removed > 0 {
+            self.pending_tombstone_tablets.drain(..removed);
+            true
+        } else {
+            false
         }
-        self.pending_tombstone_tablets.drain(..removed);
-        removed > 0
     }
 
     #[inline]

--- a/components/raftstore-v2/src/raft/storage.rs
+++ b/components/raftstore-v2/src/raft/storage.rs
@@ -442,6 +442,8 @@ mod tests {
             sched,
             Arc::default(),
             None,
+            5,
+            5,
             logger,
         );
 
@@ -460,8 +462,8 @@ mod tests {
             SnapState::Generated(ref snap) => *snap.clone(),
             ref s => panic!("unexpected state: {:?}", s),
         };
-        assert_eq!(snap.get_metadata().get_index(), 0);
-        assert_eq!(snap.get_metadata().get_term(), 0);
+        assert_eq!(snap.get_metadata().get_index(), 5);
+        assert_eq!(snap.get_metadata().get_term(), 5);
         assert_eq!(snap.get_data().is_empty(), false);
         let snap_key = TabletSnapKey::from_region_snap(4, 7, &snap);
         let checkpointer_path = mgr.tablet_gen_path(&snap_key);

--- a/components/raftstore-v2/src/raft/storage.rs
+++ b/components/raftstore-v2/src/raft/storage.rs
@@ -381,25 +381,25 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        let snapshot = new_empty_snapshot(region.clone(), 10, 1, false);
+        let snapshot = new_empty_snapshot(region.clone(), 10, 9, false);
         let mut task = WriteTask::new(region.get_id(), 5, 0);
         s.apply_snapshot(&snapshot, &mut task, mgr, reg).unwrap();
 
         // It can be set before load tablet.
         assert_eq!(PeerState::Normal, s.region_state().get_state());
         assert_eq!(10, s.entry_storage().truncated_index());
-        assert_eq!(1, s.entry_storage().truncated_term());
-        assert_eq!(1, s.entry_storage().last_term());
+        assert_eq!(9, s.entry_storage().truncated_term());
+        assert_eq!(9, s.entry_storage().last_term());
         assert_eq!(10, s.entry_storage().raft_state().last_index);
         // This index can't be set before load tablet.
         assert_ne!(10, s.entry_storage().applied_index());
-        assert_ne!(1, s.entry_storage().applied_term());
+        assert_ne!(9, s.entry_storage().applied_term());
         assert_eq!(10, s.region_state().get_tablet_index());
         assert!(!task.persisted_cbs.is_empty());
 
         s.on_applied_snapshot();
         assert_eq!(10, s.entry_storage().applied_index());
-        assert_eq!(1, s.entry_storage().applied_term());
+        assert_eq!(9, s.entry_storage().applied_term());
         assert_eq!(10, s.region_state().get_tablet_index());
     }
 

--- a/components/raftstore-v2/src/raft/storage.rs
+++ b/components/raftstore-v2/src/raft/storage.rs
@@ -298,7 +298,9 @@ mod tests {
         ctor::{CfOptions, DbOptions},
         kv::TestTabletFactory,
     };
-    use engine_traits::{RaftEngine, RaftLogBatch, TabletContext, TabletRegistry, DATA_CFS};
+    use engine_traits::{
+        FlushState, RaftEngine, RaftLogBatch, TabletContext, TabletRegistry, DATA_CFS,
+    };
     use kvproto::{
         metapb::{Peer, Region},
         raft_serverpb::PeerState,
@@ -440,9 +442,8 @@ mod tests {
             router,
             reg,
             sched,
-            Arc::default(),
+            Arc::new(FlushState::new(5)),
             None,
-            5,
             5,
             logger,
         );

--- a/components/raftstore-v2/src/router/internal_message.rs
+++ b/components/raftstore-v2/src/router/internal_message.rs
@@ -10,6 +10,7 @@ pub enum ApplyTask {
     Snapshot(GenSnapTask),
     /// Writes that doesn't care consistency.
     UnsafeWrite(Box<[u8]>),
+    ManualFlush,
 }
 
 #[derive(Debug, Default)]

--- a/components/raftstore-v2/tests/integrations/test_transfer_leader.rs
+++ b/components/raftstore-v2/tests/integrations/test_transfer_leader.rs
@@ -1,6 +1,6 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::time::Duration;
+use std::{assert_matches::assert_matches, time::Duration};
 
 use engine_traits::{Peekable, CF_DEFAULT};
 use futures::executor::block_on;
@@ -9,35 +9,32 @@ use kvproto::{
     raft_cmdpb::{AdminCmdType, TransferLeaderRequest},
 };
 use raft::prelude::ConfChangeType;
-use raftstore_v2::{router::PeerMsg, SimpleWriteEncoder};
+use raftstore_v2::{
+    router::{PeerMsg, PeerTick},
+    SimpleWriteEncoder,
+};
 use tikv_util::store::new_peer;
 
 use crate::cluster::Cluster;
 
 fn put_data(
     region_id: u64,
-    cluster: &Cluster,
+    cluster: &mut Cluster,
     node_off: usize,
     node_off_for_verify: usize,
     key: &[u8],
 ) {
-    let router = &cluster.routers[node_off];
+    let mut router = &mut cluster.routers[node_off];
 
     router.wait_applied_to_current_term(region_id, Duration::from_secs(3));
 
     // router.wait_applied_to_current_term(2, Duration::from_secs(3));
-    let tablet_registry = cluster.node(node_off).tablet_registry();
-    let tablet = tablet_registry
-        .get(region_id)
-        .unwrap()
-        .latest()
-        .unwrap()
-        .clone();
-    assert!(tablet.get_value(key).unwrap().is_none());
+    let snap = router.stale_snapshot(region_id);
+    assert_matches!(snap.get_value(key), Ok(None));
 
     let header = Box::new(router.new_request_for(region_id).take_header());
     let mut put = SimpleWriteEncoder::with_capacity(64);
-    put.put(CF_DEFAULT, &key[1..], b"value");
+    put.put(CF_DEFAULT, &key, b"value");
     let (msg, mut sub) = PeerMsg::simple_write(header, put.encode());
     router.send(region_id, msg).unwrap();
     std::thread::sleep(std::time::Duration::from_millis(10));
@@ -53,17 +50,29 @@ fn put_data(
 
     let resp = block_on(sub.result()).unwrap();
     assert!(!resp.get_header().has_error(), "{:?}", resp);
-    assert_eq!(tablet.get_value(key).unwrap().unwrap(), b"value");
+    router = &mut cluster.routers[node_off];
+    let snap = router.stale_snapshot(region_id);
+    assert_eq!(snap.get_value(key).unwrap().unwrap(), b"value");
 
-    // Verify the data is ready in the other node
-    let tablet_registry = cluster.node(node_off_for_verify).tablet_registry();
-    let tablet = tablet_registry
-        .get(region_id)
-        .unwrap()
-        .latest()
-        .unwrap()
-        .clone();
-    assert_eq!(tablet.get_value(key).unwrap().unwrap(), b"value");
+    // Because of skip bcast commit, the data should not be applied yet.
+    router = &mut cluster.routers[node_off_for_verify];
+    let snap = router.stale_snapshot(region_id);
+    assert_matches!(snap.get_value(key), Ok(None));
+    // Trigger heartbeat explicitly to commit on follower.
+    router = &mut cluster.routers[node_off];
+    for _ in 0..2 {
+        router
+            .send(region_id, PeerMsg::Tick(PeerTick::Raft))
+            .unwrap();
+        router
+            .send(region_id, PeerMsg::Tick(PeerTick::Raft))
+            .unwrap();
+    }
+    cluster.dispatch(region_id, vec![]);
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    router = &mut cluster.routers[node_off_for_verify];
+    let snap = router.stale_snapshot(region_id);
+    assert_eq!(snap.get_value(key).unwrap().unwrap(), b"value");
 }
 
 pub fn must_transfer_leader(
@@ -97,7 +106,7 @@ pub fn must_transfer_leader(
 
 #[test]
 fn test_transfer_leader() {
-    let cluster = Cluster::with_node_count(3, None);
+    let mut cluster = Cluster::with_node_count(3, None);
     let region_id = 2;
     let router0 = &cluster.routers[0];
 
@@ -137,13 +146,13 @@ fn test_transfer_leader() {
     cluster.dispatch(region_id, vec![]);
 
     // Ensure follower has latest entries before transfer leader.
-    put_data(region_id, &cluster, 0, 1, b"zkey1");
+    put_data(region_id, &mut cluster, 0, 1, b"key1");
 
     // Perform transfer leader
     must_transfer_leader(&cluster, region_id, 0, 1, peer1);
 
     // Before transfer back to peer0, put some data again.
-    put_data(region_id, &cluster, 1, 0, b"zkey2");
+    put_data(region_id, &mut cluster, 1, 0, b"key2");
 
     // Perform transfer leader
     let store_id = cluster.node(0).id();

--- a/components/raftstore-v2/tests/integrations/test_transfer_leader.rs
+++ b/components/raftstore-v2/tests/integrations/test_transfer_leader.rs
@@ -34,7 +34,7 @@ fn put_data(
 
     let header = Box::new(router.new_request_for(region_id).take_header());
     let mut put = SimpleWriteEncoder::with_capacity(64);
-    put.put(CF_DEFAULT, &key, b"value");
+    put.put(CF_DEFAULT, key, b"value");
     let (msg, mut sub) = PeerMsg::simple_write(header, put.encode());
     router.send(region_id, msg).unwrap();
     std::thread::sleep(std::time::Duration::from_millis(10));

--- a/components/raftstore/src/store/metrics.rs
+++ b/components/raftstore/src/store/metrics.rs
@@ -177,6 +177,7 @@ make_static_metric! {
         region_nonexistent,
         applying_snap,
         disk_full,
+        recovery,
     }
 
     pub label_enum ProposalType {

--- a/components/raftstore/src/store/snap.rs
+++ b/components/raftstore/src/store/snap.rs
@@ -1998,7 +1998,12 @@ impl TabletSnapManager {
             {
                 continue;
             }
-            for e in file_system::read_dir(path)? {
+            let entries = match file_system::read_dir(path) {
+                Ok(entries) => entries,
+                Err(e) if e.kind() == ErrorKind::NotFound => continue,
+                Err(e) => return Err(Error::from(e)),
+            };
+            for e in entries {
                 match e.and_then(|e| e.metadata()) {
                     Ok(m) => total_size += m.len(),
                     Err(e) if e.kind() == ErrorKind::NotFound => continue,

--- a/components/server/src/server2.rs
+++ b/components/server/src/server2.rs
@@ -61,6 +61,7 @@ use raftstore::{
     },
     RegionInfoAccessor,
 };
+use raftstore_v2::{router::RaftRouter, StateStorage};
 use security::SecurityManager;
 use tikv::{
     config::{ConfigController, DbConfigManger, DbType, LogConfigManager, TikvConfig},
@@ -136,8 +137,7 @@ fn run_impl<CER: ConfiguredRaftEngine, F: KvFormat>(config: TikvConfig) {
     tikv.init_encryption();
     let fetcher = tikv.init_io_utility();
     let listener = tikv.init_flow_receiver();
-    let (raft_engine, engines_info) = tikv.init_raw_engines(listener);
-    tikv.init_engines(raft_engine);
+    let engines_info = tikv.init_engines(listener);
     let server_config = tikv.init_servers::<F>();
     tikv.register_services();
     tikv.init_metrics_flusher(fetcher, engines_info);
@@ -201,6 +201,7 @@ struct TikvServer<ER: RaftEngine> {
     pd_client: Arc<RpcClient>,
     flow_info_sender: Option<mpsc::Sender<FlowInfo>>,
     flow_info_receiver: Option<mpsc::Receiver<FlowInfo>>,
+    router: Option<RaftRouter<RocksEngine, ER>>,
     node: Option<NodeV2<RpcClient, RocksEngine, ER>>,
     resolver: Option<resolve::PdStoreAddrResolver>,
     store_path: PathBuf,
@@ -310,6 +311,7 @@ where
             cfg_controller: Some(cfg_controller),
             security_mgr,
             pd_client,
+            router: None,
             node: None,
             resolver: None,
             store_path,
@@ -567,36 +569,6 @@ where
         engine_rocks::FlowListener::new(tx)
     }
 
-    fn init_engines(&mut self, raft_engine: ER) {
-        let tablet_registry = self.tablet_registry.clone().unwrap();
-        let mut node = NodeV2::new(
-            &self.config.server,
-            self.pd_client.clone(),
-            None,
-            tablet_registry,
-        );
-        node.try_bootstrap_store(&self.config.raft_store, &raft_engine)
-            .unwrap_or_else(|e| fatal!("failed to bootstrap store: {:?}", e));
-        assert_ne!(node.id(), 0);
-
-        let router = node.router();
-        let mut coprocessor_host: CoprocessorHost<RocksEngine> = CoprocessorHost::new(
-            router.store_router().clone(),
-            self.config.coprocessor.clone(),
-        );
-        let region_info_accessor = RegionInfoAccessor::new(&mut coprocessor_host);
-
-        let engine = RaftKv2::new(router.clone(), region_info_accessor.region_leaders());
-
-        self.engines = Some(TikvEngines {
-            raft_engine,
-            engine,
-        });
-        self.node = Some(node);
-        self.coprocessor_host = Some(coprocessor_host);
-        self.region_info_accessor = Some(region_info_accessor);
-    }
-
     fn init_gc_worker(&mut self) -> GcWorker<RaftKv2<RocksEngine, ER>> {
         let engines = self.engines.as_ref().unwrap();
         let gc_worker = GcWorker::new(
@@ -774,7 +746,7 @@ where
         };
 
         let check_leader_runner = CheckLeaderRunner::new(
-            self.node.as_ref().unwrap().router().store_meta().clone(),
+            self.router.as_ref().unwrap().store_meta().clone(),
             self.coprocessor_host.clone().unwrap(),
         );
         let check_leader_scheduler = self
@@ -855,6 +827,8 @@ where
             .unwrap()
             .start(
                 engines.raft_engine.clone(),
+                self.tablet_registry.clone().unwrap(),
+                self.router.as_ref().unwrap(),
                 server.transport(),
                 snap_mgr,
                 self.concurrency_manager.clone(),
@@ -1392,10 +1366,10 @@ impl ConfiguredRaftEngine for RaftLogEngine {
 }
 
 impl<CER: ConfiguredRaftEngine> TikvServer<CER> {
-    fn init_raw_engines(
+    fn init_engines(
         &mut self,
         flow_listener: engine_rocks::FlowListener,
-    ) -> (CER, Arc<EnginesResourceInfo>) {
+    ) -> Arc<EnginesResourceInfo> {
         let block_cache = self.config.storage.block_cache.build_shared_cache();
         let env = self
             .config
@@ -1415,6 +1389,19 @@ impl<CER: ConfiguredRaftEngine> TikvServer<CER> {
         let builder = KvEngineFactoryBuilder::new(env, &self.config, block_cache)
             .sst_recovery_sender(self.init_sst_recovery_sender())
             .flow_listener(flow_listener);
+
+        let mut node = NodeV2::new(&self.config.server, self.pd_client.clone(), None);
+        node.try_bootstrap_store(&self.config.raft_store, &raft_engine)
+            .unwrap_or_else(|e| fatal!("failed to bootstrap store: {:?}", e));
+        assert_ne!(node.id(), 0);
+
+        let router = node.router().clone();
+
+        // Create kv engine.
+        let builder = builder.state_storage(Arc::new(StateStorage::new(
+            raft_engine.clone(),
+            router.clone(),
+        )));
         let factory = Box::new(builder.build());
         self.kv_statistics = Some(factory.rocks_statistics());
         let registry = TabletRegistry::new(factory, self.store_path.join("tablets"))
@@ -1428,12 +1415,30 @@ impl<CER: ConfiguredRaftEngine> TikvServer<CER> {
         raft_engine.register_config(cfg_controller);
 
         let engines_info = Arc::new(EnginesResourceInfo::new(
-            registry,
+            registry.clone(),
             raft_engine.as_rocks_engine().cloned(),
             180, // max_samples_to_preserve
         ));
 
-        (raft_engine, engines_info)
+        let router = RaftRouter::new(node.id(), registry, router);
+        let mut coprocessor_host: CoprocessorHost<RocksEngine> = CoprocessorHost::new(
+            router.store_router().clone(),
+            self.config.coprocessor.clone(),
+        );
+        let region_info_accessor = RegionInfoAccessor::new(&mut coprocessor_host);
+
+        let engine = RaftKv2::new(router.clone(), region_info_accessor.region_leaders());
+
+        self.engines = Some(TikvEngines {
+            raft_engine,
+            engine,
+        });
+        self.router = Some(router);
+        self.node = Some(node);
+        self.coprocessor_host = Some(coprocessor_host);
+        self.region_info_accessor = Some(region_info_accessor);
+
+        engines_info
     }
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3122,6 +3122,9 @@ impl TikvConfig {
 
         if self.storage.engine == EngineType::RaftKv2 {
             self.raft_store.store_io_pool_size = cmp::max(self.raft_store.store_io_pool_size, 1);
+            if !self.raft_engine.enable {
+                panic!("raft-kv2 only supports raft log engine.");
+            }
         }
 
         self.raft_store.raftdb_path = self.infer_raft_db_path(None)?;

--- a/src/server/raftkv2/node.rs
+++ b/src/server/raftkv2/node.rs
@@ -11,7 +11,7 @@ use raftstore::{
     coprocessor::CoprocessorHost,
     store::{GlobalReplicationState, TabletSnapManager, Transport, RAFT_INIT_LOG_INDEX},
 };
-use raftstore_v2::{router::RaftRouter, Bootstrap, PdTask, StoreSystem};
+use raftstore_v2::{router::RaftRouter, Bootstrap, PdTask, StoreRouter, StoreSystem};
 use slog::{info, o, Logger};
 use tikv_util::{
     config::VersionTrack,
@@ -24,11 +24,10 @@ use crate::server::{node::init_store, Result};
 pub struct NodeV2<C: PdClient + 'static, EK: KvEngine, ER: RaftEngine> {
     cluster_id: u64,
     store: metapb::Store,
-    system: Option<(RaftRouter<EK, ER>, StoreSystem<EK, ER>)>,
+    system: Option<(StoreRouter<EK, ER>, StoreSystem<EK, ER>)>,
     has_started: bool,
 
     pd_client: Arc<C>,
-    registry: TabletRegistry<EK>,
     logger: Logger,
 }
 
@@ -43,7 +42,6 @@ where
         cfg: &crate::server::Config,
         pd_client: Arc<C>,
         store: Option<metapb::Store>,
-        registry: TabletRegistry<EK>,
     ) -> NodeV2<C, EK, ER> {
         let store = init_store(store, cfg);
 
@@ -53,7 +51,6 @@ where
             pd_client,
             system: None,
             has_started: false,
-            registry,
             logger: slog_global::borrow_global().new(o!()),
         }
     }
@@ -71,16 +68,14 @@ where
         )
         .bootstrap_store()?;
         self.store.set_id(store_id);
+
         let (router, system) =
             raftstore_v2::create_store_batch_system(cfg, store_id, self.logger.clone());
-        self.system = Some((
-            RaftRouter::new(store_id, self.registry.clone(), router),
-            system,
-        ));
+        self.system = Some((router, system));
         Ok(())
     }
 
-    pub fn router(&self) -> &RaftRouter<EK, ER> {
+    pub fn router(&self) -> &StoreRouter<EK, ER> {
         &self.system.as_ref().unwrap().0
     }
 
@@ -90,6 +85,8 @@ where
     pub fn start<T>(
         &mut self,
         raft_engine: ER,
+        registry: TabletRegistry<EK>,
+        router: &RaftRouter<EK, ER>,
         trans: T,
         snap_mgr: TabletSnapManager,
         concurrency_manager: ConcurrencyManager,
@@ -112,15 +109,10 @@ where
         )
         .bootstrap_first_region(&self.store, store_id)?
         {
-            let path = self
-                .registry
-                .tablet_path(region.get_id(), RAFT_INIT_LOG_INDEX);
+            let path = registry.tablet_path(region.get_id(), RAFT_INIT_LOG_INDEX);
             let ctx = TabletContext::new(&region, Some(RAFT_INIT_LOG_INDEX));
             // TODO: make follow line can recover from abort.
-            self.registry
-                .tablet_factory()
-                .open_tablet(ctx, &path)
-                .unwrap();
+            registry.tablet_factory().open_tablet(ctx, &path).unwrap();
         }
 
         // Put store only if the cluster is bootstrapped.
@@ -130,6 +122,8 @@ where
 
         self.start_store(
             raft_engine,
+            registry,
+            router,
             trans,
             snap_mgr,
             concurrency_manager,
@@ -187,6 +181,8 @@ where
     fn start_store<T>(
         &mut self,
         raft_engine: ER,
+        registry: TabletRegistry<EK>,
+        router: &RaftRouter<EK, ER>,
         trans: T,
         snap_mgr: TabletSnapManager,
         concurrency_manager: ConcurrencyManager,
@@ -207,13 +203,13 @@ where
         }
         self.has_started = true;
 
-        let (router, system) = self.system.as_mut().unwrap();
+        let system = &mut self.system.as_mut().unwrap().1;
 
         system.start(
             store_id,
             store_cfg,
             raft_engine,
-            self.registry.clone(),
+            registry,
             trans,
             self.pd_client.clone(),
             router.store_router(),


### PR DESCRIPTION
### What is changed and how it works?
Issue Number: Ref #12842 

What's Changed:

```commit-message
Whenever timeout, the peer will check for unapplied logs whether
there are pending conf change and trigger heavy reads. So we
wait till most logs are applied before ticking.

It also fix following issues:
- PersistenceListener is not installed
- implementation of persisted_apply_index is wrong
- parse tablet name is wrong
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
