### PR TITLE
typo: fix python client demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ $ pip3 install -i https://test.pypi.org/simple/ tikv-client
 ```python
 from tikv_client import RawClient
 
-client = RawClient.connect("127.0.0.1:2379")
+client = RawClient.connect(["127.0.0.1:2379"])
 
 client.put(b'foo', b'bar')
 print(client.get(b'foo')) # b'bar'


### PR DESCRIPTION
`tikv-client` modified parameter type ？I am using `tikv-client-0.0.3`.


```
client = RawClient.connect("127.0.0.1:2379")
...
Exception: Please use list as pd_endpoints. For example: `RawClient.connect([127.0.0.1:2379])`.
```


