### PR TITLE
raft-engine: remove confusing API cut logs

### DIFF
--- a/components/engine_panic/src/raft_engine.rs
+++ b/components/engine_panic/src/raft_engine.rs
@@ -167,11 +167,12 @@ impl RaftEngine for PanicEngine {
 }
 
 impl RaftLogBatch for PanicWriteBatch {
-    fn append(&mut self, raft_group_id: u64, entries: Vec<Entry>) -> Result<()> {
-        panic!()
-    }
-
-    fn cut_logs(&mut self, raft_group_id: u64, from: u64, to: u64) {
+    fn append(
+        &mut self,
+        raft_group_id: u64,
+        overwrite_to: Option<u64>,
+        entries: Vec<Entry>,
+    ) -> Result<()> {
         panic!()
     }
 

--- a/components/raft_log_engine/src/engine.rs
+++ b/components/raft_log_engine/src/engine.rs
@@ -385,15 +385,16 @@ const FLUSH_STATE_KEY: &[u8] = &[0x06];
 const KEY_PREFIX_LEN: usize = RAFT_LOG_STATE_KEY.len();
 
 impl RaftLogBatchTrait for RaftLogBatch {
-    fn append(&mut self, raft_group_id: u64, entries: Vec<Entry>) -> Result<()> {
+    fn append(
+        &mut self,
+        raft_group_id: u64,
+        _overwrite_to: Option<u64>,
+        entries: Vec<Entry>,
+    ) -> Result<()> {
+        // overwrite is handled within raft log engine.
         self.0
             .add_entries::<MessageExtTyped>(raft_group_id, &entries)
             .map_err(transfer_error)
-    }
-
-    fn cut_logs(&mut self, _: u64, _: u64, _: u64) {
-        // It's unnecessary because overlapped entries can be handled in
-        // `append`.
     }
 
     fn put_raft_state(&mut self, raft_group_id: u64, state: &RaftLocalState) -> Result<()> {

--- a/components/raftstore-v2/src/operation/ready/snapshot.rs
+++ b/components/raftstore-v2/src/operation/ready/snapshot.rs
@@ -507,7 +507,6 @@ impl<EK: KvEngine, ER: RaftEngine> Storage<EK, ER> {
         if self.entry_storage().first_index() <= old_last_index {
             // All states are rewritten in the following blocks. Stale states will be
             // cleaned up by compact worker.
-            task.cut_logs = Some((0, old_last_index + 1));
             self.entry_storage_mut().clear();
         }
 

--- a/components/raftstore/src/store/async_io/write.rs
+++ b/components/raftstore/src/store/async_io/write.rs
@@ -186,8 +186,8 @@ where
     pub raft_wb: Option<ER::LogBatch>,
     // called after writing to kvdb and raftdb.
     pub persisted_cbs: Vec<Box<dyn FnOnce() + Send>>,
-    pub entries: Vec<Entry>,
-    pub cut_logs: Option<(u64, u64)>,
+    overwrite_to: Option<u64>,
+    entries: Vec<Entry>,
     pub raft_state: Option<RaftLocalState>,
     pub extra_write: ExtraWrite<EK::WriteBatch, ER::LogBatch>,
     pub messages: Vec<RaftMessage>,
@@ -207,8 +207,8 @@ where
             ready_number,
             send_time: Instant::now(),
             raft_wb: None,
+            overwrite_to: None,
             entries: vec![],
-            cut_logs: None,
             raft_state: None,
             extra_write: ExtraWrite::None,
             messages: vec![],
@@ -221,9 +221,19 @@ where
     pub fn has_data(&self) -> bool {
         !(self.raft_state.is_none()
             && self.entries.is_empty()
-            && self.cut_logs.is_none()
             && self.extra_write.is_empty()
             && self.raft_wb.as_ref().map_or(true, |wb| wb.is_empty()))
+    }
+
+    /// Append continous entries.
+    ///
+    /// All existing entries with same index will be overwritten. If
+    /// `overwrite_to` is set to a larger value, then entries in
+    /// `[entries.last().get_index(), overwrite_to)` will be deleted. If
+    /// entries is empty, nothing will be deleted.
+    pub fn set_append(&mut self, overwrite_to: Option<u64>, entries: Vec<Entry>) {
+        self.entries = entries;
+        self.overwrite_to = overwrite_to;
     }
 
     #[inline]
@@ -387,11 +397,12 @@ where
             raft_wb.merge(wb).unwrap();
         }
         raft_wb
-            .append(task.region_id, std::mem::take(&mut task.entries))
+            .append(
+                task.region_id,
+                task.overwrite_to,
+                std::mem::take(&mut task.entries),
+            )
             .unwrap();
-        if let Some((from, to)) = task.cut_logs {
-            raft_wb.cut_logs(task.region_id, from, to);
-        }
 
         if let Some(raft_state) = task.raft_state.take()
             && self.raft_states.insert(task.region_id, raft_state).is_none() {

--- a/components/raftstore/src/store/entry_storage.rs
+++ b/components/raftstore/src/store/entry_storage.rs
@@ -1075,9 +1075,8 @@ impl<EK: KvEngine, ER: RaftEngine> EntryStorage<EK, ER> {
 
         self.cache.append(self.region_id, self.peer_id, &entries);
 
-        task.entries = entries;
         // Delete any previously appended log entries which never committed.
-        task.cut_logs = Some((last_index + 1, prev_last_index + 1));
+        task.set_append(Some(prev_last_index + 1), entries);
 
         self.raft_state.set_last_index(last_index);
         self.last_term = last_term;

--- a/components/raftstore/src/store/peer_storage.rs
+++ b/components/raftstore/src/store/peer_storage.rs
@@ -2082,7 +2082,7 @@ pub mod tests {
         let mut lb = engines.raft.log_batch(4096);
         // last_index < commit_index is invalid.
         raft_state.set_last_index(11);
-        lb.append(1, vec![new_entry(11, RAFT_INIT_LOG_TERM)])
+        lb.append(1, None, vec![new_entry(11, RAFT_INIT_LOG_TERM)])
             .unwrap();
         raft_state.mut_hard_state().set_commit(12);
         lb.put_raft_state(1, &raft_state).unwrap();
@@ -2093,7 +2093,7 @@ pub mod tests {
         let entries = (12..=20)
             .map(|index| new_entry(index, RAFT_INIT_LOG_TERM))
             .collect();
-        lb.append(1, entries).unwrap();
+        lb.append(1, None, entries).unwrap();
         lb.put_raft_state(1, &raft_state).unwrap();
         engines.raft.consume(&mut lb, false).unwrap();
         s = build_storage().unwrap();
@@ -2138,7 +2138,7 @@ pub mod tests {
             .map(|index| new_entry(index, RAFT_INIT_LOG_TERM))
             .collect();
         engines.raft.gc(1, 0, 21, &mut lb).unwrap();
-        lb.append(1, entries).unwrap();
+        lb.append(1, None, entries).unwrap();
         engines.raft.consume(&mut lb, false).unwrap();
         raft_state.mut_hard_state().set_commit(14);
         s = build_storage().unwrap();
@@ -2150,7 +2150,7 @@ pub mod tests {
             .map(|index| new_entry(index, RAFT_INIT_LOG_TERM))
             .collect();
         entries[0].set_term(RAFT_INIT_LOG_TERM - 1);
-        lb.append(1, entries).unwrap();
+        lb.append(1, None, entries).unwrap();
         engines.raft.consume(&mut lb, false).unwrap();
         assert!(build_storage().is_err());
 
@@ -2158,7 +2158,7 @@ pub mod tests {
         let entries = (14..=20)
             .map(|index| new_entry(index, RAFT_INIT_LOG_TERM))
             .collect();
-        lb.append(1, entries).unwrap();
+        lb.append(1, None, entries).unwrap();
         raft_state.mut_hard_state().set_term(RAFT_INIT_LOG_TERM - 1);
         lb.put_raft_state(1, &raft_state).unwrap();
         engines.raft.consume(&mut lb, false).unwrap();
@@ -2168,7 +2168,7 @@ pub mod tests {
         engines.raft.gc(1, 0, 21, &mut lb).unwrap();
         raft_state.mut_hard_state().set_term(RAFT_INIT_LOG_TERM);
         raft_state.set_last_index(13);
-        lb.append(1, vec![new_entry(13, RAFT_INIT_LOG_TERM)])
+        lb.append(1, None, vec![new_entry(13, RAFT_INIT_LOG_TERM)])
             .unwrap();
         lb.put_raft_state(1, &raft_state).unwrap();
         engines.raft.consume(&mut lb, false).unwrap();

--- a/components/raftstore/src/store/snap.rs
+++ b/components/raftstore/src/store/snap.rs
@@ -2154,7 +2154,7 @@ pub mod tests {
             apply_entry.set_term(0);
             apply_state.mut_truncated_state().set_index(10);
             kv.put_msg_cf(CF_RAFT, &keys::apply_state_key(region_id), &apply_state)?;
-            lb.append(region_id, vec![apply_entry])?;
+            lb.append(region_id, None, vec![apply_entry])?;
 
             // Put region info into kv engine.
             let region = gen_test_region(region_id, 1, 1);

--- a/components/raftstore/src/store/worker/raftlog_gc.rs
+++ b/components/raftstore/src/store/worker/raftlog_gc.rs
@@ -214,7 +214,7 @@ mod tests {
         for i in 0..100 {
             let mut e = Entry::new();
             e.set_index(i);
-            raft_wb.append(region_id, vec![e]).unwrap();
+            raft_wb.append(region_id, None, vec![e]).unwrap();
         }
         raft_db.consume(&mut raft_wb, false /* sync */).unwrap();
 

--- a/components/server/src/raft_engine_switch.rs
+++ b/components/server/src/raft_engine_switch.rs
@@ -161,7 +161,7 @@ fn run_dump_raftdb_worker(
                                     // Assume that we always scan entry first and raft state at the
                                     // end.
                                     batch
-                                        .append(region_id, std::mem::take(&mut entries))
+                                        .append(region_id, None, std::mem::take(&mut entries))
                                         .unwrap();
                                 }
                                 _ => unreachable!("There is only 2 types of keys in raft"),
@@ -170,7 +170,7 @@ fn run_dump_raftdb_worker(
                             if local_size >= BATCH_THRESHOLD {
                                 local_size = 0;
                                 batch
-                                    .append(region_id, std::mem::take(&mut entries))
+                                    .append(region_id, None, std::mem::take(&mut entries))
                                     .unwrap();
 
                                 let size = new_engine.consume(&mut batch, false).unwrap();
@@ -205,7 +205,7 @@ fn run_dump_raft_engine_worker(
                 begin += old_engine
                     .fetch_entries_to(id, begin, end, Some(BATCH_THRESHOLD), &mut entries)
                     .unwrap() as u64;
-                batch.append(id, entries).unwrap();
+                batch.append(id, None, entries).unwrap();
                 let size = new_engine.consume(&mut batch, false).unwrap();
                 count_size.fetch_add(size, Ordering::Relaxed);
             }
@@ -303,7 +303,7 @@ mod tests {
             e.set_index(i);
             entries.push(e);
         }
-        batch.append(num, entries).unwrap();
+        batch.append(num, None, entries).unwrap();
     }
 
     // Get data from raft engine and assert.

--- a/tests/integrations/server/kv_service.rs
+++ b/tests/integrations/server/kv_service.rs
@@ -966,7 +966,7 @@ fn test_debug_raft_log() {
     entry.set_entry_type(eraftpb::EntryType::EntryNormal);
     entry.set_data(vec![42].into());
     let mut lb = engine.log_batch(0);
-    lb.append(region_id, vec![entry.clone()]).unwrap();
+    lb.append(region_id, None, vec![entry.clone()]).unwrap();
     engine.consume(&mut lb, false).unwrap();
     assert_eq!(
         engine.get_entry(region_id, log_index).unwrap().unwrap(),


### PR DESCRIPTION

### What is changed and how it works?
Issue Number: Ref #12842 

What's Changed:

```commit-message
The API is supposed to be used with `append` but nowhere can we find
the clue. This PR merges `cut_logs` and `append` to reduce confusion
and mistakes.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
