### PR TITLE
raftstore-v2: only send clean snapshot

### DIFF
--- a/components/engine_panic/src/raft_engine.rs
+++ b/components/engine_panic/src/raft_engine.rs
@@ -67,6 +67,10 @@ impl RaftEngineReadOnly for PanicEngine {
         panic!()
     }
 
+    fn get_dirty_mark(&self, raft_group_id: u64, tablet_index: u64) -> Result<bool> {
+        panic!()
+    }
+
     fn get_recover_state(&self) -> Result<Option<StoreRecoverState>> {
         panic!()
     }
@@ -229,6 +233,10 @@ impl RaftLogBatch for PanicWriteBatch {
         tablet_index: u64,
         apply_index: u64,
     ) -> Result<()> {
+        panic!()
+    }
+
+    fn put_dirty_mark(&mut self, raft_group_id: u64, tablet_index: u64, dirty: bool) -> Result<()> {
         panic!()
     }
 

--- a/components/engine_rocks/src/raft_engine.rs
+++ b/components/engine_rocks/src/raft_engine.rs
@@ -166,6 +166,10 @@ impl RaftEngineReadOnly for RocksEngine {
         panic!()
     }
 
+    fn get_dirty_mark(&self, _raft_group_id: u64, _tablet_index: u64) -> Result<bool> {
+        panic!()
+    }
+
     fn get_recover_state(&self) -> Result<Option<StoreRecoverState>> {
         self.get_msg_cf(CF_DEFAULT, keys::RECOVER_STATE_KEY)
     }
@@ -435,6 +439,15 @@ impl RaftLogBatch for RocksWriteBatchVec {
         _cf: &str,
         _tablet_index: u64,
         _apply_index: u64,
+    ) -> Result<()> {
+        panic!()
+    }
+
+    fn put_dirty_mark(
+        &mut self,
+        _raft_group_id: u64,
+        _tablet_index: u64,
+        _dirty: bool,
     ) -> Result<()> {
         panic!()
     }

--- a/components/engine_traits/src/raft_engine.rs
+++ b/components/engine_traits/src/raft_engine.rs
@@ -33,6 +33,7 @@ pub trait RaftEngineReadOnly: Sync + Send + 'static {
     ) -> Result<Option<RaftApplyState>>;
     /// Get the flushed index of the given CF.
     fn get_flushed_index(&self, raft_group_id: u64, cf: &str) -> Result<Option<u64>>;
+    fn get_dirty_mark(&self, raft_group_id: u64, tablet_index: u64) -> Result<bool>;
     fn get_recover_state(&self) -> Result<Option<StoreRecoverState>>;
 
     fn get_entry(&self, raft_group_id: u64, index: u64) -> Result<Option<Entry>>;
@@ -200,6 +201,9 @@ pub trait RaftLogBatch: Send {
         tablet_index: u64,
         apply_index: u64,
     ) -> Result<()>;
+
+    /// Mark a tablet may contain data that is not supposed to be in its range.
+    fn put_dirty_mark(&mut self, raft_group_id: u64, tablet_index: u64, dirty: bool) -> Result<()>;
 
     /// Indicate whether region states should be recovered from raftdb and
     /// replay raft logs.

--- a/components/raft_log_engine/src/engine.rs
+++ b/components/raft_log_engine/src/engine.rs
@@ -381,6 +381,7 @@ const REGION_STATE_KEY: &[u8] = &[0x03];
 const APPLY_STATE_KEY: &[u8] = &[0x04];
 const RECOVER_STATE_KEY: &[u8] = &[0x05];
 const FLUSH_STATE_KEY: &[u8] = &[0x06];
+const DIRTY_MARK_KEY: &[u8] = &[0x07];
 // All keys are of the same length.
 const KEY_PREFIX_LEN: usize = RAFT_LOG_STATE_KEY.len();
 
@@ -472,6 +473,16 @@ impl RaftLogBatchTrait for RaftLogBatch {
         let mut value = vec![0; 8];
         NumberCodec::encode_u64(&mut value, apply_index);
         self.0.put(raft_group_id, key.to_vec(), value);
+        Ok(())
+    }
+
+    fn put_dirty_mark(&mut self, raft_group_id: u64, tablet_index: u64, dirty: bool) -> Result<()> {
+        let key = encode_key(DIRTY_MARK_KEY, tablet_index);
+        if dirty {
+            self.0.put(raft_group_id, key.to_vec(), vec![]);
+        } else {
+            self.0.delete(raft_group_id, key.to_vec());
+        }
         Ok(())
     }
 
@@ -599,6 +610,11 @@ impl RaftEngineReadOnly for RaftLogEngine {
             })
             .map_err(transfer_error)?;
         Ok(index)
+    }
+
+    fn get_dirty_mark(&self, raft_group_id: u64, tablet_index: u64) -> Result<bool> {
+        let key = encode_key(DIRTY_MARK_KEY, tablet_index);
+        Ok(self.0.get(raft_group_id, &key).is_some())
     }
 
     fn get_recover_state(&self) -> Result<Option<StoreRecoverState>> {

--- a/components/raftstore-v2/src/fsm/peer.rs
+++ b/components/raftstore-v2/src/fsm/peer.rs
@@ -191,7 +191,7 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> PeerFsmDelegate<'a, EK, ER,
     }
 
     fn on_start(&mut self) {
-        if !self.fsm.peer.maybe_pause_for_recovery() {
+        if !self.fsm.peer.maybe_pause_for_recovery(self.store_ctx) {
             self.schedule_tick(PeerTick::Raft);
         }
         self.schedule_tick(PeerTick::SplitRegionCheck);
@@ -308,6 +308,9 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> PeerFsmDelegate<'a, EK, ER,
                         .on_request_split(self.store_ctx, request, ch)
                 }
                 PeerMsg::ForceCompactLog => self.on_compact_log_tick(true),
+                PeerMsg::TabletTrimmed { tablet_index } => {
+                    self.fsm.peer_mut().on_tablet_trimmed(tablet_index)
+                }
                 #[cfg(feature = "testexport")]
                 PeerMsg::WaitFlush(ch) => self.fsm.peer_mut().on_wait_flush(ch),
             }

--- a/components/raftstore-v2/src/raft/storage.rs
+++ b/components/raftstore-v2/src/raft/storage.rs
@@ -35,6 +35,9 @@ pub struct Storage<EK: KvEngine, ER> {
     /// by messages, it has not persisted any states, we need to persist them
     /// at least once dispite whether the state changes since create.
     ever_persisted: bool,
+    /// It may have dirty data after split. Use a flag to indicate whether it
+    /// has finished clean up.
+    has_dirty_data: bool,
     logger: Logger,
 
     /// Snapshot part.
@@ -116,6 +119,16 @@ impl<EK: KvEngine, ER> Storage<EK, ER> {
     pub fn apply_trace(&self) -> &ApplyTrace {
         &self.apply_trace
     }
+
+    #[inline]
+    pub fn set_has_dirty_data(&mut self, has_dirty_data: bool) {
+        self.has_dirty_data = has_dirty_data;
+    }
+
+    #[inline]
+    pub fn has_dirty_data(&self) -> bool {
+        self.has_dirty_data
+    }
 }
 
 impl<EK: KvEngine, ER: RaftEngine> Storage<EK, ER> {
@@ -139,6 +152,17 @@ impl<EK: KvEngine, ER: RaftEngine> Storage<EK, ER> {
         };
         let region = region_state.get_region();
         let logger = logger.new(o!("region_id" => region.id, "peer_id" => peer.get_id()));
+        let has_dirty_data =
+            match engine.get_dirty_mark(region.get_id(), region_state.get_tablet_index()) {
+                Ok(b) => b,
+                Err(e) => {
+                    return Err(box_err!(
+                        "failed to get dirty mark for {}: {:?}",
+                        region.get_id(),
+                        e
+                    ));
+                }
+            };
         let entry_storage = EntryStorage::new(
             peer.get_id(),
             engine,
@@ -153,6 +177,7 @@ impl<EK: KvEngine, ER: RaftEngine> Storage<EK, ER> {
             peer: peer.clone(),
             region_state,
             ever_persisted: persisted,
+            has_dirty_data,
             logger,
             snap_states: RefCell::new(HashMap::default()),
             gen_snap_task: RefCell::new(Box::new(None)),

--- a/components/raftstore-v2/src/router/message.rs
+++ b/components/raftstore-v2/src/router/message.rs
@@ -182,6 +182,9 @@ pub enum PeerMsg {
         ch: CmdResChannel,
     },
     ForceCompactLog,
+    TabletTrimmed {
+        tablet_index: u64,
+    },
     /// A message that used to check if a flush is happened.
     #[cfg(feature = "testexport")]
     WaitFlush(super::FlushChannel),


### PR DESCRIPTION

### What is changed and how it works?
Issue Number: Ref #12842 

What's Changed:

```commit-message
When the tablet contains dirty data right after split, generating snapshot may
just a waste. On the other hand, split usually happens on all peers, so delay
it a bit actually makes all peers more likely to be initialized by split. So
this PR rejects generating snapshot when it detects it still has dirty data.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
