### PR TITLE
*: patch backtrace-rs to increase MAPPINGS_CACHE_SIZE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,8 +440,7 @@ dependencies = [
 [[package]]
 name = "backtrace"
 version = "0.3.61"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a905d892734eea339e896738c14b9afce22b5318f64b951e70bf3844419b01"
+source = "git+https://github.com/hehechen/backtrace-rs?branch=v0.3.61#d0aeebbea2298174e4c6edd3d1e54bda0e6624e4"
 dependencies = [
  "addr2line",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -216,6 +216,8 @@ cmake = { git = "https://github.com/rust-lang/cmake-rs" }
 # This is a workaround for cargo can't resolving the this patch in yatp.
 crossbeam-deque = { git = "https://github.com/crossbeam-rs/crossbeam", rev = "41ed3d948720f26149b2ebeaf58fe8a193134056" }
 
+# remove this when https://github.com/rust-lang/backtrace-rs/pull/503 is merged.
+backtrace = { git = 'https://github.com/hehechen/backtrace-rs', branch = "v0.3.61" }
 [target.'cfg(target_os = "linux")'.dependencies]
 procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "6599eb9dca74229b2c1fcc44118bef7eff127128" }
 # When you modify TiKV cooperatively with kvproto, this will be useful to submit the PR to TiKV and the PR to


### PR DESCRIPTION
Signed-off-by: hehechen <awd123456sss@gmail.com>


### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #14025

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```
Patch backtrace-rs to increase MAPPINGS_CACHE_SIZE
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
[Test in TiFlash proxy](https://github.com/pingcap/tiflash/issues/6347#issuecomment-1333038382), 10 seconds profiling time reduced from 80 seconds to 11 seconds.
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None.
```
