### PR TITLE
txn: Do constraint check when handling repeated acqurie_pessimsitic_lock request

### DIFF
--- a/src/storage/txn/actions/acquire_pessimistic_lock.rs
+++ b/src/storage/txn/actions/acquire_pessimistic_lock.rs
@@ -147,6 +147,8 @@ pub fn acquire_pessimistic_lock<S: Snapshot>(
             if let Some((write, commit_ts)) = write {
                 // Here `get_write_with_commit_ts` returns only the latest PUT if it exists and
                 // is not deleted. It's still ok to pass it into `check_data_constraint`.
+                // In case we are going to lock it with write conflict, we do not check it since
+                // the statement will then retry.
                 if locked_with_conflict_ts.is_none() {
                     check_data_constraint(reader, should_not_exist, &write, commit_ts, &key)?;
                 }

--- a/src/storage/txn/actions/acquire_pessimistic_lock.rs
+++ b/src/storage/txn/actions/acquire_pessimistic_lock.rs
@@ -142,10 +142,20 @@ pub fn acquire_pessimistic_lock<S: Snapshot>(
                 None
             };
 
-        if need_load_value {
-            val = reader.get(&key, for_update_ts)?;
-        } else if need_check_existence {
-            val = reader.get_write(&key, for_update_ts)?.map(|_| vec![]);
+        if need_load_value || need_check_existence || should_not_exist {
+            let write = reader.get_write_with_commit_ts(&key, for_update_ts)?;
+            if let Some((write, commit_ts)) = write {
+                // Here `get_write_with_commit_ts` returns only the latest PUT if it exists and
+                // is not deleted. It's still ok to pass it into `check_data_constraint`.
+                if locked_with_conflict_ts.is_none() {
+                    check_data_constraint(reader, should_not_exist, &write, commit_ts, &key)?;
+                }
+                if need_load_value  {
+                    val = Some(reader.load_data(&key, write)?);
+                } else if need_check_existence {
+                    val = Some(vec![]);
+                }
+            }
         }
         // Pervious write is not loaded.
         let (prev_write_loaded, prev_write) = (false, None);
@@ -342,7 +352,7 @@ pub fn acquire_pessimistic_lock<S: Snapshot>(
 
 pub mod tests {
     use concurrency_manager::ConcurrencyManager;
-    use kvproto::kvrpcpb::Context;
+    use kvproto::kvrpcpb::{Context, PrewriteRequestPessimisticAction};
     #[cfg(test)]
     use kvproto::kvrpcpb::PrewriteRequestPessimisticAction::*;
     use txn_types::{Lock, TimeStamp};
@@ -1831,5 +1841,57 @@ pub mod tests {
         must_pessimistic_locked(&mut engine, b"k1", 10, 50);
         must_pessimistic_rollback(&mut engine, b"k1", 10, 50);
         must_unlocked(&mut engine, b"k1");
+    }
+
+    #[test]
+    fn test_repeated_request_check_should_not_exist() {
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+
+        for &(return_values, check_existence) in &[(false, false), (false, true), (true, false), (true, true)] {
+            let key = &[b'k', (return_values as u8 * 2) + check_existence as u8] as &[u8];
+
+            // An empty key.
+            must_succeed(&mut engine, &key, &key, 10, 10);
+            let res = must_succeed_impl(&mut engine, &key, &key, 10, true, 1000, 10, return_values, check_existence, 15, false);
+            assert!(res.is_none());
+            must_pessimistic_prewrite_lock(&mut engine, &key, &key, 10, 10, DoPessimisticCheck);
+            must_commit(&mut engine, &key, 10, 19);
+
+            // The key has one record: Lock(10, 19)
+            must_succeed(&mut engine, &key, &key, 20, 20);
+            let res = must_succeed_impl(&mut engine, &key, &key, 20, true, 1000, 20, return_values, check_existence, 25, false);
+            assert!(res.is_none());
+            must_pessimistic_prewrite_put(&mut engine, &key, b"v1", &key, 20, 20, DoPessimisticCheck);
+            must_commit(&mut engine, &key, 20, 29);
+
+            // The key has records:
+            // Lock(10, 19), Put(20, 29)
+            must_succeed(&mut engine, &key, &key, 30, 30);
+            let error = must_err_impl(&mut engine, &key, &key, 30, true, 30, return_values, check_existence, 35, false);
+            assert!(matches!(error, MvccError(box ErrorInner::AlreadyExist {..})));
+            must_pessimistic_prewrite_lock(&mut engine, &key, &key, 30, 30, DoPessimisticCheck);
+            must_commit(&mut engine, &key, 30, 39);
+
+            // Lock(10, 19), Put(20, 29), Lock(30, 39)
+            must_succeed(&mut engine, &key, &key, 40, 40);
+            let error = must_err_impl(&mut engine, &key, &key, 40, true, 40, return_values, check_existence, 45, false);
+            assert!(matches!(error, MvccError(box ErrorInner::AlreadyExist {..})));
+            must_pessimistic_prewrite_delete(&mut engine, &key, &key, 40, 40, DoPessimisticCheck);
+            must_commit(&mut engine, &key, 40, 49);
+
+            // Lock(10, 19), Put(20, 29), Lock(30, 39), Delete(40, 49)
+            must_succeed(&mut engine, &key, &key, 50, 50);
+            let res = must_succeed_impl(&mut engine, &key, &key, 50, true, 1000, 50, return_values, check_existence, 55, false);
+            assert!(res.is_none());
+            must_pessimistic_prewrite_lock(&mut engine, &key, &key, 50, 50, DoPessimisticCheck);
+            must_commit(&mut engine, &key, 50, 59);
+
+            // Lock(10, 19), Put(20, 29), Lock(30, 39), Delete(40, 49), Lock(50, 59)
+            must_succeed(&mut engine, &key, &key, 60, 60);
+            let res = must_succeed_impl(&mut engine, &key, &key, 60, true, 1000, 60, return_values, check_existence, 65, false);
+            assert!(res.is_none());
+            must_pessimistic_prewrite_lock(&mut engine, &key, &key, 60, 60, DoPessimisticCheck);
+            must_commit(&mut engine, &key, 60, 69);
+        }
     }
 }

--- a/src/storage/txn/actions/acquire_pessimistic_lock.rs
+++ b/src/storage/txn/actions/acquire_pessimistic_lock.rs
@@ -1853,7 +1853,7 @@ pub mod tests {
             let key = &[b'k', (return_values as u8 * 2) + check_existence as u8] as &[u8];
 
             // An empty key.
-            must_succeed(&mut engine, &key, &key, 10, 10);
+            must_succeed(&mut engine, key, key, 10, 10);
             let res = must_succeed_impl(
                 &mut engine,
                 key,

--- a/src/storage/txn/actions/acquire_pessimistic_lock.rs
+++ b/src/storage/txn/actions/acquire_pessimistic_lock.rs
@@ -1856,8 +1856,8 @@ pub mod tests {
             must_succeed(&mut engine, &key, &key, 10, 10);
             let res = must_succeed_impl(
                 &mut engine,
-                &key,
-                &key,
+                key,
+                key,
                 10,
                 true,
                 1000,
@@ -1868,15 +1868,15 @@ pub mod tests {
                 false,
             );
             assert!(res.is_none());
-            must_pessimistic_prewrite_lock(&mut engine, &key, &key, 10, 10, DoPessimisticCheck);
-            must_commit(&mut engine, &key, 10, 19);
+            must_pessimistic_prewrite_lock(&mut engine, key, key, 10, 10, DoPessimisticCheck);
+            must_commit(&mut engine, key, 10, 19);
 
             // The key has one record: Lock(10, 19)
-            must_succeed(&mut engine, &key, &key, 20, 20);
+            must_succeed(&mut engine, key, key, 20, 20);
             let res = must_succeed_impl(
                 &mut engine,
-                &key,
-                &key,
+                key,
+                key,
                 20,
                 true,
                 1000,
@@ -1887,24 +1887,16 @@ pub mod tests {
                 false,
             );
             assert!(res.is_none());
-            must_pessimistic_prewrite_put(
-                &mut engine,
-                &key,
-                b"v1",
-                &key,
-                20,
-                20,
-                DoPessimisticCheck,
-            );
-            must_commit(&mut engine, &key, 20, 29);
+            must_pessimistic_prewrite_put(&mut engine, key, b"v1", key, 20, 20, DoPessimisticCheck);
+            must_commit(&mut engine, key, 20, 29);
 
             // The key has records:
             // Lock(10, 19), Put(20, 29)
-            must_succeed(&mut engine, &key, &key, 30, 30);
+            must_succeed(&mut engine, key, key, 30, 30);
             let error = must_err_impl(
                 &mut engine,
-                &key,
-                &key,
+                key,
+                key,
                 30,
                 true,
                 30,
@@ -1917,15 +1909,15 @@ pub mod tests {
                 error,
                 MvccError(box ErrorInner::AlreadyExist { .. })
             ));
-            must_pessimistic_prewrite_lock(&mut engine, &key, &key, 30, 30, DoPessimisticCheck);
-            must_commit(&mut engine, &key, 30, 39);
+            must_pessimistic_prewrite_lock(&mut engine, key, key, 30, 30, DoPessimisticCheck);
+            must_commit(&mut engine, key, 30, 39);
 
             // Lock(10, 19), Put(20, 29), Lock(30, 39)
-            must_succeed(&mut engine, &key, &key, 40, 40);
+            must_succeed(&mut engine, key, key, 40, 40);
             let error = must_err_impl(
                 &mut engine,
-                &key,
-                &key,
+                key,
+                key,
                 40,
                 true,
                 40,
@@ -1938,15 +1930,15 @@ pub mod tests {
                 error,
                 MvccError(box ErrorInner::AlreadyExist { .. })
             ));
-            must_pessimistic_prewrite_delete(&mut engine, &key, &key, 40, 40, DoPessimisticCheck);
-            must_commit(&mut engine, &key, 40, 49);
+            must_pessimistic_prewrite_delete(&mut engine, key, key, 40, 40, DoPessimisticCheck);
+            must_commit(&mut engine, key, 40, 49);
 
             // Lock(10, 19), Put(20, 29), Lock(30, 39), Delete(40, 49)
-            must_succeed(&mut engine, &key, &key, 50, 50);
+            must_succeed(&mut engine, key, key, 50, 50);
             let res = must_succeed_impl(
                 &mut engine,
-                &key,
-                &key,
+                key,
+                key,
                 50,
                 true,
                 1000,
@@ -1957,15 +1949,15 @@ pub mod tests {
                 false,
             );
             assert!(res.is_none());
-            must_pessimistic_prewrite_lock(&mut engine, &key, &key, 50, 50, DoPessimisticCheck);
-            must_commit(&mut engine, &key, 50, 59);
+            must_pessimistic_prewrite_lock(&mut engine, key, key, 50, 50, DoPessimisticCheck);
+            must_commit(&mut engine, key, 50, 59);
 
             // Lock(10, 19), Put(20, 29), Lock(30, 39), Delete(40, 49), Lock(50, 59)
-            must_succeed(&mut engine, &key, &key, 60, 60);
+            must_succeed(&mut engine, key, key, 60, 60);
             let res = must_succeed_impl(
                 &mut engine,
-                &key,
-                &key,
+                key,
+                key,
                 60,
                 true,
                 1000,
@@ -1976,8 +1968,8 @@ pub mod tests {
                 false,
             );
             assert!(res.is_none());
-            must_pessimistic_prewrite_lock(&mut engine, &key, &key, 60, 60, DoPessimisticCheck);
-            must_commit(&mut engine, &key, 60, 69);
+            must_pessimistic_prewrite_lock(&mut engine, key, key, 60, 60, DoPessimisticCheck);
+            must_commit(&mut engine, key, 60, 69);
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #14038 
Close https://github.com/pingcap/tidb/issues/40114

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Fixes the problem that when handling repeated acquire_pessimistic_lock requests is recevied, should_not_exist is ignored. 

TiKV provides idempotency for these RPC requests, but for acquire_pessimistic_lock, it ignored the possibility that the client may expect a pessimistic_rollback between two acquire_pessimistic_lock request on the same key. In this case the second request may come from another statement and carries `should_not_exist` that wasn't set in the previously finished pessimistic lock request. If the first request successfully acquired the lock and the pessimistic_rollback failed, TiKV may return a sucessful response, making the client believe that the key doesn't exist before. In some rare cases, this has risk to cause data inconsistency.
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- Performance regression
    - Consumes more CPU

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fixed a problem that when a transaction in TiDB fails to execute a pessimistic DML and then executes another DML, if there are random network failures between TiDB and TiKV, it has risk to cause data inconsistency.
```
