### PR TITLE
log-backup: an ad-hoc way for hot reloading TLS certs

### DIFF
--- a/components/backup-stream/src/metadata/store/lazy_etcd.rs
+++ b/components/backup-stream/src/metadata/store/lazy_etcd.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::{
-    sync::{Arc, Mutex},
+    sync::Arc,
     time::{Duration, SystemTime},
 };
 
@@ -14,7 +14,7 @@ use tikv_util::{
     stream::{RetryError, RetryExt},
     warn,
 };
-use tokio::sync::{Mutex as AsyncMutex, OnceCell};
+use tokio::sync::Mutex as AsyncMutex;
 
 use super::{etcd::EtcdSnapshot, EtcdStore, MetaStore};
 use crate::errors::{ContextualResultExt, Result};
@@ -162,7 +162,7 @@ impl LazyEtcdClientInner {
         .await
         .context("during connecting to the etcd")?;
         let store = EtcdStore::from(store);
-        self.cli = Some(store.clone());
+        self.cli = Some(store);
         Ok(self.cli.as_ref().unwrap())
     }
 

--- a/components/backup-stream/src/metadata/store/lazy_etcd.rs
+++ b/components/backup-stream/src/metadata/store/lazy_etcd.rs
@@ -1,15 +1,20 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{Arc, Mutex},
+    time::{Duration, SystemTime},
+};
 
 use etcd_client::{ConnectOptions, Error as EtcdError, OpenSslClientConfig};
 use futures::Future;
 use openssl::x509::verify::X509VerifyFlags;
+use security::SecurityManager;
 use tikv_util::{
     info,
     stream::{RetryError, RetryExt},
+    warn,
 };
-use tokio::sync::OnceCell;
+use tokio::sync::{Mutex as AsyncMutex, OnceCell};
 
 use super::{etcd::EtcdSnapshot, EtcdStore, MetaStore};
 use crate::errors::{ContextualResultExt, Result};
@@ -17,20 +22,34 @@ use crate::errors::{ContextualResultExt, Result};
 const RPC_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Clone)]
-pub struct LazyEtcdClient(Arc<LazyEtcdClientInner>);
+pub struct LazyEtcdClient(Arc<AsyncMutex<LazyEtcdClientInner>>);
 
-#[derive(Debug)]
+#[derive(Clone)]
 pub struct ConnectionConfig {
-    pub tls: Option<security::ClientSuite>,
+    pub tls: Arc<SecurityManager>,
     pub keep_alive_interval: Duration,
     pub keep_alive_timeout: Duration,
+}
+
+impl std::fmt::Debug for ConnectionConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ConnectionConfig")
+            .field("keep_alive_interval", &self.keep_alive_interval)
+            .field("keep_alive_timeout", &self.keep_alive_timeout)
+            .finish()
+    }
 }
 
 impl ConnectionConfig {
     /// Convert the config to the connection option.
     fn to_connection_options(&self) -> ConnectOptions {
         let mut opts = ConnectOptions::new();
-        if let Some(tls) = &self.tls {
+        if let Some(tls) = &self
+            .tls
+            .client_suite()
+            .map_err(|err| warn!("failed to load client suite!"; "err" => %err))
+            .ok()
+        {
             opts = opts.with_openssl_tls(
                 OpenSslClientConfig::default()
                     .ca_cert_pem(&tls.ca)
@@ -54,28 +73,27 @@ impl ConnectionConfig {
 
 impl LazyEtcdClient {
     pub fn new(endpoints: &[String], conf: ConnectionConfig) -> Self {
-        Self(Arc::new(LazyEtcdClientInner {
-            opt: conf.to_connection_options(),
+        Self(Arc::new(AsyncMutex::new(LazyEtcdClientInner {
+            conf,
             endpoints: endpoints.iter().map(ToString::to_string).collect(),
-            cli: OnceCell::new(),
-        }))
+            last_modified: None,
+            cli: None,
+        })))
     }
-}
 
-impl std::ops::Deref for LazyEtcdClient {
-    type Target = LazyEtcdClientInner;
-
-    fn deref(&self) -> &Self::Target {
-        Arc::deref(&self.0)
+    async fn get_cli(&self) -> Result<EtcdStore> {
+        let mut l = self.0.lock().await;
+        l.get_cli().await.cloned()
     }
 }
 
 #[derive(Clone)]
 pub struct LazyEtcdClientInner {
-    opt: ConnectOptions,
+    conf: ConnectionConfig,
     endpoints: Vec<String>,
 
-    cli: OnceCell<EtcdStore>,
+    last_modified: Option<SystemTime>,
+    cli: Option<EtcdStore>,
 }
 
 fn etcd_error_is_retryable(etcd_err: &EtcdError) -> bool {
@@ -130,23 +148,34 @@ where
 }
 
 impl LazyEtcdClientInner {
-    async fn connect(&self) -> Result<EtcdStore> {
+    async fn connect(&mut self) -> Result<&EtcdStore> {
         let store = retry(|| {
             // For now, the interface of the `etcd_client` doesn't us to control
             // how to create channels when connecting, hence we cannot update the tls config
-            // at runtime.
-            // TODO: maybe add some method like `with_channel` for `etcd_client`, and adapt
-            // the `SecurityManager` API, instead of doing everything by own.
-            etcd_client::Client::connect(self.endpoints.clone(), Some(self.opt.clone()))
+            // at runtime, now what we did is manually check that each time we are getting
+            // the clients.
+            etcd_client::Client::connect(
+                self.endpoints.clone(),
+                Some(self.conf.to_connection_options()),
+            )
         })
         .await
         .context("during connecting to the etcd")?;
-        Ok(EtcdStore::from(store))
+        let store = EtcdStore::from(store);
+        self.cli = Some(store.clone());
+        Ok(self.cli.as_ref().unwrap())
     }
 
-    pub async fn get_cli(&self) -> Result<&EtcdStore> {
-        let store = self.cli.get_or_try_init(|| self.connect()).await?;
-        Ok(store)
+    pub async fn get_cli(&mut self) -> Result<&EtcdStore> {
+        let modified = self.conf.tls.get_config().is_modified(&mut self.last_modified)
+            // Don't reload once we cannot check whether it is modified.
+            // Because when TLS disabled, this would always fail.
+            .unwrap_or(false);
+        if !modified && self.cli.is_some() {
+            return Ok(self.cli.as_ref().unwrap());
+        }
+        info!("log backup reconnecting to the etcd service."; "tls_modified" => %modified, "connected_before" => %self.cli.is_some());
+        self.connect().await
     }
 }
 
@@ -155,7 +184,7 @@ impl MetaStore for LazyEtcdClient {
     type Snap = EtcdSnapshot;
 
     async fn snapshot(&self) -> Result<Self::Snap> {
-        self.0.get_cli().await?.snapshot().await
+        self.get_cli().await?.snapshot().await
     }
 
     async fn watch(
@@ -163,14 +192,14 @@ impl MetaStore for LazyEtcdClient {
         keys: super::Keys,
         start_rev: i64,
     ) -> Result<super::KvChangeSubscription> {
-        self.0.get_cli().await?.watch(keys, start_rev).await
+        self.get_cli().await?.watch(keys, start_rev).await
     }
 
     async fn txn(&self, txn: super::Transaction) -> Result<()> {
-        self.0.get_cli().await?.txn(txn).await
+        self.get_cli().await?.txn(txn).await
     }
 
     async fn txn_cond(&self, txn: super::CondTransaction) -> Result<()> {
-        self.0.get_cli().await?.txn_cond(txn).await
+        self.get_cli().await?.txn_cond(txn).await
     }
 }

--- a/components/security/src/lib.rs
+++ b/components/security/src/lib.rs
@@ -190,6 +190,10 @@ impl SecurityManager {
             )
         }
     }
+
+    pub fn get_config(&self) -> &SecurityConfig {
+        &self.cfg
+    }
 }
 
 #[derive(Clone)]

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -1022,13 +1022,7 @@ where
                 ConnectionConfig {
                     keep_alive_interval: self.config.server.grpc_keepalive_time.0,
                     keep_alive_timeout: self.config.server.grpc_keepalive_timeout.0,
-                    tls: self
-                        .security_mgr
-                        .client_suite()
-                        .map_err(|err| {
-                            warn!("Failed to load client TLS suite, ignoring TLS config."; "err" => %err);
-                        })
-                        .ok(),
+                    tls: Arc::clone(&self.security_mgr),
                 },
             );
             let backup_stream_endpoint = backup_stream::Endpoint::new(


### PR DESCRIPTION
Signed-off-by: hillium <yujuncen@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #14071 

What's Changed:
This PR have modified the `LazyEtcd` and made it checks the TLS certification every time when retrieving the client.
Once it find the TLS certification has been modified, it would reconnect to the server.

```commit-message
Log backup would aware TLS certifications changing.
```

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

It is integrated with etcd, hence hard to make unit tests.

- Manual test (add detailed scripts or steps below)

The manual test creates a cluster where *TLS certifications are reloaded every 5 mins* and *all TLS certification lives for 10 mins*.
with the script:
```bash
#! /bin/bash

set -eu

lib=${lib:-/root/lovecloudnative/scripts}
out=${out:-/root/lovecloudnative/ssl}
profile=${profile:-internal-debug}
namespace=${namespace:-tidb-cluster}
cluster_name=${cluster_name:-basic}
cd "$out"

for comp in tidb tikv pd; do
    cfssl gencert -ca=$out/ca.pem -ca-key=$out/ca-key.pem -config=$out/ca-config.json -profile="$profile" <($lib/csr-for $comp) | cfssljson -bare $comp-server 
    kubectl delete secret/${cluster_name}-$comp-cluster-secret || true
    kubectl create secret generic ${cluster_name}-$comp-cluster-secret --namespace=${namespace} --from-file=tls.crt=$comp-server.pem --from-file=tls.key=$comp-server-key.pem --from-file=ca.crt=ca.pem
done

cfssl gencert -ca=ca.pem -ca-key=ca-key.pem -config=ca-config.json -profile=client <($lib/csr-for client) | cfssljson -bare client
kubectl delete secret/${cluster_name}-cluster-client-secret || true
kubectl create secret generic ${cluster_name}-cluster-client-secret --namespace=${namespace} --from-file=tls.crt=$comp-server.pem --from-file=tls.key=$comp-server-key.pem --from-file=ca.crt=ca.pem
```
Where the config `internal-debug` yields certs with a TTL of 10 mins.
```json
"internal-debug": {
                "expiry": "10m",
                "usages": [
                    "signing",
                    "key encipherment",
                    "server auth",
                    "client auth"
                ]
            },
```

In such a cluster, we start the `shuffle-leader-shceduler` and run it for a long time. If log backup works properly in this cluster, we can make sure that the TLS certifications reloading are well-handled.

In this cluster, we are going to do after 10mins:
- Start a task.
- Check whether the task's checkpoint can be advanced normally.
- Pause / Restart it, check whether it works normally.
- Stop the task and start a new task, check whether the task works normally.


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Now, log backup supports hot-reloading the TLS certifications.
```
