### PR TITLE
config: allow starting TiKV nodes with <1 CPU

### DIFF
--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -660,7 +660,7 @@ impl Config {
         // prevent mistakenly inputting too large values, the max limit is made
         // according to the cpu quota * 10. Notice 10 is only an estimate, not an
         // empirical value.
-        let limit = SysQuota::cpu_cores_quota() as usize * 10;
+        let limit = (SysQuota::cpu_cores_quota() * 10.0) as usize;
         if self.apply_batch_system.pool_size == 0 || self.apply_batch_system.pool_size > limit {
             return Err(box_err!(
                 "apply-pool-size should be greater than 0 and less than or equal to: {}",

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1396,7 +1396,7 @@ impl DbConfig {
         // prevent mistakenly inputting too large values, the max limit is made
         // according to the cpu quota * 10. Notice 10 is only an estimate, not an
         // empirical value.
-        let limit = SysQuota::cpu_cores_quota() as i32 * 10;
+        let limit = (SysQuota::cpu_cores_quota() * 10.0) as i32;
         if self.max_background_jobs <= 0 || self.max_background_jobs > limit {
             return Err(format!(
                 "max_background_jobs should be greater than 0 and less than or equal to {:?}",


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Close #13586, Close #13752, Ref #14017

What's Changed: Allow starting TiKV nodes with <1 CPU.

Before this change even starting a TiKV node with 0.999 CPU would fail because of rounding.

### Check List

Tests
- Manual test: started on k8s with 0.3 CPU

```release-note
Bug fix: Allow starting TiKV nodes with <1 CPU
```
