### PR TITLE
raftstore: allow the read request with a smaller ts during flashback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2729,7 +2729,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/JmPotato/kvproto?branch=flashback_ts_check#23a86a07d7c1fba1b03775af6c4f72a90a5f739d"
+source = "git+https://github.com/pingcap/kvproto.git#1b2b4114103afb06796b7e44f45f7e55133673c0"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2729,7 +2729,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#009f31598ac3200dc8b32e18f96fc4deb7b32e48"
+source = "git+https://github.com/JmPotato/kvproto?branch=flashback_ts_check#23a86a07d7c1fba1b03775af6c4f72a90a5f739d"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,8 +222,8 @@ procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "6599eb9dca74229
 # When you modify TiKV cooperatively with kvproto, this will be useful to submit the PR to TiKV and the PR to
 # kvproto at the same time.
 # After the PR to kvproto is merged, remember to comment this out and run `cargo update -p kvproto`.
-[patch.'https://github.com/pingcap/kvproto']
-kvproto = { git = "https://github.com/JmPotato/kvproto", branch = "flashback_ts_check" }
+# [patch.'https://github.com/pingcap/kvproto']
+# kvproto = { git = "https://github.com/your_github_id/kvproto", branch = "your_branch" }
 
 [workspace]
 # See https://github.com/rust-lang/rfcs/blob/master/text/2957-cargo-features2.md

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,8 +222,8 @@ procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "6599eb9dca74229
 # When you modify TiKV cooperatively with kvproto, this will be useful to submit the PR to TiKV and the PR to
 # kvproto at the same time.
 # After the PR to kvproto is merged, remember to comment this out and run `cargo update -p kvproto`.
-# [patch.'https://github.com/pingcap/kvproto']
-# kvproto = { git = "https://github.com/your_github_id/kvproto", branch = "your_branch" }
+[patch.'https://github.com/pingcap/kvproto']
+kvproto = { git = "https://github.com/JmPotato/kvproto", branch = "flashback_ts_check" }
 
 [workspace]
 # See https://github.com/rust-lang/rfcs/blob/master/text/2957-cargo-features2.md

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -1649,7 +1649,8 @@ where
             req.get_header().get_region_epoch().get_version() >= self.last_merge_version;
         check_req_region_epoch(req, &self.region, include_region)?;
         check_flashback_state(
-            self.region.get_is_in_flashback(),
+            self.region.is_in_flashback,
+            self.region.flashback_start_ts,
             req,
             self.region_id(),
             false,
@@ -2975,6 +2976,7 @@ where
         // Modify the region meta in memory.
         let mut region = self.region.clone();
         region.set_is_in_flashback(is_in_flashback);
+        region.set_flashback_start_ts(req.get_prepare_flashback().get_start_ts());
         // Modify the `RegionLocalState` persisted in disk.
         write_peer_state(ctx.kv_wb_mut(), &region, PeerState::Normal, None).unwrap_or_else(|e| {
             panic!(

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -5223,9 +5223,13 @@ where
         // the apply phase and because a read-only request doesn't need to be applied,
         // so it will be allowed during the flashback progress, for example, a snapshot
         // request.
-        if let Err(e) =
-            util::check_flashback_state(self.region().is_in_flashback, msg, region_id, true)
-        {
+        if let Err(e) = util::check_flashback_state(
+            self.region().is_in_flashback,
+            self.region().flashback_start_ts,
+            msg,
+            region_id,
+            true,
+        ) {
             match e {
                 Error::FlashbackInProgress(_) => self
                     .ctx

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -350,6 +350,8 @@ pub fn check_flashback_state(
     {
         return Ok(());
     }
+    // TODO: only use `flashback_start_ts` to check flashback state.
+    let is_in_flashback = is_in_flashback || flashback_start_ts > 0;
     let is_flashback_request = WriteBatchFlags::from_bits_truncate(req.get_header().get_flags())
         .contains(WriteBatchFlags::FLASHBACK);
     // If the region is in the flashback state:
@@ -372,11 +374,10 @@ pub fn check_flashback_state(
     Ok(())
 }
 
-pub fn encode_start_ts_into_flag_data(header: &mut RaftRequestHeader, start_ts: u64) -> Result<()> {
+pub fn encode_start_ts_into_flag_data(header: &mut RaftRequestHeader, start_ts: u64) {
     let mut data = [0u8; 8];
-    (&mut data[..]).encode_u64(start_ts)?;
+    (&mut data[..]).encode_u64(start_ts).unwrap();
     header.set_flag_data(data.into());
-    Ok(())
 }
 
 pub fn is_region_epoch_equal(

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -358,7 +358,7 @@ pub fn check_flashback_state(
     //     be allowed.
     if is_in_flashback && !is_flashback_request {
         if let Ok(read_ts) = decode_u64(&mut req.get_header().get_flag_data()) {
-            if read_ts < flashback_start_ts {
+            if read_ts != 0 && read_ts < flashback_start_ts {
                 return Ok(());
             }
         }

--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -822,7 +822,10 @@ where
         // Check whether the region is in the flashback state and the local read could
         // be performed.
         let is_in_flashback = delegate.region.is_in_flashback;
-        if let Err(e) = util::check_flashback_state(is_in_flashback, req, region_id, false) {
+        let flashback_start_ts = delegate.region.flashback_start_ts;
+        if let Err(e) =
+            util::check_flashback_state(is_in_flashback, flashback_start_ts, req, region_id, false)
+        {
             TLS_LOCAL_READ_METRICS.with(|m| match e {
                 Error::FlashbackNotPrepared(_) => {
                     m.borrow_mut().reject_reason.flashback_not_prepared.inc()

--- a/components/tikv_kv/src/lib.rs
+++ b/components/tikv_kv/src/lib.rs
@@ -288,8 +288,9 @@ impl WriteEvent {
 pub struct SnapContext<'a> {
     pub pb_ctx: &'a Context,
     pub read_id: Option<ThreadReadId>,
-    // When start_ts is None and `stale_read` is true, it means acquire a snapshot without any
-    // consistency guarantee.
+    // When `start_ts` is None and `stale_read` is true, it means acquire a snapshot without any
+    // consistency guarantee. This filed is also used to check if a read is allowed in the
+    // flashback.
     pub start_ts: Option<TimeStamp>,
     // `key_ranges` is used in replica read. It will send to
     // the leader via raft "read index" to check memory locks.
@@ -418,7 +419,7 @@ pub trait Engine: Send + Clone + 'static {
 
     /// Mark the start of flashback.
     // It's an infrequent API, use trait object for simplicity.
-    fn start_flashback(&self, _ctx: &Context) -> BoxFuture<'static, Result<()>> {
+    fn start_flashback(&self, _ctx: &Context, _start_ts: u64) -> BoxFuture<'static, Result<()>> {
         Box::pin(futures::future::ready(Ok(())))
     }
 

--- a/src/server/raftkv/mod.rs
+++ b/src/server/raftkv/mod.rs
@@ -559,8 +559,7 @@ where
             encode_start_ts_into_flag_data(
                 &mut header,
                 ctx.start_ts.unwrap_or_default().into_inner(),
-            )
-            .unwrap();
+            );
         }
 
         let mut cmd = RaftCmdRequest::default();

--- a/src/server/raftkv/mod.rs
+++ b/src/server/raftkv/mod.rs
@@ -546,15 +546,16 @@ where
 
         let mut header = new_request_header(ctx.pb_ctx);
         let mut flags = 0;
-        if ctx.pb_ctx.get_stale_read() {
+        let need_encoded_start_ts = ctx.start_ts.map_or(true, |ts| !ts.is_zero());
+        if ctx.pb_ctx.get_stale_read() && need_encoded_start_ts {
             flags |= WriteBatchFlags::STALE_READ.bits();
         }
         if ctx.allowed_in_flashback {
             flags |= WriteBatchFlags::FLASHBACK.bits();
         }
         header.set_flags(flags);
-        // Set `start_ts` in `flag_data` for the check of stale read and flashback.
-        if ctx.start_ts.map_or(true, |ts| !ts.is_zero()) {
+        // Encode `start_ts` in `flag_data` for the check of stale read and flashback.
+        if need_encoded_start_ts {
             encode_start_ts_into_flag_data(
                 &mut header,
                 ctx.start_ts.unwrap_or_default().into_inner(),

--- a/src/server/raftkv/mod.rs
+++ b/src/server/raftkv/mod.rs
@@ -44,14 +44,13 @@ use raftstore::{
     errors::Error as RaftServerError,
     router::{LocalReadRouter, RaftStoreRouter},
     store::{
-        self, Callback as StoreCallback, RaftCmdExtraOpts, ReadIndexContext, ReadResponse,
-        RegionSnapshot, StoreMsg, WriteResponse,
+        self, util::encode_start_ts_into_flag_data, Callback as StoreCallback, RaftCmdExtraOpts,
+        ReadIndexContext, ReadResponse, RegionSnapshot, StoreMsg, WriteResponse,
     },
 };
 use thiserror::Error;
 use tikv_kv::{write_modifies, OnAppliedCb, WriteEvent};
 use tikv_util::{
-    codec::number::NumberEncoder,
     future::{paired_future_callback, paired_must_called_future_callback},
     time::Instant,
 };
@@ -547,18 +546,21 @@ where
 
         let mut header = new_request_header(ctx.pb_ctx);
         let mut flags = 0;
-        if ctx.pb_ctx.get_stale_read() && ctx.start_ts.map_or(true, |ts| !ts.is_zero()) {
-            let mut data = [0u8; 8];
-            (&mut data[..])
-                .encode_u64(ctx.start_ts.unwrap_or_default().into_inner())
-                .unwrap();
+        if ctx.pb_ctx.get_stale_read() {
             flags |= WriteBatchFlags::STALE_READ.bits();
-            header.set_flag_data(data.into());
         }
         if ctx.allowed_in_flashback {
             flags |= WriteBatchFlags::FLASHBACK.bits();
         }
         header.set_flags(flags);
+        // Set `start_ts` in `flag_data` for the check of stale read and flashback.
+        if ctx.start_ts.map_or(true, |ts| !ts.is_zero()) {
+            encode_start_ts_into_flag_data(
+                &mut header,
+                ctx.start_ts.unwrap_or_default().into_inner(),
+            )
+            .unwrap();
+        }
 
         let mut cmd = RaftCmdRequest::default();
         cmd.set_header(header);
@@ -637,13 +639,16 @@ where
         }
     }
 
-    fn start_flashback(&self, ctx: &Context) -> BoxFuture<'static, kv::Result<()>> {
+    fn start_flashback(&self, ctx: &Context, start_ts: u64) -> BoxFuture<'static, kv::Result<()>> {
         // Send an `AdminCmdType::PrepareFlashback` to prepare the raftstore for the
         // later flashback. Once invoked, we will update the persistent region meta and
         // the memory state of the flashback in Peer FSM to reject all read, write
         // and scheduling operations for this region when propose/apply before we
         // start the actual data flashback transaction command in the next phase.
-        let req = new_flashback_req(ctx, AdminCmdType::PrepareFlashback);
+        let mut req = new_flashback_req(ctx, AdminCmdType::PrepareFlashback);
+        req.mut_admin_request()
+            .mut_prepare_flashback()
+            .set_start_ts(start_ts);
         exec_admin(&*self.router, req)
     }
 

--- a/src/server/raftkv2/mod.rs
+++ b/src/server/raftkv2/mod.rs
@@ -166,8 +166,7 @@ impl<EK: KvEngine, ER: RaftEngine> tikv_kv::Engine for RaftKv2<EK, ER> {
             encode_start_ts_into_flag_data(
                 &mut header,
                 ctx.start_ts.unwrap_or_default().into_inner(),
-            )
-            .unwrap();
+            );
         }
 
         let mut cmd = RaftCmdRequest::default();

--- a/src/server/raftkv2/mod.rs
+++ b/src/server/raftkv2/mod.rs
@@ -15,7 +15,7 @@ use engine_traits::{KvEngine, RaftEngine, CF_LOCK};
 use futures::{Future, Stream, StreamExt};
 use kvproto::raft_cmdpb::{CmdType, RaftCmdRequest, Request};
 pub use node::NodeV2;
-use raftstore::store::RegionSnapshot;
+use raftstore::store::{util::encode_start_ts_into_flag_data, RegionSnapshot};
 use raftstore_v2::{
     router::{
         message::SimpleWrite, CmdResChannelBuilder, CmdResEvent, CmdResStream, PeerMsg, RaftRouter,
@@ -23,7 +23,7 @@ use raftstore_v2::{
     SimpleWriteBinary, SimpleWriteEncoder,
 };
 use tikv_kv::{Modify, WriteEvent};
-use tikv_util::{codec::number::NumberEncoder, time::Instant};
+use tikv_util::time::Instant;
 use txn_types::{TxnExtra, TxnExtraScheduler, WriteBatchFlags};
 
 use super::{
@@ -153,18 +153,21 @@ impl<EK: KvEngine, ER: RaftEngine> tikv_kv::Engine for RaftKv2<EK, ER> {
 
         let mut header = new_request_header(ctx.pb_ctx);
         let mut flags = 0;
-        if ctx.pb_ctx.get_stale_read() && ctx.start_ts.map_or(true, |ts| !ts.is_zero()) {
-            let mut data = [0u8; 8];
-            (&mut data[..])
-                .encode_u64(ctx.start_ts.unwrap_or_default().into_inner())
-                .unwrap();
+        if ctx.pb_ctx.get_stale_read() {
             flags |= WriteBatchFlags::STALE_READ.bits();
-            header.set_flag_data(data.into());
         }
         if ctx.allowed_in_flashback {
             flags |= WriteBatchFlags::FLASHBACK.bits();
         }
         header.set_flags(flags);
+        // Set `start_ts` in `flag_data` for the check of stale read and flashback.
+        if ctx.start_ts.map_or(true, |ts| !ts.is_zero()) {
+            encode_start_ts_into_flag_data(
+                &mut header,
+                ctx.start_ts.unwrap_or_default().into_inner(),
+            )
+            .unwrap();
+        }
 
         let mut cmd = RaftCmdRequest::default();
         cmd.set_header(header);

--- a/tests/integrations/server/kv_service.rs
+++ b/tests/integrations/server/kv_service.rs
@@ -711,19 +711,17 @@ fn test_mvcc_flashback() {
 }
 
 #[test]
-#[cfg(feature = "failpoints")]
 fn test_mvcc_flashback_block_rw() {
     let (_cluster, client, ctx) = must_new_cluster_and_kv_client();
-    fail::cfg("skip_finish_flashback_to_version", "return").unwrap();
-    // Flashback
-    must_flashback_to_version(&client, ctx.clone(), 0, 1, 2);
-    // Try to read.
+    // Prepare the flashback.
+    must_prepare_flashback(&client, ctx.clone(), 1, 2);
+    // Try to read version 3 (after flashback, FORBIDDEN).
     let (k, v) = (b"key".to_vec(), b"value".to_vec());
     // Get
     let mut get_req = GetRequest::default();
     get_req.set_context(ctx.clone());
     get_req.key = k.clone();
-    get_req.version = 1;
+    get_req.version = 3;
     let get_resp = client.kv_get(&get_req).unwrap();
     assert!(get_resp.get_region_error().has_flashback_in_progress());
     assert!(!get_resp.has_error());
@@ -733,28 +731,48 @@ fn test_mvcc_flashback_block_rw() {
     scan_req.set_context(ctx.clone());
     scan_req.start_key = k.clone();
     scan_req.limit = 1;
-    scan_req.version = 1;
+    scan_req.version = 3;
     let scan_resp = client.kv_scan(&scan_req).unwrap();
     assert!(scan_resp.get_region_error().has_flashback_in_progress());
+    assert!(!scan_resp.has_error());
     assert!(scan_resp.pairs.is_empty());
-    // Try to write.
+    // Try to read version 1 (before flashback, ALLOWED).
+    // Get
+    let mut get_req = GetRequest::default();
+    get_req.set_context(ctx.clone());
+    get_req.key = k.clone();
+    get_req.version = 1;
+    let get_resp = client.kv_get(&get_req).unwrap();
+    assert!(!get_resp.has_region_error());
+    assert!(!get_resp.has_error());
+    assert!(get_resp.value.is_empty());
+    // Scan
+    let mut scan_req = ScanRequest::default();
+    scan_req.set_context(ctx.clone());
+    scan_req.start_key = k.clone();
+    scan_req.limit = 1;
+    scan_req.version = 1;
+    let scan_resp = client.kv_scan(&scan_req).unwrap();
+    assert!(!scan_resp.has_region_error());
+    assert!(!scan_resp.has_error());
+    assert!(scan_resp.pairs.is_empty());
+    // Try to write (FORBIDDEN).
     // Prewrite
     let mut mutation = Mutation::default();
     mutation.set_op(Op::Put);
     mutation.set_key(k.clone());
     mutation.set_value(v);
-    let prewrite_resp = try_kv_prewrite(&client, ctx, vec![mutation], k, 1);
+    let prewrite_resp = try_kv_prewrite(&client, ctx.clone(), vec![mutation], k, 1);
     assert!(prewrite_resp.get_region_error().has_flashback_in_progress());
-    fail::remove("skip_finish_flashback_to_version");
+    // Finish the flashback.
+    must_finish_flashback(&client, ctx, 1, 2, 3);
 }
 
 #[test]
-#[cfg(feature = "failpoints")]
 fn test_mvcc_flashback_block_scheduling() {
     let (mut cluster, client, ctx) = must_new_cluster_and_kv_client();
-    fail::cfg("skip_finish_flashback_to_version", "return").unwrap();
-    // Flashback
-    must_flashback_to_version(&client, ctx, 0, 1, 2);
+    // Prepare the flashback.
+    must_prepare_flashback(&client, ctx.clone(), 0, 1);
     // Try to transfer leader.
     let transfer_leader_resp = cluster.try_transfer_leader(1, new_peer(2, 2));
     assert!(
@@ -763,7 +781,8 @@ fn test_mvcc_flashback_block_scheduling() {
             .get_error()
             .has_flashback_in_progress()
     );
-    fail::remove("skip_finish_flashback_to_version");
+    // Finish the flashback.
+    must_finish_flashback(&client, ctx, 0, 1, 2);
 }
 
 #[test]
@@ -794,16 +813,7 @@ fn test_mvcc_flashback_unprepared() {
     assert!(!get_resp.has_error());
     assert_eq!(get_resp.value, b"".to_vec());
     // Mock the flashback retry.
-    let mut req = FlashbackToVersionRequest::default();
-    req.set_context(ctx);
-    req.set_start_ts(6);
-    req.set_commit_ts(7);
-    req.version = 0;
-    req.start_key = b"a".to_vec();
-    req.end_key = b"z".to_vec();
-    let resp = client.kv_flashback_to_version(&req).unwrap();
-    assert!(!resp.has_region_error());
-    assert!(resp.get_error().is_empty());
+    must_finish_flashback(&client, ctx.clone(), 0, 6, 7);
     let get_resp = client.kv_get(&get_req).unwrap();
     assert!(!get_resp.has_region_error());
     assert!(!get_resp.has_error());
@@ -811,7 +821,7 @@ fn test_mvcc_flashback_unprepared() {
 }
 
 #[test]
-fn test_mvcc_flashback_with_unlimit_range() {
+fn test_mvcc_flashback_with_unlimited_range() {
     let (_cluster, client, ctx) = must_new_cluster_and_kv_client();
     let (k, v) = (b"key".to_vec(), b"value".to_vec());
     let mut ts = 0;


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What is changed and how it works?

Issue Number: close #14045. Should merge after https://github.com/pingcap/kvproto/pull/1048.

What's Changed:

```commit-message
- Store the flashback `start_ts` in region meta.
- Allow the read request with a smaller ts during flashback.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None.
```
