### PR TITLE
raftstore-v2: fix peer not cleanup when it replicates more logs

### DIFF
--- a/components/raftstore-v2/src/fsm/store.rs
+++ b/components/raftstore-v2/src/fsm/store.rs
@@ -266,6 +266,10 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T> StoreFsmDelegate<'a, EK, ER, T> {
                     .fsm
                     .store
                     .on_store_unreachable(self.store_ctx, to_store_id),
+                #[cfg(feature = "testexport")]
+                StoreMsg::WaitFlush { region_id, ch } => {
+                    self.fsm.store.on_wait_flush(self.store_ctx, region_id, ch)
+                }
             }
         }
     }

--- a/components/raftstore-v2/src/operation/life.rs
+++ b/components/raftstore-v2/src/operation/life.rs
@@ -284,8 +284,11 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
     #[inline]
     pub fn postponed_destroy(&self) -> bool {
         let entry_storage = self.storage().entry_storage();
-        // TODO: check actual split index instead of commit index.
-        entry_storage.applied_index() != entry_storage.commit_index()
+        // If it's marked as tombstone, then it must be changed by conf change. In
+        // this case, all following entries are skipped so applied_index never equals
+        // to commit_index.
+        (self.storage().region_state().get_state() != PeerState::Tombstone
+           && entry_storage.applied_index() != entry_storage.commit_index())
             // Wait for critical commands like split.
             || self.has_pending_tombstone_tablets()
     }

--- a/components/raftstore-v2/src/raft/storage.rs
+++ b/components/raftstore-v2/src/raft/storage.rs
@@ -9,7 +9,7 @@ use collections::HashMap;
 use engine_traits::{KvEngine, RaftEngine};
 use kvproto::{
     metapb,
-    raft_serverpb::{PeerState, RaftApplyState, RaftLocalState, RegionLocalState},
+    raft_serverpb::{RaftApplyState, RaftLocalState, RegionLocalState},
 };
 use raft::{
     eraftpb::{ConfState, Entry, Snapshot},
@@ -234,10 +234,7 @@ impl<EK: KvEngine, ER: RaftEngine> Storage<EK, ER> {
 
     #[inline]
     pub fn tablet_index(&self) -> u64 {
-        match self.region_state.get_state() {
-            PeerState::Tombstone | PeerState::Applying => 0,
-            _ => self.region_state.get_tablet_index(),
-        }
+        self.region_state.get_tablet_index()
     }
 
     #[inline]

--- a/components/raftstore-v2/src/router/message.rs
+++ b/components/raftstore-v2/src/router/message.rs
@@ -260,7 +260,15 @@ pub enum StoreMsg {
     SplitInit(Box<SplitInit>),
     Tick(StoreTick),
     Start,
-    StoreUnreachable { to_store_id: u64 },
+    StoreUnreachable {
+        to_store_id: u64,
+    },
+    /// A message that used to check if a flush is happened.
+    #[cfg(feature = "testexport")]
+    WaitFlush {
+        region_id: u64,
+        ch: super::FlushChannel,
+    },
 }
 
 impl ResourceMetered for StoreMsg {}

--- a/components/raftstore-v2/tests/integrations/cluster.rs
+++ b/components/raftstore-v2/tests/integrations/cluster.rs
@@ -39,7 +39,7 @@ use raftstore::{
 };
 use raftstore_v2::{
     create_store_batch_system,
-    router::{DebugInfoChannel, FlushChannel, PeerMsg, QueryResult, RaftRouter},
+    router::{DebugInfoChannel, FlushChannel, PeerMsg, QueryResult, RaftRouter, StoreMsg},
     Bootstrap, SimpleWriteEncoder, StateStorage, StoreSystem,
 };
 use resource_metering::CollectorRegHandle;
@@ -127,7 +127,16 @@ impl TestRouter {
             let res = self.send(region_id, PeerMsg::WaitFlush(ch));
             match res {
                 Ok(_) => return block_on(sub.result()).is_some(),
-                Err(TrySendError::Disconnected(_)) => return false,
+                Err(TrySendError::Disconnected(m)) => {
+                    let PeerMsg::WaitFlush(ch) = m else { unreachable!() };
+                    match self
+                        .store_router()
+                        .send_control(StoreMsg::WaitFlush { region_id, ch })
+                    {
+                        Ok(_) => return block_on(sub.result()).is_some(),
+                        Err(_) => return false,
+                    }
+                }
                 Err(TrySendError::Full(_)) => thread::sleep(Duration::from_millis(10)),
             }
         }

--- a/components/raftstore-v2/tests/integrations/test_conf_change.rs
+++ b/components/raftstore-v2/tests/integrations/test_conf_change.rs
@@ -2,8 +2,9 @@
 
 use std::{self, time::Duration};
 
-use engine_traits::{Peekable, CF_DEFAULT};
-use kvproto::raft_cmdpb::AdminCmdType;
+use engine_traits::{Peekable, RaftEngineReadOnly, CF_DEFAULT};
+use futures::executor::block_on;
+use kvproto::{raft_cmdpb::AdminCmdType, raft_serverpb::PeerState};
 use raft::prelude::ConfChangeType;
 use raftstore_v2::{
     router::{PeerMsg, PeerTick},
@@ -101,4 +102,79 @@ fn test_simple_change() {
     // Check if WAL is skipped for admin command.
     let mut cached = cluster.node(0).tablet_registry().get(2).unwrap();
     check_skip_wal(cached.latest().unwrap().as_inner().path());
+}
+
+/// Test if a peer can be destroyed by conf change if logs after conf change are
+/// also replicated.
+#[test]
+fn test_remove_by_conf_change() {
+    let cluster = Cluster::with_node_count(2, None);
+    let region_id = 2;
+    let mut req = cluster.routers[0].new_request_for(2);
+    let admin_req = req.mut_admin_request();
+    admin_req.set_cmd_type(AdminCmdType::ChangePeer);
+    admin_req
+        .mut_change_peer()
+        .set_change_type(ConfChangeType::AddLearnerNode);
+    let store_id = cluster.node(1).id();
+    let new_peer = new_learner_peer(store_id, 10);
+    admin_req.mut_change_peer().set_peer(new_peer);
+    let resp = cluster.routers[0].admin_command(2, req.clone()).unwrap();
+    assert!(!resp.get_header().has_error(), "{:?}", resp);
+    // So heartbeat will create a learner.
+    cluster.dispatch(2, vec![]);
+    // Trigger the raft tick to replica the log to the learner and execute the
+    // snapshot task.
+    cluster.routers[0]
+        .send(region_id, PeerMsg::Tick(PeerTick::Raft))
+        .unwrap();
+    cluster.dispatch(region_id, vec![]);
+    // Wait some time so snapshot can be generated.
+    std::thread::sleep(Duration::from_millis(100));
+    cluster.dispatch(region_id, vec![]);
+
+    // write one kv to make flow control replicated.
+    let (key, val) = (b"key", b"value");
+    let header = Box::new(cluster.routers[0].new_request_for(region_id).take_header());
+    let mut put = SimpleWriteEncoder::with_capacity(64);
+    put.put(CF_DEFAULT, key, val);
+    let (msg, _) = PeerMsg::simple_write(header, put.encode());
+    cluster.routers[0].send(region_id, msg).unwrap();
+    cluster.dispatch(region_id, vec![]);
+
+    let new_conf_ver = req.get_header().get_region_epoch().get_conf_ver() + 1;
+    req.mut_header()
+        .mut_region_epoch()
+        .set_conf_ver(new_conf_ver);
+    req.mut_admin_request()
+        .mut_change_peer()
+        .set_change_type(ConfChangeType::RemoveNode);
+    let (admin_msg, admin_sub) = PeerMsg::admin_command(req.clone());
+    // write one kv after removal
+    let (key, val) = (b"key1", b"value");
+    let header = Box::new(cluster.routers[0].new_request_for(region_id).take_header());
+    let mut put = SimpleWriteEncoder::with_capacity(64);
+    put.put(CF_DEFAULT, key, val);
+    let (msg, sub) = PeerMsg::simple_write(header, put.encode());
+    // Send them at the same time so they will be all sent to learner.
+    cluster.routers[0].send(region_id, admin_msg).unwrap();
+    cluster.routers[0].send(region_id, msg).unwrap();
+    let resp = block_on(admin_sub.result()).unwrap();
+    assert!(!resp.get_header().has_error(), "{:?}", resp);
+    let resp = block_on(sub.result()).unwrap();
+    assert!(!resp.get_header().has_error(), "{:?}", resp);
+
+    // Dispatch messages so the learner will receive conf remove and write at the
+    // same time.
+    cluster.dispatch(region_id, vec![]);
+    cluster.routers[1].wait_flush(region_id, Duration::from_millis(300));
+    // Wait for apply.
+    std::thread::sleep(Duration::from_millis(100));
+    let raft_engine = &cluster.node(1).running_state().unwrap().raft_engine;
+    let region_state = raft_engine
+        .get_region_state(region_id, u64::MAX)
+        .unwrap()
+        .unwrap();
+    assert_eq!(region_state.get_state(), PeerState::Tombstone);
+    assert_eq!(raft_engine.get_raft_state(region_id).unwrap(), None);
 }

--- a/components/raftstore/src/store/async_io/read.rs
+++ b/components/raftstore/src/store/async_io/read.rs
@@ -227,10 +227,10 @@ where
                     error!("failed to create checkpointer"; "region_id" => region_id, "error" => %e);
                     SNAP_COUNTER.generate.fail.inc();
                 } else {
+                    let elapsed = start.saturating_elapsed_secs();
                     SNAP_COUNTER.generate.success.inc();
-                    SNAP_HISTOGRAM
-                        .generate
-                        .observe(start.saturating_elapsed_secs());
+                    SNAP_HISTOGRAM.generate.observe(elapsed);
+                    info!("snapshot generated"; "region_id" => region_id, "elapsed" => elapsed, "key" => ?snap_key, "for_balance" => for_balance);
                     res = Some(Box::new((snapshot, to_peer)))
                 }
 


### PR DESCRIPTION
### What is changed and how it works?
Issue Number: Ref #12842 

What's Changed:

```commit-message
If it accepts more logs than conf remove itself, applied_index == commit_index
will never be true. So we should check if it's a tombstone already first.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
