### PR TITLE
raftstore-v2: add tablet logger and update dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,7 +225,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d962799a5863fdf06fbf594e04102130582d010379137e9a98a7e2e693a5885"
 dependencies = [
  "error-code",
- "libc 0.2.132",
+ "libc 0.2.139",
  "wasm-bindgen",
  "winapi 0.3.9",
 ]
@@ -256,7 +256,7 @@ version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 dependencies = [
- "libc 0.2.132",
+ "libc 0.2.139",
  "winapi 0.3.9",
 ]
 
@@ -447,7 +447,7 @@ dependencies = [
  "addr2line",
  "cc",
  "cfg-if 1.0.0",
- "libc 0.2.132",
+ "libc 0.2.139",
  "miniz_oxide 0.4.4",
  "object",
  "rustc-demangle",
@@ -603,7 +603,7 @@ dependencies = [
  "bcc-sys",
  "bitflags",
  "byteorder",
- "libc 0.2.132",
+ "libc 0.2.139",
  "regex",
  "thiserror",
 ]
@@ -735,7 +735,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
 dependencies = [
  "cc",
- "libc 0.2.132",
+ "libc 0.2.139",
  "pkg-config",
 ]
 
@@ -761,7 +761,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7f788eaf239475a3c1e1acf89951255a46c4b9b46cf3e866fc4d0707b4b9e36"
 dependencies = [
- "libc 0.2.132",
+ "libc 0.2.139",
  "valgrind_request",
 ]
 
@@ -934,7 +934,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f54d78e30b388d4815220c8dd03fea5656b6c6d32adb59e89061552a102f8da1"
 dependencies = [
  "glob",
- "libc 0.2.132",
+ "libc 0.2.139",
  "libloading",
 ]
 
@@ -1018,7 +1018,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "error_code",
- "libc 0.2.132",
+ "libc 0.2.139",
  "panic_hook",
  "protobuf",
  "rand 0.8.5",
@@ -1077,7 +1077,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
 dependencies = [
  "core-foundation-sys",
- "libc 0.2.132",
+ "libc 0.2.139",
 ]
 
 [[package]]
@@ -1092,7 +1092,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9e393a7668fe1fad3075085b86c781883000b4ede868f43627b34a87c8b7ded"
 dependencies = [
- "libc 0.2.132",
+ "libc 0.2.139",
  "winapi 0.3.9",
 ]
 
@@ -1150,7 +1150,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63aaaf47e457badbcb376c65a49d0f182c317ebd97dc6d1ced94c8e1d09c0f3a"
 dependencies = [
  "criterion",
- "libc 0.2.132",
+ "libc 0.2.139",
 ]
 
 [[package]]
@@ -1217,7 +1217,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils 0.8.8",
  "lazy_static",
- "memoffset",
+ "memoffset 0.6.4",
  "scopeguard",
 ]
 
@@ -1229,7 +1229,7 @@ dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
  "crossbeam-utils 0.8.11",
- "memoffset",
+ "memoffset 0.6.4",
  "once_cell",
  "scopeguard",
 ]
@@ -1420,7 +1420,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
- "libc 0.2.132",
+ "libc 0.2.139",
  "redox_users",
  "winapi 0.3.9",
 ]
@@ -1681,7 +1681,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5115567ac25674e0043e472be13d14e537f37ea8aa4bdc4aef0c89add1db1ff"
 dependencies = [
- "libc 0.2.132",
+ "libc 0.2.139",
  "str-buf",
 ]
 
@@ -1789,7 +1789,7 @@ dependencies = [
  "grpcio",
  "kvproto",
  "lazy_static",
- "libc 0.2.132",
+ "libc 0.2.139",
  "libloading",
  "matches",
  "nix 0.24.1",
@@ -1845,7 +1845,7 @@ dependencies = [
  "crossbeam-utils 0.8.8",
  "fs2",
  "lazy_static",
- "libc 0.2.132",
+ "libc 0.2.139",
  "maligned",
  "online_config",
  "openssl",
@@ -1870,7 +1870,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed3d8a5e20435ff00469e51a0d82049bae66504b5c429920dadf9bb54d47b3f"
 dependencies = [
- "libc 0.2.132",
+ "libc 0.2.139",
  "thiserror",
  "winapi 0.3.9",
 ]
@@ -1882,7 +1882,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
 dependencies = [
  "cfg-if 1.0.0",
- "libc 0.2.132",
+ "libc 0.2.139",
  "redox_syscall 0.2.11",
  "winapi 0.3.9",
 ]
@@ -1895,7 +1895,7 @@ checksum = "d691fdb3f817632d259d09220d4cf0991dbb2c9e59e044a02a59194bf6e14484"
 dependencies = [
  "cc",
  "lazy_static",
- "libc 0.2.132",
+ "libc 0.2.139",
  "winapi 0.3.9",
 ]
 
@@ -1923,7 +1923,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2adaffba6388640136149e18ed080b77a78611c1e1d6de75aedcdf78df5d4682"
 dependencies = [
  "crc32fast",
- "libc 0.2.132",
+ "libc 0.2.139",
  "libz-sys",
  "miniz_oxide 0.3.7",
 ]
@@ -1964,7 +1964,7 @@ name = "fs2"
 version = "0.4.3"
 source = "git+https://github.com/tabokie/fs2-rs?branch=tikv#cd503764a19a99d74c1ab424dd13d6bcd093fcae"
 dependencies = [
- "libc 0.2.132",
+ "libc 0.2.139",
  "winapi 0.3.9",
 ]
 
@@ -1990,7 +1990,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0"
 dependencies = [
- "libc 0.2.132",
+ "libc 0.2.139",
 ]
 
 [[package]]
@@ -2226,7 +2226,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
 dependencies = [
  "cfg-if 0.1.10",
- "libc 0.2.132",
+ "libc 0.2.139",
  "wasi 0.7.0",
 ]
 
@@ -2238,7 +2238,7 @@ checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
- "libc 0.2.132",
+ "libc 0.2.139",
  "wasi 0.10.2+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
@@ -2287,7 +2287,7 @@ dependencies = [
  "futures-executor",
  "futures-util",
  "grpcio-sys",
- "libc 0.2.132",
+ "libc 0.2.139",
  "log",
  "parking_lot 0.11.1",
  "protobuf",
@@ -2324,7 +2324,7 @@ dependencies = [
  "bindgen 0.59.2",
  "cc",
  "cmake",
- "libc 0.2.132",
+ "libc 0.2.139",
  "libz-sys",
  "openssl-sys",
  "pkg-config",
@@ -2392,7 +2392,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "307c3c9f937f38e3534b1d6447ecf090cafcc9744e4a6360e8b037b2cf5af120"
 dependencies = [
- "libc 0.2.132",
+ "libc 0.2.139",
 ]
 
 [[package]]
@@ -2600,7 +2600,7 @@ checksum = "4816c66d2c8ae673df83366c18341538f234a26d65a9ecea5c348b453ac1d02f"
 dependencies = [
  "bitflags",
  "inotify-sys",
- "libc 0.2.132",
+ "libc 0.2.139",
 ]
 
 [[package]]
@@ -2609,7 +2609,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
- "libc 0.2.132",
+ "libc 0.2.139",
 ]
 
 [[package]]
@@ -2636,7 +2636,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
- "libc 0.2.132",
+ "libc 0.2.139",
 ]
 
 [[package]]
@@ -2682,7 +2682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2b1d42ef453b30b7387e113da1c83ab1605d90c5b4e0eb8e96d016ed3b8c160"
 dependencies = [
  "getrandom 0.1.12",
- "libc 0.2.132",
+ "libc 0.2.139",
  "log",
 ]
 
@@ -2823,9 +2823,9 @@ checksum = "e32a70cf75e5846d53a673923498228bbec6a8624708a9ea5645f075d6276122"
 
 [[package]]
 name = "libc"
-version = "0.2.132"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -2865,7 +2865,7 @@ dependencies = [
  "bzip2-sys",
  "cc",
  "cmake",
- "libc 0.2.132",
+ "libc 0.2.139",
  "libtitan_sys",
  "libz-sys",
  "lz4-sys",
@@ -2883,7 +2883,7 @@ dependencies = [
  "bzip2-sys",
  "cc",
  "cmake",
- "libc 0.2.132",
+ "libc 0.2.139",
  "libz-sys",
  "lz4-sys",
  "snappy-sys",
@@ -2897,7 +2897,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
 dependencies = [
  "cc",
- "libc 0.2.132",
+ "libc 0.2.139",
  "pkg-config",
  "vcpkg",
 ]
@@ -2953,7 +2953,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dca79aa95d8b3226213ad454d328369853be3a1382d89532a854f4d69640acae"
 dependencies = [
  "cc",
- "libc 0.2.132",
+ "libc 0.2.139",
 ]
 
 [[package]]
@@ -3008,7 +3008,7 @@ version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 dependencies = [
- "libc 0.2.132",
+ "libc 0.2.139",
 ]
 
 [[package]]
@@ -3017,7 +3017,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
 dependencies = [
- "libc 0.2.132",
+ "libc 0.2.139",
  "winapi 0.3.9",
 ]
 
@@ -3027,7 +3027,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "057a3db23999c867821a7a59feb06a578fcb03685e983dff90daf9e7d24ac08f"
 dependencies = [
- "libc 0.2.132",
+ "libc 0.2.139",
 ]
 
 [[package]]
@@ -3035,6 +3035,15 @@ name = "memoffset"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
 ]
@@ -3098,7 +3107,7 @@ dependencies = [
  "fuchsia-zircon-sys",
  "iovec",
  "kernel32-sys",
- "libc 0.2.132",
+ "libc 0.2.139",
  "log",
  "miow",
  "net2",
@@ -3112,7 +3121,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
- "libc 0.2.132",
+ "libc 0.2.139",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.42.0",
@@ -3158,7 +3167,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1587ebb20a5b04738f16cffa7e2526f1b8496b84f92920facd518362ff1559eb"
 dependencies = [
- "libc 0.2.132",
+ "libc 0.2.139",
 ]
 
 [[package]]
@@ -3209,7 +3218,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
 dependencies = [
  "lazy_static",
- "libc 0.2.132",
+ "libc 0.2.139",
  "log",
  "openssl",
  "openssl-probe",
@@ -3227,7 +3236,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
 dependencies = [
  "cfg-if 0.1.10",
- "libc 0.2.132",
+ "libc 0.2.139",
  "winapi 0.3.9",
 ]
 
@@ -3239,22 +3248,22 @@ checksum = "8f17df307904acd05aa8e32e97bb20f2a0df1728bbc2d771ae8f9a90463441e9"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
- "libc 0.2.132",
- "memoffset",
+ "libc 0.2.139",
+ "memoffset 0.6.4",
 ]
 
 [[package]]
 name = "nix"
-version = "0.25.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e322c04a9e3440c327fca7b6c8a63e6890a32fa2ad689db972425f07e0d22abb"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
- "autocfg",
  "bitflags",
  "cfg-if 1.0.0",
- "libc 0.2.132",
- "memoffset",
+ "libc 0.2.139",
+ "memoffset 0.7.1",
  "pin-utils",
+ "static_assertions",
 ]
 
 [[package]]
@@ -3311,7 +3320,7 @@ dependencies = [
  "fsevent",
  "fsevent-sys",
  "inotify",
- "libc 0.2.132",
+ "libc 0.2.139",
  "mio 0.6.23",
  "mio-extras",
  "walkdir",
@@ -3464,7 +3473,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
- "libc 0.2.132",
+ "libc 0.2.139",
 ]
 
 [[package]]
@@ -3542,7 +3551,7 @@ dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
  "foreign-types",
- "libc 0.2.132",
+ "libc 0.2.139",
  "once_cell",
  "openssl-macros",
  "openssl-sys",
@@ -3582,7 +3591,7 @@ checksum = "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
 dependencies = [
  "autocfg",
  "cc",
- "libc 0.2.132",
+ "libc 0.2.139",
  "openssl-src",
  "pkg-config",
  "vcpkg",
@@ -3612,7 +3621,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebde548fbbf1ea81a99b128872779c437752fb99f217c45245e1a61dcd9edcd"
 dependencies = [
- "libc 0.2.132",
+ "libc 0.2.139",
  "winapi 0.3.9",
 ]
 
@@ -3649,7 +3658,7 @@ checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
 dependencies = [
  "cfg-if 1.0.0",
  "instant",
- "libc 0.2.132",
+ "libc 0.2.139",
  "redox_syscall 0.2.11",
  "smallvec",
  "winapi 0.3.9",
@@ -3662,7 +3671,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
 dependencies = [
  "cfg-if 1.0.0",
- "libc 0.2.132",
+ "libc 0.2.139",
  "redox_syscall 0.2.11",
  "smallvec",
  "windows-sys 0.32.0",
@@ -3739,7 +3748,7 @@ checksum = "b8f94885300e262ef461aa9fd1afbf7df3caf9e84e271a74925d1c6c8b24830f"
 dependencies = [
  "bitflags",
  "byteorder",
- "libc 0.2.132",
+ "libc 0.2.139",
  "mmap",
  "nom 4.2.3",
  "phf",
@@ -3882,7 +3891,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d27361d7578b410d0eb5fe815c2b2105b01ab770a7c738cb9a231457a809fcc7"
 dependencies = [
  "ipnetwork",
- "libc 0.2.132",
+ "libc 0.2.139",
  "pnet_base",
  "pnet_sys",
  "winapi 0.2.8",
@@ -3894,7 +3903,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82f881a6d75ac98c5541db6144682d1773bb14c6fc50c6ebac7086c8f7f23c29"
 dependencies = [
- "libc 0.2.132",
+ "libc 0.2.139",
  "winapi 0.2.8",
  "ws2_32-sys",
 ]
@@ -3909,7 +3918,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "findshlibs",
  "inferno",
- "libc 0.2.132",
+ "libc 0.2.139",
  "log",
  "nix 0.24.1",
  "once_cell",
@@ -3993,7 +4002,7 @@ dependencies = [
  "byteorder",
  "hex 0.4.2",
  "lazy_static",
- "libc 0.2.132",
+ "libc 0.2.139",
 ]
 
 [[package]]
@@ -4002,7 +4011,7 @@ version = "0.4.2"
 source = "git+https://github.com/tikv/procinfo-rs?rev=6599eb9dca74229b2c1fcc44118bef7eff127128#6599eb9dca74229b2c1fcc44118bef7eff127128"
 dependencies = [
  "byteorder",
- "libc 0.2.132",
+ "libc 0.2.139",
  "nom 2.2.1",
  "rustc_version 0.2.3",
 ]
@@ -4027,7 +4036,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "fnv",
  "lazy_static",
- "libc 0.2.132",
+ "libc 0.2.139",
  "memchr",
  "parking_lot 0.11.1",
  "protobuf",
@@ -4192,7 +4201,7 @@ dependencies = [
 [[package]]
 name = "raft-engine"
 version = "0.3.0"
-source = "git+https://github.com/tikv/raft-engine.git#82f6da7b8dff1856483e8e72a59dda903fb2499b"
+source = "git+https://github.com/tikv/raft-engine.git#33530112c3a4acaf8c50ca9d0470284109926296"
 dependencies = [
  "byteorder",
  "crc32fast",
@@ -4203,11 +4212,11 @@ dependencies = [
  "hex 0.4.2",
  "if_chain",
  "lazy_static",
- "libc 0.2.132",
+ "libc 0.2.139",
  "log",
  "lz4-sys",
  "memmap2",
- "nix 0.25.0",
+ "nix 0.26.2",
  "num-derive",
  "num-traits",
  "parking_lot 0.12.1",
@@ -4226,7 +4235,7 @@ dependencies = [
 [[package]]
 name = "raft-engine-ctl"
 version = "0.3.0"
-source = "git+https://github.com/tikv/raft-engine.git#82f6da7b8dff1856483e8e72a59dda903fb2499b"
+source = "git+https://github.com/tikv/raft-engine.git#33530112c3a4acaf8c50ca9d0470284109926296"
 dependencies = [
  "clap 3.1.6",
  "env_logger",
@@ -4390,7 +4399,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 dependencies = [
  "fuchsia-cprng",
- "libc 0.2.132",
+ "libc 0.2.139",
  "rand_core 0.3.1",
  "rdrand",
  "winapi 0.3.9",
@@ -4403,7 +4412,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom 0.1.12",
- "libc 0.2.132",
+ "libc 0.2.139",
  "rand_chacha 0.2.1",
  "rand_core 0.5.1",
  "rand_hc",
@@ -4415,7 +4424,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "libc 0.2.132",
+ "libc 0.2.139",
  "rand_chacha 0.3.0",
  "rand_core 0.6.2",
 ]
@@ -4710,7 +4719,7 @@ dependencies = [
  "grpcio",
  "kvproto",
  "lazy_static",
- "libc 0.2.132",
+ "libc 0.2.139",
  "log",
  "online_config",
  "pdqselect",
@@ -4773,7 +4782,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b72b84d47e8ec5a4f2872e8262b8f8256c5be1c938a7d6d3a867a3ba8f722f74"
 dependencies = [
  "cc",
- "libc 0.2.132",
+ "libc 0.2.139",
  "once_cell",
  "spin",
  "untrusted",
@@ -4786,7 +4795,7 @@ name = "rocksdb"
 version = "0.3.0"
 source = "git+https://github.com/tikv/rust-rocksdb.git#14e4fe7f47054408cf3d2905beeca798c6656191"
 dependencies = [
- "libc 0.2.132",
+ "libc 0.2.139",
  "librocksdb_sys",
 ]
 
@@ -5034,7 +5043,7 @@ dependencies = [
  "bitflags",
  "core-foundation",
  "core-foundation-sys",
- "libc 0.2.132",
+ "libc 0.2.139",
  "security-framework-sys",
 ]
 
@@ -5045,7 +5054,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3676258fd3cfe2c9a0ec99ce3038798d847ce3e4bb17746373eb9f0f1ac16339"
 dependencies = [
  "core-foundation-sys",
- "libc 0.2.132",
+ "libc 0.2.139",
 ]
 
 [[package]]
@@ -5241,7 +5250,7 @@ dependencies = [
  "hex 0.4.2",
  "keys",
  "kvproto",
- "libc 0.2.132",
+ "libc 0.2.139",
  "log",
  "log_wrappers",
  "pd_client",
@@ -5302,7 +5311,7 @@ version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
 dependencies = [
- "libc 0.2.132",
+ "libc 0.2.139",
  "signal-hook-registry",
 ]
 
@@ -5312,7 +5321,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
- "libc 0.2.132",
+ "libc 0.2.139",
 ]
 
 [[package]]
@@ -5445,7 +5454,7 @@ version = "0.1.0"
 source = "git+https://github.com/busyjay/rust-snappy.git?branch=static-link#8c12738bad811397600455d6982aff754ea2ac44"
 dependencies = [
  "cmake",
- "libc 0.2.132",
+ "libc 0.2.139",
  "pkg-config",
 ]
 
@@ -5473,7 +5482,7 @@ version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
 dependencies = [
- "libc 0.2.132",
+ "libc 0.2.139",
  "winapi 0.3.9",
 ]
 
@@ -5683,7 +5692,7 @@ checksum = "ade661fa5e048ada64ad7901713301c21d2dbc5b65ee7967de8826c111452960"
 dependencies = [
  "cfg-if 1.0.0",
  "core-foundation-sys",
- "libc 0.2.132",
+ "libc 0.2.139",
  "ntapi",
  "once_cell",
  "rayon",
@@ -5766,7 +5775,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
  "cfg-if 1.0.0",
- "libc 0.2.132",
+ "libc 0.2.139",
  "rand 0.8.5",
  "redox_syscall 0.2.11",
  "remove_dir_all",
@@ -6009,7 +6018,7 @@ dependencies = [
  "hyper",
  "keys",
  "kvproto",
- "libc 0.2.132",
+ "libc 0.2.139",
  "log_wrappers",
  "more-asserts",
  "online_config",
@@ -6310,7 +6319,7 @@ dependencies = [
  "keys",
  "kvproto",
  "lazy_static",
- "libc 0.2.132",
+ "libc 0.2.139",
  "libloading",
  "log",
  "log_wrappers",
@@ -6410,7 +6419,7 @@ dependencies = [
  "hex 0.4.2",
  "keys",
  "kvproto",
- "libc 0.2.132",
+ "libc 0.2.139",
  "log",
  "log_wrappers",
  "pd_client",
@@ -6445,7 +6454,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e37706572f4b151dff7a0146e040804e9c26fe3a3118591112f05cf12a4216c1"
 dependencies = [
- "libc 0.2.132",
+ "libc 0.2.139",
  "paste",
  "tikv-jemalloc-sys",
 ]
@@ -6458,7 +6467,7 @@ checksum = "aeab4310214fe0226df8bfeb893a291a58b19682e8a07e1e1d4483ad4200d315"
 dependencies = [
  "cc",
  "fs_extra",
- "libc 0.2.132",
+ "libc 0.2.139",
 ]
 
 [[package]]
@@ -6467,7 +6476,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20612db8a13a6c06d57ec83953694185a367e16945f66565e8028d2c0bd76979"
 dependencies = [
- "libc 0.2.132",
+ "libc 0.2.139",
  "tikv-jemalloc-sys",
 ]
 
@@ -6490,7 +6499,7 @@ version = "0.1.0"
 dependencies = [
  "fxhash",
  "lazy_static",
- "libc 0.2.132",
+ "libc 0.2.139",
  "mimalloc",
  "snmalloc-rs",
  "tcmalloc",
@@ -6559,7 +6568,7 @@ dependencies = [
  "http",
  "kvproto",
  "lazy_static",
- "libc 0.2.132",
+ "libc 0.2.139",
  "log",
  "log_wrappers",
  "mnt",
@@ -6608,7 +6617,7 @@ version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 dependencies = [
- "libc 0.2.132",
+ "libc 0.2.139",
  "redox_syscall 0.1.56",
  "winapi 0.3.9",
 ]
@@ -6651,7 +6660,7 @@ checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
 dependencies = [
  "autocfg",
  "bytes",
- "libc 0.2.132",
+ "libc 0.2.139",
  "memchr",
  "mio 0.8.5",
  "num_cpus",
@@ -7037,7 +7046,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "055058552ca15c566082fc61da433ae678f78986a6f16957e33162d1b218792a"
 dependencies = [
  "kernel32-sys",
- "libc 0.2.132",
+ "libc 0.2.139",
  "winapi 0.2.8",
 ]
 
@@ -7222,7 +7231,7 @@ checksum = "2a5a7e487e921cf220206864a94a89b6c6905bfc19f1057fa26a4cb360e5c1d2"
 dependencies = [
  "either",
  "lazy_static",
- "libc 0.2.132",
+ "libc 0.2.139",
 ]
 
 [[package]]
@@ -7461,7 +7470,7 @@ version = "5.0.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
 dependencies = [
- "libc 0.2.132",
+ "libc 0.2.139",
  "zstd-sys",
 ]
 
@@ -7472,5 +7481,5 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
 dependencies = [
  "cc",
- "libc 0.2.132",
+ "libc 0.2.139",
 ]

--- a/cmd/tikv-ctl/src/main.rs
+++ b/cmd/tikv-ctl/src/main.rs
@@ -686,7 +686,8 @@ fn build_rocks_opts(cfg: &TikvConfig) -> engine_rocks::RocksDbOptions {
         .unwrap()
         .map(Arc::new);
     let env = get_env(key_manager, None /* io_rate_limiter */).unwrap();
-    cfg.rocksdb.build_opt(&cfg.rocksdb.build_resources(env))
+    let resource = cfg.rocksdb.build_resources(env);
+    cfg.rocksdb.build_opt(&resource, cfg.storage.engine)
 }
 
 fn run_ldb_command(args: Vec<String>, cfg: &TikvConfig) {

--- a/components/engine_rocks/src/logger.rs
+++ b/components/engine_rocks/src/logger.rs
@@ -20,6 +20,30 @@ impl Logger for RocksdbLogger {
     }
 }
 
+pub struct TabletLogger {
+    tablet_name: String,
+}
+
+impl TabletLogger {
+    pub fn new(tablet_name: String) -> Self {
+        Self { tablet_name }
+    }
+}
+
+impl Logger for TabletLogger {
+    fn logv(&self, log_level: InfoLogLevel, log: &str) {
+        match log_level {
+            InfoLogLevel::Header => info!(#"rocksdb_log_header", "[{}]{}", self.tablet_name, log),
+            InfoLogLevel::Debug => debug!(#"rocksdb_log", "[{}]{}", self.tablet_name, log),
+            InfoLogLevel::Info => info!(#"rocksdb_log", "[{}]{}", self.tablet_name, log),
+            InfoLogLevel::Warn => warn!(#"rocksdb_log", "[{}]{}", self.tablet_name, log),
+            InfoLogLevel::Error => error!(#"rocksdb_log", "[{}]{}", self.tablet_name, log),
+            InfoLogLevel::Fatal => crit!(#"rocksdb_log", "[{}]{}", self.tablet_name, log),
+            _ => {}
+        }
+    }
+}
+
 #[derive(Default)]
 pub struct RaftDbLogger;
 

--- a/components/raft_log_engine/src/engine.rs
+++ b/components/raft_log_engine/src/engine.rs
@@ -472,18 +472,21 @@ impl RaftLogBatchTrait for RaftLogBatch {
         let key = encode_flushed_key(cf, tablet_index);
         let mut value = vec![0; 8];
         NumberCodec::encode_u64(&mut value, apply_index);
-        self.0.put(raft_group_id, key.to_vec(), value);
-        Ok(())
+        self.0
+            .put(raft_group_id, key.to_vec(), value)
+            .map_err(transfer_error)
     }
 
     fn put_dirty_mark(&mut self, raft_group_id: u64, tablet_index: u64, dirty: bool) -> Result<()> {
         let key = encode_key(DIRTY_MARK_KEY, tablet_index);
         if dirty {
-            self.0.put(raft_group_id, key.to_vec(), vec![]);
+            self.0
+                .put(raft_group_id, key.to_vec(), vec![])
+                .map_err(transfer_error)
         } else {
             self.0.delete(raft_group_id, key.to_vec());
+            Ok(())
         }
-        Ok(())
     }
 
     fn put_recover_state(&mut self, state: &StoreRecoverState) -> Result<()> {

--- a/components/raftstore-v2/src/operation/ready/mod.rs
+++ b/components/raftstore-v2/src/operation/ready/mod.rs
@@ -535,11 +535,13 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         }
         if !self.serving() {
             self.start_destroy(ctx, &mut write_task);
-            ctx.coprocessor_host.on_region_changed(
-                self.region(),
-                RegionChangeEvent::Destroy,
-                self.raft_group().raft.state,
-            );
+            if self.persisted_index() != 0 {
+                ctx.coprocessor_host.on_region_changed(
+                    self.region(),
+                    RegionChangeEvent::Destroy,
+                    self.raft_group().raft.state,
+                );
+            }
         }
         // Ready number should increase monotonically.
         assert!(self.async_writer.known_largest_number() < ready.number());

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -36,8 +36,8 @@ use engine_rocks::{
     util::{FixedPrefixSliceTransform, FixedSuffixSliceTransform, NoopSliceTransform},
     RaftDbLogger, RangePropertiesCollectorFactory, RawMvccPropertiesCollectorFactory,
     RocksCfOptions, RocksDbOptions, RocksEngine, RocksEventListener, RocksStatistics,
-    RocksTitanDbOptions, RocksdbLogger, TtlPropertiesCollectorFactory,
-    DEFAULT_PROP_KEYS_INDEX_DISTANCE, DEFAULT_PROP_SIZE_INDEX_DISTANCE,
+    RocksTitanDbOptions, TtlPropertiesCollectorFactory, DEFAULT_PROP_KEYS_INDEX_DISTANCE,
+    DEFAULT_PROP_SIZE_INDEX_DISTANCE,
 };
 use engine_traits::{
     CfOptions as _, DbOptions as _, MiscExt, TitanCfOptions as _, CF_DEFAULT, CF_LOCK, CF_RAFT,
@@ -1306,7 +1306,6 @@ impl DbConfig {
         if let Some(b) = self.paranoid_checks {
             opts.set_paranoid_checks(b);
         }
-        opts.set_info_log(RocksdbLogger::default());
         opts.set_info_log_level(self.info_log_level.into());
         if self.titan.enabled {
             opts.set_titandb_options(&self.titan.build_opts());

--- a/src/server/engine_factory.rs
+++ b/src/server/engine_factory.rs
@@ -6,7 +6,7 @@ use engine_rocks::{
     raw::{Cache, Env},
     CompactedEventSender, CompactionListener, FlowListener, RocksCfOptions, RocksCompactionJobInfo,
     RocksDbOptions, RocksEngine, RocksEventListener, RocksPersistenceListener, RocksStatistics,
-    RocksdbLogger, TabletLogger,
+    TabletLogger,
 };
 use engine_traits::{
     CompactionJobInfo, MiscExt, PersistenceListener, Result, StateStorage, TabletContext,
@@ -135,12 +135,12 @@ impl KvEngineFactory {
         self.inner.db_resources.statistics.clone()
     }
 
-    fn db_opts(&self) -> RocksDbOptions {
+    fn db_opts(&self, for_engine: EngineType) -> RocksDbOptions {
         // Create kv engine.
         let mut db_opts = self
             .inner
             .rocksdb_config
-            .build_opt(&self.inner.db_resources);
+            .build_opt(&self.inner.db_resources, for_engine);
         if !self.inner.lite {
             db_opts.add_event_listener(RocksEventListener::new(
                 "kv",
@@ -171,8 +171,7 @@ impl KvEngineFactory {
     /// It will always create in path/DEFAULT_DB_SUB_DIR.
     pub fn create_shared_db(&self, path: impl AsRef<Path>) -> Result<RocksEngine> {
         let path = path.as_ref();
-        let mut db_opts = self.db_opts();
-        db_opts.set_info_log(RocksdbLogger::default());
+        let mut db_opts = self.db_opts(EngineType::RaftKv);
         let cf_opts = self.cf_opts(EngineType::RaftKv);
         if let Some(listener) = &self.inner.flow_listener {
             db_opts.add_event_listener(listener.clone());
@@ -189,7 +188,7 @@ impl KvEngineFactory {
 
 impl TabletFactory<RocksEngine> for KvEngineFactory {
     fn open_tablet(&self, ctx: TabletContext, path: &Path) -> Result<RocksEngine> {
-        let mut db_opts = self.db_opts();
+        let mut db_opts = self.db_opts(EngineType::RaftKv2);
         let tablet_name = path.file_name().unwrap().to_str().unwrap().to_string();
         db_opts.set_info_log(TabletLogger::new(tablet_name));
         let cf_opts = self.cf_opts(EngineType::RaftKv2);
@@ -219,7 +218,7 @@ impl TabletFactory<RocksEngine> for KvEngineFactory {
     fn destroy_tablet(&self, ctx: TabletContext, path: &Path) -> Result<()> {
         info!("destroy tablet"; "path" => %path.display(), "id" => ctx.id, "suffix" => ?ctx.suffix);
         // Create kv engine.
-        let _db_opts = self.db_opts();
+        let _db_opts = self.db_opts(EngineType::RaftKv2);
         let _cf_opts = self.cf_opts(EngineType::RaftKv2);
         // TODOTODO: call rust-rocks or tirocks to destroy_engine;
         // engine_rocks::util::destroy_engine(

--- a/tests/integrations/storage/test_titan.rs
+++ b/tests/integrations/storage/test_titan.rs
@@ -159,9 +159,8 @@ fn test_delete_files_in_range_for_titan() {
     cfg.rocksdb.defaultcf.titan.min_gc_batch_size = ReadableSize(0);
     cfg.rocksdb.defaultcf.titan.discardable_ratio = 0.4;
     cfg.rocksdb.defaultcf.titan.min_blob_size = ReadableSize(0);
-    let kv_db_opts = cfg
-        .rocksdb
-        .build_opt(&cfg.rocksdb.build_resources(Default::default()));
+    let resource = cfg.rocksdb.build_resources(Default::default());
+    let kv_db_opts = cfg.rocksdb.build_opt(&resource, cfg.storage.engine);
     let kv_cfs_opts = cfg.rocksdb.build_cf_opts(
         &cfg.rocksdb.build_cf_resources(cache),
         None,


### PR DESCRIPTION

### What is changed and how it works?
Issue Number: Ref #12842  

What's Changed:

```commit-message
- Update raft-engine to fix data corruption during restart
- Add tablet logger so we can know which tablet the logs belongs to
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- Breaking backward compatibility
    If a cluster is upgraded to this version, downgrade it may leave garbage in raft engine.

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
