### PR TITLE
raftstore, storage: return FlashbackNotPrepared error if the flashback commit check failed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2732,7 +2732,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#2b853bed812556901846f42820b63d8a0d9c8d24"
+source = "git+https://github.com/JmPotato/kvproto?branch=return_flashback_ts_in_err#055e9f00c03e7971b17689024ec38b0e668645c9"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2732,7 +2732,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/JmPotato/kvproto?branch=return_flashback_ts_in_err#055e9f00c03e7971b17689024ec38b0e668645c9"
+source = "git+https://github.com/pingcap/kvproto.git#eccad3776d7b076da68d6c51fb7506b8562b9802"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,8 +222,8 @@ procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "6599eb9dca74229
 # When you modify TiKV cooperatively with kvproto, this will be useful to submit the PR to TiKV and the PR to
 # kvproto at the same time.
 # After the PR to kvproto is merged, remember to comment this out and run `cargo update -p kvproto`.
-[patch.'https://github.com/pingcap/kvproto']
-kvproto = { git = "https://github.com/JmPotato/kvproto", branch = "return_flashback_ts_in_err" }
+# [patch.'https://github.com/pingcap/kvproto']
+# kvproto = { git = "https://github.com/your_github_id/kvproto", branch = "your_branch" }
 
 [workspace]
 # See https://github.com/rust-lang/rfcs/blob/master/text/2957-cargo-features2.md

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,8 +222,8 @@ procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "6599eb9dca74229
 # When you modify TiKV cooperatively with kvproto, this will be useful to submit the PR to TiKV and the PR to
 # kvproto at the same time.
 # After the PR to kvproto is merged, remember to comment this out and run `cargo update -p kvproto`.
-# [patch.'https://github.com/pingcap/kvproto']
-# kvproto = { git = "https://github.com/your_github_id/kvproto", branch = "your_branch" }
+[patch.'https://github.com/pingcap/kvproto']
+kvproto = { git = "https://github.com/JmPotato/kvproto", branch = "return_flashback_ts_in_err" }
 
 [workspace]
 # See https://github.com/rust-lang/rfcs/blob/master/text/2957-cargo-features2.md

--- a/components/error_code/src/storage.rs
+++ b/components/error_code/src/storage.rs
@@ -21,6 +21,7 @@ define_error_codes!(
     BAD_FORMAT_WRITE => ("BadFormatWrite", "",""),
     KEY_IS_LOCKED => ("KeyIsLocked", "", ""),
     MAX_TIMESTAMP_NOT_SYNCED => ("MaxTimestampNotSynced", "", ""),
+    FLASHBACK_NOT_PREPARED => ("FlashbackNotPrepared", "", ""),
     DEADLINE_EXCEEDED => ("DeadlineExceeded", "", ""),
     API_VERSION_NOT_MATCHED => ("ApiVersionNotMatched", "", ""),
     INVALID_KEY_MODE => ("InvalidKeyMode", "", ""),

--- a/components/raftstore/src/errors.rs
+++ b/components/raftstore/src/errors.rs
@@ -58,8 +58,8 @@ pub enum Error {
     #[error("region {0} is in the recovery progress")]
     RecoveryInProgress(u64),
 
-    #[error("region {0} is in the flashback progress")]
-    FlashbackInProgress(u64),
+    #[error("region {0} is in the flashback progress with start_ts {1}")]
+    FlashbackInProgress(u64, u64),
 
     #[error("region {0} not prepared the flashback")]
     FlashbackNotPrepared(u64),
@@ -256,9 +256,10 @@ impl From<Error> for errorpb::Error {
                 e.set_region_id(region_id);
                 errorpb.set_recovery_in_progress(e);
             }
-            Error::FlashbackInProgress(region_id) => {
+            Error::FlashbackInProgress(region_id, flashback_start_ts) => {
                 let mut e = errorpb::FlashbackInProgress::default();
                 e.set_region_id(region_id);
+                e.set_flashback_start_ts(flashback_start_ts);
                 errorpb.set_flashback_in_progress(e);
             }
             Error::FlashbackNotPrepared(region_id) => {

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -5234,7 +5234,7 @@ where
             true,
         ) {
             match e {
-                Error::FlashbackInProgress(_) => self
+                Error::FlashbackInProgress(..) => self
                     .ctx
                     .raft_metrics
                     .invalid_proposal

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -364,7 +364,7 @@ pub fn check_flashback_state(
                 return Ok(());
             }
         }
-        return Err(Error::FlashbackInProgress(region_id));
+        return Err(Error::FlashbackInProgress(region_id, flashback_start_ts));
     }
     // If the region is not in the flashback state, the flashback request itself
     // should be rejected.

--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -830,7 +830,7 @@ where
                 Error::FlashbackNotPrepared(_) => {
                     m.borrow_mut().reject_reason.flashback_not_prepared.inc()
                 }
-                Error::FlashbackInProgress(_) => {
+                Error::FlashbackInProgress(..) => {
                     m.borrow_mut().reject_reason.flashback_in_progress.inc()
                 }
                 _ => unreachable!(),

--- a/etc/error_code.toml
+++ b/etc/error_code.toml
@@ -563,6 +563,11 @@ error = '''
 KV:SstImporter:InvalidKeyMode
 '''
 
+["KV:SstImporter:ResourceNotEnough"]
+error = '''
+KV:SstImporter:ResourceNotEnough
+'''
+
 ["KV:Storage:Timeout"]
 error = '''
 KV:Storage:Timeout
@@ -651,6 +656,11 @@ KV:Storage:KeyIsLocked
 ["KV:Storage:MaxTimestampNotSynced"]
 error = '''
 KV:Storage:MaxTimestampNotSynced
+'''
+
+["KV:Storage:FlashbackNotPrepared"]
+error = '''
+KV:Storage:FlashbackNotPrepared
 '''
 
 ["KV:Storage:DeadlineExceeded"]

--- a/src/storage/errors.rs
+++ b/src/storage/errors.rs
@@ -255,6 +255,15 @@ pub fn extract_region_error_from_error(e: &Error) -> Option<errorpb::Error> {
             err.set_max_timestamp_not_synced(Default::default());
             Some(err)
         }
+        Error(box ErrorInner::Txn(TxnError(box TxnErrorInner::FlashbackNotPrepared(
+            region_id,
+        )))) => {
+            let mut err = errorpb::Error::default();
+            let mut flashback_not_prepared_err = errorpb::FlashbackNotPrepared::default();
+            flashback_not_prepared_err.set_region_id(*region_id);
+            err.set_flashback_not_prepared(flashback_not_prepared_err);
+            Some(err)
+        }
         Error(box ErrorInner::SchedTooBusy) => {
             let mut err = errorpb::Error::default();
             let mut server_is_busy_err = errorpb::ServerIsBusy::default();

--- a/src/storage/txn/actions/flashback_to_version.rs
+++ b/src/storage/txn/actions/flashback_to_version.rs
@@ -241,7 +241,7 @@ pub fn check_flashback_commit(
                 return Ok(false);
             }
             error!(
-                "check flashback commit exception: lock not found";
+                "check flashback commit exception: lock record mismatched";
                 "key_to_commit" => log_wrappers::Value::key(key_to_commit.as_encoded()),
                 "flashback_start_ts" => flashback_start_ts,
                 "flashback_commit_ts" => flashback_commit_ts,
@@ -266,10 +266,10 @@ pub fn check_flashback_commit(
             );
         }
     }
-    // If both the lock and flashback commit record don't exist, it means that the
-    // current region is not in the flashback state. We could just let the check
-    // pass here and wait for the later raftstore to reject the request.
-    Ok(false)
+    // If both the flashback lock and commit records are mismatched, it means the
+    // current region is not in the flashback state. In this case, we can just
+    // return true to stop the flashback and do nothing.
+    Ok(true)
 }
 
 pub fn get_first_user_key(

--- a/src/storage/txn/actions/flashback_to_version.rs
+++ b/src/storage/txn/actions/flashback_to_version.rs
@@ -266,11 +266,10 @@ pub fn check_flashback_commit(
             );
         }
     }
-    Err(txn::Error::from_mvcc(mvcc::ErrorInner::TxnLockNotFound {
-        start_ts: flashback_start_ts,
-        commit_ts: flashback_commit_ts,
-        key: key_to_commit.to_raw()?,
-    }))
+    // If both the lock and flashback commit record don't exist, it means that the
+    // current region is not in the flashback state. We could just let the check
+    // pass here and wait for the later raftstore to reject the request.
+    Ok(false)
 }
 
 pub fn get_first_user_key(

--- a/src/storage/txn/actions/flashback_to_version.rs
+++ b/src/storage/txn/actions/flashback_to_version.rs
@@ -233,6 +233,7 @@ pub fn check_flashback_commit(
     key_to_commit: &Key,
     flashback_start_ts: TimeStamp,
     flashback_commit_ts: TimeStamp,
+    region_id: u64,
 ) -> TxnResult<bool> {
     match reader.load_lock(key_to_commit)? {
         // If the lock exists, it means the flashback hasn't been finished.
@@ -266,10 +267,11 @@ pub fn check_flashback_commit(
             );
         }
     }
-    // If both the flashback lock and commit records are mismatched, it means the
-    // current region is not in the flashback state. In this case, we can just
-    // return true to stop the flashback and do nothing.
-    Ok(true)
+    // If both the flashback lock and commit records are mismatched, it means
+    // the current region is not in the flashback state.
+    Err(txn::Error::from(txn::ErrorInner::FlashbackNotPrepared(
+        region_id,
+    )))
 }
 
 pub fn get_first_user_key(

--- a/src/storage/txn/commands/flashback_to_version_read_phase.rs
+++ b/src/storage/txn/commands/flashback_to_version_read_phase.rs
@@ -213,6 +213,7 @@ impl<S: Snapshot> ReadCommand<S> for FlashbackToVersionReadPhase {
                         &start_key,
                         self.start_ts,
                         self.commit_ts,
+                        self.ctx.get_region_id(),
                     )? {
                         statistics.add(&reader.statistics);
                         return Ok(ProcessResult::Res);

--- a/src/storage/txn/mod.rs
+++ b/src/storage/txn/mod.rs
@@ -141,6 +141,9 @@ pub enum ErrorInner {
         start_ts: {start_ts}, region_id: {region_id}"
     )]
     MaxTimestampNotSynced { region_id: u64, start_ts: TimeStamp },
+
+    #[error("region {0} not prepared the flashback")]
+    FlashbackNotPrepared(u64),
 }
 
 impl ErrorInner {
@@ -174,6 +177,9 @@ impl ErrorInner {
                 region_id,
                 start_ts,
             }),
+            ErrorInner::FlashbackNotPrepared(region_id) => {
+                Some(ErrorInner::FlashbackNotPrepared(region_id))
+            }
             ErrorInner::Other(_) | ErrorInner::ProtoBuf(_) | ErrorInner::Io(_) => None,
         }
     }
@@ -224,6 +230,7 @@ impl ErrorCodeExt for Error {
             ErrorInner::MaxTimestampNotSynced { .. } => {
                 error_code::storage::MAX_TIMESTAMP_NOT_SYNCED
             }
+            ErrorInner::FlashbackNotPrepared(_) => error_code::storage::FLASHBACK_NOT_PREPARED,
         }
     }
 }

--- a/tests/integrations/server/kv_service.rs
+++ b/tests/integrations/server/kv_service.rs
@@ -800,7 +800,7 @@ fn test_mvcc_flashback_unprepared() {
     req.set_start_key(b"a".to_vec());
     req.set_end_key(b"z".to_vec());
     let resp = client.kv_flashback_to_version(&req).unwrap();
-    assert!(!resp.has_region_error());
+    assert!(resp.get_region_error().has_flashback_not_prepared());
     assert!(resp.get_error().is_empty());
     must_kv_read_equal(&client, ctx.clone(), k.clone(), v, 6);
     // Flashback with preparing.

--- a/tests/integrations/server/kv_service.rs
+++ b/tests/integrations/server/kv_service.rs
@@ -800,7 +800,8 @@ fn test_mvcc_flashback_unprepared() {
     req.set_start_key(b"a".to_vec());
     req.set_end_key(b"z".to_vec());
     let resp = client.kv_flashback_to_version(&req).unwrap();
-    assert!(resp.get_error().contains("txn lock not found"));
+    assert!(!resp.has_region_error());
+    assert!(resp.get_error().is_empty());
     must_kv_read_equal(&client, ctx.clone(), k.clone(), v, 6);
     // Flashback with preparing.
     must_flashback_to_version(&client, ctx.clone(), 0, 6, 7);


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>


### What is changed and how it works?

Issue Number: Close #14143. Should merge after https://github.com/pingcap/kvproto/pull/1054.

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
As https://github.com/tikv/tikv/issues/14143 mentioned, flashback should not
return `TxnLockNotFound` error to the client if the flashback commit check failed,
which will cause TiDB to retry the flashback forever. This PR changes this error to
`FlashbackNotPrepared` to match the client handling logic.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None.
```
