### PR TITLE
apply: ignore compute and verify hash when it's a witness

### DIFF
--- a/tests/integrations/raftstore/test_witness.rs
+++ b/tests/integrations/raftstore/test_witness.rs
@@ -12,7 +12,7 @@ use kvproto::{
 use pd_client::PdClient;
 use raft::eraftpb::ConfChangeType;
 use test_raftstore::*;
-use tikv_util::{store::find_peer, config::ReadableDuration};
+use tikv_util::{config::ReadableDuration, store::find_peer};
 
 // Test the case that region split or merge with witness peer
 #[test]

--- a/tests/integrations/raftstore/test_witness.rs
+++ b/tests/integrations/raftstore/test_witness.rs
@@ -12,7 +12,7 @@ use kvproto::{
 use pd_client::PdClient;
 use raft::eraftpb::ConfChangeType;
 use test_raftstore::*;
-use tikv_util::store::find_peer;
+use tikv_util::{store::find_peer, config::ReadableDuration};
 
 // Test the case that region split or merge with witness peer
 #[test]
@@ -555,4 +555,46 @@ fn test_witness_leader_down() {
         nodes[2],
     );
     assert_eq!(cluster.must_get(b"k9"), Some(b"v9".to_vec()));
+}
+
+// Test the case that witness ignore consistency check as it has no data
+#[test]
+fn test_witness_ignore_consistency_check() {
+    let mut cluster = new_server_cluster(0, 3);
+    cluster.cfg.raft_store.raft_election_timeout_ticks = 50;
+    // disable compact log to make test more stable.
+    cluster.cfg.raft_store.raft_log_gc_threshold = 1000;
+    cluster.cfg.raft_store.consistency_check_interval = ReadableDuration::secs(1);
+    cluster.run();
+
+    let nodes = Vec::from_iter(cluster.get_node_ids());
+    assert_eq!(nodes.len(), 3);
+
+    let pd_client = Arc::clone(&cluster.pd_client);
+    pd_client.disable_default_operator();
+
+    cluster.must_put(b"k1", b"v1");
+
+    let region = block_on(pd_client.get_region_by_id(1)).unwrap().unwrap();
+    let peer_on_store1 = find_peer(&region, nodes[0]).unwrap();
+    cluster.must_transfer_leader(region.get_id(), peer_on_store1.clone());
+
+    // nonwitness -> witness
+    let peer_on_store3 = find_peer(&region, nodes[2]).unwrap().clone();
+    cluster.pd_client.must_switch_witnesses(
+        region.get_id(),
+        vec![peer_on_store3.get_id()],
+        vec![true],
+    );
+
+    // make sure the peer_on_store3 has completed applied to witness
+    std::thread::sleep(Duration::from_millis(200));
+
+    for i in 0..300 {
+        cluster.must_put(
+            format!("k{:06}", i).as_bytes(),
+            format!("k{:06}", i).as_bytes(),
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
 }


### PR DESCRIPTION
close tikv/tikv#14142

Signed-off-by: Wenbo Zhang <ethercflow@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #14142

What's Changed:

When the peer is a witness, it has no data, so the calculated hash must be different from the one passed by the leader. 
Therefore ignore the compute and verify commands.


<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
apply: ignore compute and verify hash when it's a witness
```

### Related changes

- None

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

Side effects

- Performance regression
    - None
- None

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
