### PR TITLE
log-backup: report when watch canceled

### DIFF
--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -354,6 +354,7 @@ where
                     continue;
                 }
             };
+            info!("start watching the task changes."; "from_rev" => %revision_new);
 
             loop {
                 if let Some(event) = watcher.stream.next().await {
@@ -403,6 +404,7 @@ where
                     continue;
                 }
             };
+            info!("start watching the pausing events."; "from_rev" => %revision_new);
 
             loop {
                 if let Some(event) = watcher.stream.next().await {

--- a/components/backup-stream/src/errors.rs
+++ b/components/backup-stream/src/errors.rs
@@ -22,7 +22,7 @@ pub enum Error {
     #[error("gRPC meet error {0}")]
     Grpc(#[from] GrpcError),
     #[error("Etcd meet error {0}")]
-    Etcd(#[from] EtcdError),
+    Etcd(#[from] EtcdErrorExt),
     #[error("Protobuf meet error {0}")]
     Protobuf(#[from] ProtobufError),
     #[error("No such task {task_name:?}")]
@@ -50,6 +50,22 @@ pub enum Error {
     },
     #[error("Other Error: {0}")]
     Other(#[from] Box<dyn StdError + Send + Sync + 'static>),
+}
+
+impl From<EtcdError> for Error {
+    fn from(value: EtcdError) -> Self {
+        Self::Etcd(value.into())
+    }
+}
+
+#[derive(ThisError, Debug)]
+pub enum EtcdErrorExt {
+    #[error("{0}")]
+    Normal(#[from] EtcdError),
+    #[error("the watch canceled")]
+    WatchCanceled,
+    #[error("the required revision has been compacted, current is {current}")]
+    RevisionCompacted { current: i64 },
 }
 
 impl ErrorCodeExt for Error {


### PR DESCRIPTION
Signed-off-by: hillium <yujuncen@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/tikv/tikv/issues/14159

What's Changed:
This PR would report a "canceled" error when the server canceled the watch.

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

We executed the following step: 
1. Compact etcd to the latest revision.
2. Restart PD.
3. Pause the task and check whether TiKV can detect the pause task.

With the master version, not all TiKVs have detected the task has been paused.
With this PR, TiKVs can detect the task has been paused.

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fixed a bug caused TiKV cannot watch task change after PD restart sometimes.
```
