### PR TITLE
engine_traits: allow chaos flush notification

### DIFF
--- a/components/engine_rocks/src/lib.rs
+++ b/components/engine_rocks/src/lib.rs
@@ -18,6 +18,7 @@
 #![cfg_attr(test, feature(test))]
 #![feature(let_chains)]
 #![feature(option_get_or_insert_default)]
+#![feature(path_file_prefix)]
 
 #[allow(unused_extern_crates)]
 extern crate tikv_alloc;

--- a/components/engine_traits/src/cf_defs.rs
+++ b/components/engine_traits/src/cf_defs.rs
@@ -11,6 +11,11 @@ pub const ALL_CFS: &[CfName] = &[CF_DEFAULT, CF_LOCK, CF_WRITE, CF_RAFT];
 pub const DATA_CFS: &[CfName] = &[CF_DEFAULT, CF_LOCK, CF_WRITE];
 pub const DATA_CFS_LEN: usize = DATA_CFS.len();
 
+pub fn data_cf_offset(cf: &str) -> usize {
+    let cf = if cf.is_empty() { CF_DEFAULT } else { cf };
+    DATA_CFS.iter().position(|c| *c == cf).expect(cf)
+}
+
 pub fn name_to_cf(name: &str) -> Option<CfName> {
     if name.is_empty() {
         return Some(CF_DEFAULT);

--- a/components/engine_traits/src/flush.rs
+++ b/components/engine_traits/src/flush.rs
@@ -20,17 +20,20 @@ use std::{
     },
 };
 
-use crate::{RaftEngine, RaftLogBatch};
+use slog_global::info;
+use tikv_util::set_panic_mark;
+
+use crate::{data_cf_offset, RaftEngine, RaftLogBatch, DATA_CFS_LEN};
 
 #[derive(Debug)]
-pub struct FlushProgress {
+pub struct ApplyProgress {
     cf: String,
     apply_index: u64,
     earliest_seqno: u64,
 }
 
-impl FlushProgress {
-    fn merge(&mut self, pr: FlushProgress) {
+impl ApplyProgress {
+    fn merge(&mut self, pr: ApplyProgress) {
         debug_assert_eq!(self.cf, pr.cf);
         debug_assert!(self.apply_index <= pr.apply_index);
         self.apply_index = pr.apply_index;
@@ -43,6 +46,12 @@ impl FlushProgress {
     pub fn cf(&self) -> &str {
         &self.cf
     }
+}
+
+#[derive(Default, Debug)]
+struct FlushProgress {
+    prs: LinkedList<ApplyProgress>,
+    last_flushed: [AtomicU64; DATA_CFS_LEN],
 }
 
 /// A share state between raftstore and underlying engine.
@@ -77,7 +86,7 @@ impl FlushState {
 
 /// A helper trait to avoid exposing `RaftEngine` to `TabletFactory`.
 pub trait StateStorage: Sync + Send {
-    fn persist_progress(&self, region_id: u64, tablet_index: u64, pr: FlushProgress);
+    fn persist_progress(&self, region_id: u64, tablet_index: u64, pr: ApplyProgress);
 }
 
 /// A flush listener that maps memtable to apply index and persist the relation
@@ -86,7 +95,7 @@ pub struct PersistenceListener {
     region_id: u64,
     tablet_index: u64,
     state: Arc<FlushState>,
-    progress: Mutex<LinkedList<FlushProgress>>,
+    progress: Mutex<FlushProgress>,
     storage: Arc<dyn StateStorage>,
 }
 
@@ -101,7 +110,7 @@ impl PersistenceListener {
             region_id,
             tablet_index,
             state,
-            progress: Mutex::new(LinkedList::new()),
+            progress: Mutex::new(FlushProgress::default()),
             storage,
         }
     }
@@ -120,8 +129,17 @@ impl PersistenceListener {
         // thread writting to the DB and increasing apply index.
         // Apply index will be set within DB lock, so it's correct even with manual
         // flush.
+        let offset = data_cf_offset(&cf);
         let apply_index = self.state.applied_index.load(Ordering::SeqCst);
-        self.progress.lock().unwrap().push_back(FlushProgress {
+        let mut prs = self.progress.lock().unwrap();
+        let flushed = prs.last_flushed[offset].load(Ordering::Relaxed);
+        if flushed > earliest_seqno {
+            panic!(
+                "sealed seqno has been flushed {} {} {} <= {}",
+                cf, apply_index, earliest_seqno, flushed
+            );
+        }
+        prs.prs.push_back(ApplyProgress {
             cf,
             apply_index,
             earliest_seqno,
@@ -131,12 +149,21 @@ impl PersistenceListener {
     /// Called a memtable finished flushing.
     ///
     /// `largest_seqno` should be the largest seqno of the generated file.
-    pub fn on_flush_completed(&self, cf: &str, largest_seqno: u64) {
+    pub fn on_flush_completed(&self, cf: &str, largest_seqno: u64, file_no: u64) {
         // Maybe we should hook the compaction to avoid the file is compacted before
         // being recorded.
+        let offset = data_cf_offset(cf);
         let pr = {
             let mut prs = self.progress.lock().unwrap();
-            let mut cursor = prs.cursor_front_mut();
+            let flushed = prs.last_flushed[offset].load(Ordering::Relaxed);
+            if flushed >= largest_seqno {
+                // According to facebook/rocksdb#11183, it's possible OnFlushCompleted can be
+                // called out of order. But it's guaranteed files are installed in order.
+                info!("flush complete reorder found"; "flushed" => flushed, "largest_seqno" => largest_seqno, "file_no" => file_no, "cf" => cf);
+                return;
+            }
+            prs.last_flushed[offset].store(largest_seqno, Ordering::Relaxed);
+            let mut cursor = prs.prs.cursor_front_mut();
             let mut flushed_pr = None;
             while let Some(pr) = cursor.current() {
                 if pr.cf != cf {
@@ -157,10 +184,13 @@ impl PersistenceListener {
             }
             match flushed_pr {
                 Some(pr) => pr,
-                None => panic!(
-                    "[region_id={}] [tablet_index={}] {} not found in {:?}",
-                    self.region_id, self.tablet_index, cf, prs
-                ),
+                None => {
+                    set_panic_mark();
+                    panic!(
+                        "[region_id={}] [tablet_index={}] {} {} {} not found in {:?}",
+                        self.region_id, self.tablet_index, cf, largest_seqno, file_no, prs
+                    )
+                }
             }
         };
         self.storage
@@ -169,7 +199,7 @@ impl PersistenceListener {
 }
 
 impl<R: RaftEngine> StateStorage for R {
-    fn persist_progress(&self, region_id: u64, tablet_index: u64, pr: FlushProgress) {
+    fn persist_progress(&self, region_id: u64, tablet_index: u64, pr: ApplyProgress) {
         if pr.apply_index == 0 {
             return;
         }

--- a/components/raftstore-v2/src/operation/command/write/mod.rs
+++ b/components/raftstore-v2/src/operation/command/write/mod.rs
@@ -1,6 +1,6 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_traits::{KvEngine, Mutable, RaftEngine, CF_DEFAULT};
+use engine_traits::{data_cf_offset, KvEngine, Mutable, RaftEngine, CF_DEFAULT};
 use kvproto::raft_cmdpb::RaftRequestHeader;
 use raftstore::{
     store::{
@@ -15,7 +15,6 @@ use tikv_util::slog_panic;
 
 use crate::{
     batch::StoreContext,
-    operation::cf_offset,
     raft::{Apply, Peer},
     router::{ApplyTask, CmdResChannel},
 };
@@ -129,7 +128,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
 impl<EK: KvEngine, R> Apply<EK, R> {
     #[inline]
     pub fn apply_put(&mut self, cf: &str, index: u64, key: &[u8], value: &[u8]) -> Result<()> {
-        let off = cf_offset(cf);
+        let off = data_cf_offset(cf);
         if self.should_skip(off, index) {
             return Ok(());
         }
@@ -172,7 +171,7 @@ impl<EK: KvEngine, R> Apply<EK, R> {
 
     #[inline]
     pub fn apply_delete(&mut self, cf: &str, index: u64, key: &[u8]) -> Result<()> {
-        let off = cf_offset(cf);
+        let off = data_cf_offset(cf);
         if self.should_skip(off, index) {
             return Ok(());
         }

--- a/components/raftstore-v2/src/operation/mod.rs
+++ b/components/raftstore-v2/src/operation/mod.rs
@@ -14,8 +14,7 @@ pub use command::{
 };
 pub use life::{DestroyProgress, GcPeerContext};
 pub use ready::{
-    cf_offset, write_initial_states, ApplyTrace, AsyncWriter, DataTrace, GenSnapTask, SnapState,
-    StateStorage,
+    write_initial_states, ApplyTrace, AsyncWriter, DataTrace, GenSnapTask, SnapState, StateStorage,
 };
 
 pub(crate) use self::{

--- a/components/raftstore-v2/src/operation/ready/mod.rs
+++ b/components/raftstore-v2/src/operation/ready/mod.rs
@@ -47,7 +47,7 @@ use tikv_util::{
 };
 
 pub use self::{
-    apply_trace::{cf_offset, write_initial_states, ApplyTrace, DataTrace, StateStorage},
+    apply_trace::{write_initial_states, ApplyTrace, DataTrace, StateStorage},
     async_writer::AsyncWriter,
     snapshot::{GenSnapTask, SnapState},
 };


### PR DESCRIPTION
### What is changed and how it works?
Issue Number: Close #14113 

What's Changed:

```commit-message
`OnFlushComplete` can be called out of order. What we can assume is
when a seqno finishes flush, all SSTs have smaller seqno must also
finish flush.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
