### PR TITLE
raftstore: change default region size to 1G

### DIFF
--- a/components/raftstore/src/coprocessor/config.rs
+++ b/components/raftstore/src/coprocessor/config.rs
@@ -92,7 +92,7 @@ impl Default for Config {
             region_max_keys: None,
             consistency_check_method: ConsistencyCheckMethod::Mvcc,
             perf_level: PerfLevel::Uninitialized,
-            enable_region_bucket: false,
+            enable_region_bucket: true,
             region_bucket_size: DEFAULT_BUCKET_SIZE,
             region_size_threshold_for_approximate: DEFAULT_BUCKET_SIZE * BATCH_SPLIT_LIMIT / 2 * 3,
             region_bucket_merge_size_ratio: DEFAULT_REGION_BUCKET_MERGE_SIZE_RATIO,


### PR DESCRIPTION
Signed-off-by: cosven <yinshaowen241@gmail.com>

### What is changed and how it works?
Issue Number: ref #14186

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Set the default region size to 1GB to improve stability when dealing with massive regions
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
  See test results recorded in #14186 for details
- No code

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Set the default region size to 1GB to improve stability when dealing with massive regions
```
