### PR TITLE
resource_control: pass missing resource group name to request header

### DIFF
--- a/src/server/raftkv/mod.rs
+++ b/src/server/raftkv/mod.rs
@@ -160,6 +160,7 @@ pub fn new_request_header(ctx: &Context) -> RaftRequestHeader {
     }
     header.set_sync_log(ctx.get_sync_log());
     header.set_replica_read(ctx.get_replica_read());
+    header.set_resource_group_name(ctx.get_resource_group_name().to_owned());
     header
 }
 


### PR DESCRIPTION
Signed-off-by: Connor1996 <zbk602423539@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #14191

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
pass missing resource group name to request header
```


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
![C7sGvcTWTN](https://user-images.githubusercontent.com/13497871/217728043-76635717-4f27-46e5-a2f3-a23ae238a080.jpg)


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
