### PR TITLE
log-backup: make the download more finer-grained

### DIFF
--- a/components/sst_importer/src/metrics.rs
+++ b/components/sst_importer/src/metrics.rs
@@ -106,4 +106,14 @@ lazy_static! {
         "The operations over storage cache",
         &["operation"]
     ).unwrap();
+
+    pub static ref CACHED_FILE_IN_MEM: IntGauge = register_int_gauge!(
+        "tikv_import_apply_cached_bytes",
+        "The files cached by the apply requests of importer."
+    ).unwrap();
+    pub static ref CACHE_EVENT: IntCounterVec = register_int_counter_vec!(
+        "tikv_import_apply_cache_event",
+        "The events of caching. event = {add, remove, out-of-quota}",
+        &["type"]
+    ).unwrap();
 }

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -490,6 +490,9 @@ impl SstImporter {
             .file_locks
             .entry(dst_name)
             .or_insert((CacheKvFile::Mem(Arc::default()), Instant::now()));
+        IMPORTER_APPLY_DURATION
+            .with_label_values(&["download-get-lock"])
+            .observe(start.saturating_elapsed().as_secs_f64());
 
         if let CacheKvFile::Mem(buff) = &lock.0 {
             if !buff.is_empty() {

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -3006,19 +3006,9 @@ mod tests {
             let r = r.clone();
             std::thread::Builder::new()
                 .name(format!("rd-{}", i))
-                .spawn(move || {
-                    loop {
-                        match r.wait_until_fill() {
-                            Some(x) => {
-                                if i == 2 {
-                                    return x.fulfill(42).get();
-                                } else {
-                                    drop(x);
-                                }
-                            }
-                            None => return r.get(),
-                        }
-                    }
+                .spawn(move || match r.wait_until_fill() {
+                    Some(x) => x.fulfill(42).get(),
+                    None => r.get(),
                 })
                 .unwrap()
         });

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -115,6 +115,7 @@ pub enum CacheKvFile {
 }
 
 /// Remote presents a "remote" object which can be downloaded and then cached.
+/// The remote object should generally implement the `ShareOwned` trait.
 /// This structure doesn't manage how it is downloaded, it just manages the
 /// state. You need to provide the manually downloaded data to the
 /// [`DownloadPromise`].
@@ -136,6 +137,9 @@ pub enum CacheKvFile {
 #[derive(Clone, Debug)]
 pub struct Remote<T>(Arc<(Mutex<FileCacheInner<T>>, Condvar)>);
 
+/// When holding this, the holder has promised to downloading the remote object
+/// into local, then provide it to others waiting the object, by
+/// [`Self::fulfill()`].
 pub struct DownloadPromise<T>(Arc<(Mutex<FileCacheInner<T>>, Condvar)>);
 
 impl<T> DownloadPromise<T> {
@@ -162,8 +166,8 @@ impl<T> Drop for DownloadPromise<T> {
 
 impl<T> Remote<T> {
     /// create a downloading remote object.
-    /// it returns the handle to the remote object and a [DownloadPromise], the
-    /// latter can be used to fulfill the remote object.
+    /// it returns the handle to the remote object and a [`DownloadPromise`],
+    /// the latter can be used to fulfill the remote object.
     ///
     /// # Examples
     /// ```
@@ -645,8 +649,6 @@ impl SstImporter {
         let start = Instant::now();
         let dst_name = format!("{}_{}", meta.get_name(), meta.get_range_offset());
 
-        // TODO: handle the resource leakage once the download failed.
-
         let promise = {
             let lock = self.file_locks.entry(dst_name);
             IMPORTER_APPLY_DURATION
@@ -664,7 +666,8 @@ impl SstImporter {
                     }
                     _ => panic!(concat!(
                         "using both read-to-memory and download-to-file is unacceptable for now.",
-                        "(If you think it is possible for now, please change this line to `return item.get.0.clone()`)",
+                        "(If you think it is possible in the future you are reading this, ",
+                        "please change this line to `return item.get.0.clone()`)",
                         "(Please also check the state transform is OK too.)"
                     )),
                 },

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -1374,7 +1374,10 @@ mod tests {
     use tempfile::Builder;
     use test_sst_importer::*;
     use test_util::new_test_key_manager;
-    use tikv_util::{codec::stream_event::EventEncoder, stream::block_on_external_io};
+    use tikv_util::{
+        codec::stream_event::EventEncoder, stream::block_on_external_io,
+        sys::thread::StdThreadBuildWrapper,
+    };
     use txn_types::{Value, WriteType};
     use uuid::Uuid;
 
@@ -3006,7 +3009,7 @@ mod tests {
             let r = r.clone();
             std::thread::Builder::new()
                 .name(format!("rd-{}", i))
-                .spawn(move || match r.wait_until_fill() {
+                .spawn_wrapper(move || match r.wait_until_fill() {
                     Some(x) => x.fulfill(42).get(),
                     None => r.get(),
                 })


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #14206

What's Changed:
This PR make the downloaded cache file hold lock for itself. So we don't need to rely on the segment lock of the dashmap.

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test (TBD)
- Manual test (add detailed scripts or steps below)

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Speeded up PITR.
```
