### PR TITLE
coprocessor: use mur3 to calculate fmsketch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3214,6 +3214,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97af489e1e21b68de4c390ecca6703318bc1aa16e9733bcb62c089b73c6fbb1b"
 
 [[package]]
+name = "murmur3"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
+
+[[package]]
 name = "native-tls"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6342,6 +6348,7 @@ dependencies = [
  "mime",
  "more-asserts",
  "mur3",
+ "murmur3",
  "nom 5.1.0",
  "notify",
  "num-traits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3208,10 +3208,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "murmur3"
-version = "0.5.1"
+name = "mur3"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ead5388e485d38e622630c6b05afd3761a6701ff15c55b279ea5b31dcb62cff"
+checksum = "97af489e1e21b68de4c390ecca6703318bc1aa16e9733bcb62c089b73c6fbb1b"
 
 [[package]]
 name = "native-tls"
@@ -6341,7 +6341,7 @@ dependencies = [
  "memory_trace_macros",
  "mime",
  "more-asserts",
- "murmur3",
+ "mur3",
  "nom 5.1.0",
  "notify",
  "num-traits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3214,12 +3214,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97af489e1e21b68de4c390ecca6703318bc1aa16e9733bcb62c089b73c6fbb1b"
 
 [[package]]
-name = "murmur3"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
-
-[[package]]
 name = "native-tls"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6348,7 +6342,6 @@ dependencies = [
  "mime",
  "more-asserts",
  "mur3",
- "murmur3",
  "nom 5.1.0",
  "notify",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,6 @@ memory_trace_macros = { workspace = true }
 mime = "0.3.13"
 more-asserts = "0.2"
 mur3 = "0.1"
-murmur3 = "0.5.1"
 nom = { version = "5.1.0", default-features = false, features = ["std"] }
 notify = "4"
 num-traits = "0.2.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ match-template = "0.0.1"
 memory_trace_macros = { workspace = true }
 mime = "0.3.13"
 more-asserts = "0.2"
-murmur3 = "0.5.1"
+mur3 = "0.1"
 nom = { version = "5.1.0", default-features = false, features = ["std"] }
 notify = "4"
 num-traits = "0.2.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,7 @@ memory_trace_macros = { workspace = true }
 mime = "0.3.13"
 more-asserts = "0.2"
 mur3 = "0.1"
+murmur3 = "0.5.1"
 nom = { version = "5.1.0", default-features = false, features = ["std"] }
 notify = "4"
 num-traits = "0.2.14"

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -1,11 +1,13 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{cmp::Reverse, collections::BinaryHeap, hash::Hasher, marker::PhantomData, mem, sync::Arc};
+use std::{
+    cmp::Reverse, collections::BinaryHeap, hash::Hasher, marker::PhantomData, mem, sync::Arc,
+};
 
 use api_version::{keyspace::KvPair, KvFormat};
 use async_trait::async_trait;
-use mur3::Hasher128;
 use kvproto::coprocessor::{KeyRange, Response};
+use mur3::Hasher128;
 use protobuf::Message;
 use rand::{rngs::StdRng, Rng};
 use tidb_query_common::storage::{
@@ -1362,8 +1364,6 @@ mod tests {
             assert_eq!(collector.samples.len(), 0);
         }
     }
-
-
 }
 
 #[cfg(test)]
@@ -1371,20 +1371,27 @@ mod benches {
     use tidb_query_datatype::{
         codec::{
             batch::LazyBatchColumn,
-            collation::{Collator, collator::CollatorUtf8Mb4Bin}
-        }, 
-        EvalType, FieldTypeTp
+            collation::{collator::CollatorUtf8Mb4Bin, Collator},
+        },
+        EvalType, FieldTypeTp,
     };
 
     use super::*;
 
-    fn prepare_arguments() -> (Vec<Vec<u8>>, Vec<Vec<u8>>, Vec<tipb::ColumnInfo>, Vec<tipb::AnalyzeColumnGroup>) {
+    fn prepare_arguments() -> (
+        Vec<Vec<u8>>,
+        Vec<Vec<u8>>,
+        Vec<tipb::ColumnInfo>,
+        Vec<tipb::AnalyzeColumnGroup>,
+    ) {
         let mut columns_info = Vec::new();
         for i in 1..4 {
             let mut col_info = tipb::ColumnInfo::default();
             col_info.set_column_id(i as i64);
             col_info.as_mut_accessor().set_tp(FieldTypeTp::VarChar);
-            col_info.as_mut_accessor().set_collation(Collation::Utf8Mb4Bin);
+            col_info
+                .as_mut_accessor()
+                .set_collation(Collation::Utf8Mb4Bin);
             columns_info.push(col_info);
         }
         let mut columns_slice = Vec::new();
@@ -1397,16 +1404,21 @@ mod benches {
         let mut collation_key_vals = Vec::new();
         for i in 0..columns_info.len() {
             let mut val = vec![];
-            columns_slice[i].encode(
-                0,
-                &columns_info[i],
-                &mut EvalContext::default(),
-                &mut val,
-            ).unwrap();
+            columns_slice[i]
+                .encode(0, &columns_info[i], &mut EvalContext::default(), &mut val)
+                .unwrap();
             if columns_info[i].as_accessor().is_string_like() {
                 let mut mut_val = &val[..];
-                let decoded_val = table::decode_col_value(&mut mut_val, &mut EvalContext::default(), &columns_info[i]).unwrap();
-                let decoded_sorted_val = CollatorUtf8Mb4Bin::sort_key(&decoded_val.as_string().unwrap().unwrap().into_owned()).unwrap();
+                let decoded_val = table::decode_col_value(
+                    &mut mut_val,
+                    &mut EvalContext::default(),
+                    &columns_info[i],
+                )
+                .unwrap();
+                let decoded_sorted_val = CollatorUtf8Mb4Bin::sort_key(
+                    &decoded_val.as_string().unwrap().unwrap().into_owned(),
+                )
+                .unwrap();
                 collation_key_vals.push(decoded_sorted_val);
             } else {
                 collation_key_vals.push(Vec::new());
@@ -1434,8 +1446,12 @@ mod benches {
         let mut collector = BaseRowSampleCollector::new(10000, 4);
         let (column_vals, collation_key_vals, columns_info, column_groups) = prepare_arguments();
         b.iter(|| {
-            collector.collect_column_group(&column_vals, &collation_key_vals, &columns_info, &column_groups);
+            collector.collect_column_group(
+                &column_vals,
+                &collation_key_vals,
+                &columns_info,
+                &column_groups,
+            );
         })
     }
-
 }

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -414,7 +414,7 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
                                         } else {
                                             // Only if the `decoded_val` is Datum::Null, `decoded_val` is a Ok(None).
                                             // So it is safe the unwrap the Ok value.
-                                            let decoded_sorted_val = TT::sort_key(&decoded_val.as_string()?.unwrap().into_owned())?;
+                                            let decoded_sorted_val = TT::sort_key(&decoded_val.as_string()?.unwrap())?;
                                             decoded_sorted_val
                                         }
                                     }
@@ -1416,7 +1416,7 @@ mod benches {
                 )
                 .unwrap();
                 let decoded_sorted_val = CollatorUtf8Mb4Bin::sort_key(
-                    &decoded_val.as_string().unwrap().unwrap().into_owned(),
+                    &decoded_val.as_string().unwrap().unwrap(),
                 )
                 .unwrap();
                 collation_key_vals.push(decoded_sorted_val);

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -1415,10 +1415,9 @@ mod benches {
                     &columns_info[i],
                 )
                 .unwrap();
-                let decoded_sorted_val = CollatorUtf8Mb4Bin::sort_key(
-                    &decoded_val.as_string().unwrap().unwrap(),
-                )
-                .unwrap();
+                let decoded_sorted_val =
+                    CollatorUtf8Mb4Bin::sort_key(&decoded_val.as_string().unwrap().unwrap())
+                        .unwrap();
                 collation_key_vals.push(decoded_sorted_val);
             } else {
                 collation_key_vals.push(Vec::new());

--- a/src/coprocessor/statistics/cmsketch.rs
+++ b/src/coprocessor/statistics/cmsketch.rs
@@ -1,6 +1,6 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
-use murmur3::murmur3_x64_128;
+use mur3::murmurhash3_x64_128;
 
 /// `CmSketch` is used to estimate point queries.
 /// Refer:[Count-Min Sketch](https://en.wikipedia.org/wiki/Count-min_sketch)
@@ -30,9 +30,8 @@ impl CmSketch {
     }
 
     // `hash` hashes the data into two u64 using murmur hash.
-    fn hash(mut bytes: &[u8]) -> (u64, u64) {
-        let out = murmur3_x64_128(&mut bytes, 0).unwrap();
-        (out as u64, (out >> 64) as u64)
+    fn hash(bytes: &[u8]) -> (u64, u64) {
+        murmurhash3_x64_128(bytes, 0)
     }
 
     // `insert` inserts the data into cm sketch. For each row i, the position at

--- a/src/coprocessor/statistics/fmsketch.rs
+++ b/src/coprocessor/statistics/fmsketch.rs
@@ -1,7 +1,9 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::hash::Hasher;
+
 use collections::HashSet;
-use murmur3::murmur3_x64_128;
+use mur3::{Hasher128, murmurhash3_x64_128};
 
 /// `FmSketch` is used to count the approximate number of distinct
 /// elements in multiset.
@@ -22,12 +24,21 @@ impl FmSketch {
         }
     }
 
-    pub fn insert(&mut self, mut bytes: &[u8]) {
-        let hash = {
-            let out = murmur3_x64_128(&mut bytes, 0).unwrap();
-            out as u64
-        };
+    pub fn insert(&mut self, bytes: &[u8]) {
+        let hash = murmurhash3_x64_128(bytes, 0).0;
         self.insert_hash_value(hash);
+    }
+
+    pub fn insert_multi_values(&mut self, values: Vec<&[u8]>) {
+        if values.len() == 1 {
+            self.insert(values[0]);
+        } else {
+            let mut hasher = Hasher128::with_seed(0);
+            for b in values {
+                hasher.write(b);
+            }
+            self.insert_hash_value(hasher.finish());
+        }
     }
 
     pub fn into_proto(self) -> tipb::FmSketch {

--- a/src/coprocessor/statistics/fmsketch.rs
+++ b/src/coprocessor/statistics/fmsketch.rs
@@ -2,7 +2,6 @@
 
 use collections::HashSet;
 use mur3::murmurhash3_x64_128;
-use murmur3::murmur3_x64_128;
 
 /// `FmSketch` is used to count the approximate number of distinct
 /// elements in multiset.
@@ -21,14 +20,6 @@ impl FmSketch {
             max_size,
             hash_set: HashSet::with_capacity_and_hasher(max_size + 1, Default::default()),
         }
-    }
-
-    pub fn insert_old(&mut self, mut bytes: &[u8]) {
-        let hash = {
-            let out = murmur3_x64_128(&mut bytes, 0).unwrap();
-            out as u64
-        };
-        self.insert_hash_value(hash);
     }
 
     pub fn insert(&mut self, bytes: &[u8]) {

--- a/src/coprocessor/statistics/fmsketch.rs
+++ b/src/coprocessor/statistics/fmsketch.rs
@@ -1,9 +1,8 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::hash::Hasher;
-
 use collections::HashSet;
-use mur3::{Hasher128, murmurhash3_x64_128};
+use mur3::murmurhash3_x64_128;
+use murmur3::murmur3_x64_128;
 
 /// `FmSketch` is used to count the approximate number of distinct
 /// elements in multiset.
@@ -24,21 +23,17 @@ impl FmSketch {
         }
     }
 
-    pub fn insert(&mut self, bytes: &[u8]) {
-        let hash = murmurhash3_x64_128(bytes, 0).0;
+    pub fn insert_old(&mut self, mut bytes: &[u8]) {
+        let hash = {
+            let out = murmur3_x64_128(&mut bytes, 0).unwrap();
+            out as u64
+        };
         self.insert_hash_value(hash);
     }
 
-    pub fn insert_multi_values(&mut self, values: Vec<&[u8]>) {
-        if values.len() == 1 {
-            self.insert(values[0]);
-        } else {
-            let mut hasher = Hasher128::with_seed(0);
-            for b in values {
-                hasher.write(b);
-            }
-            self.insert_hash_value(hasher.finish());
-        }
+    pub fn insert(&mut self, bytes: &[u8]) {
+        let hash = murmurhash3_x64_128(bytes, 0).0;
+        self.insert_hash_value(hash);
     }
 
     pub fn into_proto(self) -> tipb::FmSketch {
@@ -49,7 +44,7 @@ impl FmSketch {
         proto
     }
 
-    fn insert_hash_value(&mut self, hash_val: u64) {
+    pub fn insert_hash_value(&mut self, hash_val: u64) {
         if (hash_val & self.mask) != 0 {
             return;
         }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

Signed-off-by: xuyifangreeneyes xuyifangreeneyes@gmail.com

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #14231

What's Changed:


Use https://github.com/tikv/mur3 to calculate fmsketch, which is more efficient.
<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Before the PR:
```
test coprocessor::statistics::analyze::benches::bench_collect_column                        ... bench:         215 ns/iter (+/- 29)
test coprocessor::statistics::analyze::benches::bench_collect_column_group                  ... bench:         183 ns/iter (+/- 14)
```
After the PR:
```
test coprocessor::statistics::analyze::benches::bench_collect_column                        ... bench:         119 ns/iter (+/- 24)
test coprocessor::statistics::analyze::benches::bench_collect_column_group                  ... bench:         120 ns/iter (+/- 13)
```

Also, I tested end-to-end analyze commands on OSSInsight data. The analyze time is reduced from 702s to 650s.


Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
