### PR TITLE
raftstore-v2: fix destroy blocked by apply progress

### DIFF
--- a/components/raftstore-v2/src/operation/command/mod.rs
+++ b/components/raftstore-v2/src/operation/command/mod.rs
@@ -320,11 +320,10 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
     }
 
     pub fn on_apply_res<T>(&mut self, ctx: &mut StoreContext<EK, ER, T>, apply_res: ApplyRes) {
-        if !self.serving() {
-            return;
+        if !self.serving() || !apply_res.admin_result.is_empty() {
+            // TODO: remove following log once stable.
+            info!(self.logger, "on_apply_res"; "apply_res" => ?apply_res, "apply_trace" => ?self.storage().apply_trace());
         }
-        // TODO: remove following log once stable.
-        info!(self.logger, "on_apply_res"; "apply_res" => ?apply_res, "apply_trace" => ?self.storage().apply_trace());
         // It must just applied a snapshot.
         if apply_res.applied_index < self.entry_storage().first_index() {
             // Ignore admin command side effects, otherwise it may split incomplete
@@ -391,7 +390,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         }
         let last_applying_index = self.compact_log_context().last_applying_index();
         let committed_index = self.entry_storage().commit_index();
-        if last_applying_index < committed_index {
+        if last_applying_index < committed_index || !self.serving() {
             // We need to continue to apply after previous page is finished.
             self.set_has_ready();
         }

--- a/components/raftstore-v2/src/operation/life.rs
+++ b/components/raftstore-v2/src/operation/life.rs
@@ -574,7 +574,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         let entry_storage = self.storage().entry_storage();
         // If it's marked as tombstone, then it must be changed by conf change. In
         // this case, all following entries are skipped so applied_index never equals
-        // to commit_index.
+        // to last_applying_index.
         (self.storage().region_state().get_state() != PeerState::Tombstone
             && entry_storage.applied_index() != last_applying_index)
             // Wait for critical commands like split.

--- a/components/raftstore-v2/src/operation/life.rs
+++ b/components/raftstore-v2/src/operation/life.rs
@@ -570,12 +570,13 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
     /// tablet.
     #[inline]
     pub fn postponed_destroy(&self) -> bool {
+        let last_applying_index = self.compact_log_context().last_applying_index();
         let entry_storage = self.storage().entry_storage();
         // If it's marked as tombstone, then it must be changed by conf change. In
         // this case, all following entries are skipped so applied_index never equals
         // to commit_index.
         (self.storage().region_state().get_state() != PeerState::Tombstone
-           && entry_storage.applied_index() != entry_storage.commit_index())
+            && entry_storage.applied_index() != last_applying_index)
             // Wait for critical commands like split.
             || self.has_pending_tombstone_tablets()
     }

--- a/components/raftstore-v2/src/operation/ready/mod.rs
+++ b/components/raftstore-v2/src/operation/ready/mod.rs
@@ -947,6 +947,7 @@ impl<EK: KvEngine, ER: RaftEngine> Storage<EK, ER> {
                 write_task.raft_wb = Some(raft_engine.log_batch(64));
             }
             let wb = write_task.raft_wb.as_mut().unwrap();
+            // There may be tombstone key from last peer.
             raft_engine
                 .clean(region_id, 0, entry_storage.raft_state(), wb)
                 .unwrap_or_else(|e| {

--- a/components/raftstore-v2/src/operation/ready/mod.rs
+++ b/components/raftstore-v2/src/operation/ready/mod.rs
@@ -236,6 +236,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             }
             cmp::Ordering::Greater => {
                 // We need to create the target peer.
+                info!(self.logger, "mark for destroy for larger ID"; "larger_id" => to_peer.get_id());
                 self.mark_for_destroy(Some(msg));
                 return;
             }
@@ -939,6 +940,18 @@ impl<EK: KvEngine, ER: RaftEngine> Storage<EK, ER> {
         }
         // If snapshot initializes the peer, we don't need to write apply trace again.
         if !self.ever_persisted() {
+            let region_id = self.region().get_id();
+            let entry_storage = self.entry_storage();
+            let raft_engine = entry_storage.raft_engine();
+            if write_task.raft_wb.is_none() {
+                write_task.raft_wb = Some(raft_engine.log_batch(64));
+            }
+            let wb = write_task.raft_wb.as_mut().unwrap();
+            raft_engine
+                .clean(region_id, 0, entry_storage.raft_state(), wb)
+                .unwrap_or_else(|e| {
+                    slog_panic!(self.logger(), "failed to clean up region"; "error" => ?e);
+                });
             self.init_apply_trace(write_task);
             self.set_ever_persisted();
         }

--- a/components/raftstore-v2/tests/failpoints/mod.rs
+++ b/components/raftstore-v2/tests/failpoints/mod.rs
@@ -10,5 +10,6 @@
 mod cluster;
 mod test_basic_write;
 mod test_bootstrap;
+mod test_life;
 mod test_split;
 mod test_trace_apply;

--- a/components/raftstore-v2/tests/failpoints/test_life.rs
+++ b/components/raftstore-v2/tests/failpoints/test_life.rs
@@ -1,0 +1,67 @@
+// Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::time::Duration;
+
+use engine_traits::CF_DEFAULT;
+use futures::executor::block_on;
+use kvproto::raft_serverpb::RaftMessage;
+use raft::prelude::MessageType;
+use raftstore_v2::{router::PeerMsg, SimpleWriteEncoder};
+use tikv_util::store::new_peer;
+
+use crate::cluster::{life_helper::assert_peer_not_exist, Cluster};
+
+/// Test if a peer can be destroyed when it's applying entries
+#[test]
+fn test_destroy_by_larger_id_while_applying() {
+    let fp = "APPLY_COMMITTED_ENTRIES";
+    let mut cluster = Cluster::default();
+    let router = &cluster.routers[0];
+    router.wait_applied_to_current_term(2, Duration::from_secs(3));
+
+    fail::cfg(fp, "pause").unwrap();
+
+    let header = Box::new(router.new_request_for(2).take_header());
+    let mut put = SimpleWriteEncoder::with_capacity(64);
+    put.put(CF_DEFAULT, b"key", b"value");
+    let (msg, mut sub) = PeerMsg::simple_write(header.clone(), put.clone().encode());
+    router.send(2, msg).unwrap();
+    assert!(block_on(sub.wait_committed()));
+
+    let mut larger_id_msg = Box::<RaftMessage>::default();
+    larger_id_msg.set_region_id(2);
+    let mut target_peer = header.get_peer().clone();
+    target_peer.set_id(target_peer.get_id() + 1);
+    larger_id_msg.set_to_peer(target_peer.clone());
+    larger_id_msg.set_region_epoch(header.get_region_epoch().clone());
+    larger_id_msg
+        .mut_region_epoch()
+        .set_conf_ver(header.get_region_epoch().get_conf_ver() + 1);
+    larger_id_msg.set_from_peer(new_peer(2, 8));
+    let raft_message = larger_id_msg.mut_message();
+    raft_message.set_msg_type(MessageType::MsgHeartbeat);
+    raft_message.set_from(8);
+    raft_message.set_to(target_peer.get_id());
+    raft_message.set_term(10);
+
+    // Larger ID should trigger destroy.
+    router.send_raft_message(larger_id_msg).unwrap();
+    fail::remove(fp);
+    assert_peer_not_exist(2, header.get_peer().get_id(), router);
+    let meta = router
+        .must_query_debug_info(2, Duration::from_secs(3))
+        .unwrap();
+    assert_eq!(meta.raft_status.id, target_peer.get_id());
+    assert_eq!(meta.raft_status.hard_state.term, 10);
+
+    std::thread::sleep(Duration::from_millis(10));
+
+    // New peer should survive restart.
+    cluster.restart(0);
+    let router = &cluster.routers[0];
+    let meta = router
+        .must_query_debug_info(2, Duration::from_secs(3))
+        .unwrap();
+    assert_eq!(meta.raft_status.id, target_peer.get_id());
+    assert_eq!(meta.raft_status.hard_state.term, 10);
+}

--- a/components/raftstore-v2/tests/integrations/cluster.rs
+++ b/components/raftstore-v2/tests/integrations/cluster.rs
@@ -98,7 +98,10 @@ impl TestRouter {
                 thread::sleep(Duration::from_millis(10));
                 continue;
             }
-            return block_on(sub.result());
+            let res = block_on(sub.result());
+            if res.is_some() {
+                return res;
+            }
         }
         None
     }
@@ -719,5 +722,75 @@ pub mod split_helper {
         assert_eq!(region.get_end_key(), right.get_end_key());
 
         (left, right)
+    }
+}
+
+pub mod life_helper {
+    use std::assert_matches::assert_matches;
+
+    use engine_traits::RaftEngine;
+    use kvproto::raft_serverpb::{ExtraMessageType, PeerState};
+
+    use super::*;
+
+    pub fn assert_peer_not_exist(region_id: u64, peer_id: u64, router: &TestRouter) {
+        let timer = Instant::now();
+        loop {
+            let (ch, sub) = DebugInfoChannel::pair();
+            let msg = PeerMsg::QueryDebugInfo(ch);
+            match router.send(region_id, msg) {
+                Err(TrySendError::Disconnected(_)) => return,
+                Ok(()) => {
+                    if let Some(m) = block_on(sub.result()) {
+                        if m.raft_status.id != peer_id {
+                            return;
+                        }
+                    }
+                }
+                Err(_) => (),
+            }
+            if timer.elapsed() < Duration::from_secs(3) {
+                thread::sleep(Duration::from_millis(10));
+            } else {
+                panic!("peer of {} still exists", region_id);
+            }
+        }
+    }
+
+    // TODO: make raft engine support more suitable way to verify range is empty.
+    /// Verify all states in raft engine are cleared.
+    pub fn assert_tombstone(raft_engine: &impl RaftEngine, region_id: u64, peer: &metapb::Peer) {
+        let mut buf = vec![];
+        raft_engine.get_all_entries_to(region_id, &mut buf).unwrap();
+        assert!(buf.is_empty(), "{:?}", buf);
+        assert_matches!(raft_engine.get_raft_state(region_id), Ok(None));
+        assert_matches!(raft_engine.get_apply_state(region_id, u64::MAX), Ok(None));
+        let region_state = raft_engine
+            .get_region_state(region_id, u64::MAX)
+            .unwrap()
+            .unwrap();
+        assert_matches!(region_state.get_state(), PeerState::Tombstone);
+        assert!(
+            region_state.get_region().get_peers().contains(peer),
+            "{:?}",
+            region_state
+        );
+    }
+
+    #[track_caller]
+    pub fn assert_valid_report(report: &RaftMessage, region_id: u64, peer_id: u64) {
+        assert_eq!(
+            report.get_extra_msg().get_type(),
+            ExtraMessageType::MsgGcPeerResponse
+        );
+        assert_eq!(report.get_region_id(), region_id);
+        assert_eq!(report.get_from_peer().get_id(), peer_id);
+    }
+
+    #[track_caller]
+    pub fn assert_tombstone_msg(msg: &RaftMessage, region_id: u64, peer_id: u64) {
+        assert_eq!(msg.get_region_id(), region_id);
+        assert_eq!(msg.get_to_peer().get_id(), peer_id);
+        assert!(msg.get_is_tombstone());
     }
 }

--- a/components/raftstore-v2/tests/integrations/test_life.rs
+++ b/components/raftstore-v2/tests/integrations/test_life.rs
@@ -1,88 +1,23 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{
-    assert_matches::assert_matches,
-    thread,
-    time::{Duration, Instant},
-};
+use std::time::Duration;
 
-use crossbeam::channel::TrySendError;
-use engine_traits::{RaftEngine, RaftEngineReadOnly, CF_DEFAULT};
+use engine_traits::{RaftEngineReadOnly, CF_DEFAULT};
 use futures::executor::block_on;
-use kvproto::{
-    metapb,
-    raft_cmdpb::AdminCmdType,
-    raft_serverpb::{ExtraMessageType, PeerState, RaftMessage},
-};
+use kvproto::{raft_cmdpb::AdminCmdType, raft_serverpb::RaftMessage};
 use raft::prelude::{ConfChangeType, MessageType};
 use raftstore_v2::{
-    router::{DebugInfoChannel, PeerMsg, PeerTick},
+    router::{PeerMsg, PeerTick},
     SimpleWriteEncoder,
 };
 use tikv_util::store::{new_learner_peer, new_peer};
 
-use crate::cluster::{Cluster, TestRouter};
-
-fn assert_peer_not_exist(region_id: u64, peer_id: u64, router: &TestRouter) {
-    let timer = Instant::now();
-    loop {
-        let (ch, sub) = DebugInfoChannel::pair();
-        let msg = PeerMsg::QueryDebugInfo(ch);
-        match router.send(region_id, msg) {
-            Err(TrySendError::Disconnected(_)) => return,
-            Ok(()) => {
-                if let Some(m) = block_on(sub.result()) {
-                    if m.raft_status.id != peer_id {
-                        return;
-                    }
-                }
-            }
-            Err(_) => (),
-        }
-        if timer.elapsed() < Duration::from_secs(3) {
-            thread::sleep(Duration::from_millis(10));
-        } else {
-            panic!("peer of {} still exists", region_id);
-        }
-    }
-}
-
-// TODO: make raft engine support more suitable way to verify range is empty.
-/// Verify all states in raft engine are cleared.
-fn assert_tombstone(raft_engine: &impl RaftEngine, region_id: u64, peer: &metapb::Peer) {
-    let mut buf = vec![];
-    raft_engine.get_all_entries_to(region_id, &mut buf).unwrap();
-    assert!(buf.is_empty(), "{:?}", buf);
-    assert_matches!(raft_engine.get_raft_state(region_id), Ok(None));
-    assert_matches!(raft_engine.get_apply_state(region_id, u64::MAX), Ok(None));
-    let region_state = raft_engine
-        .get_region_state(region_id, u64::MAX)
-        .unwrap()
-        .unwrap();
-    assert_matches!(region_state.get_state(), PeerState::Tombstone);
-    assert!(
-        region_state.get_region().get_peers().contains(peer),
-        "{:?}",
-        region_state
-    );
-}
-
-#[track_caller]
-fn assert_valid_report(report: &RaftMessage, region_id: u64, peer_id: u64) {
-    assert_eq!(
-        report.get_extra_msg().get_type(),
-        ExtraMessageType::MsgGcPeerResponse
-    );
-    assert_eq!(report.get_region_id(), region_id);
-    assert_eq!(report.get_from_peer().get_id(), peer_id);
-}
-
-#[track_caller]
-fn assert_tombstone_msg(msg: &RaftMessage, region_id: u64, peer_id: u64) {
-    assert_eq!(msg.get_region_id(), region_id);
-    assert_eq!(msg.get_to_peer().get_id(), peer_id);
-    assert!(msg.get_is_tombstone());
-}
+use crate::cluster::{
+    life_helper::{
+        assert_peer_not_exist, assert_tombstone, assert_tombstone_msg, assert_valid_report,
+    },
+    Cluster,
+};
 
 /// Test a peer can be created by general raft message and destroyed tombstone
 /// message.


### PR DESCRIPTION

### What is changed and how it works?
Issue Number: Close #14215

What's Changed:

```commit-message
If a peer is marked for destroy, it will skip all apply result, which
will make it never apply to committed index. This PR relaxes the check
to last_applying_index and always process apply result.

It also fixes a bug that new peer created by large ID may not survive
restart.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
