### PR TITLE
fix: ebs volume snapshot support tikv node equipped with 2 cpu or less configuration

### DIFF
--- a/components/snap_recovery/src/init_cluster.rs
+++ b/components/snap_recovery/src/init_cluster.rs
@@ -10,10 +10,7 @@ use pd_client::{Error as PdError, PdClient};
 use raft_log_engine::RaftLogEngine;
 use raftstore::store::initial_region;
 use thiserror::Error;
-use tikv::{
-    config::TikvConfig,
-    server::{config::Config as ServerConfig},
-};
+use tikv::{config::TikvConfig, server::config::Config as ServerConfig};
 use tikv_util::{
     config::{ReadableDuration, ReadableSize, VersionTrack},
     sys::SysQuota,

--- a/components/snap_recovery/src/init_cluster.rs
+++ b/components/snap_recovery/src/init_cluster.rs
@@ -1,6 +1,6 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{error::Error as StdError, result, sync::Arc, thread, time::Duration};
+use std::{cmp, error::Error as StdError, i32, result, sync::Arc, thread, time::Duration};
 
 use encryption_export::data_key_manager_from_config;
 use engine_rocks::{util::new_engine_opt, RocksEngine};
@@ -10,8 +10,14 @@ use pd_client::{Error as PdError, PdClient};
 use raft_log_engine::RaftLogEngine;
 use raftstore::store::initial_region;
 use thiserror::Error;
-use tikv::{config::TikvConfig, server::config::Config as ServerConfig};
-use tikv_util::config::{ReadableDuration, ReadableSize, VersionTrack};
+use tikv::{
+    config::TikvConfig,
+    server::{config::Config as ServerConfig, KvEngineFactoryBuilder},
+};
+use tikv_util::{
+    config::{ReadableDuration, ReadableSize, VersionTrack},
+    sys::SysQuota,
+};
 
 const CLUSTER_BOOTSTRAPPED_MAX_RETRY: u64 = 60;
 const CLUSTER_BOOTSTRAPPED_RETRY_INTERVAL: Duration = Duration::from_secs(3);
@@ -85,7 +91,9 @@ pub fn enter_snap_recovery_mode(config: &mut TikvConfig) {
     config.rocksdb.lockcf.disable_auto_compactions = true;
     config.rocksdb.raftcf.disable_auto_compactions = true;
 
-    config.rocksdb.max_background_jobs = 32;
+    // for cpu = 1, take a reasonable value min[32, maxValue].
+    let limit = (SysQuota::cpu_cores_quota() * 10.0) as i32;
+    config.rocksdb.max_background_jobs = cmp::min(32, limit);
     // disable resolve ts during the recovery
     config.resolved_ts.enable = false;
 

--- a/components/snap_recovery/src/init_cluster.rs
+++ b/components/snap_recovery/src/init_cluster.rs
@@ -12,7 +12,7 @@ use raftstore::store::initial_region;
 use thiserror::Error;
 use tikv::{
     config::TikvConfig,
-    server::{config::Config as ServerConfig, KvEngineFactoryBuilder},
+    server::{config::Config as ServerConfig},
 };
 use tikv_util::{
     config::{ReadableDuration, ReadableSize, VersionTrack},


### PR DESCRIPTION
Signed-off-by: fengou1 <feng.ou@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #14017 

What's Changed:

ebs volume snapshot support tikv node equipped with 2 cpu or less configuration.

To prevent mistakenly inputting too large values, the rocksdb max background limit is made according to the cpu quota * 10. Notice 10 is only an estimate, not an empirical value.

snapshot recovery mode has rocksdb max background job configured as 32 in recovery mode, which requires min CPU is 4. we change this value as min[32, cpu quota*10] 


### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
1. make a docker image
2. create cluster with 2 cpu tikv node
3. backup and restore
![WypWJscHNi](https://user-images.githubusercontent.com/85682690/217148561-f2f0d4ca-0f7a-4c9f-9a90-cdc50fc77df0.jpg)

- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
```
