### PR TITLE
Raftstore-v2: update peer state after persisting snapshot

### DIFF
--- a/components/raftstore-v2/src/operation/ready/snapshot.rs
+++ b/components/raftstore-v2/src/operation/ready/snapshot.rs
@@ -259,6 +259,10 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
                 meta.region_read_progress
                     .insert(region_id, self.read_progress().clone());
             }
+
+            let region_state = self.raft_group().store().region_state().clone();
+            self.storage_mut().set_region_state(region_state);
+
             if let Some(tablet) = self.set_tablet(tablet) {
                 self.record_tombstone_tablet(ctx, tablet, snapshot_index);
             }

--- a/tests/integrations/raftstore/test_conf_change.rs
+++ b/tests/integrations/raftstore/test_conf_change.rs
@@ -732,6 +732,7 @@ fn test_node_learner_conf_change() {
 }
 
 #[test_case(test_raftstore::new_server_cluster)]
+#[test_case(test_raftstore_v2::new_server_cluster)]
 fn test_learner_with_slow_snapshot() {
     let mut cluster = new_cluster(0, 3);
     configure_for_snapshot(&mut cluster.cfg);


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #12842

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Update peer state after persisting snapshot
```
If peer 1 is added to store 1 before the store1 starts, peer 1 will be in learner state. So after applying the snapshot, we should align the state with region's relevant peer state.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
```
