### PR TITLE
sst_service: add get mode rpc for import_sstpb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2733,7 +2733,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#0561adc3754362675cc08b5203d8b6444e645395"
+source = "git+https://github.com/pingcap/kvproto.git#5cc42e4327e4db459872e80241dee0ed7cce74a4"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -635,6 +635,24 @@ where
         ctx.spawn(task);
     }
 
+    fn get_mode(
+        &mut self,
+        ctx: RpcContext<'_>,
+        _req: GetModeRequest,
+        sink: UnarySink<GetModeResponse>,
+    ) {
+        let label = "get_mode";
+        let timer = Instant::now_coarse();
+
+        let mut resp = GetModeResponse::default();
+        resp.set_mode(self.importer.get_mode());
+
+        let task = async move {
+            crate::send_rpc_response!(Ok(resp), sink, label, timer);
+        };
+        ctx.spawn(task);
+    }
+
     /// Receive SST from client and save the file for later ingesting.
     fn upload(
         &mut self,


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #14249 

What's Changed:
<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
add get mode rpc for import_sstpb
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
A new client function to call this rpc, and check the response.


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
