### PR TITLE
raftstore: fix incorrect cond judgment leading to rejection of pre_proposal

### DIFF
--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -3242,6 +3242,11 @@ where
         ctx: &mut ApplyContext<EK>,
         request: &AdminRequest,
     ) -> Result<(AdminResponse, ApplyResult<EK::Snapshot>)> {
+        fail_point!(
+            "before_exec_batch_switch_witness",
+            self.id() == 2,
+            |_| unimplemented!()
+        );
         assert!(request.has_switch_witnesses());
         let switches = request
             .get_switch_witnesses()

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -2660,6 +2660,13 @@ where
                 "receive peer ready info";
                 "peer_id" => self.fsm.peer.peer.get_id(),
             );
+            info!(
+               "notify pd with change peer region";
+               "region_id" => self.fsm.region_id(),
+               "peer_id" => from.get_id(),
+               "region" => ?self.fsm.peer.region(),
+            );
+            self.fsm.peer.heartbeat_pd(self.ctx);
             return;
         }
         self.register_check_peers_availability_tick();

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -5156,6 +5156,8 @@ where
             return Err(Error::IsWitness(self.region_id()));
         }
 
+        fail_point!("ignore_forbid_leader_to_be_witness", |_| Ok(None));
+
         // Forbid requests to switch it into a witness when it's a leader
         if self.fsm.peer.is_leader()
             && msg.has_admin_request()
@@ -6474,6 +6476,8 @@ where
                     if !self.fsm.peer.is_leader() {
                         let _ = self.fsm.peer.get_store().clear_data();
                     } else {
+                        // Avoid calling `clear_data` as the region worker may be scanning snapshot,
+                        // to avoid problems (although no problems were found by testing).
                         self.fsm.peer.delay_clean_data = true;
                     }
                 } else {

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -2652,6 +2652,7 @@ where
             return;
         }
         if !msg.wait_data {
+            let original_remains_nr = self.fsm.peer.wait_data_peers.len();
             self.fsm
                 .peer
                 .wait_data_peers
@@ -2660,13 +2661,15 @@ where
                 "receive peer ready info";
                 "peer_id" => self.fsm.peer.peer.get_id(),
             );
-            info!(
-               "notify pd with change peer region";
-               "region_id" => self.fsm.region_id(),
-               "peer_id" => from.get_id(),
-               "region" => ?self.fsm.peer.region(),
-            );
-            self.fsm.peer.heartbeat_pd(self.ctx);
+            if original_remains_nr != self.fsm.peer.wait_data_peers.len() {
+                info!(
+                   "notify pd with change peer region";
+                   "region_id" => self.fsm.region_id(),
+                   "peer_id" => from.get_id(),
+                   "region" => ?self.fsm.peer.region(),
+                );
+                self.fsm.peer.heartbeat_pd(self.ctx);
+            }
             return;
         }
         self.register_check_peers_availability_tick();

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -2614,6 +2614,7 @@ where
                     ctx.apply_router
                         .schedule_task(self.region_id, ApplyTask::Recover(self.region_id));
                     self.wait_data = false;
+                    self.should_reject_msgappend = false;
                     return false;
                 }
             }

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -5731,6 +5731,7 @@ fn is_request_urgent(req: &RaftCmdRequest) -> bool {
             | AdminCmdType::PrepareMerge
             | AdminCmdType::CommitMerge
             | AdminCmdType::RollbackMerge
+            | AdminCmdType::BatchSwitchWitness
     )
 }
 
@@ -5829,6 +5830,7 @@ mod tests {
             AdminCmdType::PrepareMerge,
             AdminCmdType::CommitMerge,
             AdminCmdType::RollbackMerge,
+            AdminCmdType::BatchSwitchWitness,
         ];
         for tp in AdminCmdType::values() {
             let mut req = RaftCmdRequest::default();

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -899,6 +899,13 @@ where
     /// the request index for retrying.
     pub request_index: u64,
 
+    /// It's used to identify the situation where the region worker is
+    /// generating and sending snapshots when the newly elected leader by Raft
+    /// applies the switch witness cmd which commited before the election. This
+    /// flag will prevent immediate data clearing and will be cleared after
+    /// the successful transfer of leadership.
+    pub delay_clean_data: bool,
+
     /// When the witness becomes non-witness, it need to actively request a
     /// snapshot from the leader, In order to avoid log lag, we need to reject
     /// the leader's `MsgAppend` request unless the `term` of the `last index`
@@ -1133,6 +1140,7 @@ where
             pending_remove: false,
             wait_data,
             request_index: last_index,
+            delay_clean_data: false,
             should_reject_msgappend: false,
             should_wake_up: false,
             force_leader: None,
@@ -2323,6 +2331,10 @@ where
                     self.mut_store().cancel_generating_snap(None);
                     self.clear_disk_full_peers(ctx);
                     self.clear_in_memory_pessimistic_locks();
+                    if self.peer.is_witness && self.delay_clean_data {
+                        let _ = self.get_store().clear_data();
+                        self.delay_clean_data = false;
+                    }
                 }
                 _ => {}
             }

--- a/components/raftstore/src/store/peer_storage.rs
+++ b/components/raftstore/src/store/peer_storage.rs
@@ -524,7 +524,12 @@ where
             panic!("{} unexpected state: {:?}", self.tag, *snap_state);
         }
 
-        if *tried_cnt >= MAX_SNAP_TRY_CNT {
+        let max_snap_try_cnt = (|| {
+            fail_point!("ignore_snap_try_cnt", |_| usize::MAX);
+            MAX_SNAP_TRY_CNT
+        })();
+
+        if *tried_cnt >= max_snap_try_cnt {
             let cnt = *tried_cnt;
             *tried_cnt = 0;
             return Err(raft::Error::Store(box_err!(

--- a/tests/failpoints/cases/test_witness.rs
+++ b/tests/failpoints/cases/test_witness.rs
@@ -563,3 +563,116 @@ fn test_witness_leader_transfer_out() {
     );
     assert_eq!(cluster.must_get(b"k9"), Some(b"v9".to_vec()));
 }
+
+// Test the case that once a Raft election elects a voter as the leader,
+// and is currently generating a snapshot for another peer, then applies the
+// switch witness cmd to be a witness, the generated snapshot will be checked as
+// invalidated and will not be regenerated
+#[test]
+fn test_witness_leader_ignore_gen_snapshot() {
+    let mut cluster = new_server_cluster(0, 3);
+    cluster.cfg.raft_store.raft_log_gc_count_limit = Some(100);
+    configure_for_snapshot(&mut cluster.cfg);
+    cluster.run();
+    let nodes = Vec::from_iter(cluster.get_node_ids());
+    assert_eq!(nodes.len(), 3);
+
+    let pd_client = Arc::clone(&cluster.pd_client);
+    pd_client.disable_default_operator();
+
+    cluster.must_put(b"k0", b"v0");
+
+    let region = block_on(pd_client.get_region_by_id(1)).unwrap().unwrap();
+    let peer_on_store1 = find_peer(&region, nodes[0]).unwrap().clone();
+    cluster.must_transfer_leader(region.get_id(), peer_on_store1.clone());
+
+    // the other follower is isolated
+    cluster.add_send_filter(IsolationFilterFactory::new(3));
+
+    // make sure raft log gc is triggered
+    std::thread::sleep(Duration::from_millis(200));
+    let mut before_states = HashMap::default();
+    for (&id, engines) in &cluster.engines {
+        let mut state: RaftApplyState = get_raft_msg_or_default(engines, &keys::apply_state_key(1));
+        before_states.insert(id, state.take_truncated_state());
+    }
+
+    // write some data to make log gap exceeds the gc limit
+    for i in 1..1000 {
+        let (k, v) = (format!("k{}", i), format!("v{}", i));
+        let key = k.as_bytes();
+        let value = v.as_bytes();
+        cluster.must_put(key, value);
+    }
+
+    std::thread::sleep(Duration::from_millis(200));
+
+    // the truncated index is advanced
+    for (&id, engines) in &cluster.engines {
+        let state: RaftApplyState = get_raft_msg_or_default(engines, &keys::apply_state_key(1));
+        let diff = state.get_truncated_state().get_index() - before_states[&id].get_index();
+        error!("EEEEE";
+            "id" => &id,
+            "diff" => diff,
+            "state.get_truncated_state().get_index()" => state.get_truncated_state().get_index(),
+            "before_states[&id].get_index()" => before_states[&id].get_index()
+        );
+        assert_ne!(
+            900,
+            state.get_truncated_state().get_index() - before_states[&id].get_index()
+        );
+    }
+
+    // ingore raft log gc to avoid canceling snapshots
+    fail::cfg("on_raft_gc_log_tick", "return").unwrap();
+    // wait for leader applied switch to witness
+    fail::cfg("before_region_gen_snap", "pause").unwrap();
+    fail::cfg("ignore_snap_try_cnt", "return").unwrap();
+    // After the snapshot is generated, it will be checked as invalidated and will
+    // not be regenerated (handle_snapshot will not generate a snapshot for
+    // witness)
+    cluster.clear_send_filters();
+    std::thread::sleep(Duration::from_millis(500));
+
+    // non-witness -> witness
+    fail::cfg("ignore_forbid_leader_to_be_witness", "return").unwrap();
+    cluster.pd_client.must_switch_witnesses(
+        region.get_id(),
+        vec![peer_on_store1.get_id()],
+        vec![true],
+    );
+    fail::remove("before_region_gen_snap");
+
+    std::thread::sleep(Duration::from_millis(500));
+
+    // forbid writes
+    let put = new_put_cmd(b"k3", b"v3");
+    must_get_error_is_witness(&mut cluster, &region, put);
+    // forbid reads
+    let get = new_get_cmd(b"k1");
+    must_get_error_is_witness(&mut cluster, &region, get);
+    // forbid read index
+    let read_index = new_read_index_cmd();
+    must_get_error_is_witness(&mut cluster, &region, read_index);
+
+    // reject to transfer, as can't send snapshot to peer_on_store3, there's a log
+    // gap
+    let peer_on_store3 = find_peer(&region, nodes[2]).unwrap().clone();
+    let _ = cluster.try_transfer_leader(region.get_id(), peer_on_store3);
+    std::thread::sleep(Duration::from_secs(5));
+    assert_eq!(cluster.leader_of_region(1).unwrap(), peer_on_store1);
+
+    // should be enable to transfer leader to peer_on_store2
+    let peer_on_store2 = find_peer(&region, nodes[1]).unwrap().clone();
+    cluster.must_transfer_leader(1, peer_on_store2);
+    cluster.must_put(b"k1", b"v1");
+    assert_eq!(
+        cluster.leader_of_region(region.get_id()).unwrap().store_id,
+        nodes[1],
+    );
+    assert_eq!(cluster.must_get(b"k9"), Some(b"v9".to_vec()));
+
+    fail::remove("on_raft_gc_log_tick");
+    fail::remove("ignore_snap_try_cnt");
+    fail::remove("ignore_forbid_leader_to_be_witness");
+}


### PR DESCRIPTION
close tikv/tikv#14219

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #14219 

What's Changed:

Removed incorrect conditional judgment. The triggering scenario is:

1. The Voter has received the switch witness request, but has not yet applied it;
2. Raft elections occur, and the Voter is elected to become the leader;
3. After the Voter becomes the leader, the switch witness is applied to become the witness;

This incorrect condition judgment will incorrectly set `wait_data` to `true`, resulting in the incorrect rejection of the transfer leader request sent by PD in the pre_proposal stage, and eventually causing PITR to time out.

The left changes are:
1.  To avoid duplication of request snapshots, which has nothing to do with the scenario described above and was added for convenience;
2. Notify pd immediately, when the leader learns that non-witness has applied the snapshot;
3. Change  BatchSwitchWitness as urgent request;
 
<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
raftstore: fix incorrect cond judgment leading to rejection of pre_proposal
```

### Related changes

- None

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- E2E test: https://tcms.pingcap.net/dashboard/executions/plan/1680594 (The failure of other cases is that the region is unbalanced for a long time, which has nothing to do with this repair)


Side effects

- Performance regression
    - None
    
### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
