### PR TITLE
importer: use kv engine instead of raw API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4384,6 +4384,7 @@ dependencies = [
  "slog",
  "slog-global",
  "smallvec",
+ "sst_importer",
  "tempfile",
  "test_pd",
  "test_util",

--- a/components/raft_log_engine/src/engine.rs
+++ b/components/raft_log_engine/src/engine.rs
@@ -337,10 +337,6 @@ impl RaftLogEngine {
         )))
     }
 
-    pub fn path(&self) -> &str {
-        self.0.path()
-    }
-
     /// If path is not an empty directory, we say db exists.
     pub fn exists(path: &str) -> bool {
         let path = Path::new(path);
@@ -780,7 +776,7 @@ impl RaftEngine for RaftLogEngine {
     }
 
     fn get_engine_path(&self) -> &str {
-        self.path()
+        self.0.path()
     }
 
     fn for_each_raft_group<E, F>(&self, f: &mut F) -> std::result::Result<(), E>

--- a/components/raftstore-v2/Cargo.toml
+++ b/components/raftstore-v2/Cargo.toml
@@ -56,6 +56,7 @@ resource_control = { workspace = true }
 resource_metering = { workspace = true }
 slog = "2.3"
 smallvec = "1.4"
+sst_importer = { workspace = true }
 thiserror = "1.0"
 tikv_util = { workspace = true }
 time = "0.1"

--- a/components/raftstore-v2/src/fsm/apply.rs
+++ b/components/raftstore-v2/src/fsm/apply.rs
@@ -13,6 +13,7 @@ use kvproto::{metapb, raft_serverpb::RegionLocalState};
 use pd_client::BucketStat;
 use raftstore::store::{Config, ReadTask};
 use slog::Logger;
+use sst_importer::SstImporter;
 use tikv_util::{
     mpsc::future::{self, Receiver, Sender, WakePolicy},
     timer::GLOBAL_TIMER_HANDLE,
@@ -68,8 +69,9 @@ impl<EK: KvEngine, R> ApplyFsm<EK, R> {
         flush_state: Arc<FlushState>,
         log_recovery: Option<Box<DataTrace>>,
         applied_term: u64,
-        logger: Logger,
         buckets: Option<BucketStat>,
+        sst_importer: Arc<SstImporter>,
+        logger: Logger,
     ) -> (ApplyScheduler, Self) {
         let (tx, rx) = future::unbounded(WakePolicy::Immediately);
         let apply = Apply::new(
@@ -82,8 +84,9 @@ impl<EK: KvEngine, R> ApplyFsm<EK, R> {
             flush_state,
             log_recovery,
             applied_term,
-            logger,
             buckets,
+            sst_importer,
+            logger,
         );
         (
             ApplyScheduler { sender: tx },

--- a/components/raftstore-v2/src/operation/command/admin/split.rs
+++ b/components/raftstore-v2/src/operation/command/admin/split.rs
@@ -830,7 +830,10 @@ mod test {
     };
 
     use super::*;
-    use crate::{fsm::ApplyResReporter, raft::Apply, router::ApplyRes};
+    use crate::{
+        fsm::ApplyResReporter, operation::test_util::create_tmp_importer, raft::Apply,
+        router::ApplyRes,
+    };
 
     struct MockReporter {
         sender: Sender<ApplyRes>,
@@ -961,6 +964,7 @@ mod test {
 
         let (read_scheduler, _rx) = dummy_scheduler();
         let (reporter, _) = MockReporter::new();
+        let (_tmp_dir, importer) = create_tmp_importer();
         let mut apply = Apply::new(
             &Config::default(),
             region
@@ -976,8 +980,9 @@ mod test {
             Arc::new(FlushState::new(5)),
             None,
             5,
-            logger.clone(),
             None,
+            importer,
+            logger.clone(),
         );
 
         let mut splits = BatchSplitRequest::default();

--- a/components/raftstore-v2/src/operation/command/write/mod.rs
+++ b/components/raftstore-v2/src/operation/command/write/mod.rs
@@ -1,20 +1,23 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
 use engine_traits::{data_cf_offset, KvEngine, Mutable, RaftEngine, CF_DEFAULT};
-use kvproto::raft_cmdpb::RaftRequestHeader;
+use kvproto::{import_sstpb::SstMeta, raft_cmdpb::RaftRequestHeader};
 use raftstore::{
     store::{
-        cmd_resp,
+        check_sst_for_ingestion, cmd_resp,
         fsm::{apply, MAX_PROPOSAL_SIZE_RATIO},
+        metrics::PEER_WRITE_CMD_COUNTER,
         msg::ErrorCallback,
         util::{self, NORMAL_REQ_CHECK_CONF_VER, NORMAL_REQ_CHECK_VER},
     },
     Error, Result,
 };
+use slog::error;
 use tikv_util::slog_panic;
 
 use crate::{
     batch::StoreContext,
+    fsm::ApplyResReporter,
     raft::{Apply, Peer},
     router::{ApplyTask, CmdResChannel},
 };
@@ -132,9 +135,10 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
     }
 }
 
-impl<EK: KvEngine, R> Apply<EK, R> {
+impl<EK: KvEngine, R: ApplyResReporter> Apply<EK, R> {
     #[inline]
     pub fn apply_put(&mut self, cf: &str, index: u64, key: &[u8], value: &[u8]) -> Result<()> {
+        PEER_WRITE_CMD_COUNTER.put.inc();
         let off = data_cf_offset(cf);
         if self.should_skip(off, index) {
             return Ok(());
@@ -181,6 +185,7 @@ impl<EK: KvEngine, R> Apply<EK, R> {
 
     #[inline]
     pub fn apply_delete(&mut self, cf: &str, index: u64, key: &[u8]) -> Result<()> {
+        PEER_WRITE_CMD_COUNTER.delete.inc();
         let off = data_cf_offset(cf);
         if self.should_skip(off, index) {
             return Ok(());
@@ -226,6 +231,37 @@ impl<EK: KvEngine, R> Apply<EK, R> {
         _notify_only: bool,
     ) -> Result<()> {
         // TODO: reuse the same delete as split/merge.
+        Ok(())
+    }
+
+    #[inline]
+    pub fn apply_ingest(&mut self, ssts: Vec<SstMeta>) -> Result<()> {
+        PEER_WRITE_CMD_COUNTER.ingest_sst.inc();
+        let mut infos = Vec::with_capacity(ssts.len());
+        for sst in &ssts {
+            if let Err(e) = check_sst_for_ingestion(sst, self.region()) {
+                error!(
+                    self.logger,
+                    "ingest fail";
+                    "sst" => ?sst,
+                    "region" => ?self.region(),
+                    "error" => ?e
+                );
+                let _ = self.sst_importer().delete(sst);
+                return Err(e);
+            }
+            match self.sst_importer().validate(sst) {
+                Ok(meta_info) => infos.push(meta_info),
+                Err(e) => {
+                    slog_panic!(self.logger, "corrupted sst"; "sst" => ?sst, "error" => ?e);
+                }
+            }
+        }
+        // Unlike v1, we can't batch ssts accross regions.
+        self.flush();
+        if let Err(e) = self.sst_importer().ingest(&infos, self.tablet()) {
+            slog_panic!(self.logger, "ingest fail"; "ssts" => ?ssts, "error" => ?e);
+        }
         Ok(())
     }
 }

--- a/components/raftstore-v2/src/operation/mod.rs
+++ b/components/raftstore-v2/src/operation/mod.rs
@@ -24,3 +24,20 @@ pub(crate) use self::{
     query::{LocalReader, ReadDelegatePair, SharedReadTablet},
     txn_ext::TxnContext,
 };
+
+#[cfg(test)]
+pub mod test_util {
+    use std::sync::Arc;
+
+    use kvproto::kvrpcpb::ApiVersion;
+    use sst_importer::SstImporter;
+    use tempfile::TempDir;
+
+    pub fn create_tmp_importer() -> (TempDir, Arc<SstImporter>) {
+        let dir = TempDir::new().unwrap();
+        let importer = Arc::new(
+            SstImporter::new(&Default::default(), dir.path(), None, ApiVersion::V1).unwrap(),
+        );
+        (dir, importer)
+    }
+}

--- a/components/raftstore-v2/src/raft/storage.rs
+++ b/components/raftstore-v2/src/raft/storage.rs
@@ -339,7 +339,10 @@ mod tests {
 
     use super::*;
     use crate::{
-        fsm::ApplyResReporter, operation::write_initial_states, raft::Apply, router::ApplyRes,
+        fsm::ApplyResReporter,
+        operation::{test_util::create_tmp_importer, write_initial_states},
+        raft::Apply,
+        router::ApplyRes,
     };
 
     #[derive(Clone)]
@@ -495,6 +498,7 @@ mod tests {
         worker.start(read_runner);
         let mut state = RegionLocalState::default();
         state.set_region(region.clone());
+        let (_tmp_dir, importer) = create_tmp_importer();
         // setup peer applyer
         let mut apply = Apply::new(
             &Config::default(),
@@ -506,8 +510,9 @@ mod tests {
             Arc::new(FlushState::new(5)),
             None,
             5,
-            logger,
             None,
+            importer,
+            logger,
         );
 
         // Test get snapshot

--- a/components/raftstore-v2/tests/integrations/cluster.rs
+++ b/components/raftstore-v2/tests/integrations/cluster.rs
@@ -23,6 +23,7 @@ use engine_test::{
 use engine_traits::{TabletContext, TabletRegistry, DATA_CFS};
 use futures::executor::block_on;
 use kvproto::{
+    kvrpcpb::ApiVersion,
     metapb::{self, RegionEpoch, Store},
     raft_cmdpb::{CmdType, RaftCmdRequest, RaftCmdResponse, RaftRequestHeader, Request},
     raft_serverpb::RaftMessage,
@@ -44,6 +45,7 @@ use raftstore_v2::{
 };
 use resource_metering::CollectorRegHandle;
 use slog::{debug, o, Logger};
+use sst_importer::SstImporter;
 use tempfile::TempDir;
 use test_pd::mocker::Service;
 use tikv_util::{
@@ -297,6 +299,15 @@ impl RunningState {
         let snap_mgr = TabletSnapManager::new(path.join("tablets_snap").to_str().unwrap()).unwrap();
         let coprocessor_host =
             CoprocessorHost::new(router.store_router().clone(), cop_cfg.value().clone());
+        let importer = Arc::new(
+            SstImporter::new(
+                &Default::default(),
+                path.join("importer"),
+                None,
+                ApiVersion::V1,
+            )
+            .unwrap(),
+        );
 
         let background = Worker::new("background");
         let pd_worker = LazyWorker::new("pd-worker");
@@ -318,6 +329,7 @@ impl RunningState {
                 CollectorRegHandle::new_for_test(),
                 background.clone(),
                 pd_worker,
+                importer,
             )
             .unwrap();
 

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -1245,7 +1245,7 @@ where
         let import_service = ImportSstService::new(
             self.config.import.clone(),
             self.config.raft_store.raft_entry_max_size,
-            self.router.clone(),
+            engines.engine.clone(),
             engines.engines.kv.clone(),
             servers.importer.clone(),
         );

--- a/components/server/src/server2.rs
+++ b/components/server/src/server2.rs
@@ -31,7 +31,7 @@ use causal_ts::CausalTsProviderImpl;
 use concurrency_manager::ConcurrencyManager;
 use encryption_export::{data_key_manager_from_config, DataKeyManager};
 use engine_rocks::{
-    flush_engine_statistics,
+    flush_engine_statistics, from_rocks_compression_type,
     raw::{Cache, Env},
     FlowInfo, RocksEngine, RocksStatistics,
 };
@@ -73,6 +73,7 @@ use tikv::{
     config::{ConfigController, DbConfigManger, DbType, LogConfigManager, TikvConfig},
     coprocessor::{self, MEMTRACE_ROOT as MEMTRACE_COPROCESSOR},
     coprocessor_v2,
+    import::SstImporter,
     read_pool::{
         build_yatp_read_pool, ReadPool, ReadPoolConfigManager, UPDATE_EWMA_TIME_SLICE_INTERVAL,
     },
@@ -243,6 +244,7 @@ struct TikvEngines<EK: KvEngine, ER: RaftEngine> {
 struct Servers<EK: KvEngine, ER: RaftEngine> {
     lock_mgr: LockManager,
     server: LocalServer<EK, ER>,
+    _importer: Arc<SstImporter>,
     rsmeter_pubsub_service: resource_metering::PubSubService,
 }
 
@@ -871,6 +873,30 @@ where
             )),
         );
 
+        let import_path = self.store_path.join("import");
+        let mut importer = SstImporter::new(
+            &self.config.import,
+            import_path,
+            self.encryption_key_manager.clone(),
+            self.config.storage.api_version(),
+        )
+        .unwrap();
+        for (cf_name, compression_type) in &[
+            (
+                CF_DEFAULT,
+                self.config.rocksdb.defaultcf.bottommost_level_compression,
+            ),
+            (
+                CF_WRITE,
+                self.config.rocksdb.writecf.bottommost_level_compression,
+            ),
+        ] {
+            importer.set_compression_type(cf_name, from_rocks_compression_type(*compression_type));
+        }
+        let importer = Arc::new(importer);
+
+        // V2 starts split-check worker within raftstore.
+
         let split_config_manager =
             SplitConfigManager::new(Arc::new(VersionTrack::new(self.config.split.clone())));
         cfg_controller.register(
@@ -919,6 +945,7 @@ where
                 pd_worker,
                 raft_store,
                 &state,
+                importer.clone(),
             )
             .unwrap_or_else(|e| fatal!("failed to start node: {}", e));
 
@@ -942,6 +969,7 @@ where
         self.servers = Some(Servers {
             lock_mgr,
             server,
+            _importer: importer,
             rsmeter_pubsub_service,
         });
 
@@ -950,6 +978,23 @@ where
 
     fn register_services(&mut self) {
         let servers = self.servers.as_mut().unwrap();
+        let _engines = self.engines.as_ref().unwrap();
+
+        // Import SST service.
+        // let import_service = ImportSstService::new(
+        // self.config.import.clone(),
+        // self.config.raft_store.raft_entry_max_size,
+        // engines.engine.clone(),
+        // self.tablet_registry.as_ref().unwrap().clone(),
+        // servers.importer.clone(),
+        // );
+        // if servers
+        // .server
+        // .register_service(create_import_sst(import_service))
+        // .is_some()
+        // {
+        // fatal!("failed to register import service");
+        // }
 
         // Create Diagnostics service
         let diag_service = DiagnosticsService::new(

--- a/components/test_raftstore-v2/src/cluster.rs
+++ b/components/test_raftstore-v2/src/cluster.rs
@@ -74,6 +74,7 @@ pub trait Simulator {
         node_id: u64,
         cfg: Config,
         store_meta: Arc<Mutex<StoreMeta<RocksEngine>>>,
+        key_mgr: Option<Arc<DataKeyManager>>,
         raft_engine: RaftTestEngine,
         tablet_registry: TabletRegistry<RocksEngine>,
         resource_manager: &Option<Arc<ResourceGroupManager>>,
@@ -383,6 +384,7 @@ impl<T: Simulator> Cluster<T> {
                 id,
                 self.cfg.clone(),
                 store_meta.clone(),
+                self.key_managers_map[&id].clone(),
                 raft_engine.clone(),
                 tablet_registry.clone(),
                 &self.resource_manager,
@@ -424,10 +426,12 @@ impl<T: Simulator> Cluster<T> {
         tikv_util::thread_group::set_properties(Some(props));
 
         debug!("calling run node"; "node_id" => node_id);
+        let key_mgr = self.key_managers_map.get(&node_id).unwrap().clone();
         self.sim.wl().run_node(
             node_id,
             cfg,
             store_meta,
+            key_mgr,
             raft_engine,
             tablet_registry,
             &self.resource_manager,

--- a/components/test_raftstore-v2/src/cluster.rs
+++ b/components/test_raftstore-v2/src/cluster.rs
@@ -384,7 +384,7 @@ impl<T: Simulator> Cluster<T> {
                 id,
                 self.cfg.clone(),
                 store_meta.clone(),
-                self.key_managers_map[&id].clone(),
+                key_mgr.clone(),
                 raft_engine.clone(),
                 tablet_registry.clone(),
                 &self.resource_manager,

--- a/components/test_raftstore-v2/src/node.rs
+++ b/components/test_raftstore-v2/src/node.rs
@@ -1,12 +1,14 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::{
+    path::Path,
     sync::{Arc, Mutex, RwLock},
     time::Duration,
 };
 
 use collections::{HashMap, HashSet};
 use concurrency_manager::ConcurrencyManager;
+use encryption_export::DataKeyManager;
 use engine_rocks::RocksEngine;
 use engine_test::raft::RaftTestEngine;
 use engine_traits::{RaftEngineReadOnly, TabletRegistry};
@@ -36,6 +38,7 @@ use test_pd_client::TestPdClient;
 use test_raftstore::{Config, Filter};
 use tikv::{
     config::{ConfigController, Module},
+    import::SstImporter,
     server::{
         raftkv::ReplicaReadLockChecker, tablet_snap::copy_tablet_snapshot, NodeV2,
         Result as ServerResult,
@@ -187,6 +190,7 @@ impl Simulator for NodeCluster {
         node_id: u64,
         cfg: Config,
         store_meta: Arc<Mutex<StoreMeta<RocksEngine>>>,
+        key_manager: Option<Arc<DataKeyManager>>,
         raft_engine: RaftTestEngine,
         tablet_registry: TabletRegistry<RocksEngine>,
         _resource_manager: &Option<Arc<ResourceGroupManager>>,
@@ -265,6 +269,12 @@ impl Simulator for NodeCluster {
             // todo: Is None sufficient for test?
             None,
         );
+        let importer = {
+            let dir = Path::new(raft_engine.path()).join("../import-sst");
+            Arc::new(
+                SstImporter::new(&cfg.import, dir, key_manager, cfg.storage.api_version()).unwrap(),
+            )
+        };
 
         let bg_worker = WorkerBuilder::new("background").thread_count(2).create();
         let state: Arc<Mutex<GlobalReplicationState>> = Arc::default();
@@ -283,6 +293,7 @@ impl Simulator for NodeCluster {
             pd_worker,
             Arc::new(VersionTrack::new(raft_store)),
             &state,
+            importer,
         )?;
         assert!(
             raft_engine

--- a/components/test_raftstore-v2/src/node.rs
+++ b/components/test_raftstore-v2/src/node.rs
@@ -11,7 +11,7 @@ use concurrency_manager::ConcurrencyManager;
 use encryption_export::DataKeyManager;
 use engine_rocks::RocksEngine;
 use engine_test::raft::RaftTestEngine;
-use engine_traits::{RaftEngineReadOnly, TabletRegistry};
+use engine_traits::{RaftEngine, RaftEngineReadOnly, TabletRegistry};
 use kvproto::{
     kvrpcpb::ApiVersion,
     raft_cmdpb::{RaftCmdRequest, RaftCmdResponse},
@@ -270,7 +270,7 @@ impl Simulator for NodeCluster {
             None,
         );
         let importer = {
-            let dir = Path::new(raft_engine.path()).join("../import-sst");
+            let dir = Path::new(raft_engine.get_engine_path()).join("../import-sst");
             Arc::new(
                 SstImporter::new(&cfg.import, dir, key_manager, cfg.storage.api_version()).unwrap(),
             )

--- a/components/test_raftstore-v2/src/server.rs
+++ b/components/test_raftstore-v2/src/server.rs
@@ -14,7 +14,7 @@ use concurrency_manager::ConcurrencyManager;
 use encryption_export::DataKeyManager;
 use engine_rocks::{RocksEngine, RocksSnapshot};
 use engine_test::raft::RaftTestEngine;
-use engine_traits::{KvEngine, TabletRegistry};
+use engine_traits::{KvEngine, RaftEngine, TabletRegistry};
 use futures::executor::block_on;
 use grpcio::{ChannelBuilder, EnvBuilder, Environment, Error as GrpcError, Service};
 use grpcio_health::HealthService;
@@ -323,7 +323,7 @@ impl ServerCluster {
 
         // Create import service.
         let importer = {
-            let dir = Path::new(raft_engine.path()).join("../import-sst");
+            let dir = Path::new(raft_engine.get_engine_path()).join("../import-sst");
             Arc::new(
                 SstImporter::new(&cfg.import, dir, key_manager, cfg.storage.api_version()).unwrap(),
             )

--- a/components/test_raftstore-v2/src/server.rs
+++ b/components/test_raftstore-v2/src/server.rs
@@ -1,6 +1,7 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::{
+    path::Path,
     sync::{Arc, Mutex, RwLock},
     thread,
     time::Duration,
@@ -10,6 +11,7 @@ use api_version::{dispatch_api_version, KvFormat};
 use causal_ts::CausalTsProviderImpl;
 use collections::{HashMap, HashSet};
 use concurrency_manager::ConcurrencyManager;
+use encryption_export::DataKeyManager;
 use engine_rocks::{RocksEngine, RocksSnapshot};
 use engine_test::raft::RaftTestEngine;
 use engine_traits::{KvEngine, TabletRegistry};
@@ -45,6 +47,7 @@ use test_pd_client::TestPdClient;
 use test_raftstore::{AddressMap, Config};
 use tikv::{
     coprocessor, coprocessor_v2,
+    import::SstImporter,
     read_pool::ReadPool,
     server::{
         gc_worker::GcWorker, load_statistics::ThreadLoadPool, lock_manager::LockManager,
@@ -168,6 +171,7 @@ impl ServerCluster {
         node_id: u64,
         mut cfg: Config,
         store_meta: Arc<Mutex<StoreMeta<RocksEngine>>>,
+        key_manager: Option<Arc<DataKeyManager>>,
         raft_engine: RaftTestEngine,
         tablet_registry: TabletRegistry<RocksEngine>,
         resource_manager: &Option<Arc<ResourceGroupManager>>,
@@ -317,7 +321,20 @@ impl ServerCluster {
 
         ReplicaReadLockChecker::new(concurrency_manager.clone()).register(&mut coprocessor_host);
 
-        // todo: Import Sst Service
+        // Create import service.
+        let importer = {
+            let dir = Path::new(raft_engine.path()).join("../import-sst");
+            Arc::new(
+                SstImporter::new(&cfg.import, dir, key_manager, cfg.storage.api_version()).unwrap(),
+            )
+        };
+        // let import_service = ImportSstService::new(
+        // cfg.import.clone(),
+        // cfg.raft_store.raft_entry_max_size,
+        // raft_kv_2.clone(),
+        // tablet_registry.clone(),
+        // Arc::clone(&importer),
+        // );
 
         // Create deadlock service.
         let deadlock_service = lock_mgr.deadlock_service();
@@ -382,6 +399,7 @@ impl ServerCluster {
             .unwrap();
             svr.register_service(create_diagnostics(diag_service.clone()));
             svr.register_service(create_deadlock(deadlock_service.clone()));
+            // svr.register_service(create_import_sst(import_service.clone()));
             if let Some(svcs) = self.pending_services.get(&node_id) {
                 for fact in svcs {
                     svr.register_service(fact());
@@ -428,6 +446,7 @@ impl ServerCluster {
             pd_worker,
             Arc::new(VersionTrack::new(raft_store)),
             &state,
+            importer,
         )?;
         assert!(node_id == 0 || node_id == node.id());
         let node_id = node.id();
@@ -538,6 +557,7 @@ impl Simulator for ServerCluster {
         node_id: u64,
         cfg: Config,
         store_meta: Arc<Mutex<StoreMeta<RocksEngine>>>,
+        key_manager: Option<Arc<DataKeyManager>>,
         raft_engine: RaftTestEngine,
         tablet_registry: TabletRegistry<RocksEngine>,
         resource_manager: &Option<Arc<ResourceGroupManager>>,
@@ -548,6 +568,7 @@ impl Simulator for ServerCluster {
                 node_id,
                 cfg,
                 store_meta,
+                key_manager,
                 raft_engine,
                 tablet_registry,
                 resource_manager

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -404,7 +404,7 @@ impl ServerCluster {
         ));
         let extension = engine.raft_extension();
         let store = Storage::<_, _, F>::from_engine(
-            engine,
+            engine.clone(),
             &cfg.storage,
             storage_read_pool.handle(),
             lock_mgr.clone(),
@@ -440,7 +440,7 @@ impl ServerCluster {
         let import_service = ImportSstService::new(
             cfg.import.clone(),
             cfg.raft_store.raft_entry_max_size,
-            sim_router.clone(),
+            engine,
             engines.kv.clone(),
             Arc::clone(&importer),
         );

--- a/components/tikv_kv/src/btree_engine.rs
+++ b/components/tikv_kv/src/btree_engine.rs
@@ -290,6 +290,7 @@ fn write_modifies(engine: &BTreeEngine, modifies: Vec<Modify>) -> EngineResult<(
                 cf_tree.write().unwrap().insert(k, v);
             }
             Modify::DeleteRange(_cf, _start_key, _end_key, _notify_only) => unimplemented!(),
+            Modify::Ingest(_) => unimplemented!(),
         };
     }
     Ok(())

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -9,9 +9,9 @@ use std::{
 };
 
 use collections::HashSet;
-use engine_traits::{KvEngine, CF_DEFAULT, CF_WRITE};
+use engine_traits::{CompactExt, MiscExt, CF_DEFAULT, CF_WRITE};
 use file_system::{set_io_type, IoType};
-use futures::{sink::SinkExt, stream::TryStreamExt, TryFutureExt};
+use futures::{sink::SinkExt, stream::TryStreamExt, Stream, StreamExt, TryFutureExt};
 use futures_executor::{ThreadPool, ThreadPoolBuilder};
 use grpcio::{
     ClientStreamingSink, RequestStream, RpcContext, ServerStreamingSink, UnarySink, WriteFlags,
@@ -24,20 +24,15 @@ use kvproto::{
         SwitchMode, WriteRequest_oneof_chunk as Chunk, *,
     },
     kvrpcpb::Context,
-    raft_cmdpb::{CmdType, DeleteRequest, PutRequest, RaftCmdRequest, RaftRequestHeader, Request},
-};
-use protobuf::Message;
-use raftstore::{
-    router::RaftStoreRouter,
-    store::{Callback, RaftCmdExtraOpts, RegionSnapshot},
 };
 use sst_importer::{
     error_inc, metrics::*, sst_importer::DownloadExt, sst_meta_to_path, Config, Error, Result,
     SstImporter,
 };
+use tikv_kv::{Engine, Modify, SnapContext, Snapshot, SnapshotExt, WriteData, WriteEvent};
 use tikv_util::{
     config::ReadableSize,
-    future::{create_stream_with_buffer, paired_future_callback},
+    future::create_stream_with_buffer,
     sys::thread::ThreadBuildWrapper,
     time::{Instant, Limiter},
 };
@@ -45,22 +40,41 @@ use tokio::{runtime::Runtime, time::sleep};
 use txn_types::{Key, WriteRef, WriteType};
 
 use super::make_rpc_error;
-use crate::{import::duplicate_detect::DuplicateDetector, server::CONFIG_ROCKSDB_GAUGE};
+use crate::{
+    import::duplicate_detect::DuplicateDetector,
+    server::CONFIG_ROCKSDB_GAUGE,
+    storage::{self, errors::extract_region_error_from_error},
+};
 
 const MAX_INFLIGHT_RAFT_MSGS: usize = 64;
+
+fn transfer_error(err: storage::Error) -> ImportPbError {
+    let mut e = ImportPbError::default();
+    if let Some(region_error) = extract_region_error_from_error(&err) {
+        e.set_store_error(region_error);
+    }
+    e.set_message(format!("failed to complete raft command: {:?}", err));
+    e
+}
+
+async fn wait_write(mut s: impl Stream<Item = WriteEvent> + Send + Unpin) -> storage::Result<()> {
+    match s.next().await {
+        Some(WriteEvent::Finished(Ok(()))) => Ok(()),
+        Some(WriteEvent::Finished(Err(e))) => Err(e.into()),
+        Some(e) => Err(box_err!("unexpected event: {:?}", e)),
+        None => Err(box_err!("stream closed")),
+    }
+}
 
 /// ImportSstService provides tikv-server with the ability to ingest SST files.
 ///
 /// It saves the SST sent from client to a file and then sends a command to
 /// raftstore to trigger the ingest process.
 #[derive(Clone)]
-pub struct ImportSstService<E, Router>
-where
-    E: KvEngine,
-{
+pub struct ImportSstService<E: Engine> {
     cfg: Config,
-    engine: E,
-    router: Router,
+    engine: E::Local,
+    raftkv: E,
     threads: Arc<Runtime>,
     // For now, PiTR cannot be executed in the tokio runtime because it is synchronous and may
     // blocks. (tokio is so strict... it panics if we do insane things like blocking in an async
@@ -74,36 +88,29 @@ where
     raft_entry_max_size: ReadableSize,
 }
 
-pub struct SnapshotResult<E: KvEngine> {
-    snapshot: RegionSnapshot<E::Snapshot>,
-    term: u64,
-}
-
 struct RequestCollector {
-    context: Context,
     max_raft_req_size: usize,
     /// Retain the last ts of each key in each request.
     /// This is used for write CF because resolved ts observer hates duplicated
     /// key in the same request.
-    write_reqs: HashMap<Vec<u8>, (Request, u64)>,
+    write_reqs: HashMap<Vec<u8>, (Modify, u64)>,
     /// Collector favor that simple collect all items, and it do not contains
     /// duplicated key-value. This is used for default CF.
-    default_reqs: HashMap<Vec<u8>, Request>,
+    default_reqs: HashMap<Vec<u8>, Modify>,
     /// Size of all `Request`s.
     unpacked_size: usize,
 
-    pending_raft_reqs: Vec<RaftCmdRequest>,
+    pending_writes: Vec<WriteData>,
 }
 
 impl RequestCollector {
-    fn new(context: Context, max_raft_req_size: usize) -> Self {
+    fn new(max_raft_req_size: usize) -> Self {
         Self {
-            context,
             max_raft_req_size,
             write_reqs: HashMap::default(),
             default_reqs: HashMap::default(),
             unpacked_size: 0,
-            pending_raft_reqs: Vec::new(),
+            pending_writes: Vec::new(),
         }
     }
 
@@ -113,41 +120,37 @@ impl RequestCollector {
         if k.is_empty() || (!is_delete && v.is_empty()) {
             return;
         }
-        let mut req = Request::default();
-        if is_delete {
-            let mut del = DeleteRequest::default();
-            del.set_key(k);
-            del.set_cf(cf.to_string());
-            req.set_cmd_type(CmdType::Delete);
-            req.set_delete(del);
+        // Filter out not supported CF.
+        let cf = match cf {
+            CF_WRITE => CF_WRITE,
+            CF_DEFAULT => CF_DEFAULT,
+            _ => return,
+        };
+        let m = if is_delete {
+            Modify::Delete(cf, Key::from_encoded(k))
         } else {
             if cf == CF_WRITE && !write_needs_restore(&v) {
                 return;
             }
 
-            let mut put = PutRequest::default();
-            put.set_key(k);
-            put.set_value(v);
-            put.set_cf(cf.to_string());
-            req.set_cmd_type(CmdType::Put);
-            req.set_put(put);
-        }
-        self.accept(cf, req);
+            Modify::Put(cf, Key::from_encoded(k), v)
+        };
+        self.accept(cf, m);
     }
 
     // we need to remove duplicate keys in here, since
     // in https://github.com/tikv/tikv/blob/a401f78bc86f7e6ea6a55ad9f453ae31be835b55/components/resolved_ts/src/cmd.rs#L204
     // will panic if found duplicated entry during Vec<PutRequest>.
-    fn accept(&mut self, cf: &str, req: Request) {
-        let k = key_from_request(&req);
+    fn accept(&mut self, cf: &str, m: Modify) {
+        let k = m.key();
         match cf {
             CF_WRITE => {
-                let (encoded_key, ts) = match Key::split_on_ts_for(k) {
+                let (encoded_key, ts) = match Key::split_on_ts_for(k.as_encoded()) {
                     Ok(k) => k,
                     Err(err) => {
                         warn!(
                             "key without ts, skipping";
-                            "key" => %log_wrappers::Value::key(k),
+                            "key" => %k,
                             "err" => %err
                         );
                         return;
@@ -159,19 +162,19 @@ impl RequestCollector {
                     .map(|(_, old_ts)| *old_ts < ts.into_inner())
                     .unwrap_or(true)
                 {
-                    self.unpacked_size += req.compute_size() as usize;
+                    self.unpacked_size += m.size();
                     if let Some((v, _)) = self
                         .write_reqs
-                        .insert(encoded_key.to_owned(), (req, ts.into_inner()))
+                        .insert(encoded_key.to_owned(), (m, ts.into_inner()))
                     {
-                        self.unpacked_size -= v.get_cached_size() as usize;
+                        self.unpacked_size -= v.size();
                     }
                 }
             }
             CF_DEFAULT => {
-                self.unpacked_size += req.compute_size() as usize;
-                if let Some(v) = self.default_reqs.insert(k.to_owned(), req) {
-                    self.unpacked_size -= v.get_cached_size() as usize;
+                self.unpacked_size += m.size();
+                if let Some(v) = self.default_reqs.insert(k.as_encoded().clone(), m) {
+                    self.unpacked_size -= v.size();
                 }
             }
             _ => unreachable!(),
@@ -183,69 +186,61 @@ impl RequestCollector {
     }
 
     #[cfg(test)]
-    fn drain_unpacked_reqs(&mut self, cf: &str) -> Vec<Request> {
-        let res: Vec<Request> = if cf == CF_DEFAULT {
-            self.default_reqs.drain().map(|(_, req)| req).collect()
+    fn drain_unpacked_reqs(&mut self, cf: &str) -> Vec<Modify> {
+        let res: Vec<Modify> = if cf == CF_DEFAULT {
+            self.default_reqs.drain().map(|(_, m)| m).collect()
         } else {
-            self.write_reqs.drain().map(|(_, (req, _))| req).collect()
+            self.write_reqs.drain().map(|(_, (m, _))| m).collect()
         };
         for r in &res {
-            self.unpacked_size -= r.get_cached_size() as usize;
+            self.unpacked_size -= r.size();
         }
         res
     }
 
     #[inline]
-    fn drain_raft_reqs(&mut self, take_unpacked: bool) -> std::vec::Drain<'_, RaftCmdRequest> {
+    fn drain_pending_writes(&mut self, take_unpacked: bool) -> std::vec::Drain<'_, WriteData> {
         if take_unpacked {
             self.pack_all();
         }
-        self.pending_raft_reqs.drain(..)
+        self.pending_writes.drain(..)
     }
 
     fn pack_all(&mut self) {
         if self.unpacked_size == 0 {
             return;
         }
-        let mut cmd = RaftCmdRequest::default();
-        let mut header = make_request_header(self.context.clone());
         // Set the UUID of header to prevent raftstore batching our requests.
         // The current `resolved_ts` observer assumes that each batch of request doesn't
         // has two writes to the same key. (Even with 2 different TS). That was true
         // for normal cases because the latches reject concurrency write to keys.
         // However we have bypassed the latch layer :(
-        header.set_uuid(uuid::Uuid::new_v4().as_bytes().to_vec());
-        cmd.set_header(header);
         let mut reqs: Vec<_> = self.write_reqs.drain().map(|(_, (req, _))| req).collect();
         reqs.append(&mut self.default_reqs.drain().map(|(_, req)| req).collect());
         if reqs.is_empty() {
             debug_assert!(false, "attempt to pack an empty request");
             return;
         }
-        cmd.set_requests(reqs.into());
-
-        self.pending_raft_reqs.push(cmd);
+        let mut data = WriteData::from_modifies(reqs);
+        data.set_avoid_batch(true);
+        self.pending_writes.push(data);
         self.unpacked_size = 0;
     }
 
     #[inline]
     fn is_empty(&self) -> bool {
-        self.pending_raft_reqs.is_empty() && self.unpacked_size == 0
+        self.pending_writes.is_empty() && self.unpacked_size == 0
     }
 }
 
-impl<E, Router> ImportSstService<E, Router>
-where
-    E: KvEngine,
-    Router: 'static + RaftStoreRouter<E>,
-{
+impl<E: Engine> ImportSstService<E> {
     pub fn new(
         cfg: Config,
         raft_entry_max_size: ReadableSize,
-        router: Router,
-        engine: E,
+        raftkv: E,
+        engine: E::Local,
         importer: Arc<SstImporter>,
-    ) -> ImportSstService<E, Router> {
+    ) -> Self {
         let props = tikv_util::thread_group::current_properties();
         let threads = tokio::runtime::Builder::new_multi_thread()
             .worker_threads(cfg.num_threads)
@@ -279,7 +274,7 @@ where
             engine,
             threads: Arc::new(threads),
             block_threads: Arc::new(block_threads),
-            router,
+            raftkv,
             importer,
             limiter: Limiter::new(f64::INFINITY),
             task_slots: Arc::new(Mutex::new(HashSet::default())),
@@ -306,36 +301,26 @@ where
         Ok(slots.remove(&p))
     }
 
-    async fn async_snapshot(
-        router: Router,
-        header: RaftRequestHeader,
-    ) -> std::result::Result<SnapshotResult<E>, errorpb::Error> {
-        let mut req = Request::default();
-        req.set_cmd_type(CmdType::Snap);
-        let mut cmd = RaftCmdRequest::default();
-        cmd.set_header(header);
-        cmd.set_requests(vec![req].into());
-        let (cb, future) = paired_future_callback();
-        if let Err(e) = router.send_command(cmd, Callback::read(cb), RaftCmdExtraOpts::default()) {
-            return Err(e.into());
+    fn async_snapshot(
+        raftkv: &mut E,
+        context: &Context,
+    ) -> impl Future<Output = std::result::Result<E::Snap, errorpb::Error>> {
+        let res = raftkv.async_snapshot(SnapContext {
+            pb_ctx: context,
+            ..Default::default()
+        });
+        async move {
+            res.await.map_err(|e| {
+                let err: storage::Error = e.into();
+                if let Some(e) = extract_region_error_from_error(&err) {
+                    e
+                } else {
+                    let mut e = errorpb::Error::default();
+                    e.set_message(format!("{}", err));
+                    e
+                }
+            })
         }
-        let mut res = future.await.map_err(|_| {
-            let mut err = errorpb::Error::default();
-            let err_str = "too many sst files are ingesting";
-            let mut server_is_busy_err = errorpb::ServerIsBusy::default();
-            server_is_busy_err.set_reason(err_str.to_string());
-            err.set_message(err_str.to_string());
-            err.set_server_is_busy(server_is_busy_err);
-            err
-        })?;
-        let mut header = res.response.take_header();
-        if header.has_error() {
-            return Err(header.take_error());
-        }
-        Ok(SnapshotResult {
-            snapshot: res.snapshot.unwrap(),
-            term: header.get_current_term(),
-        })
     }
 
     fn check_write_stall(&self) -> Option<errorpb::Error> {
@@ -368,14 +353,13 @@ where
     }
 
     fn ingest_files(
-        &self,
-        context: Context,
+        &mut self,
+        mut context: Context,
         label: &'static str,
         ssts: Vec<SstMeta>,
     ) -> impl Future<Output = Result<IngestResponse>> {
-        let header = make_request_header(context);
-        let snapshot_res = Self::async_snapshot(self.router.clone(), header.clone());
-        let router = self.router.clone();
+        let snapshot_res = Self::async_snapshot(&mut self.raftkv, &context);
+        let raftkv = self.raftkv.clone();
         let importer = self.importer.clone();
         async move {
             // check api version
@@ -394,17 +378,6 @@ where
             };
 
             fail_point!("import::sst_service::ingest");
-            // Make ingest command.
-            let mut cmd = RaftCmdRequest::default();
-            cmd.set_header(header);
-            cmd.mut_header().set_term(res.term);
-            for sst in ssts.iter() {
-                let mut ingest = Request::default();
-                ingest.set_cmd_type(CmdType::IngestSst);
-                ingest.mut_ingest_sst().set_sst(sst.clone());
-                cmd.mut_requests().push(ingest);
-            }
-
             // Here we shall check whether the file has been ingested before. This operation
             // must execute after geting a snapshot from raftstore to make sure that the
             // current leader has applied to current term.
@@ -423,20 +396,31 @@ where
                     return Ok(resp);
                 }
             }
+            let modifies = ssts
+                .iter()
+                .map(|s| Modify::Ingest(Box::new(s.clone())))
+                .collect();
+            context.set_term(res.ext().get_term().unwrap().into());
+            let region_id = context.get_region_id();
+            let res = raftkv.async_write(
+                &context,
+                WriteData::from_modifies(modifies),
+                WriteEvent::BASIC_EVENT,
+                None,
+            );
 
-            let (cb, future) = paired_future_callback();
-            if let Err(e) =
-                router.send_command(cmd, Callback::write(cb), RaftCmdExtraOpts::default())
-            {
-                resp.set_error(e.into());
-                return Ok(resp);
-            }
-
-            let mut res = future.await.map_err(Error::from)?;
-            let mut header = res.response.take_header();
-            if header.has_error() {
-                pb_error_inc(label, header.get_error());
-                resp.set_error(header.take_error());
+            let mut resp = IngestResponse::default();
+            if let Err(e) = wait_write(res).await {
+                if let Some(e) = extract_region_error_from_error(&e) {
+                    pb_error_inc(label, &e);
+                    resp.set_error(e);
+                } else {
+                    IMPORTER_ERROR_VEC
+                        .with_label_values(&[label, "unknown"])
+                        .inc();
+                    resp.mut_error()
+                        .set_message(format!("[region {}] ingest failed: {:?}", region_id, e));
+                }
             }
             Ok(resp)
         }
@@ -445,33 +429,14 @@ where
     async fn apply_imp(
         mut req: ApplyRequest,
         importer: Arc<SstImporter>,
-        router: Router,
+        raftkv: E,
         limiter: Limiter,
         max_raft_size: usize,
     ) -> std::result::Result<Option<Range>, ImportPbError> {
-        type RaftWriteFuture = futures::channel::oneshot::Receiver<raftstore::store::WriteResponse>;
-        async fn handle_raft_write(fut: RaftWriteFuture) -> std::result::Result<(), ImportPbError> {
-            match fut.await {
-                Err(e) => {
-                    let msg = format!("failed to complete raft command: {}", e);
-                    let mut e = ImportPbError::default();
-                    e.set_message(msg);
-                    return Err(e);
-                }
-                Ok(mut r) if r.response.get_header().has_error() => {
-                    let mut e = ImportPbError::default();
-                    e.set_message("failed to complete raft command".to_string());
-                    e.set_store_error(r.response.take_header().take_error());
-                    return Err(e);
-                }
-                _ => {}
-            }
-            Ok(())
-        }
-
         let mut range: Option<Range> = None;
 
-        let mut collector = RequestCollector::new(req.take_context(), max_raft_size * 7 / 8);
+        let mut collector = RequestCollector::new(max_raft_size * 7 / 8);
+        let context = req.take_context();
         let mut metas = req.take_metas();
         let mut rules = req.take_rewrite_rules();
         // For compatibility with old requests.
@@ -485,7 +450,7 @@ where
             false,
         );
 
-        let mut inflight_futures: VecDeque<RaftWriteFuture> = VecDeque::new();
+        let mut inflight_futures = VecDeque::new();
 
         let mut tasks = metas.iter().zip(rules.iter()).peekable();
         while let Some((meta, rule)) = tasks.next() {
@@ -513,25 +478,19 @@ where
             }
 
             let is_last_task = tasks.peek().is_none();
-            for req in collector.drain_raft_reqs(is_last_task) {
-                while inflight_futures.len() >= MAX_INFLIGHT_RAFT_MSGS {
-                    handle_raft_write(inflight_futures.pop_front().unwrap()).await?;
-                }
-                let (cb, future) = paired_future_callback();
-                match router.send_command(req, Callback::write(cb), RaftCmdExtraOpts::default()) {
-                    Ok(_) => inflight_futures.push_back(future),
-                    Err(e) => {
-                        let msg = format!("failed to send raft command: {}", e);
-                        let mut e = ImportPbError::default();
-                        e.set_message(msg);
-                        return Err(e);
-                    }
+            for req in collector.drain_pending_writes(is_last_task) {
+                let f = raftkv.async_write(&context, req, WriteEvent::BASIC_EVENT, None);
+                inflight_futures.push_back(f);
+                if inflight_futures.len() >= MAX_INFLIGHT_RAFT_MSGS {
+                    wait_write(inflight_futures.pop_front().unwrap())
+                        .await
+                        .map_err(transfer_error)?;
                 }
             }
         }
         assert!(collector.is_empty());
-        for fut in inflight_futures {
-            handle_raft_write(fut).await?;
+        for f in inflight_futures {
+            wait_write(f).await.map_err(transfer_error)?;
         }
 
         Ok(range)
@@ -600,11 +559,7 @@ macro_rules! impl_write {
     };
 }
 
-impl<E, Router> ImportSst for ImportSstService<E, Router>
-where
-    E: KvEngine,
-    Router: 'static + RaftStoreRouter<E>,
-{
+impl<E: Engine> ImportSst for ImportSstService<E> {
     fn switch_mode(
         &mut self,
         ctx: RpcContext<'_>,
@@ -721,7 +676,7 @@ where
         let label = "apply";
         let start = Instant::now();
         let importer = self.importer.clone();
-        let router = self.router.clone();
+        let raftkv = self.raftkv.clone();
         let limiter = self.limiter.clone();
         let max_raft_size = self.raft_entry_max_size.0 as usize;
 
@@ -733,7 +688,7 @@ where
 
             let mut resp = ApplyResponse::default();
 
-            match Self::apply_imp(req, importer, router, limiter, max_raft_size).await {
+            match Self::apply_imp(req, importer, raftkv, limiter, max_raft_size).await {
                 Ok(Some(r)) => resp.set_range(r),
                 Err(e) => resp.set_error(e),
                 _ => {}
@@ -775,7 +730,7 @@ where
                 .into_option()
                 .filter(|c| c.cipher_type != EncryptionMethod::Plaintext);
 
-            let res = importer.download_ext::<E>(
+            let res = importer.download_ext::<E::Local>(
                 req.get_sst(),
                 req.get_storage_backend(),
                 req.get_name(),
@@ -984,7 +939,6 @@ where
         let label = "duplicate_detect";
         let timer = Instant::now_coarse();
         let context = request.take_context();
-        let router = self.router.clone();
         let start_key = request.take_start_key();
         let min_commit_ts = request.get_min_commit_ts();
         let end_key = if request.get_end_key().is_empty() {
@@ -993,11 +947,11 @@ where
             Some(request.take_end_key())
         };
         let key_only = request.get_key_only();
-        let snap_res = Self::async_snapshot(router, make_request_header(context));
+        let snap_res = Self::async_snapshot(&mut self.raftkv, &context);
         let handle_task = async move {
             let res = snap_res.await;
             let snapshot = match res {
-                Ok(snap) => snap.snapshot,
+                Ok(snap) => snap,
                 Err(e) => {
                     let mut resp = DuplicateDetectResponse::default();
                     pb_error_inc(label, &e);
@@ -1078,25 +1032,6 @@ fn pb_error_inc(type_: &str, e: &errorpb::Error) {
     IMPORTER_ERROR_VEC.with_label_values(&[type_, label]).inc();
 }
 
-fn key_from_request(req: &Request) -> &[u8] {
-    if req.has_put() {
-        return req.get_put().get_key();
-    }
-    if req.has_delete() {
-        return req.get_delete().get_key();
-    }
-    panic!("trying to extract key from request is neither put nor delete.")
-}
-
-fn make_request_header(mut context: Context) -> RaftRequestHeader {
-    let region_id = context.get_region_id();
-    let mut header = RaftRequestHeader::default();
-    header.set_peer(context.take_peer());
-    header.set_region_id(region_id);
-    header.set_region_epoch(context.take_region_epoch());
-    header
-}
-
 fn write_needs_restore(write: &[u8]) -> bool {
     let w = WriteRef::parse(write);
     match w {
@@ -1127,10 +1062,10 @@ mod test {
     use std::collections::HashMap;
 
     use engine_traits::{CF_DEFAULT, CF_WRITE};
-    use kvproto::{kvrpcpb::Context, raft_cmdpb::*};
+    use tikv_kv::Modify;
     use txn_types::{Key, TimeStamp, Write, WriteType};
 
-    use crate::import::sst_service::{key_from_request, RequestCollector};
+    use crate::import::sst_service::RequestCollector;
 
     fn write(key: &[u8], ty: WriteType, commit_ts: u64, start_ts: u64) -> (Vec<u8>, Vec<u8>) {
         let k = Key::from_raw(key).append_ts(TimeStamp::new(commit_ts));
@@ -1143,45 +1078,18 @@ mod test {
         (k.into_encoded(), val.to_owned())
     }
 
-    fn default_req(key: &[u8], val: &[u8], start_ts: u64) -> Request {
+    fn default_req(key: &[u8], val: &[u8], start_ts: u64) -> Modify {
         let (k, v) = default(key, val, start_ts);
-        req(k, v, CF_DEFAULT, CmdType::Put)
+        Modify::Put(CF_DEFAULT, Key::from_encoded(k), v)
     }
 
-    fn write_req(key: &[u8], ty: WriteType, commit_ts: u64, start_ts: u64) -> Request {
+    fn write_req(key: &[u8], ty: WriteType, commit_ts: u64, start_ts: u64) -> Modify {
         let (k, v) = write(key, ty, commit_ts, start_ts);
-        let cmd_type = if ty == WriteType::Delete {
-            CmdType::Delete
+        if ty == WriteType::Delete {
+            Modify::Delete(CF_WRITE, Key::from_encoded(k))
         } else {
-            CmdType::Put
-        };
-
-        req(k, v, CF_WRITE, cmd_type)
-    }
-
-    fn req(k: Vec<u8>, v: Vec<u8>, cf: &str, cmd_type: CmdType) -> Request {
-        let mut req = Request::default();
-        req.set_cmd_type(cmd_type);
-
-        match cmd_type {
-            CmdType::Put => {
-                let mut put = PutRequest::default();
-                put.set_key(k);
-                put.set_value(v);
-                put.set_cf(cf.to_string());
-
-                req.set_put(put)
-            }
-            CmdType::Delete => {
-                let mut del = DeleteRequest::default();
-                del.set_cf(cf.to_string());
-                del.set_key(k);
-
-                req.set_delete(del);
-            }
-            _ => panic!("invalid input cmd_type"),
+            Modify::Put(CF_WRITE, Key::from_encoded(k), v)
         }
-        req
     }
 
     #[test]
@@ -1191,27 +1099,30 @@ mod test {
             cf: &'static str,
             is_delete: bool,
             mutations: Vec<(Vec<u8>, Vec<u8>)>,
-            expected_reqs: Vec<Request>,
+            expected_reqs: Vec<Modify>,
         }
 
         fn run_case(c: &Case) {
-            let mut collector = RequestCollector::new(Context::new(), 1024);
+            let mut collector = RequestCollector::new(1024);
 
             for (k, v) in c.mutations.clone() {
                 collector.accept_kv(c.cf, c.is_delete, k, v);
             }
-            let reqs = collector.drain_raft_reqs(true);
+            let reqs = collector.drain_pending_writes(true);
 
             let mut req1: HashMap<_, _> = reqs
                 .into_iter()
-                .flat_map(|mut x| x.take_requests().into_iter())
+                .flat_map(|x| {
+                    assert!(x.avoid_batch);
+                    x.modifies.into_iter()
+                })
                 .map(|req| {
-                    let key = key_from_request(&req).to_owned();
+                    let key = req.key().to_owned();
                     (key, req)
                 })
                 .collect();
             for req in c.expected_reqs.iter() {
-                let r = req1.remove(key_from_request(req));
+                let r = req1.remove(req.key());
                 assert_eq!(r.as_ref(), Some(req), "{:?}", c);
             }
             assert!(req1.is_empty(), "{:?}\ncase = {:?}", req1, c);
@@ -1284,7 +1195,7 @@ mod test {
 
     #[test]
     fn test_request_collector_with_write_cf() {
-        let mut request_collector = RequestCollector::new(Context::new(), 102400);
+        let mut request_collector = RequestCollector::new(102400);
         let reqs = vec![
             write_req(b"foo", WriteType::Put, 40, 39),
             write_req(b"aar", WriteType::Put, 38, 37),
@@ -1301,18 +1212,14 @@ mod test {
             request_collector.accept(CF_WRITE, req);
         }
         let mut reqs: Vec<_> = request_collector.drain_unpacked_reqs(CF_WRITE);
-        reqs.sort_by(|r1, r2| {
-            let k1 = key_from_request(r1);
-            let k2 = key_from_request(r2);
-            k1.cmp(k2)
-        });
+        reqs.sort_by(|r1, r2| r1.key().cmp(r2.key()));
         assert_eq!(reqs, reqs_result);
         assert!(request_collector.is_empty());
     }
 
     #[test]
     fn test_request_collector_with_default_cf() {
-        let mut request_collector = RequestCollector::new(Context::new(), 102400);
+        let mut request_collector = RequestCollector::new(102400);
         let reqs = vec![
             default_req(b"foo", b"", 39),
             default_req(b"zzz", b"", 40),
@@ -1330,10 +1237,8 @@ mod test {
         }
         let mut reqs: Vec<_> = request_collector.drain_unpacked_reqs(CF_DEFAULT);
         reqs.sort_by(|r1, r2| {
-            let k1 = key_from_request(r1);
-            let (k1, ts1) = Key::split_on_ts_for(k1).unwrap();
-            let k2 = key_from_request(r2);
-            let (k2, ts2) = Key::split_on_ts_for(k2).unwrap();
+            let (k1, ts1) = Key::split_on_ts_for(r1.key().as_encoded()).unwrap();
+            let (k2, ts2) = Key::split_on_ts_for(r2.key().as_encoded()).unwrap();
 
             k1.cmp(k2).then(ts1.cmp(&ts2))
         });

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -1361,6 +1361,7 @@ pub mod test_gc_worker {
                         let bytes = keys::data_end_key(key2.as_encoded());
                         *key2 = Key::from_encoded(bytes);
                     }
+                    Modify::Ingest(_) => unimplemented!(),
                 }
             }
             write_modifies(&self.kv_engine().unwrap(), modifies)
@@ -1388,6 +1389,7 @@ pub mod test_gc_worker {
                     *start_key = Key::from_encoded(keys::data_key(start_key.as_encoded()));
                     *end_key = Key::from_encoded(keys::data_end_key(end_key.as_encoded()));
                 }
+                Modify::Ingest(_) => unimplemented!(),
             });
             self.0.async_write(ctx, batch, subscribed, on_applied)
         }

--- a/src/server/raftkv/mod.rs
+++ b/src/server/raftkv/mod.rs
@@ -393,6 +393,9 @@ where
                         let bytes = keys::data_end_key(key2.as_encoded());
                         *key2 = Key::from_encoded(bytes);
                     }
+                    Modify::Ingest(_) => {
+                        return Err(box_err!("ingest sst is not supported in local engine"));
+                    }
                 }
             }
         }
@@ -449,6 +452,9 @@ where
         let reqs: Vec<Request> = batch.modifies.into_iter().map(Into::into).collect();
         let txn_extra = batch.extra;
         let mut header = new_request_header(ctx);
+        if batch.avoid_batch {
+            header.set_uuid(uuid::Uuid::new_v4().as_bytes().to_vec());
+        }
         let mut flags = 0;
         if txn_extra.one_pc {
             flags |= WriteBatchFlags::ONE_PC.bits();

--- a/src/server/raftkv2/mod.rs
+++ b/src/server/raftkv2/mod.rs
@@ -69,6 +69,8 @@ impl Stream for Transform {
 
 fn modifies_to_simple_write(modifies: Vec<Modify>) -> SimpleWriteBinary {
     let mut encoder = SimpleWriteEncoder::with_capacity(128);
+    let modifies_len = modifies.len();
+    let mut ssts = vec![];
     for m in modifies {
         match m {
             Modify::Put(cf, k, v) => encoder.put(cf, k.as_encoded(), &v),
@@ -82,7 +84,16 @@ fn modifies_to_simple_write(modifies: Vec<Modify>) -> SimpleWriteBinary {
                 end_key.as_encoded(),
                 notify_only,
             ),
+            Modify::Ingest(sst) => {
+                if ssts.capacity() == 0 {
+                    ssts.reserve(modifies_len);
+                }
+                ssts.push(*sst);
+            }
         }
+    }
+    if !ssts.is_empty() {
+        encoder.ingest(ssts);
     }
     encoder.encode()
 }
@@ -228,7 +239,10 @@ impl<EK: KvEngine, ER: RaftEngine> tikv_kv::Engine for RaftKv2<EK, ER> {
         header.set_flags(flags);
 
         self.schedule_txn_extra(batch.extra);
-        let data = modifies_to_simple_write(batch.modifies);
+        let mut data = modifies_to_simple_write(batch.modifies);
+        if batch.avoid_batch {
+            data.freeze();
+        }
         let mut builder = CmdResChannelBuilder::default();
         if WriteEvent::subscribed_proposed(subscribed) {
             builder.subscribe_proposed();

--- a/src/server/raftkv2/node.rs
+++ b/src/server/raftkv2/node.rs
@@ -17,6 +17,7 @@ use raftstore::{
 use raftstore_v2::{router::RaftRouter, Bootstrap, PdTask, StoreRouter, StoreSystem};
 use resource_metering::CollectorRegHandle;
 use slog::{info, o, Logger};
+use sst_importer::SstImporter;
 use tikv_util::{
     config::VersionTrack,
     worker::{LazyWorker, Worker},
@@ -102,6 +103,7 @@ where
         pd_worker: LazyWorker<PdTask>,
         store_cfg: Arc<VersionTrack<raftstore_v2::Config>>,
         state: &Mutex<GlobalReplicationState>,
+        sst_importer: Arc<SstImporter>,
     ) -> Result<()>
     where
         T: Transport + 'static,
@@ -140,6 +142,7 @@ where
             background,
             pd_worker,
             store_cfg,
+            sst_importer,
         )?;
 
         Ok(())
@@ -201,6 +204,7 @@ where
         background: Worker,
         pd_worker: LazyWorker<PdTask>,
         store_cfg: Arc<VersionTrack<raftstore_v2::Config>>,
+        sst_importer: Arc<SstImporter>,
     ) -> Result<()>
     where
         T: Transport + 'static,
@@ -232,6 +236,7 @@ where
             collector_reg_handle,
             background,
             pd_worker,
+            sst_importer,
         )?;
         Ok(())
     }

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -1015,6 +1015,7 @@ pub mod tests {
                             wb.delete_range_cf(cf, &k1, &k2).unwrap();
                         }
                     }
+                    Modify::Ingest(_) => unimplemented!(),
                 }
             }
             wb.write().unwrap();

--- a/tests/integrations/server/kv_service.rs
+++ b/tests/integrations/server/kv_service.rs
@@ -1207,7 +1207,7 @@ fn test_double_run_node() {
     let snap_mgr = SnapManager::new(tmp.path().to_str().unwrap());
     let coprocessor_host = CoprocessorHost::new(router, raftstore::coprocessor::Config::default());
     let importer = {
-        let dir = Path::new(engines.kv.path()).join("import-sst");
+        let dir = Path::new(MiscExt::path(&engines.kv)).join("import-sst");
         Arc::new(SstImporter::new(&ImportConfig::default(), dir, None, ApiVersion::V1).unwrap())
     };
     let (split_check_scheduler, _) = dummy_scheduler();


### PR DESCRIPTION
### What is changed and how it works?
Issue Number: Ref #12842 

What's Changed:

```commit-message
So that it can support both v1 and v2.
```

To make it work with V2, we still need to use tablet registry.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
