### PR TITLE
importer: support raftstore v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2733,7 +2733,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#0561adc3754362675cc08b5203d8b6444e645395"
+source = "git+https://github.com/busyjay/kvproto?branch=add-missing-region-id#70c6e44471ff3ffb63199c15595a8a407252d118"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2733,7 +2733,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/busyjay/kvproto?branch=add-missing-region-id#70c6e44471ff3ffb63199c15595a8a407252d118"
+source = "git+https://github.com/pingcap/kvproto.git#02fc19e8abc41245e286d4a70f23e5139e3a33fe"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,8 +226,6 @@ procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "6599eb9dca74229
 # After the PR to kvproto is merged, remember to comment this out and run `cargo update -p kvproto`.
 # [patch.'https://github.com/pingcap/kvproto']
 # kvproto = { git = "https://github.com/your_github_id/kvproto", branch = "your_branch" }
-[patch.'https://github.com/pingcap/kvproto']
-kvproto = { git = "https://github.com/busyjay/kvproto", branch = "add-missing-region-id" }
 
 [workspace]
 # See https://github.com/rust-lang/rfcs/blob/master/text/2957-cargo-features2.md

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,6 +225,8 @@ procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "6599eb9dca74229
 # After the PR to kvproto is merged, remember to comment this out and run `cargo update -p kvproto`.
 # [patch.'https://github.com/pingcap/kvproto']
 # kvproto = { git = "https://github.com/your_github_id/kvproto", branch = "your_branch" }
+[patch.'https://github.com/pingcap/kvproto']
+kvproto = { git = "https://github.com/busyjay/kvproto", branch = "add-missing-region-id" }
 
 [workspace]
 # See https://github.com/rust-lang/rfcs/blob/master/text/2957-cargo-features2.md

--- a/components/raftstore-v2/src/batch/store.rs
+++ b/components/raftstore-v2/src/batch/store.rs
@@ -610,7 +610,11 @@ impl<EK: KvEngine, ER: RaftEngine> StoreSystem<EK, ER> {
 
         let tablet_gc_scheduler = workers.tablet_gc.start_with_timer(
             "tablet-gc-worker",
-            tablet_gc::Runner::new(tablet_registry.clone(), self.logger.clone()),
+            tablet_gc::Runner::new(
+                tablet_registry.clone(),
+                sst_importer.clone(),
+                self.logger.clone(),
+            ),
         );
 
         let schedulers = Schedulers {

--- a/components/raftstore-v2/src/fsm/peer.rs
+++ b/components/raftstore-v2/src/fsm/peer.rs
@@ -326,6 +326,10 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> PeerFsmDelegate<'a, EK, ER,
                 PeerMsg::TabletTrimmed { tablet_index } => {
                     self.fsm.peer_mut().on_tablet_trimmed(tablet_index)
                 }
+                PeerMsg::CleanupImportSst(ssts) => self
+                    .fsm
+                    .peer_mut()
+                    .on_cleanup_import_sst(self.store_ctx, ssts),
                 #[cfg(feature = "testexport")]
                 PeerMsg::WaitFlush(ch) => self.fsm.peer_mut().on_wait_flush(ch),
             }

--- a/components/raftstore-v2/src/fsm/store.rs
+++ b/components/raftstore-v2/src/fsm/store.rs
@@ -230,6 +230,10 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T> StoreFsmDelegate<'a, EK, ER, T> {
         );
 
         self.on_pd_store_heartbeat();
+        self.schedule_tick(
+            StoreTick::CleanupImportSst,
+            self.store_ctx.cfg.cleanup_import_sst_interval.0,
+        );
     }
 
     pub fn schedule_tick(&mut self, tick: StoreTick, timeout: Duration) {
@@ -253,6 +257,7 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T> StoreFsmDelegate<'a, EK, ER, T> {
     fn on_tick(&mut self, tick: StoreTick) {
         match tick {
             StoreTick::PdStoreHeartbeat => self.on_pd_store_heartbeat(),
+            StoreTick::CleanupImportSst => self.on_cleanup_import_sst(),
             _ => unimplemented!(),
         }
     }

--- a/components/raftstore-v2/src/operation/command/write/ingest.rs
+++ b/components/raftstore-v2/src/operation/command/write/ingest.rs
@@ -70,6 +70,9 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         let epoch = self.region().get_region_epoch();
         let mut stale_ssts = Vec::from(ssts);
         stale_ssts.retain(|sst| util::is_epoch_stale(sst.get_region_epoch(), epoch));
+        if stale_ssts.is_empty() {
+            return;
+        }
         let _ = ctx
             .schedulers
             .tablet_gc

--- a/components/raftstore-v2/src/operation/command/write/ingest.rs
+++ b/components/raftstore-v2/src/operation/command/write/ingest.rs
@@ -1,0 +1,123 @@
+// Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
+
+use collections::HashMap;
+use crossbeam::channel::TrySendError;
+use engine_traits::{KvEngine, RaftEngine};
+use kvproto::import_sstpb::SstMeta;
+use raftstore::{
+    store::{check_sst_for_ingestion, metrics::PEER_WRITE_CMD_COUNTER, util},
+    Result,
+};
+use slog::error;
+use tikv_util::{box_try, slog_panic};
+
+use crate::{
+    batch::StoreContext,
+    fsm::{ApplyResReporter, Store, StoreFsmDelegate},
+    raft::{Apply, Peer},
+    router::{PeerMsg, StoreTick},
+    worker::tablet_gc,
+};
+
+impl<'a, EK: KvEngine, ER: RaftEngine, T> StoreFsmDelegate<'a, EK, ER, T> {
+    #[inline]
+    pub fn on_cleanup_import_sst(&mut self) {
+        if let Err(e) = self.fsm.store.on_cleanup_import_sst(self.store_ctx) {
+            error!(self.fsm.store.logger(), "cleanup import sst failed"; "error" => ?e);
+        }
+        self.schedule_tick(
+            StoreTick::CleanupImportSst,
+            self.store_ctx.cfg.cleanup_import_sst_interval.0,
+        );
+    }
+}
+
+impl Store {
+    #[inline]
+    fn on_cleanup_import_sst<EK: KvEngine, ER: RaftEngine, T>(
+        &mut self,
+        ctx: &mut StoreContext<EK, ER, T>,
+    ) -> Result<()> {
+        let ssts = box_try!(ctx.sst_importer.list_ssts());
+        if ssts.is_empty() {
+            return Ok(());
+        }
+        let mut region_ssts: HashMap<_, Vec<_>> = HashMap::default();
+        for sst in ssts {
+            region_ssts
+                .entry(sst.get_region_id())
+                .or_default()
+                .push(sst);
+        }
+        for (region_id, ssts) in region_ssts {
+            if let Err(TrySendError::Disconnected(msg)) = ctx.router.send(region_id, PeerMsg::CleanupImportSst(ssts.into()))
+                && !ctx.router.is_shutdown() {
+                let PeerMsg::CleanupImportSst(ssts) = msg else { unreachable!() };
+                let _ = ctx.schedulers.tablet_gc.schedule(tablet_gc::Task::CleanupImportSst(ssts));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
+    pub fn on_cleanup_import_sst<T>(
+        &mut self,
+        ctx: &mut StoreContext<EK, ER, T>,
+        ssts: Box<[SstMeta]>,
+    ) {
+        let epoch = self.region().get_region_epoch();
+        let stale_cnt = ssts
+            .iter()
+            .filter(|sst| util::is_epoch_stale(sst.get_region_epoch(), epoch))
+            .count();
+        if stale_cnt == 0 {
+            return;
+        }
+        let stale_ssts = if stale_cnt == ssts.len() {
+            ssts
+        } else {
+            let mut ssts = Vec::from(ssts);
+            ssts.retain(|sst| util::is_epoch_stale(sst.get_region_epoch(), epoch));
+            ssts.into_boxed_slice()
+        };
+        let _ = ctx
+            .schedulers
+            .tablet_gc
+            .schedule(tablet_gc::Task::CleanupImportSst(stale_ssts));
+    }
+}
+
+impl<EK: KvEngine, R: ApplyResReporter> Apply<EK, R> {
+    #[inline]
+    pub fn apply_ingest(&mut self, ssts: Vec<SstMeta>) -> Result<()> {
+        PEER_WRITE_CMD_COUNTER.ingest_sst.inc();
+        let mut infos = Vec::with_capacity(ssts.len());
+        for sst in &ssts {
+            if let Err(e) = check_sst_for_ingestion(sst, self.region()) {
+                error!(
+                    self.logger,
+                    "ingest fail";
+                    "sst" => ?sst,
+                    "region" => ?self.region(),
+                    "error" => ?e
+                );
+                let _ = self.sst_importer().delete(sst);
+                return Err(e);
+            }
+            match self.sst_importer().validate(sst) {
+                Ok(meta_info) => infos.push(meta_info),
+                Err(e) => {
+                    slog_panic!(self.logger, "corrupted sst"; "sst" => ?sst, "error" => ?e);
+                }
+            }
+        }
+        // Unlike v1, we can't batch ssts accross regions.
+        self.flush();
+        if let Err(e) = self.sst_importer().ingest(&infos, self.tablet()) {
+            slog_panic!(self.logger, "ingest fail"; "ssts" => ?ssts, "error" => ?e);
+        }
+        Ok(())
+    }
+}

--- a/components/raftstore-v2/src/operation/command/write/ingest.rs
+++ b/components/raftstore-v2/src/operation/command/write/ingest.rs
@@ -75,17 +75,12 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         if stale_cnt == 0 {
             return;
         }
-        let stale_ssts = if stale_cnt == ssts.len() {
-            ssts
-        } else {
-            let mut ssts = Vec::from(ssts);
-            ssts.retain(|sst| util::is_epoch_stale(sst.get_region_epoch(), epoch));
-            ssts.into_boxed_slice()
-        };
+        let mut stale_ssts = Vec::from(ssts);
+        stale_ssts.retain(|sst| util::is_epoch_stale(sst.get_region_epoch(), epoch));
         let _ = ctx
             .schedulers
             .tablet_gc
-            .schedule(tablet_gc::Task::CleanupImportSst(stale_ssts));
+            .schedule(tablet_gc::Task::CleanupImportSst(stale_ssts.into()));
     }
 }
 

--- a/components/raftstore-v2/src/operation/command/write/ingest.rs
+++ b/components/raftstore-v2/src/operation/command/write/ingest.rs
@@ -68,13 +68,6 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         ssts: Box<[SstMeta]>,
     ) {
         let epoch = self.region().get_region_epoch();
-        let stale_cnt = ssts
-            .iter()
-            .filter(|sst| util::is_epoch_stale(sst.get_region_epoch(), epoch))
-            .count();
-        if stale_cnt == 0 {
-            return;
-        }
         let mut stale_ssts = Vec::from(ssts);
         stale_ssts.retain(|sst| util::is_epoch_stale(sst.get_region_epoch(), epoch));
         let _ = ctx

--- a/components/raftstore-v2/src/operation/command/write/mod.rs
+++ b/components/raftstore-v2/src/operation/command/write/mod.rs
@@ -1,10 +1,10 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
 use engine_traits::{data_cf_offset, KvEngine, Mutable, RaftEngine, CF_DEFAULT};
-use kvproto::{import_sstpb::SstMeta, raft_cmdpb::RaftRequestHeader};
+use kvproto::raft_cmdpb::RaftRequestHeader;
 use raftstore::{
     store::{
-        check_sst_for_ingestion, cmd_resp,
+        cmd_resp,
         fsm::{apply, MAX_PROPOSAL_SIZE_RATIO},
         metrics::PEER_WRITE_CMD_COUNTER,
         msg::ErrorCallback,
@@ -12,7 +12,6 @@ use raftstore::{
     },
     Error, Result,
 };
-use slog::error;
 use tikv_util::slog_panic;
 
 use crate::{
@@ -22,6 +21,7 @@ use crate::{
     router::{ApplyTask, CmdResChannel},
 };
 
+mod ingest;
 mod simple_write;
 
 pub use simple_write::{
@@ -231,37 +231,6 @@ impl<EK: KvEngine, R: ApplyResReporter> Apply<EK, R> {
         _notify_only: bool,
     ) -> Result<()> {
         // TODO: reuse the same delete as split/merge.
-        Ok(())
-    }
-
-    #[inline]
-    pub fn apply_ingest(&mut self, ssts: Vec<SstMeta>) -> Result<()> {
-        PEER_WRITE_CMD_COUNTER.ingest_sst.inc();
-        let mut infos = Vec::with_capacity(ssts.len());
-        for sst in &ssts {
-            if let Err(e) = check_sst_for_ingestion(sst, self.region()) {
-                error!(
-                    self.logger,
-                    "ingest fail";
-                    "sst" => ?sst,
-                    "region" => ?self.region(),
-                    "error" => ?e
-                );
-                let _ = self.sst_importer().delete(sst);
-                return Err(e);
-            }
-            match self.sst_importer().validate(sst) {
-                Ok(meta_info) => infos.push(meta_info),
-                Err(e) => {
-                    slog_panic!(self.logger, "corrupted sst"; "sst" => ?sst, "error" => ?e);
-                }
-            }
-        }
-        // Unlike v1, we can't batch ssts accross regions.
-        self.flush();
-        if let Err(e) = self.sst_importer().ingest(&infos, self.tablet()) {
-            slog_panic!(self.logger, "ingest fail"; "ssts" => ?ssts, "error" => ?e);
-        }
         Ok(())
     }
 }

--- a/components/raftstore-v2/src/router/message.rs
+++ b/components/raftstore-v2/src/router/message.rs
@@ -3,6 +3,7 @@
 // #[PerformanceCriticalPath]
 
 use kvproto::{
+    import_sstpb::SstMeta,
     metapb,
     metapb::RegionEpoch,
     raft_cmdpb::{RaftCmdRequest, RaftRequestHeader},
@@ -206,6 +207,7 @@ pub enum PeerMsg {
     TabletTrimmed {
         tablet_index: u64,
     },
+    CleanupImportSst(Box<[SstMeta]>),
     /// A message that used to check if a flush is happened.
     #[cfg(feature = "testexport")]
     WaitFlush(super::FlushChannel),

--- a/components/raftstore-v2/src/worker/tablet_gc.rs
+++ b/components/raftstore-v2/src/worker/tablet_gc.rs
@@ -3,13 +3,15 @@
 use std::{
     fmt::{self, Display, Formatter},
     path::{Path, PathBuf},
+    sync::Arc,
     time::Duration,
 };
 
 use collections::HashMap;
 use engine_traits::{DeleteStrategy, KvEngine, Range, TabletContext, TabletRegistry};
-use kvproto::metapb::Region;
+use kvproto::{import_sstpb::SstMeta, metapb::Region};
 use slog::{debug, error, info, warn, Logger};
+use sst_importer::SstImporter;
 use tikv_util::{
     worker::{Runnable, RunnableWithTimer},
     yatp_pool::{DefaultTicker, FuturePool, YatpPoolBuilder},
@@ -37,6 +39,8 @@ pub enum Task<EK> {
     },
     /// Sometimes we know for sure a tablet can be destroyed directly.
     DirectDestroy { tablet: Either<EK, PathBuf> },
+    /// Cleanup ssts.
+    CleanupImportSst(Box<[SstMeta]>),
 }
 
 impl<EK> Display for Task<EK> {
@@ -69,6 +73,9 @@ impl<EK> Display for Task<EK> {
             ),
             Task::DirectDestroy { .. } => {
                 write!(f, "direct destroy tablet")
+            }
+            Task::CleanupImportSst(ssts) => {
+                write!(f, "cleanup import ssts {:?}", ssts)
             }
         }
     }
@@ -128,6 +135,7 @@ impl<EK> Task<EK> {
 
 pub struct Runner<EK: KvEngine> {
     tablet_registry: TabletRegistry<EK>,
+    sst_importer: Arc<SstImporter>,
     logger: Logger,
 
     // region_id -> [(tablet_path, wait_for_persisted)].
@@ -140,9 +148,14 @@ pub struct Runner<EK: KvEngine> {
 }
 
 impl<EK: KvEngine> Runner<EK> {
-    pub fn new(tablet_registry: TabletRegistry<EK>, logger: Logger) -> Self {
+    pub fn new(
+        tablet_registry: TabletRegistry<EK>,
+        sst_importer: Arc<SstImporter>,
+        logger: Logger,
+    ) -> Self {
         Self {
             tablet_registry,
+            sst_importer,
             logger,
             waiting_destroy_tasks: HashMap::default(),
             pending_destroy_tasks: Vec::new(),
@@ -295,6 +308,14 @@ impl<EK: KvEngine> Runner<EK> {
         }
         false
     }
+
+    fn cleanup_ssts(&self, ssts: Box<[SstMeta]>) {
+        for sst in Vec::from(ssts) {
+            if let Err(e) = self.sst_importer.delete(&sst) {
+                info!(self.logger, "failed to cleanup sst"; "err" => ?e);
+            }
+        }
+    }
 }
 
 impl<EK> Runnable for Runner<EK>
@@ -321,6 +342,7 @@ where
                 persisted_index,
             } => self.destroy(region_id, persisted_index),
             Task::DirectDestroy { tablet, .. } => self.direct_destroy(tablet),
+            Task::CleanupImportSst(ssts) => self.cleanup_ssts(ssts),
         }
     }
 }
@@ -349,6 +371,7 @@ mod tests {
     use tempfile::Builder;
 
     use super::*;
+    use crate::operation::test_util::create_tmp_importer;
 
     #[test]
     fn test_race_between_destroy_and_trim() {
@@ -362,7 +385,8 @@ mod tests {
         ));
         let registry = TabletRegistry::new(factory, dir.path()).unwrap();
         let logger = slog_global::borrow_global().new(slog::o!());
-        let mut runner = Runner::new(registry.clone(), logger);
+        let (_dir, importer) = create_tmp_importer();
+        let mut runner = Runner::new(registry.clone(), importer, logger);
 
         let mut region = Region::default();
         let rid = 1;

--- a/components/raftstore-v2/src/worker/tablet_gc.rs
+++ b/components/raftstore-v2/src/worker/tablet_gc.rs
@@ -312,7 +312,7 @@ impl<EK: KvEngine> Runner<EK> {
     fn cleanup_ssts(&self, ssts: Box<[SstMeta]>) {
         for sst in Vec::from(ssts) {
             if let Err(e) = self.sst_importer.delete(&sst) {
-                info!(self.logger, "failed to cleanup sst"; "err" => ?e);
+                warn!(self.logger, "failed to cleanup sst"; "err" => ?e, "sst" => ?sst);
             }
         }
     }

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -91,7 +91,7 @@ use tikv::{
     config::{ConfigController, DbConfigManger, DbType, LogConfigManager, TikvConfig},
     coprocessor::{self, MEMTRACE_ROOT as MEMTRACE_COPROCESSOR},
     coprocessor_v2,
-    import::{ImportSstService, SstImporter},
+    import::{ImportSstService, LocalTablets, SstImporter},
     read_pool::{
         build_yatp_read_pool, ReadPool, ReadPoolConfigManager, UPDATE_EWMA_TIME_SLICE_INTERVAL,
     },
@@ -1246,7 +1246,7 @@ where
             self.config.import.clone(),
             self.config.raft_store.raft_entry_max_size,
             engines.engine.clone(),
-            engines.engines.kv.clone(),
+            LocalTablets::Singleton(engines.engines.kv.clone()),
             servers.importer.clone(),
         );
         if servers

--- a/components/server/src/server2.rs
+++ b/components/server/src/server2.rs
@@ -48,7 +48,8 @@ use futures::executor::block_on;
 use grpcio::{EnvBuilder, Environment};
 use grpcio_health::HealthService;
 use kvproto::{
-    deadlock::create_deadlock, diagnosticspb::create_diagnostics, kvrpcpb::ApiVersion,
+    deadlock::create_deadlock, diagnosticspb::create_diagnostics,
+    import_sstpb_grpc::create_import_sst, kvrpcpb::ApiVersion,
     resource_usage_agent::create_resource_metering_pub_sub,
 };
 use pd_client::{PdClient, RpcClient};
@@ -73,7 +74,7 @@ use tikv::{
     config::{ConfigController, DbConfigManger, DbType, LogConfigManager, TikvConfig},
     coprocessor::{self, MEMTRACE_ROOT as MEMTRACE_COPROCESSOR},
     coprocessor_v2,
-    import::SstImporter,
+    import::{ImportSstService, LocalTablets, SstImporter},
     read_pool::{
         build_yatp_read_pool, ReadPool, ReadPoolConfigManager, UPDATE_EWMA_TIME_SLICE_INTERVAL,
     },
@@ -244,7 +245,7 @@ struct TikvEngines<EK: KvEngine, ER: RaftEngine> {
 struct Servers<EK: KvEngine, ER: RaftEngine> {
     lock_mgr: LockManager,
     server: LocalServer<EK, ER>,
-    _importer: Arc<SstImporter>,
+    importer: Arc<SstImporter>,
     rsmeter_pubsub_service: resource_metering::PubSubService,
 }
 
@@ -969,7 +970,7 @@ where
         self.servers = Some(Servers {
             lock_mgr,
             server,
-            _importer: importer,
+            importer,
             rsmeter_pubsub_service,
         });
 
@@ -978,23 +979,23 @@ where
 
     fn register_services(&mut self) {
         let servers = self.servers.as_mut().unwrap();
-        let _engines = self.engines.as_ref().unwrap();
+        let engines = self.engines.as_ref().unwrap();
 
         // Import SST service.
-        // let import_service = ImportSstService::new(
-        // self.config.import.clone(),
-        // self.config.raft_store.raft_entry_max_size,
-        // engines.engine.clone(),
-        // self.tablet_registry.as_ref().unwrap().clone(),
-        // servers.importer.clone(),
-        // );
-        // if servers
-        // .server
-        // .register_service(create_import_sst(import_service))
-        // .is_some()
-        // {
-        // fatal!("failed to register import service");
-        // }
+        let import_service = ImportSstService::new(
+            self.config.import.clone(),
+            self.config.raft_store.raft_entry_max_size,
+            engines.engine.clone(),
+            LocalTablets::Registry(self.tablet_registry.as_ref().unwrap().clone()),
+            servers.importer.clone(),
+        );
+        if servers
+            .server
+            .register_service(create_import_sst(import_service))
+            .is_some()
+        {
+            fatal!("failed to register import service");
+        }
 
         // Create Diagnostics service
         let diag_service = DiagnosticsService::new(

--- a/components/test_raftstore-v2/src/server.rs
+++ b/components/test_raftstore-v2/src/server.rs
@@ -22,6 +22,7 @@ use kvproto::{
     deadlock_grpc::create_deadlock,
     debugpb_grpc::DebugClient,
     diagnosticspb_grpc::create_diagnostics,
+    import_sstpb_grpc::create_import_sst,
     kvrpcpb::{ApiVersion, Context},
     metapb,
     raft_cmdpb::RaftCmdResponse,
@@ -47,7 +48,7 @@ use test_pd_client::TestPdClient;
 use test_raftstore::{AddressMap, Config};
 use tikv::{
     coprocessor, coprocessor_v2,
-    import::SstImporter,
+    import::{ImportSstService, LocalTablets, SstImporter},
     read_pool::ReadPool,
     server::{
         gc_worker::GcWorker, load_statistics::ThreadLoadPool, lock_manager::LockManager,
@@ -317,7 +318,7 @@ impl ServerCluster {
                 .as_ref()
                 .map(|m| m.derive_controller("scheduler-worker-pool".to_owned(), true)),
         )?;
-        self.storages.insert(node_id, raft_kv_v2);
+        self.storages.insert(node_id, raft_kv_v2.clone());
 
         ReplicaReadLockChecker::new(concurrency_manager.clone()).register(&mut coprocessor_host);
 
@@ -328,13 +329,13 @@ impl ServerCluster {
                 SstImporter::new(&cfg.import, dir, key_manager, cfg.storage.api_version()).unwrap(),
             )
         };
-        // let import_service = ImportSstService::new(
-        // cfg.import.clone(),
-        // cfg.raft_store.raft_entry_max_size,
-        // raft_kv_2.clone(),
-        // tablet_registry.clone(),
-        // Arc::clone(&importer),
-        // );
+        let import_service = ImportSstService::new(
+            cfg.import.clone(),
+            cfg.raft_store.raft_entry_max_size,
+            raft_kv_v2,
+            LocalTablets::Registry(tablet_registry.clone()),
+            Arc::clone(&importer),
+        );
 
         // Create deadlock service.
         let deadlock_service = lock_mgr.deadlock_service();
@@ -399,7 +400,7 @@ impl ServerCluster {
             .unwrap();
             svr.register_service(create_diagnostics(diag_service.clone()));
             svr.register_service(create_deadlock(deadlock_service.clone()));
-            // svr.register_service(create_import_sst(import_service.clone()));
+            svr.register_service(create_import_sst(import_service.clone()));
             if let Some(svcs) = self.pending_services.get(&node_id) {
                 for fact in svcs {
                     svr.register_service(fact());

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -50,7 +50,7 @@ use test_pd_client::TestPdClient;
 use tikv::{
     config::ConfigController,
     coprocessor, coprocessor_v2,
-    import::{ImportSstService, SstImporter},
+    import::{ImportSstService, LocalTablets, SstImporter},
     read_pool::ReadPool,
     server::{
         gc_worker::GcWorker,
@@ -441,7 +441,7 @@ impl ServerCluster {
             cfg.import.clone(),
             cfg.raft_store.raft_entry_max_size,
             engine,
-            engines.kv.clone(),
+            LocalTablets::Singleton(engines.kv.clone()),
             Arc::clone(&importer),
         );
 

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -15,8 +15,9 @@
 mod duplicate_detect;
 mod sst_service;
 
-use std::fmt::Debug;
+use std::{borrow::Cow, fmt::Debug};
 
+use engine_traits::TabletRegistry;
 use grpcio::{RpcStatus, RpcStatusCode};
 pub use sst_importer::{Config, Error, Result, SstImporter, TxnSstWriter};
 
@@ -47,4 +48,27 @@ macro_rules! send_rpc_response {
         };
         let _ = res.map_err(|e| warn!("send rpc response"; "err" => %e)).await;
     }};
+}
+
+#[derive(Clone)]
+pub enum LocalTablets<EK> {
+    Singleton(EK),
+    Registry(TabletRegistry<EK>),
+}
+
+impl<EK: Clone> LocalTablets<EK> {
+    /// Get the tablet of the given region.
+    ///
+    /// If `None` is returned, the region may not exist or may not initialized.
+    /// If there are multiple versions of tablet, the latest one is returned
+    /// with best effort.
+    fn get(&self, region_id: u64) -> Option<Cow<'_, EK>> {
+        match self {
+            LocalTablets::Singleton(tablet) => Some(Cow::Borrowed(tablet)),
+            LocalTablets::Registry(registry) => {
+                let mut cached = registry.get(region_id)?;
+                cached.latest().cloned().map(Cow::Owned)
+            }
+        }
+    }
 }

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -39,7 +39,7 @@ use tikv_util::{
 use tokio::{runtime::Runtime, time::sleep};
 use txn_types::{Key, WriteRef, WriteType};
 
-use super::make_rpc_error;
+use super::{make_rpc_error, LocalTablets};
 use crate::{
     import::duplicate_detect::DuplicateDetector,
     server::CONFIG_ROCKSDB_GAUGE,
@@ -73,7 +73,7 @@ async fn wait_write(mut s: impl Stream<Item = WriteEvent> + Send + Unpin) -> sto
 #[derive(Clone)]
 pub struct ImportSstService<E: Engine> {
     cfg: Config,
-    tablet_registry: E::Local,
+    tablets: LocalTablets<E::Local>,
     engine: E,
     threads: Arc<Runtime>,
     // For now, PiTR cannot be executed in the tokio runtime because it is synchronous and may
@@ -238,7 +238,7 @@ impl<E: Engine> ImportSstService<E> {
         cfg: Config,
         raft_entry_max_size: ReadableSize,
         engine: E,
-        tablet_registry: E::Local,
+        tablets: LocalTablets<E::Local>,
         importer: Arc<SstImporter>,
     ) -> Self {
         let props = tikv_util::thread_group::current_properties();
@@ -266,12 +266,14 @@ impl<E: Engine> ImportSstService<E> {
             .before_stop_wrapper(move || tikv_alloc::remove_thread_memory_accessor())
             .create()
             .unwrap();
-        importer.start_switch_mode_check(threads.handle(), tablet_registry.clone());
+        if let LocalTablets::Singleton(tablet) = &tablets {
+            importer.start_switch_mode_check(threads.handle(), tablet.clone());
+        }
         threads.spawn(Self::tick(importer.clone()));
 
         ImportSstService {
             cfg,
-            tablet_registry,
+            tablets,
             threads: Arc::new(threads),
             block_threads: Arc::new(block_threads),
             engine,
@@ -323,14 +325,20 @@ impl<E: Engine> ImportSstService<E> {
         }
     }
 
-    fn check_write_stall(&self) -> Option<errorpb::Error> {
+    fn check_write_stall(&self, region_id: u64) -> Option<errorpb::Error> {
+        let tablet = match self.tablets.get(region_id) {
+            Some(tablet) => tablet,
+            None => {
+                let mut errorpb = errorpb::Error::default();
+                errorpb.set_message(format!("region {} not found", region_id));
+                errorpb.mut_region_not_found().set_region_id(region_id);
+                return Some(errorpb);
+            }
+        };
         if self.importer.get_mode() == SwitchMode::Normal
-            && self
-                .tablet_registry
-                .ingest_maybe_slowdown_writes(CF_WRITE)
-                .expect("cf")
+            && tablet.ingest_maybe_slowdown_writes(CF_WRITE).expect("cf")
         {
-            match self.tablet_registry.get_sst_key_ranges(CF_WRITE, 0) {
+            match tablet.get_sst_key_ranges(CF_WRITE, 0) {
                 Ok(l0_sst_ranges) => {
                     warn!(
                         "sst ingest is too slow";
@@ -507,7 +515,7 @@ macro_rules! impl_write {
             sink: ClientStreamingSink<$resp_ty>,
         ) {
             let import = self.importer.clone();
-            let tablet_registry = self.tablet_registry.clone();
+            let tablets = self.tablets.clone();
             let (rx, buf_driver) =
                 create_stream_with_buffer(stream, self.cfg.stream_channel_window);
             let mut rx = rx.map_err(Error::from);
@@ -524,8 +532,17 @@ macro_rules! impl_write {
                         },
                         _ => return Err(Error::InvalidChunk),
                     };
+                    let region_id = meta.get_region_id();
+                    let tablet = match tablets.get(region_id) {
+                        Some(t) => t,
+                        None => {
+                            return Err(Error::Engine(
+                                format!("region {} not found", region_id).into(),
+                            ));
+                        }
+                    };
 
-                    let writer = match import.$writer_fn(&tablet_registry, meta) {
+                    let writer = match import.$writer_fn(&*tablet, meta) {
                         Ok(w) => w,
                         Err(e) => {
                             error!("build writer failed {:?}", e);
@@ -574,13 +591,17 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
                 CONFIG_ROCKSDB_GAUGE.with_label_values(&[cf, name]).set(v);
             }
 
-            match req.get_mode() {
-                SwitchMode::Normal => self
-                    .importer
-                    .enter_normal_mode(self.tablet_registry.clone(), mf),
-                SwitchMode::Import => self
-                    .importer
-                    .enter_import_mode(self.tablet_registry.clone(), mf),
+            if let LocalTablets::Singleton(tablet) = &self.tablets {
+                match req.get_mode() {
+                    SwitchMode::Normal => self.importer.enter_normal_mode(tablet.clone(), mf),
+                    SwitchMode::Import => self.importer.enter_import_mode(tablet.clone(), mf),
+                }
+            } else if req.get_mode() != SwitchMode::Normal {
+                Err(sst_importer::Error::Engine(
+                    "partitioned-raft-kv doesn't support import mode".into(),
+                ))
+            } else {
+                Ok(false)
             }
         };
         match res {
@@ -715,7 +736,8 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
         let timer = Instant::now_coarse();
         let importer = Arc::clone(&self.importer);
         let limiter = self.limiter.clone();
-        let tablet_registry = self.tablet_registry.clone();
+        let region_id = req.get_sst().get_region_id();
+        let tablets = self.tablets.clone();
         let start = Instant::now();
 
         let handle_task = async move {
@@ -734,6 +756,19 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
                 .into_option()
                 .filter(|c| c.cipher_type != EncryptionMethod::Plaintext);
 
+            let tablet = match tablets.get(region_id) {
+                Some(tablet) => tablet,
+                None => {
+                    let error = sst_importer::Error::Engine(box_err!(
+                        "region {} not found, maybe it's not a replica of this store",
+                        region_id
+                    ));
+                    let mut resp = DownloadResponse::default();
+                    resp.set_error(error.into());
+                    return crate::send_rpc_response!(Ok(resp), sink, label, timer);
+                }
+            };
+
             let res = importer.download_ext::<E::Local>(
                 req.get_sst(),
                 req.get_storage_backend(),
@@ -741,7 +776,7 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
                 req.get_rewrite_rule(),
                 cipher,
                 limiter,
-                tablet_registry,
+                tablet.into_owned(),
                 DownloadExt::default()
                     .cache_key(req.get_storage_cache_id())
                     .req_type(req.get_request_type()),
@@ -775,7 +810,8 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
         let timer = Instant::now_coarse();
 
         let mut resp = IngestResponse::default();
-        if let Some(errorpb) = self.check_write_stall() {
+        let region_id = req.get_context().get_region_id();
+        if let Some(errorpb) = self.check_write_stall(region_id) {
             resp.set_error(errorpb);
             ctx.spawn(
                 sink.success(resp)
@@ -817,7 +853,7 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
         let timer = Instant::now_coarse();
 
         let mut resp = IngestResponse::default();
-        if let Some(errorpb) = self.check_write_stall() {
+        if let Some(errorpb) = self.check_write_stall(req.get_context().get_region_id()) {
             resp.set_error(errorpb);
             ctx.spawn(
                 sink.success(resp)
@@ -865,7 +901,7 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
     ) {
         let label = "compact";
         let timer = Instant::now_coarse();
-        let tablet_registry = self.tablet_registry.clone();
+        let tablets = self.tablets.clone();
 
         let handle_task = async move {
             let (start, end) = if !req.has_range() {
@@ -882,7 +918,17 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
                 Some(req.get_output_level())
             };
 
-            let res = tablet_registry.compact_files_in_range(start, end, output_level);
+            let region_id = req.get_context().get_region_id();
+            let tablet = match tablets.get(region_id) {
+                Some(tablet) => tablet,
+                None => {
+                    let e = Error::Engine(format!("region {} not found", region_id).into());
+                    crate::send_rpc_response!(Err(e), sink, label, timer);
+                    return;
+                }
+            };
+
+            let res = tablet.compact_files_in_range(start, end, output_level);
             match res {
                 Ok(_) => info!(
                     "compact files in range";


### PR DESCRIPTION

### What is changed and how it works?
Issue Number: Ref #12842 

What's Changed:

```commit-message
A few behavior changes:
- In v2, normal mode is always used, trying to switch to import mode will get error response.
- A context is added to compact range request. If not compact with region ID, the request will be rejected.
- SSTs are cleaned up immediately if its corresponding regions doesn't exist on the store anymore.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
