### PR TITLE
raftstore-v2: clear pending reads when peer is destroyed

### DIFF
--- a/components/raftstore-v2/src/fsm/peer.rs
+++ b/components/raftstore-v2/src/fsm/peer.rs
@@ -34,6 +34,12 @@ pub struct PeerFsm<EK: KvEngine, ER: RaftEngine> {
     is_stopped: bool,
 }
 
+impl<EK: KvEngine, ER: RaftEngine> Drop for PeerFsm<EK, ER> {
+    fn drop(&mut self) {
+        self.peer.pending_reads_mut().clear_all(None);
+    }
+}
+
 impl<EK: KvEngine, ER: RaftEngine> PeerFsm<EK, ER> {
     pub fn new(
         cfg: &Config,

--- a/components/raftstore-v2/src/operation/life.rs
+++ b/components/raftstore-v2/src/operation/life.rs
@@ -609,6 +609,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         lb.put_region_state(region_id, applied_index, &region_state)
             .unwrap();
         self.record_tombstone_tablet_for_destroy(ctx, write_task);
+        self.pending_reads_mut().clear_all(Some(region_id));
         self.destroy_progress_mut().start();
     }
 


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Close #14306

What's Changed:

Call clear_all as v1 did.

```commit-message
```

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
