### PR TITLE
file_system: initialize io stats sentinel on thread start

### DIFF
--- a/components/file_system/src/io_stats/proc.rs
+++ b/components/file_system/src/io_stats/proc.rs
@@ -138,6 +138,12 @@ pub fn init() -> Result<(), String> {
     ThreadId::current()
         .fetch_io_bytes()
         .map_err(|e| format!("failed to fetch I/O bytes from proc: {}", e))?;
+    // Manually initialize the sentinel so that `fetch_io_bytes` doesn't miss any
+    // thread.
+    LOCAL_IO_STATS.get_or(|| CachePadded::new(Mutex::new(LocalIoStats::current())));
+    tikv_util::sys::thread::hook_thread_start(Box::new(|| {
+        LOCAL_IO_STATS.get_or(|| CachePadded::new(Mutex::new(LocalIoStats::current())));
+    }));
     Ok(())
 }
 
@@ -174,11 +180,13 @@ mod tests {
     use std::{
         io::{Read, Write},
         os::unix::fs::OpenOptionsExt,
+        sync::mpsc,
     };
 
     use libc::O_DIRECT;
     use maligned::{AsBytes, AsBytesMut, A512};
     use tempfile::{tempdir, tempdir_in};
+    use tikv_util::sys::thread::StdThreadBuildWrapper;
 
     use super::*;
     use crate::{OpenOptions, WithIoType};
@@ -236,6 +244,61 @@ mod tests {
             let local_bytes = id.fetch_io_bytes().unwrap();
             assert_eq!(i * 4096 + base_local_bytes.write, local_bytes.write);
         }
+    }
+
+    #[test]
+    fn test_fetch_all_io_bytes() {
+        let tmp = tempdir_in("/var/tmp").unwrap_or_else(|_| tempdir().unwrap());
+
+        init().unwrap();
+
+        let file_path = tmp.path().join("test_fetch_all_io_bytes_1.txt");
+        let (tx1, rx1) = mpsc::sync_channel(0);
+        let t1 = std::thread::Builder::new()
+            .spawn_wrapper(move || {
+                set_io_type(IoType::ForegroundWrite);
+                let mut f = OpenOptions::new()
+                    .write(true)
+                    .create(true)
+                    .custom_flags(O_DIRECT)
+                    .open(file_path)
+                    .unwrap();
+                let w = vec![A512::default(); 8];
+                f.write_all(w.as_bytes()).unwrap();
+                f.sync_all().unwrap();
+                tx1.send(()).unwrap();
+                tx1.send(()).unwrap();
+            })
+            .unwrap();
+
+        let file_path = tmp.path().join("test_fetch_all_io_bytes_2.txt");
+        let (tx2, rx2) = mpsc::sync_channel(0);
+        let t2 = std::thread::Builder::new()
+            .spawn_wrapper(move || {
+                let mut f = OpenOptions::new()
+                    .write(true)
+                    .create(true)
+                    .custom_flags(O_DIRECT)
+                    .open(file_path)
+                    .unwrap();
+                let w = vec![A512::default(); 8];
+                f.write_all(w.as_bytes()).unwrap();
+                f.sync_all().unwrap();
+                tx2.send(()).unwrap();
+                tx2.send(()).unwrap();
+            })
+            .unwrap();
+
+        rx1.recv().unwrap();
+        rx2.recv().unwrap();
+        let bytes = fetch_io_bytes();
+        assert_eq!(bytes[IoType::ForegroundWrite as usize].write, 4096);
+        assert_eq!(bytes[IoType::Other as usize].write, 4096);
+
+        rx1.recv().unwrap();
+        rx2.recv().unwrap();
+        t1.join().unwrap();
+        t2.join().unwrap();
     }
 
     #[bench]

--- a/components/tikv_util/src/sys/thread.rs
+++ b/components/tikv_util/src/sys/thread.rs
@@ -384,6 +384,17 @@ pub trait ThreadBuildWrapper {
 
 lazy_static::lazy_static! {
     pub static ref THREAD_NAME_HASHMAP: Mutex<HashMap<Pid, String>> = Mutex::new(HashMap::default());
+    pub static ref THREAD_START_HOOKS: Mutex<Vec<Box<dyn Fn() + Sync + Send>>> = Mutex::new(Vec::new());
+}
+
+pub fn hook_thread_start(f: Box<dyn Fn() + Sync + Send>) {
+    THREAD_START_HOOKS.lock().unwrap().push(f);
+}
+
+pub(crate) fn call_thread_start_hooks() {
+    for f in THREAD_START_HOOKS.lock().unwrap().iter() {
+        f();
+    }
 }
 
 pub(crate) fn add_thread_name_to_map() {
@@ -411,6 +422,7 @@ impl StdThreadBuildWrapper for std::thread::Builder {
     {
         #[allow(clippy::disallowed_methods)]
         self.spawn(|| {
+            call_thread_start_hooks();
             add_thread_name_to_map();
             let res = f();
             remove_thread_name_from_map();
@@ -426,6 +438,7 @@ impl ThreadBuildWrapper for tokio::runtime::Builder {
     {
         #[allow(clippy::disallowed_methods)]
         self.on_thread_start(move || {
+            call_thread_start_hooks();
             add_thread_name_to_map();
             f();
         })
@@ -450,6 +463,7 @@ impl ThreadBuildWrapper for futures::executor::ThreadPoolBuilder {
     {
         #[allow(clippy::disallowed_methods)]
         self.after_start(move |_| {
+            call_thread_start_hooks();
             add_thread_name_to_map();
             f();
         })

--- a/components/tikv_util/src/yatp_pool/mod.rs
+++ b/components/tikv_util/src/yatp_pool/mod.rs
@@ -172,6 +172,7 @@ impl<T: PoolTicker> Runner for YatpPoolRunner<T> {
     type TaskCell = TaskCell;
 
     fn start(&mut self, local: &mut Local<Self::TaskCell>) {
+        crate::sys::thread::call_thread_start_hooks();
         crate::sys::thread::add_thread_name_to_map();
         if let Some(props) = self.props.take() {
             crate::thread_group::set_properties(Some(props));


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Ref #10867

What's Changed:

Previously, if some thread doesn't call `set_io_type`, its I/O will not be traced by the I/O stats collector.

```commit-message
Fix thread I/O not monitored if I/O type isn't set.
```

### Related changes


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
