### PR TITLE
raftstore-v2: disable merge temperarily

### DIFF
--- a/components/raftstore-v2/src/worker/pd/region.rs
+++ b/components/raftstore-v2/src/worker/pd/region.rs
@@ -311,12 +311,8 @@ where
                             );
                         }
                     } else if resp.has_merge() {
-                        PD_HEARTBEAT_COUNTER_VEC.with_label_values(&["merge"]).inc();
-
-                        let merge = resp.take_merge();
-                        info!(logger, "try to merge"; "region_id" => region_id, "merge" => ?merge);
-                        let req = new_merge_request(merge);
-                        send_admin_request(&logger, &router, region_id, epoch, peer, req, None);
+                        // TODO: add merge when it end-to-end works.
+                        info!(logger, "pd asks for merge but ignored"); 
                     } else {
                         PD_HEARTBEAT_COUNTER_VEC.with_label_values(&["noop"]).inc();
                     }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #12842

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Disable the merge for now until it end-to-end works. 
It's easy to forget to disable merge in PD. 
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
