### PR TITLE
coprocessor: avoid fmsketch calculation for single-column index

### DIFF
--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -450,6 +450,20 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
                     .inc_by(quota_delay.as_micros() as u64);
             }
         }
+        for i in 0..self.column_groups.len() {
+            let offsets = self.column_groups[i].get_column_offsets();
+            if offsets.len() != 1 {
+                continue;
+            }
+            // For the sinlge-column group, its fm_sketch is the same as that of the corresponding column. Hence, we don't
+		    // maintain its fm_sketch in collect_column_group. We just copy the corresponding column's fm_sketch after
+		    // iterating all rows. Also, we can directly copy total_size and null_count.
+            let col_pos = offsets[0] as usize;
+            let col_group_pos = self.columns_info.len() + i;
+            collector.mut_base().fm_sketches[col_group_pos] = collector.mut_base().fm_sketches[col_pos].clone();
+            collector.mut_base().null_count[col_group_pos] = collector.mut_base().null_count[col_pos];
+            collector.mut_base().total_sizes[col_group_pos] = collector.mut_base().total_sizes[col_pos];
+        }
         Ok(AnalyzeSamplingResult::new(collector))
     }
 }
@@ -527,37 +541,28 @@ impl BaseRowSampleCollector {
         let col_len = columns_val.len();
         for i in 0..column_groups.len() {
             let offsets = column_groups[i].get_column_offsets();
-            let mut has_null = true;
+            if offsets.len() == 1 {
+                // For the sinlge-column group, its fm_sketch is the same as that of the corresponding column. Hence, we
+			    // don't need to maintain its fm_sketch. We just copy the corresponding column's fm_sketch after iterating
+			    // all rows. Also, we can directly copy total_size and null_count.
+                continue;
+            }
+            // We don't maintain the null count information for the multi-column group.
             for j in offsets {
                 if columns_val[*j as usize][0] == NIL_FLAG {
                     continue;
                 }
-                has_null = false;
                 self.total_sizes[col_len + i] += columns_val[*j as usize].len() as i64 - 1
             }
-            // We only maintain the null count for single column case.
-            if has_null && offsets.len() == 1 {
-                self.null_count[col_len + i] += 1;
-                continue;
-            }
-            if offsets.len() == 1 {
-                let offset = offsets[0] as usize;
-                if columns_info[offset].as_accessor().is_string_like() {
-                    self.fm_sketches[col_len + i].insert(&collation_keys_val[offset]);
+            let mut hasher = Hasher128::with_seed(0);
+            for j in offsets {
+                if columns_info[*j as usize].as_accessor().is_string_like() {
+                    hasher.write(&collation_keys_val[*j as usize]);
                 } else {
-                    self.fm_sketches[col_len + i].insert(&columns_val[offset]);
+                    hasher.write(&columns_val[*j as usize]);
                 }
-            } else {
-                let mut hasher = Hasher128::with_seed(0);
-                for j in offsets {
-                    if columns_info[*j as usize].as_accessor().is_string_like() {
-                        hasher.write(&collation_keys_val[*j as usize]);
-                    } else {
-                        hasher.write(&columns_val[*j as usize]);
-                    }
-                }
-                self.fm_sketches[col_len + i].insert_hash_value(hasher.finish());
             }
+            self.fm_sketches[col_len + i].insert_hash_value(hasher.finish());
         }
     }
 

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -455,7 +455,7 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
             if offsets.len() != 1 {
                 continue;
             }
-            // For the sinlge-column group, its fm_sketch is the same as that of the
+            // For the single-column group, its fm_sketch is the same as that of the
             // corresponding column. Hence, we don't maintain its fm_sketch in
             // collect_column_group. We just copy the corresponding column's fm_sketch after
             // iterating all rows. Also, we can directly copy total_size and null_count.
@@ -546,7 +546,7 @@ impl BaseRowSampleCollector {
         for i in 0..column_groups.len() {
             let offsets = column_groups[i].get_column_offsets();
             if offsets.len() == 1 {
-                // For the sinlge-column group, its fm_sketch is the same as that of the
+                // For the single-column group, its fm_sketch is the same as that of the
                 // corresponding column. Hence, we don't need to maintain its
                 // fm_sketch. We just copy the corresponding column's fm_sketch after iterating
                 // all rows. Also, we can directly copy total_size and null_count.

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -455,14 +455,18 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
             if offsets.len() != 1 {
                 continue;
             }
-            // For the sinlge-column group, its fm_sketch is the same as that of the corresponding column. Hence, we don't
-		    // maintain its fm_sketch in collect_column_group. We just copy the corresponding column's fm_sketch after
-		    // iterating all rows. Also, we can directly copy total_size and null_count.
+            // For the sinlge-column group, its fm_sketch is the same as that of the
+            // corresponding column. Hence, we don't maintain its fm_sketch in
+            // collect_column_group. We just copy the corresponding column's fm_sketch after
+            // iterating all rows. Also, we can directly copy total_size and null_count.
             let col_pos = offsets[0] as usize;
             let col_group_pos = self.columns_info.len() + i;
-            collector.mut_base().fm_sketches[col_group_pos] = collector.mut_base().fm_sketches[col_pos].clone();
-            collector.mut_base().null_count[col_group_pos] = collector.mut_base().null_count[col_pos];
-            collector.mut_base().total_sizes[col_group_pos] = collector.mut_base().total_sizes[col_pos];
+            collector.mut_base().fm_sketches[col_group_pos] =
+                collector.mut_base().fm_sketches[col_pos].clone();
+            collector.mut_base().null_count[col_group_pos] =
+                collector.mut_base().null_count[col_pos];
+            collector.mut_base().total_sizes[col_group_pos] =
+                collector.mut_base().total_sizes[col_pos];
         }
         Ok(AnalyzeSamplingResult::new(collector))
     }
@@ -542,9 +546,10 @@ impl BaseRowSampleCollector {
         for i in 0..column_groups.len() {
             let offsets = column_groups[i].get_column_offsets();
             if offsets.len() == 1 {
-                // For the sinlge-column group, its fm_sketch is the same as that of the corresponding column. Hence, we
-			    // don't need to maintain its fm_sketch. We just copy the corresponding column's fm_sketch after iterating
-			    // all rows. Also, we can directly copy total_size and null_count.
+                // For the sinlge-column group, its fm_sketch is the same as that of the
+                // corresponding column. Hence, we don't need to maintain its
+                // fm_sketch. We just copy the corresponding column's fm_sketch after iterating
+                // all rows. Also, we can directly copy total_size and null_count.
                 continue;
             }
             // We don't maintain the null count information for the multi-column group.


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #14231

What's Changed:

Implement https://github.com/pingcap/tidb/pull/41931 in the tikv side. For the sinlge-column group, its `fm_sketch` is the same as that of the corresponding column. Hence, we don't maintain its `fm_sketch` in `collect_column_group`. We just copy the corresponding column's `fm_sketch` after iterating all rows. Also, we can directly copy `total_size` and `null_count`.

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)


Side effects

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
