### PR TITLE
raftstore-v2: consider None when getting mailbox

### DIFF
--- a/components/raftstore-v2/src/operation/command/admin/split.rs
+++ b/components/raftstore-v2/src/operation/command/admin/split.rs
@@ -664,13 +664,12 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
                     {
                         if store_ctx.router.is_shutdown() {
                             return;
-                        } else {
-                            slog_panic!(
-                                self.logger,
-                                "fails to send split peer intialization msg to store";
-                                "error" => ?e,
-                            );
                         }
+                        slog_panic!(
+                            self.logger,
+                            "fails to send split peer intialization msg to store";
+                            "error" => ?e,
+                        );
                     }
                 }
                 _ => unreachable!(),

--- a/components/raftstore-v2/src/operation/command/admin/split.rs
+++ b/components/raftstore-v2/src/operation/command/admin/split.rs
@@ -603,6 +603,8 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             self.add_pending_tick(PeerTick::SplitRegionCheck);
         }
         self.storage_mut().set_has_dirty_data(true);
+
+        fail_point!("before_cluster_shutdown1");
         let mailbox = {
             match store_ctx.router.mailbox(self.region_id()) {
                 Some(mailbox) => mailbox,
@@ -655,16 +657,21 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             match store_ctx.router.force_send(new_region_id, split_init) {
                 Ok(_) => {}
                 Err(SendError(PeerMsg::SplitInit(msg))) => {
-                    store_ctx
+                    fail_point!("before_cluster_shutdown2", |_| {});
+                    if let Err(e) = store_ctx
                         .router
                         .force_send_control(StoreMsg::SplitInit(msg))
-                        .unwrap_or_else(|e| {
+                    {
+                        if store_ctx.router.is_shutdown() {
+                            return;
+                        } else {
                             slog_panic!(
                                 self.logger,
                                 "fails to send split peer intialization msg to store";
                                 "error" => ?e,
-                            )
-                        });
+                            );
+                        }
+                    }
                 }
                 _ => unreachable!(),
             }

--- a/components/raftstore-v2/src/operation/command/admin/split.rs
+++ b/components/raftstore-v2/src/operation/command/admin/split.rs
@@ -603,7 +603,17 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             self.add_pending_tick(PeerTick::SplitRegionCheck);
         }
         self.storage_mut().set_has_dirty_data(true);
-        let mailbox = store_ctx.router.mailbox(self.region_id()).unwrap();
+        let mailbox = {
+            match store_ctx.router.mailbox(self.region_id()) {
+                Some(mailbox) => mailbox,
+                None => {
+                    // None means the node is shutdown concurrently and thus the
+                    // mailboxes in router have been cleared
+                    assert!(store_ctx.router.is_shutdown());
+                    return;
+                }
+            }
+        };
         let tablet_index = res.tablet_index;
         let _ = store_ctx
             .schedulers

--- a/components/raftstore-v2/src/operation/command/admin/split.rs
+++ b/components/raftstore-v2/src/operation/command/admin/split.rs
@@ -609,7 +609,11 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
                 None => {
                     // None means the node is shutdown concurrently and thus the
                     // mailboxes in router have been cleared
-                    assert!(store_ctx.router.is_shutdown());
+                    assert!(
+                        store_ctx.router.is_shutdown(),
+                        "{} router should have been closed",
+                        SlogFormat(&self.logger)
+                    );
                     return;
                 }
             }
@@ -741,7 +745,11 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             } else {
                 // None means the node is shutdown concurrently and thus the
                 // mailboxes in router have been cleared
-                assert!(store_ctx.router.is_shutdown());
+                assert!(
+                    store_ctx.router.is_shutdown(),
+                    "{} router should have been closed",
+                    SlogFormat(&self.logger)
+                );
                 return;
             }
         }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #14347

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
consider None when getting mailbox
```
When the cluster is stopped, mailboxes will be cleared.  However, on_apply_res_split may be executed concurrently, which means we cannot unwrap on `mailbox(xxx)`.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
