### PR TITLE
raftstore-v2: use compaction filter to trim tablet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2862,7 +2862,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tabokie/rust-rocksdb.git?branch=230306-filter-interface#27916089d2e2013fa776f2ab9fae2852efd6652e"
+source = "git+https://github.com/tikv/rust-rocksdb.git#9e4678857e5b4c738e95c7ee1a35ee962264f4e9"
 dependencies = [
  "bindgen 0.57.0",
  "bzip2-sys",
@@ -2881,7 +2881,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tabokie/rust-rocksdb.git?branch=230306-filter-interface#27916089d2e2013fa776f2ab9fae2852efd6652e"
+source = "git+https://github.com/tikv/rust-rocksdb.git#9e4678857e5b4c738e95c7ee1a35ee962264f4e9"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -4799,7 +4799,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tabokie/rust-rocksdb.git?branch=230306-filter-interface#27916089d2e2013fa776f2ab9fae2852efd6652e"
+source = "git+https://github.com/tikv/rust-rocksdb.git#9e4678857e5b4c738e95c7ee1a35ee962264f4e9"
 dependencies = [
  "libc 0.2.139",
  "librocksdb_sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2862,7 +2862,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tabokie/rust-rocksdb.git?branch=230306-filter-interface#0985d5b5b0fa5ce265e5a2147ec969ebf7acf3a0"
+source = "git+https://github.com/tabokie/rust-rocksdb.git?branch=230306-filter-interface#27916089d2e2013fa776f2ab9fae2852efd6652e"
 dependencies = [
  "bindgen 0.57.0",
  "bzip2-sys",
@@ -2881,7 +2881,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tabokie/rust-rocksdb.git?branch=230306-filter-interface#0985d5b5b0fa5ce265e5a2147ec969ebf7acf3a0"
+source = "git+https://github.com/tabokie/rust-rocksdb.git?branch=230306-filter-interface#27916089d2e2013fa776f2ab9fae2852efd6652e"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -4799,7 +4799,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tabokie/rust-rocksdb.git?branch=230306-filter-interface#0985d5b5b0fa5ce265e5a2147ec969ebf7acf3a0"
+source = "git+https://github.com/tabokie/rust-rocksdb.git?branch=230306-filter-interface#27916089d2e2013fa776f2ab9fae2852efd6652e"
 dependencies = [
  "libc 0.2.139",
  "librocksdb_sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2862,7 +2862,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#cd8b60758b46afbbde6fde52fa86a2776b401723"
+source = "git+https://github.com/tabokie/rust-rocksdb.git?branch=230306-filter-interface#0985d5b5b0fa5ce265e5a2147ec969ebf7acf3a0"
 dependencies = [
  "bindgen 0.57.0",
  "bzip2-sys",
@@ -2881,7 +2881,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tikv/rust-rocksdb.git#cd8b60758b46afbbde6fde52fa86a2776b401723"
+source = "git+https://github.com/tabokie/rust-rocksdb.git?branch=230306-filter-interface#0985d5b5b0fa5ce265e5a2147ec969ebf7acf3a0"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -4799,7 +4799,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#cd8b60758b46afbbde6fde52fa86a2776b401723"
+source = "git+https://github.com/tabokie/rust-rocksdb.git?branch=230306-filter-interface#0985d5b5b0fa5ce265e5a2147ec969ebf7acf3a0"
 dependencies = [
  "libc 0.2.139",
  "librocksdb_sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,6 +185,7 @@ api_version = { workspace = true, features = ["testexport"] }
 example_coprocessor_plugin = { workspace = true } # should be a binary dependency
 hyper-openssl = "0.9"
 panic_hook = { workspace = true }
+raftstore = { workspace = true, features = ["testexport"] }
 reqwest = { version = "0.11", features = ["blocking"] }
 test_sst_importer = { workspace = true }
 test_util = { workspace = true }

--- a/components/engine_rocks/Cargo.toml
+++ b/components/engine_rocks/Cargo.toml
@@ -56,10 +56,9 @@ tracker = { workspace = true }
 txn_types = { workspace = true }
 
 [dependencies.rocksdb]
-git = "https://github.com/tabokie/rust-rocksdb.git"
+git = "https://github.com/tikv/rust-rocksdb.git"
 package = "rocksdb"
 features = ["encryption"]
-branch = "230306-filter-interface"
 
 [dev-dependencies]
 rand = "0.8"

--- a/components/engine_rocks/Cargo.toml
+++ b/components/engine_rocks/Cargo.toml
@@ -56,9 +56,10 @@ tracker = { workspace = true }
 txn_types = { workspace = true }
 
 [dependencies.rocksdb]
-git = "https://github.com/tikv/rust-rocksdb.git"
+git = "https://github.com/tabokie/rust-rocksdb.git"
 package = "rocksdb"
 features = ["encryption"]
+branch = "230306-filter-interface"
 
 [dev-dependencies]
 rand = "0.8"

--- a/components/engine_rocks/src/raw.rs
+++ b/components/engine_rocks/src/raw.rs
@@ -7,13 +7,13 @@
 //! crate, but only until the engine interface is completely abstracted.
 
 pub use rocksdb::{
-    new_compaction_filter_raw, run_ldb_tool, run_sst_dump_tool, BlockBasedOptions, Cache,
-    ChecksumType, CompactOptions, CompactionFilter, CompactionFilterContext,
-    CompactionFilterDecision, CompactionFilterFactory, CompactionFilterValueType,
-    CompactionJobInfo, CompactionOptions, CompactionPriority, ConcurrentTaskLimiter,
-    DBBottommostLevelCompaction, DBCompactionFilter, DBCompactionStyle, DBCompressionType,
-    DBEntryType, DBRateLimiterMode, DBRecoveryMode, DBStatisticsTickerType, DBTitanDBBlobRunMode,
-    Env, EventListener, IngestExternalFileOptions, LRUCacheOptions, MemoryAllocator, PerfContext,
-    PrepopulateBlockCache, Range, RateLimiter, SliceTransform, Statistics,
-    TablePropertiesCollector, TablePropertiesCollectorFactory, WriteBufferManager,
+    run_ldb_tool, run_sst_dump_tool, BlockBasedOptions, Cache, ChecksumType, CompactOptions,
+    CompactionFilter, CompactionFilterContext, CompactionFilterDecision, CompactionFilterFactory,
+    CompactionFilterValueType, CompactionJobInfo, CompactionOptions, CompactionPriority,
+    ConcurrentTaskLimiter, DBBottommostLevelCompaction, DBCompactionFilter, DBCompactionStyle,
+    DBCompressionType, DBEntryType, DBRateLimiterMode, DBRecoveryMode, DBStatisticsTickerType,
+    DBTableFileCreationReason, DBTitanDBBlobRunMode, Env, EventListener, IngestExternalFileOptions,
+    LRUCacheOptions, MemoryAllocator, PerfContext, PrepopulateBlockCache, Range, RateLimiter,
+    SliceTransform, Statistics, TablePropertiesCollector, TablePropertiesCollectorFactory,
+    WriteBufferManager,
 };

--- a/components/engine_rocks/src/util.rs
+++ b/components/engine_rocks/src/util.rs
@@ -352,13 +352,6 @@ impl CompactionFilterFactory for NoopFactory {
     ) -> Option<(CString, Self::Filter)> {
         None
     }
-
-    fn should_filter_table_file_creation(&self, reason: DBTableFileCreationReason) -> bool {
-        matches!(
-            reason,
-            DBTableFileCreationReason::Flush | DBTableFileCreationReason::Compaction
-        )
-    }
 }
 
 /// Used to build `RangeCompactionFilterFactory`, optionally stacked over

--- a/components/engine_rocks/src/util.rs
+++ b/components/engine_rocks/src/util.rs
@@ -408,7 +408,7 @@ impl<A: CompactionFilterFactory, B: CompactionFilterFactory> CompactionFilterFac
             && let Some((name, filter)) = self.inner.create_compaction_filter(context)
         {
             inner_filter = Some(filter);
-            full_name += "+";
+            full_name += ".";
             full_name += name.to_str().unwrap();
         }
         let filter = StackingCompactionFilter {

--- a/components/engine_rocks/src/util.rs
+++ b/components/engine_rocks/src/util.rs
@@ -344,8 +344,8 @@ fn reason_to_index(reason: DBTableFileCreationReason) -> usize {
     match reason {
         DBTableFileCreationReason::Flush => 0,
         DBTableFileCreationReason::Compaction => 1,
-        DBTableFileCreationReason::Recovery => 3,
-        DBTableFileCreationReason::Misc => 4,
+        DBTableFileCreationReason::Recovery => 2,
+        DBTableFileCreationReason::Misc => 3,
     }
 }
 

--- a/components/engine_rocks/src/util.rs
+++ b/components/engine_rocks/src/util.rs
@@ -408,7 +408,9 @@ impl<A: CompactionFilterFactory, B: CompactionFilterFactory> CompactionFilterFac
             && let Some((name, filter)) = self.inner.create_compaction_filter(context)
         {
             inner_filter = Some(filter);
-            full_name += ".";
+            if !full_name.is_empty() {
+                full_name += ".";
+            }
             full_name += name.to_str().unwrap();
         }
         if outer_filter.is_none() && inner_filter.is_none() {

--- a/components/engine_rocks/src/util.rs
+++ b/components/engine_rocks/src/util.rs
@@ -1,11 +1,13 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{fs, path::Path, str::FromStr, sync::Arc};
+use std::{ffi::CString, fs, path::Path, str::FromStr, sync::Arc};
 
 use engine_traits::{Engines, Range, Result, CF_DEFAULT};
 use rocksdb::{
-    load_latest_options, CColumnFamilyDescriptor, CFHandle, ColumnFamilyOptions, Env,
-    Range as RocksRange, SliceTransform, DB,
+    load_latest_options, CColumnFamilyDescriptor, CFHandle, ColumnFamilyOptions, CompactionFilter,
+    CompactionFilterContext, CompactionFilterDecision, CompactionFilterFactory,
+    CompactionFilterValueType, DBTableFileCreationReason, Env, Range as RocksRange, SliceTransform,
+    DB,
 };
 use slog_global::warn;
 
@@ -328,6 +330,129 @@ pub fn from_raw_perf_level(level: rocksdb::PerfLevel) -> engine_traits::PerfLeve
         }
         rocksdb::PerfLevel::EnableTime => engine_traits::PerfLevel::EnableTime,
         rocksdb::PerfLevel::OutOfBounds => engine_traits::PerfLevel::OutOfBounds,
+    }
+}
+
+struct KeyRange {
+    start_key: Box<[u8]>,
+    end_key: Box<[u8]>,
+}
+
+pub struct NoopFilter;
+
+impl CompactionFilter for NoopFilter {}
+
+pub struct NoopFactory;
+
+impl CompactionFilterFactory for NoopFactory {
+    type Filter = NoopFilter;
+    fn create_compaction_filter(
+        &self,
+        _context: &CompactionFilterContext,
+    ) -> Option<(CString, Self::Filter)> {
+        None
+    }
+
+    fn should_filter_table_file_creation(&self, reason: DBTableFileCreationReason) -> bool {
+        matches!(
+            reason,
+            DBTableFileCreationReason::Flush | DBTableFileCreationReason::Compaction
+        )
+    }
+}
+
+/// Used to build `RangeCompactionFilterFactory`, optionally stacked over
+/// another compaction filter factory.
+pub struct RangeCompactionFilterFactoryBuilder(Arc<KeyRange>);
+
+impl RangeCompactionFilterFactoryBuilder {
+    pub fn new(start_key: Vec<u8>, end_key: Vec<u8>) -> Self {
+        Self(Arc::new(KeyRange {
+            start_key: start_key.into_boxed_slice(),
+            end_key: end_key.into_boxed_slice(),
+        }))
+    }
+
+    pub fn build_with<C: CompactionFilterFactory>(
+        &self,
+        inner: C,
+    ) -> RangeCompactionFilterFactory<C> {
+        assert!(inner.should_filter_table_file_creation(DBTableFileCreationReason::Compaction));
+        assert!(inner.should_filter_table_file_creation(DBTableFileCreationReason::Flush));
+        assert!(!inner.should_filter_table_file_creation(DBTableFileCreationReason::Recovery));
+        assert!(!inner.should_filter_table_file_creation(DBTableFileCreationReason::Misc));
+        RangeCompactionFilterFactory {
+            range: self.0.clone(),
+            inner_factory: Some(inner),
+        }
+    }
+
+    pub fn build(&self) -> RangeCompactionFilterFactory<NoopFactory> {
+        RangeCompactionFilterFactory {
+            range: self.0.clone(),
+            inner_factory: None,
+        }
+    }
+}
+
+pub struct RangeCompactionFilterFactory<C: CompactionFilterFactory> {
+    range: Arc<KeyRange>,
+    inner_factory: Option<C>,
+}
+
+impl<C: CompactionFilterFactory> CompactionFilterFactory for RangeCompactionFilterFactory<C> {
+    type Filter = RangeCompactionFilter<C::Filter>;
+
+    fn create_compaction_filter(
+        &self,
+        context: &CompactionFilterContext,
+    ) -> Option<(CString, Self::Filter)> {
+        if let Some(inner) = self.inner_factory.as_ref() {
+            if let Some((name, filter)) = inner.create_compaction_filter(context) {
+                let filter = RangeCompactionFilter {
+                    range: self.range.clone(),
+                    inner_filter: Some(filter),
+                };
+                return Some((name, filter));
+            }
+        }
+        let filter = RangeCompactionFilter {
+            range: self.range.clone(),
+            inner_filter: None,
+        };
+        Some((CString::new("region_filter").unwrap(), filter))
+    }
+
+    fn should_filter_table_file_creation(&self, reason: DBTableFileCreationReason) -> bool {
+        matches!(
+            reason,
+            DBTableFileCreationReason::Flush | DBTableFileCreationReason::Compaction
+        )
+    }
+}
+
+/// Filters out all keys within the key range.
+pub struct RangeCompactionFilter<C: CompactionFilter> {
+    range: Arc<KeyRange>,
+    inner_filter: Option<C>,
+}
+
+impl<C: CompactionFilter> CompactionFilter for RangeCompactionFilter<C> {
+    fn featured_filter(
+        &mut self,
+        level: usize,
+        key: &[u8],
+        seqno: u64,
+        value: &[u8],
+        value_type: CompactionFilterValueType,
+    ) -> CompactionFilterDecision {
+        if key < self.range.start_key.as_ref() || key >= self.range.end_key.as_ref() {
+            CompactionFilterDecision::Remove
+        } else if let Some(inner) = self.inner_filter.as_mut() {
+            inner.featured_filter(level, key, seqno, value, value_type)
+        } else {
+            CompactionFilterDecision::Keep
+        }
     }
 }
 

--- a/components/engine_rocks/src/util.rs
+++ b/components/engine_rocks/src/util.rs
@@ -411,11 +411,15 @@ impl<A: CompactionFilterFactory, B: CompactionFilterFactory> CompactionFilterFac
             full_name += ".";
             full_name += name.to_str().unwrap();
         }
-        let filter = StackingCompactionFilter {
-            outer: outer_filter,
-            inner: inner_filter,
-        };
-        Some((CString::new(full_name).unwrap(), filter))
+        if outer_filter.is_none() && inner_filter.is_none() {
+            None
+        } else {
+            let filter = StackingCompactionFilter {
+                outer: outer_filter,
+                inner: inner_filter,
+            };
+            Some((CString::new(full_name).unwrap(), filter))
+        }
     }
 
     fn should_filter_table_file_creation(&self, reason: DBTableFileCreationReason) -> bool {

--- a/components/engine_traits/src/tablet.rs
+++ b/components/engine_traits/src/tablet.rs
@@ -149,7 +149,7 @@ pub trait TabletFactory<EK>: Send + Sync {
     /// Check if the tablet with specified path exists
     fn exists(&self, path: &Path) -> bool;
 
-    #[cfg(any(test, feature = "testexport"))]
+    #[cfg(feature = "testexport")]
     fn set_state_storage(&self, _: Arc<dyn StateStorage>) {
         unimplemented!()
     }

--- a/components/raftstore-v2/src/worker/tablet_gc.rs
+++ b/components/raftstore-v2/src/worker/tablet_gc.rs
@@ -162,13 +162,7 @@ impl<EK: KvEngine> Runner<EK> {
         let end_key = keys::data_end_key(&end);
         let range1 = Range::new(&[], &start_key);
         let range2 = Range::new(&end_key, keys::DATA_MAX_KEY);
-        // TODO: Avoid `DeleteByRange` after compaction filter is ready.
-        if let Err(e) = tablet
-            .delete_ranges_cfs(DeleteStrategy::DeleteFiles, &[range1, range2])
-            .and_then(|_| {
-                tablet.delete_ranges_cfs(DeleteStrategy::DeleteByRange, &[range1, range2])
-            })
-        {
+        if let Err(e) = tablet.delete_ranges_cfs(DeleteStrategy::DeleteFiles, &[range1, range2]) {
             error!(
                 self.logger,
                 "failed to trim tablet";
@@ -184,6 +178,7 @@ impl<EK: KvEngine> Runner<EK> {
                 let range1 = Range::new(&[], &start_key);
                 let range2 = Range::new(&end_key, keys::DATA_MAX_KEY);
                 for r in [range1, range2] {
+                    // When compaction filter is present, trivial move is disallowed.
                     if let Err(e) =
                         tablet.compact_range(Some(r.start_key), Some(r.end_key), false, 1)
                     {

--- a/components/tikv_util/src/sys/cgroup.rs
+++ b/components/tikv_util/src/sys/cgroup.rs
@@ -560,7 +560,6 @@ mod tests {
             ("-18446744073709551610", None), // Raise InvalidDigit instead of NegOverflow.
             ("0.1", None),
         ];
-        println!("{:?}", "-18446744073709551610".parse::<u64>());
         for (content, expect) in cases.into_iter() {
             let limit = parse_memory_max(content);
             assert_eq!(limit, expect);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -35,7 +35,7 @@ use engine_rocks::{
     },
     util::{
         FixedPrefixSliceTransform, FixedSuffixSliceTransform, NoopSliceTransform,
-        RangeCompactionFilterFactory, StackableCompactionFilterFactory,
+        RangeCompactionFilterFactory, StackingCompactionFilterFactory,
     },
     RaftDbLogger, RangePropertiesCollectorFactory, RawMvccPropertiesCollectorFactory,
     RocksCfOptions, RocksDbOptions, RocksEngine, RocksEventListener, RocksStatistics,
@@ -705,7 +705,7 @@ impl DefaultCfConfig {
         shared: &CfResources,
         region_info_accessor: Option<&RegionInfoAccessor>,
         api_version: ApiVersion,
-        range_filter_factory: Option<&RangeCompactionFilterFactory>,
+        filter_factory: Option<&RangeCompactionFilterFactory>,
         for_engine: EngineType,
     ) -> RocksCfOptions {
         let mut cf_opts = build_cf_opt!(
@@ -725,11 +725,11 @@ impl DefaultCfConfig {
             RawMvccPropertiesCollectorFactory::default(),
         );
         cf_opts.add_table_properties_collector_factory("tikv.range-properties-collector", f);
-        if let Some(factory) = range_filter_factory {
+        if let Some(factory) = filter_factory {
             match api_version {
                 ApiVersion::V1 => {
                     cf_opts
-                        .set_compaction_filter_factory("range_filter_factory", factory.clone())
+                        .set_compaction_filter_factory("filter_factory", factory.clone())
                         .unwrap();
                 }
                 ApiVersion::V1ttl => {
@@ -737,25 +737,25 @@ impl DefaultCfConfig {
                         "tikv.ttl-properties-collector",
                         TtlPropertiesCollectorFactory::<ApiV1Ttl>::default(),
                     );
-                    let factory = StackableCompactionFilterFactory::new(
+                    let factory = StackingCompactionFilterFactory::new(
                         factory.clone(),
                         TtlCompactionFilterFactory::<ApiV1Ttl>::default(),
                     );
                     cf_opts
                         .set_compaction_filter_factory(
-                            "range_filter_factory+ttl_compaction_filter_factory",
+                            "filter_factory+ttl_compaction_filter_factory",
                             factory,
                         )
                         .unwrap();
                 }
                 ApiVersion::V2 => {
-                    let factory = StackableCompactionFilterFactory::new(
+                    let factory = StackingCompactionFilterFactory::new(
                         factory.clone(),
                         RawCompactionFilterFactory,
                     );
                     cf_opts
                         .set_compaction_filter_factory(
-                            "range_filter_factory+apiv2_gc_compaction_filter_factory",
+                            "filter_factory+apiv2_gc_compaction_filter_factory",
                             factory,
                         )
                         .unwrap();
@@ -869,7 +869,7 @@ impl WriteCfConfig {
         &self,
         shared: &CfResources,
         region_info_accessor: Option<&RegionInfoAccessor>,
-        range_filter_factory: Option<&RangeCompactionFilterFactory>,
+        filter_factory: Option<&RangeCompactionFilterFactory>,
         for_engine: EngineType,
     ) -> RocksCfOptions {
         let mut cf_opts = build_cf_opt!(
@@ -898,11 +898,9 @@ impl WriteCfConfig {
             prop_keys_index_distance: self.prop_keys_index_distance,
         };
         cf_opts.add_table_properties_collector_factory("tikv.range-properties-collector", f);
-        if let Some(factory) = range_filter_factory {
-            let factory = StackableCompactionFilterFactory::new(
-                factory.clone(),
-                WriteCompactionFilterFactory,
-            );
+        if let Some(factory) = filter_factory {
+            let factory =
+                StackingCompactionFilterFactory::new(factory.clone(), WriteCompactionFilterFactory);
             cf_opts
                 .set_compaction_filter_factory("write_compaction_filter_factory", factory)
                 .unwrap();
@@ -986,7 +984,7 @@ impl LockCfConfig {
     pub fn build_opt(
         &self,
         shared: &CfResources,
-        range_filter_factory: Option<&RangeCompactionFilterFactory>,
+        filter_factory: Option<&RangeCompactionFilterFactory>,
         for_engine: EngineType,
     ) -> RocksCfOptions {
         let no_region_info_accessor: Option<&RegionInfoAccessor> = None;
@@ -1006,9 +1004,9 @@ impl LockCfConfig {
         };
         cf_opts.add_table_properties_collector_factory("tikv.range-properties-collector", f);
         cf_opts.set_memtable_prefix_bloom_size_ratio(bloom_filter_ratio(for_engine));
-        if let Some(factory) = range_filter_factory {
+        if let Some(factory) = filter_factory {
             cf_opts
-                .set_compaction_filter_factory("range_filter_factory", factory.clone())
+                .set_compaction_filter_factory("filter_factory", factory.clone())
                 .unwrap();
         }
         cf_opts.set_titan_cf_options(&self.titan.build_opts());

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -729,7 +729,7 @@ impl DefaultCfConfig {
             match api_version {
                 ApiVersion::V1 => {
                     cf_opts
-                        .set_compaction_filter_factory("filter_factory", factory.clone())
+                        .set_compaction_filter_factory("range_filter_factory", factory.clone())
                         .unwrap();
                 }
                 ApiVersion::V1ttl => {
@@ -743,7 +743,7 @@ impl DefaultCfConfig {
                     );
                     cf_opts
                         .set_compaction_filter_factory(
-                            "filter_factory+ttl_compaction_filter_factory",
+                            "range_filter_factory.ttl_compaction_filter_factory",
                             factory,
                         )
                         .unwrap();
@@ -755,7 +755,7 @@ impl DefaultCfConfig {
                     );
                     cf_opts
                         .set_compaction_filter_factory(
-                            "filter_factory+apiv2_gc_compaction_filter_factory",
+                            "range_filter_factory.apiv2_gc_compaction_filter_factory",
                             factory,
                         )
                         .unwrap();
@@ -902,7 +902,10 @@ impl WriteCfConfig {
             let factory =
                 StackingCompactionFilterFactory::new(factory.clone(), WriteCompactionFilterFactory);
             cf_opts
-                .set_compaction_filter_factory("write_compaction_filter_factory", factory)
+                .set_compaction_filter_factory(
+                    "range_filter_factory.write_compaction_filter_factory",
+                    factory,
+                )
                 .unwrap();
         } else {
             cf_opts
@@ -1006,7 +1009,7 @@ impl LockCfConfig {
         cf_opts.set_memtable_prefix_bloom_size_ratio(bloom_filter_ratio(for_engine));
         if let Some(factory) = filter_factory {
             cf_opts
-                .set_compaction_filter_factory("filter_factory", factory.clone())
+                .set_compaction_filter_factory("range_filter_factory", factory.clone())
                 .unwrap();
         }
         cf_opts.set_titan_cf_options(&self.titan.build_opts());

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -35,7 +35,7 @@ use engine_rocks::{
     },
     util::{
         FixedPrefixSliceTransform, FixedSuffixSliceTransform, NoopSliceTransform,
-        RangeCompactionFilterFactoryBuilder,
+        RangeCompactionFilterFactory, StackableCompactionFilterFactory,
     },
     RaftDbLogger, RangePropertiesCollectorFactory, RawMvccPropertiesCollectorFactory,
     RocksCfOptions, RocksDbOptions, RocksEngine, RocksEventListener, RocksStatistics,
@@ -705,7 +705,7 @@ impl DefaultCfConfig {
         shared: &CfResources,
         region_info_accessor: Option<&RegionInfoAccessor>,
         api_version: ApiVersion,
-        range_filter_builder: Option<&RangeCompactionFilterFactoryBuilder>,
+        range_filter_factory: Option<&RangeCompactionFilterFactory>,
         for_engine: EngineType,
     ) -> RocksCfOptions {
         let mut cf_opts = build_cf_opt!(
@@ -725,11 +725,11 @@ impl DefaultCfConfig {
             RawMvccPropertiesCollectorFactory::default(),
         );
         cf_opts.add_table_properties_collector_factory("tikv.range-properties-collector", f);
-        if let Some(builder) = range_filter_builder {
+        if let Some(factory) = range_filter_factory {
             match api_version {
                 ApiVersion::V1 => {
                     cf_opts
-                        .set_compaction_filter_factory("range_filter_factory", builder.build())
+                        .set_compaction_filter_factory("range_filter_factory", factory.clone())
                         .unwrap();
                 }
                 ApiVersion::V1ttl => {
@@ -737,18 +737,26 @@ impl DefaultCfConfig {
                         "tikv.ttl-properties-collector",
                         TtlPropertiesCollectorFactory::<ApiV1Ttl>::default(),
                     );
+                    let factory = StackableCompactionFilterFactory::new(
+                        factory.clone(),
+                        TtlCompactionFilterFactory::<ApiV1Ttl>::default(),
+                    );
                     cf_opts
                         .set_compaction_filter_factory(
-                            "ttl_compaction_filter_factory",
-                            builder.build_with(TtlCompactionFilterFactory::<ApiV1Ttl>::default()),
+                            "range_filter_factory+ttl_compaction_filter_factory",
+                            factory,
                         )
                         .unwrap();
                 }
                 ApiVersion::V2 => {
+                    let factory = StackableCompactionFilterFactory::new(
+                        factory.clone(),
+                        RawCompactionFilterFactory,
+                    );
                     cf_opts
                         .set_compaction_filter_factory(
-                            "apiv2_gc_compaction_filter_factory",
-                            builder.build_with(RawCompactionFilterFactory),
+                            "range_filter_factory+apiv2_gc_compaction_filter_factory",
+                            factory,
                         )
                         .unwrap();
                 }
@@ -861,7 +869,7 @@ impl WriteCfConfig {
         &self,
         shared: &CfResources,
         region_info_accessor: Option<&RegionInfoAccessor>,
-        range_filter_builder: Option<&RangeCompactionFilterFactoryBuilder>,
+        range_filter_factory: Option<&RangeCompactionFilterFactory>,
         for_engine: EngineType,
     ) -> RocksCfOptions {
         let mut cf_opts = build_cf_opt!(
@@ -890,12 +898,13 @@ impl WriteCfConfig {
             prop_keys_index_distance: self.prop_keys_index_distance,
         };
         cf_opts.add_table_properties_collector_factory("tikv.range-properties-collector", f);
-        if let Some(builder) = range_filter_builder {
+        if let Some(factory) = range_filter_factory {
+            let factory = StackableCompactionFilterFactory::new(
+                factory.clone(),
+                WriteCompactionFilterFactory,
+            );
             cf_opts
-                .set_compaction_filter_factory(
-                    "write_compaction_filter_factory",
-                    builder.build_with(WriteCompactionFilterFactory),
-                )
+                .set_compaction_filter_factory("write_compaction_filter_factory", factory)
                 .unwrap();
         } else {
             cf_opts
@@ -977,7 +986,7 @@ impl LockCfConfig {
     pub fn build_opt(
         &self,
         shared: &CfResources,
-        range_filter_builder: Option<&RangeCompactionFilterFactoryBuilder>,
+        range_filter_factory: Option<&RangeCompactionFilterFactory>,
         for_engine: EngineType,
     ) -> RocksCfOptions {
         let no_region_info_accessor: Option<&RegionInfoAccessor> = None;
@@ -997,9 +1006,9 @@ impl LockCfConfig {
         };
         cf_opts.add_table_properties_collector_factory("tikv.range-properties-collector", f);
         cf_opts.set_memtable_prefix_bloom_size_ratio(bloom_filter_ratio(for_engine));
-        if let Some(builder) = range_filter_builder {
+        if let Some(factory) = range_filter_factory {
             cf_opts
-                .set_compaction_filter_factory("range_filter_factory", builder.build())
+                .set_compaction_filter_factory("range_filter_factory", factory.clone())
                 .unwrap();
         }
         cf_opts.set_titan_cf_options(&self.titan.build_opts());
@@ -1440,7 +1449,7 @@ impl DbConfig {
         shared: &CfResources,
         region_info_accessor: Option<&RegionInfoAccessor>,
         api_version: ApiVersion,
-        filter_builder: Option<&RangeCompactionFilterFactoryBuilder>,
+        filter_factory: Option<&RangeCompactionFilterFactory>,
         for_engine: EngineType,
     ) -> Vec<(&'static str, RocksCfOptions)> {
         let mut cf_opts = Vec::with_capacity(4);
@@ -1450,18 +1459,18 @@ impl DbConfig {
                 shared,
                 region_info_accessor,
                 api_version,
-                filter_builder,
+                filter_factory,
                 for_engine,
             ),
         ));
         cf_opts.push((
             CF_LOCK,
-            self.lockcf.build_opt(shared, filter_builder, for_engine),
+            self.lockcf.build_opt(shared, filter_factory, for_engine),
         ));
         cf_opts.push((
             CF_WRITE,
             self.writecf
-                .build_opt(shared, region_info_accessor, filter_builder, for_engine),
+                .build_opt(shared, region_info_accessor, filter_factory, for_engine),
         ));
         if for_engine == EngineType::RaftKv {
             cf_opts.push((CF_RAFT, self.raftcf.build_opt(shared)));

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -33,7 +33,10 @@ use engine_rocks::{
         DBCompactionStyle, DBCompressionType, DBRateLimiterMode, DBRecoveryMode, Env,
         PrepopulateBlockCache, RateLimiter, WriteBufferManager,
     },
-    util::{FixedPrefixSliceTransform, FixedSuffixSliceTransform, NoopSliceTransform},
+    util::{
+        FixedPrefixSliceTransform, FixedSuffixSliceTransform, NoopSliceTransform,
+        RangeCompactionFilterFactoryBuilder,
+    },
     RaftDbLogger, RangePropertiesCollectorFactory, RawMvccPropertiesCollectorFactory,
     RocksCfOptions, RocksDbOptions, RocksEngine, RocksEventListener, RocksStatistics,
     RocksTitanDbOptions, RocksdbLogger, TtlPropertiesCollectorFactory,
@@ -702,6 +705,7 @@ impl DefaultCfConfig {
         shared: &CfResources,
         region_info_accessor: Option<&RegionInfoAccessor>,
         api_version: ApiVersion,
+        range_filter_builder: Option<&RangeCompactionFilterFactoryBuilder>,
         for_engine: EngineType,
     ) -> RocksCfOptions {
         let mut cf_opts = build_cf_opt!(
@@ -721,29 +725,59 @@ impl DefaultCfConfig {
             RawMvccPropertiesCollectorFactory::default(),
         );
         cf_opts.add_table_properties_collector_factory("tikv.range-properties-collector", f);
-        match api_version {
-            ApiVersion::V1 => {
-                // nothing to do
+        if let Some(builder) = range_filter_builder {
+            match api_version {
+                ApiVersion::V1 => {
+                    cf_opts
+                        .set_compaction_filter_factory("range_filter_factory", builder.build())
+                        .unwrap();
+                }
+                ApiVersion::V1ttl => {
+                    cf_opts.add_table_properties_collector_factory(
+                        "tikv.ttl-properties-collector",
+                        TtlPropertiesCollectorFactory::<ApiV1Ttl>::default(),
+                    );
+                    cf_opts
+                        .set_compaction_filter_factory(
+                            "ttl_compaction_filter_factory",
+                            builder.build_with(TtlCompactionFilterFactory::<ApiV1Ttl>::default()),
+                        )
+                        .unwrap();
+                }
+                ApiVersion::V2 => {
+                    cf_opts
+                        .set_compaction_filter_factory(
+                            "apiv2_gc_compaction_filter_factory",
+                            builder.build_with(RawCompactionFilterFactory),
+                        )
+                        .unwrap();
+                }
             }
-            ApiVersion::V1ttl => {
-                cf_opts.add_table_properties_collector_factory(
-                    "tikv.ttl-properties-collector",
-                    TtlPropertiesCollectorFactory::<ApiV1Ttl>::default(),
-                );
-                cf_opts
-                    .set_compaction_filter_factory(
-                        "ttl_compaction_filter_factory",
-                        TtlCompactionFilterFactory::<ApiV1Ttl>::default(),
-                    )
-                    .unwrap();
-            }
-            ApiVersion::V2 => {
-                cf_opts
-                    .set_compaction_filter_factory(
-                        "apiv2_gc_compaction_filter_factory",
-                        RawCompactionFilterFactory,
-                    )
-                    .unwrap();
+        } else {
+            match api_version {
+                ApiVersion::V1 => {
+                    // nothing to do
+                }
+                ApiVersion::V1ttl => {
+                    cf_opts.add_table_properties_collector_factory(
+                        "tikv.ttl-properties-collector",
+                        TtlPropertiesCollectorFactory::<ApiV1Ttl>::default(),
+                    );
+                    cf_opts
+                        .set_compaction_filter_factory(
+                            "ttl_compaction_filter_factory",
+                            TtlCompactionFilterFactory::<ApiV1Ttl>::default(),
+                        )
+                        .unwrap();
+                }
+                ApiVersion::V2 => {
+                    cf_opts
+                        .set_compaction_filter_factory(
+                            "apiv2_gc_compaction_filter_factory",
+                            RawCompactionFilterFactory,
+                        )
+                        .unwrap();
+                }
             }
         }
         cf_opts.set_titan_cf_options(&self.titan.build_opts());
@@ -827,6 +861,7 @@ impl WriteCfConfig {
         &self,
         shared: &CfResources,
         region_info_accessor: Option<&RegionInfoAccessor>,
+        range_filter_builder: Option<&RangeCompactionFilterFactoryBuilder>,
         for_engine: EngineType,
     ) -> RocksCfOptions {
         let mut cf_opts = build_cf_opt!(
@@ -855,12 +890,21 @@ impl WriteCfConfig {
             prop_keys_index_distance: self.prop_keys_index_distance,
         };
         cf_opts.add_table_properties_collector_factory("tikv.range-properties-collector", f);
-        cf_opts
-            .set_compaction_filter_factory(
-                "write_compaction_filter_factory",
-                WriteCompactionFilterFactory,
-            )
-            .unwrap();
+        if let Some(builder) = range_filter_builder {
+            cf_opts
+                .set_compaction_filter_factory(
+                    "write_compaction_filter_factory",
+                    builder.build_with(WriteCompactionFilterFactory),
+                )
+                .unwrap();
+        } else {
+            cf_opts
+                .set_compaction_filter_factory(
+                    "write_compaction_filter_factory",
+                    WriteCompactionFilterFactory,
+                )
+                .unwrap();
+        }
         cf_opts.set_titan_cf_options(&self.titan.build_opts());
         cf_opts
     }
@@ -930,7 +974,12 @@ impl Default for LockCfConfig {
 }
 
 impl LockCfConfig {
-    pub fn build_opt(&self, shared: &CfResources, for_engine: EngineType) -> RocksCfOptions {
+    pub fn build_opt(
+        &self,
+        shared: &CfResources,
+        range_filter_builder: Option<&RangeCompactionFilterFactoryBuilder>,
+        for_engine: EngineType,
+    ) -> RocksCfOptions {
         let no_region_info_accessor: Option<&RegionInfoAccessor> = None;
         let mut cf_opts = build_cf_opt!(
             self,
@@ -948,6 +997,11 @@ impl LockCfConfig {
         };
         cf_opts.add_table_properties_collector_factory("tikv.range-properties-collector", f);
         cf_opts.set_memtable_prefix_bloom_size_ratio(bloom_filter_ratio(for_engine));
+        if let Some(builder) = range_filter_builder {
+            cf_opts
+                .set_compaction_filter_factory("range_filter_factory", builder.build())
+                .unwrap();
+        }
         cf_opts.set_titan_cf_options(&self.titan.build_opts());
         cf_opts
     }
@@ -1386,19 +1440,28 @@ impl DbConfig {
         shared: &CfResources,
         region_info_accessor: Option<&RegionInfoAccessor>,
         api_version: ApiVersion,
+        filter_builder: Option<&RangeCompactionFilterFactoryBuilder>,
         for_engine: EngineType,
     ) -> Vec<(&'static str, RocksCfOptions)> {
         let mut cf_opts = Vec::with_capacity(4);
         cf_opts.push((
             CF_DEFAULT,
-            self.defaultcf
-                .build_opt(shared, region_info_accessor, api_version, for_engine),
+            self.defaultcf.build_opt(
+                shared,
+                region_info_accessor,
+                api_version,
+                filter_builder,
+                for_engine,
+            ),
         ));
-        cf_opts.push((CF_LOCK, self.lockcf.build_opt(shared, for_engine)));
+        cf_opts.push((
+            CF_LOCK,
+            self.lockcf.build_opt(shared, filter_builder, for_engine),
+        ));
         cf_opts.push((
             CF_WRITE,
             self.writecf
-                .build_opt(shared, region_info_accessor, for_engine),
+                .build_opt(shared, region_info_accessor, filter_builder, for_engine),
         ));
         if for_engine == EngineType::RaftKv {
             cf_opts.push((CF_RAFT, self.raftcf.build_opt(shared)));
@@ -3159,7 +3222,10 @@ impl TikvConfig {
         if self.storage.engine == EngineType::RaftKv2 {
             self.raft_store.store_io_pool_size = cmp::max(self.raft_store.store_io_pool_size, 1);
             if !self.raft_engine.enable {
-                panic!("partitioned-raft-kv only supports raft log engine.");
+                return Err("partitioned-raft-kv only supports raft log engine.".into());
+            }
+            if self.rocksdb.titan.enabled {
+                return Err("partitioned-raft-kv doesn't support titan.".into());
             }
         }
 
@@ -4634,6 +4700,7 @@ mod tests {
                 ),
                 None,
                 cfg.storage.api_version(),
+                None,
                 cfg.storage.engine,
             ),
             None,

--- a/src/server/engine_factory.rs
+++ b/src/server/engine_factory.rs
@@ -156,14 +156,14 @@ impl KvEngineFactory {
 
     fn cf_opts(
         &self,
-        filter_builder: Option<&RangeCompactionFilterFactory>,
+        filter_factory: Option<&RangeCompactionFilterFactory>,
         for_engine: EngineType,
     ) -> Vec<(&str, RocksCfOptions)> {
         self.inner.rocksdb_config.build_cf_opts(
             &self.inner.cf_resources,
             self.inner.region_info_accessor.as_ref(),
             self.inner.api_version,
-            filter_builder,
+            filter_factory,
             for_engine,
         )
     }

--- a/src/server/engine_factory.rs
+++ b/src/server/engine_factory.rs
@@ -4,6 +4,7 @@ use std::{path::Path, sync::Arc};
 
 use engine_rocks::{
     raw::{Cache, Env},
+    util::RangeCompactionFilterFactoryBuilder,
     CompactedEventSender, CompactionListener, FlowListener, RocksCfOptions, RocksCompactionJobInfo,
     RocksDbOptions, RocksEngine, RocksEventListener, RocksPersistenceListener, RocksStatistics,
     TabletLogger,
@@ -153,11 +154,16 @@ impl KvEngineFactory {
         db_opts
     }
 
-    fn cf_opts(&self, for_engine: EngineType) -> Vec<(&str, RocksCfOptions)> {
+    fn cf_opts(
+        &self,
+        filter_builder: Option<&RangeCompactionFilterFactoryBuilder>,
+        for_engine: EngineType,
+    ) -> Vec<(&str, RocksCfOptions)> {
         self.inner.rocksdb_config.build_cf_opts(
             &self.inner.cf_resources,
             self.inner.region_info_accessor.as_ref(),
             self.inner.api_version,
+            filter_builder,
             for_engine,
         )
     }
@@ -172,7 +178,7 @@ impl KvEngineFactory {
     pub fn create_shared_db(&self, path: impl AsRef<Path>) -> Result<RocksEngine> {
         let path = path.as_ref();
         let mut db_opts = self.db_opts(EngineType::RaftKv);
-        let cf_opts = self.cf_opts(EngineType::RaftKv);
+        let cf_opts = self.cf_opts(None, EngineType::RaftKv);
         if let Some(listener) = &self.inner.flow_listener {
             db_opts.add_event_listener(listener.clone());
         }
@@ -191,7 +197,9 @@ impl TabletFactory<RocksEngine> for KvEngineFactory {
         let mut db_opts = self.db_opts(EngineType::RaftKv2);
         let tablet_name = path.file_name().unwrap().to_str().unwrap().to_string();
         db_opts.set_info_log(TabletLogger::new(tablet_name));
-        let cf_opts = self.cf_opts(EngineType::RaftKv2);
+        let builder =
+            RangeCompactionFilterFactoryBuilder::new(ctx.start_key.to_vec(), ctx.end_key.to_vec());
+        let cf_opts = self.cf_opts(Some(&builder), EngineType::RaftKv2);
         if let Some(listener) = &self.inner.flow_listener {
             db_opts.add_event_listener(listener.clone_with(ctx.id));
         }
@@ -219,7 +227,7 @@ impl TabletFactory<RocksEngine> for KvEngineFactory {
         info!("destroy tablet"; "path" => %path.display(), "id" => ctx.id, "suffix" => ?ctx.suffix);
         // Create kv engine.
         let _db_opts = self.db_opts(EngineType::RaftKv2);
-        let _cf_opts = self.cf_opts(EngineType::RaftKv2);
+        let _cf_opts = self.cf_opts(None, EngineType::RaftKv2);
         // TODOTODO: call rust-rocks or tirocks to destroy_engine;
         // engine_rocks::util::destroy_engine(
         //   path.to_str().unwrap(),
@@ -237,7 +245,7 @@ impl TabletFactory<RocksEngine> for KvEngineFactory {
         RocksEngine::exists(path.to_str().unwrap())
     }
 
-    #[cfg(any(test, feature = "testexport"))]
+    #[cfg(feature = "testexport")]
     fn set_state_storage(&self, state_storage: Arc<dyn StateStorage>) {
         let inner = Arc::as_ptr(&self.inner) as *mut FactoryInner;
         unsafe {
@@ -250,13 +258,13 @@ impl TabletFactory<RocksEngine> for KvEngineFactory {
 mod tests {
     use std::path::Path;
 
-    use engine_traits::TabletRegistry;
+    use engine_traits::{Peekable, SyncMutable, TabletRegistry};
+    use kvproto::metapb::Region;
 
     use super::*;
     use crate::config::TikvConfig;
 
-    #[test]
-    fn test_engine_factory() {
+    fn build_test(name: &'static str) -> (tempfile::TempDir, TabletRegistry<RocksEngine>) {
         let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
         let common_test_cfg = manifest_dir.join("components/test_raftstore/src/common-test.toml");
         let cfg = TikvConfig::from_file(&common_test_cfg, None).unwrap_or_else(|e| {
@@ -270,11 +278,18 @@ mod tests {
             .storage
             .block_cache
             .build_shared_cache(cfg.storage.engine);
-        let dir = test_util::temp_dir("test-engine-factory", false);
+        let dir = test_util::temp_dir(name, false);
         let env = cfg.build_shared_rocks_env(None, None).unwrap();
 
         let factory = KvEngineFactoryBuilder::new(env, &cfg, cache).build();
         let reg = TabletRegistry::new(Box::new(factory), dir.path()).unwrap();
+        (dir, reg)
+    }
+
+    #[test]
+    fn test_engine_factory() {
+        let (_dir, reg) = build_test("test_engine_factory");
+
         let path = reg.tablet_path(1, 3);
         assert!(!reg.tablet_factory().exists(&path));
         let mut tablet_ctx = TabletContext::with_infinite_region(1, Some(3));
@@ -293,5 +308,37 @@ mod tests {
             .destroy_tablet(tablet_ctx, &path)
             .unwrap();
         assert!(!reg.tablet_factory().exists(&path));
+    }
+
+    #[test]
+    fn test_engine_factory_compaction_filter() {
+        let (_dir, reg) = build_test("test_engine_factory_compaction_filter");
+
+        let region = Region {
+            id: 1,
+            start_key: b"k1".to_vec(),
+            end_key: b"k3".to_vec(),
+            ..Default::default()
+        };
+        let tablet_ctx = TabletContext::new(&region, Some(3));
+        let path = reg.tablet_path(1, 3);
+        let engine = reg.tablet_factory().open_tablet(tablet_ctx, &path).unwrap();
+        engine.put(&keys::data_key(b"k0"), b"v0").unwrap();
+        engine.put(&keys::data_key(b"k1"), b"v1").unwrap();
+        engine.put(&keys::data_key(b"k2"), b"v2").unwrap();
+        engine.put(&keys::data_key(b"k3"), b"v3").unwrap();
+        engine.put(&keys::data_key(b"k4"), b"v4").unwrap();
+        engine.flush_cfs(&[], true).unwrap();
+        assert!(engine.get_value(&keys::data_key(b"k0")).unwrap().is_none());
+        assert_eq!(
+            engine.get_value(&keys::data_key(b"k1")).unwrap().unwrap(),
+            b"v1"
+        );
+        assert_eq!(
+            engine.get_value(&keys::data_key(b"k2")).unwrap().unwrap(),
+            b"v2"
+        );
+        assert!(engine.get_value(&keys::data_key(b"k3")).unwrap().is_none());
+        assert!(engine.get_value(&keys::data_key(b"k4")).unwrap().is_none());
     }
 }

--- a/src/server/gc_worker/compaction_filter.rs
+++ b/src/server/gc_worker/compaction_filter.rs
@@ -14,9 +14,8 @@ use std::{
 
 use engine_rocks::{
     raw::{
-        new_compaction_filter_raw, CompactionFilter, CompactionFilterContext,
-        CompactionFilterDecision, CompactionFilterFactory, CompactionFilterValueType,
-        DBCompactionFilter,
+        CompactionFilter, CompactionFilterContext, CompactionFilterDecision,
+        CompactionFilterFactory, CompactionFilterValueType, DBTableFileCreationReason,
     },
     RocksEngine, RocksMvccProperties, RocksWriteBatchVec,
 };
@@ -199,21 +198,23 @@ impl CompactionFilterInitializer<RocksEngine> for Option<RocksEngine> {
 pub struct WriteCompactionFilterFactory;
 
 impl CompactionFilterFactory for WriteCompactionFilterFactory {
+    type Filter = WriteCompactionFilter;
+
     fn create_compaction_filter(
         &self,
         context: &CompactionFilterContext,
-    ) -> *mut DBCompactionFilter {
+    ) -> Option<(CString, Self::Filter)> {
         let gc_context_option = GC_CONTEXT.lock().unwrap();
         let gc_context = match *gc_context_option {
             Some(ref ctx) => ctx,
-            None => return std::ptr::null_mut(),
+            None => return None,
         };
 
         let safe_point = gc_context.safe_point.load(Ordering::Relaxed);
         if safe_point == 0 {
             // Safe point has not been initialized yet.
             debug!("skip gc in compaction filter because of no safe point");
-            return std::ptr::null_mut();
+            return None;
         }
 
         let (enable, skip_vcheck, ratio_threshold) = {
@@ -241,12 +242,12 @@ impl CompactionFilterFactory for WriteCompactionFilterFactory {
             .map_or(false, RocksEngine::is_stalled_or_stopped)
         {
             debug!("skip gc in compaction filter because the DB is stalled");
-            return std::ptr::null_mut();
+            return None;
         }
 
         if !do_check_allowed(enable, skip_vcheck, &gc_context.feature_gate) {
             debug!("skip gc in compaction filter because it's not allowed");
-            return std::ptr::null_mut();
+            return None;
         }
         drop(gc_context_option);
         GC_COMPACTION_FILTER_PERFORM
@@ -257,7 +258,7 @@ impl CompactionFilterFactory for WriteCompactionFilterFactory {
             GC_COMPACTION_FILTER_SKIP
                 .with_label_values(&[STAT_TXN_KEYMODE])
                 .inc();
-            return std::ptr::null_mut();
+            return None;
         }
 
         debug!(
@@ -275,7 +276,14 @@ impl CompactionFilterFactory for WriteCompactionFilterFactory {
             (store_id, region_info_provider),
         );
         let name = CString::new("write_compaction_filter").unwrap();
-        unsafe { new_compaction_filter_raw(name, filter) }
+        Some((name, filter))
+    }
+
+    fn should_filter_table_file_creation(&self, reason: DBTableFileCreationReason) -> bool {
+        matches!(
+            reason,
+            DBTableFileCreationReason::Flush | DBTableFileCreationReason::Compaction
+        )
     }
 }
 
@@ -326,7 +334,7 @@ impl<B: WriteBatch> DeleteBatch<B> {
     }
 }
 
-struct WriteCompactionFilter {
+pub struct WriteCompactionFilter {
     safe_point: u64,
     engine: Option<RocksEngine>,
     is_bottommost_level: bool,

--- a/src/server/gc_worker/compaction_filter.rs
+++ b/src/server/gc_worker/compaction_filter.rs
@@ -15,7 +15,7 @@ use std::{
 use engine_rocks::{
     raw::{
         CompactionFilter, CompactionFilterContext, CompactionFilterDecision,
-        CompactionFilterFactory, CompactionFilterValueType, DBTableFileCreationReason,
+        CompactionFilterFactory, CompactionFilterValueType,
     },
     RocksEngine, RocksMvccProperties, RocksWriteBatchVec,
 };
@@ -277,13 +277,6 @@ impl CompactionFilterFactory for WriteCompactionFilterFactory {
         );
         let name = CString::new("write_compaction_filter").unwrap();
         Some((name, filter))
-    }
-
-    fn should_filter_table_file_creation(&self, reason: DBTableFileCreationReason) -> bool {
-        matches!(
-            reason,
-            DBTableFileCreationReason::Flush | DBTableFileCreationReason::Compaction
-        )
     }
 }
 

--- a/src/server/gc_worker/compaction_filter.rs
+++ b/src/server/gc_worker/compaction_filter.rs
@@ -1068,7 +1068,7 @@ pub mod tests {
 
             // Wait up to 1 second, and treat as no task if timeout.
             if let Ok(Some(task)) = gc_runner.gc_receiver.recv_timeout(Duration::new(1, 0)) {
-                assert!(expect_tasks, "a GC task is expected");
+                assert!(expect_tasks, "unexpected GC task");
                 match task {
                     GcTask::GcKeys { keys, .. } => {
                         assert_eq!(keys.len(), 1);
@@ -1080,7 +1080,7 @@ pub mod tests {
                 }
                 return;
             }
-            assert!(!expect_tasks, "no GC task is expected");
+            assert!(!expect_tasks, "no GC task after 1 second");
         };
 
         // No key switch after the deletion mark.

--- a/src/server/gc_worker/rawkv_compaction_filter.rs
+++ b/src/server/gc_worker/rawkv_compaction_filter.rs
@@ -10,7 +10,7 @@ use api_version::{ApiV2, KeyMode, KvFormat};
 use engine_rocks::{
     raw::{
         CompactionFilter, CompactionFilterContext, CompactionFilterDecision,
-        CompactionFilterFactory, CompactionFilterValueType, DBTableFileCreationReason,
+        CompactionFilterFactory, CompactionFilterValueType,
     },
     RocksEngine,
 };
@@ -103,13 +103,6 @@ impl CompactionFilterFactory for RawCompactionFilterFactory {
         );
         let name = CString::new("raw_compaction_filter").unwrap();
         Some((name, filter))
-    }
-
-    fn should_filter_table_file_creation(&self, reason: DBTableFileCreationReason) -> bool {
-        matches!(
-            reason,
-            DBTableFileCreationReason::Flush | DBTableFileCreationReason::Compaction
-        )
     }
 }
 

--- a/src/server/gc_worker/rawkv_compaction_filter.rs
+++ b/src/server/gc_worker/rawkv_compaction_filter.rs
@@ -9,9 +9,8 @@ use std::{
 use api_version::{ApiV2, KeyMode, KvFormat};
 use engine_rocks::{
     raw::{
-        new_compaction_filter_raw, CompactionFilter, CompactionFilterContext,
-        CompactionFilterDecision, CompactionFilterFactory, CompactionFilterValueType,
-        DBCompactionFilter,
+        CompactionFilter, CompactionFilterContext, CompactionFilterDecision,
+        CompactionFilterFactory, CompactionFilterValueType, DBTableFileCreationReason,
     },
     RocksEngine,
 };
@@ -36,15 +35,17 @@ use crate::{
 pub struct RawCompactionFilterFactory;
 
 impl CompactionFilterFactory for RawCompactionFilterFactory {
+    type Filter = RawCompactionFilter;
+
     fn create_compaction_filter(
         &self,
         context: &CompactionFilterContext,
-    ) -> *mut DBCompactionFilter {
+    ) -> Option<(CString, Self::Filter)> {
         //---------------- GC context --------------
         let gc_context_option = GC_CONTEXT.lock().unwrap();
         let gc_context = match *gc_context_option {
             Some(ref ctx) => ctx,
-            None => return std::ptr::null_mut(),
+            None => return None,
         };
         //---------------- GC context END --------------
 
@@ -57,7 +58,7 @@ impl CompactionFilterFactory for RawCompactionFilterFactory {
         if safe_point == 0 {
             // Safe point has not been initialized yet.
             debug!("skip gc in compaction filter because of no safe point");
-            return std::ptr::null_mut();
+            return None;
         }
 
         let ratio_threshold = {
@@ -76,7 +77,7 @@ impl CompactionFilterFactory for RawCompactionFilterFactory {
             .map_or(false, RocksEngine::is_stalled_or_stopped)
         {
             debug!("skip gc in compaction filter because the DB is stalled");
-            return std::ptr::null_mut();
+            return None;
         }
 
         drop(gc_context_option);
@@ -90,7 +91,7 @@ impl CompactionFilterFactory for RawCompactionFilterFactory {
             GC_COMPACTION_FILTER_SKIP
                 .with_label_values(&[STAT_RAW_KEYMODE])
                 .inc();
-            return std::ptr::null_mut();
+            return None;
         }
 
         let filter = RawCompactionFilter::new(
@@ -101,11 +102,18 @@ impl CompactionFilterFactory for RawCompactionFilterFactory {
             (store_id, region_info_provider),
         );
         let name = CString::new("raw_compaction_filter").unwrap();
-        unsafe { new_compaction_filter_raw(name, filter) }
+        Some((name, filter))
+    }
+
+    fn should_filter_table_file_creation(&self, reason: DBTableFileCreationReason) -> bool {
+        matches!(
+            reason,
+            DBTableFileCreationReason::Flush | DBTableFileCreationReason::Compaction
+        )
     }
 }
 
-struct RawCompactionFilter {
+pub struct RawCompactionFilter {
     safe_point: u64,
     is_bottommost_level: bool,
     gc_scheduler: Scheduler<GcTask<RocksEngine>>,

--- a/src/server/ttl/ttl_compaction_filter.rs
+++ b/src/server/ttl/ttl_compaction_filter.rs
@@ -6,7 +6,7 @@ use api_version::{KeyMode, KvFormat, RawValue};
 use engine_rocks::{
     raw::{
         CompactionFilter, CompactionFilterContext, CompactionFilterDecision,
-        CompactionFilterFactory, CompactionFilterValueType,
+        CompactionFilterFactory, CompactionFilterValueType, DBTableFileCreationReason,
     },
     RocksTtlProperties,
 };
@@ -48,6 +48,10 @@ impl<F: KvFormat> CompactionFilterFactory for TtlCompactionFilterFactory<F> {
             _phantom: PhantomData,
         };
         Some((name, filter))
+    }
+
+    fn should_filter_table_file_creation(&self, _reason: DBTableFileCreationReason) -> bool {
+        true
     }
 }
 

--- a/src/server/ttl/ttl_compaction_filter.rs
+++ b/src/server/ttl/ttl_compaction_filter.rs
@@ -5,9 +5,8 @@ use std::{ffi::CString, marker::PhantomData};
 use api_version::{KeyMode, KvFormat, RawValue};
 use engine_rocks::{
     raw::{
-        new_compaction_filter_raw, CompactionFilter, CompactionFilterContext,
-        CompactionFilterDecision, CompactionFilterFactory, CompactionFilterValueType,
-        DBCompactionFilter,
+        CompactionFilter, CompactionFilterContext, CompactionFilterDecision,
+        CompactionFilterFactory, CompactionFilterValueType, DBTableFileCreationReason,
     },
     RocksTtlProperties,
 };
@@ -21,10 +20,12 @@ pub struct TtlCompactionFilterFactory<F: KvFormat> {
 }
 
 impl<F: KvFormat> CompactionFilterFactory for TtlCompactionFilterFactory<F> {
+    type Filter = TtlCompactionFilter<F>;
+
     fn create_compaction_filter(
         &self,
         context: &CompactionFilterContext,
-    ) -> *mut DBCompactionFilter {
+    ) -> Option<(CString, Self::Filter)> {
         let current = ttl_current_ts();
 
         let mut min_expire_ts = u64::MAX;
@@ -38,7 +39,7 @@ impl<F: KvFormat> CompactionFilterFactory for TtlCompactionFilterFactory<F> {
             }
         }
         if min_expire_ts > current {
-            return std::ptr::null_mut();
+            return None;
         }
 
         let name = CString::new("ttl_compaction_filter").unwrap();
@@ -46,11 +47,18 @@ impl<F: KvFormat> CompactionFilterFactory for TtlCompactionFilterFactory<F> {
             ts: current,
             _phantom: PhantomData,
         };
-        unsafe { new_compaction_filter_raw(name, filter) }
+        Some((name, filter))
+    }
+
+    fn should_filter_table_file_creation(&self, reason: DBTableFileCreationReason) -> bool {
+        matches!(
+            reason,
+            DBTableFileCreationReason::Flush | DBTableFileCreationReason::Compaction
+        )
     }
 }
 
-struct TtlCompactionFilter<F: KvFormat> {
+pub struct TtlCompactionFilter<F: KvFormat> {
     ts: u64,
     _phantom: PhantomData<F>,
 }

--- a/src/server/ttl/ttl_compaction_filter.rs
+++ b/src/server/ttl/ttl_compaction_filter.rs
@@ -6,7 +6,7 @@ use api_version::{KeyMode, KvFormat, RawValue};
 use engine_rocks::{
     raw::{
         CompactionFilter, CompactionFilterContext, CompactionFilterDecision,
-        CompactionFilterFactory, CompactionFilterValueType, DBTableFileCreationReason,
+        CompactionFilterFactory, CompactionFilterValueType,
     },
     RocksTtlProperties,
 };
@@ -48,13 +48,6 @@ impl<F: KvFormat> CompactionFilterFactory for TtlCompactionFilterFactory<F> {
             _phantom: PhantomData,
         };
         Some((name, filter))
-    }
-
-    fn should_filter_table_file_creation(&self, reason: DBTableFileCreationReason) -> bool {
-        matches!(
-            reason,
-            DBTableFileCreationReason::Flush | DBTableFileCreationReason::Compaction
-        )
     }
 }
 

--- a/src/storage/kv/test_engine_builder.rs
+++ b/src/storage/kv/test_engine_builder.rs
@@ -103,19 +103,25 @@ impl TestEngineBuilder {
             .map(|cf| match *cf {
                 CF_DEFAULT => (
                     CF_DEFAULT,
-                    cfg_rocksdb
-                        .defaultcf
-                        .build_opt(&shared, None, api_version, EngineType::RaftKv),
+                    cfg_rocksdb.defaultcf.build_opt(
+                        &shared,
+                        None,
+                        api_version,
+                        None,
+                        EngineType::RaftKv,
+                    ),
                 ),
                 CF_LOCK => (
                     CF_LOCK,
-                    cfg_rocksdb.lockcf.build_opt(&shared, EngineType::RaftKv),
+                    cfg_rocksdb
+                        .lockcf
+                        .build_opt(&shared, None, EngineType::RaftKv),
                 ),
                 CF_WRITE => (
                     CF_WRITE,
                     cfg_rocksdb
                         .writecf
-                        .build_opt(&shared, None, EngineType::RaftKv),
+                        .build_opt(&shared, None, None, EngineType::RaftKv),
                 ),
                 CF_RAFT => (CF_RAFT, cfg_rocksdb.raftcf.build_opt(&shared)),
                 _ => (*cf, RocksCfOptions::default()),

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -4205,18 +4205,21 @@ mod tests {
                         &shared,
                         None,
                         ApiVersion::V1,
+                        None,
                         EngineType::RaftKv,
                     ),
                 ),
                 (
                     CF_LOCK,
-                    cfg_rocksdb.lockcf.build_opt(&shared, EngineType::RaftKv),
+                    cfg_rocksdb
+                        .lockcf
+                        .build_opt(&shared, None, EngineType::RaftKv),
                 ),
                 (
                     CF_WRITE,
                     cfg_rocksdb
                         .writecf
-                        .build_opt(&shared, None, EngineType::RaftKv),
+                        .build_opt(&shared, None, None, EngineType::RaftKv),
                 ),
                 (CF_RAFT, cfg_rocksdb.raftcf.build_opt(&shared)),
             ];

--- a/tests/integrations/storage/test_titan.rs
+++ b/tests/integrations/storage/test_titan.rs
@@ -168,6 +168,7 @@ fn test_delete_files_in_range_for_titan() {
         &cfg.rocksdb.build_cf_resources(cache),
         None,
         cfg.storage.api_version(),
+        None,
         cfg.storage.engine,
     );
 


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Ref #12842 

What's Changed:

Add a new compaction filter that filters out-of-range keys, and a compaction filter that can composite multiple filters as a stack.

```commit-message
None
```

### Related changes

https://github.com/tikv/rust-rocksdb/pull/738
https://github.com/tikv/tikv/pull/14253

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
