### PR TITLE
copr: (enhance) support executor limit with partition_by fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6701,7 +6701,7 @@ dependencies = [
 [[package]]
 name = "tipb"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/tipb.git#614f3ffd42ddc84b78ff59d65f105f2099a6f1b1"
+source = "git+https://github.com/pingcap/tipb.git#955fbdc879517f16b7a2f5967f143b92a6ab03dd"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/components/resource_control/src/lib.rs
+++ b/components/resource_control/src/lib.rs
@@ -17,10 +17,16 @@ pub use service::ResourceManagerService;
 pub mod channel;
 pub use channel::ResourceMetered;
 
-#[derive(Clone, Serialize, Deserialize, PartialEq, Debug, OnlineConfig, Default)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Debug, OnlineConfig)]
 #[serde(default)]
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
     #[online_config(skip)]
     pub enabled: bool,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self { enabled: true }
+    }
 }

--- a/components/tidb_query_executors/src/runner.rs
+++ b/components/tidb_query_executors/src/runner.rs
@@ -342,6 +342,15 @@ pub fn build_executors<S: Storage + 'static, F: KvFormat>(
 
                 if partition_by.is_empty() {
                     Box::new(
+                        BatchLimitExecutor::new(
+                            executor,
+                            d.get_limit() as usize,
+                            is_src_scan_executor,
+                        )?
+                        .collect_summary(summary_slot_index),
+                    )
+                } else {
+                    Box::new(
                         BatchPartitionTopNExecutor::new(
                             config.clone(),
                             executor,
@@ -349,15 +358,6 @@ pub fn build_executors<S: Storage + 'static, F: KvFormat>(
                             vec![],
                             vec![],
                             d.get_limit() as usize,
-                        )?
-                        .collect_summary(summary_slot_index),
-                    )
-                } else {
-                    Box::new(
-                        BatchLimitExecutor::new(
-                            executor,
-                            d.get_limit() as usize,
-                            is_src_scan_executor,
                         )?
                         .collect_summary(summary_slot_index),
                     )

--- a/components/tidb_query_executors/src/runner.rs
+++ b/components/tidb_query_executors/src/runner.rs
@@ -329,14 +329,39 @@ pub fn build_executors<S: Storage + 'static, F: KvFormat>(
             ExecType::TypeLimit => {
                 EXECUTOR_COUNT_METRICS.batch_limit.inc();
 
-                Box::new(
-                    BatchLimitExecutor::new(
-                        executor,
-                        ed.get_limit().get_limit() as usize,
-                        is_src_scan_executor,
-                    )?
-                    .collect_summary(summary_slot_index),
-                )
+                let mut d = ed.take_limit();
+
+                // If there is partition_by field in Limit, we treat it as a
+                // partitionTopN without order_by.
+                // todo: refine those logics.
+                let partition_by = d
+                    .take_partition_by()
+                    .into_iter()
+                    .map(|mut item| item.take_expr())
+                    .collect_vec();
+
+                if partition_by.is_empty() {
+                    Box::new(
+                        BatchPartitionTopNExecutor::new(
+                            config.clone(),
+                            executor,
+                            partition_by,
+                            vec![],
+                            vec![],
+                            d.get_limit() as usize,
+                        )?
+                        .collect_summary(summary_slot_index),
+                    )
+                } else {
+                    Box::new(
+                        BatchLimitExecutor::new(
+                            executor,
+                            d.get_limit() as usize,
+                            is_src_scan_executor,
+                        )?
+                        .collect_summary(summary_slot_index),
+                    )
+                }
             }
             ExecType::TypeTopN => {
                 EXECUTOR_COUNT_METRICS.batch_top_n.inc();


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

Issue Number: Ref https://github.com/tikv/tikv/issues/13936

What's Changed: When find a limit with partition_by field, we treat it as a partitionTopN without order_key.


### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test has already added in https://github.com/tikv/tikv/pull/14116
- Manual test (add detailed scripts or steps below)

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
