### PR TITLE
coprocessor: reuse EvalContext in collect_column_stats

### DIFF
--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -376,6 +376,7 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
 
         let mut is_drained = false;
         let mut collector = self.new_collector();
+        let mut ctx = EvalContext::default();
         while !is_drained {
             let mut sample = self.quota_limiter.new_sample(!self.is_auto_analyze);
             let mut read_size: usize = 0;
@@ -400,7 +401,7 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
                         columns_slice[i].encode(
                             *logical_row,
                             &self.columns_info[i],
-                            &mut EvalContext::default(),
+                            &mut ctx,
                             &mut column_vals[i],
                         )?;
                         if self.columns_info[i].as_accessor().is_string_like() {
@@ -408,7 +409,7 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
                                 TT, match self.columns_info[i].as_accessor().collation()? {
                                     Collation::TT => {
                                         let mut mut_val = &column_vals[i][..];
-                                        let decoded_val = table::decode_col_value(&mut mut_val, &mut EvalContext::default(), &self.columns_info[i])?;
+                                        let decoded_val = table::decode_col_value(&mut mut_val, &mut ctx, &self.columns_info[i])?;
                                         if decoded_val == Datum::Null {
                                             collation_key_vals[i].clone_from(&column_vals[i]);
                                         } else {
@@ -895,6 +896,7 @@ impl<S: Snapshot, F: KvFormat> SampleBuilder<S, F> {
         let mut common_handle_hist = Histogram::new(self.max_bucket_size);
         let mut common_handle_cms = CmSketch::new(self.cm_sketch_depth, self.cm_sketch_width);
         let mut common_handle_fms = FmSketch::new(self.max_fm_sketch_size);
+        let mut ctx = EvalContext::default();
         while !is_drained {
             let result = self.data.next_batch(BATCH_MAX_SIZE).await;
             is_drained = result.is_drained?.stop();
@@ -904,12 +906,7 @@ impl<S: Snapshot, F: KvFormat> SampleBuilder<S, F> {
             if columns_without_handle_len + 1 == columns_slice.len() {
                 for logical_row in &result.logical_rows {
                     let mut data = vec![];
-                    columns_slice[0].encode(
-                        *logical_row,
-                        &columns_info[0],
-                        &mut EvalContext::default(),
-                        &mut data,
-                    )?;
+                    columns_slice[0].encode(*logical_row, &columns_info[0], &mut ctx, &mut data)?;
                     pk_builder.append(&data, false);
                 }
                 columns_slice = &columns_slice[1..];
@@ -929,7 +926,7 @@ impl<S: Snapshot, F: KvFormat> SampleBuilder<S, F> {
                         columns_slice[i].encode(
                             *logical_row,
                             &columns_info[i],
-                            &mut EvalContext::default(),
+                            &mut ctx,
                             &mut handle_col_val,
                         )?;
                         data.extend_from_slice(&handle_col_val);
@@ -974,12 +971,7 @@ impl<S: Snapshot, F: KvFormat> SampleBuilder<S, F> {
             for (i, collector) in collectors.iter_mut().enumerate() {
                 for logical_row in &result.logical_rows {
                     let mut val = vec![];
-                    columns_slice[i].encode(
-                        *logical_row,
-                        &columns_info[i],
-                        &mut EvalContext::default(),
-                        &mut val,
-                    )?;
+                    columns_slice[i].encode(*logical_row, &columns_info[i], &mut ctx, &mut val)?;
 
                     // This is a workaround for different encoding methods used by TiDB and TiKV for
                     // CM Sketch. We need this because we must ensure we are using the same encoding
@@ -1000,9 +992,8 @@ impl<S: Snapshot, F: KvFormat> SampleBuilder<S, F> {
                         INT_FLAG | UINT_FLAG | DURATION_FLAG => {
                             let mut mut_val = &val[..];
                             let decoded_val = mut_val.read_datum()?;
-                            let flattened =
-                                table::flatten(&mut EvalContext::default(), decoded_val)?;
-                            encode_value(&mut EvalContext::default(), &[flattened])?
+                            let flattened = table::flatten(&mut ctx, decoded_val)?;
+                            encode_value(&mut ctx, &[flattened])?
                         }
                         _ => val,
                     };
@@ -1012,14 +1003,14 @@ impl<S: Snapshot, F: KvFormat> SampleBuilder<S, F> {
                             TT, match columns_info[i].as_accessor().collation()? {
                                 Collation::TT => {
                                     let mut mut_val = &val[..];
-                                    let decoded_val = table::decode_col_value(&mut mut_val, &mut EvalContext::default(), &columns_info[i])?;
+                                    let decoded_val = table::decode_col_value(&mut mut_val, &mut ctx, &columns_info[i])?;
                                     if decoded_val == Datum::Null {
                                         val
                                     } else {
                                         // Only if the `decoded_val` is Datum::Null, `decoded_val` is a Ok(None).
                                         // So it is safe the unwrap the Ok value.
                                         let decoded_sorted_val = TT::sort_key(&decoded_val.as_string()?.unwrap().into_owned())?;
-                                        encode_value(&mut EvalContext::default(), &[Datum::Bytes(decoded_sorted_val)])?
+                                        encode_value(&mut ctx, &[Datum::Bytes(decoded_sorted_val)])?
                                     }
                                 }
                             }
@@ -1237,8 +1228,9 @@ mod tests {
         );
         let cases = vec![Datum::I64(1), Datum::Null, Datum::I64(2), Datum::I64(5)];
 
+        let mut ctx = EvalContext::default();
         for data in cases {
-            sample.collect(datum::encode_value(&mut EvalContext::default(), &[data]).unwrap());
+            sample.collect(datum::encode_value(&mut ctx, &[data]).unwrap());
         }
         assert_eq!(sample.samples.len(), max_sample_size);
         assert_eq!(sample.null_count, 1);
@@ -1254,10 +1246,9 @@ mod tests {
         let loop_cnt = 1000;
         let mut item_cnt: HashMap<Vec<u8>, usize> = HashMap::new();
         let mut nums: Vec<Vec<u8>> = Vec::with_capacity(row_num);
+        let mut ctx = EvalContext::default();
         for i in 0..row_num {
-            nums.push(
-                datum::encode_value(&mut EvalContext::default(), &[Datum::I64(i as i64)]).unwrap(),
-            );
+            nums.push(datum::encode_value(&mut ctx, &[Datum::I64(i as i64)]).unwrap());
         }
         for loop_i in 0..loop_cnt {
             let mut collector = ReservoirRowSampleCollector::new(sample_num, 1000, 1);
@@ -1302,10 +1293,9 @@ mod tests {
         let loop_cnt = 1000;
         let mut item_cnt: HashMap<Vec<u8>, usize> = HashMap::new();
         let mut nums: Vec<Vec<u8>> = Vec::with_capacity(row_num);
+        let mut ctx = EvalContext::default();
         for i in 0..row_num {
-            nums.push(
-                datum::encode_value(&mut EvalContext::default(), &[Datum::I64(i as i64)]).unwrap(),
-            );
+            nums.push(datum::encode_value(&mut ctx, &[Datum::I64(i as i64)]).unwrap());
         }
         for loop_i in 0..loop_cnt {
             let mut collector =
@@ -1348,10 +1338,9 @@ mod tests {
         let sample_num = 0; // abnormal.
         let row_num = 100;
         let mut nums: Vec<Vec<u8>> = Vec::with_capacity(row_num);
+        let mut ctx = EvalContext::default();
         for i in 0..row_num {
-            nums.push(
-                datum::encode_value(&mut EvalContext::default(), &[Datum::I64(i as i64)]).unwrap(),
-            );
+            nums.push(datum::encode_value(&mut ctx, &[Datum::I64(i as i64)]).unwrap());
         }
         {
             // Test for ReservoirRowSampleCollector
@@ -1409,19 +1398,16 @@ mod benches {
         }
         let mut column_vals = Vec::new();
         let mut collation_key_vals = Vec::new();
+        let mut ctx = EvalContext::default();
         for i in 0..columns_info.len() {
             let mut val = vec![];
             columns_slice[i]
-                .encode(0, &columns_info[i], &mut EvalContext::default(), &mut val)
+                .encode(0, &columns_info[i], &mut ctx, &mut val)
                 .unwrap();
             if columns_info[i].as_accessor().is_string_like() {
                 let mut mut_val = &val[..];
-                let decoded_val = table::decode_col_value(
-                    &mut mut_val,
-                    &mut EvalContext::default(),
-                    &columns_info[i],
-                )
-                .unwrap();
+                let decoded_val =
+                    table::decode_col_value(&mut mut_val, &mut ctx, &columns_info[i]).unwrap();
                 let decoded_sorted_val =
                     CollatorUtf8Mb4Bin::sort_key(&decoded_val.as_string().unwrap().unwrap())
                         .unwrap();


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #14231

What's Changed:

<img width="1855" alt="Screen Shot 2023-03-10 at 3 32 36 PM" src="https://user-images.githubusercontent.com/30385241/224255867-822dd504-a7d8-467e-bdbd-426daae76ce2.png">

From the flame graph, creating and dropping `EvalContext` takes up much CPU time since it is called frequently. Hence, the PR reuses `EvalContext` in `collect_column_stats` to reduce the cost.

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
