### PR TITLE
raftstore-v2: filter read index msg when sending from self

### DIFF
--- a/components/raftstore-v2/src/operation/ready/mod.rs
+++ b/components/raftstore-v2/src/operation/ready/mod.rs
@@ -255,11 +255,24 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         let pre_committed_index = self.raft_group().raft.raft_log.committed;
         if msg.get_message().get_msg_type() == MessageType::MsgTransferLeader {
             self.on_transfer_leader_msg(ctx, msg.get_message(), msg.disk_usage)
-        } else if let Err(e) = self.raft_group_mut().step(msg.take_message()) {
-            error!(self.logger, "raft step error"; "err" => ?e);
         } else {
-            let committed_index = self.raft_group().raft.raft_log.committed;
-            self.report_commit_log_duration(ctx, pre_committed_index, committed_index);
+            // This can be a message that sent when it's still a follower. Nevertheleast,
+            // it's meaningless to continue to handle the request as callbacks are cleared.
+            if msg.get_message().get_msg_type() == MessageType::MsgReadIndex
+                && self.fsm.peer.is_leader()
+                && (msg.get_message().get_from() == raft::INVALID_ID
+                    || msg.get_message().get_from() == self.fsm.peer_id())
+            {
+                ctx.raft_metrics.message_dropped.stale_msg.inc();
+                return Ok(());
+            }
+
+            if let Err(e) = self.raft_group_mut().step(msg.take_message()) {
+                error!(self.logger, "raft step error"; "err" => ?e);
+            } else {
+                let committed_index = self.raft_group().raft.raft_log.committed;
+                self.report_commit_log_duration(ctx, pre_committed_index, committed_index);
+            }
         }
 
         self.set_has_ready();

--- a/components/raftstore-v2/src/operation/ready/mod.rs
+++ b/components/raftstore-v2/src/operation/ready/mod.rs
@@ -259,12 +259,12 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             // This can be a message that sent when it's still a follower. Nevertheleast,
             // it's meaningless to continue to handle the request as callbacks are cleared.
             if msg.get_message().get_msg_type() == MessageType::MsgReadIndex
-                && self.fsm.peer.is_leader()
+                && self.is_leader()
                 && (msg.get_message().get_from() == raft::INVALID_ID
-                    || msg.get_message().get_from() == self.fsm.peer_id())
+                    || msg.get_message().get_from() == self.peer_id())
             {
                 ctx.raft_metrics.message_dropped.stale_msg.inc();
-                return Ok(());
+                return;
             }
 
             if let Err(e) = self.raft_group_mut().step(msg.take_message()) {

--- a/components/test_raftstore-v2/src/cluster.rs
+++ b/components/test_raftstore-v2/src/cluster.rs
@@ -13,11 +13,11 @@ use encryption_export::DataKeyManager;
 use engine_rocks::{RocksDbVector, RocksEngine, RocksSnapshot, RocksStatistics};
 use engine_test::raft::RaftTestEngine;
 use engine_traits::{
-    Iterable, KvEngine, MiscExt, Peekable, RaftEngine, RaftEngineReadOnly, RaftLogBatch,
-    ReadOptions, SyncMutable, TabletRegistry, CF_DEFAULT,
+    Iterable, MiscExt, Peekable, RaftEngine, RaftEngineReadOnly, RaftLogBatch, ReadOptions,
+    SyncMutable, TabletRegistry, CF_DEFAULT,
 };
 use file_system::IoRateLimiter;
-use futures::{compat::Future01CompatExt, executor::block_on, select, FutureExt};
+use futures::{compat::Future01CompatExt, executor::block_on, select, Future, FutureExt};
 use keys::{data_key, validate_data_key, DATA_PREFIX_KEY};
 use kvproto::{
     errorpb::Error as PbError,
@@ -27,7 +27,9 @@ use kvproto::{
         AdminCmdType, CmdType, RaftCmdRequest, RaftCmdResponse, RegionDetailResponse, Request,
         Response, StatusCmdType,
     },
-    raft_serverpb::{PeerState, RaftApplyState, RaftLocalState, RegionLocalState, StoreIdent},
+    raft_serverpb::{
+        PeerState, RaftApplyState, RaftLocalState, RaftMessage, RegionLocalState, StoreIdent,
+    },
 };
 use pd_client::PdClient;
 use raftstore::{
@@ -96,71 +98,93 @@ pub trait Simulator {
 
     fn get_router(&self, node_id: u64) -> Option<StoreRouter<RocksEngine, RaftTestEngine>>;
     fn get_snap_dir(&self, node_id: u64) -> String;
+    fn send_raft_msg(&mut self, msg: RaftMessage) -> Result<()>;
 
     fn read(&mut self, request: RaftCmdRequest, timeout: Duration) -> Result<RaftCmdResponse> {
+        let timeout_f = GLOBAL_TIMER_HANDLE
+            .delay(std::time::Instant::now() + timeout)
+            .compat();
+        futures::executor::block_on(async move {
+            futures::select! {
+                res = self.async_read(request).fuse() => res,
+                e = timeout_f.fuse() => {
+                    Err(Error::Timeout(format!("request timeout for {:?}: {:?}", timeout,e)))
+                },
+            }
+        })
+    }
+
+    fn async_read(
+        &mut self,
+        request: RaftCmdRequest,
+    ) -> impl Future<Output = Result<RaftCmdResponse>> + Send {
         let mut req_clone = request.clone();
         req_clone.clear_requests();
         req_clone.mut_requests().push(new_snap_cmd());
-        match self.snapshot(req_clone, timeout) {
-            Ok(snap) => {
-                let requests = request.get_requests();
-                let mut response = RaftCmdResponse::default();
-                let mut responses = Vec::with_capacity(requests.len());
-                for req in requests {
-                    let cmd_type = req.get_cmd_type();
-                    match cmd_type {
-                        CmdType::Get => {
-                            let mut resp = Response::default();
-                            let key = req.get_get().get_key();
-                            let cf = req.get_get().get_cf();
-                            let region = snap.get_region();
+        let snap = self.async_snapshot(req_clone);
+        async move {
+            match snap.await {
+                Ok(snap) => {
+                    let requests = request.get_requests();
+                    let mut response = RaftCmdResponse::default();
+                    let mut responses = Vec::with_capacity(requests.len());
+                    for req in requests {
+                        let cmd_type = req.get_cmd_type();
+                        match cmd_type {
+                            CmdType::Get => {
+                                let mut resp = Response::default();
+                                let key = req.get_get().get_key();
+                                let cf = req.get_get().get_cf();
+                                let region = snap.get_region();
 
-                            if let Err(e) = check_key_in_region(key, region) {
-                                return Ok(cmd_resp::new_error(e));
-                            }
+                                if let Err(e) = check_key_in_region(key, region) {
+                                    return Ok(cmd_resp::new_error(e));
+                                }
 
-                            let res = if cf.is_empty() {
-                                snap.get_value(key).unwrap_or_else(|e| {
-                                    panic!(
-                                        "[region {}] failed to get {} with cf {}: {:?}",
-                                        snap.get_region().get_id(),
-                                        log_wrappers::Value::key(key),
-                                        cf,
-                                        e
-                                    )
-                                })
-                            } else {
-                                snap.get_value_cf(cf, key).unwrap_or_else(|e| {
-                                    panic!(
-                                        "[region {}] failed to get {}: {:?}",
-                                        snap.get_region().get_id(),
-                                        log_wrappers::Value::key(key),
-                                        e
-                                    )
-                                })
-                            };
-                            if let Some(res) = res {
-                                resp.mut_get().set_value(res.to_vec());
+                                let res = if cf.is_empty() {
+                                    snap.get_value(key).unwrap_or_else(|e| {
+                                        panic!(
+                                            "[region {}] failed to get {} with cf {}: {:?}",
+                                            snap.get_region().get_id(),
+                                            log_wrappers::Value::key(key),
+                                            cf,
+                                            e
+                                        )
+                                    })
+                                } else {
+                                    snap.get_value_cf(cf, key).unwrap_or_else(|e| {
+                                        panic!(
+                                            "[region {}] failed to get {}: {:?}",
+                                            snap.get_region().get_id(),
+                                            log_wrappers::Value::key(key),
+                                            e
+                                        )
+                                    })
+                                };
+                                if let Some(res) = res {
+                                    resp.mut_get().set_value(res.to_vec());
+                                }
+                                resp.set_cmd_type(cmd_type);
+                                responses.push(resp);
                             }
-                            resp.set_cmd_type(cmd_type);
-                            responses.push(resp);
+                            _ => unimplemented!(),
                         }
-                        _ => unimplemented!(),
                     }
-                }
-                response.set_responses(responses.into());
+                    response.set_responses(responses.into());
 
-                Ok(response)
+                    Ok(response)
+                }
+                Err(e) => Ok(e),
             }
-            Err(e) => Ok(e),
         }
     }
 
-    fn snapshot(
+    fn async_snapshot(
         &mut self,
         request: RaftCmdRequest,
-        timeout: Duration,
-    ) -> std::result::Result<RegionSnapshot<<RocksEngine as KvEngine>::Snapshot>, RaftCmdResponse>;
+    ) -> impl Future<
+        Output = std::result::Result<RegionSnapshot<engine_rocks::RocksSnapshot>, RaftCmdResponse>,
+    > + Send;
 
     fn async_peer_msg_on_node(&self, node_id: u64, region_id: u64, msg: PeerMsg) -> Result<()>;
 
@@ -664,6 +688,10 @@ impl<T: Simulator> Cluster<T> {
             }
             return Ok(resp);
         }
+    }
+
+    pub fn send_raft_msg(&mut self, msg: RaftMessage) -> Result<()> {
+        self.sim.wl().send_raft_msg(msg)
     }
 
     pub fn call_command_on_node(

--- a/components/test_raftstore-v2/src/lib.rs
+++ b/components/test_raftstore-v2/src/lib.rs
@@ -1,4 +1,7 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+#![allow(incomplete_features)]
+#![feature(type_alias_impl_trait)]
+#![feature(return_position_impl_trait_in_trait)]
 
 mod cluster;
 mod node;

--- a/components/test_raftstore-v2/src/node.rs
+++ b/components/test_raftstore-v2/src/node.rs
@@ -3,7 +3,6 @@
 use std::{
     path::Path,
     sync::{Arc, Mutex, RwLock},
-    time::Duration,
 };
 
 use collections::{HashMap, HashSet};
@@ -12,6 +11,7 @@ use encryption_export::DataKeyManager;
 use engine_rocks::RocksEngine;
 use engine_test::raft::RaftTestEngine;
 use engine_traits::{RaftEngine, RaftEngineReadOnly, TabletRegistry};
+use futures::Future;
 use kvproto::{
     kvrpcpb::ApiVersion,
     raft_cmdpb::{RaftCmdRequest, RaftCmdResponse},
@@ -342,14 +342,12 @@ impl Simulator for NodeCluster {
         Ok(node_id)
     }
 
-    fn snapshot(
+    fn async_snapshot(
         &mut self,
         request: RaftCmdRequest,
-        timeout: Duration,
-    ) -> std::result::Result<
-        RegionSnapshot<<RocksEngine as engine_traits::KvEngine>::Snapshot>,
-        RaftCmdResponse,
-    > {
+    ) -> impl Future<
+        Output = std::result::Result<RegionSnapshot<engine_rocks::RocksSnapshot>, RaftCmdResponse>,
+    > + Send {
         let node_id = request.get_header().get_peer().get_store_id();
         if !self
             .trans
@@ -362,7 +360,7 @@ impl Simulator for NodeCluster {
             let mut resp = RaftCmdResponse::default();
             let e: RaftError = box_err!("missing sender for store {}", node_id);
             resp.mut_header().set_error(e.into());
-            return Err(resp);
+            // return async move {Err(resp)};
         }
 
         let mut router = {
@@ -370,7 +368,7 @@ impl Simulator for NodeCluster {
             guard.routers.get_mut(&node_id).unwrap().clone()
         };
 
-        router.snapshot(request, timeout)
+        router.snapshot(request)
     }
 
     fn async_peer_msg_on_node(&self, node_id: u64, region_id: u64, msg: PeerMsg) -> Result<()> {
@@ -432,6 +430,10 @@ impl Simulator for NodeCluster {
     fn clear_recv_filters(&mut self, node_id: u64) {
         let mut trans = self.trans.core.lock().unwrap();
         trans.routers.get_mut(&node_id).unwrap().clear_filters();
+    }
+
+    fn send_raft_msg(&mut self, msg: RaftMessage) -> Result<()> {
+        self.trans.send(msg)
     }
 }
 

--- a/tests/integrations/raftstore/test_replica_read.rs
+++ b/tests/integrations/raftstore/test_replica_read.rs
@@ -12,13 +12,13 @@ use std::{
     time::Duration,
 };
 
-use futures::executor::block_on;
+use futures::{compat::Future01CompatExt, executor::block_on, FutureExt};
 use kvproto::raft_serverpb::RaftMessage;
 use pd_client::PdClient;
 use raft::eraftpb::MessageType;
 use raftstore::{store::ReadIndexContext, Result};
 use test_raftstore::*;
-use tikv_util::{config::*, time::Instant, HandyRwLock};
+use tikv_util::{config::*, time::Instant, timer::GLOBAL_TIMER_HANDLE, HandyRwLock};
 use txn_types::{Key, Lock, LockType};
 use uuid::Uuid;
 
@@ -581,5 +581,81 @@ fn test_malformed_read_index() {
     let resp = async_read_on_peer(&mut cluster, new_peer(1, 1), region, b"k1", true, false);
     cluster.clear_send_filters();
     let resp = resp.recv_timeout(Duration::from_secs(10)).unwrap();
+    assert_eq!(resp.get_responses()[0].get_get().get_value(), b"v1");
+}
+
+/// The case checks if a malformed request should not corrupt the leader's read
+/// queue.
+#[test]
+fn test_malformed_read_index_v2() {
+    use test_raftstore_v2::*;
+
+    let mut cluster = new_node_cluster(0, 3);
+    configure_for_lease_read(&mut cluster.cfg, Some(50), None);
+    cluster.cfg.raft_store.raft_log_gc_threshold = 12;
+    cluster.cfg.raft_store.raft_log_gc_count_limit = Some(12);
+    cluster.cfg.raft_store.hibernate_regions = true;
+    cluster.cfg.raft_store.check_leader_lease_interval = ReadableDuration::hours(10);
+    let pd_client = Arc::clone(&cluster.pd_client);
+    pd_client.disable_default_operator();
+
+    let region_id = cluster.run_conf_change();
+    pd_client.must_add_peer(region_id, new_peer(2, 2));
+    pd_client.must_add_peer(region_id, new_peer(3, 3));
+    cluster.must_transfer_leader(1, new_peer(1, 1));
+    cluster.must_put(b"k1", b"v1");
+    for i in 1..=3 {
+        must_get_equal(&cluster.get_engine(i), b"k1", b"v1");
+    }
+
+    // Wait till lease expires.
+    std::thread::sleep(
+        cluster
+            .cfg
+            .raft_store
+            .raft_store_max_leader_lease()
+            .to_std()
+            .unwrap(),
+    );
+    let region = cluster.get_region(b"k1");
+    // Send a malformed request to leader
+    let mut raft_msg = raft::eraftpb::Message::default();
+    raft_msg.set_msg_type(MessageType::MsgReadIndex);
+    let rctx = ReadIndexContext {
+        id: Uuid::new_v4(),
+        request: None,
+        locked: None,
+    };
+    let mut e = raft::eraftpb::Entry::default();
+    e.set_data(rctx.to_bytes().into());
+    raft_msg.mut_entries().push(e);
+    raft_msg.from = 1;
+    raft_msg.to = 1;
+    let mut message = RaftMessage::default();
+    message.set_region_id(region_id);
+    message.set_from_peer(new_peer(1, 1));
+    message.set_to_peer(new_peer(1, 1));
+    message.set_region_epoch(region.get_region_epoch().clone());
+    message.set_message(raft_msg);
+    // So the read won't be handled soon.
+    cluster.add_send_filter(IsolationFilterFactory::new(1));
+    cluster.send_raft_msg(message).unwrap();
+    // Also send a correct request. If the malformed request doesn't corrupt
+    // the read queue, the correct request should be responded.
+    let resp = async_read_on_peer(&mut cluster, new_peer(1, 1), region, b"k1", true, false);
+    cluster.clear_send_filters();
+
+    let timeout = Duration::from_secs(10);
+    let timeout_f = GLOBAL_TIMER_HANDLE
+        .delay(std::time::Instant::now() + timeout)
+        .compat();
+    let resp = futures::executor::block_on(async move {
+        futures::select! {
+            res = resp.fuse() => res.unwrap(),
+            e = timeout_f.fuse() => {
+                panic!("request timeout for {:?}: {:?}", timeout,e);
+            },
+        }
+    });
     assert_eq!(resp.get_responses()[0].get_get().get_value(), b"v1");
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #14388

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
filter read index msg when sending from self
```
This PR pick the fix from https://github.com/tikv/tikv/pull/12300, which fixes the case where leader receives a read index msg from itself which is sent when it was  a follower.

To reuse the v1's test, this PR also implments `async_read` API for test cluster.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test


```release-note
None
```
