### PR TITLE
PITR: support modifying the config tikv.import.memory-use-ratio online when restore point.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5520,6 +5520,7 @@ dependencies = [
  "kvproto",
  "lazy_static",
  "log_wrappers",
+ "online_config",
  "openssl",
  "prometheus",
  "rand 0.8.5",

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -1260,10 +1260,10 @@ where
             fatal!("failed to register import service");
         }
 
-        self.cfg_controller.as_mut().unwrap().register(
-            tikv::config::Module::Import,
-            Box::new(import_cfg_mgr),
-        );
+        self.cfg_controller
+            .as_mut()
+            .unwrap()
+            .register(tikv::config::Module::Import, Box::new(import_cfg_mgr));
 
         // Debug service.
         let debug_service = DebugService::new(

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -1250,6 +1250,8 @@ where
             LocalTablets::Singleton(engines.engines.kv.clone()),
             servers.importer.clone(),
         );
+        let import_cfg_mgr = import_service.get_config_manager();
+
         if servers
             .server
             .register_service(create_import_sst(import_service))
@@ -1257,6 +1259,11 @@ where
         {
             fatal!("failed to register import service");
         }
+
+        self.cfg_controller.as_mut().unwrap().register(
+            tikv::config::Module::Import,
+            Box::new(import_cfg_mgr),
+        );
 
         // Debug service.
         let debug_service = DebugService::new(

--- a/components/server/src/server2.rs
+++ b/components/server/src/server2.rs
@@ -999,10 +999,10 @@ where
             fatal!("failed to register import service");
         }
 
-        self.cfg_controller.as_mut().unwrap().register(
-            tikv::config::Module::Import,
-            Box::new(import_cfg_mgr),
-        );
+        self.cfg_controller
+            .as_mut()
+            .unwrap()
+            .register(tikv::config::Module::Import, Box::new(import_cfg_mgr));
 
         // Create Diagnostics service
         let diag_service = DiagnosticsService::new(

--- a/components/server/src/server2.rs
+++ b/components/server/src/server2.rs
@@ -989,6 +989,8 @@ where
             LocalTablets::Registry(self.tablet_registry.as_ref().unwrap().clone()),
             servers.importer.clone(),
         );
+        let import_cfg_mgr = import_service.get_config_manager();
+
         if servers
             .server
             .register_service(create_import_sst(import_service))
@@ -996,6 +998,11 @@ where
         {
             fatal!("failed to register import service");
         }
+
+        self.cfg_controller.as_mut().unwrap().register(
+            tikv::config::Module::Import,
+            Box::new(import_cfg_mgr),
+        );
 
         // Create Diagnostics service
         let diag_service = DiagnosticsService::new(

--- a/components/sst_importer/Cargo.toml
+++ b/components/sst_importer/Cargo.toml
@@ -29,6 +29,7 @@ keys = { workspace = true }
 kvproto = { workspace = true }
 lazy_static = "1.3"
 log_wrappers = { workspace = true }
+online_config = { workspace = true }
 openssl = "0.10"
 prometheus = { version = "0.13", default-features = false }
 rand = "0.8"

--- a/components/sst_importer/src/config.rs
+++ b/components/sst_importer/src/config.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use online_config::{self, OnlineConfig};
-use tikv_util::config::ReadableDuration;
+use tikv_util::{config::ReadableDuration, HandyRwLock};
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug, OnlineConfig)]
 #[serde(default)]
@@ -74,7 +74,7 @@ impl online_config::ConfigManager for ConfigManager {
             "change" => ?change,
         );
 
-        let mut cfg = self.0.read().unwrap().clone();
+        let mut cfg = self.rl().clone();
         cfg.update(change)?;
 
         if let Err(e) = cfg.validate() {
@@ -85,7 +85,7 @@ impl online_config::ConfigManager for ConfigManager {
             return Err(e);
         }
 
-        *self.write().unwrap() = cfg;
+        *self.wl() = cfg;
         Ok(())
     }
 }

--- a/components/sst_importer/src/config.rs
+++ b/components/sst_importer/src/config.rs
@@ -81,7 +81,7 @@ impl online_config::ConfigManager for ConfigManager {
         let mut cfg = self.0.read().unwrap().clone();
         cfg.update(change)?;
 
-        if let Err(e) = cfg.validate(){
+        if let Err(e) = cfg.validate() {
             warn!(
                 "import config changed";
                 "change" => ?cfg,
@@ -89,15 +89,15 @@ impl online_config::ConfigManager for ConfigManager {
             return Err(e);
         }
 
-        *self.0.write().unwrap() = cfg;
+        *self.write().unwrap() = cfg;
         Ok(())
     }
 }
 
 impl std::ops::Deref for ConfigManager {
-    type Target = Arc<RwLock<Config>>;
+    type Target = RwLock<Config>;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        self.0.as_ref()
     }
 }

--- a/components/sst_importer/src/config.rs
+++ b/components/sst_importer/src/config.rs
@@ -52,11 +52,7 @@ impl Config {
             self.stream_channel_window = default_cfg.stream_channel_window;
         }
         if self.memory_use_ratio > 0.5 || self.memory_use_ratio < 0.0 {
-            warn!(
-                "import.mem_ratio should belong to [0.0, 0.5], change it to {}",
-                default_cfg.memory_use_ratio,
-            );
-            self.memory_use_ratio = default_cfg.memory_use_ratio;
+            return Err("import.mem_ratio should belong to [0.0, 0.5].".into());
         }
         Ok(())
     }

--- a/components/sst_importer/src/lib.rs
+++ b/components/sst_importer/src/lib.rs
@@ -24,7 +24,7 @@ pub mod metrics;
 pub mod sst_importer;
 
 pub use self::{
-    config::Config,
+    config::{Config, ConfigManager},
     errors::{error_inc, Error, Result},
     import_file::sst_meta_to_path,
     sst_importer::SstImporter,

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -36,7 +36,6 @@ use tikv_util::{
         bytes::{decode_bytes_in_place, encode_bytes},
         stream_event::{EventEncoder, EventIterator, Iterator as EIterator},
     },
-    config::ReadableSize,
     sys::{thread::ThreadBuildWrapper, SysQuota},
     time::{Instant, Limiter},
 };
@@ -49,7 +48,7 @@ use crate::{
     import_mode::{ImportModeSwitcher, RocksDbMetricsFn},
     metrics::*,
     sst_writer::{RawSstWriter, TxnSstWriter},
-    util, Config, Error, Result,
+    util, Config, Error, Result, ConfigManager,
 };
 
 pub struct LoadedFile {
@@ -278,7 +277,7 @@ pub struct SstImporter {
     download_rt: Runtime,
     file_locks: Arc<DashMap<String, (CacheKvFile, Instant)>>,
     mem_use: Arc<AtomicU64>,
-    mem_limit: ReadableSize,
+    mem_limit: Arc<AtomicU64>,
 }
 
 impl SstImporter {
@@ -321,7 +320,7 @@ impl SstImporter {
             cached_storage,
             download_rt,
             mem_use: Arc::new(AtomicU64::new(0)),
-            mem_limit: ReadableSize(memory_limit as u64),
+            mem_limit: Arc::new(AtomicU64::new(memory_limit as u64)),
         })
     }
 
@@ -583,6 +582,20 @@ impl SstImporter {
         Ok(())
     }
 
+    pub fn update_mem_limit(&self, cfg_mgr: ConfigManager) {
+        let mem_ratio = cfg_mgr.0.as_ref()
+        .read()
+        .unwrap()
+        .memory_use_ratio;
+
+        let memory_limit = (SysQuota::memory_limit_in_bytes() as f64) * mem_ratio;
+
+        if self.mem_limit.load(Ordering::SeqCst) != memory_limit as u64 {
+            self.mem_limit.store(memory_limit as u64
+                , Ordering::SeqCst);
+        }
+    }
+
     pub fn shrink_by_tick(&self) -> usize {
         let mut shrink_buff_size: usize = 0;
         let mut retain_buff_size: usize = 0;
@@ -643,7 +656,7 @@ impl SstImporter {
     // If mem_limit is 0, which represent download kv-file when import.
     // Or read kv-file into buffer directly.
     pub fn import_support_download(&self) -> bool {
-        self.mem_limit == ReadableSize(0)
+        self.mem_limit.load(Ordering::SeqCst) == 0
     }
 
     fn request_memory(&self, meta: &KvMeta) -> Option<MemUsePermit> {
@@ -651,7 +664,7 @@ impl SstImporter {
         let old = self.mem_use.fetch_add(size, Ordering::SeqCst);
 
         // If the memory is limited, roll backup the mem_use and return false.
-        if old + size > self.mem_limit.0 {
+        if old + size > self.mem_limit.load(Ordering::SeqCst) {
             self.mem_use.fetch_sub(size, Ordering::SeqCst);
             CACHE_EVENT.with_label_values(&["out-of-quota"]).inc();
             None

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3121,7 +3121,7 @@ pub struct TikvConfig {
     #[online_config(skip)]
     pub security: SecurityConfig,
 
-    #[online_config(skip)]
+    #[online_config(submodule)]
     pub import: ImportConfig,
 
     #[online_config(submodule)]

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -664,7 +664,7 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
         let import = self.importer.clone();
         let (rx, buf_driver) = create_stream_with_buffer(
             stream,
-            self.cfg.0.as_ref().read().unwrap().stream_channel_window,
+            self.cfg.read().unwrap().stream_channel_window,
         );
         let mut map_rx = rx.map_err(Error::from);
 

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -321,7 +321,7 @@ impl<E: Engine> ImportSstService<E> {
         loop {
             sleep(Duration::from_secs(10)).await;
 
-            importer.update_mem_limit(cfg.clone());
+            importer.update_config_memory_use_ratio(cfg.clone());
             importer.shrink_by_tick();
         }
     }
@@ -662,10 +662,8 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
         let label = "upload";
         let timer = Instant::now_coarse();
         let import = self.importer.clone();
-        let (rx, buf_driver) = create_stream_with_buffer(
-            stream,
-            self.cfg.read().unwrap().stream_channel_window,
-        );
+        let (rx, buf_driver) =
+            create_stream_with_buffer(stream, self.cfg.read().unwrap().stream_channel_window);
         let mut map_rx = rx.map_err(Error::from);
 
         let handle_task = async move {

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -26,8 +26,8 @@ use kvproto::{
     kvrpcpb::Context,
 };
 use sst_importer::{
-    error_inc, metrics::*, sst_importer::DownloadExt, sst_meta_to_path, Config, Error, Result,
-    SstImporter,
+    error_inc, metrics::*, sst_importer::DownloadExt, sst_meta_to_path, Config, ConfigManager,
+    Error, Result, SstImporter,
 };
 use tikv_kv::{Engine, Modify, SnapContext, Snapshot, SnapshotExt, WriteData, WriteEvent};
 use tikv_util::{
@@ -85,7 +85,7 @@ async fn wait_write(mut s: impl Stream<Item = WriteEvent> + Send + Unpin) -> sto
 /// raftstore to trigger the ingest process.
 #[derive(Clone)]
 pub struct ImportSstService<E: Engine> {
-    cfg: Config,
+    cfg: ConfigManager,
     tablets: LocalTablets<E::Local>,
     engine: E,
     threads: Arc<Runtime>,
@@ -296,10 +296,12 @@ impl<E: Engine> ImportSstService<E> {
         if let LocalTablets::Singleton(tablet) = &tablets {
             importer.start_switch_mode_check(threads.handle(), tablet.clone());
         }
-        threads.spawn(Self::tick(importer.clone()));
+
+        let cfg_mgr = ConfigManager::new(cfg);
+        threads.spawn(Self::tick(importer.clone(), cfg_mgr.clone()));
 
         ImportSstService {
-            cfg,
+            cfg: cfg_mgr,
             tablets,
             threads: Arc::new(threads),
             block_threads: Arc::new(block_threads),
@@ -311,9 +313,15 @@ impl<E: Engine> ImportSstService<E> {
         }
     }
 
-    async fn tick(importer: Arc<SstImporter>) {
+    pub fn get_config_manager(&self) -> ConfigManager {
+        self.cfg.clone()
+    }
+
+    async fn tick(importer: Arc<SstImporter>, cfg: ConfigManager) {
         loop {
             sleep(Duration::from_secs(10)).await;
+
+            importer.update_mem_limit(cfg.clone());
             importer.shrink_by_tick();
         }
     }
@@ -543,8 +551,10 @@ macro_rules! impl_write {
         ) {
             let import = self.importer.clone();
             let tablets = self.tablets.clone();
-            let (rx, buf_driver) =
-                create_stream_with_buffer(stream, self.cfg.stream_channel_window);
+            let (rx, buf_driver) = create_stream_with_buffer(
+                stream,
+                self.cfg.0.as_ref().read().unwrap().stream_channel_window,
+            );
             let mut rx = rx.map_err(Error::from);
 
             let timer = Instant::now_coarse();
@@ -652,7 +662,10 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
         let label = "upload";
         let timer = Instant::now_coarse();
         let import = self.importer.clone();
-        let (rx, buf_driver) = create_stream_with_buffer(stream, self.cfg.stream_channel_window);
+        let (rx, buf_driver) = create_stream_with_buffer(
+            stream,
+            self.cfg.0.as_ref().read().unwrap().stream_channel_window,
+        );
         let mut map_rx = rx.map_err(Error::from);
 
         let handle_task = async move {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/tikv/tikv/issues/14409

What's Changed:
As title.


<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x]  Unit test
- [ ]  Integration test
- [x]  Manual test (add detailed scripts or steps below)
- [ ]  No code

### Manual test
```
MySQL [(none)]> show config where type='tikv' and name='import.memory-use-ratio';
+------+-----------------+-------------------------+-------+
| Type | Instance        | Name                    | Value |
+------+-----------------+-------------------------+-------+
| tikv | 10.2.5.31:20162 | import.memory-use-ratio | 0.3   |
| tikv | 10.2.5.11:20160 | import.memory-use-ratio | 0.3   |
| tikv | 10.2.5.18:20161 | import.memory-use-ratio | 0.3   |
+------+-----------------+-------------------------+-------+


MySQL [(none)]> set config tikv `import.memory-use-ratio`=0.1;
MySQL [(none)]> show config where type='tikv' and name='import.memory-use-ratio';
+------+-----------------+-------------------------+-------+
| Type | Instance        | Name                    | Value |
+------+-----------------+-------------------------+-------+
| tikv | 10.2.5.31:20162 | import.memory-use-ratio | 0.1   |
| tikv | 10.2.5.11:20160 | import.memory-use-ratio | 0.1   |
| tikv | 10.2.5.18:20161 | import.memory-use-ratio | 0.1   |
+------+-----------------+-------------------------+-------+


MySQL [(none)]> set config tikv `import.memory-use-ratio`=0.2;
MySQL [(none)]> show config where type='tikv' and name='import.memory-use-ratio';
+------+-----------------+-------------------------+-------+
| Type | Instance        | Name                    | Value |
+------+-----------------+-------------------------+-------+
| tikv | 10.2.5.31:20162 | import.memory-use-ratio | 0.2   |
| tikv | 10.2.5.11:20160 | import.memory-use-ratio | 0.2   |
| tikv | 10.2.5.18:20161 | import.memory-use-ratio | 0.2   |
+------+-----------------+-------------------------+-------+

```

Find the message from tikv.log
```
[2023/03/16 19:05:03.608 +08:00] [INFO] [config.rs:76] ["import config changed"] [change="{\"memory_use_ratio\": 0.1}"]
[2023/03/16 19:05:09.598 +08:00] [INFO] [sst_importer.rs:599] ["update importer config"] [size=3435973836] [memory-use-ratio=0.1]

[2023/03/16 19:08:42.187 +08:00] [INFO] [config.rs:76] ["import config changed"] [change="{\"memory_use_ratio\": 0.2}"]
[2023/03/16 19:08:49.801 +08:00] [INFO] [sst_importer.rs:599] ["update importer config"] [size=6871947673] [memory-use-ratio=0.2]
```




Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Support modify the config tikv.import.memory-use-ratio online when restore point
```
