### PR TITLE
Revert changes that may cause performance regression introduced by write prioirty scheduling

### DIFF
--- a/components/raftstore-v2/src/operation/command/admin/merge/prepare.rs
+++ b/components/raftstore-v2/src/operation/command/admin/merge/prepare.rs
@@ -245,7 +245,8 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             if entry.get_data().is_empty() {
                 continue;
             }
-            let cmd: RaftCmdRequest = util::parse_data_at(entry.get_data(), entry.get_index());
+            let cmd: RaftCmdRequest =
+                util::parse_data_at(entry.get_data(), entry.get_index(), "tag");
             if !cmd.has_admin_request() {
                 continue;
             }

--- a/components/raftstore/src/store/entry_storage.rs
+++ b/components/raftstore/src/store/entry_storage.rs
@@ -30,11 +30,7 @@ use super::{
     metrics::*, peer_storage::storage_error, WriteTask, MEMTRACE_ENTRY_CACHE, RAFT_INIT_LOG_INDEX,
     RAFT_INIT_LOG_TERM,
 };
-use crate::{
-    bytes_capacity,
-    store::{util::ParsedEntry, ReadTask},
-    Result,
-};
+use crate::{bytes_capacity, store::ReadTask, Result};
 
 const MAX_ASYNC_FETCH_TRY_CNT: usize = 3;
 const SHRINK_CACHE_CAPACITY: usize = 64;
@@ -58,7 +54,7 @@ pub fn last_index(state: &RaftLocalState) -> u64 {
 pub struct CachedEntries {
     pub range: Range<u64>,
     // Entries and dangle size for them. `dangle` means not in entry cache.
-    entries: Arc<Mutex<(Vec<ParsedEntry>, usize)>>,
+    entries: Arc<Mutex<(Vec<Entry>, usize)>>,
 }
 
 impl CachedEntries {
@@ -68,24 +64,21 @@ impl CachedEntries {
         let end = entries.last().map(|x| x.index).unwrap() + 1;
         let range = Range { start, end };
         CachedEntries {
-            entries: Arc::new(Mutex::new((
-                entries.into_iter().map(|e| ParsedEntry::new(e)).collect(),
-                0,
-            ))),
+            entries: Arc::new(Mutex::new((entries, 0))),
             range,
         }
     }
 
-    pub fn iter_entries_mut(&self, mut f: impl FnMut(&mut ParsedEntry)) {
-        let mut entries = self.entries.lock().unwrap();
-        for entry in &mut entries.0 {
+    pub fn iter_entries(&self, mut f: impl FnMut(&Entry)) {
+        let entries = self.entries.lock().unwrap();
+        for entry in &entries.0 {
             f(entry);
         }
     }
 
     /// Take cached entries and dangle size for them. `dangle` means not in
     /// entry cache.
-    pub fn take_entries(&self) -> (Vec<ParsedEntry>, usize) {
+    pub fn take_entries(&self) -> (Vec<Entry>, usize) {
         mem::take(&mut *self.entries.lock().unwrap())
     }
 }
@@ -332,8 +325,8 @@ impl EntryCache {
         let dangle_size = {
             let mut guard = entries.entries.lock().unwrap();
 
-            let last_idx = guard.0.last().map(|e| e.get_index()).unwrap();
-            let cache_front = match self.cache.front().map(|e| e.get_index()) {
+            let last_idx = guard.0.last().map(|e| e.index).unwrap();
+            let cache_front = match self.cache.front().map(|e| e.index) {
                 Some(i) => i,
                 None => u64::MAX,
             };
@@ -341,10 +334,7 @@ impl EntryCache {
             let dangle_range = if last_idx < cache_front {
                 // All entries are not in entry cache.
                 0..guard.0.len()
-            } else if let Ok(i) = guard
-                .0
-                .binary_search_by(|e| e.get_index().cmp(&cache_front))
-            {
+            } else if let Ok(i) = guard.0.binary_search_by(|e| e.index.cmp(&cache_front)) {
                 // Some entries are in entry cache.
                 0..i
             } else {
@@ -354,7 +344,7 @@ impl EntryCache {
 
             let mut size = 0;
             for e in &guard.0[dangle_range] {
-                size += e.bytes_capacity();
+                size += bytes_capacity(&e.data) + bytes_capacity(&e.context);
             }
             guard.1 = size;
             size

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -3741,7 +3741,7 @@ impl<EK: KvEngine> ResourceMetered for Msg<EK> {
                             ResourceConsumeType::IoBytes(write_bytes),
                         );
                         if write_bytes > max_write_bytes {
-                            dominant_group = group_name.to_owned();
+                            dominant_group = group_name;
                             max_write_bytes = write_bytes;
                         }
                     });

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -9,6 +9,7 @@ use std::{
     cmp::{Ord, Ordering as CmpOrdering},
     collections::VecDeque,
     fmt::{self, Debug, Formatter},
+    io::BufRead,
     mem,
     ops::{Deref, DerefMut, Range as StdRange},
     sync::{
@@ -45,7 +46,11 @@ use kvproto::{
 };
 use pd_client::{BucketMeta, BucketStat};
 use prometheus::local::LocalHistogram;
-use raft::eraftpb::{ConfChangeType, ConfChangeV2, Entry, EntryType, Snapshot as RaftSnapshot};
+use protobuf::{wire_format::WireType, CodedInputStream, Message};
+use raft::eraftpb::{
+    ConfChange, ConfChangeType, ConfChangeV2, Entry, EntryType, Snapshot as RaftSnapshot,
+};
+use raft_proto::ConfChangeI;
 use resource_control::{ResourceConsumeType, ResourceController, ResourceMetered};
 use smallvec::{smallvec, SmallVec};
 use sst_importer::SstImporter;
@@ -88,7 +93,6 @@ use crate::{
         util::{
             self, admin_cmd_epoch_lookup, check_flashback_state, check_req_region_epoch,
             compare_region_epoch, ChangePeerI, ConfChangeKind, KeysInfoFormatter, LatencyInspector,
-            ParsedEntry,
         },
         Config, RegionSnapshot, RegionTask, WriteCallback,
     },
@@ -848,6 +852,43 @@ fn should_sync_log(cmd: &RaftCmdRequest) -> bool {
     false
 }
 
+fn can_witness_skip(entry: &Entry) -> bool {
+    // need to handle ConfChange entry type
+    if entry.get_entry_type() != EntryType::EntryNormal {
+        return false;
+    }
+
+    // HACK: check admin request field in serialized data from `RaftCmdRequest`
+    // without deserializing all. It's done by checking the existence of the
+    // field number of `admin_request`.
+    // See the encoding in `write_to_with_cached_sizes()` of `RaftCmdRequest` in
+    // `raft_cmdpb.rs` for reference.
+    let mut is = CodedInputStream::from_bytes(entry.get_data());
+    if is.eof().unwrap() {
+        return true;
+    }
+    let (mut field_number, wire_type) = is.read_tag_unpack().unwrap();
+    // Header field is of number 1
+    if field_number == 1 {
+        if wire_type != WireType::WireTypeLengthDelimited {
+            panic!("unexpected wire type");
+        }
+        let len = is.read_raw_varint32().unwrap();
+        // skip parsing the content of `Header`
+        is.consume(len as usize);
+        // read next field number
+        (field_number, _) = is.read_tag_unpack().unwrap();
+    }
+
+    // `Requests` field is of number 2 and `AdminRequest` field is of number 3.
+    // - If the next field is 2, there must be no admin request as in one
+    //   `RaftCmdRequest`, either requests or admin_request is filled.
+    // - If the next field is 3, it's exactly an admin request.
+    // - If the next field is others, neither requests nor admin_request is filled,
+    //   so there is no admin request.
+    field_number != 3
+}
+
 /// A struct that stores the state related to Merge.
 ///
 /// When executing a `CommitMerge`, the source peer may have not applied
@@ -870,7 +911,7 @@ where
 {
     /// All of the entries that need to continue to be applied after
     /// the source peer has applied its logs.
-    pending_entries: Vec<ParsedEntry>,
+    pending_entries: Vec<Entry>,
     /// All of messages that need to continue to be handled after
     /// the source peer has applied its logs and pending entries
     /// are all handled.
@@ -1050,7 +1091,7 @@ where
     fn handle_raft_committed_entries(
         &mut self,
         apply_ctx: &mut ApplyContext<EK>,
-        mut committed_entries_drainer: Drain<'_, ParsedEntry>,
+        mut committed_entries_drainer: Drain<'_, Entry>,
     ) {
         if committed_entries_drainer.len() == 0 {
             return;
@@ -1061,7 +1102,7 @@ where
         // must re-propose these commands again.
         apply_ctx.committed_count += committed_entries_drainer.len();
         let mut results = VecDeque::new();
-        while let Some(mut entry) = committed_entries_drainer.next() {
+        while let Some(entry) = committed_entries_drainer.next() {
             if self.pending_remove {
                 // This peer is about to be destroyed, skip everything.
                 break;
@@ -1083,9 +1124,9 @@ where
             // running on data written by new version tikv), but PD will reject old version
             // tikv join the cluster, so this should not happen.
             let res = match entry.get_entry_type() {
-                EntryType::EntryNormal => self.handle_raft_entry_normal(apply_ctx, &mut entry),
+                EntryType::EntryNormal => self.handle_raft_entry_normal(apply_ctx, &entry),
                 EntryType::EntryConfChange | EntryType::EntryConfChangeV2 => {
-                    self.handle_raft_entry_conf_change(apply_ctx, &mut entry)
+                    self.handle_raft_entry_conf_change(apply_ctx, &entry)
                 }
             };
 
@@ -1155,7 +1196,7 @@ where
     fn handle_raft_entry_normal(
         &mut self,
         apply_ctx: &mut ApplyContext<EK>,
-        entry: &mut ParsedEntry,
+        entry: &Entry,
     ) -> ApplyResult<EK::Snapshot> {
         fail_point!(
             "yield_apply_first_region",
@@ -1165,10 +1206,11 @@ where
 
         let index = entry.get_index();
         let term = entry.get_term();
+        let data = entry.get_data();
 
-        if !entry.is_empty() {
-            if !self.peer.is_witness || !entry.can_witness_skip() {
-                let cmd = entry.take_cmd();
+        if !data.is_empty() {
+            if !self.peer.is_witness || !can_witness_skip(entry) {
+                let cmd = util::parse_data_at(data, index, &self.tag);
                 if apply_ctx.yield_high_latency_operation && has_high_latency_operation(&cmd) {
                     self.priority = Priority::Low;
                 }
@@ -1227,7 +1269,7 @@ where
     fn handle_raft_entry_conf_change(
         &mut self,
         apply_ctx: &mut ApplyContext<EK>,
-        entry: &mut ParsedEntry,
+        entry: &Entry,
     ) -> ApplyResult<EK::Snapshot> {
         // Although conf change can't yield in normal case, it is convenient to
         // simulate yield before applying a conf change log.
@@ -1235,7 +1277,16 @@ where
             ApplyResult::Yield
         });
         let (index, term) = (entry.get_index(), entry.get_term());
-        let (conf_change, cmd) = entry.take_conf_change();
+        let conf_change: ConfChangeV2 = match entry.get_entry_type() {
+            EntryType::EntryConfChange => {
+                let conf_change: ConfChange =
+                    util::parse_data_at(entry.get_data(), index, &self.tag);
+                conf_change.into_v2()
+            }
+            EntryType::EntryConfChangeV2 => util::parse_data_at(entry.get_data(), index, &self.tag),
+            _ => unreachable!(),
+        };
+        let cmd = util::parse_data_at(conf_change.get_context(), index, &self.tag);
         match self.process_raft_cmd(apply_ctx, index, term, cmd) {
             ApplyResult::None => {
                 // If failed, tell Raft that the `ConfChange` was aborted.
@@ -3681,12 +3732,10 @@ impl<EK: KvEngine> ResourceMetered for Msg<EK> {
                 let mut dominant_group = "".to_owned();
                 let mut max_write_bytes = 0;
                 for cached_entries in &apply.entries {
-                    cached_entries.iter_entries_mut(|entry| {
-                        if entry.is_empty() {
-                            return;
-                        }
+                    cached_entries.iter_entries(|entry| {
+                        let header = util::get_entry_header(entry);
+                        let group_name = header.get_resource_group_name().to_owned();
                         let write_bytes = entry.compute_size() as u64;
-                        let group_name = entry.get_cmd().get_header().get_resource_group_name();
                         resource_ctl.consume(
                             group_name.as_bytes(),
                             ResourceConsumeType::IoBytes(write_bytes),
@@ -3883,21 +3932,19 @@ where
 
         let mut dangle_size = 0;
         for cached_entries in apply.entries {
-            let (ents, sz) = cached_entries.take_entries();
+            let (e, sz) = cached_entries.take_entries();
             dangle_size += sz;
-            if ents.is_empty() {
+            if e.is_empty() {
                 let rid = self.delegate.region_id();
                 let StdRange { start, end } = cached_entries.range;
-                let mut tmp_ents = Vec::new();
                 self.delegate
                     .raft_engine
-                    .fetch_entries_to(rid, start, end, None, &mut tmp_ents)
+                    .fetch_entries_to(rid, start, end, None, &mut entries)
                     .unwrap();
-                entries.extend(tmp_ents.into_iter().map(|e| ParsedEntry::new(e)));
             } else if entries.is_empty() {
-                entries = ents;
+                entries = e;
             } else {
-                entries.extend(ents);
+                entries.extend(e);
             }
         }
         if dangle_size > 0 {
@@ -4869,9 +4916,9 @@ mod memtrace {
         EK: KvEngine,
     {
         fn heap_size(&self) -> usize {
-            let mut size = self.pending_entries.capacity() * mem::size_of::<ParsedEntry>();
+            let mut size = self.pending_entries.capacity() * mem::size_of::<Entry>();
             for e in &self.pending_entries {
-                size += e.bytes_capacity();
+                size += bytes_capacity(&e.data) + bytes_capacity(&e.context);
             }
 
             size += self.pending_msgs.capacity() * mem::size_of::<Msg<EK>>();
@@ -4928,6 +4975,7 @@ mod tests {
         time::*,
     };
 
+    use bytes::Bytes;
     use engine_panic::PanicEngine;
     use engine_test::kv::{new_engine, KvTestEngine, KvTestSnapshot};
     use engine_traits::{Peekable as PeekableTrait, SyncMutable, WriteBatchExt};
@@ -4937,6 +4985,7 @@ mod tests {
         raft_cmdpb::*,
     };
     use protobuf::Message;
+    use raft::eraftpb::{ConfChange, ConfChangeV2};
     use sst_importer::Config as ImportConfig;
     use tempfile::{Builder, TempDir};
     use test_sst_importer::*;
@@ -5041,6 +5090,42 @@ mod tests {
                 raft_engine: Box::new(PanicEngine),
             }
         }
+    }
+
+    #[test]
+    fn test_can_witness_skip() {
+        let mut entry = Entry::new();
+        let mut req = RaftCmdRequest::default();
+        entry.set_entry_type(EntryType::EntryNormal);
+        let data = req.write_to_bytes().unwrap();
+        entry.set_data(Bytes::copy_from_slice(&data));
+        assert!(can_witness_skip(&entry));
+
+        req.mut_admin_request()
+            .set_cmd_type(AdminCmdType::CompactLog);
+        let data = req.write_to_bytes().unwrap();
+        entry.set_data(Bytes::copy_from_slice(&data));
+        assert!(!can_witness_skip(&entry));
+
+        let mut req = RaftCmdRequest::default();
+        let mut request = Request::default();
+        request.set_cmd_type(CmdType::Put);
+        req.set_requests(vec![request].into());
+        let data = req.write_to_bytes().unwrap();
+        entry.set_data(Bytes::copy_from_slice(&data));
+        assert!(can_witness_skip(&entry));
+
+        entry.set_entry_type(EntryType::EntryConfChange);
+        let conf_change = ConfChange::new();
+        let data = conf_change.write_to_bytes().unwrap();
+        entry.set_data(Bytes::copy_from_slice(&data));
+        assert!(!can_witness_skip(&entry));
+
+        entry.set_entry_type(EntryType::EntryConfChangeV2);
+        let conf_change_v2 = ConfChangeV2::new();
+        let data = conf_change_v2.write_to_bytes().unwrap();
+        entry.set_data(Bytes::copy_from_slice(&data));
+        assert!(!can_witness_skip(&entry));
     }
 
     #[test]

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -4211,7 +4211,8 @@ where
             if entry.get_data().is_empty() {
                 continue;
             }
-            let cmd: RaftCmdRequest = util::parse_data_at(entry.get_data(), entry.get_index());
+            let cmd: RaftCmdRequest =
+                util::parse_data_at(entry.get_data(), entry.get_index(), &self.tag);
             if !cmd.has_admin_request() {
                 continue;
             }

--- a/src/storage/txn/sched_pool.rs
+++ b/src/storage/txn/sched_pool.rs
@@ -102,19 +102,20 @@ impl SchedPool {
                     tls_flush(&reporter);
                 })
         };
-        if let Some(ref r) = resource_ctl {
-            SchedPool::Priority {
-                worker_pool: builder(pool_size, "sched-worker-pool")
-                    .build_priority_future_pool(r.clone()),
-                resource_ctl: r.clone(),
-            }
-        } else {
-            SchedPool::Vanilla {
-                worker_pool: builder(pool_size, "sched-worker-pool").build_future_pool(),
-                high_worker_pool: builder(std::cmp::max(1, pool_size / 2), "sched-high-pri-pool")
-                    .build_future_pool(),
-            }
+        // FIXME: for performance issue, disable priority pool temporarily
+        // if let Some(ref r) = resource_ctl {
+        //     SchedPool::Priority {
+        //         worker_pool: builder(pool_size, "sched-worker-pool")
+        //             .build_priority_future_pool(r.clone()),
+        //         resource_ctl: r.clone(),
+        //     }
+        // } else {
+        SchedPool::Vanilla {
+            worker_pool: builder(pool_size, "sched-worker-pool").build_future_pool(),
+            high_worker_pool: builder(std::cmp::max(1, pool_size / 2), "sched-high-pri-pool")
+                .build_future_pool(),
         }
+        // }
     }
 
     pub fn spawn(

--- a/src/storage/txn/sched_pool.rs
+++ b/src/storage/txn/sched_pool.rs
@@ -74,7 +74,7 @@ impl SchedPool {
         pool_size: usize,
         reporter: R,
         feature_gate: FeatureGate,
-        resource_ctl: Option<Arc<ResourceController>>,
+        _resource_ctl: Option<Arc<ResourceController>>,
     ) -> Self {
         let builder = |pool_size: usize, name_prefix: &str| {
             let engine = Arc::new(Mutex::new(engine.clone()));


### PR DESCRIPTION
This reverts commit 852af464cd48a97ec2b88c6a183a4f1ec4a84938.

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #14375 

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Revert the parsed entry that may lead to performance regression and disable priority pool for sched worker
```


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
