### PR TITLE
pitr: support modifying the config tikv.log-backup.max-flush-interval online.

### DIFF
--- a/components/backup-stream/src/config.rs
+++ b/components/backup-stream/src/config.rs
@@ -37,3 +37,4 @@ impl ConfigManager for BackupStreamConfigManager {
         Ok(())
     }
 }
+

--- a/components/backup-stream/src/config.rs
+++ b/components/backup-stream/src/config.rs
@@ -27,11 +27,12 @@ impl ConfigManager for BackupStreamConfigManager {
         change: ConfigChange,
     ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         info!(
-            " log backup config changed";
+            "log backup config changed";
             "change" => ?change,
         );
         let mut cfg = self.config.as_ref().write().unwrap();
         cfg.update(change)?;
+        cfg.validate()?;
 
         self.scheduler.schedule(Task::ChangeConfig(cfg.clone()))?;
         Ok(())

--- a/components/backup-stream/src/config.rs
+++ b/components/backup-stream/src/config.rs
@@ -1,26 +1,39 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
-use online_config::{ConfigChange, ConfigManager};
-use tikv_util::worker::Scheduler;
+use std::sync::{Arc, RwLock};
+
+use online_config::{ConfigChange, ConfigManager, OnlineConfig};
+use tikv::config::BackupStreamConfig;
+use tikv_util::{info, worker::Scheduler};
 
 use crate::endpoint::Task;
 
-pub struct BackupStreamConfigManager(pub Scheduler<Task>);
+#[derive(Clone)]
+pub struct BackupStreamConfigManager {
+    pub scheduler: Scheduler<Task>,
+    pub config: Arc<RwLock<BackupStreamConfig>>,
+}
+
+impl BackupStreamConfigManager {
+    pub fn new(scheduler: Scheduler<Task>, cfg: BackupStreamConfig) -> Self {
+        let config = Arc::new(RwLock::new(cfg));
+        Self { scheduler, config }
+    }
+}
 
 impl ConfigManager for BackupStreamConfigManager {
     fn dispatch(
         &mut self,
         change: ConfigChange,
     ) -> std::result::Result<(), Box<dyn std::error::Error>> {
-        self.0.schedule(Task::ChangeConfig(change))?;
+        info!(
+            " log backup config changed";
+            "change" => ?change,
+        );
+        let mut cfg = self.config.as_ref().write().unwrap();
+        cfg.update(change)?;
+
+        self.scheduler.schedule(Task::ChangeConfig(cfg.clone()))?;
         Ok(())
-    }
-}
-
-impl std::ops::Deref for BackupStreamConfigManager {
-    type Target = Scheduler<Task>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
     }
 }

--- a/components/backup-stream/src/config.rs
+++ b/components/backup-stream/src/config.rs
@@ -37,4 +37,3 @@ impl ConfigManager for BackupStreamConfigManager {
         Ok(())
     }
 }
-

--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -13,7 +13,6 @@ use kvproto::{
     brpb::{StreamBackupError, StreamBackupTaskInfo},
     metapb::Region,
 };
-use online_config::ConfigChange;
 use pd_client::PdClient;
 use raftstore::{
     coprocessor::{CmdBatch, ObserveHandle, RegionInfoProvider},
@@ -878,6 +877,15 @@ where
         }
     }
 
+    fn on_update_change_config(&mut self, cfg: BackupStreamConfig) {
+        info!(
+            "update log backup config";
+             "config" => ?cfg,
+        );
+        self.range_router.udpate_config(&cfg);
+        self.config = cfg;
+    }
+
     /// Modify observe over some region.
     /// This would register the region to the RaftStore.
     pub fn on_modify_observe(&self, op: ObserveOp) {
@@ -899,8 +907,8 @@ where
             Task::ModifyObserve(op) => self.on_modify_observe(op),
             Task::ForceFlush(task) => self.on_force_flush(task),
             Task::FatalError(task, err) => self.on_fatal_error(task, err),
-            Task::ChangeConfig(_) => {
-                warn!("change config online isn't supported for now.")
+            Task::ChangeConfig(cfg) => {
+                self.on_update_change_config(cfg);
             }
             Task::Sync(cb, mut cond) => {
                 if cond(&self.range_router) {
@@ -1082,7 +1090,7 @@ impl fmt::Debug for RegionCheckpointOperation {
 pub enum Task {
     WatchTask(TaskOp),
     BatchEvent(Vec<CmdBatch>),
-    ChangeConfig(ConfigChange),
+    ChangeConfig(BackupStreamConfig),
     /// Change the observe status of some region.
     ModifyObserve(ObserveOp),
     /// Convert status of some task into `flushing` and do flush then.

--- a/components/backup-stream/src/router.rs
+++ b/components/backup-stream/src/router.rs
@@ -2350,4 +2350,20 @@ mod tests {
             _ => panic!("unexpected cmd!"),
         }
     }
+
+    #[test]
+    fn test_udpate_invalid_config() {
+        let cfg = BackupStreamConfig::default();
+        let (sched, _) = dummy_scheduler();
+        let mut cfg_manager = BackupStreamConfigManager::new(sched, cfg.clone());
+
+        let new_cfg = BackupStreamConfig {
+            max_flush_interval: ReadableDuration::secs(0),
+            ..Default::default()
+        };
+
+        let changed = cfg.diff(&new_cfg);
+        let r = cfg_manager.dispatch(changed);
+        assert!(r.is_err());
+    }
 }

--- a/components/backup-stream/src/router.rs
+++ b/components/backup-stream/src/router.rs
@@ -1841,7 +1841,6 @@ mod tests {
         let task = StreamTaskInfo::new(
             tmp_dir.path().to_path_buf(),
             stream_task,
-            Duration::from_secs(300),
             vec![(vec![], vec![])],
             merged_file_size_limit,
             CompressionType::Zstd,
@@ -2200,7 +2199,6 @@ mod tests {
         let task = StreamTaskInfo::new(
             tmp_dir.path().to_path_buf(),
             stream_task,
-            Duration::from_secs(300),
             vec![(vec![], vec![])],
             0x100000,
             CompressionType::Zstd,

--- a/components/backup-stream/src/router.rs
+++ b/components/backup-stream/src/router.rs
@@ -31,6 +31,7 @@ use protobuf::Message;
 use raftstore::coprocessor::CmdBatch;
 use slog_global::debug;
 use tidb_query_datatype::codec::table::decode_table_id;
+use tikv::config::BackupStreamConfig;
 use tikv_util::{
     box_err,
     codec::stream_event::EventEncoder,
@@ -314,7 +315,7 @@ impl std::ops::Deref for Router {
     type Target = RouterInner;
 
     fn deref(&self) -> &Self::Target {
-        Arc::deref(&self.0)
+        self.0.as_ref()
     }
 }
 
@@ -341,9 +342,9 @@ pub struct RouterInner {
     /// too many temporary files.
     scheduler: Scheduler<Task>,
     /// The size limit of temporary file per task.
-    temp_file_size_limit: u64,
+    temp_file_size_limit: AtomicU64,
     /// The max duration the local data can be pending.
-    max_flush_interval: Duration,
+    max_flush_interval: SyncRwLock<Duration>,
 }
 
 impl std::fmt::Debug for RouterInner {
@@ -368,9 +369,15 @@ impl RouterInner {
             tasks: Mutex::new(HashMap::default()),
             prefix,
             scheduler,
-            temp_file_size_limit,
-            max_flush_interval,
+            temp_file_size_limit: AtomicU64::new(temp_file_size_limit),
+            max_flush_interval: SyncRwLock::new(max_flush_interval),
         }
+    }
+
+    pub fn udpate_config(&self, config: &BackupStreamConfig) {
+        *self.max_flush_interval.write().unwrap() = config.max_flush_interval.0;
+        self.temp_file_size_limit
+            .store(config.file_size_limit.0, Ordering::SeqCst);
     }
 
     /// Find the task for a region. If `end_key` is empty, search from start_key
@@ -430,7 +437,6 @@ impl RouterInner {
         let stream_task = StreamTaskInfo::new(
             prefix_path,
             task,
-            self.max_flush_interval,
             ranges.clone(),
             merged_file_size_limit,
             compression_type,
@@ -507,6 +513,7 @@ impl RouterInner {
     async fn on_event(&self, task: String, events: ApplyEvents) -> Result<()> {
         let task_info = self.get_task_info(&task).await?;
         task_info.on_events(events).await?;
+        let file_size_limit = self.temp_file_size_limit.load(Ordering::SeqCst);
 
         // When this event make the size of temporary files exceeds the size limit, make
         // a flush. Note that we only flush if the size is less than the limit before
@@ -515,10 +522,10 @@ impl RouterInner {
             "backup stream statics size";
             "task" => ?task,
             "next_size" => task_info.total_size(),
-            "size_limit" => self.temp_file_size_limit,
+            "size_limit" => file_size_limit,
         );
         let cur_size = task_info.total_size();
-        if cur_size > self.temp_file_size_limit && !task_info.is_flushing() {
+        if cur_size > file_size_limit && !task_info.is_flushing() {
             info!("try flushing task"; "task" => %task, "size" => %cur_size);
             if task_info.set_flushing_status_cas(false, true).is_ok() {
                 if let Err(e) = self.scheduler.schedule(Task::Flush(task)) {
@@ -592,6 +599,8 @@ impl RouterInner {
 
     /// tick aims to flush log/meta to extern storage periodically.
     pub async fn tick(&self) {
+        let max_flush_interval = self.max_flush_interval.rl().to_owned();
+
         for (name, task_info) in self.tasks.lock().await.iter() {
             if let Err(e) = self
                 .scheduler
@@ -602,7 +611,9 @@ impl RouterInner {
 
             // if stream task need flush this time, schedule Task::Flush, or update time
             // justly.
-            if task_info.should_flush() && task_info.set_flushing_status_cas(false, true).is_ok() {
+            if task_info.should_flush(&max_flush_interval)
+                && task_info.set_flushing_status_cas(false, true).is_ok()
+            {
                 info!(
                     "backup stream trigger flush task by tick";
                     "task" => ?task_info,
@@ -763,8 +774,6 @@ pub struct StreamTaskInfo {
     flushing_meta_files: RwLock<Vec<(TempFileKey, DataFile, DataFileInfo)>>,
     /// last_flush_ts represents last time this task flushed to storage.
     last_flush_time: AtomicPtr<Instant>,
-    /// flush_interval represents the tick interval of flush, setting by users.
-    flush_interval: Duration,
     /// The min resolved TS of all regions involved.
     min_resolved_ts: TimeStamp,
     /// Total size of all temporary files in byte.
@@ -825,7 +834,6 @@ impl StreamTaskInfo {
     pub async fn new(
         temp_dir: PathBuf,
         task: StreamTask,
-        flush_interval: Duration,
         ranges: Vec<(Vec<u8>, Vec<u8>)>,
         merged_file_size_limit: u64,
         compression_type: CompressionType,
@@ -846,7 +854,6 @@ impl StreamTaskInfo {
             flushing_files: RwLock::default(),
             flushing_meta_files: RwLock::default(),
             last_flush_time: AtomicPtr::new(Box::into_raw(Box::new(Instant::now()))),
-            flush_interval,
             total_size: AtomicUsize::new(0),
             flushing: AtomicBool::new(false),
             flush_fail_count: AtomicUsize::new(0),
@@ -946,12 +953,11 @@ impl StreamTaskInfo {
         unsafe { Box::from_raw(ptr) };
     }
 
-    pub fn should_flush(&self) -> bool {
+    pub fn should_flush(&self, flush_interval: &Duration) -> bool {
         // When it doesn't flush since 0.8x of auto-flush interval, we get ready to
         // start flushing. So that we will get a buffer for the cost of actual
         // flushing.
-        self.get_last_flush_time().saturating_elapsed_secs()
-            >= self.flush_interval.as_secs_f64() * 0.8
+        self.get_last_flush_time().saturating_elapsed_secs() >= flush_interval.as_secs_f64() * 0.8
     }
 
     pub fn is_flushing(&self) -> bool {

--- a/components/backup-stream/src/router.rs
+++ b/components/backup-stream/src/router.rs
@@ -315,7 +315,7 @@ impl std::ops::Deref for Router {
     type Target = RouterInner;
 
     fn deref(&self) -> &Self::Target {
-        self.0.as_ref()
+        Arc::deref(&self.0)
     }
 }
 

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -1025,7 +1025,7 @@ where
         );
 
         // Start backup stream
-        let backup_stream_scheduler = if self.config.backup_stream.enable {
+        let backup_stream_scheduler = if self.config.log_backup.enable {
             // Create backup stream.
             let mut backup_stream_worker = Box::new(LazyWorker::new("backup-stream"));
             let backup_stream_scheduler = backup_stream_worker.scheduler();
@@ -1036,7 +1036,10 @@ where
             // Register config manager.
             cfg_controller.register(
                 tikv::config::Module::BackupStream,
-                Box::new(BackupStreamConfigManager(backup_stream_worker.scheduler())),
+                Box::new(BackupStreamConfigManager::new(
+                    backup_stream_worker.scheduler(),
+                    self.config.log_backup.clone(),
+                )),
             );
 
             let etcd_cli = LazyEtcdClient::new(
@@ -1050,7 +1053,7 @@ where
             let backup_stream_endpoint = backup_stream::Endpoint::new(
                 node.id(),
                 etcd_cli,
-                self.config.backup_stream.clone(),
+                self.config.log_backup.clone(),
                 backup_stream_scheduler.clone(),
                 backup_stream_ob,
                 self.region_info_accessor.clone(),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2656,7 +2656,7 @@ impl Default for BackupConfig {
 pub struct BackupStreamConfig {
     #[online_config(skip)]
     pub min_ts_interval: ReadableDuration,
-    #[online_config(skip)]
+
     pub max_flush_interval: ReadableDuration,
     #[online_config(skip)]
     pub num_threads: usize,
@@ -2664,7 +2664,7 @@ pub struct BackupStreamConfig {
     pub enable: bool,
     #[online_config(skip)]
     pub temp_path: String,
-    #[online_config(skip)]
+
     pub file_size_limit: ReadableSize,
     #[online_config(skip)]
     pub initial_scan_pending_memory_quota: ReadableSize,
@@ -3130,8 +3130,8 @@ pub struct TikvConfig {
     #[online_config(submodule)]
     // The term "log backup" and "backup stream" are identity.
     // The "log backup" should be the only product name exposed to the user.
-    #[serde(rename = "log-backup")]
-    pub backup_stream: BackupStreamConfig,
+    //#[serde(rename = "log-backup")]
+    pub log_backup: BackupStreamConfig,
 
     #[online_config(submodule)]
     pub pessimistic_txn: PessimisticTxnConfig,
@@ -3196,7 +3196,7 @@ impl Default for TikvConfig {
             cdc: CdcConfig::default(),
             resolved_ts: ResolvedTsConfig::default(),
             resource_metering: ResourceMeteringConfig::default(),
-            backup_stream: BackupStreamConfig::default(),
+            log_backup: BackupStreamConfig::default(),
             causal_ts: CausalTsConfig::default(),
             resource_control: ResourceControlConfig::default(),
         }
@@ -3327,8 +3327,8 @@ impl TikvConfig {
             );
         }
 
-        if self.backup_stream.temp_path.is_empty() {
-            self.backup_stream.temp_path =
+        if self.log_backup.temp_path.is_empty() {
+            self.log_backup.temp_path =
                 config::canonicalize_sub_path(&self.storage.data_dir, "log-backup-temp")?;
         }
 
@@ -3354,7 +3354,7 @@ impl TikvConfig {
             .validate(self.storage.engine == EngineType::RaftKv2)?;
         self.import.validate()?;
         self.backup.validate()?;
-        self.backup_stream.validate()?;
+        self.log_backup.validate()?;
         self.cdc.validate()?;
         self.pessimistic_txn.validate()?;
         self.gc.validate()?;
@@ -4143,7 +4143,7 @@ impl From<&str> for Module {
             "security" => Module::Security,
             "import" => Module::Import,
             "backup" => Module::Backup,
-            "backup_stream" => Module::BackupStream,
+            "log_backup" => Module::BackupStream,
             "pessimistic_txn" => Module::PessimisticTxn,
             "gc" => Module::Gc,
             "cdc" => Module::Cdc,
@@ -5639,7 +5639,7 @@ mod tests {
         cfg.raftdb.max_sub_compactions = default_cfg.raftdb.max_sub_compactions;
         cfg.raftdb.titan.max_background_gc = default_cfg.raftdb.titan.max_background_gc;
         cfg.backup.num_threads = default_cfg.backup.num_threads;
-        cfg.backup_stream.num_threads = default_cfg.backup_stream.num_threads;
+        cfg.log_backup.num_threads = default_cfg.log_backup.num_threads;
 
         // There is another set of config values that we can't directly compare:
         // When the default values are `None`, but are then resolved to `Some(_)` later
@@ -5829,7 +5829,7 @@ mod tests {
             ("security", Module::Security),
             ("import", Module::Import),
             ("backup", Module::Backup),
-            ("backup_stream", Module::BackupStream),
+            ("log_backup", Module::BackupStream),
             ("pessimistic_txn", Module::PessimisticTxn),
             ("gc", Module::Gc),
             ("cdc", Module::Cdc),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3136,7 +3136,6 @@ pub struct TikvConfig {
     #[online_config(submodule)]
     // The term "log backup" and "backup stream" are identity.
     // The "log backup" should be the only product name exposed to the user.
-    //#[serde(rename = "log-backup")]
     pub log_backup: BackupStreamConfig,
 
     #[online_config(submodule)]

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -774,7 +774,7 @@ fn test_serde_custom_tikv_config() {
         },
         ..Default::default()
     };
-    value.backup_stream = BackupStreamConfig {
+    value.log_backup = BackupStreamConfig {
         max_flush_interval: ReadableDuration::secs(11),
         num_threads: 7,
         enable: true,


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/tikv/tikv/issues/14433

What's Changed:
As title~
<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] - Unit test
- [ ] - Integration test
- [x] - Manual test (add detailed scripts or steps below)
- [ ] - No code

### Manual test
```
MySQL [(none)]> show config where type='tikv' and name='log-backup.max-flush-interval';
+------+-----------------+-------------------------------+-------+
| Type | Instance        | Name                          | Value |
+------+-----------------+-------------------------------+-------+
| tikv | 10.2.5.31:20162 | log-backup.max-flush-interval | 3m    |
| tikv | 10.2.5.11:20160 | log-backup.max-flush-interval | 3m    |
| tikv | 10.2.5.18:20161 | log-backup.max-flush-interval | 3m    |
+------+-----------------+-------------------------------+-------+


MySQL [(none)]> set config tikv `log-backup.max-flush-interval`="2m";
MySQL [(none)]> show config where type='tikv' and name='log-backup.max-flush-interval';
+------+-----------------+-------------------------------+-------+
| Type | Instance        | Name                          | Value |
+------+-----------------+-------------------------------+-------+
| tikv | 10.2.5.31:20162 | log-backup.max-flush-interval | 2m    |
| tikv | 10.2.5.11:20160 | log-backup.max-flush-interval | 2m    |
| tikv | 10.2.5.18:20161 | log-backup.max-flush-interval | 2m    |
+------+-----------------+-------------------------------+-------+

MySQL [(none)]> set config tikv `log-backup.max-flush-interval`="1m";
MySQL [(none)]> show config where type='tikv' and name='log-backup.max-flush-interval';
+------+-----------------+-------------------------------+-------+
| Type | Instance        | Name                          | Value |
+------+-----------------+-------------------------------+-------+
| tikv | 10.2.5.31:20162 | log-backup.max-flush-interval | 1m    |
| tikv | 10.2.5.11:20160 | log-backup.max-flush-interval | 1m    |
| tikv | 10.2.5.18:20161 | log-backup.max-flush-interval | 1m    |
+------+-----------------+-------------------------------+-------+

MySQL [(none)]> set config tikv `log-backup.max-flush-interval`="0m";
Query OK, 0 rows affected, 3 warnings (0.02 sec)

MySQL [(none)]> show warnings;
+---------+------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
| Level   | Code | Message                                                                                                                                                 |
+---------+------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
| Warning | 1105 | bad request to http://10.2.5.31:20182/config: failed to update, error: "the max_flush_interval is too small, it is 0s, and should be greater than 10s." |
| Warning | 1105 | bad request to http://10.2.5.11:20180/config: failed to update, error: "the max_flush_interval is too small, it is 0s, and should be greater than 10s." |
| Warning | 1105 | bad request to http://10.2.5.18:20181/config: failed to update, error: "the max_flush_interval is too small, it is 0s, and should be greater than 10s." |
+---------+------+---------------------------------------------------------------------------------------------------------------------------------------------------------+

```

Find message from tikv.log
```
[2023/03/20 19:21:33.708 +08:00] [INFO] [config.rs:29] [" log backup config changed"] [change="{\"max_flush_interval\": 120000ms}"]
[2023/03/20 19:29:02.639 +08:00] [INFO] [config.rs:29] [" log backup config changed"] [change="{\"max_flush_interval\": 60000ms}"]
```


Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
PITR supports modifying the config tikv.log-backup.max-flush-interval online.
```
