### PR TITLE
raftstore-v2: flush memtable before proposing split

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2712,7 +2712,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/SpadeA-Tang/kvproto?branch=flush-table#8b5729fa29b6092cb5024cf73991c0deda9f33e3"
+source = "git+https://github.com/pingcap/kvproto.git#af969693ce8a7884e5bdc5d81c728f657d33065a"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2712,7 +2712,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/SpadeA-Tang/kvproto.git#ebe1796febce9965a38d03feabd4b1d57baf82fe"
+source = "git+https://github.com/SpadeA-Tang/kvproto?branch=flush-table#8b5729fa29b6092cb5024cf73991c0deda9f33e3"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2733,7 +2733,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#60b33e619c70d8abe151f086a19a82895965f28f"
+source = "git+https://github.com/SpadeA-Tang/kvproto.git#ebe1796febce9965a38d03feabd4b1d57baf82fe"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -381,7 +381,7 @@ txn_types = { path = "components/txn_types" }
 grpcio = { version = "0.10.4", default-features = false, features = ["openssl-vendored", "protobuf-codec", "nightly"] }
 grpcio-health = { version = "0.10.4", default-features = false, features = ["protobuf-codec"] }
 tipb = { git = "https://github.com/pingcap/tipb.git" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git" }
+kvproto = { git = "https://github.com/SpadeA-Tang/kvproto.git" }
 yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
 tokio-timer = { git = "https://github.com/tikv/tokio", branch = "tokio-timer-hotfix" }
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -220,8 +220,8 @@ procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "6599eb9dca74229
 # When you modify TiKV cooperatively with kvproto, this will be useful to submit the PR to TiKV and the PR to
 # kvproto at the same time.
 # After the PR to kvproto is merged, remember to comment this out and run `cargo update -p kvproto`.
-# [patch.'https://github.com/pingcap/kvproto']
-# kvproto = { git = "https://github.com/your_github_id/kvproto", branch = "your_branch" }
+[patch.'https://github.com/pingcap/kvproto']
+kvproto = { git = "https://github.com/SpadeA-Tang/kvproto", branch = "flush-table" }
 
 [workspace]
 # See https://github.com/rust-lang/rfcs/blob/master/text/2957-cargo-features2.md
@@ -377,7 +377,7 @@ txn_types = { path = "components/txn_types" }
 grpcio = { version = "0.10.4", default-features = false, features = ["openssl-vendored", "protobuf-codec", "nightly"] }
 grpcio-health = { version = "0.10.4", default-features = false, features = ["protobuf-codec"] }
 tipb = { git = "https://github.com/pingcap/tipb.git" }
-kvproto = { git = "https://github.com/SpadeA-Tang/kvproto.git" }
+kvproto = { git = "https://github.com/pingcap/kvproto.git" }
 yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
 tokio-timer = { git = "https://github.com/tikv/tokio", branch = "tokio-timer-hotfix" }
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -220,8 +220,8 @@ procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "6599eb9dca74229
 # When you modify TiKV cooperatively with kvproto, this will be useful to submit the PR to TiKV and the PR to
 # kvproto at the same time.
 # After the PR to kvproto is merged, remember to comment this out and run `cargo update -p kvproto`.
-[patch.'https://github.com/pingcap/kvproto']
-kvproto = { git = "https://github.com/SpadeA-Tang/kvproto", branch = "flush-table" }
+# [patch.'https://github.com/pingcap/kvproto']
+# kvproto = { git = "https://github.com/your_github_id/kvproto", branch = "your_branch" }
 
 [workspace]
 # See https://github.com/rust-lang/rfcs/blob/master/text/2957-cargo-features2.md

--- a/components/raftstore-v2/src/batch/store.rs
+++ b/components/raftstore-v2/src/batch/store.rs
@@ -43,7 +43,7 @@ use tikv_util::{
     sys::SysQuota,
     time::{duration_to_sec, Instant as TiInstant},
     timer::SteadyTimer,
-    worker::{LazyWorker, Scheduler, Worker},
+    worker::{Builder as WorkerBuilder, LazyWorker, Scheduler, Worker},
     yatp_pool::{DefaultTicker, FuturePool, YatpPoolBuilder},
     Either,
 };
@@ -497,13 +497,16 @@ struct Workers<EK: KvEngine, ER: RaftEngine> {
 
 impl<EK: KvEngine, ER: RaftEngine> Workers<EK, ER> {
     fn new(background: Worker, pd: LazyWorker<pd::Task>, purge: Option<Worker>) -> Self {
+        let tablet_flush = WorkerBuilder::new("tablet_flush-worker")
+            .thread_count(2)
+            .create();
         Self {
             async_read: Worker::new("async-read-worker"),
             pd,
             tablet_gc: Worker::new("tablet-gc-worker"),
             async_write: StoreWriters::new(None),
             purge,
-            tablet_flush: Worker::new("tablet_flush-worker"),
+            tablet_flush,
             background,
         }
     }

--- a/components/raftstore-v2/src/batch/store.rs
+++ b/components/raftstore-v2/src/batch/store.rs
@@ -54,7 +54,7 @@ use crate::{
     operation::{SharedReadTablet, SPLIT_PREFIX},
     raft::Storage,
     router::{PeerMsg, PeerTick, StoreMsg},
-    worker::{pd, tablet_gc},
+    worker::{pd, tablet_flush, tablet_gc},
     Error, Result,
 };
 
@@ -465,6 +465,7 @@ pub struct Schedulers<EK: KvEngine, ER: RaftEngine> {
     pub pd: Scheduler<pd::Task>,
     pub tablet_gc: Scheduler<tablet_gc::Task<EK>>,
     pub write: WriteSenders<EK, ER>,
+    pub tablet_flush: Scheduler<tablet_flush::Task>,
 
     // Following is not maintained by raftstore itself.
     pub split_check: Scheduler<SplitCheckTask>,
@@ -488,6 +489,7 @@ struct Workers<EK: KvEngine, ER: RaftEngine> {
     tablet_gc: Worker,
     async_write: StoreWriters<EK, ER>,
     purge: Option<Worker>,
+    tablet_flush: Worker,
 
     // Following is not maintained by raftstore itself.
     background: Worker,
@@ -501,6 +503,7 @@ impl<EK: KvEngine, ER: RaftEngine> Workers<EK, ER> {
             tablet_gc: Worker::new("tablet-gc-worker"),
             async_write: StoreWriters::new(None),
             purge,
+            tablet_flush: Worker::new("tablet_flush-worker"),
             background,
         }
     }
@@ -510,6 +513,7 @@ impl<EK: KvEngine, ER: RaftEngine> Workers<EK, ER> {
         self.async_read.stop();
         self.pd.stop();
         self.tablet_gc.stop();
+        self.tablet_flush.stop();
         if let Some(w) = self.purge {
             w.stop();
         }
@@ -628,12 +632,18 @@ impl<EK: KvEngine, ER: RaftEngine> StoreSystem<EK, ER> {
             ),
         );
 
+        let tablet_flush_scheduler = workers.tablet_flush.start(
+            "tablet-flush-worker",
+            tablet_flush::Runner::new(router.clone(), tablet_registry.clone(), self.logger.clone()),
+        );
+
         let schedulers = Schedulers {
             read: read_scheduler,
             pd: workers.pd.scheduler(),
             tablet_gc: tablet_gc_scheduler,
             write: workers.async_write.senders(),
             split_check: split_check_scheduler,
+            tablet_flush: tablet_flush_scheduler,
         };
 
         let builder = StorePollerBuilder::new(

--- a/components/raftstore-v2/src/lib.rs
+++ b/components/raftstore-v2/src/lib.rs
@@ -42,4 +42,7 @@ pub use bootstrap::Bootstrap;
 pub use fsm::StoreMeta;
 pub use operation::{write_initial_states, SimpleWriteBinary, SimpleWriteEncoder, StateStorage};
 pub use raftstore::{store::Config, Error, Result};
-pub use worker::pd::{PdReporter, Task as PdTask};
+pub use worker::{
+    pd::{PdReporter, Task as PdTask},
+    tablet_flush::Task as TabletFlushTask,
+};

--- a/components/raftstore-v2/src/operation/command/admin/compact_log.rs
+++ b/components/raftstore-v2/src/operation/command/admin/compact_log.rs
@@ -113,7 +113,7 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> PeerFsmDelegate<'a, EK, ER,
 
 impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
     // Mirrors v1::on_raft_gc_log_tick.
-    fn maybe_propose_compact_log<T>(
+    fn maybe_propose_compact_log<T: Transport>(
         &mut self,
         store_ctx: &mut StoreContext<EK, ER, T>,
         force: bool,

--- a/components/raftstore-v2/src/operation/command/admin/mod.rs
+++ b/components/raftstore-v2/src/operation/command/admin/mod.rs
@@ -11,6 +11,7 @@ use compact_log::CompactLogResult;
 use conf_change::{ConfChangeResult, UpdateGcPeersResult};
 use engine_traits::{KvEngine, RaftEngine};
 use kvproto::{
+    metapb::PeerRole,
     raft_cmdpb::{AdminCmdType, RaftCmdRequest},
     raft_serverpb::{ExtraMessageType, FlushMemtable, RaftMessage},
 };
@@ -173,7 +174,10 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
 
                             let peers = self.region().get_peers().to_vec();
                             for p in peers {
-                                if p == *self.peer() {
+                                if p == *self.peer()
+                                    || p.get_role() != PeerRole::Voter
+                                    || p.is_witness
+                                {
                                     continue;
                                 }
                                 let mut msg = RaftMessage::default();

--- a/components/raftstore-v2/src/operation/command/admin/mod.rs
+++ b/components/raftstore-v2/src/operation/command/admin/mod.rs
@@ -127,6 +127,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
                     "Split is deprecated. Please use BatchSplit instead."
                 )),
                 AdminCmdType::BatchSplit => {
+                    #[allow(clippy::question_mark)]
                     if let Err(err) = validate_batch_split(req.get_admin_request(), self.region()) {
                         Err(err)
                     } else {

--- a/components/raftstore-v2/src/operation/command/admin/mod.rs
+++ b/components/raftstore-v2/src/operation/command/admin/mod.rs
@@ -139,6 +139,11 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
 
                             let region_id = self.region().get_id();
                             self.set_tablet_being_flushed(true);
+                            info!(
+                                self.logger,
+                                "Schedule flush tablet";
+                                "applied_index" => self.storage().apply_state().get_applied_index(),
+                            );
                             ctx.schedulers
                                 .tablet_flush
                                 .schedule(crate::TabletFlushTask::TabletFlush {
@@ -172,6 +177,10 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
                             return;
                         }
 
+                        info!(
+                            self.logger,
+                            "Propose split";
+                        );
                         self.set_tablet_being_flushed(false);
                         self.propose_split(ctx, req)
                     }

--- a/components/raftstore-v2/src/operation/command/admin/split.rs
+++ b/components/raftstore-v2/src/operation/command/admin/split.rs
@@ -25,7 +25,7 @@
 //!   created by the store, and here init it using the data sent from the parent
 //!   peer.
 
-use std::{any::Any, borrow::Cow, cmp, path::PathBuf, time::Duration};
+use std::{any::Any, borrow::Cow, cmp, path::PathBuf};
 
 use collections::HashSet;
 use crossbeam::channel::SendError;
@@ -55,7 +55,6 @@ use raftstore::{
 };
 use slog::{error, info, warn};
 use tikv_util::{log::SlogFormat, slog_panic, time::Instant};
-use txn_types::WriteBatchFlags;
 
 use crate::{
     batch::StoreContext,
@@ -473,6 +472,10 @@ impl<EK: KvEngine, R: ApplyResReporter> Apply<EK, R> {
             )
         });
 
+        info!(
+            self.logger,
+            "Begin create checkpoint time";
+        );
         let now = Instant::now();
         let reg = self.tablet_registry();
         for new_region in &regions {

--- a/components/raftstore-v2/src/operation/command/admin/split.rs
+++ b/components/raftstore-v2/src/operation/command/admin/split.rs
@@ -516,9 +516,10 @@ impl<EK: KvEngine, R: ApplyResReporter> Apply<EK, R> {
                 });
         }
         let elapsed = now.saturating_elapsed();
+        // to be removed after when it's stable
         info!(
             self.logger,
-            "Create checkpoint time consumes";
+            "create checkpoint time consumes";
             "region" =>  ?self.region(),
             "duration" => ?elapsed
         );

--- a/components/raftstore-v2/src/operation/command/admin/split.rs
+++ b/components/raftstore-v2/src/operation/command/admin/split.rs
@@ -472,10 +472,6 @@ impl<EK: KvEngine, R: ApplyResReporter> Apply<EK, R> {
             )
         });
 
-        info!(
-            self.logger,
-            "Begin create checkpoint time";
-        );
         let now = Instant::now();
         let reg = self.tablet_registry();
         for new_region in &regions {

--- a/components/raftstore-v2/src/operation/command/admin/transfer_leader.rs
+++ b/components/raftstore-v2/src/operation/command/admin/transfer_leader.rs
@@ -15,7 +15,7 @@ use raft::{eraftpb, ProgressState, Storage};
 use raftstore::{
     store::{
         fsm::new_admin_request, make_transfer_leader_response, metrics::PEER_ADMIN_CMD_COUNTER,
-        TRANSFER_LEADER_COMMAND_REPLY_CTX,
+        Transport, TRANSFER_LEADER_COMMAND_REPLY_CTX,
     },
     Result,
 };
@@ -146,7 +146,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         true
     }
 
-    pub fn on_transfer_leader_msg<T>(
+    pub fn on_transfer_leader_msg<T: Transport>(
         &mut self,
         ctx: &mut StoreContext<EK, ER, T>,
         msg: &eraftpb::Message,

--- a/components/raftstore-v2/src/operation/ready/mod.rs
+++ b/components/raftstore-v2/src/operation/ready/mod.rs
@@ -218,16 +218,16 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
                     if util::is_epoch_stale(region_epoch, self.region().get_region_epoch()) {
                         return;
                     }
-                    ctx.schedulers
-                        .tablet_flush
-                        .schedule(crate::TabletFlushTask::TabletFlush {
-                            region_id: self.region().get_id(),
-                            req: None,
-                            is_leader: false,
-                            applied_index: self.storage().apply_state().get_applied_index(),
-                            ch: None,
-                        })
-                        .unwrap(); // todo
+                    let _ =
+                        ctx.schedulers
+                            .tablet_flush
+                            .schedule(crate::TabletFlushTask::TabletFlush {
+                                region_id: self.region().get_id(),
+                                req: None,
+                                is_leader: false,
+                                applied_index: self.storage().apply_state().get_applied_index(),
+                                ch: None,
+                            });
                     return;
                 }
                 _ => {}

--- a/components/raftstore-v2/src/operation/ready/mod.rs
+++ b/components/raftstore-v2/src/operation/ready/mod.rs
@@ -362,7 +362,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
     ///
     /// The message is pushed into the send buffer, it may not be sent out until
     /// transport is flushed explicitly.
-    fn send_raft_message<T: Transport>(
+    pub fn send_raft_message<T: Transport>(
         &mut self,
         ctx: &mut StoreContext<EK, ER, T>,
         msg: RaftMessage,

--- a/components/raftstore-v2/src/operation/ready/mod.rs
+++ b/components/raftstore-v2/src/operation/ready/mod.rs
@@ -225,7 +225,6 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
                                 region_id: self.region().get_id(),
                                 req: None,
                                 is_leader: false,
-                                applied_index: self.storage().apply_state().get_applied_index(),
                                 ch: None,
                             });
                     return;

--- a/components/raftstore-v2/src/operation/ready/mod.rs
+++ b/components/raftstore-v2/src/operation/ready/mod.rs
@@ -368,7 +368,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
     ///
     /// The message is pushed into the send buffer, it may not be sent out until
     /// transport is flushed explicitly.
-    pub fn send_raft_message<T: Transport>(
+    pub(crate) fn send_raft_message<T: Transport>(
         &mut self,
         ctx: &mut StoreContext<EK, ER, T>,
         msg: RaftMessage,

--- a/components/raftstore-v2/src/raft/peer.rs
+++ b/components/raftstore-v2/src/raft/peer.rs
@@ -44,6 +44,7 @@ const REGION_READ_PROGRESS_CAP: usize = 128;
 pub struct Peer<EK: KvEngine, ER: RaftEngine> {
     raft_group: RawNode<Storage<EK, ER>>,
     tablet: CachedTablet<EK>,
+    tablet_being_flushed: bool,
 
     /// Statistics for self.
     self_stat: PeerStat,
@@ -154,6 +155,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         let tag = format!("[region {}] {}", region.get_id(), peer_id);
         let mut peer = Peer {
             tablet: cached_tablet,
+            tablet_being_flushed: false,
             self_stat: PeerStat::default(),
             peer_cache: vec![],
             peer_heartbeats: HashMap::default(),
@@ -299,6 +301,16 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
     #[inline]
     pub fn peer_id(&self) -> u64 {
         self.peer().get_id()
+    }
+
+    #[inline]
+    pub fn tablet_being_flushed(&self) -> bool {
+        self.tablet_being_flushed
+    }
+
+    #[inline]
+    pub fn set_tablet_being_flushed(&mut self, v: bool) {
+        self.tablet_being_flushed = v;
     }
 
     #[inline]

--- a/components/raftstore-v2/src/worker/mod.rs
+++ b/components/raftstore-v2/src/worker/mod.rs
@@ -1,4 +1,5 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
 pub mod pd;
+pub mod tablet_flush;
 pub mod tablet_gc;

--- a/components/raftstore-v2/src/worker/tablet_flush.rs
+++ b/components/raftstore-v2/src/worker/tablet_flush.rs
@@ -65,9 +65,10 @@ impl<EK: KvEngine, ER: RaftEngine> Runner<EK, ER> {
         let now = Instant::now();
         tablet.flush_cfs(DATA_CFS, true).unwrap();
         let elapsed = now.saturating_elapsed();
+        // to be removed after when it's stable
         info!(
             self.logger,
-            "Flush memtable time consumes";
+            "flush memtable time consumes";
             "region_id" =>  region_id,
             "duration" => ?elapsed,
             "is_leader" => is_leader,

--- a/components/raftstore-v2/src/worker/tablet_flush.rs
+++ b/components/raftstore-v2/src/worker/tablet_flush.rs
@@ -74,6 +74,15 @@ impl<EK: KvEngine, ER: RaftEngine> Runner<EK, ER> {
             .get(&region_id)
             .unwrap_or_else(|| &0);
         assert!(prev_applied_index < applied_index);
+        if prev_applied_index < applied_index {
+            warn!(
+                self.logger,
+                "Applied index is less than before";
+                "prev_applied_index" => prev_applied_index,
+                "current_applied_index" => applied_index,
+                "is_leader" => is_leader,
+            );
+        }
         if applied_index - prev_applied_index <= 100 {
             // We dont need to flush memtable if we just flushed before
             // figure out an appropriate number

--- a/components/raftstore-v2/src/worker/tablet_flush.rs
+++ b/components/raftstore-v2/src/worker/tablet_flush.rs
@@ -1,0 +1,120 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::fmt::{Display, Formatter};
+
+use collections::HashMap;
+use engine_traits::{KvEngine, RaftEngine, TabletRegistry, DATA_CFS};
+use kvproto::raft_cmdpb::RaftCmdRequest;
+use slog::{error, info, Logger};
+use tikv_util::{time::Instant, worker::Runnable};
+use txn_types::WriteBatchFlags;
+
+use crate::{
+    router::{CmdResChannel, PeerMsg, RaftRequest},
+    StoreRouter,
+};
+
+pub enum Task {
+    TabletFlush {
+        req: RaftCmdRequest,
+        applied_index: u64,
+        ch: CmdResChannel,
+    },
+}
+
+impl Display for Task {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Task::TabletFlush {
+                req,
+                applied_index,
+                ch,
+            } => unimplemented!(),
+        }
+    }
+}
+
+pub struct Runner<EK: KvEngine, ER: RaftEngine> {
+    router: StoreRouter<EK, ER>,
+    tablet_registry: TabletRegistry<EK>,
+    logger: Logger,
+
+    // region_id -> last applied index
+    last_applied_indexes: HashMap<u64, u64>,
+}
+
+impl<EK: KvEngine, ER: RaftEngine> Runner<EK, ER> {
+    pub fn new(
+        router: StoreRouter<EK, ER>,
+        tablet_registry: TabletRegistry<EK>,
+        logger: Logger,
+    ) -> Self {
+        Self {
+            router,
+            tablet_registry,
+            logger,
+            last_applied_indexes: HashMap::default(),
+        }
+    }
+
+    fn flush_tablet(&mut self, mut req: RaftCmdRequest, applied_index: u64, ch: CmdResChannel) {
+        let region_id = req.get_header().get_region_id();
+        let prev_applied_index = self
+            .last_applied_indexes
+            .get(&region_id)
+            .unwrap_or_else(|| &0)
+            .clone();
+        assert!(prev_applied_index < applied_index);
+        if applied_index - prev_applied_index <= 100 {
+            // We dont need to flush memtable if we just flushed before
+            // figure out an appropriate number
+        }
+
+        self.last_applied_indexes.insert(region_id, applied_index);
+        if let Some(mut cache) = self.tablet_registry.get(req.get_header().get_region_id()) {
+            if let Some(tablet) = cache.latest() {
+                let now = Instant::now();
+                tablet.flush_cfs(DATA_CFS, true).unwrap();
+                let elapsed = now.saturating_elapsed();
+                info!(
+                    self.logger,
+                    "Flush memtable time consumes";
+                    "region_id" =>  region_id,
+                    "duration" => ?elapsed,
+                    "prev_applied_index" => prev_applied_index,
+                    "current_applied_index" => applied_index,
+                );
+                req.mut_header()
+                    .set_flags(WriteBatchFlags::SPLIT_SECOND_PHASE.bits());
+                if let Err(e) = self
+                    .router
+                    .send(region_id, PeerMsg::AdminCommand(RaftRequest::new(req, ch)))
+                {
+                    error!(
+                        self.logger,
+                        "send split request fail in the second phase";
+                        "region_id" => region_id, "err" => ?e,
+                    );
+                }
+            }
+        }
+    }
+}
+
+impl<EK, ER> Runnable for Runner<EK, ER>
+where
+    EK: KvEngine,
+    ER: RaftEngine,
+{
+    type Task = Task;
+
+    fn run(&mut self, task: Self::Task) {
+        match task {
+            Task::TabletFlush {
+                req,
+                applied_index,
+                ch,
+            } => self.flush_tablet(req, applied_index, ch),
+        }
+    }
+}

--- a/components/raftstore-v2/src/worker/tablet_flush.rs
+++ b/components/raftstore-v2/src/worker/tablet_flush.rs
@@ -82,9 +82,10 @@ impl<EK: KvEngine, ER: RaftEngine> Runner<EK, ER> {
         if applied_index > prev_applied_index && applied_index - prev_applied_index <= 200 {
             // We dont need to flush memtable if we just flushed before
             need_flush = false;
+        } else {
+            self.last_applied_indexes.insert(region_id, applied_index);
         }
 
-        self.last_applied_indexes.insert(region_id, applied_index);
         if let Some(mut cache) = self.tablet_registry.get(region_id) {
             if let Some(tablet) = cache.latest() {
                 info!(

--- a/components/raftstore-v2/src/worker/tablet_flush.rs
+++ b/components/raftstore-v2/src/worker/tablet_flush.rs
@@ -79,7 +79,7 @@ impl<EK: KvEngine, ER: RaftEngine> Runner<EK, ER> {
             );
         }
         let mut need_flush = true;
-        if applied_index > prev_applied_index && applied_index - prev_applied_index <= 200 {
+        if applied_index > prev_applied_index && applied_index - prev_applied_index <= 100 {
             // We dont need to flush memtable if we just flushed before
             need_flush = false;
         } else {

--- a/components/raftstore-v2/src/worker/tablet_flush.rs
+++ b/components/raftstore-v2/src/worker/tablet_flush.rs
@@ -69,7 +69,7 @@ impl<EK: KvEngine, ER: RaftEngine> Runner<EK, ER> {
         info!(
             self.logger,
             "flush memtable time consumes";
-            "region_id" =>  region_id,
+            "region_id" => region_id,
             "duration" => ?elapsed,
             "is_leader" => is_leader,
         );

--- a/components/raftstore-v2/src/worker/tablet_flush.rs
+++ b/components/raftstore-v2/src/worker/tablet_flush.rs
@@ -5,7 +5,7 @@ use std::fmt::{Display, Formatter};
 use collections::HashMap;
 use engine_traits::{KvEngine, RaftEngine, TabletRegistry, DATA_CFS};
 use kvproto::raft_cmdpb::RaftCmdRequest;
-use slog::{error, info, Logger};
+use slog::{error, info, warn, Logger};
 use tikv_util::{time::Instant, worker::Runnable};
 use txn_types::WriteBatchFlags;
 

--- a/components/raftstore-v2/src/worker/tablet_flush.rs
+++ b/components/raftstore-v2/src/worker/tablet_flush.rs
@@ -88,7 +88,8 @@ impl<EK: KvEngine, ER: RaftEngine> Runner<EK, ER> {
             error!(
                 self.logger,
                 "send split request fail in the second phase";
-                "region_id" => region_id, "err" => ?e,
+                "region_id" => region_id,
+                "err" => ?e,
             );
         }
     }

--- a/components/raftstore-v2/src/worker/tablet_flush.rs
+++ b/components/raftstore-v2/src/worker/tablet_flush.rs
@@ -73,7 +73,6 @@ impl<EK: KvEngine, ER: RaftEngine> Runner<EK, ER> {
             .last_applied_indexes
             .get(&region_id)
             .unwrap_or_else(|| &0);
-        assert!(prev_applied_index < applied_index);
         if prev_applied_index < applied_index {
             warn!(
                 self.logger,

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -2797,6 +2797,7 @@ where
             }
             // It's v2 only message and ignore does no harm.
             ExtraMessageType::MsgGcPeerRequest | ExtraMessageType::MsgGcPeerResponse => (),
+            ExtraMessageType::MsgFlushMemtable => (),
         }
     }
 

--- a/components/test_raftstore-v2/Cargo.toml
+++ b/components/test_raftstore-v2/Cargo.toml
@@ -40,7 +40,7 @@ futures = "0.3"
 grpcio = { workspace = true }
 grpcio-health = { version = "0.10", default-features = false, features = ["protobuf-codec"] }
 keys = { workspace = true }
-kvproto = { git = "https://github.com/pingcap/kvproto.git" }
+kvproto = { workspace = true }
 lazy_static = "1.3"
 log_wrappers = { workspace = true }
 pd_client = { workspace = true }

--- a/components/test_raftstore-v2/src/cluster.rs
+++ b/components/test_raftstore-v2/src/cluster.rs
@@ -1004,6 +1004,10 @@ impl<T: Simulator> Cluster<T> {
             region_end_key
         };
 
+        if amended_start_key > amended_end_key {
+            return Ok(())
+        }
+
         tablet.scan(cf, amended_start_key, amended_end_key, fill_cache, f)
     }
 

--- a/components/test_raftstore-v2/src/cluster.rs
+++ b/components/test_raftstore-v2/src/cluster.rs
@@ -1005,7 +1005,7 @@ impl<T: Simulator> Cluster<T> {
         };
 
         if amended_start_key > amended_end_key {
-            return Ok(())
+            return Ok(());
         }
 
         tablet.scan(cf, amended_start_key, amended_end_key, fill_cache, f)

--- a/components/test_raftstore-v2/src/node.rs
+++ b/components/test_raftstore-v2/src/node.rs
@@ -437,12 +437,16 @@ impl Simulator for NodeCluster {
     }
 }
 
+// Compare to server cluster, node cluster does not have server layer and
+// storage layer.
 pub fn new_node_cluster(id: u64, count: usize) -> Cluster<NodeCluster> {
     let pd_client = Arc::new(TestPdClient::new(id, false));
     let sim = Arc::new(RwLock::new(NodeCluster::new(Arc::clone(&pd_client))));
     Cluster::new(id, count, sim, pd_client, ApiVersion::V1)
 }
 
+// This cluster does not support batch split, we expect it to transfer the
+// `BatchSplit` request to `split` request
 pub fn new_incompatible_node_cluster(id: u64, count: usize) -> Cluster<NodeCluster> {
     let pd_client = Arc::new(TestPdClient::new(id, true));
     let sim = Arc::new(RwLock::new(NodeCluster::new(Arc::clone(&pd_client))));

--- a/components/test_raftstore/src/node.rs
+++ b/components/test_raftstore/src/node.rs
@@ -505,12 +505,16 @@ impl Simulator for NodeCluster {
     }
 }
 
+// Compare to server cluster, node cluster does not have server layer and
+// storage layer.
 pub fn new_node_cluster(id: u64, count: usize) -> Cluster<NodeCluster> {
     let pd_client = Arc::new(TestPdClient::new(id, false));
     let sim = Arc::new(RwLock::new(NodeCluster::new(Arc::clone(&pd_client))));
     Cluster::new(id, count, sim, pd_client, ApiVersion::V1)
 }
 
+// This cluster does not support batch split, we expect it to transfer the
+// `BatchSplit` request to `split` request
 pub fn new_incompatible_node_cluster(id: u64, count: usize) -> Cluster<NodeCluster> {
     let pd_client = Arc::new(TestPdClient::new(id, true));
     let sim = Arc::new(RwLock::new(NodeCluster::new(Arc::clone(&pd_client))));

--- a/components/txn_types/src/types.rs
+++ b/components/txn_types/src/types.rs
@@ -570,6 +570,8 @@ bitflags! {
         const TRANSFER_LEADER_PROPOSAL = 0b00000100;
         /// Indicates this request is a flashback transaction.
         const FLASHBACK = 0b00001000;
+        /// Indicates the relevant tablet has been flushed, and we can propose split now.
+        const SPLIT_SECOND_PHASE = 0b00010000;
     }
 }
 

--- a/tests/integrations/raftstore/test_split_region.rs
+++ b/tests/integrations/raftstore/test_split_region.rs
@@ -150,7 +150,6 @@ fn test_server_split_region_twice() {
 #[test_case(test_raftstore::new_incompatible_node_cluster)]
 #[test_case(test_raftstore_v2::new_node_cluster)]
 #[test_case(test_raftstore_v2::new_server_cluster)]
-#[test_case(test_raftstore_v2::new_incompatible_node_cluster)]
 fn test_auto_split_region() {
     let count = 5;
     let mut cluster = new_cluster(0, count);

--- a/tests/integrations/raftstore/test_split_region.rs
+++ b/tests/integrations/raftstore/test_split_region.rs
@@ -223,11 +223,86 @@ fn test_auto_split_region<T: Simulator>(cluster: &mut Cluster<T>) {
     assert!(resp.get_header().get_error().has_key_not_in_region());
 }
 
-#[test]
+#[test_case(test_raftstore::new_node_cluster)]
+#[test_case(test_raftstore_v2::new_node_cluster)]
 fn test_node_auto_split_region() {
     let count = 5;
-    let mut cluster = new_node_cluster(0, count);
-    test_auto_split_region(&mut cluster);
+    let mut cluster = new_cluster(0, count);
+    cluster.cfg.raft_store.split_region_check_tick_interval = ReadableDuration::millis(100);
+    cluster.cfg.coprocessor.region_max_size = Some(ReadableSize(REGION_MAX_SIZE));
+    cluster.cfg.coprocessor.region_split_size = Some(ReadableSize(REGION_SPLIT_SIZE));
+
+    let check_size_diff = cluster.cfg.raft_store.region_split_check_diff().0;
+    let mut range = 1..;
+
+    cluster.run();
+
+    let pd_client = Arc::clone(&cluster.pd_client);
+
+    let region = pd_client.get_region(b"").unwrap();
+
+    let last_key = put_till_size(&mut cluster, REGION_SPLIT_SIZE, &mut range);
+
+    // it should be finished in millis if split.
+    thread::sleep(Duration::from_millis(300));
+
+    let target = pd_client.get_region(&last_key).unwrap();
+
+    assert_eq!(region, target);
+
+    let max_key = put_cf_till_size(
+        &mut cluster,
+        CF_WRITE,
+        REGION_MAX_SIZE - REGION_SPLIT_SIZE + check_size_diff,
+        &mut range,
+    );
+
+    let left = pd_client.get_region(b"").unwrap();
+    let right = pd_client.get_region(&max_key).unwrap();
+    if left == right {
+        cluster.wait_region_split(&region);
+    }
+
+    let left = pd_client.get_region(b"").unwrap();
+    let right = pd_client.get_region(&max_key).unwrap();
+
+    assert_ne!(left, right);
+    assert_eq!(region.get_start_key(), left.get_start_key());
+    assert_eq!(right.get_start_key(), left.get_end_key());
+    assert_eq!(region.get_end_key(), right.get_end_key());
+    assert_eq!(pd_client.get_region(&max_key).unwrap(), right);
+    assert_eq!(pd_client.get_region(left.get_end_key()).unwrap(), right);
+
+    let middle_key = left.get_end_key();
+    let leader = cluster.leader_of_region(left.get_id()).unwrap();
+    let store_id = leader.get_store_id();
+    let mut size = 0;
+    // cluster.engines[&store_id]
+    //     .kv
+    //     .scan(
+    //         CF_DEFAULT,
+    //         &data_key(b""),
+    //         &data_key(middle_key),
+    //         false,
+    //         |k, v| {
+    //             size += k.len() as u64;
+    //             size += v.len() as u64;
+    //             Ok(true)
+    //         },
+    //     )
+    //     .expect("");
+    // assert!(size <= REGION_SPLIT_SIZE);
+    // // although size may be smaller than REGION_SPLIT_SIZE, but the diff should
+    // // be small.
+    // assert!(size > REGION_SPLIT_SIZE - 1000);
+
+    let epoch = left.get_region_epoch().clone();
+    let get = new_request(left.get_id(), epoch, vec![new_get_cmd(&max_key)], false);
+    let resp = cluster
+        .call_command_on_leader(get, Duration::from_secs(5))
+        .unwrap();
+    assert!(resp.get_header().has_error());
+    assert!(resp.get_header().get_error().has_key_not_in_region());
 }
 
 #[test]

--- a/tests/integrations/raftstore/test_split_region.rs
+++ b/tests/integrations/raftstore/test_split_region.rs
@@ -7,7 +7,7 @@ use std::{
     time::Duration,
 };
 
-use engine_traits::{Iterable, Peekable, CF_DEFAULT, CF_WRITE};
+use engine_traits::{Peekable, CF_DEFAULT, CF_WRITE};
 use keys::data_key;
 use kvproto::{metapb, pdpb, raft_cmdpb::*, raft_serverpb::RaftMessage};
 use pd_client::PdClient;


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #14447

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
flush memtable before proposing split
```
Split calls `checkpoint` API of RocksDB which can easily cost more than 500ms.
As the main expensive operation of the `checkpoint `is the memtable flush, this PR schedule memtable flush before proposing the split.
So, when split is to be proposed, schedule a memtable flush task to the relevant worker, and at the same time, send raft messages with extra msg to followers to let them flush their memtables.
After the flush task finishes, the split can be proposed, and this time, `checkpoint` will be much more lightweight.


### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
```
