### PR TITLE
cop: support return applied index rejecting cop tasks by busy threshold

### DIFF
--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -1003,6 +1003,7 @@ where
                 self.concurrency_manager.clone(),
                 resource_tag_factory,
                 Arc::clone(&self.quota_limiter),
+                engines.engine.clone(),
             ),
             coprocessor_v2::Endpoint::new(&self.config.coprocessor_v2),
             self.resolver.clone().unwrap(),

--- a/components/server/src/server2.rs
+++ b/components/server/src/server2.rs
@@ -853,6 +853,7 @@ where
                 self.concurrency_manager.clone(),
                 resource_tag_factory,
                 Arc::clone(&self.quota_limiter),
+                engines.engine.clone(),
             ),
             coprocessor_v2::Endpoint::new(&self.config.coprocessor_v2),
             self.resolver.clone().unwrap(),

--- a/components/test_coprocessor/src/fixture.rs
+++ b/components/test_coprocessor/src/fixture.rs
@@ -79,6 +79,7 @@ pub fn init_data_with_details<E: Engine>(
     commit: bool,
     cfg: &Config,
 ) -> (Store<E>, Endpoint<E>, Arc<QuotaLimiter>) {
+    let engine_for_cop = engine.clone();
     let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, MockLockManager::new())
         .build()
         .unwrap();
@@ -110,6 +111,7 @@ pub fn init_data_with_details<E: Engine>(
         cm,
         ResourceTagFactory::new_for_test(),
         limiter.clone(),
+        engine_for_cop,
     );
     (store, copr, limiter)
 }

--- a/components/test_coprocessor/src/util.rs
+++ b/components/test_coprocessor/src/util.rs
@@ -14,14 +14,14 @@ pub fn next_id() -> i64 {
     ID_GENERATOR.fetch_add(1, Ordering::Relaxed) as i64
 }
 
-pub fn handle_request<E>(copr: &Endpoint<E>, req: Request) -> Response
+pub fn handle_request<E>(copr: &mut Endpoint<E>, req: Request) -> Response
 where
     E: Engine,
 {
     block_on(copr.parse_and_handle_unary_request(req, None)).consume()
 }
 
-pub fn handle_select<E>(copr: &Endpoint<E>, req: Request) -> SelectResponse
+pub fn handle_select<E>(copr: &mut Endpoint<E>, req: Request) -> SelectResponse
 where
     E: Engine,
 {
@@ -33,7 +33,7 @@ where
 }
 
 pub fn handle_streaming_select<E, F>(
-    copr: &Endpoint<E>,
+    copr: &mut Endpoint<E>,
     req: Request,
     mut check_range: F,
 ) -> Vec<StreamResponse>

--- a/components/test_raftstore-v2/src/server.rs
+++ b/components/test_raftstore-v2/src/server.rs
@@ -379,6 +379,7 @@ impl ServerCluster {
             RaftKv2::new(raft_router.clone(), region_info_accessor.region_leaders()),
             sim_router.filters().clone(),
         );
+        let raft_engine_for_cop = raft_kv_v2.clone();
 
         // Create storage.
         let pd_worker = LazyWorker::new("test-pd-worker");
@@ -503,6 +504,7 @@ impl ServerCluster {
             concurrency_manager.clone(),
             res_tag_factory,
             quota_limiter,
+            raft_engine_for_cop,
         );
         let copr_v2 = coprocessor_v2::Endpoint::new(&cfg.coprocessor_v2);
         let mut server = None;

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -326,6 +326,7 @@ impl ServerCluster {
             engines.kv.clone(),
             region_info_accessor.region_leaders(),
         );
+        let raft_engine_for_cop = raft_engine.clone();
         if let Some(scheduler) = self.txn_extra_schedulers.remove(&node_id) {
             engine.set_txn_extra_scheduler(scheduler);
         }
@@ -472,6 +473,7 @@ impl ServerCluster {
             concurrency_manager.clone(),
             res_tag_factory,
             quota_limiter,
+            raft_engine_for_cop,
         );
         let copr_v2 = coprocessor_v2::Endpoint::new(&cfg.coprocessor_v2);
         let mut server = None;

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -1,8 +1,6 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{
-    borrow::Cow, future::Future, iter::FromIterator, marker::PhantomData, sync::Arc, time::Duration,
-};
+use std::{borrow::Cow, future::Future, iter::FromIterator, sync::Arc, time::Duration};
 
 use ::tracker::{
     set_tls_tracker_token, with_tls_tracker, RequestInfo, RequestType, GLOBAL_TRACKERS,
@@ -68,7 +66,8 @@ pub struct Endpoint<E: Engine> {
 
     slow_log_threshold: Duration,
 
-    _phantom: PhantomData<E>,
+    // TODO: Too many Arcs, would be slow when clone.
+    engine: E,
 
     quota_limiter: Arc<QuotaLimiter>,
 }
@@ -82,6 +81,7 @@ impl<E: Engine> Endpoint<E> {
         concurrency_manager: ConcurrencyManager,
         resource_tag_factory: ResourceTagFactory,
         quota_limiter: Arc<QuotaLimiter>,
+        engine: E,
     ) -> Self {
         // FIXME: When yatp is used, we need to limit coprocessor requests in progress
         // to avoid using too much memory. However, if there are a number of large
@@ -104,7 +104,7 @@ impl<E: Engine> Endpoint<E> {
             stream_channel_size: cfg.end_point_stream_channel_size,
             max_handle_duration: cfg.end_point_request_max_handle_duration.0,
             slow_log_threshold: cfg.end_point_slow_log_threshold.0,
-            _phantom: Default::default(),
+            engine,
             quota_limiter,
         }
     }
@@ -512,7 +512,7 @@ impl<E: Engine> Endpoint<E> {
     /// converted into a `Response` as the success result of the future.
     #[inline]
     pub fn parse_and_handle_unary_request(
-        &self,
+        &mut self,
         mut req: coppb::Request,
         peer: Option<String>,
     ) -> impl Future<Output = MemoryTraceGuard<coppb::Response>> {
@@ -521,9 +521,11 @@ impl<E: Engine> Endpoint<E> {
         if let Err(busy_err) = self.read_pool.check_busy_threshold(Duration::from_millis(
             req.get_context().get_busy_threshold_ms() as u64,
         )) {
-            let mut resp = coppb::Response::default();
-            resp.mut_region_error().set_server_is_busy(busy_err);
-            return Either::Left(async move { resp.into() });
+            let fut = self.process_busy_err(req, peer.clone(), busy_err);
+            return Either::Left(async move {
+                let res = fut.await;
+                res.into()
+            });
         }
 
         let tracker = GLOBAL_TRACKERS.insert(::tracker::Tracker::new(RequestInfo::new(
@@ -560,6 +562,48 @@ impl<E: Engine> Endpoint<E> {
         Either::Right(fut)
     }
 
+    fn process_busy_err(
+        &mut self,
+        mut req: coppb::Request,
+        peer: Option<String>,
+        busy_err: errorpb::ServerIsBusy,
+    ) -> impl Future<Output = coppb::Response> {
+        let mut resp = coppb::Response::default();
+        resp.mut_region_error().set_server_is_busy(busy_err.clone());
+        let result_of_batch = self.process_batch_tasks_busy_err(&mut req, &peer, busy_err.clone());
+        let snap_fut = self
+            .parse_request_and_check_memory_locks(req, peer.clone(), false)
+            .map(|(_, req_ctx)| Self::async_snapshot(&mut self.engine, &req_ctx));
+        let fut = async move {
+            match snap_fut {
+                Ok(snap) => {
+                    let (handle_res, batch_res) = futures::join!(snap, result_of_batch);
+                    match handle_res {
+                        Ok(snap_res) => {
+                            resp.mut_region_error().mut_server_is_busy().applied_index = snap_res
+                                .ext()
+                                .get_data_version()
+                                .map_or(0, |applied_index| applied_index);
+                        }
+                        Err(e) => {
+                            resp = make_error_response(e);
+                        }
+                    }
+                    resp.set_batch_responses(batch_res.into());
+                }
+                Err(e) => {
+                    resp = make_error_response(e);
+                    resp.mut_region_error().set_server_is_busy(busy_err.clone());
+                    let batch_res = result_of_batch.await;
+                    resp.set_batch_responses(batch_res.into());
+                }
+            }
+            resp.into()
+        };
+
+        fut
+    }
+
     // process_batch_tasks process the input batched coprocessor tasks if any,
     // prepare all the requests and schedule them into the read pool, then
     // collect all the responses and convert them into the `StoreBatchResponse`
@@ -570,23 +614,7 @@ impl<E: Engine> Endpoint<E> {
         peer: &Option<String>,
     ) -> impl Future<Output = Vec<coppb::StoreBatchTaskResponse>> {
         let mut batch_futs = Vec::with_capacity(req.tasks.len());
-        let batch_reqs: Vec<(coppb::Request, u64)> = req
-            .take_tasks()
-            .iter_mut()
-            .map(|task| {
-                let mut new_req = req.clone();
-                // Disable the coprocessor cache path for the batched tasks, the
-                // coprocessor cache related fields are not passed in the "task" by now.
-                new_req.is_cache_enabled = false;
-                new_req.ranges = task.take_ranges();
-                let new_context = new_req.mut_context();
-                new_context.set_region_id(task.get_region_id());
-                new_context.set_region_epoch(task.take_region_epoch());
-                new_context.set_peer(task.take_peer());
-                (new_req, task.get_task_id())
-            })
-            .collect();
-        for (cur_req, task_id) in batch_reqs.into_iter() {
+        for (cur_req, task_id) in self.collect_batch_requests(req).into_iter() {
             let request_info = RequestInfo::new(
                 cur_req.get_context(),
                 RequestType::Unknown,
@@ -636,6 +664,66 @@ impl<E: Engine> Endpoint<E> {
             }
         }
         stream::FuturesOrdered::from_iter(batch_futs).collect()
+    }
+
+    fn process_batch_tasks_busy_err(
+        &mut self,
+        req: &mut coppb::Request,
+        peer: &Option<String>,
+        busy_err: errorpb::ServerIsBusy,
+    ) -> impl Future<Output = Vec<coppb::StoreBatchTaskResponse>> {
+        let mut batch_futs = Vec::with_capacity(req.tasks.len());
+        for (cur_req, task_id) in self.collect_batch_requests(req).into_iter() {
+            let err = busy_err.clone();
+            let mut response = coppb::StoreBatchTaskResponse::new();
+            response.set_task_id(task_id);
+            match self.parse_request_and_check_memory_locks(cur_req, peer.clone(), false) {
+                Ok((_, req_ctx)) => {
+                    let snap = Self::async_snapshot(&mut self.engine, &req_ctx);
+                    let fut = async move {
+                        match snap.await {
+                            Ok(snap) => {
+                                response.mut_region_error().set_server_is_busy(err);
+                                if let Some(applied_index) = snap.ext().get_data_version() {
+                                    response
+                                        .mut_region_error()
+                                        .mut_server_is_busy()
+                                        .applied_index = applied_index;
+                                }
+                            }
+                            Err(e) => {
+                                make_error_batch_response(&mut response, e);
+                            }
+                        }
+                        response
+                    };
+                    batch_futs.push(future::Either::Left(fut));
+                }
+                Err(e) => batch_futs.push(future::Either::Right(async move {
+                    make_error_batch_response(&mut response, e);
+                    response
+                })),
+            }
+        }
+        stream::FuturesOrdered::from_iter(batch_futs).collect()
+    }
+
+    fn collect_batch_requests(&self, req: &mut coppb::Request) -> Vec<(coppb::Request, u64)> {
+        req.take_tasks()
+            .iter_mut()
+            .map(|task| {
+                let mut new_req = req.clone();
+                // Disable the coprocessor cache path for the batched tasks, the
+                // coprocessor cache related fields are not passed in the "task" by now.
+                new_req.is_cache_enabled = false;
+                new_req.ranges = task.take_ranges();
+                let new_context = new_req.mut_context();
+                new_context.set_region_id(task.get_region_id());
+                new_context.set_region_epoch(task.take_region_epoch());
+                new_context.set_peer(task.take_peer());
+                (new_req, task.get_task_id())
+            })
+            .collect()
     }
 
     /// The real implementation of handling a stream request.
@@ -1026,6 +1114,7 @@ mod tests {
     #[test]
     fn test_outdated_request() {
         let engine = TestEngineBuilder::new().build().unwrap();
+        let engine_for_cop = engine.clone();
         let read_pool = ReadPool::from(build_read_pool_for_test(
             &CoprReadPoolConfig::default_for_test(),
             engine,
@@ -1037,6 +1126,7 @@ mod tests {
             cm,
             ResourceTagFactory::new_for_test(),
             Arc::new(QuotaLimiter::default()),
+            engine_for_cop,
         );
 
         // a normal request
@@ -1067,6 +1157,7 @@ mod tests {
     #[test]
     fn test_stack_guard() {
         let engine = TestEngineBuilder::new().build().unwrap();
+        let engine_for_cop = engine.clone();
         let read_pool = ReadPool::from(build_read_pool_for_test(
             &CoprReadPoolConfig::default_for_test(),
             engine,
@@ -1078,6 +1169,7 @@ mod tests {
             cm,
             ResourceTagFactory::new_for_test(),
             Arc::new(QuotaLimiter::default()),
+            engine_for_cop,
         );
         copr.recursion_limit = 100;
 
@@ -1105,17 +1197,19 @@ mod tests {
     #[test]
     fn test_invalid_req_type() {
         let engine = TestEngineBuilder::new().build().unwrap();
+        let engine_for_cop = engine.clone();
         let read_pool = ReadPool::from(build_read_pool_for_test(
             &CoprReadPoolConfig::default_for_test(),
             engine,
         ));
         let cm = ConcurrencyManager::new(1.into());
-        let copr = Endpoint::<RocksEngine>::new(
+        let mut copr = Endpoint::<RocksEngine>::new(
             &Config::default(),
             read_pool.handle(),
             cm,
             ResourceTagFactory::new_for_test(),
             Arc::new(QuotaLimiter::default()),
+            engine_for_cop,
         );
 
         let mut req = coppb::Request::default();
@@ -1128,17 +1222,19 @@ mod tests {
     #[test]
     fn test_invalid_req_body() {
         let engine = TestEngineBuilder::new().build().unwrap();
+        let engine_for_cop = engine.clone();
         let read_pool = ReadPool::from(build_read_pool_for_test(
             &CoprReadPoolConfig::default_for_test(),
             engine,
         ));
         let cm = ConcurrencyManager::new(1.into());
-        let copr = Endpoint::<RocksEngine>::new(
+        let mut copr = Endpoint::<RocksEngine>::new(
             &Config::default(),
             read_pool.handle(),
             cm,
             ResourceTagFactory::new_for_test(),
             Arc::new(QuotaLimiter::default()),
+            engine_for_cop,
         );
 
         let mut req = coppb::Request::default();
@@ -1158,6 +1254,7 @@ mod tests {
         use crate::storage::kv::{destroy_tls_engine, set_tls_engine};
 
         let engine = TestEngineBuilder::new().build().unwrap();
+        let engine_for_cop = engine.clone();
 
         let read_pool = ReadPool::from(
             CoprReadPoolConfig {
@@ -1187,6 +1284,7 @@ mod tests {
             cm,
             ResourceTagFactory::new_for_test(),
             Arc::new(QuotaLimiter::default()),
+            engine_for_cop,
         );
 
         let (tx, rx) = mpsc::channel();
@@ -1227,6 +1325,7 @@ mod tests {
     #[test]
     fn test_error_unary_response() {
         let engine = TestEngineBuilder::new().build().unwrap();
+        let engine_for_cop = engine.clone();
         let read_pool = ReadPool::from(build_read_pool_for_test(
             &CoprReadPoolConfig::default_for_test(),
             engine,
@@ -1238,6 +1337,7 @@ mod tests {
             cm,
             ResourceTagFactory::new_for_test(),
             Arc::new(QuotaLimiter::default()),
+            engine_for_cop,
         );
 
         let handler_builder =
@@ -1252,6 +1352,7 @@ mod tests {
     #[test]
     fn test_error_streaming_response() {
         let engine = TestEngineBuilder::new().build().unwrap();
+        let engine_for_cop = engine.clone();
         let read_pool = ReadPool::from(build_read_pool_for_test(
             &CoprReadPoolConfig::default_for_test(),
             engine,
@@ -1263,6 +1364,7 @@ mod tests {
             cm,
             ResourceTagFactory::new_for_test(),
             Arc::new(QuotaLimiter::default()),
+            engine_for_cop,
         );
 
         // Fail immediately
@@ -1305,6 +1407,7 @@ mod tests {
     #[test]
     fn test_empty_streaming_response() {
         let engine = TestEngineBuilder::new().build().unwrap();
+        let engine_for_cop = engine.clone();
         let read_pool = ReadPool::from(build_read_pool_for_test(
             &CoprReadPoolConfig::default_for_test(),
             engine,
@@ -1316,6 +1419,7 @@ mod tests {
             cm,
             ResourceTagFactory::new_for_test(),
             Arc::new(QuotaLimiter::default()),
+            engine_for_cop,
         );
 
         let handler_builder = Box::new(|_, _: &_| Ok(StreamFixture::new(vec![]).into_boxed()));
@@ -1333,6 +1437,7 @@ mod tests {
     #[test]
     fn test_special_streaming_handlers() {
         let engine = TestEngineBuilder::new().build().unwrap();
+        let engine_for_cop = engine.clone();
         let read_pool = ReadPool::from(build_read_pool_for_test(
             &CoprReadPoolConfig::default_for_test(),
             engine,
@@ -1344,6 +1449,7 @@ mod tests {
             cm,
             ResourceTagFactory::new_for_test(),
             Arc::new(QuotaLimiter::default()),
+            engine_for_cop,
         );
 
         // handler returns `finished == true` should not be called again.
@@ -1429,6 +1535,7 @@ mod tests {
     #[test]
     fn test_channel_size() {
         let engine = TestEngineBuilder::new().build().unwrap();
+        let engine_for_cop = engine.clone();
         let read_pool = ReadPool::from(build_read_pool_for_test(
             &CoprReadPoolConfig::default_for_test(),
             engine,
@@ -1443,6 +1550,7 @@ mod tests {
             cm,
             ResourceTagFactory::new_for_test(),
             Arc::new(QuotaLimiter::default()),
+            engine_for_cop,
         );
 
         let counter = Arc::new(atomic::AtomicIsize::new(0));
@@ -1487,6 +1595,7 @@ mod tests {
         const PAYLOAD_LARGE: Duration = Duration::from_millis(6000);
 
         let engine = TestEngineBuilder::new().build().unwrap();
+        let engine_for_cop = engine.clone();
 
         let read_pool = ReadPool::from(build_read_pool_for_test(
             &CoprReadPoolConfig {
@@ -1512,6 +1621,7 @@ mod tests {
             cm,
             ResourceTagFactory::new_for_test(),
             Arc::new(QuotaLimiter::default()),
+            engine_for_cop,
         );
 
         let (tx, rx) = std::sync::mpsc::channel();
@@ -1888,6 +1998,7 @@ mod tests {
     #[test]
     fn test_exceed_deadline() {
         let engine = TestEngineBuilder::new().build().unwrap();
+        let engine_for_cop = engine.clone();
         let read_pool = ReadPool::from(build_read_pool_for_test(
             &CoprReadPoolConfig::default_for_test(),
             engine,
@@ -1899,6 +2010,7 @@ mod tests {
             cm,
             ResourceTagFactory::new_for_test(),
             Arc::new(QuotaLimiter::default()),
+            engine_for_cop,
         );
 
         {
@@ -1936,6 +2048,7 @@ mod tests {
     #[test]
     fn test_check_memory_locks() {
         let engine = TestEngineBuilder::new().build().unwrap();
+        let engine_for_cop = engine.clone();
         let read_pool = ReadPool::from(build_read_pool_for_test(
             &CoprReadPoolConfig::default_for_test(),
             engine,
@@ -1957,12 +2070,13 @@ mod tests {
         });
 
         let config = Config::default();
-        let copr = Endpoint::<RocksEngine>::new(
+        let mut copr = Endpoint::<RocksEngine>::new(
             &config,
             read_pool.handle(),
             cm,
             ResourceTagFactory::new_for_test(),
             Arc::new(QuotaLimiter::default()),
+            engine_for_cop,
         );
         let mut req = coppb::Request::default();
         req.mut_context().set_isolation_level(IsolationLevel::Si);

--- a/src/read_pool.rs
+++ b/src/read_pool.rs
@@ -290,6 +290,12 @@ impl ReadPoolHandle {
         &self,
         busy_threshold: Duration,
     ) -> Result<(), errorpb::ServerIsBusy> {
+        fail_point!("read_pool_busy_err", |_| {
+            let mut busy_err = errorpb::ServerIsBusy::default();
+            busy_err.set_reason("estimated wait time exceeds threshold".to_owned());
+            busy_err.estimated_wait_ms = 777;
+            Err(busy_err)
+        });
         if busy_threshold.is_zero() {
             return Ok(());
         }

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -520,6 +520,7 @@ mod tests {
             .build()
             .unwrap()
             .with_raft_extension(RaftRouterWrap::new(router.clone()));
+        let engine_for_cop = engine.clone();
 
         let storage =
             TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, MockLockManager::new())
@@ -557,6 +558,7 @@ mod tests {
             storage.get_concurrency_manager(),
             ResourceTagFactory::new_for_test(),
             Arc::new(QuotaLimiter::default()),
+            engine_for_cop,
         );
         let copr_v2 = coprocessor_v2::Endpoint::new(&coprocessor_v2::Config::default());
         let debug_thread_pool = Arc::new(

--- a/tests/integrations/coprocessor/test_analyze.rs
+++ b/tests/integrations/coprocessor/test_analyze.rs
@@ -114,14 +114,14 @@ fn test_analyze_column_with_lock() {
 
     let product = ProductTable::new();
     for &iso_level in &[IsolationLevel::Si, IsolationLevel::Rc] {
-        let (_, endpoint, _) = init_data_with_commit(&product, &data, false);
+        let (_, mut endpoint, _) = init_data_with_commit(&product, &data, false);
 
         let mut req = new_analyze_column_req(&product, 3, 3, 3, 3, 4, 32);
         let mut ctx = Context::default();
         ctx.set_isolation_level(iso_level);
         req.set_context(ctx);
 
-        let resp = handle_request(&endpoint, req);
+        let resp = handle_request(&mut endpoint, req);
         match iso_level {
             IsolationLevel::Si => {
                 assert!(resp.get_data().is_empty(), "{:?}", resp);
@@ -149,10 +149,10 @@ fn test_analyze_column() {
     ];
 
     let product = ProductTable::new();
-    let (_, endpoint, _) = init_data_with_commit(&product, &data, true);
+    let (_, mut endpoint, _) = init_data_with_commit(&product, &data, true);
 
     let req = new_analyze_column_req(&product, 3, 3, 3, 3, 4, 32);
-    let resp = handle_request(&endpoint, req);
+    let resp = handle_request(&mut endpoint, req);
     assert!(!resp.get_data().is_empty());
     let mut analyze_resp = AnalyzeColumnsResp::default();
     analyze_resp.merge_from_bytes(resp.get_data()).unwrap();
@@ -181,10 +181,10 @@ fn test_analyze_single_primary_column() {
     ];
 
     let product = ProductTable::new();
-    let (_, endpoint, _) = init_data_with_commit(&product, &data, true);
+    let (_, mut endpoint, _) = init_data_with_commit(&product, &data, true);
 
     let req = new_analyze_column_req(&product, 1, 3, 3, 3, 4, 32);
-    let resp = handle_request(&endpoint, req);
+    let resp = handle_request(&mut endpoint, req);
     assert!(!resp.get_data().is_empty());
     let mut analyze_resp = AnalyzeColumnsResp::default();
     analyze_resp.merge_from_bytes(resp.get_data()).unwrap();
@@ -206,14 +206,14 @@ fn test_analyze_index_with_lock() {
 
     let product = ProductTable::new();
     for &iso_level in &[IsolationLevel::Si, IsolationLevel::Rc] {
-        let (_, endpoint, _) = init_data_with_commit(&product, &data, false);
+        let (_, mut endpoint, _) = init_data_with_commit(&product, &data, false);
 
         let mut req = new_analyze_index_req(&product, 3, product["name"].index, 4, 32, 0, 1);
         let mut ctx = Context::default();
         ctx.set_isolation_level(iso_level);
         req.set_context(ctx);
 
-        let resp = handle_request(&endpoint, req);
+        let resp = handle_request(&mut endpoint, req);
         match iso_level {
             IsolationLevel::Si => {
                 assert!(resp.get_data().is_empty(), "{:?}", resp);
@@ -246,10 +246,10 @@ fn test_analyze_index() {
     ];
 
     let product = ProductTable::new();
-    let (_, endpoint, _) = init_data_with_commit(&product, &data, true);
+    let (_, mut endpoint, _) = init_data_with_commit(&product, &data, true);
 
     let req = new_analyze_index_req(&product, 3, product["name"].index, 4, 32, 2, 2);
-    let resp = handle_request(&endpoint, req);
+    let resp = handle_request(&mut endpoint, req);
     assert!(!resp.get_data().is_empty());
     let mut analyze_resp = AnalyzeIndexResp::default();
     analyze_resp.merge_from_bytes(resp.get_data()).unwrap();
@@ -288,11 +288,11 @@ fn test_analyze_sampling_reservoir() {
     ];
 
     let product = ProductTable::new();
-    let (_, endpoint, _) = init_data_with_commit(&product, &data, true);
+    let (_, mut endpoint, _) = init_data_with_commit(&product, &data, true);
 
     // Pass the 2nd column as a column group.
     let req = new_analyze_sampling_req(&product, 1, 5, 0.0);
-    let resp = handle_request(&endpoint, req);
+    let resp = handle_request(&mut endpoint, req);
     assert!(!resp.get_data().is_empty());
     let mut analyze_resp = AnalyzeColumnsResp::default();
     analyze_resp.merge_from_bytes(resp.get_data()).unwrap();
@@ -320,11 +320,11 @@ fn test_analyze_sampling_bernoulli() {
     ];
 
     let product = ProductTable::new();
-    let (_, endpoint, _) = init_data_with_commit(&product, &data, true);
+    let (_, mut endpoint, _) = init_data_with_commit(&product, &data, true);
 
     // Pass the 2nd column as a column group.
     let req = new_analyze_sampling_req(&product, 1, 0, 0.5);
-    let resp = handle_request(&endpoint, req);
+    let resp = handle_request(&mut endpoint, req);
     assert!(!resp.get_data().is_empty());
     let mut analyze_resp = AnalyzeColumnsResp::default();
     analyze_resp.merge_from_bytes(resp.get_data()).unwrap();
@@ -346,12 +346,12 @@ fn test_invalid_range() {
     ];
 
     let product = ProductTable::new();
-    let (_, endpoint, _) = init_data_with_commit(&product, &data, true);
+    let (_, mut endpoint, _) = init_data_with_commit(&product, &data, true);
     let mut req = new_analyze_index_req(&product, 3, product["name"].index, 4, 32, 0, 1);
     let mut key_range = KeyRange::default();
     key_range.set_start(b"xxx".to_vec());
     key_range.set_end(b"zzz".to_vec());
     req.set_ranges(vec![key_range].into());
-    let resp = handle_request(&endpoint, req);
+    let resp = handle_request(&mut endpoint, req);
     assert!(!resp.get_other_error().is_empty());
 }

--- a/tests/integrations/coprocessor/test_checksum.rs
+++ b/tests/integrations/coprocessor/test_checksum.rs
@@ -48,7 +48,7 @@ fn test_checksum() {
     ];
 
     let product = ProductTable::new();
-    let (store, endpoint, _) = init_data_with_commit(&product, &data, true);
+    let (store, mut endpoint, _) = init_data_with_commit(&product, &data, true);
 
     for column in &[&product["id"], &product["name"], &product["count"]] {
         assert!(column.index >= 0);
@@ -62,7 +62,7 @@ fn test_checksum() {
         let request = new_checksum_request(range.clone(), scan_on);
         let expected = reversed_checksum_crc64_xor(&store, range);
 
-        let response = handle_request(&endpoint, request);
+        let response = handle_request(&mut endpoint, request);
         let mut resp = ChecksumResponse::default();
         resp.merge_from_bytes(response.get_data()).unwrap();
         assert_eq!(resp.get_checksum(), expected);

--- a/tests/integrations/resource_metering/test_cpu.rs
+++ b/tests/integrations/resource_metering/test_cpu.rs
@@ -75,7 +75,7 @@ pub fn test_commit() {
 pub fn test_reschedule_coprocessor() {
     let tag = "tag_coprocessor";
 
-    let (test_suite, mut store, endpoint) = setup_test_suite();
+    let (test_suite, mut store, mut endpoint) = setup_test_suite();
     fail::cfg("copr_reschedule", "return").unwrap();
     fail::cfg_callback("scanner_next", || cpu_load(Duration::from_millis(100))).unwrap();
     defer!({
@@ -217,6 +217,7 @@ fn setup_test_suite() -> (TestSuite, Store<RocksEngine>, Endpoint<RocksEngine>) 
         ..Default::default()
     });
     let store = Store::from_storage(test_suite.get_storage());
+    let engine_for_cop = store.get_engine().clone();
     tikv_util::thread_group::set_properties(Some(GroupProperties::default()));
     let pool = ReadPool::from(readpool_impl::build_read_pool_for_test(
         &CoprReadPoolConfig::default_for_test(),
@@ -229,6 +230,7 @@ fn setup_test_suite() -> (TestSuite, Store<RocksEngine>, Endpoint<RocksEngine>) 
         cm,
         test_suite.get_tag_factory(),
         Arc::new(QuotaLimiter::default()),
+        engine_for_cop,
     );
     (test_suite, store, endpoint)
 }

--- a/tests/integrations/resource_metering/test_read_keys.rs
+++ b/tests/integrations/resource_metering/test_read_keys.rs
@@ -172,7 +172,7 @@ fn test_read_keys_coprocessor() {
         (5, Some("name:1"), 4),
     ];
     let product = ProductTable::new();
-    let endpoint = init_coprocessor_with_data(&product, &data, resource_tag_factory);
+    let mut endpoint = init_coprocessor_with_data(&product, &data, resource_tag_factory);
     let runtime = tokio::runtime::Builder::new_current_thread()
         .build()
         .unwrap();
@@ -182,13 +182,13 @@ fn test_read_keys_coprocessor() {
     let mut ctx = Context::default();
     ctx.set_resource_group_tag("TEST-TAG".into());
     req.set_context(ctx);
-    runtime.block_on(handle_select(&endpoint, req.clone()));
+    runtime.block_on(handle_select(&mut endpoint, req.clone()));
 
     // Clear current result.
     let _ = data_sink.wait_read_keys(Duration::from_secs(3));
 
     // Do DAG select again.
-    runtime.block_on(handle_select(&endpoint, req));
+    runtime.block_on(handle_select(&mut endpoint, req));
 
     // Wait & receive & assert.
     assert_eq!(
@@ -207,6 +207,7 @@ fn init_coprocessor_with_data(
     tag_factory: ResourceTagFactory,
 ) -> Endpoint<RocksEngine> {
     let mut store = Store::default();
+    let engine_for_cop = store.get_engine().clone();
     store.begin();
     for &(id, name, count) in vals {
         store
@@ -229,10 +230,11 @@ fn init_coprocessor_with_data(
         cm,
         tag_factory,
         Arc::new(QuotaLimiter::default()),
+        engine_for_cop,
     )
 }
 
-async fn handle_select<E>(copr: &Endpoint<E>, req: coprocessor::Request) -> SelectResponse
+async fn handle_select<E>(copr: &mut Endpoint<E>, req: coprocessor::Request) -> SelectResponse
 where
     E: Engine,
 {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #14151

What's Changed:


<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Support returning applied_index from the leader in ServerIsBusy error to avoid ReadIndex.
In the current tikv implementation, there could be 2 possible solutions to get snapshots in 
the gRPC threads:
1. Add an `Engine` or `RaftKV` field in the coprocessor `Endpoint` which already contains a phantom 
data type field.The side effects are like the `Engine` in the `Storage` object that there would be 
many `Arc` objects.
2. Try to add thread local `Engine` for gRPC threads like the other thread pools. This may not be 
a good design as the gRPC threads know nothing about the engine things.
```

TODO: 
1. The tidb part change is not finished yet.
2. The replica-read requests carrying applied index, it does not need to raise an `readIndex` request any more.
3. Integrated performance tests for web3 scenarios are to be done in which there could be many rejected requests.

### Related changes



### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
