### PR TITLE
raftstore-v2: flush memtable before proposing split

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2712,7 +2712,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#b47a4830141f7c8d2719db0f0184652e692eb672"
+source = "git+https://github.com/SpadeA-Tang/kvproto?branch=pick-extra#58863d0cb8f2e0d76775dcc79b0489c5fbea043e"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -220,8 +220,8 @@ procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "6599eb9dca74229
 # When you modify TiKV cooperatively with kvproto, this will be useful to submit the PR to TiKV and the PR to
 # kvproto at the same time.
 # After the PR to kvproto is merged, remember to comment this out and run `cargo update -p kvproto`.
-# [patch.'https://github.com/pingcap/kvproto']
-# kvproto = { git = "https://github.com/your_github_id/kvproto", branch = "your_branch" }
+[patch.'https://github.com/pingcap/kvproto']
+kvproto = { git = "https://github.com/SpadeA-Tang/kvproto", branch = "pick-extra" }
 
 [workspace]
 # See https://github.com/rust-lang/rfcs/blob/master/text/2957-cargo-features2.md

--- a/components/raftstore-v2/src/batch/store.rs
+++ b/components/raftstore-v2/src/batch/store.rs
@@ -43,7 +43,7 @@ use tikv_util::{
     sys::SysQuota,
     time::{duration_to_sec, Instant as TiInstant},
     timer::SteadyTimer,
-    worker::{LazyWorker, Scheduler, Worker},
+    worker::{Builder as WorkerBuilder, LazyWorker, Scheduler, Worker},
     yatp_pool::{DefaultTicker, FuturePool, YatpPoolBuilder},
     Either,
 };
@@ -54,7 +54,7 @@ use crate::{
     operation::{SharedReadTablet, SPLIT_PREFIX},
     raft::Storage,
     router::{PeerMsg, PeerTick, StoreMsg},
-    worker::{pd, tablet_gc},
+    worker::{pd, tablet_flush, tablet_gc},
     Error, Result,
 };
 
@@ -465,6 +465,7 @@ pub struct Schedulers<EK: KvEngine, ER: RaftEngine> {
     pub pd: Scheduler<pd::Task>,
     pub tablet_gc: Scheduler<tablet_gc::Task<EK>>,
     pub write: WriteSenders<EK, ER>,
+    pub tablet_flush: Scheduler<tablet_flush::Task>,
 
     // Following is not maintained by raftstore itself.
     pub split_check: Scheduler<SplitCheckTask>,
@@ -488,6 +489,7 @@ struct Workers<EK: KvEngine, ER: RaftEngine> {
     tablet_gc: Worker,
     async_write: StoreWriters<EK, ER>,
     purge: Option<Worker>,
+    tablet_flush: Worker,
 
     // Following is not maintained by raftstore itself.
     background: Worker,
@@ -495,12 +497,16 @@ struct Workers<EK: KvEngine, ER: RaftEngine> {
 
 impl<EK: KvEngine, ER: RaftEngine> Workers<EK, ER> {
     fn new(background: Worker, pd: LazyWorker<pd::Task>, purge: Option<Worker>) -> Self {
+        let tablet_flush = WorkerBuilder::new("tablet_flush-worker")
+            .thread_count(2)
+            .create();
         Self {
             async_read: Worker::new("async-read-worker"),
             pd,
             tablet_gc: Worker::new("tablet-gc-worker"),
             async_write: StoreWriters::new(None),
             purge,
+            tablet_flush,
             background,
         }
     }
@@ -510,6 +516,7 @@ impl<EK: KvEngine, ER: RaftEngine> Workers<EK, ER> {
         self.async_read.stop();
         self.pd.stop();
         self.tablet_gc.stop();
+        self.tablet_flush.stop();
         if let Some(w) = self.purge {
             w.stop();
         }
@@ -628,12 +635,18 @@ impl<EK: KvEngine, ER: RaftEngine> StoreSystem<EK, ER> {
             ),
         );
 
+        let tablet_flush_scheduler = workers.tablet_flush.start(
+            "tablet-flush-worker",
+            tablet_flush::Runner::new(router.clone(), tablet_registry.clone(), self.logger.clone()),
+        );
+
         let schedulers = Schedulers {
             read: read_scheduler,
             pd: workers.pd.scheduler(),
             tablet_gc: tablet_gc_scheduler,
             write: workers.async_write.senders(),
             split_check: split_check_scheduler,
+            tablet_flush: tablet_flush_scheduler,
         };
 
         let builder = StorePollerBuilder::new(

--- a/components/raftstore-v2/src/lib.rs
+++ b/components/raftstore-v2/src/lib.rs
@@ -42,4 +42,7 @@ pub use bootstrap::Bootstrap;
 pub use fsm::StoreMeta;
 pub use operation::{write_initial_states, SimpleWriteBinary, SimpleWriteEncoder, StateStorage};
 pub use raftstore::{store::Config, Error, Result};
-pub use worker::pd::{PdReporter, Task as PdTask};
+pub use worker::{
+    pd::{PdReporter, Task as PdTask},
+    tablet_flush::Task as TabletFlushTask,
+};

--- a/components/raftstore-v2/src/operation/command/admin/compact_log.rs
+++ b/components/raftstore-v2/src/operation/command/admin/compact_log.rs
@@ -113,7 +113,7 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> PeerFsmDelegate<'a, EK, ER,
 
 impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
     // Mirrors v1::on_raft_gc_log_tick.
-    fn maybe_propose_compact_log<T>(
+    fn maybe_propose_compact_log<T: Transport>(
         &mut self,
         store_ctx: &mut StoreContext<EK, ER, T>,
         force: bool,

--- a/components/raftstore-v2/src/operation/command/admin/merge/commit.rs
+++ b/components/raftstore-v2/src/operation/command/admin/merge/commit.rs
@@ -1,0 +1,792 @@
+// Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
+
+//! This module contains merge related processing logic.
+//!
+//! ## Propose
+//!
+//! The proposal is initiated by the source region. After `PrepareMerge` is
+//! applied, the source peer will send an `AskCommitMerge` message to the target
+//! peer. (For simplicity, we send this message regardless of whether the target
+//! peer is leader.) The message will also carry some source region logs that
+//! may not be committed by some source peers.
+//!
+//! The source region cannot serve any writes until the merge is committed or
+//! rollback-ed. This is guaranteed by `MergeContext::prepare_status`.
+//!
+//! ## Apply (`Apply::apply_commit_merge`)
+//!
+//! At first, target region will not apply the `CommitMerge` command. Instead
+//! the apply progress will be paused and it redirects the log entries from
+//! source region, as a `CatchUpLogs` message, to the local source region peer.
+//! When the source region peer has applied all logs up to the prior
+//! `PrepareMerge` command, it will signal the target peer. Here we use a
+//! temporary channel instead of directly sending message between apply FSMs
+//! like in v1.
+//!
+//! Here is a complete view of the process:
+//!
+//! ```text
+//! |               Store 1               |              Store 2              |
+//! |   Source Peer   |   Target Leader   |   Source Peer   |   Target Peer   |
+//!         |
+//!  apply PrepareMerge
+//!          \
+//!           +--------------+
+//!           `AskCommitMerge`\
+//!                            \
+//!                    propose CommitMerge ---------------> append CommitMerge
+//!                     apply CommitMerge                    apply CommitMerge
+//!                        on apply res                             /|
+//!                           /|                      +------------+ |
+//!          +---------------+ |                     / `CatchUpLogs` |
+//!         / `AckCommitMerge` |                    /                |
+//!        /              (complete)          append logs         (pause)
+//!    destroy self                                |                 .
+//!                                        apply PrepareMerge        .
+//!                                                |                 .
+//!                                                +-----------> (continue)
+//!                                                |                 |
+//!                                           destroy self       (complete)
+//! ```
+
+use std::{
+    any::Any,
+    cmp, fs, io,
+    path::{Path, PathBuf},
+};
+
+use crossbeam::channel::SendError;
+use engine_traits::{KvEngine, RaftEngine, RaftLogBatch, TabletContext, TabletRegistry};
+use futures::channel::oneshot;
+use kvproto::{
+    metapb::Region,
+    raft_cmdpb::{AdminCmdType, AdminRequest, AdminResponse, CommitMergeRequest, RaftCmdRequest},
+    raft_serverpb::{MergedRecord, PeerState, RegionLocalState},
+};
+use protobuf::Message;
+use raft::{GetEntriesContext, Storage, INVALID_ID, NO_LIMIT};
+use raftstore::{
+    coprocessor::RegionChangeReason,
+    store::{
+        fsm::new_admin_request, metrics::PEER_ADMIN_CMD_COUNTER, util, ProposalContext, Transport,
+    },
+    Result,
+};
+use slog::{debug, error, info, Logger};
+use tikv_util::{
+    config::ReadableDuration,
+    log::SlogFormat,
+    slog_panic,
+    store::{find_peer, region_on_same_stores},
+    time::Instant,
+};
+
+use super::merge_source_path;
+use crate::{
+    batch::StoreContext,
+    fsm::ApplyResReporter,
+    operation::{AdminCmdResult, SharedReadTablet},
+    raft::{Apply, Peer},
+    router::{CmdResChannel, PeerMsg, PeerTick, StoreMsg},
+};
+
+#[derive(Debug)]
+pub struct CommitMergeResult {
+    pub index: u64,
+    // Only used to respond `CatchUpLogs` to source peer.
+    prepare_merge_index: u64,
+    source_path: PathBuf,
+    region_state: RegionLocalState,
+    source: Region,
+    source_safe_ts: u64,
+    tablet: Box<dyn Any + Send + Sync>,
+}
+
+#[derive(Debug)]
+pub struct CatchUpLogs {
+    target_region_id: u64,
+    merge: CommitMergeRequest,
+    // safe_ts.
+    tx: oneshot::Sender<u64>,
+}
+
+pub const MERGE_IN_PROGRESS_PREFIX: &str = "merge-in-progress";
+
+struct MergeInProgressGuard(PathBuf);
+
+impl MergeInProgressGuard {
+    // `index` is the commit index of `CommitMergeRequest`
+    fn new<EK>(
+        logger: &Logger,
+        registry: &TabletRegistry<EK>,
+        target_region_id: u64,
+        index: u64,
+        tablet_path: &Path,
+    ) -> io::Result<Option<Self>> {
+        let name = registry.tablet_name(MERGE_IN_PROGRESS_PREFIX, target_region_id, index);
+        let marker_path = registry.tablet_root().join(name);
+        if !marker_path.exists() {
+            if tablet_path.exists() {
+                return Ok(None);
+            } else {
+                fs::create_dir(&marker_path)?;
+                file_system::sync_dir(marker_path.parent().unwrap())?;
+            }
+        } else if tablet_path.exists() {
+            info!(logger, "remove incomplete merged tablet"; "path" => %tablet_path.display());
+            fs::remove_dir_all(tablet_path)?;
+        }
+        Ok(Some(Self(marker_path)))
+    }
+
+    fn defuse(self) -> io::Result<()> {
+        fs::remove_dir(&self.0)?;
+        file_system::sync_dir(self.0.parent().unwrap())
+    }
+}
+
+fn commit_of_merge(r: &CommitMergeRequest) -> u64 {
+    r.get_source_state().get_merge_state().get_commit()
+}
+
+// Source peer initiates commit merge on target peer.
+impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
+    // Called after applying `PrepareMerge`.
+    pub fn start_commit_merge<T: Transport>(&mut self, store_ctx: &mut StoreContext<EK, ER, T>) {
+        assert!(self.applied_merge_state().is_some());
+        // Target already committed `CommitMerge`.
+        if let Some(c) = &self.merge_context().unwrap().catch_up_logs {
+            if self.catch_up_logs_ready(c) {
+                let c = self.merge_context_mut().catch_up_logs.take().unwrap();
+                self.finish_catch_up_logs(store_ctx, c);
+            }
+        } else {
+            self.on_check_merge(store_ctx);
+        }
+    }
+
+    // Match v1::on_check_merge.
+    pub fn on_check_merge<T: Transport>(&mut self, store_ctx: &mut StoreContext<EK, ER, T>) {
+        if !self.serving() || self.applied_merge_state().is_none() {
+            return;
+        }
+        self.add_pending_tick(PeerTick::CheckMerge);
+        self.ask_target_peer_to_commit_merge(store_ctx);
+    }
+
+    // Match v1::schedule_merge.
+    fn ask_target_peer_to_commit_merge<T>(&mut self, store_ctx: &mut StoreContext<EK, ER, T>) {
+        let state = self.applied_merge_state().unwrap();
+        let target = state.get_target();
+        let target_id = target.get_id();
+
+        let (min_index, _) = self.calculate_min_progress().unwrap();
+        let low = cmp::max(min_index + 1, state.get_min_index());
+        // TODO: move this into raft module.
+        // > over >= to include the PrepareMerge proposal.
+        let entries = if low > state.get_commit() {
+            Vec::new()
+        } else {
+            // TODO: fetch entries in async way
+            match self.storage().entries(
+                low,
+                state.get_commit() + 1,
+                NO_LIMIT,
+                GetEntriesContext::empty(false),
+            ) {
+                Ok(ents) => ents,
+                Err(e) => slog_panic!(
+                    self.logger,
+                    "failed to get merge entires";
+                    "err" => ?e,
+                    "low" => low,
+                    "commit" => state.get_commit()
+                ),
+            }
+        };
+
+        let target_peer = find_peer(target, store_ctx.store_id).unwrap();
+        let mut request = new_admin_request(target.get_id(), target_peer.clone());
+        request
+            .mut_header()
+            .set_region_epoch(target.get_region_epoch().clone());
+        let mut admin = AdminRequest::default();
+        admin.set_cmd_type(AdminCmdType::CommitMerge);
+        admin.mut_commit_merge().set_entries(entries.into());
+        admin
+            .mut_commit_merge()
+            .set_source_state(self.storage().region_state().clone());
+        request.set_admin_request(admin);
+        // Please note that, here assumes that the unit of network isolation is store
+        // rather than peer. So a quorum stores of source region should also be the
+        // quorum stores of target region. Otherwise we need to enable proposal
+        // forwarding.
+        let msg = PeerMsg::AskCommitMerge(request);
+        // If target peer is destroyed, life.rs is responsible for telling us to
+        // rollback.
+        match store_ctx.router.force_send(target_id, msg) {
+            Ok(_) => (),
+            Err(SendError(PeerMsg::AskCommitMerge(msg))) => {
+                if let Err(e) = store_ctx
+                    .router
+                    .force_send_control(StoreMsg::AskCommitMerge(msg))
+                {
+                    if store_ctx.router.is_shutdown() {
+                        return;
+                    }
+                    slog_panic!(
+                        self.logger,
+                        "fails to send `AskCommitMerge` msg to store";
+                        "error" => ?e,
+                    );
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+// Target peer handles the commit merge request.
+impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
+    pub fn on_ask_commit_merge<T: Transport>(
+        &mut self,
+        store_ctx: &mut StoreContext<EK, ER, T>,
+        req: RaftCmdRequest,
+    ) {
+        match self.validate_commit_merge(&req) {
+            Some(true) if self.is_leader() => {
+                let (ch, _) = CmdResChannel::pair();
+                self.on_admin_command(store_ctx, req, ch);
+            }
+            Some(false) => {
+                let commit_merge = req.get_admin_request().get_commit_merge();
+                let source_id = commit_merge.get_source_state().get_region().get_id();
+                let _ = store_ctx.router.force_send(
+                    source_id,
+                    PeerMsg::RejectCommitMerge {
+                        index: commit_of_merge(commit_merge),
+                    },
+                );
+            }
+            _ => (),
+        }
+    }
+
+    fn validate_commit_merge(&self, req: &RaftCmdRequest) -> Option<bool> {
+        let expected_epoch = req.get_header().get_region_epoch();
+        let merge = req.get_admin_request().get_commit_merge();
+        assert!(merge.has_source_state() && merge.get_source_state().has_merge_state());
+        let source_region = merge.get_source_state().get_region();
+        let region = self.region();
+        if self
+            .storage()
+            .region_state()
+            .get_merged_records()
+            .iter()
+            .any(|p| p.get_source_region_id() == source_region.get_id())
+        {
+            info!(
+                self.logger,
+                "ignore commit merge because peer is already in merged_records";
+                "source" => ?source_region,
+            );
+            None
+        } else if util::is_epoch_stale(expected_epoch, region.get_region_epoch()) {
+            info!(
+                self.logger,
+                "reject commit merge because of stale";
+                "current_epoch" => ?region.get_region_epoch(),
+                "expected_epoch" => ?expected_epoch,
+            );
+            Some(false)
+        } else if expected_epoch == region.get_region_epoch() {
+            assert!(
+                util::is_sibling_regions(source_region, region),
+                "{}: {:?}, {:?}",
+                SlogFormat(&self.logger),
+                source_region,
+                region
+            );
+            assert!(
+                region_on_same_stores(source_region, region),
+                "{:?}, {:?}",
+                source_region,
+                region
+            );
+            // Best effort. Remove when trim check is implemented.
+            if self.storage().has_dirty_data() {
+                info!(self.logger, "ignore commit merge because of dirty data");
+                None
+            } else {
+                Some(true)
+            }
+        } else {
+            info!(
+                self.logger,
+                "ignore commit merge because self epoch is stale";
+                "source" => ?source_region,
+            );
+            None
+        }
+    }
+
+    pub fn propose_commit_merge<T>(
+        &mut self,
+        store_ctx: &mut StoreContext<EK, ER, T>,
+        req: RaftCmdRequest,
+    ) -> Result<u64> {
+        let mut proposal_ctx = ProposalContext::empty();
+        proposal_ctx.insert(ProposalContext::COMMIT_MERGE);
+        let data = req.write_to_bytes().unwrap();
+        self.propose_with_ctx(store_ctx, data, proposal_ctx.to_vec())
+    }
+}
+
+impl<EK: KvEngine, R: ApplyResReporter> Apply<EK, R> {
+    // Match v1::exec_commit_merge.
+    pub async fn apply_commit_merge(
+        &mut self,
+        req: &AdminRequest,
+        index: u64,
+    ) -> Result<(AdminResponse, AdminCmdResult)> {
+        PEER_ADMIN_CMD_COUNTER.commit_merge.all.inc();
+
+        self.flush();
+
+        // Note: compared to v1, doesn't validate region state from kvdb any more.
+        let reg = self.tablet_registry();
+        let merge = req.get_commit_merge();
+        let merge_commit = commit_of_merge(merge);
+        let source_state = merge.get_source_state();
+        let source_region = source_state.get_region();
+        let source_path = merge_source_path(reg, source_region.get_id(), merge_commit);
+        let mut source_safe_ts = 0;
+
+        let mut start_time = Instant::now_coarse();
+        let mut wait_duration = None;
+        let force_send = (|| {
+            fail::fail_point!("force_send_catch_up_logs", |_| true);
+            false
+        })();
+        if !source_path.exists() || force_send {
+            let (tx, rx) = oneshot::channel();
+            self.res_reporter().redirect_catch_up_logs(CatchUpLogs {
+                target_region_id: self.region_id(),
+                merge: merge.clone(),
+                tx,
+            });
+            match rx.await {
+                Ok(ts) => {
+                    source_safe_ts = ts;
+                }
+                Err(_) => {
+                    if tikv_util::thread_group::is_shutdown(!cfg!(test)) {
+                        return futures::future::pending().await;
+                    } else {
+                        slog_panic!(
+                            self.logger,
+                            "source peer is missing when getting checkpoint for merge"
+                        );
+                    }
+                }
+            }
+            let now = Instant::now_coarse();
+            wait_duration = Some(now.saturating_duration_since(start_time));
+            start_time = now;
+        };
+        fail::fail_point!("after_acquire_source_checkpoint", |_| Err(
+            tikv_util::box_err!("fp")
+        ));
+
+        info!(
+            self.logger,
+            "execute CommitMerge";
+            "commit" => merge_commit,
+            "entries" => merge.get_entries().len(),
+            "index" => index,
+            "source_region" => ?source_region,
+        );
+
+        let ctx = TabletContext::new(source_region, None);
+        let source_tablet = reg
+            .tablet_factory()
+            .open_tablet(ctx, &source_path)
+            .unwrap_or_else(|e| {
+                slog_panic!(self.logger, "failed to open source checkpoint"; "err" => ?e);
+            });
+        let open_time = Instant::now_coarse();
+
+        let mut region = self.region().clone();
+        // Use a max value so that pd can ensure overlapped region has a priority.
+        let version = cmp::max(
+            source_region.get_region_epoch().get_version(),
+            region.get_region_epoch().get_version(),
+        ) + 1;
+        region.mut_region_epoch().set_version(version);
+        if keys::enc_end_key(&region) == keys::enc_start_key(source_region) {
+            region.set_end_key(source_region.get_end_key().to_vec());
+        } else {
+            region.set_start_key(source_region.get_start_key().to_vec());
+        }
+
+        let path = reg.tablet_path(self.region_id(), index);
+
+        // Avoid seqno jump back between self.tablet and the newly created tablet.
+        // If we are recovering, this flush would just be a noop.
+        self.tablet().flush_cfs(&[], true).unwrap();
+        let flush_time = Instant::now_coarse();
+
+        let mut ctx = TabletContext::new(&region, Some(index));
+        ctx.flush_state = Some(self.flush_state().clone());
+        let guard = MergeInProgressGuard::new(&self.logger, reg, self.region_id(), index, &path)
+            .unwrap_or_else(|e| {
+                slog_panic!(
+                    self.logger,
+                    "fails to create MergeInProgressGuard";
+                    "path" => %path.display(),
+                    "error" => ?e
+                )
+            });
+        let tablet = reg.tablet_factory().open_tablet(ctx, &path).unwrap();
+        if let Some(guard) = guard {
+            tablet
+                .merge(&[&source_tablet, self.tablet()])
+                .unwrap_or_else(|e| {
+                    slog_panic!(
+                        self.logger,
+                        "fails to merge tablet";
+                        "path" => %path.display(),
+                        "error" => ?e
+                    )
+                });
+            guard.defuse().unwrap_or_else(|e| {
+                slog_panic!(
+                    self.logger,
+                    "fails to defuse MergeInProgressGuard";
+                    "path" => %path.display(),
+                    "error" => ?e
+                )
+            });
+        } else {
+            info!(self.logger, "reuse merged tablet");
+        }
+        let merge_time = Instant::now_coarse();
+        fail::fail_point!("after_merge_source_checkpoint", |_| Err(
+            tikv_util::box_err!("fp")
+        ));
+
+        info!(
+            self.logger,
+            "applied CommitMerge";
+            "source_region" => ?source_region,
+            "wait" => ?wait_duration.map(|d| format!("{}", ReadableDuration(d))),
+            "open" => %ReadableDuration(open_time.saturating_duration_since(start_time)),
+            "merge" => %ReadableDuration(flush_time.saturating_duration_since(open_time)),
+            "flush" => %ReadableDuration(merge_time.saturating_duration_since(flush_time)),
+        );
+
+        self.set_tablet(tablet.clone());
+
+        let state = self.region_state_mut();
+        state.set_region(region.clone());
+        state.set_state(PeerState::Normal);
+        assert!(!state.has_merge_state());
+        state.set_tablet_index(index);
+        let mut removed_records: Vec<_> = state.take_removed_records().into();
+        removed_records.append(&mut source_state.get_removed_records().into());
+        state.set_removed_records(removed_records.into());
+        let mut merged_records: Vec<_> = state.take_merged_records().into();
+        merged_records.append(&mut source_state.get_merged_records().into());
+        state.set_merged_records(merged_records.into());
+        let mut merged_record = MergedRecord::default();
+        merged_record.set_source_region_id(source_region.get_id());
+        merged_record.set_source_epoch(source_region.get_region_epoch().clone());
+        merged_record.set_source_peers(source_region.get_peers().into());
+        merged_record.set_target_region_id(region.get_id());
+        merged_record.set_target_epoch(region.get_region_epoch().clone());
+        merged_record.set_target_peers(region.get_peers().into());
+        merged_record.set_index(index);
+        state.mut_merged_records().push(merged_record);
+
+        PEER_ADMIN_CMD_COUNTER.commit_merge.success.inc();
+
+        Ok((
+            AdminResponse::default(),
+            AdminCmdResult::CommitMerge(CommitMergeResult {
+                index,
+                prepare_merge_index: merge_commit,
+                source_path,
+                region_state: self.region_state().clone(),
+                source: source_region.to_owned(),
+                source_safe_ts,
+                tablet: Box::new(tablet),
+            }),
+        ))
+    }
+}
+
+// Source peer catches up logs (optionally), and destroy itself.
+impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
+    // Target peer.
+    #[inline]
+    pub fn on_redirect_catch_up_logs<T>(
+        &mut self,
+        store_ctx: &mut StoreContext<EK, ER, T>,
+        catch_up_logs: CatchUpLogs,
+    ) {
+        let source_id = catch_up_logs.merge.get_source_state().get_region().get_id();
+        assert_eq!(catch_up_logs.target_region_id, self.region_id());
+        let _ = store_ctx
+            .router
+            .force_send(source_id, PeerMsg::CatchUpLogs(catch_up_logs));
+    }
+
+    // Match v1::on_catch_up_logs_for_merge.
+    pub fn on_catch_up_logs<T>(
+        &mut self,
+        store_ctx: &mut StoreContext<EK, ER, T>,
+        mut catch_up_logs: CatchUpLogs,
+    ) {
+        let source_id = catch_up_logs.merge.get_source_state().get_region().get_id();
+        if source_id != self.region_id() {
+            slog_panic!(
+                self.logger,
+                "get unexpected catch_up_logs";
+                "merge" => ?catch_up_logs.merge,
+            );
+        }
+
+        // Context would be empty if this peer hasn't applied PrepareMerge.
+        if let Some(cul) = self.merge_context().and_then(|c| c.catch_up_logs.as_ref()) {
+            slog_panic!(
+                self.logger,
+                "get conflicting catch_up_logs";
+                "new" => ?catch_up_logs.merge,
+                "current" => ?cul.merge,
+            );
+        }
+        if !self.catch_up_logs_ready(&catch_up_logs) {
+            // Directly append these logs to raft log and then commit them.
+            match self.maybe_append_merge_entries(&catch_up_logs.merge) {
+                Some(last_index) => {
+                    info!(
+                        self.logger,
+                        "append and commit entries to source region";
+                        "last_index" => last_index,
+                    );
+                    self.set_has_ready();
+                }
+                None => {
+                    info!(self.logger, "no need to catch up logs");
+                }
+            }
+            catch_up_logs.merge.clear_entries();
+            self.merge_context_mut().catch_up_logs = Some(catch_up_logs);
+        } else {
+            self.finish_catch_up_logs(store_ctx, catch_up_logs);
+        }
+    }
+
+    #[inline]
+    fn catch_up_logs_ready(&self, catch_up_logs: &CatchUpLogs) -> bool {
+        if let Some(state) = self.applied_merge_state()
+            && state.get_commit() == commit_of_merge(&catch_up_logs.merge)
+        {
+            assert_eq!(
+                state.get_target().get_id(),
+                catch_up_logs.target_region_id
+            );
+            true
+        } else {
+            false
+        }
+    }
+
+    fn maybe_append_merge_entries(&mut self, merge: &CommitMergeRequest) -> Option<u64> {
+        let mut entries = merge.get_entries();
+        let merge_commit = commit_of_merge(merge);
+        if entries.is_empty() {
+            // Though the entries is empty, it is possible that one source peer has caught
+            // up the logs but commit index is not updated. If other source peers are
+            // already destroyed, so the raft group will not make any progress, namely the
+            // source peer can not get the latest commit index anymore.
+            // Here update the commit index to let source apply rest uncommitted entries.
+            return if merge_commit > self.raft_group().raft.raft_log.committed {
+                self.raft_group_mut().raft.raft_log.commit_to(merge_commit);
+                Some(merge_commit)
+            } else {
+                None
+            };
+        }
+        let first = entries.first().unwrap();
+        // make sure message should be with index not smaller than committed
+        let mut log_idx = first.get_index() - 1;
+        debug!(
+            self.logger,
+            "append merge entries";
+            "log_index" => log_idx,
+            "merge_commit" => merge_commit,
+            "commit_index" => self.raft_group().raft.raft_log.committed,
+        );
+        if log_idx < self.raft_group().raft.raft_log.committed {
+            // There may be some logs not included in CommitMergeRequest's entries, like
+            // CompactLog, so the commit index may exceed the last index of the entires from
+            // CommitMergeRequest. If that, no need to append
+            if self.raft_group().raft.raft_log.committed - log_idx >= entries.len() as u64 {
+                return None;
+            }
+            entries = &entries[(self.raft_group().raft.raft_log.committed - log_idx) as usize..];
+            log_idx = self.raft_group().raft.raft_log.committed;
+        }
+        let log_term = self.index_term(log_idx);
+
+        let last_log = entries.last().unwrap();
+        if last_log.term > self.term() {
+            // Hack: In normal flow, when leader sends the entries, it will use a term
+            // that's not less than the last log term. And follower will update its states
+            // correctly. For merge, we append the log without raft, so we have to take care
+            // of term explicitly to get correct metadata.
+            info!(
+                self.logger,
+                "become follower for new logs";
+                "new_log_term" => last_log.term,
+                "new_log_index" => last_log.index,
+                "term" => self.term(),
+            );
+            self.raft_group_mut()
+                .raft
+                .become_follower(last_log.term, INVALID_ID);
+        }
+
+        self.raft_group_mut()
+            .raft
+            .raft_log
+            .maybe_append(log_idx, log_term, merge_commit, entries)
+            .map(|(_, last_index)| last_index)
+    }
+
+    #[inline]
+    fn finish_catch_up_logs<T>(&mut self, store_ctx: &mut StoreContext<EK, ER, T>, c: CatchUpLogs) {
+        let safe_ts = store_ctx
+            .store_meta
+            .lock()
+            .unwrap()
+            .region_read_progress
+            .get(&self.region_id())
+            .unwrap()
+            .safe_ts();
+        if c.tx.send(safe_ts).is_err() {
+            error!(
+                self.logger,
+                "failed to respond to merge target, are we shutting down?"
+            );
+        }
+        self.take_merge_context();
+        self.mark_for_destroy(None);
+    }
+}
+
+impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
+    // Match v1::on_ready_commit_merge.
+    pub fn on_apply_res_commit_merge<T>(
+        &mut self,
+        store_ctx: &mut StoreContext<EK, ER, T>,
+        mut res: CommitMergeResult,
+    ) {
+        let region = res.region_state.get_region();
+        assert!(
+            res.source.get_end_key() == region.get_end_key()
+                || res.source.get_start_key() == region.get_start_key()
+        );
+        let tablet: EK = match res.tablet.downcast() {
+            Ok(t) => *t,
+            Err(t) => unreachable!("tablet type should be the same: {:?}", t),
+        };
+        let acquired_source_safe_ts_before = res.source_safe_ts > 0;
+
+        {
+            let mut meta = store_ctx.store_meta.lock().unwrap();
+            if let Some(p) = meta.region_read_progress.get(&res.source.get_id()) {
+                res.source_safe_ts = p.safe_ts();
+            }
+            meta.set_region(region, true, &self.logger);
+            let (reader, read_tablet) = meta.readers.get_mut(&region.get_id()).unwrap();
+            self.set_region(
+                &store_ctx.coprocessor_host,
+                reader,
+                region.clone(),
+                RegionChangeReason::CommitMerge,
+                res.index,
+            );
+
+            // Tablet should be updated in lock to match the epoch.
+            *read_tablet = SharedReadTablet::new(tablet.clone());
+
+            // After the region commit merged, the region's key range is extended and the
+            // region's `safe_ts` should reset to `min(source_safe_ts, target_safe_ts)`
+            self.read_progress_mut().merge_safe_ts(
+                res.source_safe_ts,
+                res.index,
+                &store_ctx.coprocessor_host,
+            );
+            self.txn_context()
+                .after_commit_merge(store_ctx, self.term(), region, &self.logger);
+        }
+
+        // We could only have gotten safe ts by sending `CatchUpLogs` earlier. If we
+        // haven't, need to acknowledge that we have committed the merge, so that the
+        // source peer can destroy itself. Note that the timing is deliberately
+        // delayed after reading `store_ctx.meta` to get the source safe ts
+        // before its meta gets cleaned up.
+        if !acquired_source_safe_ts_before {
+            let _ = store_ctx.router.force_send(
+                res.source.get_id(),
+                PeerMsg::AckCommitMerge {
+                    index: res.prepare_merge_index,
+                    target_id: self.region_id(),
+                },
+            );
+        }
+
+        if let Some(tablet) = self.set_tablet(tablet) {
+            self.record_tombstone_tablet(store_ctx, tablet, res.index);
+        }
+        self.record_tombstone_tablet_path(store_ctx, res.source_path, res.index);
+
+        // make approximate size and keys updated in time.
+        // the reason why follower need to update is that there is a issue that after
+        // merge and then transfer leader, the new leader may have stale size and keys.
+        self.force_split_check(store_ctx);
+        self.region_buckets_info_mut().set_bucket_stat(None);
+
+        let region_id = self.region_id();
+        self.state_changes_mut()
+            .put_region_state(region_id, res.index, &res.region_state)
+            .unwrap();
+        self.storage_mut().set_region_state(res.region_state);
+        self.storage_mut()
+            .apply_trace_mut()
+            .on_admin_flush(res.index);
+        self.set_has_extra_write();
+
+        if self.is_leader() {
+            self.region_heartbeat_pd(store_ctx);
+            info!(
+                self.logger,
+                "notify pd with merge";
+                "source_region" => ?res.source,
+                "target_region" => ?self.region(),
+            );
+            self.add_pending_tick(PeerTick::SplitRegionCheck);
+        }
+    }
+
+    // Called on source peer.
+    pub fn on_ack_commit_merge(&mut self, index: u64, target_id: u64) {
+        // We don't check it against merge state because source peer might just restart
+        // and haven't replayed `PrepareMerge` yet.
+        info!(self.logger, "destroy self on AckCommitMerge"; "index" => index, "target_id" => target_id);
+        self.take_merge_context();
+        self.mark_for_destroy(None);
+    }
+}

--- a/components/raftstore-v2/src/operation/command/admin/mod.rs
+++ b/components/raftstore-v2/src/operation/command/admin/mod.rs
@@ -10,15 +10,24 @@ pub use compact_log::CompactLogContext;
 use compact_log::CompactLogResult;
 use conf_change::{ConfChangeResult, UpdateGcPeersResult};
 use engine_traits::{KvEngine, RaftEngine};
-use kvproto::raft_cmdpb::{AdminCmdType, RaftCmdRequest};
+use kvproto::{
+    metapb::PeerRole,
+    raft_cmdpb::{AdminCmdType, RaftCmdRequest},
+    raft_serverpb::{ExtraMessageType, FlushMemtable, RaftMessage},
+};
 use merge::prepare::PrepareMergeResult;
 pub use merge::MergeContext;
 use protobuf::Message;
 use raftstore::{
-    store::{cmd_resp, fsm::apply, msg::ErrorCallback},
+    store::{
+        cmd_resp,
+        fsm::{apply, apply::validate_batch_split},
+        msg::ErrorCallback,
+        Transport,
+    },
     Error,
 };
-use slog::info;
+use slog::{error, info};
 use split::SplitResult;
 pub use split::{
     report_split_init_finish, temp_split_path, RequestHalfSplit, RequestSplit, SplitFlowControl,
@@ -43,7 +52,7 @@ pub enum AdminCmdResult {
 
 impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
     #[inline]
-    pub fn on_admin_command<T>(
+    pub fn on_admin_command<T: Transport>(
         &mut self,
         ctx: &mut StoreContext<EK, ER, T>,
         mut req: RaftCmdRequest,
@@ -118,7 +127,84 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
                 AdminCmdType::Split => Err(box_err!(
                     "Split is deprecated. Please use BatchSplit instead."
                 )),
-                AdminCmdType::BatchSplit => self.propose_split(ctx, req),
+                AdminCmdType::BatchSplit => {
+                    #[allow(clippy::question_mark)]
+                    if let Err(err) = validate_batch_split(req.get_admin_request(), self.region()) {
+                        Err(err)
+                    } else {
+                        // To reduce the impact of the expensive operation of `checkpoint` (it will
+                        // flush memtables of the rocksdb) in applying batch split, we split the
+                        // BatchSplit cmd into two phases:
+                        //
+                        // 1. Schedule flush memtable task so that the memtables of the rocksdb can
+                        // be flushed in advance in a way that will not block the normal raft
+                        // operations (`checkpoint` will still cause flush but it will be
+                        // significantly lightweight). At the same time, send flush memtable msgs to
+                        // the follower so that they can flush memtalbes in advance too.
+                        //
+                        // 2. When the task finishes, it will propose a batch split with
+                        // `SPLIT_SECOND_PHASE` flag.
+                        if !WriteBatchFlags::from_bits_truncate(req.get_header().get_flags())
+                            .contains(WriteBatchFlags::SPLIT_SECOND_PHASE)
+                        {
+                            if self.tablet_being_flushed() {
+                                return;
+                            }
+
+                            let region_id = self.region().get_id();
+                            self.set_tablet_being_flushed(true);
+                            info!(
+                                self.logger,
+                                "Schedule flush tablet";
+                            );
+                            if let Err(e) = ctx.schedulers.tablet_flush.schedule(
+                                crate::TabletFlushTask::TabletFlush {
+                                    region_id,
+                                    req: Some(req),
+                                    is_leader: true,
+                                    ch: Some(ch),
+                                },
+                            ) {
+                                error!(
+                                    self.logger,
+                                    "Fail to schedule flush task";
+                                    "err" => ?e,
+                                )
+                            }
+
+                            let peers = self.region().get_peers().to_vec();
+                            for p in peers {
+                                if p == *self.peer()
+                                    || p.get_role() != PeerRole::Voter
+                                    || p.is_witness
+                                {
+                                    continue;
+                                }
+                                let mut msg = RaftMessage::default();
+                                msg.set_region_id(region_id);
+                                msg.set_from_peer(self.peer().clone());
+                                msg.set_to_peer(p.clone());
+                                msg.set_region_epoch(self.region().get_region_epoch().clone());
+                                let extra_msg = msg.mut_extra_msg();
+                                extra_msg.set_type(ExtraMessageType::MsgFlushMemtable);
+                                let mut flush_memtable = FlushMemtable::new();
+                                flush_memtable.set_region_id(region_id);
+                                extra_msg.set_flush_memtable(flush_memtable);
+
+                                self.send_raft_message(ctx, msg);
+                            }
+
+                            return;
+                        }
+
+                        info!(
+                            self.logger,
+                            "Propose split";
+                        );
+                        self.set_tablet_being_flushed(false);
+                        self.propose_split(ctx, req)
+                    }
+                }
                 AdminCmdType::TransferLeader => {
                     // Containing TRANSFER_LEADER_PROPOSAL flag means the this transfer leader
                     // request should be proposed to the raft group

--- a/components/raftstore-v2/src/operation/command/admin/transfer_leader.rs
+++ b/components/raftstore-v2/src/operation/command/admin/transfer_leader.rs
@@ -15,7 +15,7 @@ use raft::{eraftpb, ProgressState, Storage};
 use raftstore::{
     store::{
         fsm::new_admin_request, make_transfer_leader_response, metrics::PEER_ADMIN_CMD_COUNTER,
-        TRANSFER_LEADER_COMMAND_REPLY_CTX,
+        Transport, TRANSFER_LEADER_COMMAND_REPLY_CTX,
     },
     Result,
 };
@@ -146,7 +146,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         true
     }
 
-    pub fn on_transfer_leader_msg<T>(
+    pub fn on_transfer_leader_msg<T: Transport>(
         &mut self,
         ctx: &mut StoreContext<EK, ER, T>,
         msg: &eraftpb::Message,

--- a/components/raftstore-v2/src/operation/ready/mod.rs
+++ b/components/raftstore-v2/src/operation/ready/mod.rs
@@ -213,6 +213,22 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
                     self.on_gc_peer_request(ctx, &msg);
                     return;
                 }
+                ExtraMessageType::MsgFlushMemtable => {
+                    let region_epoch = msg.as_ref().get_region_epoch();
+                    if util::is_epoch_stale(region_epoch, self.region().get_region_epoch()) {
+                        return;
+                    }
+                    let _ =
+                        ctx.schedulers
+                            .tablet_flush
+                            .schedule(crate::TabletFlushTask::TabletFlush {
+                                region_id: self.region().get_id(),
+                                req: None,
+                                is_leader: false,
+                                ch: None,
+                            });
+                    return;
+                }
                 _ => (),
             }
         }
@@ -345,7 +361,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
     ///
     /// The message is pushed into the send buffer, it may not be sent out until
     /// transport is flushed explicitly.
-    fn send_raft_message<T: Transport>(
+    pub(crate) fn send_raft_message<T: Transport>(
         &mut self,
         ctx: &mut StoreContext<EK, ER, T>,
         msg: RaftMessage,

--- a/components/raftstore-v2/src/raft/peer.rs
+++ b/components/raftstore-v2/src/raft/peer.rs
@@ -44,6 +44,7 @@ const REGION_READ_PROGRESS_CAP: usize = 128;
 pub struct Peer<EK: KvEngine, ER: RaftEngine> {
     raft_group: RawNode<Storage<EK, ER>>,
     tablet: CachedTablet<EK>,
+    tablet_being_flushed: bool,
 
     /// Statistics for self.
     self_stat: PeerStat,
@@ -154,6 +155,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         let tag = format!("[region {}] {}", region.get_id(), peer_id);
         let mut peer = Peer {
             tablet: cached_tablet,
+            tablet_being_flushed: false,
             self_stat: PeerStat::default(),
             peer_cache: vec![],
             peer_heartbeats: HashMap::default(),
@@ -299,6 +301,16 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
     #[inline]
     pub fn peer_id(&self) -> u64 {
         self.peer().get_id()
+    }
+
+    #[inline]
+    pub fn tablet_being_flushed(&self) -> bool {
+        self.tablet_being_flushed
+    }
+
+    #[inline]
+    pub fn set_tablet_being_flushed(&mut self, v: bool) {
+        self.tablet_being_flushed = v;
     }
 
     #[inline]

--- a/components/raftstore-v2/src/worker/mod.rs
+++ b/components/raftstore-v2/src/worker/mod.rs
@@ -1,4 +1,5 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
 pub mod pd;
+pub mod tablet_flush;
 pub mod tablet_gc;

--- a/components/raftstore-v2/src/worker/tablet_flush.rs
+++ b/components/raftstore-v2/src/worker/tablet_flush.rs
@@ -1,0 +1,115 @@
+// Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::fmt::{Display, Formatter};
+
+use engine_traits::{KvEngine, RaftEngine, TabletRegistry, DATA_CFS};
+use kvproto::raft_cmdpb::RaftCmdRequest;
+use slog::{error, info, Logger};
+use tikv_util::{time::Instant, worker::Runnable};
+use txn_types::WriteBatchFlags;
+
+use crate::{
+    router::{CmdResChannel, PeerMsg, RaftRequest},
+    StoreRouter,
+};
+
+pub enum Task {
+    TabletFlush {
+        region_id: u64,
+        req: Option<RaftCmdRequest>,
+        is_leader: bool,
+        ch: Option<CmdResChannel>,
+    },
+}
+
+impl Display for Task {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Task::TabletFlush { region_id, .. } => {
+                write!(f, "Flush tablet before split for region {}", region_id)
+            }
+        }
+    }
+}
+
+pub struct Runner<EK: KvEngine, ER: RaftEngine> {
+    router: StoreRouter<EK, ER>,
+    tablet_registry: TabletRegistry<EK>,
+    logger: Logger,
+}
+
+impl<EK: KvEngine, ER: RaftEngine> Runner<EK, ER> {
+    pub fn new(
+        router: StoreRouter<EK, ER>,
+        tablet_registry: TabletRegistry<EK>,
+        logger: Logger,
+    ) -> Self {
+        Self {
+            router,
+            tablet_registry,
+            logger,
+        }
+    }
+
+    fn flush_tablet(
+        &mut self,
+        region_id: u64,
+        req: Option<RaftCmdRequest>,
+        is_leader: bool,
+        ch: Option<CmdResChannel>,
+    ) {
+        let Some(Some(tablet)) = self
+            .tablet_registry
+            .get(region_id)
+            .map(|mut cache| cache.latest().cloned()) else {return};
+        let now = Instant::now();
+        tablet.flush_cfs(DATA_CFS, true).unwrap();
+        let elapsed = now.saturating_elapsed();
+        // to be removed after when it's stable
+        info!(
+            self.logger,
+            "flush memtable time consumes";
+            "region_id" => region_id,
+            "duration" => ?elapsed,
+            "is_leader" => is_leader,
+        );
+
+        if !is_leader {
+            return;
+        }
+
+        let mut req = req.unwrap();
+        req.mut_header()
+            .set_flags(WriteBatchFlags::SPLIT_SECOND_PHASE.bits());
+        if let Err(e) = self.router.send(
+            region_id,
+            PeerMsg::AdminCommand(RaftRequest::new(req, ch.unwrap())),
+        ) {
+            error!(
+                self.logger,
+                "send split request fail in the second phase";
+                "region_id" => region_id,
+                "err" => ?e,
+            );
+        }
+    }
+}
+
+impl<EK, ER> Runnable for Runner<EK, ER>
+where
+    EK: KvEngine,
+    ER: RaftEngine,
+{
+    type Task = Task;
+
+    fn run(&mut self, task: Self::Task) {
+        match task {
+            Task::TabletFlush {
+                region_id,
+                req,
+                is_leader,
+                ch,
+            } => self.flush_tablet(region_id, req, is_leader, ch),
+        }
+    }
+}

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -2797,6 +2797,7 @@ where
             }
             // It's v2 only message and ignore does no harm.
             ExtraMessageType::MsgGcPeerRequest | ExtraMessageType::MsgGcPeerResponse => (),
+            ExtraMessageType::MsgFlushMemtable => (),
         }
     }
 

--- a/components/test_raftstore-v2/src/cluster.rs
+++ b/components/test_raftstore-v2/src/cluster.rs
@@ -1004,6 +1004,10 @@ impl<T: Simulator> Cluster<T> {
             region_end_key
         };
 
+        if amended_start_key > amended_end_key {
+            return Ok(());
+        }
+
         tablet.scan(cf, amended_start_key, amended_end_key, fill_cache, f)
     }
 

--- a/components/test_raftstore-v2/src/node.rs
+++ b/components/test_raftstore-v2/src/node.rs
@@ -437,12 +437,16 @@ impl Simulator for NodeCluster {
     }
 }
 
+// Compare to server cluster, node cluster does not have server layer and
+// storage layer.
 pub fn new_node_cluster(id: u64, count: usize) -> Cluster<NodeCluster> {
     let pd_client = Arc::new(TestPdClient::new(id, false));
     let sim = Arc::new(RwLock::new(NodeCluster::new(Arc::clone(&pd_client))));
     Cluster::new(id, count, sim, pd_client, ApiVersion::V1)
 }
 
+// This cluster does not support batch split, we expect it to transfer the
+// `BatchSplit` request to `split` request
 pub fn new_incompatible_node_cluster(id: u64, count: usize) -> Cluster<NodeCluster> {
     let pd_client = Arc::new(TestPdClient::new(id, true));
     let sim = Arc::new(RwLock::new(NodeCluster::new(Arc::clone(&pd_client))));

--- a/components/test_raftstore/src/node.rs
+++ b/components/test_raftstore/src/node.rs
@@ -505,12 +505,16 @@ impl Simulator for NodeCluster {
     }
 }
 
+// Compare to server cluster, node cluster does not have server layer and
+// storage layer.
 pub fn new_node_cluster(id: u64, count: usize) -> Cluster<NodeCluster> {
     let pd_client = Arc::new(TestPdClient::new(id, false));
     let sim = Arc::new(RwLock::new(NodeCluster::new(Arc::clone(&pd_client))));
     Cluster::new(id, count, sim, pd_client, ApiVersion::V1)
 }
 
+// This cluster does not support batch split, we expect it to transfer the
+// `BatchSplit` request to `split` request
 pub fn new_incompatible_node_cluster(id: u64, count: usize) -> Cluster<NodeCluster> {
     let pd_client = Arc::new(TestPdClient::new(id, true));
     let sim = Arc::new(RwLock::new(NodeCluster::new(Arc::clone(&pd_client))));

--- a/components/txn_types/src/types.rs
+++ b/components/txn_types/src/types.rs
@@ -570,6 +570,8 @@ bitflags! {
         const TRANSFER_LEADER_PROPOSAL = 0b00000100;
         /// Indicates this request is a flashback transaction.
         const FLASHBACK = 0b00001000;
+        /// Indicates the relevant tablet has been flushed, and we can propose split now.
+        const SPLIT_SECOND_PHASE = 0b00010000;
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #14447

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
flush memtable before proposing split
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
