### PR TITLE
log-backup: eliminate some verbose logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,6 +537,7 @@ dependencies = [
  "openssl",
  "pd_client",
  "prometheus",
+ "prometheus-static-metric",
  "protobuf",
  "raft",
  "raftstore",

--- a/components/backup-stream/Cargo.toml
+++ b/components/backup-stream/Cargo.toml
@@ -71,6 +71,7 @@ tonic = "0.8"
 txn_types = { workspace = true }
 uuid = "0.8"
 yatp = { workspace = true }
+prometheus-static-metric = "0.5"
 
 [dev-dependencies]
 async-trait = "0.1"

--- a/components/backup-stream/Cargo.toml
+++ b/components/backup-stream/Cargo.toml
@@ -50,6 +50,7 @@ online_config = { workspace = true }
 openssl = "0.10"
 pd_client = { workspace = true }
 prometheus = { version = "0.13", default-features = false, features = ["nightly"] }
+prometheus-static-metric = "0.5"
 protobuf = { version = "2.8", features = ["bytes"] }
 raft = { version = "0.7.0", default-features = false, features = ["protobuf-codec"] }
 raftstore = { workspace = true }
@@ -71,7 +72,6 @@ tonic = "0.8"
 txn_types = { workspace = true }
 uuid = "0.8"
 yatp = { workspace = true }
-prometheus-static-metric = "0.5"
 
 [dev-dependencies]
 async-trait = "0.1"

--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -973,6 +973,10 @@ where
                 });
             }
             RegionCheckpointOperation::PrepareMinTsForResolve => {
+                if self.observer.is_hibernating() {
+                    metrics::MISC_EVENTS.skip_resolve_no_subscription.inc();
+                    return;
+                }
                 let min_ts = self.pool.block_on(self.prepare_min_ts());
                 let start_time = Instant::now();
                 // We need to reschedule the `Resolve` task to queue, because the subscription

--- a/components/backup-stream/src/metrics.rs
+++ b/components/backup-stream/src/metrics.rs
@@ -2,6 +2,7 @@
 
 use lazy_static::lazy_static;
 use prometheus::*;
+use prometheus_static_metric::*;
 
 /// The status of a task.
 /// The ordering of this imples the priority for presenting to the user.
@@ -155,9 +156,11 @@ lazy_static! {
         &["stage"]
     )
     .unwrap();
-    pub static ref LOST_LEADER_REGION: IntCounter = register_int_counter!(
-        "tikv_log_backup_lost_leader_region",
-        "The regions that lost leadership during resolving"
+    pub static ref MISC_EVENTS: MiscEvents = register_static_int_counter_vec!(
+        MiscEvents,
+        "tikv_log_backup_misc_events",
+        "Events counter, including 'plain' events(i.e. events without extra information).",
+        &["name"]
     )
     .unwrap();
     pub static ref MIN_TS_RESOLVE_DURATION: Histogram = register_histogram!(
@@ -166,4 +169,18 @@ lazy_static! {
         exponential_buckets(0.001, 2.0, 16).unwrap()
     )
     .unwrap();
+}
+
+make_static_metric! {
+    pub label_enum MIscEventsName {
+        skip_resolve_non_leader,
+        skip_resolve_no_subscription,
+    }
+
+    pub struct MiscEvents: IntCounter {
+        "name" => {
+            skip_resolve_non_leader,
+            skip_resolve_no_subscription,
+        }
+    }
 }

--- a/components/backup-stream/src/metrics.rs
+++ b/components/backup-stream/src/metrics.rs
@@ -172,7 +172,7 @@ lazy_static! {
 }
 
 make_static_metric! {
-    pub label_enum MIscEventsName {
+    pub label_enum MiscEventsName {
         skip_resolve_non_leader,
         skip_resolve_no_subscription,
     }

--- a/components/backup-stream/src/observer.rs
+++ b/components/backup-stream/src/observer.rs
@@ -100,7 +100,7 @@ impl BackupStreamObserver {
     /// Check whether there are any task range registered to the observer.
     /// when there isn't any task, we can ignore the events, so we don't need to
     /// handle useless events. (Also won't yield verbose logs.)
-    fn is_hibernating(&self) -> bool {
+    pub fn is_hibernating(&self) -> bool {
         self.ranges.rl().is_empty()
     }
 }

--- a/components/backup-stream/src/subscription_manager.rs
+++ b/components/backup-stream/src/subscription_manager.rs
@@ -38,7 +38,7 @@ use crate::{
     metrics,
     observer::BackupStreamObserver,
     router::{Router, TaskSelector},
-    subscription_track::{ResolveResult, SubscriptionTracer},
+    subscription_track::{CheckpointType, ResolveResult, SubscriptionTracer},
     try_send,
     utils::{self, CallbackWaitGroup, Work},
     Task,
@@ -407,7 +407,10 @@ where
         mut leader_checker: LeadershipResolver,
     ) {
         while let Some(op) = message_box.recv().await {
-            info!("backup stream: on_modify_observe"; "op" => ?op);
+            // Skip some trivial resolve commands.
+            if !matches!(op, ObserveOp::ResolveRegions { .. }) {
+                info!("backup stream: on_modify_observe"; "op" => ?op);
+            }
             match op {
                 ObserveOp::Start { region } => {
                     fail::fail_point!("delay_on_start_observe");
@@ -477,7 +480,12 @@ where
                     // If there isn't any region observed, the `min_ts` can be used as resolved ts
                     // safely.
                     let rts = min_region.map(|rs| rs.checkpoint).unwrap_or(min_ts);
-                    info!("getting checkpoint"; "defined_by_region" => ?min_region);
+                    if min_region
+                        .map(|mr| mr.checkpoint_type != CheckpointType::MinTs)
+                        .unwrap_or(false)
+                    {
+                        info!("getting non-trivial checkpoint"; "defined_by_region" => ?min_region);
+                    }
                     callback(ResolvedRegions::new(rts, cps));
                 }
             }

--- a/components/backup-stream/src/subscription_track.rs
+++ b/components/backup-stream/src/subscription_track.rs
@@ -250,7 +250,7 @@ impl SubscriptionTracer {
                 SubscribeState::Running(sub) => {
                     let contains = rs.contains(&region_id);
                     if !contains {
-                        crate::metrics::LOST_LEADER_REGION.inc();
+                        crate::metrics::MISC_EVENTS.skip_resolve_non_leader.inc();
                     }
                     contains.then(|| ResolveResult::resolve(sub, min_ts))
                 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #14453 

What's Changed:
Remove handler for `PrepareMinTsForResolve` when there isn't any task. 

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
1. Start a new cluster in master. -- Many logs described in #14453 printed.
2. Start a new cluster in this PR. -- Logs described in #14453 don't print again as long as no log backup task triggered.


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fixed a bug that may cause TiKV print too many meanless logs about log backup.
```
