### PR TITLE
Bg quota limiter auto tune

### DIFF
--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -101,8 +101,9 @@ use tikv_util::{
     check_environment_variables,
     config::{ensure_dir_exist, RaftDataStateMachine, VersionTrack},
     math::MovingAvgU32,
+    metrics::INSTANCE_BACKEND_CPU_QUOTA,
     quota_limiter::{QuotaLimitConfigManager, QuotaLimiter},
-    sys::{disk, register_memory_usage_high_water, SysQuota},
+    sys::{cpu_time::ProcessStat, disk, register_memory_usage_high_water, SysQuota},
     thread_group::GroupProperties,
     time::{Instant, Monitor},
     worker::{Builder as WorkerBuilder, LazyWorker, Scheduler, Worker},
@@ -110,6 +111,19 @@ use tikv_util::{
 use tokio::runtime::Builder;
 
 use crate::{memory::*, raft_engine_switch::*, setup::*, signal_handler};
+
+// minimum number of core kept for background requests
+const BACKGROUND_REQUEST_CORE_LOWER_BOUND: f64 = 1.0;
+// max ratio of core quota for background requests
+const BACKGROUND_REQUEST_CORE_MAX_RATIO: f64 = 0.95;
+// default ratio of core quota for background requests = core_number * 0.5
+const BACKGROUND_REQUEST_CORE_DEFAULT_RATIO: f64 = 0.5;
+// indication of TiKV instance is short of cpu
+const SYSTEM_BUSY_THRESHOLD: f64 = 0.80;
+// indication of TiKV instance in healthy state when cpu usage is in [0.5, 0.80)
+const SYSTEM_HEALTHY_THRESHOLD: f64 = 0.50;
+// pace of cpu quota adjustment
+const CPU_QUOTA_ADJUSTMENT_PACE: f64 = 200.0; // 0.2 vcpu
 
 #[inline]
 fn run_impl<CER: ConfiguredRaftEngine, F: KvFormat>(config: TiKvConfig) {
@@ -134,6 +148,7 @@ fn run_impl<CER: ConfiguredRaftEngine, F: KvFormat>(config: TiKvConfig) {
     tikv.init_storage_stats_task(engines);
     tikv.run_server(server_config);
     tikv.run_status_server();
+    tikv.init_quota_tuning_task(tikv.quota_limiter.clone());
 
     signal_handler::wait_for_signal(Some(tikv.engines.take().unwrap().engines));
     tikv.stop();
@@ -175,6 +190,7 @@ const DEFAULT_METRICS_FLUSH_INTERVAL: Duration = Duration::from_millis(10_000);
 const DEFAULT_MEMTRACE_FLUSH_INTERVAL: Duration = Duration::from_millis(1_000);
 const DEFAULT_ENGINE_METRICS_RESET_INTERVAL: Duration = Duration::from_millis(60_000);
 const DEFAULT_STORAGE_STATS_INTERVAL: Duration = Duration::from_secs(1);
+const DEFAULT_QUOTA_LIMITER_TUNE_INTERVAL: Duration = Duration::from_secs(5);
 
 /// A complete TiKV server.
 struct TiKvServer<ER: RaftEngine> {
@@ -269,11 +285,16 @@ impl<ER: RaftEngine> TiKvServer<ER> {
         let latest_ts = block_on(pd_client.get_tso()).expect("failed to get timestamp from PD");
         let concurrency_manager = ConcurrencyManager::new(latest_ts);
 
+        // use different quota for front-end and back-end requests
         let quota_limiter = Arc::new(QuotaLimiter::new(
             config.quota.foreground_cpu_time,
             config.quota.foreground_write_bandwidth,
             config.quota.foreground_read_bandwidth,
+            config.quota.background_cpu_time,
+            config.quota.background_write_bandwidth,
+            config.quota.background_read_bandwidth,
             config.quota.max_delay_duration,
+            config.quota.enable_auto_tune,
         ));
 
         TiKvServer {
@@ -1203,6 +1224,82 @@ impl<ER: RaftEngine> TiKvServer<ER> {
                 let now = Instant::now();
                 mem_trace_metrics.flush(now);
             });
+    }
+
+    // Only background cpu quota tuning is implemented at present. iops and frontend quota tuning is on the way
+    fn init_quota_tuning_task(&self, quota_limiter: Arc<QuotaLimiter>) {
+        // No need to do auto tune when capacity is really low
+        if SysQuota::cpu_cores_quota() * BACKGROUND_REQUEST_CORE_MAX_RATIO
+            < BACKGROUND_REQUEST_CORE_LOWER_BOUND
+        {
+            return;
+        };
+
+        // Determine the base cpu quota
+        let base_cpu_quota = {
+            // if cpu quota is not specified, start from optimistic case
+            if quota_limiter.cputime_limiter(false).is_infinite() {
+                let quota = 1000_f64
+                    * f64::max(
+                        BACKGROUND_REQUEST_CORE_LOWER_BOUND,
+                        SysQuota::cpu_cores_quota() * BACKGROUND_REQUEST_CORE_DEFAULT_RATIO,
+                    );
+                quota_limiter.set_cpu_time_limit(quota as usize, false);
+                quota
+            } else {
+                quota_limiter.cputime_limiter(false) / 1000_f64
+            }
+        };
+
+        // Calculate the celling and floor quota
+        let celling_quota = f64::min(
+            base_cpu_quota * 2.0,
+            1_000_f64 * SysQuota::cpu_cores_quota() * BACKGROUND_REQUEST_CORE_MAX_RATIO,
+        );
+        let floor_quota = f64::max(
+            base_cpu_quota * 0.5,
+            1_000_f64 * BACKGROUND_REQUEST_CORE_LOWER_BOUND,
+        );
+
+        let mut proc_stats: ProcessStat = ProcessStat::cur_proc_stat().unwrap();
+        self.background_worker.spawn_interval_task(
+            DEFAULT_QUOTA_LIMITER_TUNE_INTERVAL,
+            move || {
+                if quota_limiter.auto_tune_enabled() {
+                    let old_quota = quota_limiter.cputime_limiter(false) / 1000_f64;
+                    let cpu_usage = match proc_stats.cpu_usage() {
+                        Ok(r) => r,
+                        Err(_e) => 0.0,
+                    };
+                    // Try tuning quota when cpu_usage is correctly collected.
+                    // rule based tuning:
+                    //      1) if instance is busy, shrink cpu quota for analyze by one quota pace until lower bound is hit;
+                    //      2) if instance cpu usage is healthy, no op;
+                    //      3) if instance is idle, increase cpu quota by one quota pace  until upper bound is hit.
+                    if cpu_usage > 0.0f64 {
+                        let mut target_quota = old_quota;
+
+                        let cpu_util = cpu_usage / SysQuota::cpu_cores_quota();
+                        if cpu_util >= SYSTEM_BUSY_THRESHOLD {
+                            target_quota =
+                                f64::max(target_quota - CPU_QUOTA_ADJUSTMENT_PACE, floor_quota);
+                        } else if cpu_util < SYSTEM_HEALTHY_THRESHOLD {
+                            target_quota =
+                                f64::min(target_quota + CPU_QUOTA_ADJUSTMENT_PACE, celling_quota);
+                        }
+
+                        if old_quota != target_quota {
+                            quota_limiter.set_cpu_time_limit(target_quota as usize, false);
+                            debug!(
+                                "cpu_time_limiter tuned for backend request";
+                                "cpu_util" => ?cpu_util,
+                                "new quota" => ?target_quota);
+                            INSTANCE_BACKEND_CPU_QUOTA.set(target_quota as i64);
+                        }
+                    }
+                }
+            },
+        );
     }
 
     fn init_storage_stats_task(&self, engines: Engines<RocksEngine, ER>) {

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -382,7 +382,11 @@ impl ServerCluster {
             cfg.quota.foreground_cpu_time,
             cfg.quota.foreground_write_bandwidth,
             cfg.quota.foreground_read_bandwidth,
+            cfg.quota.background_cpu_time,
+            cfg.quota.background_write_bandwidth,
+            cfg.quota.background_read_bandwidth,
             cfg.quota.max_delay_duration,
+            cfg.quota.enable_auto_tune,
         ));
         let store = create_raft_storage::<_, _, _, F>(
             engine,

--- a/components/tidb_query_executors/src/runner.rs
+++ b/components/tidb_query_executors/src/runner.rs
@@ -451,7 +451,7 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
 
             let mut chunk = Chunk::default();
 
-            let mut sample = self.quota_limiter.new_sample();
+            let mut sample = self.quota_limiter.new_sample(true);
             let (drained, record_len) = {
                 let _guard = sample.observe_cpu();
                 self.internal_handle_request(

--- a/components/tidb_query_executors/src/runner.rs
+++ b/components/tidb_query_executors/src/runner.rs
@@ -463,7 +463,7 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
                 )?
             };
 
-            let quota_delay = self.quota_limiter.async_consume(sample).await;
+            let quota_delay = self.quota_limiter.consume_sample(sample, true).await;
             if !quota_delay.is_zero() {
                 NON_TXN_COMMAND_THROTTLE_TIME_COUNTER_VEC_STATIC
                     .get(ThrottleType::dag)

--- a/components/tikv_util/src/metrics/mod.rs
+++ b/components/tikv_util/src/metrics/mod.rs
@@ -77,6 +77,7 @@ make_auto_flush_static_metric! {
     pub label_enum ThrottleType {
         dag,
         analyze_full_sampling,
+        quota_limiter_auto_tuned,
     }
 
     pub struct NonTxnCommandThrottleTimeCounterVec: LocalIntCounter {
@@ -102,6 +103,8 @@ lazy_static! {
         NON_TXN_COMMAND_THROTTLE_TIME_COUNTER_VEC,
         NonTxnCommandThrottleTimeCounterVec
     );
+    pub static ref INSTANCE_BACKEND_CPU_QUOTA: IntGauge =
+        register_int_gauge!("tikv_backend_cpu_quota", "cpu quota for backend request").unwrap();
 }
 
 pub fn convert_record_pairs(m: HashMap<String, u64>) -> RecordPairVec {

--- a/components/tikv_util/src/quota_limiter.rs
+++ b/components/tikv_util/src/quota_limiter.rs
@@ -234,21 +234,24 @@ impl QuotaLimiter {
     }
 
     // To generate a sampler.
-    pub fn new_sample(&self) -> Sample {
+    pub fn new_sample(&self, is_foreground: bool) -> Sample {
         Sample {
             read_bytes: 0,
             write_bytes: 0,
             cpu_time: Duration::ZERO,
-            enable_cpu_limit: !self
-                .foreground_limiters
-                .cputime_limiter
-                .speed_limit()
-                .is_infinite()
-                || !self
+            enable_cpu_limit: if is_foreground {
+                !self
+                    .foreground_limiters
+                    .cputime_limiter
+                    .speed_limit()
+                    .is_infinite()
+            } else {
+                !self
                     .background_limiters
                     .cputime_limiter
                     .speed_limit()
-                    .is_infinite(),
+                    .is_infinite()
+            },
         }
     }
 
@@ -389,25 +392,25 @@ mod tests {
             );
         };
 
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(true);
         sample.add_cpu_time(Duration::from_millis(60));
         let should_delay = block_on(quota_limiter.consume_sample(sample, true));
         check_duration(should_delay, Duration::ZERO);
 
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(true);
         sample.add_cpu_time(Duration::from_millis(50));
         let should_delay = block_on(quota_limiter.consume_sample(sample, true));
         check_duration(should_delay, Duration::from_millis(110));
 
         std::thread::sleep(Duration::from_millis(10));
 
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(true);
         sample.add_cpu_time(Duration::from_millis(20));
         let should_delay = block_on(quota_limiter.consume_sample(sample, true));
         // should less 60+50+20
         assert!(should_delay < Duration::from_millis(130));
 
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(true);
         sample.add_cpu_time(Duration::from_millis(200));
         sample.add_write_bytes(256);
         let should_delay = block_on(quota_limiter.consume_sample(sample, true));
@@ -417,25 +420,25 @@ mod tests {
         assert!(thread_start_time.elapsed() < Duration::from_millis(50));
 
         quota_limiter.set_cpu_time_limit(2000, true);
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(true);
         sample.add_cpu_time(Duration::from_millis(200));
         let should_delay = block_on(quota_limiter.consume_sample(sample, true));
         check_duration(should_delay, Duration::from_millis(100));
 
         quota_limiter.set_read_bandwidth_limit(ReadableSize(512), true);
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(true);
         sample.add_read_bytes(128);
         let should_delay = block_on(quota_limiter.consume_sample(sample, true));
         check_duration(should_delay, Duration::from_millis(250));
 
         quota_limiter.set_write_bandwidth_limit(ReadableSize::kb(2), true);
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(true);
         sample.add_write_bytes(256);
         let should_delay = block_on(quota_limiter.consume_sample(sample, true));
         check_duration(should_delay, Duration::from_millis(125));
 
         quota_limiter.set_max_delay_duration(ReadableDuration::millis(40));
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(true);
         sample.add_read_bytes(256);
         sample.add_write_bytes(512);
         let should_delay = block_on(quota_limiter.consume_sample(sample, true));
@@ -443,19 +446,19 @@ mod tests {
 
         // test change limiter to 0
         quota_limiter.set_cpu_time_limit(0, true);
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(true);
         sample.add_cpu_time(Duration::from_millis(100));
         let should_delay = block_on(quota_limiter.consume_sample(sample, true));
         check_duration(should_delay, Duration::ZERO);
 
         quota_limiter.set_write_bandwidth_limit(ReadableSize::kb(0), true);
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(true);
         sample.add_write_bytes(256);
         let should_delay = block_on(quota_limiter.consume_sample(sample, true));
         check_duration(should_delay, Duration::ZERO);
 
         quota_limiter.set_read_bandwidth_limit(ReadableSize::kb(0), true);
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(true);
         sample.add_read_bytes(256);
         let should_delay = block_on(quota_limiter.consume_sample(sample, true));
         check_duration(should_delay, Duration::ZERO);
@@ -463,30 +466,30 @@ mod tests {
         // set bandwidth back
         quota_limiter.set_write_bandwidth_limit(ReadableSize::kb(1), true);
         quota_limiter.set_max_delay_duration(ReadableDuration::millis(0));
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(true);
         sample.add_write_bytes(128);
         let should_delay = block_on(quota_limiter.consume_sample(sample, true));
         check_duration(should_delay, Duration::from_millis(125));
 
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(false);
         sample.add_cpu_time(Duration::from_millis(60));
         let should_delay = block_on(quota_limiter.consume_sample(sample, false));
         check_duration(should_delay, Duration::ZERO);
 
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(false);
         sample.add_cpu_time(Duration::from_millis(50));
         let should_delay = block_on(quota_limiter.consume_sample(sample, false));
         check_duration(should_delay, Duration::from_millis(110));
 
         std::thread::sleep(Duration::from_millis(10));
 
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(false);
         sample.add_cpu_time(Duration::from_millis(20));
         let should_delay = block_on(quota_limiter.consume_sample(sample, false));
         // should less 60+50+20
         assert!(should_delay < Duration::from_millis(130));
 
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(false);
         sample.add_cpu_time(Duration::from_millis(200));
         sample.add_write_bytes(256);
         let should_delay = block_on(quota_limiter.consume_sample(sample, false));
@@ -496,25 +499,25 @@ mod tests {
         assert!(thread_start_time.elapsed() < Duration::from_millis(50));
 
         quota_limiter.set_cpu_time_limit(2000, false);
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(false);
         sample.add_cpu_time(Duration::from_millis(200));
         let should_delay = block_on(quota_limiter.consume_sample(sample, false));
         check_duration(should_delay, Duration::from_millis(100));
 
         quota_limiter.set_read_bandwidth_limit(ReadableSize(512), false);
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(false);
         sample.add_read_bytes(128);
         let should_delay = block_on(quota_limiter.consume_sample(sample, false));
         check_duration(should_delay, Duration::from_millis(250));
 
         quota_limiter.set_write_bandwidth_limit(ReadableSize::kb(2), false);
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(false);
         sample.add_write_bytes(256);
         let should_delay = block_on(quota_limiter.consume_sample(sample, false));
         check_duration(should_delay, Duration::from_millis(125));
 
         quota_limiter.set_max_delay_duration(ReadableDuration::millis(40));
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(false);
         sample.add_read_bytes(256);
         sample.add_write_bytes(512);
         let should_delay = block_on(quota_limiter.consume_sample(sample, false));
@@ -522,19 +525,19 @@ mod tests {
 
         // test change limiter to 0
         quota_limiter.set_cpu_time_limit(0, false);
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(false);
         sample.add_cpu_time(Duration::from_millis(100));
         let should_delay = block_on(quota_limiter.consume_sample(sample, false));
         check_duration(should_delay, Duration::ZERO);
 
         quota_limiter.set_write_bandwidth_limit(ReadableSize::kb(0), false);
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(false);
         sample.add_write_bytes(256);
         let should_delay = block_on(quota_limiter.consume_sample(sample, false));
         check_duration(should_delay, Duration::ZERO);
 
         quota_limiter.set_read_bandwidth_limit(ReadableSize::kb(0), false);
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(false);
         sample.add_read_bytes(256);
         let should_delay = block_on(quota_limiter.consume_sample(sample, false));
         check_duration(should_delay, Duration::ZERO);
@@ -542,7 +545,7 @@ mod tests {
         // set bandwidth back
         quota_limiter.set_write_bandwidth_limit(ReadableSize::kb(1), false);
         quota_limiter.set_max_delay_duration(ReadableDuration::millis(0));
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(false);
         sample.add_write_bytes(128);
         let should_delay = block_on(quota_limiter.consume_sample(sample, false));
         check_duration(should_delay, Duration::from_millis(125));

--- a/components/tikv_util/src/quota_limiter.rs
+++ b/components/tikv_util/src/quota_limiter.rs
@@ -2,7 +2,7 @@
 
 use std::{
     sync::{
-        atomic::{AtomicU64, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
         Arc,
     },
     time::Duration,
@@ -22,15 +22,59 @@ use super::{
 // It's better to use a universal approach.
 const CPU_LIMITER_REFILL_DURATION: Duration = Duration::from_millis(100);
 
+// Limter can be issued to cpu, write and read bandwidth
+#[derive(Debug)]
+pub struct LimiterItems {
+    cputime_limiter: Limiter,
+    write_bandwidth_limiter: Limiter,
+    read_bandwidth_limiter: Limiter,
+}
+
+impl LimiterItems {
+    pub fn new(
+        cpu_quota: usize,
+        write_bandwidth: ReadableSize,
+        read_bandwidth: ReadableSize,
+    ) -> Self {
+        let cputime_limiter =
+            Limiter::builder(QuotaLimiter::speed_limit(cpu_quota as f64 * 1000_f64))
+                .refill(CPU_LIMITER_REFILL_DURATION)
+                .build();
+
+        let write_bandwidth_limiter =
+            Limiter::new(QuotaLimiter::speed_limit(write_bandwidth.0 as f64));
+
+        let read_bandwidth_limiter =
+            Limiter::new(QuotaLimiter::speed_limit(read_bandwidth.0 as f64));
+
+        Self {
+            cputime_limiter,
+            write_bandwidth_limiter,
+            read_bandwidth_limiter,
+        }
+    }
+}
+
+impl Default for LimiterItems {
+    fn default() -> Self {
+        Self {
+            cputime_limiter: Limiter::new(f64::INFINITY),
+            write_bandwidth_limiter: Limiter::new(f64::INFINITY),
+            read_bandwidth_limiter: Limiter::new(f64::INFINITY),
+        }
+    }
+}
+
 // Quota limiter allows users to obtain stable performance by increasing the
 // completion time of tasks through restrictions of different metrics.
 #[derive(Debug)]
 pub struct QuotaLimiter {
-    cputime_limiter: Limiter,
-    write_bandwidth_limiter: Limiter,
-    read_bandwidth_limiter: Limiter,
+    foreground_limiters: LimiterItems,
+    background_limiters: LimiterItems,
     // max delay nano seconds
     max_delay_duration: AtomicU64,
+    // if auto tune is enabled
+    enable_auto_tune: AtomicBool,
 }
 
 // Throttle must be consumed in quota limiter.
@@ -86,11 +130,13 @@ impl<'a> Drop for CpuObserveGuard<'a> {
 
 impl Default for QuotaLimiter {
     fn default() -> Self {
+        let foreground_limiters = LimiterItems::default();
+        let background_limiters = LimiterItems::default();
         Self {
-            cputime_limiter: Limiter::new(f64::INFINITY),
-            write_bandwidth_limiter: Limiter::new(f64::INFINITY),
-            read_bandwidth_limiter: Limiter::new(f64::INFINITY),
+            foreground_limiters,
+            background_limiters,
             max_delay_duration: AtomicU64::new(0),
+            enable_auto_tune: AtomicBool::new(false),
         }
     }
 }
@@ -98,26 +144,33 @@ impl Default for QuotaLimiter {
 impl QuotaLimiter {
     // 1000 millicpu equals to 1vCPU, 0 means unlimited
     pub fn new(
-        cpu_quota: usize,
-        write_bandwidth: ReadableSize,
-        read_bandwidth: ReadableSize,
+        foreground_cpu_quota: usize,
+        foreground_write_bandwidth: ReadableSize,
+        foreground_read_bandwidth: ReadableSize,
+        background_cpu_quota: usize,
+        background_write_bandwidth: ReadableSize,
+        background_read_bandwidth: ReadableSize,
         max_delay_duration: ReadableDuration,
+        enable_auto_tune: bool,
     ) -> Self {
-        let cputime_limiter = Limiter::builder(Self::speed_limit(cpu_quota as f64 * 1000_f64))
-            .refill(CPU_LIMITER_REFILL_DURATION)
-            .build();
-
-        let write_bandwidth_limiter = Limiter::new(Self::speed_limit(write_bandwidth.0 as f64));
-
-        let read_bandwidth_limiter = Limiter::new(Self::speed_limit(read_bandwidth.0 as f64));
-
+        let foreground_limiters = LimiterItems::new(
+            foreground_cpu_quota,
+            foreground_write_bandwidth,
+            foreground_read_bandwidth,
+        );
+        let background_limiters = LimiterItems::new(
+            background_cpu_quota,
+            background_write_bandwidth,
+            background_read_bandwidth,
+        );
         let max_delay_duration = AtomicU64::new(max_delay_duration.0.as_nanos() as u64);
+        let enable_auto_tune = AtomicBool::new(enable_auto_tune);
 
         Self {
-            cputime_limiter,
-            write_bandwidth_limiter,
-            read_bandwidth_limiter,
+            foreground_limiters,
+            background_limiters,
             max_delay_duration,
+            enable_auto_tune,
         }
     }
 
@@ -129,18 +182,30 @@ impl QuotaLimiter {
         }
     }
 
-    pub fn set_cpu_time_limit(&self, quota_limit: usize) {
-        self.cputime_limiter
+    #[inline]
+    fn get_limiters(&self, is_foreground: bool) -> &LimiterItems {
+        if is_foreground {
+            &self.foreground_limiters
+        } else {
+            &self.background_limiters
+        }
+    }
+
+    pub fn set_cpu_time_limit(&self, quota_limit: usize, is_foreground: bool) {
+        self.get_limiters(is_foreground)
+            .cputime_limiter
             .set_speed_limit(Self::speed_limit(quota_limit as f64 * 1000_f64));
     }
 
-    pub fn set_write_bandwidth_limit(&self, write_bandwidth: ReadableSize) {
-        self.write_bandwidth_limiter
+    pub fn set_write_bandwidth_limit(&self, write_bandwidth: ReadableSize, is_foreground: bool) {
+        self.get_limiters(is_foreground)
+            .write_bandwidth_limiter
             .set_speed_limit(Self::speed_limit(write_bandwidth.0 as f64));
     }
 
-    pub fn set_read_bandwidth_limit(&self, read_bandwidth: ReadableSize) {
-        self.read_bandwidth_limiter
+    pub fn set_read_bandwidth_limit(&self, read_bandwidth: ReadableSize, is_foreground: bool) {
+        self.get_limiters(is_foreground)
+            .read_bandwidth_limiter
             .set_speed_limit(Self::speed_limit(read_bandwidth.0 as f64));
     }
 
@@ -149,8 +214,23 @@ impl QuotaLimiter {
             .store(duration.0.as_nanos() as u64, Ordering::Relaxed);
     }
 
+    pub fn set_enable_auto_tune(&self, enable_auto_tune: bool) {
+        self.enable_auto_tune
+            .store(enable_auto_tune, Ordering::Relaxed);
+    }
+
+    pub fn cputime_limiter(&self, is_foreground: bool) -> f64 {
+        self.get_limiters(is_foreground)
+            .cputime_limiter
+            .speed_limit()
+    }
+
     fn max_delay_duration(&self) -> Duration {
         Duration::from_nanos(self.max_delay_duration.load(Ordering::Relaxed))
+    }
+
+    pub fn auto_tune_enabled(&self) -> bool {
+        self.enable_auto_tune.load(Ordering::Relaxed)
     }
 
     // To generate a sampler.
@@ -159,29 +239,43 @@ impl QuotaLimiter {
             read_bytes: 0,
             write_bytes: 0,
             cpu_time: Duration::ZERO,
-            enable_cpu_limit: !self.cputime_limiter.speed_limit().is_infinite(),
+            enable_cpu_limit: !self
+                .foreground_limiters
+                .cputime_limiter
+                .speed_limit()
+                .is_infinite()
+                || !self
+                    .background_limiters
+                    .cputime_limiter
+                    .speed_limit()
+                    .is_infinite(),
         }
     }
 
     // To consume a sampler and return delayed duration.
     // If the sampler is null, the speed limiter will just return ZERO.
-    pub async fn async_consume(&self, sample: Sample) -> Duration {
+    pub async fn consume_sample(&self, sample: Sample, is_foreground: bool) -> Duration {
+        let limiters = self.get_limiters(is_foreground);
+
         let cpu_dur = if sample.cpu_time > Duration::ZERO {
-            self.cputime_limiter
+            limiters
+                .cputime_limiter
                 .consume_duration(sample.cpu_time.as_micros() as usize)
         } else {
             Duration::ZERO
         };
 
         let w_bw_dur = if sample.write_bytes > 0 {
-            self.write_bandwidth_limiter
+            limiters
+                .write_bandwidth_limiter
                 .consume_duration(sample.write_bytes)
         } else {
             Duration::ZERO
         };
 
         let r_bw_dur = if sample.read_bytes > 0 {
-            self.read_bandwidth_limiter
+            limiters
+                .read_bandwidth_limiter
                 .consume_duration(sample.read_bytes)
         } else {
             Duration::ZERO
@@ -206,12 +300,12 @@ impl QuotaLimiter {
 }
 
 pub struct QuotaLimitConfigManager {
-    limiter: Arc<QuotaLimiter>,
+    quota_limiter: Arc<QuotaLimiter>,
 }
 
 impl QuotaLimitConfigManager {
-    pub fn new(limiter: Arc<QuotaLimiter>) -> Self {
-        Self { limiter }
+    pub fn new(quota_limiter: Arc<QuotaLimiter>) -> Self {
+        Self { quota_limiter }
     }
 }
 
@@ -221,21 +315,45 @@ impl ConfigManager for QuotaLimitConfigManager {
         change: ConfigChange,
     ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         if let Some(cpu_limit) = change.get("foreground_cpu_time") {
-            self.limiter.set_cpu_time_limit(cpu_limit.into());
+            self.quota_limiter
+                .set_cpu_time_limit(cpu_limit.into(), true);
         }
+
         if let Some(write_bandwidth) = change.get("foreground_write_bandwidth") {
-            self.limiter
-                .set_write_bandwidth_limit(write_bandwidth.clone().into())
+            self.quota_limiter
+                .set_write_bandwidth_limit(write_bandwidth.clone().into(), true);
         }
+
         if let Some(read_bandwidth) = change.get("foreground_read_bandwidth") {
-            self.limiter
-                .set_write_bandwidth_limit(read_bandwidth.clone().into());
+            self.quota_limiter
+                .set_read_bandwidth_limit(read_bandwidth.clone().into(), true);
         }
+
+        if let Some(cpu_limit) = change.get("background_cpu_time") {
+            self.quota_limiter
+                .set_cpu_time_limit(cpu_limit.into(), false);
+        }
+
+        if let Some(write_bandwidth) = change.get("background_write_bandwidth") {
+            self.quota_limiter
+                .set_write_bandwidth_limit(write_bandwidth.clone().into(), false);
+        }
+
+        if let Some(read_bandwidth) = change.get("background_read_bandwidth") {
+            self.quota_limiter
+                .set_read_bandwidth_limit(read_bandwidth.clone().into(), false);
+        }
+
         if let Some(duration) = change.get("max_delay_duration") {
             let delay_dur: ReadableDuration = duration.clone().into();
-            self.limiter
+            self.quota_limiter
                 .max_delay_duration
                 .store(delay_dur.0.as_nanos() as u64, Ordering::Relaxed);
+        }
+
+        if let Some(enable_auto_tune) = change.get("enable_auto_tune") {
+            self.quota_limiter
+                .set_enable_auto_tune(enable_auto_tune.clone().into());
         }
         Ok(())
     }
@@ -255,7 +373,11 @@ mod tests {
             1000,
             ReadableSize::kb(1),
             ReadableSize::kb(1),
+            1000,
+            ReadableSize::kb(1),
+            ReadableSize::kb(1),
             ReadableDuration::millis(0),
+            false,
         );
 
         let thread_start_time = ThreadTime::now();
@@ -269,81 +391,160 @@ mod tests {
 
         let mut sample = quota_limiter.new_sample();
         sample.add_cpu_time(Duration::from_millis(60));
-        let should_delay = block_on(quota_limiter.async_consume(sample));
+        let should_delay = block_on(quota_limiter.consume_sample(sample, true));
         check_duration(should_delay, Duration::ZERO);
 
         let mut sample = quota_limiter.new_sample();
         sample.add_cpu_time(Duration::from_millis(50));
-        let should_delay = block_on(quota_limiter.async_consume(sample));
+        let should_delay = block_on(quota_limiter.consume_sample(sample, true));
         check_duration(should_delay, Duration::from_millis(110));
 
         std::thread::sleep(Duration::from_millis(10));
 
         let mut sample = quota_limiter.new_sample();
         sample.add_cpu_time(Duration::from_millis(20));
-        let should_delay = block_on(quota_limiter.async_consume(sample));
+        let should_delay = block_on(quota_limiter.consume_sample(sample, true));
         // should less 60+50+20
         assert!(should_delay < Duration::from_millis(130));
 
         let mut sample = quota_limiter.new_sample();
         sample.add_cpu_time(Duration::from_millis(200));
         sample.add_write_bytes(256);
-        let should_delay = block_on(quota_limiter.async_consume(sample));
+        let should_delay = block_on(quota_limiter.consume_sample(sample, true));
         check_duration(should_delay, Duration::from_millis(250));
 
         // ThreadTime elapsed time is not long.
         assert!(thread_start_time.elapsed() < Duration::from_millis(50));
 
-        quota_limiter.set_cpu_time_limit(2000);
+        quota_limiter.set_cpu_time_limit(2000, true);
         let mut sample = quota_limiter.new_sample();
         sample.add_cpu_time(Duration::from_millis(200));
-        let should_delay = block_on(quota_limiter.async_consume(sample));
+        let should_delay = block_on(quota_limiter.consume_sample(sample, true));
         check_duration(should_delay, Duration::from_millis(100));
 
-        quota_limiter.set_read_bandwidth_limit(ReadableSize(512));
+        quota_limiter.set_read_bandwidth_limit(ReadableSize(512), true);
         let mut sample = quota_limiter.new_sample();
         sample.add_read_bytes(128);
-        let should_delay = block_on(quota_limiter.async_consume(sample));
+        let should_delay = block_on(quota_limiter.consume_sample(sample, true));
         check_duration(should_delay, Duration::from_millis(250));
 
-        quota_limiter.set_write_bandwidth_limit(ReadableSize::kb(2));
+        quota_limiter.set_write_bandwidth_limit(ReadableSize::kb(2), true);
         let mut sample = quota_limiter.new_sample();
         sample.add_write_bytes(256);
-        let should_delay = block_on(quota_limiter.async_consume(sample));
+        let should_delay = block_on(quota_limiter.consume_sample(sample, true));
         check_duration(should_delay, Duration::from_millis(125));
 
         quota_limiter.set_max_delay_duration(ReadableDuration::millis(40));
         let mut sample = quota_limiter.new_sample();
         sample.add_read_bytes(256);
         sample.add_write_bytes(512);
-        let should_delay = block_on(quota_limiter.async_consume(sample));
+        let should_delay = block_on(quota_limiter.consume_sample(sample, true));
         check_duration(should_delay, Duration::from_millis(40));
 
         // test change limiter to 0
-        quota_limiter.set_cpu_time_limit(0);
+        quota_limiter.set_cpu_time_limit(0, true);
         let mut sample = quota_limiter.new_sample();
         sample.add_cpu_time(Duration::from_millis(100));
-        let should_delay = block_on(quota_limiter.async_consume(sample));
+        let should_delay = block_on(quota_limiter.consume_sample(sample, true));
         check_duration(should_delay, Duration::ZERO);
 
-        quota_limiter.set_write_bandwidth_limit(ReadableSize::kb(0));
+        quota_limiter.set_write_bandwidth_limit(ReadableSize::kb(0), true);
         let mut sample = quota_limiter.new_sample();
         sample.add_write_bytes(256);
-        let should_delay = block_on(quota_limiter.async_consume(sample));
+        let should_delay = block_on(quota_limiter.consume_sample(sample, true));
         check_duration(should_delay, Duration::ZERO);
 
-        quota_limiter.set_read_bandwidth_limit(ReadableSize::kb(0));
+        quota_limiter.set_read_bandwidth_limit(ReadableSize::kb(0), true);
         let mut sample = quota_limiter.new_sample();
         sample.add_read_bytes(256);
-        let should_delay = block_on(quota_limiter.async_consume(sample));
+        let should_delay = block_on(quota_limiter.consume_sample(sample, true));
         check_duration(should_delay, Duration::ZERO);
 
         // set bandwidth back
-        quota_limiter.set_write_bandwidth_limit(ReadableSize::kb(1));
+        quota_limiter.set_write_bandwidth_limit(ReadableSize::kb(1), true);
         quota_limiter.set_max_delay_duration(ReadableDuration::millis(0));
         let mut sample = quota_limiter.new_sample();
         sample.add_write_bytes(128);
-        let should_delay = block_on(quota_limiter.async_consume(sample));
+        let should_delay = block_on(quota_limiter.consume_sample(sample, true));
+        check_duration(should_delay, Duration::from_millis(125));
+
+        let mut sample = quota_limiter.new_sample();
+        sample.add_cpu_time(Duration::from_millis(60));
+        let should_delay = block_on(quota_limiter.consume_sample(sample, false));
+        check_duration(should_delay, Duration::ZERO);
+
+        let mut sample = quota_limiter.new_sample();
+        sample.add_cpu_time(Duration::from_millis(50));
+        let should_delay = block_on(quota_limiter.consume_sample(sample, false));
+        check_duration(should_delay, Duration::from_millis(110));
+
+        std::thread::sleep(Duration::from_millis(10));
+
+        let mut sample = quota_limiter.new_sample();
+        sample.add_cpu_time(Duration::from_millis(20));
+        let should_delay = block_on(quota_limiter.consume_sample(sample, false));
+        // should less 60+50+20
+        assert!(should_delay < Duration::from_millis(130));
+
+        let mut sample = quota_limiter.new_sample();
+        sample.add_cpu_time(Duration::from_millis(200));
+        sample.add_write_bytes(256);
+        let should_delay = block_on(quota_limiter.consume_sample(sample, false));
+        check_duration(should_delay, Duration::from_millis(250));
+
+        // ThreadTime elapsed time is not long.
+        assert!(thread_start_time.elapsed() < Duration::from_millis(50));
+
+        quota_limiter.set_cpu_time_limit(2000, false);
+        let mut sample = quota_limiter.new_sample();
+        sample.add_cpu_time(Duration::from_millis(200));
+        let should_delay = block_on(quota_limiter.consume_sample(sample, false));
+        check_duration(should_delay, Duration::from_millis(100));
+
+        quota_limiter.set_read_bandwidth_limit(ReadableSize(512), false);
+        let mut sample = quota_limiter.new_sample();
+        sample.add_read_bytes(128);
+        let should_delay = block_on(quota_limiter.consume_sample(sample, false));
+        check_duration(should_delay, Duration::from_millis(250));
+
+        quota_limiter.set_write_bandwidth_limit(ReadableSize::kb(2), false);
+        let mut sample = quota_limiter.new_sample();
+        sample.add_write_bytes(256);
+        let should_delay = block_on(quota_limiter.consume_sample(sample, false));
+        check_duration(should_delay, Duration::from_millis(125));
+
+        quota_limiter.set_max_delay_duration(ReadableDuration::millis(40));
+        let mut sample = quota_limiter.new_sample();
+        sample.add_read_bytes(256);
+        sample.add_write_bytes(512);
+        let should_delay = block_on(quota_limiter.consume_sample(sample, false));
+        check_duration(should_delay, Duration::from_millis(40));
+
+        // test change limiter to 0
+        quota_limiter.set_cpu_time_limit(0, false);
+        let mut sample = quota_limiter.new_sample();
+        sample.add_cpu_time(Duration::from_millis(100));
+        let should_delay = block_on(quota_limiter.consume_sample(sample, false));
+        check_duration(should_delay, Duration::ZERO);
+
+        quota_limiter.set_write_bandwidth_limit(ReadableSize::kb(0), false);
+        let mut sample = quota_limiter.new_sample();
+        sample.add_write_bytes(256);
+        let should_delay = block_on(quota_limiter.consume_sample(sample, false));
+        check_duration(should_delay, Duration::ZERO);
+
+        quota_limiter.set_read_bandwidth_limit(ReadableSize::kb(0), false);
+        let mut sample = quota_limiter.new_sample();
+        sample.add_read_bytes(256);
+        let should_delay = block_on(quota_limiter.consume_sample(sample, false));
+        check_duration(should_delay, Duration::ZERO);
+
+        // set bandwidth back
+        quota_limiter.set_write_bandwidth_limit(ReadableSize::kb(1), false);
+        quota_limiter.set_max_delay_duration(ReadableDuration::millis(0));
+        let mut sample = quota_limiter.new_sample();
+        sample.add_write_bytes(128);
+        let should_delay = block_on(quota_limiter.consume_sample(sample, false));
         check_duration(should_delay, Duration::from_millis(125));
     }
 }

--- a/components/tikv_util/src/sys/cpu_time.rs
+++ b/components/tikv_util/src/sys/cpu_time.rs
@@ -2,12 +2,15 @@
 // Modified from https://github.com/rust-lang/cargo/blob/426fae51f39ebf6c545a2c12f78bc09fbfdb7aa9/src/cargo/util/cpu.rs
 // TODO: Maybe use https://github.com/heim-rs/heim is better after https://github.com/heim-rs/heim/issues/233 is fixed.
 
-use std::io;
+use std::{
+    io, mem,
+    time::{Duration, Instant},
+};
 
 use derive_more::{Add, Sub};
 
-#[derive(Debug, Clone, Copy, Add, Sub)]
-pub struct LiunxStyleCpuTime {
+#[derive(Add, Sub)]
+pub struct LinuxStyleCpuTime {
     pub user: u64,
     pub nice: u64,
     pub system: u64,
@@ -20,7 +23,7 @@ pub struct LiunxStyleCpuTime {
     pub guest_nice: u64,
 }
 
-impl LiunxStyleCpuTime {
+impl LinuxStyleCpuTime {
     pub fn total(&self) -> u64 {
         // Note: guest(_nice) is not counted, since it is already in user.
         // See https://unix.stackexchange.com/questions/178045/proc-stat-is-guest-counted-into-user-time
@@ -34,19 +37,57 @@ impl LiunxStyleCpuTime {
             + self.steal
     }
 
-    pub fn current() -> io::Result<LiunxStyleCpuTime> {
+    pub fn current() -> io::Result<LinuxStyleCpuTime> {
         imp::current()
+    }
+}
+
+pub use std::io::Result;
+
+pub use imp::cpu_time;
+
+/// A struct to monitor process cpu usage
+#[derive(Clone, Copy)]
+pub struct ProcessStat {
+    current_time: Instant,
+    cpu_time: Duration,
+}
+
+impl ProcessStat {
+    pub fn cur_proc_stat() -> io::Result<Self> {
+        Ok(ProcessStat {
+            current_time: Instant::now(),
+            cpu_time: imp::cpu_time()?,
+        })
+    }
+
+    /// return the cpu usage from last invoke,
+    /// or when this struct created if it is the first invoke.
+    pub fn cpu_usage(&mut self) -> io::Result<f64> {
+        let new_time = imp::cpu_time()?;
+        let old_time = mem::replace(&mut self.cpu_time, new_time);
+
+        let old_now = mem::replace(&mut self.current_time, Instant::now());
+        let real_time = self.current_time.duration_since(old_now).as_secs_f64();
+
+        if real_time > 0.0 {
+            let cpu_time = new_time
+                .checked_sub(old_time)
+                .map(|dur| dur.as_secs_f64())
+                .unwrap_or(0.0);
+
+            Ok(cpu_time / real_time)
+        } else {
+            Ok(0.0)
+        }
     }
 }
 
 #[cfg(target_os = "linux")]
 mod imp {
-    use std::{
-        fs::File,
-        io::{self, Read},
-    };
+    use std::{fs::File, io, io::Read, time::Duration};
 
-    pub fn current() -> io::Result<super::LiunxStyleCpuTime> {
+    pub fn current() -> io::Result<super::LinuxStyleCpuTime> {
         let mut state = String::new();
         File::open("/proc/stat")?.read_to_string(&mut state)?;
 
@@ -55,7 +96,7 @@ mod imp {
             if parts.next()? != "cpu" {
                 return None;
             }
-            Some(super::LiunxStyleCpuTime {
+            Some(super::LinuxStyleCpuTime {
                 user: parts.next()?.parse::<u64>().ok()?,
                 nice: parts.next()?.parse::<u64>().ok()?,
                 system: parts.next()?.parse::<u64>().ok()?,
@@ -70,6 +111,19 @@ mod imp {
         })()
         .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "first line of /proc/stat malformed"))
     }
+
+    pub fn cpu_time() -> io::Result<Duration> {
+        let mut time = libc::timespec {
+            tv_sec: 0,
+            tv_nsec: 0,
+        };
+
+        if unsafe { libc::clock_gettime(libc::CLOCK_PROCESS_CPUTIME_ID, &mut time) } == 0 {
+            Ok(Duration::new(time.tv_sec as u64, time.tv_nsec as u32))
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -78,7 +132,7 @@ mod imp {
 
     use libc::*;
 
-    pub fn current() -> io::Result<super::LiunxStyleCpuTime> {
+    pub fn current() -> io::Result<super::LinuxStyleCpuTime> {
         // There's scant little documentation on `host_processor_info`
         // throughout the internet, so this is just modeled after what everyone
         // else is doing. For now this is modeled largely after libuv.
@@ -98,7 +152,7 @@ mod imp {
                 return Err(io::Error::from_raw_os_error(ret));
             }
 
-            let mut ret = super::LiunxStyleCpuTime {
+            let mut ret = super::LinuxStyleCpuTime {
                 user: 0,
                 system: 0,
                 idle: 0,
@@ -122,16 +176,172 @@ mod imp {
             Ok(ret)
         }
     }
+
+    pub fn cpu_time() -> io::Result<std::time::Duration> {
+        let mut time = unsafe { std::mem::zeroed() };
+
+        if unsafe { libc::getrusage(libc::RUSAGE_SELF, &mut time) } == 0 {
+            let sec = time.ru_utime.tv_sec as u64 + time.ru_stime.tv_sec as u64;
+            let nsec = (time.ru_utime.tv_usec as u32 + time.ru_stime.tv_usec as u32) * 1000;
+
+            Ok(std::time::Duration::new(sec, nsec))
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
 }
 
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
 mod imp {
     use std::io;
 
-    pub fn current() -> io::Result<super::LiunxStyleCpuTime> {
+    pub fn current() -> io::Result<super::LinuxStyleCpuTime> {
         Err(io::Error::new(
             io::ErrorKind::Other,
             "unsupported platform to learn CPU state",
         ))
+    }
+
+    use std::{io, mem, time::Duration};
+
+    use scopeguard::defer;
+    use winapi::{
+        shared::{
+            minwindef::FILETIME,
+            ntdef::{FALSE, NULL},
+        },
+        um::{
+            handleapi::CloseHandle,
+            processthreadsapi::{
+                GetCurrentProcess, GetCurrentThreadId, GetProcessTimes, GetSystemTimes,
+                GetThreadTimes, OpenThread,
+            },
+            sysinfoapi::{GetSystemInfo, SYSTEM_INFO},
+            winnt::THREAD_QUERY_INFORMATION,
+        },
+    };
+
+    /// convert to u64, unit 100 ns
+    fn filetime_to_ns100(ft: FILETIME) -> u64 {
+        ((ft.dwHighDateTime as u64) << 32) + ft.dwLowDateTime as u64
+    }
+
+    fn get_sys_times() -> io::Result<(u64, u64, u64)> {
+        let mut idle = FILETIME::default();
+        let mut kernel = FILETIME::default();
+        let mut user = FILETIME::default();
+
+        let ret = unsafe { GetSystemTimes(&mut idle, &mut kernel, &mut user) };
+        if ret == 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        let idle = filetime_to_ns100(idle);
+        let kernel = filetime_to_ns100(kernel);
+        let user = filetime_to_ns100(user);
+        Ok((idle, kernel, user))
+    }
+
+    fn get_thread_times(tid: u32) -> io::Result<(u64, u64)> {
+        let handler = unsafe { OpenThread(THREAD_QUERY_INFORMATION, FALSE as i32, tid) };
+        if handler == NULL {
+            return Err(io::Error::last_os_error());
+        }
+        defer! {{
+            unsafe { CloseHandle(handler) };
+        }}
+
+        let mut create_time = FILETIME::default();
+        let mut exit_time = FILETIME::default();
+        let mut kernel_time = FILETIME::default();
+        let mut user_time = FILETIME::default();
+
+        let ret = unsafe {
+            GetThreadTimes(
+                handler,
+                &mut create_time,
+                &mut exit_time,
+                &mut kernel_time,
+                &mut user_time,
+            )
+        };
+        if ret == 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        let kernel_time = filetime_to_ns100(kernel_time);
+        let user_time = filetime_to_ns100(user_time);
+        Ok((kernel_time, user_time))
+    }
+
+    #[inline]
+    pub fn cpu_time() -> io::Result<Duration> {
+        let (kernel_time, user_time) = unsafe {
+            let process = GetCurrentProcess();
+            let mut create_time = mem::zeroed();
+            let mut exit_time = mem::zeroed();
+            let mut kernel_time = mem::zeroed();
+            let mut user_time = mem::zeroed();
+
+            let ret = GetProcessTimes(
+                process,
+                &mut create_time,
+                &mut exit_time,
+                &mut kernel_time,
+                &mut user_time,
+            );
+
+            if ret != 0 {
+                (kernel_time, user_time)
+            } else {
+                return Err(io::Error::last_os_error());
+            }
+        };
+
+        let kt = filetime_to_ns100(kernel_time);
+        let ut = filetime_to_ns100(user_time);
+
+        // convert ns
+        //
+        // Note: make it ns unit may overflow in some cases.
+        // For example, a machine with 128 cores runs for one year.
+        let cpu = (kt + ut) * 100;
+
+        // make it un-normalized
+        let cpu = cpu * processor_numbers()? as u64;
+
+        Ok(Duration::from_nanos(cpu))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // this test should be executed alone.
+    #[test]
+    fn test_process_usage() {
+        let mut stat = ProcessStat::cur_proc_stat().unwrap();
+
+        std::thread::sleep(std::time::Duration::from_secs(1));
+
+        let usage = stat.cpu_usage().unwrap();
+
+        assert!(usage < 0.01);
+
+        let num = 1;
+        for _ in 0..num * 10 {
+            std::thread::spawn(move || {
+                loop {
+                    let _ = (0..10_000_000).into_iter().sum::<u128>();
+                }
+            });
+        }
+
+        std::thread::sleep(std::time::Duration::from_secs(1));
+
+        let usage = stat.cpu_usage().unwrap();
+
+        assert!(usage > 0.9_f64)
     }
 }

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -52,8 +52,17 @@
 # foreground-write-bandwidth = "0B"
 ## Read bandwidth limitation for this TiKV instance, default value is 0 which means unlimited.
 # foreground-read-bandwidth = "0B"
-## Limitation of max delay duration for each request, default value is 0 which means unlimited.
+## CPU quota for these background requests can use, default value is 0, it means unlimited.
+## The unit is millicpu but for now this config is approximate and soft limit.
+# background-cpu-time = 0
+## Write bandwidth limitation for backgroud request for this TiKV instance, default value is 0 which means unlimited.
+# background-write-bandwidth = "0B"
+## Read bandwidth limitation for background request for this TiKV instance, default value is 0 which means unlimited.
+# background-read-bandwidth = "0B"
+## Limitation of max delay duration, default value is 0 which means unlimited.
 # max-delay-duration = "500ms"
+## Whether to enable quota auto tune
+# enable-auto-tune = false
 
 [log]
 ## Log levels: debug, info, warn, error, fatal.

--- a/src/config.rs
+++ b/src/config.rs
@@ -4621,7 +4621,7 @@ mod tests {
         cfg.quota.foreground_write_bandwidth = ReadableSize::mb(256);
         assert_eq!(cfg_controller.get_current(), cfg);
 
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(true);
         sample.add_read_bytes(ReadableSize::mb(32).0 as usize);
         let should_delay = block_on(quota_limiter.consume_sample(sample, true));
         assert_eq!(should_delay, Duration::from_millis(125));
@@ -4631,7 +4631,7 @@ mod tests {
             .unwrap();
         cfg.quota.foreground_read_bandwidth = ReadableSize::mb(512);
         assert_eq!(cfg_controller.get_current(), cfg);
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(true);
         sample.add_write_bytes(ReadableSize::mb(128).0 as usize);
         let should_delay = block_on(quota_limiter.consume_sample(sample, true));
         assert_eq!(should_delay, Duration::from_millis(500));
@@ -4648,7 +4648,7 @@ mod tests {
         cfg.quota.background_write_bandwidth = ReadableSize::mb(256);
         assert_eq!(cfg_controller.get_current(), cfg);
 
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(false);
         sample.add_read_bytes(ReadableSize::mb(32).0 as usize);
         let should_delay = block_on(quota_limiter.consume_sample(sample, false));
         assert_eq!(should_delay, Duration::from_millis(125));
@@ -4658,7 +4658,7 @@ mod tests {
             .unwrap();
         cfg.quota.background_read_bandwidth = ReadableSize::mb(512);
         assert_eq!(cfg_controller.get_current(), cfg);
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(false);
         sample.add_write_bytes(ReadableSize::mb(128).0 as usize);
         let should_delay = block_on(quota_limiter.consume_sample(sample, false));
         assert_eq!(should_delay, Duration::from_millis(500));
@@ -4668,12 +4668,12 @@ mod tests {
             .unwrap();
         cfg.quota.max_delay_duration = ReadableDuration::millis(50);
         assert_eq!(cfg_controller.get_current(), cfg);
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(true);
         sample.add_write_bytes(ReadableSize::mb(128).0 as usize);
         let should_delay = block_on(quota_limiter.consume_sample(sample, true));
         assert_eq!(should_delay, Duration::from_millis(50));
 
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(false);
         sample.add_write_bytes(ReadableSize::mb(128).0 as usize);
         let should_delay = block_on(quota_limiter.consume_sample(sample, false));
         assert_eq!(should_delay, Duration::from_millis(50));

--- a/src/config.rs
+++ b/src/config.rs
@@ -2613,6 +2613,10 @@ pub struct QuotaConfig {
     pub foreground_write_bandwidth: ReadableSize,
     pub foreground_read_bandwidth: ReadableSize,
     pub max_delay_duration: ReadableDuration,
+    pub background_cpu_time: usize,
+    pub background_write_bandwidth: ReadableSize,
+    pub background_read_bandwidth: ReadableSize,
+    pub enable_auto_tune: bool,
 }
 
 impl Default for QuotaConfig {
@@ -2622,6 +2626,10 @@ impl Default for QuotaConfig {
             foreground_write_bandwidth: ReadableSize(0),
             foreground_read_bandwidth: ReadableSize(0),
             max_delay_duration: ReadableDuration::millis(500),
+            background_cpu_time: 0,
+            background_write_bandwidth: ReadableSize(0),
+            background_read_bandwidth: ReadableSize(0),
+            enable_auto_tune: false,
         }
     }
 }
@@ -4569,6 +4577,9 @@ mod tests {
         cfg.quota.foreground_cpu_time = 1000;
         cfg.quota.foreground_write_bandwidth = ReadableSize::mb(128);
         cfg.quota.foreground_read_bandwidth = ReadableSize::mb(256);
+        cfg.quota.background_cpu_time = 1000;
+        cfg.quota.background_write_bandwidth = ReadableSize::mb(128);
+        cfg.quota.background_read_bandwidth = ReadableSize::mb(256);
         cfg.quota.max_delay_duration = ReadableDuration::secs(1);
         cfg.validate().unwrap();
 
@@ -4576,7 +4587,11 @@ mod tests {
             cfg.quota.foreground_cpu_time,
             cfg.quota.foreground_write_bandwidth,
             cfg.quota.foreground_read_bandwidth,
+            cfg.quota.background_cpu_time,
+            cfg.quota.background_write_bandwidth,
+            cfg.quota.background_read_bandwidth,
             cfg.quota.max_delay_duration,
+            false,
         ));
 
         let cfg_controller = ConfigController::new(cfg.clone());
@@ -4608,7 +4623,7 @@ mod tests {
 
         let mut sample = quota_limiter.new_sample();
         sample.add_read_bytes(ReadableSize::mb(32).0 as usize);
-        let should_delay = block_on(quota_limiter.async_consume(sample));
+        let should_delay = block_on(quota_limiter.consume_sample(sample, true));
         assert_eq!(should_delay, Duration::from_millis(125));
 
         cfg_controller
@@ -4618,8 +4633,35 @@ mod tests {
         assert_eq!(cfg_controller.get_current(), cfg);
         let mut sample = quota_limiter.new_sample();
         sample.add_write_bytes(ReadableSize::mb(128).0 as usize);
-        let should_delay = block_on(quota_limiter.async_consume(sample));
-        assert_eq!(should_delay, Duration::from_millis(250));
+        let should_delay = block_on(quota_limiter.consume_sample(sample, true));
+        assert_eq!(should_delay, Duration::from_millis(500));
+
+        cfg_controller
+            .update_config("quota.background-cpu-time", "2000")
+            .unwrap();
+        cfg.quota.background_cpu_time = 2000;
+        assert_eq!(cfg_controller.get_current(), cfg);
+
+        cfg_controller
+            .update_config("quota.background-write-bandwidth", "256MB")
+            .unwrap();
+        cfg.quota.background_write_bandwidth = ReadableSize::mb(256);
+        assert_eq!(cfg_controller.get_current(), cfg);
+
+        let mut sample = quota_limiter.new_sample();
+        sample.add_read_bytes(ReadableSize::mb(32).0 as usize);
+        let should_delay = block_on(quota_limiter.consume_sample(sample, false));
+        assert_eq!(should_delay, Duration::from_millis(125));
+
+        cfg_controller
+            .update_config("quota.background-read-bandwidth", "512MB")
+            .unwrap();
+        cfg.quota.background_read_bandwidth = ReadableSize::mb(512);
+        assert_eq!(cfg_controller.get_current(), cfg);
+        let mut sample = quota_limiter.new_sample();
+        sample.add_write_bytes(ReadableSize::mb(128).0 as usize);
+        let should_delay = block_on(quota_limiter.consume_sample(sample, false));
+        assert_eq!(should_delay, Duration::from_millis(500));
 
         cfg_controller
             .update_config("quota.max-delay-duration", "50ms")
@@ -4628,8 +4670,20 @@ mod tests {
         assert_eq!(cfg_controller.get_current(), cfg);
         let mut sample = quota_limiter.new_sample();
         sample.add_write_bytes(ReadableSize::mb(128).0 as usize);
-        let should_delay = block_on(quota_limiter.async_consume(sample));
+        let should_delay = block_on(quota_limiter.consume_sample(sample, true));
         assert_eq!(should_delay, Duration::from_millis(50));
+
+        let mut sample = quota_limiter.new_sample();
+        sample.add_write_bytes(ReadableSize::mb(128).0 as usize);
+        let should_delay = block_on(quota_limiter.consume_sample(sample, false));
+        assert_eq!(should_delay, Duration::from_millis(50));
+
+        assert_eq!(cfg.quota.enable_auto_tune, false);
+        cfg_controller
+            .update_config("quota.enable-auto-tune", "true")
+            .unwrap();
+        cfg.quota.enable_auto_tune = true;
+        assert_eq!(cfg_controller.get_current(), cfg);
     }
 
     #[test]

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -262,6 +262,7 @@ impl<E: Engine> Endpoint<E> {
                 );
 
                 self.check_memory_locks(&req_ctx)?;
+
                 let quota_limiter = self.quota_limiter.clone();
 
                 builder = Box::new(move |snap, req_ctx| {

--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -54,6 +54,8 @@ pub const REQ_TYPE_DAG: i64 = 103;
 pub const REQ_TYPE_ANALYZE: i64 = 104;
 pub const REQ_TYPE_CHECKSUM: i64 = 105;
 
+pub const REQ_FLAG_TIDB_SYSSESSION: u64 = 2048;
+
 type HandlerStreamStepResult = Result<(Option<coppb::Response>, bool)>;
 
 /// An interface for all kind of Coprocessor request handlers.

--- a/src/server/service/diagnostics/sys.rs
+++ b/src/server/service/diagnostics/sys.rs
@@ -5,13 +5,13 @@ use std::{collections::HashMap, string::ToString};
 use kvproto::diagnosticspb::{ServerInfoItem, ServerInfoPair};
 use tikv_util::{
     config::KIB,
-    sys::{cpu_time::LiunxStyleCpuTime, SysQuota, *},
+    sys::{cpu_time::LinuxStyleCpuTime, SysQuota, *},
 };
 use walkdir::WalkDir;
 
 use crate::server::service::diagnostics::{ioload, SYS_INFO};
 
-type CpuTimeSnapshot = Option<LiunxStyleCpuTime>;
+type CpuTimeSnapshot = Option<LinuxStyleCpuTime>;
 
 #[derive(Clone, Debug)]
 pub struct NicSnapshot {
@@ -87,7 +87,7 @@ fn cpu_load_info(prev_cpu: CpuTimeSnapshot, collector: &mut Vec<ServerInfoItem>)
         return;
     }
 
-    let t2 = LiunxStyleCpuTime::current();
+    let t2 = LinuxStyleCpuTime::current();
     if t2.is_err() {
         return;
     }
@@ -265,7 +265,7 @@ fn io_load_info(prev_io: HashMap<String, ioload::IoLoad>, collector: &mut Vec<Se
 }
 
 pub fn cpu_time_snapshot() -> CpuTimeSnapshot {
-    let t1 = LiunxStyleCpuTime::current();
+    let t1 = LinuxStyleCpuTime::current();
     if t1.is_err() {
         return None;
     }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -559,7 +559,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         let api_version = self.api_version;
 
         let quota_limiter = self.quota_limiter.clone();
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(true);
 
         let res = self.read_pool.spawn_handle(
             async move {
@@ -885,7 +885,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         let concurrency_manager = self.concurrency_manager.clone();
         let api_version = self.api_version;
         let quota_limiter = self.quota_limiter.clone();
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(true);
         let res = self.read_pool.spawn_handle(
             async move {
                 let stage_scheduled_ts = Instant::now_coarse();

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -649,7 +649,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                             .as_ref()
                             .map_or(0, |v| v.len());
                     sample.add_read_bytes(read_bytes);
-                    let quota_delay = quota_limiter.async_consume(sample).await;
+                    let quota_delay = quota_limiter.consume_sample(sample, true).await;
                     if !quota_delay.is_zero() {
                         TXN_COMMAND_THROTTLE_TIME_COUNTER_VEC_STATIC
                             .get(CMD)
@@ -992,7 +992,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                         + stats.cf_statistics(CF_LOCK).flow_stats.read_bytes
                         + stats.cf_statistics(CF_WRITE).flow_stats.read_bytes;
                     sample.add_read_bytes(read_bytes);
-                    let quota_delay = quota_limiter.async_consume(sample).await;
+                    let quota_delay = quota_limiter.consume_sample(sample, true).await;
                     if !quota_delay.is_zero() {
                         TXN_COMMAND_THROTTLE_TIME_COUNTER_VEC_STATIC
                             .get(CMD)

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -814,7 +814,7 @@ impl<E: Engine, L: LockManager> Scheduler<E, L> {
         let ts = task.cmd.ts();
         let scheduler = self.clone();
         let quota_limiter = self.inner.quota_limiter.clone();
-        let mut sample = quota_limiter.new_sample();
+        let mut sample = quota_limiter.new_sample(true);
         let pessimistic_lock_mode = self.pessimistic_lock_mode();
         let pipelined =
             task.cmd.can_be_pipelined() && pessimistic_lock_mode == PessimisticLockMode::Pipelined;

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -844,7 +844,7 @@ impl<E: Engine, L: LockManager> Scheduler<E, L> {
             + statistics.cf_statistics(CF_LOCK).flow_stats.read_bytes
             + statistics.cf_statistics(CF_WRITE).flow_stats.read_bytes;
         sample.add_read_bytes(read_bytes);
-        let quota_delay = quota_limiter.async_consume(sample).await;
+        let quota_delay = quota_limiter.consume_sample(sample, true).await;
         if !quota_delay.is_zero() {
             TXN_COMMAND_THROTTLE_TIME_COUNTER_VEC_STATIC
                 .get(tag)


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #13084

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```
The new parameters are quota.background-cpu-time, quota.background-write-bandwidth and
quota.background-read-bandwidth.

At present, only background-cpu-time can take effect on auto analyze job.  The cpu quota for
auto analyze can adjust according to the TiKV instance workload if quota.enable-auto-tune is
set to true.  A system thread will check the instance status, and could adjust the cpu quota periodically. 
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [X] Manual test (add detailed scripts or steps below)
Verify logic by debug

Side effects

- auto analyze might become slower.

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
