### PR TITLE
log-backup: use conservativer batch strategy

### DIFF
--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -59,10 +59,12 @@ const MAX_INFLIGHT_RAFT_MSGS: usize = 64;
 /// .  + the value field
 /// .  + the CF field (None for CF_DEFAULT)
 /// - 2 bytes for the embedded message field `PutRequest` (Tag+Length).
+/// - 2 bytes for the request itself (which would be embedded into a
+///   [`RaftCmdRequest`].)
 /// In fact, the length field is encoded by varint, which may grow when the
 /// content length is greater than 128, however when the length is greater than
 /// 128, the extra 1~4 bytes can be ignored.
-const WIRE_EXTRA_BYTES: usize = 10;
+const WIRE_EXTRA_BYTES: usize = 12;
 
 fn transfer_error(err: storage::Error) -> ImportPbError {
     let mut e = ImportPbError::default();
@@ -106,6 +108,7 @@ pub struct ImportSstService<E: Engine> {
 
 struct RequestCollector {
     max_raft_req_size: usize,
+
     /// Retain the last ts of each key in each request.
     /// This is used for write CF because resolved ts observer hates duplicated
     /// key in the same request.
@@ -168,10 +171,26 @@ impl RequestCollector {
         self.accept(cf, m);
     }
 
+    /// check whether the unpacked size would exceed the max_raft_req_size after
+    /// accepting the modify.
+    fn should_send_batch_before_adding(&self, m: &Modify) -> bool {
+        let message_size = m.size() + WIRE_EXTRA_BYTES;
+        // If there isn't any records in the collector, and there is a huge modify, we
+        // should give it a change to enter the collector. Or we may fall into an
+        // eternal loop.
+        let batched = self.unpacked_size != 0;
+        let exceeds_max_size = message_size + self.unpacked_size > self.max_raft_req_size;
+        batched && exceeds_max_size
+    }
+
     // we need to remove duplicate keys in here, since
     // in https://github.com/tikv/tikv/blob/a401f78bc86f7e6ea6a55ad9f453ae31be835b55/components/resolved_ts/src/cmd.rs#L204
     // will panic if found duplicated entry during Vec<PutRequest>.
     fn accept(&mut self, cf: &str, m: Modify) {
+        if self.should_send_batch_before_adding(&m) {
+            self.pack_all();
+        }
+
         let k = m.key();
         match cf {
             CF_WRITE => {
@@ -208,10 +227,6 @@ impl RequestCollector {
                 }
             }
             _ => unreachable!(),
-        }
-
-        if self.unpacked_size >= self.max_raft_req_size {
-            self.pack_all();
         }
     }
 
@@ -481,7 +496,7 @@ impl<E: Engine> ImportSstService<E> {
     ) -> std::result::Result<Option<Range>, ImportPbError> {
         let mut range: Option<Range> = None;
 
-        let mut collector = RequestCollector::new(max_raft_size * 7 / 8);
+        let mut collector = RequestCollector::new(max_raft_size / 2);
         let context = req.take_context();
         let mut metas = req.take_metas();
         let mut rules = req.take_rewrite_rules();
@@ -1151,12 +1166,16 @@ mod test {
     use std::collections::HashMap;
 
     use engine_traits::{CF_DEFAULT, CF_WRITE};
-    use kvproto::raft_cmdpb::Request;
+    use kvproto::{
+        kvrpcpb::Context,
+        metapb::RegionEpoch,
+        raft_cmdpb::{RaftCmdRequest, Request},
+    };
     use protobuf::Message;
-    use tikv_kv::Modify;
-    use txn_types::{Key, TimeStamp, Write, WriteType};
+    use tikv_kv::{Modify, WriteData};
+    use txn_types::{Key, TimeStamp, Write, WriteBatchFlags, WriteType};
 
-    use crate::import::sst_service::RequestCollector;
+    use crate::{import::sst_service::RequestCollector, server::raftkv};
 
     fn write(key: &[u8], ty: WriteType, commit_ts: u64, start_ts: u64) -> (Vec<u8>, Vec<u8>) {
         let k = Key::from_raw(key).append_ts(TimeStamp::new(commit_ts));
@@ -1337,22 +1356,98 @@ mod test {
         assert!(request_collector.is_empty());
     }
 
+    fn convert_write_batch_to_request_raftkv1(ctx: &Context, batch: WriteData) -> RaftCmdRequest {
+        let reqs: Vec<Request> = batch.modifies.into_iter().map(Into::into).collect();
+        let txn_extra = batch.extra;
+        let mut header = raftkv::new_request_header(ctx);
+        if batch.avoid_batch {
+            header.set_uuid(uuid::Uuid::new_v4().as_bytes().to_vec());
+        }
+        let mut flags = 0;
+        if txn_extra.one_pc {
+            flags |= WriteBatchFlags::ONE_PC.bits();
+        }
+        if txn_extra.allowed_in_flashback {
+            flags |= WriteBatchFlags::FLASHBACK.bits();
+        }
+        header.set_flags(flags);
+
+        let mut cmd = RaftCmdRequest::default();
+        cmd.set_header(header);
+        cmd.set_requests(reqs.into());
+        cmd
+    }
+
+    fn fake_ctx() -> Context {
+        let mut fake_ctx = Context::new();
+        fake_ctx.set_region_id(42);
+        fake_ctx.set_region_epoch({
+            let mut e = RegionEpoch::new();
+            e.set_version(1024);
+            e.set_conf_ver(56);
+            e
+        });
+        fake_ctx
+    }
+
     #[test]
     fn test_collector_size() {
         let mut request_collector = RequestCollector::new(1024);
 
-        for i in 0..100u64 {
-            request_collector.accept(CF_DEFAULT, default_req(&i.to_ne_bytes(), b"egg", i));
+        for i in 0..100u8 {
+            request_collector.accept(CF_DEFAULT, default_req(&i.to_ne_bytes(), b"egg", i as _));
         }
 
         let pws = request_collector.pending_writes;
         for w in pws {
-            let req_size = w
-                .modifies
-                .into_iter()
-                .map(Request::from)
-                .map(|x| x.compute_size())
-                .sum::<u32>();
+            let req_size = convert_write_batch_to_request_raftkv1(&fake_ctx(), w).compute_size();
+            assert!(req_size < 1024, "{}", req_size);
+        }
+    }
+
+    #[test]
+    fn test_collector_huge_write_liveness() {
+        let mut request_collector = RequestCollector::new(1024);
+        for i in 0..100u8 {
+            if i % 10 == 2 {
+                // Inject some huge requests.
+                request_collector.accept(
+                    CF_DEFAULT,
+                    default_req(&i.to_ne_bytes(), &[42u8; 1025], i as _),
+                );
+            } else {
+                request_collector.accept(CF_DEFAULT, default_req(&i.to_ne_bytes(), b"egg", i as _));
+            }
+        }
+        let pws = request_collector.pending_writes;
+        for w in pws {
+            let req_size = convert_write_batch_to_request_raftkv1(&fake_ctx(), w).compute_size();
+            assert!(req_size < 2048, "{}", req_size);
+        }
+    }
+
+    #[test]
+    fn test_collector_mid_size_write_no_exceed_max() {
+        let mut request_collector = RequestCollector::new(1024);
+        for i in 0..100u8 {
+            if i % 10 == 2 {
+                let huge_req = default_req(&i.to_ne_bytes(), &[42u8; 960], i as _);
+                // Inject some huge requests.
+                request_collector.accept(CF_DEFAULT, huge_req);
+            } else {
+                request_collector.accept(
+                    CF_DEFAULT,
+                    default_req(
+                        &i.to_ne_bytes(),
+                        b"noodles with beef, egg, bacon and spinach; in chicken soup",
+                        i as _,
+                    ),
+                );
+            }
+        }
+        let pws = request_collector.pending_writes;
+        for w in pws {
+            let req_size = convert_write_batch_to_request_raftkv1(&fake_ctx(), w).compute_size();
             assert!(req_size < 1024, "{}", req_size);
         }
     }

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -61,7 +61,7 @@ use crate::{
 /// this value?
 const REQUEST_WRITE_CONCURRENCY: usize = 16;
 /// The extra bytes required by the wire encoding.
-/// Generally, a field (and a embedded message) would introduce 2 extra
+/// Generally, a field (and a embedded message) would introduce some extra
 /// bytes. In detail, they are:
 /// - 2 bytes for the request type (Tag+Value).
 /// - 2 bytes for every string or bytes field (Tag+Length), they are:
@@ -188,11 +188,10 @@ impl RequestCollector {
     fn should_send_batch_before_adding(&self, m: &Modify) -> bool {
         let message_size = m.size() + WIRE_EXTRA_BYTES;
         // If there isn't any records in the collector, and there is a huge modify, we
-        // should give it a change to enter the collector. Or we may fall into an
-        // eternal loop.
-        let batched = self.unpacked_size != 0;
-        let exceeds_max_size = message_size + self.unpacked_size > self.max_raft_req_size;
-        batched && exceeds_max_size
+        // should give it a change to enter the collector. Or we may generate empty
+        // batch.
+        self.unpacked_size != 0 /* batched */
+        && message_size + self.unpacked_size > self.max_raft_req_size /* exceed the max_raft_req_size */
     }
 
     // we need to remove duplicate keys in here, since


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #14313

What's Changed:
This PR make the default max batch size 1/2 of the max raft command size. (IMO 4 MiB would be a fair choice for batching, even we batch up to 7MiB, perhaps the throughput won't be greatly increased.)

This PR also make the `Collector` try its best to don't make batch greater than `max_raft_cmd_size`. In the past, it fire the batch after noticing the current `unpacked_size` is greater than the max batch size, which make the real batch size will be slightly greater than the real size. After this, it will check the total size BEFORE it add the request.

```commit-message
```


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fixed a bug that may cause PITR fail when there are too many tiny or huge rows. 
```
