### PR TITLE
txn: return duration_to_last_update when lock wait timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2715,7 +2715,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#af969693ce8a7884e5bdc5d81c728f657d33065a"
+source = "git+https://github.com/ekexium/kvproto?branch=locked-duration#2647c215acdb9ce9cda44b69c3e5757b06c93727"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -220,8 +220,8 @@ procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "6599eb9dca74229
 # When you modify TiKV cooperatively with kvproto, this will be useful to submit the PR to TiKV and the PR to
 # kvproto at the same time.
 # After the PR to kvproto is merged, remember to comment this out and run `cargo update -p kvproto`.
-# [patch.'https://github.com/pingcap/kvproto']
-# kvproto = { git = "https://github.com/your_github_id/kvproto", branch = "your_branch" }
+ [patch.'https://github.com/pingcap/kvproto']
+ kvproto = { git = "https://github.com/ekexium/kvproto", branch = "locked-duration" }
 
 [workspace]
 # See https://github.com/rust-lang/rfcs/blob/master/text/2957-cargo-features2.md

--- a/src/server/lock_manager/waiter_manager.rs
+++ b/src/server/lock_manager/waiter_manager.rs
@@ -203,6 +203,7 @@ pub(crate) struct Waiter {
     pub diag_ctx: DiagnosticContext,
     delay: Delay,
     start_waiting_time: Instant,
+    last_updated_time: Option<Instant>,
 }
 
 impl Waiter {
@@ -224,6 +225,7 @@ impl Waiter {
             delay: Delay::new(deadline),
             diag_ctx,
             start_waiting_time,
+            last_updated_time: None,
         }
     }
 
@@ -264,8 +266,13 @@ impl Waiter {
         self.cancel(None)
     }
 
-    fn cancel_for_timeout(self, _skip_resolving_lock: bool) -> KeyLockWaitInfo {
-        let lock_info = self.wait_info.lock_info.clone();
+    fn cancel_for_timeout(self) -> KeyLockWaitInfo {
+        let mut lock_info = self.wait_info.lock_info.clone();
+        lock_info.set_duration_to_last_update_ms(
+            self.last_updated_time
+                .map(|t| t.elapsed().as_millis() as u64)
+                .unwrap_or_default(),
+        );
         // lock_info.set_skip_resolving_lock(skip_resolving_lock);
         let error = MvccError::from(MvccErrorInner::KeyIsLocked(lock_info));
         self.cancel(Some(StorageError::from(TxnError::from(error))))
@@ -343,8 +350,10 @@ impl WaitTable {
     fn update_waiter(
         &mut self,
         update_event: &UpdateWaitForEvent,
+        now: Instant,
     ) -> Option<(KeyLockWaitInfo, DiagnosticContext)> {
         let waiter = self.waiter_pool.get_mut(&update_event.token)?;
+        waiter.last_updated_time = Some(now);
 
         assert_eq!(waiter.wait_info.key, update_event.wait_info.key);
 
@@ -511,7 +520,7 @@ impl WaiterManager {
             let mut wait_table = wait_table.borrow_mut();
             if let Some(waiter) = wait_table.take_waiter(token) {
                 let start_ts = waiter.start_ts;
-                let wait_info = waiter.cancel_for_timeout(false);
+                let wait_info = waiter.cancel_for_timeout();
                 detector_scheduler.clean_up_wait_for(start_ts, wait_info);
             }
         });
@@ -537,8 +546,9 @@ impl WaiterManager {
 
     fn handle_update_wait_for(&mut self, events: Vec<UpdateWaitForEvent>) {
         let mut wait_table = self.wait_table.borrow_mut();
+        let now = Instant::now();
         for event in events {
-            let previous_wait_info = wait_table.update_waiter(&event);
+            let previous_wait_info = wait_table.update_waiter(&event, now);
 
             if event.is_first_lock {
                 continue;
@@ -673,6 +683,7 @@ pub mod tests {
             diag_ctx: DiagnosticContext::default(),
             delay: Delay::new(Instant::now()),
             start_waiting_time: Instant::now(),
+            last_updated_time: None,
         }
     }
 
@@ -869,7 +880,7 @@ pub mod tests {
     #[test]
     fn test_waiter_notify() {
         let (waiter, lock_info, f) = new_test_waiter(10.into(), 20.into(), 20);
-        waiter.cancel_for_timeout(false);
+        waiter.cancel_for_timeout();
         expect_key_is_locked(block_on(f).unwrap(), lock_info);
 
         // Deadlock
@@ -902,7 +913,7 @@ pub mod tests {
         waiter.reset_timeout(Instant::now() + Duration::from_millis(100));
         let (tx, rx) = mpsc::sync_channel(1);
         let f = waiter.on_timeout(move || tx.send(1).unwrap());
-        waiter.cancel_for_timeout(false);
+        waiter.cancel_for_timeout();
         assert_elapsed(|| block_on(f), 0, 200);
         rx.try_recv().unwrap_err();
     }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #14497 

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
When a timeout occurs during waiting for a lock, provide the duration of time that has passed since the last update of the lock wait. 
Let the client decide whether it is necessary to resolve locks based on this info.
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
```
