### PR TITLE
storage: implement the row value checksum encode logic in tikv side

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6320,6 +6320,7 @@ dependencies = [
  "chrono-tz",
  "codec",
  "collections",
+ "crc32fast",
  "encoding_rs 0.8.29 (git+https://github.com/xiongjiwei/encoding_rs.git?rev=68e0bc5a72a37a78228d80cd98047326559cf43c)",
  "error_code",
  "hex 0.4.2",

--- a/components/tidb_query_datatype/Cargo.toml
+++ b/components/tidb_query_datatype/Cargo.toml
@@ -16,6 +16,7 @@ chrono = "0.4"
 chrono-tz = "0.5.1"
 codec = { workspace = true }
 collections = { workspace = true }
+crc32fast = "1.2"
 encoding_rs = { git = "https://github.com/xiongjiwei/encoding_rs.git", rev = "68e0bc5a72a37a78228d80cd98047326559cf43c" }
 error_code = { workspace = true }
 hex = "0.4"

--- a/components/tidb_query_datatype/src/codec/row/v2/encoder_for_test.rs
+++ b/components/tidb_query_datatype/src/codec/row/v2/encoder_for_test.rs
@@ -91,20 +91,11 @@ impl Column {
 }
 
 /// Checksum
-///
-/// 	0               1               2               3               4
-/// 5               6               7               8
-/// 	+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-/// 	|       |E| VER |                            CHECKSUM
-/// |                    EXTRA_CHECKSUM(OPTIONAL)                   |
-/// 	+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-/// 	     HEADER
-///
-/// 	- HEADER
-/// 	  - VER: version(3 bit)
-/// 	  - E:   has extra checksum
-/// 	- CHECKSUM
-/// 	  - little-endian CRC32(IEEE) when hdr.ver = 0 (default)
+/// - HEADER(1 byte)
+///   - VER: version(3 bit)
+///   - E:   has extra checksum
+/// - CHECKSUM(4 bytes)
+///   - little-endian CRC32(IEEE) when hdr.ver = 0 (default)
 pub trait CheckSumHandler {
     // update_col updates the checksum with the encoded value of the column.
     fn checksum(&mut self, buf: &[u8]) -> Result<()>;


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #14528 

What's Changed:
Implement the checksum row value encode logic on the tikv side, mainly used for test cases in tikv. 
In the previous design, there was no anticipation of introducing development work related to compatibility. However, testing coverage is still required, especially to verify if row values containing checksum parts can be processed by the decoder with lower versions.

Related to https://github.com/pingcap/tidb/pull/42859


### Related changes



### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects



### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
