### PR TITLE
tikv_util: cgroup path parsing fix

### DIFF
--- a/components/tikv_util/src/sys/cgroup.rs
+++ b/components/tikv_util/src/sys/cgroup.rs
@@ -189,9 +189,11 @@ fn parse_proc_cgroup_v1(lines: &str) -> HashMap<String, String> {
         let mut iter = line.split(':');
         if let Some(_id) = iter.next() {
             if let Some(systems) = iter.next() {
-                if let Some(path) = iter.next() {
+                // If the path itself contains ":", we need to concat them
+                let path = iter.collect::<Vec<_>>().join(":");
+                if !path.is_empty() {
                     for system in systems.split(',') {
-                        subsystems.insert(system.to_owned(), path.to_owned());
+                        subsystems.insert(system.to_owned(), path.clone());
                     }
                     continue;
                 }
@@ -696,5 +698,20 @@ mod tests {
             .spawn()
             .unwrap();
         assert!(child.wait().unwrap().success());
+    }
+
+    #[test]
+    fn test_cgroup_path_with_semicolon() {
+        let id = "1";
+        let devices = "test_device";
+        let path = "/dir1:dir2:dir3";
+        let mut lines = String::new();
+        lines.push_str(id);
+        lines.push_str(":");
+        lines.push_str(devices);
+        lines.push_str(":");
+        lines.push_str(path);
+        let ret = parse_proc_cgroup_v1(&lines);
+        assert_eq!(ret.get(devices).unwrap(), path);
     }
 }

--- a/components/tikv_util/src/sys/cgroup.rs
+++ b/components/tikv_util/src/sys/cgroup.rs
@@ -183,6 +183,8 @@ fn is_cgroup2_unified_mode() -> Result<bool, String> {
 //
 // The format is "<id>:<hierarchy>:<path>". For example,
 // "10:cpuset:/test-cpuset".
+//
+// Note: path may contains ":" in some envrionment.
 fn parse_proc_cgroup_v1(lines: &str) -> HashMap<String, String> {
     let mut subsystems = HashMap::new();
     for line in lines.lines().map(|s| s.trim()).filter(|s| !s.is_empty()) {

--- a/components/tikv_util/src/sys/cgroup.rs
+++ b/components/tikv_util/src/sys/cgroup.rs
@@ -707,9 +707,9 @@ mod tests {
         let path = "/dir1:dir2:dir3";
         let mut lines = String::new();
         lines.push_str(id);
-        lines.push_str(":");
+        lines.push(':');
         lines.push_str(devices);
-        lines.push_str(":");
+        lines.push(':');
         lines.push_str(path);
         let ret = parse_proc_cgroup_v1(&lines);
         assert_eq!(ret.get(devices).unwrap(), path);


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #14538

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```
This PR considers that the cgroup path may contains ":" in it.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
