### PR TITLE
storage: use local read for stale read request on valid leader

### DIFF
--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -561,6 +561,13 @@ impl ReadDelegate {
 
     pub fn check_stale_read_safe(&self, read_ts: u64) -> std::result::Result<(), RaftCmdResponse> {
         let safe_ts = self.read_progress.safe_ts();
+        fail_point!("check_stale_read_safe_report_err", |_| {
+            Err(cmd_resp::new_error(Error::DataIsNotReady {
+                region_id: self.region.get_id(),
+                peer_id: self.peer_id,
+                safe_ts,
+            }))
+        });
         if safe_ts >= read_ts {
             return Ok(());
         }

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -111,9 +111,7 @@ impl<E: Engine> Endpoint<E> {
 
     fn check_memory_locks(&self, req_ctx: &ReqContext) -> Result<()> {
         let start_ts = req_ctx.txn_start_ts;
-        if !req_ctx.context.get_stale_read() {
-            self.concurrency_manager.update_max_ts(start_ts);
-        }
+        self.concurrency_manager.update_max_ts(start_ts);
         if need_check_locks(req_ctx.context.get_isolation_level()) {
             let begin_instant = Instant::now();
             for range in &req_ctx.ranges {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1175,9 +1175,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                 let access_locks = TsSet::from_u64s(ctx.take_committed_locks());
 
                 // Update max_ts and check the in-memory lock table before getting the snapshot
-                if !ctx.get_stale_read() {
-                    concurrency_manager.update_max_ts(start_ts);
-                }
+                concurrency_manager.update_max_ts(start_ts);
                 if need_check_locks(ctx.get_isolation_level()) {
                     let begin_instant = Instant::now();
                     concurrency_manager
@@ -2921,9 +2919,7 @@ fn prepare_snap_ctx<'a>(
     cmd: CommandKind,
 ) -> Result<SnapContext<'a>> {
     // Update max_ts and check the in-memory lock table before getting the snapshot
-    if !pb_ctx.get_stale_read() {
-        concurrency_manager.update_max_ts(start_ts);
-    }
+    concurrency_manager.update_max_ts(start_ts);
     fail_point!("before-storage-check-memory-locks");
     let isolation_level = pb_ctx.get_isolation_level();
     if need_check_locks(isolation_level) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #14553 

What's Changed:
Use the local reader if the stale read request is processed by a valid leader.

Currently, if ResolvedTS cannot be advanced in a timely manner, stale read requests will continue to fail.

Master:
```sql
mysql> SET @@tidb_read_staleness="-5";
Query OK, 0 rows affected (0.00 sec)

mysql> select * from t;
ERROR 1105 (HY000): region data not ready
```

All the 2 peers are retried:
```
[WARN] [region_request.go:1791] ["tikv reports `DataIsNotReady` retry later"] [store-id=1] [peer-id=43] [region-id=42]
[WARN] [region_request.go:1791] ["tikv reports `DataIsNotReady` retry later"] [store-id=12] [peer-id=44] [region-id=42]
```

This PR:
```sql
mysql> SET @@tidb_read_staleness="-5";
Query OK, 0 rows affected (0.00 sec)

mysql> select * from t;
+---+------+
| a | b    |
+---+------+
| 1 |   14 |
+---+------+
1 row in set (0.02 sec)
```



TODO: There will be more detailed test results in the future, which will be in conjunction with the changes made to client-go.

### Related changes


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
