### PR TITLE
txn: round up last_update_duration_ms

### DIFF
--- a/src/server/lock_manager/metrics.rs
+++ b/src/server/lock_manager/metrics.rs
@@ -52,13 +52,7 @@ lazy_static! {
     pub static ref WAITER_LIFETIME_HISTOGRAM: Histogram = register_histogram!(
         "tikv_lock_manager_waiter_lifetime_duration",
         "Duration of waiters' lifetime in seconds",
-        exponential_buckets(0.00001, 2.0, 26).unwrap() // 10us ~ 11min
-    )
-    .unwrap();
-    pub static ref WAITER_LAST_UPDATE_DURATION_HISTOGRAM: Histogram = register_histogram!(
-        "tikv_lock_manager_waiter_last_update_duration",
-        "Duration of waiters' last update in seconds",
-        exponential_buckets(0.001, 2.0, 20).unwrap() // 0.1ms ~ 17min
+        exponential_buckets(0.00001, 2.0, 26).unwrap() // 0.5ms ~ 524s
     )
     .unwrap();
     pub static ref DETECT_DURATION_HISTOGRAM: Histogram = register_histogram!(

--- a/src/server/lock_manager/metrics.rs
+++ b/src/server/lock_manager/metrics.rs
@@ -52,7 +52,13 @@ lazy_static! {
     pub static ref WAITER_LIFETIME_HISTOGRAM: Histogram = register_histogram!(
         "tikv_lock_manager_waiter_lifetime_duration",
         "Duration of waiters' lifetime in seconds",
-        exponential_buckets(0.00001, 2.0, 26).unwrap() // 0.5ms ~ 524s
+        exponential_buckets(0.00001, 2.0, 26).unwrap() // 10us ~ 11min
+    )
+    .unwrap();
+    pub static ref WAITER_LAST_UPDATE_DURATION_HISTOGRAM: Histogram = register_histogram!(
+        "tikv_lock_manager_waiter_last_update_duration",
+        "Duration of waiters' last update in seconds",
+        exponential_buckets(0.001, 2.0, 20).unwrap() // 0.1ms ~ 17min
     )
     .unwrap();
     pub static ref DETECT_DURATION_HISTOGRAM: Histogram = register_histogram!(

--- a/src/server/lock_manager/waiter_manager.rs
+++ b/src/server/lock_manager/waiter_manager.rs
@@ -268,12 +268,12 @@ impl Waiter {
 
     fn cancel_for_timeout(self) -> KeyLockWaitInfo {
         let mut lock_info = self.wait_info.lock_info.clone();
-        lock_info.set_duration_to_last_update_ms(
-            self.last_updated_time
-                .map(|t| t.elapsed().as_millis() as u64)
-                .unwrap_or_default(),
-        );
-        // lock_info.set_skip_resolving_lock(skip_resolving_lock);
+        let elapsed_ms = self
+            .last_updated_time
+            .map(|t| t.elapsed().as_millis() as u64)
+            .unwrap_or_default();
+        lock_info.set_duration_to_last_update_ms(elapsed_ms);
+        WAITER_LAST_UPDATE_DURATION_HISTOGRAM.observe(elapsed_ms as f64 / 1000.0);
         let error = MvccError::from(MvccErrorInner::KeyIsLocked(lock_info));
         self.cancel(Some(StorageError::from(TxnError::from(error))))
     }

--- a/src/server/lock_manager/waiter_manager.rs
+++ b/src/server/lock_manager/waiter_manager.rs
@@ -271,7 +271,7 @@ impl Waiter {
         lock_info.set_duration_to_last_update_ms(
             self.last_updated_time
                 // round up, so that duration in (0, 1ms] won't be treated as 0.
-                .map(|t| (t.elapsed().as_micros() as f64 / 1000.0).ceil() as u64)
+                .map(|t| (t.elapsed().as_millis() as u64).max(1))
                 .unwrap_or_default(),
         );
         let error = MvccError::from(MvccErrorInner::KeyIsLocked(lock_info));

--- a/src/server/lock_manager/waiter_manager.rs
+++ b/src/server/lock_manager/waiter_manager.rs
@@ -268,9 +268,10 @@ impl Waiter {
 
     fn cancel_for_timeout(self) -> KeyLockWaitInfo {
         let mut lock_info = self.wait_info.lock_info.clone();
+        // round up, so that duration < 1ms won't be treated as 0.
         let elapsed_ms = self
             .last_updated_time
-            .map(|t| t.elapsed().as_millis() as u64)
+            .map(|t| (t.elapsed().as_micros() as f64 / 1000.0).ceil() as u64)
             .unwrap_or_default();
         lock_info.set_duration_to_last_update_ms(elapsed_ms);
         WAITER_LAST_UPDATE_DURATION_HISTOGRAM.observe(elapsed_ms as f64 / 1000.0);


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #14497 

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Round up last_update_duration_ms, so that duration in (0, 1ms] won't be treated as 0.
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
