### PR TITLE
encryption: fix key collision handling

### DIFF
--- a/components/encryption/src/manager/mod.rs
+++ b/components/encryption/src/manager/mod.rs
@@ -342,16 +342,6 @@ impl Dicts {
         let duration = now.duration_since(UNIX_EPOCH).unwrap();
         let creation_time = duration.as_secs();
 
-        // let (key_id, key) = generate_data_key(method);
-        // let data_key = DataKey {
-        //     key,
-        //     method,
-        //     creation_time,
-        //     was_exposed: false,
-        //     ..Default::default()
-        // };
-        // self.rotate_key(key_id, data_key, master_key)
-
         // Generate new data key.
         let generate_limit = 10;
         for _ in 0..generate_limit {

--- a/components/encryption/src/manager/mod.rs
+++ b/components/encryption/src/manager/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::{
+    collections::hash_map::Entry,
     io::{Error as IoError, ErrorKind, Result as IoResult},
     path::{Path, PathBuf},
     sync::{
@@ -287,11 +288,15 @@ impl Dicts {
         Ok(Some(()))
     }
 
-    fn rotate_key(&self, key_id: u64, key: DataKey, master_key: &dyn Backend) -> Result<()> {
+    fn rotate_key(&self, key_id: u64, key: DataKey, master_key: &dyn Backend) -> Result<bool> {
         info!("encryption: rotate data key."; "key_id" => key_id);
         {
             let mut key_dict = self.key_dict.lock().unwrap();
-            key_dict.keys.insert(key_id, key);
+            match key_dict.keys.entry(key_id) {
+                // key id collides
+                Entry::Occupied(_) => return Ok(false),
+                Entry::Vacant(e) => e.insert(key),
+            };
             key_dict.current_key_id = key_id;
         };
 
@@ -299,7 +304,7 @@ impl Dicts {
         self.save_key_dict(master_key)?;
         // Update current data key id.
         self.current_key_id.store(key_id, Ordering::SeqCst);
-        Ok(())
+        Ok(true)
     }
 
     fn maybe_rotate_data_key(
@@ -337,15 +342,40 @@ impl Dicts {
         let duration = now.duration_since(UNIX_EPOCH).unwrap();
         let creation_time = duration.as_secs();
 
-        let (key_id, key) = generate_data_key(method);
-        let data_key = DataKey {
-            key,
-            method,
-            creation_time,
-            was_exposed: false,
-            ..Default::default()
-        };
-        self.rotate_key(key_id, data_key, master_key)
+        // let (key_id, key) = generate_data_key(method);
+        // let data_key = DataKey {
+        //     key,
+        //     method,
+        //     creation_time,
+        //     was_exposed: false,
+        //     ..Default::default()
+        // };
+        // self.rotate_key(key_id, data_key, master_key)
+
+        // Generate new data key.
+        let generate_limit = 10;
+        for _ in 0..generate_limit {
+            let (key_id, key) = generate_data_key(method);
+            if key_id == 0 {
+                // 0 is invalid
+                continue;
+            }
+            let data_key = DataKey {
+                key,
+                method,
+                creation_time,
+                was_exposed: false,
+                ..Default::default()
+            };
+
+            let ok = self.rotate_key(key_id, data_key, master_key)?;
+            if !ok {
+                // key id collides, retry
+                continue;
+            }
+            return Ok(());
+        }
+        Err(box_err!("key id collides {} times!", generate_limit))
     }
 }
 


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Close #14585

What's Changed:

The old key handling logic is mistakenly reverted in https://github.com/tikv/tikv/pull/8805, restoring them now.

```commit-message
Fix a bug that a newly generated encryption key might erase an old key and make data unreadable
```

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix a bug that a newly generated encryption key might erase an old key and make data unreadable
```
