### PR TITLE
fix engine type config on existing cluster

### DIFF
--- a/cmd/tikv-server/src/main.rs
+++ b/cmd/tikv-server/src/main.rs
@@ -210,6 +210,13 @@ fn main() {
         process::exit(0);
     }
 
+    // engine config needs to be validated
+    // so that it can adjust the engine type before too late
+    if let Err(e) = config.storage.validate_engine_type() {
+        println!("invalid storage.engine configuration: {}", e);
+        process::exit(1)
+    }
+
     match config.storage.engine {
         EngineType::RaftKv => server::server::run_tikv(config),
         EngineType::RaftKv2 => server::server2::run_tikv(config),

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -113,7 +113,11 @@ impl Default for Config {
 }
 
 impl Config {
-    fn validate_engine_type(&mut self) -> Result<(), Box<dyn Error>> {
+    pub fn validate_engine_type(&mut self) -> Result<(), Box<dyn Error>> {
+        if self.data_dir != DEFAULT_DATA_DIR {
+            self.data_dir = config::canonicalize_path(&self.data_dir)?
+        }
+
         let v1_kv_db_path =
             config::canonicalize_sub_path(&self.data_dir, DEFAULT_ROCKSDB_SUB_DIR).unwrap();
         let v2_tablet_path =
@@ -144,10 +148,6 @@ impl Config {
     }
 
     pub fn validate(&mut self) -> Result<(), Box<dyn Error>> {
-        if self.data_dir != DEFAULT_DATA_DIR {
-            self.data_dir = config::canonicalize_path(&self.data_dir)?
-        }
-
         self.validate_engine_type()?;
 
         if self.scheduler_concurrency > MAX_SCHED_CONCURRENCY {

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -9,7 +9,9 @@ use kvproto::kvrpcpb::LockInfo;
 use txn_types::{Key, Lock, PessimisticLock, TimeStamp, Value};
 
 use super::metrics::{GC_DELETE_VERSIONS_HISTOGRAM, MVCC_VERSIONS_HISTOGRAM};
-use crate::storage::{kv::Modify, mvcc::PessimisticLockNotFoundReason};
+use crate::storage::kv::Modify;
+#[cfg(feature = "failpoints")]
+use crate::storage::mvcc::PessimisticLockNotFoundReason;
 
 pub const MAX_TXN_WRITE_SIZE: usize = 32 * 1024;
 

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -10,8 +10,6 @@ use txn_types::{Key, Lock, PessimisticLock, TimeStamp, Value};
 
 use super::metrics::{GC_DELETE_VERSIONS_HISTOGRAM, MVCC_VERSIONS_HISTOGRAM};
 use crate::storage::kv::Modify;
-#[cfg(feature = "failpoints")]
-use crate::storage::mvcc::PessimisticLockNotFoundReason;
 
 pub const MAX_TXN_WRITE_SIZE: usize = 32 * 1024;
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #12842

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Adjust engine type config before running tikv server. Otherwise it will be too late. 
Fix some other compile warnings. 
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
