### PR TITLE
storage: add checksum logic in row slice, add cop and get test cases

### DIFF
--- a/components/test_coprocessor/src/fixture.rs
+++ b/components/test_coprocessor/src/fixture.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use concurrency_manager::ConcurrencyManager;
 use kvproto::kvrpcpb::Context;
 use resource_metering::ResourceTagFactory;
-use tidb_query_datatype::codec::Datum;
+use tidb_query_datatype::codec::{row::v2::CODEC_VERSION, Datum};
 use tikv::{
     config::CoprReadPoolConfig,
     coprocessor::{readpool_impl, Endpoint},
@@ -71,6 +71,27 @@ pub fn init_data_with_engine_and_commit<E: Engine>(
     init_data_with_details(ctx, engine, tbl, vals, commit, &Config::default())
 }
 
+pub fn init_data_with_engine_and_commit_v2_checksum<E: Engine>(
+    ctx: Context,
+    engine: E,
+    tbl: &ProductTable,
+    vals: &[(i64, Option<&str>, i64)],
+    commit: bool,
+    with_checksum: bool,
+    extra_checksum: Option<u32>,
+) -> (Store<E>, Endpoint<E>, Arc<QuotaLimiter>) {
+    init_data_with_details_v2_checksum(
+        ctx,
+        engine,
+        tbl,
+        vals,
+        commit,
+        &Config::default(),
+        with_checksum,
+        extra_checksum,
+    )
+}
+
 pub fn init_data_with_details<E: Engine>(
     ctx: Context,
     engine: E,
@@ -79,6 +100,43 @@ pub fn init_data_with_details<E: Engine>(
     commit: bool,
     cfg: &Config,
 ) -> (Store<E>, Endpoint<E>, Arc<QuotaLimiter>) {
+    init_data_with_details_impl(ctx, engine, tbl, vals, commit, cfg, 0, false, None)
+}
+
+pub fn init_data_with_details_v2_checksum<E: Engine>(
+    ctx: Context,
+    engine: E,
+    tbl: &ProductTable,
+    vals: &[(i64, Option<&str>, i64)],
+    commit: bool,
+    cfg: &Config,
+    with_checksum: bool,
+    extra_checksum: Option<u32>,
+) -> (Store<E>, Endpoint<E>, Arc<QuotaLimiter>) {
+    init_data_with_details_impl(
+        ctx,
+        engine,
+        tbl,
+        vals,
+        commit,
+        cfg,
+        CODEC_VERSION,
+        with_checksum,
+        extra_checksum,
+    )
+}
+
+fn init_data_with_details_impl<E: Engine>(
+    ctx: Context,
+    engine: E,
+    tbl: &ProductTable,
+    vals: &[(i64, Option<&str>, i64)],
+    commit: bool,
+    cfg: &Config,
+    codec_ver: u8,
+    with_checksum: bool,
+    extra_checksum: Option<u32>,
+) -> (Store<E>, Endpoint<E>, Arc<QuotaLimiter>) {
     let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(engine, MockLockManager::new())
         .build()
         .unwrap();
@@ -86,12 +144,20 @@ pub fn init_data_with_details<E: Engine>(
 
     store.begin();
     for &(id, name, count) in vals {
-        store
+        let mut inserts = store
             .insert_into(tbl)
             .set(&tbl["id"], Datum::I64(id))
             .set(&tbl["name"], name.map(str::as_bytes).into())
-            .set(&tbl["count"], Datum::I64(count))
-            .execute_with_ctx(ctx.clone());
+            .set(&tbl["count"], Datum::I64(count));
+        if codec_ver == CODEC_VERSION {
+            inserts = inserts
+                .set_v2(&tbl["id"], id.into())
+                .set_v2(&tbl["name"], name.unwrap().into())
+                .set_v2(&tbl["count"], count.into());
+            inserts.execute_with_v2_checksum(ctx.clone(), with_checksum, extra_checksum);
+        } else {
+            inserts.execute_with_ctx(ctx.clone());
+        }
     }
     if commit {
         store.commit_with_ctx(ctx);
@@ -139,4 +205,23 @@ pub fn init_with_data_ext(
     vals: &[(i64, Option<&str>, i64)],
 ) -> (Store<RocksEngine>, Endpoint<RocksEngine>, Arc<QuotaLimiter>) {
     init_data_with_commit(tbl, vals, true)
+}
+
+pub fn init_data_with_commit_v2_checksum(
+    tbl: &ProductTable,
+    vals: &[(i64, Option<&str>, i64)],
+    with_checksum: bool,
+    extra_checksum: Option<u32>,
+) -> (Store<RocksEngine>, Endpoint<RocksEngine>) {
+    let engine = TestEngineBuilder::new().build().unwrap();
+    let (store, endpoint, _) = init_data_with_engine_and_commit_v2_checksum(
+        Context::default(),
+        engine,
+        tbl,
+        vals,
+        true,
+        with_checksum,
+        extra_checksum,
+    );
+    (store, endpoint)
 }

--- a/components/test_coprocessor/src/store.rs
+++ b/components/test_coprocessor/src/store.rs
@@ -6,7 +6,12 @@ use collections::HashMap;
 use kvproto::kvrpcpb::{Context, IsolationLevel};
 use test_storage::SyncTestStorageApiV1;
 use tidb_query_datatype::{
-    codec::{datum, table, Datum},
+    codec::{
+        data_type::ScalarValue,
+        datum,
+        row::v2::encoder_for_test::{Column as ColumnV2, RowEncoder},
+        table, Datum,
+    },
     expr::EvalContext,
 };
 use tikv::{
@@ -26,6 +31,7 @@ pub struct Insert<'a, E: Engine> {
     store: &'a mut Store<E>,
     table: &'a Table,
     values: BTreeMap<i64, Datum>,
+    values_v2: BTreeMap<i64, ScalarValue>,
 }
 
 impl<'a, E: Engine> Insert<'a, E> {
@@ -34,6 +40,7 @@ impl<'a, E: Engine> Insert<'a, E> {
             store,
             table,
             values: BTreeMap::new(),
+            values_v2: BTreeMap::new(),
         }
     }
 
@@ -44,8 +51,24 @@ impl<'a, E: Engine> Insert<'a, E> {
         self
     }
 
+    pub fn set_v2(mut self, col: &Column, value: ScalarValue) -> Self {
+        assert!(self.table.column_by_id(col.id).is_some());
+        self.values_v2.insert(col.id, value);
+        self
+    }
+
     pub fn execute(self) -> i64 {
         self.execute_with_ctx(Context::default())
+    }
+
+    fn prepare_index_kv(&self, handle: &Datum, buf: &mut Vec<(Vec<u8>, Vec<u8>)>) {
+        for (&id, idxs) in &self.table.idxs {
+            let mut v: Vec<_> = idxs.iter().map(|id| self.values[id].clone()).collect();
+            v.push(handle.clone());
+            let encoded = datum::encode_key(&mut EvalContext::default(), &v).unwrap();
+            let idx_key = table::encode_index_seek_key(self.table.id, id, &encoded);
+            buf.push((idx_key, vec![0]));
+        }
     }
 
     pub fn execute_with_ctx(self, ctx: Context) -> i64 {
@@ -59,13 +82,44 @@ impl<'a, E: Engine> Insert<'a, E> {
         let values: Vec<_> = self.values.values().cloned().collect();
         let value = table::encode_row(&mut EvalContext::default(), values, &ids).unwrap();
         let mut kvs = vec![(key, value)];
-        for (&id, idxs) in &self.table.idxs {
-            let mut v: Vec<_> = idxs.iter().map(|id| self.values[id].clone()).collect();
-            v.push(handle.clone());
-            let encoded = datum::encode_key(&mut EvalContext::default(), &v).unwrap();
-            let idx_key = table::encode_index_seek_key(self.table.id, id, &encoded);
-            kvs.push((idx_key, vec![0]));
+        self.prepare_index_kv(&handle, &mut kvs);
+        self.store.put(ctx, kvs);
+        handle.i64()
+    }
+
+    pub fn execute_with_v2_checksum(
+        self,
+        ctx: Context,
+        with_checksum: bool,
+        extra_checksum: Option<u32>,
+    ) -> i64 {
+        let handle = self
+            .values
+            .get(&self.table.handle_id)
+            .cloned()
+            .unwrap_or_else(|| Datum::I64(next_id()));
+        let key = table::encode_row_key(self.table.id, handle.i64());
+        let mut columns: Vec<ColumnV2> = Vec::new();
+        for (id, value) in self.values_v2.iter() {
+            let col_info = self.table.column_by_id(*id).unwrap();
+            columns.push(ColumnV2::new_with_ft(
+                *id,
+                col_info.as_field_type(),
+                value.to_owned(),
+            ));
         }
+        let mut val_buf = Vec::new();
+        if with_checksum {
+            val_buf
+                .write_row_with_checksum(&mut EvalContext::default(), columns, extra_checksum)
+                .unwrap();
+        } else {
+            val_buf
+                .write_row(&mut EvalContext::default(), columns)
+                .unwrap();
+        }
+        let mut kvs = vec![(key, val_buf)];
+        self.prepare_index_kv(&handle, &mut kvs);
         self.store.put(ctx, kvs);
         handle.i64()
     }

--- a/components/tidb_query_datatype/src/codec/data_type/scalar.rs
+++ b/components/tidb_query_datatype/src/codec/data_type/scalar.rs
@@ -403,6 +403,34 @@ impl_as_ref! { Duration, as_duration }
 
 impl ScalarValue {
     #[inline]
+    pub fn as_enum(&self) -> Option<EnumRef<'_>> {
+        match self {
+            ScalarValue::Enum(x) => x.as_ref().map(|x| x.as_ref()),
+            other => panic!(
+                "Cannot cast {} scalar value into {}",
+                other.eval_type(),
+                stringify!(Int),
+            ),
+        }
+    }
+}
+
+impl ScalarValue {
+    #[inline]
+    pub fn as_set(&self) -> Option<SetRef<'_>> {
+        match self {
+            ScalarValue::Set(x) => x.as_ref().map(|x| x.as_ref()),
+            other => panic!(
+                "Cannot cast {} scalar value into {}",
+                other.eval_type(),
+                stringify!(Int),
+            ),
+        }
+    }
+}
+
+impl ScalarValue {
+    #[inline]
     pub fn as_json(&self) -> Option<JsonRef<'_>> {
         EvaluableRef::borrow_scalar_value(self)
     }

--- a/components/tidb_query_datatype/src/codec/data_type/scalar.rs
+++ b/components/tidb_query_datatype/src/codec/data_type/scalar.rs
@@ -162,6 +162,14 @@ impl From<f64> for ScalarValue {
     }
 }
 
+impl From<&str> for ScalarValue {
+    #[inline]
+    fn from(s: &str) -> ScalarValue {
+        let bytes = Bytes::from(s);
+        ScalarValue::Bytes(Some(bytes))
+    }
+}
+
 impl From<ScalarValue> for Option<f64> {
     #[inline]
     fn from(s: ScalarValue) -> Option<f64> {

--- a/components/tidb_query_datatype/src/codec/row/v2/encoder_for_test.rs
+++ b/components/tidb_query_datatype/src/codec/row/v2/encoder_for_test.rs
@@ -99,6 +99,9 @@ impl Column {
     }
 
     // The encode rule follows https://github.com/pingcap/tidb/pull/43141.
+    // It's different from the other encoding rules and used for verification
+    // test cases in tikv, the actual checksum encoding would be done on the
+    // tidb side with row value generation.
     pub fn encode_for_checksum(&self, buf: &mut Vec<u8>) -> Result<()> {
         match self.ft.as_accessor().tp() {
             FieldTypeTp::Tiny
@@ -204,7 +207,8 @@ impl Column {
                 buf.write_u64_le(res)?;
             }
             FieldTypeTp::Bit => {
-                // TODO: it's not supported yet.
+                // TODO: it's not supported yet. In current test only `INT` and `Varchar`
+                // types would be used.
                 buf.write_u64_le(u64::MAX)?;
             }
             FieldTypeTp::Json => {

--- a/components/tidb_query_datatype/src/codec/row/v2/encoder_for_test.rs
+++ b/components/tidb_query_datatype/src/codec/row/v2/encoder_for_test.rs
@@ -243,7 +243,7 @@ impl Column {
 ///   - little-endian CRC32(IEEE) when hdr.ver = 0 (default)
 pub trait ChecksumHandler {
     // checksum calculates the checksum value according to the input column values.
-    fn checksum(&mut self, cols: &Vec<Column>) -> Result<()>;
+    fn checksum(&mut self, cols: &[Column]) -> Result<()>;
 
     // header_value returns the checksum header value.
     fn header_value(&self) -> u8;
@@ -258,7 +258,7 @@ pub struct Crc32RowChecksumHandler {
     buf: Vec<u8>,
 }
 
-fn get_non_null_columns(cols: &Vec<Column>) -> Vec<Column> {
+fn get_non_null_columns(cols: &[Column]) -> Vec<Column> {
     let mut res = vec![];
     for col in cols {
         if col.value.is_some() {
@@ -270,7 +270,7 @@ fn get_non_null_columns(cols: &Vec<Column>) -> Vec<Column> {
 }
 
 impl ChecksumHandler for Crc32RowChecksumHandler {
-    fn checksum(&mut self, cols: &Vec<Column>) -> Result<()> {
+    fn checksum(&mut self, cols: &[Column]) -> Result<()> {
         // For testing purposes, the DDL compatibility was not fully considered for
         // checksum calculation, using all non-null columns regardless of the column's
         // DDL status, such as write-reorg.

--- a/components/tidb_query_datatype/src/codec/row/v2/mod.rs
+++ b/components/tidb_query_datatype/src/codec/row/v2/mod.rs
@@ -11,6 +11,7 @@ bitflags! {
     #[derive(Default)]
     struct Flags: u8 {
         const BIG = 1;
+        const WITH_CHECKSUM = 2;
     }
 }
 

--- a/components/tidb_query_datatype/src/codec/row/v2/row_slice.rs
+++ b/components/tidb_query_datatype/src/codec/row/v2/row_slice.rs
@@ -199,11 +199,6 @@ impl RowSlice<'_> {
     }
 
     #[inline]
-    fn has_checksum(&self) -> bool {
-        self.get_checksum().is_some()
-    }
-
-    #[inline]
     pub fn values(&self) -> &[u8] {
         match self {
             RowSlice::Big { values, .. } => values.slice,
@@ -237,15 +232,13 @@ impl RowSlice<'_> {
                 offsets, values, ..
             } => {
                 let last_slice_idx = offsets.get(non_null_col_num - 1).unwrap() as usize;
-                let res = &values.slice[last_slice_idx..];
-                res
+                &values.slice[last_slice_idx..]
             }
             RowSlice::Small {
                 offsets, values, ..
             } => {
                 let last_slice_idx = offsets.get(non_null_col_num - 1).unwrap() as usize;
-                let res = &values.slice[last_slice_idx..];
-                res
+                &values.slice[last_slice_idx..]
             }
         }
     }
@@ -490,7 +483,6 @@ mod tests {
                 let data = encoded_data_with_checksum(extra_checksum, null_row_id);
                 let row = RowSlice::from_bytes(&data).unwrap();
                 assert_eq!(null_row_id > 255, row.is_big());
-                assert!(row.has_checksum());
                 assert_eq!(Some((0, 2)), row.search_in_non_null_ids(1).unwrap());
                 assert_eq!(Some((2, 10)), row.search_in_non_null_ids(3).unwrap());
                 assert_eq!(Some((10, 13)), row.search_in_non_null_ids(8).unwrap());

--- a/components/tidb_query_datatype/src/codec/row/v2/row_slice.rs
+++ b/components/tidb_query_datatype/src/codec/row/v2/row_slice.rs
@@ -10,6 +10,7 @@ use num_traits::PrimInt;
 
 use crate::codec::{Error, Result};
 
+#[derive(Debug)]
 pub enum RowSlice<'a> {
     Small {
         origin: &'a [u8],
@@ -17,6 +18,7 @@ pub enum RowSlice<'a> {
         null_ids: LeBytes<'a, u8>,
         offsets: LeBytes<'a, u16>,
         values: LeBytes<'a, u8>,
+        checksum: Option<Checksum>,
     },
     Big {
         origin: &'a [u8],
@@ -24,7 +26,47 @@ pub enum RowSlice<'a> {
         null_ids: LeBytes<'a, u32>,
         offsets: LeBytes<'a, u32>,
         values: LeBytes<'a, u8>,
+        checksum: Option<Checksum>,
     },
+}
+
+/// Checksum
+/// - HEADER(1 byte)
+///   - VER: version(3 bit)
+///   - E:   has extra checksum
+/// - CHECKSUM(4 bytes)
+///   - little-endian CRC32(IEEE) when hdr.ver = 0 (default)
+#[derive(Copy, Clone, Debug)]
+pub struct Checksum {
+    header: u8,
+    val: u32,
+    extra_val: u32,
+}
+
+impl Checksum {
+    fn new(header: u8, val: u32) -> Self {
+        Self {
+            header,
+            val,
+            extra_val: 0,
+        }
+    }
+
+    pub fn get_checksum_val(&self) -> u32 {
+        self.val
+    }
+
+    pub fn has_extra_checksum(&self) -> bool {
+        (self.header & 0b1000) > 0
+    }
+
+    fn set_extra_checksum(&mut self, extra_val: u32) {
+        self.extra_val = extra_val;
+    }
+
+    pub fn get_extra_checksum_val(&self) -> u32 {
+        self.extra_val
+    }
 }
 
 impl RowSlice<'_> {
@@ -34,18 +76,21 @@ impl RowSlice<'_> {
     pub fn from_bytes(mut data: &[u8]) -> Result<RowSlice<'_>> {
         let origin = data;
         assert_eq!(data.read_u8()?, super::CODEC_VERSION);
-        let is_big = super::Flags::from_bits_truncate(data.read_u8()?) == super::Flags::BIG;
+        let flags = super::Flags::from_bits_truncate(data.read_u8()?);
+        let is_big = flags.contains(super::Flags::BIG);
+        let with_checksum = flags.contains(super::Flags::WITH_CHECKSUM);
 
         // read ids count
         let non_null_cnt = data.read_u16_le()? as usize;
         let null_cnt = data.read_u16_le()? as usize;
-        let row = if is_big {
+        let mut row = if is_big {
             RowSlice::Big {
                 origin,
                 non_null_ids: read_le_bytes(&mut data, non_null_cnt)?,
                 null_ids: read_le_bytes(&mut data, null_cnt)?,
                 offsets: read_le_bytes(&mut data, non_null_cnt)?,
                 values: LeBytes::new(data),
+                checksum: None,
             }
         } else {
             RowSlice::Small {
@@ -54,7 +99,20 @@ impl RowSlice<'_> {
                 null_ids: read_le_bytes(&mut data, null_cnt)?,
                 offsets: read_le_bytes(&mut data, non_null_cnt)?,
                 values: LeBytes::new(data),
+                checksum: None,
             }
+        };
+        if with_checksum {
+            let mut checksum_bytes = row.get_checksum_bytes(non_null_cnt);
+            assert!(checksum_bytes.len() == 5 || checksum_bytes.len() == 9);
+            let header = checksum_bytes.read_u8()?;
+            let val = checksum_bytes.read_u32_le()?;
+            let mut checksum = Checksum::new(header, val);
+            if checksum.has_extra_checksum() {
+                let extra_val = checksum_bytes.read_u32_le()?;
+                checksum.set_extra_checksum(extra_val);
+            }
+            row.set_checksum(Some(checksum));
         };
         Ok(row)
     }
@@ -141,6 +199,11 @@ impl RowSlice<'_> {
     }
 
     #[inline]
+    fn has_checksum(&self) -> bool {
+        self.get_checksum().is_some()
+    }
+
+    #[inline]
     pub fn values(&self) -> &[u8] {
         match self {
             RowSlice::Big { values, .. } => values.slice,
@@ -166,6 +229,42 @@ impl RowSlice<'_> {
             Ok(None)
         }
     }
+
+    #[inline]
+    pub fn get_checksum_bytes(&self, non_null_col_num: usize) -> &[u8] {
+        match self {
+            RowSlice::Big {
+                offsets, values, ..
+            } => {
+                let last_slice_idx = offsets.get(non_null_col_num - 1).unwrap() as usize;
+                let res = &values.slice[last_slice_idx..];
+                res
+            }
+            RowSlice::Small {
+                offsets, values, ..
+            } => {
+                let last_slice_idx = offsets.get(non_null_col_num - 1).unwrap() as usize;
+                let res = &values.slice[last_slice_idx..];
+                res
+            }
+        }
+    }
+
+    #[inline]
+    pub fn get_checksum(&self) -> Option<Checksum> {
+        match self {
+            RowSlice::Big { checksum, .. } => *checksum,
+            RowSlice::Small { checksum, .. } => *checksum,
+        }
+    }
+
+    #[inline]
+    fn set_checksum(&mut self, checksum_input: Option<Checksum>) {
+        match self {
+            RowSlice::Big { checksum, .. } => *checksum = checksum_input,
+            RowSlice::Small { checksum, .. } => *checksum = checksum_input,
+        }
+    }
 }
 
 /// Decodes `len` number of ints from `buf` in little endian
@@ -189,6 +288,7 @@ where
 }
 
 #[cfg(target_endian = "little")]
+#[derive(Debug)]
 pub struct LeBytes<'a, T: PrimInt> {
     slice: &'a [u8],
     _marker: PhantomData<T>,
@@ -255,12 +355,17 @@ mod tests {
     use std::u16;
 
     use codec::prelude::NumberEncoder;
+    use tipb::FieldType;
 
     use super::{
         super::encoder_for_test::{Column, RowEncoder},
         read_le_bytes, RowSlice,
     };
-    use crate::{codec::data_type::ScalarValue, expr::EvalContext};
+    use crate::{
+        codec::data_type::{Duration, ScalarValue},
+        expr::EvalContext,
+        FieldTypeTp,
+    };
 
     #[test]
     fn test_read_le_bytes() {
@@ -353,6 +458,57 @@ mod tests {
         assert!(!row.search_in_null_ids(0xCC21));
         assert!(!row.search_in_null_ids(0xFF0021));
         assert!(!row.search_in_null_ids(0xFF00000021));
+    }
+
+    fn encoded_data_with_checksum(extra_checksum: Option<u32>, null_row_id: i64) -> Vec<u8> {
+        let cols = vec![
+            Column::new_with_ft(1, FieldType::from(FieldTypeTp::Short), 1000),
+            Column::new_with_ft(12, FieldType::from(FieldTypeTp::Long), 2),
+            Column::new_with_ft(
+                null_row_id,
+                FieldType::from(FieldTypeTp::Short),
+                ScalarValue::Int(None),
+            ),
+            Column::new_with_ft(3, FieldType::from(FieldTypeTp::Float), 3.55),
+            Column::new_with_ft(8, FieldType::from(FieldTypeTp::VarChar), b"abc".to_vec()),
+            Column::new_with_ft(
+                17,
+                FieldType::from(FieldTypeTp::Duration),
+                Duration::from_millis(34, 2).unwrap(),
+            ),
+        ];
+        let mut buf = vec![];
+        buf.write_row_with_checksum(&mut EvalContext::default(), cols, extra_checksum)
+            .unwrap();
+        buf
+    }
+
+    #[test]
+    fn test_decode_with_checksum() {
+        for null_row_id in [235, 355] {
+            for extra_checksum in [None, Some(37217)] {
+                let data = encoded_data_with_checksum(extra_checksum, null_row_id);
+                let row = RowSlice::from_bytes(&data).unwrap();
+                assert_eq!(null_row_id > 255, row.is_big());
+                assert!(row.has_checksum());
+                assert_eq!(Some((0, 2)), row.search_in_non_null_ids(1).unwrap());
+                assert_eq!(Some((2, 10)), row.search_in_non_null_ids(3).unwrap());
+                assert_eq!(Some((10, 13)), row.search_in_non_null_ids(8).unwrap());
+                assert_eq!(Some((13, 14)), row.search_in_non_null_ids(12).unwrap());
+                assert_eq!(Some((14, 18)), row.search_in_non_null_ids(17).unwrap());
+                assert_eq!(None, row.search_in_non_null_ids(235).unwrap());
+                assert!(row.search_in_null_ids(null_row_id));
+                assert!(!row.search_in_null_ids(8));
+
+                let checksum = row.get_checksum().unwrap();
+                assert!(checksum.get_checksum_val() > 0);
+                assert_eq!(extra_checksum.is_some(), checksum.has_extra_checksum());
+                assert_eq!(
+                    extra_checksum.unwrap_or(0),
+                    checksum.get_extra_checksum_val()
+                );
+            }
+        }
     }
 }
 

--- a/components/tidb_query_datatype/src/def/field_type.rs
+++ b/components/tidb_query_datatype/src/def/field_type.rs
@@ -50,7 +50,7 @@ pub enum FieldTypeTp {
 }
 
 impl FieldTypeTp {
-    fn from_i32(i: i32) -> Option<FieldTypeTp> {
+    pub fn from_i32(i: i32) -> Option<FieldTypeTp> {
         if (i >= FieldTypeTp::Unspecified as i32 && i <= FieldTypeTp::Bit as i32)
             || (i >= FieldTypeTp::Json as i32 && i <= FieldTypeTp::Geometry as i32)
         {

--- a/tests/integrations/coprocessor/test_select.rs
+++ b/tests/integrations/coprocessor/test_select.rs
@@ -2055,6 +2055,39 @@ fn test_buckets() {
 }
 
 #[test]
+fn test_select_v2_format_with_checksum() {
+    let data = vec![
+        (1, Some("name:0"), 2),
+        (2, Some("name:4"), 3),
+        (4, Some("name:3"), 1),
+        (5, Some("name:1"), 4),
+        (9, Some("name:8"), 7),
+        (10, Some("name:6"), 8),
+    ];
+
+    let product = ProductTable::new();
+    for extra_checksum in [None, Some(132423)] {
+        // The row value encoded with checksum bytes should have no impact on cop task
+        // processing.
+        let (_, endpoint) =
+            init_data_with_commit_v2_checksum(&product, &data, true, extra_checksum);
+        let req = DagSelect::from(&product).build();
+        let mut resp = handle_select(&endpoint, req);
+        let spliter = DagChunkSpliter::new(resp.take_chunks().into(), 3);
+        for (row, (id, name, cnt)) in spliter.zip(data.clone()) {
+            let name_datum = name.map(|s| s.as_bytes()).into();
+            let expected_encoded = datum::encode_value(
+                &mut EvalContext::default(),
+                &[Datum::I64(id), name_datum, cnt.into()],
+            )
+            .unwrap();
+            let result_encoded = datum::encode_value(&mut EvalContext::default(), &row).unwrap();
+            assert_eq!(result_encoded, &*expected_encoded);
+        }
+    }
+}
+
+#[test]
 fn test_batch_request() {
     let data = vec![
         (1, Some("name:0"), 2),

--- a/tests/integrations/coprocessor/test_select.rs
+++ b/tests/integrations/coprocessor/test_select.rs
@@ -2068,7 +2068,7 @@ fn test_select_v2_format_with_checksum() {
     let product = ProductTable::new();
     for extra_checksum in [None, Some(132423)] {
         // The row value encoded with checksum bytes should have no impact on cop task
-        // processing.
+        // processing and related result chunk filling.
         let (_, endpoint) =
             init_data_with_commit_v2_checksum(&product, &data, true, extra_checksum);
         let req = DagSelect::from(&product).build();


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #14528 

What's Changed:
Add checksum calculation logic in `RowSlice`, add `cop` and `kv-get` test cases, the target is to verify the checksum encoding impact on read paths.



### Related changes



### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
