### PR TITLE
raftstore-v2: fix stale read by correct updating peers

### DIFF
--- a/components/raftstore-v2/src/operation/ready/mod.rs
+++ b/components/raftstore-v2/src/operation/ready/mod.rs
@@ -897,6 +897,8 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
                 }
                 _ => {}
             }
+            self.read_progress()
+                .update_leader_info(ss.leader_id, term, self.region());
             let target = self.refresh_leader_transferee();
             ctx.coprocessor_host.on_role_change(
                 self.region(),

--- a/tests/integrations/raftstore/mod.rs
+++ b/tests/integrations/raftstore/mod.rs
@@ -25,6 +25,7 @@ mod test_snap;
 mod test_snap_recovery;
 mod test_split_region;
 mod test_stale_peer;
+mod test_stale_read;
 mod test_stats;
 mod test_status_command;
 mod test_tombstone;

--- a/tests/integrations/raftstore/test_lease_read.rs
+++ b/tests/integrations/raftstore/test_lease_read.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use engine_rocks::RocksSnapshot;
-use kvproto::{kvrpcpb::Op, metapb};
+use kvproto::metapb;
 use more_asserts::assert_le;
 use pd_client::PdClient;
 use raft::eraftpb::{ConfChangeType, MessageType};
@@ -827,48 +827,4 @@ fn test_node_local_read_renew_lease() {
         assert_le!(detector.ctx.rl().len(), max_renew_lease_time + 1, "{}", i);
         thread::sleep(request_wait);
     }
-}
-
-#[test]
-fn test_stale_read_with_ts0() {
-    let mut cluster = new_server_cluster(0, 3);
-    let pd_client = Arc::clone(&cluster.pd_client);
-    pd_client.disable_default_operator();
-    cluster.cfg.resolved_ts.enable = true;
-    cluster.run();
-
-    let leader = new_peer(1, 1);
-    cluster.must_transfer_leader(1, leader.clone());
-    let mut leader_client = PeerClient::new(&cluster, 1, leader);
-
-    let mut follower_client2 = PeerClient::new(&cluster, 1, new_peer(2, 2));
-
-    // Set the `stale_read` flag
-    leader_client.ctx.set_stale_read(true);
-    follower_client2.ctx.set_stale_read(true);
-
-    let commit_ts1 = leader_client.must_kv_write(
-        &pd_client,
-        vec![new_mutation(Op::Put, &b"key1"[..], &b"value1"[..])],
-        b"key1".to_vec(),
-    );
-
-    let commit_ts2 = leader_client.must_kv_write(
-        &pd_client,
-        vec![new_mutation(Op::Put, &b"key1"[..], &b"value2"[..])],
-        b"key1".to_vec(),
-    );
-
-    follower_client2.must_kv_read_equal(b"key1".to_vec(), b"value1".to_vec(), commit_ts1);
-    follower_client2.must_kv_read_equal(b"key1".to_vec(), b"value2".to_vec(), commit_ts2);
-    assert!(
-        follower_client2
-            .kv_read(b"key1".to_vec(), 0)
-            .region_error
-            .into_option()
-            .unwrap()
-            .not_leader
-            .is_some()
-    );
-    assert!(leader_client.kv_read(b"key1".to_vec(), 0).not_found);
 }

--- a/tests/integrations/raftstore/test_stale_read.rs
+++ b/tests/integrations/raftstore/test_stale_read.rs
@@ -1,0 +1,133 @@
+// Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::{cell::RefCell, sync::Arc, time::Duration};
+
+use grpcio::{ChannelBuilder, Environment};
+use kvproto::{
+    kvrpcpb::{Context, Op},
+    metapb::{Peer, Region},
+    tikvpb_grpc::TikvClient,
+};
+use test_raftstore::{new_mutation, new_peer, new_server_cluster, PeerClient};
+use test_raftstore_macro::test_case;
+use tikv_util::{config::ReadableDuration, time::Instant};
+
+use crate::tikv_util::HandyRwLock;
+
+#[test_case(test_raftstore::new_server_cluster)]
+#[test_case(test_raftstore_v2::new_server_cluster)]
+fn test_stale_read_with_ts0() {
+    let mut cluster = new_cluster(0, 3);
+    let pd_client = Arc::clone(&cluster.pd_client);
+    pd_client.disable_default_operator();
+    cluster.cfg.resolved_ts.enable = true;
+    cluster.cfg.resolved_ts.advance_ts_interval = ReadableDuration::millis(200);
+    cluster.run();
+
+    let region_id = 1;
+    let env = Arc::new(Environment::new(1));
+    let new_client = |peer: Peer| {
+        let cli = TikvClient::new(
+            ChannelBuilder::new(env.clone())
+                .connect(&cluster.sim.rl().get_addr(peer.get_store_id())),
+        );
+        let epoch = cluster.get_region_epoch(region_id);
+        let mut ctx = Context::default();
+        ctx.set_region_id(region_id);
+        ctx.set_peer(peer);
+        ctx.set_region_epoch(epoch);
+        PeerClient { cli, ctx }
+    };
+    let leader = new_peer(1, 1);
+    let mut leader_client = new_client(leader.clone());
+    let follower = new_peer(2, 2);
+    let mut follower_client2 = new_client(follower);
+
+    cluster.must_transfer_leader(1, leader);
+
+    // Set the `stale_read` flag
+    leader_client.ctx.set_stale_read(true);
+    follower_client2.ctx.set_stale_read(true);
+
+    let commit_ts1 = leader_client.must_kv_write(
+        &pd_client,
+        vec![new_mutation(Op::Put, &b"key1"[..], &b"value1"[..])],
+        b"key1".to_vec(),
+    );
+
+    let commit_ts2 = leader_client.must_kv_write(
+        &pd_client,
+        vec![new_mutation(Op::Put, &b"key1"[..], &b"value2"[..])],
+        b"key1".to_vec(),
+    );
+
+    follower_client2.must_kv_read_equal(b"key1".to_vec(), b"value1".to_vec(), commit_ts1);
+    follower_client2.must_kv_read_equal(b"key1".to_vec(), b"value2".to_vec(), commit_ts2);
+    assert!(
+        follower_client2
+            .kv_read(b"key1".to_vec(), 0)
+            .region_error
+            .into_option()
+            .unwrap()
+            .not_leader
+            .is_some()
+    );
+    assert!(leader_client.kv_read(b"key1".to_vec(), 0).not_found);
+}
+
+#[test_case(test_raftstore::new_server_cluster)]
+#[test_case(test_raftstore_v2::new_server_cluster)]
+fn test_stale_read_resolved_ts_advance() {
+    let mut cluster = new_server_cluster(0, 3);
+    cluster.cfg.resolved_ts.enable = true;
+    cluster.cfg.resolved_ts.advance_ts_interval = ReadableDuration::millis(200);
+
+    cluster.run();
+    let cluster = RefCell::new(cluster);
+
+    let must_resolved_ts_advance = |region: &Region| {
+        let cluster = cluster.borrow_mut();
+        let ts = cluster.store_metas[&region.get_peers()[0].get_store_id()]
+            .lock()
+            .unwrap()
+            .region_read_progress
+            .get_resolved_ts(&region.get_id())
+            .unwrap();
+        let now = Instant::now();
+        for peer in region.get_peers() {
+            loop {
+                let new_ts = cluster.store_metas[&peer.get_store_id()]
+                    .lock()
+                    .unwrap()
+                    .region_read_progress
+                    .get_resolved_ts(&region.get_id())
+                    .unwrap();
+                if new_ts <= ts {
+                    if now.saturating_elapsed() > Duration::from_secs(5) {
+                        panic!("timeout");
+                    }
+                    continue;
+                }
+                break;
+            }
+        }
+    };
+
+    // Make sure resolved ts advances.
+    let region = cluster.borrow().get_region(&[]);
+    must_resolved_ts_advance(&region);
+
+    // Test transfer leader.
+    cluster
+        .borrow_mut()
+        .must_transfer_leader(region.get_id(), region.get_peers()[1].clone());
+    must_resolved_ts_advance(&region);
+
+    // Test split.
+    let split_key = b"k1";
+    cluster.borrow_mut().must_split(&region, split_key);
+    let left = cluster.borrow().get_region(&[]);
+    let right = cluster.borrow().get_region(split_key);
+    must_resolved_ts_advance(&left);
+    must_resolved_ts_advance(&right);
+}


### PR DESCRIPTION
### What is changed and how it works?
<!--
 
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #14664

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Fix stale read by correct updating peers
```

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
