### PR TITLE
txn: persist fair lock type in lock information and handle stale fair lock resolve

### DIFF
--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -1438,6 +1438,7 @@ mod tests {
                 TimeStamp::zero(),
                 0,
                 TimeStamp::zero(),
+                false,
             )
             .to_bytes();
             delegate
@@ -1506,6 +1507,7 @@ mod tests {
                 TimeStamp::zero(),
                 0,
                 TimeStamp::zero(),
+                false,
             );
             // Only the key `a` is a normal write.
             if k != b'a' {

--- a/components/cdc/tests/integrations/test_cdc.rs
+++ b/components/cdc/tests/integrations/test_cdc.rs
@@ -1228,6 +1228,7 @@ fn test_cdc_resolve_ts_checking_concurrency_manager_impl<F: KvFormat>() {
                 0.into(),
                 1,
                 ts.into(),
+                false,
             ))
         });
         guard

--- a/components/concurrency_manager/benches/lock_table.rs
+++ b/components/concurrency_manager/benches/lock_table.rs
@@ -32,6 +32,7 @@ fn prepare_cm() -> ConcurrencyManager {
                 10.into(),
                 1,
                 20.into(),
+                false,
             ));
         });
         // Leak the guard so the lock won't be removed.

--- a/components/concurrency_manager/src/lib.rs
+++ b/components/concurrency_manager/src/lib.rs
@@ -161,7 +161,17 @@ mod tests {
 
     fn new_lock(ts: impl Into<TimeStamp>, primary: &[u8], lock_type: LockType) -> Lock {
         let ts = ts.into();
-        Lock::new(lock_type, primary.to_vec(), ts, 0, None, 0.into(), 1, ts)
+        Lock::new(
+            lock_type,
+            primary.to_vec(),
+            ts,
+            0,
+            None,
+            0.into(),
+            1,
+            ts,
+            false,
+        )
     }
 
     #[tokio::test]

--- a/components/concurrency_manager/src/lock_table.rs
+++ b/components/concurrency_manager/src/lock_table.rs
@@ -183,6 +183,7 @@ mod test {
             10.into(),
             1,
             10.into(),
+            false,
         );
         let guard = lock_table.lock_key(&key_k).await;
         guard.with_lock(|l| {
@@ -212,6 +213,7 @@ mod test {
             20.into(),
             1,
             20.into(),
+            false,
         );
         let guard = lock_table.lock_key(&Key::from_raw(b"k")).await;
         guard.with_lock(|l| {
@@ -227,6 +229,7 @@ mod test {
             10.into(),
             1,
             10.into(),
+            false,
         );
         let guard = lock_table.lock_key(&Key::from_raw(b"l")).await;
         guard.with_lock(|l| {
@@ -284,6 +287,7 @@ mod test {
             20.into(),
             1,
             20.into(),
+            false,
         );
         let guard_a = lock_table.lock_key(&Key::from_raw(b"a")).await;
         guard_a.with_lock(|l| {
@@ -304,6 +308,7 @@ mod test {
             30.into(),
             2,
             30.into(),
+            false,
         )
         .use_async_commit(vec![b"c".to_vec()]);
         let guard_b = lock_table.lock_key(&Key::from_raw(b"b")).await;

--- a/components/concurrency_manager/tests/memory_usage.rs
+++ b/components/concurrency_manager/tests/memory_usage.rs
@@ -48,6 +48,7 @@ fn test_memory_usage() {
                     10.into(),
                     1,
                     20.into(),
+                    false,
                 );
 
                 // Key already exists

--- a/components/raftstore/src/store/txn_ext.rs
+++ b/components/raftstore/src/store/txn_ext.rs
@@ -326,6 +326,7 @@ mod tests {
             min_commit_ts: 110.into(),
             last_change_ts: 105.into(),
             versions_to_last_change: 2,
+            is_locked_with_conflict: false,
         }
     }
 
@@ -428,6 +429,7 @@ mod tests {
                         min_commit_ts: 20.into(),
                         last_change_ts: 5.into(),
                         versions_to_last_change: 2,
+                        is_locked_with_conflict: false,
                     },
                     deleted,
                 ),

--- a/components/snap_recovery/src/data_resolver.rs
+++ b/components/snap_recovery/src/data_resolver.rs
@@ -382,6 +382,7 @@ mod tests {
                 for_update_ts.into(),
                 0,
                 TimeStamp::zero(),
+                false,
             );
             kv.push((CF_LOCK, Key::from_raw(key), lock.to_bytes()));
         }

--- a/components/tikv_kv/src/lib.rs
+++ b/components/tikv_kv/src/lib.rs
@@ -1327,6 +1327,7 @@ mod unit_tests {
                     min_commit_ts: 102.into(),
                     last_change_ts: 80.into(),
                     versions_to_last_change: 2,
+                    is_locked_with_conflict: false,
                 },
             ),
             Modify::DeleteRange(
@@ -1371,6 +1372,7 @@ mod unit_tests {
                         min_commit_ts: 102.into(),
                         last_change_ts: 80.into(),
                         versions_to_last_change: 2,
+                        is_locked_with_conflict: false,
                     }
                     .into_lock()
                     .to_bytes(),

--- a/components/txn_types/src/lock.rs
+++ b/components/txn_types/src/lock.rs
@@ -27,7 +27,6 @@ const FLAG_PUT: u8 = b'P';
 const FLAG_DELETE: u8 = b'D';
 const FLAG_LOCK: u8 = b'L';
 const FLAG_PESSIMISTIC: u8 = b'S';
-const FLAG_PESSIMISTIC_WITH_CONFLICT: u8 = b'F';
 
 const FOR_UPDATE_TS_PREFIX: u8 = b'f';
 const TXN_SIZE_PREFIX: u8 = b't';
@@ -36,6 +35,7 @@ const ASYNC_COMMIT_PREFIX: u8 = b'a';
 const ROLLBACK_TS_PREFIX: u8 = b'r';
 const LAST_CHANGE_PREFIX: u8 = b'l';
 const TXN_SOURCE_PREFIX: u8 = b's';
+const PESSIMISTIC_LOCK_WITH_CONFLICT_PREFIX: u8 = b'F';
 
 impl LockType {
     pub fn from_mutation(mutation: &Mutation) -> Option<LockType> {
@@ -246,7 +246,7 @@ impl Lock {
             b.encode_var_u64(self.txn_source).unwrap();
         }
         if self.is_locked_with_conflict {
-            b.push(FLAG_PESSIMISTIC_WITH_CONFLICT);
+            b.push(PESSIMISTIC_LOCK_WITH_CONFLICT_PREFIX);
         }
         b
     }
@@ -367,7 +367,7 @@ impl Lock {
                 TXN_SOURCE_PREFIX => {
                     txn_source = number::decode_var_u64(&mut b)?;
                 }
-                FLAG_PESSIMISTIC_WITH_CONFLICT => {
+                PESSIMISTIC_LOCK_WITH_CONFLICT_PREFIX => {
                     is_locked_with_conflict = true;
                 }
                 _ => {
@@ -535,7 +535,7 @@ impl Lock {
     }
 
     pub fn is_pessimistic_lock_with_conflict(&self) -> bool {
-        self.is_locked_with_conflict
+        self.is_pessimistic_lock() && self.is_locked_with_conflict
     }
 }
 

--- a/components/txn_types/src/lock.rs
+++ b/components/txn_types/src/lock.rs
@@ -27,6 +27,7 @@ const FLAG_PUT: u8 = b'P';
 const FLAG_DELETE: u8 = b'D';
 const FLAG_LOCK: u8 = b'L';
 const FLAG_PESSIMISTIC: u8 = b'S';
+const FLAG_PESSIMISTIC_WITH_CONFLICT: u8 = b'F';
 
 const FOR_UPDATE_TS_PREFIX: u8 = b'f';
 const TXN_SIZE_PREFIX: u8 = b't';
@@ -103,6 +104,8 @@ pub struct Lock {
     /// application is limited to setting this value under `0x80`,
     /// so there will no more cost to change it to `u64`.
     pub txn_source: u64,
+    /// The lock is locked with conflict using fair lock mode.
+    pub is_locked_with_conflict: bool,
 }
 
 impl std::fmt::Debug for Lock {
@@ -129,6 +132,7 @@ impl std::fmt::Debug for Lock {
             .field("last_change_ts", &self.last_change_ts)
             .field("versions_to_last_change", &self.versions_to_last_change)
             .field("txn_source", &self.txn_source)
+            .field("is_locked_with_conflict", &self.is_locked_with_conflict)
             .finish()
     }
 }
@@ -143,6 +147,7 @@ impl Lock {
         for_update_ts: TimeStamp,
         txn_size: u64,
         min_commit_ts: TimeStamp,
+        is_locked_with_conflict: bool,
     ) -> Self {
         Self {
             lock_type,
@@ -159,6 +164,7 @@ impl Lock {
             last_change_ts: TimeStamp::zero(),
             versions_to_last_change: 0,
             txn_source: 0,
+            is_locked_with_conflict,
         }
     }
 
@@ -239,6 +245,9 @@ impl Lock {
             b.push(TXN_SOURCE_PREFIX);
             b.encode_var_u64(self.txn_source).unwrap();
         }
+        if self.is_locked_with_conflict {
+            b.push(FLAG_PESSIMISTIC_WITH_CONFLICT);
+        }
         b
     }
 
@@ -274,6 +283,9 @@ impl Lock {
         if self.txn_source != 0 {
             size += 1 + MAX_VAR_U64_LEN;
         }
+        if self.is_locked_with_conflict {
+            size += 1;
+        }
         size
     }
 
@@ -300,6 +312,7 @@ impl Lock {
                 TimeStamp::zero(),
                 0,
                 TimeStamp::zero(),
+                false,
             ));
         }
 
@@ -313,6 +326,7 @@ impl Lock {
         let mut last_change_ts = TimeStamp::zero();
         let mut versions_to_last_change = 0;
         let mut txn_source = 0;
+        let mut is_locked_with_conflict = false;
         while !b.is_empty() {
             match b.read_u8()? {
                 SHORT_VALUE_PREFIX => {
@@ -353,6 +367,9 @@ impl Lock {
                 TXN_SOURCE_PREFIX => {
                     txn_source = number::decode_var_u64(&mut b)?;
                 }
+                FLAG_PESSIMISTIC_WITH_CONFLICT => {
+                    is_locked_with_conflict = true;
+                }
                 _ => {
                     // To support forward compatibility, all fields should be serialized in order
                     // and stop parsing if meets an unknown byte.
@@ -369,6 +386,7 @@ impl Lock {
             for_update_ts,
             txn_size,
             min_commit_ts,
+            is_locked_with_conflict,
         )
         .set_last_change(last_change_ts, versions_to_last_change)
         .set_txn_source(txn_source);
@@ -411,10 +429,7 @@ impl Lock {
         bypass_locks: &TsSet,
         is_replica_read: bool,
     ) -> Result<()> {
-        if lock.ts > ts
-            || lock.lock_type == LockType::Lock
-            || lock.lock_type == LockType::Pessimistic
-        {
+        if lock.ts > ts || lock.lock_type == LockType::Lock || lock.is_pessimistic_lock() {
             // Ignore lock when lock.ts > ts or lock's type is Lock or Pessimistic
             return Ok(());
         }
@@ -458,7 +473,7 @@ impl Lock {
         ts: TimeStamp,
         bypass_locks: &TsSet,
     ) -> Result<()> {
-        if lock.lock_type == LockType::Lock || lock.lock_type == LockType::Pessimistic {
+        if lock.lock_type == LockType::Lock || lock.is_pessimistic_lock() {
             // Ignore lock when the lock's type is Lock or Pessimistic.
             return Ok(());
         }
@@ -518,6 +533,10 @@ impl Lock {
     pub fn is_pessimistic_lock(&self) -> bool {
         self.lock_type == LockType::Pessimistic
     }
+
+    pub fn is_pessimistic_lock_with_conflict(&self) -> bool {
+        self.is_locked_with_conflict
+    }
 }
 
 /// A specialized lock only for pessimistic lock. This saves memory for cases
@@ -533,6 +552,7 @@ pub struct PessimisticLock {
 
     pub last_change_ts: TimeStamp,
     pub versions_to_last_change: u64,
+    pub is_locked_with_conflict: bool,
 }
 
 impl PessimisticLock {
@@ -546,6 +566,7 @@ impl PessimisticLock {
             self.for_update_ts,
             0,
             self.min_commit_ts,
+            self.is_locked_with_conflict,
         )
         .set_last_change(self.last_change_ts, self.versions_to_last_change)
     }
@@ -561,6 +582,7 @@ impl PessimisticLock {
             self.for_update_ts,
             0,
             self.min_commit_ts,
+            self.is_locked_with_conflict,
         )
         .set_last_change(self.last_change_ts, self.versions_to_last_change)
     }
@@ -580,6 +602,7 @@ impl std::fmt::Debug for PessimisticLock {
             .field("min_commit_ts", &self.min_commit_ts)
             .field("last_change_ts", &self.last_change_ts)
             .field("versions_to_last_change", &self.versions_to_last_change)
+            .field("is_locked_with_conflict", &self.is_locked_with_conflict)
             .finish()
     }
 }
@@ -643,6 +666,7 @@ mod tests {
                 TimeStamp::zero(),
                 0,
                 TimeStamp::zero(),
+                false,
             ),
             Lock::new(
                 LockType::Delete,
@@ -653,6 +677,7 @@ mod tests {
                 TimeStamp::zero(),
                 0,
                 TimeStamp::zero(),
+                false,
             ),
             Lock::new(
                 LockType::Put,
@@ -663,6 +688,7 @@ mod tests {
                 10.into(),
                 0,
                 TimeStamp::zero(),
+                false,
             ),
             Lock::new(
                 LockType::Delete,
@@ -673,6 +699,7 @@ mod tests {
                 10.into(),
                 0,
                 TimeStamp::zero(),
+                false,
             ),
             Lock::new(
                 LockType::Put,
@@ -683,6 +710,7 @@ mod tests {
                 TimeStamp::zero(),
                 16,
                 TimeStamp::zero(),
+                false,
             ),
             Lock::new(
                 LockType::Delete,
@@ -693,6 +721,7 @@ mod tests {
                 TimeStamp::zero(),
                 16,
                 TimeStamp::zero(),
+                false,
             ),
             Lock::new(
                 LockType::Put,
@@ -703,6 +732,7 @@ mod tests {
                 10.into(),
                 16,
                 TimeStamp::zero(),
+                false,
             ),
             Lock::new(
                 LockType::Delete,
@@ -713,6 +743,7 @@ mod tests {
                 10.into(),
                 0,
                 TimeStamp::zero(),
+                false,
             ),
             Lock::new(
                 LockType::Put,
@@ -723,6 +754,7 @@ mod tests {
                 333.into(),
                 444,
                 555.into(),
+                false,
             ),
             Lock::new(
                 LockType::Put,
@@ -733,6 +765,7 @@ mod tests {
                 333.into(),
                 444,
                 555.into(),
+                false,
             )
             .use_async_commit(vec![]),
             Lock::new(
@@ -744,6 +777,7 @@ mod tests {
                 333.into(),
                 444,
                 555.into(),
+                false,
             )
             .use_async_commit(vec![b"k".to_vec()]),
             Lock::new(
@@ -755,6 +789,7 @@ mod tests {
                 333.into(),
                 444,
                 555.into(),
+                false,
             )
             .use_async_commit(vec![
                 b"k1".to_vec(),
@@ -771,6 +806,7 @@ mod tests {
                 333.into(),
                 444,
                 555.into(),
+                false,
             )
             .use_async_commit(vec![
                 b"k1".to_vec(),
@@ -788,6 +824,7 @@ mod tests {
                 333.into(),
                 444,
                 555.into(),
+                false,
             )
             .with_rollback_ts(vec![12.into(), 24.into(), 13.into()]),
             Lock::new(
@@ -799,6 +836,7 @@ mod tests {
                 6.into(),
                 16,
                 8.into(),
+                false,
             )
             .set_last_change(0.into(), 2),
             Lock::new(
@@ -810,6 +848,7 @@ mod tests {
                 6.into(),
                 16,
                 8.into(),
+                false,
             )
             .set_last_change(4.into(), 2)
             .set_txn_source(1),
@@ -833,6 +872,7 @@ mod tests {
             TimeStamp::zero(),
             0,
             TimeStamp::zero(),
+            false,
         );
         let mut v = lock.to_bytes();
         Lock::parse(&v[..4]).unwrap_err();
@@ -854,6 +894,7 @@ mod tests {
             TimeStamp::zero(),
             1,
             TimeStamp::zero(),
+            false,
         );
 
         let empty = Default::default();
@@ -1008,6 +1049,7 @@ mod tests {
             100.into(),
             1,
             TimeStamp::zero(),
+            false,
         );
 
         let empty = Default::default();
@@ -1051,6 +1093,7 @@ mod tests {
             101.into(),
             10,
             127.into(),
+            false,
         )
         .use_async_commit(vec![
             b"secondary_k1".to_vec(),
@@ -1111,6 +1154,7 @@ mod tests {
             min_commit_ts: 20.into(),
             last_change_ts: 8.into(),
             versions_to_last_change: 2,
+            is_locked_with_conflict: false,
         };
         let expected_lock = Lock {
             lock_type: LockType::Pessimistic,
@@ -1127,6 +1171,7 @@ mod tests {
             last_change_ts: 8.into(),
             versions_to_last_change: 2,
             txn_source: 0,
+            is_locked_with_conflict: false,
         };
         assert_eq!(pessimistic_lock.to_lock(), expected_lock);
         assert_eq!(pessimistic_lock.into_lock(), expected_lock);
@@ -1142,6 +1187,7 @@ mod tests {
             min_commit_ts: 20.into(),
             last_change_ts: 8.into(),
             versions_to_last_change: 2,
+            is_locked_with_conflict: false,
         };
         assert_eq!(
             format!("{:?}", pessimistic_lock),
@@ -1170,8 +1216,9 @@ mod tests {
             min_commit_ts: 20.into(),
             last_change_ts: 8.into(),
             versions_to_last_change: 2,
+            is_locked_with_conflict: false,
         };
         // 7 bytes for primary key, 16 bytes for Box<[u8]>, and 6 8-byte integers.
-        assert_eq!(lock.memory_size(), 7 + 16 + 6 * 8);
+        assert_eq!(lock.memory_size(), 7 + 16 + 7 * 8);
     }
 }

--- a/components/txn_types/src/lock.rs
+++ b/components/txn_types/src/lock.rs
@@ -1193,7 +1193,7 @@ mod tests {
             format!("{:?}", pessimistic_lock),
             "PessimisticLock { primary_key: 7072696D617279, start_ts: TimeStamp(5), ttl: 1000, \
             for_update_ts: TimeStamp(10), min_commit_ts: TimeStamp(20), last_change_ts: TimeStamp(8), \
-            versions_to_last_change: 2 }"
+            versions_to_last_change: 2, is_locked_with_conflict: false }"
         );
         log_wrappers::set_redact_info_log(true);
         let redact_result = format!("{:?}", pessimistic_lock);
@@ -1202,7 +1202,7 @@ mod tests {
             redact_result,
             "PessimisticLock { primary_key: ?, start_ts: TimeStamp(5), ttl: 1000, \
             for_update_ts: TimeStamp(10), min_commit_ts: TimeStamp(20), last_change_ts: TimeStamp(8), \
-            versions_to_last_change: 2 }"
+            versions_to_last_change: 2, is_locked_with_conflict: false }"
         );
     }
 

--- a/components/txn_types/src/lock.rs
+++ b/components/txn_types/src/lock.rs
@@ -1110,7 +1110,7 @@ mod tests {
             min_commit_ts: TimeStamp(127), use_async_commit: true, \
             secondaries: [7365636F6E646172795F6B31, 7365636F6E646172795F6B6B6B6B6B32, \
             7365636F6E646172795F6B336B336B336B336B336B33, 7365636F6E646172795F6B34], rollback_ts: [], \
-            last_change_ts: TimeStamp(80), versions_to_last_change: 4, txn_source: 0 }"
+            last_change_ts: TimeStamp(80), versions_to_last_change: 4, txn_source: 0, is_locked_with_conflict: false }"
         );
         log_wrappers::set_redact_info_log(true);
         let redact_result = format!("{:?}", lock);
@@ -1120,7 +1120,7 @@ mod tests {
             "Lock { lock_type: Put, primary_key: ?, start_ts: TimeStamp(100), ttl: 3, \
             short_value: ?, for_update_ts: TimeStamp(101), txn_size: 10, min_commit_ts: TimeStamp(127), \
             use_async_commit: true, secondaries: [?, ?, ?, ?], rollback_ts: [], \
-            last_change_ts: TimeStamp(80), versions_to_last_change: 4, txn_source: 0 }"
+            last_change_ts: TimeStamp(80), versions_to_last_change: 4, txn_source: 0, is_locked_with_conflict: false }"
         );
 
         lock.short_value = None;
@@ -1130,7 +1130,7 @@ mod tests {
             "Lock { lock_type: Put, primary_key: 706B, start_ts: TimeStamp(100), ttl: 3, short_value: , \
             for_update_ts: TimeStamp(101), txn_size: 10, min_commit_ts: TimeStamp(127), \
             use_async_commit: true, secondaries: [], rollback_ts: [], last_change_ts: TimeStamp(80), \
-            versions_to_last_change: 4, txn_source: 0 }"
+            versions_to_last_change: 4, txn_source: 0, is_locked_with_conflict: false }"
         );
         log_wrappers::set_redact_info_log(true);
         let redact_result = format!("{:?}", lock);
@@ -1140,7 +1140,7 @@ mod tests {
             "Lock { lock_type: Put, primary_key: ?, start_ts: TimeStamp(100), ttl: 3, short_value: ?, \
             for_update_ts: TimeStamp(101), txn_size: 10, min_commit_ts: TimeStamp(127), \
             use_async_commit: true, secondaries: [], rollback_ts: [], last_change_ts: TimeStamp(80), \
-            versions_to_last_change: 4, txn_source: 0 }"
+            versions_to_last_change: 4, txn_source: 0, is_locked_with_conflict: false }"
         );
     }
 

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -1947,6 +1947,7 @@ mod tests {
                 0.into(),
                 1,
                 20.into(),
+                false,
             ));
         });
 

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -2213,6 +2213,7 @@ mod tests {
                 for_update_ts.into(),
                 0,
                 TimeStamp::zero(),
+                false,
             );
             kv.push((CF_LOCK, Key::from_raw(key), lock.to_bytes(), expect));
         }

--- a/src/server/reset_to_version.rs
+++ b/src/server/reset_to_version.rs
@@ -333,6 +333,7 @@ mod tests {
                 for_update_ts.into(),
                 0,
                 TimeStamp::zero(),
+                false,
             );
             kv.push((CF_LOCK, Key::from_raw(key), lock.to_bytes()));
         }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -2941,7 +2941,7 @@ pub async fn get_raw_key_guard(
         // get maximum resolved-ts from concurrency_manager.global_min_lock_ts
         let encode_key = ApiV2::encode_raw_key(&raw_key, Some(ts));
         let key_guard = concurrency_manager.lock_key(&encode_key).await;
-        let lock = Lock::new(LockType::Put, raw_key, ts, 0, None, 0.into(), 1, ts);
+        let lock = Lock::new(LockType::Put, raw_key, ts, 0, None, 0.into(), 1, ts, false);
         key_guard.with_lock(|l| *l = Some(lock));
         Ok(Some(key_guard))
     } else {
@@ -7514,6 +7514,7 @@ mod tests {
                     0.into(),
                     1,
                     20.into(),
+                    false,
                 ));
             });
             guard
@@ -7843,6 +7844,7 @@ mod tests {
                 0.into(),
                 0,
                 0.into(),
+                false,
             )
         };
 
@@ -8009,6 +8011,7 @@ mod tests {
                             0.into(),
                             3,
                             ts(10, 1),
+                            false,
                         )
                         .use_async_commit(vec![b"k1".to_vec(), b"k2".to_vec()]),
                         false,
@@ -9430,6 +9433,7 @@ mod tests {
                             0.into(),
                             0,
                             0.into(),
+                            false,
                         ),
                         false,
                     ),
@@ -9479,6 +9483,7 @@ mod tests {
                 0.into(),
                 1,
                 20.into(),
+                false,
             ));
         });
 
@@ -10172,6 +10177,7 @@ mod tests {
                                 10.into(),
                                 0,
                                 11.into(),
+                                false,
                             ),
                         ),
                         (
@@ -10185,6 +10191,7 @@ mod tests {
                                 10.into(),
                                 0,
                                 11.into(),
+                                false,
                             ),
                         ),
                     ],
@@ -10213,6 +10220,7 @@ mod tests {
                                 10.into(),
                                 0,
                                 11.into(),
+                                false,
                             ),
                         ),
                         (
@@ -10226,6 +10234,7 @@ mod tests {
                                 10.into(),
                                 0,
                                 11.into(),
+                                false,
                             ),
                         ),
                     ],
@@ -10256,6 +10265,7 @@ mod tests {
                                 10.into(),
                                 0,
                                 11.into(),
+                                false,
                             ),
                         ),
                         (
@@ -10269,6 +10279,7 @@ mod tests {
                                 10.into(),
                                 0,
                                 11.into(),
+                                false,
                             ),
                         ),
                     ],
@@ -10667,6 +10678,7 @@ mod tests {
                         min_commit_ts: 11.into(),
                         last_change_ts: TimeStamp::zero(),
                         versions_to_last_change: 1,
+                        is_locked_with_conflict: false,
                     },
                     false
                 )

--- a/src/storage/mvcc/consistency_check.rs
+++ b/src/storage/mvcc/consistency_check.rs
@@ -532,6 +532,7 @@ mod tests {
                 TimeStamp::zero(),
                 0,
                 TimeStamp::zero(),
+                false,
             );
             let value = lock.to_bytes();
             engine

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -598,7 +598,7 @@ pub mod tests {
         let mut reader = MvccReader::new(snapshot, None, true);
         let lock = reader.load_lock(&Key::from_raw(key)).unwrap().unwrap();
         assert_eq!(lock.ts, start_ts.into());
-        assert_ne!(lock.lock_type, LockType::Pessimistic);
+        assert!(!lock.is_pessimistic_lock());
         lock
     }
 
@@ -612,7 +612,7 @@ pub mod tests {
         let mut reader = MvccReader::new(snapshot, None, true);
         let lock = reader.load_lock(&Key::from_raw(key)).unwrap().unwrap();
         assert_eq!(lock.ts, start_ts.into());
-        assert_ne!(lock.lock_type, LockType::Pessimistic);
+        assert!(!lock.is_pessimistic_lock());
         assert_eq!(lock.ttl, ttl);
     }
 
@@ -631,9 +631,9 @@ pub mod tests {
         assert_eq!(lock.ttl, ttl);
         assert_eq!(lock.min_commit_ts, min_commit_ts.into());
         if is_pessimistic {
-            assert_eq!(lock.lock_type, LockType::Pessimistic);
+            assert!(lock.is_pessimistic_lock())
         } else {
-            assert_ne!(lock.lock_type, LockType::Pessimistic);
+            assert!(!lock.is_pessimistic_lock());
         }
     }
 

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -1674,6 +1674,7 @@ pub mod tests {
                     for_update_ts,
                     0,
                     TimeStamp::zero(),
+                    false,
                 )
                 .set_last_change(
                     TimeStamp::zero(),

--- a/src/storage/mvcc/reader/scanner/forward.rs
+++ b/src/storage/mvcc/reader/scanner/forward.rs
@@ -1007,6 +1007,7 @@ pub mod test_util {
                 self.for_update_ts,
                 0,
                 0.into(),
+                false,
             )
             .set_last_change(self.last_change_ts, self.versions_to_last_change);
             TxnEntry::Prewrite {

--- a/src/storage/txn/actions/check_txn_status.rs
+++ b/src/storage/txn/actions/check_txn_status.rs
@@ -92,20 +92,23 @@ fn check_txn_status_from_pessimistic_primary_lock(
 /// Evaluate transaction status if a lock exists with the anticipated
 /// 'start_ts'. 1. Validate whether the existing lock indeed corresponds to the
 /// primary lock. The primary key    may switch under certain circumstances. If
-/// it's a stale lock, the transaction status should    not be determined by it. Refer to https://github.com/tikv/tikv/issues/14636 for additional information.
+/// it's a stale lock, the transaction status should    not be determined by it.
+/// Refer to https://github.com/tikv/tikv/issues/14636 for additional information.
 ///    Note that the primary key should remain unaltered if the transaction is
-/// already in the commit or 2PC phase. 2. Manage the check in accordance with
-/// the primary lock type:   2.1 For the pessimistic type:
+/// already in the commit or 2PC phase.
+/// 2. Manage the check in accordance with the primary lock type:
+///   2.1 For the pessimistic type:
 ///     2.1.1 If it's a forced lock, validate the storage data initially to
-/// ensure the forced lock isn't stale.     2.1.2 If it's a regular lock, verify
-/// the lock's TTL and the current timestamp to determine the status. If the
-///           `resolving_pessimistic` parameter is true, perform a pessimistic
-/// rollback, else carry out a real rollback.   2.2 For the prewrite type,
-/// verify the lock's TTL and the current timestamp to establish the status.
+///           ensure the forced lock isn't stale.
+///     2.1.2 If it's a regular lock, verify the lock's TTL and the current
+/// timestamp           to determine the status. If the `resolving_pessimistic`
+/// parameter           is true, perform a pessimistic rollback, else carry out
+/// a real rollback.   2.2 For the prewrite type, verify the lock's TTL and the
+/// current timestamp to       establish the status.
 /// 3. Perform required operations on the valid primary lock, such as
-/// incrementing `min_commit_ts`. The actual procedure for executing the
-/// rollback differs based on the presence or absence of an overlapping write
-/// record.
+///    incrementing `min_commit_ts`.
+/// The actual procedure for executing the rollback differs based on the
+/// presence or absence of an overlapping write record.
 pub fn check_txn_status_lock_exists(
     txn: &mut MvccTxn,
     reader: &mut SnapshotReader<impl Snapshot>,

--- a/src/storage/txn/actions/check_txn_status.rs
+++ b/src/storage/txn/actions/check_txn_status.rs
@@ -90,25 +90,29 @@ fn check_txn_status_from_pessimistic_primary_lock(
 }
 
 /// Evaluate transaction status if a lock exists with the anticipated
-/// 'start_ts'. 1. Validate whether the existing lock indeed corresponds to the
+/// 'start_ts'.
+///
+/// 1. Validate whether the existing lock indeed corresponds to the
 /// primary lock. The primary key    may switch under certain circumstances. If
 /// it's a stale lock, the transaction status should    not be determined by it.
 /// Refer to https://github.com/tikv/tikv/issues/14636 for additional information.
 ///    Note that the primary key should remain unaltered if the transaction is
 /// already in the commit or 2PC phase.
+///
 /// 2. Manage the check in accordance with the primary lock type:
-///   2.1 For the pessimistic type:
-///     2.1.1 If it's a forced lock, validate the storage data initially to
-///           ensure the forced lock isn't stale.
-///     2.1.2 If it's a regular lock, verify the lock's TTL and the current
-/// timestamp           to determine the status. If the `resolving_pessimistic`
-/// parameter           is true, perform a pessimistic rollback, else carry out
-/// a real rollback.   2.2 For the prewrite type, verify the lock's TTL and the
-/// current timestamp to       establish the status.
+/// 2.1 For the pessimistic type:
+/// 2.1.1 If it's a forced lock, validate the storage data initially to ensure
+/// the forced lock isn't stale.
+/// 2.1.2 If it's a regular lock, verify the lock's TTL and the current
+/// timestamp to determine the status. If the `resolving_pessimistic` parameter
+/// is true, perform a pessimistic rollback, else carry out a real rollback.
+/// 2.2 For the prewrite type, verify the lock's TTL and the current timestamp
+/// to decide the status.
+///
 /// 3. Perform required operations on the valid primary lock, such as
-///    incrementing `min_commit_ts`.
-/// The actual procedure for executing the rollback differs based on the
-/// presence or absence of an overlapping write record.
+/// incrementing `min_commit_ts`. The actual procedure for executing the
+/// rollback differs based on the presence or absence of an overlapping write
+/// record.
 pub fn check_txn_status_lock_exists(
     txn: &mut MvccTxn,
     reader: &mut SnapshotReader<impl Snapshot>,

--- a/src/storage/txn/actions/check_txn_status.rs
+++ b/src/storage/txn/actions/check_txn_status.rs
@@ -25,6 +25,10 @@ fn check_txn_status_from_pessimistic_primary_lock(
     // Check the storage information first in case the force lock could be stale.
     // See https://github.com/pingcap/tidb/issues/43540 for more details.
     if lock.is_pessimistic_lock_with_conflict() {
+        // Use `check_txn_status_missing_lock` to check if there exists a commit or
+        // rollback record in the write CF, if so the current primary
+        // pessimistic lock is stale. Otherwise the primary pessimistic lock is
+        // regarded as valid, and the transaction status is determined by it.
         let (txn_status, is_current_lock_stale) = match check_txn_status_missing_lock(
             txn,
             reader,

--- a/src/storage/txn/actions/flashback_to_version.rs
+++ b/src/storage/txn/actions/flashback_to_version.rs
@@ -185,6 +185,7 @@ pub fn prewrite_flashback_key(
             TimeStamp::zero(),
             1,
             TimeStamp::zero(),
+            false,
         ),
         false, // Assuming flashback transactions won't participate any lock conflicts.
     );

--- a/src/storage/txn/actions/prewrite.rs
+++ b/src/storage/txn/actions/prewrite.rs
@@ -341,7 +341,7 @@ impl<'a> PrewriteMutation<'a> {
         self.last_change_ts = lock.last_change_ts;
         self.versions_to_last_change = lock.versions_to_last_change;
 
-        if lock.lock_type == LockType::Pessimistic {
+        if lock.is_pessimistic_lock() {
             // TODO: remove it in future
             if !self.txn_props.is_pessimistic() {
                 return Err(ErrorInner::LockTypeNotMatch {
@@ -530,6 +530,7 @@ impl<'a> PrewriteMutation<'a> {
             for_update_ts_to_write,
             self.txn_props.txn_size,
             self.min_commit_ts,
+            false,
         )
         .set_txn_source(self.txn_props.txn_source);
         // Only Lock needs to record `last_change_ts` in its write record, Put or Delete
@@ -2556,6 +2557,7 @@ pub mod tests {
                     ts.into(),
                     5,
                     ts.into(),
+                    false,
                 )
                 .set_last_change(last_change_ts.into(), versions_to_last_change);
                 engine

--- a/src/storage/txn/commands/check_secondary_locks.rs
+++ b/src/storage/txn/commands/check_secondary_locks.rs
@@ -6,7 +6,7 @@ use txn_types::{Key, Lock, WriteType};
 use crate::storage::{
     kv::WriteData,
     lock_manager::LockManager,
-    mvcc::{LockType, MvccTxn, SnapshotReader, TimeStamp, TxnCommitRecord},
+    mvcc::{MvccTxn, OverlappedWrite, ReleasedLock, SnapshotReader, TimeStamp, TxnCommitRecord},
     txn::{
         actions::check_txn_status::{collapse_prev_rollback, make_rollback},
         commands::{
@@ -54,6 +54,78 @@ enum SecondaryLockStatus {
     RolledBack,
 }
 
+// The returned `bool` indicates whether the rollback record should be written,
+// it should be false if and only if the txn commit record is not found.
+fn check_status_from_store<S: Snapshot>(
+    reader: &mut ReaderWithStats<'_, S>,
+    key: &Key,
+) -> Result<(SecondaryLockStatus, bool, Option<OverlappedWrite>)> {
+    match reader.get_txn_commit_record(key)? {
+        TxnCommitRecord::SingleRecord { commit_ts, write } => {
+            let status = if write.write_type != WriteType::Rollback {
+                SecondaryLockStatus::Committed(commit_ts)
+            } else {
+                SecondaryLockStatus::RolledBack
+            };
+            // We needn't write a rollback once there is a write record for it:
+            // If it's a committed record, it cannot be changed.
+            // If it's a rollback record, it either comes from another
+            // check_secondary_lock (thus protected) or the client stops commit
+            // actively. So we don't need to make it protected again.
+            Ok((status, false, None))
+        }
+        TxnCommitRecord::OverlappedRollback { .. } => {
+            Ok((SecondaryLockStatus::RolledBack, false, None))
+        }
+        TxnCommitRecord::None { overlapped_write } => {
+            Ok((SecondaryLockStatus::RolledBack, true, overlapped_write))
+        }
+    }
+}
+
+fn check_status_from_lock<S: Snapshot>(
+    txn: &mut MvccTxn,
+    reader: &mut ReaderWithStats<'_, S>,
+    lock: Lock,
+    key: &Key,
+    region_id: u64,
+) -> Result<(
+    SecondaryLockStatus,
+    bool,
+    Option<OverlappedWrite>,
+    Option<ReleasedLock>,
+)> {
+    if lock.is_pessimistic_lock_with_conflict() {
+        assert!(lock.is_pessimistic_lock());
+        let (status, need_rollback, rollback_overlapped_write) =
+            check_status_from_store(reader, key)?;
+        // If there exists commit or rollback record, the pessimistic lock is stale, in
+        // this case the returned need_rollback is false.
+        if !need_rollback {
+            let released_lock = txn.unlock_key(key.clone(), true, TimeStamp::zero());
+            return Ok((
+                status,
+                need_rollback,
+                rollback_overlapped_write,
+                released_lock,
+            ));
+        }
+    }
+
+    if lock.is_pessimistic_lock() {
+        let released_lock = txn.unlock_key(key.clone(), true, TimeStamp::zero());
+        let overlapped_write = reader.get_txn_commit_record(key)?.unwrap_none(region_id);
+        Ok((
+            SecondaryLockStatus::RolledBack,
+            true,
+            overlapped_write,
+            released_lock,
+        ))
+    } else {
+        Ok((SecondaryLockStatus::Locked(lock), false, None, None))
+    }
+}
+
 impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for CheckSecondaryLocks {
     fn process_write(self, snapshot: S, context: WriteContext<'_, L>) -> Result<WriteResult> {
         // It is not allowed for commit to overwrite a protected rollback. So we update
@@ -76,40 +148,16 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for CheckSecondaryLocks {
             let (status, need_rollback, rollback_overlapped_write) = match reader.load_lock(&key)? {
                 // The lock exists, the lock information is returned.
                 Some(lock) if lock.ts == self.start_ts => {
-                    if lock.lock_type == LockType::Pessimistic {
-                        released_lock = txn.unlock_key(key.clone(), true, TimeStamp::zero());
-                        let overlapped_write =
-                            reader.get_txn_commit_record(&key)?.unwrap_none(region_id);
-                        (SecondaryLockStatus::RolledBack, true, overlapped_write)
-                    } else {
-                        (SecondaryLockStatus::Locked(lock), false, None)
-                    }
+                    let (status, need_rollback, rollback_overlapped_write, lock_released) =
+                        check_status_from_lock(&mut txn, &mut reader, lock, &key, region_id)?;
+                    released_lock = lock_released;
+                    (status, need_rollback, rollback_overlapped_write)
                 }
                 // Searches the write CF for the commit record of the lock and returns the commit
                 // timestamp (0 if the lock is not committed).
                 l => {
                     mismatch_lock = l;
-                    match reader.get_txn_commit_record(&key)? {
-                        TxnCommitRecord::SingleRecord { commit_ts, write } => {
-                            let status = if write.write_type != WriteType::Rollback {
-                                SecondaryLockStatus::Committed(commit_ts)
-                            } else {
-                                SecondaryLockStatus::RolledBack
-                            };
-                            // We needn't write a rollback once there is a write record for it:
-                            // If it's a committed record, it cannot be changed.
-                            // If it's a rollback record, it either comes from another
-                            // check_secondary_lock (thus protected) or the client stops commit
-                            // actively. So we don't need to make it protected again.
-                            (status, false, None)
-                        }
-                        TxnCommitRecord::OverlappedRollback { .. } => {
-                            (SecondaryLockStatus::RolledBack, false, None)
-                        }
-                        TxnCommitRecord::None { overlapped_write } => {
-                            (SecondaryLockStatus::RolledBack, true, overlapped_write)
-                        }
-                    }
+                    check_status_from_store(&mut reader, &key)?
                 }
             };
             // If the lock does not exist or is a pessimistic lock, to prevent the
@@ -346,5 +394,54 @@ pub mod tests {
             res => panic!("unexpected lock status: {:?}", res),
         }
         must_get_overlapped_rollback(&mut engine, b"k1", 15, 13, WriteType::Lock, Some(0));
+
+        // Lock CF has an stale pessimistic lock, the transaction is already committed
+        // or rolled back.
+        //
+        // LOCK CF       | WRITE CF
+        // ------------------------------------
+        //               | 15: start_ts = 13 with overlapped rollback
+        //               | 14: rollback
+        //               | 11: rollback
+        //               |  9: start_ts = 7
+        //               |  5: rollback
+        //               |  3: start_ts = 1
+        must_acquire_pessimistic_lock_allow_lock_with_conflict(
+            &mut engine,
+            b"k1",
+            b"key",
+            7,
+            7,
+            true,
+            false,
+            10,
+        )
+        .assert_locked_with_conflict(None, 15);
+        match check_secondary(b"k1", 7) {
+            SecondaryLocksStatus::Committed(ts) => {
+                assert!(ts.eq(&9.into()));
+            }
+            res => panic!("unexpected lock status: {:?}", res),
+        }
+        must_unlocked(&mut engine, b"k1");
+
+        // Lock CF has an pessimistic lock, the transaction status is not found
+        // in storage.
+        must_acquire_pessimistic_lock_allow_lock_with_conflict(
+            &mut engine,
+            b"k1",
+            b"key",
+            8,
+            8,
+            true,
+            false,
+            10,
+        )
+        .assert_locked_with_conflict(None, 15);
+        match check_secondary(b"k1", 8) {
+            SecondaryLocksStatus::RolledBack => {}
+            res => panic!("unexpected lock status: {:?}", res),
+        }
+        must_unlocked(&mut engine, b"k1");
     }
 }

--- a/src/storage/txn/commands/check_secondary_locks.rs
+++ b/src/storage/txn/commands/check_secondary_locks.rs
@@ -117,6 +117,10 @@ fn check_status_from_lock<S: Snapshot>(
 
     if lock.is_pessimistic_lock() {
         let released_lock = txn.unlock_key(key.clone(), true, TimeStamp::zero());
+        // If the `is_pessimistic_lock_with_conflict` is true, the `overlapped_write` is
+        // already fetched in the above `check_determined_txn_status` call. So
+        // we don't need to fetch it again and the `overlapped_write` could be
+        // reused here.
         let overlapped_write_res = if lock.is_pessimistic_lock_with_conflict() {
             overlapped_write
         } else {

--- a/src/storage/txn/commands/check_txn_status.rs
+++ b/src/storage/txn/commands/check_txn_status.rs
@@ -113,6 +113,7 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for CheckTxnStatus {
                 self.force_sync_commit,
                 self.resolving_pessimistic_lock,
                 self.verify_is_primary,
+                self.rollback_if_not_exist,
             )?,
             l => (
                 check_txn_status_missing_lock(
@@ -163,6 +164,7 @@ pub mod tests {
         mvcc::tests::*,
         txn::{
             self,
+            actions::acquire_pessimistic_lock::tests::acquire_pessimistic_lock_allow_lock_with_conflict,
             commands::{pessimistic_rollback, WriteCommand, WriteContext},
             scheduler::DEFAULT_EXECUTION_DURATION_LIMIT,
             tests::*,
@@ -294,6 +296,18 @@ pub mod tests {
                 false
             }
         }
+    }
+
+    fn pessimistic_rollback() -> impl FnOnce(TxnStatus) -> bool {
+        move |s| s == PessimisticRollBack
+    }
+
+    fn ttl_expire() -> impl FnOnce(TxnStatus) -> bool {
+        move |s| s == TtlExpire
+    }
+
+    fn lock_not_exist() -> impl FnOnce(TxnStatus) -> bool {
+        move |s| s == LockNotExist
     }
 
     #[test]
@@ -1243,5 +1257,175 @@ pub mod tests {
             b"k2",
             kvrpcpb::Op::Put,
         );
+    }
+
+    #[test]
+    fn test_check_txn_status_resolving_primary_pessimistic_lock() {
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+        let k1 = b"k1";
+        let v1 = b"v1";
+        let k2 = b"k2";
+        let v2 = b"v2";
+        let ts = TimeStamp::compose;
+
+        must_acquire_pessimistic_lock_with_ttl(&mut engine, k1, k1, ts(1, 0), ts(1, 0), 10);
+        must_acquire_pessimistic_lock_with_ttl(&mut engine, k2, k1, ts(1, 0), ts(1, 0), 10);
+        must_pessimistic_prewrite_put(
+            &mut engine,
+            k1,
+            v1,
+            k1,
+            ts(1, 0),
+            ts(1, 0),
+            DoPessimisticCheck,
+        );
+        must_pessimistic_prewrite_put(
+            &mut engine,
+            k2,
+            v2,
+            k1,
+            ts(1, 0),
+            ts(1, 0),
+            DoPessimisticCheck,
+        );
+        must_commit(&mut engine, k1, ts(1, 0), ts(2, 0));
+
+        // 1. Test resolve the stale pessimistic primary lock. Note the force lock
+        // could succeed only if there's no corresponding rollback record.
+        must_acquire_pessimistic_lock_allow_lock_with_conflict(
+            &mut engine,
+            k1,
+            k1,
+            ts(1, 0),
+            ts(1, 0),
+            false,
+            false,
+            10,
+        )
+        .assert_locked_with_conflict(Some(v1), ts(2, 0));
+
+        // Try to resolve k2, the stale pessimistic lock is on k1, the check txn status
+        // result should be "committed".
+        must_success(
+            &mut engine,
+            k1,
+            ts(1, 0),
+            ts(5, 0),
+            ts(5, 0),
+            false,
+            false,
+            false,
+            committed(ts(2, 0)),
+        );
+        must_commit(&mut engine, k2, ts(1, 0), ts(2, 0));
+
+        // 2. Test resolve the normal pessimistic primary lock.
+        must_acquire_pessimistic_lock_with_ttl(&mut engine, k1, k1, ts(11, 0), ts(11, 0), 10);
+        must_acquire_pessimistic_lock_with_ttl(&mut engine, k2, k1, ts(11, 0), ts(11, 0), 10);
+
+        // 2.1 The secondary is pessimistic which means `resolving_pessimistic` is true,
+        // and the primary does not expire.
+        must_success(
+            &mut engine,
+            k1,
+            ts(11, 0),
+            ts(15, 0),
+            ts(15, 0),
+            false,
+            false,
+            false,
+            uncommitted(10, 0, false),
+        );
+
+        // 2.2 The secondary is pessimistic, the primary has expired. The primary
+        // pessimistic lock should be rolled back pessimsitically.
+        must_success(
+            &mut engine,
+            k1,
+            ts(11, 0),
+            ts(25, 0),
+            ts(25, 0),
+            false,
+            false,
+            true,
+            pessimistic_rollback(),
+        );
+
+        // 2.3 The secondary is prewrite lock, the primary has expired. The
+        // transaction would be rolled back with persist rollback record on primary key.
+        must_acquire_pessimistic_lock_with_ttl(&mut engine, k1, k1, ts(11, 0), ts(11, 0), 10);
+        must_success(
+            &mut engine,
+            k1,
+            ts(11, 0),
+            ts(25, 0),
+            ts(25, 0),
+            false,
+            false,
+            false,
+            ttl_expire(),
+        );
+        must_get_rollback_protected(&mut engine, k1, ts(11, 0), true);
+        must_rollback(&mut engine, k2, ts(11, 0), false);
+
+        // 3. The stale pessimistic lock is invalid whose primary key is not equal to
+        // the primary key of the resolving key.
+        must_acquire_pessimistic_lock_with_ttl(&mut engine, k2, k1, ts(12, 0), ts(12, 0), 10);
+        // 3.1 The primary key does match error is returned.
+        must_err(
+            &mut engine,
+            k2,
+            ts(12, 0),
+            ts(25, 0),
+            ts(25, 0),
+            false,
+            false,
+            true,
+        );
+        // 3.2 The txn not found error is returned because rollback_if_not_exist is
+        // false.
+        must_err(
+            &mut engine,
+            k2,
+            ts(12, 0),
+            ts(25, 0),
+            ts(25, 0),
+            false,
+            false,
+            false,
+        );
+        // 3.3 The invalid lock is pessimistically rolled back and the protected
+        // rollback is written.
+        must_success(
+            &mut engine,
+            k2,
+            ts(12, 0),
+            ts(25, 0),
+            ts(25, 0),
+            true,
+            false,
+            false,
+            lock_not_exist(),
+        );
+        must_unlocked(&mut engine, k2);
+        must_get_rollback_protected(&mut engine, k2, ts(12, 0), true);
+
+        // 4. The stale pessimistic lock request would succeed if there's no lock and
+        // rollback record.
+        must_prewrite_put(&mut engine, k1, v2, k1, ts(31, 0));
+        must_commit(&mut engine, k1, ts(31, 0), ts(32, 0));
+        acquire_pessimistic_lock_allow_lock_with_conflict(
+            &mut engine,
+            k1,
+            k1,
+            ts(11, 0),
+            ts(11, 0),
+            false,
+            false,
+            false,
+            false,
+            10,
+        )
+        .unwrap_err();
     }
 }

--- a/src/storage/txn/commands/pessimistic_rollback.rs
+++ b/src/storage/txn/commands/pessimistic_rollback.rs
@@ -3,7 +3,7 @@
 // #[PerformanceCriticalPath]
 use std::mem;
 
-use txn_types::{Key, LockType, TimeStamp};
+use txn_types::{Key, TimeStamp};
 
 use crate::storage::{
     kv::WriteData,
@@ -69,7 +69,7 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for PessimisticRollback {
                 .into()
             ));
             let released_lock: MvccResult<_> = if let Some(lock) = reader.load_lock(&key)? {
-                if lock.lock_type == LockType::Pessimistic
+                if lock.is_pessimistic_lock()
                     && lock.ts == self.start_ts
                     && lock.for_update_ts <= self.for_update_ts
                 {

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -2012,6 +2012,7 @@ mod tests {
                         TimeStamp::zero(),
                         0,
                         TimeStamp::zero(),
+                        false,
                     ),
                 )],
                 Context::default(),

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -122,6 +122,14 @@ impl TxnStatus {
     pub fn committed(commit_ts: TimeStamp) -> Self {
         Self::Committed { commit_ts }
     }
+
+    // Returns if the transaction is already committed or rolled back.
+    pub fn is_decided(&self) -> bool {
+        matches!(
+            self,
+            TxnStatus::RolledBack | TxnStatus::TtlExpire | TxnStatus::Committed { .. }
+        )
+    }
 }
 
 #[derive(Debug)]

--- a/tests/failpoints/cases/test_coprocessor.rs
+++ b/tests/failpoints/cases/test_coprocessor.rs
@@ -403,6 +403,7 @@ fn test_read_index_lock_checking_on_follower() {
         10.into(),
         1,
         20.into(),
+        false,
     )
     .use_async_commit(vec![]);
     // Set a memory lock which is in the coprocessor query range on the leader

--- a/tests/failpoints/cases/test_merge.rs
+++ b/tests/failpoints/cases/test_merge.rs
@@ -1348,6 +1348,7 @@ fn test_merge_with_concurrent_pessimistic_locking() {
                 min_commit_ts: 30.into(),
                 last_change_ts: 15.into(),
                 versions_to_last_change: 3,
+                is_locked_with_conflict: false,
             },
         )])
         .unwrap();
@@ -1437,6 +1438,7 @@ fn test_merge_pessimistic_locks_with_concurrent_prewrite() {
         min_commit_ts: 30.into(),
         last_change_ts: 15.into(),
         versions_to_last_change: 3,
+        is_locked_with_conflict: false,
     };
     txn_ext
         .pessimistic_locks
@@ -1518,6 +1520,7 @@ fn test_retry_pending_prepare_merge_fail() {
         min_commit_ts: 30.into(),
         last_change_ts: 15.into(),
         versions_to_last_change: 3,
+        is_locked_with_conflict: false,
     };
     txn_ext
         .pessimistic_locks
@@ -1594,6 +1597,7 @@ fn test_merge_pessimistic_locks_propose_fail() {
         min_commit_ts: 30.into(),
         last_change_ts: 15.into(),
         versions_to_last_change: 3,
+        is_locked_with_conflict: false,
     };
     txn_ext
         .pessimistic_locks

--- a/tests/failpoints/cases/test_replica_read.rs
+++ b/tests/failpoints/cases/test_replica_read.rs
@@ -708,6 +708,7 @@ fn test_read_index_lock_checking_on_follower() {
         10.into(),
         1,
         20.into(),
+        false,
     )
     .use_async_commit(vec![]);
     let guard = block_on(leader_cm.lock_key(&Key::from_raw(b"k1")));
@@ -787,6 +788,7 @@ fn test_read_index_lock_checking_on_false_leader() {
         10.into(),
         1,
         20.into(),
+        false,
     )
     .use_async_commit(vec![]);
     let guard = block_on(leader_cm.lock_key(&Key::from_raw(b"k1")));

--- a/tests/failpoints/cases/test_split_region.rs
+++ b/tests/failpoints/cases/test_split_region.rs
@@ -952,6 +952,7 @@ fn test_split_pessimistic_locks_with_concurrent_prewrite() {
         min_commit_ts: (commit_ts + 10).into(),
         last_change_ts: 5.into(),
         versions_to_last_change: 3,
+        is_locked_with_conflict: false,
     };
     let lock_c = PessimisticLock {
         primary: b"c".to_vec().into_boxed_slice(),
@@ -961,6 +962,7 @@ fn test_split_pessimistic_locks_with_concurrent_prewrite() {
         min_commit_ts: (commit_ts + 10).into(),
         last_change_ts: 5.into(),
         versions_to_last_change: 3,
+        is_locked_with_conflict: false,
     };
     {
         let mut locks = txn_ext.pessimistic_locks.write();

--- a/tests/failpoints/cases/test_transaction.rs
+++ b/tests/failpoints/cases/test_transaction.rs
@@ -568,6 +568,7 @@ fn test_concurrent_write_after_transfer_leader_invalidates_locks() {
         min_commit_ts: 30.into(),
         last_change_ts: 5.into(),
         versions_to_last_change: 3,
+        is_locked_with_conflict: false,
     };
     txn_ext
         .pessimistic_locks

--- a/tests/failpoints/cases/test_transfer_leader.rs
+++ b/tests/failpoints/cases/test_transfer_leader.rs
@@ -136,6 +136,7 @@ fn test_delete_lock_proposed_after_proposing_locks_impl(transfer_msg_count: usiz
                 min_commit_ts: 20.into(),
                 last_change_ts: 5.into(),
                 versions_to_last_change: 3,
+                is_locked_with_conflict: false,
             },
         )])
         .unwrap();
@@ -215,6 +216,7 @@ fn test_delete_lock_proposed_before_proposing_locks() {
                 min_commit_ts: 20.into(),
                 last_change_ts: 5.into(),
                 versions_to_last_change: 3,
+                is_locked_with_conflict: false,
             },
         )])
         .unwrap();
@@ -299,6 +301,7 @@ fn test_read_lock_after_become_follower() {
                 min_commit_ts: for_update_ts,
                 last_change_ts: start_ts.prev(),
                 versions_to_last_change: 1,
+                is_locked_with_conflict: false,
             },
         )])
         .unwrap();

--- a/tests/integrations/coprocessor/test_select.rs
+++ b/tests/integrations/coprocessor/test_select.rs
@@ -2324,6 +2324,7 @@ fn test_batch_request() {
                     TimeStamp::zero(),
                     1,
                     TimeStamp::zero(),
+                    false,
                 );
                 cluster.must_put_cf(CF_LOCK, lock_key.as_encoded(), lock.to_bytes().as_slice());
             }

--- a/tests/integrations/raftstore/test_merge.rs
+++ b/tests/integrations/raftstore/test_merge.rs
@@ -1356,6 +1356,7 @@ fn test_propose_in_memory_pessimistic_locks() {
         min_commit_ts: 30.into(),
         last_change_ts: 5.into(),
         versions_to_last_change: 3,
+        is_locked_with_conflict: false,
     };
     txn_ext
         .pessimistic_locks
@@ -1374,6 +1375,7 @@ fn test_propose_in_memory_pessimistic_locks() {
         min_commit_ts: 30.into(),
         last_change_ts: 5.into(),
         versions_to_last_change: 3,
+        is_locked_with_conflict: false,
     };
     txn_ext
         .pessimistic_locks
@@ -1485,6 +1487,7 @@ fn test_merge_pessimistic_locks_repeated_merge() {
         min_commit_ts: 30.into(),
         last_change_ts: 5.into(),
         versions_to_last_change: 3,
+        is_locked_with_conflict: false,
     };
     txn_ext
         .pessimistic_locks

--- a/tests/integrations/raftstore/test_multi.rs
+++ b/tests/integrations/raftstore/test_multi.rs
@@ -835,6 +835,7 @@ fn test_leader_drop_with_pessimistic_lock() {
                 min_commit_ts: 10.into(),
                 last_change_ts: 5.into(),
                 versions_to_last_change: 3,
+                is_locked_with_conflict: false,
             },
         )])
         .unwrap();

--- a/tests/integrations/raftstore/test_replica_read.rs
+++ b/tests/integrations/raftstore/test_replica_read.rs
@@ -375,6 +375,7 @@ fn test_read_index_retry_lock_checking() {
         10.into(),
         1,
         20.into(),
+        false,
     )
     .use_async_commit(vec![]);
     let guard = block_on(leader_cm.lock_key(&Key::from_raw(b"k1")));

--- a/tests/integrations/raftstore/test_split_region.rs
+++ b/tests/integrations/raftstore/test_split_region.rs
@@ -916,6 +916,7 @@ fn test_split_with_in_memory_pessimistic_locks() {
         min_commit_ts: 30.into(),
         last_change_ts: 5.into(),
         versions_to_last_change: 3,
+        is_locked_with_conflict: false,
     };
     let lock_c = PessimisticLock {
         primary: b"c".to_vec().into_boxed_slice(),
@@ -925,6 +926,7 @@ fn test_split_with_in_memory_pessimistic_locks() {
         min_commit_ts: 30.into(),
         last_change_ts: 5.into(),
         versions_to_last_change: 3,
+        is_locked_with_conflict: false,
     };
     {
         let mut locks = txn_ext.pessimistic_locks.write();

--- a/tests/integrations/raftstore/test_transfer_leader.rs
+++ b/tests/integrations/raftstore/test_transfer_leader.rs
@@ -273,6 +273,7 @@ fn test_propose_in_memory_pessimistic_locks() {
         min_commit_ts: 30.into(),
         last_change_ts: 5.into(),
         versions_to_last_change: 3,
+        is_locked_with_conflict: false,
     };
     // Write a pessimistic lock to the in-memory pessimistic lock table.
     {
@@ -316,6 +317,7 @@ fn test_memory_pessimistic_locks_status_after_transfer_leader_failure() {
         min_commit_ts: 30.into(),
         last_change_ts: 5.into(),
         versions_to_last_change: 3,
+        is_locked_with_conflict: false,
     };
     // Write a pessimistic lock to the in-memory pessimistic lock table.
     txn_ext

--- a/tests/integrations/server/kv_service.rs
+++ b/tests/integrations/server/kv_service.rs
@@ -1348,6 +1348,7 @@ fn test_debug_scan_mvcc() {
             TimeStamp::zero(),
             0,
             TimeStamp::zero(),
+            false,
         )
         .to_bytes();
         engine.put_cf(CF_LOCK, k.as_slice(), &v).unwrap();
@@ -1924,6 +1925,7 @@ fn test_with_memory_lock_cluster(
         10.into(),
         1,
         20.into(),
+        false,
     )
     .use_async_commit(vec![]);
     guard.with_lock(|l| {

--- a/tests/integrations/storage/test_raftkv.rs
+++ b/tests/integrations/storage/test_raftkv.rs
@@ -233,6 +233,7 @@ fn test_read_on_replica_check_memory_locks() {
         10.into(),
         1,
         20.into(),
+        false,
     );
     let guard = block_on(leader_cm.lock_key(&encoded_key));
     guard.with_lock(|l| *l = Some(lock.clone()));


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #13298  https://github.com/pingcap/tidb/issues/43540

What's Changed:
1. Persist the `lock with conflict` information in the pessimistic lock type.
2. Check the persisted transaction information first resolving the primary pessimistic lock, if the lock is stale return
the actual transaction status and unlock the stale lock.
3. Check the persisted transaction information first checking secondary locks,  if the lock is stale return
the actual transaction status and unlock the stale lock.


### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects

- Performance regression
    - Consumes more CPU if there are lots of conflict pessimistic lock to resolve.

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix the incorrect transaction status returned processing stale pessimistic lock with conflict.
```
