### PR TITLE
Migrate to 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["KV", "distributed-systems", "raft"]
 homepage = "https://tikv.org"
 repository = "https://github.com/tikv/tikv/"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/cmd/tikv-ctl/Cargo.toml
+++ b/cmd/tikv-ctl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tikv-ctl"
 version = "0.0.1"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/cmd/tikv-server/Cargo.toml
+++ b/cmd/tikv-server/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tikv-server"
 version = "0.0.1"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/components/api_version/Cargo.toml
+++ b/components/api_version/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "api_version"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/components/backup-stream/Cargo.toml
+++ b/components/backup-stream/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "backup-stream"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [features]
 default = ["test-engine-kv-rocksdb", "test-engine-raft-raft-engine"]

--- a/components/backup/Cargo.toml
+++ b/components/backup/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "backup"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -899,6 +899,9 @@ impl<E: Engine, R: RegionInfoProvider + Clone + 'static> Endpoint<E, R> {
         let limit = self.softlimit.limit();
 
         self.pool.borrow_mut().spawn(async move {
+            // Migrated to 2021 migration. This let statement is probably not needed, see
+            //   https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html
+            let _ = &request;
             loop {
                 // when get the guard, release it until we finish scanning a batch,
                 // because if we were suspended during scanning,

--- a/components/batch-system/Cargo.toml
+++ b/components/batch-system/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "batch-system"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [features]
 default = ["test-runner"]

--- a/components/case_macros/Cargo.toml
+++ b/components/case_macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "case_macros"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [lib]
 proc-macro = true

--- a/components/causal_ts/Cargo.toml
+++ b/components/causal_ts/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "causal_ts"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/components/cdc/Cargo.toml
+++ b/components/cdc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cdc"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/components/cdc/src/initializer.rs
+++ b/components/cdc/src/initializer.rs
@@ -1030,6 +1030,14 @@ mod tests {
         let (tx1, rx1) = sync_channel(1);
         let change_cmd = ChangeObserver::from_cdc(1, ObserveHandle::new());
         pool.spawn(async move {
+            // Migrated to 2021 migration. This let statement is probably not needed, see
+            //   https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html
+            let _ = (
+                &initializer,
+                &change_cmd,
+                &raft_router,
+                &concurrency_semaphore,
+            );
             let res = initializer
                 .initialize(change_cmd, raft_router, concurrency_semaphore)
                 .await;

--- a/components/cloud/Cargo.toml
+++ b/components/cloud/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cloud"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/components/cloud/aws/Cargo.toml
+++ b/components/cloud/aws/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aws"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/components/cloud/azure/Cargo.toml
+++ b/components/cloud/azure/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "azure"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/components/cloud/gcp/Cargo.toml
+++ b/components/cloud/gcp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gcp"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/components/cloud/gcp/src/gcs.rs
+++ b/components/cloud/gcp/src/gcs.rs
@@ -465,7 +465,6 @@ impl BlobStorage for GcsStorage {
                 "no content to write",
             ));
         }
-        use std::convert::TryFrom;
 
         let key = self.maybe_prefix_key(name);
         debug!("save file to GCS storage"; "key" => %key);

--- a/components/codec/Cargo.toml
+++ b/components/codec/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "codec"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/components/collections/Cargo.toml
+++ b/components/collections/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "collections"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/components/concurrency_manager/Cargo.toml
+++ b/components/concurrency_manager/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2018"
+edition = "2021"
 name = "concurrency_manager"
 publish = false
 version = "0.0.1"

--- a/components/coprocessor_plugin_api/Cargo.toml
+++ b/components/coprocessor_plugin_api/Cargo.toml
@@ -2,7 +2,7 @@
 name = "coprocessor_plugin_api"
 version = "0.1.0"
 description = "Types and trait for custom coprocessor plugins for TiKV."
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/components/coprocessor_plugin_api/src/util.rs
+++ b/components/coprocessor_plugin_api/src/util.rs
@@ -118,7 +118,7 @@ macro_rules! declare_plugin {
         #[no_mangle]
         pub unsafe extern "C" fn _plugin_create(
             host_allocator: $crate::allocator::HostAllocatorPtr,
-        ) -> *mut $crate::CoprocessorPlugin {
+        ) -> *mut dyn $crate::CoprocessorPlugin {
             #[cfg(not(test))]
             HOST_ALLOCATOR.set_allocator(host_allocator);
 

--- a/components/encryption/Cargo.toml
+++ b/components/encryption/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "encryption"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/components/encryption/export/Cargo.toml
+++ b/components/encryption/export/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "encryption_export"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/components/engine_panic/Cargo.toml
+++ b/components/engine_panic/Cargo.toml
@@ -2,7 +2,7 @@
 name = "engine_panic"
 version = "0.0.1"
 description = "An example TiKV storage engine that does nothing but panic"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/components/engine_rocks/Cargo.toml
+++ b/components/engine_rocks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "engine_rocks"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/components/engine_rocks_helper/Cargo.toml
+++ b/components/engine_rocks_helper/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "engine_rocks_helper"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/components/engine_test/Cargo.toml
+++ b/components/engine_test/Cargo.toml
@@ -2,7 +2,7 @@
 name = "engine_test"
 version = "0.0.1"
 description = "A single engine that masquerades as all other engines, for testing"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/components/engine_traits/Cargo.toml
+++ b/components/engine_traits/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "engine_traits"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/components/engine_traits_tests/Cargo.toml
+++ b/components/engine_traits_tests/Cargo.toml
@@ -2,7 +2,7 @@
 name = "engine_traits_tests"
 version = "0.0.1"
 description = "Engine-agnostic tests for the engine_traits interface"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [lib]

--- a/components/error_code/Cargo.toml
+++ b/components/error_code/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "error_code"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [lib]

--- a/components/external_storage/Cargo.toml
+++ b/components/external_storage/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "external_storage"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/components/external_storage/export/Cargo.toml
+++ b/components/external_storage/export/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "external_storage_export"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [[bin]]

--- a/components/file_system/Cargo.toml
+++ b/components/file_system/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "file_system"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/components/into_other/Cargo.toml
+++ b/components/into_other/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "into_other"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/components/keys/Cargo.toml
+++ b/components/keys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "keys"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/components/log_wrappers/Cargo.toml
+++ b/components/log_wrappers/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "log_wrappers"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/components/memory_trace_macros/Cargo.toml
+++ b/components/memory_trace_macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "memory_trace_macros"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [lib]
 proc-macro = true

--- a/components/online_config/Cargo.toml
+++ b/components/online_config/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "online_config"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/components/online_config/online_config_derive/Cargo.toml
+++ b/components/online_config/online_config_derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "online_config_derive"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [lib]

--- a/components/online_config/src/lib.rs
+++ b/components/online_config/src/lib.rs
@@ -133,8 +133,6 @@ pub trait ConfigManager: Send + Sync {
 
 #[cfg(test)]
 mod tests {
-    use std::convert::TryFrom;
-
     use serde::Serialize;
 
     use super::*;

--- a/components/panic_hook/Cargo.toml
+++ b/components/panic_hook/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
 name = "panic_hook"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false

--- a/components/pd_client/Cargo.toml
+++ b/components/pd_client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pd_client"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/components/pd_client/src/client.rs
+++ b/components/pd_client/src/client.rs
@@ -215,6 +215,9 @@ impl RpcClient {
             };
 
             Box::pin(async move {
+                // Migrated to 2021 migration. This let statement is probably not needed, see
+                //   https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html
+                let _ = &req;
                 let mut resp = handler.await?;
                 check_resp_header(resp.get_header())?;
                 let region = if resp.has_region() {
@@ -1143,6 +1146,9 @@ impl MetaStorageClient for RpcClient {
                 futures::future::ready(r).err_into().try_flatten()
             };
             Box::pin(async move {
+                // Migrated to 2021 migration. This let statement is probably not needed, see
+                //   https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html
+                let _ = &req;
                 fail::fail_point!("meta_storage_get", req.key.ends_with(b"rejectme"), |_| {
                     Err(super::Error::Grpc(grpcio::Error::RemoteStopped))
                 });

--- a/components/profiler/Cargo.toml
+++ b/components/profiler/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "profiler"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/components/raft_log_engine/Cargo.toml
+++ b/components/raft_log_engine/Cargo.toml
@@ -2,7 +2,7 @@
 name = "raft_log_engine"
 version = "0.0.1"
 publish = false
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 encryption = { workspace = true }

--- a/components/raftstore/Cargo.toml
+++ b/components/raftstore/Cargo.toml
@@ -3,7 +3,7 @@ name = "raftstore"
 version = "0.0.1"
 authors = ["The TiKV Authors"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -5351,6 +5351,9 @@ mod tests {
         reg.apply_state.set_applied_index(3);
         router.schedule_task(2, Msg::Registration(reg.dup()));
         validate(&router, 2, move |delegate| {
+            // Migrated to 2021 migration. This let statement is probably not needed, see
+            //   https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html
+            let _ = &reg;
             assert_eq!(delegate.id(), 1);
             assert_eq!(delegate.peer, peer);
             assert_eq!(delegate.tag, "[region 2] 1");

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -6061,6 +6061,10 @@ mod tests {
         fn must_call() -> ExtCallback {
             let mut d = DropPanic(true);
             Box::new(move || {
+                // Must move the entire struct to closure,
+                // or else it will be dropped early in 2021 edition
+                // https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html
+                let _ = &d;
                 d.0 = false;
             })
         }

--- a/components/raftstore/src/store/replication_mode.rs
+++ b/components/raftstore/src/store/replication_mode.rs
@@ -329,6 +329,9 @@ mod tests {
         );
         // But a calculated group id can't be changed.
         let res = panic_hook::recover_safe(move || {
+            // Migrated to 2021 migration. This let statement is probably not needed, see
+            //   https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html
+            let _ = &state;
             state
                 .group
                 .register_store(1, vec![label1.clone(), label3.clone()])

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -1861,6 +1861,9 @@ where
             .pd_client
             .report_region_buckets(&delta, Duration::from_secs(interval_second));
         let f = async move {
+            // Migrated to 2021 migration. This let statement is probably not needed, see
+            //   https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html
+            let _ = &delta;
             if let Err(e) = resp.await {
                 debug!(
                     "failed to send buckets";

--- a/components/resolved_ts/Cargo.toml
+++ b/components/resolved_ts/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "resolved_ts"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/components/resolved_ts/tests/mod.rs
+++ b/components/resolved_ts/tests/mod.rs
@@ -62,6 +62,9 @@ impl TestSuite {
             obs.insert(id, rts_ob.clone());
             sim.coprocessor_hooks.entry(id).or_default().push(Box::new(
                 move |host: &mut CoprocessorHost<_>| {
+                    // Migrated to 2021 migration. This let statement is probably not needed, see
+                    //   https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html
+                    let _ = &rts_ob;
                     rts_ob.register_to(host);
                 },
             ));

--- a/components/resource_metering/Cargo.toml
+++ b/components/resource_metering/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "resource_metering"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 collections = { workspace = true }

--- a/components/security/Cargo.toml
+++ b/components/security/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "security"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/components/server/Cargo.toml
+++ b/components/server/Cargo.toml
@@ -2,7 +2,7 @@
 name = "server"
 version = "0.0.1"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/components/sst_importer/Cargo.toml
+++ b/components/sst_importer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sst_importer"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/components/test_backup/Cargo.toml
+++ b/components/test_backup/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test_backup"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/components/test_coprocessor/Cargo.toml
+++ b/components/test_coprocessor/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test_coprocessor"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/components/test_coprocessor_plugin/example_plugin/Cargo.toml
+++ b/components/test_coprocessor_plugin/example_plugin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "example_coprocessor_plugin"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [lib]

--- a/components/test_pd/Cargo.toml
+++ b/components/test_pd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test_pd"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/components/test_pd/src/server.rs
+++ b/components/test_pd/src/server.rs
@@ -258,6 +258,9 @@ impl<C: PdMocker + Send + Sync + 'static> Pd for PdMock<C> {
     ) {
         let cli = self.etcd_client.clone();
         let future = async move {
+            // Migrated to 2021 migration. This let statement is probably not needed, see
+            //   https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html
+            let _ = &req;
             let mut watcher = match cli
                 .lock()
                 .await

--- a/components/test_pd_client/Cargo.toml
+++ b/components/test_pd_client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test_pd_client"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/components/test_raftstore-v2/Cargo.toml
+++ b/components/test_raftstore-v2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test_raftstore-v2"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/components/test_raftstore/Cargo.toml
+++ b/components/test_raftstore/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test_raftstore"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/components/test_raftstore/Cargo.toml
+++ b/components/test_raftstore/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test_raftstore"
 version = "0.0.1"
-edition = "2021"
+edition = "2018"
 publish = false
 
 [features]

--- a/components/test_raftstore_macro/Cargo.toml
+++ b/components/test_raftstore_macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test_raftstore_macro"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [lib]

--- a/components/test_sst_importer/Cargo.toml
+++ b/components/test_sst_importer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test_sst_importer"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 description = "test helpers for sst_importer"
 

--- a/components/test_storage/Cargo.toml
+++ b/components/test_storage/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test_storage"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/components/test_util/Cargo.toml
+++ b/components/test_util/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test_util"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/components/tidb_query_aggr/Cargo.toml
+++ b/components/tidb_query_aggr/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tidb_query_aggr"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false
 description = "Vector aggr functions of query engine to run TiDB pushed down executors"
 

--- a/components/tidb_query_aggr/src/impl_avg.rs
+++ b/components/tidb_query_aggr/src/impl_avg.rs
@@ -30,8 +30,6 @@ impl super::AggrDefinitionParser for AggrFnDefinitionParserAvg {
         out_schema: &mut Vec<FieldType>,
         out_exp: &mut Vec<RpnExpression>,
     ) -> Result<Box<dyn AggrFunction>> {
-        use std::convert::TryFrom;
-
         use tidb_query_datatype::FieldTypeAccessor;
 
         assert_eq!(root_expr.get_tp(), ExprType::Avg);

--- a/components/tidb_query_aggr/src/impl_first.rs
+++ b/components/tidb_query_aggr/src/impl_first.rs
@@ -29,8 +29,6 @@ impl super::AggrDefinitionParser for AggrFnDefinitionParserFirst {
         out_schema: &mut Vec<FieldType>,
         out_exp: &mut Vec<RpnExpression>,
     ) -> Result<Box<dyn AggrFunction>> {
-        use std::convert::TryFrom;
-
         use tidb_query_datatype::FieldTypeAccessor;
 
         assert_eq!(root_expr.get_tp(), ExprType::First);

--- a/components/tidb_query_aggr/src/impl_sum.rs
+++ b/components/tidb_query_aggr/src/impl_sum.rs
@@ -27,8 +27,6 @@ impl super::parser::AggrDefinitionParser for AggrFnDefinitionParserSum {
         out_schema: &mut Vec<FieldType>,
         out_exp: &mut Vec<RpnExpression>,
     ) -> Result<Box<dyn AggrFunction>> {
-        use std::convert::TryFrom;
-
         use tidb_query_datatype::FieldTypeAccessor;
 
         assert_eq!(root_expr.get_tp(), ExprType::Sum);

--- a/components/tidb_query_aggr/src/impl_variance.rs
+++ b/components/tidb_query_aggr/src/impl_variance.rs
@@ -71,8 +71,6 @@ impl<V: VarianceType> super::AggrDefinitionParser for AggrFnDefinitionParserVari
         out_schema: &mut Vec<FieldType>,
         out_exp: &mut Vec<RpnExpression>,
     ) -> Result<Box<dyn AggrFunction>> {
-        use std::convert::TryFrom;
-
         use tidb_query_datatype::FieldTypeAccessor;
 
         assert!(V::check_expr_type(root_expr.get_tp()));

--- a/components/tidb_query_aggr/src/util.rs
+++ b/components/tidb_query_aggr/src/util.rs
@@ -1,7 +1,5 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::convert::TryFrom;
-
 use tidb_query_common::Result;
 use tidb_query_datatype::{builder::FieldTypeBuilder, EvalType, FieldTypeAccessor, FieldTypeTp};
 use tidb_query_expr::{impl_cast::get_cast_fn_rpn_node, RpnExpression, RpnExpressionBuilder};

--- a/components/tidb_query_codegen/Cargo.toml
+++ b/components/tidb_query_codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tidb_query_codegen"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [lib]

--- a/components/tidb_query_codegen/src/rpn_function.rs
+++ b/components/tidb_query_codegen/src/rpn_function.rs
@@ -794,7 +794,7 @@ fn generate_init_metadata_fn(
 fn generate_downcast_metadata(has_metadata: bool) -> TokenStream {
     if has_metadata {
         quote! {
-            let metadata = std::any::Any::downcast_ref(metadata).expect("downcast metadata error");
+            let metadata = <dyn std::any::Any>::downcast_ref(metadata).expect("downcast metadata error");
         }
     } else {
         quote! {}

--- a/components/tidb_query_common/Cargo.toml
+++ b/components/tidb_query_common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tidb_query_common"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false
 description = "Common utility of a query engine to run TiDB pushed down executors"
 
@@ -25,4 +25,3 @@ yatp = { workspace = true }
 
 [dev-dependencies]
 byteorder = "1.2"
-

--- a/components/tidb_query_datatype/Cargo.toml
+++ b/components/tidb_query_datatype/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tidb_query_datatype"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false
 description = "Data type of a query engine to run TiDB pushed down executors"
 

--- a/components/tidb_query_datatype/src/codec/batch/lazy_column.rs
+++ b/components/tidb_query_datatype/src/codec/batch/lazy_column.rs
@@ -1,7 +1,5 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::convert::TryFrom;
-
 use tikv_util::buffer_vec::BufferVec;
 use tipb::FieldType;
 

--- a/components/tidb_query_datatype/src/codec/chunk/column.rs
+++ b/components/tidb_query_datatype/src/codec/chunk/column.rs
@@ -1,7 +1,5 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::convert::TryFrom;
-
 use codec::{
     buffer::{BufferReader, BufferWriter},
     number::{NumberDecoder, NumberEncoder},

--- a/components/tidb_query_datatype/src/codec/data_type/chunked_vec_json.rs
+++ b/components/tidb_query_datatype/src/codec/data_type/chunked_vec_json.rs
@@ -1,7 +1,5 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::convert::TryFrom;
-
 use super::{bit_vec::BitVec, ChunkRef, ChunkedVec, Json, JsonRef, JsonType, UnsafeRefInto};
 use crate::impl_chunked_vec_common;
 

--- a/components/tidb_query_datatype/src/def/eval_type.rs
+++ b/components/tidb_query_datatype/src/def/eval_type.rs
@@ -90,8 +90,6 @@ impl std::convert::TryFrom<crate::FieldTypeTp> for EvalType {
 
 #[cfg(test)]
 mod tests {
-    use std::convert::TryFrom;
-
     use super::*;
     use crate::{FieldTypeAccessor, FieldTypeTp::*};
 

--- a/components/tidb_query_executors/Cargo.toml
+++ b/components/tidb_query_executors/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tidb_query_executors"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false
 description = "A vector query engine to run TiDB pushed down executors"
 

--- a/components/tidb_query_executors/src/util/scan_executor.rs
+++ b/components/tidb_query_executors/src/util/scan_executor.rs
@@ -151,8 +151,6 @@ pub fn field_type_from_column_info(ci: &ColumnInfo) -> FieldType {
 
 /// Checks whether the given columns info are supported.
 pub fn check_columns_info_supported(columns_info: &[ColumnInfo]) -> Result<()> {
-    use std::convert::TryFrom;
-
     use tidb_query_datatype::{EvalType, FieldTypeAccessor};
 
     for column in columns_info {

--- a/components/tidb_query_expr/Cargo.toml
+++ b/components/tidb_query_expr/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tidb_query_expr"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false
 description = "Vector expressions of query engine to run TiDB pushed down executors"
 

--- a/components/tikv_alloc/Cargo.toml
+++ b/components/tikv_alloc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tikv_alloc"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 authors = ["Brian Anderson <andersrb@gmail.com>"]
 publish = false
 

--- a/components/tikv_kv/Cargo.toml
+++ b/components/tikv_kv/Cargo.toml
@@ -3,7 +3,7 @@ name = "tikv_kv"
 version = "0.1.0"
 authors = ["The TiKV Authors"]
 description = "The key-value abstraction directly used by TiKV"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/components/tikv_util/Cargo.toml
+++ b/components/tikv_util/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tikv_util"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/components/tipb_helper/Cargo.toml
+++ b/components/tipb_helper/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tipb_helper"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/components/tracker/Cargo.toml
+++ b/components/tracker/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tracker"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/components/txn_types/Cargo.toml
+++ b/components/txn_types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "txn_types"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fuzz"
 version = "0.0.1"
 publish = false
-edition = "2018"
+edition = "2021"
 
 [[bin]]
 name = "fuzz"

--- a/fuzz/targets/Cargo.toml
+++ b/fuzz/targets/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fuzz-targets"
 version = "0.0.1"
 publish = false
-edition = "2018"
+edition = "2021"
 
 [lib]
 path = "mod.rs"

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -628,6 +628,9 @@ macro_rules! impl_write {
                     };
                     let writer = rx
                         .try_fold(writer, |mut writer, req| async move {
+                            // Migrated to 2021 migration. This let statement is probably not
+                            // needed, see   https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html
+                            let _ = &req;
                             let batch = match req.chunk {
                                 Some($chunk_ty::Batch(b)) => b,
                                 _ => return Err(Error::InvalidChunk),

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -1366,6 +1366,9 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
             // Safety: `self.sched_pool` ensures a TLS engine exists.
             unsafe {
                 with_tls_engine(|engine: &mut E| {
+                    // Migrated to 2021 migration. This let statement is probably not needed, see
+                    //   https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html
+                    let _ = &to_be_write;
                     // We skip writing the raftstore, but to improve CDC old value hit rate,
                     // we should send the old values to the CDC scheduler.
                     engine.schedule_txn_extra(to_be_write.extra);

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tests"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [[test]]

--- a/tests/integrations/storage/test_storage.rs
+++ b/tests/integrations/storage/test_storage.rs
@@ -1237,6 +1237,9 @@ fn test_isolation_inc() {
         let (punch_card, store, oracle) =
             (Arc::clone(&punch_card), store.clone(), Arc::clone(&oracle));
         threads.push(thread::spawn(move || {
+            // Migrated to 2021 migration. This let statement is probably not needed, see
+            //   https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html
+            let _ = &store;
             for _ in 0..INC_PER_THREAD {
                 let number = inc(&store.store, &oracle, b"key").unwrap() as usize;
                 let mut punch = punch_card.lock().unwrap();
@@ -1326,6 +1329,9 @@ fn test_isolation_multi_inc() {
     for _ in 0..THREAD_NUM {
         let (store, oracle) = (store.clone(), Arc::clone(&oracle));
         threads.push(thread::spawn(move || {
+            // Migrated to 2021 migration. This let statement is probably not needed, see
+            //   https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html
+            let _ = &store;
             for _ in 0..INC_PER_THREAD {
                 assert!(inc_multi(&store.store, &oracle, KEY_NUM));
             }


### PR DESCRIPTION
Migrated all crates from `edition = "2018"` to `2021`.  I have seen other projects like `clap` use `workspace` to inherit these types of values for all crates - not certain if this is useful for tikv.

* Removed all `use std::convert::TryFrom;` as it is no longer required and produces compiler warning
* `components/tidb_query_codegen/src/rpn_function.rs`

```
// old
let metadata = std::any::Any::downcast_ref(metadata).expect("...");
// new
let metadata = <dyn std::any::Any>::downcast_ref(metadata).expect("...");
```

* `components/coprocessor_plugin_api/src/util.rs`

```
// old
pub unsafe extern "C" fn _plugin_create(
            host_allocator: $crate::allocator::HostAllocatorPtr,
        ) -> *mut $crate::CoprocessorPlugin {...}
// new
        ) -> *mut dyn $crate::CoprocessorPlugin {...}
```

### TODO
Migrating `test_raftstore` crate to 2021 does NOT pass unit tests - no idea why, but it could be migrated separately.

Issue Number: Close #14726

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
