### PR TITLE
sst_importer: load SST start key from sst while cleaning up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5776,6 +5776,7 @@ dependencies = [
  "online_config",
  "openssl",
  "prometheus",
+ "protobuf",
  "rand 0.8.5",
  "serde",
  "serde_derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5762,6 +5762,7 @@ dependencies = [
  "dashmap",
  "encryption",
  "engine_rocks",
+ "engine_test",
  "engine_traits",
  "error_code",
  "external_storage_export",

--- a/components/engine_panic/src/sst.rs
+++ b/components/engine_panic/src/sst.rs
@@ -21,7 +21,10 @@ impl SstReader for PanicSstReader {
     fn open(path: &str) -> Result<Self> {
         panic!()
     }
-    fn open_encrypted<E: engine_traits::EncryptionKeyManager>(path: &str, mgr: Arc<E>) -> Result<Self> {
+    fn open_encrypted<E: engine_traits::EncryptionKeyManager>(
+        path: &str,
+        mgr: Arc<E>,
+    ) -> Result<Self> {
         panic!()
     }
     fn verify_checksum(&self) -> Result<()> {

--- a/components/engine_panic/src/sst.rs
+++ b/components/engine_panic/src/sst.rs
@@ -1,6 +1,6 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{marker::PhantomData, path::PathBuf};
+use std::{marker::PhantomData, path::PathBuf, sync::Arc};
 
 use engine_traits::{
     CfName, ExternalSstFileInfo, IterOptions, Iterable, Iterator, RefIterable, Result,
@@ -19,6 +19,9 @@ pub struct PanicSstReader;
 
 impl SstReader for PanicSstReader {
     fn open(path: &str) -> Result<Self> {
+        panic!()
+    }
+    fn open_encrypted<E: engine_traits::EncryptionKeyManager>(path: &str, mgr: Arc<E>) -> Result<Self> {
         panic!()
     }
     fn verify_checksum(&self) -> Result<()> {

--- a/components/engine_rocks/src/encryption.rs
+++ b/components/engine_rocks/src/encryption.rs
@@ -31,6 +31,12 @@ pub struct WrappedEncryptionKeyManager<T: EncryptionKeyManager> {
     manager: Arc<T>,
 }
 
+impl<T: EncryptionKeyManager> WrappedEncryptionKeyManager<T> {
+    pub fn new(manager: Arc<T>) -> Self {
+        Self { manager }
+    }
+}
+
 impl<T: EncryptionKeyManager> DBEncryptionKeyManager for WrappedEncryptionKeyManager<T> {
     fn get_file(&self, fname: &str) -> Result<DBFileEncryptionInfo> {
         self.manager

--- a/components/engine_rocks/src/sst.rs
+++ b/components/engine_rocks/src/sst.rs
@@ -16,10 +16,7 @@ use rocksdb::{
 use tikv_util::box_err;
 
 use crate::{
-    encryption::WrappedEncryptionKeyManager,
-    engine::RocksEngine,
-    options::RocksReadOptions,
-    r2e,
+    encryption::WrappedEncryptionKeyManager, engine::RocksEngine, options::RocksReadOptions, r2e,
 };
 
 impl SstExt for RocksEngine {

--- a/components/engine_rocks/src/sst.rs
+++ b/components/engine_rocks/src/sst.rs
@@ -16,7 +16,7 @@ use rocksdb::{
 use tikv_util::box_err;
 
 use crate::{
-    encryption::{get_env, WrappedEncryptionKeyManager},
+    encryption::WrappedEncryptionKeyManager,
     engine::RocksEngine,
     options::RocksReadOptions,
     r2e,

--- a/components/engine_rocks/src/sst.rs
+++ b/components/engine_rocks/src/sst.rs
@@ -3,8 +3,8 @@
 use std::{path::PathBuf, sync::Arc};
 
 use engine_traits::{
-    Error, ExternalSstFileInfo, IterOptions, Iterator, RefIterable, Result, SstCompressionType,
-    SstExt, SstMetaInfo, SstReader, SstWriter, SstWriterBuilder, CF_DEFAULT,
+    EncryptionKeyManager, Error, ExternalSstFileInfo, IterOptions, Iterator, RefIterable, Result,
+    SstCompressionType, SstExt, SstMetaInfo, SstReader, SstWriter, SstWriterBuilder, CF_DEFAULT,
 };
 use fail::fail_point;
 use kvproto::import_sstpb::SstMeta;
@@ -13,8 +13,14 @@ use rocksdb::{
     EnvOptions, ExternalSstFileInfo as RawExternalSstFileInfo, SequentialFile, SstFileReader,
     SstFileWriter, DB,
 };
+use tikv_util::box_err;
 
-use crate::{engine::RocksEngine, options::RocksReadOptions, r2e};
+use crate::{
+    encryption::{get_env, WrappedEncryptionKeyManager},
+    engine::RocksEngine,
+    options::RocksReadOptions,
+    r2e,
+};
 
 impl SstExt for RocksEngine {
     type SstReader = RocksSstReader;
@@ -62,6 +68,14 @@ impl RocksSstReader {
 impl SstReader for RocksSstReader {
     fn open(path: &str) -> Result<Self> {
         Self::open_with_env(path, None)
+    }
+    fn open_encrypted<E: EncryptionKeyManager>(path: &str, mgr: Arc<E>) -> Result<Self> {
+        let env = Env::new_key_managed_encrypted_env(
+            Arc::default(),
+            WrappedEncryptionKeyManager::new(mgr),
+        )
+        .map_err(|err| Error::Other(box_err!("failed to open encrypted env: {}", err)))?;
+        Self::open_with_env(path, Some(Arc::new(env)))
     }
     fn verify_checksum(&self) -> Result<()> {
         self.inner.verify_checksum().map_err(r2e)?;

--- a/components/engine_traits/src/sst.rs
+++ b/components/engine_traits/src/sst.rs
@@ -1,10 +1,10 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::Arc};
 
 use kvproto::import_sstpb::SstMeta;
 
-use crate::{errors::Result, RefIterable};
+use crate::{errors::Result, RefIterable, EncryptionKeyManager};
 
 #[derive(Clone, Debug)]
 pub struct SstMetaInfo {
@@ -22,6 +22,7 @@ pub trait SstExt: Sized {
 /// SstReader is used to read an SST file.
 pub trait SstReader: RefIterable + Sized {
     fn open(path: &str) -> Result<Self>;
+    fn open_encrypted<E: EncryptionKeyManager>(path: &str, mgr: Arc<E>) -> Result<Self>;
     fn verify_checksum(&self) -> Result<()>;
 }
 

--- a/components/engine_traits/src/sst.rs
+++ b/components/engine_traits/src/sst.rs
@@ -4,7 +4,7 @@ use std::{path::PathBuf, sync::Arc};
 
 use kvproto::import_sstpb::SstMeta;
 
-use crate::{errors::Result, RefIterable, EncryptionKeyManager};
+use crate::{errors::Result, EncryptionKeyManager, RefIterable};
 
 #[derive(Clone, Debug)]
 pub struct SstMetaInfo {

--- a/components/raftstore/src/store/worker/cleanup_sst.rs
+++ b/components/raftstore/src/store/worker/cleanup_sst.rs
@@ -1,14 +1,17 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{fmt, marker::PhantomData, sync::Arc};
+use std::{error::Error, fmt, marker::PhantomData, sync::Arc};
 
 use engine_traits::KvEngine;
-use kvproto::import_sstpb::SstMeta;
+use futures::executor::block_on;
+use kvproto::{import_sstpb::SstMeta, metapb::Region};
 use pd_client::PdClient;
 use sst_importer::SstImporter;
-use tikv_util::{error, worker::Runnable};
+use tikv_util::{box_err, error, worker::Runnable};
 
 use crate::store::{util::is_epoch_stale, StoreMsg, StoreRouter};
+
+type Result<T> = std::result::Result<T, Box<dyn Error>>;
 
 pub enum Task {
     DeleteSst { ssts: Vec<SstMeta> },
@@ -64,12 +67,31 @@ where
         }
     }
 
+    fn get_region_by_meta(&self, sst: &SstMeta) -> Result<Region> {
+        // The SST meta has been delivered with a range, use it directly.
+        if !sst.get_range().get_start().is_empty() || !sst.get_range().get_end().is_empty() {
+            return self
+                .pd_client
+                .get_region(sst.get_range().get_start())
+                .map_err(Into::into);
+        }
+        // Once there isn't range provided.
+        let query_by_start_key_of_full_meta = || {
+            let meta = self.importer.try_fetch_full_meta(&sst)?;
+            let region = self.pd_client.get_region(meta.get_range().get_start())?;
+            Result::Ok(region)
+        };
+        query_by_start_key_of_full_meta().map_err(|err| 
+            format!("failed to load full sst meta from disk for {:?} and there isn't extra information provided: {err}", sst.get_uuid()).into()
+        )
+    }
+
     /// Validates whether the SST is stale or not.
     fn handle_validate_sst(&self, ssts: Vec<SstMeta>) {
         let store_id = self.store_id;
         let mut invalid_ssts = Vec::new();
         for sst in ssts {
-            match self.pd_client.get_region(sst.get_range().get_start()) {
+            match self.get_region_by_meta(&sst) {
                 Ok(r) => {
                     // The region id may or may not be the same as the
                     // SST file, but it doesn't matter, because the
@@ -87,7 +109,7 @@ where
                     invalid_ssts.push(sst);
                 }
                 Err(e) => {
-                    error!(%e; "get region failed");
+                    error!("get region failed"; "err" => %e);
                 }
             }
         }

--- a/components/raftstore/src/store/worker/cleanup_sst.rs
+++ b/components/raftstore/src/store/worker/cleanup_sst.rs
@@ -76,8 +76,10 @@ where
         }
         // Once there isn't range provided.
         let query_by_start_key_of_full_meta = || {
-            let meta = self.importer.try_fetch_full_meta(sst)?;
-            let region = self.pd_client.get_region(meta.get_range().get_start())?;
+            let start_key = self.importer.load_start_key_by_meta::<EK>(sst)?.ok_or_else(|| -> Box<dyn Error> {
+                format!("failed to load start key from sst, the sst might be empty").into()
+            })?;
+            let region = self.pd_client.get_region(&start_key)?;
             Result::Ok(region)
         };
         query_by_start_key_of_full_meta()

--- a/components/raftstore/src/store/worker/cleanup_sst.rs
+++ b/components/raftstore/src/store/worker/cleanup_sst.rs
@@ -77,7 +77,7 @@ where
         // Once there isn't range provided.
         let query_by_start_key_of_full_meta = || {
             let start_key = self.importer.load_start_key_by_meta::<EK>(sst)?.ok_or_else(|| -> Box<dyn Error> {
-                format!("failed to load start key from sst, the sst might be empty").into()
+                "failed to load start key from sst, the sst might be empty".into()
             })?;
             let region = self.pd_client.get_region(&start_key)?;
             Result::Ok(region)

--- a/components/raftstore/src/store/worker/cleanup_sst.rs
+++ b/components/raftstore/src/store/worker/cleanup_sst.rs
@@ -76,9 +76,12 @@ where
         }
         // Once there isn't range provided.
         let query_by_start_key_of_full_meta = || {
-            let start_key = self.importer.load_start_key_by_meta::<EK>(sst)?.ok_or_else(|| -> Box<dyn Error> {
-                "failed to load start key from sst, the sst might be empty".into()
-            })?;
+            let start_key = self
+                .importer
+                .load_start_key_by_meta::<EK>(sst)?
+                .ok_or_else(|| -> Box<dyn Error> {
+                    "failed to load start key from sst, the sst might be empty".into()
+                })?;
             let region = self.pd_client.get_region(&start_key)?;
             Result::Ok(region)
         };

--- a/components/raftstore/src/store/worker/cleanup_sst.rs
+++ b/components/raftstore/src/store/worker/cleanup_sst.rs
@@ -68,6 +68,8 @@ where
 
     fn get_region_by_meta(&self, sst: &SstMeta) -> Result<Region> {
         // The SST meta has been delivered with a range, use it directly.
+        // For now, no case will reach this. But this still could be a guard for
+        // reducing the superise in the future...
         if !sst.get_range().get_start().is_empty() || !sst.get_range().get_end().is_empty() {
             return self
                 .pd_client

--- a/components/sst_importer/Cargo.toml
+++ b/components/sst_importer/Cargo.toml
@@ -15,9 +15,6 @@ cloud-storage-dylib = ["external_storage_export/cloud-storage-dylib"]
 test-engines-rocksdb = [
   "engine_test/test-engines-rocksdb",
 ]
-test-engines-panic = [
-  "engine_test/test-engines-panic",
-]
 
 [dependencies]
 api_version = { workspace = true }

--- a/components/sst_importer/Cargo.toml
+++ b/components/sst_importer/Cargo.toml
@@ -12,6 +12,16 @@ cloud-azure = ["external_storage_export/cloud-azure"]
 cloud-storage-grpc = ["external_storage_export/cloud-storage-grpc"]
 cloud-storage-dylib = ["external_storage_export/cloud-storage-dylib"]
 
+test-engine-raft-raft-engine = [
+  "engine_test/test-engine-raft-raft-engine",
+]
+test-engines-rocksdb = [
+  "engine_test/test-engines-rocksdb",
+]
+test-engines-panic = [
+  "engine_test/test-engines-panic",
+]
+
 [dependencies]
 api_version = { workspace = true }
 crc32fast = "1.2"
@@ -49,4 +59,4 @@ uuid = { version = "0.8.1", features = ["serde", "v4"] }
 tempfile = "3.0"
 test_sst_importer = { workspace = true }
 test_util = { workspace = true }
-engine_test = { workspace = true, features = ["test-engines-rocksdb"] }
+engine_test = { workspace = true }

--- a/components/sst_importer/Cargo.toml
+++ b/components/sst_importer/Cargo.toml
@@ -32,6 +32,7 @@ log_wrappers = { workspace = true }
 online_config = { workspace = true }
 openssl = "0.10"
 prometheus = { version = "0.13", default-features = false }
+protobuf = { version = "2.8", features = ["bytes"] }
 rand = "0.8"
 serde = "1.0"
 serde_derive = "1.0"
@@ -43,7 +44,6 @@ tikv_util = { workspace = true }
 tokio = { version = "1.5", features = ["time", "rt-multi-thread", "macros"] }
 txn_types = { workspace = true }
 uuid = { version = "0.8.1", features = ["serde", "v4"] }
-protobuf = { version = "2.8", features = ["bytes"] }
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/components/sst_importer/Cargo.toml
+++ b/components/sst_importer/Cargo.toml
@@ -12,9 +12,6 @@ cloud-azure = ["external_storage_export/cloud-azure"]
 cloud-storage-grpc = ["external_storage_export/cloud-storage-grpc"]
 cloud-storage-dylib = ["external_storage_export/cloud-storage-dylib"]
 
-test-engine-raft-raft-engine = [
-  "engine_test/test-engine-raft-raft-engine",
-]
 test-engines-rocksdb = [
   "engine_test/test-engines-rocksdb",
 ]
@@ -56,7 +53,7 @@ txn_types = { workspace = true }
 uuid = { version = "0.8.1", features = ["serde", "v4"] }
 
 [dev-dependencies]
+engine_test = { workspace = true }
 tempfile = "3.0"
 test_sst_importer = { workspace = true }
 test_util = { workspace = true }
-engine_test = { workspace = true }

--- a/components/sst_importer/Cargo.toml
+++ b/components/sst_importer/Cargo.toml
@@ -43,6 +43,7 @@ tikv_util = { workspace = true }
 tokio = { version = "1.5", features = ["time", "rt-multi-thread", "macros"] }
 txn_types = { workspace = true }
 uuid = { version = "0.8.1", features = ["serde", "v4"] }
+protobuf = { version = "2.8", features = ["bytes"] }
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/components/sst_importer/Cargo.toml
+++ b/components/sst_importer/Cargo.toml
@@ -49,3 +49,4 @@ uuid = { version = "0.8.1", features = ["serde", "v4"] }
 tempfile = "3.0"
 test_sst_importer = { workspace = true }
 test_util = { workspace = true }
+engine_test = { workspace = true, features = ["test-engines-rocksdb"] }

--- a/components/sst_importer/src/import_file.rs
+++ b/components/sst_importer/src/import_file.rs
@@ -505,8 +505,7 @@ pub fn parse_meta_from_path<P: AsRef<Path>>(path: P) -> Result<SstMeta> {
 
 #[cfg(test)]
 mod test {
-    use tempfile::TempDir;
-    use test_util::new_test_key_manager;
+    use engine_traits::CF_DEFAULT;
 
     use super::*;
 
@@ -552,7 +551,8 @@ mod test {
     fn test_path_with_range_and_km(km: Option<DataKeyManager>) {
         use engine_rocks::{RocksEngine, RocksSstWriterBuilder};
         use engine_test::ctor::{CfOptions, DbOptions};
-        use engine_traits::{SstWriter, SstWriterBuilder, CF_DEFAULT};
+        use engine_traits::{SstWriter, SstWriterBuilder};
+        use tempfile::TempDir;
         let arcmgr = km.map(Arc::new);
         let tmp = TempDir::new().unwrap();
         let dir = ImportDir::new(tmp.path()).unwrap();
@@ -615,6 +615,8 @@ mod test {
     #[test]
     #[cfg(feature = "test-engines-rocksdb")]
     fn test_path_with_range_encrypted() {
+        use tempfile::TempDir;
+        use test_util::new_test_key_manager;
         let dir = TempDir::new().unwrap();
         let enc = new_test_key_manager(&dir, None, None, None)
             .unwrap()

--- a/components/sst_importer/src/import_file.rs
+++ b/components/sst_importer/src/import_file.rs
@@ -81,6 +81,13 @@ impl ImportPath {
         sync_dir(&self.save)?;
         Ok(())
     }
+
+    pub fn save_meta(&self, km: Option<&DataKeyManager>, meta: &SstMeta) -> Result<()> {
+        use std::io::{Error as IoErr, ErrorKind as IoErrs};
+        meta.write_to_bytes()
+            .map_err(|err| Error::from(IoErr::new(IoErrs::InvalidInput, err)))
+            .and_then(|v| write_bytes(&self.meta, v, km))
+    }
 }
 
 impl fmt::Debug for ImportPath {
@@ -280,16 +287,11 @@ impl ImportDir {
         meta: &SstMeta,
         key_manager: Option<Arc<DataKeyManager>>,
     ) -> Result<ImportFile> {
-        use std::io::{Error as IoErr, ErrorKind as IoErrs};
         let path = self.join(meta)?;
         if path.save.exists() {
             return Err(Error::FileExists(path.save, "create SST upload cache"));
         }
-        let write_meta_res = meta
-            .write_to_bytes()
-            .map_err(|err| Error::from(IoErr::new(IoErrs::InvalidInput, err)))
-            .and_then(|v| write_bytes(&path.meta, v, key_manager.as_deref()));
-        if let Err(err) = write_meta_res {
+        if let Err(err) = path.save_meta(key_manager.as_deref(), meta) {
             warn!(
                 "failed to encode and save the sst meta, skipping.";
                 "err" => %err

--- a/components/sst_importer/src/import_file.rs
+++ b/components/sst_importer/src/import_file.rs
@@ -505,9 +505,6 @@ pub fn parse_meta_from_path<P: AsRef<Path>>(path: P) -> Result<SstMeta> {
 
 #[cfg(test)]
 mod test {
-    use engine_rocks::{RocksEngine, RocksSstWriterBuilder};
-    use engine_test::ctor::{CfOptions, DbOptions};
-    use engine_traits::{SstWriter, SstWriterBuilder, CF_DEFAULT};
     use tempfile::TempDir;
     use test_util::new_test_key_manager;
 
@@ -551,7 +548,11 @@ mod test {
         assert_eq!(meta, new_meta);
     }
 
+    #[cfg(feature = "test-engines-rocksdb")]
     fn test_path_with_range_and_km(km: Option<DataKeyManager>) {
+        use engine_rocks::{RocksEngine, RocksSstWriterBuilder};
+        use engine_test::ctor::{CfOptions, DbOptions};
+        use engine_traits::{SstWriter, SstWriterBuilder, CF_DEFAULT};
         let arcmgr = km.map(Arc::new);
         let tmp = TempDir::new().unwrap();
         let dir = ImportDir::new(tmp.path()).unwrap();
@@ -606,11 +607,13 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "test-engines-rocksdb")]
     fn test_path_with_range() {
         test_path_with_range_and_km(None)
     }
 
     #[test]
+    #[cfg(feature = "test-engines-rocksdb")]
     fn test_path_with_range_encrypted() {
         let dir = TempDir::new().unwrap();
         let enc = new_test_key_manager(&dir, None, None, None)

--- a/components/sst_importer/src/import_file.rs
+++ b/components/sst_importer/src/import_file.rs
@@ -49,7 +49,13 @@ pub struct ImportPath {
     pub temp: PathBuf,
     // The path of the file that is going to be ingested.
     pub clone: PathBuf,
-    // The path of the origin `SstMeta` (encoded in wire) of the file.
+    // The path of the origin `SstMeta` (encoded by wire) of the file.
+    // We have encoded a subset of SstMeta to the file name, but that isn't enough,
+    // for now, we need to get the range of the SST to check whether we are still needing it
+    // (Check it solely by region ID isn't good enough -- regions may be destroyed by merging.).
+    // "But why not directly read the start key from the SST file?"
+    // "Because that couples the `Engine` and `ImportDir` -- In fact, we cannot access `Engine` in
+    // the context of validating the SST."
     pub meta: PathBuf,
 }
 

--- a/components/sst_importer/src/import_file.rs
+++ b/components/sst_importer/src/import_file.rs
@@ -268,7 +268,7 @@ impl ImportDir {
         let save_path = self.root_dir.join(file_name);
         let temp_path = self.temp_dir.join(file_name);
         let clone_path = self.clone_dir.join(file_name);
-        let meta_path = self.meta_dir.join(self.get_meta_file_name(file_name));
+        let meta_path = self.meta_dir.join(file_name);
         Ok(ImportPath {
             save: save_path,
             temp: temp_path,
@@ -450,7 +450,7 @@ impl ImportDir {
             .ok_or_else(|| Error::InvalidSstPath(p.to_owned()))?;
         let meta_path = self
             .meta_dir
-            .join(self.get_meta_file_name(&fname.to_string_lossy()));
+            .join(fname);
 
         let meta_bytes = match sc {
             None => file_system::read(&meta_path)?,
@@ -480,20 +480,15 @@ impl ImportDir {
         Ok(())
     }
 
-    fn get_meta_file_name(&self, n: &str) -> String {
-        format!("{n}.meta.wire")
+    pub fn try_fetch_full_meta(&self, meta: &SstMeta, km: Option<&DataKeyManager>) -> Result<SstMeta> {
+        let path = sst_meta_to_path(meta)?;
+        let meta_path = self.meta_dir.join(path);
+        let mut m1 = meta.clone();
+        self.fill_by_persisted_meta(&meta_path, km, &mut m1)?;
+        Ok(m1)
     }
 
-    fn get_meta_by_path(&self, p: &Path, km: Option<&DataKeyManager>) -> Result<SstMeta> {
-        let mut m0 = parse_meta_from_path(p)?;
-        if let Err(err) = self.fill_by_persisted_meta(p, km, &mut m0) {
-            info!("failed to load sst meta from .meta dir, maybe upgrade from old versions."; "err" => %err, "path" => %p.display());
-        }
-
-        Ok(m0)
-    }
-
-    pub fn list_ssts(&self, km: Option<&DataKeyManager>) -> Result<Vec<SstMeta>> {
+    pub fn list_ssts(&self) -> Result<Vec<SstMeta>> {
         let mut ssts = Vec::new();
         for e in file_system::read_dir(&self.root_dir)? {
             let e = e?;
@@ -501,7 +496,7 @@ impl ImportDir {
                 continue;
             }
             let path = e.path();
-            match self.get_meta_by_path(&path, km) {
+            match parse_meta_from_path(&path) {
                 Ok(sst) => ssts.push(sst),
                 Err(e) => error!(%e; "path_to_sst_meta failed"; "path" => %path.display(),),
             }
@@ -627,7 +622,11 @@ mod test {
         meta.mut_region_epoch().set_version(333);
         let f = dir.create(&meta, arcmgr.clone()).unwrap();
         std::fs::rename(&f.path.temp, &f.path.save).unwrap();
-        assert_eq!(dir.list_ssts(arcmgr.as_deref()).unwrap(), vec![meta]);
+        let mut ssts = dir.list_ssts().unwrap();
+        ssts.iter_mut().for_each(|meta| {
+            *meta = dir.try_fetch_full_meta(&meta, arcmgr.as_deref()).unwrap()
+        });
+        assert_eq!(ssts, vec![meta]);
     }
 
     #[test]

--- a/components/sst_importer/src/import_file.rs
+++ b/components/sst_importer/src/import_file.rs
@@ -182,7 +182,7 @@ impl ImportFile {
                 if let Some(ref manager) = self.key_manager {
                     manager.delete_file(path.to_str().unwrap())?;
                 }
-                file_system::remove_file(&path)?;
+                file_system::remove_file(path)?;
             }
             Result::Ok(())
         };

--- a/components/sst_importer/src/import_file.rs
+++ b/components/sst_importer/src/import_file.rs
@@ -1,9 +1,9 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     fmt,
-    io::{self, Read, Write},
+    io::{self, Write},
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -18,7 +18,6 @@ use engine_traits::{
 use file_system::{get_io_rate_limiter, sync_dir, File, OpenOptions};
 use keys::data_key;
 use kvproto::{import_sstpb::*, kvrpcpb::ApiVersion};
-use protobuf::Message;
 use tikv_util::time::Instant;
 use uuid::{Builder as UuidBuilder, Uuid};
 
@@ -50,14 +49,6 @@ pub struct ImportPath {
     pub temp: PathBuf,
     // The path of the file that is going to be ingested.
     pub clone: PathBuf,
-    // The path of the origin `SstMeta` (encoded by wire) of the file.
-    // We have encoded a subset of SstMeta to the file name, but that isn't enough,
-    // for now, we need to get the range of the SST to check whether we are still needing it
-    // (Check it solely by region ID isn't good enough -- regions may be destroyed by merging.).
-    // "But why not directly read the start key from the SST file?"
-    // "Because that couples the `Engine` and `ImportDir` -- In fact, we cannot access `Engine` in
-    // the context of validating the SST."
-    pub meta: PathBuf,
 }
 
 impl ImportPath {
@@ -88,13 +79,6 @@ impl ImportPath {
         sync_dir(&self.save)?;
         Ok(())
     }
-
-    pub fn save_meta(&self, km: Option<&DataKeyManager>, meta: &SstMeta) -> Result<()> {
-        use std::io::{Error as IoErr, ErrorKind as IoErrs};
-        meta.write_to_bytes()
-            .map_err(|err| Error::from(IoErr::new(IoErrs::InvalidInput, err)))
-            .and_then(|v| write_bytes(&self.meta, v, km))
-    }
 }
 
 impl fmt::Debug for ImportPath {
@@ -103,7 +87,6 @@ impl fmt::Debug for ImportPath {
             .field("save", &self.save)
             .field("temp", &self.temp)
             .field("clone", &self.clone)
-            .field("meta", &self.meta)
             .finish()
     }
 }
@@ -184,17 +167,13 @@ impl ImportFile {
 
     fn cleanup(&mut self) -> Result<()> {
         self.file.take();
-        let delete_file_if_exist = |path: &Path| {
-            if path.exists() {
-                if let Some(ref manager) = self.key_manager {
-                    manager.delete_file(path.to_str().unwrap())?;
-                }
-                file_system::remove_file(path)?;
+        let path = &self.path.temp;
+        if path.exists() {
+            if let Some(ref manager) = self.key_manager {
+                manager.delete_file(path.to_str().unwrap())?;
             }
-            Result::Ok(())
-        };
-        delete_file_if_exist(&self.path.temp)?;
-        delete_file_if_exist(&self.path.meta)?;
+            file_system::remove_file(path)?;
+        }
         Ok(())
     }
 
@@ -240,19 +219,16 @@ pub struct ImportDir {
     root_dir: PathBuf,
     temp_dir: PathBuf,
     clone_dir: PathBuf,
-    meta_dir: PathBuf,
 }
 
 impl ImportDir {
     const TEMP_DIR: &'static str = ".temp";
     const CLONE_DIR: &'static str = ".clone";
-    const META_DIR: &'static str = ".meta";
 
     pub fn new<P: AsRef<Path>>(root: P) -> Result<ImportDir> {
         let root_dir = root.as_ref().to_owned();
         let temp_dir = root_dir.join(Self::TEMP_DIR);
         let clone_dir = root_dir.join(Self::CLONE_DIR);
-        let meta_dir = root_dir.join(Self::META_DIR);
         if temp_dir.exists() {
             file_system::remove_dir_all(&temp_dir)?;
         }
@@ -261,12 +237,10 @@ impl ImportDir {
         }
         file_system::create_dir_all(&temp_dir)?;
         file_system::create_dir_all(&clone_dir)?;
-        file_system::create_dir_all(&meta_dir)?;
         Ok(ImportDir {
             root_dir,
             temp_dir,
             clone_dir,
-            meta_dir,
         })
     }
 
@@ -279,12 +253,10 @@ impl ImportDir {
         let save_path = self.root_dir.join(file_name);
         let temp_path = self.temp_dir.join(file_name);
         let clone_path = self.clone_dir.join(file_name);
-        let meta_path = self.meta_dir.join(file_name);
         Ok(ImportPath {
             save: save_path,
             temp: temp_path,
             clone: clone_path,
-            meta: meta_path,
         })
     }
 
@@ -321,7 +293,6 @@ impl ImportDir {
         self.delete_file(&path.save, manager)?;
         self.delete_file(&path.temp, manager)?;
         self.delete_file(&path.clone, manager)?;
-        self.delete_file(&path.meta, manager)?;
         Ok(path)
     }
 
@@ -444,69 +415,6 @@ impl ImportDir {
         Ok(())
     }
 
-    fn fill_by_persisted_meta(
-        &self,
-        p: &Path,
-        sc: Option<&DataKeyManager>,
-        m0: &mut SstMeta,
-    ) -> Result<()> {
-        use std::io::{Error as IoErr, ErrorKind as IoErrs};
-        let fname = p
-            .file_name()
-            .ok_or_else(|| Error::InvalidSstPath(p.to_owned()))?;
-        let meta_path = self.meta_dir.join(fname);
-
-        let meta_bytes = match sc {
-            None => file_system::read(&meta_path)?,
-            Some(s) => {
-                let mut v = Vec::new();
-                s.open_file_for_read(&meta_path)?.read_to_end(&mut v)?;
-                v
-            }
-        };
-        let old_uuid = m0.get_uuid().to_owned();
-        let backup = m0.clone();
-        m0.merge_from_bytes(&meta_bytes)
-            .map_err(|err| IoErr::new(IoErrs::InvalidData, err))?;
-        if old_uuid != m0.get_uuid() {
-            // The meta might be modified by the `merge_from_bytes`, let's
-            // restore it.
-            *m0 = backup;
-            return Err(Error::FileCorrupted(
-                meta_path,
-                format!(
-                    "the meta file uuid doesn't match the filename: {:?} vs {:?}",
-                    old_uuid,
-                    m0.get_uuid()
-                ),
-            ));
-        }
-        Ok(())
-    }
-
-    pub fn clean_unused_meta(&self, km: Option<&DataKeyManager>) -> Result<()> {
-        let start = Instant::now_coarse();
-        let ssts = self.list_ssts()?;
-        let sst_set = ssts
-            .iter()
-            .filter_map(|m| {
-                let p: PathBuf = sst_meta_to_path(m).ok()?;
-                let file_name = p.file_name()?.to_owned();
-                Some(file_name)
-            })
-            .collect::<HashSet<_>>();
-        let mut cleaned = 0;
-        for e in file_system::read_dir(&self.meta_dir)? {
-            let e = e?;
-            if !sst_set.contains(&e.file_name()) {
-                self.delete_file(&e.path(), km)?;
-                cleaned += 1;
-            }
-        }
-        info!("SST metadata dir cleaned."; "removed_stale_meta" => %cleaned, "take" => ?start.saturating_elapsed());
-        Ok(())
-    }
-
     pub fn load_start_key_by_meta<E: SstExt>(
         &self,
         meta: &SstMeta,
@@ -522,19 +430,14 @@ impl ImportDir {
         if !i.seek_to_first()? || !i.valid()? {
             return Ok(None);
         }
-        Ok(Some(i.key().to_owned()))
-    }
-
-    pub fn try_fetch_full_meta(
-        &self,
-        meta: &SstMeta,
-        km: Option<&DataKeyManager>,
-    ) -> Result<SstMeta> {
-        let path = sst_meta_to_path(meta)?;
-        let meta_path = self.meta_dir.join(path);
-        let mut m1 = meta.clone();
-        self.fill_by_persisted_meta(&meta_path, km, &mut m1)?;
-        Ok(m1)
+        // Should we warn if the key doesn't start with the prefix key? (Is that
+        // possible?)
+        // Also note this brings implicit coupling between this and
+        // RocksEngine. Perhaps it is better to make the engine to provide
+        // decode functions. Anyway we have directly used the RocksSstReader
+        // somewhere... This won't make things worse.
+        let real_key = i.key().strip_prefix(keys::DATA_PREFIX_KEY);
+        Ok(real_key.map(ToOwned::to_owned))
     }
 
     pub fn list_ssts(&self) -> Result<Vec<SstMeta>> {
@@ -555,14 +458,6 @@ impl ImportDir {
 }
 
 const SST_SUFFIX: &str = ".sst";
-
-fn write_bytes(p: impl AsRef<Path>, content: Vec<u8>, km: Option<&DataKeyManager>) -> Result<()> {
-    match km {
-        Some(sc) => sc.create_file_for_write(p)?.write_all(&content)?,
-        None => file_system::write(p, content)?,
-    };
-    Ok(())
-}
 
 pub fn sst_meta_to_path(meta: &SstMeta) -> Result<PathBuf> {
     Ok(PathBuf::from(format!(
@@ -610,9 +505,7 @@ pub fn parse_meta_from_path<P: AsRef<Path>>(path: P) -> Result<SstMeta> {
 
 #[cfg(test)]
 mod test {
-    use std::mem::ManuallyDrop;
-
-    use engine_rocks::{RocksEngine, RocksSstWriter, RocksSstWriterBuilder};
+    use engine_rocks::{RocksEngine, RocksSstWriterBuilder};
     use engine_test::ctor::{CfOptions, DbOptions};
     use engine_traits::{SstWriter, SstWriterBuilder, CF_DEFAULT};
     use tempfile::TempDir;
@@ -686,14 +579,15 @@ mod test {
             .set_cf(CF_DEFAULT)
             .build(f.path.temp.to_str().unwrap())
             .unwrap();
-        w.put(b"hello", concat!("This is the start key of the SST, ",
+        w.put(b"zhello", concat!("This is the start key of the SST, ",
               "how about some of our users uploads metas with range not aligned with the content of SST?",
-              "May the real region still be in the current store.").as_bytes()).unwrap();
+              "No, at least for now, tidb-lightning won't do so.").as_bytes()).unwrap();
         w.put(
-            b"world",
+            b"zworld",
             concat!(
                 "This is the end key of the SST, ",
-                "it is so we can check whether we are loding the right key from the SST."
+                "you might notice that all keys have a extra prefix 'z', that was appended by the RocksEngine implementation.",
+                "It is a little weird that the user key isn't the same in SST. But anyway reasonable. We have bypassed some layers."
             )
             .as_bytes(),
         )

--- a/components/sst_importer/src/import_file.rs
+++ b/components/sst_importer/src/import_file.rs
@@ -12,7 +12,8 @@ use api_version::api_v2::TIDB_RANGES_COMPLEMENT;
 use encryption::{DataKeyManager, EncrypterWriter};
 use engine_rocks::{get_env, RocksSstReader};
 use engine_traits::{
-    iter_option, EncryptionKeyManager, Iterator, KvEngine, RefIterable, SstMetaInfo, SstReader,
+    iter_option, EncryptionKeyManager, IterOptions, Iterator, KvEngine, RefIterable, SstExt,
+    SstMetaInfo, SstReader,
 };
 use file_system::{get_io_rate_limiter, sync_dir, File, OpenOptions};
 use keys::data_key;
@@ -506,6 +507,24 @@ impl ImportDir {
         Ok(())
     }
 
+    pub fn load_start_key_by_meta<E: SstExt>(
+        &self,
+        meta: &SstMeta,
+        km: Option<Arc<DataKeyManager>>,
+    ) -> Result<Option<Vec<u8>>> {
+        let path = self.join(meta)?;
+        let r = match km {
+            Some(km) => E::SstReader::open_encrypted(&path.save.to_string_lossy(), km)?,
+            None => E::SstReader::open(&path.save.to_string_lossy())?,
+        };
+        let opts = IterOptions::new(None, None, false);
+        let mut i = r.iter(opts)?;
+        if !i.seek_to_first()? || !i.valid()? {
+            return Ok(None);
+        }
+        Ok(Some(i.key().to_owned()))
+    }
+
     pub fn try_fetch_full_meta(
         &self,
         meta: &SstMeta,
@@ -593,7 +612,9 @@ pub fn parse_meta_from_path<P: AsRef<Path>>(path: P) -> Result<SstMeta> {
 mod test {
     use std::mem::ManuallyDrop;
 
-    use engine_traits::CF_DEFAULT;
+    use engine_rocks::{RocksEngine, RocksSstWriter, RocksSstWriterBuilder};
+    use engine_test::ctor::{CfOptions, DbOptions};
+    use engine_traits::{SstWriter, SstWriterBuilder, CF_DEFAULT};
     use tempfile::TempDir;
     use test_util::new_test_key_manager;
 
@@ -644,20 +665,49 @@ mod test {
         let mut meta = SstMeta::default();
         let mut rng = Range::new();
         rng.set_start(b"hello".to_vec());
-        rng.set_end(b"hello".to_vec());
         let uuid = Uuid::new_v4();
         meta.set_uuid(uuid.as_bytes().to_vec());
         meta.set_region_id(1);
         meta.set_range(rng);
         meta.mut_region_epoch().set_conf_ver(222);
         meta.mut_region_epoch().set_version(333);
+        let mut db_opt = DbOptions::default();
+        db_opt.set_key_manager(arcmgr.clone());
+        let e = engine_test::kv::new_engine_opt(
+            &tmp.path().join("eng").to_string_lossy(),
+            db_opt,
+            vec![(CF_DEFAULT, CfOptions::new())],
+        )
+        .unwrap();
         let f = dir.create(&meta, arcmgr.clone()).unwrap();
         let dp = f.path.clone();
-        dp.save_meta(None, &meta).unwrap();
-        dp.save(None).unwrap();
+        let mut w = RocksSstWriterBuilder::new()
+            .set_db(&e)
+            .set_cf(CF_DEFAULT)
+            .build(f.path.temp.to_str().unwrap())
+            .unwrap();
+        w.put(b"hello", concat!("This is the start key of the SST, ",
+              "how about some of our users uploads metas with range not aligned with the content of SST?",
+              "May the real region still be in the current store.").as_bytes()).unwrap();
+        w.put(
+            b"world",
+            concat!(
+                "This is the end key of the SST, ",
+                "it is so we can check whether we are loding the right key from the SST."
+            )
+            .as_bytes(),
+        )
+        .unwrap();
+        w.finish().unwrap();
+        dp.save(arcmgr.as_deref()).unwrap();
         let mut ssts = dir.list_ssts().unwrap();
-        ssts.iter_mut()
-            .for_each(|meta| *meta = dir.try_fetch_full_meta(&meta, arcmgr.as_deref()).unwrap());
+        ssts.iter_mut().for_each(|meta| {
+            let start = dir
+                .load_start_key_by_meta::<RocksEngine>(meta, arcmgr.clone())
+                .unwrap()
+                .unwrap();
+            meta.mut_range().set_start(start)
+        });
         assert_eq!(ssts, vec![meta]);
     }
 
@@ -673,51 +723,5 @@ mod test {
             .unwrap()
             .unwrap();
         test_path_with_range_and_km(Some(enc));
-    }
-
-    #[test]
-    fn test_cleanup_meta_dir() {
-        test_util::init_log_for_test();
-        let tmp = TempDir::new().unwrap();
-        let dir = ImportDir::new(tmp.path()).unwrap();
-        let gen_file = || {
-            let uuid = Uuid::new_v4();
-            let mut meta = SstMeta::default();
-            meta.set_uuid(uuid.as_bytes().to_vec());
-            meta.set_region_id(1);
-            meta.mut_region_epoch().set_conf_ver(222);
-            meta.mut_region_epoch().set_version(333);
-            let d = dir.create(&meta, None).unwrap();
-            let dp = d.path.clone();
-            dp.save_meta(None, &meta).unwrap();
-            dp.save(None).unwrap();
-            d
-        };
-        let count_meta_dir = || {
-            file_system::read_dir(&dir.meta_dir)
-                .unwrap()
-                .filter_map(|e| {
-                    let e = e.unwrap();
-                    e.metadata().unwrap().is_file().then_some(())
-                })
-                .count()
-        };
-
-        let mut files = std::iter::repeat_with(gen_file).take(8).collect::<Vec<_>>();
-        dir.clean_unused_meta(None).unwrap();
-        assert_eq!(count_meta_dir(), 8);
-        drop(files.drain(..4));
-        assert_eq!(count_meta_dir(), 4);
-        dir.clean_unused_meta(None).unwrap();
-        assert_eq!(count_meta_dir(), 4);
-
-        // simulating the case that we have created the meta but not the real file.
-        files.drain(..3).for_each(|f| {
-            assert!(file_system::delete_file_if_exist(&f.path.save).unwrap());
-            let _ = ManuallyDrop::new(f);
-        });
-        assert_eq!(count_meta_dir(), 4);
-        dir.clean_unused_meta(None).unwrap();
-        assert_eq!(count_meta_dir(), 1);
     }
 }

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -1279,12 +1279,15 @@ impl SstImporter {
 
     /// List the basic information of the current SST files.
     /// The information contains UUID, region ID, region Epoch.
-    /// Other fields may be left blank. They can be fetched via
-    /// [`Self::try_fetch_full_meta`].
+    /// Other fields may be left blank. 
     pub fn list_ssts(&self) -> Result<Vec<SstMeta>> {
         self.dir.list_ssts()
     }
 
+    /// Load the start key by a metadata.
+    /// This will open the internal SST and try to load the first user key.
+    /// (For RocksEngine, that is the key without the 'z' prefix.)
+    /// When the SST is empty or the first key cannot be parsed as user key, return None.
     pub fn load_start_key_by_meta<S: SstExt>(&self, meta: &SstMeta) -> Result<Option<Vec<u8>>> {
         self.dir
             .load_start_key_by_meta::<S>(meta, self.key_manager.clone())

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -1279,7 +1279,7 @@ impl SstImporter {
 
     /// List the basic information of the current SST files.
     /// The information contains UUID, region ID, region Epoch.
-    /// Other fields may be left blank. 
+    /// Other fields may be left blank.
     pub fn list_ssts(&self) -> Result<Vec<SstMeta>> {
         self.dir.list_ssts()
     }
@@ -1287,7 +1287,8 @@ impl SstImporter {
     /// Load the start key by a metadata.
     /// This will open the internal SST and try to load the first user key.
     /// (For RocksEngine, that is the key without the 'z' prefix.)
-    /// When the SST is empty or the first key cannot be parsed as user key, return None.
+    /// When the SST is empty or the first key cannot be parsed as user key,
+    /// return None.
     pub fn load_start_key_by_meta<S: SstExt>(&self, meta: &SstMeta) -> Result<Option<Vec<u8>>> {
         self.dir
             .load_start_key_by_meta::<S>(meta, self.key_manager.clone())

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -199,8 +199,13 @@ impl SstImporter {
             "size" => ?memory_limit,
         );
 
+        let dir = ImportDir::new(root)?;
+        if let Err(err) = dir.clean_unused_meta(key_manager.as_deref()) {
+            warn!("failed to gc the metadata of SSTs to be imported."; "err" => %err);
+        };
+
         Ok(SstImporter {
-            dir: ImportDir::new(root)?,
+            dir,
             key_manager,
             switcher,
             api_version,

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -1291,7 +1291,7 @@ impl SstImporter {
     /// Try to fetch the full metadata from the disk.
     pub fn try_fetch_full_meta(&self, meta: &SstMeta) -> Result<SstMeta> {
         self.dir
-            .try_fetch_full_meta(&meta, self.key_manager.as_deref())
+            .try_fetch_full_meta(meta, self.key_manager.as_deref())
     }
 
     pub fn new_txn_writer<E: KvEngine>(&self, db: &E, meta: SstMeta) -> Result<TxnSstWriter<E>> {

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -1276,7 +1276,7 @@ impl SstImporter {
     }
 
     pub fn list_ssts(&self) -> Result<Vec<SstMeta>> {
-        self.dir.list_ssts()
+        self.dir.list_ssts(self.key_manager.as_deref())
     }
 
     pub fn new_txn_writer<E: KvEngine>(&self, db: &E, meta: SstMeta) -> Result<TxnSstWriter<E>> {
@@ -1460,7 +1460,7 @@ mod tests {
             ingested.push(meta);
         }
 
-        let ssts = dir.list_ssts().unwrap();
+        let ssts = dir.list_ssts(key_manager.as_deref()).unwrap();
         assert_eq!(ssts.len(), ingested.len());
         for sst in &ssts {
             ingested
@@ -1469,7 +1469,7 @@ mod tests {
                 .unwrap();
             dir.delete(sst, key_manager.as_deref()).unwrap();
         }
-        assert!(dir.list_ssts().unwrap().is_empty());
+        assert!(dir.list_ssts(key_manager.as_deref()).unwrap().is_empty());
     }
 
     #[test]
@@ -1487,6 +1487,7 @@ mod tests {
             save: temp_dir.path().join("save"),
             temp: temp_dir.path().join("temp"),
             clone: temp_dir.path().join("clone"),
+            meta: temp_dir.path().join("meta"),
         };
 
         let data = b"test_data";

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -200,9 +200,6 @@ impl SstImporter {
         );
 
         let dir = ImportDir::new(root)?;
-        if let Err(err) = dir.clean_unused_meta(key_manager.as_deref()) {
-            warn!("failed to gc the metadata of SSTs to be imported."; "err" => %err);
-        };
 
         Ok(SstImporter {
             dir,
@@ -1288,12 +1285,6 @@ impl SstImporter {
         self.dir.list_ssts()
     }
 
-    /// Try to fetch the full metadata from the disk.
-    pub fn try_fetch_full_meta(&self, meta: &SstMeta) -> Result<SstMeta> {
-        self.dir
-            .try_fetch_full_meta(meta, self.key_manager.as_deref())
-    }
-
     pub fn load_start_key_by_meta<S: SstExt>(&self, meta: &SstMeta) -> Result<Option<Vec<u8>>> {
         self.dir
             .load_start_key_by_meta::<S>(meta, self.key_manager.clone())
@@ -1507,7 +1498,6 @@ mod tests {
             save: temp_dir.path().join("save"),
             temp: temp_dir.path().join("temp"),
             clone: temp_dir.path().join("clone"),
-            meta: temp_dir.path().join("meta"),
         };
 
         let data = b"test_data";

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -1294,6 +1294,11 @@ impl SstImporter {
             .try_fetch_full_meta(meta, self.key_manager.as_deref())
     }
 
+    pub fn load_start_key_by_meta<S: SstExt>(&self, meta: &SstMeta) -> Result<Option<Vec<u8>>> {
+        self.dir
+            .load_start_key_by_meta::<S>(meta, self.key_manager.clone())
+    }
+
     pub fn new_txn_writer<E: KvEngine>(&self, db: &E, meta: SstMeta) -> Result<TxnSstWriter<E>> {
         let mut default_meta = meta.clone();
         default_meta.set_cf_name(CF_DEFAULT.to_owned());

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -1275,8 +1275,18 @@ impl SstImporter {
         }
     }
 
+    /// List the basic information of the current SST files.
+    /// The information contains UUID, region ID, region Epoch.
+    /// Other fields may be left blank. They can be fetched via
+    /// [`Self::try_fetch_full_meta`].
     pub fn list_ssts(&self) -> Result<Vec<SstMeta>> {
-        self.dir.list_ssts(self.key_manager.as_deref())
+        self.dir.list_ssts()
+    }
+
+    /// Try to fetch the full metadata from the disk.
+    pub fn try_fetch_full_meta(&self, meta: &SstMeta) -> Result<SstMeta> {
+        self.dir
+            .try_fetch_full_meta(&meta, self.key_manager.as_deref())
     }
 
     pub fn new_txn_writer<E: KvEngine>(&self, db: &E, meta: SstMeta) -> Result<TxnSstWriter<E>> {
@@ -1460,7 +1470,7 @@ mod tests {
             ingested.push(meta);
         }
 
-        let ssts = dir.list_ssts(key_manager.as_deref()).unwrap();
+        let ssts = dir.list_ssts().unwrap();
         assert_eq!(ssts.len(), ingested.len());
         for sst in &ssts {
             ingested
@@ -1469,7 +1479,7 @@ mod tests {
                 .unwrap();
             dir.delete(sst, key_manager.as_deref()).unwrap();
         }
-        assert!(dir.list_ssts(key_manager.as_deref()).unwrap().is_empty());
+        assert!(dir.list_ssts().unwrap().is_empty());
     }
 
     #[test]

--- a/components/sst_importer/src/sst_writer.rs
+++ b/components/sst_importer/src/sst_writer.rs
@@ -120,17 +120,11 @@ impl<E: KvEngine> TxnSstWriter<E> {
 
         if default_entries > 0 {
             w1.finish()?;
-            if let Err(err) = p1.save_meta(key_manager.as_deref(), &default_meta) {
-                info!("failed to save meta for default CF"; "err" => %err);
-            }
             p1.save(key_manager.as_deref())?;
             metas.push(default_meta);
         }
         if write_entries > 0 {
             w2.finish()?;
-            if let Err(err) = p2.save_meta(key_manager.as_deref(), &write_meta) {
-                info!("failed to save meta for write CF"; "err" => %err);
-            }
             p2.save(key_manager.as_deref())?;
             metas.push(write_meta);
         }
@@ -272,12 +266,6 @@ impl<E: KvEngine> RawSstWriter<E> {
         }
 
         self.default.finish()?;
-        if let Err(err) = self
-            .default_path
-            .save_meta(self.key_manager.as_deref(), &self.default_meta)
-        {
-            info!("failed to save meta for raw KV"; "err" => %err);
-        }
         self.default_path.save(self.key_manager.as_deref())?;
 
         info!(

--- a/components/sst_importer/src/sst_writer.rs
+++ b/components/sst_importer/src/sst_writer.rs
@@ -121,11 +121,17 @@ impl<E: KvEngine> TxnSstWriter<E> {
         if default_entries > 0 {
             w1.finish()?;
             p1.save(key_manager.as_deref())?;
+            if let Err(err) = p1.save_meta(key_manager.as_deref(), &default_meta) {
+                info!("failed to save meta for default CF"; "err" => %err);
+            }
             metas.push(default_meta);
         }
         if write_entries > 0 {
             w2.finish()?;
             p2.save(key_manager.as_deref())?;
+            if let Err(err) = p2.save_meta(key_manager.as_deref(), &write_meta) {
+                info!("failed to save meta for write CF"; "err" => %err);
+            }
             metas.push(write_meta);
         }
 
@@ -267,6 +273,9 @@ impl<E: KvEngine> RawSstWriter<E> {
 
         self.default.finish()?;
         self.default_path.save(self.key_manager.as_deref())?;
+        if let Err(err) = self.default_path.save_meta(self.key_manager.as_deref(), &self.default_meta) {
+            info!("failed to save meta for raw KV"; "err" => %err);
+        }
 
         info!(
             "finish raw write to sst";

--- a/components/sst_importer/src/sst_writer.rs
+++ b/components/sst_importer/src/sst_writer.rs
@@ -120,18 +120,18 @@ impl<E: KvEngine> TxnSstWriter<E> {
 
         if default_entries > 0 {
             w1.finish()?;
-            p1.save(key_manager.as_deref())?;
             if let Err(err) = p1.save_meta(key_manager.as_deref(), &default_meta) {
                 info!("failed to save meta for default CF"; "err" => %err);
             }
+            p1.save(key_manager.as_deref())?;
             metas.push(default_meta);
         }
         if write_entries > 0 {
             w2.finish()?;
-            p2.save(key_manager.as_deref())?;
             if let Err(err) = p2.save_meta(key_manager.as_deref(), &write_meta) {
                 info!("failed to save meta for write CF"; "err" => %err);
             }
+            p2.save(key_manager.as_deref())?;
             metas.push(write_meta);
         }
 
@@ -272,10 +272,10 @@ impl<E: KvEngine> RawSstWriter<E> {
         }
 
         self.default.finish()?;
-        self.default_path.save(self.key_manager.as_deref())?;
         if let Err(err) = self.default_path.save_meta(self.key_manager.as_deref(), &self.default_meta) {
             info!("failed to save meta for raw KV"; "err" => %err);
         }
+        self.default_path.save(self.key_manager.as_deref())?;
 
         info!(
             "finish raw write to sst";

--- a/components/sst_importer/src/sst_writer.rs
+++ b/components/sst_importer/src/sst_writer.rs
@@ -272,7 +272,10 @@ impl<E: KvEngine> RawSstWriter<E> {
         }
 
         self.default.finish()?;
-        if let Err(err) = self.default_path.save_meta(self.key_manager.as_deref(), &self.default_meta) {
+        if let Err(err) = self
+            .default_path
+            .save_meta(self.key_manager.as_deref(), &self.default_meta)
+        {
             info!("failed to save meta for raw KV"; "err" => %err);
         }
         self.default_path.save(self.key_manager.as_deref())?;


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/tikv/tikv/issues/14745

What's Changed:
This PR opens the SST while fetching the range of the SST. So we can peoperly query the region bound to the SST meta and clean up SST in time.

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fixed a bug that may cause lightning leak SST files no longer needing to be ingested.
```
