### PR TITLE
fix: find the correct last_change_ts after upgrade from versions < 6.5

### DIFF
--- a/components/txn_types/src/write.rs
+++ b/components/txn_types/src/write.rs
@@ -274,25 +274,6 @@ impl Write {
             txn_source: self.txn_source,
         }
     }
-
-    /// Returns the new `last_change_ts` and `versions_to_last_change` according
-    /// to this write record.
-    pub fn next_last_change_info(&self, commit_ts: TimeStamp) -> (TimeStamp, u64) {
-        match self.write_type {
-            WriteType::Put | WriteType::Delete => (commit_ts, 1),
-            WriteType::Lock | WriteType::Rollback => {
-                // If neither `last_change_ts` nor `versions_to_last_change` exists, do not
-                // set `last_change_ts` to indicate we don't know where is the last change.
-                // This should not happen if data is written in new version TiKV. If we hope to
-                // support data from old TiKV, consider iterating to the last change to find it.
-                if !self.last_change_ts.is_zero() || self.versions_to_last_change != 0 {
-                    (self.last_change_ts, self.versions_to_last_change + 1)
-                } else {
-                    (TimeStamp::zero(), 0)
-                }
-            }
-        }
-    }
 }
 
 #[derive(PartialEq, Clone)]

--- a/components/txn_types/src/write.rs
+++ b/components/txn_types/src/write.rs
@@ -158,6 +158,9 @@ pub struct Write {
     pub last_change_ts: TimeStamp,
     /// The number of versions that need skipping from this record
     /// to find the latest PUT/DELETE record
+    /// NOTE: `last_change_ts` == 0 && `versions_to_last_change` > 0 means the
+    /// key does not exist. Either there is no such key **or the last write
+    /// is a DELETE**.
     pub versions_to_last_change: u64,
     /// The source of this txn.
     pub txn_source: u64,
@@ -303,7 +306,8 @@ pub struct WriteRef<'a> {
     /// The number of versions that need skipping from this record
     /// to find the latest PUT/DELETE record.
     /// If versions_to_last_change > 0 but last_change_ts == 0, the key does not
-    /// have a PUT/DELETE record before this write record.
+    /// have a PUT/DELETE record before this write record, OR the previous
+    /// change is a DELETE.
     pub versions_to_last_change: u64,
     /// The source of this txn.
     pub txn_source: u64,

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -402,6 +402,10 @@ impl<S: EngineSnapshot> MvccReader<S> {
                                 return Ok(None);
                             }
                             if write.versions_to_last_change < SEEK_BOUND {
+                                if ts.is_zero() {
+                                    // this should only happen in tests
+                                    return Ok(None);
+                                }
                                 ts = commit_ts.prev();
                             } else {
                                 let commit_ts = write.last_change_ts;

--- a/src/storage/mvcc/reader/scanner/forward.rs
+++ b/src/storage/mvcc/reader/scanner/forward.rs
@@ -1219,8 +1219,9 @@ mod latest_kv_tests {
         must_prewrite_put(&mut engine, b"a", b"a_value", b"a", SEEK_BOUND * 2);
         must_commit(&mut engine, b"a", SEEK_BOUND * 2, SEEK_BOUND * 2);
 
-        // Generate SEEK_BOUND / 2 rollback and 1 put for [b] .
-        for ts in 0..SEEK_BOUND / 2 {
+        // Generate SEEK_BOUND / 2 - 1 rollback and 1 put for [b] .
+        // A ROLLBACK of commit_ts=0 is impossible in reality.
+        for ts in 1..SEEK_BOUND / 2 {
             let modifies = vec![
                 // ts is rather small, so it is ok to `as u8`
                 Modify::Put(
@@ -1274,7 +1275,7 @@ mod latest_kv_tests {
         );
         let statistics = scanner.take_statistics();
         assert_eq!(statistics.write.seek, 0);
-        assert_eq!(statistics.write.next, (SEEK_BOUND / 2 + 1) as usize);
+        assert_eq!(statistics.write.next, (SEEK_BOUND / 2) as usize);
         assert_eq!(
             statistics.processed_size,
             Key::from_raw(b"b").len() + b"b_value".len()
@@ -1789,8 +1790,9 @@ mod latest_entry_tests {
         must_prewrite_put(&mut engine, b"a", b"a_value", b"a", SEEK_BOUND * 2);
         must_commit(&mut engine, b"a", SEEK_BOUND * 2, SEEK_BOUND * 2);
 
-        // Generate SEEK_BOUND / 2 rollback and 1 put for [b] .
-        for ts in 0..SEEK_BOUND / 2 {
+        // Generate SEEK_BOUND / 2 - 1 rollback and 1 put for [b] .
+        // A ROLLBACK of commit_ts=0 is impossible in reality.
+        for ts in 1..SEEK_BOUND / 2 {
             let modifies = vec![
                 // ts is rather small, so it is ok to `as u8`
                 Modify::Put(
@@ -1849,7 +1851,7 @@ mod latest_entry_tests {
         assert_eq!(scanner.next_entry().unwrap(), Some(entry),);
         let statistics = scanner.take_statistics();
         assert_eq!(statistics.write.seek, 0);
-        assert_eq!(statistics.write.next, (SEEK_BOUND / 2 + 1) as usize);
+        assert_eq!(statistics.write.next, (SEEK_BOUND / 2) as usize);
         assert_eq!(statistics.processed_size, size);
 
         // Next we should get nothing.
@@ -2220,8 +2222,9 @@ mod delta_entry_tests {
         must_prewrite_put(&mut engine, b"a", b"a_value", b"a", SEEK_BOUND * 2);
         must_commit(&mut engine, b"a", SEEK_BOUND * 2, SEEK_BOUND * 2);
 
-        // Generate SEEK_BOUND / 2 rollback and 1 put for [b] .
-        for ts in 0..SEEK_BOUND / 2 {
+        // Generate SEEK_BOUND / 2 -1 rollback and 1 put for [b] .
+        // A ROLLBACK of commit_ts=0 is impossible in reality.
+        for ts in 1..SEEK_BOUND / 2 {
             let modifies = vec![
                 // ts is rather small, so it is ok to `as u8`
                 Modify::Put(
@@ -2287,7 +2290,7 @@ mod delta_entry_tests {
         assert_eq!(scanner.next_entry().unwrap(), None);
         let statistics = scanner.take_statistics();
         assert_eq!(statistics.write.seek, 0);
-        assert_eq!(statistics.write.next, 4);
+        assert_eq!(statistics.write.next, 3);
         assert_eq!(statistics.processed_size, 0);
     }
 

--- a/src/storage/mvcc/reader/scanner/forward.rs
+++ b/src/storage/mvcc/reader/scanner/forward.rs
@@ -1219,9 +1219,8 @@ mod latest_kv_tests {
         must_prewrite_put(&mut engine, b"a", b"a_value", b"a", SEEK_BOUND * 2);
         must_commit(&mut engine, b"a", SEEK_BOUND * 2, SEEK_BOUND * 2);
 
-        // Generate SEEK_BOUND / 2 - 1 rollback and 1 put for [b] .
-        // A ROLLBACK of commit_ts=0 is impossible in reality.
-        for ts in 1..SEEK_BOUND / 2 {
+        // Generate SEEK_BOUND / 2 rollback and 1 put for [b] .
+        for ts in 0..SEEK_BOUND / 2 {
             let modifies = vec![
                 // ts is rather small, so it is ok to `as u8`
                 Modify::Put(
@@ -1275,7 +1274,7 @@ mod latest_kv_tests {
         );
         let statistics = scanner.take_statistics();
         assert_eq!(statistics.write.seek, 0);
-        assert_eq!(statistics.write.next, (SEEK_BOUND / 2) as usize);
+        assert_eq!(statistics.write.next, (SEEK_BOUND / 2 + 1) as usize);
         assert_eq!(
             statistics.processed_size,
             Key::from_raw(b"b").len() + b"b_value".len()
@@ -1790,9 +1789,8 @@ mod latest_entry_tests {
         must_prewrite_put(&mut engine, b"a", b"a_value", b"a", SEEK_BOUND * 2);
         must_commit(&mut engine, b"a", SEEK_BOUND * 2, SEEK_BOUND * 2);
 
-        // Generate SEEK_BOUND / 2 - 1 rollback and 1 put for [b] .
-        // A ROLLBACK of commit_ts=0 is impossible in reality.
-        for ts in 1..SEEK_BOUND / 2 {
+        // Generate SEEK_BOUND / 2 rollback and 1 put for [b] .
+        for ts in 0..SEEK_BOUND / 2 {
             let modifies = vec![
                 // ts is rather small, so it is ok to `as u8`
                 Modify::Put(
@@ -1851,7 +1849,7 @@ mod latest_entry_tests {
         assert_eq!(scanner.next_entry().unwrap(), Some(entry),);
         let statistics = scanner.take_statistics();
         assert_eq!(statistics.write.seek, 0);
-        assert_eq!(statistics.write.next, (SEEK_BOUND / 2) as usize);
+        assert_eq!(statistics.write.next, (SEEK_BOUND / 2 + 1) as usize);
         assert_eq!(statistics.processed_size, size);
 
         // Next we should get nothing.
@@ -2222,9 +2220,8 @@ mod delta_entry_tests {
         must_prewrite_put(&mut engine, b"a", b"a_value", b"a", SEEK_BOUND * 2);
         must_commit(&mut engine, b"a", SEEK_BOUND * 2, SEEK_BOUND * 2);
 
-        // Generate SEEK_BOUND / 2 -1 rollback and 1 put for [b] .
-        // A ROLLBACK of commit_ts=0 is impossible in reality.
-        for ts in 1..SEEK_BOUND / 2 {
+        // Generate SEEK_BOUND / 2 rollback and 1 put for [b] .
+        for ts in 0..SEEK_BOUND / 2 {
             let modifies = vec![
                 // ts is rather small, so it is ok to `as u8`
                 Modify::Put(
@@ -2290,7 +2287,7 @@ mod delta_entry_tests {
         assert_eq!(scanner.next_entry().unwrap(), None);
         let statistics = scanner.take_statistics();
         assert_eq!(statistics.write.seek, 0);
-        assert_eq!(statistics.write.next, 3);
+        assert_eq!(statistics.write.next, 4);
         assert_eq!(statistics.processed_size, 0);
     }
 

--- a/src/storage/txn/actions/acquire_pessimistic_lock.rs
+++ b/src/storage/txn/actions/acquire_pessimistic_lock.rs
@@ -1777,7 +1777,7 @@ pub mod tests {
         must_succeed(&mut engine, key, key, 80, 80);
         let lock = must_pessimistic_locked(&mut engine, key, 80, 80);
         assert!(lock.last_change_ts.is_zero());
-        assert_eq!(lock.versions_to_last_change, 0);
+        assert_eq!(lock.versions_to_last_change, 1);
         pessimistic_rollback::tests::must_success(&mut engine, key, 80, 80);
 
         // Latest version is a ROLLBACK without last_change_ts
@@ -1793,7 +1793,7 @@ pub mod tests {
         must_succeed(&mut engine, key, key, 95, 95);
         let lock = must_pessimistic_locked(&mut engine, key, 95, 95);
         assert!(lock.last_change_ts.is_zero());
-        assert_eq!(lock.versions_to_last_change, 0);
+        assert_eq!(lock.versions_to_last_change, 1);
         pessimistic_rollback::tests::must_success(&mut engine, key, 95, 95);
 
         // Latest version is a LOCK with last_change_ts

--- a/src/storage/txn/actions/common.rs
+++ b/src/storage/txn/actions/common.rs
@@ -1,6 +1,6 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
-use tikv_kv::Snapshot;
+use tikv_kv::{Snapshot, SEEK_BOUND};
 use txn_types::{Key, TimeStamp, Write, WriteType};
 
 use crate::storage::mvcc::{Result, SnapshotReader};
@@ -43,7 +43,9 @@ pub fn next_last_change_info<S: Snapshot>(
                     None => Ok((TimeStamp::zero(), 1)),
                     Some((w, last_change_ts)) => {
                         assert!(matches!(w.write_type, WriteType::Put));
-                        Ok((last_change_ts, stat.write.next as u64))
+                        // We don't know how many versions there are. Make `versions_to_last_change`
+                        // big enough so that later reads won't try to `next` to it.
+                        Ok((last_change_ts, SEEK_BOUND + 1))
                     }
                 }
             }

--- a/src/storage/txn/actions/common.rs
+++ b/src/storage/txn/actions/common.rs
@@ -38,7 +38,7 @@ pub fn next_last_change_info<S: Snapshot>(
                     // exist.
                     None => Ok((TimeStamp::zero(), 1)),
                     Some((w, last_change_ts)) => {
-                        assert!(matches!(w.write_type, WriteType::Put | WriteType::Delete));
+                        assert!(matches!(w.write_type, WriteType::Put));
                         Ok((last_change_ts, stat.write.next as u64))
                     }
                 }

--- a/src/storage/txn/actions/common.rs
+++ b/src/storage/txn/actions/common.rs
@@ -30,6 +30,10 @@ pub fn next_last_change_info<S: Snapshot>(
                 // TODO: can we reuse the reader?
                 let snapshot = original_reader.reader.snapshot().clone();
                 let mut reader = SnapshotReader::new(start_ts, snapshot, true);
+
+                // Note that the scan can also utilize `last_change`. So once it finds a LOCK
+                // version with useful `last_change` pointer, it just needs one more `seek` or
+                // several `next`s to get to the final result.
                 let res = reader.get_write_with_commit_ts(key, commit_ts);
                 let stat = reader.take_statistics();
                 original_reader.reader.statistics.add(&stat);

--- a/src/storage/txn/actions/common.rs
+++ b/src/storage/txn/actions/common.rs
@@ -1,6 +1,6 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
-use tikv_kv::{Snapshot, SEEK_BOUND};
+use tikv_kv::Snapshot;
 use txn_types::{Key, TimeStamp, Write, WriteType};
 
 use crate::storage::mvcc::{Result, SnapshotReader};
@@ -12,12 +12,13 @@ pub fn next_last_change_info<S: Snapshot>(
     key: &Key,
     write: &Write,
     start_ts: TimeStamp,
-    reader: &SnapshotReader<S>,
+    original_reader: &mut SnapshotReader<S>,
     commit_ts: TimeStamp,
 ) -> Result<(TimeStamp, u64)> {
     match write.write_type {
         WriteType::Put | WriteType::Delete => Ok((commit_ts, 1)),
         WriteType::Lock | WriteType::Rollback => {
+            assert!(write.last_change_ts.is_zero() || write.versions_to_last_change > 0);
             if !write.last_change_ts.is_zero() || write.versions_to_last_change != 0 {
                 Ok((write.last_change_ts, write.versions_to_last_change + 1))
             } else {
@@ -27,17 +28,18 @@ pub fn next_last_change_info<S: Snapshot>(
                 // find it.
 
                 // TODO: can we reuse the reader?
-                let snapshot = reader.reader.snapshot().clone();
+                let snapshot = original_reader.reader.snapshot().clone();
                 let mut reader = SnapshotReader::new(start_ts, snapshot, true);
-                match reader.get_write_with_commit_ts(key, commit_ts)? {
+                let res = reader.get_write_with_commit_ts(key, commit_ts);
+                let stat = reader.take_statistics();
+                original_reader.reader.statistics.add(&stat);
+                match res? {
                     // last_change_ts == 0 && versions_to_last_change > 0 means the key does not
                     // exist.
                     None => Ok((TimeStamp::zero(), 1)),
                     Some((w, last_change_ts)) => {
                         assert!(matches!(w.write_type, WriteType::Put | WriteType::Delete));
-                        // we don't know how many versions there are, make `versions_to_last_change`
-                        // big enough so that later reads won't try to `next` to it.
-                        Ok((last_change_ts, SEEK_BOUND + 1))
+                        Ok((last_change_ts, stat.write.next as u64))
                     }
                 }
             }

--- a/src/storage/txn/actions/common.rs
+++ b/src/storage/txn/actions/common.rs
@@ -1,0 +1,46 @@
+// Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
+
+use tikv_kv::{Snapshot, SEEK_BOUND};
+use txn_types::{Key, TimeStamp, Write, WriteType};
+
+use crate::storage::mvcc::{Result, SnapshotReader};
+
+/// Returns the new `last_change_ts` and `versions_to_last_change` according
+/// to this write record. If it is unknown from the given write, try iterate to
+/// the last change and find the answer.
+pub fn next_last_change_info<S: Snapshot>(
+    key: &Key,
+    write: &Write,
+    start_ts: TimeStamp,
+    reader: &SnapshotReader<S>,
+    commit_ts: TimeStamp,
+) -> Result<(TimeStamp, u64)> {
+    match write.write_type {
+        WriteType::Put | WriteType::Delete => Ok((commit_ts, 1)),
+        WriteType::Lock | WriteType::Rollback => {
+            if !write.last_change_ts.is_zero() || write.versions_to_last_change != 0 {
+                Ok((write.last_change_ts, write.versions_to_last_change + 1))
+            } else {
+                // If neither `last_change_ts` nor `versions_to_last_change` exists, it means we
+                // do not know the last change info, probably because it comes from an older
+                // version TiKV. To support data from old TiKV, we iterate to the last change to
+                // find it.
+
+                // TODO: can we reuse the reader?
+                let snapshot = reader.reader.snapshot().clone();
+                let mut reader = SnapshotReader::new(start_ts, snapshot, true);
+                match reader.get_write_with_commit_ts(key, commit_ts)? {
+                    // last_change_ts == 0 && versions_to_last_change > 0 means the key does not
+                    // exist.
+                    None => Ok((TimeStamp::zero(), 1)),
+                    Some((w, last_change_ts)) => {
+                        assert!(matches!(w.write_type, WriteType::Put | WriteType::Delete));
+                        // we don't know how many versions there are, make `versions_to_last_change`
+                        // big enough so that later reads won't try to `next` to it.
+                        Ok((last_change_ts, SEEK_BOUND + 1))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/storage/txn/actions/mod.rs
+++ b/src/storage/txn/actions/mod.rs
@@ -12,6 +12,7 @@ pub mod check_data_constraint;
 pub mod check_txn_status;
 pub mod cleanup;
 pub mod commit;
+pub mod common;
 pub mod flashback_to_version;
 pub mod gc;
 pub mod prewrite;

--- a/src/storage/txn/actions/prewrite.rs
+++ b/src/storage/txn/actions/prewrite.rs
@@ -2428,8 +2428,10 @@ pub mod tests {
         assert_eq!(lock.versions_to_last_change, 1);
         must_rollback(&mut engine, key, 55, false);
 
-        // Latest version is a LOCK without last_change_ts. Set the last_change_ts of
-        // the new record to zero.
+        // Latest version is a LOCK without last_change_ts. It iterates back to find the
+        // actual last write. In this case it is a DELETE, so it returns
+        // (last_change_ts == 0 && versions_to_last_change == 1), indicating the key
+        // does not exist.
         let write = Write::new(WriteType::Lock, 60.into(), None);
         engine
             .put_cf(
@@ -2442,7 +2444,7 @@ pub mod tests {
         prewrite_func(&mut engine, LockType::Lock, 70);
         let lock = must_locked(&mut engine, key, 70);
         assert!(lock.last_change_ts.is_zero());
-        assert_eq!(lock.versions_to_last_change, 0);
+        assert_eq!(lock.versions_to_last_change, 1);
         must_rollback(&mut engine, key, 70, false);
 
         // Latest version is a ROLLBACK without last_change_ts. Set the last_change_ts

--- a/src/storage/txn/actions/prewrite.rs
+++ b/src/storage/txn/actions/prewrite.rs
@@ -2447,8 +2447,8 @@ pub mod tests {
         assert_eq!(lock.versions_to_last_change, 1);
         must_rollback(&mut engine, key, 70, false);
 
-        // Latest version is a ROLLBACK without last_change_ts. Set the last_change_ts
-        // of the new record to zero.
+        // Latest version is a ROLLBACK without last_change_ts. Iterate back to find the
+        // DELETE.
         let write = Write::new(WriteType::Rollback, 75.into(), None);
         engine
             .put_cf(
@@ -2461,7 +2461,7 @@ pub mod tests {
         prewrite_func(&mut engine, LockType::Lock, 85);
         let lock = must_locked(&mut engine, key, 85);
         assert!(lock.last_change_ts.is_zero());
-        assert_eq!(lock.versions_to_last_change, 0);
+        assert_eq!(lock.versions_to_last_change, 1);
         must_rollback(&mut engine, key, 85, false);
 
         // Latest version is a LOCK with last_change_ts


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #14780

What's Changed:

Cherry pick #14784 

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix the bug that accumulated LOCKs may slow read operations after upgrade.
```
