### PR TITLE
server: make task lifetime consistent

### DIFF
--- a/src/storage/metrics.rs
+++ b/src/storage/metrics.rs
@@ -181,6 +181,8 @@ make_auto_flush_static_metric! {
         pipelined_write_finish,
         async_apply_prewrite,
         async_apply_prewrite_finish,
+        deadline_exceeded_error,
+        precheck_error,
     }
 
     pub label_enum CommandPriority {


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Close #14838 

What's Changed:
1. Make sure that the lifetime of the `Task` is consistent with its actual processing and response. Release resources such as latches when it is certain that the task will no longer be processed to avoid holding resources by timed-out tasks, which can lead to availability risks when a large number of latch resources are held by timed-out tasks.
2. Ensure that the `deadline_exceed` error is recorded in the scheduler counter.
3. Prevent time-out tasks from using `pending_cmd` and eliminate false reports of `ServerIsBusy` errors.

Test with injected `raftkv_async_write` pause.

- The master branch: the grpc duration is large(20s+) while the scheduler command duration is small, the `pending_cmds` keeps increasing
![image](https://github.com/tikv/tikv/assets/3692139/70bdf5bb-ee23-47e7-a84d-9e84652e7800)
![image](https://github.com/tikv/tikv/assets/3692139/fa64290c-c1df-4b40-a27f-3847f9a2b05f)
![image](https://github.com/tikv/tikv/assets/3692139/4a1ed61b-bbdd-4b4b-8c1a-730eaff59a40)
![image](https://github.com/tikv/tikv/assets/3692139/c5d2d8a8-9c48-46d9-8916-f32a82fbafc2)
![image](https://github.com/tikv/tikv/assets/3692139/1c9f404c-625c-41e6-8814-72b03d4e8e84)

- This PR: the grpc duration is consistent with the command duration, and the `pending_cmds` does not keep increasing.
![image](https://github.com/tikv/tikv/assets/3692139/f555193c-57d4-48d5-bf2e-6fdf12973835)
![image](https://github.com/tikv/tikv/assets/3692139/3cde877f-ec21-4d56-aab7-ba32f92ddc83)
![image](https://github.com/tikv/tikv/assets/3692139/884e4d0d-af46-4400-9eea-9213ab941f41)





### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
