### PR TITLE
tikc-ctl: deprecated reset to version

### DIFF
--- a/cmd/tikv-ctl/src/cmd.rs
+++ b/cmd/tikv-ctl/src/cmd.rs
@@ -556,6 +556,10 @@ pub enum Cmd {
         #[structopt(short = "v")]
         /// The version to reset TiKV to
         version: u64,
+
+        #[structopt(long)]
+        /// Force to reset TiKV to a version.
+        force: bool,
     },
     /// Control for Raft Engine
     /// Usage: tikv-ctl raft-engine-ctl -- --help

--- a/cmd/tikv-ctl/src/executor.rs
+++ b/cmd/tikv-ctl/src/executor.rs
@@ -677,6 +677,7 @@ pub trait DebugExecutor {
 
     fn dump_cluster_info(&self);
 
+    // Deprecated, use `flashback to version` instead.
     fn reset_to_version(&self, version: u64);
 }
 

--- a/cmd/tikv-ctl/src/main.rs
+++ b/cmd/tikv-ctl/src/main.rs
@@ -519,7 +519,15 @@ fn main() {
                 Cmd::Cluster {} => {
                     debug_executor.dump_cluster_info();
                 }
-                Cmd::ResetToVersion { version } => debug_executor.reset_to_version(version),
+                Cmd::ResetToVersion { version, force } => {
+                    // This command is deprecated which cannot make sure transaction correctness.
+                    // See: https://github.com/tikv/tikv/issues/13203
+                    println!("Deprecated, please use `tikv-ctl flashback` instead.");
+                    if force {
+                        debug_executor.reset_to_version(version);
+                        println!("Reset to version {} successfully.", version);
+                    }
+                },
                 _ => {
                     unreachable!()
                 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #14748 

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
after https://github.com/tikv/tikv/pull/14768 merged, can deprecate `reset-to-version`
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
