### PR TITLE
scheduler: use must_call for async write callback, add assertion for expected path

### DIFF
--- a/components/error_code/src/storage.rs
+++ b/components/error_code/src/storage.rs
@@ -44,6 +44,7 @@ define_error_codes!(
     LOCK_IF_EXISTS_FAILED => ("LockIfExistsFailed", "", ""),
 
     PRIMARY_MISMATCH => ("PrimaryMismatch", "", ""),
+    UNDETERMINED => ("Undetermined", "", ""),
 
     UNKNOWN => ("Unknown", "", "")
 );

--- a/components/test_raftstore/src/util.rs
+++ b/components/test_raftstore/src/util.rs
@@ -1001,6 +1001,29 @@ pub fn try_kv_prewrite_with(
     use_async_commit: bool,
     try_one_pc: bool,
 ) -> PrewriteResponse {
+    try_kv_prewrite_with_impl(
+        client,
+        ctx,
+        muts,
+        pk,
+        ts,
+        for_update_ts,
+        use_async_commit,
+        try_one_pc,
+    )
+    .unwrap()
+}
+
+pub fn try_kv_prewrite_with_impl(
+    client: &TikvClient,
+    ctx: Context,
+    muts: Vec<Mutation>,
+    pk: Vec<u8>,
+    ts: u64,
+    for_update_ts: u64,
+    use_async_commit: bool,
+    try_one_pc: bool,
+) -> grpcio::Result<PrewriteResponse> {
     let mut prewrite_req = PrewriteRequest::default();
     prewrite_req.set_context(ctx);
     if for_update_ts != 0 {
@@ -1014,7 +1037,7 @@ pub fn try_kv_prewrite_with(
     prewrite_req.min_commit_ts = prewrite_req.start_version + 1;
     prewrite_req.use_async_commit = use_async_commit;
     prewrite_req.try_one_pc = try_one_pc;
-    client.kv_prewrite(&prewrite_req).unwrap()
+    client.kv_prewrite(&prewrite_req)
 }
 
 pub fn try_kv_prewrite(

--- a/components/tikv_kv/src/lib.rs
+++ b/components/tikv_kv/src/lib.rs
@@ -572,6 +572,8 @@ pub enum ErrorInner {
     EmptyRequest,
     #[error("key is locked (backoff or cleanup) {0:?}")]
     KeyIsLocked(kvproto::kvrpcpb::LockInfo),
+    #[error("undetermined write result {0:?}")]
+    Undetermined(String),
     #[error("unknown error {0:?}")]
     Other(#[from] Box<dyn error::Error + Send + Sync>),
 }
@@ -595,6 +597,7 @@ impl ErrorInner {
             ErrorInner::Timeout(d) => Some(ErrorInner::Timeout(d)),
             ErrorInner::EmptyRequest => Some(ErrorInner::EmptyRequest),
             ErrorInner::KeyIsLocked(ref info) => Some(ErrorInner::KeyIsLocked(info.clone())),
+            ErrorInner::Undetermined(ref msg) => Some(ErrorInner::Undetermined(msg.clone())),
             ErrorInner::Other(_) => None,
         }
     }
@@ -632,6 +635,7 @@ impl ErrorCodeExt for Error {
             ErrorInner::KeyIsLocked(_) => error_code::storage::KEY_IS_LOCKED,
             ErrorInner::Timeout(_) => error_code::storage::TIMEOUT,
             ErrorInner::EmptyRequest => error_code::storage::EMPTY_REQUEST,
+            ErrorInner::Undetermined(_) => error_code::storage::UNDETERMINED,
             ErrorInner::Other(_) => error_code::storage::UNKNOWN,
         }
     }

--- a/src/server/metrics.rs
+++ b/src/server/metrics.rs
@@ -476,6 +476,7 @@ make_auto_flush_static_metric! {
         err_disk_full,
         err_recovery_in_progress,
         err_flashback_in_progress,
+        err_undetermind,
     }
 
     pub label_enum RequestTypeKind {

--- a/src/server/raftkv/mod.rs
+++ b/src/server/raftkv/mod.rs
@@ -99,7 +99,7 @@ pub fn get_status_kind_from_engine_error(e: &kv::Error) -> RequestStatusKind {
         }
         KvError(box KvErrorInner::Timeout(_)) => RequestStatusKind::err_timeout,
         KvError(box KvErrorInner::EmptyRequest) => RequestStatusKind::err_empty_request,
-        KvError(box tikv_kv::ErrorInner::Undetermined(_)) => RequestStatusKind::err_undetermind,
+        KvError(box KvErrorInner::Undetermined(_)) => RequestStatusKind::err_undetermind,
         KvError(box KvErrorInner::Other(_)) => RequestStatusKind::err_other,
     }
 }
@@ -522,8 +522,8 @@ where
         let applied_cb = must_call(
             Box::new(move |resp: WriteResponse| {
                 fail_point!("applied_cb_return_undetermined_err", |_| {
-                    applied_tx.notify(Err(kv::Error::from(Error::RequestFailed(
-                        async_write_callback_dropped_err(),
+                    applied_tx.notify(Err(kv::Error::from(Error::Undetermined(
+                        ASYNC_WRITE_CALLBACK_DROPPED_ERR_MSG.to_string(),
                     ))));
                 });
                 let mut res = match on_write_result::<E::Snapshot>(resp) {

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -832,6 +832,11 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
                 Err(e) => {
                     if !Self::is_undetermined_error(&e) {
                         do_wake_up = false;
+                    } else {
+                        panic!(
+                            "undetermined error: {:?} cid={}, tag={}, process result={:?}",
+                            e, cid, tag, &pr
+                        );
                     }
                     ProcessResult::Failed {
                         err: StorageError::from(e),
@@ -1069,10 +1074,14 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
             .unwrap();
     }
 
-    fn is_undetermined_error(_e: &tikv_kv::Error) -> bool {
-        // TODO: If there's some cases that `engine.async_write` returns error but it's
-        // still possible that the data is successfully written, return true.
-        false
+    // Return true if raftstore returns error and the underlying write status could
+    // not be decided.
+    fn is_undetermined_error(e: &tikv_kv::Error) -> bool {
+        if let tikv_kv::ErrorInner::Request(error_header) = &*(e.0) {
+            error_header.message == "async write on_applied callback is dropped"
+        } else {
+            false
+        }
     }
 
     fn early_response(

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -834,7 +834,8 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
                         do_wake_up = false;
                     } else {
                         panic!(
-                            "undetermined error: {:?} cid={}, tag={}, process result={:?}",
+                            "undetermined error: {:?} cid={}, tag={}, process
+                        result={:?}",
                             e, cid, tag, &pr
                         );
                     }

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -1077,8 +1077,12 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
     // Return true if raftstore returns error and the underlying write status could
     // not be decided.
     fn is_undetermined_error(e: &tikv_kv::Error) -> bool {
-        if let tikv_kv::ErrorInner::Request(error_header) = &*(e.0) {
-            error_header.message == "async write on_applied callback is dropped"
+        if let tikv_kv::ErrorInner::Undetermined(err_msg) = &*(e.0) {
+            error!(
+                "undetermined error is encountered, exit the tikv-server msg={:?}",
+                err_msg
+            );
+            true
         } else {
             false
         }

--- a/tests/failpoints/cases/test_kv_service.rs
+++ b/tests/failpoints/cases/test_kv_service.rs
@@ -4,7 +4,10 @@ use std::{sync::Arc, time::Duration};
 
 use grpcio::{ChannelBuilder, Environment};
 use kvproto::{kvrpcpb::*, tikvpb::TikvClient};
-use test_raftstore::{must_kv_prewrite, must_new_cluster_and_kv_client, must_new_cluster_mul};
+use test_raftstore::{
+    must_kv_prewrite, must_new_cluster_and_kv_client, must_new_cluster_mul,
+    try_kv_prewrite_with_impl,
+};
 
 #[test]
 fn test_batch_get_memory_lock() {
@@ -67,4 +70,34 @@ fn test_snapshot_not_block_grpc() {
     fail::cfg("after-snapshot", "sleep(2000)").unwrap();
     must_kv_prewrite(&client, ctx, vec![mutation], b"k".to_vec(), 10);
     fail::remove("after-snapshot");
+}
+
+#[test]
+fn test_undetermined_write_err() {
+    let (cluster, leader, ctx) = must_new_cluster_mul(1);
+    let env = Arc::new(Environment::new(1));
+    let channel = ChannelBuilder::new(env)
+        .keepalive_time(Duration::from_millis(500))
+        .keepalive_timeout(Duration::from_millis(500))
+        .connect(&cluster.sim.read().unwrap().get_addr(leader.get_store_id()));
+    let client = TikvClient::new(channel);
+
+    let mut mutation = Mutation::default();
+    mutation.set_op(Op::Put);
+    mutation.set_key(b"k".to_vec());
+    mutation.set_value(b"v".to_vec());
+    fail::cfg("applied_cb_return_undetermined_err", "return()").unwrap();
+    let err = try_kv_prewrite_with_impl(
+        &client,
+        ctx,
+        vec![mutation],
+        b"k".to_vec(),
+        10,
+        0,
+        false,
+        false,
+    )
+    .unwrap_err();
+    assert_eq!(err.to_string(), "RpcFailure: 1-CANCELLED CANCELLED",);
+    fail::remove("applied_cb_return_undetermined_err");
 }

--- a/tests/failpoints/cases/test_storage.rs
+++ b/tests/failpoints/cases/test_storage.rs
@@ -26,6 +26,7 @@ use resource_control::ResourceGroupManager;
 use test_raftstore::*;
 use tikv::{
     config::{ConfigController, Module},
+    server::raftkv::ASYNC_WRITE_CALLBACK_DROPPED_ERR_MSG,
     storage::{
         self,
         config_manager::StorageConfigManger,
@@ -41,6 +42,7 @@ use tikv::{
         Error as StorageError, ErrorInner as StorageErrorInner, *,
     },
 };
+use tikv_kv::ErrorInner::Undetermined;
 use tikv_util::{future::paired_future_callback, worker::dummy_scheduler, HandyRwLock};
 use txn_types::{Key, Mutation, TimeStamp};
 
@@ -112,6 +114,9 @@ fn test_scheduler_leader_change_twice() {
 fn test_server_catching_api_error() {
     let raftkv_fp = "raftkv_early_error_report";
     let mut cluster = new_server_cluster(0, 1);
+    // One scheduler worker thread would panic after processing the prewrite
+    // request because of undetermined error.
+    cluster.cfg.storage.scheduler_worker_pool_size = 2;
     cluster.run();
     let region = cluster.get_region(b"");
     let leader = region.get_peers()[0].clone();
@@ -140,12 +145,10 @@ fn test_server_catching_api_error() {
     prewrite_req.primary_lock = b"k3".to_vec();
     prewrite_req.start_version = 1;
     prewrite_req.lock_ttl = prewrite_req.start_version + 1;
-    let prewrite_resp = client.kv_prewrite(&prewrite_req).unwrap();
-    assert!(prewrite_resp.has_region_error(), "{:?}", prewrite_resp);
-    assert!(
-        prewrite_resp.get_region_error().has_region_not_found(),
-        "{:?}",
-        prewrite_resp
+    let prewrite_err = client.kv_prewrite(&prewrite_req).unwrap_err();
+    assert_eq!(
+        prewrite_err.to_string(),
+        "RpcFailure: 1-CANCELLED CANCELLED"
     );
     must_get_none(&cluster.get_engine(1), b"k3");
 
@@ -154,11 +157,9 @@ fn test_server_catching_api_error() {
     put_req.key = b"k3".to_vec();
     put_req.value = b"v3".to_vec();
     let put_resp = client.raw_put(&put_req).unwrap();
-    assert!(put_resp.has_region_error(), "{:?}", put_resp);
-    assert!(
-        put_resp.get_region_error().has_region_not_found(),
-        "{:?}",
-        put_resp
+    assert_eq!(
+        put_resp.get_error(),
+        Undetermined(ASYNC_WRITE_CALLBACK_DROPPED_ERR_MSG.to_string()).to_string()
     );
     must_get_none(&cluster.get_engine(1), b"k3");
 
@@ -198,11 +199,9 @@ fn test_raftkv_early_error_report() {
         put_req.key = k.to_vec();
         put_req.value = b"v".to_vec();
         let put_resp = client.raw_put(&put_req).unwrap();
-        assert!(put_resp.has_region_error(), "{:?}", put_resp);
-        assert!(
-            put_resp.get_region_error().has_region_not_found(),
-            "{:?}",
-            put_resp
+        assert_eq!(
+            put_resp.get_error(),
+            Undetermined(ASYNC_WRITE_CALLBACK_DROPPED_ERR_MSG.to_string()).to_string()
         );
         must_get_none(&cluster.get_engine(1), k);
     }
@@ -218,15 +217,12 @@ fn test_raftkv_early_error_report() {
         put_req.value = b"v".to_vec();
         let put_resp = client.raw_put(&put_req).unwrap();
         if ctx.get_region_id() == injected_region_id {
-            assert!(put_resp.has_region_error(), "{:?}", put_resp);
-            assert!(
-                put_resp.get_region_error().has_region_not_found(),
-                "{:?}",
-                put_resp
+            assert_eq!(
+                put_resp.get_error(),
+                Undetermined(ASYNC_WRITE_CALLBACK_DROPPED_ERR_MSG.to_string()).to_string()
             );
             must_get_none(&cluster.get_engine(1), k);
         } else {
-            assert!(!put_resp.has_region_error(), "{:?}", put_resp);
             must_get_equal(&cluster.get_engine(1), k, b"v");
         }
     }


### PR DESCRIPTION


### What is changed and how it works?

Issue Number: Ref #14838 

What's Changed:
1. Use `must_call` for the `async_write` callback.
2. Add assertion for the path the task is finished unexpectedly and the latch is not released.


### Related changes



### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)
  - Inject the failpoint `applied_cb_return_undetermined_err` and raise a write task, tikv-server panics.

Side effects


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
