### PR TITLE
scheduler: record process and write durtaion details

### DIFF
--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -1885,11 +1885,11 @@ struct SchedulerDetails {
     tracker: TrackerToken,
     stat: Statistics,
     start_process_instant: Instant,
-    // A write command processing could be divided into 4 stages:
-    // 1. Process the command using snapshot and generate the write content.
-    // 2. Delay if the quota is exceeded.
-    // 3. Throttle if the write flow exceeds the limit.
-    // 4. Send the write request to the raftkv and wait for responses.
+    // A write command processing can be divided into four stages:
+    // 1. The command is processed using a snapshot to generate the write content.
+    // 2. If the quota is exceeded, there will be a delay.
+    // 3. If the write flow exceeds the limit, it will be throttled.
+    // 4. Finally, the write request is sent to raftkv and responses are awaited.
     cmd_process_nanos: u64,
     quota_limit_delay_nanos: u64,
     flow_control_nanos: u64,

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -1237,13 +1237,14 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
                         .map_err(StorageError::from)
                 })
             };
+            let cmd_process_duration = begin_instant.saturating_elapsed();
+            sched_details.cmd_process_nanos = cmd_process_duration.as_nanos() as u64;
             SCHED_PROCESSING_READ_HISTOGRAM_STATIC
                 .get(tag)
-                .observe(begin_instant.saturating_elapsed_secs());
+                .observe(cmd_process_duration.as_secs_f64());
             res
         };
 
-        let process_end = Instant::now();
         if write_result.is_ok() {
             // TODO: write bytes can be a bit inaccurate due to error requests or in-memory
             // pessimistic locks.
@@ -1267,8 +1268,7 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         sample.add_read_bytes(read_bytes);
         let quota_delay = quota_limiter.consume_sample(sample, true).await;
         if !quota_delay.is_zero() {
-            let actual_quota_delay = process_end.saturating_elapsed();
-            sched_details.quota_limit_delay_nanos = actual_quota_delay.as_nanos() as u64;
+            sched_details.quota_limit_delay_nanos = quota_delay.as_nanos() as u64;
             TXN_COMMAND_THROTTLE_TIME_COUNTER_VEC_STATIC
                 .get(tag)
                 .inc_by(quota_delay.as_micros() as u64);
@@ -1526,6 +1526,7 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
             }
         });
 
+        let async_write_start = Instant::now_coarse();
         let mut res = unsafe {
             with_tls_engine(|e: &mut E| {
                 e.async_write(&ctx, to_be_write, subscribed, Some(on_applied))
@@ -1607,6 +1608,8 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
                             sched.inner.flow_controller.unconsume(region_id, write_size);
                         }
                     }
+                    sched_details.async_write_nanos =
+                        async_write_start.saturating_elapsed().as_nanos() as u64;
                     return;
                 }
             }
@@ -1882,8 +1885,15 @@ struct SchedulerDetails {
     tracker: TrackerToken,
     stat: Statistics,
     start_process_instant: Instant,
+    // A write command processing could be divided into 4 stages:
+    // 1. Process the command using snapshot and generate the write content.
+    // 2. Delay if the quota is exceeded.
+    // 3. Throttle if the write flow exceeds the limit.
+    // 4. Send the write request to the raftkv and wait for responses.
+    cmd_process_nanos: u64,
     quota_limit_delay_nanos: u64,
     flow_control_nanos: u64,
+    async_write_nanos: u64,
 }
 
 impl SchedulerDetails {
@@ -1892,8 +1902,10 @@ impl SchedulerDetails {
             tracker,
             stat: Default::default(),
             start_process_instant,
+            cmd_process_nanos: 0,
             quota_limit_delay_nanos: 0,
             flow_control_nanos: 0,
+            async_write_nanos: 0,
         }
     }
 }


### PR DESCRIPTION
Issue Number: Ref #12362

What's Changed:
1. Record scheduler process durations and async write durations, and print them in the tikv slow log like
```
[region 40] scheduler handle command: prewrite, ts: 442011940292132869, details: SchedulerDetails { tracker: TrackerToken { shard_id: 58, seq: 21, key: 0 }, stat: Statistics { lock: CfStatistics { processed_keys: 0, get: 1, next: 0, prev: 0, seek: 0, seek_for_prev: 0, over_seek_bound: 0, flow_stats: FlowStatistics { read_keys: 0, read_bytes: 0 }, next_tombstone: 0, prev_tombstone: 0, seek_tombstone: 0, seek_for_prev_tombstone: 0, raw_value_tombstone: 0 }, write: CfStatistics { processed_keys: 0, get: 0, next: 0, prev: 0, seek: 1, seek_for_prev: 0, over_seek_bound: 0, flow_stats: FlowStatistics { read_keys: 1, read_bytes: 151 }, next_tombstone: 0, prev_tombstone: 0, seek_tombstone: 0, seek_for_prev_tombstone: 0, raw_value_tombstone: 0 }, data: CfStatistics { processed_keys: 0, get: 0, next: 0, prev: 0, seek: 0, seek_for_prev: 0, over_seek_bound: 0, flow_stats: FlowStatistics { read_keys: 0, read_bytes: 0 }, next_tombstone: 0, prev_tombstone: 0, seek_tombstone: 0, seek_for_prev_tombstone: 0, raw_value_tombstone: 0 }, processed_size: 0 }, start_process_instant: Monotonic(Timespec { sec: 38490, nsec: 896203961 }), cmd_process_nanos: 211012, quota_limit_delay_nanos: 0, flow_control_nanos: 0, async_write_nanos: 4000000 }"]
```
2. Remove unnecesarry `Instant::now` call to reduce cost calculating quota limited delay.

### Related changes



### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->



Side effects



### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
