### PR TITLE
Cherry pick 4f25a8555b92aeee2b67d4afa6fb6677746efc1c to 6.1 hotfix branch

### DIFF
--- a/src/storage/txn/actions/prewrite.rs
+++ b/src/storage/txn/actions/prewrite.rs
@@ -342,12 +342,33 @@ impl<'a> PrewriteMutation<'a> {
     ) -> Result<Option<(Write, TimeStamp)>> {
         match reader.seek_write(&self.key, TimeStamp::max())? {
             Some((commit_ts, write)) => {
-                // Abort on writes after our start timestamp ...
-                // If exists a commit version whose commit timestamp is larger than current start
+                // Abort on writes after our start/for_update timestamp ...
+                // If exists a commit version whose commit timestamp is larger than current start/for_update
                 // timestamp, we should abort current prewrite.
-                if commit_ts > self.txn_props.start_ts {
-                    MVCC_CONFLICT_COUNTER.prewrite_write_conflict.inc();
-                    self.write_conflict_error(&write, commit_ts)?;
+                match self.txn_props.kind {
+                    TransactionKind::Optimistic(_) => {
+                        if commit_ts > self.txn_props.start_ts {
+                            MVCC_CONFLICT_COUNTER.prewrite_write_conflict.inc();
+                            self.write_conflict_error(&write, commit_ts)?;
+                        }
+                    }
+                    // Note: PessimisticLockNotFound can happen on a non-pessimistically locked key,
+                    // if it is a retrying prewrite request.
+                    TransactionKind::Pessimistic(for_update_ts) => {
+                        if commit_ts > for_update_ts {
+                            warn!("conflicting write was found, pessimistic lock must be lost for the corresponding row key"; 
+                                "key" => %self.key, 
+                                "start_ts" => self.txn_props.start_ts, 
+                                "for_update_ts" => for_update_ts,
+                                "conflicting start_ts" => write.start_ts,
+                                "conflicting commit_ts" => commit_ts);
+                            return Err(ErrorInner::PessimisticLockNotFound {
+                                start_ts: self.txn_props.start_ts,
+                                key: self.key.clone().into_raw()?,
+                            }
+                            .into());
+                        }
+                    }
                 }
                 // If there's a write record whose commit_ts equals to our start ts, the current
                 // transaction is ok to continue, unless the record means that the current
@@ -1352,7 +1373,7 @@ pub mod tests {
         must_commit(&engine, b"k1", 10, 20);
         must_commit(&engine, b"k2", 10, 20);
 
-        // This is a re-sent prewrite. It should report a WriteConflict. In production, the caller
+        // This is a re-sent prewrite. It should report a PessimisticLockNotFound. In production, the caller
         // will need to check if the current transaction is already committed before, in order to
         // provide the idempotency.
         let err = must_retry_pessimistic_prewrite_put_err(
@@ -1366,7 +1387,10 @@ pub mod tests {
             false,
             0,
         );
-        assert!(matches!(err, Error(box ErrorInner::WriteConflict { .. })));
+        assert!(matches!(
+            err,
+            Error(box ErrorInner::PessimisticLockNotFound { .. })
+        ));
         // Commit repeatedly, these operations should have no effect.
         must_commit(&engine, b"k1", 10, 25);
         must_commit(&engine, b"k2", 10, 25);
@@ -1382,7 +1406,7 @@ pub mod tests {
         must_commit(&engine, b"k2", 35, 40);
 
         // A retrying non-pessimistic-lock prewrite request should not skip constraint checks.
-        // It reports a WriteConflict.
+        // It reports a PessimisticLockNotFound.
         let err = must_retry_pessimistic_prewrite_put_err(
             &engine,
             b"k2",
@@ -1394,13 +1418,19 @@ pub mod tests {
             false,
             0,
         );
-        assert!(matches!(err, Error(box ErrorInner::WriteConflict { .. })));
+        assert!(matches!(
+            err,
+            Error(box ErrorInner::PessimisticLockNotFound { .. })
+        ));
         must_unlocked(&engine, b"k2");
 
         let err = must_retry_pessimistic_prewrite_put_err(
             &engine, b"k2", b"v2", b"k1", &None, 10, 10, false, 0,
         );
-        assert!(matches!(err, Error(box ErrorInner::WriteConflict { .. })));
+        assert!(matches!(
+            err,
+            Error(box ErrorInner::PessimisticLockNotFound { .. })
+        ));
         must_unlocked(&engine, b"k2");
         // Committing still does nothing.
         must_commit(&engine, b"k2", 10, 25);
@@ -1408,7 +1438,10 @@ pub mod tests {
         let err = must_retry_pessimistic_prewrite_put_err(
             &engine, b"k2", b"v2", b"k1", &None, 11, 11, false, 0,
         );
-        assert!(matches!(err, Error(box ErrorInner::WriteConflict { .. })));
+        assert!(matches!(
+            err,
+            Error(box ErrorInner::PessimisticLockNotFound { .. })
+        ));
         must_unlocked(&engine, b"k2");
         // However conflict still won't be checked if there's a non-retry request arriving.
         must_prewrite_put_impl(
@@ -1417,10 +1450,10 @@ pub mod tests {
             b"v2",
             b"k1",
             &None,
-            10.into(),
+            12.into(),
             false,
             100,
-            10.into(),
+            12.into(),
             1,
             15.into(),
             TimeStamp::default(),
@@ -1428,7 +1461,29 @@ pub mod tests {
             kvproto::kvrpcpb::Assertion::None,
             kvproto::kvrpcpb::AssertionLevel::Off,
         );
-        must_locked(&engine, b"k2", 10);
+        must_locked(&engine, b"k2", 12);
+        must_rollback(&engine, b"k2", 12, false);
+
+        // And conflict check is according to the for_update_ts for pessimistic prewrite.
+        // So, it will not report error if for_update_ts is large enough.
+        must_prewrite_put_impl(
+            &engine,
+            b"k2",
+            b"v2",
+            b"k1",
+            &None,
+            13.into(),
+            false,
+            100,
+            55.into(),
+            1,
+            60.into(),
+            TimeStamp::default(),
+            true,
+            kvproto::kvrpcpb::Assertion::None,
+            kvproto::kvrpcpb::AssertionLevel::Off,
+        );
+        must_locked(&engine, b"k2", 13);
     }
 
     #[test]

--- a/src/storage/txn/commands/prewrite.rs
+++ b/src/storage/txn/commands/prewrite.rs
@@ -462,7 +462,7 @@ impl<K: PrewriteKind> Prewriter<K> {
         let mut final_min_commit_ts = TimeStamp::zero();
         let mut locks = Vec::new();
 
-        // Further check whether the prewrited transaction has been committed
+        // Further check whether the prewritten transaction has been committed
         // when encountering a WriteConflict or PessimisticLockNotFound error.
         // This extra check manages to make prewrite idempotent after the transaction
         // was committed.
@@ -479,7 +479,7 @@ impl<K: PrewriteKind> Prewriter<K> {
                 TxnCommitRecord::SingleRecord { commit_ts, write }
                     if write.write_type != WriteType::Rollback =>
                 {
-                    info!("prewrited transaction has been committed";
+                    info!("prewritten transaction has been committed";
                         "start_ts" => reader.start_ts, "commit_ts" => commit_ts,
                         "key" => ?key, "write_type" => ?write.write_type);
                     txn.clear();
@@ -943,7 +943,7 @@ mod tests {
             None,
         )
         .unwrap();
-        // All keys are prewrited successful with only one seek operations.
+        // All keys are prewritten successful with only one seek operations.
         assert_eq!(1, statistic.write.seek);
         let keys: Vec<Key> = mutations.iter().map(|m| m.key().clone()).collect();
         commit(&engine, &mut statistic, keys.clone(), 104, 105).unwrap();
@@ -1981,12 +1981,12 @@ mod tests {
         // Committing still does nothing.
         must_commit(&engine, b"k2", 10, 25);
         // Try a different txn start ts (which haven't been successfully committed before).
-        // It should report a WriteConflict.
+        // It should report a PessimisticLockNotFound.
         let err = prewrite_with_retry_flag(b"k2", b"v2", b"k1", None, 11, false, true).unwrap_err();
         assert!(matches!(
             err,
             Error(box ErrorInner::Mvcc(MvccError(
-                box MvccErrorInner::WriteConflict { .. }
+                box MvccErrorInner::PessimisticLockNotFound { .. }
             )))
         ));
         must_unlocked(&engine, b"k2");
@@ -2209,7 +2209,7 @@ mod tests {
         );
         assert!(matches!(
             err,
-            MvccError(box MvccErrorInner::WriteConflict { .. })
+            MvccError(box MvccErrorInner::PessimisticLockNotFound { .. })
         ));
     }
 

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -820,7 +820,7 @@ impl<E: Engine, L: LockManager> Scheduler<E, L> {
             // error to the callback, and releases the latches.
             Err(err) => {
                 SCHED_STAGE_COUNTER_VEC.get(tag).prepare_write_err.inc();
-                debug!("write command failed at prewrite"; "cid" => cid, "err" => ?err);
+                debug!("write command failed"; "cid" => cid, "err" => ?err);
                 scheduler.finish_with_err(cid, err);
                 return;
             }


### PR DESCRIPTION
…12713) (#12766)

ref tikv/tikv#11612, ref tikv/tikv#12713

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #xxx

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
```
