### PR TITLE
tests: make test_flashback_with_in_memory_pessimistic_locks stable

### DIFF
--- a/tests/integrations/raftstore/test_flashback.rs
+++ b/tests/integrations/raftstore/test_flashback.rs
@@ -68,9 +68,9 @@ fn test_flashback_with_in_memory_pessimistic_locks() {
         eventually_meet(
             Box::new(move || {
                 let pessimistic_locks = txn_ext.pessimistic_locks.read();
-                return !pessimistic_locks.is_writable()
+                !pessimistic_locks.is_writable()
                     && pessimistic_locks.status == LocksStatus::IsInFlashback
-                    && pessimistic_locks.is_empty();
+                    && pessimistic_locks.is_empty()
             }),
             "pessimistic locks status should be LocksStatus::IsInFlashback",
         );
@@ -84,9 +84,9 @@ fn test_flashback_with_in_memory_pessimistic_locks() {
         eventually_meet(
             Box::new(move || {
                 let pessimistic_locks = txn_ext.pessimistic_locks.read();
-                return pessimistic_locks.is_writable() && pessimistic_locks.is_empty();
+                pessimistic_locks.is_writable() && pessimistic_locks.is_empty()
             }),
-            "pessimistic locks status should be writable again",
+            "pessimistic locks should be writable again",
         );
     }
 }

--- a/tests/integrations/raftstore/test_flashback.rs
+++ b/tests/integrations/raftstore/test_flashback.rs
@@ -66,7 +66,7 @@ fn test_flashback_with_in_memory_pessimistic_locks() {
         );
         let txn_ext = snapshot.txn_ext.unwrap();
         eventually_meet(
-            Box::new(|| {
+            Box::new(move || {
                 let pessimistic_locks = txn_ext.pessimistic_locks.read();
                 return !pessimistic_locks.is_writable()
                     && pessimistic_locks.status == LocksStatus::IsInFlashback
@@ -82,7 +82,7 @@ fn test_flashback_with_in_memory_pessimistic_locks() {
         let snapshot = cluster.must_get_snapshot_of_region(region.get_id());
         let txn_ext = snapshot.txn_ext.unwrap();
         eventually_meet(
-            Box::new(|| {
+            Box::new(move || {
                 let pessimistic_locks = txn_ext.pessimistic_locks.read();
                 return pessimistic_locks.is_writable() && pessimistic_locks.is_empty();
             }),

--- a/tests/integrations/raftstore/test_flashback.rs
+++ b/tests/integrations/raftstore/test_flashback.rs
@@ -65,10 +65,15 @@ fn test_flashback_with_in_memory_pessimistic_locks() {
             },
         );
         let txn_ext = snapshot.txn_ext.unwrap();
-        let pessimistic_locks = txn_ext.pessimistic_locks.read();
-        assert!(!pessimistic_locks.is_writable());
-        assert_eq!(pessimistic_locks.status, LocksStatus::IsInFlashback);
-        assert_eq!(pessimistic_locks.len(), 0);
+        eventually_meet(
+            Box::new(|| {
+                let pessimistic_locks = txn_ext.pessimistic_locks.read();
+                return !pessimistic_locks.is_writable()
+                    && pessimistic_locks.status == LocksStatus::IsInFlashback
+                    && pessimistic_locks.is_empty();
+            }),
+            "pessimistic locks status should be LocksStatus::IsInFlashback",
+        );
     }
     // Finish flashback.
     cluster.must_send_wait_flashback_msg(region.get_id(), AdminCmdType::FinishFlashback);
@@ -76,10 +81,24 @@ fn test_flashback_with_in_memory_pessimistic_locks() {
     {
         let snapshot = cluster.must_get_snapshot_of_region(region.get_id());
         let txn_ext = snapshot.txn_ext.unwrap();
-        let pessimistic_locks = txn_ext.pessimistic_locks.read();
-        assert!(pessimistic_locks.is_writable());
-        assert_eq!(pessimistic_locks.len(), 0);
+        eventually_meet(
+            Box::new(|| {
+                let pessimistic_locks = txn_ext.pessimistic_locks.read();
+                return pessimistic_locks.is_writable() && pessimistic_locks.is_empty();
+            }),
+            "pessimistic locks status should be writable again",
+        );
     }
+}
+
+fn eventually_meet(condition: Box<dyn Fn() -> bool>, purpose: &str) {
+    for _ in 0..30 {
+        if condition() {
+            return;
+        }
+        sleep(Duration::from_millis(100));
+    }
+    panic!("condition never meet: {}", purpose);
 }
 
 #[test_case(test_raftstore::new_node_cluster)]


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #13303, ref https://github.com/pingcap/tidb/issues/44292.

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Make `test_flashback_with_in_memory_pessimistic_locks` stable.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None.
```
