### PR TITLE
raftstore-v2: bugfix for terminated `last_report_ts`.

### DIFF
--- a/components/raftstore-v2/src/worker/pd/mod.rs
+++ b/components/raftstore-v2/src/worker/pd/mod.rs
@@ -297,7 +297,9 @@ where
     fn run(&mut self, task: Task) {
         self.maybe_schedule_heartbeat_receiver();
         match task {
-            Task::StoreHeartbeat { stats } => self.handle_store_heartbeat(stats),
+            Task::StoreHeartbeat { stats } => {
+                self.handle_store_heartbeat(stats, false /* is_fake_hb */)
+            }
             Task::UpdateStoreInfos {
                 cpu_usages,
                 read_io_rates,

--- a/components/raftstore-v2/src/worker/pd/store.rs
+++ b/components/raftstore-v2/src/worker/pd/store.rs
@@ -240,14 +240,15 @@ where
         self.store_stat
             .engine_last_query_num
             .fill_query_stats(&self.store_stat.engine_total_query_num);
-        self.store_stat.last_report_ts = if stats.get_start_time() == STORE_HEARTBEAT_DELAY_LIMIT as u32 {
-            // The given Task::StoreHeartbeat should be a fake heartbeat to PD, we won't
-            // update the last_report_ts to avoid incorrectly marking current TiKV node in
-            // normal state.
-            self.store_stat.last_report_ts
-        } else {
-            UnixSecs::now()
-        };
+        self.store_stat.last_report_ts =
+            if stats.get_start_time() == STORE_HEARTBEAT_DELAY_LIMIT as u32 {
+                // The given Task::StoreHeartbeat should be a fake heartbeat to PD, we won't
+                // update the last_report_ts to avoid incorrectly marking current TiKV node in
+                // normal state.
+                self.store_stat.last_report_ts
+            } else {
+                UnixSecs::now()
+            };
         self.store_stat.region_bytes_written.flush();
         self.store_stat.region_keys_written.flush();
         self.store_stat.region_bytes_read.flush();

--- a/components/raftstore-v2/src/worker/pd/store.rs
+++ b/components/raftstore-v2/src/worker/pd/store.rs
@@ -175,7 +175,7 @@ where
     ER: RaftEngine,
     T: PdClient + 'static,
 {
-    pub fn handle_store_heartbeat(&mut self, mut stats: pdpb::StoreStats) {
+    pub fn handle_store_heartbeat(&mut self, mut stats: pdpb::StoreStats, is_fake_hb: bool) {
         let mut report_peers = HashMap::default();
         for (region_id, region_peer) in &mut self.region_peers {
             let read_bytes = region_peer.read_bytes - region_peer.last_store_report_read_bytes;
@@ -240,15 +240,14 @@ where
         self.store_stat
             .engine_last_query_num
             .fill_query_stats(&self.store_stat.engine_total_query_num);
-        self.store_stat.last_report_ts =
-            if stats.get_start_time() == STORE_HEARTBEAT_DELAY_LIMIT as u32 {
-                // The given Task::StoreHeartbeat should be a fake heartbeat to PD, we won't
-                // update the last_report_ts to avoid incorrectly marking current TiKV node in
-                // normal state.
-                self.store_stat.last_report_ts
-            } else {
-                UnixSecs::now()
-            };
+        self.store_stat.last_report_ts = if is_fake_hb {
+            // The given Task::StoreHeartbeat should be a fake heartbeat to PD, we won't
+            // update the last_report_ts to avoid incorrectly marking current TiKV node in
+            // normal state.
+            self.store_stat.last_report_ts
+        } else {
+            UnixSecs::now()
+        };
         self.store_stat.region_bytes_written.flush();
         self.store_stat.region_keys_written.flush();
         self.store_stat.region_bytes_read.flush();
@@ -310,14 +309,12 @@ where
             .set(snap_stats.receiving_count as i64);
 
         // This calling means that the current node cannot report heartbeat in normaly
-        // scheduler. That is, the current node must in `busy` state. Meanwhile, mark
-        // this fake `StoreStats.start_time` == `STORE_HEARTBEAT_DELAY_LIMIT` to reveal
-        // that current heartbeat is fake and used for reporting slowness forcely.
-        stats.set_start_time(STORE_HEARTBEAT_DELAY_LIMIT as u32);
+        // scheduler. That is, the current node must in `busy` state.
         stats.set_is_busy(true);
 
-        // We do not need to report store_info, so we just set `None` here.
-        self.handle_store_heartbeat(stats);
+        // And here, the `is_fake_hb` should be marked with `True` to represent that
+        // this heartbeat message is a fake one.
+        self.handle_store_heartbeat(stats, true);
         warn!(self.logger, "scheduling store_heartbeat timeout, force report store slow score to pd.";
             "store_id" => self.store_id,
         );

--- a/components/raftstore-v2/tests/failpoints/mod.rs
+++ b/components/raftstore-v2/tests/failpoints/mod.rs
@@ -13,5 +13,6 @@ mod test_bootstrap;
 mod test_bucket;
 mod test_life;
 mod test_merge;
+mod test_pd_heartbeat;
 mod test_split;
 mod test_trace_apply;

--- a/components/raftstore-v2/tests/failpoints/test_pd_heartbeat.rs
+++ b/components/raftstore-v2/tests/failpoints/test_pd_heartbeat.rs
@@ -17,7 +17,6 @@ fn test_fake_store_heartbeat() {
     });
     let store_id = cluster.node(0).id();
     let router = &cluster.routers[0];
-
     // Report store heartbeat to pd.
     router
         .store_router()
@@ -30,7 +29,6 @@ fn test_fake_store_heartbeat() {
         assert_ne!(prev_stats.get_used_size(), 0);
         assert_eq!(prev_stats.get_keys_written(), 0);
     }
-
     // Inject failpoints to trigger reporting fake store heartbeat to pd.
     fail::cfg("mock_slowness_last_tick_unfinished", "return(0)").unwrap();
     std::thread::sleep(std::time::Duration::from_millis(50));

--- a/components/raftstore-v2/tests/failpoints/test_pd_heartbeat.rs
+++ b/components/raftstore-v2/tests/failpoints/test_pd_heartbeat.rs
@@ -1,0 +1,50 @@
+// Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
+
+use futures::executor::block_on;
+use pd_client::PdClient;
+use raftstore_v2::router::{StoreMsg, StoreTick};
+use tikv_util::config::ReadableDuration;
+
+use crate::cluster::{v2_default_config, Cluster};
+
+#[test]
+fn test_fake_store_heartbeat() {
+    fail::cfg("mock_collect_tick_interval", "return(0)").unwrap();
+
+    let cluster = Cluster::with_config_and_extra_setting(v2_default_config(), |config| {
+        config.pd_store_heartbeat_tick_interval = ReadableDuration::millis(10);
+        config.inspect_interval = ReadableDuration::millis(10);
+    });
+    let store_id = cluster.node(0).id();
+    let router = &cluster.routers[0];
+
+    // Report store heartbeat to pd.
+    router
+        .store_router()
+        .send_control(StoreMsg::Tick(StoreTick::PdStoreHeartbeat))
+        .unwrap();
+    std::thread::sleep(std::time::Duration::from_millis(50));
+    let prev_stats = block_on(cluster.node(0).pd_client().get_store_stats_async(store_id)).unwrap();
+    if prev_stats.get_start_time() > 0 {
+        assert_ne!(prev_stats.get_capacity(), 0);
+        assert_ne!(prev_stats.get_used_size(), 0);
+        assert_eq!(prev_stats.get_keys_written(), 0);
+    }
+
+    // Inject failpoints to trigger reporting fake store heartbeat to pd.
+    fail::cfg("mock_slowness_last_tick_unfinished", "return(0)").unwrap();
+    std::thread::sleep(std::time::Duration::from_millis(50));
+    let after_stats =
+        block_on(cluster.node(0).pd_client().get_store_stats_async(store_id)).unwrap();
+    assert_ne!(after_stats.get_capacity(), 0);
+    assert_ne!(after_stats.get_used_size(), 0);
+    assert_eq!(after_stats.get_keys_written(), 0);
+    if after_stats.get_start_time() == 0 {
+        assert!(after_stats.get_is_busy());
+    } else {
+        assert!(!after_stats.get_is_busy());
+    }
+
+    fail::remove("mock_slowness_last_tick_unfinished");
+    fail::remove("mock_collect_tick_interval");
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #15011 

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
This pr fixes an unexpected error which will terminate the updating of `last_report_ts` in raftstore-v2.
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None.
```
