### PR TITLE
raftstore-v2: disable coprocessor cache

### DIFF
--- a/components/raftstore-v2/src/operation/query/local.rs
+++ b/components/raftstore-v2/src/operation/query/local.rs
@@ -276,7 +276,8 @@ where
                     }
                 };
 
-                snap.set_from_v2();
+                // FIXME: Tests show it causing TiDB failed to start.
+                // snap.set_from_v2();
                 snap.txn_ext = Some(delegate.txn_ext.clone());
                 snap.term = NonZeroU64::new(delegate.term);
                 snap.txn_extra_op = delegate.txn_extra_op.load();


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #15091

Ref #14997 

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Disable coprocessor cache temporarily because of issue #15091
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
Enable multi rocksdb and run TiDB cluster.

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
