### PR TITLE
bucket polish and enable evict-cache-on-memory-ratio by default

### DIFF
--- a/components/pd_client/src/lib.rs
+++ b/components/pd_client/src/lib.rs
@@ -125,6 +125,11 @@ impl BucketMeta {
         self.keys.remove(idx);
         self.sizes.remove(idx);
     }
+
+    // total size of the whole buckets
+    pub fn total_size(&self) -> u64 {
+        self.sizes.iter().sum()
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/components/raftstore-v2/src/operation/bucket.rs
+++ b/components/raftstore-v2/src/operation/bucket.rs
@@ -246,6 +246,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         }
 
         let buckets_count = region_buckets.meta.keys.len() - 1;
+        info!(self.logger, "refreshed region bucket info"; "buckets_count" => buckets_count);
         store_ctx.coprocessor_host.on_region_changed(
             region,
             RegionChangeEvent::UpdateBuckets(buckets_count),

--- a/components/raftstore-v2/src/operation/bucket.rs
+++ b/components/raftstore-v2/src/operation/bucket.rs
@@ -11,7 +11,7 @@ use raftstore::{
     coprocessor::RegionChangeEvent,
     store::{util, Bucket, BucketRange, ReadProgress, SplitCheckTask, Transport},
 };
-use slog::{error, info, warn};
+use slog::{error, warn};
 
 use crate::{
     batch::StoreContext,

--- a/components/raftstore-v2/src/operation/bucket.rs
+++ b/components/raftstore-v2/src/operation/bucket.rs
@@ -11,7 +11,7 @@ use raftstore::{
     coprocessor::RegionChangeEvent,
     store::{util, Bucket, BucketRange, ReadProgress, SplitCheckTask, Transport},
 };
-use slog::{error, warn};
+use slog::{error, info, warn};
 
 use crate::{
     batch::StoreContext,

--- a/components/raftstore-v2/src/operation/bucket.rs
+++ b/components/raftstore-v2/src/operation/bucket.rs
@@ -272,7 +272,9 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         let buckets_count = region_buckets.meta.keys.len() - 1;
         if change_bucket_version {
             // TODO: we may need to make it debug once the coprocessor timeout is resolved.
-            info!(self.logger, "refreshed region bucket info";
+            info!(
+                self.logger, 
+                "refreshed region bucket info";
                 "bucket_version" => next_bucket_version,
                 "buckets_count" => buckets_count,
                 "estimated_region_size" => region_buckets.meta.total_size(),

--- a/components/raftstore-v2/src/operation/bucket.rs
+++ b/components/raftstore-v2/src/operation/bucket.rs
@@ -29,7 +29,7 @@ pub struct BucketStatsInfo {
     // the report bucket stat records the increment stats after last report pd.
     // it will be reset after report pd.
     report_bucket_stat: Option<BucketStat>,
-    // last bucket count. 
+    // last bucket count.
     // BucketStat.meta is Arc so it cannot be used for last bucket count
     last_bucket_count: usize,
 }
@@ -273,7 +273,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         if change_bucket_version {
             // TODO: we may need to make it debug once the coprocessor timeout is resolved.
             info!(
-                self.logger, 
+                self.logger,
                 "refreshed region bucket info";
                 "bucket_version" => next_bucket_version,
                 "buckets_count" => buckets_count,

--- a/components/raftstore-v2/src/operation/command/admin/split.rs
+++ b/components/raftstore-v2/src/operation/command/admin/split.rs
@@ -280,10 +280,11 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         self.add_pending_tick(PeerTick::SplitRegionCheck);
     }
 
-    pub fn update_split_flow_control(&mut self, metrics: &ApplyMetrics) {
+    pub fn update_split_flow_control(&mut self, metrics: &ApplyMetrics, threshold: i64) {
         let control = self.split_flow_control_mut();
         control.size_diff_hint += metrics.size_diff_hint;
-        if self.is_leader() {
+        let size_diff_hint = control.size_diff_hint;
+        if self.is_leader() && size_diff_hint >= threshold {
             self.add_pending_tick(PeerTick::SplitRegionCheck);
         }
     }

--- a/components/raftstore-v2/src/operation/command/mod.rs
+++ b/components/raftstore-v2/src/operation/command/mod.rs
@@ -406,7 +406,10 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         }
         self.region_buckets_info_mut()
             .add_bucket_flow(&apply_res.bucket_stat);
-        self.update_split_flow_control(&apply_res.metrics);
+        self.update_split_flow_control(
+            &apply_res.metrics,
+            ctx.cfg.region_split_check_diff().0 as i64,
+        );
         self.update_stat(&apply_res.metrics);
         ctx.store_stat.engine_total_bytes_written += apply_res.metrics.written_bytes;
         ctx.store_stat.engine_total_keys_written += apply_res.metrics.written_keys;

--- a/components/raftstore/src/coprocessor/config.rs
+++ b/components/raftstore/src/coprocessor/config.rs
@@ -76,7 +76,7 @@ pub const RAFTSTORE_V2_SPLIT_SIZE: ReadableSize = ReadableSize::gb(10);
 /// Default batch split limit.
 pub const BATCH_SPLIT_LIMIT: u64 = 10;
 
-pub const DEFAULT_BUCKET_SIZE: ReadableSize = ReadableSize::mb(48);
+pub const DEFAULT_BUCKET_SIZE: ReadableSize = ReadableSize::mb(50);
 
 pub const DEFAULT_REGION_BUCKET_MERGE_SIZE_RATIO: f64 = 0.33;
 

--- a/components/raftstore/src/coprocessor/config.rs
+++ b/components/raftstore/src/coprocessor/config.rs
@@ -76,6 +76,10 @@ pub const RAFTSTORE_V2_SPLIT_SIZE: ReadableSize = ReadableSize::gb(10);
 /// Default batch split limit.
 pub const BATCH_SPLIT_LIMIT: u64 = 10;
 
+// A bucket will be split only when its size is larger than 2x of
+// DEFAULT_BUCKET_SIZE So the avg of the actual bucket size is 75MB, which is
+// slightly less than region size We don't use 48MB size because it will enable
+// the automatic bucket under default 96MB region size.
 pub const DEFAULT_BUCKET_SIZE: ReadableSize = ReadableSize::mb(50);
 
 pub const DEFAULT_REGION_BUCKET_MERGE_SIZE_RATIO: f64 = 0.33;

--- a/components/raftstore/src/coprocessor/config.rs
+++ b/components/raftstore/src/coprocessor/config.rs
@@ -76,7 +76,7 @@ pub const RAFTSTORE_V2_SPLIT_SIZE: ReadableSize = ReadableSize::gb(10);
 /// Default batch split limit.
 pub const BATCH_SPLIT_LIMIT: u64 = 10;
 
-pub const DEFAULT_BUCKET_SIZE: ReadableSize = ReadableSize::mb(96);
+pub const DEFAULT_BUCKET_SIZE: ReadableSize = ReadableSize::mb(48);
 
 pub const DEFAULT_REGION_BUCKET_MERGE_SIZE_RATIO: f64 = 0.33;
 

--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -271,10 +271,10 @@ pub struct Config {
     /// `evict_cache_on_memory_ratio` * total.
     ///
     /// Set it to 0 can disable cache evict.
-    // By default it's 0.2. So for different system memory capacity, cache evict happens:
-    // * system=8G,  memory_usage_limit=6G,  evict=1.2G
-    // * system=16G, memory_usage_limit=12G, evict=2.4G
-    // * system=32G, memory_usage_limit=24G, evict=4.8G
+    // By default it's 0.1. So for different system memory capacity, cache evict happens:
+    // * system=8G,  memory_usage_limit=6G,  evict=0.6G
+    // * system=16G, memory_usage_limit=12G, evict=1.2G
+    // * system=32G, memory_usage_limit=24G, evict=2.4G
     pub evict_cache_on_memory_ratio: f64,
 
     pub cmd_batch: bool,
@@ -452,7 +452,7 @@ impl Default for Config {
             apply_yield_duration: ReadableDuration::millis(500),
             apply_yield_write_size: ReadableSize::kb(32),
             perf_level: PerfLevel::Uninitialized,
-            evict_cache_on_memory_ratio: 0.0,
+            evict_cache_on_memory_ratio: 0.1,
             cmd_batch: true,
             cmd_batch_concurrent_ready_max_count: 1,
             raft_write_size_limit: ReadableSize::mb(1),

--- a/components/raftstore/src/store/worker/split_check.rs
+++ b/components/raftstore/src/store/worker/split_check.rs
@@ -269,13 +269,13 @@ impl<EK: KvEngine, S: StoreHandle> Runner<EK, S> {
             bucket.set_end_key(range.1.clone());
             let bucket_entry = host.approximate_bucket_keys(&bucket, tablet)?;
             debug!(
-                "bucket_entry size {} keys count {}",
+                "bucket_entry size {} keys count {}, region_id {}",
                 bucket_entry.size,
-                bucket_entry.keys.len()
+                bucket_entry.keys.len(),
+                region.get_id(),
             );
             buckets.push(bucket_entry);
         }
-
         self.on_buckets_created(&mut buckets, region, &ranges);
         self.refresh_region_buckets(buckets, region, bucket_ranges);
         Ok(())


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #14356

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
1) avoid sending PeerTick::SplitRegionCheck for each write
2) reduce default bucket size from 96MB to 50MB to reduce chance of client side timeout
3) change the default value of evict-cache-on-memory-ratio to 0.1. 
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
1) reduce default bucket size from 96MB to 50MB to reduce chance of client side timeout
2) change the default value of evict-cache-on-memory-ratio to 0.1. 
```
