### PR TITLE
raftstore-v2: implement force leader

### DIFF
--- a/components/raftstore-v2/src/fsm/peer.rs
+++ b/components/raftstore-v2/src/fsm/peer.rs
@@ -365,10 +365,11 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> PeerFsmDelegate<'a, EK, ER,
                 PeerMsg::EnterForceLeaderState {
                     syncer,
                     failed_stores,
-                } => self
-                    .fsm
-                    .peer_mut()
-                    .on_enter_pre_force_leader(syncer, failed_stores),
+                } => self.fsm.peer_mut().on_enter_pre_force_leader(
+                    self.store_ctx,
+                    syncer,
+                    failed_stores,
+                ),
                 PeerMsg::ExitForceLeaderState => {
                     self.fsm.peer_mut().on_exit_force_leader(self.store_ctx)
                 }

--- a/components/raftstore-v2/src/fsm/peer.rs
+++ b/components/raftstore-v2/src/fsm/peer.rs
@@ -362,6 +362,8 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> PeerFsmDelegate<'a, EK, ER,
                 PeerMsg::FlushBeforeClose { tx } => {
                     self.fsm.peer_mut().flush_before_close(self.store_ctx, tx)
                 }
+                PeerMsg::EnterForceLeaderState { .. } | PeerMsg::ExitForceLeaderState => (),
+                PeerMsg::UnsafeRecoveryWaitApply(_) | PeerMsg::UnsafeRecoveryFillOutReport(_) => (),
             }
         }
         // TODO: instead of propose pending commands immediately, we should use timeout.

--- a/components/raftstore-v2/src/fsm/peer.rs
+++ b/components/raftstore-v2/src/fsm/peer.rs
@@ -362,7 +362,19 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> PeerFsmDelegate<'a, EK, ER,
                 PeerMsg::FlushBeforeClose { tx } => {
                     self.fsm.peer_mut().flush_before_close(self.store_ctx, tx)
                 }
-                PeerMsg::EnterForceLeaderState { .. } | PeerMsg::ExitForceLeaderState => (),
+                PeerMsg::EnterForceLeaderState {
+                    syncer,
+                    failed_stores,
+                } => self
+                    .fsm
+                    .peer_mut()
+                    .on_enter_pre_force_leader(syncer, failed_stores),
+                PeerMsg::ExitForceLeaderState => {
+                    self.fsm.peer_mut().on_exit_force_leader(self.store_ctx)
+                }
+                PeerMsg::ExitForceLeaderStateCampaign => {
+                    self.fsm.peer_mut().on_exit_force_leader_campaign()
+                }
                 PeerMsg::UnsafeRecoveryWaitApply(_) | PeerMsg::UnsafeRecoveryFillOutReport(_) => (),
             }
         }

--- a/components/raftstore-v2/src/fsm/store.rs
+++ b/components/raftstore-v2/src/fsm/store.rs
@@ -318,6 +318,10 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T> StoreFsmDelegate<'a, EK, ER, T> {
                     send_time,
                     inspector,
                 ),
+                StoreMsg::UnsafeRecoveryReport(report) => self
+                    .fsm
+                    .store
+                    .on_unsafe_recovery_report(self.store_ctx, report),
             }
         }
     }

--- a/components/raftstore-v2/src/operation/command/admin/conf_change.rs
+++ b/components/raftstore-v2/src/operation/command/admin/conf_change.rs
@@ -104,7 +104,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             self.peer(),
             changes.as_ref(),
             &cc,
-            false,
+            self.is_in_force_leader(),
         )?;
 
         // TODO: check if the new peer is already in history record.
@@ -279,7 +279,7 @@ impl<EK: KvEngine, R> Apply<EK, R> {
                         self.apply_single_change(kind, cp, &mut new_region)
                     };
                     if let Err(e) = res {
-                        error!(self.logger, "failed to apply conf change"; 
+                        error!(self.logger, "failed to apply conf change";
                         "changes" => ?changes,
                         "legacy" => legacy,
                         "original region" => ?region, "err" => ?e);

--- a/components/raftstore-v2/src/operation/command/admin/merge/rollback.rs
+++ b/components/raftstore-v2/src/operation/command/admin/merge/rollback.rs
@@ -65,6 +65,8 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         admin.set_cmd_type(AdminCmdType::RollbackMerge);
         admin.mut_rollback_merge().set_commit(index);
         request.set_admin_request(admin);
+        // TODO: it should propose via on_admin_command, otherwise it may panic
+        //       during force leader.
         if let Err(e) = self.propose(store_ctx, request.write_to_bytes().unwrap()) {
             error!(self.logger, "failed to propose RollbackMerge"; "err" => ?e);
         }

--- a/components/raftstore-v2/src/operation/command/mod.rs
+++ b/components/raftstore-v2/src/operation/command/mod.rs
@@ -195,6 +195,17 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             }
             return Err(e);
         }
+        if self.has_force_leader() {
+            metrics.invalid_proposal.force_leader.inc();
+            // in force leader state, forbid requests to make the recovery
+            // progress less error-prone.
+            if !(admin_type.is_some()
+                && (admin_type.unwrap() == AdminCmdType::ChangePeer
+                    || admin_type.unwrap() == AdminCmdType::ChangePeerV2))
+            {
+                return Err(Error::RecoveryInProgress(self.region_id()));
+            }
+        }
         // Check whether the region is in the flashback state and the request could be
         // proposed. Skip the not prepared error because the
         // `self.region().is_in_flashback` may not be the latest right after applying
@@ -237,6 +248,19 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         data: Vec<u8>,
         proposal_ctx: Vec<u8>,
     ) -> Result<u64> {
+        // Should not propose normal in force leader state.
+        // In `pre_propose_raft_command`, it rejects all the requests expect
+        // conf-change if in force leader state.
+        if self.has_force_leader() {
+            store_ctx.raft_metrics.invalid_proposal.force_leader.inc();
+            panic!(
+                "[{}] {} propose normal in force leader state {:?}",
+                self.region_id(),
+                self.peer_id(),
+                self.force_leader()
+            );
+        };
+
         store_ctx.raft_metrics.propose.normal.inc();
         store_ctx
             .raft_metrics

--- a/components/raftstore-v2/src/operation/mod.rs
+++ b/components/raftstore-v2/src/operation/mod.rs
@@ -8,6 +8,7 @@ mod pd;
 mod query;
 mod ready;
 mod txn_ext;
+mod unsafe_recovery;
 
 pub use command::{
     merge_source_path, AdminCmdResult, ApplyFlowControl, CatchUpLogs, CommittedEntries,

--- a/components/raftstore-v2/src/operation/pd.rs
+++ b/components/raftstore-v2/src/operation/pd.rs
@@ -22,7 +22,7 @@ use crate::{
 impl<'a, EK: KvEngine, ER: RaftEngine, T> StoreFsmDelegate<'a, EK, ER, T> {
     #[inline]
     pub fn on_pd_store_heartbeat(&mut self) {
-        self.fsm.store.store_heartbeat_pd(self.store_ctx);
+        self.fsm.store.store_heartbeat_pd(self.store_ctx, None);
         self.schedule_tick(
             StoreTick::PdStoreHeartbeat,
             self.store_ctx.cfg.pd_store_heartbeat_tick_interval.0,
@@ -31,8 +31,11 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T> StoreFsmDelegate<'a, EK, ER, T> {
 }
 
 impl Store {
-    pub fn store_heartbeat_pd<EK, ER, T>(&self, ctx: &StoreContext<EK, ER, T>)
-    where
+    pub fn store_heartbeat_pd<EK, ER, T>(
+        &self,
+        ctx: &StoreContext<EK, ER, T>,
+        report: Option<pdpb::StoreReport>,
+    ) where
         EK: KvEngine,
         ER: RaftEngine,
     {
@@ -45,7 +48,6 @@ impl Store {
         }
 
         let snap_stats = ctx.snap_mgr.stats();
-        // todo: imple snapshot status report
         stats.set_sending_snap_count(snap_stats.sending_count as u32);
         stats.set_receiving_snap_count(snap_stats.receiving_count as u32);
         stats.set_snapshot_stats(snap_stats.stats.into());
@@ -73,7 +75,7 @@ impl Store {
         );
         stats.set_is_busy(false);
         // TODO: add query stats
-        let task = pd::Task::StoreHeartbeat { stats };
+        let task = pd::Task::StoreHeartbeat { stats, report };
         if let Err(e) = ctx.schedulers.pd.schedule(task) {
             error!(self.logger(), "notify pd failed";
                 "store_id" => self.store_id(),

--- a/components/raftstore-v2/src/operation/ready/mod.rs
+++ b/components/raftstore-v2/src/operation/ready/mod.rs
@@ -1057,15 +1057,13 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
                 _ => {}
             }
 
-            if self.is_in_force_leader() {
-                if ss.raft_state != StateRole::Leader {
-                    // for some reason, it's not leader anymore
-                    info!(self.logger,
-                        "step down in force leader state";
-                        "state" => ?ss.raft_state,
-                    );
-                    self.on_force_leader_fail();
-                }
+            if self.is_in_force_leader() && ss.raft_state != StateRole::Leader {
+                // for some reason, it's not leader anymore
+                info!(self.logger,
+                    "step down in force leader state";
+                    "state" => ?ss.raft_state,
+                );
+                self.on_force_leader_fail();
             }
 
             self.read_progress()

--- a/components/raftstore-v2/src/operation/unsafe_recovery/force_leader.rs
+++ b/components/raftstore-v2/src/operation/unsafe_recovery/force_leader.rs
@@ -175,7 +175,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
     }
 
     pub fn on_exit_force_leader<T>(&mut self, ctx: &StoreContext<EK, ER, T>) {
-        if self.has_force_leader() {
+        if !self.has_force_leader() {
             return;
         }
 

--- a/components/raftstore-v2/src/operation/unsafe_recovery/force_leader.rs
+++ b/components/raftstore-v2/src/operation/unsafe_recovery/force_leader.rs
@@ -1,1 +1,342 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::mem;
+
+use collections::HashSet;
+use engine_traits::{KvEngine, RaftEngine};
+use raft::{eraftpb::MessageType, StateRole, Storage};
+use raftstore::store::{util::LeaseState, ForceLeaderState, UnsafeRecoveryForceLeaderSyncer};
+use slog::{info, warn};
+use tikv_util::time::Instant as TiInstant;
+
+use crate::{batch::StoreContext, raft::Peer, router::PeerMsg};
+
+impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
+    pub fn on_enter_pre_force_leader(
+        &mut self,
+        syncer: UnsafeRecoveryForceLeaderSyncer,
+        failed_stores: HashSet<u64>,
+    ) {
+        match self.force_leader() {
+            Some(ForceLeaderState::PreForceLeader { .. }) => {
+                self.on_force_leader_fail();
+            }
+            Some(ForceLeaderState::ForceLeader { .. }) => {
+                // already is a force leader, do nothing
+                return;
+            }
+            Some(ForceLeaderState::WaitTicks { .. }) => {
+                *self.force_leader_mut() = None;
+            }
+            None => {}
+        }
+
+        if !self.storage().is_initialized() {
+            warn!(self.logger,
+                "Unsafe recovery, cannot force leader since this peer is not initialized";
+            );
+            return;
+        }
+
+        let ticks = if self.is_leader() {
+            // wait two rounds of election timeout to trigger check quorum to
+            // step down the leader.
+            // Note: check quorum is triggered every `election_timeout` instead
+            // of `randomized_election_timeout`
+            Some(
+                self.raft_group().raft.election_timeout() * 2
+                    - self.raft_group().raft.election_elapsed,
+            )
+        // When election timeout is triggered, leader_id is set to INVALID_ID.
+        // But learner(not promotable) is a exception here as it wouldn't tick
+        // election.
+        } else if self.raft_group().raft.promotable() && self.leader_id() != raft::INVALID_ID {
+            // wait one round of election timeout to make sure leader_id is invalid
+            Some(
+                self.raft_group().raft.randomized_election_timeout()
+                    - self.raft_group().raft.election_elapsed,
+            )
+        } else {
+            None
+        };
+
+        if let Some(ticks) = ticks {
+            info!(self.logger,
+                "Unsafe recovery, enter wait ticks";
+                "ticks" => ticks,
+            );
+            *self.force_leader_mut() = Some(ForceLeaderState::WaitTicks {
+                syncer,
+                failed_stores,
+                ticks,
+            });
+            self.set_has_ready();
+            return;
+        }
+
+        let expected_alive_voter = self.get_force_leader_expected_alive_voter(&failed_stores);
+        if !expected_alive_voter.is_empty()
+            && self
+                .raft_group()
+                .raft
+                .prs()
+                .has_quorum(&expected_alive_voter)
+        {
+            warn!(self.logger,
+                "Unsafe recovery, reject pre force leader due to has quorum";
+            );
+            return;
+        }
+
+        info!(self.logger,
+            "Unsafe recovery, enter pre force leader state";
+            "alive_voter" => ?expected_alive_voter,
+        );
+
+        // Do not use prevote as prevote won't set `vote` to itself.
+        // When PD issues force leader on two different peer, it may cause
+        // two force leader in same term.
+        self.raft_group_mut().raft.pre_vote = false;
+        // trigger vote request to all voters, will check the vote result in
+        // `check_force_leader`
+        if let Err(e) = self.raft_group_mut().campaign() {
+            warn!(self.logger, "Unsafe recovery, campaign failed"; "err" => ?e);
+        }
+        assert_eq!(self.raft_group().raft.state, StateRole::Candidate);
+        if !self
+            .raft_group()
+            .raft
+            .prs()
+            .votes()
+            .get(&self.peer_id())
+            .unwrap()
+        {
+            warn!(self.logger,
+                "Unsafe recovery, pre force leader failed to campaign";
+            );
+            self.on_force_leader_fail();
+            return;
+        }
+
+        *self.force_leader_mut() = Some(ForceLeaderState::PreForceLeader {
+            syncer,
+            failed_stores,
+        });
+        self.set_has_ready();
+    }
+
+    pub fn on_force_leader_fail(&mut self) {
+        self.raft_group_mut().raft.pre_vote = true;
+        self.raft_group_mut().raft.set_check_quorum(true);
+        *self.force_leader_mut() = None;
+    }
+
+    fn on_enter_force_leader(&mut self) {
+        info!(self.logger, "Unsafe recovery, enter force leader state");
+        assert_eq!(self.raft_group().raft.state, StateRole::Candidate);
+
+        let failed_stores = match self.force_leader_mut().take() {
+            Some(ForceLeaderState::PreForceLeader { failed_stores, .. }) => failed_stores,
+            _ => unreachable!(),
+        };
+
+        let peer_ids: Vec<_> = self.voters().iter().collect();
+        for peer_id in peer_ids {
+            let store_id = self
+                .region()
+                .get_peers()
+                .iter()
+                .find(|p| p.get_id() == peer_id)
+                .unwrap()
+                .get_store_id();
+            if !failed_stores.contains(&store_id) {
+                continue;
+            }
+
+            // make fake vote responses from peers on failed store.
+            let mut msg = raft::eraftpb::Message::new();
+            msg.msg_type = MessageType::MsgRequestVoteResponse;
+            msg.reject = false;
+            msg.term = self.term();
+            msg.from = peer_id;
+            msg.to = self.peer_id();
+            self.raft_group_mut().step(msg).unwrap();
+        }
+
+        // after receiving all votes, should become leader
+        assert!(self.is_leader());
+        self.raft_group_mut().raft.set_check_quorum(false);
+
+        *self.force_leader_mut() = Some(ForceLeaderState::ForceLeader {
+            time: TiInstant::now_coarse(),
+            failed_stores,
+        });
+        self.set_has_ready();
+    }
+
+    pub fn on_exit_force_leader<T>(&mut self, ctx: &StoreContext<EK, ER, T>) {
+        if self.has_force_leader() {
+            return;
+        }
+
+        info!(self.logger, "exit force leader state");
+        *self.force_leader_mut() = None;
+        // leader lease shouldn't be renewed in force leader state.
+        assert_eq!(self.leader_lease().inspect(None), LeaseState::Expired);
+        let term = self.term();
+        self.raft_group_mut()
+            .raft
+            .become_follower(term, raft::INVALID_ID);
+
+        self.raft_group_mut().raft.set_check_quorum(true);
+        self.raft_group_mut().raft.pre_vote = true;
+        if self.raft_group().raft.promotable() {
+            // Do not campaign directly here, otherwise on_role_changed() won't called for
+            // follower state
+            let _ = ctx
+                .router
+                .send(self.region_id(), PeerMsg::ExitForceLeaderStateCampaign);
+        }
+        self.set_has_ready();
+    }
+
+    pub fn on_exit_force_leader_campaign(&mut self) {
+        let _ = self.raft_group_mut().campaign();
+        self.set_has_ready();
+    }
+
+    fn get_force_leader_expected_alive_voter(&self, failed_stores: &HashSet<u64>) -> HashSet<u64> {
+        let region = self.region();
+        self.voters()
+            .iter()
+            .filter(|peer_id| {
+                let store_id = region
+                    .get_peers()
+                    .iter()
+                    .find(|p| p.get_id() == *peer_id)
+                    .unwrap()
+                    .get_store_id();
+                !failed_stores.contains(&store_id)
+            })
+            .collect()
+    }
+
+    pub fn check_force_leader<T>(&mut self, ctx: &StoreContext<EK, ER, T>) {
+        if let Some(ForceLeaderState::WaitTicks {
+            syncer,
+            failed_stores,
+            ticks,
+        }) = self.force_leader_mut()
+        {
+            if *ticks == 0 {
+                let syncer_clone = syncer.clone();
+                let s = mem::take(failed_stores);
+                self.on_enter_pre_force_leader(syncer_clone, s);
+            } else {
+                *ticks -= 1;
+            }
+            return;
+        };
+
+        let failed_stores = match self.force_leader() {
+            None => return,
+            Some(ForceLeaderState::ForceLeader { .. }) => {
+                if self.maybe_force_forward_commit_index() {
+                    self.set_has_ready();
+                }
+                return;
+            }
+            Some(ForceLeaderState::PreForceLeader { failed_stores, .. }) => failed_stores,
+            Some(ForceLeaderState::WaitTicks { .. }) => unreachable!(),
+        };
+
+        if self.raft_group().raft.election_elapsed + 1 < ctx.cfg.raft_election_timeout_ticks {
+            // wait as longer as it can to collect responses of request vote
+            return;
+        }
+
+        let expected_alive_voter = self.get_force_leader_expected_alive_voter(failed_stores);
+        let check = || {
+            if self.raft_group().raft.state != StateRole::Candidate {
+                Err(format!(
+                    "unexpected role {:?}",
+                    self.raft_group().raft.state
+                ))
+            } else {
+                let mut granted = 0;
+                for (id, vote) in self.raft_group().raft.prs().votes() {
+                    if expected_alive_voter.contains(id) {
+                        if *vote {
+                            granted += 1;
+                        } else {
+                            return Err(format!("receive reject response from {}", *id));
+                        }
+                    } else if *id == self.peer_id() {
+                        // self may be a learner
+                        continue;
+                    } else {
+                        return Err(format!(
+                            "receive unexpected vote from {} vote {}",
+                            *id, *vote
+                        ));
+                    }
+                }
+                Ok(granted)
+            }
+        };
+
+        match check() {
+            Err(err) => {
+                warn!(self.logger,
+                    "Unsafe recovery, pre force leader check failed";
+                    "alive_voter" => ?expected_alive_voter,
+                    "reason" => err,
+                );
+                self.on_force_leader_fail();
+            }
+            Ok(granted) => {
+                info!(self.logger,
+                    "Unsafe recovery, expected live voters:";
+                    "voters" => ?expected_alive_voter,
+                    "granted" => granted,
+                );
+                if granted == expected_alive_voter.len() {
+                    self.on_enter_force_leader();
+                }
+            }
+        }
+    }
+
+    pub fn maybe_force_forward_commit_index(&mut self) -> bool {
+        let failed_stores = match self.force_leader() {
+            Some(ForceLeaderState::ForceLeader { failed_stores, .. }) => failed_stores,
+            _ => unreachable!(),
+        };
+
+        let region = self.region();
+        let mut replicated_idx = self.raft_group().raft.raft_log.persisted;
+        for (peer_id, p) in self.raft_group().raft.prs().iter() {
+            let store_id = region
+                .get_peers()
+                .iter()
+                .find(|p| p.get_id() == *peer_id)
+                .unwrap()
+                .get_store_id();
+            if failed_stores.contains(&store_id) {
+                continue;
+            }
+            if replicated_idx > p.matched {
+                replicated_idx = p.matched;
+            }
+        }
+
+        if self.raft_group().store().term(replicated_idx).unwrap_or(0) < self.term() {
+            // do not commit logs of previous term directly
+            return false;
+        }
+
+        let idx = std::cmp::max(self.raft_group().raft.raft_log.committed, replicated_idx);
+        self.raft_group_mut().raft.raft_log.committed = idx;
+        true
+    }
+}

--- a/components/raftstore-v2/src/operation/unsafe_recovery/force_leader.rs
+++ b/components/raftstore-v2/src/operation/unsafe_recovery/force_leader.rs
@@ -1,0 +1,1 @@
+// Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.

--- a/components/raftstore-v2/src/operation/unsafe_recovery/mod.rs
+++ b/components/raftstore-v2/src/operation/unsafe_recovery/mod.rs
@@ -1,0 +1,4 @@
+// Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
+
+mod force_leader;
+mod report;

--- a/components/raftstore-v2/src/operation/unsafe_recovery/report.rs
+++ b/components/raftstore-v2/src/operation/unsafe_recovery/report.rs
@@ -1,0 +1,21 @@
+// Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
+
+use engine_traits::{KvEngine, RaftEngine};
+use kvproto::pdpb;
+use raftstore::store::Transport;
+
+use crate::{batch::StoreContext, fsm::Store};
+
+impl Store {
+    pub fn on_unsafe_recovery_report<EK, ER, T>(
+        &self,
+        ctx: &StoreContext<EK, ER, T>,
+        report: pdpb::StoreReport,
+    ) where
+        EK: KvEngine,
+        ER: RaftEngine,
+        T: Transport,
+    {
+        self.store_heartbeat_pd(ctx, Some(report))
+    }
+}

--- a/components/raftstore-v2/src/router/imp.rs
+++ b/components/raftstore-v2/src/router/imp.rs
@@ -5,12 +5,14 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use collections::HashSet;
 use crossbeam::channel::{SendError, TrySendError};
 use engine_traits::{KvEngine, RaftEngine};
 use futures::Future;
 use kvproto::{
     kvrpcpb::ExtraOp,
     metapb::RegionEpoch,
+    pdpb,
     raft_cmdpb::{RaftCmdRequest, RaftCmdResponse},
     raft_serverpb::RaftMessage,
 };
@@ -18,11 +20,16 @@ use raftstore::{
     router::CdcHandle,
     store::{
         fsm::ChangeObserver, AsyncReadNotifier, Callback, FetchedLogs, GenSnapRes, RegionSnapshot,
+        UnsafeRecoveryFillOutReportSyncer, UnsafeRecoveryForceLeaderSyncer, UnsafeRecoveryHandle,
+        UnsafeRecoveryWaitApplySyncer,
     },
 };
 use slog::warn;
+use tikv_util::box_err;
 
-use super::{build_any_channel, message::CaptureChange, PeerMsg, QueryResChannel, QueryResult};
+use super::{
+    build_any_channel, message::CaptureChange, PeerMsg, QueryResChannel, QueryResult, StoreMsg,
+};
 use crate::{batch::StoreRouter, operation::LocalReader, StoreMeta};
 
 impl<EK: KvEngine, ER: RaftEngine> AsyncReadNotifier for StoreRouter<EK, ER> {
@@ -248,5 +255,56 @@ impl<EK: KvEngine, ER: RaftEngine> CdcHandle<EK> for RaftRouter<EK, ER> {
             return Err(crate::Error::RegionNotFound(region_id));
         }
         Ok(())
+    }
+}
+
+/// A wrapper of StoreRouter that is specialized for implementing
+/// UnsafeRecoveryRouter.
+pub struct UnsafeRecoveryRouter<EK: KvEngine, ER: RaftEngine>(Mutex<StoreRouter<EK, ER>>);
+
+impl<EK: KvEngine, ER: RaftEngine> UnsafeRecoveryRouter<EK, ER> {
+    pub fn new(router: StoreRouter<EK, ER>) -> UnsafeRecoveryRouter<EK, ER> {
+        UnsafeRecoveryRouter(Mutex::new(router))
+    }
+}
+
+impl<EK: KvEngine, ER: RaftEngine> UnsafeRecoveryHandle for UnsafeRecoveryRouter<EK, ER> {
+    fn send_enter_force_leader(
+        &self,
+        region_id: u64,
+        syncer: UnsafeRecoveryForceLeaderSyncer,
+        failed_stores: HashSet<u64>,
+    ) -> crate::Result<()> {
+        let router = self.0.lock().unwrap();
+        router.check_send(
+            region_id,
+            PeerMsg::EnterForceLeaderState {
+                syncer,
+                failed_stores,
+            },
+        )
+    }
+
+    fn broadcast_exit_force_leader(&self) {
+        let router = self.0.lock().unwrap();
+        router.broadcast_normal(|| PeerMsg::ExitForceLeaderState);
+    }
+
+    fn broadcast_wait_apply(&self, syncer: UnsafeRecoveryWaitApplySyncer) {
+        let router = self.0.lock().unwrap();
+        router.broadcast_normal(|| PeerMsg::UnsafeRecoveryWaitApply(syncer.clone()));
+    }
+
+    fn broadcast_fill_out_report(&self, syncer: UnsafeRecoveryFillOutReportSyncer) {
+        let router = self.0.lock().unwrap();
+        router.broadcast_normal(|| PeerMsg::UnsafeRecoveryFillOutReport(syncer.clone()));
+    }
+
+    fn send_report(&self, report: pdpb::StoreReport) -> crate::Result<()> {
+        let router = self.0.lock().unwrap();
+        match router.force_send_control(StoreMsg::UnsafeRecoveryReport(report)) {
+            Ok(()) => Ok(()),
+            Err(SendError(_)) => Err(box_err!("fail to send unsafe recovery store report")),
+        }
     }
 }

--- a/components/raftstore-v2/src/router/message.rs
+++ b/components/raftstore-v2/src/router/message.rs
@@ -258,6 +258,8 @@ pub enum PeerMsg {
     },
     /// Let a peer exits force leader state.
     ExitForceLeaderState,
+    /// Let a peer campaign directly after exit force leader.
+    ExitForceLeaderStateCampaign,
     /// Wait for a peer to apply to the latest commit index.
     UnsafeRecoveryWaitApply(UnsafeRecoveryWaitApplySyncer),
     /// Wait for a peer to fill its status to the report.

--- a/components/raftstore-v2/src/router/message.rs
+++ b/components/raftstore-v2/src/router/message.rs
@@ -3,16 +3,20 @@
 // #[PerformanceCriticalPath]
 use std::sync::{mpsc::SyncSender, Arc};
 
+use collections::HashSet;
 use kvproto::{
     import_sstpb::SstMeta,
     metapb,
     metapb::RegionEpoch,
+    pdpb,
     raft_cmdpb::{RaftCmdRequest, RaftRequestHeader},
     raft_serverpb::RaftMessage,
 };
 use raftstore::store::{
     fsm::ChangeObserver, metrics::RaftEventDurationType, simple_write::SimpleWriteBinary,
     util::LatencyInspector, FetchedLogs, GenSnapRes, TabletSnapKey,
+    UnsafeRecoveryFillOutReportSyncer, UnsafeRecoveryForceLeaderSyncer,
+    UnsafeRecoveryWaitApplySyncer,
 };
 use resource_control::ResourceMetered;
 use tikv_util::time::Instant;
@@ -246,6 +250,18 @@ pub enum PeerMsg {
     },
     /// A message that used to check if a snapshot gc is happened.
     SnapGc(Box<[TabletSnapKey]>),
+
+    /// Let a peer enters force leader state during unsafe recovery.
+    EnterForceLeaderState {
+        syncer: UnsafeRecoveryForceLeaderSyncer,
+        failed_stores: HashSet<u64>,
+    },
+    /// Let a peer exits force leader state.
+    ExitForceLeaderState,
+    /// Wait for a peer to apply to the latest commit index.
+    UnsafeRecoveryWaitApply(UnsafeRecoveryWaitApplySyncer),
+    /// Wait for a peer to fill its status to the report.
+    UnsafeRecoveryFillOutReport(UnsafeRecoveryFillOutReportSyncer),
 }
 
 impl ResourceMetered for PeerMsg {}
@@ -346,6 +362,8 @@ pub enum StoreMsg {
         send_time: Instant,
         inspector: LatencyInspector,
     },
+    /// Send a store report for unsafe recovery.
+    UnsafeRecoveryReport(pdpb::StoreReport),
 }
 
 impl ResourceMetered for StoreMsg {}

--- a/components/raftstore-v2/src/router/mod.rs
+++ b/components/raftstore-v2/src/router/mod.rs
@@ -11,7 +11,7 @@ pub use self::response_channel::FlushChannel;
 #[cfg(feature = "testexport")]
 pub use self::response_channel::FlushSubscriber;
 pub use self::{
-    imp::RaftRouter,
+    imp::{RaftRouter, UnsafeRecoveryRouter},
     internal_message::ApplyRes,
     message::{PeerMsg, PeerTick, RaftRequest, StoreMsg, StoreTick},
     response_channel::{

--- a/components/raftstore-v2/src/worker/pd/mod.rs
+++ b/components/raftstore-v2/src/worker/pd/mod.rs
@@ -47,7 +47,8 @@ pub enum Task {
     // In store.rs.
     StoreHeartbeat {
         stats: pdpb::StoreStats,
-        // TODO: StoreReport, StoreDrAutoSyncStatus
+        report: Option<pdpb::StoreReport>,
+        // TODO: StoreDrAutoSyncStatus
     },
     UpdateStoreInfos {
         cpu_usages: RecordPairVec,
@@ -303,8 +304,8 @@ where
     fn run(&mut self, task: Task) {
         self.maybe_schedule_heartbeat_receiver();
         match task {
-            Task::StoreHeartbeat { stats } => {
-                self.handle_store_heartbeat(stats, false /* is_fake_hb */)
+            Task::StoreHeartbeat { stats, report } => {
+                self.handle_store_heartbeat(stats, false /* is_fake_hb */, report)
             }
             Task::UpdateStoreInfos {
                 cpu_usages,

--- a/components/raftstore-v2/src/worker/pd/store.rs
+++ b/components/raftstore-v2/src/worker/pd/store.rs
@@ -1,8 +1,8 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::cmp;
+use std::{cmp, sync::Arc};
 
-use collections::HashMap;
+use collections::{HashMap, HashSet};
 use engine_traits::{KvEngine, RaftEngine};
 use fail::fail_point;
 use kvproto::pdpb;
@@ -14,7 +14,10 @@ use pd_client::{
     PdClient,
 };
 use prometheus::local::LocalHistogram;
-use raftstore::store::{metrics::STORE_SNAPSHOT_TRAFFIC_GAUGE_VEC, util::LatencyInspector};
+use raftstore::store::{
+    metrics::STORE_SNAPSHOT_TRAFFIC_GAUGE_VEC, util::LatencyInspector,
+    UnsafeRecoveryForceLeaderSyncer, UnsafeRecoveryHandle,
+};
 use slog::{error, info, warn};
 use tikv_util::{
     metrics::RecordPairVec,
@@ -24,7 +27,7 @@ use tikv_util::{
 };
 
 use super::Runner;
-use crate::router::StoreMsg;
+use crate::router::{StoreMsg, UnsafeRecoveryRouter};
 
 const HOTSPOT_REPORT_CAPACITY: usize = 1000;
 
@@ -175,7 +178,12 @@ where
     ER: RaftEngine,
     T: PdClient + 'static,
 {
-    pub fn handle_store_heartbeat(&mut self, mut stats: pdpb::StoreStats, is_fake_hb: bool) {
+    pub fn handle_store_heartbeat(
+        &mut self,
+        mut stats: pdpb::StoreStats,
+        is_fake_hb: bool,
+        store_report: Option<pdpb::StoreReport>,
+    ) {
         let mut report_peers = HashMap::default();
         for (region_id, region_peer) in &mut self.region_peers {
             let read_bytes = region_peer.read_bytes - region_peer.last_store_report_read_bytes;
@@ -268,13 +276,43 @@ where
         // Update slowness statistics
         self.update_slowness_in_store_stats(&mut stats, last_query_sum);
 
-        let resp = self.pd_client.store_heartbeat(stats, None, None);
+        let resp = self.pd_client.store_heartbeat(stats, store_report, None);
         let logger = self.logger.clone();
+        let router = self.router.clone();
         let mut grpc_service_manager = self.grpc_service_manager.clone();
         let f = async move {
             match resp.await {
                 Ok(mut resp) => {
-                    // TODO: unsafe recovery
+                    // TODO: handle replication_status
+
+                    if let Some(plan) = resp.recovery_plan.take() {
+                        let router = Arc::new(UnsafeRecoveryRouter::new(router));
+                        info!(logger, "Unsafe recovery, received a recovery plan");
+                        if plan.has_force_leader() {
+                            let mut failed_stores = HashSet::default();
+                            for failed_store in plan.get_force_leader().get_failed_stores() {
+                                failed_stores.insert(*failed_store);
+                            }
+                            let syncer = UnsafeRecoveryForceLeaderSyncer::new(
+                                plan.get_step(),
+                                router.clone(),
+                            );
+                            for region in plan.get_force_leader().get_enter_force_leaders() {
+                                if let Err(e) = router.send_enter_force_leader(
+                                    *region,
+                                    syncer.clone(),
+                                    failed_stores.clone(),
+                                ) {
+                                    error!(logger,
+                                        "fail to send force leader message for recovery";
+                                        "err" => ?e);
+                                }
+                            }
+                        }
+                        // else {
+                        // TODO: handle creates/tombstone/demotes
+                        // }
+                    }
 
                     // Attention, as Hibernate Region is eliminated in
                     // raftstore-v2, followings just mock the awaken
@@ -338,7 +376,7 @@ where
 
         // And here, the `is_fake_hb` should be marked with `True` to represent that
         // this heartbeat message is a fake one.
-        self.handle_store_heartbeat(stats, true);
+        self.handle_store_heartbeat(stats, true, None);
         warn!(self.logger, "scheduling store_heartbeat timeout, force report store slow score to pd.";
             "store_id" => self.store_id,
         );

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -1968,17 +1968,15 @@ where
                 self.register_check_long_uncommitted_tick();
             }
 
-            if self.fsm.peer.is_in_force_leader() {
-                if r != StateRole::Leader {
-                    // for some reason, it's not leader anymore
-                    info!(
-                        "step down in force leader state";
-                        "region_id" => self.fsm.region_id(),
-                        "peer_id" => self.fsm.peer_id(),
-                        "state" => ?r,
-                    );
-                    self.on_force_leader_fail();
-                }
+            if self.fsm.peer.is_in_force_leader() && r != StateRole::Leader {
+                // for some reason, it's not leader anymore
+                info!(
+                    "step down in force leader state";
+                    "region_id" => self.fsm.region_id(),
+                    "peer_id" => self.fsm.peer_id(),
+                    "state" => ?r,
+                );
+                self.on_force_leader_fail();
             }
         }
     }

--- a/components/raftstore/src/store/mod.rs
+++ b/components/raftstore/src/store/mod.rs
@@ -25,6 +25,7 @@ mod replication_mode;
 pub mod simple_write;
 pub mod snap;
 mod txn_ext;
+mod unsafe_recovery;
 mod worker;
 
 #[cfg(any(test, feature = "testexport"))]
@@ -58,6 +59,8 @@ pub use self::{
         can_amend_read, get_sync_log_from_request, make_transfer_leader_response,
         propose_read_index, should_renew_lease, Peer, PeerStat, ProposalContext, ProposalQueue,
         RequestInspector, RequestPolicy, SnapshotRecoveryWaitApplySyncer,
+        UnsafeRecoveryExecutePlanSyncer, UnsafeRecoveryFillOutReportSyncer,
+        UnsafeRecoveryForceLeaderSyncer, UnsafeRecoveryWaitApplySyncer,
         TRANSFER_LEADER_COMMAND_REPLY_CTX,
     },
     peer_storage::{
@@ -76,6 +79,7 @@ pub use self::{
     },
     transport::{CasualRouter, ProposalRouter, SignificantRouter, StoreRouter, Transport},
     txn_ext::{LocksStatus, PeerPessimisticLocks, PessimisticLockPair, TxnExt},
+    unsafe_recovery::UnsafeRecoveryHandle,
     util::{RegionReadProgress, RegionReadProgressRegistry},
     worker::{
         metrics as worker_metrics, AutoSplitController, BatchComponent, Bucket, BucketRange,

--- a/components/raftstore/src/store/mod.rs
+++ b/components/raftstore/src/store/mod.rs
@@ -57,8 +57,8 @@ pub use self::{
     },
     peer::{
         can_amend_read, get_sync_log_from_request, make_transfer_leader_response,
-        propose_read_index, should_renew_lease, Peer, PeerStat, ProposalContext, ProposalQueue,
-        RequestInspector, RequestPolicy, SnapshotRecoveryWaitApplySyncer,
+        propose_read_index, should_renew_lease, ForceLeaderState, Peer, PeerStat, ProposalContext,
+        ProposalQueue, RequestInspector, RequestPolicy, SnapshotRecoveryWaitApplySyncer,
         UnsafeRecoveryExecutePlanSyncer, UnsafeRecoveryFillOutReportSyncer,
         UnsafeRecoveryForceLeaderSyncer, UnsafeRecoveryWaitApplySyncer,
         TRANSFER_LEADER_COMMAND_REPLY_CTX,

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -89,14 +89,15 @@ use crate::{
         async_io::{read::ReadTask, write::WriteMsg, write_router::WriteRouter},
         fsm::{
             apply::{self, CatchUpLogs},
-            store::{PollContext, RaftRouter},
+            store::PollContext,
             Apply, ApplyMetrics, ApplyTask, Proposal,
         },
         hibernate_state::GroupState,
         memory::{needs_evict_entry_cache, MEMTRACE_RAFT_ENTRIES},
-        msg::{CasualMessage, ErrorCallback, PeerMsg, RaftCommand, SignificantMsg, StoreMsg},
+        msg::{CasualMessage, ErrorCallback, RaftCommand},
         peer_storage::HandleSnapshotResult,
         txn_ext::LocksStatus,
+        unsafe_recovery::UnsafeRecoveryHandle,
         util::{admin_cmd_epoch_lookup, RegionReadProgress},
         worker::{
             HeartbeatTask, RaftlogGcTask, ReadDelegate, ReadExecutor, ReadProgress, RegionTask,
@@ -539,7 +540,7 @@ pub enum ForceLeaderState {
 // addition to that, it uses a closure to avoid having a raft router as a member
 // variable, which is statically dispatched, thus needs to propagate the
 // generics everywhere.
-pub struct InvokeClosureOnDrop(Box<dyn Fn() + Send + Sync>);
+pub struct InvokeClosureOnDrop(Option<Box<dyn FnOnce() + Send + Sync>>);
 
 impl fmt::Debug for InvokeClosureOnDrop {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -549,20 +550,18 @@ impl fmt::Debug for InvokeClosureOnDrop {
 
 impl Drop for InvokeClosureOnDrop {
     fn drop(&mut self) {
-        self.0();
+        self.0.take().map(|on_drop| on_drop());
     }
 }
 
-pub fn start_unsafe_recovery_report<EK: KvEngine, ER: RaftEngine>(
-    router: &RaftRouter<EK, ER>,
+pub fn start_unsafe_recovery_report(
+    router: Arc<dyn UnsafeRecoveryHandle>,
     report_id: u64,
     exit_force_leader: bool,
 ) {
     let wait_apply =
         UnsafeRecoveryWaitApplySyncer::new(report_id, router.clone(), exit_force_leader);
-    router.broadcast_normal(|| {
-        PeerMsg::SignificantMsg(SignificantMsg::UnsafeRecoveryWaitApply(wait_apply.clone()))
-    });
+    router.broadcast_wait_apply(wait_apply.clone());
 }
 
 // Propose a read index request to the raft group, return the request id and
@@ -647,13 +646,11 @@ pub fn can_amend_read<C>(
 pub struct UnsafeRecoveryForceLeaderSyncer(Arc<InvokeClosureOnDrop>);
 
 impl UnsafeRecoveryForceLeaderSyncer {
-    pub fn new(report_id: u64, router: RaftRouter<impl KvEngine, impl RaftEngine>) -> Self {
-        let thread_safe_router = Mutex::new(router);
-        let inner = InvokeClosureOnDrop(Box::new(move || {
+    pub fn new(report_id: u64, router: Arc<dyn UnsafeRecoveryHandle>) -> Self {
+        let inner = InvokeClosureOnDrop(Some(Box::new(move || {
             info!("Unsafe recovery, force leader finished.");
-            let router_ptr = thread_safe_router.lock().unwrap();
-            start_unsafe_recovery_report(&*router_ptr, report_id, false);
-        }));
+            start_unsafe_recovery_report(router, report_id, false);
+        })));
         UnsafeRecoveryForceLeaderSyncer(Arc::new(inner))
     }
 }
@@ -665,19 +662,17 @@ pub struct UnsafeRecoveryExecutePlanSyncer {
 }
 
 impl UnsafeRecoveryExecutePlanSyncer {
-    pub fn new(report_id: u64, router: RaftRouter<impl KvEngine, impl RaftEngine>) -> Self {
-        let thread_safe_router = Mutex::new(router);
+    pub fn new(report_id: u64, router: Arc<dyn UnsafeRecoveryHandle>) -> Self {
         let abort = Arc::new(Mutex::new(false));
         let abort_clone = abort.clone();
-        let closure = InvokeClosureOnDrop(Box::new(move || {
+        let closure = InvokeClosureOnDrop(Some(Box::new(move || {
             info!("Unsafe recovery, plan execution finished");
             if *abort_clone.lock().unwrap() {
                 warn!("Unsafe recovery, plan execution aborted");
                 return;
             }
-            let router_ptr = thread_safe_router.lock().unwrap();
-            start_unsafe_recovery_report(&*router_ptr, report_id, true);
-        }));
+            start_unsafe_recovery_report(router, report_id, true);
+        })));
         UnsafeRecoveryExecutePlanSyncer {
             _closure: Arc::new(closure),
             abort,
@@ -700,7 +695,7 @@ impl SnapshotRecoveryWaitApplySyncer {
         let thread_safe_router = Mutex::new(sender);
         let abort = Arc::new(Mutex::new(false));
         let abort_clone = abort.clone();
-        let closure = InvokeClosureOnDrop(Box::new(move || {
+        let closure = InvokeClosureOnDrop(Some(Box::new(move || {
             info!("region {} wait apply finished", region_id);
             if *abort_clone.lock().unwrap() {
                 warn!("wait apply aborted");
@@ -711,7 +706,7 @@ impl SnapshotRecoveryWaitApplySyncer {
             _ = router_ptr.send(region_id).map_err(|_| {
                 warn!("reply waitapply states failure.");
             });
-        }));
+        })));
         SnapshotRecoveryWaitApplySyncer {
             _closure: Arc::new(closure),
             abort,
@@ -732,32 +727,23 @@ pub struct UnsafeRecoveryWaitApplySyncer {
 impl UnsafeRecoveryWaitApplySyncer {
     pub fn new(
         report_id: u64,
-        router: RaftRouter<impl KvEngine, impl RaftEngine>,
+        router: Arc<dyn UnsafeRecoveryHandle>,
         exit_force_leader: bool,
     ) -> Self {
-        let thread_safe_router = Mutex::new(router);
         let abort = Arc::new(Mutex::new(false));
         let abort_clone = abort.clone();
-        let closure = InvokeClosureOnDrop(Box::new(move || {
+        let closure = InvokeClosureOnDrop(Some(Box::new(move || {
             info!("Unsafe recovery, wait apply finished");
             if *abort_clone.lock().unwrap() {
                 warn!("Unsafe recovery, wait apply aborted");
                 return;
             }
-            let router_ptr = thread_safe_router.lock().unwrap();
             if exit_force_leader {
-                (*router_ptr).broadcast_normal(|| {
-                    PeerMsg::SignificantMsg(SignificantMsg::ExitForceLeaderState)
-                });
+                router.broadcast_exit_force_leader();
             }
-            let fill_out_report =
-                UnsafeRecoveryFillOutReportSyncer::new(report_id, (*router_ptr).clone());
-            (*router_ptr).broadcast_normal(|| {
-                PeerMsg::SignificantMsg(SignificantMsg::UnsafeRecoveryFillOutReport(
-                    fill_out_report.clone(),
-                ))
-            });
-        }));
+            let fill_out_report = UnsafeRecoveryFillOutReportSyncer::new(report_id, router.clone());
+            router.broadcast_fill_out_report(fill_out_report);
+        })));
         UnsafeRecoveryWaitApplySyncer {
             _closure: Arc::new(closure),
             abort,
@@ -776,11 +762,10 @@ pub struct UnsafeRecoveryFillOutReportSyncer {
 }
 
 impl UnsafeRecoveryFillOutReportSyncer {
-    pub fn new(report_id: u64, router: RaftRouter<impl KvEngine, impl RaftEngine>) -> Self {
-        let thread_safe_router = Mutex::new(router);
+    pub fn new(report_id: u64, router: Arc<dyn UnsafeRecoveryHandle>) -> Self {
         let reports = Arc::new(Mutex::new(vec![]));
         let reports_clone = reports.clone();
-        let closure = InvokeClosureOnDrop(Box::new(move || {
+        let closure = InvokeClosureOnDrop(Some(Box::new(move || {
             info!("Unsafe recovery, peer reports collected");
             let mut store_report = pdpb::StoreReport::default();
             {
@@ -788,12 +773,10 @@ impl UnsafeRecoveryFillOutReportSyncer {
                 store_report.set_peer_reports(mem::take(&mut *reports_ptr).into());
             }
             store_report.set_step(report_id);
-            let router_ptr = thread_safe_router.lock().unwrap();
-            if let Err(e) = (*router_ptr).send_control(StoreMsg::UnsafeRecoveryReport(store_report))
-            {
+            if let Err(e) = router.send_report(store_report) {
                 error!("Unsafe recovery, fail to schedule reporting"; "err" => ?e);
             }
-        }));
+        })));
         UnsafeRecoveryFillOutReportSyncer {
             _closure: Arc::new(closure),
             reports,

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -550,7 +550,9 @@ impl fmt::Debug for InvokeClosureOnDrop {
 
 impl Drop for InvokeClosureOnDrop {
     fn drop(&mut self) {
-        self.0.take().map(|on_drop| on_drop());
+        if let Some(on_drop) = self.0.take() {
+            on_drop();
+        }
     }
 }
 
@@ -561,7 +563,7 @@ pub fn start_unsafe_recovery_report(
 ) {
     let wait_apply =
         UnsafeRecoveryWaitApplySyncer::new(report_id, router.clone(), exit_force_leader);
-    router.broadcast_wait_apply(wait_apply.clone());
+    router.broadcast_wait_apply(wait_apply);
 }
 
 // Propose a read index request to the raft group, return the request id and

--- a/components/raftstore/src/store/unsafe_recovery.rs
+++ b/components/raftstore/src/store/unsafe_recovery.rs
@@ -1,0 +1,82 @@
+// Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::sync::Mutex;
+
+use collections::HashSet;
+use crossbeam::channel::SendError;
+use engine_traits::{KvEngine, RaftEngine};
+use kvproto::pdpb::StoreReport;
+use tikv_util::box_err;
+
+use super::{
+    peer::{
+        UnsafeRecoveryFillOutReportSyncer, UnsafeRecoveryForceLeaderSyncer,
+        UnsafeRecoveryWaitApplySyncer,
+    },
+    PeerMsg, RaftRouter, SignificantMsg, SignificantRouter, StoreMsg,
+};
+use crate::Result;
+
+/// A handle for PD to schedule online unsafe recovery commands back to
+/// raftstore.
+pub trait UnsafeRecoveryHandle: Sync + Send {
+    fn send_enter_force_leader(
+        &self,
+        region_id: u64,
+        syncer: UnsafeRecoveryForceLeaderSyncer,
+        failed_stores: HashSet<u64>,
+    ) -> Result<()>;
+
+    fn broadcast_exit_force_leader(&self);
+
+    fn broadcast_wait_apply(&self, syncer: UnsafeRecoveryWaitApplySyncer);
+
+    fn broadcast_fill_out_report(&self, syncer: UnsafeRecoveryFillOutReportSyncer);
+
+    fn send_report(&self, report: StoreReport) -> Result<()>;
+}
+
+impl<EK: KvEngine, ER: RaftEngine> UnsafeRecoveryHandle for Mutex<RaftRouter<EK, ER>> {
+    fn send_enter_force_leader(
+        &self,
+        region_id: u64,
+        syncer: UnsafeRecoveryForceLeaderSyncer,
+        failed_stores: HashSet<u64>,
+    ) -> Result<()> {
+        let router = self.lock().unwrap();
+        router.significant_send(
+            region_id,
+            SignificantMsg::EnterForceLeaderState {
+                syncer,
+                failed_stores,
+            },
+        )
+    }
+
+    fn broadcast_exit_force_leader(&self) {
+        let router = self.lock().unwrap();
+        router.broadcast_normal(|| PeerMsg::SignificantMsg(SignificantMsg::ExitForceLeaderState));
+    }
+
+    fn broadcast_wait_apply(&self, syncer: UnsafeRecoveryWaitApplySyncer) {
+        let router = self.lock().unwrap();
+        router.broadcast_normal(|| {
+            PeerMsg::SignificantMsg(SignificantMsg::UnsafeRecoveryWaitApply(syncer.clone()))
+        });
+    }
+
+    fn broadcast_fill_out_report(&self, syncer: UnsafeRecoveryFillOutReportSyncer) {
+        let router = self.lock().unwrap();
+        router.broadcast_normal(|| {
+            PeerMsg::SignificantMsg(SignificantMsg::UnsafeRecoveryFillOutReport(syncer.clone()))
+        });
+    }
+
+    fn send_report(&self, report: StoreReport) -> Result<()> {
+        let router = self.lock().unwrap();
+        match router.force_send_control(StoreMsg::UnsafeRecoveryReport(report)) {
+            Ok(()) => Ok(()),
+            Err(SendError(_)) => Err(box_err!("fail to send unsafe recovery store report")),
+        }
+    }
+}

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -8,7 +8,7 @@ use std::{
     sync::{
         atomic::Ordering,
         mpsc::{self, Receiver, Sender},
-        Arc,
+        Arc, Mutex,
     },
     thread::{Builder, JoinHandle},
     time::{Duration, Instant},
@@ -61,6 +61,7 @@ use crate::{
         metrics::*,
         peer::{UnsafeRecoveryExecutePlanSyncer, UnsafeRecoveryForceLeaderSyncer},
         transport::SignificantRouter,
+        unsafe_recovery::UnsafeRecoveryHandle,
         util::{is_epoch_stale, KeysInfoFormatter, LatencyInspector, RaftstoreDuration},
         worker::{
             split_controller::{SplitInfo, TOP_N},
@@ -1385,17 +1386,16 @@ where
                             for failed_store in plan.get_force_leader().get_failed_stores() {
                                 failed_stores.insert(*failed_store);
                             }
+                            let router = Arc::new(Mutex::new(router.clone()));
                             let syncer = UnsafeRecoveryForceLeaderSyncer::new(
                                 plan.get_step(),
                                 router.clone(),
                             );
                             for region in plan.get_force_leader().get_enter_force_leaders() {
-                                if let Err(e) = router.significant_send(
+                                if let Err(e) = router.send_enter_force_leader(
                                     *region,
-                                    SignificantMsg::EnterForceLeaderState {
-                                        syncer: syncer.clone(),
-                                        failed_stores: failed_stores.clone(),
-                                    },
+                                    syncer.clone(),
+                                    failed_stores.clone(),
                                 ) {
                                     error!("fail to send force leader message for recovery"; "err" => ?e);
                                 }
@@ -1403,7 +1403,7 @@ where
                         } else {
                             let syncer = UnsafeRecoveryExecutePlanSyncer::new(
                                 plan.get_step(),
-                                router.clone(),
+                                Arc::new(Mutex::new(router.clone())),
                             );
                             for create in plan.take_creates().into_iter() {
                                 if let Err(e) =

--- a/components/test_raftstore-v2/src/cluster.rs
+++ b/components/test_raftstore-v2/src/cluster.rs
@@ -25,6 +25,7 @@ use kvproto::{
     errorpb::Error as PbError,
     kvrpcpb::ApiVersion,
     metapb::{self, Buckets, PeerRole, RegionEpoch},
+    pdpb,
     raft_cmdpb::{
         AdminCmdType, AdminRequest, CmdType, RaftCmdRequest, RaftCmdResponse, RegionDetailResponse,
         Request, Response, StatusCmdType,
@@ -44,7 +45,7 @@ use raftstore::{
     Error, Result,
 };
 use raftstore_v2::{
-    router::{DebugInfoChannel, PeerMsg, QueryResult},
+    router::{DebugInfoChannel, PeerMsg, QueryResult, StoreMsg, StoreTick},
     write_initial_states, SimpleWriteEncoder, StoreMeta, StoreRouter,
 };
 use resource_control::ResourceGroupManager;
@@ -1767,6 +1768,50 @@ impl<T: Simulator<EK>, EK: KvEngine> Cluster<T, EK> {
         }
 
         debug!("all nodes are shut down.");
+    }
+
+    pub fn must_send_store_heartbeat(&self, node_id: u64) {
+        let router = self.sim.rl().get_router(node_id).unwrap();
+        router
+            .send_control(StoreMsg::Tick(StoreTick::PdStoreHeartbeat))
+            .unwrap();
+    }
+
+    pub fn enter_force_leader(&mut self, region_id: u64, store_id: u64, failed_stores: Vec<u64>) {
+        let mut plan = pdpb::RecoveryPlan::default();
+        let mut force_leader = pdpb::ForceLeader::default();
+        force_leader.set_enter_force_leaders([region_id].to_vec());
+        force_leader.set_failed_stores(failed_stores.to_vec());
+        plan.set_force_leader(force_leader);
+        // Triggers the unsafe recovery plan execution.
+        self.pd_client.must_set_unsafe_recovery_plan(store_id, plan);
+        self.must_send_store_heartbeat(store_id);
+    }
+
+    pub fn must_enter_force_leader(
+        &mut self,
+        region_id: u64,
+        store_id: u64,
+        failed_stores: Vec<u64>,
+    ) -> pdpb::StoreReport {
+        self.enter_force_leader(region_id, store_id, failed_stores);
+        let mut store_report = None;
+        for _ in 0..20 {
+            store_report = self.pd_client.must_get_store_report(store_id);
+            if store_report.is_some() {
+                break;
+            }
+            sleep_ms(100);
+        }
+        assert_ne!(store_report, None);
+        store_report.unwrap()
+    }
+
+    pub fn exit_force_leader(&mut self, region_id: u64, store_id: u64) {
+        let router = self.sim.rl().get_router(store_id).unwrap();
+        router
+            .send(region_id, PeerMsg::ExitForceLeaderState)
+            .unwrap();
     }
 
     pub fn must_send_flashback_msg(

--- a/src/server/tablet_snap.rs
+++ b/src/server/tablet_snap.rs
@@ -1031,6 +1031,12 @@ pub fn copy_tablet_snapshot(
     if let Some(m) = recver_snap_mgr.key_manager() {
         m.link_file(recv_path.to_str().unwrap(), final_path.to_str().unwrap())?;
     }
+    // Remove final path to make snapshot retryable.
+    if fs::remove_dir_all(&final_path).is_ok() {
+        if let Some(m) = recver_snap_mgr.key_manager() {
+            let _ = m.remove_dir(&final_path, None);
+        }
+    }
     fs::rename(&recv_path, &final_path).map_err(|e| {
         if let Some(m) = recver_snap_mgr.key_manager() {
             let _ = m.remove_dir(&final_path, Some(&recv_path));

--- a/tests/integrations/raftstore/test_unsafe_recovery.rs
+++ b/tests/integrations/raftstore/test_unsafe_recovery.rs
@@ -730,9 +730,10 @@ fn test_force_leader_on_hibernated_follower() {
 
 // Test the case that three of five nodes fail and force leader on the rest node
 // with triggering snapshot.
-#[test]
+#[test_case(test_raftstore::new_node_cluster)]
+#[test_case(test_raftstore_v2::new_node_cluster)]
 fn test_force_leader_trigger_snapshot() {
-    let mut cluster = new_node_cluster(0, 5);
+    let mut cluster = new_cluster(0, 5);
     cluster.cfg.raft_store.raft_base_tick_interval = ReadableDuration::millis(10);
     cluster.cfg.raft_store.raft_election_timeout_ticks = 10;
     cluster.cfg.raft_store.raft_store_max_leader_lease = ReadableDuration::millis(90);

--- a/tests/integrations/raftstore/test_unsafe_recovery.rs
+++ b/tests/integrations/raftstore/test_unsafe_recovery.rs
@@ -508,7 +508,8 @@ fn test_force_leader_three_nodes() {
 
 // Test the case that three of five nodes fail and force leader on one of the
 // rest nodes.
-#[test]
+#[test_case(test_raftstore::new_node_cluster)]
+#[test_case(test_raftstore_v2::new_node_cluster)]
 fn test_force_leader_five_nodes() {
     let mut cluster = new_node_cluster(0, 5);
     cluster.pd_client.disable_default_operator();

--- a/tests/integrations/raftstore/test_unsafe_recovery.rs
+++ b/tests/integrations/raftstore/test_unsafe_recovery.rs
@@ -7,20 +7,23 @@ use kvproto::{metapb, pdpb};
 use pd_client::PdClient;
 use raft::eraftpb::{ConfChangeType, MessageType};
 use test_raftstore::*;
+use test_raftstore_macro::test_case;
 use tikv_util::{config::ReadableDuration, store::find_peer, HandyRwLock};
 
-fn confirm_quorum_is_lost<T: Simulator>(cluster: &mut Cluster<T>, region: &metapb::Region) {
-    let put = new_put_cmd(b"k2", b"v2");
-    let req = new_request(
-        region.get_id(),
-        region.get_region_epoch().clone(),
-        vec![put],
-        true,
-    );
-    // marjority is lost, can't propose command successfully.
-    cluster
-        .call_command_on_leader(req, Duration::from_millis(10))
-        .unwrap_err();
+macro_rules! confirm_quorum_is_lost {
+    ($cluster:expr, $region:expr) => {{
+        let put = new_put_cmd(b"k2", b"v2");
+        let req = new_request(
+            $region.get_id(),
+            $region.get_region_epoch().clone(),
+            vec![put],
+            true,
+        );
+        // marjority is lost, can't propose command successfully.
+        $cluster
+            .call_command_on_leader(req, Duration::from_millis(10))
+            .unwrap_err();
+    }};
 }
 
 #[test]
@@ -41,7 +44,7 @@ fn test_unsafe_recovery_demote_failed_voters() {
     cluster.stop_node(nodes[1]);
     cluster.stop_node(nodes[2]);
 
-    confirm_quorum_is_lost(&mut cluster, &region);
+    confirm_quorum_is_lost!(cluster, region);
 
     cluster.must_enter_force_leader(region.get_id(), nodes[0], vec![nodes[1], nodes[2]]);
 
@@ -96,7 +99,7 @@ fn test_unsafe_recovery_demote_non_exist_voters() {
     cluster.stop_node(nodes[1]);
     cluster.stop_node(nodes[2]);
 
-    confirm_quorum_is_lost(&mut cluster, &region);
+    confirm_quorum_is_lost!(cluster, region);
     cluster.must_enter_force_leader(region.get_id(), nodes[0], vec![nodes[1], nodes[2]]);
 
     let mut plan = pdpb::RecoveryPlan::default();
@@ -172,7 +175,7 @@ fn test_unsafe_recovery_auto_promote_learner() {
     cluster.stop_node(nodes[1]);
     cluster.stop_node(nodes[2]);
 
-    confirm_quorum_is_lost(&mut cluster, &region);
+    confirm_quorum_is_lost!(cluster, region);
     cluster.must_enter_force_leader(region.get_id(), nodes[0], vec![nodes[1], nodes[2]]);
 
     let to_be_removed: Vec<metapb::Peer> = region
@@ -258,7 +261,7 @@ fn test_unsafe_recovery_already_in_joint_state() {
     cluster.stop_node(nodes[2]);
     cluster.must_wait_for_leader_expire(nodes[0], region.get_id());
 
-    confirm_quorum_is_lost(&mut cluster, &region);
+    confirm_quorum_is_lost!(cluster, region);
     cluster.must_enter_force_leader(region.get_id(), nodes[0], vec![nodes[1], nodes[2]]);
 
     let to_be_removed: Vec<metapb::Peer> = region
@@ -356,7 +359,7 @@ fn test_unsafe_recovery_early_return_after_exit_joint_state() {
     cluster.stop_node(nodes[2]);
     cluster.must_wait_for_leader_expire(nodes[0], region.get_id());
 
-    confirm_quorum_is_lost(&mut cluster, &region);
+    confirm_quorum_is_lost!(cluster, region);
     cluster.must_enter_force_leader(region.get_id(), nodes[0], vec![nodes[1], nodes[2]]);
 
     let to_be_removed: Vec<metapb::Peer> = region
@@ -434,33 +437,32 @@ fn test_unsafe_recovery_create_region() {
     assert_eq!(created, true);
 }
 
-fn must_get_error_recovery_in_progress<T: Simulator>(
-    cluster: &mut Cluster<T>,
-    region: &metapb::Region,
-    cmd: kvproto::raft_cmdpb::Request,
-) {
-    let req = new_request(
-        region.get_id(),
-        region.get_region_epoch().clone(),
-        vec![cmd],
-        true,
-    );
-    let resp = cluster
-        .call_command_on_leader(req, Duration::from_millis(100))
-        .unwrap();
-    assert_eq!(
-        resp.get_header().get_error().get_recovery_in_progress(),
-        &kvproto::errorpb::RecoveryInProgress {
-            region_id: region.get_id(),
-            ..Default::default()
-        }
-    );
+macro_rules! must_get_error_recovery_in_progress {
+    ($cluster:expr, $region:expr, $cmd:expr) => {
+        let req = new_request(
+            $region.get_id(),
+            $region.get_region_epoch().clone(),
+            vec![$cmd],
+            true,
+        );
+        let resp = $cluster
+            .call_command_on_leader(req, Duration::from_millis(100))
+            .unwrap();
+        assert_eq!(
+            resp.get_header().get_error().get_recovery_in_progress(),
+            &kvproto::errorpb::RecoveryInProgress {
+                region_id: $region.get_id(),
+                ..Default::default()
+            }
+        );
+    };
 }
 
 // Test the case that two of three nodes fail and force leader on the rest node.
-#[test]
+#[test_case(test_raftstore::new_node_cluster)]
+#[test_case(test_raftstore_v2::new_node_cluster)]
 fn test_force_leader_three_nodes() {
-    let mut cluster = new_node_cluster(0, 3);
+    let mut cluster = new_cluster(0, 3);
     cluster.pd_client.disable_default_operator();
 
     cluster.run();
@@ -476,7 +478,7 @@ fn test_force_leader_three_nodes() {
     cluster.stop_node(3);
 
     // quorum is lost, can't propose command successfully.
-    confirm_quorum_is_lost(&mut cluster, &region);
+    confirm_quorum_is_lost!(cluster, region);
 
     cluster.must_enter_force_leader(region.get_id(), 1, vec![2, 3]);
     // remove the peers on failed nodes
@@ -488,13 +490,13 @@ fn test_force_leader_three_nodes() {
         .must_remove_peer(region.get_id(), find_peer(&region, 3).unwrap().clone());
     // forbid writes in force leader state
     let put = new_put_cmd(b"k3", b"v3");
-    must_get_error_recovery_in_progress(&mut cluster, &region, put);
+    must_get_error_recovery_in_progress!(cluster, region, put);
     // forbid reads in force leader state
     let get = new_get_cmd(b"k1");
-    must_get_error_recovery_in_progress(&mut cluster, &region, get);
+    must_get_error_recovery_in_progress!(cluster, region, get);
     // forbid read index in force leader state
     let read_index = new_read_index_cmd();
-    must_get_error_recovery_in_progress(&mut cluster, &region, read_index);
+    must_get_error_recovery_in_progress!(cluster, region, read_index);
     cluster.exit_force_leader(region.get_id(), 1);
 
     // quorum is formed, can propose command successfully now
@@ -525,7 +527,7 @@ fn test_force_leader_five_nodes() {
     cluster.stop_node(5);
 
     // quorum is lost, can't propose command successfully.
-    confirm_quorum_is_lost(&mut cluster, &region);
+    confirm_quorum_is_lost!(cluster, region);
 
     cluster.must_enter_force_leader(region.get_id(), 1, vec![3, 4, 5]);
     // remove the peers on failed nodes
@@ -540,13 +542,13 @@ fn test_force_leader_five_nodes() {
         .must_remove_peer(region.get_id(), find_peer(&region, 5).unwrap().clone());
     // forbid writes in force leader state
     let put = new_put_cmd(b"k3", b"v3");
-    must_get_error_recovery_in_progress(&mut cluster, &region, put);
+    must_get_error_recovery_in_progress!(cluster, region, put);
     // forbid reads in force leader state
     let get = new_get_cmd(b"k1");
-    must_get_error_recovery_in_progress(&mut cluster, &region, get);
+    must_get_error_recovery_in_progress!(cluster, region, get);
     // forbid read index in force leader state
     let read_index = new_read_index_cmd();
-    must_get_error_recovery_in_progress(&mut cluster, &region, read_index);
+    must_get_error_recovery_in_progress!(cluster, region, read_index);
 
     cluster.exit_force_leader(region.get_id(), 1);
 
@@ -594,7 +596,7 @@ fn test_force_leader_for_learner() {
     cluster.stop_node(4);
     cluster.stop_node(5);
 
-    confirm_quorum_is_lost(&mut cluster, &region);
+    confirm_quorum_is_lost!(cluster, region);
 
     // wait election timeout
     std::thread::sleep(Duration::from_millis(
@@ -842,7 +844,7 @@ fn test_force_leader_with_uncommitted_conf_change() {
     cluster.stop_node(4);
     cluster.stop_node(5);
 
-    confirm_quorum_is_lost(&mut cluster, &region);
+    confirm_quorum_is_lost!(cluster, region);
 
     // an uncommitted conf-change
     let cmd = new_change_peer_request(
@@ -957,7 +959,7 @@ fn test_force_leader_on_wrong_leader() {
     cluster.stop_node(1);
     cluster.run_node(1).unwrap();
 
-    confirm_quorum_is_lost(&mut cluster, &region);
+    confirm_quorum_is_lost!(cluster, region);
 
     // try to force leader on peer of node2 which is stale
     cluster.must_enter_force_leader(region.get_id(), 2, vec![3, 4, 5]);
@@ -1001,7 +1003,7 @@ fn test_force_leader_twice_on_different_peers() {
     cluster.run_node(1).unwrap();
     cluster.stop_node(2);
     cluster.run_node(2).unwrap();
-    confirm_quorum_is_lost(&mut cluster, &region);
+    confirm_quorum_is_lost!(cluster, region);
 
     cluster.must_enter_force_leader(region.get_id(), 1, vec![3, 4, 5]);
     // enter force leader on a different peer
@@ -1260,7 +1262,7 @@ fn test_unsafe_recovery_during_merge() {
 
     cluster.stop_node(1);
     cluster.stop_node(3);
-    confirm_quorum_is_lost(&mut cluster, &region);
+    confirm_quorum_is_lost!(cluster, region);
 
     let report = cluster.must_enter_force_leader(right.get_id(), 2, vec![1, 3]);
     assert_eq!(report.get_peer_reports().len(), 1);

--- a/tests/integrations/raftstore/test_unsafe_recovery.rs
+++ b/tests/integrations/raftstore/test_unsafe_recovery.rs
@@ -19,7 +19,7 @@ macro_rules! confirm_quorum_is_lost {
             vec![put],
             true,
         );
-        // marjority is lost, can't propose command successfully.
+        // majority is lost, can't propose command successfully.
         $cluster
             .call_command_on_leader(req, Duration::from_millis(10))
             .unwrap_err();
@@ -830,9 +830,10 @@ fn test_force_leader_trigger_snapshot() {
 
 // Test the case that three of five nodes fail and force leader on the rest node
 // with uncommitted conf change.
-#[test]
+#[test_case(test_raftstore::new_node_cluster)]
+#[test_case(test_raftstore_v2::new_node_cluster)]
 fn test_force_leader_with_uncommitted_conf_change() {
-    let mut cluster = new_node_cluster(0, 5);
+    let mut cluster = new_cluster(0, 5);
     cluster.cfg.raft_store.raft_base_tick_interval = ReadableDuration::millis(10);
     cluster.cfg.raft_store.raft_election_timeout_ticks = 10;
     cluster.cfg.raft_store.raft_store_max_leader_lease = ReadableDuration::millis(90);
@@ -867,7 +868,7 @@ fn test_force_leader_with_uncommitted_conf_change() {
     std::thread::sleep(Duration::from_millis(
         cluster.cfg.raft_store.raft_election_timeout_ticks as u64
             * cluster.cfg.raft_store.raft_base_tick_interval.as_millis()
-            * 2,
+            * 8,
     ));
     cluster.must_enter_force_leader(region.get_id(), 1, vec![3, 4, 5]);
     // the uncommitted conf-change is committed successfully after being force
@@ -900,9 +901,10 @@ fn test_force_leader_with_uncommitted_conf_change() {
 // is sent to b and break lease constrain, then b will reject a's heartbeat
 // while can vote for c. So c becomes leader and there are two leaders in the
 // group.
-#[test]
+#[test_case(test_raftstore::new_node_cluster)]
+#[test_case(test_raftstore_v2::new_node_cluster)]
 fn test_force_leader_on_healthy_region() {
-    let mut cluster = new_node_cluster(0, 5);
+    let mut cluster = new_cluster(0, 5);
     cluster.cfg.raft_store.raft_base_tick_interval = ReadableDuration::millis(30);
     cluster.cfg.raft_store.raft_election_timeout_ticks = 5;
     cluster.cfg.raft_store.raft_store_max_leader_lease = ReadableDuration::millis(40);
@@ -939,9 +941,10 @@ fn test_force_leader_on_healthy_region() {
 
 // Test the case that three of five nodes fail and force leader on the one not
 // having latest log
-#[test]
+#[test_case(test_raftstore::new_node_cluster)]
+#[test_case(test_raftstore_v2::new_node_cluster)]
 fn test_force_leader_on_wrong_leader() {
-    let mut cluster = new_node_cluster(0, 5);
+    let mut cluster = new_cluster(0, 5);
     cluster.pd_client.disable_default_operator();
 
     cluster.run();
@@ -987,9 +990,10 @@ fn test_force_leader_on_wrong_leader() {
 
 // Test the case that three of five nodes fail and force leader twice on
 // peers on different nodes
-#[test]
+#[test_case(test_raftstore::new_node_cluster)]
+#[test_case(test_raftstore_v2::new_node_cluster)]
 fn test_force_leader_twice_on_different_peers() {
-    let mut cluster = new_node_cluster(0, 5);
+    let mut cluster = new_cluster(0, 5);
     cluster.pd_client.disable_default_operator();
 
     cluster.run();
@@ -1053,9 +1057,10 @@ fn test_force_leader_twice_on_different_peers() {
 
 // Test the case that three of five nodes fail and force leader twice on
 // peer on the same node
-#[test]
+#[test_case(test_raftstore::new_node_cluster)]
+#[test_case(test_raftstore_v2::new_node_cluster)]
 fn test_force_leader_twice_on_same_peer() {
-    let mut cluster = new_node_cluster(0, 5);
+    let mut cluster = new_cluster(0, 5);
     cluster.pd_client.disable_default_operator();
 
     cluster.run();
@@ -1098,9 +1103,10 @@ fn test_force_leader_twice_on_same_peer() {
 
 // Test the case that three of five nodes fail and force leader doesn't finish
 // in one election rounds due to network partition.
-#[test]
+#[test_case(test_raftstore::new_node_cluster)]
+#[test_case(test_raftstore_v2::new_node_cluster)]
 fn test_force_leader_multiple_election_rounds() {
-    let mut cluster = new_node_cluster(0, 5);
+    let mut cluster = new_cluster(0, 5);
     cluster.cfg.raft_store.raft_base_tick_interval = ReadableDuration::millis(30);
     cluster.cfg.raft_store.raft_election_timeout_ticks = 5;
     cluster.cfg.raft_store.raft_store_max_leader_lease = ReadableDuration::millis(40);
@@ -1166,9 +1172,10 @@ fn test_force_leader_multiple_election_rounds() {
 // leader state before the peer(s) of the target region, thus proposes a no-op
 // entry (while becoming the leader) which is conflict with part of the catch up
 // logs, there will be data loss.
-#[test]
+#[test_case(test_raftstore::new_node_cluster)]
+// #[test_case(test_raftstore_v2::new_node_cluster)]
 fn test_unsafe_recovery_has_commit_merge() {
-    let mut cluster = new_node_cluster(0, 3);
+    let mut cluster = new_cluster(0, 3);
     configure_for_merge(&mut cluster.cfg);
 
     cluster.run();
@@ -1224,9 +1231,10 @@ fn test_unsafe_recovery_has_commit_merge() {
     assert!(has_commit_merge);
 }
 
-#[test]
+#[test_case(test_raftstore::new_node_cluster)]
+// #[test_case(test_raftstore_v2::new_node_cluster)]
 fn test_unsafe_recovery_during_merge() {
-    let mut cluster = new_node_cluster(0, 3);
+    let mut cluster = new_cluster(0, 3);
     configure_for_merge(&mut cluster.cfg);
 
     cluster.run();


### PR DESCRIPTION

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->

Support force for raftstore v2.

Issue Number: ref #15108

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
* Add UnsafeRecoveryHandle trait to abstract unsafe recovery APIs
* Implement UnsafeRecoveryHandle for raftstore v1 router
* Implement UnsafeRecoveryHandle for raftstore v2 router
* Add unsafe recovery messages to v2 Store and v2 Peer
* raftstore-v2: implement force leader 
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
