### PR TITLE
storage: skip the lock and rollback record in scan_latest_user_keys

### DIFF
--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -641,10 +641,12 @@ impl<S: EngineSnapshot> MvccReader<S> {
             let user_key = key.truncate_ts()?;
             // Skip the key if its latest write type is `WriteType::Lock` or
             // `WriteType::Rollback`.
-            let write = WriteRef::parse(cursor.value(&mut self.statistics.write))?;
-            if write.write_type != WriteType::Put && write.write_type != WriteType::Delete {
-                cursor.next(&mut self.statistics.write);
-                continue;
+            match WriteRef::parse(cursor.value(&mut self.statistics.write))?.write_type {
+                WriteType::Put | WriteType::Delete => {}
+                WriteType::Lock | WriteType::Rollback => {
+                    cursor.next(&mut self.statistics.write);
+                    continue;
+                }
             }
             // To make sure we only check each unique user key once and the filter returns
             // true.

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -1872,13 +1872,27 @@ pub mod tests {
             8,
         );
         engine.commit(b"k3", 8, 9);
-        // Prewrite and rollback k4.
+        // Prewrite and commit k4.
         engine.prewrite(
             Mutation::make_put(Key::from_raw(b"k4"), b"v4@1".to_vec()),
             b"k4",
             10,
         );
-        engine.rollback(b"k4", 10);
+        engine.commit(b"k4", 10, 11);
+        // Prewrite and rollback k4.
+        engine.prewrite(
+            Mutation::make_put(Key::from_raw(b"k4"), b"v4@2".to_vec()),
+            b"k4",
+            12,
+        );
+        engine.rollback(b"k4", 12);
+        // Prewrite and rollback k5.
+        engine.prewrite(
+            Mutation::make_put(Key::from_raw(b"k5"), b"v5@1".to_vec()),
+            b"k5",
+            13,
+        );
+        engine.rollback(b"k5", 13);
 
         // Current MVCC keys in `CF_WRITE` should be:
         // PUT      k0 -> v0@999
@@ -1890,7 +1904,9 @@ pub mod tests {
         // PUT      k3 -> v3@8
         // ROLLBACK k3 -> v3@7
         // PUT      k3 -> v3@5
-        // ROLLBACK k4 -> v4@1
+        // ROLLBACK k4 -> v4@2
+        // PUT      k4 -> v4@1
+        // ROLLBACK k5 -> v5@1
 
         struct Case {
             start_key: Option<Key>,
@@ -1918,6 +1934,7 @@ pub mod tests {
                     Key::from_raw(b"k1"),
                     Key::from_raw(b"k2"),
                     Key::from_raw(b"k3"),
+                    Key::from_raw(b"k4"),
                 ],
                 expect_is_remain: false,
             },
@@ -1926,7 +1943,11 @@ pub mod tests {
                 start_key: Some(Key::from_raw(b"k2")),
                 end_key: None,
                 limit: 4,
-                expect_res: vec![Key::from_raw(b"k2"), Key::from_raw(b"k3")],
+                expect_res: vec![
+                    Key::from_raw(b"k2"),
+                    Key::from_raw(b"k3"),
+                    Key::from_raw(b"k4"),
+                ],
                 expect_is_remain: false,
             },
             Case {

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -639,8 +639,8 @@ impl<S: EngineSnapshot> MvccReader<S> {
             }
             let commit_ts = key.decode_ts()?;
             let user_key = key.truncate_ts()?;
-            // Skip the key if its latest write type is `WriteType::Lock` or
-            // `WriteType::Rollback`.
+            // Skip the key if its latest write type is not `WriteType::Put` or
+            // `WriteType::Delete`.
             match WriteRef::parse(cursor.value(&mut self.statistics.write))?.write_type {
                 WriteType::Put | WriteType::Delete => {}
                 WriteType::Lock | WriteType::Rollback => {

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -594,7 +594,10 @@ impl<S: EngineSnapshot> MvccReader<S> {
         Ok((locks, has_remain))
     }
 
-    /// Scan the writes to get all the latest user keys. The return type is:
+    /// Scan the writes to get all the latest user keys. This scan will skip
+    /// `WriteType::Lock` and `WriteType::Rollback`, only return the key that
+    /// has a latest `WriteType::Put` or `WriteType::Delete` record. The return
+    /// type is:
     /// * `(Vec<key>, has_remain)`.
     ///   - `key` is the encoded user key without `commit_ts`.
     ///   - `has_remain` indicates whether there MAY be remaining user keys that
@@ -636,6 +639,13 @@ impl<S: EngineSnapshot> MvccReader<S> {
             }
             let commit_ts = key.decode_ts()?;
             let user_key = key.truncate_ts()?;
+            // Skip the key if its latest write type is `WriteType::Lock` or
+            // `WriteType::Rollback`.
+            let write = WriteRef::parse(cursor.value(&mut self.statistics.write))?;
+            if write.write_type != WriteType::Put && write.write_type != WriteType::Delete {
+                cursor.next(&mut self.statistics.write);
+                continue;
+            }
             // To make sure we only check each unique user key once and the filter returns
             // true.
             let is_same_user_key = cur_user_key.as_ref() == Some(&user_key);
@@ -1906,7 +1916,6 @@ pub mod tests {
                     Key::from_raw(b"k1"),
                     Key::from_raw(b"k2"),
                     Key::from_raw(b"k3"),
-                    Key::from_raw(b"k4"),
                 ],
                 expect_is_remain: false,
             },
@@ -1915,11 +1924,7 @@ pub mod tests {
                 start_key: Some(Key::from_raw(b"k2")),
                 end_key: None,
                 limit: 4,
-                expect_res: vec![
-                    Key::from_raw(b"k2"),
-                    Key::from_raw(b"k3"),
-                    Key::from_raw(b"k4"),
-                ],
+                expect_res: vec![Key::from_raw(b"k2"), Key::from_raw(b"k3")],
                 expect_is_remain: false,
             },
             Case {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #15219.

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Skip the `WriteType:Lock` and `WriteType::Rollback` record in `scan_latest_user_keys`.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None.
```
