### PR TITLE
raftstore: Observe when applying snapshot is cancelled

### DIFF
--- a/components/engine_traits/src/engine.rs
+++ b/components/engine_traits/src/engine.rs
@@ -63,7 +63,13 @@ pub trait KvEngine:
     /// Some KvEngines need to do some transforms before apply data from
     /// snapshot. These procedures can be batched in background if there are
     /// more than one incoming snapshots, thus not blocking applying thread.
-    fn can_apply_snapshot(&self, _is_timeout: bool, _new_batch: bool, _region_id: u64) -> bool {
+    fn can_apply_snapshot(
+        &self,
+        _is_timeout: bool,
+        _new_batch: bool,
+        _region_id: u64,
+        queue_size: u64,
+    ) -> bool {
         true
     }
 

--- a/components/engine_traits/src/engine.rs
+++ b/components/engine_traits/src/engine.rs
@@ -68,7 +68,7 @@ pub trait KvEngine:
         _is_timeout: bool,
         _new_batch: bool,
         _region_id: u64,
-        _queue_size: u64,
+        _queue_size: usize,
     ) -> bool {
         true
     }

--- a/components/engine_traits/src/engine.rs
+++ b/components/engine_traits/src/engine.rs
@@ -68,7 +68,7 @@ pub trait KvEngine:
         _is_timeout: bool,
         _new_batch: bool,
         _region_id: u64,
-        queue_size: u64,
+        _queue_size: u64,
     ) -> bool {
         true
     }

--- a/components/raftstore/src/coprocessor/dispatcher.rs
+++ b/components/raftstore/src/coprocessor/dispatcher.rs
@@ -676,10 +676,10 @@ impl<E: KvEngine> CoprocessorHost<E> {
         }
     }
 
-    pub fn cancel_apply_snapshot(&self, region_id: u64, peer_id: u64, queue_size: u64) {
+    pub fn cancel_apply_snapshot(&self, region_id: u64, peer_id: u64) {
         for observer in &self.registry.apply_snapshot_observers {
             let observer = observer.observer.inner();
-            observer.cancel_apply_snapshot(region_id, peer_id, queue_size);
+            observer.cancel_apply_snapshot(region_id, peer_id);
         }
     }
 

--- a/components/raftstore/src/coprocessor/dispatcher.rs
+++ b/components/raftstore/src/coprocessor/dispatcher.rs
@@ -668,11 +668,12 @@ impl<E: KvEngine> CoprocessorHost<E> {
         peer_id: u64,
         snap_key: &crate::store::SnapKey,
         snap: Option<&crate::store::Snapshot>,
+        current_size: u64,
     ) {
         let mut ctx = ObserverContext::new(region);
         for observer in &self.registry.apply_snapshot_observers {
             let observer = observer.observer.inner();
-            observer.post_apply_snapshot(&mut ctx, peer_id, snap_key, snap);
+            observer.post_apply_snapshot(&mut ctx, peer_id, snap_key, snap, current_size);
         }
     }
 
@@ -1115,6 +1116,7 @@ mod tests {
             _: u64,
             _: &crate::store::SnapKey,
             _: Option<&Snapshot>,
+            _: u64,
         ) {
             self.called
                 .fetch_add(ObserverIndex::PostApplySnapshot as usize, Ordering::SeqCst);
@@ -1297,7 +1299,7 @@ mod tests {
         index += ObserverIndex::PreApplySnapshot as usize;
         assert_all!([&ob.called], &[index]);
 
-        host.post_apply_snapshot(&region, 0, &key, None);
+        host.post_apply_snapshot(&region, 0, &key, None, 0);
         index += ObserverIndex::PostApplySnapshot as usize;
         assert_all!([&ob.called], &[index]);
 

--- a/components/raftstore/src/coprocessor/dispatcher.rs
+++ b/components/raftstore/src/coprocessor/dispatcher.rs
@@ -917,6 +917,7 @@ mod tests {
         PrePersist = 24,
         PreWriteApplyState = 25,
         OnRaftMessage = 26,
+        CancelApplySnapshot = 27,
     }
 
     impl Coprocessor for TestCoprocessor {}
@@ -1323,6 +1324,10 @@ mod tests {
         let msg = RaftMessage::default();
         host.on_raft_message(&msg);
         index += ObserverIndex::OnRaftMessage as usize;
+        assert_all!([&ob.called], &[index]);
+
+        host.cancel_apply_snapshot(region.get_id(), 0);
+        index += ObserverIndex::CancelApplySnapshot as usize;
         assert_all!([&ob.called], &[index]);
     }
 

--- a/components/raftstore/src/coprocessor/dispatcher.rs
+++ b/components/raftstore/src/coprocessor/dispatcher.rs
@@ -1136,6 +1136,13 @@ mod tests {
             );
             false
         }
+
+        fn cancel_apply_snapshot(&self, _: u64, _: u64) {
+            self.called.fetch_add(
+                ObserverIndex::CancelApplySnapshot as usize,
+                Ordering::SeqCst,
+            );
+        }
     }
 
     impl CmdObserver<PanicEngine> for TestCoprocessor {

--- a/components/raftstore/src/coprocessor/mod.rs
+++ b/components/raftstore/src/coprocessor/mod.rs
@@ -203,9 +203,10 @@ pub trait ApplySnapshotObserver: Coprocessor {
         _: u64,
         _: &crate::store::SnapKey,
         _snapshot: Option<&crate::store::Snapshot>,
-        _: u64,
     ) {
     }
+
+    fn cancel_apply_snapshot(&self, _: u64, _: u64, _: u64) {}
 
     /// We call pre_apply_snapshot only when one of the observer returns true.
     fn should_pre_apply_snapshot(&self) -> bool {

--- a/components/raftstore/src/coprocessor/mod.rs
+++ b/components/raftstore/src/coprocessor/mod.rs
@@ -203,6 +203,7 @@ pub trait ApplySnapshotObserver: Coprocessor {
         _: u64,
         _: &crate::store::SnapKey,
         _snapshot: Option<&crate::store::Snapshot>,
+        _: u64,
     ) {
     }
 

--- a/components/raftstore/src/coprocessor/mod.rs
+++ b/components/raftstore/src/coprocessor/mod.rs
@@ -206,7 +206,7 @@ pub trait ApplySnapshotObserver: Coprocessor {
     ) {
     }
 
-    fn cancel_apply_snapshot(&self, _: u64, _: u64, _: u64) {}
+    fn cancel_apply_snapshot(&self, _: u64, _: u64) {}
 
     /// We call pre_apply_snapshot only when one of the observer returns true.
     fn should_pre_apply_snapshot(&self) -> bool {

--- a/components/raftstore/src/store/worker/region.rs
+++ b/components/raftstore/src/store/worker/region.rs
@@ -1338,6 +1338,7 @@ pub(crate) mod tests {
             obs.pre_apply_hash.load(Ordering::SeqCst),
             obs.post_apply_hash.load(Ordering::SeqCst)
         );
+        assert_eq!(obs.cancel_apply.load(Ordering::SeqCst), 0);
 
         // the pending apply task should be finished and snapshots are ingested.
         // note that when ingest sst, it may flush memtable if overlap,
@@ -1467,6 +1468,7 @@ pub(crate) mod tests {
         pub post_apply_count: Arc<AtomicUsize>,
         pub pre_apply_hash: Arc<AtomicUsize>,
         pub post_apply_hash: Arc<AtomicUsize>,
+        pub cancel_apply: Arc<AtomicUsize>,
     }
 
     impl Coprocessor for MockApplySnapshotObserver {}
@@ -1502,6 +1504,10 @@ pub(crate) mod tests {
 
         fn should_pre_apply_snapshot(&self) -> bool {
             true
+        }
+
+        fn cancel_apply_snapshot(&self, _: u64, _: u64) {
+            self.cancel_apply.fetch_add(1, Ordering::SeqCst)
         }
     }
 }

--- a/components/raftstore/src/store/worker/region.rs
+++ b/components/raftstore/src/store/worker/region.rs
@@ -1507,7 +1507,7 @@ pub(crate) mod tests {
         }
 
         fn cancel_apply_snapshot(&self, _: u64, _: u64) {
-            self.cancel_apply.fetch_add(1, Ordering::SeqCst)
+            self.cancel_apply.fetch_add(1, Ordering::SeqCst);
         }
     }
 }

--- a/components/raftstore/src/store/worker/region.rs
+++ b/components/raftstore/src/store/worker/region.rs
@@ -529,7 +529,7 @@ where
             Err(Error::Abort) => {
                 warn!("applying snapshot is aborted"; "region_id" => region_id);
                 self.coprocessor_host
-                    .cancel_apply_snapshot(region_id, peer_id, current_size);
+                    .cancel_apply_snapshot(region_id, peer_id);
                 assert_eq!(
                     status.swap(JOB_STATUS_CANCELLED, Ordering::SeqCst),
                     JOB_STATUS_CANCELLING

--- a/components/raftstore/src/store/worker/region.rs
+++ b/components/raftstore/src/store/worker/region.rs
@@ -451,13 +451,7 @@ where
     }
 
     /// Applies snapshot data of the Region.
-    fn apply_snap(
-        &mut self,
-        region_id: u64,
-        peer_id: u64,
-        abort: Arc<AtomicUsize>,
-        current_size: u64,
-    ) -> Result<()> {
+    fn apply_snap(&mut self, region_id: u64, peer_id: u64, abort: Arc<AtomicUsize>) -> Result<()> {
         info!("begin apply snap data"; "region_id" => region_id, "peer_id" => peer_id);
         fail_point!("region_apply_snap", |_| { Ok(()) });
         check_abort(&abort)?;
@@ -495,13 +489,8 @@ where
             ingest_copy_symlink: self.ingest_copy_symlink,
         };
         s.apply(options)?;
-        self.coprocessor_host.post_apply_snapshot(
-            &region,
-            peer_id,
-            &snap_key,
-            Some(&s),
-            current_size,
-        );
+        self.coprocessor_host
+            .post_apply_snapshot(&region, peer_id, &snap_key, Some(&s));
 
         // delete snapshot state.
         let mut wb = self.engine.write_batch();
@@ -521,13 +510,7 @@ where
 
     /// Tries to apply the snapshot of the specified Region. It calls
     /// `apply_snap` to do the actual work.
-    fn handle_apply(
-        &mut self,
-        region_id: u64,
-        peer_id: u64,
-        status: Arc<AtomicUsize>,
-        current_size: u64,
-    ) {
+    fn handle_apply(&mut self, region_id: u64, peer_id: u64, status: Arc<AtomicUsize>) {
         let _ = status.compare_exchange(
             JOB_STATUS_PENDING,
             JOB_STATUS_RUNNING,
@@ -538,20 +521,15 @@ where
 
         let start = Instant::now();
 
-        match self.apply_snap(region_id, peer_id, Arc::clone(&status), current_size) {
+        match self.apply_snap(region_id, peer_id, Arc::clone(&status)) {
             Ok(()) => {
                 status.swap(JOB_STATUS_FINISHED, Ordering::SeqCst);
                 SNAP_COUNTER.apply.success.inc();
             }
             Err(Error::Abort) => {
                 warn!("applying snapshot is aborted"; "region_id" => region_id);
-                self.coprocessor_host.post_apply_snapshot(
-                    &region,
-                    peer_id,
-                    &snap_key,
-                    None,
-                    current_size,
-                );
+                self.coprocessor_host
+                    .cancel_apply_snapshot(region_id, peer_id, current_size);
                 assert_eq!(
                     status.swap(JOB_STATUS_CANCELLED, Ordering::SeqCst),
                     JOB_STATUS_CANCELLING
@@ -805,10 +783,12 @@ where
             }
             if let Some(Task::Apply { region_id, .. }) = self.pending_applies.front() {
                 fail_point!("handle_new_pending_applies", |_| {});
-                if !self
-                    .engine
-                    .can_apply_snapshot(is_timeout, new_batch, *region_id)
-                {
+                if !self.engine.can_apply_snapshot(
+                    is_timeout,
+                    new_batch,
+                    *region_id,
+                    self.pending_applies.len(),
+                ) {
                     // KvEngine can't apply snapshot for other reasons.
                     break;
                 }
@@ -819,7 +799,7 @@ where
                 }) = self.pending_applies.pop_front()
                 {
                     new_batch = false;
-                    self.handle_apply(region_id, peer_id, status, self.pending_applies.len());
+                    self.handle_apply(region_id, peer_id, status);
                 }
             }
         }
@@ -1512,7 +1492,6 @@ pub(crate) mod tests {
             peer_id: u64,
             key: &crate::store::SnapKey,
             snapshot: Option<&crate::store::Snapshot>,
-            _: u64,
         ) {
             let code =
                 snapshot.unwrap().total_size() + key.term + key.region_id + key.idx + peer_id;

--- a/tests/integrations/raftstore/test_snap.rs
+++ b/tests/integrations/raftstore/test_snap.rs
@@ -826,6 +826,7 @@ impl ApplySnapshotObserver for MockApplySnapshotObserver {
         peer_id: u64,
         _: &raftstore::store::SnapKey,
         snap: Option<&raftstore::store::Snapshot>,
+        _: u64,
     ) {
         let tablet_path = snap.unwrap().tablet_snap_path().as_ref().unwrap().clone();
         match self.tablet_snap_paths.lock().unwrap().entry(peer_id) {

--- a/tests/integrations/raftstore/test_snap.rs
+++ b/tests/integrations/raftstore/test_snap.rs
@@ -826,7 +826,6 @@ impl ApplySnapshotObserver for MockApplySnapshotObserver {
         peer_id: u64,
         _: &raftstore::store::SnapKey,
         snap: Option<&raftstore::store::Snapshot>,
-        _: u64,
     ) {
         let tablet_path = snap.unwrap().tablet_snap_path().as_ref().unwrap().clone();
         match self.tablet_snap_paths.lock().unwrap().entry(peer_id) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #15227 ref [tiflash#7855](https://github.com/pingcap/tiflash/issues/7855)

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Deliver message to observer when applying snapshot is cancelled
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
