### PR TITLE
txn: Fix possible assertion failure in next_last_change_info

### DIFF
--- a/src/storage/txn/actions/common.rs
+++ b/src/storage/txn/actions/common.rs
@@ -28,6 +28,7 @@ pub fn next_last_change_info<S: Snapshot>(
                 )),
                 LastChange::NotExist => Ok(LastChange::NotExist),
                 LastChange::Unknown => {
+                    fail_point!("before_get_write_in_next_last_change_info");
                     // We do not know the last change info, probably
                     // because it comes from an older version TiKV. To support data
                     // from old TiKV, we iterate to the last change to find it.
@@ -49,7 +50,7 @@ pub fn next_last_change_info<S: Snapshot>(
                             assert!(matches!(w.write_type, WriteType::Put));
                             Ok(LastChange::make_exist(
                                 last_change_ts,
-                                stat.write.next as u64,
+                                stat.write.next as u64 + 1,
                             ))
                         }
                     }

--- a/tests/failpoints/cases/test_transaction.rs
+++ b/tests/failpoints/cases/test_transaction.rs
@@ -31,15 +31,19 @@ use test_raftstore::{
     configure_for_lease_read, new_learner_peer, new_server_cluster, try_kv_prewrite,
     DropMessageFilter,
 };
-use tikv::storage::{
-    self,
-    kv::SnapshotExt,
-    lock_manager::MockLockManager,
-    txn::tests::{
-        must_acquire_pessimistic_lock, must_commit, must_pessimistic_prewrite_put,
-        must_pessimistic_prewrite_put_err, must_prewrite_put, must_prewrite_put_err,
+use tikv::{
+    server::gc_worker::gc_by_compact,
+    storage::{
+        self,
+        kv::SnapshotExt,
+        lock_manager::MockLockManager,
+        txn::tests::{
+            must_acquire_pessimistic_lock, must_acquire_pessimistic_lock_return_value, must_commit,
+            must_pessimistic_prewrite_put, must_pessimistic_prewrite_put_err, must_prewrite_put,
+            must_prewrite_put_err, must_rollback,
+        },
+        Snapshot, TestEngineBuilder, TestStorageBuilderApiV1,
     },
-    Snapshot, TestEngineBuilder, TestStorageBuilderApiV1,
 };
 use tikv_util::{
     store::{new_peer, peer::new_incoming_voter},
@@ -772,4 +776,30 @@ fn test_proposal_concurrent_with_conf_change_and_transfer_leader() {
     cluster.clear_send_filter_on_node(4);
 
     handle.join().unwrap();
+}
+
+#[test]
+fn test_next_last_change_info_called_when_gc() {
+    let mut engine = TestEngineBuilder::new().build().unwrap();
+    let k = b"zk";
+
+    must_prewrite_put(&mut engine, k, b"v", k, 5);
+    must_commit(&mut engine, k, 5, 6);
+
+    must_rollback(&mut engine, k, 10, true);
+
+    fail::cfg("before_get_write_in_next_last_change_info", "pause").unwrap();
+
+    let mut engine2 = engine.clone();
+    let h = thread::spawn(move || {
+        must_acquire_pessimistic_lock_return_value(&mut engine2, k, k, 30, 30, false)
+    });
+    thread::sleep(Duration::from_millis(200));
+    assert!(!h.is_finished());
+
+    gc_by_compact(&mut engine, &[], 20);
+
+    fail::remove("before_get_write_in_next_last_change_info");
+
+    assert_eq!(h.join().unwrap().unwrap().as_ref(), b"v");
 }

--- a/tests/failpoints/cases/test_transaction.rs
+++ b/tests/failpoints/cases/test_transaction.rs
@@ -801,5 +801,5 @@ fn test_next_last_change_info_called_when_gc() {
 
     fail::remove("before_get_write_in_next_last_change_info");
 
-    assert_eq!(h.join().unwrap().unwrap().as_ref(), b"v");
+    assert_eq!(h.join().unwrap().unwrap().as_slice(), b"v");
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #15109

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
This PR updates the way to calculate the last_change_info, which is not very proper before. This also fixes a assertion failure 
in `next_last_change_info` that might happen when it executes in parallel with GC in compaction filter.
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

(Release note needed as the bug is released in 7.2.0)

```release-note
Fix a panic that may happen in some rare cases that transaction reading old data that's being GC-ed by the compaction filter.
```
