### PR TITLE
ctl: add get_region_read_progress (release-7.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2797,7 +2797,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/ekexium/kvproto?branch=release-7.1-debug-safe-ts#e089081103f371efb874a29e6c452fe7db9f6755"
+source = "git+https://github.com/pingcap/kvproto.git?branch=release-7.1#37c54a91447dc99d883873d6e2459e3435443ef8"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2797,7 +2797,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git?branch=release-7.1#0af0becd87ae89dfd48ef313a4fca7e04688b2b2"
+source = "git+https://github.com/ekexium/kvproto?branch=release-7.1-debug-safe-ts#e089081103f371efb874a29e6c452fe7db9f6755"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,8 +221,8 @@ procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "6599eb9dca74229
 # When you modify TiKV cooperatively with kvproto, this will be useful to submit the PR to TiKV and the PR to
 # kvproto at the same time.
 # After the PR to kvproto is merged, remember to comment this out and run `cargo update -p kvproto`.
-[patch.'https://github.com/pingcap/kvproto']
-kvproto = { git = "https://github.com/ekexium/kvproto", branch = "release-7.1-debug-safe-ts" }
+# [patch.'https://github.com/pingcap/kvproto']
+# kvproto = { git = "https://github.com/your_github_id/kvproto", branch = "your_branch" }
 
 [workspace]
 # See https://github.com/rust-lang/rfcs/blob/master/text/2957-cargo-features2.md

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,8 +221,8 @@ procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "6599eb9dca74229
 # When you modify TiKV cooperatively with kvproto, this will be useful to submit the PR to TiKV and the PR to
 # kvproto at the same time.
 # After the PR to kvproto is merged, remember to comment this out and run `cargo update -p kvproto`.
-# [patch.'https://github.com/pingcap/kvproto']
-# kvproto = { git = "https://github.com/your_github_id/kvproto", branch = "your_branch" }
+[patch.'https://github.com/pingcap/kvproto']
+kvproto = { git = "https://github.com/ekexium/kvproto", branch = "release-7.1-debug-safe-ts" }
 
 [workspace]
 # See https://github.com/rust-lang/rfcs/blob/master/text/2957-cargo-features2.md

--- a/cmd/tikv-ctl/src/cmd.rs
+++ b/cmd/tikv-ctl/src/cmd.rs
@@ -565,6 +565,7 @@ pub enum Cmd {
     },
     #[structopt(external_subcommand)]
     External(Vec<String>),
+    /// Get the state of a region's RegionReadProgress.
     GetRegionReadProgress {
         #[structopt(short = "r", long)]
         /// The target region id

--- a/cmd/tikv-ctl/src/cmd.rs
+++ b/cmd/tikv-ctl/src/cmd.rs
@@ -565,6 +565,23 @@ pub enum Cmd {
     },
     #[structopt(external_subcommand)]
     External(Vec<String>),
+    GetRegionReadProgress {
+        #[structopt(short = "r", long)]
+        /// The target region id
+        region: u64,
+
+        #[structopt(long)]
+        /// When specified, prints the locks associated with the transaction
+        /// that has the smallest 'start_ts' in the resolver, which is
+        /// preventing the 'resolved_ts' from advancing.
+        log: bool,
+
+        #[structopt(long, requires = "log")]
+        /// The smallest start_ts of the target transaction. Namely, only the
+        /// transaction whose start_ts is greater than or equal to this value
+        /// can be recorded in TiKV logs.
+        min_start_ts: Option<u64>,
+    },
 }
 
 #[derive(StructOpt)]

--- a/cmd/tikv-ctl/src/executor.rs
+++ b/cmd/tikv-ctl/src/executor.rs
@@ -2,7 +2,7 @@
 
 use std::{
     borrow::ToOwned, cmp::Ordering, path::Path, pin::Pin, str, string::ToString, sync::Arc,
-    time::Duration, u64,
+    time::Duration,
 };
 
 use encryption_export::data_key_manager_from_config;
@@ -935,15 +935,20 @@ impl DebugExecutor for DebugClient {
             ),
             ("paused", resp.get_region_read_progress_paused().to_string()),
             ("discarding", resp.get_discard().to_string()),
-            // TODO: figure out the performance impact here before implementing it.
-            // (
-            //     "duration to last update_safe_ts",
-            //     format!("{} ms", resp.get_duration_to_last_update_safe_ts_ms()),
-            // ),
-            // (
-            //     "duration to last consume_leader_info",
-            //     format!("{} ms", resp.get_duration_to_last_consume_leader_ms()),
-            // ),
+            (
+                "duration since resolved-ts last called update_safe_ts()",
+                match resp.get_duration_to_last_update_safe_ts_ms() {
+                    u64::MAX => "none".to_owned(),
+                    x => format!("{} ms", x),
+                },
+            ),
+            (
+                "duration to last consume_leader_info()",
+                match resp.get_duration_to_last_consume_leader_ms() {
+                    u64::MAX => "none".to_owned(),
+                    x => format!("{} ms", x),
+                },
+            ),
             ("Resolver:", "".to_owned()),
             ("exist", resp.get_resolver_exist().to_string()),
             ("resolved_ts", resp.get_resolved_ts().to_string()),

--- a/cmd/tikv-ctl/src/executor.rs
+++ b/cmd/tikv-ctl/src/executor.rs
@@ -678,6 +678,8 @@ pub trait DebugExecutor {
     fn dump_cluster_info(&self);
 
     fn reset_to_version(&self, version: u64);
+
+    fn get_region_read_progress(&self, region_id: u64, log: bool, min_start_ts: u64);
 }
 
 impl DebugExecutor for DebugClient {
@@ -891,6 +893,78 @@ impl DebugExecutor for DebugClient {
         req.set_ts(version);
         DebugClient::reset_to_version(self, &req)
             .unwrap_or_else(|e| perror_and_exit("DebugClient::get_cluster_info", e));
+    }
+
+    fn get_region_read_progress(&self, region_id: u64, log: bool, min_start_ts: u64) {
+        let mut req = GetRegionReadProgressRequest::default();
+        req.set_region_id(region_id);
+        req.set_log_locks(log);
+        req.set_min_start_ts(min_start_ts);
+        let opt = grpcio::CallOption::default().timeout(Duration::from_secs(10));
+        let resp = self
+            .get_region_read_progress_opt(&req, opt)
+            .unwrap_or_else(|e| perror_and_exit("DebugClient::get_region_read_progress", e));
+        if !resp.get_error().is_empty() {
+            println!("error: {}", resp.get_error());
+        }
+        let fields = [
+            ("Region read progress:", "".to_owned()),
+            ("exist", resp.get_region_read_progress_exist().to_string()),
+            ("safe_ts", resp.get_safe_ts().to_string()),
+            ("applied_index", resp.get_applied_index().to_string()),
+            ("read_state.ts", resp.get_read_state_ts().to_string()),
+            (
+                "read_state.apply_index",
+                resp.get_read_state_apply_index().to_string(),
+            ),
+            (
+                "pending front item (oldest) ts",
+                resp.get_pending_front_ts().to_string(),
+            ),
+            (
+                "pending front item (oldest) applied index",
+                resp.get_pending_front_applied_index().to_string(),
+            ),
+            (
+                "pending back item (latest) ts",
+                resp.get_pending_back_ts().to_string(),
+            ),
+            (
+                "pending back item (latest) applied index",
+                resp.get_pending_back_applied_index().to_string(),
+            ),
+            ("paused", resp.get_region_read_progress_paused().to_string()),
+            ("discarding", resp.get_discard().to_string()),
+            // TODO: figure out the performance impact here before implementing it.
+            // (
+            //     "duration to last update_safe_ts",
+            //     format!("{} ms", resp.get_duration_to_last_update_safe_ts_ms()),
+            // ),
+            // (
+            //     "duration to last consume_leader_info",
+            //     format!("{} ms", resp.get_duration_to_last_consume_leader_ms()),
+            // ),
+            ("Resolver:", "".to_owned()),
+            ("exist", resp.get_resolver_exist().to_string()),
+            ("resolved_ts", resp.get_resolved_ts().to_string()),
+            (
+                "tracked index",
+                resp.get_resolver_tracked_index().to_string(),
+            ),
+            ("number of locks", resp.get_num_locks().to_string()),
+            (
+                "number of transactions",
+                resp.get_num_transactions().to_string(),
+            ),
+            ("stopped", resp.get_resolver_stopped().to_string()),
+        ];
+        for (name, value) in &fields {
+            if value.is_empty() {
+                println!("{}", name);
+            } else {
+                println!("    {}: {}, ", name, value);
+            }
+        }
     }
 }
 
@@ -1126,6 +1200,11 @@ impl<ER: RaftEngine> DebugExecutor for DebuggerImpl<ER> {
     fn reset_to_version(&self, version: u64) {
         Debugger::reset_to_version(self, version);
     }
+
+    fn get_region_read_progress(&self, _region_id: u64, _log: bool, _min_start_ts: u64) {
+        println!("only available for remote mode");
+        tikv_util::logger::exit_process_gracefully(-1);
+    }
 }
 
 fn handle_engine_error(err: EngineError) -> ! {
@@ -1266,5 +1345,10 @@ impl<ER: RaftEngine> DebugExecutor for DebuggerImplV2<ER> {
 
     fn reset_to_version(&self, _version: u64) {
         unimplemented!()
+    }
+
+    fn get_region_read_progress(&self, _region_id: u64, _log: bool, _min_start_ts: u64) {
+        println!("only available for remote mode");
+        tikv_util::logger::exit_process_gracefully(-1);
     }
 }

--- a/cmd/tikv-ctl/src/main.rs
+++ b/cmd/tikv-ctl/src/main.rs
@@ -520,6 +520,17 @@ fn main() {
                     debug_executor.dump_cluster_info();
                 }
                 Cmd::ResetToVersion { version } => debug_executor.reset_to_version(version),
+                Cmd::GetRegionReadProgress {
+                    region,
+                    log,
+                    min_start_ts,
+                } => {
+                    debug_executor.get_region_read_progress(
+                        region,
+                        log,
+                        min_start_ts.unwrap_or_default(),
+                    );
+                }
                 _ => {
                     unreachable!()
                 }

--- a/components/backup-stream/src/subscription_track.rs
+++ b/components/backup-stream/src/subscription_track.rs
@@ -511,7 +511,7 @@ impl TwoPhaseResolver {
             return min_ts.min(stable_ts);
         }
 
-        self.resolver.resolve(min_ts)
+        self.resolver.resolve(min_ts, None)
     }
 
     pub fn resolved_ts(&self) -> TimeStamp {
@@ -541,7 +541,7 @@ impl TwoPhaseResolver {
                 // advance the internal resolver.
                 // the start ts of initial scanning would be a safe ts for min ts
                 // -- because is used to be a resolved ts.
-                self.resolver.resolve(ts);
+                self.resolver.resolve(ts, None);
             }
             None => {
                 warn!("BUG: a two-phase resolver is executing phase_one_done when not in phase one"; "resolver" => ?self)

--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -436,7 +436,7 @@ impl Delegate {
         }
         debug!("cdc try to advance ts"; "region_id" => self.region_id, "min_ts" => min_ts);
         let resolver = self.resolver.as_mut().unwrap();
-        let resolved_ts = resolver.resolve(min_ts);
+        let resolved_ts = resolver.resolve(min_ts, None);
         debug!("cdc resolved ts updated";
             "region_id" => self.region_id, "resolved_ts" => resolved_ts);
         Some(resolved_ts)

--- a/components/cdc/src/initializer.rs
+++ b/components/cdc/src/initializer.rs
@@ -457,7 +457,7 @@ impl<E: KvEngine> Initializer<E> {
 
     fn finish_building_resolver(&self, mut resolver: Resolver, region: Region) {
         let observe_id = self.observe_id;
-        let rts = resolver.resolve(TimeStamp::zero());
+        let rts = resolver.resolve(TimeStamp::zero(), None);
         info!(
             "cdc resolver initialized and schedule resolver ready";
             "region_id" => region.get_id(),

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -1653,6 +1653,26 @@ impl RegionReadProgressCore {
     pub fn get_local_leader_info(&self) -> &LocalLeaderInfo {
         &self.leader_info
     }
+
+    pub fn applied_index(&self) -> u64 {
+        self.applied_index
+    }
+
+    pub fn paused(&self) -> bool {
+        self.pause
+    }
+
+    pub fn pending_items(&self) -> &VecDeque<ReadState> {
+        &self.pending_items
+    }
+
+    pub fn read_state(&self) -> &ReadState {
+        &self.read_state
+    }
+
+    pub fn discarding(&self) -> bool {
+        self.discard
+    }
 }
 
 /// Represent the duration of all stages of raftstore recorded by one

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -35,7 +35,7 @@ use tikv_util::{
     codec::number::{decode_u64, NumberEncoder},
     debug, info,
     store::{find_peer_by_id, region},
-    time::monotonic_raw_now,
+    time::{monotonic_raw_now, Instant},
     Either,
 };
 use time::{Duration, Timespec};
@@ -1199,10 +1199,11 @@ impl RegionReadProgressRegistry {
     ) -> Vec<u64> {
         let mut regions = Vec::with_capacity(leaders.len());
         let registry = self.registry.lock().unwrap();
+        let now = Some(Instant::now_coarse());
         for leader_info in &leaders {
             let region_id = leader_info.get_region_id();
             if let Some(rp) = registry.get(&region_id) {
-                if rp.consume_leader_info(leader_info, coprocessor) {
+                if rp.consume_leader_info(leader_info, coprocessor, now) {
                     regions.push(region_id);
                 }
             }
@@ -1308,7 +1309,7 @@ impl RegionReadProgress {
         }
     }
 
-    pub fn update_safe_ts(&self, apply_index: u64, ts: u64) {
+    pub fn update_safe_ts_with_time(&self, apply_index: u64, ts: u64, now: Option<Instant>) {
         if apply_index == 0 || ts == 0 {
             return;
         }
@@ -1316,11 +1317,15 @@ impl RegionReadProgress {
         if core.discard {
             return;
         }
-        if let Some(ts) = core.update_safe_ts(apply_index, ts) {
+        if let Some(ts) = core.update_safe_ts(apply_index, ts, now) {
             if !core.pause {
                 self.safe_ts.store(ts, AtomicOrdering::Release);
             }
         }
+    }
+
+    pub fn update_safe_ts(&self, apply_index: u64, ts: u64) {
+        self.update_safe_ts_with_time(apply_index, ts, None)
     }
 
     pub fn merge_safe_ts<E: KvEngine>(
@@ -1346,15 +1351,21 @@ impl RegionReadProgress {
         &self,
         leader_info: &LeaderInfo,
         coprocessor: &CoprocessorHost<E>,
+        now: Option<Instant>,
     ) -> bool {
         let mut core = self.core.lock().unwrap();
+        if matches!((core.last_instant_of_consume_leader, now), (None, Some(_)))
+            || matches!((core.last_instant_of_consume_leader, now), (Some(l), Some(r)) if l < r)
+        {
+            core.last_instant_of_consume_leader = now;
+        }
         if leader_info.has_read_state() {
             // It is okay to update `safe_ts` without checking the `LeaderInfo`, the
             // `read_state` is guaranteed to be valid when it is published by the leader
             let rs = leader_info.get_read_state();
             let (apply_index, ts) = (rs.get_applied_index(), rs.get_safe_ts());
             if apply_index != 0 && ts != 0 && !core.discard {
-                if let Some(ts) = core.update_safe_ts(apply_index, ts) {
+                if let Some(ts) = core.update_safe_ts(apply_index, ts, now) {
                     if !core.pause {
                         self.safe_ts.store(ts, AtomicOrdering::Release);
                     }
@@ -1456,6 +1467,11 @@ pub struct RegionReadProgressCore {
     discard: bool,
     // A notify to trigger advancing resolved ts immediately.
     advance_notify: Option<Arc<Notify>>,
+    // The approximate last instant of calling update_safe_ts(), used for diagnosis.
+    // Only the update from advance of resolved-ts is counted. Other sources like CDC or
+    // backup-stream are ignored.
+    last_instant_of_update_safe_ts: Option<Instant>,
+    last_instant_of_consume_leader: Option<Instant>,
 }
 
 // A helpful wrapper of `(apply_index, safe_ts)` item
@@ -1528,6 +1544,8 @@ impl RegionReadProgressCore {
             pause: is_witness,
             discard: is_witness,
             advance_notify: None,
+            last_instant_of_update_safe_ts: None,
+            last_instant_of_consume_leader: None,
         }
     }
 
@@ -1581,9 +1599,14 @@ impl RegionReadProgressCore {
     }
 
     // Return the `safe_ts` if it is updated
-    fn update_safe_ts(&mut self, idx: u64, ts: u64) -> Option<u64> {
+    fn update_safe_ts(&mut self, idx: u64, ts: u64, now: Option<Instant>) -> Option<u64> {
         // Discard stale item with `apply_index` before `last_merge_index`
         // in order to prevent the stale item makes the `safe_ts` larger again
+        if matches!((self.last_instant_of_update_safe_ts, now), (None, Some(_)))
+            || matches!((self.last_instant_of_update_safe_ts, now), (Some(l), Some(r)) if l < r)
+        {
+            self.last_instant_of_update_safe_ts = now;
+        }
         if idx < self.last_merge_index {
             return None;
         }
@@ -1672,6 +1695,14 @@ impl RegionReadProgressCore {
 
     pub fn discarding(&self) -> bool {
         self.discard
+    }
+
+    pub fn last_instant_of_update_ts(&self) -> &Option<Instant> {
+        &self.last_instant_of_update_safe_ts
+    }
+
+    pub fn last_instant_of_consume_leader(&self) -> &Option<Instant> {
+        &self.last_instant_of_consume_leader
     }
 }
 

--- a/components/resolved_ts/src/endpoint.rs
+++ b/components/resolved_ts/src/endpoint.rs
@@ -597,6 +597,29 @@ where
             self.store_id
         })
     }
+
+    fn handle_get_diagnosis_info(
+        &self,
+        region_id: u64,
+        log_locks: bool,
+        min_start_ts: u64,
+        callback: tikv::server::service::ResolvedTsDiagnosisCallback,
+    ) {
+        if let Some(r) = self.regions.get(&region_id) {
+            if log_locks {
+                r.resolver.log_locks(min_start_ts);
+            }
+            callback(Some((
+                r.resolver.stopped(),
+                r.resolver.resolved_ts().into_inner(),
+                r.resolver.tracked_index(),
+                r.resolver.num_locks(),
+                r.resolver.num_transactions(),
+            )));
+        } else {
+            callback(None);
+        }
+    }
 }
 
 pub enum Task {
@@ -631,6 +654,12 @@ pub enum Task {
     },
     ChangeConfig {
         change: ConfigChange,
+    },
+    GetDiagnosisInfo {
+        region_id: u64,
+        log_locks: bool,
+        min_start_ts: u64,
+        callback: tikv::server::service::ResolvedTsDiagnosisCallback,
     },
 }
 
@@ -689,6 +718,11 @@ impl fmt::Debug for Task {
                 .field("name", &"change_config")
                 .field("change", &change)
                 .finish(),
+            Task::GetDiagnosisInfo { region_id, .. } => de
+                .field("name", &"get_diagnosis_info")
+                .field("region_id", &region_id)
+                .field("callback", &"callback")
+                .finish(),
         }
     }
 }
@@ -733,6 +767,12 @@ where
                 apply_index,
             } => self.handle_scan_locks(region_id, observe_id, entries, apply_index),
             Task::ChangeConfig { change } => self.handle_change_config(change),
+            Task::GetDiagnosisInfo {
+                region_id,
+                log_locks,
+                min_start_ts,
+                callback,
+            } => self.handle_get_diagnosis_info(region_id, log_locks, min_start_ts, callback),
         }
     }
 }

--- a/components/resolved_ts/src/metrics.rs
+++ b/components/resolved_ts/src/metrics.rs
@@ -69,6 +69,16 @@ lazy_static! {
         "The minimal (non-zero) resolved ts for observe regions"
     )
     .unwrap();
+    pub static ref RTS_MIN_SAFE_TS_DUATION_TO_UPDATE_SAFE_TS: IntGauge = register_int_gauge!(
+        "tikv_resolved_ts_min_safe_ts_duration_to_update_safe_ts",
+        "The duration since last update_safe_ts() called by resolved-ts routine. -1 denotes None."
+    )
+    .unwrap();
+    pub static ref RTS_MIN_SAFE_TS_DURATION_TO_LAST_CONSUME_LEADER: IntGauge = register_int_gauge!(
+        "tikv_resolved_ts_min_safe_ts_duration_to_last_consume_leader",
+        "The duration since last check_leader(). -1 denotes None."
+    )
+    .unwrap();
     pub static ref RTS_ZERO_RESOLVED_TS: IntGauge = register_int_gauge!(
         "tikv_resolved_ts_zero_resolved_ts",
         "The number of zero resolved ts for observe regions"

--- a/components/resolved_ts/src/resolver.rs
+++ b/components/resolved_ts/src/resolver.rs
@@ -4,6 +4,7 @@ use std::{cmp, collections::BTreeMap, sync::Arc};
 
 use collections::{HashMap, HashSet};
 use raftstore::store::RegionReadProgress;
+use tikv_util::time::Instant;
 use txn_types::TimeStamp;
 
 use crate::metrics::RTS_RESOLVED_FAIL_ADVANCE_VEC;
@@ -159,7 +160,7 @@ impl Resolver {
     ///
     /// `min_ts` advances the resolver even if there is no write.
     /// Return None means the resolver is not initialized.
-    pub fn resolve(&mut self, min_ts: TimeStamp) -> TimeStamp {
+    pub fn resolve(&mut self, min_ts: TimeStamp, now: Option<Instant>) -> TimeStamp {
         // The `Resolver` is stopped, not need to advance, just return the current
         // `resolved_ts`
         if self.stopped {
@@ -184,7 +185,7 @@ impl Resolver {
 
         // Publish an `(apply index, safe ts)` item into the region read progress
         if let Some(rrp) = &self.read_progress {
-            rrp.update_safe_ts(self.tracked_index, self.resolved_ts.into_inner());
+            rrp.update_safe_ts_with_time(self.tracked_index, self.resolved_ts.into_inner(), now);
         }
 
         let new_min_ts = if has_lock {
@@ -307,7 +308,12 @@ mod tests {
                     }
                     Event::Unlock(key) => resolver.untrack_lock(&key.into_raw().unwrap(), None),
                     Event::Resolve(min_ts, expect) => {
-                        assert_eq!(resolver.resolve(min_ts.into()), expect.into(), "case {}", i)
+                        assert_eq!(
+                            resolver.resolve(min_ts.into(), None),
+                            expect.into(),
+                            "case {}",
+                            i
+                        )
                     }
                 }
             }

--- a/components/resolved_ts/src/resolver.rs
+++ b/components/resolved_ts/src/resolver.rs
@@ -8,6 +8,8 @@ use txn_types::TimeStamp;
 
 use crate::metrics::RTS_RESOLVED_FAIL_ADVANCE_VEC;
 
+const MAX_NUMBER_OF_LOCKS_IN_LOG: usize = 10;
+
 // Resolver resolves timestamps that guarantee no more commit will happen before
 // the timestamp.
 pub struct Resolver {
@@ -72,6 +74,14 @@ impl Resolver {
 
     pub fn resolved_ts(&self) -> TimeStamp {
         self.resolved_ts
+    }
+
+    pub fn tracked_index(&self) -> u64 {
+        self.tracked_index
+    }
+
+    pub fn stopped(&self) -> bool {
+        self.stopped
     }
 
     pub fn size(&self) -> usize {
@@ -189,6 +199,35 @@ impl Resolver {
         self.min_ts = cmp::max(self.min_ts, new_min_ts);
 
         self.resolved_ts
+    }
+
+    pub(crate) fn log_locks(&self, min_start_ts: u64) {
+        // log lock with the minimum start_ts >= min_start_ts
+        if let Some((start_ts, keys)) = self
+            .lock_ts_heap
+            .range(TimeStamp::new(min_start_ts)..)
+            .next()
+        {
+            let keys_for_log = keys
+                .iter()
+                .map(|key| log_wrappers::Value::key(key))
+                .take(MAX_NUMBER_OF_LOCKS_IN_LOG)
+                .collect::<Vec<_>>();
+            info!(
+                "locks with the minimum start_ts in resolver";
+                "region_id" => self.region_id,
+                "start_ts" => start_ts,
+                "sampled keys" => ?keys_for_log,
+            );
+        }
+    }
+
+    pub(crate) fn num_locks(&self) -> u64 {
+        self.locks_by_key.len() as u64
+    }
+
+    pub(crate) fn num_transactions(&self) -> u64 {
+        self.lock_ts_heap.len() as u64
     }
 }
 

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -69,7 +69,7 @@ use raftstore::{
     },
     RaftRouterCompactedEventSender,
 };
-use resolved_ts::LeadershipResolver;
+use resolved_ts::{LeadershipResolver, Task};
 use resource_control::{
     ResourceGroupManager, ResourceManagerService, MIN_PRIORITY_UPDATE_INTERVAL,
 };
@@ -252,6 +252,7 @@ struct TikvServer<ER: RaftEngine> {
     causal_ts_provider: Option<Arc<CausalTsProviderImpl>>, // used for rawkv apiv2
     tablet_registry: Option<TabletRegistry<RocksEngine>>,
     br_snap_recovery_mode: bool, // use for br snapshot recovery
+    resolved_ts_scheduler: Option<Scheduler<Task>>,
     grpc_service_mgr: GrpcServiceManager,
 }
 
@@ -435,6 +436,7 @@ where
             causal_ts_provider,
             tablet_registry: None,
             br_snap_recovery_mode: is_recovering_marked,
+            resolved_ts_scheduler: None,
             grpc_service_mgr: GrpcServiceManager::new(tx),
         }
     }
@@ -1017,6 +1019,7 @@ where
                 server.env(),
                 self.security_mgr.clone(),
             );
+            self.resolved_ts_scheduler = Some(rts_worker.scheduler());
             rts_worker.start_with_timer(rts_endpoint);
             self.core.to_stop.push(rts_worker);
         }
@@ -1078,10 +1081,27 @@ where
         debugger.set_raft_statistics(self.raft_statistics.clone());
 
         // Debug service.
+        let resolved_ts_scheduler = Arc::new(self.resolved_ts_scheduler.clone());
         let debug_service = DebugService::new(
             debugger,
             servers.server.get_debug_thread_pool().clone(),
             engines.engine.raft_extension(),
+            self.engines.as_ref().unwrap().store_meta.clone(),
+            Arc::new(
+                move |region_id, log_locks, min_start_ts, callback| -> bool {
+                    if let Some(s) = resolved_ts_scheduler.as_ref() {
+                        let res = s.schedule(Task::GetDiagnosisInfo {
+                            region_id,
+                            log_locks,
+                            min_start_ts,
+                            callback,
+                        });
+                        res.is_ok()
+                    } else {
+                        false
+                    }
+                },
+            ),
         );
         if servers
             .server

--- a/components/server/src/server2.rs
+++ b/components/server/src/server2.rs
@@ -59,6 +59,7 @@ use raftstore::{
     RegionInfoAccessor,
 };
 use raftstore_v2::{router::RaftRouter, StateStorage};
+use resolved_ts::Task;
 use resource_control::{
     ResourceGroupManager, ResourceManagerService, MIN_PRIORITY_UPDATE_INTERVAL,
 };
@@ -241,6 +242,7 @@ struct TikvServer<ER: RaftEngine> {
     resource_manager: Option<Arc<ResourceGroupManager>>,
     causal_ts_provider: Option<Arc<CausalTsProviderImpl>>, // used for rawkv apiv2
     tablet_registry: Option<TabletRegistry<RocksEngine>>,
+    resolved_ts_scheduler: Option<Scheduler<Task>>,
     grpc_service_mgr: GrpcServiceManager,
 }
 
@@ -383,6 +385,7 @@ where
             resource_manager,
             causal_ts_provider,
             tablet_registry: None,
+            resolved_ts_scheduler: None,
             grpc_service_mgr: GrpcServiceManager::new(tx),
         }
     }
@@ -674,6 +677,7 @@ where
                 self.env.clone(),
                 self.security_mgr.clone(),
             );
+            self.resolved_ts_scheduler = Some(rts_worker.scheduler());
             rts_worker.start_with_timer(rts_endpoint);
             self.core.to_stop.push(rts_worker);
         }
@@ -957,10 +961,27 @@ where
         debugger.set_raft_statistics(self.raft_statistics.clone());
 
         // Debug service.
+        let resolved_ts_scheduler = Arc::new(self.resolved_ts_scheduler.clone());
         let debug_service = DebugService::new(
             debugger,
             servers.server.get_debug_thread_pool().clone(),
             engines.engine.raft_extension(),
+            self.router.as_ref().unwrap().store_meta().clone(),
+            Arc::new(
+                move |region_id, log_locks, min_start_ts, callback| -> bool {
+                    if let Some(s) = resolved_ts_scheduler.as_ref() {
+                        let res = s.schedule(Task::GetDiagnosisInfo {
+                            region_id,
+                            log_locks,
+                            min_start_ts,
+                            callback,
+                        });
+                        res.is_ok()
+                    } else {
+                        false
+                    }
+                },
+            ),
         );
         if servers
             .server

--- a/components/test_raftstore-v2/src/server.rs
+++ b/components/test_raftstore-v2/src/server.rs
@@ -1076,12 +1076,15 @@ pub fn must_new_cluster_and_debug_client() -> (
             DebuggerImplV2::new(tablet_registry, raft_engine, ConfigController::default());
 
         sim.pending_debug_service = Some(Box::new(move |cluster, debug_thread_handle| {
-            let raft_extension = cluster.storages.get(&1).unwrap().raft_extension();
+            let raftkv = cluster.storages.get(&1).unwrap();
+            let raft_extension = raftkv.raft_extension();
 
             create_debug(DebugService::new(
                 debugger.clone(),
                 debug_thread_handle,
                 raft_extension,
+                raftkv.raftkv.router().store_meta().clone(),
+                Arc::new(|_, _, _, _| false),
             ))
         }));
     }

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -491,7 +491,13 @@ impl ServerCluster {
 
         let debugger = DebuggerImpl::new(engines.clone(), ConfigController::default());
         let debug_thread_handle = debug_thread_pool.handle().clone();
-        let debug_service = DebugService::new(debugger, debug_thread_handle, extension);
+        let debug_service = DebugService::new(
+            debugger,
+            debug_thread_handle,
+            extension,
+            store_meta.clone(),
+            Arc::new(|_, _, _, _| false),
+        );
 
         let apply_router = system.apply_router();
         // Create node.

--- a/src/server/raftkv2/mod.rs
+++ b/src/server/raftkv2/mod.rs
@@ -128,6 +128,11 @@ impl<EK: KvEngine, ER: RaftEngine> RaftKv2<EK, ER> {
     pub fn set_txn_extra_scheduler(&mut self, txn_extra_scheduler: Arc<dyn TxnExtraScheduler>) {
         self.txn_extra_scheduler = Some(txn_extra_scheduler);
     }
+
+    // for test only
+    pub fn router(&self) -> &RaftRouter<EK, ER> {
+        &self.router
+    }
 }
 
 impl<EK: KvEngine, ER: RaftEngine> tikv_kv::Engine for RaftKv2<EK, ER> {

--- a/src/server/service/debug.rs
+++ b/src/server/service/debug.rs
@@ -1,5 +1,7 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::sync::{Arc, Mutex};
+
 use futures::{
     future::{Future, FutureExt, TryFutureExt},
     sink::SinkExt,
@@ -10,8 +12,9 @@ use grpcio::{
     WriteFlags,
 };
 use kvproto::debugpb::{self, *};
+use raftstore::store::fsm::store::StoreRegionMeta;
 use tikv_kv::RaftExtension;
-use tikv_util::metrics;
+use tikv_util::{future::paired_future_callback, metrics};
 use tokio::runtime::Handle;
 
 use crate::server::debug::{Debugger, Error, Result};
@@ -36,30 +39,79 @@ fn error_to_grpc_error(tag: &'static str, e: Error) -> GrpcError {
     e
 }
 
+pub type Callback<T> = Box<dyn FnOnce(T) + Send>;
+pub type ResolvedTsDiagnosisCallback = Callback<
+    Option<(
+        bool, // stopped
+        u64,  // resolved_ts
+        u64,  // tracked index
+        u64,  // num_locks
+        u64,  // num_transactions
+    )>,
+>;
+pub type ScheduleResolvedTsTask = Arc<
+    dyn Fn(
+            u64,  // region id
+            bool, // log_locks
+            u64,  // min_start_ts
+            ResolvedTsDiagnosisCallback,
+        ) -> bool
+        + Send
+        + Sync,
+>;
+
 /// Service handles the RPC messages for the `Debug` service.
-#[derive(Clone)]
-pub struct Service<T, D>
+pub struct Service<T, D, S>
 where
-    T: RaftExtension,
-    D: Debugger,
+    T: RaftExtension + Clone,
+    D: Debugger + Clone,
+    S: StoreRegionMeta,
 {
     pool: Handle,
     debugger: D,
     raft_router: T,
+    store_meta: Arc<Mutex<S>>,
+    resolved_ts_scheduler: ScheduleResolvedTsTask,
 }
 
-impl<T, D> Service<T, D>
+impl<T, D, S> Clone for Service<T, D, S>
 where
-    T: RaftExtension,
-    D: Debugger,
+    T: RaftExtension + Clone,
+    D: Debugger + Clone,
+    S: StoreRegionMeta,
+{
+    fn clone(&self) -> Self {
+        Service {
+            pool: self.pool.clone(),
+            debugger: self.debugger.clone(),
+            raft_router: self.raft_router.clone(),
+            store_meta: self.store_meta.clone(),
+            resolved_ts_scheduler: self.resolved_ts_scheduler.clone(),
+        }
+    }
+}
+
+impl<T, D, S> Service<T, D, S>
+where
+    T: RaftExtension + Clone,
+    D: Debugger + Clone,
+    S: StoreRegionMeta,
 {
     /// Constructs a new `Service` with `Engines`, a `RaftExtension` and a
     /// `GcWorker`.
-    pub fn new(debugger: D, pool: Handle, raft_router: T) -> Self {
+    pub fn new(
+        debugger: D,
+        pool: Handle,
+        raft_router: T,
+        store_meta: Arc<Mutex<S>>,
+        resolved_ts_scheduler: ScheduleResolvedTsTask,
+    ) -> Self {
         Service {
             pool,
             debugger,
             raft_router,
+            store_meta,
+            resolved_ts_scheduler,
         }
     }
 
@@ -84,10 +136,11 @@ where
     }
 }
 
-impl<T, D> debugpb::Debug for Service<T, D>
+impl<T, D, S> debugpb::Debug for Service<T, D, S>
 where
     T: RaftExtension + 'static,
     D: Debugger + Clone + Send + 'static,
+    S: StoreRegionMeta,
 {
     fn get(&mut self, ctx: RpcContext<'_>, mut req: GetRequest, sink: UnarySink<GetResponse>) {
         const TAG: &str = "debug_get";
@@ -516,6 +569,86 @@ where
     ) {
         self.debugger.reset_to_version(req.get_ts());
         sink.success(ResetToVersionResponse::default());
+    }
+
+    fn get_region_read_progress(
+        &mut self,
+        ctx: RpcContext<'_>,
+        req: GetRegionReadProgressRequest,
+        sink: UnarySink<GetRegionReadProgressResponse>,
+    ) {
+        let store_meta = self.store_meta.lock().unwrap();
+        let rrp = store_meta.region_read_progress();
+        let mut resp = GetRegionReadProgressResponse::default();
+        rrp.with(|registry| {
+            let region = registry.get(&req.get_region_id());
+            if let Some(r) = region {
+                resp.set_region_read_progress_exist(true);
+                resp.set_safe_ts(r.safe_ts());
+                let core = r.get_core();
+                resp.set_applied_index(core.applied_index());
+                resp.set_region_read_progress_paused(core.paused());
+                if let Some(back) = core.pending_items().back() {
+                    resp.set_pending_back_ts(back.ts);
+                    resp.set_pending_back_applied_index(back.idx);
+                }
+                if let Some(front) = core.pending_items().front() {
+                    resp.set_pending_front_ts(front.ts);
+                    resp.set_pending_front_applied_index(front.idx)
+                }
+                resp.set_read_state_ts(core.read_state().ts);
+                resp.set_read_state_apply_index(core.read_state().idx);
+                resp.set_discard(core.discarding());
+                // TODO: set durations
+                // resp.set_duration_to_last_consume_leader_ms();
+                // resp.set_duration_to_last_update_safe_ts_ms();
+            } else {
+                resp.set_region_read_progress_exist(false);
+            }
+        });
+
+        // get from resolver
+        let (cb, f) = paired_future_callback();
+        if (*self.resolved_ts_scheduler)(
+            req.get_region_id(),
+            req.get_log_locks(),
+            req.get_min_start_ts(),
+            cb,
+        ) {
+            let f = async move {
+                let res = f.await;
+                match res {
+                    Err(e) => {
+                        resp.set_error("get resolved-ts info failed".to_owned());
+                        error!("tikv-ctl get resolved-ts info failed"; "err" => ?e);
+                    }
+                    Ok(Some((
+                        stopped,
+                        resolved_ts,
+                        resolver_tracked_index,
+                        num_locks,
+                        num_transactions,
+                    ))) => {
+                        resp.set_resolver_exist(true);
+                        resp.set_resolver_stopped(stopped);
+                        resp.set_resolved_ts(resolved_ts);
+                        resp.set_resolver_tracked_index(resolver_tracked_index);
+                        resp.set_num_locks(num_locks);
+                        resp.set_num_transactions(num_transactions);
+                    }
+                    Ok(None) => {
+                        resp.set_resolver_exist(false);
+                    }
+                }
+
+                Ok(resp)
+            };
+            self.handle_response(ctx, sink, f, "debug_get_region_read_progress");
+        } else {
+            resp.set_error("resolved-ts is not enabled".to_owned());
+            let f = async move { Ok(resp) };
+            self.handle_response(ctx, sink, f, "debug_get_region_read_progress");
+        }
     }
 }
 

--- a/src/server/service/debug.rs
+++ b/src/server/service/debug.rs
@@ -599,9 +599,16 @@ where
                 resp.set_read_state_ts(core.read_state().ts);
                 resp.set_read_state_apply_index(core.read_state().idx);
                 resp.set_discard(core.discarding());
-                // TODO: set durations
-                // resp.set_duration_to_last_consume_leader_ms();
-                // resp.set_duration_to_last_update_safe_ts_ms();
+                resp.set_duration_to_last_consume_leader_ms(
+                    core.last_instant_of_consume_leader()
+                        .map(|t| t.saturating_elapsed().as_millis() as u64)
+                        .unwrap_or(u64::MAX),
+                );
+                resp.set_duration_to_last_update_safe_ts_ms(
+                    core.last_instant_of_update_ts()
+                        .map(|t| t.saturating_elapsed().as_millis() as u64)
+                        .unwrap_or(u64::MAX),
+                );
             } else {
                 resp.set_region_read_progress_exist(false);
             }

--- a/src/server/service/mod.rs
+++ b/src/server/service/mod.rs
@@ -6,7 +6,7 @@ pub mod diagnostics;
 mod kv;
 
 pub use self::{
-    debug::Service as DebugService,
+    debug::{ResolvedTsDiagnosisCallback, Service as DebugService},
     diagnostics::Service as DiagnosticsService,
     kv::{
         batch_commands_request, batch_commands_response, GrpcRequestDuration,


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #15082 

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Cherry pick #15099 and #15327: add get_region_read_progress command in tikv-ctl
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

Side effects

- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Add get_region_read_progress command in tikv-ctl
```
