### PR TITLE
raftstore: online unsafe recovery aborts on timeout

### DIFF
--- a/components/raftstore-v2/src/operation/unsafe_recovery/create.rs
+++ b/components/raftstore-v2/src/operation/unsafe_recovery/create.rs
@@ -110,9 +110,10 @@ impl Store {
 
 impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
     pub fn on_unsafe_recovery_wait_initialized(&mut self, syncer: UnsafeRecoveryExecutePlanSyncer) {
-        if self.unsafe_recovery_state().is_some() {
+        if let Some(state) = self.unsafe_recovery_state() && !state.is_abort() {
             warn!(self.logger,
                 "Unsafe recovery, can't wait initialize, another plan is executing in progress";
+                "state" => ?state,
             );
             syncer.abort();
             return;

--- a/components/raftstore-v2/src/operation/unsafe_recovery/report.rs
+++ b/components/raftstore-v2/src/operation/unsafe_recovery/report.rs
@@ -27,12 +27,13 @@ impl Store {
 
 impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
     pub fn on_unsafe_recovery_wait_apply(&mut self, syncer: UnsafeRecoveryWaitApplySyncer) {
-        if self.unsafe_recovery_state().is_some() {
-            warn!(self.logger,
-                "Unsafe recovery, can't wait apply, another plan is executing in progress";
-            );
-            syncer.abort();
-            return;
+        if let Some(state) = self.unsafe_recovery_state() && !state.is_abort() {
+                warn!(self.logger,
+                    "Unsafe recovery, can't wait apply, another plan is executing in progress";
+                    "state" => ?state,
+                );
+                syncer.abort();
+                return;
         }
         let target_index = if self.has_force_leader() {
             // For regions that lose quorum (or regions have force leader), whatever has

--- a/components/raftstore/src/store/unsafe_recovery.rs
+++ b/components/raftstore/src/store/unsafe_recovery.rs
@@ -3,6 +3,7 @@
 use std::{
     fmt, mem,
     sync::{mpsc::SyncSender, Arc, Mutex},
+    time::Duration,
 };
 
 use collections::HashSet;
@@ -177,7 +178,7 @@ pub enum ForceLeaderState {
 //      type explosion problem.
 //   2. Invoke on drop, so that it can be easily and safely used (together with
 //      Arc) as a coordinator between all concerning peers. Each of the peers
-//      holds a reference to the same strcuture, and whoever finishes the task
+//      holds a reference to the same structure, and whoever finishes the task
 //      drops its reference. Once the last reference is dropped, indicating all
 //      the peers have finished their own tasks, the closure is invoked.
 pub struct InvokeClosureOnDrop(Option<Box<dyn FnOnce() + Send + Sync>>);
@@ -221,8 +222,9 @@ impl UnsafeRecoveryForceLeaderSyncer {
 
 #[derive(Clone, Debug)]
 pub struct UnsafeRecoveryExecutePlanSyncer {
+    pub(self) time: TiInstant,
     _closure: Arc<InvokeClosureOnDrop>,
-    abort: Arc<Mutex<bool>>,
+    pub(self) abort: Arc<Mutex<bool>>,
 }
 
 impl UnsafeRecoveryExecutePlanSyncer {
@@ -238,6 +240,7 @@ impl UnsafeRecoveryExecutePlanSyncer {
             start_unsafe_recovery_report(router, report_id, true);
         })));
         UnsafeRecoveryExecutePlanSyncer {
+            time: TiInstant::now(),
             _closure: Arc::new(closure),
             abort,
         }
@@ -284,8 +287,9 @@ impl SnapshotRecoveryWaitApplySyncer {
 
 #[derive(Clone, Debug)]
 pub struct UnsafeRecoveryWaitApplySyncer {
+    pub(self) time: TiInstant,
     _closure: Arc<InvokeClosureOnDrop>,
-    abort: Arc<Mutex<bool>>,
+    pub(self) abort: Arc<Mutex<bool>>,
 }
 
 impl UnsafeRecoveryWaitApplySyncer {
@@ -297,11 +301,11 @@ impl UnsafeRecoveryWaitApplySyncer {
         let abort = Arc::new(Mutex::new(false));
         let abort_clone = abort.clone();
         let closure = InvokeClosureOnDrop(Some(Box::new(move || {
-            info!("Unsafe recovery, wait apply finished");
             if *abort_clone.lock().unwrap() {
                 warn!("Unsafe recovery, wait apply aborted");
                 return;
             }
+            info!("Unsafe recovery, wait apply finished");
             if exit_force_leader {
                 router.broadcast_exit_force_leader();
             }
@@ -309,6 +313,7 @@ impl UnsafeRecoveryWaitApplySyncer {
             router.broadcast_fill_out_report(fill_out_report);
         })));
         UnsafeRecoveryWaitApplySyncer {
+            time: TiInstant::now(),
             _closure: Arc::new(closure),
             abort,
         }
@@ -353,6 +358,7 @@ impl UnsafeRecoveryFillOutReportSyncer {
     }
 }
 
+#[derive(Debug)]
 pub enum SnapshotRecoveryState {
     // This state is set by the leader peer fsm. Once set, it sync and check leader commit index
     // and force forward to last index once follower appended and then it also is checked
@@ -365,6 +371,7 @@ pub enum SnapshotRecoveryState {
     },
 }
 
+#[derive(Debug)]
 pub enum UnsafeRecoveryState {
     // Stores the state that is necessary for the wait apply stage of unsafe recovery process.
     // This state is set by the peer fsm. Once set, it is checked every time this peer applies a
@@ -385,4 +392,35 @@ pub enum UnsafeRecoveryState {
     },
     Destroy(UnsafeRecoveryExecutePlanSyncer),
     WaitInitialize(UnsafeRecoveryExecutePlanSyncer),
+}
+
+impl UnsafeRecoveryState {
+    pub fn check_timeout(&self, timeout: Duration) -> bool {
+        let time = match self {
+            UnsafeRecoveryState::WaitApply { syncer, .. } => syncer.time,
+            UnsafeRecoveryState::DemoteFailedVoters { syncer, .. }
+            | UnsafeRecoveryState::Destroy(syncer)
+            | UnsafeRecoveryState::WaitInitialize(syncer) => syncer.time,
+        };
+        time.saturating_elapsed() >= timeout
+    }
+
+    pub fn is_abort(&self) -> bool {
+        let abort = match &self {
+            UnsafeRecoveryState::WaitApply { syncer, .. } => &syncer.abort,
+            UnsafeRecoveryState::DemoteFailedVoters { syncer, .. }
+            | UnsafeRecoveryState::Destroy(syncer)
+            | UnsafeRecoveryState::WaitInitialize(syncer) => &syncer.abort,
+        };
+        *abort.lock().unwrap()
+    }
+
+    pub fn abort(&mut self) {
+        match self {
+            UnsafeRecoveryState::WaitApply { syncer, .. } => syncer.abort(),
+            UnsafeRecoveryState::DemoteFailedVoters { syncer, .. }
+            | UnsafeRecoveryState::Destroy(syncer)
+            | UnsafeRecoveryState::WaitInitialize(syncer) => syncer.abort(),
+        }
+    }
 }

--- a/tests/failpoints/cases/test_unsafe_recovery.rs
+++ b/tests/failpoints/cases/test_unsafe_recovery.rs
@@ -73,6 +73,84 @@ fn test_unsafe_recovery_send_report() {
     fail::remove("on_handle_apply_store_1");
 }
 
+#[test_case(test_raftstore::new_node_cluster)]
+// #[test_case(test_raftstore_v2::new_node_cluster)] // TODO: enable it after
+// raftstore-v2 implements stale peer check
+fn test_unsafe_recovery_timeout_abort() {
+    let mut cluster = new_cluster(0, 3);
+    cluster.cfg.raft_store.raft_election_timeout_ticks = 5;
+    cluster.cfg.raft_store.raft_store_max_leader_lease = ReadableDuration::millis(40);
+    cluster.cfg.raft_store.max_leader_missing_duration = ReadableDuration::millis(150);
+    cluster.cfg.raft_store.abnormal_leader_missing_duration = ReadableDuration::millis(100);
+    cluster.cfg.raft_store.peer_stale_state_check_interval = ReadableDuration::millis(100);
+    cluster.run();
+    let nodes = Vec::from_iter(cluster.get_node_ids());
+    assert_eq!(nodes.len(), 3);
+
+    let pd_client = Arc::clone(&cluster.pd_client);
+    pd_client.disable_default_operator();
+    let region = block_on(pd_client.get_region_by_id(1)).unwrap().unwrap();
+
+    // Makes the leadership definite.
+    let store2_peer = find_peer(&region, nodes[1]).unwrap().to_owned();
+    cluster.must_transfer_leader(region.get_id(), store2_peer);
+    cluster.put(b"random_key1", b"random_val1").unwrap();
+
+    // Blocks the raft apply process on store 1 entirely.
+    let (apply_triggered_tx, apply_triggered_rx) = mpsc::bounded::<()>(1);
+    let (apply_released_tx, apply_released_rx) = mpsc::bounded::<()>(1);
+    fail::cfg_callback("on_handle_apply_store_1", move || {
+        let _ = apply_triggered_tx.send(());
+        let _ = apply_released_rx.recv();
+    })
+    .unwrap();
+
+    // Manually makes an update, and wait for the apply to be triggered, to
+    // simulate "some entries are committed but not applied" scenario.
+    cluster.put(b"random_key2", b"random_val2").unwrap();
+    apply_triggered_rx
+        .recv_timeout(Duration::from_secs(1))
+        .unwrap();
+
+    // Makes the group lose its quorum.
+    cluster.stop_node(nodes[1]);
+    cluster.stop_node(nodes[2]);
+
+    // Triggers the unsafe recovery store reporting process.
+    let plan = pdpb::RecoveryPlan::default();
+    pd_client.must_set_unsafe_recovery_plan(nodes[0], plan);
+    cluster.must_send_store_heartbeat(nodes[0]);
+
+    // sleep for a while to trigger timeout
+    sleep_ms(200);
+
+    // Unblocks the apply process.
+    drop(apply_released_tx);
+
+    // No store report is sent, cause the plan is aborted.
+    for _ in 0..20 {
+        assert_eq!(pd_client.must_get_store_report(nodes[0]), None);
+        sleep_ms(100);
+    }
+
+    // resend the plan
+    let plan = pdpb::RecoveryPlan::default();
+    pd_client.must_set_unsafe_recovery_plan(nodes[0], plan);
+    cluster.must_send_store_heartbeat(nodes[0]);
+
+    // Store reports are sent once the entries are applied.
+    let mut store_report = None;
+    for _ in 0..20 {
+        store_report = pd_client.must_get_store_report(nodes[0]);
+        if store_report.is_some() {
+            break;
+        }
+        sleep_ms(100);
+    }
+    assert_ne!(store_report, None);
+    fail::remove("on_handle_apply_store_1");
+}
+
 #[test]
 fn test_unsafe_recovery_execution_result_report() {
     let mut cluster = new_server_cluster(0, 3);


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/tikv/pd/issues/6803

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Make online unsafe recovery abort on timeout
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Make online unsafe recovery abort on timeout
```
