### PR TITLE
snap_restore: fix snapshot recovery leader election

### DIFF
--- a/components/snap_recovery/src/init_cluster.rs
+++ b/components/snap_recovery/src/init_cluster.rs
@@ -92,6 +92,7 @@ pub fn enter_snap_recovery_mode(config: &mut TikvConfig) {
     // reboots, the followers will reject to vote for it again.
     // We need to disable the lease for avoiding that.
     config.raft_store.unsafe_disable_check_quorum = true;
+    // The election is fully controlled by the restore procedure of BR.
     config.raft_store.allow_unsafe_vote_after_start = true;
 
     // disable auto compactions during the restore

--- a/components/snap_recovery/src/init_cluster.rs
+++ b/components/snap_recovery/src/init_cluster.rs
@@ -92,6 +92,7 @@ pub fn enter_snap_recovery_mode(config: &mut TikvConfig) {
     // reboots, the followers will reject to vote for it again.
     // We need to disable the lease for avoiding that.
     config.raft_store.unsafe_disable_check_quorum = true;
+    config.raft_store.allow_unsafe_vote_after_start = true;
 
     // disable auto compactions during the restore
     config.rocksdb.defaultcf.disable_auto_compactions = true;


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #15296

What's Changed:
This PR make the config allow_unsafe_vote_after_start to true while we are in recovery mode.

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
- No code

### Release note 

**NOTE:** The bug hasn't been released.

```release-note
None
```
