### PR TITLE
oneline_config: CamelCase encoder name 

### DIFF
--- a/components/online_config/online_config_derive/src/lib.rs
+++ b/components/online_config/online_config_derive/src/lib.rs
@@ -30,7 +30,7 @@ fn generate_token(ast: DeriveInput) -> std::result::Result<TokenStream, Error> {
             // Avoid naming conflict
             let mut hasher = DefaultHasher::new();
             format!("{}", &name).hash(&mut hasher);
-            format!("{}_encoder_{:x}", name, hasher.finish()).as_str()
+            format!("{}Encoder{:x}", name, hasher.finish()).as_str()
         },
         Span::call_site(),
     );

--- a/components/online_config/src/lib.rs
+++ b/components/online_config/src/lib.rs
@@ -140,6 +140,8 @@ mod tests {
 
     #[derive(Clone, OnlineConfig, Debug, Default, PartialEq)]
     pub struct TestConfig {
+        // Test doc hidden fields support online config change.
+        #[doc(hidden)]
         field1: usize,
         field2: String,
         optional_field1: Option<usize>,


### PR DESCRIPTION

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #15310

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Rust uses CamelCase for struct names.
And add a test for #[doc(hidden)] field.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
