### PR TITLE
batch-system: free leaked mailbox

### DIFF
--- a/components/batch-system/src/router.rs
+++ b/components/batch-system/src/router.rs
@@ -20,6 +20,8 @@ use crate::{
     metrics::*,
 };
 
+const ROUTER_CACHE_CAP: usize = 256;
+
 /// A struct that traces the approximate memory usage of router.
 #[derive(Default)]
 pub struct RouterTrace {
@@ -56,6 +58,7 @@ enum CheckDoResult<T> {
 pub struct Router<N: Fsm, C: Fsm, Ns, Cs> {
     normals: Arc<Mutex<NormalMailMap<N>>>,
     caches: Cell<LruCache<u64, BasicMailbox<N>>>,
+    clean_cache_cnt: Cell<usize>,
     pub(super) control_box: BasicMailbox<C>,
     // TODO: These two schedulers should be unified as single one. However
     // it's not possible to write FsmScheduler<Fsm=C> + FsmScheduler<Fsm=N>
@@ -89,7 +92,8 @@ where
                 map: HashMap::default(),
                 alive_cnt: Arc::default(),
             })),
-            caches: Cell::new(LruCache::with_capacity_and_sample(1024, 7)),
+            caches: Cell::new(LruCache::with_capacity_and_sample(ROUTER_CACHE_CAP, 7)),
+            clean_cache_cnt: Cell::new(0),
             control_box,
             normal_scheduler,
             control_scheduler,
@@ -118,15 +122,40 @@ where
     where
         F: FnMut(&BasicMailbox<N>) -> Option<R>,
     {
+        let maybe_clean_cache_leak = |alive_cnt, caches: &mut LruCache<u64, BasicMailbox<N>>| {
+            let leak = self.leak_count(alive_cnt);
+            for _ in 0..leak {
+                // Maybe the cache is hold leaked mailbox, so we need to remove it.
+                let _ = caches.remove_lru();
+            }
+            // Free memory holden by the cache when cache len / cache cap < 0.6.
+            caches.maybe_shrink_to_fit(0.6);
+            self.clean_cache_cnt.set(0);
+        };
+
         let caches = unsafe { &mut *self.caches.as_ptr() };
         let mut connected = true;
+        let mut res = None;
         if let Some(mailbox) = caches.get(&addr) {
             match f(mailbox) {
-                Some(r) => return CheckDoResult::Valid(r),
+                Some(r) => {
+                    res = Some(CheckDoResult::Valid(r));
+                }
                 None => {
                     connected = false;
                 }
             }
+        }
+        if let Some(res) = res {
+            let hit_count = self.clean_cache_cnt.get();
+            if hit_count > 1024 {
+                // amortizes overhead.
+                let alive_cnt = self.normals.lock().unwrap().map.len();
+                maybe_clean_cache_leak(alive_cnt, caches);
+            } else {
+                self.clean_cache_cnt.set(hit_count + 1);
+            }
+            return res;
         }
 
         let (cnt, mailbox) = {
@@ -144,6 +173,7 @@ where
             };
             (cnt, b)
         };
+        maybe_clean_cache_leak(cnt, caches);
         if cnt > caches.capacity() || cnt < caches.capacity() / 2 {
             caches.resize(cnt);
         }
@@ -368,16 +398,24 @@ where
         self.normals.lock().unwrap().alive_cnt.clone()
     }
 
-    pub fn trace(&self) -> RouterTrace {
-        let alive = self.normals.lock().unwrap().alive_cnt.clone();
+    fn leak_count(&self, alive: usize) -> usize {
         let total = self.state_cnt.load(Ordering::Relaxed);
-        let alive = alive.load(Ordering::Relaxed);
         // 1 represents the control fsm.
-        let leak = if total > alive + 1 {
+        if total > alive + 1 {
             total - alive - 1
         } else {
             0
-        };
+        }
+    }
+
+    pub fn trace(&self) -> RouterTrace {
+        let alive = self
+            .normals
+            .lock()
+            .unwrap()
+            .alive_cnt
+            .load(Ordering::Relaxed);
+        let leak = self.leak_count(alive);
         let mailbox_unit = mem::size_of::<(u64, BasicMailbox<N>)>();
         let state_unit = mem::size_of::<FsmState<N>>();
         // Every message in crossbeam sender needs 8 bytes to store state.
@@ -398,7 +436,8 @@ impl<N: Fsm, C: Fsm, Ns: Clone, Cs: Clone> Clone for Router<N, C, Ns, Cs> {
     fn clone(&self) -> Router<N, C, Ns, Cs> {
         Router {
             normals: self.normals.clone(),
-            caches: Cell::new(LruCache::with_capacity_and_sample(1024, 7)),
+            caches: Cell::new(LruCache::with_capacity_and_sample(ROUTER_CACHE_CAP, 7)),
+            clean_cache_cnt: Cell::new(0),
             control_box: self.control_box.clone(),
             // These two schedulers should be unified as single one. However
             // it's not possible to write FsmScheduler<Fsm=C> + FsmScheduler<Fsm=N>

--- a/components/tikv_util/src/lru.rs
+++ b/components/tikv_util/src/lru.rs
@@ -215,6 +215,7 @@ where
         self.trace.clear();
         self.size_policy.on_reset(0);
     }
+
     #[inline]
     pub fn capacity(&self) -> usize {
         self.capacity
@@ -303,6 +304,18 @@ where
     }
 
     #[inline]
+    pub fn remove_lru(&mut self) -> Option<(K, V)> {
+        if !self.is_empty() {
+            let key = self.trace.remove_tail();
+            let entry = self.map.remove(&key)?;
+            self.size_policy.on_remove(&key, &entry.value);
+            Some((key, entry.value))
+        } else {
+            None
+        }
+    }
+
+    #[inline]
     pub fn get(&mut self, key: &K) -> Option<&V> {
         match self.map.get(key) {
             Some(v) => {
@@ -352,6 +365,16 @@ where
             self.map.shrink_to_fit();
         }
         self.capacity = new_cap;
+    }
+
+    // Shrink the memory allocated by the cache without changing size and capacity.
+    #[inline]
+    pub fn maybe_shrink_to_fit(&mut self, ratio: f64) {
+        let map_len = self.map.len();
+        let map_cap = self.map.capacity();
+        if map_len < map_cap && (map_len as f64) < (map_cap as f64 * ratio) {
+            self.map.shrink_to_fit();
+        }
     }
 }
 
@@ -481,6 +504,48 @@ mod tests {
         for i in (3..8).chain(10..15) {
             assert_eq!(map.get(&i), Some(&i));
         }
+    }
+
+    #[test]
+    fn test_remove_lru() {
+        let mut map = LruCache::with_capacity(3);
+        for i in 0..3 {
+            map.insert(i, i);
+        }
+        assert_eq!(map.remove_lru(), Some((0, 0)));
+        assert_eq!(map.get(&0), None);
+
+        assert_eq!(map.get(&1), Some(&1));
+        assert_eq!(map.remove_lru(), Some((2, 2)));
+        assert_eq!(map.capacity(), 3);
+        assert_eq!(map.size(), 1);
+    }
+
+    #[test]
+    fn test_maybe_shrink_to_hit() {
+        let mut map = LruCache::with_capacity(10);
+        map.map.reserve(10);
+        for i in 0..10 {
+            map.insert(i, i);
+        }
+        assert_eq!(map.size(), 10);
+        assert_eq!(map.capacity(), 10);
+
+        let real_cap = map.map.capacity();
+        for i in 0..5 {
+            map.remove(&i);
+        }
+        // The capacity should not change.
+        map.maybe_shrink_to_fit(0.1);
+        assert_eq!(map.map.capacity(), real_cap);
+        assert_eq!(map.size(), 5);
+        assert_eq!(map.capacity(), 10);
+
+        // The capacity should change.
+        map.maybe_shrink_to_fit(0.9);
+        assert!(map.map.capacity() < real_cap);
+        assert_eq!(map.size(), 5);
+        assert_eq!(map.capacity(), 10);
     }
 
     #[test]


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #xxx

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Mailbox are leaked because they are holding by LRU cache in Router.
This change frees least recently used Mailboxes, up to leaked count.
```

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
