### PR TITLE
[cherry-pick-v7.1]compaction: disable periodic-compaction and ttl as default. (#15359)

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -860,16 +860,16 @@
 
 ## SST files containing updates older than TTL will go through the compaction
 ## process. This usually happens in a cascading way so that those entries
-## will be compacted to bottommost level/file.
+## will be compacted to bottommost level/file. Disabled as default.
 ##
-## Default: 30 days.
-# ttl = "30d"
+## Default: 0s.
+# ttl = "0s"
 
 ## SST files older than this value will be picked up for compaction, and
-## re-written to the same level as they were before.
+## re-written to the same level as they were before. Disabled as default.
 ##
-## Default: 30 days.
-# periodic-compaction-seconds = "30d"
+## Default: 0s.
+# periodic-compaction-seconds = "0s"
 
 ## Options for "Default" Column Family for `Titan`.
 [rocksdb.defaultcf.titan]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -375,11 +375,11 @@ macro_rules! cf_config {
             pub checksum: ChecksumType,
             #[online_config(skip)]
             pub max_compactions: u32,
-            // `ttl == None` means using default setting in Rocksdb.
+            // `ttl == None` means disable this feature in Rocksdb.
             // `ttl` in Rocksdb is 30 days as default.
             #[online_config(skip)]
             pub ttl: Option<ReadableDuration>,
-            // `periodic_compaction_seconds == None` means using default setting in Rocksdb.
+            // `periodic_compaction_seconds == None` means disabled this feature in Rocksdb.
             // `periodic_compaction_seconds` in Rocksdb is 30 days as default.
             #[online_config(skip)]
             pub periodic_compaction_seconds: Option<ReadableDuration>,
@@ -635,12 +635,13 @@ macro_rules! build_cf_opt {
         if let Some(r) = $compaction_limiter {
             cf_opts.set_compaction_thread_limiter(r);
         }
-        if let Some(ttl) = $opt.ttl {
-            cf_opts.set_ttl(ttl.0.as_secs());
-        }
-        if let Some(secs) = $opt.periodic_compaction_seconds {
-            cf_opts.set_periodic_compaction_seconds(secs.0.as_secs());
-        }
+        cf_opts.set_ttl($opt.ttl.unwrap_or(ReadableDuration::secs(0)).0.as_secs());
+        cf_opts.set_periodic_compaction_seconds(
+            $opt.periodic_compaction_seconds
+                .unwrap_or(ReadableDuration::secs(0))
+                .0
+                .as_secs(),
+        );
         cf_opts
     }};
 }

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -378,8 +378,8 @@ fn test_serde_custom_tikv_config() {
             format_version: 5,
             checksum: ChecksumType::XXH3,
             max_compactions: 3,
-            ttl: None,
-            periodic_compaction_seconds: None,
+            ttl: Some(ReadableDuration::days(10)),
+            periodic_compaction_seconds: Some(ReadableDuration::days(10)),
         },
         writecf: WriteCfConfig {
             block_size: ReadableSize::kb(12),
@@ -449,8 +449,8 @@ fn test_serde_custom_tikv_config() {
             format_version: 5,
             checksum: ChecksumType::XXH3,
             max_compactions: 3,
-            ttl: None,
-            periodic_compaction_seconds: None,
+            ttl: Some(ReadableDuration::days(10)),
+            periodic_compaction_seconds: Some(ReadableDuration::days(10)),
         },
         lockcf: LockCfConfig {
             block_size: ReadableSize::kb(12),
@@ -520,8 +520,8 @@ fn test_serde_custom_tikv_config() {
             format_version: 5,
             checksum: ChecksumType::XXH3,
             max_compactions: 3,
-            ttl: None,
-            periodic_compaction_seconds: None,
+            ttl: Some(ReadableDuration::days(10)),
+            periodic_compaction_seconds: Some(ReadableDuration::days(10)),
         },
         raftcf: RaftCfConfig {
             block_size: ReadableSize::kb(12),
@@ -591,8 +591,8 @@ fn test_serde_custom_tikv_config() {
             format_version: 5,
             checksum: ChecksumType::XXH3,
             max_compactions: 3,
-            ttl: None,
-            periodic_compaction_seconds: None,
+            ttl: Some(ReadableDuration::days(10)),
+            periodic_compaction_seconds: Some(ReadableDuration::days(10)),
         },
         titan: titan_db_config.clone(),
     };

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -336,6 +336,8 @@ prepopulate-block-cache = "flush-only"
 format-version = 5
 checksum = "xxh3"
 max-compactions = 3
+ttl = "10d"
+periodic-compaction-seconds = "10d"
 
 [rocksdb.defaultcf.titan]
 min-blob-size = "2018B"
@@ -399,6 +401,8 @@ prepopulate-block-cache = "flush-only"
 format-version = 5
 checksum = "xxh3"
 max-compactions = 3
+ttl = "10d"
+periodic-compaction-seconds = "10d"
 
 [rocksdb.lockcf]
 block-size = "12KB"
@@ -449,6 +453,8 @@ prepopulate-block-cache = "flush-only"
 format-version = 5
 checksum = "xxh3"
 max-compactions = 3
+ttl = "10d"
+periodic-compaction-seconds = "10d"
 
 [rocksdb.raftcf]
 block-size = "12KB"
@@ -499,6 +505,8 @@ prepopulate-block-cache = "flush-only"
 format-version = 5
 checksum = "xxh3"
 max-compactions = 3
+ttl = "10d"
+periodic-compaction-seconds = "10d"
 
 [raftdb]
 wal-recovery-mode = "skip-any-corrupted-records"


### PR DESCRIPTION
close tikv/tikv#15355

Disable `periodic-compaction` and `ttl` features as default.

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #xxx

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
```
