### PR TITLE
resource_metering: free leaked thread CPU stats

### DIFF
--- a/components/resource_metering/src/recorder/sub_recorder/cpu.rs
+++ b/components/resource_metering/src/recorder/sub_recorder/cpu.rs
@@ -49,10 +49,13 @@ impl SubRecorder for CpuRecorder {
     fn cleanup(
         &mut self,
         _records: &mut RawRecords,
-        _thread_stores: &mut HashMap<Pid, LocalStorage>,
+        thread_stores: &mut HashMap<Pid, LocalStorage>,
     ) {
-        const THREAD_STAT_LEN_THRESHOLD: usize = 500;
+        // Remove thread stats that are no longer in thread_stores.
+        self.thread_stats
+            .retain(|tid, _| thread_stores.contains_key(tid));
 
+        const THREAD_STAT_LEN_THRESHOLD: usize = 500;
         if self.thread_stats.capacity() > THREAD_STAT_LEN_THRESHOLD
             && self.thread_stats.len() < THREAD_STAT_LEN_THRESHOLD / 2
         {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #15304

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
resource_metering: free leaked thread CPU stats
```

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
