### PR TITLE
raftstore: more log information for region meta

### DIFF
--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -97,7 +97,7 @@ use crate::{
             UnsafeRecoveryState, UnsafeRecoveryWaitApplySyncer,
         },
         util,
-        util::{KeysInfoFormatter, LeaseState},
+        util::{is_region_initialized, KeysInfoFormatter, LeaseState},
         worker::{
             Bucket, BucketRange, CleanupTask, ConsistencyCheckTask, GcSnapshotTask, RaftlogGcTask,
             ReadDelegate, ReadProgress, RegionTask, SplitCheckTask,
@@ -2952,6 +2952,7 @@ where
                             "region_id" => self.fsm.region_id(),
                             "peer_id" => self.fsm.peer_id(),
                             "target_peer" => ?target,
+                            "job.initialized" => job.initialized,
                         );
                         if self.handle_destroy_peer(job) {
                             // It's not frequent, so use 0 as `heap_size` is ok.
@@ -3662,13 +3663,15 @@ where
             return false;
         }
 
+        let region_id = self.region_id();
+        let is_initialized = self.fsm.peer.is_initialized();
         info!(
             "starts destroy";
-            "region_id" => self.fsm.region_id(),
+            "region_id" => region_id,
             "peer_id" => self.fsm.peer_id(),
             "merged_by_target" => merged_by_target,
+            "is_initialized" => is_initialized,
         );
-        let region_id = self.region_id();
         // We can't destroy a peer which is handling snapshot.
         assert!(!self.fsm.peer.is_handling_snapshot());
 
@@ -3686,6 +3689,24 @@ where
         }
 
         let mut meta = self.ctx.store_meta.lock().unwrap();
+        let is_region_initialized_in_meta = meta
+            .regions
+            .get(&region_id)
+            .map_or(false, |region| is_region_initialized(region));
+        if !is_initialized && is_region_initialized_in_meta {
+            let region_in_meta = meta.regions.get(&region_id).unwrap();
+            error!(
+                "peer is destroyed inconsistently";
+                "region_id" => region_id,
+                "peer_id" => self.fsm.peer_id(),
+                "merged_by_target" => merged_by_target,
+                "is_initialized" => is_initialized,
+                "is_region_initialized_in_meta" => is_region_initialized_in_meta,
+                "start_key" => log_wrappers::Value::key(region_in_meta.get_start_key()),
+                "end_key" => log_wrappers::Value::key(region_in_meta.get_end_key()),
+                "peers" => ?region_in_meta.get_peers(),
+            );
+        }
 
         if meta.atomic_snap_regions.contains_key(&self.region_id()) {
             drop(meta);
@@ -3723,7 +3744,6 @@ where
                 "err" => %e,
             );
         }
-        let is_initialized = self.fsm.peer.is_initialized();
         if let Err(e) = self.fsm.peer.destroy(
             &self.ctx.engines,
             &mut self.ctx.raft_perf_context,
@@ -4117,11 +4137,7 @@ where
             }
 
             // Insert new regions and validation
-            info!(
-                "insert new region";
-                "region_id" => new_region_id,
-                "region" => ?new_region,
-            );
+            let mut is_uninitialized_peer_exist = false;
             if let Some(r) = meta.regions.get(&new_region_id) {
                 // Suppose a new node is added by conf change and the snapshot comes slowly.
                 // Then, the region splits and the first vote message comes to the new node
@@ -4135,8 +4151,15 @@ where
                         new_region_id, r, new_region
                     );
                 }
+                is_uninitialized_peer_exist = true;
                 self.ctx.router.close(new_region_id);
             }
+            info!(
+                "insert new region";
+                "region_id" => new_region_id,
+                "region" => ?new_region,
+                "is_uninitialized_peer_exist" => is_uninitialized_peer_exist,
+            );
 
             let (sender, mut new_peer) = match PeerFsm::create(
                 self.ctx.store_id(),

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -3699,12 +3699,13 @@ where
                 "peer is destroyed inconsistently";
                 "region_id" => region_id,
                 "peer_id" => self.fsm.peer_id(),
+                "peers" => ?self.region().get_peers(),
                 "merged_by_target" => merged_by_target,
                 "is_initialized" => is_initialized,
                 "is_region_initialized_in_meta" => is_region_initialized_in_meta,
-                "start_key" => log_wrappers::Value::key(region_in_meta.get_start_key()),
-                "end_key" => log_wrappers::Value::key(region_in_meta.get_end_key()),
-                "peers" => ?region_in_meta.get_peers(),
+                "start_key_in_meta" => log_wrappers::Value::key(region_in_meta.get_start_key()),
+                "end_key_in_meta" => log_wrappers::Value::key(region_in_meta.get_end_key()),
+                "peers_in_meta" => ?region_in_meta.get_peers(),
             );
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #13311 

What's Changed:


<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Adding more log information for diagnosing the issue where inconsistencies between `region` and `region range` information in the meta may occur during region split and self-destroy scenarios.
```

### Related changes


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


Side effects



### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
