### PR TITLE
charset: implement utf8mb4_0900_bin collation

### DIFF
--- a/components/tidb_query_datatype/src/codec/collation/collator/mod.rs
+++ b/components/tidb_query_datatype/src/codec/collation/collator/mod.rs
@@ -44,6 +44,7 @@ mod tests {
             (Collation::GbkBin, 5),
             (Collation::GbkChineseCi, 6),
             (Collation::Utf8Mb40900AiCi, 7),
+            (Collation::Utf8Mb40900Bin, 8),
         ];
         let cases = vec![
             // (sa, sb, [Utf8Mb4Bin, Utf8Mb4BinNoPadding, Utf8Mb4GeneralCi, Utf8Mb4UnicodeCi,
@@ -52,6 +53,7 @@ mod tests {
                 "a".as_bytes(),
                 "a".as_bytes(),
                 [
+                    Ordering::Equal,
                     Ordering::Equal,
                     Ordering::Equal,
                     Ordering::Equal,
@@ -74,6 +76,7 @@ mod tests {
                     Ordering::Equal,
                     Ordering::Equal,
                     Ordering::Less,
+                    Ordering::Less,
                 ],
             ),
             (
@@ -88,12 +91,14 @@ mod tests {
                     Ordering::Greater,
                     Ordering::Equal,
                     Ordering::Less,
+                    Ordering::Greater,
                 ],
             ),
             (
                 "aa ".as_bytes(),
                 "a a".as_bytes(),
                 [
+                    Ordering::Greater,
                     Ordering::Greater,
                     Ordering::Greater,
                     Ordering::Greater,
@@ -116,6 +121,7 @@ mod tests {
                     Ordering::Less,
                     Ordering::Less,
                     Ordering::Less,
+                    Ordering::Less,
                 ],
             ),
             (
@@ -130,6 +136,7 @@ mod tests {
                     Ordering::Less,
                     Ordering::Less,
                     Ordering::Equal,
+                    Ordering::Less,
                 ],
             ),
             (
@@ -144,6 +151,7 @@ mod tests {
                     Ordering::Less,
                     Ordering::Less,
                     Ordering::Greater,
+                    Ordering::Less,
                 ],
             ),
             (
@@ -158,6 +166,7 @@ mod tests {
                     Ordering::Less,
                     Ordering::Less,
                     Ordering::Equal,
+                    Ordering::Greater,
                 ],
             ),
             (
@@ -172,12 +181,14 @@ mod tests {
                     Ordering::Greater,
                     Ordering::Greater,
                     Ordering::Less,
+                    Ordering::Less,
                 ],
             ),
             (
                 "啊".as_bytes(),
                 "把".as_bytes(),
                 [
+                    Ordering::Less,
                     Ordering::Less,
                     Ordering::Less,
                     Ordering::Less,
@@ -243,6 +254,7 @@ mod tests {
             (Collation::GbkBin, 5),
             (Collation::GbkChineseCi, 6),
             (Collation::Utf8Mb40900AiCi, 7),
+            (Collation::Utf8Mb40900Bin, 8),
         ];
         let cases = vec![
             // (str, [Utf8Mb4Bin, Utf8Mb4BinNoPadding, Utf8Mb4GeneralCi, Utf8Mb4UnicodeCi, Latin1,
@@ -258,6 +270,7 @@ mod tests {
                     vec![0x61],
                     vec![0x41],
                     vec![0x1C, 0x47],
+                    vec![0x61],
                 ],
             ),
             (
@@ -271,6 +284,7 @@ mod tests {
                     vec![0x41],
                     vec![0x41],
                     vec![0x1C, 0x47, 0x2, 0x9],
+                    vec![0x41, 0x20],
                 ],
             ),
             (
@@ -284,6 +298,7 @@ mod tests {
                     vec![0x41],
                     vec![0x41],
                     vec![0x1C, 0x47],
+                    vec![0x41],
                 ],
             ),
             (
@@ -297,6 +312,7 @@ mod tests {
                     vec![0x3F],
                     vec![0x3F],
                     vec![0x15, 0xFE],
+                    vec![0xF0, 0x9F, 0x98, 0x83],
                 ],
             ),
             (
@@ -343,6 +359,11 @@ mod tests {
                         0x1C, 0x47, 0x1F, 0x21, 0x2, 0x9, 0x9, 0x1B, 0x2, 0x9, 0x1E, 0x21, 0x1E,
                         0xB5, 0x1E, 0xFF,
                     ],
+                    vec![
+                        0x46, 0x6F, 0x6F, 0x20, 0xC2, 0xA9, 0x20, 0x62, 0x61, 0x72, 0x20, 0xF0,
+                        0x9D, 0x8C, 0x86, 0x20, 0x62, 0x61, 0x7A, 0x20, 0xE2, 0x98, 0x83, 0x20,
+                        0x71, 0x75, 0x78,
+                    ],
                 ],
             ),
             (
@@ -362,6 +383,7 @@ mod tests {
                         0x23, 0x25, 0x23, 0x9C, 0x2, 0x9, 0x23, 0x25, 0x23, 0x9C, 0x23, 0xB, 0x23,
                         0x9C, 0x23, 0xB1,
                     ],
+                    vec![0xEF, 0xB7, 0xBB],
                 ],
             ),
             (
@@ -375,6 +397,7 @@ mod tests {
                     vec![0xD6, 0xD0, 0xCE, 0xC4],
                     vec![0xD3, 0x21, 0xC1, 0xAD],
                     vec![0xFB, 0x40, 0xCE, 0x2D, 0xFB, 0x40, 0xE5, 0x87],
+                    vec![0xE4, 0xB8, 0xAD, 0xE6, 0x96, 0x87],
                 ],
             ),
         ];

--- a/components/tidb_query_datatype/src/codec/collation/collator/utf8mb4_uca/mod.rs
+++ b/components/tidb_query_datatype/src/codec/collation/collator/utf8mb4_uca/mod.rs
@@ -11,7 +11,7 @@ use super::*;
 /// right spaces).
 pub type CollatorUtf8Mb4UnicodeCi = CollatorUca<data_0400::Unicode0400>;
 
-/// Collator for `utf8mb4_0900_ai-ci` collation without padding
+/// Collator for `utf8mb4_0900_ai_ci` collation without padding
 pub type CollatorUtf8Mb40900AiCi = CollatorUca<data_0900::Unicode0900>;
 
 pub trait UnicodeVersion: 'static + Send + Sync + Debug {

--- a/components/tidb_query_datatype/src/codec/collation/mod.rs
+++ b/components/tidb_query_datatype/src/codec/collation/mod.rs
@@ -33,6 +33,7 @@ macro_rules! match_template_collator {
                 Utf8Mb4GeneralCi => CollatorUtf8Mb4GeneralCi,
                 Utf8Mb4UnicodeCi => CollatorUtf8Mb4UnicodeCi,
                 Utf8Mb40900AiCi => CollatorUtf8Mb40900AiCi,
+                Utf8Mb40900Bin => CollatorUtf8Mb4BinNoPadding,
                 Latin1Bin => CollatorLatin1Bin,
                 GbkBin => CollatorGbkBin,
                 GbkChineseCi => CollatorGbkChineseCi,

--- a/components/tidb_query_datatype/src/def/field_type.rs
+++ b/components/tidb_query_datatype/src/def/field_type.rs
@@ -111,6 +111,7 @@ pub enum Collation {
     Utf8Mb4GeneralCi = -45,
     Utf8Mb4UnicodeCi = -224,
     Utf8Mb40900AiCi = -255,
+    Utf8Mb40900Bin = -309,
     Latin1Bin = -47,
     GbkBin = -87,
     GbkChineseCi = -28,
@@ -132,6 +133,7 @@ impl Collation {
             -87 => Ok(Collation::GbkBin),
             -28 => Ok(Collation::GbkChineseCi),
             -255 => Ok(Collation::Utf8Mb40900AiCi),
+            -309 => Ok(Collation::Utf8Mb40900Bin),
             n if n >= 0 => Ok(Collation::Utf8Mb4BinNoPadding),
             n => Err(DataTypeError::UnsupportedCollation { code: n }),
         }
@@ -533,6 +535,7 @@ mod tests {
             (-83, Some(Collation::Utf8Mb4Bin)),
             (255, Some(Collation::Utf8Mb4BinNoPadding)),
             (-255, Some(Collation::Utf8Mb40900AiCi)),
+            (-309, Some(Collation::Utf8Mb40900Bin)),
             (i32::MAX, Some(Collation::Utf8Mb4BinNoPadding)),
             (i32::MIN, None),
             (-192, Some(Collation::Utf8Mb4UnicodeCi)),

--- a/components/tidb_query_expr/src/impl_compare.rs
+++ b/components/tidb_query_expr/src/impl_compare.rs
@@ -980,12 +980,14 @@ mod tests {
                     Ordering::Equal,
                     Ordering::Equal,
                     Ordering::Less,
+                    Ordering::Less,
                 ],
             ),
             (
                 "a",
                 "b",
                 [
+                    Ordering::Less,
                     Ordering::Less,
                     Ordering::Less,
                     Ordering::Less,
@@ -1004,6 +1006,7 @@ mod tests {
                     Ordering::Equal,
                     Ordering::Equal,
                     Ordering::Equal,
+                    Ordering::Greater,
                 ],
             ),
             (
@@ -1016,6 +1019,7 @@ mod tests {
                     Ordering::Equal,
                     Ordering::Equal,
                     Ordering::Less,
+                    Ordering::Greater,
                 ],
             ),
             (
@@ -1027,6 +1031,7 @@ mod tests {
                     Ordering::Equal,
                     Ordering::Equal,
                     Ordering::Equal,
+                    Ordering::Less,
                     Ordering::Less,
                 ],
             ),
@@ -1040,12 +1045,14 @@ mod tests {
                     Ordering::Equal,
                     Ordering::Equal,
                     Ordering::Equal,
+                    Ordering::Greater,
                 ],
             ),
             (
                 "À\t",
                 "A",
                 [
+                    Ordering::Greater,
                     Ordering::Greater,
                     Ordering::Greater,
                     Ordering::Greater,
@@ -1064,12 +1071,14 @@ mod tests {
                     Ordering::Greater,
                     Ordering::Greater,
                     Ordering::Greater,
+                    Ordering::Greater,
                 ],
             ),
             (
                 "a bc",
                 "ab ",
                 [
+                    Ordering::Less,
                     Ordering::Less,
                     Ordering::Less,
                     Ordering::Less,
@@ -1088,6 +1097,7 @@ mod tests {
                     Ordering::Equal,
                     Ordering::Equal,
                     Ordering::Equal,
+                    Ordering::Less,
                 ],
             ),
             (
@@ -1100,6 +1110,7 @@ mod tests {
                     Ordering::Less,
                     Ordering::Less,
                     Ordering::Less,
+                    Ordering::Greater,
                 ],
             ),
             (
@@ -1111,6 +1122,7 @@ mod tests {
                     Ordering::Greater,
                     Ordering::Equal,
                     Ordering::Equal,
+                    Ordering::Greater,
                     Ordering::Greater,
                 ],
             ),
@@ -1124,6 +1136,7 @@ mod tests {
                     Ordering::Less,
                     Ordering::Equal,
                     Ordering::Equal,
+                    Ordering::Greater,
                 ],
             ),
         ];
@@ -1134,6 +1147,7 @@ mod tests {
             (Collation::Utf8Mb4GeneralCi, 3),
             (Collation::Utf8Mb4UnicodeCi, 4),
             (Collation::Utf8Mb40900AiCi, 5),
+            (Collation::Utf8Mb40900Bin, 6),
         ];
 
         for (str_a, str_b, ordering_in_collations) in cases {


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Close #15397

What's Changed:

A new collation utf8mb4_0900_bin is added into TiKV. It's simply an alias of `CollatorUtf8Mb4BinNoPadding`.

Ref, the TiDB's implementation: https://github.com/pingcap/tidb/pull/46269

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Support the `utf8mb4_0900_bin` collation.
```
