### PR TITLE
titan: update titan to avoid manifest mutex on release-6.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2959,7 +2959,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-6.5.4#7d48b10712cbc8fb6cd5f29552c4f4bf2067749b"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-6.5#632ff557efc3965e5c876f09380747b80d9c15a8"
 dependencies = [
  "bindgen 0.57.0",
  "bzip2-sys",
@@ -2978,7 +2978,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-6.5.4#7d48b10712cbc8fb6cd5f29552c4f4bf2067749b"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-6.5#632ff557efc3965e5c876f09380747b80d9c15a8"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -4854,7 +4854,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-6.5.4#7d48b10712cbc8fb6cd5f29552c4f4bf2067749b"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-6.5#632ff557efc3965e5c876f09380747b80d9c15a8"
 dependencies = [
  "libc 0.2.139",
  "librocksdb_sys",

--- a/components/engine_rocks/Cargo.toml
+++ b/components/engine_rocks/Cargo.toml
@@ -58,7 +58,7 @@ txn_types = { workspace = true }
 git = "https://github.com/tikv/rust-rocksdb.git"
 package = "rocksdb"
 features = ["encryption"]
-branch = "tikv-6.5.4"
+branch = "tikv-6.5"
 
 [dev-dependencies]
 rand = "0.8"


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/tikv/tikv/issues/15351

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
update titan to avoid manifest mutex
```

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Avoid holding mutex when writing titan manifest
```
