### PR TITLE
server: add back heap profile HTTP API and make it secure

### DIFF
--- a/src/server/status_server/mod.rs
+++ b/src/server/status_server/mod.rs
@@ -40,8 +40,8 @@ use openssl::{
 };
 use pin_project::pin_project;
 pub use profile::{
-    activate_heap_profile, deactivate_heap_profile, jeprof_heap_profile, list_heap_profiles,
-    read_file, start_one_cpu_profile, start_one_heap_profile,
+    activate_heap_profile, deactivate_heap_profile, heap_profiles_dir, jeprof_heap_profile,
+    list_heap_profiles, read_file, start_one_cpu_profile, start_one_heap_profile,
 };
 use prometheus::TEXT_FORMAT;
 use regex::Regex;
@@ -207,10 +207,29 @@ where
         let use_jeprof = query_pairs.get("jeprof").map(|x| x.as_ref()) == Some("true");
 
         let result = if let Some(name) = query_pairs.get("name") {
-            if use_jeprof {
-                jeprof_heap_profile(name)
+            let profiles = match list_heap_profiles() {
+                Ok(s) => s,
+                Err(e) => return Ok(make_response(StatusCode::INTERNAL_SERVER_ERROR, e)),
+            };
+            if profiles.iter().any(|(f, _)| f == name) {
+                let dir = match heap_profiles_dir() {
+                    Some(path) => path,
+                    None => {
+                        return Ok(make_response(
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            "heap profile is not active",
+                        ));
+                    }
+                };
+                let path = dir.join(name.as_ref());
+                if use_jeprof {
+                    jeprof_heap_profile(path.to_str().unwrap())
+                } else {
+                    read_file(path.to_str().unwrap())
+                }
             } else {
-                read_file(name)
+                let errmsg = format!("heap profile {} not found", name);
+                return Ok(make_response(StatusCode::BAD_REQUEST, errmsg));
             }
         } else {
             let mut seconds = 10;
@@ -649,9 +668,9 @@ where
                             (Method::GET, "/debug/pprof/heap_deactivate") => {
                                 Self::deactivate_heap_prof(req)
                             }
-                            // (Method::GET, "/debug/pprof/heap") => {
-                            //     Self::dump_heap_prof_to_resp(req).await
-                            // }
+                            (Method::GET, "/debug/pprof/heap") => {
+                                Self::dump_heap_prof_to_resp(req).await
+                            }
                             (Method::GET, "/config") => {
                                 Self::get_config(req, &cfg_controller).await
                             }

--- a/src/server/status_server/profile.rs
+++ b/src/server/status_server/profile.rs
@@ -31,7 +31,8 @@ pub use self::test_utils::TEST_PROFILE_MUTEX;
 use self::test_utils::{activate_prof, deactivate_prof, dump_prof};
 
 // File name suffix for periodically dumped heap profiles.
-const HEAP_PROFILE_SUFFIX: &str = ".heap";
+pub const HEAP_PROFILE_SUFFIX: &str = ".heap";
+pub const HEAP_PROFILE_REGEX: &str = r"^[0-9]{6,6}\.heap$";
 
 lazy_static! {
     // If it's locked it means there are already a heap or CPU profiling.

--- a/src/server/status_server/profile.rs
+++ b/src/server/status_server/profile.rs
@@ -244,9 +244,17 @@ pub fn jeprof_heap_profile(path: &str) -> Result<Vec<u8>, String> {
     Ok(output.stdout)
 }
 
+pub fn heap_profiles_dir() -> Option<PathBuf> {
+    PROFILE_ACTIVE
+        .lock()
+        .unwrap()
+        .as_ref()
+        .map(|(_, dir)| dir.path().to_owned())
+}
+
 pub fn list_heap_profiles() -> Result<Vec<(String, String)>, String> {
-    let path = match &*PROFILE_ACTIVE.lock().unwrap() {
-        Some((_, ref dir)) => dir.path().to_str().unwrap().to_owned(),
+    let path = match heap_profiles_dir() {
+        Some(path) => path.into_os_string().into_string().unwrap(),
         None => return Ok(vec![]),
     };
 
@@ -257,7 +265,7 @@ pub fn list_heap_profiles() -> Result<Vec<(String, String)>, String> {
             Ok(x) => x,
             _ => continue,
         };
-        let f = item.path().to_str().unwrap().to_owned();
+        let f = item.file_name().to_str().unwrap().to_owned();
         if !f.ends_with(HEAP_PROFILE_SUFFIX) {
             continue;
         }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #11161 

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Add back heap profile HTTP API and make it secure. The API is removed by #11162 due to a 
secure issue that can visit arbitrary files on the server. This PR makes it only show the file 
name instead of the absolute path, and adds a paranoid check to make sure the passed file
name is in the set of heap profiles.
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
`heap_list` only outputs file names
<img width="432" alt="截屏2023-08-23 19 09 13" src="https://github.com/tikv/tikv/assets/13497871/9f6b2b56-5dea-4c69-a3ed-77e1bf27bf58">

`heap` only accepts the file name
![image](https://github.com/tikv/tikv/assets/13497871/c97d8dd9-913e-44ec-9bdd-2e37237f6a07)


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
add back heap profile HTTP API and make it secure
```
