### PR TITLE
resolved_ts: re-register region if memory quota exceeded 

### DIFF
--- a/components/resolved_ts/src/errors.rs
+++ b/components/resolved_ts/src/errors.rs
@@ -1,62 +1,13 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::io::Error as IoError;
-
-use engine_traits::Error as EngineTraitsError;
-use kvproto::errorpb::Error as ErrorHeader;
-use raftstore::Error as RaftstoreError;
 use thiserror::Error;
-use tikv::storage::{
-    kv::{Error as KvError, ErrorInner as EngineErrorInner},
-    mvcc::{Error as MvccError, ErrorInner as MvccErrorInner},
-    txn::{Error as TxnError, ErrorInner as TxnErrorInner},
-};
-use txn_types::Error as TxnTypesError;
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("IO error {0}")]
-    Io(#[from] IoError),
-    #[error("Engine error {0}")]
-    Kv(#[from] KvError),
-    #[error("Transaction error {0}")]
-    Txn(#[from] TxnError),
-    #[error("Mvcc error {0}")]
-    Mvcc(#[from] MvccError),
-    #[error("Request error {0:?}")]
-    Request(Box<ErrorHeader>),
-    #[error("Engine traits error {0}")]
-    EngineTraits(#[from] EngineTraitsError),
-    #[error("Txn types error {0}")]
-    TxnTypes(#[from] TxnTypesError),
-    #[error("Raftstore error {0}")]
-    Raftstore(#[from] RaftstoreError),
+    #[error("Memory quota exceeded")]
+    MemoryQuotaExceeded,
     #[error("Other error {0}")]
     Other(#[from] Box<dyn std::error::Error + Sync + Send>),
-}
-
-impl Error {
-    pub fn request(err: ErrorHeader) -> Error {
-        Error::Request(Box::new(err))
-    }
-
-    pub fn extract_error_header(self) -> ErrorHeader {
-        match self {
-            Error::Kv(KvError(box EngineErrorInner::Request(e)))
-            | Error::Txn(TxnError(box TxnErrorInner::Engine(KvError(
-                box EngineErrorInner::Request(e),
-            ))))
-            | Error::Txn(TxnError(box TxnErrorInner::Mvcc(MvccError(box MvccErrorInner::Kv(
-                KvError(box EngineErrorInner::Request(e)),
-            )))))
-            | Error::Request(box e) => e,
-            other => {
-                let mut e = ErrorHeader::default();
-                e.set_message(format!("{:?}", other));
-                e
-            }
-        }
-    }
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/components/resolved_ts/src/scanner.rs
+++ b/components/resolved_ts/src/scanner.rs
@@ -45,6 +45,7 @@ pub struct ScanTask {
     pub mode: ScanMode,
     pub region: Region,
     pub checkpoint_ts: TimeStamp,
+    pub backoff: Option<Duration>,
     pub is_cancelled: IsCancelledCallback,
     pub send_entries: OnEntriesCallback,
     pub on_error: Option<OnErrorCallback>,
@@ -84,6 +85,18 @@ impl<T: 'static + CdcHandle<E>, E: KvEngine> ScannerPool<T, E> {
     pub fn spawn_task(&self, mut task: ScanTask) {
         let cdc_handle = self.cdc_handle.clone();
         let fut = async move {
+            if let Some(backoff) = task.backoff {
+                if let Err(e) = GLOBAL_TIMER_HANDLE
+                    .delay(std::time::Instant::now() + backoff)
+                    .compat()
+                    .await
+                {
+                    error!("failed to backoff"; "err" => ?e);
+                }
+                if (task.is_cancelled)() {
+                    return;
+                }
+            }
             let snap = match Self::get_snapshot(&mut task, cdc_handle).await {
                 Ok(snap) => snap,
                 Err(e) => {
@@ -193,37 +206,36 @@ impl<T: 'static + CdcHandle<E>, E: KvEngine> ScannerPool<T, E> {
                     error!("failed to backoff"; "err" => ?e);
                 }
                 if (task.is_cancelled)() {
-                    return Err(Error::Other("scan task cancelled".into()));
+                    return Err(box_err!("scan task cancelled"));
                 }
             }
             let (cb, fut) = tikv_util::future::paired_future_callback();
             let change_cmd = ChangeObserver::from_rts(task.region.id, task.handle.clone());
-            cdc_handle.capture_change(
-                task.region.id,
-                task.region.get_region_epoch().clone(),
-                change_cmd,
-                Callback::read(Box::new(cb)),
-            )?;
+            cdc_handle
+                .capture_change(
+                    task.region.id,
+                    task.region.get_region_epoch().clone(),
+                    change_cmd,
+                    Callback::read(Box::new(cb)),
+                )
+                .map_err(|e| Error::Other(box_err!("{:?}", e)))?;
             let mut resp = box_try!(fut.await);
             if resp.response.get_header().has_error() {
                 let err = resp.response.take_header().take_error();
                 // These two errors can't handled by retrying since the epoch and observe id is
                 // unchanged
                 if err.has_epoch_not_match() || err.get_message().contains("stale observe id") {
-                    return Err(Error::request(err));
+                    return Err(box_err!("get snapshot failed: {:?}", err));
                 }
                 last_err = Some(err)
             } else {
                 return Ok(resp.snapshot.unwrap());
             }
         }
-        Err(Error::Other(
-            format!(
-                "backoff timeout after {} try, last error: {:?}",
-                GET_SNAPSHOT_RETRY_TIME,
-                last_err.unwrap()
-            )
-            .into(),
+        Err(box_err!(
+            "backoff timeout after {} try, last error: {:?}",
+            GET_SNAPSHOT_RETRY_TIME,
+            last_err.unwrap()
         ))
     }
 
@@ -232,12 +244,14 @@ impl<T: 'static + CdcHandle<E>, E: KvEngine> ScannerPool<T, E> {
         start: Option<&Key>,
         _checkpoint_ts: TimeStamp,
     ) -> Result<(Vec<(Key, Lock)>, bool)> {
-        let (locks, has_remaining) = reader.scan_locks(
-            start,
-            None,
-            |lock| matches!(lock.lock_type, LockType::Put | LockType::Delete),
-            DEFAULT_SCAN_BATCH_SIZE,
-        )?;
+        let (locks, has_remaining) = reader
+            .scan_locks(
+                start,
+                None,
+                |lock| matches!(lock.lock_type, LockType::Put | LockType::Delete),
+                DEFAULT_SCAN_BATCH_SIZE,
+            )
+            .map_err(|e| Error::Other(box_err!("{:?}", e)))?;
         Ok((locks, has_remaining))
     }
 
@@ -245,7 +259,10 @@ impl<T: 'static + CdcHandle<E>, E: KvEngine> ScannerPool<T, E> {
         let mut entries = Vec::with_capacity(DEFAULT_SCAN_BATCH_SIZE);
         let mut has_remaining = true;
         while entries.len() < entries.capacity() {
-            match scanner.next_entry()? {
+            match scanner
+                .next_entry()
+                .map_err(|e| Error::Other(box_err!("{:?}", e)))?
+            {
                 Some(entry) => {
                     entries.push(entry);
                 }

--- a/components/resolved_ts/tests/integrations/mod.rs
+++ b/components/resolved_ts/tests/integrations/mod.rs
@@ -2,11 +2,12 @@
 
 #[path = "../mod.rs"]
 mod testsuite;
-use std::time::Duration;
+use std::{sync::mpsc::channel, time::Duration};
 
 use futures::executor::block_on;
 use kvproto::{kvrpcpb::*, metapb::RegionEpoch};
 use pd_client::PdClient;
+use resolved_ts::Task;
 use tempfile::Builder;
 use test_raftstore::sleep_ms;
 use test_sst_importer::*;
@@ -138,6 +139,95 @@ fn test_dynamic_change_advance_ts_interval() {
         region.id,
         block_on(suite.cluster.pd_client.get_tso()).unwrap(),
     );
+
+    suite.stop();
+}
+
+#[test]
+fn test_change_log_memory_quota_exceeded() {
+    let mut suite = TestSuite::new(1);
+    let region = suite.cluster.get_region(&[]);
+
+    suite.must_get_rts_ge(
+        region.id,
+        block_on(suite.cluster.pd_client.get_tso()).unwrap(),
+    );
+
+    // Set a small memory quota to trigger memory quota exceeded.
+    suite.must_change_memory_quota(1, 1);
+    let (k, v) = (b"k1", b"v");
+    let start_ts = block_on(suite.cluster.pd_client.get_tso()).unwrap();
+    let mut mutation = Mutation::default();
+    mutation.set_op(Op::Put);
+    mutation.key = k.to_vec();
+    mutation.value = v.to_vec();
+    suite.must_kv_prewrite(region.id, vec![mutation], k.to_vec(), start_ts, false);
+
+    // Resolved ts should not advance.
+    let (tx, rx) = channel();
+    suite.must_schedule_task(
+        1,
+        Task::GetDiagnosisInfo {
+            region_id: 1,
+            log_locks: false,
+            min_start_ts: u64::MAX,
+            callback: Box::new(move |res| {
+                tx.send(res).unwrap();
+            }),
+        },
+    );
+    let res = rx.recv_timeout(Duration::from_secs(5)).unwrap();
+    assert_eq!(res.unwrap().1, 0, "{:?}", res);
+
+    suite.stop();
+}
+
+#[test]
+fn test_scan_log_memory_quota_exceeded() {
+    let mut suite = TestSuite::new(1);
+    let region = suite.cluster.get_region(&[]);
+
+    suite.must_get_rts_ge(
+        region.id,
+        block_on(suite.cluster.pd_client.get_tso()).unwrap(),
+    );
+
+    let (k, v) = (b"k1", b"v");
+    let start_ts = block_on(suite.cluster.pd_client.get_tso()).unwrap();
+    let mut mutation = Mutation::default();
+    mutation.set_op(Op::Put);
+    mutation.key = k.to_vec();
+    mutation.value = v.to_vec();
+    suite.must_kv_prewrite(region.id, vec![mutation], k.to_vec(), start_ts, false);
+
+    // Set a small memory quota to trigger memory quota exceeded.
+    suite.must_change_memory_quota(1, 1);
+    // Split region
+    suite.cluster.must_split(&region, k);
+
+    let r1 = suite.cluster.get_region(&[]);
+    let r2 = suite.cluster.get_region(k);
+    let current_ts = block_on(suite.cluster.pd_client.get_tso()).unwrap();
+    // Wait for scan log.
+    sleep_ms(500);
+    // Resolved ts of region1 should be advanced
+    suite.must_get_rts_ge(r1.id, current_ts);
+
+    // Resolved ts should not advance.
+    let (tx, rx) = channel();
+    suite.must_schedule_task(
+        r2.id,
+        Task::GetDiagnosisInfo {
+            region_id: r2.id,
+            log_locks: false,
+            min_start_ts: u64::MAX,
+            callback: Box::new(move |res| {
+                tx.send(res).unwrap();
+            }),
+        },
+    );
+    let res = rx.recv_timeout(Duration::from_secs(5)).unwrap();
+    assert_eq!(res.unwrap().1, 0, "{:?}", res);
 
     suite.stop();
 }

--- a/components/resolved_ts/tests/mod.rs
+++ b/components/resolved_ts/tests/mod.rs
@@ -122,8 +122,21 @@ impl TestSuite {
             );
             c
         };
+        self.must_schedule_task(store_id, Task::ChangeConfig { change });
+    }
+
+    pub fn must_change_memory_quota(&self, store_id: u64, bytes: u64) {
+        let change = {
+            let mut c = std::collections::HashMap::default();
+            c.insert("memory_quota".to_owned(), ConfigValue::Size(bytes));
+            c
+        };
+        self.must_schedule_task(store_id, Task::ChangeConfig { change });
+    }
+
+    pub fn must_schedule_task(&self, store_id: u64, task: Task) {
         let scheduler = self.endpoints.get(&store_id).unwrap().scheduler();
-        scheduler.schedule(Task::ChangeConfig { change }).unwrap();
+        scheduler.schedule(task).unwrap();
     }
 
     pub fn must_kv_prewrite(

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2937,6 +2937,7 @@ pub struct ResolvedTsConfig {
     pub advance_ts_interval: ReadableDuration,
     #[online_config(skip)]
     pub scan_lock_pool_size: usize,
+    pub memory_quota: ReadableSize,
 }
 
 impl ResolvedTsConfig {
@@ -2957,6 +2958,7 @@ impl Default for ResolvedTsConfig {
             enable: true,
             advance_ts_interval: ReadableDuration::secs(20),
             scan_lock_pool_size: 2,
+            memory_quota: ReadableSize::mb(512),
         }
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2958,7 +2958,7 @@ impl Default for ResolvedTsConfig {
             enable: true,
             advance_ts_interval: ReadableDuration::secs(20),
             scan_lock_pool_size: 2,
-            memory_quota: ReadableSize::mb(512),
+            memory_quota: ReadableSize::mb(256),
         }
     }
 }

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -851,6 +851,7 @@ fn test_serde_custom_tikv_config() {
         enable: true,
         advance_ts_interval: ReadableDuration::secs(5),
         scan_lock_pool_size: 1,
+        memory_quota: ReadableSize::mb(1),
     };
     value.causal_ts = CausalTsConfig {
         renew_interval: ReadableDuration::millis(100),

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -705,6 +705,7 @@ sink-memory-quota = "7MB"
 enable = true
 advance-ts-interval = "5s"
 scan-lock-pool-size = 1
+memory-quota = "1MB"
 
 [split]
 detect-times = 10


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #14864

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Fix resolved ts OOM caused by Resolver tracking large txns. `ObserveRegion` is
deregistered if it exceeds memory quota. It may cause higher CPU usage because
of scanning locks, but it's better than OOM.
```

Running a transaction that updates 100,000,000 lines.
Left: master branch, right: this PR.

<img width="1843" alt="image" src="https://github.com/tikv/tikv/assets/2150711/a15cea6b-89e8-4cb0-bcfe-d667b9c66165">


### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

Side effects

- Performance regression
    - Consumes more CPU

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix an OOM issue that is caused by stale read tracking large transactions. 
```
