### PR TITLE
raftstore: fix meta inconsistency issue

### DIFF
--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -97,7 +97,7 @@ use crate::{
             UnsafeRecoveryState, UnsafeRecoveryWaitApplySyncer,
         },
         util,
-        util::{is_region_initialized, KeysInfoFormatter, LeaseState},
+        util::{KeysInfoFormatter, LeaseState},
         worker::{
             Bucket, BucketRange, CleanupTask, ConsistencyCheckTask, GcSnapshotTask, RaftlogGcTask,
             ReadDelegate, ReadProgress, RegionTask, SplitCheckTask,
@@ -322,6 +322,7 @@ where
             "replicate peer";
             "region_id" => region_id,
             "peer_id" => peer.get_id(),
+            "store_id" => store_id,
         );
 
         let mut region = metapb::Region::default();
@@ -2460,6 +2461,7 @@ where
             }
         });
 
+        let is_initialized_peer = self.fsm.peer.is_initialized();
         debug!(
             "handle raft message";
             "region_id" => self.region_id(),
@@ -2467,6 +2469,7 @@ where
             "message_type" => %util::MsgType(&msg),
             "from_peer_id" => msg.get_from_peer().get_id(),
             "to_peer_id" => msg.get_to_peer().get_id(),
+            "is_initialized_peer" => is_initialized_peer,
         );
 
         if self.fsm.peer.pending_remove || self.fsm.stopped {
@@ -3664,14 +3667,7 @@ where
         }
 
         let region_id = self.region_id();
-        let is_initialized = self.fsm.peer.is_initialized();
-        info!(
-            "starts destroy";
-            "region_id" => region_id,
-            "peer_id" => self.fsm.peer_id(),
-            "merged_by_target" => merged_by_target,
-            "is_initialized" => is_initialized,
-        );
+        let is_peer_initialized = self.fsm.peer.is_initialized();
         // We can't destroy a peer which is handling snapshot.
         assert!(!self.fsm.peer.is_handling_snapshot());
 
@@ -3688,26 +3684,29 @@ where
                 .snapshot_recovery_maybe_finish_wait_apply(/* force= */ true);
         }
 
-        let mut meta = self.ctx.store_meta.lock().unwrap();
-        let is_region_initialized_in_meta = meta
-            .regions
-            .get(&region_id)
-            .map_or(false, |region| is_region_initialized(region));
-        if !is_initialized && is_region_initialized_in_meta {
-            let region_in_meta = meta.regions.get(&region_id).unwrap();
-            error!(
-                "peer is destroyed inconsistently";
-                "region_id" => region_id,
-                "peer_id" => self.fsm.peer_id(),
-                "peers" => ?self.region().get_peers(),
-                "merged_by_target" => merged_by_target,
-                "is_initialized" => is_initialized,
-                "is_region_initialized_in_meta" => is_region_initialized_in_meta,
-                "start_key_in_meta" => log_wrappers::Value::key(region_in_meta.get_start_key()),
-                "end_key_in_meta" => log_wrappers::Value::key(region_in_meta.get_end_key()),
-                "peers_in_meta" => ?region_in_meta.get_peers(),
+        (|| {
+            fail_point!(
+                "before_destroy_peer_on_peer_1003",
+                self.fsm.peer.peer_id() == 1003,
+                |_| {}
             );
-        }
+        })();
+        let mut meta = self.ctx.store_meta.lock().unwrap();
+        let is_latest_initialized = {
+            if let Some(latest_region_info) = meta.regions.get(&region_id) {
+                util::is_region_initialized(latest_region_info)
+            } else {
+                false
+            }
+        };
+        info!(
+            "starts destroy";
+            "region_id" => self.fsm.region_id(),
+            "peer_id" => self.fsm.peer_id(),
+            "merged_by_target" => merged_by_target,
+            "is_peer_initialized" => is_peer_initialized,
+            "is_latest_initialized" => is_latest_initialized,
+        );
 
         if meta.atomic_snap_regions.contains_key(&self.region_id()) {
             drop(meta);
@@ -3764,15 +3763,24 @@ where
         self.ctx.router.close(region_id);
         self.fsm.stop();
 
-        if is_initialized
-            && !merged_by_target
-            && meta
-                .region_ranges
-                .remove(&enc_end_key(self.fsm.peer.region()))
-                .is_none()
-        {
-            panic!("{} meta corruption detected", self.fsm.peer.tag);
+        if !merged_by_target {
+            let key = if is_peer_initialized {
+                let region_info = self.fsm.peer.region();
+                Some(enc_end_key(region_info))
+            } else if is_latest_initialized {
+                let latest_region_info = meta.regions.get(&region_id).unwrap();
+                Some(enc_end_key(latest_region_info))
+            } else {
+                None
+            };
+
+            if let Some(delete_key) = key {
+                if meta.region_ranges.remove(&delete_key).is_none() {
+                    panic!("{} meta corruption detected", self.fsm.peer.tag);
+                }
+            }
         }
+
         if meta.regions.remove(&region_id).is_none() && !merged_by_target {
             panic!("{} meta corruption detected", self.fsm.peer.tag)
         }
@@ -4139,6 +4147,7 @@ where
 
             // Insert new regions and validation
             let mut is_uninitialized_peer_exist = false;
+            let self_store_id = self.ctx.store.get_id();
             if let Some(r) = meta.regions.get(&new_region_id) {
                 // Suppose a new node is added by conf change and the snapshot comes slowly.
                 // Then, the region splits and the first vote message comes to the new node
@@ -4160,6 +4169,7 @@ where
                 "region_id" => new_region_id,
                 "region" => ?new_region,
                 "is_uninitialized_peer_exist" => is_uninitialized_peer_exist,
+                "store_id" => self_store_id,
             );
 
             let (sender, mut new_peer) = match PeerFsm::create(

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -1961,7 +1961,8 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
             }
             info!(
                 "region doesn't exist yet, wait for it to be split";
-                "region_id" => region_id
+                "region_id" => region_id,
+                "to_peer_id" => msg.get_to_peer().get_id(),
             );
             return Ok(CheckMsgStatus::FirstRequest);
         }

--- a/components/raftstore/src/store/peer_storage.rs
+++ b/components/raftstore/src/store/peer_storage.rs
@@ -1017,6 +1017,9 @@ where
         // The `region` is updated after persisting in order to stay consistent with the
         // one in `StoreMeta::regions` (will be updated soon).
         // See comments in `apply_snapshot` for more details.
+        (|| {
+            fail_point!("before_set_region_on_peer_3", self.peer_id == 3, |_| {});
+        })();
         self.set_region(res.region.clone());
     }
 }

--- a/tests/failpoints/cases/test_split_region.rs
+++ b/tests/failpoints/cases/test_split_region.rs
@@ -43,7 +43,6 @@ use txn_types::{Key, LastChange, PessimisticLock, TimeStamp};
 
 #[test]
 fn test_meta_inconsistency() {
-    init_log_for_test();
     let mut cluster = new_server_cluster(0, 3);
     cluster.cfg.raft_store.store_batch_system.pool_size = 2;
     cluster.cfg.raft_store.store_batch_system.max_batch_size = Some(1);

--- a/tests/failpoints/cases/test_split_region.rs
+++ b/tests/failpoints/cases/test_split_region.rs
@@ -31,7 +31,6 @@ use raftstore::{
     Result,
 };
 use test_raftstore::*;
-use test_util::init_log_for_test;
 use tikv::storage::{kv::SnapshotExt, Snapshot};
 use tikv_util::{
     config::{ReadableDuration, ReadableSize},

--- a/tests/failpoints/cases/test_split_region.rs
+++ b/tests/failpoints/cases/test_split_region.rs
@@ -64,10 +64,10 @@ fn test_meta_inconsistency() {
     // for peer 1003.
     let region_packet_filter_region_1000_peer_1003 =
         RegionPacketFilter::new(1000, 3).skip(MessageType::MsgHeartbeat);
-    cluster.sim.wl().add_recv_filter(
-        3,
-        Box::new(region_packet_filter_region_1000_peer_1003.clone()),
-    );
+    cluster
+        .sim
+        .wl()
+        .add_recv_filter(3, Box::new(region_packet_filter_region_1000_peer_1003));
 
     // Trigger a region split to create region 1000 with peer 1001, 1002 and 1003.
     let region = cluster.get_region(b"");

--- a/tests/failpoints/cases/test_split_region.rs
+++ b/tests/failpoints/cases/test_split_region.rs
@@ -1,5 +1,4 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
-
 use std::{
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -40,6 +39,84 @@ use tikv_util::{
     HandyRwLock,
 };
 use txn_types::{Key, LastChange, PessimisticLock, TimeStamp};
+
+#[test]
+fn test_meta_inconsistency() {
+    let mut cluster = new_server_cluster(0, 3);
+    cluster.cfg.raft_store.store_batch_system.pool_size = 2;
+    cluster.cfg.raft_store.store_batch_system.max_batch_size = Some(1);
+    cluster.cfg.raft_store.apply_batch_system.pool_size = 2;
+    cluster.cfg.raft_store.apply_batch_system.max_batch_size = Some(1);
+    cluster.cfg.raft_store.hibernate_regions = false;
+    cluster.cfg.raft_store.raft_log_gc_threshold = 1000;
+    let pd_client = Arc::clone(&cluster.pd_client);
+    pd_client.disable_default_operator();
+    let region_id = cluster.run_conf_change();
+    pd_client.must_add_peer(region_id, new_peer(2, 2));
+    cluster.must_transfer_leader(region_id, new_peer(1, 1));
+    cluster.must_put(b"k1", b"v1");
+
+    // Add new peer on node 3, its snapshot apply is paused.
+    fail::cfg("before_set_region_on_peer_3", "pause").unwrap();
+    pd_client.must_add_peer(region_id, new_peer(3, 3));
+
+    // Let only heartbeat msg to pass so a replicate peer could be created on node 3
+    // for peer 1003.
+    let region_packet_filter_region_1000_peer_1003 =
+        RegionPacketFilter::new(1000, 3).skip(MessageType::MsgHeartbeat);
+    cluster.sim.wl().add_recv_filter(
+        3,
+        Box::new(region_packet_filter_region_1000_peer_1003.clone()),
+    );
+
+    // Trigger a region split to create region 1000 with peer 1001, 1002 and 1003.
+    let region = cluster.get_region(b"");
+    cluster.must_split(&region, b"k5");
+
+    // Scheduler a larger peed id heartbeat msg to trigger peer destroy for peer
+    // 1003, pause it before the meta.lock operation so new region insertions by
+    // region split could go first.
+    // Thus a inconsistency could happen because the destroy is handled
+    // by a uninitialized peer but the new initialized region info is inserted into
+    // the meta by region split.
+    fail::cfg("before_destroy_peer_on_peer_1003", "pause").unwrap();
+    let new_region = cluster.get_region(b"k4");
+    let mut larger_id_msg = Box::<RaftMessage>::default();
+    larger_id_msg.set_region_id(1000);
+    larger_id_msg.set_to_peer(new_peer(3, 1113));
+    larger_id_msg.set_region_epoch(new_region.get_region_epoch().clone());
+    larger_id_msg
+        .mut_region_epoch()
+        .set_conf_ver(new_region.get_region_epoch().get_conf_ver() + 1);
+    larger_id_msg.set_from_peer(new_peer(1, 1001));
+    let raft_message = larger_id_msg.mut_message();
+    raft_message.set_msg_type(MessageType::MsgHeartbeat);
+    raft_message.set_from(1001);
+    raft_message.set_to(1113);
+    raft_message.set_term(6);
+    cluster.sim.wl().send_raft_msg(*larger_id_msg).unwrap();
+    thread::sleep(Duration::from_millis(500));
+
+    // Let snapshot apply continue on peer 3 from region 0, then region split would
+    // be applied too.
+    fail::remove("before_set_region_on_peer_3");
+    thread::sleep(Duration::from_millis(2000));
+
+    // Let self destroy continue after the region split is finished.
+    fail::remove("before_destroy_peer_on_peer_1003");
+    sleep_ms(1000);
+
+    // Clear the network partition nemesis, trigger a new region split, panic would
+    // be encountered The thread 'raftstore-3-1::test_message_order_3' panicked
+    // at 'meta corrupted: no region for 1000 7A6B35 when creating 1004
+    // region_id: 1004 from_peer { id: 1005 store_id: 1 } to_peer { id: 1007
+    // store_id: 3 } message { msg_type: MsgRequestPreVote to: 1007 from: 1005
+    // term: 6 log_term: 5 index: 5 commit: 5 commit_term: 5 } region_epoch {
+    // conf_ver: 3 version: 3 } end_key: 6B32'.
+    cluster.sim.wl().clear_recv_filters(3);
+    let region = cluster.get_region(b"k1");
+    cluster.must_split(&region, b"k2");
+}
 
 #[test]
 fn test_follower_slow_split() {

--- a/tests/failpoints/cases/test_split_region.rs
+++ b/tests/failpoints/cases/test_split_region.rs
@@ -31,6 +31,7 @@ use raftstore::{
     Result,
 };
 use test_raftstore::*;
+use test_util::init_log_for_test;
 use tikv::storage::{kv::SnapshotExt, Snapshot};
 use tikv_util::{
     config::{ReadableDuration, ReadableSize},
@@ -42,6 +43,7 @@ use txn_types::{Key, LastChange, PessimisticLock, TimeStamp};
 
 #[test]
 fn test_meta_inconsistency() {
+    init_log_for_test();
     let mut cluster = new_server_cluster(0, 3);
     cluster.cfg.raft_store.store_batch_system.pool_size = 2;
     cluster.cfg.raft_store.store_batch_system.max_batch_size = Some(1);
@@ -116,6 +118,7 @@ fn test_meta_inconsistency() {
     cluster.sim.wl().clear_recv_filters(3);
     let region = cluster.get_region(b"k1");
     cluster.must_split(&region, b"k2");
+    cluster.must_put(b"k1", b"v1");
 }
 
 #[test]


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #13311 

What's Changed:
When a replicated uninitialized peer is destroyed when its related new region is also being created by region split at the same time, the region meta information could be inconsistent thus causing tikv panic.

Try to check the meta information when destroying an uninitialized peer, if it's initialized in the meta information delete related information to keep consistency.

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Fix the possible meta inconsistency issue.
```

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix the tikv panic caused by inconsistent region meta information.
```
