### PR TITLE
scheduler: not panic in the case of unexepected dropped channel when shutting dowm

### DIFF
--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -1666,8 +1666,8 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         // However, not release latch will cause deadlock which may ultimately block all
         // following txns, so we panic here.
         //
-        // todo(spadea): Now, we only panic if it's not shutting down, although even in close, this behavior
-        // is not acceptable.
+        // todo(spadea): Now, we only panic if it's not shutting down, although even in
+        // close, this behavior is not acceptable.
         if !tikv_util::thread_group::is_shutdown(!cfg!(test)) {
             panic!(
                 "response channel is unexpectedly dropped, tag {:?}, cid {}",

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -1665,10 +1665,15 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         // it may break correctness.
         // However, not release latch will cause deadlock which may ultimately block all
         // following txns, so we panic here.
-        panic!(
-            "response channel is unexpectedly dropped, tag {:?}, cid {}",
-            tag, cid
-        );
+        //
+        // todo(spadea): Now, we only panic if it's not shutting down, although even in close, this behavior
+        // is not acceptable.
+        if !tikv_util::thread_group::is_shutdown(!cfg!(test)) {
+            panic!(
+                "response channel is unexpectedly dropped, tag {:?}, cid {}",
+                tag, cid
+            );
+        }
     }
 
     /// Returns whether it succeeds to write pessimistic locks to the in-memory


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #15202

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
not panic in the case of unexepected dropped channel when shutting dowm
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
