### PR TITLE
raftstore: fix unwrap panic of region_compact_redundant_rows_percent

### DIFF
--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -608,9 +608,15 @@ impl Config {
         if self.region_compact_check_step.is_none() {
             if raft_kv_v2 {
                 self.region_compact_check_step = Some(5);
-                self.region_compact_redundant_rows_percent = Some(20);
             } else {
                 self.region_compact_check_step = Some(100);
+            }
+        }
+
+        if self.region_compact_redundant_rows_percent.is_none() {
+            if raft_kv_v2 {
+                self.region_compact_redundant_rows_percent = Some(20);
+            } else {
                 // Disable redundant rows check in default for v1.
                 self.region_compact_redundant_rows_percent = Some(100);
             }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6428,4 +6428,47 @@ mod tests {
             Some(ReadableSize::gb(1))
         );
     }
+
+    #[test]
+    fn test_compact_check_default() {
+        let content = r#"
+            [raftstore]
+            region-compact-check-step = 50
+        "#;
+        let mut cfg: TikvConfig = toml::from_str(content).unwrap();
+        cfg.validate().unwrap();
+        assert_eq!(cfg.raft_store.region_compact_check_step.unwrap(), 50);
+        assert_eq!(cfg.raft_store.region_compact_redundant_rows_percent.unwrap(), 100);
+
+        let content = r#"
+            [raftstore]
+            region-compact-check-step = 50
+            [storage]
+            engine = "partitioned-raft-kv"
+        "#;
+        let mut cfg: TikvConfig = toml::from_str(content).unwrap();
+        cfg.validate().unwrap();
+        assert_eq!(cfg.raft_store.region_compact_check_step.unwrap(), 50);
+        assert_eq!(cfg.raft_store.region_compact_redundant_rows_percent.unwrap(), 20);
+
+        let content = r#"
+            [raftstore]
+            region-compact-redundant-rows-percent = 50
+        "#;
+        let mut cfg: TikvConfig = toml::from_str(content).unwrap();
+        cfg.validate().unwrap();
+        assert_eq!(cfg.raft_store.region_compact_check_step.unwrap(), 100);
+        assert_eq!(cfg.raft_store.region_compact_redundant_rows_percent.unwrap(), 50);
+
+        let content = r#"
+            [raftstore]
+            region-compact-redundant-rows-percent = 50
+            [storage]
+            engine = "partitioned-raft-kv"
+        "#;
+        let mut cfg: TikvConfig = toml::from_str(content).unwrap();
+        cfg.validate().unwrap();
+        assert_eq!(cfg.raft_store.region_compact_check_step.unwrap(), 5);
+        assert_eq!(cfg.raft_store.region_compact_redundant_rows_percent.unwrap(), 50);
+    }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6438,7 +6438,12 @@ mod tests {
         let mut cfg: TikvConfig = toml::from_str(content).unwrap();
         cfg.validate().unwrap();
         assert_eq!(cfg.raft_store.region_compact_check_step.unwrap(), 50);
-        assert_eq!(cfg.raft_store.region_compact_redundant_rows_percent.unwrap(), 100);
+        assert_eq!(
+            cfg.raft_store
+                .region_compact_redundant_rows_percent
+                .unwrap(),
+            100
+        );
 
         let content = r#"
             [raftstore]
@@ -6449,7 +6454,12 @@ mod tests {
         let mut cfg: TikvConfig = toml::from_str(content).unwrap();
         cfg.validate().unwrap();
         assert_eq!(cfg.raft_store.region_compact_check_step.unwrap(), 50);
-        assert_eq!(cfg.raft_store.region_compact_redundant_rows_percent.unwrap(), 20);
+        assert_eq!(
+            cfg.raft_store
+                .region_compact_redundant_rows_percent
+                .unwrap(),
+            20
+        );
 
         let content = r#"
             [raftstore]
@@ -6458,7 +6468,12 @@ mod tests {
         let mut cfg: TikvConfig = toml::from_str(content).unwrap();
         cfg.validate().unwrap();
         assert_eq!(cfg.raft_store.region_compact_check_step.unwrap(), 100);
-        assert_eq!(cfg.raft_store.region_compact_redundant_rows_percent.unwrap(), 50);
+        assert_eq!(
+            cfg.raft_store
+                .region_compact_redundant_rows_percent
+                .unwrap(),
+            50
+        );
 
         let content = r#"
             [raftstore]
@@ -6469,6 +6484,11 @@ mod tests {
         let mut cfg: TikvConfig = toml::from_str(content).unwrap();
         cfg.validate().unwrap();
         assert_eq!(cfg.raft_store.region_compact_check_step.unwrap(), 5);
-        assert_eq!(cfg.raft_store.region_compact_redundant_rows_percent.unwrap(), 50);
+        assert_eq!(
+            cfg.raft_store
+                .region_compact_redundant_rows_percent
+                .unwrap(),
+            50
+        );
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #15438

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
fix unwrap panic of region_compact_redundant_rows_percent
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
