### PR TITLE
raftstore-v2: init persisted_tablet_index on startup

### DIFF
--- a/components/raftstore-v2/src/operation/command/admin/compact_log.rs
+++ b/components/raftstore-v2/src/operation/command/admin/compact_log.rs
@@ -63,14 +63,14 @@ pub struct CompactLogContext {
 }
 
 impl CompactLogContext {
-    pub fn new(last_applying_index: u64) -> CompactLogContext {
+    pub fn new(last_applying_index: u64, persisted_applied: u64) -> CompactLogContext {
         CompactLogContext {
             skipped_ticks: 0,
             approximate_log_size: 0,
             last_applying_index,
             last_compacted_idx: 0,
             tombstone_tablets_wait_index: vec![],
-            persisted_tablet_index: AtomicU64::new(0).into(),
+            persisted_tablet_index: AtomicU64::new(persisted_applied).into(),
         }
     }
 

--- a/components/raftstore-v2/src/operation/life.rs
+++ b/components/raftstore-v2/src/operation/life.rs
@@ -797,11 +797,15 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         if self.has_pending_tombstone_tablets() {
             let applied_index = self.entry_storage().applied_index();
             let last_index = self.entry_storage().last_index();
+            let persisted = self
+                .remember_persisted_tablet_index()
+                .load(std::sync::atomic::Ordering::Relaxed);
             info!(
                 self.logger,
                 "postpone destroy because there're pending tombstone tablets";
                 "applied_index" => applied_index,
                 "last_index" => last_index,
+                "persisted_applied" => persisted,
             );
             return true;
         }

--- a/components/raftstore-v2/src/raft/peer.rs
+++ b/components/raftstore-v2/src/raft/peer.rs
@@ -158,6 +158,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         let region_id = storage.region().get_id();
         let tablet_index = storage.region_state().get_tablet_index();
         let merge_context = MergeContext::from_region_state(&logger, storage.region_state());
+        let persisted_applied = storage.apply_trace().persisted_apply_index();
 
         let raft_group = RawNode::new(&raft_cfg, storage, &logger)?;
         let region = raft_group.store().region_state().get_region().clone();
@@ -184,7 +185,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             self_stat: PeerStat::default(),
             peer_cache: vec![],
             peer_heartbeats: HashMap::default(),
-            compact_log_context: CompactLogContext::new(applied_index),
+            compact_log_context: CompactLogContext::new(applied_index, persisted_applied),
             merge_context: merge_context.map(|c| Box::new(c)),
             last_sent_snapshot_index: 0,
             raw_write_encoder: None,


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Ref #12842 

What's Changed:

```commit-message
- Initialize `persisted_apply_index` on startup.
```

### Related changes

https://github.com/pingcap/tidb/issues/45517

#15332

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
