### PR TITLE
resolved_ts: track pending lock memory usage

### DIFF
--- a/components/resolved_ts/src/endpoint.rs
+++ b/components/resolved_ts/src/endpoint.rs
@@ -81,6 +81,8 @@ impl Drop for ResolverStatus {
             warn!("drop huge ResolverStatus";
                 "bytes" => bytes,
                 "num_locks" => num_locks,
+                "memory_quota_in_use" => memory_quota.in_use(),
+                "memory_quota_capacity" => memory_quota.capacity(),
             );
         }
         memory_quota.free(bytes);

--- a/components/resolved_ts/src/endpoint.rs
+++ b/components/resolved_ts/src/endpoint.rs
@@ -167,8 +167,8 @@ impl ResolverStatus {
             } = &mut self else {
                 panic!("region {:?} resolver has ready", region_id)
             };
-        // Must replace with an empty vec, otherwise it may double free memory quota.
-        for lock in std::mem::replace(locks, vec![]) {
+        // Must take locks, otherwise it may double free memory quota on drop.
+        for lock in std::mem::take(locks) {
             memory_quota.free(lock.heap_size());
             match lock {
                 PendingLock::Track { key, start_ts } => {

--- a/components/resolved_ts/src/endpoint.rs
+++ b/components/resolved_ts/src/endpoint.rs
@@ -139,6 +139,7 @@ impl ResolverStatus {
                         // Check if adding a new lock or unlock will exceed the memory
                         // quota.
                         if !memory_quota.alloc(lock.heap_size()) {
+                            fail::fail_point!("resolved_ts_on_pending_locks_memory_quota_exceeded");
                             return Err(Error::MemoryQuotaExceeded);
                         }
                         locks.push(lock);

--- a/components/resolved_ts/src/endpoint.rs
+++ b/components/resolved_ts/src/endpoint.rs
@@ -28,7 +28,7 @@ use raftstore::{
 use security::SecurityManager;
 use tikv::config::ResolvedTsConfig;
 use tikv_util::{
-    memory::MemoryQuota,
+    memory::{HeapSize, MemoryQuota},
     warn,
     worker::{Runnable, RunnableWithTimer, Scheduler},
 };
@@ -41,7 +41,7 @@ use crate::{
     metrics::*,
     resolver::Resolver,
     scanner::{ScanEntry, ScanMode, ScanTask, ScannerPool},
-    Error, Result,
+    Error, Result, ON_DROP_WARN_HEAP_SIZE,
 };
 
 /// grace period for logging safe-ts and resolved-ts gap in slow log
@@ -53,8 +53,135 @@ enum ResolverStatus {
         tracked_index: u64,
         locks: Vec<PendingLock>,
         cancelled: Arc<AtomicBool>,
+        memory_quota: Arc<MemoryQuota>,
     },
     Ready,
+}
+
+impl Drop for ResolverStatus {
+    fn drop(&mut self) {
+        let ResolverStatus::Pending {
+            locks,
+            memory_quota,
+            ..
+        } = self else {
+            return;
+        };
+        if locks.is_empty() {
+            return;
+        }
+
+        // Free memory quota used by pending locks and unlocks.
+        let mut bytes = 0;
+        let num_locks = locks.len();
+        for lock in locks {
+            bytes += lock.heap_size();
+        }
+        if bytes > ON_DROP_WARN_HEAP_SIZE {
+            warn!("drop huge ResolverStatus";
+                "bytes" => bytes,
+                "num_locks" => num_locks,
+            );
+        }
+        memory_quota.free(bytes);
+    }
+}
+
+impl ResolverStatus {
+    fn track_change_log(&mut self, region_id: u64, change_logs: &[ChangeLog]) -> Result<()> {
+        let ResolverStatus::Pending {
+            locks,
+            tracked_index,
+            memory_quota,
+            ..
+        } = self else {
+            panic!("region {:?} resolver has ready", region_id)
+        };
+        for log in change_logs {
+            match log {
+                ChangeLog::Error(e) => {
+                    debug!(
+                        "skip change log error";
+                        "region" => region_id,
+                        "error" => ?e,
+                    );
+                    continue;
+                }
+                ChangeLog::Admin(req_type) => {
+                    // TODO: for admin cmd that won't change the region meta like peer list
+                    // and key range (i.e. `CompactLog`, `ComputeHash`) we may not need to
+                    // return error
+                    return Err(box_err!(
+                        "region met admin command {:?} while initializing resolver",
+                        req_type
+                    ));
+                }
+                ChangeLog::Rows { rows, index } => {
+                    for row in rows {
+                        let lock = match row {
+                            ChangeRow::Prewrite { key, start_ts, .. } => PendingLock::Track {
+                                key: key.clone(),
+                                start_ts: *start_ts,
+                            },
+                            ChangeRow::Commit {
+                                key,
+                                start_ts,
+                                commit_ts,
+                                ..
+                            } => PendingLock::Untrack {
+                                key: key.clone(),
+                                start_ts: *start_ts,
+                                commit_ts: *commit_ts,
+                            },
+                            // One pc command do not contains any lock, so just skip it
+                            ChangeRow::OnePc { .. } | ChangeRow::IngestSsT => continue,
+                        };
+                        // Check if adding a new lock or unlock will exceed the memory
+                        // quota.
+                        if !memory_quota.alloc(lock.heap_size()) {
+                            return Err(Error::MemoryQuotaExceeded);
+                        }
+                        locks.push(lock);
+                    }
+                    assert!(
+                        *tracked_index < *index,
+                        "region {}, tracked_index: {}, incoming index: {}",
+                        region_id,
+                        *tracked_index,
+                        *index
+                    );
+                    *tracked_index = *index;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn on_scan_finished(mut self, region_id: u64, resolver: &mut Resolver) -> Result<u64> {
+        let ResolverStatus::Pending {
+                locks,
+                tracked_index,
+                memory_quota,
+                ..
+            } = &mut self else {
+                panic!("region {:?} resolver has ready", region_id)
+            };
+        // Must replace with an empty vec, otherwise it may double free memory quota.
+        for lock in std::mem::replace(locks, vec![]) {
+            memory_quota.free(lock.heap_size());
+            match lock {
+                PendingLock::Track { key, start_ts } => {
+                    if !resolver.track_lock(start_ts, key.to_raw().unwrap(), Some(*tracked_index)) {
+                        return Err(Error::MemoryQuotaExceeded);
+                    }
+                }
+                PendingLock::Untrack { key, .. } => {
+                    resolver.untrack_lock(&key.to_raw().unwrap(), Some(*tracked_index))
+                }
+            }
+        }
+        Ok(*tracked_index)
+    }
 }
 
 #[allow(dead_code)]
@@ -68,6 +195,16 @@ enum PendingLock {
         start_ts: Option<TimeStamp>,
         commit_ts: Option<TimeStamp>,
     },
+}
+
+impl HeapSize for PendingLock {
+    fn heap_size(&self) -> usize {
+        match self {
+            PendingLock::Track { key, .. } | PendingLock::Untrack { key, .. } => {
+                key.as_encoded().heap_size()
+            }
+        }
+    }
 }
 
 // Records information related to observed region.
@@ -85,13 +222,14 @@ struct ObserveRegion {
 impl ObserveRegion {
     fn new(meta: Region, rrp: Arc<RegionReadProgress>, memory_quota: Arc<MemoryQuota>) -> Self {
         ObserveRegion {
-            resolver: Resolver::with_read_progress(meta.id, Some(rrp), memory_quota),
+            resolver: Resolver::with_read_progress(meta.id, Some(rrp), memory_quota.clone()),
             meta,
             handle: ObserveHandle::new(),
             resolver_status: ResolverStatus::Pending {
                 tracked_index: 0,
                 locks: vec![],
                 cancelled: Arc::new(AtomicBool::new(false)),
+                memory_quota,
             },
         }
     }
@@ -101,129 +239,72 @@ impl ObserveRegion {
     }
 
     fn track_change_log(&mut self, change_logs: &[ChangeLog]) -> Result<()> {
-        match &mut self.resolver_status {
-            ResolverStatus::Pending {
-                locks,
-                tracked_index,
-                ..
-            } => {
-                for log in change_logs {
-                    match log {
-                        ChangeLog::Error(e) => {
-                            debug!(
-                                "skip change log error";
-                                "region" => self.meta.id,
-                                "error" => ?e,
+        if matches!(self.resolver_status, ResolverStatus::Pending { .. }) {
+            self.resolver_status
+                .track_change_log(self.meta.id, change_logs)
+        } else {
+            for log in change_logs {
+                match log {
+                    ChangeLog::Error(e) => {
+                        debug!(
+                            "skip change log error";
+                            "region" => self.meta.id,
+                            "error" => ?e,
+                        );
+                        continue;
+                    }
+                    ChangeLog::Admin(req_type) => match req_type {
+                        AdminCmdType::Split
+                        | AdminCmdType::BatchSplit
+                        | AdminCmdType::PrepareMerge
+                        | AdminCmdType::RollbackMerge
+                        | AdminCmdType::CommitMerge => {
+                            info!(
+                                "region met split/merge command, stop tracking since key range changed, wait for re-register";
+                                "req_type" => ?req_type,
                             );
-                            continue;
+                            // Stop tracking so that `tracked_index` larger than the split/merge
+                            // command index won't be published until `RegionUpdate` event
+                            // trigger the region re-register and re-scan the new key range
+                            self.resolver.stop_tracking();
                         }
-                        ChangeLog::Admin(req_type) => {
-                            // TODO: for admin cmd that won't change the region meta like peer list
-                            // and key range (i.e. `CompactLog`, `ComputeHash`) we may not need to
-                            // return error
-                            return Err(box_err!(
-                                "region met admin command {:?} while initializing resolver",
-                                req_type
-                            ));
+                        _ => {
+                            debug!(
+                                "skip change log admin";
+                                "region" => self.meta.id,
+                                "req_type" => ?req_type,
+                            );
                         }
-                        ChangeLog::Rows { rows, index } => {
-                            rows.iter().for_each(|row| match row {
+                    },
+                    ChangeLog::Rows { rows, index } => {
+                        for row in rows {
+                            match row {
                                 ChangeRow::Prewrite { key, start_ts, .. } => {
-                                    locks.push(PendingLock::Track {
-                                        key: key.clone(),
-                                        start_ts: *start_ts,
-                                    })
+                                    if !self.resolver.track_lock(
+                                        *start_ts,
+                                        key.to_raw().unwrap(),
+                                        Some(*index),
+                                    ) {
+                                        return Err(Error::MemoryQuotaExceeded);
+                                    }
                                 }
-                                ChangeRow::Commit {
-                                    key,
-                                    start_ts,
-                                    commit_ts,
-                                    ..
-                                } => locks.push(PendingLock::Untrack {
-                                    key: key.clone(),
-                                    start_ts: *start_ts,
-                                    commit_ts: *commit_ts,
-                                }),
+                                ChangeRow::Commit { key, .. } => self
+                                    .resolver
+                                    .untrack_lock(&key.to_raw().unwrap(), Some(*index)),
                                 // One pc command do not contains any lock, so just skip it
-                                ChangeRow::OnePc { .. } => {}
-                                ChangeRow::IngestSsT => {}
-                            });
-                            assert!(
-                                *tracked_index < *index,
-                                "region {}, tracked_index: {}, incoming index: {}",
-                                self.meta.id,
-                                *tracked_index,
-                                *index
-                            );
-                            *tracked_index = *index;
-                        }
-                    }
-                }
-            }
-            ResolverStatus::Ready => {
-                for log in change_logs {
-                    match log {
-                        ChangeLog::Error(e) => {
-                            debug!(
-                                "skip change log error";
-                                "region" => self.meta.id,
-                                "error" => ?e,
-                            );
-                            continue;
-                        }
-                        ChangeLog::Admin(req_type) => match req_type {
-                            AdminCmdType::Split
-                            | AdminCmdType::BatchSplit
-                            | AdminCmdType::PrepareMerge
-                            | AdminCmdType::RollbackMerge
-                            | AdminCmdType::CommitMerge => {
-                                info!(
-                                    "region met split/merge command, stop tracking since key range changed, wait for re-register";
-                                    "req_type" => ?req_type,
-                                );
-                                // Stop tracking so that `tracked_index` larger than the split/merge
-                                // command index won't be published until `RegionUpdate` event
-                                // trigger the region re-register and re-scan the new key range
-                                self.resolver.stop_tracking();
-                            }
-                            _ => {
-                                debug!(
-                                    "skip change log admin";
-                                    "region" => self.meta.id,
-                                    "req_type" => ?req_type,
-                                );
-                            }
-                        },
-                        ChangeLog::Rows { rows, index } => {
-                            for row in rows {
-                                match row {
-                                    ChangeRow::Prewrite { key, start_ts, .. } => {
-                                        if !self.resolver.track_lock(
-                                            *start_ts,
-                                            key.to_raw().unwrap(),
-                                            Some(*index),
-                                        ) {
-                                            return Err(Error::MemoryQuotaExceeded);
-                                        }
-                                    }
-                                    ChangeRow::Commit { key, .. } => self
-                                        .resolver
-                                        .untrack_lock(&key.to_raw().unwrap(), Some(*index)),
-                                    // One pc command do not contains any lock, so just skip it
-                                    ChangeRow::OnePc { .. } => {
-                                        self.resolver.update_tracked_index(*index);
-                                    }
-                                    ChangeRow::IngestSsT => {
-                                        self.resolver.update_tracked_index(*index);
-                                    }
+                                ChangeRow::OnePc { .. } => {
+                                    self.resolver.update_tracked_index(*index);
+                                }
+                                ChangeRow::IngestSsT => {
+                                    self.resolver.update_tracked_index(*index);
                                 }
                             }
                         }
                     }
                 }
             }
+            Ok(())
         }
-        Ok(())
     }
 
     /// Track locks in incoming scan entries.
@@ -247,38 +328,10 @@ impl ObserveRegion {
                 ScanEntry::None => {
                     // Update the `tracked_index` to the snapshot's `apply_index`
                     self.resolver.update_tracked_index(apply_index);
+                    let resolver_status =
+                        std::mem::replace(&mut self.resolver_status, ResolverStatus::Ready);
                     let pending_tracked_index =
-                        match std::mem::replace(&mut self.resolver_status, ResolverStatus::Ready) {
-                            ResolverStatus::Pending {
-                                locks,
-                                tracked_index,
-                                ..
-                            } => {
-                                for lock in locks {
-                                    match lock {
-                                        PendingLock::Track { key, start_ts } => {
-                                            if !self.resolver.track_lock(
-                                                start_ts,
-                                                key.to_raw().unwrap(),
-                                                Some(tracked_index),
-                                            ) {
-                                                return Err(Error::MemoryQuotaExceeded);
-                                            }
-                                        }
-                                        PendingLock::Untrack { key, .. } => {
-                                            self.resolver.untrack_lock(
-                                                &key.to_raw().unwrap(),
-                                                Some(tracked_index),
-                                            )
-                                        }
-                                    }
-                                }
-                                tracked_index
-                            }
-                            ResolverStatus::Ready => {
-                                panic!("region {:?} resolver has ready", self.meta.id)
-                            }
-                        };
+                        resolver_status.on_scan_finished(self.meta.id, &mut self.resolver)?;
                     info!(
                         "Resolver initialized";
                         "region" => self.meta.id,
@@ -457,7 +510,7 @@ where
             // Stop observing data
             handle.stop_observing();
             // Stop scanning data
-            if let ResolverStatus::Pending { cancelled, .. } = resolver_status {
+            if let ResolverStatus::Pending { ref cancelled, .. } = resolver_status {
                 cancelled.store(true, Ordering::Release);
             }
         } else {

--- a/components/resolved_ts/src/metrics.rs
+++ b/components/resolved_ts/src/metrics.rs
@@ -138,4 +138,10 @@ lazy_static! {
         "The minimal (non-zero) resolved ts gap for observe leader peers"
     )
     .unwrap();
+    pub static ref RTS_INITIAL_SCAN_BACKOFF_DURATION_HISTOGRAM: Histogram = register_histogram!(
+        "tikv_resolved_ts_initial_scan_backoff_duration_seconds",
+        "Bucketed histogram of resolved-ts initial scan backoff duration",
+        exponential_buckets(0.1, 2.0, 16).unwrap(),
+    )
+    .unwrap();
 }

--- a/components/resolved_ts/src/resolver.rs
+++ b/components/resolved_ts/src/resolver.rs
@@ -72,6 +72,8 @@ impl Drop for Resolver {
                 "region_id" => self.region_id,
                 "bytes" => bytes,
                 "num_locks" => num_locks,
+                "memory_quota_in_use" => self.memory_quota.in_use(),
+                "memory_quota_capacity" => self.memory_quota.capacity(),
             );
         }
         self.memory_quota.free(bytes);

--- a/components/resolved_ts/src/resolver.rs
+++ b/components/resolved_ts/src/resolver.rs
@@ -68,7 +68,7 @@ impl Drop for Resolver {
             bytes += self.lock_heap_size(key);
         }
         if bytes > ON_DROP_WARN_HEAP_SIZE {
-            warn!("drop huge Resolver";
+            warn!("drop huge resolver";
                 "region_id" => self.region_id,
                 "bytes" => bytes,
                 "num_locks" => num_locks,

--- a/components/resolved_ts/src/resolver.rs
+++ b/components/resolved_ts/src/resolver.rs
@@ -13,7 +13,7 @@ use txn_types::TimeStamp;
 use crate::metrics::RTS_RESOLVED_FAIL_ADVANCE_VEC;
 
 const MAX_NUMBER_OF_LOCKS_IN_LOG: usize = 10;
-const ON_DROP_WARN_HEAP_SIZE: usize = 64 * 1024 * 1024; // 64MB
+pub(crate) const ON_DROP_WARN_HEAP_SIZE: usize = 64 * 1024 * 1024; // 64MB
 
 // Resolver resolves timestamps that guarantee no more commit will happen before
 // the timestamp.
@@ -68,7 +68,7 @@ impl Drop for Resolver {
             bytes += self.lock_heap_size(key);
         }
         if bytes > ON_DROP_WARN_HEAP_SIZE {
-            warn!("drop huge resolver";
+            warn!("drop huge Resolver";
                 "region_id" => self.region_id,
                 "bytes" => bytes,
                 "num_locks" => num_locks,

--- a/components/resolved_ts/src/scanner.rs
+++ b/components/resolved_ts/src/scanner.rs
@@ -97,6 +97,7 @@ impl<T: 'static + CdcHandle<E>, E: KvEngine> ScannerPool<T, E> {
                     return;
                 }
             }
+            fail::fail_point!("resolved_ts_before_scanner_get_snapshot");
             let snap = match Self::get_snapshot(&mut task, cdc_handle).await {
                 Ok(snap) => snap,
                 Err(e) => {

--- a/components/resolved_ts/src/scanner.rs
+++ b/components/resolved_ts/src/scanner.rs
@@ -98,7 +98,6 @@ impl<T: 'static + CdcHandle<E>, E: KvEngine> ScannerPool<T, E> {
                     return;
                 }
             }
-            fail::fail_point!("resolved_ts_before_scanner_get_snapshot");
             let snap = match Self::get_snapshot(&mut task, cdc_handle).await {
                 Ok(snap) => snap,
                 Err(e) => {
@@ -115,6 +114,7 @@ impl<T: 'static + CdcHandle<E>, E: KvEngine> ScannerPool<T, E> {
                     return;
                 }
             };
+            fail::fail_point!("resolved_ts_after_scanner_get_snapshot");
             let start = Instant::now();
             let apply_index = snap.get_apply_index().unwrap();
             let mut entries = vec![];

--- a/components/resolved_ts/src/scanner.rs
+++ b/components/resolved_ts/src/scanner.rs
@@ -21,7 +21,7 @@ use txn_types::{Key, Lock, LockType, TimeStamp};
 
 use crate::{
     errors::{Error, Result},
-    metrics::RTS_SCAN_DURATION_HISTOGRAM,
+    metrics::*,
 };
 
 const DEFAULT_SCAN_BATCH_SIZE: usize = 1024;
@@ -86,6 +86,7 @@ impl<T: 'static + CdcHandle<E>, E: KvEngine> ScannerPool<T, E> {
         let cdc_handle = self.cdc_handle.clone();
         let fut = async move {
             if let Some(backoff) = task.backoff {
+                RTS_INITIAL_SCAN_BACKOFF_DURATION_HISTOGRAM.observe(backoff.as_secs_f64());
                 if let Err(e) = GLOBAL_TIMER_HANDLE
                     .delay(std::time::Instant::now() + backoff)
                     .compat()

--- a/components/resolved_ts/tests/failpoints/mod.rs
+++ b/components/resolved_ts/tests/failpoints/mod.rs
@@ -2,6 +2,11 @@
 
 #[path = "../mod.rs"]
 mod testsuite;
+use std::{
+    sync::{mpsc::channel, Mutex},
+    time::Duration,
+};
+
 use futures::executor::block_on;
 use kvproto::kvrpcpb::*;
 use pd_client::PdClient;
@@ -126,5 +131,45 @@ fn test_report_min_resolved_ts_disable() {
     fail::remove("mock_tick_interval");
     fail::remove("mock_collect_tick_interval");
     fail::remove("mock_min_resolved_ts_interval_disable");
+    suite.stop();
+}
+
+#[test]
+fn test_pending_locks_memory_quota_exceeded() {
+    // Pause scan lock so that locks will be put in pending locks.
+    fail::cfg("resolved_ts_before_scanner_get_snapshot", "pause").unwrap();
+    // Check if memory quota exceeded is triggered.
+    let (tx, rx) = channel();
+    let tx = Mutex::new(tx);
+    fail::cfg_callback(
+        "resolved_ts_on_pending_locks_memory_quota_exceeded",
+        move || {
+            let sender = tx.lock().unwrap();
+            sender.send(()).unwrap();
+        },
+    )
+    .unwrap();
+
+    let mut suite = TestSuite::new(1);
+    let region = suite.cluster.get_region(&[]);
+
+    // Must not trigger memory quota exceeded.
+    rx.recv_timeout(Duration::from_millis(100)).unwrap_err();
+
+    // Set a small memory quota to trigger memory quota exceeded.
+    suite.must_change_memory_quota(1, 1);
+    let (k, v) = (b"k1", b"v");
+    let start_ts = block_on(suite.cluster.pd_client.get_tso()).unwrap();
+    let mut mutation = Mutation::default();
+    mutation.set_op(Op::Put);
+    mutation.key = k.to_vec();
+    mutation.value = v.to_vec();
+    suite.must_kv_prewrite(region.id, vec![mutation], k.to_vec(), start_ts, false);
+
+    // Must trigger memory quota exceeded.
+    rx.recv_timeout(Duration::from_secs(5)).unwrap_err();
+
+    fail::remove("resolved_ts_before_scanner_get_snapshot");
+    fail::remove("resolved_ts_on_pending_locks_memory_quota_exceeded");
     suite.stop();
 }

--- a/components/resolved_ts/tests/failpoints/mod.rs
+++ b/components/resolved_ts/tests/failpoints/mod.rs
@@ -137,7 +137,7 @@ fn test_report_min_resolved_ts_disable() {
 #[test]
 fn test_pending_locks_memory_quota_exceeded() {
     // Pause scan lock so that locks will be put in pending locks.
-    fail::cfg("resolved_ts_before_scanner_get_snapshot", "pause").unwrap();
+    fail::cfg("resolved_ts_after_scanner_get_snapshot", "pause").unwrap();
     // Check if memory quota exceeded is triggered.
     let (tx, rx) = channel();
     let tx = Mutex::new(tx);
@@ -167,9 +167,9 @@ fn test_pending_locks_memory_quota_exceeded() {
     suite.must_kv_prewrite(region.id, vec![mutation], k.to_vec(), start_ts, false);
 
     // Must trigger memory quota exceeded.
-    rx.recv_timeout(Duration::from_secs(5)).unwrap_err();
+    rx.recv_timeout(Duration::from_secs(5)).unwrap();
 
-    fail::remove("resolved_ts_before_scanner_get_snapshot");
+    fail::remove("resolved_ts_after_scanner_get_snapshot");
     fail::remove("resolved_ts_on_pending_locks_memory_quota_exceeded");
     suite.stop();
 }

--- a/components/tikv_util/src/memory.rs
+++ b/components/tikv_util/src/memory.rs
@@ -25,21 +25,7 @@ pub unsafe fn vec_transmute<F, T>(from: Vec<F>) -> Vec<T> {
     Vec::from_raw_parts(ptr as _, len, cap)
 }
 
-// pub trait TotalSize {
-//     /// Return the size of the object itself and all objects it refers to.
-//     fn total_size(&self) -> usize {
-//         0
-//     }
-// }
-
-// impl<T: HeapSize> TotalSize for T {
-//     fn total_size(&self) -> usize {
-//         self.heap_size() + mem::size_of::<T>()
-//     }
-// }
-
 pub trait HeapSize {
-    /// Return the size of objects it refers to.
     fn heap_size(&self) -> usize {
         0
     }

--- a/components/tikv_util/src/memory.rs
+++ b/components/tikv_util/src/memory.rs
@@ -25,7 +25,21 @@ pub unsafe fn vec_transmute<F, T>(from: Vec<F>) -> Vec<T> {
     Vec::from_raw_parts(ptr as _, len, cap)
 }
 
+// pub trait TotalSize {
+//     /// Return the size of the object itself and all objects it refers to.
+//     fn total_size(&self) -> usize {
+//         0
+//     }
+// }
+
+// impl<T: HeapSize> TotalSize for T {
+//     fn total_size(&self) -> usize {
+//         self.heap_size() + mem::size_of::<T>()
+//     }
+// }
+
 pub trait HeapSize {
+    /// Return the size of objects it refers to.
     fn heap_size(&self) -> usize {
         0
     }

--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -39472,6 +39472,79 @@
           "yBucketSize": null
         },
         {
+          "cards": {
+            "cardPadding": null,
+            "cardRound": null
+          },
+          "color": {
+            "cardColor": "#b4ff00",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateSpectral",
+            "exponent": 0.5,
+            "mode": "spectrum"
+          },
+          "dataFormat": "tsbuckets",
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "The backoff duration before starting initial scan",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 70
+          },
+          "heatmap": {},
+          "hideZeroBuckets": true,
+          "highlightCards": true,
+          "id": 23763573950,
+          "legend": {
+            "show": false
+          },
+          "links": [],
+          "reverseYBuckets": false,
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(rate(tikv_resolved_ts_initial_scan_backoff_duration_seconds_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (le)",
+              "format": "heatmap",
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "{{le}}",
+              "metric": "",
+              "refId": "A",
+              "step": 4
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Initial scan backoff duration",
+          "tooltip": {
+            "show": true,
+            "showHistogram": false
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "xBucketNumber": null,
+          "xBucketSize": null,
+          "yAxis": {
+            "decimals": 0,
+            "format": "s",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true,
+            "splitFactor": null
+          },
+          "yBucketBound": "upper",
+          "yBucketNumber": null,
+          "yBucketSize": null
+        },
+        {
           "aliasColors": {},
           "bars": false,
           "dashLength": 10,


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #14864

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
* Fix resolved ts OOM caused by adding large txns locks to `ResolverStatus`.
* Add initial scan backoff duration metrics.
```

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
