### PR TITLE
raftstore-v2: consider unmatch between region range and tablet range for mvcc scan

### DIFF
--- a/src/server/debug2.rs
+++ b/src/server/debug2.rs
@@ -1,6 +1,6 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{sync::Arc, thread::JoinHandle};
+use std::{path::Path, sync::Arc, thread::JoinHandle};
 
 use engine_rocks::{
     raw::CompactOptions, util::get_cf_handle, RocksEngine, RocksEngineIterator, RocksStatistics,
@@ -10,7 +10,7 @@ use engine_traits::{
     TabletRegistry, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE,
 };
 use futures::future::Future;
-use keys::{data_key, DATA_MAX_KEY, DATA_PREFIX_KEY};
+use keys::{data_key, enc_end_key, enc_start_key, DATA_MAX_KEY, DATA_PREFIX_KEY};
 use kvproto::{
     debugpb::Db as DbType,
     kvrpcpb::MvccInfo,
@@ -19,6 +19,7 @@ use kvproto::{
 };
 use nom::AsBytes;
 use raft::{prelude::Entry, RawNode};
+use raft_log_engine::RaftLogEngine;
 use raftstore::{
     coprocessor::{get_region_approximate_middle, get_region_approximate_size},
     store::util::check_key_in_region,
@@ -35,6 +36,34 @@ use crate::{
     server::debug::{dump_default_cf_properties, dump_write_cf_properties, Error, Result},
     storage::mvcc::{MvccInfoCollector, MvccInfoScanner},
 };
+
+// `key1` and `key2` should both be start_key or end_key.
+fn smaller_key<'a>(key1: &'a [u8], key2: &'a [u8], end_key: bool) -> &'a [u8] {
+    if end_key && key1.is_empty() {
+        return key2;
+    }
+    if end_key && key2.is_empty() {
+        return key1;
+    }
+    if key1 < key2 {
+        return key1;
+    }
+    key2
+}
+
+// `key1` and `key2` should both be start_key or end_key.
+fn larger_key<'a>(key1: &'a [u8], key2: &'a [u8], end_key: bool) -> &'a [u8] {
+    if end_key && key1.is_empty() {
+        return key1;
+    }
+    if end_key && key2.is_empty() {
+        return key2;
+    }
+    if key1 < key2 {
+        return key2;
+    }
+    key1
+}
 
 // return the region containing the seek_key or the next region if not existed
 fn seek_region(
@@ -98,11 +127,16 @@ impl MvccInfoIteratorV2 {
             )?;
 
             let tablet = tablet_cache.latest().unwrap();
+            let region_start_key = enc_start_key(first_region_state.get_region());
+            let region_end_key = enc_end_key(first_region_state.get_region());
+            let iter_start = larger_key(start, &region_start_key, false);
+            let iter_end = smaller_key(end, &region_end_key, true);
+            assert!(!iter_start.is_empty() && !iter_start.is_empty());
             let scanner = Some(
                 MvccInfoScanner::new(
                     |cf, opts| tablet.iterator_opt(cf, opts).map_err(|e| box_err!(e)),
-                    if start.is_empty() { None } else { Some(start) },
-                    if end.is_empty() { None } else { Some(end) },
+                    Some(iter_start),
+                    Some(iter_end),
                     MvccInfoCollector::default(),
                 )
                 .map_err(|e| -> Error { box_err!(e) })?,
@@ -171,19 +205,16 @@ impl Iterator for MvccInfoIteratorV2 {
                     )
                     .unwrap();
                     let tablet = tablet_cache.latest().unwrap();
+                    let region_start_key = enc_start_key(&self.cur_region);
+                    let region_end_key = enc_end_key(&self.cur_region);
+                    let iter_start = larger_key(&self.start, &region_start_key, false);
+                    let iter_end = smaller_key(&self.end, &region_end_key, true);
+                    assert!(!iter_start.is_empty() && !iter_start.is_empty());
                     self.scanner = Some(
                         MvccInfoScanner::new(
                             |cf, opts| tablet.iterator_opt(cf, opts).map_err(|e| box_err!(e)),
-                            if self.start.is_empty() {
-                                None
-                            } else {
-                                Some(self.start.as_bytes())
-                            },
-                            if self.end.is_empty() {
-                                None
-                            } else {
-                                Some(self.end.as_bytes())
-                            },
+                            Some(iter_start),
+                            Some(iter_end),
                             MvccInfoCollector::default(),
                         )
                         .unwrap(),
@@ -1154,38 +1185,27 @@ fn deivde_regions_for_concurrency<ER: RaftEngine>(
     Ok(regions_groups)
 }
 
-// `key1` and `key2` should both be start_key or end_key.
-fn smaller_key<'a>(key1: &'a [u8], key2: &'a [u8], end_key: bool) -> &'a [u8] {
-    if end_key && key1.is_empty() {
-        return key2;
-    }
-    if end_key && key2.is_empty() {
-        return key1;
-    }
-    if key1 < key2 {
-        return key1;
-    }
-    key2
-}
+#[cfg(any(test, feature = "testexport"))]
+pub fn new_debugger(path: &Path) -> DebuggerImplV2<RaftLogEngine> {
+    use crate::{config::TikvConfig, server::KvEngineFactoryBuilder};
 
-// `key1` and `key2` should both be start_key or end_key.
-fn larger_key<'a>(key1: &'a [u8], key2: &'a [u8], end_key: bool) -> &'a [u8] {
-    if end_key && key1.is_empty() {
-        return key1;
-    }
-    if end_key && key2.is_empty() {
-        return key2;
-    }
-    if key1 < key2 {
-        return key2;
-    }
-    key1
+    let mut cfg = TikvConfig::default();
+    cfg.storage.data_dir = path.to_str().unwrap().to_string();
+    cfg.raft_store.raftdb_path = cfg.infer_raft_db_path(None).unwrap();
+    cfg.raft_engine.mut_config().dir = cfg.infer_raft_engine_path(None).unwrap();
+    let cache = cfg.storage.block_cache.build_shared_cache();
+    let env = cfg.build_shared_rocks_env(None, None).unwrap();
+
+    let factory = KvEngineFactoryBuilder::new(env, &cfg, cache, None).build();
+    let reg = TabletRegistry::new(Box::new(factory), path).unwrap();
+
+    let raft_engine = RaftLogEngine::new(cfg.raft_engine.config(), None, None).unwrap();
+
+    DebuggerImplV2::new(reg, raft_engine, ConfigController::default())
 }
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
-
     use collections::HashMap;
     use engine_traits::{
         RaftEngineReadOnly, RaftLogBatch, SyncMutable, ALL_CFS, CF_DEFAULT, CF_LOCK, CF_WRITE,
@@ -1196,35 +1216,12 @@ mod tests {
         raft_serverpb::*,
     };
     use raft::prelude::EntryType;
-    use raft_log_engine::RaftLogEngine;
     use raftstore::store::RAFT_INIT_LOG_INDEX;
     use tikv_util::store::new_peer;
 
     use super::*;
-    use crate::{
-        config::TikvConfig,
-        server::KvEngineFactoryBuilder,
-        storage::{txn::tests::must_prewrite_put, TestEngineBuilder},
-    };
 
-    const INITIAL_TABLET_INDEX: u64 = 5;
     const INITIAL_APPLY_INDEX: u64 = 5;
-
-    fn new_debugger(path: &Path) -> DebuggerImplV2<RaftLogEngine> {
-        let mut cfg = TikvConfig::default();
-        cfg.storage.data_dir = path.to_str().unwrap().to_string();
-        cfg.raft_store.raftdb_path = cfg.infer_raft_db_path(None).unwrap();
-        cfg.raft_engine.mut_config().dir = cfg.infer_raft_engine_path(None).unwrap();
-        let cache = cfg.storage.block_cache.build_shared_cache();
-        let env = cfg.build_shared_rocks_env(None, None).unwrap();
-
-        let factory = KvEngineFactoryBuilder::new(env, &cfg, cache, None).build();
-        let reg = TabletRegistry::new(Box::new(factory), path).unwrap();
-
-        let raft_engine = RaftLogEngine::new(cfg.raft_engine.config(), None, None).unwrap();
-
-        DebuggerImplV2::new(reg, raft_engine, ConfigController::default())
-    }
 
     impl<ER: RaftEngine> DebuggerImplV2<ER> {
         fn set_store_id(&self, store_id: u64) {
@@ -1456,123 +1453,6 @@ mod tests {
         wb.put_region_state(region_id, 10, &state).unwrap();
         raft_engine.consume(&mut wb, true).unwrap();
         debugger.region_size(region_id, cfs.clone()).unwrap_err();
-    }
-
-    // For simplicity, the format of the key is inline with data in
-    // prepare_data_on_disk
-    fn extract_key(key: &[u8]) -> &[u8] {
-        &key[1..4]
-    }
-
-    // Prepare some data
-    // Data for each region:
-    // Region 1: k00 .. k04
-    // Region 2: k05 .. k09
-    // Region 3: k10 .. k14
-    // Region 4: k15 .. k19  <tombstone>
-    // Region 5: k20 .. k24
-    // Region 6: k26 .. k28  <range of region and tablet not matched>
-    fn prepare_data_on_disk(path: &Path) {
-        let mut cfg = TikvConfig::default();
-        cfg.storage.data_dir = path.to_str().unwrap().to_string();
-        cfg.raft_store.raftdb_path = cfg.infer_raft_db_path(None).unwrap();
-        cfg.raft_engine.mut_config().dir = cfg.infer_raft_engine_path(None).unwrap();
-        cfg.gc.enable_compaction_filter = false;
-        let cache = cfg.storage.block_cache.build_shared_cache();
-        let env = cfg.build_shared_rocks_env(None, None).unwrap();
-
-        let factory = KvEngineFactoryBuilder::new(env, &cfg, cache, None).build();
-        let reg = TabletRegistry::new(Box::new(factory), path).unwrap();
-
-        let raft_engine = RaftLogEngine::new(cfg.raft_engine.config(), None, None).unwrap();
-        let mut wb = raft_engine.log_batch(5);
-        for i in 0..6 {
-            let mut region = metapb::Region::default();
-            let start_key = format!("k{:02}", i * 5);
-            let end_key = format!("k{:02}", (i + 1) * 5);
-            region.set_id(i + 1);
-            region.set_start_key(start_key.into_bytes());
-            region.set_end_key(end_key.into_bytes());
-            let mut region_state = RegionLocalState::default();
-            region_state.set_tablet_index(INITIAL_TABLET_INDEX);
-            if region.get_id() == 4 {
-                region_state.set_state(PeerState::Tombstone);
-            } else if region.get_id() == 6 {
-                region.set_start_key(b"k26".to_vec());
-                region.set_end_key(b"k28".to_vec());
-            }
-            region_state.set_region(region);
-
-            let tablet_path = reg.tablet_path(i + 1, INITIAL_TABLET_INDEX);
-            // Use tikv_kv::RocksEngine instead of loading tablet from registry in order to
-            // use prewrite method to prepare mvcc data
-            let mut engine = TestEngineBuilder::new().path(tablet_path).build().unwrap();
-            for i in i * 5..(i + 1) * 5 {
-                let key = format!("zk{:02}", i);
-                let val = format!("val{:02}", i);
-                // Use prewrite only is enough for preparing mvcc data
-                must_prewrite_put(
-                    &mut engine,
-                    key.as_bytes(),
-                    val.as_bytes(),
-                    key.as_bytes(),
-                    10,
-                );
-            }
-
-            wb.put_region_state(i + 1, INITIAL_APPLY_INDEX, &region_state)
-                .unwrap();
-        }
-        raft_engine.consume(&mut wb, true).unwrap();
-    }
-
-    #[test]
-    fn test_scan_mvcc() {
-        let dir = test_util::temp_dir("test-debugger", false);
-        prepare_data_on_disk(dir.path());
-        let debugger = new_debugger(dir.path());
-        // Test scan with bad start, end or limit.
-        assert!(debugger.scan_mvcc(b"z", b"", 0).is_err());
-        assert!(debugger.scan_mvcc(b"z", b"x", 3).is_err());
-
-        let verify_scanner =
-            |range, scanner: &mut dyn Iterator<Item = raftstore::Result<(Vec<u8>, MvccInfo)>>| {
-                for i in range {
-                    let key = format!("k{:02}", i).into_bytes();
-                    assert_eq!(key, extract_key(&scanner.next().unwrap().unwrap().0));
-                }
-            };
-
-        // full scann
-        let mut scanner = debugger.scan_mvcc(b"", b"", 100).unwrap();
-        verify_scanner(0..15, &mut scanner);
-        verify_scanner(20..25, &mut scanner);
-        verify_scanner(26..28, &mut scanner);
-        assert!(scanner.next().is_none());
-
-        // Range has more elements than limit
-        let mut scanner = debugger.scan_mvcc(b"zk01", b"zk09", 5).unwrap();
-        verify_scanner(1..6, &mut scanner);
-        assert!(scanner.next().is_none());
-
-        // Range has less elements than limit
-        let mut scanner = debugger.scan_mvcc(b"zk07", b"zk10", 10).unwrap();
-        verify_scanner(7..10, &mut scanner);
-        assert!(scanner.next().is_none());
-
-        // Start from the key where no region contains it
-        let mut scanner = debugger.scan_mvcc(b"zk16", b"", 100).unwrap();
-        verify_scanner(20..25, &mut scanner);
-        verify_scanner(26..28, &mut scanner);
-        assert!(scanner.next().is_none());
-
-        // Scan a range not existed in the cluster
-        let mut scanner = debugger.scan_mvcc(b"zk16", b"zk19", 100).unwrap();
-        assert!(scanner.next().is_none());
-
-        // The end key is less than the start_key of the first region
-        let mut scanner = debugger.scan_mvcc(b"", b"zj", 100).unwrap();
-        assert!(scanner.next().is_none());
     }
 
     #[test]

--- a/tests/failpoints/cases/mod.rs
+++ b/tests/failpoints/cases/mod.rs
@@ -7,6 +7,7 @@ mod test_bootstrap;
 mod test_cmd_epoch_checker;
 mod test_conf_change;
 mod test_coprocessor;
+mod test_debugger;
 mod test_disk_full;
 mod test_early_apply;
 mod test_encryption;

--- a/tests/failpoints/cases/test_debugger.rs
+++ b/tests/failpoints/cases/test_debugger.rs
@@ -1,0 +1,145 @@
+use std::path::Path;
+
+use engine_traits::{RaftEngine, RaftLogBatch, TabletRegistry};
+use kvproto::{
+    kvrpcpb::MvccInfo,
+    metapb,
+    raft_serverpb::{PeerState, RegionLocalState},
+};
+use raft_log_engine::RaftLogEngine;
+use test_raftstore::new_peer;
+use tikv::{
+    config::TikvConfig,
+    server::{debug::Debugger, debug2::new_debugger, KvEngineFactoryBuilder},
+    storage::{txn::tests::must_prewrite_put, TestEngineBuilder},
+};
+
+const INITIAL_TABLET_INDEX: u64 = 5;
+const INITIAL_APPLY_INDEX: u64 = 5;
+
+// Prepare some data
+// Region meta range and rocksdb range of each region:
+// Region 1: k01 .. k04 rocksdb: k00 .. k04
+// Region 2: k05 .. k09 rocksdb: k05 .. k09
+// Region 3: k10 .. k14 rocksdb: k10 .. k14
+// Region 4: k15 .. k19 rocksdb: k15 .. k19 <tombstone>
+// Region 5: k20 .. k24 rocksdb: k20 .. k24
+// Region 6: k26 .. k27 rocksdb: k25 .. k29
+fn prepare_data_on_disk(path: &Path) {
+    let mut cfg = TikvConfig::default();
+    cfg.storage.data_dir = path.to_str().unwrap().to_string();
+    cfg.raft_store.raftdb_path = cfg.infer_raft_db_path(None).unwrap();
+    cfg.raft_engine.mut_config().dir = cfg.infer_raft_engine_path(None).unwrap();
+    cfg.gc.enable_compaction_filter = false;
+    let cache = cfg.storage.block_cache.build_shared_cache();
+    let env = cfg.build_shared_rocks_env(None, None).unwrap();
+
+    let factory = KvEngineFactoryBuilder::new(env, &cfg, cache, None).build();
+    let reg = TabletRegistry::new(Box::new(factory), path).unwrap();
+
+    let raft_engine = RaftLogEngine::new(cfg.raft_engine.config(), None, None).unwrap();
+    let mut wb = raft_engine.log_batch(5);
+    for i in 0..6 {
+        let mut region = metapb::Region::default();
+        let start_key = if i != 0 {
+            format!("k{:02}", i * 5)
+        } else {
+            String::from("k01")
+        };
+        let end_key = format!("k{:02}", (i + 1) * 5);
+        region.set_id(i + 1);
+        region.set_start_key(start_key.into_bytes());
+        region.set_end_key(end_key.into_bytes());
+        let mut region_state = RegionLocalState::default();
+        region_state.set_tablet_index(INITIAL_TABLET_INDEX);
+        if region.get_id() == 4 {
+            region_state.set_state(PeerState::Tombstone);
+        } else if region.get_id() == 6 {
+            region.set_start_key(b"k26".to_vec());
+            region.set_end_key(b"k28".to_vec());
+        }
+        // add dummy peer to pass verification
+        region.mut_peers().push(new_peer(0, 0));
+        region_state.set_region(region);
+
+        let tablet_path = reg.tablet_path(i + 1, INITIAL_TABLET_INDEX);
+        // Use tikv_kv::RocksEngine instead of loading tablet from registry in order to
+        // use prewrite method to prepare mvcc data
+        let mut engine = TestEngineBuilder::new().path(tablet_path).build().unwrap();
+        for i in i * 5..(i + 1) * 5 {
+            let key = format!("zk{:02}", i);
+            let val = format!("val{:02}", i);
+            // Use prewrite only is enough for preparing mvcc data
+            must_prewrite_put(
+                &mut engine,
+                key.as_bytes(),
+                val.as_bytes(),
+                key.as_bytes(),
+                10,
+            );
+        }
+
+        wb.put_region_state(i + 1, INITIAL_APPLY_INDEX, &region_state)
+            .unwrap();
+    }
+    raft_engine.consume(&mut wb, true).unwrap();
+}
+
+// For simplicity, the format of the key is inline with data in
+// prepare_data_on_disk
+fn extract_key(key: &[u8]) -> &[u8] {
+    &key[1..4]
+}
+
+#[test]
+fn test_scan_mvcc() {
+    // We deliberately make region meta not match with rocksdb, set unlimited range
+    // compaction filter to avoid trim operation.
+    fail::cfg("unlimited_range_compaction_filter", "return").unwrap();
+
+    let dir = test_util::temp_dir("test-debugger", false);
+    prepare_data_on_disk(dir.path());
+    let debugger = new_debugger(dir.path());
+    // Test scan with bad start, end or limit.
+    assert!(debugger.scan_mvcc(b"z", b"", 0).is_err());
+    assert!(debugger.scan_mvcc(b"z", b"x", 3).is_err());
+
+    let verify_scanner =
+        |range, scanner: &mut dyn Iterator<Item = raftstore::Result<(Vec<u8>, MvccInfo)>>| {
+            for i in range {
+                let key = format!("k{:02}", i).into_bytes();
+                assert_eq!(key, extract_key(&scanner.next().unwrap().unwrap().0));
+            }
+        };
+
+    // full scan
+    let mut scanner = debugger.scan_mvcc(b"", b"", 100).unwrap();
+    verify_scanner(1..15, &mut scanner);
+    verify_scanner(20..25, &mut scanner);
+    verify_scanner(26..28, &mut scanner);
+    assert!(scanner.next().is_none());
+
+    // Range has more elements than limit
+    let mut scanner = debugger.scan_mvcc(b"zk01", b"zk09", 5).unwrap();
+    verify_scanner(1..6, &mut scanner);
+    assert!(scanner.next().is_none());
+
+    // Range has less elements than limit
+    let mut scanner = debugger.scan_mvcc(b"zk07", b"zk10", 10).unwrap();
+    verify_scanner(7..10, &mut scanner);
+    assert!(scanner.next().is_none());
+
+    // Start from the key where no region contains it
+    let mut scanner = debugger.scan_mvcc(b"zk16", b"", 100).unwrap();
+    verify_scanner(20..25, &mut scanner);
+    verify_scanner(26..28, &mut scanner);
+    assert!(scanner.next().is_none());
+
+    // Scan a range not existed in the cluster
+    let mut scanner = debugger.scan_mvcc(b"zk16", b"zk19", 100).unwrap();
+    assert!(scanner.next().is_none());
+
+    // The end key is less than the start_key of the first region
+    let mut scanner = debugger.scan_mvcc(b"", b"zj", 100).unwrap();
+    assert!(scanner.next().is_none());
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #14654

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
consider unmatch between region range and tablet range for mvcc scan
```
The origin mvcc scan unit test covers the senario where region meta range is not matched with tablet range. However, range compaction filter implicitly trim the tablet and makes the range matched.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
