### PR TITLE
resolved_ts: shrink resolver lock map

### DIFF
--- a/components/resolved_ts/src/lib.rs
+++ b/components/resolved_ts/src/lib.rs
@@ -14,6 +14,7 @@
 
 #![feature(box_patterns)]
 #![feature(result_flattening)]
+#![feature(let_chains)]
 
 #[macro_use]
 extern crate tikv_util;

--- a/components/resolved_ts/src/resolver.rs
+++ b/components/resolved_ts/src/resolver.rs
@@ -175,10 +175,9 @@ impl Resolver {
         {
             self.locks_by_key.shrink_to_fit();
         }
-        if let Some(ts) = timestamp && let Some(lock_set) = self.lock_ts_heap.get_mut(&ts) {
-            if lock_set.capacity() > lock_set.len() * cmp::max(MIN_SHRINK_RATIO, ratio) {
-                lock_set.shrink_to_fit();
-            }
+        if let Some(ts) = timestamp && let Some(lock_set) = self.lock_ts_heap.get_mut(&ts)
+            && lock_set.capacity() > lock_set.len() * cmp::max(MIN_SHRINK_RATIO, ratio) {
+            lock_set.shrink_to_fit();
         }
     }
 

--- a/components/resolved_ts/src/resolver.rs
+++ b/components/resolved_ts/src/resolver.rs
@@ -1,6 +1,6 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{cmp, collections::BTreeMap, sync::Arc};
+use std::{cmp, collections::BTreeMap, sync::Arc, time::Duration};
 
 use collections::{HashMap, HashSet};
 use raftstore::store::RegionReadProgress;
@@ -23,6 +23,8 @@ pub struct Resolver {
     locks_by_key: HashMap<Arc<[u8]>, TimeStamp>,
     // start_ts -> locked keys.
     lock_ts_heap: BTreeMap<TimeStamp, HashSet<Arc<[u8]>>>,
+    // The last shrink time.
+    last_aggressive_shrink_time: Instant,
     // The timestamps that guarantees no more commit will happen before.
     resolved_ts: TimeStamp,
     // The highest index `Resolver` had been tracked
@@ -93,6 +95,7 @@ impl Resolver {
             resolved_ts: TimeStamp::zero(),
             locks_by_key: HashMap::default(),
             lock_ts_heap: BTreeMap::new(),
+            last_aggressive_shrink_time: Instant::now_coarse(),
             read_progress,
             tracked_index: 0,
             min_ts: TimeStamp::zero(),
@@ -161,6 +164,24 @@ impl Resolver {
         key.heap_size() + std::mem::size_of::<TimeStamp>()
     }
 
+    fn shrink_ratio(&mut self, ratio: usize, timestamp: Option<TimeStamp>) {
+        // HashMap load factor is 87% approximately, leave some margin to avoid
+        // frequent rehash.
+        //
+        // See https://github.com/rust-lang/hashbrown/blob/v0.14.0/src/raw/mod.rs#L208-L220
+        const MIN_SHRINK_RATIO: usize = 2;
+        if self.locks_by_key.capacity()
+            > self.locks_by_key.len() * cmp::max(MIN_SHRINK_RATIO, ratio)
+        {
+            self.locks_by_key.shrink_to_fit();
+        }
+        if let Some(ts) = timestamp && let Some(lock_set) = self.lock_ts_heap.get_mut(&ts) {
+            if lock_set.capacity() > lock_set.len() * cmp::max(MIN_SHRINK_RATIO, ratio) {
+                lock_set.shrink_to_fit();
+            }
+        }
+    }
+
     #[must_use]
     pub fn track_lock(&mut self, start_ts: TimeStamp, key: Vec<u8>, index: Option<u64>) -> bool {
         if let Some(index) = index {
@@ -201,13 +222,22 @@ impl Resolver {
             self.region_id,
         );
 
-        let entry = self.lock_ts_heap.get_mut(&start_ts);
-        if let Some(locked_keys) = entry {
+        let mut shrink_ts = None;
+        if let Some(locked_keys) = self.lock_ts_heap.get_mut(&start_ts) {
+            // Only shrink large set, because committing a small transaction is
+            // fast and shrink adds unnecessary overhead.
+            const SHRINK_SET_CAPACITY: usize = 256;
+            if locked_keys.capacity() > SHRINK_SET_CAPACITY {
+                shrink_ts = Some(start_ts);
+            }
             locked_keys.remove(key);
             if locked_keys.is_empty() {
                 self.lock_ts_heap.remove(&start_ts);
             }
         }
+        // Use a large ratio to amortize the cost of rehash.
+        let shrink_ratio = 8;
+        self.shrink_ratio(shrink_ratio, shrink_ts);
     }
 
     /// Try to advance resolved ts.
@@ -215,11 +245,20 @@ impl Resolver {
     /// `min_ts` advances the resolver even if there is no write.
     /// Return None means the resolver is not initialized.
     pub fn resolve(&mut self, min_ts: TimeStamp, now: Option<Instant>) -> TimeStamp {
+        // Use a small ratio to shrink the memory usage aggressively.
+        const AGGRESSIVE_SHRINK_RATIO: usize = 2;
+        const AGGRESSIVE_SHRINK_INTERVAL: Duration = Duration::from_secs(5);
+        if self.last_aggressive_shrink_time.saturating_elapsed() > AGGRESSIVE_SHRINK_INTERVAL {
+            self.shrink_ratio(AGGRESSIVE_SHRINK_RATIO, None);
+            self.last_aggressive_shrink_time = Instant::now_coarse();
+        }
+
         // The `Resolver` is stopped, not need to advance, just return the current
         // `resolved_ts`
         if self.stopped {
             return self.resolved_ts;
         }
+
         // Find the min start ts.
         let min_lock = self.lock_ts_heap.keys().next().cloned();
         let has_lock = min_lock.is_some();
@@ -406,5 +445,80 @@ mod tests {
         assert_eq!(memory_quota.in_use(), 1024 - 5 * lock_size - remain);
         drop(resolver);
         assert_eq!(memory_quota.in_use(), 0);
+    }
+
+    #[test]
+    fn test_untrack_lock_shrink_ratio() {
+        let memory_quota = Arc::new(MemoryQuota::new(std::usize::MAX));
+        let mut resolver = Resolver::new(1, memory_quota);
+        let mut key = vec![0; 16];
+        let mut ts = TimeStamp::default();
+        for _ in 0..1000 {
+            ts.incr();
+            key[0..8].copy_from_slice(&ts.into_inner().to_be_bytes());
+            let _ = resolver.track_lock(ts, key.clone(), None);
+        }
+        assert!(
+            resolver.locks_by_key.capacity() >= 1000,
+            "{}",
+            resolver.locks_by_key.capacity()
+        );
+
+        let mut ts = TimeStamp::default();
+        for _ in 0..901 {
+            ts.incr();
+            key[0..8].copy_from_slice(&ts.into_inner().to_be_bytes());
+            resolver.untrack_lock(&key, None);
+        }
+        // shrink_to_fit may reserve some space in accordance with the resize
+        // policy, but it is expected to be less than 500.
+        assert!(
+            resolver.locks_by_key.capacity() < 500,
+            "{}, {}",
+            resolver.locks_by_key.capacity(),
+            resolver.locks_by_key.len(),
+        );
+
+        for _ in 0..99 {
+            ts.incr();
+            key[0..8].copy_from_slice(&ts.into_inner().to_be_bytes());
+            resolver.untrack_lock(&key, None);
+        }
+        assert!(
+            resolver.locks_by_key.capacity() < 100,
+            "{}, {}",
+            resolver.locks_by_key.capacity(),
+            resolver.locks_by_key.len(),
+        );
+    }
+
+    #[test]
+    fn test_untrack_lock_set_shrink_ratio() {
+        let memory_quota = Arc::new(MemoryQuota::new(std::usize::MAX));
+        let mut resolver = Resolver::new(1, memory_quota);
+        let mut key = vec![0; 16];
+        let ts = TimeStamp::new(1);
+        for i in 0..1000usize {
+            key[0..8].copy_from_slice(&i.to_be_bytes());
+            let _ = resolver.track_lock(ts, key.clone(), None);
+        }
+        assert!(
+            resolver.lock_ts_heap[&ts].capacity() >= 1000,
+            "{}",
+            resolver.lock_ts_heap[&ts].capacity()
+        );
+
+        for i in 0..990usize {
+            key[0..8].copy_from_slice(&i.to_be_bytes());
+            resolver.untrack_lock(&key, None);
+        }
+        // shrink_to_fit may reserve some space in accordance with the resize
+        // policy, but it is expected to be less than 100.
+        assert!(
+            resolver.lock_ts_heap[&ts].capacity() < 500,
+            "{}, {}",
+            resolver.lock_ts_heap[&ts].capacity(),
+            resolver.lock_ts_heap[&ts].len(),
+        );
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format: 
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #15458

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Resolver owns a hash map to tracking locks and unlock events, and so
for calculating resolved ts. However, it does not shrink map even after
all lock are removed, this may result OOM if there are transactions
that modify many rows across many regions. The total memory usage is
proportional to the number of modified rows.
```

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)

```mysql
sysbench --db-driver=mysql --mysql-host=<HOST> --mysql-port=<PORT> --mysql-user=root \
        --mysql-db=test --tables=2 --table-size=100000000 --create_secondary=false \
        ./oltp_update_index prepare

-- warm up cache and others.
update sbtest1 set c='a';

-- sbtest2 leak.
update sbtest2 set c='b';
```

Master Branch | This Fix
-- | --
![image](https://github.com/tikv/tikv/assets/2150711/f1922b7b-c00d-4a7a-9921-dfbf029e7014) | ![image](https://github.com/tikv/tikv/assets/2150711/23a84c08-c91a-4cad-b13e-81266d1fbf90)
 
### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix an issue that TiKV may OOM if many keys are being modified concurrently.
```
