### PR TITLE
cdc: deregister delegate if memory quota exceeded

### DIFF
--- a/components/cdc/src/channel.rs
+++ b/components/cdc/src/channel.rs
@@ -52,6 +52,9 @@ pub enum CdcEvent {
 
 impl CdcEvent {
     pub fn size(&self) -> u32 {
+        fail::fail_point!("cdc_event_size", |size| size
+            .map(|s| s.parse::<u32>().unwrap())
+            .unwrap_or(0));
         match self {
             CdcEvent::ResolvedTs(ref r) => {
                 // For region id, it is unlikely to exceed 100,000,000 which is

--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -28,9 +28,13 @@ use raftstore::{
     store::util::compare_region_epoch,
     Error as RaftStoreError,
 };
-use resolved_ts::Resolver;
+use resolved_ts::{Resolver, ON_DROP_WARN_HEAP_SIZE};
 use tikv::storage::{txn::TxnEntry, Statistics};
-use tikv_util::{debug, info, warn};
+use tikv_util::{
+    debug, info,
+    memory::{HeapSize, MemoryQuota},
+    warn,
+};
 use txn_types::{Key, Lock, LockType, TimeStamp, WriteBatchFlags, WriteRef, WriteType};
 
 use crate::{
@@ -226,22 +230,88 @@ impl Downstream {
     }
 }
 
-#[derive(Default)]
 struct Pending {
-    pub downstreams: Vec<Downstream>,
-    pub locks: Vec<PendingLock>,
-    pub pending_bytes: usize,
+    downstreams: Vec<Downstream>,
+    locks: Vec<PendingLock>,
+    pending_bytes: usize,
+    memory_quota: Arc<MemoryQuota>,
+}
+
+impl Pending {
+    fn new(memory_quota: Arc<MemoryQuota>) -> Pending {
+        Pending {
+            downstreams: vec![],
+            locks: vec![],
+            pending_bytes: 0,
+            memory_quota,
+        }
+    }
+
+    fn push_pending_lock(&mut self, lock: PendingLock) -> Result<()> {
+        let bytes = lock.heap_size();
+        if !self.memory_quota.alloc(bytes) {
+            return Err(Error::MemoryQuotaExceeded);
+        }
+        self.locks.push(lock);
+        self.pending_bytes += bytes;
+        CDC_PENDING_BYTES_GAUGE.add(bytes as i64);
+        Ok(())
+    }
+
+    fn on_region_ready(&mut self, resolver: &mut Resolver) -> Result<()> {
+        // Must replace with an empty vec, otherwise it may double free memory quota.
+        for lock in mem::replace(&mut self.locks, vec![]) {
+            self.memory_quota.free(lock.heap_size());
+            match lock {
+                PendingLock::Track { key, start_ts } => {
+                    if !resolver.track_lock(start_ts, key, None) {
+                        return Err(Error::MemoryQuotaExceeded);
+                    }
+                }
+                PendingLock::Untrack { key } => resolver.untrack_lock(&key, None),
+            }
+        }
+        Ok(())
+    }
 }
 
 impl Drop for Pending {
     fn drop(&mut self) {
         CDC_PENDING_BYTES_GAUGE.sub(self.pending_bytes as i64);
+        let locks = mem::take(&mut self.locks);
+        if locks.is_empty() {
+            return;
+        }
+
+        // Free memory quota used by pending locks and unlocks.
+        let mut bytes = 0;
+        let num_locks = locks.len();
+        for lock in locks {
+            bytes += lock.heap_size();
+        }
+        if bytes > ON_DROP_WARN_HEAP_SIZE {
+            warn!("cdc drop huge Pending";
+                "bytes" => bytes,
+                "num_locks" => num_locks,
+                "memory_quota_in_use" => self.memory_quota.in_use(),
+                "memory_quota_capacity" => self.memory_quota.capacity(),
+            );
+        }
+        self.memory_quota.free(bytes);
     }
 }
 
 enum PendingLock {
     Track { key: Vec<u8>, start_ts: TimeStamp },
     Untrack { key: Vec<u8> },
+}
+
+impl HeapSize for PendingLock {
+    fn heap_size(&self) -> usize {
+        match self {
+            PendingLock::Track { key, .. } | PendingLock::Untrack { key } => key.heap_size(),
+        }
+    }
 }
 
 /// A CDC delegate of a raftstore region peer.
@@ -265,14 +335,18 @@ pub struct Delegate {
 
 impl Delegate {
     /// Create a Delegate the given region.
-    pub fn new(region_id: u64, txn_extra_op: Arc<AtomicCell<TxnExtraOp>>) -> Delegate {
+    pub fn new(
+        region_id: u64,
+        txn_extra_op: Arc<AtomicCell<TxnExtraOp>>,
+        memory_quota: Arc<MemoryQuota>,
+    ) -> Delegate {
         Delegate {
             region_id,
             handle: ObserveHandle::new(),
             resolver: None,
             region: None,
             resolved_downstreams: Vec::new(),
-            pending: Some(Pending::default()),
+            pending: Some(Pending::new(memory_quota)),
             txn_extra_op,
             failed: false,
         }
@@ -395,7 +469,7 @@ impl Delegate {
         &mut self,
         mut resolver: Resolver,
         region: Region,
-    ) -> Vec<(&Downstream, Error)> {
+    ) -> Result<Vec<(&Downstream, Error)>> {
         assert!(
             self.resolver.is_none(),
             "region {} resolver should not be ready",
@@ -412,15 +486,7 @@ impl Delegate {
         self.region = Some(region);
         info!("cdc region is ready"; "region_id" => self.region_id);
 
-        for lock in mem::take(&mut pending.locks) {
-            match lock {
-                PendingLock::Track { key, start_ts } => {
-                    // TODO: handle memory quota exceed, for now, quota is set to usize::MAX.
-                    assert!(resolver.track_lock(start_ts, key, None));
-                }
-                PendingLock::Untrack { key } => resolver.untrack_lock(&key, None),
-            }
-        }
+        pending.on_region_ready(&mut resolver)?;
         self.resolver = Some(resolver);
 
         self.resolved_downstreams = mem::take(&mut pending.downstreams);
@@ -430,7 +496,7 @@ impl Delegate {
                 failed_downstreams.push((downstream, e));
             }
         }
-        failed_downstreams
+        Ok(failed_downstreams)
     }
 
     /// Try advance and broadcast resolved ts.
@@ -621,7 +687,7 @@ impl Delegate {
                         &mut read_old_value,
                     )?;
                 }
-                CmdType::Delete => self.sink_delete(req.take_delete()),
+                CmdType::Delete => self.sink_delete(req.take_delete())?,
                 _ => {
                     debug!(
                         "skip other command";
@@ -825,18 +891,17 @@ impl Delegate {
                 // In order to compute resolved ts, we must track inflight txns.
                 match self.resolver {
                     Some(ref mut resolver) => {
-                        // TODO: handle memory quota exceed, for now, quota is set to usize::MAX.
-                        assert!(resolver.track_lock(row.start_ts.into(), row.key.clone(), None));
+                        if !resolver.track_lock(row.start_ts.into(), row.key.clone(), None) {
+                            return Err(Error::MemoryQuotaExceeded);
+                        }
                     }
                     None => {
                         assert!(self.pending.is_some(), "region resolver not ready");
                         let pending = self.pending.as_mut().unwrap();
-                        pending.locks.push(PendingLock::Track {
+                        pending.push_pending_lock(PendingLock::Track {
                             key: row.key.clone(),
                             start_ts: row.start_ts.into(),
-                        });
-                        pending.pending_bytes += row.key.len();
-                        CDC_PENDING_BYTES_GAUGE.add(row.key.len() as i64);
+                        })?;
                     }
                 }
 
@@ -858,7 +923,7 @@ impl Delegate {
         Ok(())
     }
 
-    fn sink_delete(&mut self, mut delete: DeleteRequest) {
+    fn sink_delete(&mut self, mut delete: DeleteRequest) -> Result<()> {
         match delete.cf.as_str() {
             "lock" => {
                 let raw_key = Key::from_encoded(delete.take_key()).into_raw().unwrap();
@@ -866,11 +931,8 @@ impl Delegate {
                     Some(ref mut resolver) => resolver.untrack_lock(&raw_key, None),
                     None => {
                         assert!(self.pending.is_some(), "region resolver not ready");
-                        let key_len = raw_key.len();
                         let pending = self.pending.as_mut().unwrap();
-                        pending.locks.push(PendingLock::Untrack { key: raw_key });
-                        pending.pending_bytes += key_len;
-                        CDC_PENDING_BYTES_GAUGE.add(key_len as i64);
+                        pending.push_pending_lock(PendingLock::Untrack { key: raw_key })?;
                     }
                 }
             }
@@ -879,6 +941,7 @@ impl Delegate {
                 panic!("invalid cf {}", other);
             }
         }
+        Ok(())
     }
 
     fn sink_admin(&mut self, request: AdminRequest, mut response: AdminResponse) -> Result<()> {
@@ -1184,12 +1247,18 @@ mod tests {
             ObservedRange::default(),
         );
         downstream.set_sink(sink);
-        let mut delegate = Delegate::new(region_id, Default::default());
+        let memory_quota = Arc::new(MemoryQuota::new(usize::MAX));
+        let mut delegate = Delegate::new(region_id, Default::default(), memory_quota);
         delegate.subscribe(downstream).unwrap();
         assert!(delegate.handle.is_observing());
         let memory_quota = Arc::new(MemoryQuota::new(std::usize::MAX));
         let resolver = Resolver::new(region_id, memory_quota);
-        assert!(delegate.on_region_ready(resolver, region).is_empty());
+        assert!(
+            delegate
+                .on_region_ready(resolver, region)
+                .unwrap()
+                .is_empty()
+        );
         assert!(delegate.downstreams()[0].observed_range.all_key_covered);
 
         let rx_wrap = Cell::new(Some(rx));
@@ -1313,8 +1382,9 @@ mod tests {
         };
 
         // Create a new delegate.
+        let memory_quota = Arc::new(MemoryQuota::new(usize::MAX));
         let txn_extra_op = Arc::new(AtomicCell::new(TxnExtraOp::Noop));
-        let mut delegate = Delegate::new(1, txn_extra_op.clone());
+        let mut delegate = Delegate::new(1, txn_extra_op.clone(), memory_quota);
         assert_eq!(txn_extra_op.load(), TxnExtraOp::Noop);
         assert!(delegate.handle.is_observing());
 
@@ -1340,7 +1410,9 @@ mod tests {
         region.mut_region_epoch().set_version(1);
         {
             let memory_quota = Arc::new(MemoryQuota::new(std::usize::MAX));
-            let failures = delegate.on_region_ready(Resolver::new(1, memory_quota), region);
+            let failures = delegate
+                .on_region_ready(Resolver::new(1, memory_quota), region)
+                .unwrap();
             assert_eq!(failures.len(), 1);
             let id = failures[0].0.id;
             delegate.unsubscribe(id, None);
@@ -1431,8 +1503,9 @@ mod tests {
             Key::from_raw(b"d").into_encoded(),
         )
         .unwrap();
+        let memory_quota = Arc::new(MemoryQuota::new(usize::MAX));
         let txn_extra_op = Arc::new(AtomicCell::new(TxnExtraOp::Noop));
-        let mut delegate = Delegate::new(1, txn_extra_op);
+        let mut delegate = Delegate::new(1, txn_extra_op, memory_quota);
         assert!(delegate.handle.is_observing());
 
         let mut map = HashMap::default();
@@ -1500,8 +1573,9 @@ mod tests {
             Key::from_raw(b"f").into_encoded(),
         )
         .unwrap();
+        let memory_quota = Arc::new(MemoryQuota::new(usize::MAX));
         let txn_extra_op = Arc::new(AtomicCell::new(TxnExtraOp::Noop));
-        let mut delegate = Delegate::new(1, txn_extra_op);
+        let mut delegate = Delegate::new(1, txn_extra_op, memory_quota);
         assert!(delegate.handle.is_observing());
 
         let mut map = HashMap::default();

--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -262,8 +262,8 @@ impl Pending {
         fail::fail_point!("cdc_pending_on_region_ready", |_| Err(
             Error::MemoryQuotaExceeded
         ));
-        // Must replace with an empty vec, otherwise it may double free memory quota.
-        for lock in mem::replace(&mut self.locks, vec![]) {
+        // Must take locks, otherwise it may double free memory quota on drop.
+        for lock in mem::take(&mut self.locks) {
             self.memory_quota.free(lock.heap_size());
             match lock {
                 PendingLock::Track { key, start_ts } => {

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -709,7 +709,11 @@ impl<T: 'static + CdcHandle<E>, E: KvEngine, S: StoreRegionMeta> Endpoint<T, E, 
             HashMapEntry::Occupied(e) => e.into_mut(),
             HashMapEntry::Vacant(e) => {
                 is_new_delegate = true;
-                e.insert(Delegate::new(region_id, txn_extra_op))
+                e.insert(Delegate::new(
+                    region_id,
+                    txn_extra_op,
+                    self.sink_memory_quota.clone(),
+                ))
             }
         };
 
@@ -775,10 +779,11 @@ impl<T: 'static + CdcHandle<E>, E: KvEngine, S: StoreRegionMeta> Endpoint<T, E, 
 
         let cdc_handle = self.cdc_handle.clone();
         let concurrency_semaphore = self.scan_concurrency_semaphore.clone();
+        let memory_quota = self.sink_memory_quota.clone();
         self.workers.spawn(async move {
             CDC_SCAN_TASKS.with_label_values(&["total"]).inc();
             match init
-                .initialize(change_cmd, cdc_handle, concurrency_semaphore)
+                .initialize(change_cmd, cdc_handle, concurrency_semaphore, memory_quota)
                 .await
             {
                 Ok(()) => {
@@ -831,18 +836,26 @@ impl<T: 'static + CdcHandle<E>, E: KvEngine, S: StoreRegionMeta> Endpoint<T, E, 
 
     fn on_region_ready(&mut self, observe_id: ObserveId, resolver: Resolver, region: Region) {
         let region_id = region.get_id();
-        let mut failed_downstreams = Vec::new();
+        let mut deregisters = Vec::new();
         if let Some(delegate) = self.capture_regions.get_mut(&region_id) {
             if delegate.handle.id == observe_id {
-                let region_id = delegate.region_id;
-                for (downstream, e) in delegate.on_region_ready(resolver, region) {
-                    failed_downstreams.push(Deregister::Downstream {
-                        conn_id: downstream.get_conn_id(),
-                        request_id: downstream.get_req_id(),
+                match delegate.on_region_ready(resolver, region) {
+                    Ok(fails) => {
+                        for (downstream, e) in fails {
+                            deregisters.push(Deregister::Downstream {
+                                conn_id: downstream.get_conn_id(),
+                                request_id: downstream.get_req_id(),
+                                region_id,
+                                downstream_id: downstream.get_id(),
+                                err: Some(e),
+                            });
+                        }
+                    }
+                    Err(e) => deregisters.push(Deregister::Delegate {
                         region_id,
-                        downstream_id: downstream.get_id(),
-                        err: Some(e),
-                    });
+                        observe_id,
+                        err: e,
+                    }),
                 }
             } else {
                 debug!("cdc stale region ready";
@@ -856,7 +869,7 @@ impl<T: 'static + CdcHandle<E>, E: KvEngine, S: StoreRegionMeta> Endpoint<T, E, 
         }
 
         // Deregister downstreams if there is any downstream fails to subscribe.
-        for deregister in failed_downstreams {
+        for deregister in deregisters {
             self.on_deregister(deregister);
         }
     }
@@ -2612,7 +2625,8 @@ mod tests {
                 .capture_regions
                 .get_mut(&id)
                 .unwrap()
-                .on_region_ready(resolver, region);
+                .on_region_ready(resolver, region)
+                .unwrap();
             assert!(failed.is_empty());
         }
         suite

--- a/components/cdc/src/errors.rs
+++ b/components/cdc/src/errors.rs
@@ -35,6 +35,8 @@ pub enum Error {
     EngineTraits(#[from] EngineTraitsError),
     #[error("Sink send error {0:?}")]
     Sink(#[from] SendError),
+    #[error("Memory quota exceeded")]
+    MemoryQuotaExceeded,
 }
 
 macro_rules! impl_from {

--- a/components/cdc/src/initializer.rs
+++ b/components/cdc/src/initializer.rs
@@ -811,7 +811,7 @@ mod tests {
         initializer
             .downstream_state
             .store(DownstreamState::Initializing);
-        block_on(initializer.on_change_cmd_response(resp, memory_quota.clone())).unwrap_err();
+        block_on(initializer.on_change_cmd_response(resp, memory_quota)).unwrap_err();
 
         worker.stop();
     }

--- a/components/cdc/src/initializer.rs
+++ b/components/cdc/src/initializer.rs
@@ -108,6 +108,7 @@ impl<E: KvEngine> Initializer<E> {
         change_observer: ChangeObserver,
         cdc_handle: T,
         concurrency_semaphore: Arc<Semaphore>,
+        memory_quota: Arc<MemoryQuota>,
     ) -> Result<()> {
         fail_point!("cdc_before_initialize");
         let _permit = concurrency_semaphore.acquire().await;
@@ -173,7 +174,7 @@ impl<E: KvEngine> Initializer<E> {
         }
 
         match fut.await {
-            Ok(resp) => self.on_change_cmd_response(resp).await,
+            Ok(resp) => self.on_change_cmd_response(resp, memory_quota).await,
             Err(e) => Err(Error::Other(box_err!(e))),
         }
     }
@@ -181,11 +182,13 @@ impl<E: KvEngine> Initializer<E> {
     pub(crate) async fn on_change_cmd_response(
         &mut self,
         mut resp: ReadResponse<impl EngineSnapshot>,
+        memory_quota: Arc<MemoryQuota>,
     ) -> Result<()> {
         if let Some(region_snapshot) = resp.snapshot {
             assert_eq!(self.region_id, region_snapshot.get_region().get_id());
             let region = region_snapshot.get_region().clone();
-            self.async_incremental_scan(region_snapshot, region).await
+            self.async_incremental_scan(region_snapshot, region, memory_quota)
+                .await
         } else {
             assert!(
                 resp.response.get_header().has_error(),
@@ -201,6 +204,7 @@ impl<E: KvEngine> Initializer<E> {
         &mut self,
         snap: S,
         region: Region,
+        memory_quota: Arc<MemoryQuota>,
     ) -> Result<()> {
         let downstream_id = self.downstream_id;
         let region_id = region.get_id();
@@ -216,8 +220,6 @@ impl<E: KvEngine> Initializer<E> {
             "end_key" => log_wrappers::Value::key(snap.upper_bound().unwrap_or_default()));
 
         let mut resolver = if self.build_resolver {
-            // TODO: limit the memory usage of the resolver.
-            let memory_quota = Arc::new(MemoryQuota::new(std::usize::MAX));
             Some(Resolver::new(region_id, memory_quota))
         } else {
             None
@@ -422,9 +424,9 @@ impl<E: KvEngine> Initializer<E> {
                     let lock = Lock::parse(value)?;
                     match lock.lock_type {
                         LockType::Put | LockType::Delete => {
-                            // TODO: handle memory quota exceed, for now, quota is set to
-                            // usize::MAX.
-                            assert!(resolver.track_lock(lock.ts, key, None));
+                            if !resolver.track_lock(lock.ts, key, None) {
+                                return Err(Error::MemoryQuotaExceeded);
+                            }
                         }
                         _ => (),
                     };
@@ -745,21 +747,37 @@ mod tests {
             }
         });
 
-        block_on(initializer.async_incremental_scan(snap.clone(), region.clone())).unwrap();
+        let memory_quota = Arc::new(MemoryQuota::new(usize::MAX));
+        block_on(initializer.async_incremental_scan(
+            snap.clone(),
+            region.clone(),
+            memory_quota.clone(),
+        ))
+        .unwrap();
         check_result();
 
         initializer
             .downstream_state
             .store(DownstreamState::Initializing);
         initializer.max_scan_batch_bytes = total_bytes;
-        block_on(initializer.async_incremental_scan(snap.clone(), region.clone())).unwrap();
+        block_on(initializer.async_incremental_scan(
+            snap.clone(),
+            region.clone(),
+            memory_quota.clone(),
+        ))
+        .unwrap();
         check_result();
 
         initializer
             .downstream_state
             .store(DownstreamState::Initializing);
         initializer.build_resolver = false;
-        block_on(initializer.async_incremental_scan(snap.clone(), region.clone())).unwrap();
+        block_on(initializer.async_incremental_scan(
+            snap.clone(),
+            region.clone(),
+            memory_quota.clone(),
+        ))
+        .unwrap();
 
         loop {
             let task = rx.recv_timeout(Duration::from_millis(100));
@@ -772,7 +790,8 @@ mod tests {
 
         // Test cancellation.
         initializer.downstream_state.store(DownstreamState::Stopped);
-        block_on(initializer.async_incremental_scan(snap.clone(), region)).unwrap_err();
+        block_on(initializer.async_incremental_scan(snap.clone(), region, memory_quota.clone()))
+            .unwrap_err();
 
         // Cancel error should trigger a deregsiter.
         let mut region = Region::default();
@@ -784,14 +803,15 @@ mod tests {
             response: Default::default(),
             txn_extra_op: Default::default(),
         };
-        block_on(initializer.on_change_cmd_response(resp.clone())).unwrap_err();
+        block_on(initializer.on_change_cmd_response(resp.clone(), memory_quota.clone()))
+            .unwrap_err();
 
         // Disconnect sink by dropping runtime (it also drops drain).
         drop(pool);
         initializer
             .downstream_state
             .store(DownstreamState::Initializing);
-        block_on(initializer.on_change_cmd_response(resp)).unwrap_err();
+        block_on(initializer.on_change_cmd_response(resp, memory_quota.clone())).unwrap_err();
 
         worker.stop();
     }
@@ -819,8 +839,9 @@ mod tests {
             filter_loop,
         );
         let th = pool.spawn(async move {
+            let memory_quota = Arc::new(MemoryQuota::new(usize::MAX));
             initializer
-                .async_incremental_scan(snap, Region::default())
+                .async_incremental_scan(snap, Region::default(), memory_quota)
                 .await
                 .unwrap();
         });
@@ -904,8 +925,9 @@ mod tests {
 
                 let snap = engine.snapshot(Default::default()).unwrap();
                 let th = pool.spawn(async move {
+                    let memory_qutoa = Arc::new(MemoryQuota::new(usize::MAX));
                     initializer
-                        .async_incremental_scan(snap, Region::default())
+                        .async_incremental_scan(snap, Region::default(), memory_qutoa)
                         .await
                         .unwrap();
                 });
@@ -1017,12 +1039,14 @@ mod tests {
         let change_cmd = ChangeObserver::from_cdc(1, ObserveHandle::new());
         let raft_router = CdcRaftRouter(MockRaftStoreRouter::new());
         let concurrency_semaphore = Arc::new(Semaphore::new(1));
+        let memory_quota = Arc::new(MemoryQuota::new(usize::MAX));
 
         initializer.downstream_state.store(DownstreamState::Stopped);
         block_on(initializer.initialize(
             change_cmd,
             raft_router.clone(),
             concurrency_semaphore.clone(),
+            memory_quota.clone(),
         ))
         .unwrap_err();
 
@@ -1048,7 +1072,7 @@ mod tests {
                 &concurrency_semaphore,
             );
             let res = initializer
-                .initialize(change_cmd, raft_router, concurrency_semaphore)
+                .initialize(change_cmd, raft_router, concurrency_semaphore, memory_quota)
                 .await;
             tx1.send(res).unwrap();
         });

--- a/components/cdc/tests/failpoints/mod.rs
+++ b/components/cdc/tests/failpoints/mod.rs
@@ -4,6 +4,7 @@
 #![test_runner(test_util::run_failpoint_tests)]
 
 mod test_endpoint;
+mod test_memory_quota;
 mod test_observe;
 mod test_register;
 mod test_resolve;

--- a/components/cdc/tests/failpoints/test_memory_quota.rs
+++ b/components/cdc/tests/failpoints/test_memory_quota.rs
@@ -104,7 +104,72 @@ fn test_resolver_track_lock_memory_quota_exceeded() {
 }
 
 #[test]
-fn test_pending_lock_memory_quota_exceeded() {
+fn test_pending_on_region_ready_memory_quota_exceeded() {
+    let mut cluster = new_server_cluster(1, 1);
+    // Increase the Raft tick interval to make this test case running reliably.
+    configure_for_lease_read(&mut cluster.cfg, Some(100), None);
+    let memory_quota = 1024; // 1KB
+    let mut suite = TestSuiteBuilder::new()
+        .cluster(cluster)
+        .memory_quota(memory_quota)
+        .build();
+
+    // Let CdcEvent size be 0 to effectively disable memory quota for CdcEvent.
+    fail::cfg("cdc_event_size", "return(0)").unwrap();
+
+    // Trigger memory quota exceeded error.
+    fail::cfg("cdc_pending_on_region_ready", "return").unwrap();
+    let req = suite.new_changedata_request(1);
+    let (mut req_tx, _event_feed_wrap, receive_event) =
+        new_event_feed(suite.get_region_cdc_client(1));
+    block_on(req_tx.send((req, WriteFlags::default()))).unwrap();
+    let event = receive_event(false);
+    event.events.into_iter().for_each(|e| {
+        match e.event.unwrap() {
+            // Even if there is no write,
+            // it should always outputs an Initialized event.
+            Event_oneof_event::Entries(es) => {
+                assert!(es.entries.len() == 1, "{:?}", es);
+                let e = &es.entries[0];
+                assert_eq!(e.get_type(), EventLogType::Initialized, "{:?}", es);
+            }
+            other => panic!("unknown event {:?}", other),
+        }
+    });
+    // MemoryQuotaExceeded error is triggered on_region_ready.
+    let mut events = receive_event(false).events.to_vec();
+    assert_eq!(events.len(), 1, "{:?}", events);
+    match events.pop().unwrap().event.unwrap() {
+        Event_oneof_event::Error(e) => {
+            // Unknown errors are translated into region_not_found.
+            assert!(e.has_region_not_found(), "{:?}", e);
+        }
+        other => panic!("unknown event {:?}", other),
+    }
+
+    // The delegate must be removed.
+    let scheduler = suite.endpoints.values().next().unwrap().scheduler();
+    let (tx, rx) = mpsc::channel();
+    scheduler
+        .schedule(Task::Validate(Validate::Region(
+            1,
+            Box::new(move |delegate| {
+                tx.send(delegate.is_none()).unwrap();
+            }),
+        )))
+        .unwrap();
+
+    assert!(
+        rx.recv_timeout(Duration::from_millis(1000)).unwrap(),
+        "find unexpected delegate"
+    );
+
+    fail::remove("cdc_incremental_scan_start");
+    suite.stop();
+}
+
+#[test]
+fn test_pending_push_lock_memory_quota_exceeded() {
     let mut cluster = new_server_cluster(1, 1);
     // Increase the Raft tick interval to make this test case running reliably.
     configure_for_lease_read(&mut cluster.cfg, Some(100), None);

--- a/components/cdc/tests/failpoints/test_memory_quota.rs
+++ b/components/cdc/tests/failpoints/test_memory_quota.rs
@@ -1,0 +1,224 @@
+// Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::{sync::*, time::Duration};
+
+use cdc::{Task, Validate};
+use futures::{executor::block_on, SinkExt};
+use grpcio::WriteFlags;
+use kvproto::{cdcpb::*, kvrpcpb::*};
+use pd_client::PdClient;
+use test_raftstore::*;
+
+use crate::{new_event_feed, TestSuiteBuilder};
+
+#[test]
+fn test_resolver_track_lock_memory_quota_exceeded() {
+    let mut cluster = new_server_cluster(1, 1);
+    // Increase the Raft tick interval to make this test case running reliably.
+    configure_for_lease_read(&mut cluster.cfg, Some(100), None);
+    let memory_quota = 1024; // 1KB
+    let mut suite = TestSuiteBuilder::new()
+        .cluster(cluster)
+        .memory_quota(memory_quota)
+        .build();
+
+    // Let CdcEvent size be 0 to effectively disable memory quota for CdcEvent.
+    fail::cfg("cdc_event_size", "return(0)").unwrap();
+
+    let req = suite.new_changedata_request(1);
+    let (mut req_tx, _event_feed_wrap, receive_event) =
+        new_event_feed(suite.get_region_cdc_client(1));
+    block_on(req_tx.send((req, WriteFlags::default()))).unwrap();
+    let event = receive_event(false);
+    event.events.into_iter().for_each(|e| {
+        match e.event.unwrap() {
+            // Even if there is no write,
+            // it should always outputs an Initialized event.
+            Event_oneof_event::Entries(es) => {
+                assert!(es.entries.len() == 1, "{:?}", es);
+                let e = &es.entries[0];
+                assert_eq!(e.get_type(), EventLogType::Initialized, "{:?}", es);
+            }
+            other => panic!("unknown event {:?}", other),
+        }
+    });
+
+    // Client must receive messages when there is no congest error.
+    let key_size = memory_quota / 2;
+    let (k, v) = (vec![1; key_size], vec![5]);
+    // Prewrite
+    let start_ts = block_on(suite.cluster.pd_client.get_tso()).unwrap();
+    let mut mutation = Mutation::default();
+    mutation.set_op(Op::Put);
+    mutation.key = k.clone();
+    mutation.value = v;
+    suite.must_kv_prewrite(1, vec![mutation], k, start_ts);
+    let mut events = receive_event(false).events.to_vec();
+    assert_eq!(events.len(), 1, "{:?}", events);
+    match events.pop().unwrap().event.unwrap() {
+        Event_oneof_event::Entries(entries) => {
+            assert_eq!(entries.entries.len(), 1);
+            assert_eq!(entries.entries[0].get_type(), EventLogType::Prewrite);
+        }
+        other => panic!("unknown event {:?}", other),
+    }
+
+    // Trigger congest error.
+    let key_size = memory_quota * 2;
+    let (k, v) = (vec![2; key_size], vec![5]);
+    // Prewrite
+    let start_ts = block_on(suite.cluster.pd_client.get_tso()).unwrap();
+    let mut mutation = Mutation::default();
+    mutation.set_op(Op::Put);
+    mutation.key = k.clone();
+    mutation.value = v;
+    suite.must_kv_prewrite(1, vec![mutation], k, start_ts);
+    let mut events = receive_event(false).events.to_vec();
+    assert_eq!(events.len(), 1, "{:?}", events);
+    match events.pop().unwrap().event.unwrap() {
+        Event_oneof_event::Error(e) => {
+            // Unknown errors are translated into region_not_found.
+            assert!(e.has_region_not_found(), "{:?}", e);
+        }
+        other => panic!("unknown event {:?}", other),
+    }
+
+    // The delegate must be removed.
+    let scheduler = suite.endpoints.values().next().unwrap().scheduler();
+    let (tx, rx) = mpsc::channel();
+    scheduler
+        .schedule(Task::Validate(Validate::Region(
+            1,
+            Box::new(move |delegate| {
+                tx.send(delegate.is_none()).unwrap();
+            }),
+        )))
+        .unwrap();
+
+    assert!(
+        rx.recv_timeout(Duration::from_millis(1000)).unwrap(),
+        "find unexpected delegate"
+    );
+
+    suite.stop();
+}
+
+#[test]
+fn test_pending_lock_memory_quota_exceeded() {
+    let mut cluster = new_server_cluster(1, 1);
+    // Increase the Raft tick interval to make this test case running reliably.
+    configure_for_lease_read(&mut cluster.cfg, Some(100), None);
+    let memory_quota = 1024; // 1KB
+    let mut suite = TestSuiteBuilder::new()
+        .cluster(cluster)
+        .memory_quota(memory_quota)
+        .build();
+
+    // Let CdcEvent size be 0 to effectively disable memory quota for CdcEvent.
+    fail::cfg("cdc_event_size", "return(0)").unwrap();
+
+    // Pause scan so that no region can be initialized, and all locks will be
+    // put in pending locks.
+    fail::cfg("cdc_incremental_scan_start", "pause").unwrap();
+
+    let req = suite.new_changedata_request(1);
+    let (mut req_tx, _event_feed_wrap, receive_event) =
+        new_event_feed(suite.get_region_cdc_client(1));
+    block_on(req_tx.send((req, WriteFlags::default()))).unwrap();
+
+    // Trigger congest error.
+    let key_size = memory_quota * 2;
+    let (k, v) = (vec![1; key_size], vec![5]);
+    let start_ts = block_on(suite.cluster.pd_client.get_tso()).unwrap();
+    let mut mutation = Mutation::default();
+    mutation.set_op(Op::Put);
+    mutation.key = k.clone();
+    mutation.value = v;
+    suite.must_kv_prewrite(1, vec![mutation], k, start_ts);
+    let mut events = receive_event(false).events.to_vec();
+    assert_eq!(events.len(), 1, "{:?}", events);
+    match events.pop().unwrap().event.unwrap() {
+        Event_oneof_event::Error(e) => {
+            // Unknown errors are translated into region_not_found.
+            assert!(e.has_region_not_found(), "{:?}", e);
+        }
+        other => panic!("unknown event {:?}", other),
+    }
+
+    // The delegate must be removed.
+    let scheduler = suite.endpoints.values().next().unwrap().scheduler();
+    let (tx, rx) = mpsc::channel();
+    scheduler
+        .schedule(Task::Validate(Validate::Region(
+            1,
+            Box::new(move |delegate| {
+                tx.send(delegate.is_none()).unwrap();
+            }),
+        )))
+        .unwrap();
+
+    assert!(
+        rx.recv_timeout(Duration::from_millis(1000)).unwrap(),
+        "find unexpected delegate"
+    );
+
+    fail::remove("cdc_incremental_scan_start");
+    suite.stop();
+}
+
+#[test]
+fn test_scan_lock_memory_quota_exceeded() {
+    let mut cluster = new_server_cluster(1, 1);
+    // Increase the Raft tick interval to make this test case running reliably.
+    configure_for_lease_read(&mut cluster.cfg, Some(100), None);
+    let memory_quota = 1024; // 1KB
+    let mut suite = TestSuiteBuilder::new()
+        .cluster(cluster)
+        .memory_quota(memory_quota)
+        .build();
+
+    // Let CdcEvent size be 0 to effectively disable memory quota for CdcEvent.
+    fail::cfg("cdc_event_size", "return(0)").unwrap();
+
+    // Put a lock that exceeds memory quota.
+    let key_size = memory_quota * 2;
+    let (k, v) = (vec![1; key_size], vec![5]);
+    let start_ts = block_on(suite.cluster.pd_client.get_tso()).unwrap();
+    let mut mutation = Mutation::default();
+    mutation.set_op(Op::Put);
+    mutation.key = k.clone();
+    mutation.value = v;
+    suite.must_kv_prewrite(1, vec![mutation], k, start_ts);
+
+    // No region can be initialized.
+    let req = suite.new_changedata_request(1);
+    let (mut req_tx, _event_feed_wrap, receive_event) =
+        new_event_feed(suite.get_region_cdc_client(1));
+    block_on(req_tx.send((req, WriteFlags::default()))).unwrap();
+    let mut events = receive_event(false).events.to_vec();
+    assert_eq!(events.len(), 1, "{:?}", events);
+    match events.pop().unwrap().event.unwrap() {
+        Event_oneof_event::Error(e) => {
+            // Unknown errors are translated into region_not_found.
+            assert!(e.has_region_not_found(), "{:?}", e);
+        }
+        other => panic!("unknown event {:?}", other),
+    }
+    let scheduler = suite.endpoints.values().next().unwrap().scheduler();
+    let (tx, rx) = mpsc::channel();
+    scheduler
+        .schedule(Task::Validate(Validate::Region(
+            1,
+            Box::new(move |delegate| {
+                tx.send(delegate.is_none()).unwrap();
+            }),
+        )))
+        .unwrap();
+
+    assert!(
+        rx.recv_timeout(Duration::from_millis(1000)).unwrap(),
+        "find unexpected delegate"
+    );
+
+    suite.stop();
+}

--- a/components/resolved_ts/src/resolver.rs
+++ b/components/resolved_ts/src/resolver.rs
@@ -166,13 +166,16 @@ impl Resolver {
         if let Some(index) = index {
             self.update_tracked_index(index);
         }
-        debug!(
-            "track lock {}@{}, region {}",
-            &log_wrappers::Value::key(&key),
-            start_ts,
-            self.region_id
-        );
         let bytes = self.lock_heap_size(&key);
+        debug!(
+            "track lock {}@{}",
+            &log_wrappers::Value::key(&key),
+            start_ts;
+            "region_id" => self.region_id,
+            "memory_in_use" => self.memory_quota.in_use(),
+            "memory_capacity" => self.memory_quota.capacity(),
+            "key_heap_size" => bytes,
+        );
         if !self.memory_quota.alloc(bytes) {
             return false;
         }
@@ -191,14 +194,18 @@ impl Resolver {
             self.memory_quota.free(bytes);
             start_ts
         } else {
-            debug!("untrack a lock that was not tracked before"; "key" => &log_wrappers::Value::key(key));
+            debug!("untrack a lock that was not tracked before";
+                "key" => &log_wrappers::Value::key(key),
+                "region_id" => self.region_id,
+            );
             return;
         };
         debug!(
-            "untrack lock {}@{}, region {}",
+            "untrack lock {}@{}",
             &log_wrappers::Value::key(key),
-            start_ts,
-            self.region_id,
+            start_ts;
+            "region_id" => self.region_id,
+            "memory_in_use" => self.memory_quota.in_use(),
         );
 
         let entry = self.lock_ts_heap.get_mut(&start_ts);

--- a/components/resolved_ts/src/resolver.rs
+++ b/components/resolved_ts/src/resolver.rs
@@ -13,7 +13,7 @@ use txn_types::TimeStamp;
 use crate::metrics::RTS_RESOLVED_FAIL_ADVANCE_VEC;
 
 const MAX_NUMBER_OF_LOCKS_IN_LOG: usize = 10;
-const ON_DROP_WARN_HEAP_SIZE: usize = 64 * 1024 * 1024; // 64MB
+pub const ON_DROP_WARN_HEAP_SIZE: usize = 64 * 1024 * 1024; // 64MB
 
 // Resolver resolves timestamps that guarantee no more commit will happen before
 // the timestamp.


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #15412 

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Similar to resolved-ts endpoint, cdc endpoint maintains resolvers for
subscribed regions. These resolvers also need memory quota, otherwise
they may cause OOM.
This commit lets cdc endpoint deregister regions if they exceed
memory quota.
```

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test
- Manual test (add detailed scripts or steps below)

```mysql
sysbench --db-driver=mysql --mysql-host=<HOST> --mysql-port=<PORT> --mysql-user=root \
        --mysql-db=test --tables=1 --table-size=100000000 --create_secondary=false \
        ./oltp_update_index prepare

update sbtest1 set c='a';
```

| master branch | this fix |
| -- | -- |
| ![image](https://github.com/tikv/tikv/assets/2150711/e243e055-d0fa-4790-887f-6d31880de9ad) | ![image](https://github.com/tikv/tikv/assets/2150711/d0308cf7-76aa-47fc-a79d-d1ac3b58f291) |


Side effects

- Performance regression
    - Consumes more CPU

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix an OOM issue that is caused by CDC tracking large transactions.
```
