### PR TITLE
raftstore-v2: reuse failpoint tests in test_early_apply.rs

### DIFF
--- a/components/test_raftstore-v2/src/util.rs
+++ b/components/test_raftstore-v2/src/util.rs
@@ -27,7 +27,11 @@ use tikv::{
     },
 };
 use tikv_util::{
-    config::{ReadableDuration, ReadableSize}, escape, future::block_on_timeout, worker::LazyWorker, HandyRwLock,
+    config::{ReadableDuration, ReadableSize},
+    escape,
+    future::block_on_timeout,
+    worker::LazyWorker,
+    HandyRwLock,
 };
 use txn_types::Key;
 

--- a/components/test_raftstore-v2/src/util.rs
+++ b/components/test_raftstore-v2/src/util.rs
@@ -27,7 +27,7 @@ use tikv::{
     },
 };
 use tikv_util::{
-    config::ReadableDuration, escape, future::block_on_timeout, worker::LazyWorker, HandyRwLock,
+    config::{ReadableDuration, ReadableSize}, escape, future::block_on_timeout, worker::LazyWorker, HandyRwLock,
 };
 use txn_types::Key;
 
@@ -137,6 +137,13 @@ pub fn configure_for_encryption(config: &mut Config) {
     cfg.data_encryption_method = EncryptionMethod::Aes128Ctr;
     cfg.data_key_rotation_period = ReadableDuration(Duration::from_millis(100));
     cfg.master_key = test_util::new_test_file_master_key(manifest_dir);
+}
+
+pub fn configure_for_request_snapshot(config: &mut Config) {
+    // We don't want to generate snapshots due to compact log.
+    config.raft_store.raft_log_gc_threshold = 1000;
+    config.raft_store.raft_log_gc_count_limit = Some(1000);
+    config.raft_store.raft_log_gc_size_limit = Some(ReadableSize::mb(20));
 }
 
 pub fn configure_for_snapshot(config: &mut Config) {

--- a/components/test_raftstore-v2/src/util.rs
+++ b/components/test_raftstore-v2/src/util.rs
@@ -27,11 +27,7 @@ use tikv::{
     },
 };
 use tikv_util::{
-    config::{ReadableDuration, ReadableSize},
-    escape,
-    future::block_on_timeout,
-    worker::LazyWorker,
-    HandyRwLock,
+    config::ReadableDuration, escape, future::block_on_timeout, worker::LazyWorker, HandyRwLock,
 };
 use txn_types::Key;
 
@@ -141,13 +137,6 @@ pub fn configure_for_encryption(config: &mut Config) {
     cfg.data_encryption_method = EncryptionMethod::Aes128Ctr;
     cfg.data_key_rotation_period = ReadableDuration(Duration::from_millis(100));
     cfg.master_key = test_util::new_test_file_master_key(manifest_dir);
-}
-
-pub fn configure_for_request_snapshot(config: &mut Config) {
-    // We don't want to generate snapshots due to compact log.
-    config.raft_store.raft_log_gc_threshold = 1000;
-    config.raft_store.raft_log_gc_count_limit = Some(1000);
-    config.raft_store.raft_log_gc_size_limit = Some(ReadableSize::mb(20));
 }
 
 pub fn configure_for_snapshot(config: &mut Config) {

--- a/components/test_raftstore/src/util.rs
+++ b/components/test_raftstore/src/util.rs
@@ -668,11 +668,11 @@ pub fn create_test_engine(
     )
 }
 
-pub fn configure_for_request_snapshot<T: Simulator>(cluster: &mut Cluster<T>) {
+pub fn configure_for_request_snapshot(config: &mut Config) {
     // We don't want to generate snapshots due to compact log.
-    cluster.cfg.raft_store.raft_log_gc_threshold = 1000;
-    cluster.cfg.raft_store.raft_log_gc_count_limit = Some(1000);
-    cluster.cfg.raft_store.raft_log_gc_size_limit = Some(ReadableSize::mb(20));
+    config.raft_store.raft_log_gc_threshold = 1000;
+    config.raft_store.raft_log_gc_count_limit = Some(1000);
+    config.raft_store.raft_log_gc_size_limit = Some(ReadableSize::mb(20));
 }
 
 pub fn configure_for_hibernate(config: &mut Config) {

--- a/tests/failpoints/cases/test_early_apply.rs
+++ b/tests/failpoints/cases/test_early_apply.rs
@@ -71,9 +71,11 @@ fn test_multi_early_apply() {
             })),
     ));
     cluster.async_put(b"k4", b"v4").unwrap();
-    // Sleep a while so that follower will send append response.
+    // Sleep a while so that follower will send append response.c
     sleep_ms(100);
     cluster.async_put(b"k11", b"v22").unwrap();
+    // Sleep a while so that follower will send append response.
+    sleep_ms(100);
     // Now the store thread of store 1 pauses on `store_1_fp`.
     // Set `store_1_fp` again to make this store thread does not pause on it.
     // Then leader 1 will receive the append response and commit the log.
@@ -95,10 +97,12 @@ fn test_multi_early_apply() {
 /// the peer to fix this issue.
 /// For simplicity, this test uses region merge to ensure that the apply state
 /// will be written to kv db before crash.
-#[test_case(test_raftstore::new_node_cluster)]
-#[test_case(test_raftstore_v2::new_node_cluster)]
+///
+/// Note: partitioned-raft-kv does not need this due to change in disk
+/// persistence logic
+#[test]
 fn test_early_apply_yield_followed_with_many_entries() {
-    let mut cluster = new_cluster(0, 3);
+    let mut cluster = new_node_cluster(0, 3);
     cluster.pd_client.disable_default_operator();
 
     configure_for_merge(&mut cluster.cfg);

--- a/tests/failpoints/cases/test_early_apply.rs
+++ b/tests/failpoints/cases/test_early_apply.rs
@@ -7,14 +7,16 @@ use std::sync::{
 
 use raft::eraftpb::MessageType;
 use test_raftstore::*;
+use test_raftstore_macro::test_case;
 
 // Test if a singleton can apply a log before persisting it.
-#[test]
+#[test_case(test_raftstore::new_node_cluster)]
+#[test_case(test_raftstore_v2::new_node_cluster)]
 fn test_singleton_cannot_early_apply() {
-    let mut cluster = new_node_cluster(0, 1);
+    let mut cluster = new_cluster(0, 1);
     cluster.pd_client.disable_default_operator();
     // So compact log will not be triggered automatically.
-    configure_for_request_snapshot(&mut cluster);
+    configure_for_request_snapshot(&mut cluster.cfg);
 
     cluster.run();
     // Put one key first to cache leader.
@@ -33,13 +35,14 @@ fn test_singleton_cannot_early_apply() {
     must_get_equal(&cluster.get_engine(1), b"k1", b"v1");
 }
 
-#[test]
+#[test_case(test_raftstore::new_node_cluster)]
+#[test_case(test_raftstore_v2::new_node_cluster)]
 fn test_multi_early_apply() {
-    let mut cluster = new_node_cluster(0, 3);
+    let mut cluster = new_cluster(0, 3);
     cluster.pd_client.disable_default_operator();
     cluster.cfg.raft_store.store_batch_system.pool_size = 1;
     // So compact log will not be triggered automatically.
-    configure_for_request_snapshot(&mut cluster);
+    configure_for_request_snapshot(&mut cluster.cfg);
 
     cluster.run_conf_change();
     // Check mixed regions can be scheduled correctly.
@@ -92,9 +95,10 @@ fn test_multi_early_apply() {
 /// the peer to fix this issue.
 /// For simplicity, this test uses region merge to ensure that the apply state
 /// will be written to kv db before crash.
-#[test]
+#[test_case(test_raftstore::new_node_cluster)]
+#[test_case(test_raftstore_v2::new_node_cluster)]
 fn test_early_apply_yield_followed_with_many_entries() {
-    let mut cluster = new_node_cluster(0, 3);
+    let mut cluster = new_cluster(0, 3);
     cluster.pd_client.disable_default_operator();
 
     configure_for_merge(&mut cluster.cfg);

--- a/tests/failpoints/cases/test_early_apply.rs
+++ b/tests/failpoints/cases/test_early_apply.rs
@@ -71,7 +71,7 @@ fn test_multi_early_apply() {
             })),
     ));
     cluster.async_put(b"k4", b"v4").unwrap();
-    // Sleep a while so that follower will send append response.c
+    // Sleep a while so that follower will send append response
     sleep_ms(100);
     cluster.async_put(b"k11", b"v22").unwrap();
     // Sleep a while so that follower will send append response.

--- a/tests/failpoints/cases/test_split_region.rs
+++ b/tests/failpoints/cases/test_split_region.rs
@@ -752,7 +752,7 @@ impl Filter for CollectSnapshotFilter {
 #[test]
 fn test_split_duplicated_batch() {
     let mut cluster = new_node_cluster(0, 3);
-    configure_for_request_snapshot(&mut cluster);
+    configure_for_request_snapshot(&mut cluster.cfg);
     // Disable raft log gc in this test case.
     cluster.cfg.raft_store.raft_log_gc_tick_interval = ReadableDuration::secs(60);
     // Use one thread to make it more possible to be fetched into one batch.

--- a/tests/failpoints/cases/test_stale_read.rs
+++ b/tests/failpoints/cases/test_stale_read.rs
@@ -325,7 +325,7 @@ fn test_read_index_when_transfer_leader_2() {
     // Increase the election tick to make this test case running reliably.
     configure_for_lease_read(&mut cluster.cfg, Some(50), Some(10_000));
     // Stop log compaction to transfer leader with filter easier.
-    configure_for_request_snapshot(&mut cluster);
+    configure_for_request_snapshot(&mut cluster.cfg);
     let max_lease = Duration::from_secs(2);
     cluster.cfg.raft_store.raft_store_max_leader_lease = ReadableDuration(max_lease);
 

--- a/tests/integrations/raftstore/test_early_apply.rs
+++ b/tests/integrations/raftstore/test_early_apply.rs
@@ -109,7 +109,7 @@ fn test_early_apply(mode: DataLost) {
     let mut cluster = new_node_cluster(0, 3);
     cluster.pd_client.disable_default_operator();
     // So compact log will not be triggered automatically.
-    configure_for_request_snapshot(&mut cluster);
+    configure_for_request_snapshot(&mut cluster.cfg);
     cluster.run();
     if mode == DataLost::LeaderCommit || mode == DataLost::AllLost {
         cluster.must_transfer_leader(1, new_peer(1, 1));
@@ -175,7 +175,7 @@ fn test_update_internal_apply_index() {
     let mut cluster = new_node_cluster(0, 4);
     cluster.pd_client.disable_default_operator();
     // So compact log will not be triggered automatically.
-    configure_for_request_snapshot(&mut cluster);
+    configure_for_request_snapshot(&mut cluster.cfg);
     cluster.run();
     cluster.must_transfer_leader(1, new_peer(3, 3));
     cluster.must_put(b"k1", b"v1");

--- a/tests/integrations/raftstore/test_lease_read.rs
+++ b/tests/integrations/raftstore/test_lease_read.rs
@@ -481,7 +481,7 @@ fn test_read_index_stale_in_suspect_lease() {
     configure_for_lease_read(&mut cluster.cfg, Some(50), Some(10_000));
     let max_lease = Duration::from_secs(2);
     // Stop log compaction to transfer leader with filter easier.
-    configure_for_request_snapshot(&mut cluster);
+    configure_for_request_snapshot(&mut cluster.cfg);
     cluster.cfg.raft_store.raft_store_max_leader_lease = ReadableDuration(max_lease);
 
     cluster.pd_client.disable_default_operator();


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #15409

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
reuse failpoint tests in test_early_apply
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
