### PR TITLE
raftstore-v2: fix panic of dynamic changing write-buffer-limit

### DIFF
--- a/components/engine_panic/src/db_options.rs
+++ b/components/engine_panic/src/db_options.rs
@@ -40,6 +40,10 @@ impl DbOptions for PanicDbOptions {
         panic!()
     }
 
+    fn get_flush_size(&self) -> Result<u64> {
+        panic!()
+    }
+
     fn set_rate_limiter_auto_tuned(&mut self, rate_limiter_auto_tuned: bool) -> Result<()> {
         panic!()
     }

--- a/components/engine_rocks/src/db_options.rs
+++ b/components/engine_rocks/src/db_options.rs
@@ -100,6 +100,14 @@ impl DbOptions for RocksDbOptions {
         Ok(())
     }
 
+    fn get_flush_size(&self) -> Result<u64> {
+        if let Some(m) = self.0.get_write_buffer_manager() {
+            return Ok(m.flush_size() as u64);
+        }
+
+        Err(box_err!("write buffer manager not found"))
+    }
+
     fn set_flush_oldest_first(&mut self, f: bool) -> Result<()> {
         if let Some(m) = self.0.get_write_buffer_manager() {
             m.set_flush_oldest_first(f);

--- a/components/engine_traits/src/db_options.rs
+++ b/components/engine_traits/src/db_options.rs
@@ -19,6 +19,9 @@ pub trait DbOptions {
     fn get_rate_bytes_per_sec(&self) -> Option<i64>;
     fn set_rate_bytes_per_sec(&mut self, rate_bytes_per_sec: i64) -> Result<()>;
     fn get_rate_limiter_auto_tuned(&self) -> Option<bool>;
+    fn get_flush_size(&self) -> Result<u64> {
+        unimplemented!()
+    }
     fn set_rate_limiter_auto_tuned(&mut self, rate_limiter_auto_tuned: bool) -> Result<()>;
     fn set_flush_size(&mut self, f: usize) -> Result<()>;
     fn set_flush_oldest_first(&mut self, f: bool) -> Result<()>;

--- a/components/engine_traits/src/db_options.rs
+++ b/components/engine_traits/src/db_options.rs
@@ -19,11 +19,9 @@ pub trait DbOptions {
     fn get_rate_bytes_per_sec(&self) -> Option<i64>;
     fn set_rate_bytes_per_sec(&mut self, rate_bytes_per_sec: i64) -> Result<()>;
     fn get_rate_limiter_auto_tuned(&self) -> Option<bool>;
-    fn get_flush_size(&self) -> Result<u64> {
-        unimplemented!()
-    }
     fn set_rate_limiter_auto_tuned(&mut self, rate_limiter_auto_tuned: bool) -> Result<()>;
     fn set_flush_size(&mut self, f: usize) -> Result<()>;
+    fn get_flush_size(&self) -> Result<u64>;
     fn set_flush_oldest_first(&mut self, f: bool) -> Result<()>;
     fn set_titandb_options(&mut self, opts: &Self::TitanDbOptions);
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1406,7 +1406,7 @@ impl DbConfig {
                     .get_or_insert(ReadableSize::mb(4));
                 self.lockcf
                     .write_buffer_limit
-                    .get_or_insert(ReadableSize::mb(DEFAULT_LOCK_BUFFER_MEMORY_LIMIT));
+                    .get_or_insert(DEFAULT_LOCK_BUFFER_MEMORY_LIMIT);
             }
         }
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -110,7 +110,7 @@ const RAFT_ENGINE_MEMORY_LIMIT_RATE: f64 = 0.15;
 const WRITE_BUFFER_MEMORY_LIMIT_RATE: f64 = 0.2;
 // Too large will increase Raft Engine memory usage.
 const WRITE_BUFFER_MEMORY_LIMIT_MAX: u64 = ReadableSize::gb(8).0;
-const DEFAULT_LOCK_BUFFER_MEMORY_LIMIT: u64 = ReadableSize::mb(32).0;
+const DEFAULT_LOCK_BUFFER_MEMORY_LIMIT: ReadableSize = ReadableSize::mb(32);
 
 /// Configs that actually took effect in the last run
 pub const LAST_CONFIG_FILE: &str = "last_tikv.toml";


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #15503

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
fix panic of dynamic changing write-buffer-limit
```

![image](https://github.com/tikv/tikv/assets/71589810/96885d04-c975-4490-ba36-125ac55a48cc)


### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
