### PR TITLE
raftstore-v2: support to make protection when disk full.

### DIFF
--- a/components/raftstore-v2/src/batch/store.rs
+++ b/components/raftstore-v2/src/batch/store.rs
@@ -48,7 +48,7 @@ use tikv_util::{
     box_err,
     config::{Tracker, VersionTrack},
     log::SlogFormat,
-    sys::SysQuota,
+    sys::{disk::get_disk_status, SysQuota},
     time::{duration_to_sec, monotonic_raw_now, Instant as TiInstant, Limiter},
     timer::{SteadyTimer, GLOBAL_TIMER_HANDLE},
     worker::{Builder, LazyWorker, Scheduler, Worker},
@@ -105,6 +105,10 @@ pub struct StoreContext<EK: KvEngine, ER: RaftEngine, T> {
 
     /// Disk usage for the store itself.
     pub self_disk_usage: DiskUsage,
+    // TODO: how to remove offlined stores?
+    /// Disk usage for other stores. The store itself is not included.
+    /// Only contains items which is not `DiskUsage::Normal`.
+    pub store_disk_usages: HashMap<u64, DiskUsage>,
 
     pub snap_mgr: TabletSnapManager,
     pub global_stat: GlobalStoreStat,
@@ -229,6 +233,7 @@ impl<EK: KvEngine, ER: RaftEngine, T: Transport + 'static> PollHandler<PeerFsm<E
         if self.store_msg_buf.capacity() == 0 || self.peer_msg_buf.capacity() == 0 {
             self.apply_buf_capacity();
         }
+        self.poll_ctx.self_disk_usage = get_disk_status(self.poll_ctx.store_id);
         // Apply configuration changes.
         if let Some(cfg) = self.cfg_tracker.any_new().map(|c| c.clone()) {
             let last_messages_per_tick = self.messages_per_tick();
@@ -562,6 +567,7 @@ where
             apply_pool: self.apply_pool.clone(),
             high_priority_pool: self.high_priority_pool.clone(),
             self_disk_usage: DiskUsage::Normal,
+            store_disk_usages: Default::default(),
             snap_mgr: self.snap_mgr.clone(),
             coprocessor_host: self.coprocessor_host.clone(),
             global_stat: self.global_stat.clone(),

--- a/components/raftstore-v2/src/fsm/peer.rs
+++ b/components/raftstore-v2/src/fsm/peer.rs
@@ -259,6 +259,7 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> PeerFsmDelegate<'a, EK, ER,
                         write.header,
                         write.data,
                         write.ch,
+                        Some(write.disk_full_opt),
                     );
                 }
                 PeerMsg::UnsafeWrite(write) => {

--- a/components/raftstore-v2/src/operation/command/admin/mod.rs
+++ b/components/raftstore-v2/src/operation/command/admin/mod.rs
@@ -168,7 +168,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
                 "adjust max inflight msgs";
                 "cmd_type" => ?cmd_type,
                 "raft_max_inflight_msgs" => ctx.cfg.raft_max_inflight_msgs,
-                "to region" => self.region_id()
+                "region" => self.region_id()
             );
             self.adjust_peers_max_inflight_msgs(&peers, ctx.cfg.raft_max_inflight_msgs);
         }

--- a/components/raftstore-v2/src/operation/command/admin/mod.rs
+++ b/components/raftstore-v2/src/operation/command/admin/mod.rs
@@ -100,7 +100,9 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             return;
         }
         // Check whether the admin request can be proposed when disk full.
-        if let Err(e) = self.validate_with_disk_full_opt(ctx, DiskFullOpt::AllowedOnAlmostFull) {
+        if let Err(e) =
+            self.check_proposal_with_disk_full_opt(ctx, DiskFullOpt::AllowedOnAlmostFull)
+        {
             let resp = cmd_resp::new_error(e);
             ch.report_error(resp);
             self.post_propose_fail(cmd_type);

--- a/components/raftstore-v2/src/operation/command/admin/split.rs
+++ b/components/raftstore-v2/src/operation/command/admin/split.rs
@@ -334,7 +334,9 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             return;
         }
         // Check whether the admin request can be proposed when disk full.
-        if let Err(e) = self.validate_with_disk_full_opt(ctx, DiskFullOpt::AllowedOnAlmostFull) {
+        if let Err(e) =
+            self.check_proposal_with_disk_full_opt(ctx, DiskFullOpt::AllowedOnAlmostFull)
+        {
             info!(self.logger, "disk is full, skip split"; "err" => ?e);
             ch.set_result(cmd_resp::new_error(e));
             return;
@@ -373,7 +375,9 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             return;
         }
         // Check whether the admin request can be proposed when disk full.
-        if let Err(e) = self.validate_with_disk_full_opt(ctx, DiskFullOpt::AllowedOnAlmostFull) {
+        if let Err(e) =
+            self.check_proposal_with_disk_full_opt(ctx, DiskFullOpt::AllowedOnAlmostFull)
+        {
             info!(self.logger, "disk is full, skip half split"; "err" => ?e);
             return;
         }

--- a/components/raftstore-v2/src/operation/command/admin/split.rs
+++ b/components/raftstore-v2/src/operation/command/admin/split.rs
@@ -35,6 +35,7 @@ use engine_traits::{
 use fail::fail_point;
 use futures::channel::oneshot;
 use kvproto::{
+    kvrpcpb::DiskFullOpt,
     metapb::{self, Region, RegionEpoch},
     pdpb::CheckPolicy,
     raft_cmdpb::{AdminRequest, AdminResponse, RaftCmdRequest, SplitRequest},
@@ -325,6 +326,12 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             ))));
             return;
         }
+        // Check whether the admin request can be proposed when disk full.
+        if let Err(e) = self.validate_with_disk_full_opt(ctx, DiskFullOpt::AllowedOnAlmostFull) {
+            info!(self.logger, "disk is full, skip split"; "err" => ?e);
+            ch.set_result(cmd_resp::new_error(e));
+            return;
+        }
         if let Err(e) = util::validate_split_region(
             self.region_id(),
             self.peer_id(),
@@ -356,6 +363,11 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         if !self.is_leader() {
             // region on this store is no longer leader, skipped.
             info!(self.logger, "not leader, skip.");
+            return;
+        }
+        // Check whether the admin request can be proposed when disk full.
+        if let Err(e) = self.validate_with_disk_full_opt(ctx, DiskFullOpt::AllowedOnAlmostFull) {
+            info!(self.logger, "disk is full, skip half split"; "err" => ?e);
             return;
         }
 

--- a/components/raftstore-v2/src/operation/command/admin/transfer_leader.rs
+++ b/components/raftstore-v2/src/operation/command/admin/transfer_leader.rs
@@ -118,7 +118,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         transferee
     }
 
-    fn pre_transfer_leader(&mut self, peer: &metapb::Peer) -> bool {
+    pub fn pre_transfer_leader(&mut self, peer: &metapb::Peer) -> bool {
         if self.raft_group().raft.has_pending_conf() {
             info!(
                 self.logger,

--- a/components/raftstore-v2/src/operation/command/mod.rs
+++ b/components/raftstore-v2/src/operation/command/mod.rs
@@ -24,10 +24,8 @@ use std::{
 
 use engine_traits::{KvEngine, PerfContext, RaftEngine, WriteBatch, WriteOptions};
 use fail::fail_point;
-use kvproto::{
-    kvrpcpb::DiskFullOpt,
-    metapb::PeerRole,
-    raft_cmdpb::{AdminCmdType, CmdType, RaftCmdRequest, RaftCmdResponse, RaftRequestHeader},
+use kvproto::raft_cmdpb::{
+    AdminCmdType, CmdType, RaftCmdRequest, RaftCmdResponse, RaftRequestHeader,
 };
 use raft::eraftpb::{ConfChange, ConfChangeV2, Entry, EntryType};
 use raft_proto::ConfChangeI;
@@ -54,7 +52,6 @@ use tikv_util::{
     box_err,
     log::SlogFormat,
     slog_panic,
-    sys::disk::DiskUsage,
     time::{duration_to_sec, monotonic_raw_now, Instant},
 };
 
@@ -234,83 +231,6 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             return Err(e);
         }
         Ok(())
-    }
-
-    // Check disk usages for the peer itself and other peers in the raft group.
-    // The return value indicates whether the proposal is allowed or not.
-    pub fn validate_with_disk_full_opt<T>(
-        &mut self,
-        ctx: &StoreContext<EK, ER, T>,
-        disk_full_opt: DiskFullOpt,
-    ) -> Result<()> {
-        let leader_allowed = match ctx.self_disk_usage {
-            DiskUsage::Normal => true,
-            DiskUsage::AlmostFull => !matches!(disk_full_opt, DiskFullOpt::NotAllowedOnFull),
-            DiskUsage::AlreadyFull => false,
-        };
-        let mut disk_full_stores = Vec::new();
-        let abnormal_peer_context = self.abnormal_peer_context();
-        let disk_full_peers = abnormal_peer_context.disk_full_peers();
-        if !leader_allowed {
-            disk_full_stores.push(ctx.store_id);
-            // Try to transfer leader to a node with disk usage normal to maintain write
-            // availability. If majority node is disk full, to transfer leader or not is not
-            // necessary. Note: Need to exclude learner node.
-            if !disk_full_peers.majority() {
-                let target_peer = self
-                    .region()
-                    .get_peers()
-                    .iter()
-                    .find(|x| {
-                        !disk_full_peers.has(x.get_id())
-                            && x.get_id() != self.peer_id()
-                            && !self
-                                .abnormal_peer_context()
-                                .down_peers()
-                                .contains(&x.get_id())
-                            && !matches!(x.get_role(), PeerRole::Learner)
-                    })
-                    .cloned();
-                if let Some(p) = target_peer {
-                    debug!(
-                        self.logger,
-                        "try to transfer leader because of current leader disk full";
-                        "region_id" => self.region().get_id(),
-                        "peer_id" => self.peer_id(),
-                        "target_peer_id" => p.get_id(),
-                    );
-                    self.pre_transfer_leader(&p);
-                }
-            }
-        } else {
-            // Check followers.
-            if disk_full_peers.is_empty() {
-                return Ok(());
-            }
-            if !abnormal_peer_context.is_dangerous_majority_set() {
-                if !disk_full_peers.majority() {
-                    return Ok(());
-                }
-                // Majority peers are in disk full status but the request carries a special
-                // flag.
-                if matches!(disk_full_opt, DiskFullOpt::AllowedOnAlmostFull)
-                    && disk_full_peers.peers().values().any(|x| x.1)
-                {
-                    return Ok(());
-                }
-            }
-            for peer in self.region().get_peers() {
-                let (peer_id, store_id) = (peer.get_id(), peer.get_store_id());
-                if disk_full_peers.peers().get(&peer_id).is_some() {
-                    disk_full_stores.push(store_id);
-                }
-            }
-        }
-        let errmsg = format!(
-            "propose failed: tikv disk full, cmd diskFullOpt={:?}, leader diskUsage={:?}",
-            disk_full_opt, ctx.self_disk_usage
-        );
-        Err(Error::DiskFull(disk_full_stores, errmsg))
     }
 
     #[inline]

--- a/components/raftstore-v2/src/operation/command/write/mod.rs
+++ b/components/raftstore-v2/src/operation/command/write/mod.rs
@@ -62,7 +62,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         }
         // Check whether the write request can be proposed with the given disk full
         // option.
-        if let Some(opt) = disk_full_opt && let Err(e) = self.validate_with_disk_full_opt(ctx, opt) {
+        if let Some(opt) = disk_full_opt && let Err(e) = self.check_proposal_with_disk_full_opt(ctx, opt) {
             let resp = cmd_resp::new_error(e);
             ch.report_error(resp);
             return;

--- a/components/raftstore-v2/src/operation/life.rs
+++ b/components/raftstore-v2/src/operation/life.rs
@@ -26,7 +26,7 @@
 //! `merged_records`, to avoid race between destroy and merge, leader needs to
 //! ask target peer to destroy source peer.
 
-use std::{cmp, mem};
+use std::{cmp, collections::HashSet, mem};
 
 use batch_system::BasicMailbox;
 use crossbeam::channel::{SendError, TrySendError};
@@ -36,6 +36,7 @@ use kvproto::{
     raft_cmdpb::{AdminCmdType, RaftCmdRequest},
     raft_serverpb::{ExtraMessage, ExtraMessageType, PeerState, RaftMessage},
 };
+use raft::eraftpb::MessageType;
 use raftstore::store::{
     fsm::{
         apply,
@@ -43,11 +44,13 @@ use raftstore::store::{
         Proposal,
     },
     metrics::RAFT_PEER_PENDING_DURATION,
-    util, Transport, WriteTask,
+    util::{self, ChangePeerI},
+    DiskFullPeers, Transport, WriteTask,
 };
 use slog::{debug, error, info, warn};
 use tikv_util::{
     store::find_peer,
+    sys::disk::DiskUsage,
     time::{duration_to_sec, Instant},
 };
 
@@ -126,18 +129,23 @@ pub struct AbnormalPeerContext {
     pending_peers: Vec<(u64, Instant)>,
     /// A inaccurate cache about which peer is marked as down.
     down_peers: Vec<u64>,
+    // disk full peer set.
+    disk_full_peers: DiskFullPeers,
+    // show whether an already disk full TiKV appears in the potential majority set.
+    dangerous_majority_set: bool,
 }
 
 impl AbnormalPeerContext {
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.pending_peers.is_empty() && self.down_peers.is_empty()
+        self.pending_peers.is_empty() && self.down_peers.is_empty() /* && self.disk_full_peers.is_empty() */
     }
 
     #[inline]
     pub fn reset(&mut self) {
         self.pending_peers.clear();
         self.down_peers.clear();
+        // self.disk_full_peers.clear();
     }
 
     #[inline]
@@ -173,6 +181,26 @@ impl AbnormalPeerContext {
             let elapsed = duration_to_sec(pending_after.saturating_elapsed());
             RAFT_PEER_PENDING_DURATION.observe(elapsed);
         });
+    }
+
+    #[inline]
+    pub fn disk_full_peers(&self) -> &DiskFullPeers {
+        &self.disk_full_peers
+    }
+
+    #[inline]
+    pub fn disk_full_peers_mut(&mut self) -> &mut DiskFullPeers {
+        &mut self.disk_full_peers
+    }
+
+    #[inline]
+    pub fn is_dangerous_majority_set(&self) -> bool {
+        self.dangerous_majority_set
+    }
+
+    #[inline]
+    pub fn setup_dangerous_majority_set(&mut self, is_dangerous: bool) {
+        self.dangerous_majority_set = is_dangerous;
     }
 }
 
@@ -415,6 +443,20 @@ impl Store {
             ctx.raft_metrics.message_dropped.stale_msg.inc();
             return false;
         }
+        // Check whether this message should be dropped when disk full.
+        let msg_type = msg.get_message().get_msg_type();
+        if matches!(ctx.self_disk_usage, DiskUsage::AlreadyFull)
+            && MessageType::MsgTimeoutNow == msg_type
+        {
+            debug!(
+                self.logger(),
+                "skip {:?} because of disk full", msg_type;
+                "region_id" => region_id, "peer_id" => to_peer.id,
+            );
+            ctx.raft_metrics.message_dropped.disk_full.inc();
+            return false;
+        }
+
         let destroyed = match check_if_to_peer_destroyed(&ctx.engine, &msg, self.store_id()) {
             Ok(d) => d,
             Err(e) => {
@@ -750,6 +792,193 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             self.on_admin_command(ctx, req, ch);
         }
         self.maybe_schedule_gc_peer_tick();
+    }
+
+    pub fn adjust_peers_max_inflight_msgs(
+        &mut self,
+        peers: &Vec<u64>,
+        raft_max_inflight_msgs: usize,
+    ) {
+        peers.iter().for_each(|id| {
+            self.raft_group_mut()
+                .raft
+                .adjust_max_inflight_msgs(*id, raft_max_inflight_msgs);
+            debug!(
+                self.logger,
+                "adjust max inflight msgs";
+                "raft_max_inflight_msgs" => raft_max_inflight_msgs,
+                "peer_id" => id
+            );
+        });
+    }
+
+    pub fn clear_disk_full_peers<T>(&mut self, ctx: &StoreContext<EK, ER, T>) {
+        let disk_full_peers = mem::take(self.abnormal_peer_context_mut().disk_full_peers_mut());
+        let raft = &mut self.raft_group_mut().raft;
+        for peer in disk_full_peers.peers().iter() {
+            raft.adjust_max_inflight_msgs(*peer.0, ctx.cfg.raft_max_inflight_msgs);
+        }
+    }
+
+    pub fn refill_disk_full_peers<T>(&mut self, ctx: &StoreContext<EK, ER, T>) {
+        self.clear_disk_full_peers(ctx);
+        debug!(
+            self.logger,
+            "region id {}, peer id {}, store id {}: refill disk full peers when peer disk usage status changed or merge triggered",
+            self.region().get_id(),
+            self.peer_id(),
+            ctx.store_id,
+        );
+
+        // Collect disk full peers and all peers' `next_idx` to find a potential quorum.
+        let peers_len = self.region().get_peers().len();
+        let mut normal_peers = HashSet::default();
+        let mut next_idxs = Vec::with_capacity(peers_len);
+        let mut min_peer_index = u64::MAX;
+        for peer in self.region().get_peers() {
+            let (peer_id, store_id) = (peer.get_id(), peer.get_store_id());
+            let usage = ctx.store_disk_usages.get(&store_id);
+            if usage.is_none() {
+                // Always treat the leader itself as normal.
+                normal_peers.insert(peer_id);
+            }
+            if let Some(pr) = self.raft_group().raft.prs().get(peer_id) {
+                // status 3-normal, 2-almostfull, 1-alreadyfull, only for simplying the sort
+                // func belowing.
+                let mut status = 3;
+                if let Some(usg) = usage {
+                    status = match usg {
+                        DiskUsage::Normal => 3,
+                        DiskUsage::AlmostFull => 2,
+                        DiskUsage::AlreadyFull => 1,
+                    };
+                }
+
+                if !self.abnormal_peer_context().down_peers().contains(&peer_id) {
+                    next_idxs.push((peer_id, pr.next_idx, usage, status));
+                    if min_peer_index > pr.next_idx {
+                        min_peer_index = pr.next_idx;
+                    }
+                }
+            }
+        }
+        if self.has_region_merge_proposal {
+            debug!(
+                self.logger,
+                "region id {}, peer id {}, store id {} has a merge request, with region_merge_proposal_index {}",
+                self.region_id(),
+                self.peer_id(),
+                ctx.store_id,
+                self.region_merge_proposal_index
+            );
+            if min_peer_index > self.region_merge_proposal_index {
+                self.has_region_merge_proposal = false;
+            }
+        }
+
+        if normal_peers.len() == peers_len {
+            return;
+        }
+
+        // Reverse sort peers based on `next_idx`, `usage` and `store healthy status`,
+        // then try to get a potential quorum.
+        next_idxs.sort_by(|x, y| {
+            if x.3 == y.3 {
+                y.1.cmp(&x.1)
+            } else {
+                y.3.cmp(&x.3)
+            }
+        });
+
+        let majority = !self.raft_group().raft.prs().has_quorum(&normal_peers);
+        self.abnormal_peer_context_mut()
+            .disk_full_peers_mut()
+            .set_majority(majority);
+        // Here set all peers can be sent when merging.
+        for &(peer, _, usage, ..) in &next_idxs {
+            if let Some(usage) = usage {
+                if self.has_region_merge_proposal && !matches!(*usage, DiskUsage::AlreadyFull) {
+                    self.abnormal_peer_context_mut()
+                        .disk_full_peers_mut()
+                        .peers_mut()
+                        .insert(peer, (*usage, true));
+                    self.raft_group_mut()
+                        .raft
+                        .adjust_max_inflight_msgs(peer, ctx.cfg.raft_max_inflight_msgs);
+                    debug!(
+                        self.logger,
+                        "refill disk full peer max inflight to {} on a merging region: region id {}, peer id {}",
+                        ctx.cfg.raft_max_inflight_msgs,
+                        self.region_id(),
+                        peer
+                    );
+                } else {
+                    self.abnormal_peer_context_mut()
+                        .disk_full_peers_mut()
+                        .peers_mut()
+                        .insert(peer, (*usage, false));
+                    self.raft_group_mut().raft.adjust_max_inflight_msgs(peer, 0);
+                    debug!(
+                        self.logger,
+                        "refill disk full peer max inflight to {} on region without merging: region id {}, peer id {}",
+                        0,
+                        self.region_id(),
+                        peer
+                    );
+                }
+            }
+        }
+
+        if !self.abnormal_peer_context().disk_full_peers().majority() {
+            // Less than majority peers are in disk full status.
+            return;
+        }
+
+        let (mut potential_quorum, mut quorum_ok) = (HashSet::default(), false);
+        let mut is_dangerous_set = false;
+        for &(peer_id, _, _, status) in &next_idxs {
+            potential_quorum.insert(peer_id);
+
+            if status == 1 {
+                // already full peer.
+                is_dangerous_set = true;
+            }
+
+            if self.raft_group().raft.prs().has_quorum(&potential_quorum) {
+                quorum_ok = true;
+                break;
+            }
+        }
+
+        self.abnormal_peer_context_mut()
+            .setup_dangerous_majority_set(is_dangerous_set);
+
+        // For the Peer with AlreadFull in potential quorum set, we still need to send
+        // logs to it. To support incoming configure change.
+        if quorum_ok {
+            let has_region_merge_proposal = self.has_region_merge_proposal;
+            let peers = self
+                .abnormal_peer_context_mut()
+                .disk_full_peers_mut()
+                .peers_mut();
+            let mut inflight_peers = vec![];
+            for peer in potential_quorum {
+                if let Some(x) = peers.get_mut(&peer) {
+                    // It can help to establish a quorum.
+                    x.1 = true;
+                    // for merge region, all peers have been set to the max.
+                    if !has_region_merge_proposal {
+                        inflight_peers.push(peer);
+                    }
+                }
+            }
+            self.adjust_peers_max_inflight_msgs(&inflight_peers, 1);
+            debug!(
+                self.logger,
+                "refill disk full peer max inflight to 1 in potential quorum set: region id {}",
+                self.region_id(),
+            );
+        }
     }
 
     /// A peer can be destroyed in four cases:

--- a/components/raftstore-v2/src/operation/life.rs
+++ b/components/raftstore-v2/src/operation/life.rs
@@ -967,12 +967,12 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
                     }
                 }
             }
-            self.adjust_peers_max_inflight_msgs(&inflight_peers, 1);
             debug!(
                 self.logger,
                 "refill disk full peer max inflight to 1 in potential quorum set: region id {}",
                 self.region_id(),
             );
+            self.adjust_peers_max_inflight_msgs(&inflight_peers, 1);
         }
     }
 

--- a/components/raftstore-v2/src/operation/life.rs
+++ b/components/raftstore-v2/src/operation/life.rs
@@ -44,8 +44,7 @@ use raftstore::store::{
         Proposal,
     },
     metrics::RAFT_PEER_PENDING_DURATION,
-    util::{self, ChangePeerI},
-    DiskFullPeers, Transport, WriteTask,
+    util, DiskFullPeers, Transport, WriteTask,
 };
 use slog::{debug, error, info, warn};
 use tikv_util::{
@@ -794,11 +793,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         self.maybe_schedule_gc_peer_tick();
     }
 
-    pub fn adjust_peers_max_inflight_msgs(
-        &mut self,
-        peers: &Vec<u64>,
-        raft_max_inflight_msgs: usize,
-    ) {
+    pub fn adjust_peers_max_inflight_msgs(&mut self, peers: &[u64], raft_max_inflight_msgs: usize) {
         peers.iter().for_each(|id| {
             self.raft_group_mut()
                 .raft

--- a/components/raftstore-v2/src/operation/pd.rs
+++ b/components/raftstore-v2/src/operation/pd.rs
@@ -103,7 +103,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         let task = pd::Task::RegionHeartbeat(pd::RegionHeartbeatTask {
             term: self.term(),
             region: self.region().clone(),
-            down_peers: self.collect_down_peers(ctx.cfg.max_peer_down_duration.0),
+            down_peers: self.collect_down_peers(ctx),
             peer: self.peer().clone(),
             pending_peers: self.collect_pending_peers(ctx),
             written_bytes: self.self_stat().written_bytes,

--- a/components/raftstore-v2/src/operation/query/lease.rs
+++ b/components/raftstore-v2/src/operation/query/lease.rs
@@ -168,7 +168,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         header.set_term(self.term());
         let empty_data = SimpleWriteEncoder::with_capacity(0).encode();
         let (ch, _) = CmdResChannel::pair();
-        self.on_simple_write(ctx, header, empty_data, ch);
+        self.on_simple_write(ctx, header, empty_data, ch, None);
     }
 
     /// response the read index request

--- a/components/raftstore-v2/src/operation/txn_ext.rs
+++ b/components/raftstore-v2/src/operation/txn_ext.rs
@@ -270,13 +270,13 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             self.logger,
             "propose {} locks before transferring leader", lock_count;
         );
-        let PeerMsg::SimpleWrite(write) = PeerMsg::simple_write(header, encoder.encode()).0 else {unreachable!()};
+        let PeerMsg::SimpleWrite(write) = PeerMsg::simple_write_with_opt(header, encoder.encode(), DiskFullOpt::AllowedOnAlmostFull).0 else {unreachable!()};
         self.on_simple_write(
             ctx,
             write.header,
             write.data,
             write.ch,
-            Some(DiskFullOpt::AllowedOnAlmostFull),
+            Some(write.disk_full_opt),
         );
         true
     }

--- a/components/raftstore-v2/src/operation/txn_ext.rs
+++ b/components/raftstore-v2/src/operation/txn_ext.rs
@@ -9,7 +9,11 @@ use std::sync::{atomic::Ordering, Arc};
 
 use crossbeam::atomic::AtomicCell;
 use engine_traits::{KvEngine, RaftEngine, CF_LOCK};
-use kvproto::{kvrpcpb::ExtraOp, metapb::Region, raft_cmdpb::RaftRequestHeader};
+use kvproto::{
+    kvrpcpb::{DiskFullOpt, ExtraOp},
+    metapb::Region,
+    raft_cmdpb::RaftRequestHeader,
+};
 use parking_lot::RwLockWriteGuard;
 use raft::eraftpb;
 use raftstore::store::{
@@ -267,7 +271,13 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             "propose {} locks before transferring leader", lock_count;
         );
         let PeerMsg::SimpleWrite(write) = PeerMsg::simple_write(header, encoder.encode()).0 else {unreachable!()};
-        self.on_simple_write(ctx, write.header, write.data, write.ch);
+        self.on_simple_write(
+            ctx,
+            write.header,
+            write.data,
+            write.ch,
+            Some(DiskFullOpt::AllowedOnAlmostFull),
+        );
         true
     }
 }

--- a/components/raftstore-v2/src/raft/peer.rs
+++ b/components/raftstore-v2/src/raft/peer.rs
@@ -32,6 +32,7 @@ use tikv_util::{slog_panic, time::duration_to_sec};
 
 use super::storage::Storage;
 use crate::{
+    batch::StoreContext,
     fsm::ApplyScheduler,
     operation::{
         AbnormalPeerContext, AsyncWriter, BucketStatsInfo, CompactLogContext, DestroyProgress,
@@ -125,6 +126,10 @@ pub struct Peer<EK: KvEngine, ER: RaftEngine> {
     gc_peer_context: GcPeerContext,
 
     abnormal_peer_context: AbnormalPeerContext,
+
+    // region merge logic need to be broadcast to all followers when disk full happens.
+    pub has_region_merge_proposal: bool,
+    pub region_merge_proposal_index: u64,
 
     /// Force leader state is only used in online recovery when the majority of
     /// peers are missing. In this state, it forces one peer to become leader
@@ -227,6 +232,8 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             pending_messages: vec![],
             gc_peer_context: GcPeerContext::default(),
             abnormal_peer_context: AbnormalPeerContext::default(),
+            has_region_merge_proposal: false,
+            region_merge_proposal_index: 0_u64,
             force_leader_state: None,
             unsafe_recovery_state: None,
         };
@@ -595,7 +602,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         )
     }
 
-    pub fn collect_down_peers(&mut self, max_duration: Duration) -> Vec<pdpb::PeerStats> {
+    pub fn collect_down_peers<T>(&mut self, ctx: &StoreContext<EK, ER, T>) -> Vec<pdpb::PeerStats> {
         let mut down_peers = Vec::new();
         let mut down_peer_ids = Vec::new();
         let now = Instant::now();
@@ -605,7 +612,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             }
             if let Some(instant) = self.peer_heartbeats.get(&p.get_id()) {
                 let elapsed = now.saturating_duration_since(*instant);
-                if elapsed >= max_duration {
+                if elapsed >= ctx.cfg.max_peer_down_duration.0 {
                     let mut stats = pdpb::PeerStats::default();
                     stats.set_peer(p.clone());
                     stats.set_down_seconds(elapsed.as_secs());
@@ -614,8 +621,11 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
                 }
             }
         }
+        let exist_down_peers = !down_peer_ids.is_empty();
         *self.abnormal_peer_context_mut().down_peers_mut() = down_peer_ids;
-        // TODO: `refill_disk_full_peers`
+        if exist_down_peers {
+            self.refill_disk_full_peers(ctx);
+        }
         down_peers
     }
 
@@ -908,6 +918,11 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
     #[inline]
     pub fn last_sent_snapshot_index(&self) -> u64 {
         self.last_sent_snapshot_index
+    }
+
+    #[inline]
+    pub fn next_proposal_index(&self) -> u64 {
+        self.raft_group.raft.raft_log.last_index() + 1
     }
 
     #[inline]

--- a/components/raftstore-v2/src/router/message.rs
+++ b/components/raftstore-v2/src/router/message.rs
@@ -294,6 +294,14 @@ impl PeerMsg {
         header: Box<RaftRequestHeader>,
         data: SimpleWriteBinary,
     ) -> (Self, CmdResSubscriber) {
+        PeerMsg::simple_write_with_opt(header, data, DiskFullOpt::default())
+    }
+
+    pub fn simple_write_with_opt(
+        header: Box<RaftRequestHeader>,
+        data: SimpleWriteBinary,
+        disk_full_opt: DiskFullOpt,
+    ) -> (Self, CmdResSubscriber) {
         let (ch, sub) = CmdResChannel::pair();
         (
             PeerMsg::SimpleWrite(SimpleWrite {
@@ -301,7 +309,7 @@ impl PeerMsg {
                 header,
                 data,
                 ch,
-                disk_full_opt: DiskFullOpt::default(),
+                disk_full_opt,
             }),
             sub,
         )

--- a/components/raftstore-v2/src/router/message.rs
+++ b/components/raftstore-v2/src/router/message.rs
@@ -6,6 +6,7 @@ use std::sync::{mpsc::SyncSender, Arc};
 use collections::HashSet;
 use kvproto::{
     import_sstpb::SstMeta,
+    kvrpcpb::DiskFullOpt,
     metapb,
     metapb::RegionEpoch,
     pdpb,
@@ -134,6 +135,7 @@ pub struct SimpleWrite {
     pub header: Box<RaftRequestHeader>,
     pub data: SimpleWriteBinary,
     pub ch: CmdResChannel,
+    pub disk_full_opt: DiskFullOpt,
 }
 
 #[derive(Debug)]
@@ -299,6 +301,7 @@ impl PeerMsg {
                 header,
                 data,
                 ch,
+                disk_full_opt: DiskFullOpt::default(),
             }),
             sub,
         )

--- a/components/raftstore/src/store/mod.rs
+++ b/components/raftstore/src/store/mod.rs
@@ -57,8 +57,8 @@ pub use self::{
     },
     peer::{
         can_amend_read, get_sync_log_from_request, make_transfer_leader_response,
-        propose_read_index, should_renew_lease, Peer, PeerStat, ProposalContext, ProposalQueue,
-        RequestInspector, RequestPolicy, TRANSFER_LEADER_COMMAND_REPLY_CTX,
+        propose_read_index, should_renew_lease, DiskFullPeers, Peer, PeerStat, ProposalContext,
+        ProposalQueue, RequestInspector, RequestPolicy, TRANSFER_LEADER_COMMAND_REPLY_CTX,
     },
     peer_storage::{
         clear_meta, do_snapshot, write_initial_apply_state, write_initial_raft_state,

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -5047,6 +5047,15 @@ impl DiskFullPeers {
     pub fn majority(&self) -> bool {
         self.majority
     }
+    pub fn set_majority(&mut self, majority: bool) {
+        self.majority = majority;
+    }
+    pub fn peers(&self) -> &HashMap<u64, (DiskUsage, bool)> {
+        &self.peers
+    }
+    pub fn peers_mut(&mut self) -> &mut HashMap<u64, (DiskUsage, bool)> {
+        &mut self.peers
+    }
     pub fn has(&self, peer_id: u64) -> bool {
         !self.peers.is_empty() && self.peers.contains_key(&peer_id)
     }

--- a/components/test_raftstore-v2/src/cluster.rs
+++ b/components/test_raftstore-v2/src/cluster.rs
@@ -37,7 +37,7 @@ use pd_client::PdClient;
 use raftstore::{
     store::{
         cmd_resp, initial_region, region_meta::RegionMeta, util::check_key_in_region, Bucket,
-        BucketRange, Callback, RegionSnapshot, TabletSnapManager, WriteResponse,
+        BucketRange, Callback, RaftCmdExtraOpts, RegionSnapshot, TabletSnapManager, WriteResponse,
         INIT_EPOCH_CONF_VER, INIT_EPOCH_VER,
     },
     Error, Result,
@@ -285,7 +285,16 @@ pub trait Simulator<EK: KvEngine> {
     fn async_command_on_node(
         &mut self,
         node_id: u64,
+        request: RaftCmdRequest,
+    ) -> BoxFuture<'static, RaftCmdResponse> {
+        self.async_command_on_node_with_opts(node_id, request, RaftCmdExtraOpts::default())
+    }
+
+    fn async_command_on_node_with_opts(
+        &mut self,
+        node_id: u64,
         mut request: RaftCmdRequest,
+        opts: RaftCmdExtraOpts,
     ) -> BoxFuture<'static, RaftCmdResponse> {
         let region_id = request.get_header().get_region_id();
 
@@ -316,7 +325,11 @@ pub trait Simulator<EK: KvEngine> {
                     _ => unreachable!(),
                 }
             }
-            PeerMsg::simple_write(Box::new(request.take_header()), write_encoder.encode())
+            PeerMsg::simple_write_with_opt(
+                Box::new(request.take_header()),
+                write_encoder.encode(),
+                opts.disk_full_opt,
+            )
         };
 
         self.async_peer_msg_on_node(node_id, region_id, msg)
@@ -1273,6 +1286,20 @@ impl<T: Simulator<EK>, EK: KvEngine> Cluster<T, EK> {
         self.sim
             .wl()
             .async_command_on_node(leader.get_store_id(), req)
+    }
+
+    pub fn async_request_with_opts(
+        &mut self,
+        mut req: RaftCmdRequest,
+        opts: RaftCmdExtraOpts,
+    ) -> Result<BoxFuture<'static, RaftCmdResponse>> {
+        let region_id = req.get_header().get_region_id();
+        let leader = self.leader_of_region(region_id).unwrap();
+        req.mut_header().set_peer(leader.clone());
+        Ok(self
+            .sim
+            .wl()
+            .async_command_on_node_with_opts(leader.get_store_id(), req, opts))
     }
 
     pub fn async_put(

--- a/src/server/raftkv2/mod.rs
+++ b/src/server/raftkv2/mod.rs
@@ -280,6 +280,7 @@ impl<EK: KvEngine, ER: RaftEngine> tikv_kv::Engine for RaftKv2<EK, ER> {
             data,
             ch,
             send_time: Instant::now_coarse(),
+            disk_full_opt: batch.disk_full_opt,
         });
         let res = self
             .router

--- a/tests/failpoints/cases/test_disk_full.rs
+++ b/tests/failpoints/cases/test_disk_full.rs
@@ -11,6 +11,7 @@ use kvproto::{
 use raft::eraftpb::MessageType;
 use raftstore::store::msg::*;
 use test_raftstore::*;
+use test_raftstore_macro::test_case;
 use tikv_util::{config::ReadableDuration, future::block_on_timeout, time::Instant};
 
 fn assert_disk_full(resp: &RaftCmdResponse) {
@@ -121,7 +122,8 @@ fn test_disk_full_leader_behaviors(usage: DiskUsage) {
     fail::remove(get_fp(usage, 1));
 }
 
-#[test]
+#[test_case(test_raftstore::new_node_cluster)]
+#[test_case(test_raftstore_v2::new_node_cluster)]
 fn test_disk_full_for_region_leader() {
     test_disk_full_leader_behaviors(DiskUsage::AlmostFull);
     test_disk_full_leader_behaviors(DiskUsage::AlreadyFull);
@@ -168,7 +170,8 @@ fn test_disk_full_follower_behaviors(usage: DiskUsage) {
     fail::remove(get_fp(usage, 2));
 }
 
-#[test]
+#[test_case(test_raftstore::new_node_cluster)]
+#[test_case(test_raftstore_v2::new_node_cluster)]
 fn test_disk_full_for_region_follower() {
     test_disk_full_follower_behaviors(DiskUsage::AlmostFull);
     test_disk_full_follower_behaviors(DiskUsage::AlreadyFull);
@@ -269,12 +272,14 @@ fn test_disk_full_txn_behaviors(usage: DiskUsage) {
     fail::remove(get_fp(usage, 1));
 }
 
-#[test]
+#[test_case(test_raftstore::new_server_cluster)]
+#[test_case(test_raftstore_v2::new_server_cluster)]
 fn test_disk_full_for_txn_operations() {
     test_disk_full_txn_behaviors(DiskUsage::AlmostFull);
 }
 
-#[test]
+#[test_case(test_raftstore::new_node_cluster)]
+#[test_case(test_raftstore_v2::new_node_cluster)]
 fn test_majority_disk_full() {
     let mut cluster = new_node_cluster(0, 3);
     // To ensure the thread has full store disk usage infomation.
@@ -364,7 +369,8 @@ fn test_majority_disk_full() {
     }
 }
 
-#[test]
+#[test_case(test_raftstore::new_node_cluster)]
+#[test_case(test_raftstore_v2::new_node_cluster)]
 fn test_disk_full_followers_with_hibernate_regions() {
     let mut cluster = new_node_cluster(0, 2);
     // To ensure the thread has full store disk usage infomation.
@@ -413,7 +419,8 @@ fn assert_region_merged<T: Simulator>(
     }
 }
 
-#[test]
+#[test_case(test_raftstore::new_server_cluster)]
+#[test_case(test_raftstore_v2::new_server_cluster)]
 fn test_merge_on_majority_disk_full() {
     let mut cluster = new_server_cluster(0, 3);
     // To ensure the thread has full store disk usage infomation.
@@ -462,7 +469,8 @@ fn test_merge_on_majority_disk_full() {
     }
 }
 
-#[test]
+#[test_case(test_raftstore::new_server_cluster)]
+#[test_case(test_raftstore_v2::new_server_cluster)]
 fn test_almost_and_already_full_behavior() {
     let mut cluster = new_server_cluster(0, 5);
     // To ensure the thread has full store disk usage infomation.
@@ -541,7 +549,8 @@ fn wait_down_peers_reported<T: Simulator>(
     }
 }
 
-#[test]
+#[test_case(test_raftstore::new_server_cluster)]
+#[test_case(test_raftstore_v2::new_server_cluster)]
 fn test_down_node_when_disk_full() {
     let mut cluster = new_server_cluster(0, 5);
     // To ensure the thread has full store disk usage infomation.


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #15170 

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
This pr is used to protect `raftstore-v2` when disk full. And all checking and validation is transplant from `raftstore`.
```

All compatible implementations in `raftstore-v2` are transplanted from `raftstore`, and the difference between these two part can be reviewed as followings show:
<img width="1758" alt="DiskFullOpt" src="https://github.com/tikv/tikv/assets/18441614/9ee8f035-37aa-4a61-a53e-3951adcc5f26">

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List
 <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Raftstore-v2 can percept `DiskFull` exceptions and refuse to execute `Write` operations when disk full.
```
