### PR TITLE
*: add alloc_high_water and return result

### DIFF
--- a/components/backup-stream/src/subscription_track.rs
+++ b/components/backup-stream/src/subscription_track.rs
@@ -480,7 +480,7 @@ impl TwoPhaseResolver {
             warn!("backup stream tracking lock as if in phase one"; "start_ts" => %start_ts, "key" => %utils::redact(&key))
         }
         // TODO: handle memory quota exceed, for now, quota is set to usize::MAX.
-        assert!(self.resolver.track_lock(start_ts, key, None));
+        self.resolver.track_lock(start_ts, key, None).unwrap();
     }
 
     pub fn track_lock(&mut self, start_ts: TimeStamp, key: Vec<u8>) {
@@ -489,7 +489,7 @@ impl TwoPhaseResolver {
             return;
         }
         // TODO: handle memory quota exceed, for now, quota is set to usize::MAX.
-        assert!(self.resolver.track_lock(start_ts, key, None));
+        self.resolver.track_lock(start_ts, key, None).unwrap();
     }
 
     pub fn untrack_lock(&mut self, key: &[u8]) {
@@ -505,7 +505,7 @@ impl TwoPhaseResolver {
         match lock {
             FutureLock::Lock(key, ts) => {
                 // TODO: handle memory quota exceed, for now, quota is set to usize::MAX.
-                assert!(self.resolver.track_lock(ts, key, None));
+                self.resolver.track_lock(ts, key, None).unwrap();
             }
             FutureLock::Unlock(key) => self.resolver.untrack_lock(&key, None),
         }

--- a/components/cdc/src/channel.rs
+++ b/components/cdc/src/channel.rs
@@ -14,7 +14,11 @@ use grpcio::WriteFlags;
 use kvproto::cdcpb::{ChangeDataEvent, Event, ResolvedTs};
 use protobuf::Message;
 use tikv_util::{
-    future::block_on_timeout, impl_display_as_debug, memory::MemoryQuota, time::Instant, warn,
+    future::block_on_timeout,
+    impl_display_as_debug,
+    memory::{MemoryQuota, MemoryQuotaExceeded},
+    time::Instant,
+    warn,
 };
 
 use crate::metrics::*;
@@ -234,6 +238,12 @@ impl_from_future_send_error! {
     TrySendError<(CdcEvent, usize)>,
 }
 
+impl From<MemoryQuotaExceeded> for SendError {
+    fn from(_: MemoryQuotaExceeded) -> Self {
+        SendError::Congested
+    }
+}
+
 #[derive(Clone)]
 pub struct Sink {
     unbounded_sender: UnboundedSender<(CdcEvent, usize)>,
@@ -245,8 +255,8 @@ impl Sink {
     pub fn unbounded_send(&self, event: CdcEvent, force: bool) -> Result<(), SendError> {
         // Try it's best to send error events.
         let bytes = if !force { event.size() as usize } else { 0 };
-        if bytes != 0 && !self.memory_quota.alloc(bytes) {
-            return Err(SendError::Congested);
+        if bytes != 0 {
+            self.memory_quota.alloc(bytes)?;
         }
         match self.unbounded_sender.unbounded_send((event, bytes)) {
             Ok(_) => Ok(()),
@@ -265,9 +275,7 @@ impl Sink {
             let bytes = event.size();
             total_bytes += bytes;
         }
-        if !self.memory_quota.alloc(total_bytes as _) {
-            return Err(SendError::Congested);
-        }
+        self.memory_quota.alloc(total_bytes as _)?;
         for event in events {
             let bytes = event.size() as usize;
             if let Err(e) = self.bounded_sender.feed((event, bytes)).await {
@@ -570,9 +578,9 @@ mod tests {
                 }
             }
             let memory_quota = rx.memory_quota.clone();
-            assert_eq!(memory_quota.alloc(event.size() as _), false,);
+            memory_quota.alloc(event.size() as _).unwrap_err();
             drop(rx);
-            assert_eq!(memory_quota.alloc(1024), true);
+            memory_quota.alloc(1024).unwrap();
         }
         // Make sure memory quota is freed when tx is dropped before rx.
         {
@@ -587,10 +595,10 @@ mod tests {
                 }
             }
             let memory_quota = rx.memory_quota.clone();
-            assert_eq!(memory_quota.alloc(event.size() as _), false,);
+            memory_quota.alloc(event.size() as _).unwrap_err();
             drop(send);
             drop(rx);
-            assert_eq!(memory_quota.alloc(1024), true);
+            memory_quota.alloc(1024).unwrap();
         }
         // Make sure sending message to a closed channel does not leak memory quota.
         {
@@ -602,7 +610,7 @@ mod tests {
                 send(CdcEvent::Event(e.clone())).unwrap_err();
             }
             assert_eq!(memory_quota.in_use(), 0);
-            assert_eq!(memory_quota.alloc(1024), true);
+            memory_quota.alloc(1024).unwrap();
 
             // Freeing bytes should not cause overflow.
             memory_quota.free(1024);

--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -249,9 +249,7 @@ impl Pending {
 
     fn push_pending_lock(&mut self, lock: PendingLock) -> Result<()> {
         let bytes = lock.heap_size();
-        if !self.memory_quota.alloc(bytes) {
-            return Err(Error::MemoryQuotaExceeded);
-        }
+        self.memory_quota.alloc(bytes)?;
         self.locks.push(lock);
         self.pending_bytes += bytes;
         CDC_PENDING_BYTES_GAUGE.add(bytes as i64);
@@ -260,16 +258,14 @@ impl Pending {
 
     fn on_region_ready(&mut self, resolver: &mut Resolver) -> Result<()> {
         fail::fail_point!("cdc_pending_on_region_ready", |_| Err(
-            Error::MemoryQuotaExceeded
+            Error::MemoryQuotaExceeded(tikv_util::memory::MemoryQuotaExceeded)
         ));
         // Must take locks, otherwise it may double free memory quota on drop.
         for lock in mem::take(&mut self.locks) {
             self.memory_quota.free(lock.heap_size());
             match lock {
                 PendingLock::Track { key, start_ts } => {
-                    if !resolver.track_lock(start_ts, key, None) {
-                        return Err(Error::MemoryQuotaExceeded);
-                    }
+                    resolver.track_lock(start_ts, key, None)?;
                 }
                 PendingLock::Untrack { key } => resolver.untrack_lock(&key, None),
             }
@@ -900,9 +896,7 @@ impl Delegate {
                 // In order to compute resolved ts, we must track inflight txns.
                 match self.resolver {
                     Some(ref mut resolver) => {
-                        if !resolver.track_lock(row.start_ts.into(), row.key.clone(), None) {
-                            return Err(Error::MemoryQuotaExceeded);
-                        }
+                        resolver.track_lock(row.start_ts.into(), row.key.clone(), None)?;
                     }
                     None => {
                         assert!(self.pending.is_some(), "region resolver not ready");

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -2644,7 +2644,9 @@ mod tests {
 
             let memory_quota = Arc::new(MemoryQuota::new(std::usize::MAX));
             let mut resolver = Resolver::new(id, memory_quota);
-            assert!(resolver.track_lock(TimeStamp::compose(0, id), vec![], None));
+            resolver
+                .track_lock(TimeStamp::compose(0, id), vec![], None)
+                .unwrap();
             let mut region = Region::default();
             region.id = id;
             region.set_region_epoch(region_epoch);

--- a/components/cdc/src/errors.rs
+++ b/components/cdc/src/errors.rs
@@ -10,6 +10,7 @@ use tikv::storage::{
     mvcc::{Error as MvccError, ErrorInner as MvccErrorInner},
     txn::{Error as TxnError, ErrorInner as TxnErrorInner},
 };
+use tikv_util::memory::MemoryQuotaExceeded;
 use txn_types::Error as TxnTypesError;
 
 use crate::channel::SendError;
@@ -36,7 +37,7 @@ pub enum Error {
     #[error("Sink send error {0:?}")]
     Sink(#[from] SendError),
     #[error("Memory quota exceeded")]
-    MemoryQuotaExceeded,
+    MemoryQuotaExceeded(#[from] MemoryQuotaExceeded),
 }
 
 macro_rules! impl_from {

--- a/components/cdc/src/initializer.rs
+++ b/components/cdc/src/initializer.rs
@@ -424,9 +424,7 @@ impl<E: KvEngine> Initializer<E> {
                     let lock = Lock::parse(value)?;
                     match lock.lock_type {
                         LockType::Put | LockType::Delete => {
-                            if !resolver.track_lock(lock.ts, key, None) {
-                                return Err(Error::MemoryQuotaExceeded);
-                            }
+                            resolver.track_lock(lock.ts, key, None)?;
                         }
                         _ => (),
                     };

--- a/components/resolved_ts/src/endpoint.rs
+++ b/components/resolved_ts/src/endpoint.rs
@@ -100,10 +100,10 @@ impl ResolverStatus {
         };
         // Check if adding a new lock or unlock will exceed the memory
         // quota.
-        if !memory_quota.alloc(lock.heap_size()) {
+        memory_quota.alloc(lock.heap_size()).map_err(|e| {
             fail::fail_point!("resolved_ts_on_pending_locks_memory_quota_exceeded");
-            return Err(Error::MemoryQuotaExceeded);
-        }
+            Error::MemoryQuotaExceeded(e)
+        })?;
         locks.push(lock);
         Ok(())
     }
@@ -289,13 +289,11 @@ impl ObserveRegion {
                         for row in rows {
                             match row {
                                 ChangeRow::Prewrite { key, start_ts, .. } => {
-                                    if !self.resolver.track_lock(
+                                    self.resolver.track_lock(
                                         *start_ts,
                                         key.to_raw().unwrap(),
                                         Some(*index),
-                                    ) {
-                                        return Err(Error::MemoryQuotaExceeded);
-                                    }
+                                    )?;
                                 }
                                 ChangeRow::Commit { key, .. } => self
                                     .resolver
@@ -325,13 +323,11 @@ impl ObserveRegion {
                         panic!("region {:?} resolver has ready", self.meta.id)
                     }
                     for (key, lock) in locks {
-                        if !self.resolver.track_lock(
+                        self.resolver.track_lock(
                             lock.ts,
                             key.to_raw().unwrap(),
                             Some(apply_index),
-                        ) {
-                            return Err(Error::MemoryQuotaExceeded);
-                        }
+                        )?;
                     }
                 }
                 ScanEntry::None => {
@@ -344,13 +340,11 @@ impl ObserveRegion {
                     for lock in pending_locks {
                         match lock {
                             PendingLock::Track { key, start_ts } => {
-                                if !self.resolver.track_lock(
+                                self.resolver.track_lock(
                                     start_ts,
                                     key.to_raw().unwrap(),
                                     Some(pending_tracked_index),
-                                ) {
-                                    return Err(Error::MemoryQuotaExceeded);
-                                }
+                                )?;
                             }
                             PendingLock::Untrack { key, .. } => self
                                 .resolver
@@ -655,7 +649,7 @@ where
                     if let Err(e) = observe_region.track_change_log(&logs) {
                         drop(observe_region);
                         let backoff = match e {
-                            Error::MemoryQuotaExceeded => Some(MEMORY_QUOTA_EXCEEDED_BACKOFF),
+                            Error::MemoryQuotaExceeded(_) => Some(MEMORY_QUOTA_EXCEEDED_BACKOFF),
                             Error::Other(_) => None,
                         };
                         self.re_register_region(region_id, observe_id, e, backoff);
@@ -678,13 +672,13 @@ where
         entries: Vec<ScanEntry>,
         apply_index: u64,
     ) {
-        let mut is_memory_quota_exceeded = false;
+        let mut memory_quota_exceeded = None;
         if let Some(observe_region) = self.regions.get_mut(&region_id) {
             if observe_region.handle.id == observe_id {
-                if let Err(Error::MemoryQuotaExceeded) =
+                if let Err(Error::MemoryQuotaExceeded(e)) =
                     observe_region.track_scan_locks(entries, apply_index)
                 {
-                    is_memory_quota_exceeded = true;
+                    memory_quota_exceeded = Some(Error::MemoryQuotaExceeded(e));
                 }
             }
         } else {
@@ -692,9 +686,9 @@ where
                 "region_id" => region_id,
                 "observe_id" => ?observe_id);
         }
-        if is_memory_quota_exceeded {
+        if let Some(e) = memory_quota_exceeded {
             let backoff = Some(MEMORY_QUOTA_EXCEEDED_BACKOFF);
-            self.re_register_region(region_id, observe_id, Error::MemoryQuotaExceeded, backoff);
+            self.re_register_region(region_id, observe_id, e, backoff);
         }
     }
 

--- a/components/resolved_ts/src/errors.rs
+++ b/components/resolved_ts/src/errors.rs
@@ -1,11 +1,12 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
 use thiserror::Error;
+use tikv_util::memory::MemoryQuotaExceeded;
 
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("Memory quota exceeded")]
-    MemoryQuotaExceeded,
+    MemoryQuotaExceeded(#[from] MemoryQuotaExceeded),
     #[error("Other error {0}")]
     Other(#[from] Box<dyn std::error::Error + Sync + Send>),
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #15412 

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
* Add `alloc_high_water`, it can be used for resources that have lower
  priority, so that higher priority resources do not be disrupted easily.
* Use `alloc_high_water` for CDC sink events, so that resolvers are not
  disrupted even if downstream TiCDC is slow.
* MemoryQuota alloc API returns result, make it more ergonomic.
```

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
