### PR TITLE
executor, expression: add support for array type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7097,7 +7097,7 @@ dependencies = [
 [[package]]
 name = "tipb"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/tipb.git#711da6fede03533302fbc9fa3a8fca3556683197"
+source = "git+https://github.com/pingcap/tipb.git#204a4b33468ef0351f4d00c34cdda2e7f9ed4163"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/components/tidb_query_datatype/src/builder/field_type.rs
+++ b/components/tidb_query_datatype/src/builder/field_type.rs
@@ -49,6 +49,12 @@ impl FieldTypeBuilder {
         self
     }
 
+    #[must_use]
+    pub fn array(mut self, v: bool) -> Self {
+        self.0.set_array(v);
+        self
+    }
+
     pub fn build(self) -> FieldType {
         self.0
     }

--- a/components/tidb_query_datatype/src/def/field_type.rs
+++ b/components/tidb_query_datatype/src/def/field_type.rs
@@ -223,6 +223,10 @@ pub trait FieldTypeAccessor {
 
     fn set_collation(&mut self, collation: Collation) -> &mut dyn FieldTypeAccessor;
 
+    fn array(&self) -> bool;
+
+    fn set_array(&mut self, array: bool) -> &mut dyn FieldTypeAccessor;
+
     /// Convert reference to `FieldTypeAccessor` interface. Useful when an
     /// implementer provides inherent methods with the same name as the accessor
     /// trait methods.
@@ -331,6 +335,7 @@ pub trait FieldTypeAccessor {
     #[inline]
     fn need_restored_data(&self) -> bool {
         self.is_non_binary_string_like()
+            && !self.array()
             && (!self
                 .collation()
                 .map(|col| col.is_bin_collation())
@@ -398,6 +403,17 @@ impl FieldTypeAccessor for FieldType {
         FieldType::set_collate(self, collation as i32);
         self as &mut dyn FieldTypeAccessor
     }
+
+    #[inline]
+    fn array(&self) -> bool {
+        self.get_array()
+    }
+
+    #[inline]
+    fn set_array(&mut self, array: bool) -> &mut dyn FieldTypeAccessor {
+        FieldType::set_array(self, array);
+        self as &mut dyn FieldTypeAccessor
+    }
 }
 
 impl FieldTypeAccessor for ColumnInfo {
@@ -453,6 +469,17 @@ impl FieldTypeAccessor for ColumnInfo {
     #[inline]
     fn set_collation(&mut self, collation: Collation) -> &mut dyn FieldTypeAccessor {
         ColumnInfo::set_collation(self, collation as i32);
+        self as &mut dyn FieldTypeAccessor
+    }
+
+    #[inline]
+    fn array(&self) -> bool {
+        self.get_array()
+    }
+
+    #[inline]
+    fn set_array(&mut self, array: bool) -> &mut dyn FieldTypeAccessor {
+        ColumnInfo::set_array(self, array);
         self as &mut dyn FieldTypeAccessor
     }
 }

--- a/components/tidb_query_executors/src/util/scan_executor.rs
+++ b/components/tidb_query_executors/src/util/scan_executor.rs
@@ -145,6 +145,7 @@ pub fn field_type_from_column_info(ci: &ColumnInfo) -> FieldType {
     field_type.set_decimal(ci.get_decimal());
     field_type.set_collate(ci.get_collation());
     field_type.set_elems(protobuf::RepeatedField::from(ci.get_elems()));
+    field_type.set_array(ci.get_array());
     // Note: Charset is not provided in column info.
     field_type
 }


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Close #15531

What's Changed:

Upgrade the `tipb`, and use the `array` field to align with the change in TiDB side: https://github.com/pingcap/tidb/pull/39992/files#diff-7f1116d41040b590372f81a91d25057b8ef7f6bdf503f6c2b27af3f35294cda1R93-R95

It also adds the `array` field to `ColumnInfo`, which is also needed by the `IndexScanExecutor`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- Integration test
- [x] Manual test (add detailed scripts or steps below)
- No code

Execute the following SQL with the TiDB from https://github.com/pingcap/tidb/pull/46718:

```
create table t (pk varchar(4) primary key clustered, j json, str varchar(255), value int, key idx((cast(j as char(100) array)), str));
insert into t values ("1", '["a"]', 'b', 1);
select * from t use index(idx) where "a" member of (j);
```

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix the issue that the compound of multi value index and a string will return error in some situations.
```
