### PR TITLE
raftstore-v2: persist applied index after ingset sst

### DIFF
--- a/components/raftstore-v2/src/operation/command/mod.rs
+++ b/components/raftstore-v2/src/operation/command/mod.rs
@@ -871,7 +871,7 @@ impl<EK: KvEngine, R: ApplyResReporter> Apply<EK, R> {
         apply_res.modifications = *self.modifications_mut();
         apply_res.metrics = mem::take(&mut self.metrics);
         apply_res.bucket_stat = self.buckets.clone();
-        apply_res.sst_applied_index = mem::take(&mut self.sst_applied_index);
+        apply_res.sst_applied_index = self.take_sst_applied_index();
         let written_bytes = apply_res.metrics.written_bytes;
 
         let skip_report = || -> bool {

--- a/components/raftstore-v2/src/operation/command/mod.rs
+++ b/components/raftstore-v2/src/operation/command/mod.rs
@@ -455,6 +455,11 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         if is_leader {
             self.retry_pending_prepare_merge(ctx, apply_res.applied_index);
         }
+        if !apply_res.sst_applied_index.is_empty() {
+            self.storage_mut()
+                .apply_trace_mut()
+                .on_sst_ingested(&apply_res.sst_applied_index);
+        }
         self.on_data_modified(apply_res.modifications);
         self.handle_read_on_apply(
             ctx,
@@ -866,6 +871,7 @@ impl<EK: KvEngine, R: ApplyResReporter> Apply<EK, R> {
         apply_res.modifications = *self.modifications_mut();
         apply_res.metrics = mem::take(&mut self.metrics);
         apply_res.bucket_stat = self.buckets.clone();
+        apply_res.sst_applied_index = mem::take(&mut self.sst_applied_index);
         let written_bytes = apply_res.metrics.written_bytes;
 
         let skip_report = || -> bool {

--- a/components/raftstore-v2/src/operation/command/write/ingest.rs
+++ b/components/raftstore-v2/src/operation/command/write/ingest.rs
@@ -159,8 +159,7 @@ impl<EK: KvEngine, R: ApplyResReporter> Apply<EK, R> {
         self.metrics.written_keys += keys;
         for (cf_index, index) in cf_indexes.into_iter().enumerate() {
             if index != u64::MAX {
-                self.sst_applied_index
-                    .push(SstApplyIndex { cf_index, index });
+                self.push_sst_applied_index(SstApplyIndex { cf_index, index });
             }
         }
         Ok(())

--- a/components/raftstore-v2/src/operation/command/write/ingest.rs
+++ b/components/raftstore-v2/src/operation/command/write/ingest.rs
@@ -107,6 +107,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
 impl<EK: KvEngine, R: ApplyResReporter> Apply<EK, R> {
     #[inline]
     pub fn apply_ingest(&mut self, index: u64, ssts: Vec<SstMeta>) -> Result<()> {
+        fail::fail_point!("on_apply_ingest");
         PEER_WRITE_CMD_COUNTER.ingest_sst.inc();
         let mut infos = Vec::with_capacity(ssts.len());
         let mut size: i64 = 0;

--- a/components/raftstore-v2/src/operation/command/write/ingest.rs
+++ b/components/raftstore-v2/src/operation/command/write/ingest.rs
@@ -158,7 +158,6 @@ impl<EK: KvEngine, R: ApplyResReporter> Apply<EK, R> {
         self.metrics.written_keys += keys;
         for (cf_index, index) in cf_indexes.into_iter().enumerate() {
             if index != u64::MAX {
-                // self.modifications_mut()[i] = idx;
                 self.sst_applied_index
                     .push(SstApplyIndex { cf_index, index });
             }

--- a/components/raftstore-v2/src/operation/ready/apply_trace.rs
+++ b/components/raftstore-v2/src/operation/ready/apply_trace.rs
@@ -151,12 +151,13 @@ struct Progress {
     pending_sst_ranges: VecDeque<IndexRange>,
 }
 
+// A range representing [start, end], upper bound inclusive for handling
+// convenience.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-// A range represent [start, end]
 struct IndexRange(u64, u64);
 
 #[derive(Debug)]
-// track the global flushed index in the write task.
+// track the global flushed index related to the write task.
 struct ReadyFlushedIndex {
     ready_number: u64,
     flushed_index: u64,
@@ -192,6 +193,8 @@ pub struct ApplyTrace {
     last_flush_trigger: u64,
     /// `true` means the raft cf record should be persisted in next ready.
     try_persist: bool,
+    // Because we persist the global flushed in the write task, so we should track
+    // the task and handle sst cleanup after the write task finished.
     flushed_index_queue: VecDeque<ReadyFlushedIndex>,
 }
 

--- a/components/raftstore-v2/src/operation/ready/apply_trace.rs
+++ b/components/raftstore-v2/src/operation/ready/apply_trace.rs
@@ -315,7 +315,8 @@ impl ApplyTrace {
 
         // At best effort, we can only advance the index to `mem_index`.
         let candidate = cmp::min(mem_index, min_flushed.unwrap_or(u64::MAX));
-        // always flush if there is any sst ingestion.
+        // try advance the index if there are any sst ingestion next to the flushed
+        // index, and always trigger a flush if there is any sst ingestion.
         let (candidate, has_ingested_sst) = self.advance_flushed_index_for_ingest(candidate);
         if candidate > self.admin.flushed {
             self.admin.flushed = candidate;

--- a/components/raftstore-v2/src/operation/ready/mod.rs
+++ b/components/raftstore-v2/src/operation/ready/mod.rs
@@ -903,7 +903,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         info!(self.logger, "take_flush_index"; "ready" => ready_number, "index" => ?flushed_idx);
         if let Some(idx) = flushed_idx {
             let apply_index = self.flush_state().applied_index();
-            self.gc_stale_ssts(ctx, DATA_CFS, idx, apply_index);
+            self.cleanup_stale_ssts(ctx, DATA_CFS, idx, apply_index);
         }
 
         if self.is_in_force_leader() {

--- a/components/raftstore-v2/src/operation/ready/mod.rs
+++ b/components/raftstore-v2/src/operation/ready/mod.rs
@@ -896,12 +896,11 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         self.storage_mut()
             .entry_storage_mut()
             .update_cache_persisted(persisted_index);
-        let flushed_idx = self
+        if let Some(idx) = self
             .storage_mut()
             .apply_trace_mut()
-            .take_flush_index(ready_number);
-        info!(self.logger, "take_flush_index"; "ready" => ready_number, "index" => ?flushed_idx);
-        if let Some(idx) = flushed_idx {
+            .take_flush_index(ready_number)
+        {
             let apply_index = self.flush_state().applied_index();
             self.cleanup_stale_ssts(ctx, DATA_CFS, idx, apply_index);
         }

--- a/components/raftstore-v2/src/raft/apply.rs
+++ b/components/raftstore-v2/src/raft/apply.rs
@@ -20,7 +20,7 @@ use tikv_util::{log::SlogFormat, worker::Scheduler, yatp_pool::FuturePool};
 
 use crate::{
     operation::{AdminCmdResult, ApplyFlowControl, DataTrace},
-    router::CmdResChannel,
+    router::{CmdResChannel, SstApplyIndex},
     TabletTask,
 };
 
@@ -64,6 +64,7 @@ pub struct Apply<EK: KvEngine, R> {
     admin_cmd_result: Vec<AdminCmdResult>,
     flush_state: Arc<FlushState>,
     sst_apply_state: SstApplyState,
+    pub(crate) sst_applied_index: Vec<SstApplyIndex>,
     /// The flushed indexes of each column family before being restarted.
     ///
     /// If an apply index is less than the flushed index, the log can be
@@ -138,6 +139,7 @@ impl<EK: KvEngine, R> Apply<EK, R> {
             res_reporter,
             flush_state,
             sst_apply_state,
+            sst_applied_index: vec![],
             log_recovery,
             metrics: ApplyMetrics::default(),
             buckets,

--- a/components/raftstore-v2/src/raft/apply.rs
+++ b/components/raftstore-v2/src/raft/apply.rs
@@ -64,7 +64,7 @@ pub struct Apply<EK: KvEngine, R> {
     admin_cmd_result: Vec<AdminCmdResult>,
     flush_state: Arc<FlushState>,
     sst_apply_state: SstApplyState,
-    pub(crate) sst_applied_index: Vec<SstApplyIndex>,
+    sst_applied_index: Vec<SstApplyIndex>,
     /// The flushed indexes of each column family before being restarted.
     ///
     /// If an apply index is less than the flushed index, the log can be
@@ -308,6 +308,16 @@ impl<EK: KvEngine, R> Apply<EK, R> {
     #[inline]
     pub fn sst_apply_state(&self) -> &SstApplyState {
         &self.sst_apply_state
+    }
+
+    #[inline]
+    pub fn push_sst_applied_index(&mut self, sst_index: SstApplyIndex) {
+        self.sst_applied_index.push(sst_index);
+    }
+
+    #[inline]
+    pub fn take_sst_applied_index(&mut self) -> Vec<SstApplyIndex> {
+        mem::take(&mut self.sst_applied_index)
     }
 
     #[inline]

--- a/components/raftstore-v2/src/router/internal_message.rs
+++ b/components/raftstore-v2/src/router/internal_message.rs
@@ -25,4 +25,11 @@ pub struct ApplyRes {
     pub modifications: DataTrace,
     pub metrics: ApplyMetrics,
     pub bucket_stat: Option<BucketStat>,
+    pub sst_applied_index: Vec<SstApplyIndex>,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct SstApplyIndex {
+    pub cf_index: usize,
+    pub index: u64,
 }

--- a/components/raftstore-v2/src/router/mod.rs
+++ b/components/raftstore-v2/src/router/mod.rs
@@ -12,7 +12,7 @@ pub use self::response_channel::FlushChannel;
 pub use self::response_channel::FlushSubscriber;
 pub use self::{
     imp::{RaftRouter, UnsafeRecoveryRouter},
-    internal_message::ApplyRes,
+    internal_message::{ApplyRes, SstApplyIndex},
     message::{PeerMsg, PeerTick, RaftRequest, StoreMsg, StoreTick},
     response_channel::{
         build_any_channel, AnyResChannel, AnyResSubscriber, BaseSubscriber, CmdResChannel,

--- a/tests/failpoints/cases/test_import_service.rs
+++ b/tests/failpoints/cases/test_import_service.rs
@@ -511,7 +511,7 @@ fn test_flushed_applied_index_after_ingset() {
     assert_eq!(1, count);
 
     // file a write to trigger ready flush, even if the write is not flushed.
-    must_raw_put(&client, ctx.clone(), b"key1".to_vec(), b"value1".to_vec());
+    must_raw_put(&client, ctx, b"key1".to_vec(), b"value1".to_vec());
     let count = sst_file_count(&cluster.paths);
     assert_eq!(0, count);
 

--- a/tests/failpoints/cases/test_import_service.rs
+++ b/tests/failpoints/cases/test_import_service.rs
@@ -7,10 +7,10 @@ use std::{
 
 use file_system::calc_crc32;
 use futures::{executor::block_on, stream, SinkExt};
-use grpcio::{Result, WriteFlags};
-use kvproto::import_sstpb::*;
+use grpcio::{ChannelBuilder, Environment, Result, WriteFlags};
+use kvproto::{import_sstpb::*, tikvpb_grpc::TikvClient};
 use tempfile::{Builder, TempDir};
-use test_raftstore::Simulator;
+use test_raftstore::{must_raw_put, Simulator};
 use test_sst_importer::*;
 use tikv::config::TikvConfig;
 use tikv_util::{config::ReadableSize, HandyRwLock};
@@ -454,4 +454,74 @@ fn sst_file_count(paths: &Vec<TempDir>) -> u64 {
         }
     }
     count
+}
+
+#[test]
+fn test_flushed_applied_index_after_ingset() {
+    // disable data flushed
+    fail::cfg("on_flush_completed", "return()").unwrap();
+    // disable data flushed
+    let (mut cluster, ctx, _tikv, import) = open_cluster_and_tikv_import_client_v2(None);
+    let temp_dir = Builder::new().prefix("test_ingest_sst").tempdir().unwrap();
+    let sst_path = temp_dir.path().join("test.sst");
+
+    // Create clients.
+    let env = Arc::new(Environment::new(1));
+    let channel = ChannelBuilder::new(Arc::clone(&env)).connect(&cluster.sim.rl().get_addr(1));
+    let client = TikvClient::new(channel);
+
+    for i in 0..5 {
+        let sst_range = (i * 20, (i + 1) * 20);
+        let (mut meta, data) = gen_sst_file(sst_path.clone(), sst_range);
+        // No region id and epoch.
+        send_upload_sst(&import, &meta, &data).unwrap();
+        let mut ingest = IngestRequest::default();
+        ingest.set_context(ctx.clone());
+        ingest.set_sst(meta.clone());
+        meta.set_region_id(ctx.get_region_id());
+        meta.set_region_epoch(ctx.get_region_epoch().clone());
+        send_upload_sst(&import, &meta, &data).unwrap();
+        ingest.set_sst(meta.clone());
+        let resp = import.ingest(&ingest).unwrap();
+        assert!(!resp.has_error(), "{:?}", resp.get_error());
+    }
+
+    // only 1 sst left because there is no more event to trigger a raft ready flush.
+    let count = sst_file_count(&cluster.paths);
+    assert_eq!(1, count);
+
+    for i in 5..8 {
+        let sst_range = (i * 20, (i + 1) * 20);
+        let (mut meta, data) = gen_sst_file(sst_path.clone(), sst_range);
+        // No region id and epoch.
+        send_upload_sst(&import, &meta, &data).unwrap();
+        let mut ingest = IngestRequest::default();
+        ingest.set_context(ctx.clone());
+        ingest.set_sst(meta.clone());
+        meta.set_region_id(ctx.get_region_id());
+        meta.set_region_epoch(ctx.get_region_epoch().clone());
+        send_upload_sst(&import, &meta, &data).unwrap();
+        ingest.set_sst(meta.clone());
+        let resp = import.ingest(&ingest).unwrap();
+        assert!(!resp.has_error(), "{:?}", resp.get_error());
+    }
+
+    // ingest more sst files, unflushed index still be 1.
+    let count = sst_file_count(&cluster.paths);
+    assert_eq!(1, count);
+
+    // file a write to trigger ready flush, even if the write is not flushed.
+    must_raw_put(&client, ctx.clone(), b"key1".to_vec(), b"value1".to_vec());
+    let count = sst_file_count(&cluster.paths);
+    assert_eq!(0, count);
+
+    // restart node, should not tirgger any ingest
+    fail::cfg("on_apply_ingest", "panic").unwrap();
+    cluster.stop_node(1);
+    cluster.start().unwrap();
+    let count = sst_file_count(&cluster.paths);
+    assert_eq!(0, count);
+
+    fail::remove("on_apply_ingest");
+    fail::remove("on_flush_completed");
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #15461

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```
Add ingest sst index to ApplyRes and return it to raftstore and store these ingest index in apply trace. In check advance admin index, if there are and sst ingest before this flush, directly trigger a new flush. And also try to gc stale sst files after the write task is persisted.
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
 - In my local env, after this change there is no sst files leat in the import dir after br restore. Before this change, there are handreds of ssts there.
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
