### PR TITLE
add option to update config without persist

### DIFF
--- a/src/server/status_server/mod.rs
+++ b/src/server/status_server/mod.rs
@@ -1304,7 +1304,7 @@ mod tests {
                     .await
                     .unwrap();
                 let resp_json = String::from_utf8_lossy(&v).to_string();
-                assert!(resp_json.find("\"region-split-size\":\"1GiB\"").is_some());
+                assert!(resp_json.contains("\"region-split-size\":\"1GiB\""));
             });
             block_on(handle2).unwrap();
             status_server.stop();

--- a/src/server/status_server/mod.rs
+++ b/src/server/status_server/mod.rs
@@ -313,6 +313,18 @@ where
         req: Request<Body>,
     ) -> hyper::Result<Response<Body>> {
         let mut body = Vec::new();
+        let mut persist = true;
+        if let Some(query) = req.uri().query() {
+            let query_pairs: HashMap<_, _> =
+                url::form_urlencoded::parse(query.as_bytes()).collect();
+            persist = match query_pairs.get("persist") {
+                Some(val) => match val.parse() {
+                    Ok(val) => val,
+                    Err(err) => return Ok(make_response(StatusCode::BAD_REQUEST, err.to_string())),
+                },
+                None => false,
+            };
+        }
         req.into_body()
             .try_for_each(|bytes| {
                 body.extend(bytes);
@@ -320,7 +332,11 @@ where
             })
             .await?;
         Ok(match decode_json(&body) {
-            Ok(change) => match cfg_controller.update(change) {
+            Ok(change) => match if persist {
+                cfg_controller.update(change)
+            } else {
+                cfg_controller.update_without_persist(change)
+            } {
                 Err(e) => {
                     if let Some(e) = e.downcast_ref::<std::io::Error>() {
                         make_response(
@@ -1184,47 +1200,60 @@ mod tests {
 
     #[test]
     fn test_config_endpoint() {
-        let temp_dir = tempfile::TempDir::new().unwrap();
-        let mut status_server = StatusServer::new(
-            1,
-            ConfigController::default(),
-            Arc::new(SecurityConfig::default()),
-            MockRouter,
-            temp_dir.path().to_path_buf(),
-            None,
-            GrpcServiceManager::dummy(),
-        )
-        .unwrap();
-        let addr = "127.0.0.1:0".to_owned();
-        let _ = status_server.start(addr);
-        let client = Client::new();
-        let uri = Uri::builder()
-            .scheme("http")
-            .authority(status_server.listening_addr().to_string().as_str())
-            .path_and_query("/config")
-            .build()
+        let test_config = |persisit: bool| {
+            let temp_dir = tempfile::TempDir::new().unwrap();
+            let mut status_server = StatusServer::new(
+                1,
+                ConfigController::default(),
+                Arc::new(SecurityConfig::default()),
+                MockRouter,
+                temp_dir.path().to_path_buf(),
+                None,
+                GrpcServiceManager::dummy(),
+            )
             .unwrap();
-        let handle = status_server.thread_pool.spawn(async move {
-            let resp = client.get(uri).await.unwrap();
-            assert_eq!(resp.status(), StatusCode::OK);
-            let mut v = Vec::new();
-            resp.into_body()
-                .try_for_each(|bytes| {
-                    v.extend(bytes);
-                    ok(())
-                })
-                .await
-                .unwrap();
-            let resp_json = String::from_utf8_lossy(&v).to_string();
-            let cfg = TikvConfig::default();
-            serde_json::to_string(&cfg.get_encoder())
-                .map(|cfg_json| {
-                    assert_eq!(resp_json, cfg_json);
-                })
-                .expect("Could not convert TikvConfig to string");
-        });
-        block_on(handle).unwrap();
-        status_server.stop();
+            let addr = "127.0.0.1:0".to_owned();
+            let _ = status_server.start(addr);
+            let client = Client::new();
+            let uri = if persisit {
+                Uri::builder()
+                    .scheme("http")
+                    .authority(status_server.listening_addr().to_string().as_str())
+                    .path_and_query("/config")
+                    .build()
+                    .unwrap()
+            } else {
+                Uri::builder()
+                    .scheme("http")
+                    .authority(status_server.listening_addr().to_string().as_str())
+                    .path_and_query("/config?persist=false")
+                    .build()
+                    .unwrap()
+            };
+            let handle = status_server.thread_pool.spawn(async move {
+                let resp = client.get(uri).await.unwrap();
+                assert_eq!(resp.status(), StatusCode::OK);
+                let mut v = Vec::new();
+                resp.into_body()
+                    .try_for_each(|bytes| {
+                        v.extend(bytes);
+                        ok(())
+                    })
+                    .await
+                    .unwrap();
+                let resp_json = String::from_utf8_lossy(&v).to_string();
+                let cfg = TikvConfig::default();
+                serde_json::to_string(&cfg.get_encoder())
+                    .map(|cfg_json| {
+                        assert_eq!(resp_json, cfg_json);
+                    })
+                    .expect("Could not convert TikvConfig to string");
+            });
+            block_on(handle).unwrap();
+            status_server.stop();
+        };
+        test_config(true);
+        test_config(false);
     }
 
     #[cfg(feature = "failpoints")]

--- a/src/server/status_server/mod.rs
+++ b/src/server/status_server/mod.rs
@@ -1245,7 +1245,7 @@ mod tests {
 
     #[test]
     fn test_update_config_endpoint() {
-        let test_config = |persisit: bool| {
+        let test_config = |persist: bool| {
             let temp_dir = tempfile::TempDir::new().unwrap();
             let mut config = TikvConfig::default();
             config.cfg_path = temp_dir
@@ -1267,7 +1267,7 @@ mod tests {
             let addr = "127.0.0.1:0".to_owned();
             let _ = status_server.start(addr);
             let client = Client::new();
-            let uri = if persisit {
+            let uri = if persist {
                 Uri::builder()
                     .scheme("http")
                     .authority(status_server.listening_addr().to_string().as_str())


### PR DESCRIPTION
### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #15588

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
add option to update TiKV config without persist in status API  "POST /config?persist=false|true"
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Support update config without actually persisting config to disk. This is to refresh config on container environment when the disk is read-only. 
By default, POST /config would refresh the config and persisting the update to disk. However, if POST /config?persist=false, the persistence to disk would be skipped. 
```
