### PR TITLE
rust-rocksdb: Reconcile cargo toml and lock files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3108,7 +3108,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/SpadeA-Tang/rust-rocksdb.git?branch=fix-sealed-chaos#f5121f48a1543c5d576ad7964c617f30f79a3d66"
+source = "git+https://github.com/SpadeA-Tang/rust-rocksdb?branch=fix-sealed-chaos#3918735e13250892b712d063a526cef4c206334f"
 dependencies = [
  "bindgen 0.65.1",
  "bzip2-sys",
@@ -3127,7 +3127,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/SpadeA-Tang/rust-rocksdb.git?branch=fix-sealed-chaos#f5121f48a1543c5d576ad7964c617f30f79a3d66"
+source = "git+https://github.com/SpadeA-Tang/rust-rocksdb?branch=fix-sealed-chaos#3918735e13250892b712d063a526cef4c206334f"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -5101,7 +5101,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/SpadeA-Tang/rust-rocksdb.git?branch=fix-sealed-chaos#f5121f48a1543c5d576ad7964c617f30f79a3d66"
+source = "git+https://github.com/SpadeA-Tang/rust-rocksdb?branch=fix-sealed-chaos#3918735e13250892b712d063a526cef4c206334f"
 dependencies = [
  "libc 0.2.146",
  "librocksdb_sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -207,6 +207,8 @@ procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "7693954bd1dd86e
 # After the PR to rust-rocksdb is merged, remember to comment this out and run `cargo update -p rocksdb`.
 # [patch.'https://github.com/tikv/rust-rocksdb']
 # rocksdb = { git = "https://github.com/your_github_id/rust-rocksdb", branch = "your_branch" }
+[patch.'https://github.com/tikv/rust-rocksdb']
+rocksdb = { git = "https://github.com/SpadeA-Tang/rust-rocksdb", branch = "fix-sealed-chaos" }
 
 [workspace]
 # See https://github.com/rust-lang/rfcs/blob/master/text/2957-cargo-features2.md


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #15609

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Patch rust-rocksdb in Cargo.toml, instead of merely in Cargo.lock.
```

### Related changes

n/a

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

n/a

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
