### PR TITLE
test: make test test_destroy_missing more stable

### DIFF
--- a/components/raftstore-v2/src/worker/tablet.rs
+++ b/components/raftstore-v2/src/worker/tablet.rs
@@ -832,9 +832,10 @@ mod tests {
         // waiting for async `pause_background_work` to be finished,
         // this task can block tablet's destroy.
         for _i in 0..100 {
-            if runner.get_running_task_count() > 0 {
-                std::thread::sleep(Duration::from_millis(5));
+            if runner.get_running_task_count() == 0 {
+                break;
             }
+            std::thread::sleep(Duration::from_millis(5));
         }
         runner.on_timeout();
         assert!(!path.exists());


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #15615

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```
Add a loop to wait async pause_background_work task finish before trying to clean up tablet.
The `pause_background_work` task can block tablet's close because it also hold a valid arc reference.
```

### Related changes


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
