### PR TITLE
log backup: fix the race of on events and do flush

### DIFF
--- a/components/backup-stream/src/router.rs
+++ b/components/backup-stream/src/router.rs
@@ -1042,7 +1042,7 @@ impl StreamTaskInfo {
                 let file = shared_pool
                     .open_raw_for_read(data_file.inner.path())
                     .context(format_args!(
-                        "open raw for read {:?}",
+                        "failed to open read file {:?}",
                         data_file.inner.path()
                     ))?;
                 let compress_length = file.len().await?;
@@ -1225,7 +1225,6 @@ impl StreamTaskInfo {
                 .map(|d| (d.length, d.data_files_info.len()))
                 .collect::<Vec<_>>();
             // flush meta file to storage.
-
             self.flush_meta(metadata_info).await?;
             crate::metrics::FLUSH_DURATION
                 .with_label_values(&["save_files"])
@@ -2499,7 +2498,7 @@ mod tests {
             tokio::spawn(async move {
                 router_clone.do_flush("race", 42, TimeStamp::max()).await;
             }),
-            router.on_events(events_after_flush).await;
+            router.on_events(events_after_flush)
         );
         fail::remove("after_write_to_file");
         fail::remove("before_generate_temp_file");

--- a/components/backup-stream/src/router.rs
+++ b/components/backup-stream/src/router.rs
@@ -976,7 +976,7 @@ impl StreamTaskInfo {
     pub async fn move_to_flushing_files(&self) -> Result<&Self> {
         // if flushing_files is not empty, which represents this flush is a retry
         // operation.
-        if !self.flushing_files.read().await.is_empty() {
+        if !self.flushing_files.read().await.is_empty() || !self.flushing_meta_files.read().await.is_empty() {
             return Ok(self);
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/tikv/tikv/issues/15602
What's Changed:

add uuid for temporary files to avoid race as describe in above issue.
<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix the issue that log backup may get stuck when flush too frequently.
```
