### PR TITLE
raftstore-v2: fix rollback merge and commit merge can happen simultaneously

### DIFF
--- a/components/raftstore-v2/src/operation/command/admin/merge/commit.rs
+++ b/components/raftstore-v2/src/operation/command/admin/merge/commit.rs
@@ -161,7 +161,6 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
     // Match v1::on_check_merge.
     pub fn on_check_merge<T: Transport>(&mut self, store_ctx: &mut StoreContext<EK, ER, T>) {
         if !self.serving() || self.applied_merge_state().is_none() {
-            info!(self.logger, "exit on_check_merge",);
             return;
         }
         self.add_pending_tick(PeerTick::CheckMerge);

--- a/components/raftstore-v2/src/operation/command/admin/merge/commit.rs
+++ b/components/raftstore-v2/src/operation/command/admin/merge/commit.rs
@@ -348,6 +348,12 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
                 let _ = store_ctx
                     .router
                     .force_send(source_id, PeerMsg::RejectCommitMerge { index });
+            } else if self.leader_transferring() {
+                info!(
+                    self.logger,
+                    "not to propose commit merge when transferring leader";
+                    "transferee" => self.leader_transferee(),
+                );
             }
         } else {
             info!(

--- a/components/raftstore-v2/src/operation/command/admin/merge/rollback.rs
+++ b/components/raftstore-v2/src/operation/command/admin/merge/rollback.rs
@@ -38,6 +38,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         store_ctx: &mut StoreContext<EK, ER, T>,
         index: u64,
     ) {
+        fail::fail_point!("on_reject_commit_merge_1", store_ctx.store_id == 1, |_| {});
         let self_index = self.merge_context().and_then(|c| c.prepare_merge_index());
         if self_index != Some(index) {
             info!(

--- a/components/raftstore-v2/src/raft/peer.rs
+++ b/components/raftstore-v2/src/raft/peer.rs
@@ -863,6 +863,11 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
     }
 
     #[inline]
+    pub fn leader_transferee(&self) -> u64 {
+        self.leader_transferee
+    }
+
+    #[inline]
     pub fn leader_transferring(&self) -> bool {
         self.leader_transferee != raft::INVALID_ID
     }

--- a/components/raftstore-v2/src/raft/peer.rs
+++ b/components/raftstore-v2/src/raft/peer.rs
@@ -863,6 +863,11 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
     }
 
     #[inline]
+    pub fn leader_transferring(&self) -> bool {
+        self.leader_transferee != raft::INVALID_ID
+    }
+
+    #[inline]
     pub fn long_uncommitted_threshold(&self) -> Duration {
         Duration::from_secs(self.long_uncommitted_threshold)
     }

--- a/tests/failpoints/cases/test_merge.rs
+++ b/tests/failpoints/cases/test_merge.rs
@@ -1822,13 +1822,14 @@ fn test_concurrent_between_transfer_leader_and_merge() {
 
     cluster.merge_region(left.get_id(), right.get_id(), Callback::None);
 
+    // Actually, store 1 should not reach the line of propose_commit_merge_1
     let _ = rx.recv_timeout(Duration::from_secs(2));
     router
         .force_send(msg.get_region_id(), PeerMsg::RaftMessage(Box::new(msg)))
         .unwrap();
 
     // Wait region 1 of node 2 to become leader
-    let _ = rx2.recv().unwrap();
+    rx2.recv().unwrap();
     fail::remove("on_reject_commit_merge_1");
 
     let timer = Instant::now();

--- a/tests/failpoints/cases/test_merge.rs
+++ b/tests/failpoints/cases/test_merge.rs
@@ -3,6 +3,7 @@
 use std::{
     sync::{
         atomic::{AtomicBool, Ordering},
+        mpsc::{channel, Sender},
         *,
     },
     thread,
@@ -19,6 +20,7 @@ use kvproto::{
 use pd_client::PdClient;
 use raft::eraftpb::MessageType;
 use raftstore::store::*;
+use raftstore_v2::router::PeerMsg;
 use test_raftstore::*;
 use tikv::storage::{kv::SnapshotExt, Snapshot};
 use tikv_util::{config::*, future::block_on_timeout, time::Instant, HandyRwLock};
@@ -1705,4 +1707,143 @@ fn test_destroy_source_peer_while_merging() {
     for i in 2..=5 {
         must_get_equal(&cluster.get_engine(i), b"k5", b"v5");
     }
+}
+
+struct MsgTimeoutFilter {
+    tx: Sender<RaftMessage>,
+}
+
+impl Filter for MsgTimeoutFilter {
+    fn before(&self, msgs: &mut Vec<RaftMessage>) -> raftstore::Result<()> {
+        let mut res = Vec::with_capacity(msgs.len());
+        for m in msgs.drain(..) {
+            if m.get_message().msg_type == MessageType::MsgTimeoutNow {
+                self.tx.send(m).unwrap();
+            } else {
+                res.push(m);
+            }
+        }
+
+        *msgs = res;
+        check_messages(msgs)
+    }
+}
+
+// Concurrent execution between transfer leader and merge can cause rollback and
+// commit merge at the same time before this fix which corrupt the region.
+// It can happen as this:
+// Assume at the begin, leader of source and target are both on node-1
+// 1. node-1 transfer leader to node-2: execute up to sending MsgTimeoutNow
+// (leader_transferre has been set), but before becoming follower.
+// 2. node-1 source region propose, and apply PrepareMerge
+// 3. node-1 target region propose CommitMerge but fail (due to
+//    leader_transferre being set)
+// 4. node-1 source region successfully proposed rollback merge
+// 5. node-2 target region became leader and apply the first no-op entry
+// 6. node-2 target region successfully proposed commit merge
+// Now, rollback at source region and commit at target region are both proposed
+// and will be executed which will cause region corrupt
+#[test]
+fn test_concurrent_between_transfer_leader_and_merge() {
+    use test_raftstore_v2::*;
+    let mut cluster = new_node_cluster(0, 3);
+    configure_for_merge(&mut cluster.cfg);
+    cluster.run();
+
+    cluster.must_put(b"k1", b"v1");
+    cluster.must_put(b"k3", b"v3");
+    for i in 0..3 {
+        must_get_equal(&cluster.get_engine(i + 1), b"k1", b"v1");
+        must_get_equal(&cluster.get_engine(i + 1), b"k3", b"v3");
+    }
+
+    let pd_client = Arc::clone(&cluster.pd_client);
+    let region = pd_client.get_region(b"k1").unwrap();
+    cluster.must_split(&region, b"k2");
+
+    let right = pd_client.get_region(b"k1").unwrap();
+    let left = pd_client.get_region(b"k3").unwrap();
+    cluster.must_transfer_leader(
+        left.get_id(),
+        left.get_peers()
+            .iter()
+            .find(|p| p.store_id == 1)
+            .cloned()
+            .unwrap(),
+    );
+
+    cluster.must_transfer_leader(
+        right.get_id(),
+        right
+            .get_peers()
+            .iter()
+            .find(|p| p.store_id == 1)
+            .cloned()
+            .unwrap(),
+    );
+
+    // Source region: 1, Target Region: 1000
+    // Let target region in leader_transfering status by interceptting MsgTimeoutNow
+    // msg by using Filter
+    let (tx, rx_msg) = channel();
+    let filter = MsgTimeoutFilter { tx };
+    cluster.add_send_filter_on_node(1, Box::new(filter));
+
+    pd_client.transfer_leader(
+        right.get_id(),
+        right
+            .get_peers()
+            .iter()
+            .find(|p| p.store_id == 2)
+            .cloned()
+            .unwrap(),
+        vec![],
+    );
+
+    let msg = rx_msg.recv().unwrap();
+
+    fail::cfg("on_reject_commit_merge_1", "pause").unwrap();
+
+    let router = cluster.get_router(2).unwrap();
+    let (tx, rx) = channel();
+    let _ = fail::cfg_callback("propose_commit_merge_1", move || {
+        tx.send(()).unwrap();
+    });
+
+    let (tx2, rx2) = channel();
+    let _ = fail::cfg_callback("on_propose_commit_merge_success", move || {
+        tx2.send(()).unwrap();
+    });
+
+    cluster.merge_region(left.get_id(), right.get_id(), Callback::None);
+
+    let _ = rx.recv_timeout(Duration::from_secs(2));
+    router
+        .force_send(msg.get_region_id(), PeerMsg::RaftMessage(Box::new(msg)))
+        .unwrap();
+
+    // Wait region 1 of node 2 to become leader
+    let _ = rx2.recv().unwrap();
+    fail::remove("on_reject_commit_merge_1");
+
+    let timer = Instant::now();
+    loop {
+        if right.get_region_epoch().get_version()
+            == cluster.get_region_epoch(right.get_id()).get_version()
+        {
+            if timer.saturating_elapsed() > Duration::from_secs(5) {
+                panic!("region {:?} is still not merged.", right);
+            }
+        } else {
+            break;
+        }
+        sleep_ms(10);
+    }
+
+    let region = pd_client.get_region(b"k1").unwrap();
+    assert_eq!(region.get_id(), right.get_id());
+    assert_eq!(region.get_start_key(), right.get_start_key());
+    assert_eq!(region.get_end_key(), left.get_end_key());
+
+    cluster.must_put(b"k4", b"v4");
 }

--- a/tests/failpoints/cases/test_merge.rs
+++ b/tests/failpoints/cases/test_merge.rs
@@ -1784,7 +1784,8 @@ fn test_concurrent_between_transfer_leader_and_merge() {
 
     // Source region: 1, Target Region: 1000
     // Let target region in leader_transfering status by interceptting MsgTimeoutNow
-    // msg by using Filter
+    // msg by using Filter. So we make node-1-1000 be in leader_transferring status
+    // for some time.
     let (tx, rx_msg) = channel();
     let filter = MsgTimeoutFilter { tx };
     cluster.add_send_filter_on_node(1, Box::new(filter));
@@ -1801,6 +1802,10 @@ fn test_concurrent_between_transfer_leader_and_merge() {
     );
 
     let msg = rx_msg.recv().unwrap();
+
+    // Now, node-1-1000 is in leader_transferring status. After it reject proposing
+    // commit merge, make node-1-1 block before proposing rollback merge until
+    // node-2-1000 propose commit merge.
 
     fail::cfg("on_reject_commit_merge_1", "pause").unwrap();
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #15242

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
fix rollback merge and commit merge can happen simultaneously
```

See comments of `test_concurrent_between_transfer_leader_and_merge ` to see the reproduce steps.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
