### PR TITLE
raftstore: Introduce failed state for unsafe recovery to fix rollback merge timeout

### DIFF
--- a/components/raftstore-v2/src/fsm/peer.rs
+++ b/components/raftstore-v2/src/fsm/peer.rs
@@ -382,9 +382,10 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> PeerFsmDelegate<'a, EK, ER,
                     syncer,
                     failed_stores,
                 ),
-                PeerMsg::ExitForceLeaderState => {
-                    self.fsm.peer_mut().on_exit_force_leader(self.store_ctx)
-                }
+                PeerMsg::ExitForceLeaderState => self
+                    .fsm
+                    .peer_mut()
+                    .on_exit_force_leader(self.store_ctx, false),
                 PeerMsg::ExitForceLeaderStateCampaign => {
                     self.fsm.peer_mut().on_exit_force_leader_campaign()
                 }

--- a/components/raftstore-v2/src/operation/unsafe_recovery/demote.rs
+++ b/components/raftstore-v2/src/operation/unsafe_recovery/demote.rs
@@ -75,6 +75,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
                     "Unsafe recovery, fail to finish demotion";
                     "err" => ?resp.get_header().get_error(),
                 );
+                *self.unsafe_recovery_state_mut() = Some(UnsafeRecoveryState::Failed);
                 return;
             }
             *self.unsafe_recovery_state_mut() = Some(UnsafeRecoveryState::DemoteFailedVoters {
@@ -129,6 +130,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
                             "Unsafe recovery, fail to exit joint state";
                             "err" => ?resp.get_header().get_error(),
                         );
+                        *self.unsafe_recovery_state_mut()= Some(UnsafeRecoveryState::Failed);
                     }
                 } else {
                     error!(self.logger,

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -824,6 +824,8 @@ where
                         target_index: self.fsm.peer.raft_group.raft.raft_log.last_index(),
                         demote_after_exit: true,
                     });
+            } else {
+                self.fsm.peer.unsafe_recovery_state = Some(UnsafeRecoveryState::Failed);
             }
         } else {
             self.unsafe_recovery_demote_failed_voters(syncer, failed_voters);
@@ -863,6 +865,8 @@ where
                         target_index: self.fsm.peer.raft_group.raft.raft_log.last_index(),
                         demote_after_exit: false,
                     });
+            } else {
+                self.fsm.peer.unsafe_recovery_state = Some(UnsafeRecoveryState::Failed);
             }
         } else {
             warn!(
@@ -913,13 +917,22 @@ where
             self.fsm.peer.raft_group.raft.raft_log.committed
         };
 
-        self.fsm.peer.unsafe_recovery_state = Some(UnsafeRecoveryState::WaitApply {
-            target_index,
-            syncer,
-        });
-        self.fsm
-            .peer
-            .unsafe_recovery_maybe_finish_wait_apply(/* force= */ self.fsm.stopped);
+        if target_index > self.fsm.peer.raft_group.raft.raft_log.applied {
+            info!(
+                "Unsafe recovery, start wait apply";
+                "region_id" => self.region().get_id(),
+                "peer_id" => self.fsm.peer_id(),
+                "target_index" => target_index,
+                "applied" =>  self.fsm.peer.raft_group.raft.raft_log.applied,
+            );
+            self.fsm.peer.unsafe_recovery_state = Some(UnsafeRecoveryState::WaitApply {
+                target_index,
+                syncer,
+            });
+            self.fsm
+                .peer
+                .unsafe_recovery_maybe_finish_wait_apply(/* force= */ self.fsm.stopped);
+        }
     }
 
     // func be invoked firstly after assigned leader by BR, wait all leader apply to
@@ -1466,7 +1479,7 @@ where
             } => {
                 self.on_enter_pre_force_leader(syncer, failed_stores);
             }
-            SignificantMsg::ExitForceLeaderState => self.on_exit_force_leader(),
+            SignificantMsg::ExitForceLeaderState => self.on_exit_force_leader(false),
             SignificantMsg::UnsafeRecoveryDemoteFailedVoters {
                 syncer,
                 failed_voters,
@@ -1700,8 +1713,17 @@ where
         self.fsm.has_ready = true;
     }
 
-    fn on_exit_force_leader(&mut self) {
+    fn on_exit_force_leader(&mut self, force: bool) {
         if self.fsm.peer.force_leader.is_none() {
+            return;
+        }
+        if let Some(UnsafeRecoveryState::Failed) = self.fsm.peer.unsafe_recovery_state && !force {
+            // Skip force leader if the plan failed, so wait for the next retry of plan with force leader state holding
+            info!(
+                "skip exiting force leader state";
+                "region_id" => self.fsm.region_id(),
+                "peer_id" => self.fsm.peer_id(),
+            );
             return;
         }
 
@@ -1712,7 +1734,7 @@ where
         );
         self.fsm.peer.force_leader = None;
         // make sure it's not hibernated
-        assert_eq!(self.fsm.hibernate_state.group_state(), GroupState::Ordered);
+        assert_ne!(self.fsm.hibernate_state.group_state(), GroupState::Idle);
         // leader lease shouldn't be renewed in force leader state.
         assert_eq!(
             self.fsm.peer.leader_lease().inspect(None),
@@ -2274,7 +2296,10 @@ where
                 }
             }
             // Destroy does not need be processed, the state is cleaned up together with peer.
-            Some(_) | None => {}
+            Some(UnsafeRecoveryState::Destroy { .. })
+            | Some(UnsafeRecoveryState::Failed)
+            | Some(UnsafeRecoveryState::WaitInitialize(..))
+            | None => {}
         }
     }
 
@@ -6360,13 +6385,6 @@ where
             return;
         }
 
-        if let Some(ForceLeaderState::ForceLeader { time, .. }) = self.fsm.peer.force_leader {
-            // Clean up the force leader state after a timeout, since the PD recovery
-            // process may have been aborted for some reasons.
-            if time.saturating_elapsed() > UNSAFE_RECOVERY_STATE_TIMEOUT {
-                self.on_exit_force_leader();
-            }
-        }
         if let Some(state) = &mut self.fsm.peer.unsafe_recovery_state {
             let unsafe_recovery_state_timeout_failpoint = || -> bool {
                 fail_point!("unsafe_recovery_state_timeout", |_| true);
@@ -6379,6 +6397,15 @@ where
             {
                 info!("timeout, abort unsafe recovery"; "state" => ?state);
                 state.abort();
+                self.fsm.peer.unsafe_recovery_state = None;
+            }
+        }
+
+        if let Some(ForceLeaderState::ForceLeader { time, .. }) = self.fsm.peer.force_leader {
+            // Clean up the force leader state after a timeout, since the PD recovery
+            // process may have been aborted for some reasons.
+            if time.saturating_elapsed() > UNSAFE_RECOVERY_STATE_TIMEOUT {
+                self.on_exit_force_leader(true);
             }
         }
 

--- a/components/raftstore/src/store/unsafe_recovery.rs
+++ b/components/raftstore/src/store/unsafe_recovery.rs
@@ -241,7 +241,7 @@ pub struct UnsafeRecoveryForceLeaderSyncer(Arc<InvokeClosureOnDrop>);
 impl UnsafeRecoveryForceLeaderSyncer {
     pub fn new(report_id: u64, router: Arc<dyn UnsafeRecoveryHandle>) -> Self {
         let inner = InvokeClosureOnDrop(Some(Box::new(move || {
-            info!("Unsafe recovery, force leader finished.");
+            info!("Unsafe recovery, force leader finished."; "report_id" => report_id);
             start_unsafe_recovery_report(router, report_id, false);
         })));
         UnsafeRecoveryForceLeaderSyncer(Arc::new(inner))
@@ -260,11 +260,11 @@ impl UnsafeRecoveryExecutePlanSyncer {
         let abort = Arc::new(Mutex::new(false));
         let abort_clone = abort.clone();
         let closure = InvokeClosureOnDrop(Some(Box::new(move || {
-            info!("Unsafe recovery, plan execution finished");
             if *abort_clone.lock().unwrap() {
-                warn!("Unsafe recovery, plan execution aborted");
+                warn!("Unsafe recovery, plan execution aborted"; "report_id" => report_id);
                 return;
             }
+            info!("Unsafe recovery, plan execution finished"; "report_id" => report_id);
             start_unsafe_recovery_report(router, report_id, true);
         })));
         UnsafeRecoveryExecutePlanSyncer {
@@ -330,7 +330,7 @@ impl UnsafeRecoveryWaitApplySyncer {
         let abort_clone = abort.clone();
         let closure = InvokeClosureOnDrop(Some(Box::new(move || {
             if *abort_clone.lock().unwrap() {
-                warn!("Unsafe recovery, wait apply aborted");
+                warn!("Unsafe recovery, wait apply aborted"; "report_id" => report_id);
                 return;
             }
             info!("Unsafe recovery, wait apply finished");
@@ -363,7 +363,7 @@ impl UnsafeRecoveryFillOutReportSyncer {
         let reports = Arc::new(Mutex::new(vec![]));
         let reports_clone = reports.clone();
         let closure = InvokeClosureOnDrop(Some(Box::new(move || {
-            info!("Unsafe recovery, peer reports collected");
+            info!("Unsafe recovery, peer reports collected"; "report_id" => report_id);
             let mut store_report = StoreReport::default();
             {
                 let mut reports_ptr = reports_clone.lock().unwrap();
@@ -420,6 +420,9 @@ pub enum UnsafeRecoveryState {
     },
     Destroy(UnsafeRecoveryExecutePlanSyncer),
     WaitInitialize(UnsafeRecoveryExecutePlanSyncer),
+    // DemoteFailedVoter may fail due to some reasons. It's just a marker to avoid exiting force
+    // leader state
+    Failed,
 }
 
 impl UnsafeRecoveryState {
@@ -429,6 +432,7 @@ impl UnsafeRecoveryState {
             UnsafeRecoveryState::DemoteFailedVoters { syncer, .. }
             | UnsafeRecoveryState::Destroy(syncer)
             | UnsafeRecoveryState::WaitInitialize(syncer) => syncer.time,
+            UnsafeRecoveryState::Failed => return false,
         };
         time.saturating_elapsed() >= timeout
     }
@@ -439,6 +443,7 @@ impl UnsafeRecoveryState {
             UnsafeRecoveryState::DemoteFailedVoters { syncer, .. }
             | UnsafeRecoveryState::Destroy(syncer)
             | UnsafeRecoveryState::WaitInitialize(syncer) => &syncer.abort,
+            UnsafeRecoveryState::Failed => return true,
         };
         *abort.lock().unwrap()
     }
@@ -449,6 +454,7 @@ impl UnsafeRecoveryState {
             UnsafeRecoveryState::DemoteFailedVoters { syncer, .. }
             | UnsafeRecoveryState::Destroy(syncer)
             | UnsafeRecoveryState::WaitInitialize(syncer) => syncer.abort(),
+            UnsafeRecoveryState::Failed => (),
         }
     }
 }

--- a/tests/failpoints/cases/test_unsafe_recovery.rs
+++ b/tests/failpoints/cases/test_unsafe_recovery.rs
@@ -458,7 +458,7 @@ fn test_unsafe_recovery_rollback_merge() {
     }
 
     // Block merge commit, let go of the merge prepare.
-    fail::cfg("on_schedule_merge_ret_err", "return()").unwrap();
+    fail::cfg("on_schedule_merge", "return()").unwrap();
 
     let region = pd_client.get_region(b"k1").unwrap();
     cluster.must_split(&region, b"k2");
@@ -521,6 +521,48 @@ fn test_unsafe_recovery_rollback_merge() {
     pd_client.must_set_unsafe_recovery_plan(nodes[0], plan.clone());
     cluster.must_send_store_heartbeat(nodes[0]);
 
+    // Can't propose demotion as it's in merging mode
+    let mut store_report = None;
+    for _ in 0..20 {
+        store_report = pd_client.must_get_store_report(nodes[0]);
+        if store_report.is_some() {
+            break;
+        }
+        sleep_ms(100);
+    }
+    assert_ne!(store_report, None);
+    let has_force_leader = store_report
+        .unwrap()
+        .get_peer_reports()
+        .iter()
+        .any(|p| p.get_is_force_leader());
+    // Force leader is not exited due to demotion failure
+    assert!(has_force_leader);
+
+    fail::remove("on_schedule_merge");
+    fail::cfg("on_schedule_merge_ret_err", "return()").unwrap();
+
+    // Make sure merge check is scheduled, and rollback merge is triggered
+    sleep_ms(50);
+
+    // Re-triggers the unsafe recovery plan execution.
+    pd_client.must_set_unsafe_recovery_plan(nodes[0], plan);
+    cluster.must_send_store_heartbeat(nodes[0]);
+    let mut store_report = None;
+    for _ in 0..20 {
+        store_report = pd_client.must_get_store_report(nodes[0]);
+        if store_report.is_some() {
+            break;
+        }
+        sleep_ms(100);
+    }
+    assert_ne!(store_report, None);
+    // No force leader
+    for peer_report in store_report.unwrap().get_peer_reports() {
+        assert!(!peer_report.get_is_force_leader());
+    }
+
+    // Demotion is done
     let mut demoted = false;
     for _ in 0..10 {
         let new_left = block_on(pd_client.get_region_by_id(left.get_id()))

--- a/tests/integrations/raftstore/test_unsafe_recovery.rs
+++ b/tests/integrations/raftstore/test_unsafe_recovery.rs
@@ -827,12 +827,6 @@ fn test_force_leader_on_hibernated_leader() {
 #[test]
 fn test_force_leader_on_hibernated_follower() {
     let mut cluster = new_node_cluster(0, 5);
-    cluster.cfg.raft_store.raft_base_tick_interval = ReadableDuration::millis(10);
-    cluster.cfg.raft_store.raft_election_timeout_ticks = 10;
-    cluster.cfg.raft_store.raft_store_max_leader_lease = ReadableDuration::millis(90);
-    cluster.cfg.raft_store.raft_log_gc_count_limit = Some(8);
-    cluster.cfg.raft_store.merge_max_log_gap = 3;
-    cluster.cfg.raft_store.raft_log_gc_tick_interval = ReadableDuration::millis(10);
     cluster.pd_client.disable_default_operator();
 
     cluster.run();
@@ -866,16 +860,6 @@ fn test_force_leader_on_hibernated_follower() {
     cluster
         .pd_client
         .must_remove_peer(region.get_id(), find_peer(&region, 5).unwrap().clone());
-    // wait a while to trigger message to set the state to chaos
-    // Isolate node 2
-    cluster.add_send_filter(IsolationFilterFactory::new(2));
-    // wait election timeout
-    sleep_ms(
-        cluster.cfg.raft_store.raft_election_timeout_ticks as u64
-            * cluster.cfg.raft_store.raft_base_tick_interval.as_millis()
-            * 5,
-    );
-
     cluster.exit_force_leader(region.get_id(), 1);
 
     // quorum is formed, can propose command successfully now

--- a/tests/integrations/raftstore/test_unsafe_recovery.rs
+++ b/tests/integrations/raftstore/test_unsafe_recovery.rs
@@ -827,6 +827,12 @@ fn test_force_leader_on_hibernated_leader() {
 #[test]
 fn test_force_leader_on_hibernated_follower() {
     let mut cluster = new_node_cluster(0, 5);
+    cluster.cfg.raft_store.raft_base_tick_interval = ReadableDuration::millis(10);
+    cluster.cfg.raft_store.raft_election_timeout_ticks = 10;
+    cluster.cfg.raft_store.raft_store_max_leader_lease = ReadableDuration::millis(90);
+    cluster.cfg.raft_store.raft_log_gc_count_limit = Some(8);
+    cluster.cfg.raft_store.merge_max_log_gap = 3;
+    cluster.cfg.raft_store.raft_log_gc_tick_interval = ReadableDuration::millis(10);
     cluster.pd_client.disable_default_operator();
 
     cluster.run();
@@ -860,6 +866,16 @@ fn test_force_leader_on_hibernated_follower() {
     cluster
         .pd_client
         .must_remove_peer(region.get_id(), find_peer(&region, 5).unwrap().clone());
+    // wait a while to trigger message to set the state to chaos
+    // Isolate node 2
+    cluster.add_send_filter(IsolationFilterFactory::new(2));
+    // wait election timeout
+    sleep_ms(
+        cluster.cfg.raft_store.raft_election_timeout_ticks as u64
+            * cluster.cfg.raft_store.raft_base_tick_interval.as_millis()
+            * 5,
+    );
+
     cluster.exit_force_leader(region.get_id(), 1);
 
     // quorum is formed, can propose command successfully now


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/tikv/tikv/issues/15629

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Introduce failed state for unsafe recovery to fix rollback merge timeout. 

To rollback merge, it has to be in force leader state when performing online recovery. Force leader state would exit after executing the plan no matter succeeded or failed. While rollback merge is triggered on check merge tick periodically. So there is a chance that check merge can't always be in the time window of being force leader state. To solve that, let it skip exiting force leader state when failed to demote, so later rollback merge can be triggered.
```

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix online recovery panic on exit force leader
```
