### PR TITLE
wip: fix wrong result of `0 / decimal` and `0 % decimal`

### DIFF
--- a/components/tidb_query_datatype/src/codec/mysql/decimal.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/decimal.rs
@@ -791,8 +791,8 @@ fn do_div_mod(lhs: &Decimal, rhs: &Decimal, frac_incr: u8, do_mod: bool) -> Opti
 }
 
 /// `do_mul` multiplies two decimals.
-fn do_mul(lhs: &Decimal, rhs: &Decimal) -> Res<Decimal> {
-    let (l_int_word_cnt, mut l_frac_word_cnt) = (
+let (l_int_word_cnt, mut l_frac_word_cnt) = (
+        fn do_mul(lhs: &Decimal, rhs: &Decimal) -> Res<Decimal> {
         i32::from(word_cnt!(lhs.int_cnt)),
         i32::from(word_cnt!(lhs.frac_cnt)),
     );
@@ -2364,7 +2364,7 @@ impl<'a, 'b> Rem<&'a Decimal> for &'b Decimal {
     type Output = Option<Res<Decimal>>;
     fn rem(self, rhs: &'a Decimal) -> Self::Output {
         let result_frac_cnt = cmp::max(self.result_frac_cnt, rhs.result_frac_cnt);
-        let mut res = do_div_mod_impl(self, rhs, 0, true);
+        let mut res = do_div_mod(self, rhs, 0, true);
         if let Some(ref mut dec) = res {
             dec.result_frac_cnt = result_frac_cnt;
         }
@@ -3545,11 +3545,10 @@ mod tests {
         for (frac_incr, lhs_str, rhs_str, div_exp, rem_exp) in cases {
             let lhs: Decimal = lhs_str.parse().unwrap();
             let rhs: Decimal = rhs_str.parse().unwrap();
-            let res =
-                super::do_div_mod(&lhs, &rhs, frac_incr, false).map(|d| d.unwrap().to_string());
+            let res = lhs.div(&rhs, frac_incr).map(|d| d.unwrap().to_string());
             assert_eq!(res, div_exp.map(|s| s.to_owned()));
 
-            let res =
+            let res = 
                 super::do_div_mod(&lhs, &rhs, frac_incr, true).map(|d| d.unwrap().to_string());
             assert_eq!(res, rem_exp.map(|s| s.to_owned()));
         }

--- a/components/tidb_query_datatype/src/codec/mysql/decimal.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/decimal.rs
@@ -791,8 +791,8 @@ fn do_div_mod(lhs: &Decimal, rhs: &Decimal, frac_incr: u8, do_mod: bool) -> Opti
 }
 
 /// `do_mul` multiplies two decimals.
-let (l_int_word_cnt, mut l_frac_word_cnt) = (
-        fn do_mul(lhs: &Decimal, rhs: &Decimal) -> Res<Decimal> {
+fn do_mul(lhs: &Decimal, rhs: &Decimal) -> Res<Decimal> {
+    let (l_int_word_cnt, mut l_frac_word_cnt) = (
         i32::from(word_cnt!(lhs.int_cnt)),
         i32::from(word_cnt!(lhs.frac_cnt)),
     );
@@ -3545,10 +3545,11 @@ mod tests {
         for (frac_incr, lhs_str, rhs_str, div_exp, rem_exp) in cases {
             let lhs: Decimal = lhs_str.parse().unwrap();
             let rhs: Decimal = rhs_str.parse().unwrap();
-            let res = lhs.div(&rhs, frac_incr).map(|d| d.unwrap().to_string());
+            let res =
+                super::do_div_mod(&lhs, &rhs, frac_incr, false).map(|d| d.unwrap().to_string());
             assert_eq!(res, div_exp.map(|s| s.to_owned()));
 
-            let res = 
+            let res =
                 super::do_div_mod(&lhs, &rhs, frac_incr, true).map(|d| d.unwrap().to_string());
             assert_eq!(res, rem_exp.map(|s| s.to_owned()));
         }

--- a/components/tidb_query_datatype/src/codec/mysql/decimal.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/decimal.rs
@@ -791,6 +791,7 @@ fn do_div_mod_impl(
     Some(res)
 }
 
+#[allow(dead_code)]
 fn do_div_mod(lhs: &Decimal, rhs: &Decimal, frac_incr: u8, do_mod: bool) -> Option<Res<Decimal>> {
     do_div_mod_impl(lhs, rhs, frac_incr, do_mod, None)
 }

--- a/components/tidb_query_datatype/src/codec/mysql/decimal.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/decimal.rs
@@ -3566,7 +3566,7 @@ mod tests {
         for (lhs_str, rhs_str, div_exp) in div_cases {
             let lhs: Decimal = lhs_str.parse().unwrap();
             let rhs: Decimal = rhs_str.parse().unwrap();
-            let res = (lhs / rhs).unwrap().map(|d| d.to_string());
+            let res = (&lhs / &rhs).unwrap().map(|d| d.to_string());
             assert_eq!(res, div_exp.map(|s| s.to_owned()))
         }
 
@@ -3574,7 +3574,7 @@ mod tests {
         for (lhs_str, rhs_str, rem_exp) in rem_cases {
             let lhs: Decimal = lhs_str.parse().unwrap();
             let rhs: Decimal = rhs_str.parse().unwrap();
-            let res = (lhs % rhs).unwrap().map(|d| d.to_string());
+            let res = (&lhs % &rhs).unwrap().map(|d| d.to_string());
             assert_eq!(res, rem_exp.map(|s| s.to_owned()))
         }
     }

--- a/components/tidb_query_datatype/src/codec/mysql/decimal.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/decimal.rs
@@ -3566,7 +3566,7 @@ mod tests {
         for (lhs_str, rhs_str, div_exp) in div_cases {
             let lhs: Decimal = lhs_str.parse().unwrap();
             let rhs: Decimal = rhs_str.parse().unwrap();
-            let res = (&lhs / &rhs).unwrap().map(|d| d.to_string());
+            let res = (lhs / rhs).unwrap().map(|d| d.to_string());
             assert_eq!(res, div_exp.map(|s| s.to_owned()))
         }
 
@@ -3574,7 +3574,7 @@ mod tests {
         for (lhs_str, rhs_str, rem_exp) in rem_cases {
             let lhs: Decimal = lhs_str.parse().unwrap();
             let rhs: Decimal = rhs_str.parse().unwrap();
-            let res = (&lhs % &rhs).unwrap().map(|d| d.to_string());
+            let res = (lhs % rhs).unwrap().map(|d| d.to_string());
             assert_eq!(res, rem_exp.map(|s| s.to_owned()))
         }
     }

--- a/components/tidb_query_datatype/src/codec/mysql/decimal.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/decimal.rs
@@ -594,12 +594,14 @@ fn do_div_mod_impl(
     let r_frac_cnt = word_cnt!(rhs.frac_cnt) * DIGITS_PER_WORD;
     let (r_idx, r_prec) = rhs.remove_leading_zeroes(rhs.int_cnt + r_frac_cnt);
     if r_prec == 0 {
+        /* short-circuit everything: rhs == 0 */
         return None;
     }
 
     let l_frac_cnt = word_cnt!(lhs.frac_cnt) * DIGITS_PER_WORD;
     let (l_idx, l_prec) = lhs.remove_leading_zeroes(lhs.int_cnt + l_frac_cnt);
     if l_prec == 0 {
+        /* short-circuit everything: lhs == 0 */
         return Some(Res::Ok(Decimal::zero()));
     }
 

--- a/components/tidb_query_datatype/src/codec/mysql/decimal.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/decimal.rs
@@ -3574,7 +3574,7 @@ mod tests {
         for (lhs_str, rhs_str, rem_exp) in rem_cases {
             let lhs: Decimal = lhs_str.parse().unwrap();
             let rhs: Decimal = rhs_str.parse().unwrap();
-            let res = (&lhs % &rhs).unwrap().map(|d| d.to_string());
+            let res = (lhs % rhs).unwrap().map(|d| d.to_string());
             assert_eq!(res, rem_exp.map(|s| s.to_owned()))
         }
     }

--- a/components/tidb_query_datatype/src/codec/mysql/decimal.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/decimal.rs
@@ -590,6 +590,7 @@ fn do_div_mod_impl(
     rhs: &Decimal,
     mut frac_incr: u8,
     do_mod: bool,
+    result_frac_cnt: Option<u8>,
 ) -> Option<Res<Decimal>> {
     let r_frac_cnt = word_cnt!(rhs.frac_cnt) * DIGITS_PER_WORD;
     let (r_idx, r_prec) = rhs.remove_leading_zeroes(rhs.int_cnt + r_frac_cnt);
@@ -602,7 +603,11 @@ fn do_div_mod_impl(
     let (l_idx, l_prec) = lhs.remove_leading_zeroes(lhs.int_cnt + l_frac_cnt);
     if l_prec == 0 {
         /* short-circuit everything: lhs == 0 */
-        return Some(Res::Ok(Decimal::zero()));
+        if let Some(result_frac) = result_frac_cnt {
+            return Some(Res::Ok(Decimal::new(0, result_frac, false)))
+        } else {
+            return Some(Res::Ok(Decimal::zero()));
+        }
     }
 
     frac_incr = frac_incr.saturating_sub(l_frac_cnt - lhs.frac_cnt + r_frac_cnt - rhs.frac_cnt);
@@ -787,7 +792,7 @@ fn do_div_mod_impl(
 }
 
 fn do_div_mod(lhs: &Decimal, rhs: &Decimal, frac_incr: u8, do_mod: bool) -> Option<Res<Decimal>> {
-    do_div_mod_impl(lhs, rhs, frac_incr, do_mod)
+    do_div_mod_impl(lhs, rhs, frac_incr, do_mod, None)
 }
 
 /// `do_mul` multiplies two decimals.
@@ -1706,7 +1711,7 @@ impl Decimal {
     fn div(&self, rhs: &Decimal, frac_incr: u8) -> Option<Res<Decimal>> {
         let result_frac_cnt =
             cmp::min(self.result_frac_cnt.saturating_add(frac_incr), MAX_FRACTION);
-        let mut res = do_div_mod(self, rhs, frac_incr, false);
+        let mut res = do_div_mod_impl(self, rhs, frac_incr, false, Some(result_frac_cnt));
         if let Some(ref mut dec) = res {
             dec.result_frac_cnt = result_frac_cnt;
         }
@@ -2364,7 +2369,7 @@ impl<'a, 'b> Rem<&'a Decimal> for &'b Decimal {
     type Output = Option<Res<Decimal>>;
     fn rem(self, rhs: &'a Decimal) -> Self::Output {
         let result_frac_cnt = cmp::max(self.result_frac_cnt, rhs.result_frac_cnt);
-        let mut res = do_div_mod(self, rhs, 0, true);
+        let mut res = do_div_mod_impl(self, rhs, 0, true, Some(result_frac_cnt));
         if let Some(ref mut dec) = res {
             dec.result_frac_cnt = result_frac_cnt;
         }
@@ -3554,17 +3559,36 @@ mod tests {
             assert_eq!(res, rem_exp.map(|s| s.to_owned()));
         }
 
-        let div_cases = vec![(
-            "-43791957044243810000000000000000000000000000000000000000000000000000000000000",
-            "-0.0000000000000000000000000000000000000000000000000012867433602814482",
-            Res::Overflow(
-                "34033171179267041433424155279291553259014210153022524070386565694757521640",
+        let div_cases = vec![
+            (
+                "-43791957044243810000000000000000000000000000000000000000000000000000000000000",
+                "-0.0000000000000000000000000000000000000000000000000012867433602814482",
+                Res::Overflow("34033171179267041433424155279291553259014210153022524070386565694757521640"),
             ),
-        )];
-        for (lhs_str, rhs_str, rem_exp) in div_cases {
+            (
+                "0",
+                "0.5",
+                Res::Ok("0.0000"),
+            ),
+        ];
+        for (lhs_str, rhs_str, div_exp) in div_cases {
             let lhs: Decimal = lhs_str.parse().unwrap();
             let rhs: Decimal = rhs_str.parse().unwrap();
             let res = (&lhs / &rhs).unwrap().map(|d| d.to_string());
+            assert_eq!(res, div_exp.map(|s| s.to_owned()))
+        }
+
+        let rem_cases = vec![
+            (
+                "0",
+                "0.5",
+                Res::Ok("0.0"),
+            ),
+        ];
+        for (lhs_str, rhs_str, rem_exp) in rem_cases {
+            let lhs: Decimal = lhs_str.parse().unwrap();
+            let rhs: Decimal = rhs_str.parse().unwrap();
+            let res = (&lhs % &rhs).unwrap().map(|d| d.to_string());
             assert_eq!(res, rem_exp.map(|s| s.to_owned()))
         }
     }

--- a/components/tidb_query_datatype/src/codec/mysql/decimal.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/decimal.rs
@@ -3531,6 +3531,13 @@ mod tests {
                 Some("0.000000000"),
                 Some("-56"),
             ),
+            (
+                DEFAULT_DIV_FRAC_INCR,
+                "0",
+                "0.5",
+                Some("0.0000"),
+                Some("0.0"),
+            ),
         ];
 
         for (frac_incr, lhs_str, rhs_str, div_exp, rem_exp) in cases {

--- a/components/tidb_query_datatype/src/codec/mysql/decimal.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/decimal.rs
@@ -3538,13 +3538,6 @@ mod tests {
                 Some("0.000000000"),
                 Some("-56"),
             ),
-            (
-                DEFAULT_DIV_FRAC_INCR,
-                "0",
-                "0.5",
-                Some("0.0000"),
-                Some("0.0"),
-            ),
         ];
 
         for (frac_incr, lhs_str, rhs_str, div_exp, rem_exp) in cases {

--- a/components/tidb_query_datatype/src/codec/mysql/decimal.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/decimal.rs
@@ -595,16 +595,16 @@ fn do_div_mod_impl(
     let r_frac_cnt = word_cnt!(rhs.frac_cnt) * DIGITS_PER_WORD;
     let (r_idx, r_prec) = rhs.remove_leading_zeroes(rhs.int_cnt + r_frac_cnt);
     if r_prec == 0 {
-        /* short-circuit everything: rhs == 0 */
+        // short-circuit everything: rhs == 0
         return None;
     }
 
     let l_frac_cnt = word_cnt!(lhs.frac_cnt) * DIGITS_PER_WORD;
     let (l_idx, l_prec) = lhs.remove_leading_zeroes(lhs.int_cnt + l_frac_cnt);
     if l_prec == 0 {
-        /* short-circuit everything: lhs == 0 */
+        // short-circuit everything: lhs == 0
         if let Some(result_frac) = result_frac_cnt {
-            return Some(Res::Ok(Decimal::new(0, result_frac, false)))
+            return Some(Res::Ok(Decimal::new(0, result_frac, false)));
         } else {
             return Some(Res::Ok(Decimal::zero()));
         }
@@ -3557,13 +3557,11 @@ mod tests {
             (
                 "-43791957044243810000000000000000000000000000000000000000000000000000000000000",
                 "-0.0000000000000000000000000000000000000000000000000012867433602814482",
-                Res::Overflow("34033171179267041433424155279291553259014210153022524070386565694757521640"),
+                Res::Overflow(
+                    "34033171179267041433424155279291553259014210153022524070386565694757521640",
+                ),
             ),
-            (
-                "0",
-                "0.5",
-                Res::Ok("0.0000"),
-            ),
+            ("0", "0.5", Res::Ok("0.0000")),
         ];
         for (lhs_str, rhs_str, div_exp) in div_cases {
             let lhs: Decimal = lhs_str.parse().unwrap();
@@ -3572,13 +3570,7 @@ mod tests {
             assert_eq!(res, div_exp.map(|s| s.to_owned()))
         }
 
-        let rem_cases = vec![
-            (
-                "0",
-                "0.5",
-                Res::Ok("0.0"),
-            ),
-        ];
+        let rem_cases = vec![("0", "0.5", Res::Ok("0.0"))];
         for (lhs_str, rhs_str, rem_exp) in rem_cases {
             let lhs: Decimal = lhs_str.parse().unwrap();
             let rhs: Decimal = rhs_str.parse().unwrap();


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #15631

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
