### PR TITLE
raftstore-v2: gc removed_records and merged_records on tombstone store 

### DIFF
--- a/components/raftstore-v2/src/fsm/peer.rs
+++ b/components/raftstore-v2/src/fsm/peer.rs
@@ -315,6 +315,9 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> PeerFsmDelegate<'a, EK, ER,
                 PeerMsg::StoreUnreachable { to_store_id } => {
                     self.fsm.peer_mut().on_store_unreachable(to_store_id)
                 }
+                PeerMsg::StoreMaybeTombstone { store_id } => {
+                    self.fsm.peer_mut().on_store_maybe_tombstone(store_id)
+                }
                 PeerMsg::SnapshotSent { to_peer_id, status } => {
                     self.fsm.peer_mut().on_snapshot_sent(to_peer_id, status)
                 }

--- a/components/raftstore-v2/src/operation/life.rs
+++ b/components/raftstore-v2/src/operation/life.rs
@@ -713,6 +713,37 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         ctx.confirmed_ids.push(gc_peer_id);
     }
 
+    // Clean up removed and merged records for peers on tombstone stores,
+    // otherwise it may keep sending gc peer request to the tombstone store.
+    pub fn on_store_maybe_tombstone_gc_peer(&mut self, store_id: u64) {
+        let mut peers_on_tombstone = vec![];
+        let state = self.storage().region_state();
+        for peer in state.get_removed_records() {
+            if peer.get_store_id() == store_id {
+                peers_on_tombstone.push(peer.clone());
+            }
+        }
+        for record in state.get_merged_records() {
+            for peer in record.get_source_peers() {
+                if peer.get_store_id() == store_id {
+                    peers_on_tombstone.push(peer.clone());
+                }
+            }
+        }
+        if peers_on_tombstone.is_empty() {
+            return;
+        }
+        info!(self.logger, "gc peer on tombstone store";
+            "tombstone_store_id" => store_id,
+            "peers" => ?peers_on_tombstone);
+        let ctx = self.gc_peer_context_mut();
+        for peer in peers_on_tombstone {
+            if !ctx.confirmed_ids.contains(&peer.get_id()) {
+                ctx.confirmed_ids.push(peer.get_id());
+            }
+        }
+    }
+
     // Removes deleted peers from region state by proposing a `UpdateGcPeer`
     // command.
     pub fn on_gc_peer_tick<T: Transport>(&mut self, ctx: &mut StoreContext<EK, ER, T>) {

--- a/components/raftstore-v2/src/operation/ready/mod.rs
+++ b/components/raftstore-v2/src/operation/ready/mod.rs
@@ -247,6 +247,13 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         }
     }
 
+    pub fn on_store_maybe_tombstone(&mut self, store_id: u64) {
+        if !self.is_leader() {
+            return;
+        }
+        self.on_store_maybe_tombstone_gc_peer(store_id);
+    }
+
     pub fn on_raft_message<T: Transport>(
         &mut self,
         ctx: &mut StoreContext<EK, ER, T>,

--- a/components/raftstore-v2/src/router/message.rs
+++ b/components/raftstore-v2/src/router/message.rs
@@ -197,7 +197,7 @@ pub enum PeerMsg {
     StoreUnreachable {
         to_store_id: u64,
     },
-    // A store may be tombstone. Use it with cautious, it also means store not
+    // A store may be tombstone. Use it with caution, it also means store not
     // found, PD can not distinguish them now, as PD may delete tombstone stores.
     StoreMaybeTombstone {
         store_id: u64,

--- a/components/raftstore-v2/src/router/message.rs
+++ b/components/raftstore-v2/src/router/message.rs
@@ -197,6 +197,11 @@ pub enum PeerMsg {
     StoreUnreachable {
         to_store_id: u64,
     },
+    // A store may be tombstone. Use it with cautious, it also means store not
+    // found, PD can not distinguish them now, as PD may delete tombstone stores.
+    StoreMaybeTombstone {
+        store_id: u64,
+    },
     /// Reports whether the snapshot sending is successful or not.
     SnapshotSent {
         to_peer_id: u64,

--- a/components/test_pd_client/src/pd.rs
+++ b/components/test_pd_client/src/pd.rs
@@ -547,7 +547,9 @@ impl PdCluster {
     fn get_store(&self, store_id: u64) -> Result<metapb::Store> {
         match self.stores.get(&store_id) {
             Some(s) if s.store.get_id() != 0 => Ok(s.store.clone()),
-            _ => Err(box_err!("store {} not found", store_id)),
+            // Matches PD error message.
+            // See https://github.com/tikv/pd/blob/v7.3.0/server/grpc_service.go#L777-L780
+            _ => Err(box_err!("invalid store ID {}, not found", store_id)),
         }
     }
 

--- a/components/test_raftstore-v2/src/server.rs
+++ b/components/test_raftstore-v2/src/server.rs
@@ -223,6 +223,11 @@ impl<EK: KvEngine> RaftExtension for TestExtension<EK> {
     }
 
     #[inline]
+    fn report_store_maybe_tombstone(&self, store_id: u64) {
+        self.extension.report_store_maybe_tombstone(store_id)
+    }
+
+    #[inline]
     fn report_snapshot_status(
         &self,
         region_id: u64,

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -113,8 +113,8 @@ impl StoreAddrResolver for AddressMap {
     fn resolve(
         &self,
         store_id: u64,
-        cb: Box<dyn FnOnce(ServerResult<String>) + Send>,
-    ) -> ServerResult<()> {
+        cb: Box<dyn FnOnce(resolve::Result<String>) + Send>,
+    ) -> resolve::Result<()> {
         let addr = self.get(store_id);
         match addr {
             Some(addr) => cb(Ok(addr)),

--- a/components/tikv_kv/src/raft_extension.rs
+++ b/components/tikv_kv/src/raft_extension.rs
@@ -32,6 +32,9 @@ pub trait RaftExtension: Clone + Send {
     /// Report the target store is unreachable.
     fn report_store_unreachable(&self, _store_id: u64) {}
 
+    /// Report the target store may be tombstone.
+    fn report_store_maybe_tombstone(&self, _store_id: u64) {}
+
     /// Report the status of snapshot.
     fn report_snapshot_status(&self, _region_id: u64, _to_peer_id: u64, _status: SnapshotStatus) {}
 

--- a/src/server/lock_manager/deadlock.rs
+++ b/src/server/lock_manager/deadlock.rs
@@ -1119,7 +1119,7 @@ pub mod tests {
     use tikv_util::worker::FutureWorker;
 
     use super::*;
-    use crate::server::resolve::Callback;
+    use crate::server::resolve;
 
     #[test]
     fn test_detect_table() {
@@ -1467,15 +1467,6 @@ pub mod tests {
 
     impl PdClient for MockPdClient {}
 
-    #[derive(Clone)]
-    pub(crate) struct MockResolver;
-
-    impl StoreAddrResolver for MockResolver {
-        fn resolve(&self, _store_id: u64, _cb: Callback) -> Result<()> {
-            Err(Error::Other(box_err!("unimplemented")))
-        }
-    }
-
     fn start_deadlock_detector(
         host: &mut CoprocessorHost<KvTestEngine>,
     ) -> (FutureWorker<Task>, Scheduler) {
@@ -1485,7 +1476,7 @@ pub mod tests {
         let detector_runner = Detector::new(
             1,
             Arc::new(MockPdClient {}),
-            MockResolver {},
+            resolve::MockStoreAddrResolver::default(),
             Arc::new(SecurityManager::new(&SecurityConfig::default()).unwrap()),
             waiter_mgr_scheduler,
             &Config::default(),

--- a/src/server/lock_manager/mod.rs
+++ b/src/server/lock_manager/mod.rs
@@ -318,7 +318,7 @@ mod tests {
 
     use self::{deadlock::tests::*, metrics::*, waiter_manager::tests::*};
     use super::*;
-    use crate::storage::lock_manager::LockDigest;
+    use crate::{server::resolve::MockStoreAddrResolver, storage::lock_manager::LockDigest};
 
     fn start_lock_manager() -> LockManager {
         let mut coprocessor_host = CoprocessorHost::<KvTestEngine>::default();
@@ -336,7 +336,7 @@ mod tests {
             .start(
                 1,
                 Arc::new(MockPdClient {}),
-                MockResolver {},
+                MockStoreAddrResolver::default(),
                 Arc::new(SecurityManager::new(&SecurityConfig::default()).unwrap()),
                 &cfg,
             )

--- a/src/server/metrics.rs
+++ b/src/server/metrics.rs
@@ -86,6 +86,7 @@ make_auto_flush_static_metric! {
         failed,
         success,
         tombstone,
+        not_found,
     }
 
     pub label_enum ReplicaReadLockCheckResult {

--- a/src/server/raftkv2/raft_extension.rs
+++ b/src/server/raftkv2/raft_extension.rs
@@ -49,6 +49,11 @@ impl<EK: KvEngine, ER: RaftEngine> tikv_kv::RaftExtension for Extension<EK, ER> 
             .send_control(StoreMsg::StoreUnreachable { to_store_id });
     }
 
+    fn report_store_maybe_tombstone(&self, store_id: u64) {
+        self.router
+            .broadcast_normal(|| PeerMsg::StoreMaybeTombstone { store_id });
+    }
+
     fn report_snapshot_status(
         &self,
         region_id: u64,

--- a/src/server/resolve.rs
+++ b/src/server/resolve.rs
@@ -1,6 +1,7 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::{
+    error::Error as StdError,
     fmt::{self, Display, Formatter},
     sync::{Arc, Mutex},
 };
@@ -9,15 +10,27 @@ use collections::HashMap;
 use kvproto::replication_modepb::ReplicationMode;
 use pd_client::{take_peer_address, PdClient};
 use raftstore::store::GlobalReplicationState;
+use thiserror::Error;
 use tikv_kv::RaftExtension;
 use tikv_util::{
+    info,
     time::Instant,
     worker::{Runnable, Scheduler, Worker},
 };
 
-use super::{metrics::*, Result};
+use super::metrics::*;
 
 const STORE_ADDRESS_REFRESH_SECONDS: u64 = 60;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("{0:?}")]
+    Other(#[from] Box<dyn StdError + Sync + Send>),
+    #[error("store {0} has been removed")]
+    StoreTombstone(u64),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
 
 pub type Callback = Box<dyn FnOnce(Result<String>) + Send>;
 
@@ -95,9 +108,20 @@ where
             // it explicitly.
             Err(pd_client::Error::StoreTombstone(_)) => {
                 RESOLVE_STORE_COUNTER_STATIC.tombstone.inc();
-                return Err(box_err!("store {} has been removed", store_id));
+                self.router.report_store_maybe_tombstone(store_id);
+                return Err(Error::StoreTombstone(store_id));
             }
-            Err(e) => return Err(box_err!(e)),
+            Err(e) => {
+                // Tombstone store may be removed manually or automatically
+                // after 30 days of deletion. PD returns
+                // "invalid store ID %d, not found" for such store id.
+                // See https://github.com/tikv/pd/blob/v7.3.0/server/grpc_service.go#L777-L780
+                if format!("{:?}", e).contains("not found") {
+                    info!("resolve store not found"; "store_id" => store_id);
+                    self.router.report_store_maybe_tombstone(store_id);
+                }
+                return Err(box_err!(e));
+            }
         };
         let mut group_id = None;
         let mut state = self.state.lock().unwrap();
@@ -178,6 +202,25 @@ impl StoreAddrResolver for PdStoreAddrResolver {
         let task = Task { store_id, cb };
         box_try!(self.sched.schedule(task));
         Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct MockStoreAddrResolver {
+    pub resolve_fn: Arc<dyn Fn(u64, Callback) -> Result<()> + Send + Sync>,
+}
+
+impl StoreAddrResolver for MockStoreAddrResolver {
+    fn resolve(&self, store_id: u64, cb: Callback) -> Result<()> {
+        (self.resolve_fn)(store_id, cb)
+    }
+}
+
+impl Default for MockStoreAddrResolver {
+    fn default() -> MockStoreAddrResolver {
+        MockStoreAddrResolver {
+            resolve_fn: Arc::new(|_, _| unimplemented!()),
+        }
     }
 }
 

--- a/src/server/resolve.rs
+++ b/src/server/resolve.rs
@@ -117,6 +117,7 @@ where
                 // "invalid store ID %d, not found" for such store id.
                 // See https://github.com/tikv/pd/blob/v7.3.0/server/grpc_service.go#L777-L780
                 if format!("{:?}", e).contains("not found") {
+                    RESOLVE_STORE_COUNTER_STATIC.not_found.inc();
                     info!("resolve store not found"; "store_id" => store_id);
                     self.router.report_store_maybe_tombstone(store_id);
                 }

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -533,8 +533,8 @@ mod tests {
 
     use super::{
         super::{
-            resolve::{Callback as ResolveCallback, StoreAddrResolver},
-            Config, Result,
+            resolve::{self, Callback as ResolveCallback, StoreAddrResolver},
+            Config,
         },
         *,
     };
@@ -552,7 +552,7 @@ mod tests {
     }
 
     impl StoreAddrResolver for MockResolver {
-        fn resolve(&self, _: u64, cb: ResolveCallback) -> Result<()> {
+        fn resolve(&self, _: u64, cb: ResolveCallback) -> resolve::Result<()> {
             if self.quick_fail.load(Ordering::SeqCst) {
                 return Err(box_err!("quick fail"));
             }

--- a/tests/failpoints/cases/mod.rs
+++ b/tests/failpoints/cases/mod.rs
@@ -17,6 +17,7 @@ mod test_gc_worker;
 mod test_hibernate;
 mod test_import_service;
 mod test_kv_service;
+mod test_life;
 mod test_local_read;
 mod test_memory_usage_limit;
 mod test_merge;

--- a/tests/failpoints/cases/test_life.rs
+++ b/tests/failpoints/cases/test_life.rs
@@ -22,7 +22,7 @@ fn test_gc_peer_on_tombstone_store() {
     let peer_on_store3 = find_peer(&region, 3).unwrap().clone();
     cluster.must_transfer_leader(region.get_id(), peer_on_store1);
     cluster.add_send_filter(IsolationFilterFactory::new(3));
-    pd_client.must_remove_peer(region.get_id(), peer_on_store3.clone());
+    pd_client.must_remove_peer(region.get_id(), peer_on_store3);
 
     // Immediately invalidate store address cache.
     fail::cfg("mock_store_refresh_interval_secs", "return(0)").unwrap();

--- a/tests/failpoints/cases/test_life.rs
+++ b/tests/failpoints/cases/test_life.rs
@@ -1,0 +1,36 @@
+// Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::sync::Arc;
+
+use test_raftstore::*;
+use test_raftstore_macro::test_case;
+use tikv_util::config::ReadableDuration;
+
+#[test_case(test_raftstore_v2::new_server_cluster)]
+fn test_gc_peer_on_tombstone_store() {
+    let mut cluster = new_cluster(0, 3);
+    configure_for_merge(&mut cluster.cfg);
+    cluster.cfg.raft_store.gc_peer_check_interval = ReadableDuration::millis(500);
+    let pd_client = Arc::clone(&cluster.pd_client);
+    pd_client.disable_default_operator();
+    cluster.run();
+    cluster.must_put(b"k1", b"v1");
+
+    let region = cluster.get_region(b"k1");
+
+    let peer_on_store1 = find_peer(&region, 1).unwrap().clone();
+    let peer_on_store3 = find_peer(&region, 3).unwrap().clone();
+    cluster.must_transfer_leader(region.get_id(), peer_on_store1);
+    cluster.add_send_filter(IsolationFilterFactory::new(3));
+    pd_client.must_remove_peer(region.get_id(), peer_on_store3.clone());
+
+    // Immediately invalidate store address cache.
+    fail::cfg("mock_store_refresh_interval_secs", "return(0)").unwrap();
+
+    // Shutdown store 3 and wait for gc peer ticks.
+    cluster.stop_node(3);
+    cluster.clear_send_filters();
+    sleep_ms(3 * cluster.cfg.raft_store.gc_peer_check_interval.as_millis());
+
+    cluster.must_empty_region_removed_records(region.get_id());
+}

--- a/tests/integrations/config/dynamic/pessimistic_txn.rs
+++ b/tests/integrations/config/dynamic/pessimistic_txn.rs
@@ -9,11 +9,7 @@ use security::SecurityManager;
 use test_pd_client::TestPdClient;
 use tikv::{
     config::*,
-    server::{
-        lock_manager::*,
-        resolve::{Callback, StoreAddrResolver},
-        Error, Result,
-    },
+    server::{lock_manager::*, resolve},
 };
 use tikv_util::config::ReadableDuration;
 
@@ -25,14 +21,6 @@ fn test_config_validate() {
     let mut invalid_cfg = Config::default();
     invalid_cfg.wait_for_lock_timeout = ReadableDuration::millis(0);
     invalid_cfg.validate().unwrap_err();
-}
-
-#[derive(Clone)]
-struct MockResolver;
-impl StoreAddrResolver for MockResolver {
-    fn resolve(&self, _store_id: u64, _cb: Callback) -> Result<()> {
-        Err(Error::Other(box_err!("unimplemented")))
-    }
 }
 
 fn setup(
@@ -50,7 +38,7 @@ fn setup(
         .start(
             1,
             pd_client,
-            MockResolver,
+            resolve::MockStoreAddrResolver::default(),
             security_mgr,
             &cfg.pessimistic_txn,
         )


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #15669

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Let leader directly GC removed_records and merged_records on tombstone store,
instead of sending GcPeerRequests to such store.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
