### PR TITLE
Add symbol service to support remote fetching symbolized heap profile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,9 +104,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.26"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7825f6833612eb2414095684fcf6c635becf3ce97fe48cf6421321e93bfbd53c"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "api_version"
@@ -713,6 +713,29 @@ dependencies = [
  "cexpr",
  "clang-sys",
  "clap 2.33.0",
+ "env_logger 0.9.0",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex 1.1.0",
+ "which",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.60.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "clap 3.1.6",
  "env_logger 0.9.0",
  "lazy_static",
  "lazycell",
@@ -3146,6 +3169,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libproc"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b799ad155d75ce914c467ee5627b62247c20d4aedbd446f821484cebf3cded7"
+dependencies = [
+ "bindgen 0.59.2",
+ "errno",
+ "libc 0.2.146",
+]
+
+[[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
 source = "git+https://github.com/tikv/rust-rocksdb.git#d861ede96cc2aae3c2ed5ea1c1c71454130a325e"
@@ -3248,6 +3282,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dca79aa95d8b3226213ad454d328369853be3a1382d89532a854f4d69640acae"
 dependencies = [
  "cc",
+ "libc 0.2.146",
+]
+
+[[package]]
+name = "mach2"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d0d1830bcd151a6fc4aea1369af235b36c1528fe976b8ff678683c9995eade8"
+dependencies = [
  "libc 0.2.146",
 ]
 
@@ -4338,6 +4381,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-maps"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d17946c951c8e8c4233375fdbfc212b215bd14ea1b18388eae8c95bb03a0174"
+dependencies = [
+ "anyhow",
+ "bindgen 0.60.1",
+ "libc 0.2.146",
+ "libproc",
+ "mach2",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -6858,6 +6915,7 @@ dependencies = [
  "pin-project",
  "pnet_datalink",
  "pprof",
+ "proc-maps",
  "procinfo",
  "prometheus",
  "prometheus-static-metric",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,22 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e61f2b7f93d2c7d2b08263acaa4a363b3e276806c68af6134c44f523bf1aacd"
 dependencies = [
- "gimli",
+ "gimli 0.25.0",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+dependencies = [
+ "cpp_demangle",
+ "fallible-iterator",
+ "gimli 0.28.0",
+ "memmap2 0.5.10",
+ "object 0.32.1",
+ "rustc-demangle",
+ "smallvec",
 ]
 
 [[package]]
@@ -505,12 +520,12 @@ version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7a905d892734eea339e896738c14b9afce22b5318f64b951e70bf3844419b01"
 dependencies = [
- "addr2line",
+ "addr2line 0.16.0",
  "cc",
  "cfg-if 1.0.0",
  "libc 0.2.146",
  "miniz_oxide 0.4.4",
- "object",
+ "object 0.26.2",
  "rustc-demangle",
 ]
 
@@ -800,9 +815,9 @@ checksum = "cdead85bdec19c194affaeeb670c0e41fe23de31459efd1c174d049269cf02cc"
 
 [[package]]
 name = "byteorder"
-version = "1.3.4"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -1181,6 +1196,15 @@ name = "core-foundation-sys"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
+
+[[package]]
+name = "cpp_demangle"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8227005286ec39567949b33df9896bcadfa6051bccca2488129f108ca23119"
+dependencies = [
+ "cfg-if 1.0.0",
+]
 
 [[package]]
 name = "cpu-time"
@@ -1957,6 +1981,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
 name = "farmhash"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2091,6 +2121,7 @@ dependencies = [
  "crc32fast",
  "libc 0.2.146",
  "libz-sys",
+ "miniz-sys",
  "miniz_oxide 0.3.7",
 ]
 
@@ -2441,6 +2472,16 @@ name = "gimli"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
+
+[[package]]
+name = "gimli"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+dependencies = [
+ "fallible-iterator",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "glob"
@@ -3277,9 +3318,9 @@ dependencies = [
 
 [[package]]
 name = "memmap2"
-version = "0.5.3"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057a3db23999c867821a7a59feb06a578fcb03685e983dff90daf9e7d24ac08f"
+checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
 dependencies = [
  "libc 0.2.146",
 ]
@@ -3339,6 +3380,16 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz-sys"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9e3ae51cea1576ceba0dde3d484d30e6e5b86dee0b2d412fe3a16a15c98202"
+dependencies = [
+ "cc",
+ "libc 0.2.146",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -3774,6 +3825,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39f37e50073ccad23b6d09bcb5b263f4e76d3bb6038e4a3c08e52162ffa8abc2"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
+dependencies = [
+ "flate2",
+ "memchr",
+ "ruzstd",
 ]
 
 [[package]]
@@ -5299,6 +5361,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5d2a036dc6d2d8fd16fde3498b04306e29bd193bf306a57427019b823d5acd"
 
 [[package]]
+name = "ruzstd"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3ffab8f9715a0d455df4bbb9d21e91135aab3cd3ca187af0cd0c3c3f868fdc"
+dependencies = [
+ "byteorder",
+ "thiserror-core",
+ "twox-hash",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5998,7 +6071,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac457d054f793cedfde6f32d21d692b8351cfec9084fefd0470c0373f6d799bc"
 dependencies = [
  "debugid",
- "memmap2 0.5.3",
+ "memmap2 0.5.10",
  "stable_deref_trait",
  "uuid 1.2.1",
 ]
@@ -6513,6 +6586,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror-core"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d97345f6437bb2004cd58819d8a9ef8e36cdd7661c2abc4bbde0a7c40d9f497"
+dependencies = [
+ "thiserror-core-impl",
+]
+
+[[package]]
+name = "thiserror-core-impl"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10ac1c5050e43014d16b2f94d0d2ce79e65ffdd8b38d8048f9c8f6a8a6da62ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.103",
+]
+
+[[package]]
 name = "thiserror-impl"
 version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6693,6 +6786,7 @@ dependencies = [
 name = "tikv"
 version = "7.4.0-alpha"
 dependencies = [
+ "addr2line 0.21.0",
  "anyhow",
  "api_version",
  "async-stream 0.2.0",
@@ -6754,6 +6848,7 @@ dependencies = [
  "notify",
  "num-traits",
  "num_cpus",
+ "object 0.32.1",
  "online_config",
  "openssl",
  "panic_hook",
@@ -7403,9 +7498,13 @@ dependencies = [
 
 [[package]]
 name = "twox-hash"
-version = "1.5.0"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bfd5b7557925ce778ff9b9ef90e3ade34c524b5ff10e239c69a42d546d2af56"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if 1.0.0",
+ "static_assertions",
+]
 
 [[package]]
 name = "txn_types"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ testing = []
 name = "tikv"
 
 [dependencies]
+addr2line = "0.21.0"
 anyhow = "1.0"
 api_version = { workspace = true }
 async-stream = "0.2"
@@ -101,6 +102,7 @@ nom = { version = "5.1.0", default-features = false, features = ["std"] }
 notify = "4"
 num-traits = "0.2.14"
 num_cpus = "1"
+object = "0.32.1"
 online_config = { workspace = true }
 openssl = "0.10"
 parking_lot = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,7 @@ pd_client = { workspace = true }
 pin-project = "1.0"
 pnet_datalink = "0.23"
 pprof = { version = "0.11", default-features = false, features = ["flamegraph", "protobuf-codec"] }
+proc-maps = "0.3.1"
 prometheus = { version = "0.13", features = ["nightly"] }
 prometheus-static-metric = "0.5"
 protobuf = { version = "2.8", features = ["bytes"] }

--- a/src/server/status_server/mod.rs
+++ b/src/server/status_server/mod.rs
@@ -371,24 +371,22 @@ where
                 };
 
                 // Look up the function name for the address.
-                let frames = ctx.find_frames(addr as u64).skip_all_loads().unwrap();
+                let mut frames = ctx.find_frames(addr as u64).skip_all_loads().unwrap();
                 let mut found = false;
                 while let Some(frame) = frames.next().unwrap() {
                     found = true;
-                    let f = if let Some(func) = frame.function {
-                        func.demangle().unwrap().as_ref()
-                    } else {
-                        "??"
-                    };
-                    // should be "<hex address> <function name>"
-                    info!(
-                        "resolve: {:#x} {:#x} {}",
-                        addr,
-                        pc,
-                        f,
-                    );
-                    text.push_str(
-                        format!("{:#x} {}\n", pc, f).as_str()); // TODO: handle error
+                    if let Some(func) = frame.function {
+                        let f = func.demangle().unwrap().as_ref();
+                         // should be "<hex address> <function name>"
+                        info!(
+                            "resolve: {:#x} {:#x} {}",
+                            addr,
+                            pc,
+                            f,
+                        );
+                        text.push_str(
+                            format!("{:#x} {}\n", pc, f).as_str()); // TODO: handle error
+                    }
                 }; 
                 if !found {
                     info!("can't resolve mapped addr: {:#x}, pc: {:#x}", addr, pc);

--- a/src/server/status_server/mod.rs
+++ b/src/server/status_server/mod.rs
@@ -375,18 +375,20 @@ where
                 let mut found = false;
                 while let Some(frame) = frames.next().unwrap() {
                     found = true;
-                    if let Some(func) = frame.function {
-                        let f = func.demangle().unwrap().as_ref();
-                         // should be "<hex address> <function name>"
-                        info!(
-                            "resolve: {:#x} {:#x} {}",
-                            addr,
-                            pc,
-                            f,
-                        );
-                        text.push_str(
-                            format!("{:#x} {}\n", pc, f).as_str()); // TODO: handle error
-                    }
+                    let f = if let Some(func) = frame.function {
+                        func.demangle().unwrap().into_owned()
+                    } else {
+                        "??".to_owned()
+                    };
+                    // should be "<hex address> <function name>"
+                    info!(
+                        "resolve: {:#x} {:#x} {}",
+                        addr,
+                        pc,
+                        f,
+                    );
+                    text.push_str(
+                        format!("{:#x} {}\n", pc, f).as_str()); // TODO: handle error
                 }; 
                 if !found {
                     info!("can't resolve mapped addr: {:#x}, pc: {:#x}", addr, pc);

--- a/src/server/status_server/mod.rs
+++ b/src/server/status_server/mod.rs
@@ -310,7 +310,7 @@ where
         })
     }
 
-    async fn get_cmdline(req: Request<Body>) -> hyper::Result<Response<Body>> {
+    async fn get_cmdline(_req: Request<Body>) -> hyper::Result<Response<Body>> {
         let args = args().into_iter().fold(String::new(), |mut a, b| {
             a.push_str(&b);
             a.push_str("\x00");
@@ -348,20 +348,26 @@ where
             let ctx = addr2line::Context::new(&object).unwrap();
 
             for pc in body.split('+') {
-                let pc = pc.parse::<u64>().unwrap_or(0);
+                let pc = u64::from_str_radix(pc.trim_start_matches("0x"), 16).unwrap_or(0);
                 if pc == 0 {
+                    info!("invalid pc: {}", pc);
                     continue;
                 }
                 // Look up the function name for the address.
                 let f = ctx.find_frames(pc);
-                let func = f
-                    .skip_all_loads()
-                    .unwrap()
-                    .next()
-                    .unwrap()
-                    .unwrap()
-                    .function; // TODO: handle error
+                let func = if let Some(func) = f.skip_all_loads().unwrap().next().unwrap() {
+                    func.function
+                } else {
+                    info!("can't resolve: {:#x}", pc);
+                    continue;
+                };
+
                 // should be "<hex address> <function name>"
+                info!(
+                    "resolve: {:#x} {}",
+                    pc,
+                    func.as_ref().unwrap().demangle().unwrap()
+                );
                 text.push_str(
                     format!("{:#x} {}\n", pc, func.unwrap().demangle().unwrap()).as_str(),
                 ); // TODO: handle error
@@ -1639,6 +1645,48 @@ mod tests {
         assert_eq!(
             resp.headers().get("Content-Type").unwrap(),
             &mime::IMAGE_SVG.to_string()
+        );
+        status_server.stop();
+    }
+
+    #[test]
+    fn test_pprof_symbol_service() {
+        let _test_guard = TEST_PROFILE_MUTEX.lock().unwrap();
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let mut status_server = StatusServer::new(
+            1,
+            ConfigController::default(),
+            Arc::new(SecurityConfig::default()),
+            MockRouter,
+            temp_dir.path().to_path_buf(),
+            None,
+            GrpcServiceManager::dummy(),
+        )
+        .unwrap();
+        let addr = "127.0.0.1:0".to_owned();
+        let _ = status_server.start(addr);
+        let client = Client::new();
+
+        let uri = Uri::builder()
+            .scheme("http")
+            .authority(status_server.listening_addr().to_string().as_str())
+            .path_and_query("/debug/pprof/symbol")
+            .build()
+            .unwrap();
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri(uri)
+            .body(Body::from("0x000055ffb1a948a1+0x000055ffb1fbbb46+0x000055ffb294cfdf+0x000055ffb2a4e952+0x000055ffb2b666df+0x000055ffb2b6755d+0x000055ffb2ec7052+0x000055ffb2ef13e3+0x000055ffb2fc0b00+0x000055ffb2fc1d54+0x000055ffb2fc4011+0x000055ffb2fc5080+0x000055ffb31e0925+0x000055ffb32661dd+0x000055ffb326a21d+0x000055ffb34c04c0+0x000055ffb34cb446+0x000055ffb36cd37f+0x000055ffb36f1cd4+0x000055ffb378004c+0x000055ffb37a13dc+0x000055ffb37a3fbc+0x000055ffb3941db5+0x000055ffb394abd5+0x000055ffb398cc1d+0x000055ffb398cf8d+0x000055ffb3a2e04c+0x000055ffb3a2f2f0+0x000055ffb3d3960c+0x000055ffb422166f+0x000055ffb459c8d6+0x000055ffb45ce7bc+0x000055ffb46b691d+0x000055ffb46d4a4d+0x000055ffb497f538+0x000055ffb510a14d+0x000055ffb510abb9+0x000055ffb510d827+0x000055ffb5116524+0x000055ffb513ac91+0x000055ffb52481da+0x000055ffb53fa82d+0x000055ffb53fd497+0x000055ffb5400795+0x000055ffb5404b4f+0x000055ffb54772b3+0x000055ffb5484bf0+0x000055ffb54851d0+0x00007f5fe05af132+0x00007f5fe07d960"))
+            .expect("request builder");
+        let handle = status_server
+            .thread_pool
+            .spawn(async move { client.request(req).await.unwrap() });
+        let resp = block_on(handle).unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body_bytes = block_on(hyper::body::to_bytes(resp.into_body())).unwrap();
+        println!(
+            "{}",
+            String::from_utf8(body_bytes.as_ref().to_owned()).unwrap()
         );
         status_server.stop();
     }

--- a/src/server/status_server/mod.rs
+++ b/src/server/status_server/mod.rs
@@ -13,7 +13,8 @@ use std::{
     task::{Context, Poll},
     time::{Duration, Instant},
 };
-use proc_maps::linux_maps::{get_process_maps, MapRange, Pid};
+#[cfg(target_os = "linux")]
+use proc_maps::linux_maps::{get_process_maps, Pid};
 use async_stream::stream;
 use collections::HashMap;
 use flate2::{write::GzEncoder, Compression};
@@ -358,10 +359,10 @@ where
                 }
 
                 let mut addr = None;
-                for map in maps {
+                for map in maps.iter() {
                     let start = map.start();
                     if (pc >= start) && (pc < (start + map.size())) {
-                        let addr = Some(pc - map.offset);
+                        addr = Some(pc - start + map.offset);
                         break;
                     }
                 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #xxx

What's Changed:
<img width="731" alt="截屏2023-09-27 01 46 34" src="https://github.com/tikv/tikv/assets/13497871/b552a551-050d-4715-badf-9fd5a9fe461c">

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Jeprof supports generating the svg by remote fetching, so we can add a symbol service 
following the [pprof format](https://gperftools.github.io/gperftools/pprof_remote_servers.html), 
then with ` jeprof --show_bytes http://<tikv_host>:20180/debug/pprof/heap --svg` it can simply
get the heap profiling svg from remote.

With this PR, we can get rid of the limitation that the heap profile must be processed with the 
corresponding tikv binary and perl runtime which is used by `jeprof`. Later, we only need to 
install `jeprof` and `perl` in tidb_dashboard environment and collect the heap profile just like
how CPU profile does.

```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)

run
```
jeprof --show_bytes http://127.0.0.1:20180/debug/pprof/heap --svg > new_profile.svg
```
here is the result
![new_profile](https://github.com/tikv/tikv/assets/13497871/2e4a49e4-cff4-4c51-a8e0-b6dba81e1bd0)


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Add symbol service to support remote fetching symbolized heap profile
```
