### PR TITLE
raftstore-v2: fix non-deterministic region merge

### DIFF
--- a/components/raftstore-v2/src/operation/command/admin/merge/commit.rs
+++ b/components/raftstore-v2/src/operation/command/admin/merge/commit.rs
@@ -687,6 +687,8 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             info!(
                 self.logger,
                 "become follower for new logs";
+                "first_log_term" => first.term,
+                "first_log_index" => first.index,
                 "new_log_term" => last_log.term,
                 "new_log_index" => last_log.index,
                 "term" => self.term(),

--- a/components/raftstore-v2/src/operation/command/admin/merge/commit.rs
+++ b/components/raftstore-v2/src/operation/command/admin/merge/commit.rs
@@ -178,6 +178,11 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             self.region_id() == 2,
             |_| {}
         );
+        fail::fail_point!(
+            "ask_target_peer_to_commit_merge_store_1",
+            store_ctx.store_id == 1,
+            |_| {}
+        );
         let state = self.applied_merge_state().unwrap();
         let target = state.get_target();
         let target_id = target.get_id();
@@ -347,6 +352,11 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
                         return;
                     }
                 }
+                fail::fail_point!(
+                    "on_propose_commit_merge_fail_store_1",
+                    store_ctx.store_id == 1,
+                    |_| {}
+                );
                 let _ = store_ctx
                     .router
                     .force_send(source_id, PeerMsg::RejectCommitMerge { index });

--- a/components/raftstore-v2/src/operation/command/admin/merge/commit.rs
+++ b/components/raftstore-v2/src/operation/command/admin/merge/commit.rs
@@ -300,7 +300,10 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
                     target_id: self.region_id(),
                 },
             );
-        } else if util::is_epoch_stale(expected_epoch, region.get_region_epoch()) {
+            return;
+        }
+        // current region_epoch > region epoch in commit merge.
+        if util::is_epoch_stale(expected_epoch, region.get_region_epoch()) {
             info!(
                 self.logger,
                 "reject commit merge because of stale";
@@ -311,68 +314,51 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             let _ = store_ctx
                 .router
                 .force_send(source_id, PeerMsg::RejectCommitMerge { index });
-        } else if expected_epoch == region.get_region_epoch() {
-            assert!(
-                util::is_sibling_regions(source_region, region),
-                "{}: {:?}, {:?}",
-                SlogFormat(&self.logger),
-                source_region,
-                region
-            );
-            assert!(
-                region_on_same_stores(source_region, region),
-                "{:?}, {:?}",
-                source_region,
-                region
-            );
-            assert!(!self.storage().has_dirty_data());
-            if self.is_leader() && !self.leader_transferring() {
-                let index = commit_of_merge(req.get_admin_request().get_commit_merge());
-                if self.proposal_control().is_merging() {
-                    // `on_admin_command` may delay our request indefinitely. It's better to check
-                    // directly.
-                    info!(
-                        self.logger,
-                        "reject commit merge because of target is merging with another region";
-                    );
-                } else {
-                    let (ch, res) = CmdResChannel::pair();
-                    self.on_admin_command(store_ctx, req, ch);
-                    if let Some(res) = res.take_result()
-                        && res.get_header().has_error()
-                    {
-                        error!(
-                            self.logger,
-                            "failed to propose commit merge";
-                            "source" => source_id,
-                            "res" => ?res,
-                        );
-                    } else {
-                        fail::fail_point!("on_propose_commit_merge_success");
-                        return;
-                    }
-                }
-                fail::fail_point!(
-                    "on_propose_commit_merge_fail_store_1",
-                    store_ctx.store_id == 1,
-                    |_| {}
-                );
-                let _ = store_ctx
-                    .router
-                    .force_send(source_id, PeerMsg::RejectCommitMerge { index });
-            } else if self.leader_transferring() {
-                info!(
-                    self.logger,
-                    "not to propose commit merge when transferring leader";
-                    "transferee" => self.leader_transferee(),
-                );
-            }
-        } else {
+            return;
+        }
+        // current region_epoch < region epoch in commit merge.
+        if util::is_epoch_stale(region.get_region_epoch(), expected_epoch) {
             info!(
                 self.logger,
-                "ignore commit merge because self epoch is stale";
+                "target region still not catch up, skip.";
                 "source" => ?source_region,
+                "target_region_epoch" => ?expected_epoch,
+                "exist_region_epoch" => ?self.region().get_region_epoch(),
             );
+            return;
+        }
+        assert!(
+            util::is_sibling_regions(source_region, region),
+            "{}: {:?}, {:?}",
+            SlogFormat(&self.logger),
+            source_region,
+            region
+        );
+        assert!(
+            region_on_same_stores(source_region, region),
+            "{:?}, {:?}",
+            source_region,
+            region
+        );
+        assert!(!self.storage().has_dirty_data());
+        let (ch, res) = CmdResChannel::pair();
+        self.on_admin_command(store_ctx, req, ch);
+        if let Some(res) = res.take_result()
+            && res.get_header().has_error()
+        {
+            error!(
+                self.logger,
+                "failed to propose commit merge";
+                "source" => source_id,
+                "res" => ?res,
+            );
+            fail::fail_point!(
+                "on_propose_commit_merge_fail_store_1",
+                store_ctx.store_id == 1,
+                |_| {}
+            );
+        } else {
+            fail::fail_point!("on_propose_commit_merge_success");
         }
     }
 

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -1086,6 +1086,8 @@ where
             // of term explicitly to get correct metadata.
             info!(
                 "become follower for new logs";
+                "first_log_term" => first.term,
+                "first_log_index" => first.index,
                 "new_log_term" => last_log.term,
                 "new_log_index" => last_log.index,
                 "term" => self.term(),

--- a/tests/failpoints/cases/test_merge.rs
+++ b/tests/failpoints/cases/test_merge.rs
@@ -1846,7 +1846,6 @@ fn test_concurrent_between_transfer_leader_and_merge() {
     assert_eq!(region.get_end_key(), left.get_end_key());
 
     cluster.must_put(b"k4", b"v4");
-    panic!();
 }
 
 #[test]


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #15682

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
This commit addresses the issue where a "region corrupted" error still
occurs in certain scenarios despite PR #15625 resolving the problem in
the transfer leader scenario. The root cause of the issue is the
non-deterministic nature of commit merge and rollback merge, allowing
transient errors during propose to trigger the problem again.

To fix this issue, the proposed solution ensures that TiKV only
initiates rollback merge when either the target region is not found or
the epoch has increased.
```

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix an issue that may cause "region corrupted" panic during region merge.
```
