### PR TITLE
raftstore-v2: avoid follower forwarding propose msg

### DIFF
--- a/components/raftstore-v2/src/operation/command/write/mod.rs
+++ b/components/raftstore-v2/src/operation/command/write/mod.rs
@@ -125,16 +125,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
                 false
             } else {
                 // Epoch may have changed since last check.
-                let from_epoch = header.get_region_epoch();
-                let res = util::compare_region_epoch(
-                    from_epoch,
-                    self.region(),
-                    NORMAL_REQ_CHECK_CONF_VER,
-                    NORMAL_REQ_CHECK_VER,
-                    true,
-                );
-                if let Err(e) = res {
-                    // TODO: query sibling regions.
+                if let Err(e) = validate_res && matches!(e, Error::EpochNotMatch { .. }) {
                     ctx.raft_metrics.invalid_proposal.epoch_not_match.inc();
                     encoder.encode().1.report_error(cmd_resp::new_error(e));
                     return;

--- a/components/raftstore-v2/src/operation/command/write/mod.rs
+++ b/components/raftstore-v2/src/operation/command/write/mod.rs
@@ -12,7 +12,7 @@ use raftstore::{
         fsm::{apply, MAX_PROPOSAL_SIZE_RATIO},
         metrics::PEER_WRITE_CMD_COUNTER,
         msg::ErrorCallback,
-        util::{self, NORMAL_REQ_CHECK_CONF_VER, NORMAL_REQ_CHECK_VER},
+        util::{self},
     },
     Error, Result,
 };
@@ -80,13 +80,10 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             ch.report_error(resp);
             return;
         }
-        // ProposalControl is reliable only when applied to current term.
-        let call_proposed_on_success = self.applied_to_current_term();
         let mut encoder = SimpleWriteReqEncoder::new(
             header,
             data,
             (ctx.cfg.raft_entry_max_size.0 as f64 * MAX_PROPOSAL_SIZE_RATIO) as usize,
-            call_proposed_on_success,
         );
         encoder.add_response_channel(ch);
         self.set_has_ready();
@@ -106,7 +103,6 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             Box::<RaftRequestHeader>::default(),
             data,
             ctx.cfg.raft_entry_max_size.0 as usize,
-            false,
         )
         .encode()
         .0
@@ -119,23 +115,15 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
     pub fn propose_pending_writes<T>(&mut self, ctx: &mut StoreContext<EK, ER, T>) {
         if let Some(encoder) = self.simple_write_encoder_mut().take() {
             let header = encoder.header();
-            let validate_res = self.validate_command(header, None, &mut ctx.raft_metrics);
-            let call_proposed_on_success = if encoder.notify_proposed() {
-                // The request has pass conflict check and called all proposed callbacks.
+            let res = self.validate_command(header, None, &mut ctx.raft_metrics);
+            let call_proposed_on_success = if matches!(res, Err(Error::EpochNotMatch { .. })) {
                 false
             } else {
-                // Epoch may have changed since last check.
-                if let Err(e) = validate_res && matches!(e, Error::EpochNotMatch { .. }) {
-                    ctx.raft_metrics.invalid_proposal.epoch_not_match.inc();
-                    encoder.encode().1.report_error(cmd_resp::new_error(e));
-                    return;
-                }
-                // Only when it applies to current term, the epoch check can be reliable.
                 self.applied_to_current_term()
             };
 
             let (data, chs) = encoder.encode();
-            let res = validate_res.and_then(|_| self.propose(ctx, data));
+            let res = res.and_then(|_| self.propose(ctx, data));
 
             fail_point!("after_propose_pending_writes");
 

--- a/components/raftstore-v2/src/operation/mod.rs
+++ b/components/raftstore-v2/src/operation/mod.rs
@@ -87,7 +87,7 @@ pub mod test_util {
         let mut header = Box::<RaftRequestHeader>::default();
         header.set_region_id(region_id);
         header.set_region_epoch(region_epoch);
-        let req_encoder = SimpleWriteReqEncoder::new(header, encoder.encode(), 512, false);
+        let req_encoder = SimpleWriteReqEncoder::new(header, encoder.encode(), 512);
         let (bin, _) = req_encoder.encode();
         let mut e = Entry::default();
         e.set_entry_type(EntryType::EntryNormal);
@@ -112,7 +112,7 @@ pub mod test_util {
         let mut header = Box::<RaftRequestHeader>::default();
         header.set_region_id(region_id);
         header.set_region_epoch(region_epoch);
-        let req_encoder = SimpleWriteReqEncoder::new(header, encoder.encode(), 512, false);
+        let req_encoder = SimpleWriteReqEncoder::new(header, encoder.encode(), 512);
         let (bin, _) = req_encoder.encode();
         let mut e = Entry::default();
         e.set_entry_type(EntryType::EntryNormal);

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -5745,7 +5745,6 @@ mod tests {
                 self.header.clone(),
                 bin,
                 1000,
-                false,
             );
             let (bytes, _) = req_encoder.encode();
             self.entry.set_data(bytes.into());

--- a/components/raftstore/src/store/simple_write.rs
+++ b/components/raftstore/src/store/simple_write.rs
@@ -544,7 +544,6 @@ mod tests {
             header.clone(),
             bin,
             usize::MAX,
-            false,
         );
 
         let mut encoder = SimpleWriteEncoder::with_capacity(512);
@@ -556,7 +555,6 @@ mod tests {
             header.clone(),
             bin,
             0,
-            false,
         );
 
         let (bytes, _) = req_encoder.encode();
@@ -605,9 +603,8 @@ mod tests {
             .collect();
         encoder.ingest(exp.clone());
         let bin = encoder.encode();
-        let req_encoder = SimpleWriteReqEncoder::<Callback<engine_rocks::RocksSnapshot>>::new(
-            header, bin, 0, false,
-        );
+        let req_encoder =
+            SimpleWriteReqEncoder::<Callback<engine_rocks::RocksSnapshot>>::new(header, bin, 0);
         let (bytes, _) = req_encoder.encode();
         let mut decoder =
             SimpleWriteReqDecoder::new(decoder_fallback, &logger, &bytes, 0, 0).unwrap();
@@ -669,7 +666,6 @@ mod tests {
                 header.clone(),
                 bin.clone(),
                 512,
-                false,
             );
 
         let mut header2 = Box::<RaftRequestHeader>::default();
@@ -686,7 +682,6 @@ mod tests {
                 header.clone(),
                 bin2.clone(),
                 512,
-                false,
             );
         assert!(!req_encoder2.amend(&header, &bin));
 
@@ -721,7 +716,6 @@ mod tests {
             header.clone(),
             SimpleWriteEncoder::with_capacity(512).encode(),
             512,
-            false,
         );
         let (bin, _) = req_encoder.encode();
         assert_eq!(
@@ -739,7 +733,6 @@ mod tests {
             header.clone(),
             encoder.encode(),
             512,
-            false,
         );
         let (bin, _) = req_encoder.encode();
         let req = SimpleWriteReqDecoder::new(decoder_fallback, &logger, &bin, 0, 0)
@@ -757,7 +750,6 @@ mod tests {
             header.clone(),
             encoder.encode(),
             512,
-            false,
         );
         let (bin, _) = req_encoder.encode();
         let req = SimpleWriteReqDecoder::new(decoder_fallback, &logger, &bin, 0, 0)
@@ -774,7 +766,6 @@ mod tests {
             header.clone(),
             encoder.encode(),
             512,
-            false,
         );
         let (bin, _) = req_encoder.encode();
         let req = SimpleWriteReqDecoder::new(decoder_fallback, &logger, &bin, 0, 0)
@@ -802,7 +793,6 @@ mod tests {
             header,
             encoder.encode(),
             512,
-            false,
         );
         let (bin, _) = req_encoder.encode();
         let req = SimpleWriteReqDecoder::new(decoder_fallback, &logger, &bin, 0, 0)

--- a/components/raftstore/src/store/simple_write.rs
+++ b/components/raftstore/src/store/simple_write.rs
@@ -49,7 +49,6 @@ where
     channels: Vec<C>,
     size_limit: usize,
     write_type: WriteType,
-    notify_proposed: bool,
 }
 
 impl<C> SimpleWriteReqEncoder<C>
@@ -57,14 +56,10 @@ where
     C: ErrorCallback + WriteCallback,
 {
     /// Create a request encoder.
-    ///
-    /// If `notify_proposed` is true, channels will be called `notify_proposed`
-    /// when it's appended.
     pub fn new(
         header: Box<RaftRequestHeader>,
         bin: SimpleWriteBinary,
         size_limit: usize,
-        notify_proposed: bool,
     ) -> SimpleWriteReqEncoder<C> {
         let mut buf = Vec::with_capacity(256);
         buf.push(MAGIC_PREFIX);
@@ -77,7 +72,6 @@ where
             channels: vec![],
             size_limit,
             write_type: bin.write_type,
-            notify_proposed,
         }
     }
 
@@ -112,16 +106,8 @@ where
     }
 
     #[inline]
-    pub fn add_response_channel(&mut self, mut ch: C) {
-        if self.notify_proposed {
-            ch.notify_proposed();
-        }
+    pub fn add_response_channel(&mut self, ch: C) {
         self.channels.push(ch);
-    }
-
-    #[inline]
-    pub fn notify_proposed(&self) -> bool {
-        self.notify_proposed
     }
 
     #[inline]

--- a/tests/failpoints/cases/test_transaction.rs
+++ b/tests/failpoints/cases/test_transaction.rs
@@ -855,7 +855,7 @@ fn test_forbid_forward_propose() {
     let mut ctx = Context::default();
     ctx.set_region_id(region.get_id());
     ctx.set_region_epoch(region.get_region_epoch().clone());
-    ctx.set_peer(peer2.clone());
+    ctx.set_peer(peer2);
 
     // block node when collecting message to make some msgs in a single batch
     fail::cfg("on_peer_collect_message_2", "pause").unwrap();
@@ -879,7 +879,7 @@ fn test_forbid_forward_propose() {
 
     std::thread::sleep(Duration::from_secs(1));
 
-    ctx.set_peer(peer1.clone());
+    ctx.set_peer(peer1);
     must_put(&ctx, &storage, b"k", b"val");
     must_delete(&ctx, &storage, b"k");
 

--- a/tests/integrations/storage/test_raftkv.rs
+++ b/tests/integrations/storage/test_raftkv.rs
@@ -1,8 +1,7 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 use std::{
     sync::{atomic::AtomicBool, Arc},
-    thread,
-    time::{self},
+    thread, time,
 };
 
 use engine_traits::{CfName, IterOptions, CF_DEFAULT};

--- a/tests/integrations/storage/test_raftkv.rs
+++ b/tests/integrations/storage/test_raftkv.rs
@@ -2,7 +2,7 @@
 use std::{
     sync::{atomic::AtomicBool, Arc},
     thread,
-    time::{self, Duration},
+    time::{self},
 };
 
 use engine_traits::{CfName, IterOptions, CF_DEFAULT};

--- a/tests/integrations/storage/test_raftkv.rs
+++ b/tests/integrations/storage/test_raftkv.rs
@@ -1,7 +1,8 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 use std::{
     sync::{atomic::AtomicBool, Arc},
-    thread, time,
+    thread,
+    time::{self, Duration},
 };
 
 use engine_traits::{CfName, IterOptions, CF_DEFAULT};


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #14390

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
avoid follower forwarding propose msg
```
This PR fixes the panic of "txn record found but not expected".
Now, validation and propose may not be atomic, which means a raft message in between with higher term can make the node become follower. So, when it begins to propose, it's not a leader which triggers a msg forward.
Forwarding proposal msg by follower can make proposal be proposed twice which is decribed in the comment
of the test in this PR. So, if a `prewrite` is proposed twice where the `commit` is proposed between them, the lock
with `start_ts` of the comitted txn will lock again, leading to the panic.

The PR also removes the `notify_proposed` in `add_response_channel`, as the propose may fail even it passes the validation at very beginning.


Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
