### PR TITLE
remove the unhold assert in warmup raft entry

### DIFF
--- a/components/raftstore/src/store/entry_storage.rs
+++ b/components/raftstore/src/store/entry_storage.rs
@@ -1177,7 +1177,18 @@ impl<EK: KvEngine, ER: RaftEngine> EntryStorage<EK, ER> {
                         } else {
                             range.1 == self.last_index() + 1
                         };
-                        assert!(is_valid, "the warmup range should still be valid");
+                        if !is_valid {
+                            error!(
+                                "unexpected warmup state";
+                                "region_id" => self.region_id,
+                                "peer_id" => self.peer_id,
+                                "cache_first" => ?self.entry_cache_first_index(),
+                                "last_index" => self.last_index(),
+                                "warmup_state_high" => range.1,
+                                "last_entry_index" => index,
+                            );
+                            return false;
+                        }
                         entries.truncate((range.1 - range.0) as usize);
                         self.cache.prepend(entries);
                         WARM_UP_ENTRY_CACHE_COUNTER.finished.inc();


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #15289

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Remove the incorrect assert. 
In master, the related PR is #15243, but it's too big to cherry-pick. 
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
