### PR TITLE
coprocessor: do not treat deadline exceeded error as other error

### DIFF
--- a/src/coprocessor/dag/mod.rs
+++ b/src/coprocessor/dag/mod.rs
@@ -143,8 +143,9 @@ fn handle_qe_response(
     can_be_cached: bool,
     data_version: Option<u64>,
 ) -> Result<Response> {
-    use crate::coprocessor::Error;
     use tidb_query_common::error::{ErrorInner, EvaluateError};
+
+    use crate::coprocessor::Error;
 
     match result {
         Ok((sel_resp, range)) => {
@@ -181,8 +182,9 @@ fn handle_qe_response(
 fn handle_qe_stream_response(
     result: tidb_query_common::Result<(Option<(StreamResponse, IntervalRange)>, bool)>,
 ) -> Result<(Option<Response>, bool)> {
-    use crate::coprocessor::Error;
     use tidb_query_common::error::{ErrorInner, EvaluateError};
+
+    use crate::coprocessor::Error;
 
     match result {
         Ok((Some((s_resp, range)), finished)) => {

--- a/src/coprocessor/dag/mod.rs
+++ b/src/coprocessor/dag/mod.rs
@@ -237,13 +237,13 @@ mod tests {
 
         // Evaluate Error
         let err = CommonError::from(EvaluateError::DeadlineExceeded);
-        let res = handle_qe_response(Err(err.into()), false, None);
+        let res = handle_qe_response(Err(err), false, None);
         assert!(matches!(res, Err(Error::DeadlineExceeded)));
 
         let err = CommonError::from(EvaluateError::InvalidCharacterString {
             charset: "test".into(),
         });
-        let res = handle_qe_response(Err(err.into()), false, None).unwrap();
+        let res = handle_qe_response(Err(err), false, None).unwrap();
         let mut select_res = SelectResponse::new();
         Message::merge_from_bytes(&mut select_res, res.get_data()).unwrap();
         assert_eq!(select_res.get_error().get_code(), 1300);

--- a/src/coprocessor/dag/mod.rs
+++ b/src/coprocessor/dag/mod.rs
@@ -209,3 +209,43 @@ fn handle_qe_stream_response(
         },
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use anyhow::anyhow;
+    use protobuf::Message;
+    use tidb_query_common::error::{Error as CommonError, EvaluateError, StorageError};
+
+    use super::*;
+    use crate::coprocessor::Error;
+
+    #[test]
+    fn test_handle_qe_response() {
+        // Ok Response
+        let ok_res = Ok((SelectResponse::default(), None));
+        let res = handle_qe_response(ok_res, true, Some(1)).unwrap();
+        assert!(res.can_be_cached);
+        assert_eq!(res.get_cache_last_version(), 1);
+        let mut select_res = SelectResponse::new();
+        Message::merge_from_bytes(&mut select_res, res.get_data()).unwrap();
+        assert!(!select_res.has_error());
+
+        // Storage Error
+        let storage_err = CommonError::from(StorageError(anyhow!("unknown")));
+        let res = handle_qe_response(Err(storage_err), false, None);
+        assert!(matches!(res, Err(Error::Other(_))));
+
+        // Evaluate Error
+        let err = CommonError::from(EvaluateError::DeadlineExceeded);
+        let res = handle_qe_response(Err(err.into()), false, None);
+        assert!(matches!(res, Err(Error::DeadlineExceeded)));
+
+        let err = CommonError::from(EvaluateError::InvalidCharacterString {
+            charset: "test".into(),
+        });
+        let res = handle_qe_response(Err(err.into()), false, None).unwrap();
+        let mut select_res = SelectResponse::new();
+        Message::merge_from_bytes(&mut select_res, res.get_data()).unwrap();
+        assert_eq!(select_res.get_error().get_code(), 1300);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #15566

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```
Fix the bug that coprocessor may convert DeadlineExceeded error to Other error so tidb can handle backoff correctly.
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
