### PR TITLE
s3: support backup with session token and assume role

### DIFF
--- a/components/cloud/aws/src/s3.rs
+++ b/components/cloud/aws/src/s3.rs
@@ -91,7 +91,7 @@ impl Config {
             let secret_access_key = attrs.get("secret_access_key").unwrap_or(def).clone();
             let session_token = attrs
                 .get("session_token")
-                .map_or(None, |x| StringNonEmpty::opt(x.to_string()));
+                .and_then(|x| StringNonEmpty::opt(x.to_string()));
             Some(AccessKeyPair {
                 access_key: StringNonEmpty::required_field(access_key.clone(), "access_key")?,
                 secret_access_key: StringNonEmpty::required_field(

--- a/components/cloud/aws/src/s3.rs
+++ b/components/cloud/aws/src/s3.rs
@@ -693,7 +693,7 @@ mod tests {
         config.access_key_pair = Some(AccessKeyPair {
             access_key: StringNonEmpty::required("abc".to_string()).unwrap(),
             secret_access_key: StringNonEmpty::required("xyz".to_string()).unwrap(),
-            None,
+            session_token: Some(StringNonEmpty::required("token".to_string()).unwrap()),
         });
         let mut s = S3Storage::new(config.clone()).unwrap();
         // set a less than 5M value not work

--- a/components/cloud/aws/src/s3.rs
+++ b/components/cloud/aws/src/s3.rs
@@ -230,7 +230,7 @@ impl S3Storage {
         P: ProvideAwsCredentials + Send + Sync + 'static,
         D: DispatchSignedRequest + Send + Sync + 'static,
     {
-        if let Some(role_arn) = config.role_arn.clone() {
+        if config.role_arn.is_some() {
             // try use role arn anyway with current creds when it's not nil.
             let bucket_region = none_to_empty(config.bucket.region.clone());
             let bucket_endpoint = config.bucket.endpoint.clone();

--- a/components/cloud/aws/src/s3.rs
+++ b/components/cloud/aws/src/s3.rs
@@ -243,9 +243,9 @@ impl S3Storage {
             let timestamp_secs = duration_since_epoch.as_secs();
             let cred_provider = StsAssumeRoleSessionCredentialsProvider::new(
                 sts,
-                none_to_empty(Some(role_arn)),
+                String::clone(config.role_arn.as_deref().unwrap()),
                 format!("{}", timestamp_secs),
-                config.external_id.clone().as_deref_mut().map(|e| e.clone()),
+                config.external_id.as_deref().map(String::clone),
                 // default duration is 15min
                 None,
                 None,
@@ -267,11 +267,7 @@ impl S3Storage {
             let cred_provider = StaticProvider::new(
                 (*access_key_pair.access_key).to_owned(),
                 (*access_key_pair.secret_access_key).to_owned(),
-                access_key_pair
-                    .session_token
-                    .to_owned()
-                    .as_deref_mut()
-                    .map(|s| s.clone()),
+                access_key_pair.session_token.as_deref().map(String::clone),
                 None,
             );
             Self::maybe_assume_role(config, cred_provider, dispatcher)

--- a/components/cloud/aws/src/s3.rs
+++ b/components/cloud/aws/src/s3.rs
@@ -1,5 +1,9 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
-use std::{error::Error as StdError, io, time::Duration};
+use std::{
+    error::Error as StdError,
+    io,
+    time::{Duration, SystemTime},
+};
 
 use async_trait::async_trait;
 use cloud::{
@@ -16,6 +20,7 @@ pub use kvproto::brpb::{Bucket as InputBucket, CloudDynamic, S3 as InputConfig};
 use rusoto_core::{request::DispatchSignedRequest, ByteStream, RusotoError};
 use rusoto_credential::{ProvideAwsCredentials, StaticProvider};
 use rusoto_s3::{util::AddressingStyle, *};
+use rusoto_sts::{StsAssumeRoleSessionCredentialsProvider, StsClient};
 use thiserror::Error;
 use tikv_util::{debug, stream::error_stream, time::Instant};
 use tokio::time::{sleep, timeout};
@@ -29,6 +34,7 @@ pub const STORAGE_VENDOR_NAME_AWS: &str = "aws";
 pub struct AccessKeyPair {
     pub access_key: StringNonEmpty,
     pub secret_access_key: StringNonEmpty,
+    pub session_token: Option<StringNonEmpty>,
 }
 
 impl std::fmt::Debug for AccessKeyPair {
@@ -36,6 +42,7 @@ impl std::fmt::Debug for AccessKeyPair {
         f.debug_struct("AccessKeyPair")
             .field("access_key", &self.access_key)
             .field("secret_access_key", &"?")
+            .field("session_token", &self.session_token)
             .finish()
     }
 }
@@ -51,6 +58,8 @@ pub struct Config {
     storage_class: Option<StringNonEmpty>,
     multi_part_size: usize,
     object_lock_enabled: bool,
+    role_arn: Option<StringNonEmpty>,
+    external_id: Option<StringNonEmpty>,
 }
 
 impl Config {
@@ -66,6 +75,8 @@ impl Config {
             storage_class: None,
             multi_part_size: MINIMUM_PART_SIZE,
             object_lock_enabled: false,
+            role_arn: None,
+            external_id: None,
         }
     }
 
@@ -78,12 +89,16 @@ impl Config {
         let access_key_opt = attrs.get("access_key");
         let access_key_pair = if let Some(access_key) = access_key_opt {
             let secret_access_key = attrs.get("secret_access_key").unwrap_or(def).clone();
+            let session_token = attrs
+                .get("session_token")
+                .map_or(None, |x| StringNonEmpty::opt(x.to_string()));
             Some(AccessKeyPair {
                 access_key: StringNonEmpty::required_field(access_key.clone(), "access_key")?,
                 secret_access_key: StringNonEmpty::required_field(
                     secret_access_key,
                     "secret_access_key",
                 )?,
+                session_token,
             })
         } else {
             None
@@ -99,6 +114,8 @@ impl Config {
             sse_kms_key_id: StringNonEmpty::opt(attrs.get("sse_kms_key_id").unwrap_or(def).clone()),
             multi_part_size: MINIMUM_PART_SIZE,
             object_lock_enabled: false,
+            role_arn: StringNonEmpty::opt(attrs.get("role_arn").unwrap_or(def).clone()),
+            external_id: StringNonEmpty::opt(attrs.get("external_id").unwrap_or(def).clone()),
         })
     }
 
@@ -114,13 +131,17 @@ impl Config {
         };
         let access_key_pair = match StringNonEmpty::opt(input.access_key) {
             None => None,
-            Some(ak) => Some(AccessKeyPair {
-                access_key: ak,
-                secret_access_key: StringNonEmpty::required_field(
-                    input.secret_access_key,
-                    "secret_access_key",
-                )?,
-            }),
+            Some(ak) => {
+                let session_token = StringNonEmpty::opt(input.session_token);
+                Some(AccessKeyPair {
+                    access_key: ak,
+                    secret_access_key: StringNonEmpty::required_field(
+                        input.secret_access_key,
+                        "secret_access_key",
+                    )?,
+                    session_token,
+                })
+            }
         };
         Ok(Config {
             storage_class,
@@ -132,6 +153,8 @@ impl Config {
             sse_kms_key_id: StringNonEmpty::opt(input.sse_kms_key_id),
             multi_part_size: MINIMUM_PART_SIZE,
             object_lock_enabled: input.object_lock_enabled,
+            role_arn: StringNonEmpty::opt(input.role_arn),
+            external_id: StringNonEmpty::opt(input.external_id),
         })
     }
 }
@@ -203,15 +226,48 @@ impl S3Storage {
         D: DispatchSignedRequest + Send + Sync + 'static,
     {
         // static credentials are used with minio
-        if let Some(access_key_pair) = &config.access_key_pair {
-            let cred_provider = StaticProvider::new_minimal(
-                (*access_key_pair.access_key).to_owned(),
-                (*access_key_pair.secret_access_key).to_owned(),
-            );
-            Self::new_creds_dispatcher(config, dispatcher, cred_provider)
-        } else {
-            let cred_provider = util::CredentialsProvider::new()?;
-            Self::new_creds_dispatcher(config, dispatcher, cred_provider)
+        match (&config.access_key_pair, &config.role_arn) {
+            // ak/sk has the highiest prority
+            (Some(access_key_pair), None) => {
+                let cred_provider = StaticProvider::new(
+                    (*access_key_pair.access_key).to_owned(),
+                    (*access_key_pair.secret_access_key).to_owned(),
+                    access_key_pair
+                        .session_token
+                        .to_owned()
+                        .as_deref_mut()
+                        .map(|s| s.clone()),
+                    None,
+                );
+                Self::new_creds_dispatcher(config, dispatcher, cred_provider)
+            }
+            (None, role_arn) => {
+                // try assume role if it's not nil
+                let bucket_region = none_to_empty(config.bucket.region.clone());
+                let bucket_endpoint = config.bucket.endpoint.clone();
+                let region = util::get_region(&bucket_region, &none_to_empty(bucket_endpoint))?;
+                let sts = StsClient::new(region);
+                let duration_since_epoch = SystemTime::now()
+                    .duration_since(SystemTime::UNIX_EPOCH)
+                    .unwrap();
+                let timestamp_secs = duration_since_epoch.as_secs();
+                let cred_provider = StsAssumeRoleSessionCredentialsProvider::new(
+                    sts,
+                    none_to_empty(role_arn.clone()),
+                    format!("{}", timestamp_secs),
+                    config.external_id.clone().as_deref_mut().map(|e| e.clone()),
+                    // default duration is 15min
+                    None,
+                    None,
+                    None,
+                );
+                Self::new_creds_dispatcher(config, dispatcher, cred_provider)
+            }
+            _ => {
+                // default credentials from env
+                let cred_provider = util::CredentialsProvider::new()?;
+                Self::new_creds_dispatcher(config, dispatcher, cred_provider)
+            }
         }
     }
 
@@ -637,6 +693,7 @@ mod tests {
         config.access_key_pair = Some(AccessKeyPair {
             access_key: StringNonEmpty::required("abc".to_string()).unwrap(),
             secret_access_key: StringNonEmpty::required("xyz".to_string()).unwrap(),
+            None,
         });
         let mut s = S3Storage::new(config.clone()).unwrap();
         // set a less than 5M value not work

--- a/components/cloud/src/blob.rs
+++ b/components/cloud/src/blob.rs
@@ -133,6 +133,12 @@ impl std::ops::Deref for StringNonEmpty {
     }
 }
 
+impl std::ops::DerefMut for StringNonEmpty {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
 impl std::fmt::Display for StringNonEmpty {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.0.fmt(f)

--- a/components/cloud/src/blob.rs
+++ b/components/cloud/src/blob.rs
@@ -133,12 +133,6 @@ impl std::ops::Deref for StringNonEmpty {
     }
 }
 
-impl std::ops::DerefMut for StringNonEmpty {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
 impl std::fmt::Display for StringNonEmpty {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.0.fmt(f)


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/pingcap/tidb/issues/39832
Issue Number: Close https://github.com/tikv/tikv/issues/15781

What's Changed:
1. support retrive `session-token` from input. 
2. support assume role with `role-arn` and `extrenal-id` and keep the same behavior with tidb side.

```  
 s3: support backup with session token and assume role
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

session-token:
1. set env of token.
```
export AWS_ACCESS_KEY_ID="xxx"
export AWS_SECRET_ACCESS_KEY="yyy"
export AWS_SESSION_TOKEN="zzz"
```
2. do a full backup and check backup data in s3.
<img width="1506" alt="image" src="https://github.com/tikv/tikv/assets/5906259/e748dfe1-5cf4-4690-a6b5-4782f989dd9a">

role-arn:
1. prepare two AWS account (A, B).
2. create a bucket in account A.
3. create a role for this bucket in account A.
4. create a trust relationship in account A for account B to assume above role.
```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Principal": {
                "AWS": "arn:aws:iam::ACCOUNTB:root"
            },
            "Action": "sts:AssumeRole",
            "Condition": {
                "StringEquals": {
                    "sts:ExternalId": "test-external-id"
                }
            }
        }
    ]
}
```

run backup with role-arn and external-id.

<img width="758" alt="image" src="https://github.com/tikv/tikv/assets/5906259/b8b3f3ad-8e8f-46f6-9ec5-0213a662ccf4">


Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
support backup and restore with session token and assume role.
```
