### PR TITLE
retry leader read when stale read encounters data not ready

### DIFF
--- a/components/raftstore/src/store/worker/metrics.rs
+++ b/components/raftstore/src/store/worker/metrics.rs
@@ -70,6 +70,8 @@ make_static_metric! {
 pub struct LocalReadMetrics {
     pub local_executed_requests: LocalIntCounter,
     pub local_executed_stale_read_requests: LocalIntCounter,
+    pub local_executed_stale_read_fallback_success_requests: LocalIntCounter,
+    pub local_executed_stale_read_fallback_failure_requests: LocalIntCounter,
     pub local_executed_replica_read_requests: LocalIntCounter,
     pub local_executed_snapshot_cache_hit: LocalIntCounter,
     pub reject_reason: LocalReadRejectCounter,
@@ -82,6 +84,8 @@ thread_local! {
         LocalReadMetrics {
             local_executed_requests: LOCAL_READ_EXECUTED_REQUESTS.local(),
             local_executed_stale_read_requests: LOCAL_READ_EXECUTED_STALE_READ_REQUESTS.local(),
+            local_executed_stale_read_fallback_success_requests: LOCAL_READ_EXECUTED_STALE_READ_FALLBACK_SUCCESS_REQUESTS.local(),
+            local_executed_stale_read_fallback_failure_requests: LOCAL_READ_EXECUTED_STALE_READ_FALLBACK_FAILURE_REQUESTS.local(),
             local_executed_replica_read_requests: LOCAL_READ_EXECUTED_REPLICA_READ_REQUESTS.local(),
             local_executed_snapshot_cache_hit: LOCAL_READ_EXECUTED_CACHE_REQUESTS.local(),
             reject_reason: LocalReadRejectCounter::from(&LOCAL_READ_REJECT_VEC),
@@ -100,6 +104,10 @@ pub fn maybe_tls_local_read_metrics_flush() {
         if m.last_flush_time.saturating_elapsed() >= Duration::from_millis(METRICS_FLUSH_INTERVAL) {
             m.local_executed_requests.flush();
             m.local_executed_stale_read_requests.flush();
+            m.local_executed_stale_read_fallback_success_requests
+                .flush();
+            m.local_executed_stale_read_fallback_failure_requests
+                .flush();
             m.local_executed_replica_read_requests.flush();
             m.local_executed_snapshot_cache_hit.flush();
             m.reject_reason.flush();
@@ -189,6 +197,18 @@ lazy_static! {
         "Total number of stale read requests directly executed by local reader."
     )
     .unwrap();
+    pub static ref LOCAL_READ_EXECUTED_STALE_READ_FALLBACK_SUCCESS_REQUESTS: IntCounter =
+        register_int_counter!(
+            "tikv_raftstore_local_read_executed_stale_read_fallback_success_requests",
+            "Total number of stale read requests executed by local leader peer as snapshot read."
+        )
+        .unwrap();
+    pub static ref LOCAL_READ_EXECUTED_STALE_READ_FALLBACK_FAILURE_REQUESTS: IntCounter =
+        register_int_counter!(
+            "tikv_raftstore_local_read_executed_stale_read_fallback_failure_requests",
+            "Total number of stale read requests failed to be executed by local leader peer as snapshot read."
+        )
+        .unwrap();
     pub static ref LOCAL_READ_EXECUTED_REPLICA_READ_REQUESTS: IntCounter = register_int_counter!(
         "tikv_raftstore_local_read_executed_replica_read_requests",
         "Total number of stale read requests directly executed by local reader."

--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -2358,8 +2358,8 @@ mod tests {
             1,
             term6,
             pr_ids1,
-            epoch13.clone(),
-            store_meta.clone(),
+            epoch13,
+            store_meta,
             Duration::milliseconds(1),
         );
         thread::sleep(std::time::Duration::from_millis(50));

--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -30,7 +30,7 @@ use tikv_util::{
 };
 use time::Timespec;
 use tracker::GLOBAL_TRACKERS;
-use txn_types::TimeStamp;
+use txn_types::{TimeStamp, WriteBatchFlags};
 
 use super::metrics::*;
 use crate::{
@@ -974,80 +974,155 @@ where
         cmd.callback.set_result(read_resp);
     }
 
+    /// Try to handle the read request using local read, if the leader is valid
+    /// the read response is returned, otherwise None is returned.
+    fn try_local_leader_read(
+        &mut self,
+        req: &RaftCmdRequest,
+        delegate: &mut CachedReadDelegate<E>,
+        read_id: Option<ThreadReadId>,
+        snap_updated: &mut bool,
+        last_valid_ts: Timespec,
+    ) -> Option<ReadResponse<E::Snapshot>> {
+        let mut local_read_ctx = LocalReadContext::new(&mut self.snap_cache, read_id);
+
+        (*snap_updated) =
+            local_read_ctx.maybe_update_snapshot(delegate.get_tablet(), last_valid_ts);
+
+        let snapshot_ts = local_read_ctx.snapshot_ts().unwrap();
+        if !delegate.is_in_leader_lease(snapshot_ts) {
+            return None;
+        }
+
+        let region = Arc::clone(&delegate.region);
+        let mut response = delegate.execute(req, &region, None, Some(local_read_ctx));
+        if let Some(snap) = response.snapshot.as_mut() {
+            snap.bucket_meta = delegate.bucket_meta.clone();
+        }
+        // Try renew lease in advance
+        delegate.maybe_renew_lease_advance(&self.router, snapshot_ts);
+        Some(response)
+    }
+
+    /// Try to handle the stale read request, if the read_ts < safe_ts the read
+    /// response is returned, otherwise the raft command response with
+    /// `DataIsNotReady` error is returned.
+    fn try_local_stale_read(
+        &mut self,
+        req: &RaftCmdRequest,
+        delegate: &mut CachedReadDelegate<E>,
+        snap_updated: &mut bool,
+        last_valid_ts: Timespec,
+    ) -> std::result::Result<ReadResponse<E::Snapshot>, RaftCmdResponse> {
+        let read_ts = decode_u64(&mut req.get_header().get_flag_data()).unwrap();
+        delegate.check_stale_read_safe(read_ts)?;
+
+        // Stale read does not use cache, so we pass None for read_id
+        let mut local_read_ctx = LocalReadContext::new(&mut self.snap_cache, None);
+        (*snap_updated) =
+            local_read_ctx.maybe_update_snapshot(delegate.get_tablet(), last_valid_ts);
+
+        let region = Arc::clone(&delegate.region);
+        // Getting the snapshot
+        let mut response = delegate.execute(req, &region, None, Some(local_read_ctx));
+        if let Some(snap) = response.snapshot.as_mut() {
+            snap.bucket_meta = delegate.bucket_meta.clone();
+        }
+        // Double check in case `safe_ts` change after the first check and before
+        // getting snapshot
+        delegate.check_stale_read_safe(read_ts)?;
+
+        TLS_LOCAL_READ_METRICS.with(|m| m.borrow_mut().local_executed_stale_read_requests.inc());
+        Ok(response)
+    }
+
     pub fn propose_raft_command(
         &mut self,
         read_id: Option<ThreadReadId>,
-        req: RaftCmdRequest,
+        mut req: RaftCmdRequest,
         cb: Callback<E::Snapshot>,
     ) {
         match self.pre_propose_raft_command(&req) {
             Ok(Some((mut delegate, policy))) => {
-                let snap_updated;
+                let mut snap_updated = false;
                 let last_valid_ts = delegate.last_valid_ts;
                 let mut response = match policy {
                     // Leader can read local if and only if it is in lease.
                     RequestPolicy::ReadLocal => {
-                        let mut local_read_ctx =
-                            LocalReadContext::new(&mut self.snap_cache, read_id);
-
-                        snap_updated = local_read_ctx
-                            .maybe_update_snapshot(delegate.get_tablet(), last_valid_ts);
-
-                        let snapshot_ts = local_read_ctx.snapshot_ts().unwrap();
-                        if !delegate.is_in_leader_lease(snapshot_ts) {
+                        if let Some(read_resp) = self.try_local_leader_read(
+                            &req,
+                            &mut delegate,
+                            read_id,
+                            &mut snap_updated,
+                            last_valid_ts,
+                        ) {
+                            read_resp
+                        } else {
                             fail_point!("localreader_before_redirect", |_| {});
                             // Forward to raftstore.
                             self.redirect(RaftCommand::new(req, cb));
                             return;
                         }
-
-                        let region = Arc::clone(&delegate.region);
-                        let mut response =
-                            delegate.execute(&req, &region, None, Some(local_read_ctx));
-                        if let Some(snap) = response.snapshot.as_mut() {
-                            snap.bucket_meta = delegate.bucket_meta.clone();
-                        }
-                        // Try renew lease in advance
-                        delegate.maybe_renew_lease_advance(&self.router, snapshot_ts);
-                        response
                     }
                     // Replica can serve stale read if and only if its `safe_ts` >= `read_ts`
                     RequestPolicy::StaleRead => {
-                        let read_ts = decode_u64(&mut req.get_header().get_flag_data()).unwrap();
-                        if let Err(resp) = delegate.check_stale_read_safe(read_ts) {
-                            cb.set_result(ReadResponse {
-                                response: resp,
-                                snapshot: None,
-                                txn_extra_op: TxnExtraOp::Noop,
-                            });
-                            return;
+                        match self.try_local_stale_read(
+                            &req,
+                            &mut delegate,
+                            &mut snap_updated,
+                            last_valid_ts,
+                        ) {
+                            Ok(read_resp) => read_resp,
+                            Err(err_resp) => {
+                                // It's safe to change the header of the `RaftCmdRequest`, as it
+                                // would not affect the `SnapCtx` used in upper layer like.
+                                let unset_stale_flag = req.get_header().get_flags()
+                                    & (!WriteBatchFlags::STALE_READ.bits());
+                                req.mut_header().set_flags(unset_stale_flag);
+                                let mut inspector = Inspector {
+                                    delegate: &delegate,
+                                };
+                                // The read request could be handled using snapshot read if the
+                                // local peer is a valid leader.
+                                let allow_fallback_leader_read = inspector
+                                    .inspect(&req)
+                                    .map_or(false, |r| r == RequestPolicy::ReadLocal);
+                                if !allow_fallback_leader_read {
+                                    cb.set_result(ReadResponse {
+                                        response: err_resp,
+                                        snapshot: None,
+                                        txn_extra_op: TxnExtraOp::Noop,
+                                    });
+                                    return;
+                                }
+                                if let Some(read_resp) = self.try_local_leader_read(
+                                    &req,
+                                    &mut delegate,
+                                    None,
+                                    &mut snap_updated,
+                                    last_valid_ts,
+                                ) {
+                                    TLS_LOCAL_READ_METRICS.with(|m| {
+                                        m.borrow_mut()
+                                            .local_executed_stale_read_fallback_success_requests
+                                            .inc()
+                                    });
+                                    read_resp
+                                } else {
+                                    TLS_LOCAL_READ_METRICS.with(|m| {
+                                        m.borrow_mut()
+                                            .local_executed_stale_read_fallback_failure_requests
+                                            .inc()
+                                    });
+                                    cb.set_result(ReadResponse {
+                                        response: err_resp,
+                                        snapshot: None,
+                                        txn_extra_op: TxnExtraOp::Noop,
+                                    });
+                                    return;
+                                }
+                            }
                         }
-
-                        // Stale read does not use cache, so we pass None for read_id
-                        let mut local_read_ctx = LocalReadContext::new(&mut self.snap_cache, None);
-                        snap_updated = local_read_ctx
-                            .maybe_update_snapshot(delegate.get_tablet(), last_valid_ts);
-
-                        let region = Arc::clone(&delegate.region);
-                        // Getting the snapshot
-                        let mut response =
-                            delegate.execute(&req, &region, None, Some(local_read_ctx));
-                        if let Some(snap) = response.snapshot.as_mut() {
-                            snap.bucket_meta = delegate.bucket_meta.clone();
-                        }
-                        // Double check in case `safe_ts` change after the first check and before
-                        // getting snapshot
-                        if let Err(resp) = delegate.check_stale_read_safe(read_ts) {
-                            cb.set_result(ReadResponse {
-                                response: resp,
-                                snapshot: None,
-                                txn_extra_op: TxnExtraOp::Noop,
-                            });
-                            return;
-                        }
-                        TLS_LOCAL_READ_METRICS
-                            .with(|m| m.borrow_mut().local_executed_stale_read_requests.inc());
-                        response
                     }
                     _ => unreachable!(),
                 };
@@ -1598,6 +1673,8 @@ mod tests {
         read_progress.update_safe_ts(1, 1);
         assert_eq!(read_progress.safe_ts(), 1);
 
+        // Expire lease manually to avoid local retry on leader peer.
+        lease.expire();
         let data = {
             let mut d = [0u8; 8];
             (&mut d[..]).encode_u64(2).unwrap();
@@ -1755,13 +1832,14 @@ mod tests {
         assert_eq!(kv_engine.path(), tablet.path());
     }
 
-    fn prepare_read_delegate(
+    fn prepare_read_delegate_with_lease(
         store_id: u64,
         region_id: u64,
         term: u64,
         pr_ids: Vec<u64>,
         region_epoch: RegionEpoch,
         store_meta: Arc<Mutex<StoreMeta>>,
+        max_lease: Duration,
     ) {
         let mut region = metapb::Region::default();
         region.set_id(region_id);
@@ -1770,7 +1848,7 @@ mod tests {
 
         let leader = prs[0].clone();
         region.set_region_epoch(region_epoch);
-        let mut lease = Lease::new(Duration::seconds(1), Duration::milliseconds(250)); // 1s is long enough.
+        let mut lease = Lease::new(max_lease, Duration::milliseconds(250)); // 1s is long enough.
         let read_progress = Arc::new(RegionReadProgress::new(&region, 1, 1, 1));
 
         // Register region
@@ -1797,6 +1875,25 @@ mod tests {
             };
             meta.readers.insert(region_id, read_delegate);
         }
+    }
+
+    fn prepare_read_delegate(
+        store_id: u64,
+        region_id: u64,
+        term: u64,
+        pr_ids: Vec<u64>,
+        region_epoch: RegionEpoch,
+        store_meta: Arc<Mutex<StoreMeta>>,
+    ) {
+        prepare_read_delegate_with_lease(
+            store_id,
+            region_id,
+            term,
+            pr_ids,
+            region_epoch,
+            store_meta,
+            Duration::seconds(1),
+        )
     }
 
     #[test]
@@ -2164,5 +2261,94 @@ mod tests {
         thread::sleep(std::time::Duration::from_millis(500)); // Prevent lost notify.
         must_not_redirect(&mut reader, &rx, task);
         notify_rx.recv().unwrap();
+    }
+
+    #[test]
+    fn test_stale_read_local_leader_fallback() {
+        let store_id = 2;
+        let store_meta = Arc::new(Mutex::new(StoreMeta::new(0)));
+        let (_tmp, mut reader, rx) = new_reader(
+            "test-stale-local-leader-fallback",
+            store_id,
+            store_meta.clone(),
+        );
+        reader.kv_engine.put(b"key", b"value").unwrap();
+
+        let epoch13 = {
+            let mut ep = metapb::RegionEpoch::default();
+            ep.set_conf_ver(1);
+            ep.set_version(3);
+            ep
+        };
+        let term6 = 6;
+
+        // Register region1
+        let pr_ids1 = vec![2, 3, 4];
+        let prs1 = new_peers(store_id, pr_ids1.clone());
+        prepare_read_delegate_with_lease(
+            store_id,
+            1,
+            term6,
+            pr_ids1,
+            epoch13.clone(),
+            store_meta.clone(),
+            Duration::seconds(10),
+        );
+        let leader1 = prs1[0].clone();
+
+        // Local read
+        let mut cmd = RaftCmdRequest::default();
+        let mut header = RaftRequestHeader::default();
+        header.set_region_id(1);
+        header.set_peer(leader1);
+        header.set_region_epoch(epoch13);
+        header.set_term(term6);
+        header.set_flags(header.get_flags() | WriteBatchFlags::STALE_READ.bits());
+        cmd.set_header(header.clone());
+        let mut req = Request::default();
+        req.set_cmd_type(CmdType::Snap);
+        cmd.set_requests(vec![req].into());
+
+        // A peer can serve read_ts < safe_ts.
+        let safe_ts = TimeStamp::compose(2, 0);
+        {
+            let mut meta = store_meta.lock().unwrap();
+            let delegate = meta.readers.get_mut(&1).unwrap();
+            delegate
+                .read_progress
+                .update_safe_ts(1, safe_ts.into_inner());
+            assert_eq!(delegate.read_progress.safe_ts(), safe_ts.into_inner());
+        }
+        let read_ts_1 = TimeStamp::compose(1, 0);
+        let mut data = [0u8; 8];
+        (&mut data[..]).encode_u64(read_ts_1.into_inner()).unwrap();
+        header.set_flag_data(data.into());
+        cmd.set_header(header.clone());
+        let (snap_tx, snap_rx) = channel();
+        let task = RaftCommand::<KvTestSnapshot>::new(
+            cmd.clone(),
+            Callback::read(Box::new(move |resp: ReadResponse<KvTestSnapshot>| {
+                snap_tx.send(resp).unwrap();
+            })),
+        );
+        must_not_redirect(&mut reader, &rx, task);
+        snap_rx.recv().unwrap().snapshot.unwrap();
+
+        // When read_ts > safe_ts, the leader peer could still serve if its lease is
+        // valid.
+        let read_ts_2 = TimeStamp::compose(safe_ts.physical() + 201, 0);
+        let mut data = [0u8; 8];
+        (&mut data[..]).encode_u64(read_ts_2.into_inner()).unwrap();
+        header.set_flag_data(data.into());
+        cmd.set_header(header.clone());
+        let (snap_tx, snap_rx) = channel();
+        let task = RaftCommand::<KvTestSnapshot>::new(
+            cmd.clone(),
+            Callback::read(Box::new(move |resp: ReadResponse<KvTestSnapshot>| {
+                snap_tx.send(resp).unwrap();
+            })),
+        );
+        must_not_redirect(&mut reader, &rx, task);
+        snap_rx.recv().unwrap().snapshot.unwrap();
     }
 }

--- a/tests/failpoints/cases/test_kv_service.rs
+++ b/tests/failpoints/cases/test_kv_service.rs
@@ -5,9 +5,10 @@ use std::{sync::Arc, time::Duration};
 use grpcio::{ChannelBuilder, Environment};
 use kvproto::{kvrpcpb::*, tikvpb::TikvClient};
 use test_raftstore::{
-    must_kv_prewrite, must_new_cluster_and_kv_client, must_new_cluster_mul,
-    try_kv_prewrite_with_impl,
+    configure_for_lease_read, must_kv_commit, must_kv_prewrite, must_new_cluster_and_kv_client,
+    must_new_cluster_mul, new_server_cluster, try_kv_prewrite_with_impl,
 };
+use tikv_util::{config::ReadableDuration, HandyRwLock};
 
 #[test]
 fn test_batch_get_memory_lock() {
@@ -102,4 +103,56 @@ fn test_undetermined_write_err() {
     fail::remove("applied_cb_return_undetermined_err");
     // The previous panic hasn't been captured.
     assert!(std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| drop(cluster))).is_err());
+}
+#[test]
+fn test_stale_read_on_local_leader() {
+    let mut cluster = new_server_cluster(0, 1);
+    // Increase the election tick to make this test case running reliably.
+    configure_for_lease_read(&mut cluster.cfg, Some(50), Some(10_000));
+    let max_lease = Duration::from_secs(2);
+    cluster.cfg.raft_store.raft_store_max_leader_lease = ReadableDuration(max_lease);
+    cluster.pd_client.disable_default_operator();
+    cluster.run();
+
+    let region_id = 1;
+    let leader = cluster.leader_of_region(region_id).unwrap();
+    let epoch = cluster.get_region_epoch(region_id);
+    let mut ctx = Context::default();
+    ctx.set_region_id(region_id);
+    ctx.set_peer(leader.clone());
+    ctx.set_region_epoch(epoch);
+    let env = Arc::new(Environment::new(1));
+    let channel =
+        ChannelBuilder::new(env).connect(&cluster.sim.rl().get_addr(leader.get_store_id()));
+    let client = TikvClient::new(channel);
+
+    let (k, v) = (b"key".to_vec(), b"value".to_vec());
+    let v1 = b"value1".to_vec();
+
+    // Write record.
+    let mut mutation = Mutation::default();
+    mutation.set_op(Op::Put);
+    mutation.set_key(k.clone());
+    mutation.set_value(v.clone());
+    must_kv_prewrite(&client, ctx.clone(), vec![mutation], k.clone(), 10);
+    must_kv_commit(&client, ctx.clone(), vec![k.clone()], 10, 30, 30);
+
+    // Prewrite and leave a lock.
+    let mut mutation = Mutation::default();
+    mutation.set_op(Op::Put);
+    mutation.set_key(k.clone());
+    mutation.set_value(v1);
+    must_kv_prewrite(&client, ctx.clone(), vec![mutation], k.clone(), 50);
+
+    let mut req = GetRequest::default();
+    req.set_context(ctx);
+    req.set_key(k);
+    req.version = 40;
+    req.mut_context().set_stale_read(true);
+
+    // The stale read should fallback and succeed on the leader peer.
+    let resp = client.kv_get(&req).unwrap();
+    assert!(resp.error.is_none());
+    assert!(resp.region_error.is_none());
+    assert_eq!(v, resp.get_value());
 }

--- a/tests/failpoints/cases/test_replica_stale_read.rs
+++ b/tests/failpoints/cases/test_replica_stale_read.rs
@@ -288,9 +288,11 @@ fn test_update_resoved_ts_before_apply_index() {
     sleep_ms(100);
 
     // The leader can't handle stale read with `commit_ts2` because its `safe_ts`
-    // can't update due to its `apply_index` not update
+    // can't update due to its `apply_index` not update.
+    // The request would be handled as a snapshot read on the valid leader peer
+    // after fallback.
     let resp = leader_client.kv_read(b"key1".to_vec(), commit_ts2);
-    assert!(resp.get_region_error().has_data_is_not_ready(),);
+    assert_eq!(resp.get_value(), b"value2");
     // The follower can't handle stale read with `commit_ts2` because it don't
     // have enough data
     let resp = follower_client2.kv_read(b"key1".to_vec(), commit_ts2);
@@ -667,10 +669,10 @@ fn test_stale_read_future_ts_not_update_max_ts() {
         b"key1".to_vec(),
     );
 
-    // Perform stale read with a future ts should return error
+    // Perform stale read with a future ts, the stale read could be processed
+    // falling back to snapshot read on the leader peer.
     let read_ts = get_tso(&pd_client) + 10000000;
-    let resp = leader_client.kv_read(b"key1".to_vec(), read_ts);
-    assert!(resp.get_region_error().has_data_is_not_ready());
+    leader_client.must_kv_read_equal(b"key1".to_vec(), b"value1".to_vec(), read_ts);
 
     // The `max_ts` should not updated by the stale read request, so we can prewrite
     // and commit `async_commit` transaction with a ts that smaller than the
@@ -687,10 +689,10 @@ fn test_stale_read_future_ts_not_update_max_ts() {
     leader_client.must_kv_commit(vec![b"key2".to_vec()], prewrite_ts, commit_ts);
     leader_client.must_kv_read_equal(b"key2".to_vec(), b"value1".to_vec(), get_tso(&pd_client));
 
-    // Perform stale read with a future ts should return error
+    // Perform stale read with a future ts, the stale read could be processed
+    // falling back to snapshot read on the leader peer.
     let read_ts = get_tso(&pd_client) + 10000000;
-    let resp = leader_client.kv_read(b"key1".to_vec(), read_ts);
-    assert!(resp.get_region_error().has_data_is_not_ready());
+    leader_client.must_kv_read_equal(b"key2".to_vec(), b"value1".to_vec(), read_ts);
 
     // The `max_ts` should not updated by the stale read request, so 1pc transaction
     // with a ts that smaller than the `read_ts` should not be fallbacked to 2pc


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #14553 

What's Changed:
When the local peer handling the stale read encounters a 'data is not ready' error, if the current local peer is a valid leader, attempt to directly fallback to leader snapshot read processing instead of returning an error directly to the KV client.
Save unnecessary handling of 'data not ready' errors and gRPC request processing, because the KV client will fallback to the leader peer for snapshot read upon receiving a 'data not ready' error too.


From the local test using command
```
mysqlslap --user=root --host=127.0.0.1 --port=4000 --create-schema=test --concurrency=10 --iterations=10000 --query="set tidb_read_staleness = '-5'; use test; select * from sbtest1 where id = 1"
```

Master:
![image](https://github.com/tikv/tikv/assets/3692139/29da4df3-962b-4f9b-81b8-6aa1e20a1669)
![image](https://github.com/tikv/tikv/assets/3692139/af4c9914-5242-4baf-ad7b-27a6d5ed3a92)
![image](https://github.com/tikv/tikv/assets/3692139/fabe28ac-5896-4290-9dd7-13de5614b310)


This PR:
![image](https://github.com/tikv/tikv/assets/3692139/ea450b49-ab9f-4a59-b316-b17dc022a744)
![image](https://github.com/tikv/tikv/assets/3692139/2da10c58-7a16-4da8-a9e2-fc6058d8a316)
![image](https://github.com/tikv/tikv/assets/3692139/ce9fb788-e659-4c78-8b53-44682a3efa94)
![image](https://github.com/tikv/tikv/assets/3692139/8c620e27-a83b-45e0-8fa6-63f8fbed4b1d)


- There's no data is not ready error in the kv client, and kv request number is only half compared with the vanilla version. 
- Retry locally also saves resources.

Resource usage compare
![20231011-211813](https://github.com/tikv/tikv/assets/3692139/4a5f6a33-eacf-4178-ae50-ca06bf22f560)
![image](https://github.com/tikv/tikv/assets/3692139/43c102cc-a305-4935-ac27-2930e0d52126)




### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects



### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Retry leader read when stale read encounters data not ready.
```
