### PR TITLE
metrics: distinguish read index requests from leader and follower

### DIFF
--- a/components/raftstore/src/store/local_metrics.rs
+++ b/components/raftstore/src/store/local_metrics.rs
@@ -109,6 +109,7 @@ pub struct RaftMetrics {
     pub propose: RaftProposalCounterVec,
     pub invalid_proposal: RaftInvalidProposalCounterVec,
     pub raft_log_gc_skipped: RaftLogGcSkippedCounterVec,
+    pub read_index_source: ReadIndexCounterVec,
 
     // local histogram
     pub store_time: LocalHistogram,
@@ -150,6 +151,7 @@ impl RaftMetrics {
                 &RAFT_INVALID_PROPOSAL_COUNTER_VEC,
             ),
             raft_log_gc_skipped: RaftLogGcSkippedCounterVec::from(&RAFT_LOG_GC_SKIPPED_VEC),
+            read_index_source: ReadIndexCounterVec::from(&READ_INDEX_SOURCE_VEC),
             store_time: STORE_TIME_HISTOGRAM.local(),
             propose_wait_time: REQUEST_WAIT_TIME_HISTOGRAM.local(),
             process_ready: PEER_RAFT_PROCESS_DURATION
@@ -187,6 +189,7 @@ impl RaftMetrics {
         self.propose.flush();
         self.invalid_proposal.flush();
         self.raft_log_gc_skipped.flush();
+        self.read_index_source.flush();
 
         self.store_time.flush();
         self.propose_wait_time.flush();

--- a/components/raftstore/src/store/metrics.rs
+++ b/components/raftstore/src/store/metrics.rs
@@ -257,6 +257,15 @@ make_static_metric! {
         unable_to_split_cpu_top,
     }
 
+    pub label_enum Role {
+        leader,
+        follower,
+    }
+
+    pub struct ReadIndexCounterVec : LocalIntCounter {
+        "type" => Role,
+    }
+
     pub struct HibernatedPeerStateGauge: IntGauge {
         "state" => {
             awaken,
@@ -855,6 +864,13 @@ lazy_static! {
         "tikv_raftstore_raft_log_gc_skipped",
         "Total number of skipped raft log gc.",
         &["reason"]
+    )
+    .unwrap();
+
+    pub static ref READ_INDEX_SOURCE_VEC: IntCounterVec = register_int_counter_vec!(
+        "tikv_raftstore_read_index_source",
+        "Total number of read index source.",
+        &["type"]
     )
     .unwrap();
 

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -3858,6 +3858,11 @@ where
             return false;
         }
 
+        if self.is_leader() {
+            poll_ctx.raft_metrics.read_index_source.leader.inc();
+        } else {
+            poll_ctx.raft_metrics.read_index_source.follower.inc();
+        }
         let mut read = ReadIndexRequest::with_command(id, req, cb, now);
         read.addition_request = request.map(Box::new);
         self.push_pending_read(read, self.is_leader());


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #14860 

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Add a counter tikv_raftstore_read_index_source.
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

Side effects


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
