### PR TITLE
Revert "log-bakcup: make initial scan asynchronous (#15541)"

### DIFF
--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -1,24 +1,16 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{
-    any::Any,
-    collections::HashSet,
-    fmt,
-    marker::PhantomData,
-    sync::{Arc, Mutex},
-    time::Duration,
-};
+use std::{any::Any, collections::HashSet, fmt, marker::PhantomData, sync::Arc, time::Duration};
 
 use concurrency_manager::ConcurrencyManager;
 use engine_traits::KvEngine;
 use error_code::ErrorCodeExt;
-use futures::{stream::AbortHandle, FutureExt, TryFutureExt};
+use futures::{stream::AbortHandle, FutureExt};
 use kvproto::{
     brpb::{StreamBackupError, StreamBackupTaskInfo},
     metapb::Region,
 };
 use pd_client::PdClient;
-use raft::StateRole;
 use raftstore::{
     coprocessor::{CmdBatch, ObserveHandle, RegionInfoProvider},
     router::CdcHandle,
@@ -38,7 +30,7 @@ use tikv_util::{
 use tokio::{
     io::Result as TokioResult,
     runtime::{Handle, Runtime},
-    sync::{oneshot, Semaphore},
+    sync::oneshot,
 };
 use tokio_stream::StreamExt;
 use txn_types::TimeStamp;
@@ -68,7 +60,7 @@ const SLOW_EVENT_THRESHOLD: f64 = 120.0;
 /// task has fatal error.
 const CHECKPOINT_SAFEPOINT_TTL_IF_ERROR: u64 = 24;
 
-pub struct Endpoint<S, R, E: KvEngine, PDC> {
+pub struct Endpoint<S, R, E, RT, PDC> {
     // Note: those fields are more like a shared context between components.
     // For now, we copied them everywhere, maybe we'd better extract them into a
     // context type.
@@ -77,6 +69,7 @@ pub struct Endpoint<S, R, E: KvEngine, PDC> {
     pub(crate) store_id: u64,
     pub(crate) regions: R,
     pub(crate) engine: PhantomData<E>,
+    pub(crate) router: RT,
     pub(crate) pd_client: Arc<PDC>,
     pub(crate) subs: SubscriptionTracer,
     pub(crate) concurrency_manager: ConcurrencyManager,
@@ -85,6 +78,8 @@ pub struct Endpoint<S, R, E: KvEngine, PDC> {
     pub range_router: Router,
     observer: BackupStreamObserver,
     pool: Runtime,
+    initial_scan_memory_quota: PendingMemoryQuota,
+    initial_scan_throughput_quota: Limiter,
     region_operator: RegionSubscriptionManager<S, R, PDC>,
     failover_time: Option<Instant>,
     // We holds the config before, even it is useless for now,
@@ -97,17 +92,17 @@ pub struct Endpoint<S, R, E: KvEngine, PDC> {
     /// This is used for simulating an asynchronous background worker.
     /// Each time we spawn a task, once time goes by, we abort that task.
     pub abort_last_storage_save: Option<AbortHandle>,
-    pub initial_scan_semaphore: Arc<Semaphore>,
 }
 
-impl<S, R, E, PDC> Endpoint<S, R, E, PDC>
+impl<S, R, E, RT, PDC> Endpoint<S, R, E, RT, PDC>
 where
     R: RegionInfoProvider + 'static + Clone,
     E: KvEngine,
+    RT: CdcHandle<E> + 'static,
     PDC: PdClient + 'static,
     S: MetaStore + 'static,
 {
-    pub fn new<RT: CdcHandle<E> + 'static>(
+    pub fn new(
         store_id: u64,
         store: S,
         config: BackupStreamConfig,
@@ -150,21 +145,17 @@ where
         info!("the endpoint of stream backup started"; "path" => %config.temp_path);
         let subs = SubscriptionTracer::default();
 
-        let initial_scan_semaphore = Arc::new(Semaphore::new(config.initial_scan_concurrency));
         let (region_operator, op_loop) = RegionSubscriptionManager::start(
             InitialDataLoader::new(
+                router.clone(),
+                accessor.clone(),
                 range_router.clone(),
                 subs.clone(),
                 scheduler.clone(),
-                initial_scan_memory_quota,
-                initial_scan_throughput_quota,
-                // NOTE: in fact we can get rid of the `Arc`. Just need to warp the router when the
-                // scanner pool is created. But at that time the handle has been sealed in the
-                // `InitialScan` trait -- we cannot do that.
-                Arc::new(Mutex::new(router)),
-                Arc::clone(&initial_scan_semaphore),
+                initial_scan_memory_quota.clone(),
+                pool.handle().clone(),
+                initial_scan_throughput_quota.clone(),
             ),
-            accessor.clone(),
             observer.clone(),
             meta_client.clone(),
             pd_client.clone(),
@@ -175,7 +166,6 @@ where
         let mut checkpoint_mgr = CheckpointManager::default();
         pool.spawn(checkpoint_mgr.spawn_subscription_mgr());
         let ep = Endpoint {
-            initial_scan_semaphore,
             meta_client,
             range_router,
             scheduler,
@@ -184,9 +174,12 @@ where
             store_id,
             regions: accessor,
             engine: PhantomData,
+            router,
             pd_client,
             subs,
             concurrency_manager,
+            initial_scan_memory_quota,
+            initial_scan_throughput_quota,
             region_operator,
             failover_time: None,
             config,
@@ -198,11 +191,12 @@ where
     }
 }
 
-impl<S, R, E, PDC> Endpoint<S, R, E, PDC>
+impl<S, R, E, RT, PDC> Endpoint<S, R, E, RT, PDC>
 where
     S: MetaStore + 'static,
     R: RegionInfoProvider + Clone + 'static,
     E: KvEngine,
+    RT: CdcHandle<E> + 'static,
     PDC: PdClient + 'static,
 {
     fn get_meta_client(&self) -> MetadataClient<S> {
@@ -500,6 +494,20 @@ where
         });
     }
 
+    /// Make an initial data loader using the resource of the endpoint.
+    pub fn make_initial_loader(&self) -> InitialDataLoader<E, R, RT> {
+        InitialDataLoader::new(
+            self.router.clone(),
+            self.regions.clone(),
+            self.range_router.clone(),
+            self.subs.clone(),
+            self.scheduler.clone(),
+            self.initial_scan_memory_quota.clone(),
+            self.pool.handle().clone(),
+            self.initial_scan_throughput_quota.clone(),
+        )
+    }
+
     pub fn handle_watch_task(&self, op: TaskOp) {
         match op {
             TaskOp::AddTask(task) => {
@@ -517,12 +525,13 @@ where
         }
     }
 
-    async fn observe_regions_in_range(
+    async fn observe_and_scan_region(
         &self,
+        init: InitialDataLoader<E, R, RT>,
         task: &StreamTask,
         start_key: Vec<u8>,
         end_key: Vec<u8>,
-    ) {
+    ) -> Result<()> {
         let start = Instant::now_coarse();
         let success = self
             .observer
@@ -540,9 +549,7 @@ where
         // directly and this would be fast. If this gets slow, maybe make it async
         // again. (Will that bring race conditions? say `Start` handled after
         // `ResfreshResolver` of some region.)
-        let range_init_result = self
-            .initialize_range(start_key.clone(), end_key.clone())
-            .await;
+        let range_init_result = init.initialize_range(start_key.clone(), end_key.clone());
         match range_init_result {
             Ok(()) => {
                 info!("backup stream success to initialize";
@@ -553,45 +560,6 @@ where
             Err(e) => {
                 e.report("backup stream initialize failed");
             }
-        }
-    }
-
-    /// initialize a range: it simply scan the regions with leader role and send
-    /// them to [`initialize_region`].
-    pub async fn initialize_range(&self, start_key: Vec<u8>, end_key: Vec<u8>) -> Result<()> {
-        // Generally we will be very very fast to consume.
-        // Directly clone the initial data loader to the background thread looks a
-        // little heavier than creating a new channel. TODO: Perhaps we need a
-        // handle to the `InitialDataLoader`. Making it a `Runnable` worker might be a
-        // good idea.
-        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
-        self.regions
-            .seek_region(
-                &start_key,
-                Box::new(move |i| {
-                    // Ignore the error, this can only happen while the server is shutting down, the
-                    // future has been canceled.
-                    let _ = i
-                        .filter(|r| r.role == StateRole::Leader)
-                        .take_while(|r| r.region.start_key < end_key)
-                        .try_for_each(|r| {
-                            tx.blocking_send(ObserveOp::Start {
-                                region: r.region.clone(),
-                            })
-                        });
-                }),
-            )
-            .map_err(|err| {
-                Error::Other(box_err!(
-                    "failed to seek region for start key {}: {}",
-                    utils::redact(&start_key),
-                    err
-                ))
-            })?;
-        // Don't reschedule this command: or once the endpoint's mailbox gets
-        // full, the system might deadlock.
-        while let Some(cmd) = rx.recv().await {
-            self.region_operator.request(cmd).await;
         }
         Ok(())
     }
@@ -610,6 +578,7 @@ where
     /// Load the task into memory: this would make the endpint start to observe.
     fn load_task(&self, task: StreamTask) {
         let cli = self.meta_client.clone();
+        let init = self.make_initial_loader();
         let range_router = self.range_router.clone();
 
         info!(
@@ -652,8 +621,10 @@ where
                     .await?;
 
                 for (start_key, end_key) in ranges {
-                    self.observe_regions_in_range(&task, start_key, end_key)
-                        .await
+                    let init = init.clone();
+
+                    self.observe_and_scan_region(init, &task, start_key, end_key)
+                        .await?
                 }
                 info!(
                     "finish register backup stream ranges";
@@ -888,16 +859,11 @@ where
     }
 
     fn on_update_change_config(&mut self, cfg: BackupStreamConfig) {
-        let concurrency_diff =
-            cfg.initial_scan_concurrency as isize - self.config.initial_scan_concurrency as isize;
         info!(
             "update log backup config";
              "config" => ?cfg,
-             "concurrency_diff" => concurrency_diff,
         );
         self.range_router.udpate_config(&cfg);
-        self.update_semaphore_capacity(&self.initial_scan_semaphore, concurrency_diff);
-
         self.config = cfg;
     }
 
@@ -905,24 +871,6 @@ where
     /// This would register the region to the RaftStore.
     pub fn on_modify_observe(&self, op: ObserveOp) {
         self.pool.block_on(self.region_operator.request(op));
-    }
-
-    fn update_semaphore_capacity(&self, sema: &Arc<Semaphore>, diff: isize) {
-        use std::cmp::Ordering::*;
-        match diff.cmp(&0) {
-            Less => {
-                self.pool.spawn(
-                    Arc::clone(sema)
-                    .acquire_many_owned(-diff as _)
-                    // It is OK to trivially ignore the Error case (semaphore has been closed, we are shutting down the server.)
-                    .map_ok(|p| p.forget()),
-                );
-            }
-            Equal => {}
-            Greater => {
-                sema.add_permits(diff as _);
-            }
-        }
     }
 
     pub fn run_task(&mut self, task: Task) {
@@ -1331,11 +1279,12 @@ impl Task {
     }
 }
 
-impl<S, R, E, PDC> Runnable for Endpoint<S, R, E, PDC>
+impl<S, R, E, RT, PDC> Runnable for Endpoint<S, R, E, RT, PDC>
 where
     S: MetaStore + 'static,
     R: RegionInfoProvider + Clone + 'static,
     E: KvEngine,
+    RT: CdcHandle<E> + 'static,
     PDC: PdClient + 'static,
 {
     type Task = Task;
@@ -1348,7 +1297,10 @@ where
 #[cfg(test)]
 mod test {
     use engine_rocks::RocksEngine;
-    use raftstore::coprocessor::region_info_accessor::MockRegionInfoProvider;
+    use raftstore::{
+        coprocessor::region_info_accessor::MockRegionInfoProvider, router::CdcRaftRouter,
+    };
+    use test_raftstore::MockRaftStoreRouter;
     use tikv_util::worker::dummy_scheduler;
 
     use crate::{
@@ -1363,9 +1315,13 @@ mod test {
         cli.insert_task_with_range(&task, &[]).await.unwrap();
 
         fail::cfg("failed_to_get_tasks", "1*return").unwrap();
-        Endpoint::<_, MockRegionInfoProvider, RocksEngine, MockPdClient>::start_and_watch_tasks(
-            cli, sched,
-        )
+        Endpoint::<
+            _,
+            MockRegionInfoProvider,
+            RocksEngine,
+            CdcRaftRouter<MockRaftStoreRouter>,
+            MockPdClient,
+        >::start_and_watch_tasks(cli, sched)
         .await
         .unwrap();
         fail::remove("failed_to_get_tasks");

--- a/components/backup-stream/src/event_loader.rs
+++ b/components/backup-stream/src/event_loader.rs
@@ -3,9 +3,10 @@
 use std::{marker::PhantomData, sync::Arc, time::Duration};
 
 use engine_traits::{KvEngine, CF_DEFAULT, CF_WRITE};
+use futures::executor::block_on;
 use kvproto::{kvrpcpb::ExtraOp, metapb::Region, raft_cmdpb::CmdType};
 use raftstore::{
-    coprocessor::ObserveHandle,
+    coprocessor::{ObserveHandle, RegionInfoProvider},
     router::CdcHandle,
     store::{fsm::ChangeObserver, Callback},
 };
@@ -20,16 +21,22 @@ use tikv_util::{
     time::{Instant, Limiter},
     worker::Scheduler,
 };
-use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio::{
+    runtime::Handle,
+    sync::{OwnedSemaphorePermit, Semaphore},
+};
 use txn_types::{Key, Lock, TimeStamp};
 
 use crate::{
     annotate, debug,
+    endpoint::ObserveOp,
     errors::{ContextualResultExt, Error, Result},
     metrics,
     router::{ApplyEvent, ApplyEvents, Router},
     subscription_track::{Ref, RefMut, SubscriptionTracer, TwoPhaseResolver},
-    utils, Task,
+    try_send,
+    utils::{self, RegionPager},
+    Task,
 };
 
 const MAX_GET_SNAPSHOT_RETRY: usize = 5;
@@ -53,12 +60,10 @@ impl PendingMemoryQuota {
         Self(Arc::new(Semaphore::new(quota)))
     }
 
-    pub async fn pending(&self, size: usize) -> PendingMemory {
+    pub fn pending(&self, size: usize) -> PendingMemory {
         PendingMemory(
-            self.0
-                .clone()
-                .acquire_many_owned(size as _)
-                .await
+            Handle::current()
+                .block_on(self.0.clone().acquire_many_owned(size as _))
                 .expect("BUG: the semaphore is closed unexpectedly."),
         )
     }
@@ -170,108 +175,57 @@ impl<S: Snapshot> EventLoader<S> {
 }
 
 /// The context for loading incremental data between range.
-/// Like [`cdc::Initializer`].
+/// Like [`cdc::Initializer`], but supports initialize over range.
 /// Note: maybe we can merge those two structures?
+/// Note': maybe extract more fields to trait so it would be easier to test.
 #[derive(Clone)]
-pub struct InitialDataLoader<E: KvEngine, H> {
+pub struct InitialDataLoader<E, R, RT> {
     // Note: maybe we can make it an abstract thing like `EventSink` with
     //       method `async (KvEvent) -> Result<()>`?
     pub(crate) sink: Router,
     pub(crate) tracing: SubscriptionTracer,
     pub(crate) scheduler: Scheduler<Task>,
-
+    // Note: this is only for `init_range`, maybe make it an argument?
+    pub(crate) regions: R,
+    // Note: Maybe move those fields about initial scanning into some trait?
+    pub(crate) router: RT,
     pub(crate) quota: PendingMemoryQuota,
     pub(crate) limit: Limiter,
-    // If there are too many concurrent initial scanning, the limit of disk speed or pending memory
-    // quota will probably be triggered. Then the whole scanning will be pretty slow. And when
-    // we are holding a iterator for a long time, the memtable may not be able to be flushed.
-    // Using this to restrict the possibility of that.
-    concurrency_limit: Arc<Semaphore>,
 
-    cdc_handle: H,
-
+    pub(crate) handle: Handle,
     _engine: PhantomData<E>,
 }
 
-impl<E, H> InitialDataLoader<E, H>
+impl<E, R, RT> InitialDataLoader<E, R, RT>
 where
     E: KvEngine,
-    H: CdcHandle<E> + Sync,
+    R: RegionInfoProvider + Clone + 'static,
+    RT: CdcHandle<E>,
 {
     pub fn new(
+        router: RT,
+        regions: R,
         sink: Router,
         tracing: SubscriptionTracer,
         sched: Scheduler<Task>,
         quota: PendingMemoryQuota,
+        handle: Handle,
         limiter: Limiter,
-        cdc_handle: H,
-        concurrency_limit: Arc<Semaphore>,
     ) -> Self {
         Self {
+            router,
+            regions,
             sink,
             tracing,
             scheduler: sched,
             _engine: PhantomData,
             quota,
-            cdc_handle,
-            concurrency_limit,
+            handle,
             limit: limiter,
         }
     }
 
-    pub async fn capture_change(
-        &self,
-        region: &Region,
-        cmd: ChangeObserver,
-    ) -> Result<impl Snapshot> {
-        let (callback, fut) =
-            tikv_util::future::paired_future_callback::<std::result::Result<_, Error>>();
-
-        self.cdc_handle
-            .capture_change(
-                region.get_id(),
-                region.get_region_epoch().clone(),
-                cmd,
-                Callback::read(Box::new(|snapshot| {
-                    if snapshot.response.get_header().has_error() {
-                        callback(Err(Error::RaftRequest(
-                            snapshot.response.get_header().get_error().clone(),
-                        )));
-                        return;
-                    }
-                    if let Some(snap) = snapshot.snapshot {
-                        callback(Ok(snap));
-                        return;
-                    }
-                    callback(Err(Error::Other(box_err!(
-                        "PROBABLY BUG: the response contains neither error nor snapshot"
-                    ))))
-                })),
-            )
-            .context(format_args!(
-                "failed to register the observer to region {}",
-                region.get_id()
-            ))?;
-
-        let snap = fut
-            .await
-            .map_err(|err| {
-                annotate!(
-                    err,
-                    "message 'CaptureChange' dropped for region {}",
-                    region.id
-                )
-            })
-            .flatten()
-            .context(format_args!(
-                "failed to get initial snapshot: failed to get the snapshot (region_id = {})",
-                region.get_id(),
-            ))?;
-        // Note: maybe warp the snapshot via `RegionSnapshot`?
-        Ok(snap)
-    }
-
-    pub async fn observe_over_with_retry(
+    pub fn observe_over_with_retry(
         &self,
         region: &Region,
         mut cmd: impl FnMut() -> ChangeObserver,
@@ -279,7 +233,7 @@ where
         let mut last_err = None;
         for _ in 0..MAX_GET_SNAPSHOT_RETRY {
             let c = cmd();
-            let r = self.capture_change(region, c).await;
+            let r = self.observe_over(region, c);
             match r {
                 Ok(s) => {
                     return Ok(s);
@@ -311,12 +265,71 @@ where
                     if !can_retry {
                         break;
                     }
-                    tokio::time::sleep(Duration::from_secs(1)).await;
+                    std::thread::sleep(Duration::from_secs(1));
                     continue;
                 }
             }
         }
         Err(last_err.expect("BUG: max retry time exceed but no error"))
+    }
+
+    /// Start observe over some region.
+    /// This will register the region to the raftstore as observing,
+    /// and return the current snapshot of that region.
+    fn observe_over(&self, region: &Region, cmd: ChangeObserver) -> Result<impl Snapshot> {
+        // There are 2 ways for getting the initial snapshot of a region:
+        // - the BR method: use the interface in the RaftKv interface, read the
+        //   key-values directly.
+        // - the CDC method: use the raftstore message `SignificantMsg::CaptureChange`
+        //   to register the region to CDC observer and get a snapshot at the same time.
+        // Registering the observer to the raftstore is necessary because we should only
+        // listen events from leader. In CDC, the change observer is
+        // per-delegate(i.e. per-region), we can create the command per-region here too.
+
+        let (callback, fut) =
+            tikv_util::future::paired_future_callback::<std::result::Result<_, Error>>();
+
+        self.router
+            .capture_change(
+                region.get_id(),
+                region.get_region_epoch().clone(),
+                cmd,
+                Callback::read(Box::new(|snapshot| {
+                    if snapshot.response.get_header().has_error() {
+                        callback(Err(Error::RaftRequest(
+                            snapshot.response.get_header().get_error().clone(),
+                        )));
+                        return;
+                    }
+                    if let Some(snap) = snapshot.snapshot {
+                        callback(Ok(snap));
+                        return;
+                    }
+                    callback(Err(Error::Other(box_err!(
+                        "PROBABLY BUG: the response contains neither error nor snapshot"
+                    ))))
+                })),
+            )
+            .context(format_args!(
+                "failed to register the observer to region {}",
+                region.get_id()
+            ))?;
+
+        let snap = block_on(fut)
+            .map_err(|err| {
+                annotate!(
+                    err,
+                    "message 'CaptureChange' dropped for region {}",
+                    region.id
+                )
+            })
+            .flatten()
+            .context(format_args!(
+                "failed to get initial snapshot: failed to get the snapshot (region_id = {})",
+                region.get_id(),
+            ))?;
+        // Note: maybe warp the snapshot via `RegionSnapshot`?
+        Ok(snap)
     }
 
     fn with_resolver<T: 'static>(
@@ -368,7 +381,7 @@ where
         f(v.value_mut().resolver())
     }
 
-    async fn scan_and_async_send(
+    fn scan_and_async_send(
         &self,
         region: &Region,
         handle: &ObserveHandle,
@@ -406,8 +419,8 @@ where
             let sink = self.sink.clone();
             let event_size = events.size();
             let sched = self.scheduler.clone();
-            let permit = self.quota.pending(event_size).await;
-            self.limit.consume(disk_read as _).await;
+            let permit = self.quota.pending(event_size);
+            self.limit.blocking_consume(disk_read as _);
             debug!("sending events to router"; "size" => %event_size, "region" => %region_id);
             metrics::INCREMENTAL_SCAN_SIZE.observe(event_size as f64);
             metrics::INCREMENTAL_SCAN_DISK_READ.inc_by(disk_read as f64);
@@ -421,7 +434,7 @@ where
         }
     }
 
-    pub async fn do_initial_scan(
+    pub fn do_initial_scan(
         &self,
         region: &Region,
         // We are using this handle for checking whether the initial scan is stale.
@@ -429,25 +442,18 @@ where
         start_ts: TimeStamp,
         snap: impl Snapshot,
     ) -> Result<Statistics> {
+        let _guard = self.handle.enter();
         let tr = self.tracing.clone();
         let region_id = region.get_id();
 
         let mut join_handles = Vec::with_capacity(8);
 
-        let permit = self
-            .concurrency_limit
-            .acquire()
-            .await
-            .expect("BUG: semaphore closed");
         // It is ok to sink more data than needed. So scan to +inf TS for convenance.
         let event_loader = EventLoader::load_from(snap, start_ts, TimeStamp::max(), region)?;
-        let stats = self
-            .scan_and_async_send(region, &handle, event_loader, &mut join_handles)
-            .await?;
-        drop(permit);
+        let stats = self.scan_and_async_send(region, &handle, event_loader, &mut join_handles)?;
 
-        futures::future::try_join_all(join_handles)
-            .await
+        Handle::current()
+            .block_on(futures::future::try_join_all(join_handles))
             .map_err(|err| annotate!(err, "tokio runtime failed to join consuming threads"))?;
 
         Self::with_resolver_by(&tr, region, &handle, |r| {
@@ -460,6 +466,31 @@ where
         ))?;
 
         Ok(stats)
+    }
+
+    /// initialize a range: it simply scan the regions with leader role and send
+    /// them to [`initialize_region`].
+    pub fn initialize_range(&self, start_key: Vec<u8>, end_key: Vec<u8>) -> Result<()> {
+        let mut pager = RegionPager::scan_from(self.regions.clone(), start_key, end_key);
+        loop {
+            let regions = pager.next_page(8)?;
+            debug!("scanning for entries in region."; "regions" => ?regions);
+            if regions.is_empty() {
+                break;
+            }
+            for r in regions {
+                // Note: Even we did the initial scanning, and blocking resolved ts from
+                // advancing, if the next_backup_ts was updated in some extreme condition, there
+                // is still little chance to lost data: For example, if a region cannot elect
+                // the leader for long time. (say, net work partition) At that time, we have
+                // nowhere to record the lock status of this region.
+                try_send!(
+                    self.scheduler,
+                    Task::ModifyObserve(ObserveOp::Start { region: r.region })
+                );
+            }
+        }
+        Ok(())
     }
 }
 

--- a/components/backup-stream/src/subscription_manager.rs
+++ b/components/backup-stream/src/subscription_manager.rs
@@ -1,7 +1,15 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
 
+use crossbeam::channel::{Receiver as SyncReceiver, Sender as SyncSender};
+use crossbeam_channel::SendError;
 use engine_traits::KvEngine;
 use error_code::ErrorCodeExt;
 use futures::FutureExt;
@@ -14,11 +22,10 @@ use raftstore::{
     store::fsm::ChangeObserver,
 };
 use tikv::storage::Statistics;
-use tikv_util::{
-    box_err, debug, info, sys::thread::ThreadBuildWrapper, time::Instant, warn, worker::Scheduler,
-};
-use tokio::sync::mpsc::{channel, error::SendError, Receiver, Sender};
+use tikv_util::{box_err, debug, info, time::Instant, warn, worker::Scheduler};
+use tokio::sync::mpsc::{channel, Receiver, Sender};
 use txn_types::TimeStamp;
+use yatp::task::callback::Handle as YatpHandle;
 
 use crate::{
     annotate,
@@ -36,7 +43,7 @@ use crate::{
     Task,
 };
 
-type ScanPool = tokio::runtime::Runtime;
+type ScanPool = yatp::ThreadPool<yatp::task::callback::TaskCell>;
 
 const INITIAL_SCAN_FAILURE_MAX_RETRY_TIME: usize = 10;
 
@@ -121,9 +128,8 @@ fn should_retry(err: &Error) -> bool {
 }
 
 /// the abstraction over a "DB" which provides the initial scanning.
-#[async_trait::async_trait]
-trait InitialScan: Clone + Sync + Send + 'static {
-    async fn do_initial_scan(
+trait InitialScan: Clone {
+    fn do_initial_scan(
         &self,
         region: &Region,
         start_ts: TimeStamp,
@@ -133,13 +139,13 @@ trait InitialScan: Clone + Sync + Send + 'static {
     fn handle_fatal_error(&self, region: &Region, err: Error);
 }
 
-#[async_trait::async_trait]
-impl<E, RT> InitialScan for InitialDataLoader<E, RT>
+impl<E, R, RT> InitialScan for InitialDataLoader<E, R, RT>
 where
     E: KvEngine,
-    RT: CdcHandle<E> + Sync + 'static,
+    R: RegionInfoProvider + Clone + 'static,
+    RT: CdcHandle<E>,
 {
-    async fn do_initial_scan(
+    fn do_initial_scan(
         &self,
         region: &Region,
         start_ts: TimeStamp,
@@ -149,14 +155,12 @@ where
         let h = handle.clone();
         // Note: we have external retry at `ScanCmd::exec_by_with_retry`, should we keep
         // retrying here?
-        let snap = self
-            .observe_over_with_retry(region, move || {
-                ChangeObserver::from_pitr(region_id, handle.clone())
-            })
-            .await?;
+        let snap = self.observe_over_with_retry(region, move || {
+            ChangeObserver::from_pitr(region_id, handle.clone())
+        })?;
         #[cfg(feature = "failpoints")]
         fail::fail_point!("scan_after_get_snapshot");
-        let stat = self.do_initial_scan(region, h, start_ts, snap).await?;
+        let stat = self.do_initial_scan(region, h, start_ts, snap)?;
         Ok(stat)
     }
 
@@ -176,7 +180,7 @@ where
 
 impl ScanCmd {
     /// execute the initial scanning via the specificated [`InitialDataLoader`].
-    async fn exec_by(&self, initial_scan: impl InitialScan) -> Result<()> {
+    fn exec_by(&self, initial_scan: impl InitialScan) -> Result<()> {
         let Self {
             region,
             handle,
@@ -184,9 +188,7 @@ impl ScanCmd {
             ..
         } = self;
         let begin = Instant::now_coarse();
-        let stat = initial_scan
-            .do_initial_scan(region, *last_checkpoint, handle.clone())
-            .await?;
+        let stat = initial_scan.do_initial_scan(region, *last_checkpoint, handle.clone())?;
         info!("initial scanning finished!"; "takes" => ?begin.saturating_elapsed(), "from_ts" => %last_checkpoint, utils::slog_region(region));
         utils::record_cf_stat("lock", &stat.lock);
         utils::record_cf_stat("write", &stat.write);
@@ -195,12 +197,17 @@ impl ScanCmd {
     }
 
     /// execute the command, when meeting error, retrying.
-    async fn exec_by_with_retry(self, init: impl InitialScan) {
+    fn exec_by_with_retry(self, init: impl InitialScan, cancel: &AtomicBool) {
         let mut retry_time = INITIAL_SCAN_FAILURE_MAX_RETRY_TIME;
         loop {
-            match self.exec_by(init.clone()).await {
+            if cancel.load(Ordering::SeqCst) {
+                return;
+            }
+            match self.exec_by(init.clone()) {
                 Err(err) if should_retry(&err) && retry_time > 0 => {
-                    tokio::time::sleep(Duration::from_millis(500)).await;
+                    // NOTE: blocking this thread may stick the process.
+                    // Maybe spawn a task to tokio and reschedule the task then?
+                    std::thread::sleep(Duration::from_millis(500));
                     warn!("meet retryable error"; "err" => %err, "retry_time" => retry_time);
                     retry_time -= 1;
                     continue;
@@ -216,62 +223,82 @@ impl ScanCmd {
     }
 }
 
-async fn scan_executor_loop(init: impl InitialScan, mut cmds: Receiver<ScanCmd>) {
-    while let Some(cmd) = cmds.recv().await {
+fn scan_executor_loop(
+    init: impl InitialScan,
+    cmds: SyncReceiver<ScanCmd>,
+    canceled: Arc<AtomicBool>,
+) {
+    while let Ok(cmd) = cmds.recv() {
+        fail::fail_point!("execute_scan_command");
         debug!("handling initial scan request"; "region_id" => %cmd.region.get_id());
         metrics::PENDING_INITIAL_SCAN_LEN
             .with_label_values(&["queuing"])
             .dec();
-        #[cfg(feature = "failpoints")]
-        {
-            let sleep = (|| {
-                fail::fail_point!("execute_scan_command_sleep_100", |_| { 100 });
-                0
-            })();
-            tokio::time::sleep(std::time::Duration::from_secs(sleep)).await;
+        if canceled.load(Ordering::Acquire) {
+            return;
         }
 
-        let init = init.clone();
-        tokio::task::spawn(async move {
-            metrics::PENDING_INITIAL_SCAN_LEN
-                .with_label_values(&["executing"])
-                .inc();
-            cmd.exec_by_with_retry(init).await;
-            metrics::PENDING_INITIAL_SCAN_LEN
-                .with_label_values(&["executing"])
-                .dec();
-        });
+        metrics::PENDING_INITIAL_SCAN_LEN
+            .with_label_values(&["executing"])
+            .inc();
+        cmd.exec_by_with_retry(init.clone(), &canceled);
+        metrics::PENDING_INITIAL_SCAN_LEN
+            .with_label_values(&["executing"])
+            .dec();
     }
 }
 
 /// spawn the executors in the scan pool.
-fn spawn_executors(
-    init: impl InitialScan + Send + Sync + 'static,
-    number: usize,
-) -> ScanPoolHandle {
-    let (tx, rx) = tokio::sync::mpsc::channel(MESSAGE_BUFFER_SIZE);
+/// we make workers thread instead of spawn scan task directly into the pool
+/// because the [`InitialDataLoader`] isn't `Sync` hence we must use it very
+/// carefully or rustc (along with tokio) would complain that we made a `!Send`
+/// future. so we have moved the data loader to the synchronous context so its
+/// reference won't be shared between threads any more.
+fn spawn_executors(init: impl InitialScan + Send + 'static, number: usize) -> ScanPoolHandle {
+    let (tx, rx) = crossbeam::channel::bounded(MESSAGE_BUFFER_SIZE);
     let pool = create_scan_pool(number);
-    pool.spawn(async move {
-        scan_executor_loop(init, rx).await;
-    });
-    ScanPoolHandle { tx, _pool: pool }
+    let stopped = Arc::new(AtomicBool::new(false));
+    for _ in 0..number {
+        let init = init.clone();
+        let rx = rx.clone();
+        let stopped = stopped.clone();
+        pool.spawn(move |_: &mut YatpHandle<'_>| {
+            let _io_guard = file_system::WithIoType::new(file_system::IoType::Replication);
+            scan_executor_loop(init, rx, stopped);
+        })
+    }
+    ScanPoolHandle {
+        tx,
+        _pool: pool,
+        stopped,
+    }
 }
 
 struct ScanPoolHandle {
-    // Theoretically, we can get rid of the sender, and spawn a new task via initial loader in each
-    // thread. But that will make `SubscribeManager` holds a reference to the implementation of
-    // `InitialScan`, which will get the type information a mass.
-    tx: Sender<ScanCmd>,
+    tx: SyncSender<ScanCmd>,
+    stopped: Arc<AtomicBool>,
 
+    // in fact, we won't use the pool any more.
+    // but we should hold the reference to the pool so it won't try to join the threads running.
     _pool: ScanPool,
 }
 
+impl Drop for ScanPoolHandle {
+    fn drop(&mut self) {
+        self.stopped.store(true, Ordering::Release);
+    }
+}
+
 impl ScanPoolHandle {
-    async fn request(&self, cmd: ScanCmd) -> std::result::Result<(), SendError<ScanCmd>> {
+    fn request(&self, cmd: ScanCmd) -> std::result::Result<(), SendError<ScanCmd>> {
+        if self.stopped.load(Ordering::Acquire) {
+            warn!("scan pool is stopped, ignore the scan command"; "region" => %cmd.region.get_id());
+            return Ok(());
+        }
         metrics::PENDING_INITIAL_SCAN_LEN
             .with_label_values(&["queuing"])
             .inc();
-        self.tx.send(cmd).await
+        self.tx.send(cmd)
     }
 }
 
@@ -321,20 +348,11 @@ where
     }
 }
 
-/// Create a pool for doing initial scanning.
+/// Create a yatp pool for doing initial scanning.
 fn create_scan_pool(num_threads: usize) -> ScanPool {
-    tokio::runtime::Builder::new_multi_thread()
-        .with_sys_and_custom_hooks(
-            move || {
-                file_system::set_io_type(file_system::IoType::Replication);
-            },
-            || {},
-        )
-        .thread_name("log-backup-scan")
-        .enable_time()
-        .worker_threads(num_threads)
-        .build()
-        .unwrap()
+    yatp::Builder::new("log-backup-scan")
+        .max_thread_count(num_threads)
+        .build_callback_pool()
 }
 
 impl<S, R, PDC> RegionSubscriptionManager<S, R, PDC>
@@ -349,24 +367,22 @@ where
     ///
     /// a two-tuple, the first is the handle to the manager, the second is the
     /// operator loop future.
-    pub fn start<E, HInit, HChkLd>(
-        initial_loader: InitialDataLoader<E, HInit>,
-        regions: R,
+    pub fn start<E, RT>(
+        initial_loader: InitialDataLoader<E, R, RT>,
         observer: BackupStreamObserver,
         meta_cli: MetadataClient<S>,
         pd_client: Arc<PDC>,
         scan_pool_size: usize,
-        resolver: BackupStreamResolver<HChkLd, E>,
+        resolver: BackupStreamResolver<RT, E>,
     ) -> (Self, future![()])
     where
         E: KvEngine,
-        HInit: CdcHandle<E> + Sync + 'static,
-        HChkLd: CdcHandle<E> + 'static,
+        RT: CdcHandle<E> + 'static,
     {
         let (tx, rx) = channel(MESSAGE_BUFFER_SIZE);
         let scan_pool_handle = spawn_executors(initial_loader.clone(), scan_pool_size);
         let op = Self {
-            regions,
+            regions: initial_loader.regions.clone(),
             meta_cli,
             pd_client,
             range_router: initial_loader.sink.clone(),
@@ -506,8 +522,7 @@ where
                             region,
                             self.get_last_checkpoint_of(&for_task, region).await?,
                             handle.clone(),
-                        )
-                        .await;
+                        );
                         Result::Ok(())
                     }
                     .await;
@@ -552,8 +567,7 @@ where
                     Err(Error::Other(box_err!("Nature is boring")))
                 });
                 let tso = self.get_last_checkpoint_of(&for_task, region).await?;
-                self.observe_over_with_initial_data_from_checkpoint(region, tso, handle.clone())
-                    .await;
+                self.observe_over_with_initial_data_from_checkpoint(region, tso, handle.clone());
             }
         }
         Ok(())
@@ -688,13 +702,13 @@ where
         Ok(cp.ts)
     }
 
-    async fn spawn_scan(&self, cmd: ScanCmd) {
+    fn spawn_scan(&self, cmd: ScanCmd) {
         // we should not spawn initial scanning tasks to the tokio blocking pool
         // because it is also used for converting sync File I/O to async. (for now!)
         // In that condition, if we blocking for some resources(for example, the
         // `MemoryQuota`) at the block threads, we may meet some ghosty
         // deadlock.
-        let s = self.scan_pool_handle.request(cmd).await;
+        let s = self.scan_pool_handle.request(cmd);
         if let Err(err) = s {
             let region_id = err.0.region.get_id();
             annotate!(err, "BUG: scan_pool closed")
@@ -702,7 +716,7 @@ where
         }
     }
 
-    async fn observe_over_with_initial_data_from_checkpoint(
+    fn observe_over_with_initial_data_from_checkpoint(
         &self,
         region: &Region,
         last_checkpoint: TimeStamp,
@@ -716,7 +730,6 @@ where
             last_checkpoint,
             _work: self.scans.clone().work(),
         })
-        .await
     }
 
     fn find_task_by_region(&self, r: &Region) -> Option<String> {
@@ -735,9 +748,8 @@ mod test {
     #[derive(Clone, Copy)]
     struct NoopInitialScan;
 
-    #[async_trait::async_trait]
     impl InitialScan for NoopInitialScan {
-        async fn do_initial_scan(
+        fn do_initial_scan(
             &self,
             _region: &Region,
             _start_ts: txn_types::TimeStamp,
@@ -775,20 +787,17 @@ mod test {
 
         let pool = spawn_executors(NoopInitialScan, 1);
         let wg = CallbackWaitGroup::new();
-        fail::cfg("execute_scan_command_sleep_100", "return").unwrap();
+        fail::cfg("execute_scan_command", "sleep(100)").unwrap();
         for _ in 0..100 {
             let wg = wg.clone();
-            assert!(
-                pool._pool
-                    .block_on(pool.request(ScanCmd {
-                        region: Default::default(),
-                        handle: Default::default(),
-                        last_checkpoint: Default::default(),
-                        // Note: Maybe make here a Box<dyn FnOnce()> or some other trait?
-                        _work: wg.work(),
-                    }))
-                    .is_ok()
-            )
+            pool.request(ScanCmd {
+                region: Default::default(),
+                handle: Default::default(),
+                last_checkpoint: Default::default(),
+                // Note: Maybe make here a Box<dyn FnOnce()> or some other trait?
+                _work: wg.work(),
+            })
+            .unwrap()
         }
 
         should_finish_in(move || drop(pool), Duration::from_secs(5));

--- a/components/backup-stream/src/subscription_track.rs
+++ b/components/backup-stream/src/subscription_track.rs
@@ -82,7 +82,6 @@ impl ActiveSubscription {
         self.handle.stop_observing();
     }
 
-    #[cfg(test)]
     pub fn is_observing(&self) -> bool {
         self.handle.is_observing()
     }
@@ -320,7 +319,6 @@ impl SubscriptionTracer {
     }
 
     /// check whether the region_id should be observed by this observer.
-    #[cfg(test)]
     pub fn is_observing(&self, region_id: u64) -> bool {
         let sub = self.0.get_mut(&region_id);
         match sub {

--- a/components/backup-stream/src/utils.rs
+++ b/components/backup-stream/src/utils.rs
@@ -18,12 +18,14 @@ use std::{
 use async_compression::{tokio::write::ZstdEncoder, Level};
 use engine_rocks::ReadPerfInstant;
 use engine_traits::{CfName, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
-use futures::{ready, task::Poll, FutureExt};
+use futures::{channel::mpsc, executor::block_on, ready, task::Poll, FutureExt, StreamExt};
 use kvproto::{
     brpb::CompressionType,
     metapb::Region,
     raft_cmdpb::{CmdType, Request},
 };
+use raft::StateRole;
+use raftstore::{coprocessor::RegionInfoProvider, RegionInfo};
 use tikv::storage::CfStatistics;
 use tikv_util::{
     box_err,
@@ -31,6 +33,7 @@ use tikv_util::{
         self_thread_inspector, IoStat, ThreadInspector, ThreadInspectorImpl as OsInspector,
     },
     time::Instant,
+    warn,
     worker::Scheduler,
     Either,
 };
@@ -74,6 +77,65 @@ pub fn cf_name(s: &str) -> CfName {
 
 pub fn redact(key: &impl AsRef<[u8]>) -> log_wrappers::Value<'_> {
     log_wrappers::Value::key(key.as_ref())
+}
+
+/// RegionPager seeks regions with leader role in the range.
+pub struct RegionPager<P> {
+    regions: P,
+    start_key: Vec<u8>,
+    end_key: Vec<u8>,
+    reach_last_region: bool,
+}
+
+impl<P: RegionInfoProvider> RegionPager<P> {
+    pub fn scan_from(regions: P, start_key: Vec<u8>, end_key: Vec<u8>) -> Self {
+        Self {
+            regions,
+            start_key,
+            end_key,
+            reach_last_region: false,
+        }
+    }
+
+    pub fn next_page(&mut self, size: usize) -> Result<Vec<RegionInfo>> {
+        if self.start_key >= self.end_key || self.reach_last_region {
+            return Ok(vec![]);
+        }
+
+        let (mut tx, rx) = mpsc::channel(size);
+        let end_key = self.end_key.clone();
+        self.regions
+            .seek_region(
+                &self.start_key,
+                Box::new(move |i| {
+                    let r = i
+                        .filter(|r| r.role == StateRole::Leader)
+                        .take(size)
+                        .take_while(|r| r.region.start_key < end_key)
+                        .try_for_each(|r| tx.try_send(r.clone()));
+                    if let Err(_err) = r {
+                        warn!("failed to scan region and send to initlizer")
+                    }
+                }),
+            )
+            .map_err(|err| {
+                Error::Other(box_err!(
+                    "failed to seek region for start key {}: {}",
+                    redact(&self.start_key),
+                    err
+                ))
+            })?;
+        let collected_regions = block_on(rx.collect::<Vec<_>>());
+        self.start_key = collected_regions
+            .last()
+            .map(|region| region.region.end_key.to_owned())
+            // no leader region found.
+            .unwrap_or_default();
+        if self.start_key.is_empty() {
+            self.reach_last_region = true;
+        }
+        Ok(collected_regions)
+    }
 }
 
 /// StopWatch is a utility for record time cost in multi-stage tasks.

--- a/components/backup-stream/tests/integration/mod.rs
+++ b/components/backup-stream/tests/integration/mod.rs
@@ -16,7 +16,6 @@ mod all {
     use futures::{Stream, StreamExt};
     use pd_client::PdClient;
     use test_raftstore::IsolationFilterFactory;
-    use tikv::config::BackupStreamConfig;
     use tikv_util::{box_err, defer, info, HandyRwLock};
     use tokio::time::timeout;
     use txn_types::{Key, TimeStamp};
@@ -430,26 +429,5 @@ mod all {
             suite.flushed_files.path(),
             round1.iter().map(|k| k.as_slice()),
         ))
-    }
-
-    #[test]
-    fn update_config() {
-        let suite = SuiteBuilder::new_named("network_partition")
-            .nodes(1)
-            .build();
-        let mut basic_config = BackupStreamConfig::default();
-        basic_config.initial_scan_concurrency = 4;
-        suite.run(|| Task::ChangeConfig(basic_config.clone()));
-        suite.wait_with(|e| {
-            assert_eq!(e.initial_scan_semaphore.available_permits(), 4,);
-            true
-        });
-
-        basic_config.initial_scan_concurrency = 16;
-        suite.run(|| Task::ChangeConfig(basic_config.clone()));
-        suite.wait_with(|e| {
-            assert_eq!(e.initial_scan_semaphore.available_permits(), 16,);
-            true
-        });
     }
 }

--- a/components/backup-stream/tests/suite.rs
+++ b/components/backup-stream/tests/suite.rs
@@ -31,11 +31,14 @@ use kvproto::{
 };
 use pd_client::PdClient;
 use protobuf::parse_from_bytes;
-use raftstore::{router::CdcRaftRouter, RegionInfoAccessor};
+use raftstore::{
+    router::{CdcRaftRouter, ServerRaftStoreRouter},
+    RegionInfoAccessor,
+};
 use resolved_ts::LeadershipResolver;
 use tempdir::TempDir;
 use test_pd_client::TestPdClient;
-use test_raftstore::{new_server_cluster, Cluster, ServerCluster};
+use test_raftstore::{new_server_cluster, Cluster, ServerCluster, SimulateTransport};
 use test_util::retry;
 use tikv::config::BackupStreamConfig;
 use tikv_util::{
@@ -54,6 +57,11 @@ pub type TestEndpoint = Endpoint<
     ErrorStore<SlashEtcStore>,
     RegionInfoAccessor,
     engine_test::kv::KvTestEngine,
+    CdcRaftRouter<
+        SimulateTransport<
+            ServerRaftStoreRouter<engine_test::kv::KvTestEngine, engine_test::raft::RaftTestEngine>,
+        >,
+    >,
     TestPdClient,
 >;
 

--- a/components/raftstore/src/router.rs
+++ b/components/raftstore/src/router.rs
@@ -1,9 +1,6 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{
-    borrow::Cow,
-    sync::{Arc, Mutex},
-};
+use std::borrow::Cow;
 
 // #[PerformanceCriticalPath]
 use crossbeam::channel::TrySendError;
@@ -407,33 +404,6 @@ where
         region_id: u64,
         callback: Callback<EK::Snapshot>,
     ) -> RaftStoreResult<()>;
-}
-
-impl<EK: KvEngine, T: CdcHandle<EK>> CdcHandle<EK> for Arc<Mutex<T>> {
-    fn capture_change(
-        &self,
-        region_id: u64,
-        region_epoch: metapb::RegionEpoch,
-        change_observer: ChangeObserver,
-        callback: Callback<<EK as KvEngine>::Snapshot>,
-    ) -> RaftStoreResult<()> {
-        Mutex::lock(self).unwrap().capture_change(
-            region_id,
-            region_epoch,
-            change_observer,
-            callback,
-        )
-    }
-
-    fn check_leadership(
-        &self,
-        region_id: u64,
-        callback: Callback<<EK as KvEngine>::Snapshot>,
-    ) -> RaftStoreResult<()> {
-        Mutex::lock(self)
-            .unwrap()
-            .check_leadership(region_id, callback)
-    }
 }
 
 /// A wrapper of SignificantRouter that is specialized for implementing

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2833,7 +2833,6 @@ pub struct BackupStreamConfig {
     pub initial_scan_pending_memory_quota: ReadableSize,
     #[online_config(skip)]
     pub initial_scan_rate_limit: ReadableSize,
-    pub initial_scan_concurrency: usize,
 }
 
 impl BackupStreamConfig {
@@ -2860,9 +2859,6 @@ impl BackupStreamConfig {
                 self.min_ts_interval
             )
             .into());
-        }
-        if self.initial_scan_concurrency == 0 {
-            return Err("the `initial_scan_concurrency` shouldn't be zero".into());
         }
         Ok(())
     }
@@ -2891,7 +2887,6 @@ impl Default for BackupStreamConfig {
             file_size_limit,
             initial_scan_pending_memory_quota: ReadableSize(quota_size as _),
             initial_scan_rate_limit: ReadableSize::mb(60),
-            initial_scan_concurrency: 6,
             temp_file_memory_quota: cache_size,
         }
     }


### PR DESCRIPTION
This reverts commit 9b76ac97e1de01c1b0e70af406720b2c368d9624.

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #15714 

What's Changed:
revert 15541 on release-7.4
<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
```
