### PR TITLE
tikv_util: Support customizing evict policy and operations without promoting for LruCache

### DIFF
--- a/components/tikv_util/src/lru.rs
+++ b/components/tikv_util/src/lru.rs
@@ -230,20 +230,11 @@ where
     T: SizePolicy<K, V>,
 {
     pub fn with_capacity_sample_and_trace(
-        mut capacity: usize,
+        capacity: usize,
         sample_mask: usize,
         size_policy: T,
     ) -> LruCache<K, V, T> {
-        if capacity == 0 {
-            capacity = 1;
-        }
-        LruCache {
-            map: HashMap::default(),
-            trace: Trace::new(sample_mask),
-            capacity,
-            size_policy,
-            evict_policy: EvictOnFull,
-        }
+        Self::new(capacity, sample_mask, size_policy, EvictOnFull)
     }
 }
 
@@ -253,6 +244,7 @@ where
     E: EvictPolicy<K, V>,
 {
     pub fn new(mut capacity: usize, sample_mask: usize, size_policy: T, evict_policy: E) -> Self {
+        // The capacity is at least 1.
         if capacity == 0 {
             capacity = 1;
         }

--- a/components/tikv_util/src/lru.rs
+++ b/components/tikv_util/src/lru.rs
@@ -194,7 +194,7 @@ pub trait EvictPolicy<K, V> {
         &self,
         current_size: usize,
         capacity: usize,
-        get_tail_kv: &impl GetTailEntry<K, V>,
+        get_tail_entry: &impl GetTailEntry<K, V>,
     ) -> bool;
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #11187

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
This PR makes the `LruCache` in `tikv_util` to support customizing how to determine an entries in the cache should be evicted.
This is part of solving the issue #11187, which needs a `TxnStatusCache`. The `TxnStatusCache` is desinged to use `LruCache` internally, with ability to get or insert items without promoting items to the head (most-recently-used) position. This PR adds `get_no_promote` and `insert_if_not_exist` functions to `LruCache`.
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

\-

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
