### PR TITLE
raftstore-v2: Increase default raft gc threshold

### DIFF
--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -633,10 +633,6 @@ impl Config {
         if self.raft_log_gc_size_limit.is_none() && raft_kv_v2 {
             self.raft_log_gc_size_limit = Some(ReadableSize::mb(200));
         }
-
-        if self.raft_log_gc_count_limit.is_none() && raft_kv_v2 {
-            self.raft_log_gc_count_limit = Some(10000);
-        }
     }
 
     pub fn validate(
@@ -1538,7 +1534,10 @@ mod tests {
         cfg.validate(split_size, true, split_size / 20, false)
             .unwrap();
         assert_eq!(cfg.raft_log_gc_size_limit(), ReadableSize::mb(200));
-        assert_eq!(cfg.raft_log_gc_count_limit(), 10000);
+        assert_eq!(
+            cfg.raft_log_gc_count_limit(),
+            split_size * 3 / 4 / ReadableSize::kb(1)
+        );
 
         cfg = Config::new();
         cfg.optimize_for(false);


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref https://github.com/tikv/tikv/issues/14912

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Increase default raft gc count limit to 7.5x (original config for v1) for raftstore v2.

10000 is too small in many cases, a raft group easily take 10000 logs in 1 minute, change it back to the original setting (96M split size/ 1K avg log size * 3/4), so that raftstore v2 prefer catching up through logs instead of snapshot.
```

### Related changes

N/A

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

Raft log accumulates during partial node unavailability. 

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Increase default raft gc count limit to 10x for raftstore v2.
```
