### PR TITLE
config: adjust rocksdb background compaction threads

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -264,7 +264,7 @@ fn get_background_job_limits_impl(
     // v2: decrease the compaction threads to make the qps more stable.
     let max_compactions = match engine_type {
         EngineType::RaftKv => max_background_jobs - max_background_flushes,
-        EngineType::RaftKv2 => (max_background_jobs + 7) / 8,
+        EngineType::RaftKv2 => (max_background_jobs + 3) / 4,
     };
     let max_sub_compactions: u32 = (max_compactions - 1).clamp(1, defaults.max_sub_compactions);
     max_background_jobs = max_background_flushes + max_compactions;
@@ -6052,7 +6052,7 @@ mod tests {
                 &KVDB_DEFAULT_BACKGROUND_JOB_LIMITS
             ),
             BackgroundJobLimits {
-                max_background_jobs: 3,
+                max_background_jobs: 4,
                 max_background_flushes: 2,
                 max_sub_compactions: 1,
                 max_titan_background_gc: 4,
@@ -6082,9 +6082,9 @@ mod tests {
                 &KVDB_DEFAULT_BACKGROUND_JOB_LIMITS
             ),
             BackgroundJobLimits {
-                max_background_jobs: 5,
+                max_background_jobs: 6,
                 max_background_flushes: 3,
-                max_sub_compactions: 1,
+                max_sub_compactions: 2,
                 max_titan_background_gc: 4,
             }
         );


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #14470

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```
#15723 change the default rocksdb background compaction threads to cpu-num * 1/8, this default config is too small that it can easily trigger flow control because for a 8c instance there is only 1 compaction thread. If there is a on-going slow compaction, it can block the lockcf's compaction and triggers flow control. This PR changes the default to cpu-num * 1/4
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
