### PR TITLE
titan: update titan to avoid manifest mutex on release-7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2819,7 +2819,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#3282f221d2c84968d05b79dc13b73fc5539e27ad"
+source = "git+https://github.com/Connor1996/rust-rocksdb.git?branch=tikv-7.1#37709a4e1e381dd86c9a55f093212c69c531f8e6"
 dependencies = [
  "bindgen 0.57.0",
  "bzip2-sys",
@@ -2838,7 +2838,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tikv/rust-rocksdb.git#3282f221d2c84968d05b79dc13b73fc5539e27ad"
+source = "git+https://github.com/Connor1996/rust-rocksdb.git?branch=tikv-7.1#37709a4e1e381dd86c9a55f093212c69c531f8e6"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -4700,7 +4700,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#3282f221d2c84968d05b79dc13b73fc5539e27ad"
+source = "git+https://github.com/Connor1996/rust-rocksdb.git?branch=tikv-7.1#37709a4e1e381dd86c9a55f093212c69c531f8e6"
 dependencies = [
  "libc 0.2.139",
  "librocksdb_sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2819,7 +2819,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/Connor1996/rust-rocksdb.git?branch=tikv-7.1#37709a4e1e381dd86c9a55f093212c69c531f8e6"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-7.1#dd213275abc5613f22815323d7b77ee046bf6a86"
 dependencies = [
  "bindgen 0.57.0",
  "bzip2-sys",
@@ -2838,7 +2838,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/Connor1996/rust-rocksdb.git?branch=tikv-7.1#37709a4e1e381dd86c9a55f093212c69c531f8e6"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-7.1#dd213275abc5613f22815323d7b77ee046bf6a86"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -4700,7 +4700,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/Connor1996/rust-rocksdb.git?branch=tikv-7.1#37709a4e1e381dd86c9a55f093212c69c531f8e6"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-7.1#dd213275abc5613f22815323d7b77ee046bf6a86"
 dependencies = [
  "libc 0.2.139",
  "librocksdb_sys",

--- a/components/engine_rocks/Cargo.toml
+++ b/components/engine_rocks/Cargo.toml
@@ -57,7 +57,7 @@ tracker = { workspace = true }
 txn_types = { workspace = true }
 
 [dependencies.rocksdb]
-git = "https://github.com/Connor1996/rust-rocksdb.git"
+git = "https://github.com/tikv/rust-rocksdb.git"
 package = "rocksdb"
 features = ["encryption"]
 branch = "tikv-7.1"

--- a/components/engine_rocks/Cargo.toml
+++ b/components/engine_rocks/Cargo.toml
@@ -57,9 +57,10 @@ tracker = { workspace = true }
 txn_types = { workspace = true }
 
 [dependencies.rocksdb]
-git = "https://github.com/tikv/rust-rocksdb.git"
+git = "https://github.com/Connor1996/rust-rocksdb.git"
 package = "rocksdb"
 features = ["encryption"]
+branch = "tikv-7.1"
 
 [dev-dependencies]
 rand = "0.8"


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/tikv/tikv/issues/15351

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
update titan to avoid manifest mutex
```

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Avoid holding mutex when writing titan manifest
```
