### PR TITLE
raftstore-v2: Allow rollback merge during unsafe recovery for raftstore v2

### DIFF
--- a/components/raftstore-v2/src/operation/command/admin/merge/commit.rs
+++ b/components/raftstore-v2/src/operation/command/admin/merge/commit.rs
@@ -371,7 +371,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         let mut proposal_ctx = ProposalContext::empty();
         proposal_ctx.insert(ProposalContext::COMMIT_MERGE);
         let data = req.write_to_bytes().unwrap();
-        self.propose_with_ctx(store_ctx, data, proposal_ctx.to_vec())
+        self.propose_with_ctx(store_ctx, data, proposal_ctx)
     }
 }
 

--- a/components/raftstore-v2/src/operation/command/admin/merge/prepare.rs
+++ b/components/raftstore-v2/src/operation/command/admin/merge/prepare.rs
@@ -214,7 +214,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
                 let mut proposal_ctx = ProposalContext::empty();
                 proposal_ctx.insert(ProposalContext::PREPARE_MERGE);
                 let data = req.write_to_bytes().unwrap();
-                self.propose_with_ctx(store_ctx, data, proposal_ctx.to_vec())
+                self.propose_with_ctx(store_ctx, data, proposal_ctx)
             });
         if r.is_ok() {
             self.proposal_control_mut().set_pending_prepare_merge(false);

--- a/components/raftstore-v2/src/operation/command/admin/mod.rs
+++ b/components/raftstore-v2/src/operation/command/admin/mod.rs
@@ -30,7 +30,7 @@ use raftstore::{
         cmd_resp,
         fsm::{apply, apply::validate_batch_split},
         msg::ErrorCallback,
-        Transport,
+        ProposalContext, Transport,
     },
     Error,
 };
@@ -237,9 +237,13 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
                     }
                 }
                 AdminCmdType::CompactLog => self.propose_compact_log(ctx, req),
-                AdminCmdType::UpdateGcPeer | AdminCmdType::RollbackMerge => {
+                AdminCmdType::UpdateGcPeer => {
                     let data = req.write_to_bytes().unwrap();
                     self.propose(ctx, data)
+                }
+                AdminCmdType::RollbackMerge => {
+                    let data = req.write_to_bytes().unwrap();
+                    self.propose_with_ctx(ctx, data, ProposalContext::ROLLBACK_MERGE)
                 }
                 AdminCmdType::PrepareMerge => self.propose_prepare_merge(ctx, req),
                 AdminCmdType::CommitMerge => self.propose_commit_merge(ctx, req),

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -242,6 +242,7 @@ bitflags! {
         const SPLIT          = 0b0000_0010;
         const PREPARE_MERGE  = 0b0000_0100;
         const COMMIT_MERGE   = 0b0000_1000;
+        const ROLLBACK_MERGE = 0b0001_0000;
     }
 }
 

--- a/tests/failpoints/cases/test_unsafe_recovery.rs
+++ b/tests/failpoints/cases/test_unsafe_recovery.rs
@@ -442,6 +442,7 @@ fn test_unsafe_recovery_demotion_reentrancy() {
 }
 
 #[test_case(test_raftstore::new_node_cluster)]
+#[test_case(test_raftstore_v2::new_node_cluster)]
 fn test_unsafe_recovery_rollback_merge() {
     let mut cluster = new_cluster(0, 3);
     cluster.cfg.raft_store.raft_store_max_leader_lease = ReadableDuration::millis(40);
@@ -471,11 +472,15 @@ fn test_unsafe_recovery_rollback_merge() {
     let right_peer_2 = find_peer(&right, nodes[2]).unwrap().to_owned();
     cluster.must_transfer_leader(left.get_id(), left_peer_2);
     cluster.must_transfer_leader(right.get_id(), right_peer_2);
-    cluster.must_try_merge(left.get_id(), right.get_id());
+    cluster.try_merge(left.get_id(), right.get_id());
 
+    let right_peer_0 = find_peer(&right, nodes[0]).unwrap().to_owned();
+    pd_client.must_remove_peer(right.get_id(), right_peer_0);
+    cluster.must_remove_region(nodes[0], right.get_id());
     // Makes the group lose its quorum.
     cluster.stop_node(nodes[1]);
     cluster.stop_node(nodes[2]);
+    fail::remove("on_schedule_merge");
     {
         let put = new_put_cmd(b"k2", b"v2");
         let req = new_request(
@@ -491,7 +496,8 @@ fn test_unsafe_recovery_rollback_merge() {
     }
 
     cluster.must_enter_force_leader(left.get_id(), nodes[0], vec![nodes[1], nodes[2]]);
-    cluster.must_enter_force_leader(right.get_id(), nodes[0], vec![nodes[1], nodes[2]]);
+    // Allow rollback merge to finish.
+    sleep_ms(100);
 
     // Construct recovery plan.
     let mut plan = pdpb::RecoveryPlan::default();
@@ -505,23 +511,12 @@ fn test_unsafe_recovery_rollback_merge() {
     let mut left_demote = pdpb::DemoteFailedVoters::default();
     left_demote.set_region_id(left.get_id());
     left_demote.set_failed_voters(left_demote_peers.into());
-    let right_demote_peers: Vec<metapb::Peer> = right
-        .get_peers()
-        .iter()
-        .filter(|&peer| peer.get_store_id() != nodes[0])
-        .cloned()
-        .collect();
-    let mut right_demote = pdpb::DemoteFailedVoters::default();
-    right_demote.set_region_id(right.get_id());
-    right_demote.set_failed_voters(right_demote_peers.into());
     plan.mut_demotes().push(left_demote);
-    plan.mut_demotes().push(right_demote);
 
     // Triggers the unsafe recovery plan execution.
     pd_client.must_set_unsafe_recovery_plan(nodes[0], plan.clone());
     cluster.must_send_store_heartbeat(nodes[0]);
 
-    // Can't propose demotion as it's in merging mode
     let mut store_report = None;
     for _ in 0..20 {
         store_report = pd_client.must_get_store_report(nodes[0]);
@@ -531,58 +526,18 @@ fn test_unsafe_recovery_rollback_merge() {
         sleep_ms(100);
     }
     assert_ne!(store_report, None);
-    let has_force_leader = store_report
-        .unwrap()
-        .get_peer_reports()
-        .iter()
-        .any(|p| p.get_is_force_leader());
-    // Force leader is not exited due to demotion failure
-    assert!(has_force_leader);
-
-    fail::remove("on_schedule_merge");
-    fail::cfg("on_schedule_merge_ret_err", "return()").unwrap();
-
-    // Make sure merge check is scheduled, and rollback merge is triggered
-    sleep_ms(50);
-
-    // Re-triggers the unsafe recovery plan execution.
-    pd_client.must_set_unsafe_recovery_plan(nodes[0], plan);
-    cluster.must_send_store_heartbeat(nodes[0]);
-    let mut store_report = None;
-    for _ in 0..20 {
-        store_report = pd_client.must_get_store_report(nodes[0]);
-        if store_report.is_some() {
-            break;
-        }
-        sleep_ms(100);
-    }
-    assert_ne!(store_report, None);
-    // No force leader
-    for peer_report in store_report.unwrap().get_peer_reports() {
-        assert!(!peer_report.get_is_force_leader());
-    }
-
     // Demotion is done
     let mut demoted = false;
     for _ in 0..10 {
         let new_left = block_on(pd_client.get_region_by_id(left.get_id()))
             .unwrap()
             .unwrap();
-        let new_right = block_on(pd_client.get_region_by_id(right.get_id()))
-            .unwrap()
-            .unwrap();
         assert_eq!(new_left.get_peers().len(), 3);
-        assert_eq!(new_right.get_peers().len(), 3);
         demoted = new_left
             .get_peers()
             .iter()
             .filter(|peer| peer.get_store_id() != nodes[0])
-            .all(|peer| peer.get_role() == metapb::PeerRole::Learner)
-            && new_right
-                .get_peers()
-                .iter()
-                .filter(|peer| peer.get_store_id() != nodes[0])
-                .all(|peer| peer.get_role() == metapb::PeerRole::Learner);
+            .all(|peer| peer.get_role() == metapb::PeerRole::Learner);
         if demoted {
             break;
         }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #15580

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Allow rollback merge during unsafe recovery for raftstore v2
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

Side effects

n/a

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
