### PR TITLE
readability: Move initialization closer to utilization

### DIFF
--- a/cmd/tikv-server/src/main.rs
+++ b/cmd/tikv-server/src/main.rs
@@ -217,11 +217,8 @@ fn main() {
         process::exit(1)
     }
 
-    let (service_event_tx, service_event_rx) = tikv_util::mpsc::unbounded(); // pipe for controling service
     match config.storage.engine {
-        EngineType::RaftKv => server::server::run_tikv(config, service_event_tx, service_event_rx),
-        EngineType::RaftKv2 => {
-            server::server2::run_tikv(config, service_event_tx, service_event_rx)
-        }
+        EngineType::RaftKv => server::server::run_tikv(config),
+        EngineType::RaftKv2 => server::server2::run_tikv(config),
     }
 }

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -130,11 +130,8 @@ use crate::{
 };
 
 #[inline]
-fn run_impl<CER: ConfiguredRaftEngine, F: KvFormat>(
-    config: TikvConfig,
-    service_event_tx: TikvMpsc::Sender<ServiceEvent>,
-    service_event_rx: TikvMpsc::Receiver<ServiceEvent>,
-) {
+fn run_impl<CER: ConfiguredRaftEngine, F: KvFormat>(config: TikvConfig) {
+    let (service_event_tx, service_event_rx) = tikv_util::mpsc::unbounded(); // pipe for controling service
     let mut tikv = TikvServer::<CER, F>::init(config, service_event_tx.clone());
     // Must be called after `TikvServer::init`.
     let memory_limit = tikv.core.config.memory_usage_limit.unwrap().0;
@@ -191,11 +188,7 @@ fn run_impl<CER: ConfiguredRaftEngine, F: KvFormat>(
 
 /// Run a TiKV server. Returns when the server is shutdown by the user, in which
 /// case the server will be properly stopped.
-pub fn run_tikv(
-    config: TikvConfig,
-    service_event_tx: TikvMpsc::Sender<ServiceEvent>,
-    service_event_rx: TikvMpsc::Receiver<ServiceEvent>,
-) {
+pub fn run_tikv(config: TikvConfig) {
     // Sets the global logger ASAP.
     // It is okay to use the config w/o `validate()`,
     // because `initial_logger()` handles various conditions.
@@ -216,9 +209,9 @@ pub fn run_tikv(
 
     dispatch_api_version!(config.storage.api_version(), {
         if !config.raft_engine.enable {
-            run_impl::<RocksEngine, API>(config, service_event_tx, service_event_rx)
+            run_impl::<RocksEngine, API>(config)
         } else {
-            run_impl::<RaftLogEngine, API>(config, service_event_tx, service_event_rx)
+            run_impl::<RaftLogEngine, API>(config)
         }
     })
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #15086

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Move initialization closer to utilization
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Readability improvements.
```
