### PR TITLE
add a new RPC ScanTxnEntry to scan txn entries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2933,7 +2933,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#87bebcc0d071a18cbbd94a4fc02de9c4988af815"
+source = "git+https://github.com/hicqu/kvproto?branch=scan-txn-entries#155d810a451fa244a72cd85c8a85663729a55ba2"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,8 +201,8 @@ procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "7693954bd1dd86e
 # When you modify TiKV cooperatively with kvproto, this will be useful to submit the PR to TiKV and the PR to
 # kvproto at the same time.
 # After the PR to kvproto is merged, remember to comment this out and run `cargo update -p kvproto`.
-# [patch.'https://github.com/pingcap/kvproto']
-# kvproto = { git = "https://github.com/your_github_id/kvproto", branch = "your_branch" }
+[patch.'https://github.com/pingcap/kvproto']
+kvproto = { git = "https://github.com/hicqu/kvproto", branch = "scan-txn-entries" }
 #
 # After the PR to rust-rocksdb is merged, remember to comment this out and run `cargo update -p rocksdb`.
 # [patch.'https://github.com/tikv/rust-rocksdb']

--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -390,7 +390,7 @@ impl BackupRange {
         // Incremental backup needs to output delete records.
         let incremental = !begin_ts.is_zero();
         let mut scanner = snap_store
-            .entry_scanner(start_key, end_key, begin_ts, incremental)
+            .entry_scanner(start_key, end_key, false, begin_ts, incremental)
             .unwrap();
 
         let start_scan = Instant::now();
@@ -414,15 +414,12 @@ impl BackupRange {
 
             let entries = batch.drain();
             if writer.need_split_keys() {
-                let this_end_key = entries.as_slice().get(0).map_or_else(
-                    || Err(Error::Other(box_err!("get entry error: nothing in batch"))),
-                    |x| {
-                        x.to_key().map(|k| k.into_raw().unwrap()).map_err(|e| {
-                            error!(?e; "backup save file failed");
-                            Error::Other(box_err!("Decode error: {:?}", e))
-                        })
-                    },
-                )?;
+                let this_end_key = match entries.as_slice().get(0) {
+                    Some(x) => x.to_key().into_raw().unwrap(),
+                    None => {
+                        return Err(Error::Other(box_err!("get entry error: nothing in batch")));
+                    }
+                };
                 let this_start_key = next_file_start_key.clone();
                 let msg = InMemBackupFiles {
                     files: KvWriter::Txn(writer),

--- a/components/tracker/src/lib.rs
+++ b/components/tracker/src/lib.rs
@@ -110,6 +110,7 @@ pub enum RequestType {
     KvBatchGet,
     KvBatchGetCommand,
     KvScan,
+    KvScanTxnEntry,
     KvScanLock,
     KvPrewrite,
     KvCommit,

--- a/src/server/metrics.rs
+++ b/src/server/metrics.rs
@@ -20,6 +20,7 @@ make_auto_flush_static_metric! {
         invalid,
         kv_get,
         kv_scan,
+        kv_scan_txn_entry,
         kv_prewrite,
         kv_pessimistic_lock,
         kv_pessimistic_rollback,

--- a/src/storage/metrics.rs
+++ b/src/storage/metrics.rs
@@ -122,6 +122,7 @@ make_auto_flush_static_metric! {
         get,
         raw_batch_get_command,
         scan,
+        scan_txn_entry,
         batch_get,
         batch_get_command,
         prewrite,


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Close #xxx

What's Changed:

```commit-message
add a new RPC ScanTxnEntry to scan latest transaction entries.
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
