### PR TITLE
raftstore: Fix group commit is mistakenly enabled in sync recover state

### DIFF
--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -966,7 +966,10 @@ where
             return;
         }
         self.replication_mode_version = state.status().get_dr_auto_sync().state_id;
-        let enable = state.status().get_dr_auto_sync().get_state() != DrAutoSyncState::Async;
+        let enable = match state.status().get_dr_auto_sync().get_state() {
+            DrAutoSyncState::Async | DrAutoSyncState::SyncRecover => false,
+            _ => true,
+        };
         self.raft_group.raft.enable_group_commit(enable);
         self.dr_auto_sync_state = state.status().get_dr_auto_sync().get_state();
     }

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -966,10 +966,10 @@ where
             return;
         }
         self.replication_mode_version = state.status().get_dr_auto_sync().state_id;
-        let enable = match state.status().get_dr_auto_sync().get_state() {
-            DrAutoSyncState::Async | DrAutoSyncState::SyncRecover => false,
-            _ => true,
-        };
+        let enable = !matches!(
+            state.status().get_dr_auto_sync().get_state(),
+            DrAutoSyncState::Async | DrAutoSyncState::SyncRecover
+        );
         self.raft_group.raft.enable_group_commit(enable);
         self.dr_auto_sync_state = state.status().get_dr_auto_sync().get_state();
     }

--- a/components/test_pd_client/src/pd.rs
+++ b/components/test_pd_client/src/pd.rs
@@ -1450,6 +1450,7 @@ impl TestPdClient {
             dr.state_id += 1;
             return;
         }
+        status.set_mode(ReplicationMode::DrAutoSync);
         let mut dr = status.mut_dr_auto_sync();
         dr.state_id += 1;
         dr.set_state(state.unwrap());

--- a/components/test_pd_client/src/pd.rs
+++ b/components/test_pd_client/src/pd.rs
@@ -1456,14 +1456,6 @@ impl TestPdClient {
         dr.available_stores = available_stores;
     }
 
-    pub fn switch_to_drautosync_mode(&self) {
-        let mut cluster = self.cluster.wl();
-        let status = cluster.replication_status.as_mut().unwrap();
-        status.set_mode(ReplicationMode::DrAutoSync);
-        let mut dr = status.mut_dr_auto_sync();
-        dr.state_id += 1;
-    }
-
     pub fn region_replication_status(&self, region_id: u64) -> RegionReplicationStatus {
         self.cluster
             .rl()


### PR DESCRIPTION

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #15817

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
When splitting a region, group commit is mistakenly enabled in the sync-recover state. 
If the region is in joint state and demoting voter is down, the commit condition can't meet. 
Fix group commit is mistakenly enabled in sync recover state
```

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix possible timeout leave joint state for dr auto sync when doing scaling out
```
