### PR TITLE
grafana: Fix wrong scheduler command variables of grafana in cloud env

### DIFF
--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -48858,7 +48858,7 @@
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
-        "regex": "/type=\"([^\"]+)\"/",
+        "regex": "/\btype=\"([^\"]+)\"/",
         "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #15832

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
We use regex `/type="([^"]+)"/` to grep the command variables. In cloud env, there is a field called `instance_type` apart from `type`. So it would accidentally grep the name of `instance_type`.
```commit-message
Fix wrong scheduler command variables of grafana in cloud env by adding a `\b` to regex to make sure it's at the word boundary.
```

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
Before
![FjNHXtqT8G](https://github.com/tikv/tikv/assets/13497871/3768dc4f-c995-409d-b206-087175553284)
After
![XahayOTOT7](https://github.com/tikv/tikv/assets/13497871/66f84e7f-5173-4885-85ad-aa611f5b57ed)


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix wrong scheduler command variables of grafana in cloud env
```
