### PR TITLE
sst_service: don't drop source stream before write response

### DIFF
--- a/components/error_code/src/sst_importer.rs
+++ b/components/error_code/src/sst_importer.rs
@@ -25,5 +25,7 @@ define_error_codes!(
     RESOURCE_NOT_ENOUTH => ("ResourceNotEnough", "", ""),
     SUSPENDED => ("Suspended",
         "this request has been suspended.",
-        "Probably there are some export tools don't support exporting data inserted by `ingest`(say, snapshot backup). Check the user manual and stop them.")
+        "Probably there are some export tools don't support exporting data inserted by `ingest`(say, snapshot backup). Check the user manual and stop them."),
+    REQUEST_TOO_NEW => ("RequestTooNew", "", ""),
+    REQUEST_TOO_OLD => ("RequestTooOld", "", "")
 );

--- a/components/raftstore-v2/src/operation/command/write/ingest.rs
+++ b/components/raftstore-v2/src/operation/command/write/ingest.rs
@@ -46,7 +46,7 @@ impl Store {
         // filter old version SSTs
         let ssts: Vec<_> = ssts
             .into_iter()
-            .filter(|sst| sst.api_version >= sst_importer::API_VERSION_2)
+            .filter(|sst| sst.1 >= sst_importer::API_VERSION_2)
             .collect();
         if ssts.is_empty() {
             return Ok(());
@@ -55,9 +55,9 @@ impl Store {
         let mut region_ssts: HashMap<_, Vec<_>> = HashMap::default();
         for sst in ssts {
             region_ssts
-                .entry(sst.meta.get_region_id())
+                .entry(sst.0.get_region_id())
                 .or_default()
-                .push(sst.meta);
+                .push(sst.0);
         }
 
         let ranges = ctx.sst_importer.ranges_in_import();

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -2764,22 +2764,22 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
         {
             let meta = self.ctx.store_meta.lock().unwrap();
             for sst in ssts {
-                if sst.api_version < sst_importer::API_VERSION_2 {
+                if sst.1 < sst_importer::API_VERSION_2 {
                     // SST of old versions are created by old TiKV and have different prerequisite
                     // we can't delete them here. They can only be deleted manually
                     continue;
                 }
-                if let Some(r) = meta.regions.get(&sst.meta.get_region_id()) {
+                if let Some(r) = meta.regions.get(&sst.0.get_region_id()) {
                     let region_epoch = r.get_region_epoch();
-                    if util::is_epoch_stale(sst.meta.get_region_epoch(), region_epoch) {
+                    if util::is_epoch_stale(sst.0.get_region_epoch(), region_epoch) {
                         // If the SST epoch is stale, it will not be ingested anymore.
-                        delete_ssts.push(sst.meta);
+                        delete_ssts.push(sst.0);
                     }
                 } else {
                     // The write RPC of import sst service have make sure the region do exist at the
                     // write time, and now the region is not found, sst can be
                     // deleted because it won't be used by ingest in future.
-                    delete_ssts.push(sst.meta);
+                    delete_ssts.push(sst.0);
                 }
             }
         }

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -14,7 +14,7 @@ use std::{
         atomic::{AtomicU64, Ordering},
         Arc, Mutex,
     },
-    time::{Duration, Instant},
+    time::{Duration, Instant, SystemTime},
     u64,
 };
 
@@ -2753,6 +2753,9 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
     }
 }
 
+// we will remove 1-week old version 1 SST files.
+const VERSION_1_SST_CLEANUP_DURATION: Duration = Duration::from_secs(7 * 24 * 60 * 60);
+
 impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER, T> {
     fn on_cleanup_import_sst(&mut self) -> Result<()> {
         let mut delete_ssts = Vec::new();
@@ -2761,25 +2764,36 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
         if ssts.is_empty() {
             return Ok(());
         }
+        let now = SystemTime::now();
         {
             let meta = self.ctx.store_meta.lock().unwrap();
             for sst in ssts {
-                if sst.1 < sst_importer::API_VERSION_2 {
-                    // SST of old versions are created by old TiKV and have different prerequisite
-                    // we can't delete them here. They can only be deleted manually
-                    continue;
-                }
                 if let Some(r) = meta.regions.get(&sst.0.get_region_id()) {
                     let region_epoch = r.get_region_epoch();
                     if util::is_epoch_stale(sst.0.get_region_epoch(), region_epoch) {
                         // If the SST epoch is stale, it will not be ingested anymore.
                         delete_ssts.push(sst.0);
                     }
-                } else {
-                    // The write RPC of import sst service have make sure the region do exist at the
-                    // write time, and now the region is not found, sst can be
-                    // deleted because it won't be used by ingest in future.
+                } else if sst.1 >= sst_importer::API_VERSION_2 {
+                    // The write RPC of import sst service have make sure the region do exist at
+                    // the write time, and now the region is not found,
+                    // sst can be deleted because it won't be used by
+                    // ingest in future.
                     delete_ssts.push(sst.0);
+                } else {
+                    // in the old protocol, we can't easily know if the SST will be used in the
+                    // committed raft log, so we only delete the SST
+                    // files that has not be modified for 1 week.
+                    if let Ok(duration) = now.duration_since(sst.2) {
+                        if duration > VERSION_1_SST_CLEANUP_DURATION {
+                            warn!(
+                                "found 1-week old SST file of version 1, will delete it";
+                                "sst_meta" => ?sst.0,
+                                "last_modified" => ?sst.2
+                            );
+                            delete_ssts.push(sst.0);
+                        }
+                    }
                 }
             }
         }

--- a/components/sst_importer/src/errors.rs
+++ b/components/sst_importer/src/errors.rs
@@ -9,7 +9,7 @@ use encryption::Error as EncryptionError;
 use error_code::{self, ErrorCode, ErrorCodeExt};
 use futures::channel::oneshot::Canceled;
 use grpcio::Error as GrpcError;
-use kvproto::{errorpb, import_sstpb, kvrpcpb::ApiVersion, metapb::RegionEpoch};
+use kvproto::{errorpb, import_sstpb, kvrpcpb::ApiVersion};
 use tikv_util::codec::Error as CodecError;
 use uuid::Error as UuidError;
 
@@ -118,19 +118,11 @@ pub enum Error {
     #[error("Importing a SST file with imcompatible api version")]
     IncompatibleApiVersion,
 
-    #[error("request region {} is ahead of local region, local epoch {:?}, request epoch {:?}, please retry write later", .region_id, .local_region_epoch, .request_region_epoch)]
-    RequestTooNew {
-        region_id: u64,
-        local_region_epoch: RegionEpoch,
-        request_region_epoch: RegionEpoch,
-    },
+    #[error("{0}, please retry write later")]
+    RequestTooNew(String),
 
-    #[error("request region {} is staler than local region, local epoch {:?}, request epoch {:?}, please rescan region later", .region_id, .local_region_epoch, .request_region_epoch)]
-    RequestTooOld {
-        region_id: u64,
-        local_region_epoch: RegionEpoch,
-        request_region_epoch: RegionEpoch,
-    },
+    #[error("{0}, please rescan region later")]
+    RequestTooOld(String),
 
     #[error("Key mode mismatched with the request mode, writer: {:?}, storage: {:?}, key: {}", .writer, .storage_api_version, .key)]
     InvalidKeyMode {
@@ -227,8 +219,8 @@ impl ErrorCodeExt for Error {
             Error::InvalidKeyMode { .. } => error_code::sst_importer::INVALID_KEY_MODE,
             Error::ResourceNotEnough(_) => error_code::sst_importer::RESOURCE_NOT_ENOUTH,
             Error::Suspended { .. } => error_code::sst_importer::SUSPENDED,
-            Error::RequestTooNew { .. } => error_code::sst_importer::REQUEST_TOO_NEW,
-            Error::RequestTooOld { .. } => error_code::sst_importer::REQUEST_TOO_OLD,
+            Error::RequestTooNew(_) => error_code::sst_importer::REQUEST_TOO_NEW,
+            Error::RequestTooOld(_) => error_code::sst_importer::REQUEST_TOO_OLD,
         }
     }
 }

--- a/components/sst_importer/src/import_file.rs
+++ b/components/sst_importer/src/import_file.rs
@@ -512,7 +512,7 @@ pub fn parse_meta_from_path<P: AsRef<Path>>(path: P) -> Result<(SstMeta, i32)> {
     if elems.len() > 5 {
         api_version = elems[5].parse()?;
     }
-    Ok(( meta, api_version ))
+    Ok((meta, api_version))
 }
 
 #[cfg(test)]

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -11,7 +11,7 @@ use std::{
         atomic::{AtomicU64, Ordering},
         Arc,
     },
-    time::Duration,
+    time::{Duration, SystemTime},
 };
 
 use collections::HashSet;
@@ -1385,9 +1385,9 @@ impl SstImporter {
     }
 
     /// List the basic information of the current SST files.
-    /// The information contains UUID, region ID, region Epoch.
-    /// Other fields may be left blank.
-    pub fn list_ssts(&self) -> Result<Vec<(SstMeta, i32)>> {
+    /// The information contains UUID, region ID, region Epoch, api version,
+    /// last modified time. Other fields may be left blank.
+    pub fn list_ssts(&self) -> Result<Vec<(SstMeta, i32, SystemTime)>> {
         self.dir.list_ssts()
     }
 

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -51,7 +51,7 @@ use txn_types::{Key, TimeStamp, WriteRef};
 
 use crate::{
     caching::cache_map::{CacheMap, ShareOwned},
-    import_file::{ImportDir, ImportFile, SstMetaWithApiVersion},
+    import_file::{ImportDir, ImportFile},
     import_mode::{ImportModeSwitcher, RocksDbMetricsFn},
     import_mode2::{HashRange, ImportModeSwitcherV2},
     metrics::*,
@@ -1387,7 +1387,7 @@ impl SstImporter {
     /// List the basic information of the current SST files.
     /// The information contains UUID, region ID, region Epoch.
     /// Other fields may be left blank.
-    pub fn list_ssts(&self) -> Result<Vec<SstMetaWithApiVersion>> {
+    pub fn list_ssts(&self) -> Result<Vec<(SstMeta, i32)>> {
         self.dir.list_ssts()
     }
 
@@ -1587,9 +1587,9 @@ mod tests {
         for sst in &ssts {
             ingested
                 .iter()
-                .find(|s| s.get_uuid() == sst.meta.get_uuid())
+                .find(|s| s.get_uuid() == sst.0.get_uuid())
                 .unwrap();
-            dir.delete(&sst.meta, key_manager.as_deref()).unwrap();
+            dir.delete(&sst.0, key_manager.as_deref()).unwrap();
         }
         assert!(dir.list_ssts().unwrap().is_empty());
     }

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -784,23 +784,29 @@ macro_rules! impl_write {
                             Error::Engine(
                                 format!("failed to find region {} err {:?}", region_id, e).into(),
                             )
-                        }) {
+                        })
+                    {
                         return (Err(From::from(e)), Some(rx));
                     };
                     let res = match f.await {
                         Ok(r) => r,
                         Err(e) => return (Err(From::from(e)), Some(rx)),
                     };
-                    if let Err(e) = check_local_region_stale(region_id, meta.get_region_epoch(), res) {
+                    if let Err(e) =
+                        check_local_region_stale(region_id, meta.get_region_epoch(), res)
+                    {
                         return (Err(From::from(e)), Some(rx));
                     };
 
                     let tablet = match tablets.get(region_id) {
                         Some(t) => t,
                         None => {
-                            return (Err(Error::Engine(
-                                format!("region {} not found", region_id).into(),
-                            )), Some(rx));
+                            return (
+                                Err(Error::Engine(
+                                    format!("region {} not found", region_id).into(),
+                                )),
+                                Some(rx),
+                            );
                         }
                     };
 

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -1458,10 +1458,7 @@ fn write_needs_restore(write: &[u8]) -> bool {
 
 #[cfg(test)]
 mod test {
-    use std::{
-        collections::HashMap,
-        sync::{Arc, Mutex},
-    };
+    use std::collections::HashMap;
 
     use engine_traits::{CF_DEFAULT, CF_WRITE};
     use kvproto::{
@@ -1471,10 +1468,7 @@ mod test {
     };
     use protobuf::{Message, SingularPtrField};
     use raft::StateRole::Follower;
-    use raftstore::{
-        coprocessor::{region_info_accessor::Callback, RegionInfoProvider},
-        RegionInfo,
-    };
+    use raftstore::RegionInfo;
     use tikv_kv::{Modify, WriteData};
     use txn_types::{Key, TimeStamp, Write, WriteBatchFlags, WriteType};
 

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -695,7 +695,12 @@ fn check_local_region_stale(
 
             // when local region epoch is stale, client can retry write later
             if is_epoch_stale(&local_region_epoch, epoch) {
-                let request_region_epoch = *epoch;
+                let request_region_epoch = RegionEpoch {
+                    conf_ver: epoch.conf_ver,
+                    version: epoch.version,
+                    unknown_fields: Default::default(),
+                    cached_size: Default::default(),
+                };
                 return Err(Error::RequestTooNew {
                     region_id,
                     local_region_epoch,
@@ -705,7 +710,12 @@ fn check_local_region_stale(
             // when local region epoch is ahead, client need to rescan region from PD to get
             // latest region later
             if is_epoch_stale(epoch, &local_region_epoch) {
-                let request_region_epoch = *epoch;
+                let request_region_epoch = RegionEpoch {
+                    conf_ver: epoch.conf_ver,
+                    version: epoch.version,
+                    unknown_fields: Default::default(),
+                    cached_size: Default::default(),
+                };
                 return Err(Error::RequestTooOld {
                     region_id,
                     local_region_epoch,

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -784,11 +784,13 @@ macro_rules! impl_write {
                             )
                         })?;
                     let res = f.await?;
-                    if let Err(e) = check_local_region_stale(region_id, meta.get_region_epoch(), res) {
+                    if let Err(e) =
+                        check_local_region_stale(region_id, meta.get_region_epoch(), res)
+                    {
                         let _ = rx.for_each(|i| {
                             drop(i);
                             future::ready(())
-                        });
+                        }).await;
                         return Err(e);
                     }
 

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -773,9 +773,12 @@ macro_rules! impl_write {
                     if let Err(e) = region_info_accessor
                         .find_region_by_id(region_id, cb)
                         .map_err(|e| {
-                            Error::Engine(
-                                format!("failed to find region {} err {:?}", region_id, e).into(),
-                            )
+                            // when region not found, we can't tell whether it's stale or ahead, so
+                            // we just return the safest case
+                            Error::RequestTooOld(format!(
+                                "failed to find region {} err {:?}",
+                                region_id, e
+                            ))
                         })
                     {
                         return (Err(e), Some(rx));
@@ -794,9 +797,10 @@ macro_rules! impl_write {
                         Some(t) => t,
                         None => {
                             return (
-                                Err(Error::Engine(
-                                    format!("region {} not found", region_id).into(),
-                                )),
+                                Err(Error::RequestTooOld(format!(
+                                    "region {} not found",
+                                    region_id
+                                ))),
                                 Some(rx),
                             );
                         }

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -1768,20 +1768,6 @@ mod test {
 
     #[test]
     fn test_write_rpc_check_region_epoch() {
-        struct MockRegionInfoProvider {
-            map: Mutex<HashMap<u64, RegionInfo>>,
-        }
-        impl RegionInfoProvider for MockRegionInfoProvider {
-            fn find_region_by_id(
-                &self,
-                region_id: u64,
-                callback: Callback<Option<RegionInfo>>,
-            ) -> Result<(), raftstore::coprocessor::Error> {
-                callback(self.map.lock().unwrap().get(&region_id).cloned());
-                Ok(())
-            }
-        }
-
         let mut req_epoch = RegionEpoch {
             conf_ver: 10,
             version: 10,

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -14,8 +14,7 @@ use std::{
 
 use engine_traits::{CompactExt, MiscExt, CF_DEFAULT, CF_WRITE};
 use file_system::{set_io_type, IoType};
-use futures::{future, sink::SinkExt, stream::TryStreamExt, FutureExt, TryFutureExt};
-use futures_util::StreamExt;
+use futures::{sink::SinkExt, stream::TryStreamExt, FutureExt, TryFutureExt};
 use grpcio::{
     ClientStreamingSink, RequestStream, RpcContext, ServerStreamingSink, UnarySink, WriteFlags,
 };


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #xxx

What's Changed:

- `check_local_region_stale` use RegionInfo as input, now caller should wait async getter.
- change `SstMetaWithApiVersion` to tuple
- The most important change is return response with `rx`, so `rx` and its source stream will not be dropped before we handle response

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
```
