### PR TITLE
rafstore, engine_rocks: periodic full compaction (#12729)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4359,6 +4359,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "causal_ts",
+ "chrono",
  "collections",
  "concurrency_manager",
  "crc32fast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3565,6 +3565,7 @@ checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 name = "online_config"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "online_config_derive",
  "serde",
  "serde_derive",

--- a/components/online_config/Cargo.toml
+++ b/components/online_config/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
+chrono = "0.4"
 online_config_derive = { path = "./online_config_derive" }
 serde = { version = "1.0", features = ["derive"] }
 

--- a/components/online_config/src/lib.rs
+++ b/components/online_config/src/lib.rs
@@ -5,9 +5,12 @@ use std::{
     fmt::{self, Debug, Display, Formatter},
 };
 
+use chrono::{FixedOffset, NaiveTime};
 pub use online_config_derive::*;
 
 pub type ConfigChange = HashMap<String, ConfigValue>;
+pub type OffsetTime = (NaiveTime, FixedOffset);
+pub type Schedule = Vec<OffsetTime>;
 
 #[derive(Clone, PartialEq)]
 pub enum ConfigValue {
@@ -21,6 +24,8 @@ pub enum ConfigValue {
     Bool(bool),
     String(String),
     Module(ConfigChange),
+    OffsetTime(OffsetTime),
+    Schedule(Schedule),
     Skip,
     None,
 }
@@ -38,6 +43,8 @@ impl Display for ConfigValue {
             ConfigValue::Bool(v) => write!(f, "{}", v),
             ConfigValue::String(v) => write!(f, "{}", v),
             ConfigValue::Module(v) => write!(f, "{:?}", v),
+            ConfigValue::OffsetTime((t, o)) => write!(f, "{} {}", t, o),
+            ConfigValue::Schedule(v) => write!(f, "{:?}", v),
             ConfigValue::Skip => write!(f, "ConfigValue::Skip"),
             ConfigValue::None => write!(f, ""),
         }

--- a/components/raftstore/Cargo.toml
+++ b/components/raftstore/Cargo.toml
@@ -29,6 +29,7 @@ bitflags = "1.0.1"
 byteorder = "1.2"
 bytes = "1.0"
 causal_ts = { workspace = true }
+chrono = "0.4"
 collections = { workspace = true }
 concurrency_manager = { workspace = true }
 crc32fast = "1.2"

--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -152,6 +152,16 @@ pub struct Config {
     pub lock_cf_compact_interval: ReadableDuration,
     pub lock_cf_compact_bytes_threshold: ReadableSize,
 
+    /// The duration of time to attempt scheduling a full compaction. If not
+    /// set, full compaction is not run automatically.
+    pub full_compact_tick_interval: ReadableDuration,
+    /// Hours of the day during which we may execute a full compaction. If not
+    /// set or empty, full compaction may be started every
+    /// `full_compact_tick_interval`. This should be a list in of hours (in
+    /// the local timezone) e.g., ["23", "4"]
+    #[online_config(skip)]
+    pub full_compact_restrict_hours_local_tz: Vec<u32>,
+
     #[online_config(skip)]
     pub notify_capacity: usize,
     pub messages_per_tick: usize,
@@ -435,6 +445,9 @@ impl Default for Config {
             region_compact_redundant_rows_percent: None,
             pd_heartbeat_tick_interval: ReadableDuration::minutes(1),
             pd_store_heartbeat_tick_interval: ReadableDuration::secs(10),
+            // Disable full compaction by default
+            full_compact_tick_interval: ReadableDuration::secs(0),
+            full_compact_restrict_hours_local_tz: Vec::new(),
             notify_capacity: 40960,
             snap_mgr_gc_tick_interval: ReadableDuration::minutes(1),
             snap_gc_timeout: ReadableDuration::hours(4),

--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -450,9 +450,10 @@ impl Default for Config {
             region_compact_redundant_rows_percent: None,
             pd_heartbeat_tick_interval: ReadableDuration::minutes(1),
             pd_store_heartbeat_tick_interval: ReadableDuration::secs(10),
-            // Disable full compaction by default
+            // Disable periodic full compaction by default
             periodic_full_compact_tick_interval: ReadableDuration::secs(0),
-            periodic_full_compact_start_times: ReadableSchedule(Vec::new()),
+            // Do not restrict to specified start times by default
+            periodic_full_compact_start_times: ReadableSchedule::default(),
             notify_capacity: 40960,
             snap_mgr_gc_tick_interval: ReadableDuration::minutes(1),
             snap_gc_timeout: ReadableDuration::hours(4),

--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::with_prefix;
 use tikv_util::{
     box_err,
-    config::{ReadableDuration, ReadableSize, VersionTrack},
+    config::{ReadableDuration, ReadableSchedule, ReadableSize, VersionTrack},
     error, info,
     sys::SysQuota,
     warn,
@@ -152,15 +152,20 @@ pub struct Config {
     pub lock_cf_compact_interval: ReadableDuration,
     pub lock_cf_compact_bytes_threshold: ReadableSize,
 
-    /// The duration of time to attempt scheduling a full compaction. If not
-    /// set, full compaction is not run automatically.
-    pub full_compact_tick_interval: ReadableDuration,
-    /// Hours of the day during which we may execute a full compaction. If not
-    /// set or empty, full compaction may be started every
-    /// `full_compact_tick_interval`. This should be a list in of hours (in
-    /// the local timezone) e.g., ["23", "4"]
-    #[online_config(skip)]
-    pub full_compact_restrict_hours_local_tz: Vec<u32>,
+    /// The duration of time to wait before attempt scheduling a full
+    /// compaction. If not set, periodic full compaction is not run
+    /// automatically.
+    ///
+    /// NOTE: This feature is highly experimental!
+    pub periodic_full_compact_tick_interval: ReadableDuration,
+
+    /// Hours of the day during which we may execute a periodic full compaction.
+    /// If not set or empty, periodic full compaction may be started every
+    /// `periodic_full_compact_tick_interval`. In toml this should be a list of
+    /// timesin "HH:MM" format with an optional timezone offset. If no timezone
+    /// is specified, local timezone is used. E.g.,
+    /// `["23:00 +0000", "03:00 +0700"]` or `["23:00", "03:00"]`.
+    pub periodic_full_compact_start_times: ReadableSchedule,
 
     #[online_config(skip)]
     pub notify_capacity: usize,
@@ -446,8 +451,8 @@ impl Default for Config {
             pd_heartbeat_tick_interval: ReadableDuration::minutes(1),
             pd_store_heartbeat_tick_interval: ReadableDuration::secs(10),
             // Disable full compaction by default
-            full_compact_tick_interval: ReadableDuration::secs(0),
-            full_compact_restrict_hours_local_tz: Vec::new(),
+            periodic_full_compact_tick_interval: ReadableDuration::secs(0),
+            periodic_full_compact_start_times: ReadableSchedule(Vec::new()),
             notify_capacity: 40960,
             snap_mgr_gc_tick_interval: ReadableDuration::minutes(1),
             snap_gc_timeout: ReadableDuration::hours(4),

--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -152,18 +152,10 @@ pub struct Config {
     pub lock_cf_compact_interval: ReadableDuration,
     pub lock_cf_compact_bytes_threshold: ReadableSize,
 
-    /// The duration of time to wait before attempt scheduling a full
-    /// compaction. If not set, periodic full compaction is not run
-    /// automatically.
-    ///
-    /// NOTE: This feature is highly experimental!
-    pub periodic_full_compact_tick_interval: ReadableDuration,
-
     /// Hours of the day during which we may execute a periodic full compaction.
-    /// If not set or empty, periodic full compaction may be started every
-    /// `periodic_full_compact_tick_interval`. In toml this should be a list of
-    /// timesin "HH:MM" format with an optional timezone offset. If no timezone
-    /// is specified, local timezone is used. E.g.,
+    /// If not set or empty, periodic full compaction will not run. In toml this
+    /// should be a list of timesin "HH:MM" format with an optional timezone
+    /// offset. If no timezone is specified, local timezone is used. E.g.,
     /// `["23:00 +0000", "03:00 +0700"]` or `["23:00", "03:00"]`.
     pub periodic_full_compact_start_times: ReadableSchedule,
 
@@ -450,9 +442,7 @@ impl Default for Config {
             region_compact_redundant_rows_percent: None,
             pd_heartbeat_tick_interval: ReadableDuration::minutes(1),
             pd_store_heartbeat_tick_interval: ReadableDuration::secs(10),
-            // Disable periodic full compaction by default
-            periodic_full_compact_tick_interval: ReadableDuration::secs(0),
-            // Do not restrict to specified start times by default
+            // Disable periodic full compaction by default.
             periodic_full_compact_start_times: ReadableSchedule::default(),
             notify_capacity: 40960,
             snap_mgr_gc_tick_interval: ReadableDuration::minutes(1),

--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -158,6 +158,8 @@ pub struct Config {
     /// offset. If no timezone is specified, local timezone is used. E.g.,
     /// `["23:00 +0000", "03:00 +0700"]` or `["23:00", "03:00"]`.
     pub periodic_full_compact_start_times: ReadableSchedule,
+    /// Do not start a full compaction if cpu utilization exceeds this number.
+    pub periodic_full_compact_start_max_cpu: f64,
 
     #[online_config(skip)]
     pub notify_capacity: usize,
@@ -444,6 +446,9 @@ impl Default for Config {
             pd_store_heartbeat_tick_interval: ReadableDuration::secs(10),
             // Disable periodic full compaction by default.
             periodic_full_compact_start_times: ReadableSchedule::default(),
+            // If periodic full compaction is enabled, do not start a full compaction
+            // if the CPU utilization is over 10%.
+            periodic_full_compact_start_max_cpu: 0.1,
             notify_capacity: 40960,
             snap_mgr_gc_tick_interval: ReadableDuration::minutes(1),
             snap_gc_timeout: ReadableDuration::hours(4),

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -120,8 +120,9 @@ pub const PENDING_MSG_CAP: usize = 100;
 pub const ENTRY_CACHE_EVICT_TICK_DURATION: Duration = Duration::from_secs(1);
 pub const MULTI_FILES_SNAPSHOT_FEATURE: Feature = Feature::require(6, 1, 0); // it only makes sense for large region
 
-const PERIODIC_FULL_COMPACT_TICK_INTERVAL_DURATION: Duration = Duration::from_secs(30 * 60); // Check every half hour.
-const PERIODIC_FULL_COMPACT_CPU_MAX_USAGE_PCT: f64 = 0.10;
+// Every 30 minutes, check if we can run full compaction. This allows the config
+// setting `periodic_full_compact_start_max_cpu` to be changed dynamically.
+const PERIODIC_FULL_COMPACT_TICK_INTERVAL_DURATION: Duration = Duration::from_secs(30 * 60);
 
 pub struct StoreInfo<EK, ER> {
     pub kv_engine: EK,
@@ -2478,16 +2479,18 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
 
         let mut proc_stats = ProcessStat::cur_proc_stat().unwrap();
         let cpu_usage = proc_stats.cpu_usage().unwrap();
-        if cpu_usage > PERIODIC_FULL_COMPACT_CPU_MAX_USAGE_PCT {
+        let max_start_cpu_usage = self.ctx.cfg.periodic_full_compact_start_max_cpu;
+        if cpu_usage > max_start_cpu_usage {
             warn!(
-                "full compaction may not run at this time, cpu usage is above threshold";
+                "full compaction may not run at this time, cpu usage is above max";
                 "cpu_usage" => cpu_usage,
-                "threshold" => PERIODIC_FULL_COMPACT_CPU_MAX_USAGE_PCT,
+                "threshold" => max_start_cpu_usage,
             );
             return;
         }
 
-        // full compact
+        // Attempt executing a periodic full compaction.
+        // Note that full compaction will not run if other compaction tasks are running.
         if let Err(e) = self
             .ctx
             .cleanup_scheduler

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -2447,15 +2447,13 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
 
     fn on_full_compact_tick(&mut self) {
         self.register_full_compact_tick();
-        if !self.ctx.cfg.periodic_full_compact_start_times.0.is_empty() {
+        if !self.ctx.cfg.periodic_full_compact_start_times.is_empty() {
             let local_time = chrono::Local::now();
             if !self
                 .ctx
                 .cfg
                 .periodic_full_compact_start_times
-                .0
-                .iter()
-                .any(|time| time.hour_matches(local_time))
+                .is_scheduled_this_hour(&local_time)
             {
                 debug!(
                     "full compaction may not run at this time";

--- a/components/raftstore/src/store/metrics.rs
+++ b/components/raftstore/src/store/metrics.rs
@@ -214,7 +214,7 @@ make_static_metric! {
 
     pub label_enum RaftEventDurationType {
         compact_check,
-        full_compact,
+        periodic_full_compact,
         pd_store_heartbeat,
         snap_gc,
         compact_lock_cf,

--- a/components/raftstore/src/store/metrics.rs
+++ b/components/raftstore/src/store/metrics.rs
@@ -214,6 +214,7 @@ make_static_metric! {
 
     pub label_enum RaftEventDurationType {
         compact_check,
+        full_compact,
         pd_store_heartbeat,
         snap_gc,
         compact_lock_cf,

--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -435,7 +435,7 @@ impl PeerTick {
 #[derive(Debug, Clone, Copy)]
 pub enum StoreTick {
     CompactCheck,
-    FullCompact,
+    PeriodicFullCompact,
     PdStoreHeartbeat,
     SnapGc,
     CompactLockCf,
@@ -448,7 +448,7 @@ impl StoreTick {
     pub fn tag(self) -> RaftEventDurationType {
         match self {
             StoreTick::CompactCheck => RaftEventDurationType::compact_check,
-            StoreTick::FullCompact => RaftEventDurationType::full_compact,
+            StoreTick::PeriodicFullCompact => RaftEventDurationType::periodic_full_compact,
             StoreTick::PdStoreHeartbeat => RaftEventDurationType::pd_store_heartbeat,
             StoreTick::SnapGc => RaftEventDurationType::snap_gc,
             StoreTick::CompactLockCf => RaftEventDurationType::compact_lock_cf,

--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -435,6 +435,7 @@ impl PeerTick {
 #[derive(Debug, Clone, Copy)]
 pub enum StoreTick {
     CompactCheck,
+    FullCompact,
     PdStoreHeartbeat,
     SnapGc,
     CompactLockCf,
@@ -447,6 +448,7 @@ impl StoreTick {
     pub fn tag(self) -> RaftEventDurationType {
         match self {
             StoreTick::CompactCheck => RaftEventDurationType::compact_check,
+            StoreTick::FullCompact => RaftEventDurationType::full_compact,
             StoreTick::PdStoreHeartbeat => RaftEventDurationType::pd_store_heartbeat,
             StoreTick::SnapGc => RaftEventDurationType::snap_gc,
             StoreTick::CompactLockCf => RaftEventDurationType::compact_lock_cf,

--- a/components/raftstore/src/store/worker/compact.rs
+++ b/components/raftstore/src/store/worker/compact.rs
@@ -144,7 +144,7 @@ where
         let full_compact_timer = FULL_COMPACT.start_coarse_timer();
         box_try!(self.engine.compact_range(
             None, None, // Compact the entire key range.
-            true, // exclusive manual: do not run if background compaction is running
+            true, // no other compaction will run when this is running
             1,    // number of threads threads
         ));
         full_compact_timer.observe_duration();

--- a/components/raftstore/src/store/worker/compact.rs
+++ b/components/raftstore/src/store/worker/compact.rs
@@ -135,10 +135,11 @@ where
         fail_point!("on_full_compact");
         let timer = Instant::now();
         let full_compact_timer = FULL_COMPACT.start_coarse_timer();
-        box_try!(
-            self.engine
-                .compact_range(None, None, false, 1 /* threads */,)
-        );
+        box_try!(self.engine.compact_range(
+            None, None, // Compact the entire key range
+            true, // exclusive manual: do not run if background compaction is running
+            1,    // number of threads threads
+        ));
         full_compact_timer.observe_duration();
         info!(
             "full compaction finished";

--- a/components/raftstore/src/store/worker/compact.rs
+++ b/components/raftstore/src/store/worker/compact.rs
@@ -139,6 +139,7 @@ where
     /// a range at a time.
     pub fn full_compact(&mut self) -> Result<(), Error> {
         fail_point!("on_full_compact");
+        info!("full compaction started");
         let timer = Instant::now();
         let full_compact_timer = FULL_COMPACT.start_coarse_timer();
         box_try!(self.engine.compact_range(

--- a/components/raftstore/src/store/worker/metrics.rs
+++ b/components/raftstore/src/store/worker/metrics.rs
@@ -160,6 +160,11 @@ lazy_static! {
         &["cf"]
     )
     .unwrap();
+    pub static ref FULL_COMPACT: Histogram = register_histogram!(
+        "tikv_raftstore_full_compact_duration_seconds",
+        "Bucketed histogram of full compaction"
+    )
+    .unwrap();
     pub static ref REGION_HASH_HISTOGRAM: Histogram = register_histogram!(
         "tikv_raftstore_hash_duration_seconds",
         "Bucketed histogram of raftstore hash computation duration"

--- a/components/raftstore/src/store/worker/metrics.rs
+++ b/components/raftstore/src/store/worker/metrics.rs
@@ -161,8 +161,8 @@ lazy_static! {
     )
     .unwrap();
     pub static ref FULL_COMPACT: Histogram = register_histogram!(
-        "tikv_raftstore_full_compact_duration_seconds",
-        "Bucketed histogram of full compaction"
+        "tikv_storage_full_compact_duration_seconds",
+        "Bucketed histogram of full compaction for the storage."
     )
     .unwrap();
     pub static ref REGION_HASH_HISTOGRAM: Histogram = register_histogram!(

--- a/components/tikv_util/src/config.rs
+++ b/components/tikv_util/src/config.rs
@@ -563,7 +563,7 @@ impl From<ConfigValue> for ReadableSchedule {
                     .collect::<Vec<_>>(),
             )
         } else {
-            panic!("expect: ConfigValue::OffsetTimeVec, got :{:?}", c)
+            panic!("expect: ConfigValue::Schedule, got: {:?}", c)
         }
     }
 }

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -271,7 +271,7 @@ fn test_serde_custom_tikv_config() {
         enable_v2_compatible_learner: false,
         unsafe_disable_check_quorum: false,
         periodic_full_compact_tick_interval: ReadableDuration::secs(0),
-        periodic_full_compact_start_times: ReadableSchedule(Vec::new()),
+        periodic_full_compact_start_times: ReadableSchedule::default(),
     };
     value.pd = PdConfig::new(vec!["example.com:443".to_owned()]);
     let titan_cf_config = TitanCfConfig {

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -270,6 +270,8 @@ fn test_serde_custom_tikv_config() {
         slow_trend_unsensitive_result: 0.5,
         enable_v2_compatible_learner: false,
         unsafe_disable_check_quorum: false,
+        full_compact_tick_interval: ReadableDuration::secs(0),
+        full_compact_restrict_hours_local_tz: Vec::new(),
     };
     value.pd = PdConfig::new(vec!["example.com:443".to_owned()]);
     let titan_cf_config = TitanCfConfig {

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -37,7 +37,7 @@ use tikv::{
         BlockCacheConfig, Config as StorageConfig, EngineType, FlowControlConfig, IoRateLimitConfig,
     },
 };
-use tikv_util::config::{LogFormat, ReadableDuration, ReadableSize};
+use tikv_util::config::{LogFormat, ReadableDuration, ReadableSchedule, ReadableSize};
 
 mod dynamic;
 mod test_config_client;
@@ -270,8 +270,8 @@ fn test_serde_custom_tikv_config() {
         slow_trend_unsensitive_result: 0.5,
         enable_v2_compatible_learner: false,
         unsafe_disable_check_quorum: false,
-        full_compact_tick_interval: ReadableDuration::secs(0),
-        full_compact_restrict_hours_local_tz: Vec::new(),
+        periodic_full_compact_tick_interval: ReadableDuration::secs(0),
+        periodic_full_compact_start_times: ReadableSchedule(Vec::new()),
     };
     value.pd = PdConfig::new(vec!["example.com:443".to_owned()]);
     let titan_cf_config = TitanCfConfig {

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -270,7 +270,6 @@ fn test_serde_custom_tikv_config() {
         slow_trend_unsensitive_result: 0.5,
         enable_v2_compatible_learner: false,
         unsafe_disable_check_quorum: false,
-        periodic_full_compact_tick_interval: ReadableDuration::secs(0),
         periodic_full_compact_start_times: ReadableSchedule::default(),
     };
     value.pd = PdConfig::new(vec!["example.com:443".to_owned()]);

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -271,6 +271,7 @@ fn test_serde_custom_tikv_config() {
         enable_v2_compatible_learner: false,
         unsafe_disable_check_quorum: false,
         periodic_full_compact_start_times: ReadableSchedule::default(),
+        periodic_full_compact_start_max_cpu: 0.1,
     };
     value.pd = PdConfig::new(vec!["example.com:443".to_owned()]);
     let titan_cf_config = TitanCfConfig {


### PR DESCRIPTION
Issue number: ref tikv/tikv#12729

Adds the concept of a full compaction: a compaction that compacts
all columns families, ranges, and levels. this has the effect of
deleting all of the tombstone markers.

If ``raftstore.periodic-full-compact-start-times`` is set, run full
compaction only during the hours specified if normal I/O can be handled
and CPU load is low (below ``raftstore.periodic-full-compact-start-max-cpu`` 
which is `0.1` by default.)

The tikv.yaml segment below will run compaction at 03:00 and 23:00
(3am and 11pm respectively) in the tikv nodes' local timezone if CPU
usage is below 90%.

```
[raftstore]
periodic-full-compact-start-max-cpu = 0.9
periodic-full-compact-start-times = ["03:00", "23:00"]
```

If ``raftstore.periodic-full-compact-start-times`` is not set, periodic full
compaction never runs. 

### Testing 
* Manual tests
* Unit test

### Future work
To address in in follow up PRs:
* Integration tests.
* Pausing/rate-limiting full compactions to avoid disrupting live
  traffic.

### Release note
```release-note
*Experimental* support for full compaction. Off by default.
```
