### PR TITLE
server: make grpc metrics consistent

### DIFF
--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -491,8 +491,8 @@ impl<E: Engine, L: LockManager, F: KvFormat> Tikv for Service<E, L, F> {
         let future = future_copr(&self.copr, Some(ctx.peer()), req);
         let task = async move {
             let resp = future.await?.consume();
-            sink.success(resp).await?;
             let elapsed = begin_instant.saturating_elapsed();
+            sink.success(resp).await?;
             GRPC_MSG_HISTOGRAM_STATIC
                 .coprocessor
                 .observe(elapsed.as_secs_f64());
@@ -529,8 +529,8 @@ impl<E: Engine, L: LockManager, F: KvFormat> Tikv for Service<E, L, F> {
         let future = future_raw_coprocessor(&self.copr_v2, &self.storage, req);
         let task = async move {
             let resp = future.await?;
-            sink.success(resp).await?;
             let elapsed = begin_instant.saturating_elapsed();
+            sink.success(resp).await?;
             GRPC_MSG_HISTOGRAM_STATIC
                 .raw_coprocessor
                 .observe(elapsed.as_secs_f64());
@@ -580,8 +580,8 @@ impl<E: Engine, L: LockManager, F: KvFormat> Tikv for Service<E, L, F> {
             if let Err(e) = res {
                 resp.set_error(format!("{}", e));
             }
-            sink.success(resp).await?;
             let elapsed = begin_instant.saturating_elapsed();
+            sink.success(resp).await?;
             GRPC_MSG_HISTOGRAM_STATIC
                 .unsafe_destroy_range
                 .observe(elapsed.as_secs_f64());
@@ -863,10 +863,10 @@ impl<E: Engine, L: LockManager, F: KvFormat> Tikv for Service<E, L, F> {
                     }
                 }
             }
-            sink.success(resp).await?;
             GRPC_MSG_HISTOGRAM_STATIC
                 .split_region
                 .observe(begin_instant.saturating_elapsed().as_secs_f64());
+            sink.success(resp).await?;
             ServerResult::Ok(())
         }
         .map_err(|e| {
@@ -1015,6 +1015,9 @@ impl<E: Engine, L: LockManager, F: KvFormat> Tikv for Service<E, L, F> {
                 .schedule(CheckLeaderTask::CheckLeader { leaders, cb })
                 .map_err(|e| Error::Other(format!("{}", e).into()))?;
             let regions = resp.await?;
+            GRPC_MSG_HISTOGRAM_STATIC
+                .check_leader
+                .observe(begin_instant.saturating_elapsed().as_secs_f64());
             let mut resp = CheckLeaderResponse::default();
             resp.set_ts(ts);
             resp.set_regions(regions);
@@ -1026,10 +1029,6 @@ impl<E: Engine, L: LockManager, F: KvFormat> Tikv for Service<E, L, F> {
                 }
                 return Err(Error::from(e));
             }
-            let elapsed = begin_instant.saturating_elapsed();
-            GRPC_MSG_HISTOGRAM_STATIC
-                .check_leader
-                .observe(elapsed.as_secs_f64());
             ServerResult::Ok(())
         }
         .map_err(move |e| {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: : ref https://github.com/tikv/tikv/issues/15803

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
the grpc duration should not  include the stream sink.
```

### Related changes



### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


- Manual test (add detailed scripts or steps below)


Side effects



### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
