### PR TITLE
*: allow dynamic link openssl library

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,3 @@
-# This file is almost the same as .gitignore expect the next line.
-.git
-
 # OSX leaves these everywhere on SMB shares
 ._*
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2950,7 +2950,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#aa41eb102d373f56846be88ffd250c2b581b48d4"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=dyn-openssl#ad88f0a7e1150430fc64b43ad0f3eb3aa5ab8783"
 dependencies = [
  "bindgen 0.65.1",
  "bzip2-sys",
@@ -2969,7 +2969,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tikv/rust-rocksdb.git#aa41eb102d373f56846be88ffd250c2b581b48d4"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=dyn-openssl#ad88f0a7e1150430fc64b43ad0f3eb3aa5ab8783"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -4890,7 +4890,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#aa41eb102d373f56846be88ffd250c2b581b48d4"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=dyn-openssl#ad88f0a7e1150430fc64b43ad0f3eb3aa5ab8783"
 dependencies = [
  "libc 0.2.146",
  "librocksdb_sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2950,7 +2950,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=dyn-openssl#ad88f0a7e1150430fc64b43ad0f3eb3aa5ab8783"
+source = "git+https://github.com/tikv/rust-rocksdb.git#bd84144327cfb22bee21b6043673d12b90415e24"
 dependencies = [
  "bindgen 0.65.1",
  "bzip2-sys",
@@ -2969,7 +2969,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=dyn-openssl#ad88f0a7e1150430fc64b43ad0f3eb3aa5ab8783"
+source = "git+https://github.com/tikv/rust-rocksdb.git#bd84144327cfb22bee21b6043673d12b90415e24"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -4890,7 +4890,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=dyn-openssl#ad88f0a7e1150430fc64b43ad0f3eb3aa5ab8783"
+source = "git+https://github.com/tikv/rust-rocksdb.git#bd84144327cfb22bee21b6043673d12b90415e24"
 dependencies = [
  "libc 0.2.146",
  "librocksdb_sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -390,9 +390,6 @@ opt-level = 1
 [profile.dev.package.libtitan_sys]
 debug = false
 opt-level = 1
-# [profile.dev.package.tirocks-sys]
-# debug = false
-# opt-level = 1
 
 [profile.dev.package.tests]
 debug = 1
@@ -413,7 +410,7 @@ rpath = false
 opt-level = 3
 debug = false
 codegen-units = 1
-lto = false
+lto = "thin"
 incremental = false
 panic = 'unwind'
 debug-assertions = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,11 @@ test-engine-raft-raft-engine = ["engine_test/test-engine-raft-raft-engine"]
 test-engines-rocksdb = ["engine_test/test-engines-rocksdb"]
 test-engines-panic = ["engine_test/test-engines-panic"]
 pprof-fp = ["pprof/frame-pointer"]
+openssl-vendored = [
+  "openssl/vendored",
+  "grpcio/openssl-vendored",
+  "hyper-tls/vendored",
+]
 
 # for testing configure propegate to other crates
 # https://stackoverflow.com/questions/41700543/can-we-share-test-utilites-between-crates
@@ -358,7 +363,7 @@ tracker = { path = "components/tracker" }
 txn_types = { path = "components/txn_types" }
 # External libs
 raft = { version = "0.7.0", default-features = false, features = ["protobuf-codec"] }
-grpcio = { version = "0.10.4", default-features = false, features = ["openssl-vendored", "protobuf-codec", "nightly"] }
+grpcio = { version = "0.10.4", default-features = false, features = ["openssl", "protobuf-codec", "nightly"] }
 grpcio-health = { version = "0.10.4", default-features = false, features = ["protobuf-codec"] }
 tipb = { git = "https://github.com/pingcap/tipb.git" }
 kvproto = { git = "https://github.com/pingcap/kvproto.git" }
@@ -380,9 +385,9 @@ opt-level = 1
 debug = false
 opt-level = 1
 
-[profile.dev.package.tirocks-sys]
-debug = false
-opt-level = 1
+# [profile.dev.package.tirocks-sys]
+# debug = false
+# opt-level = 1
 
 [profile.dev.package.tests]
 debug = 1
@@ -403,7 +408,7 @@ rpath = false
 opt-level = 3
 debug = false
 codegen-units = 1
-lto = "thin"
+lto = false
 incremental = false
 panic = 'unwind'
 debug-assertions = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,14 @@ test-engines-panic = ["engine_test/test-engines-panic"]
 pprof-fp = ["pprof/frame-pointer"]
 openssl-vendored = [
   "openssl/vendored",
-  "grpcio/openssl-vendored",
   "hyper-tls/vendored",
+  # NB: the "openssl" feature does not make grpcio-sys v0.10 depends on
+  # openssl-sys, and it can not find the static openssl built by openssl-sys.
+  # Enabling "grpcio/openssl-vendored" explicitly makes grpcio-sys depends on
+  # openssl-sys and correctly links to the static openssl.
+  "grpcio/openssl-vendored",
+  # NB: Enable SM4 support if OpenSSL is built from source and statically linked.
+  "encryption_export/sm4",
 ]
 
 # for testing configure propegate to other crates
@@ -384,7 +390,6 @@ opt-level = 1
 [profile.dev.package.libtitan_sys]
 debug = false
 opt-level = 1
-
 # [profile.dev.package.tirocks-sys]
 # debug = false
 # opt-level = 1

--- a/Dockerfile.FIPS
+++ b/Dockerfile.FIPS
@@ -1,23 +1,5 @@
 # This Docker image contains a minimal build environment for a FIPS compliant TiKV.
-#
-# It contains all the tools necessary to reproduce official production builds of TiKV
 
-# We need to use CentOS 7 because many of our users choose this as their deploy machine.
-# Since the glibc it uses (2.17) is from 2012 (https://sourceware.org/glibc/wiki/Glibc%20Timeline)
-# it is our lowest common denominator in terms of distro support.
-
-# Some commands in this script are structured in order to reduce the number of layers Docker
-# generates. Unfortunately Docker is limited to only 125 layers:
-# https://github.com/moby/moby/blob/a9507c6f76627fdc092edc542d5a7ef4a6df5eec/layer/layer.go#L50-L53
-
-# We require epel packages, so enable the fedora EPEL repo then install dependencies.
-# Install the system dependencies
-# Attempt to clean and rebuild the cache to avoid 404s
-
-# To avoid rebuilds we first install all Cargo dependencies
-
-
-# The prepare image avoid ruining the cache of the builder
 FROM redhat/ubi8-minimal:8.6 as builder
 
 RUN microdnf install -y openssl-devel

--- a/Dockerfile.FIPS
+++ b/Dockerfile.FIPS
@@ -1,0 +1,61 @@
+# This Docker image contains a minimal build environment for a FIPS compliant TiKV.
+#
+# It contains all the tools necessary to reproduce official production builds of TiKV
+
+# We need to use CentOS 7 because many of our users choose this as their deploy machine.
+# Since the glibc it uses (2.17) is from 2012 (https://sourceware.org/glibc/wiki/Glibc%20Timeline)
+# it is our lowest common denominator in terms of distro support.
+
+# Some commands in this script are structured in order to reduce the number of layers Docker
+# generates. Unfortunately Docker is limited to only 125 layers:
+# https://github.com/moby/moby/blob/a9507c6f76627fdc092edc542d5a7ef4a6df5eec/layer/layer.go#L50-L53
+
+# We require epel packages, so enable the fedora EPEL repo then install dependencies.
+# Install the system dependencies
+# Attempt to clean and rebuild the cache to avoid 404s
+
+# To avoid rebuilds we first install all Cargo dependencies
+
+
+# The prepare image avoid ruining the cache of the builder
+FROM redhat/ubi8-minimal:8.6 as builder
+
+RUN microdnf install -y openssl-devel
+
+RUN microdnf install -y \
+      gcc \
+      gcc-c++ \
+      libstdc++-static \
+      make \
+      cmake \
+      perl \
+      git \
+      findutils \
+      curl \
+      python3 && \
+    microdnf clean all
+
+# Install Rustup
+RUN curl https://sh.rustup.rs -sSf | sh -s -- --no-modify-path --default-toolchain none -y
+ENV PATH /root/.cargo/bin/:$PATH
+
+# Checkout TiKV source code.
+WORKDIR /tikv
+COPY .git .git
+ARG GIT_HASH
+RUN git checkout ${GIT_HASH} && git checkout .
+
+# Do not static link OpenSSL.
+ENV ENABLE_FIPS 1
+RUN ls -lash && make build_dist_release
+
+# Export to a clean image
+FROM redhat/ubi8-minimal:8.6
+COPY --from=builder /tikv/target/release/tikv-server /tikv-server
+COPY --from=builder /tikv/target/release/tikv-ctl /tikv-ctl
+
+RUN microdnf install -y openssl
+
+EXPOSE 20160 20180
+
+ENTRYPOINT ["/tikv-server"]

--- a/Dockerfile.FIPS
+++ b/Dockerfile.FIPS
@@ -29,7 +29,7 @@ RUN git checkout ${GIT_HASH} && git checkout .
 
 # Do not static link OpenSSL.
 ENV ENABLE_FIPS 1
-RUN ls -lash && make build_dist_release
+RUN make build_dist_release
 
 # Export to a clean image
 FROM redhat/ubi8-minimal:8.6

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ export DEV_DOCKER_IMAGE_NAME ?= pingcap/tikv_dev
 export ENABLE_FIPS ?= 0
 
 ifeq ($(ENABLE_FIPS),1)
-DOCKER_IMAGE_NAME := ${DOCKER_IMAGE_NAME}-fips
+DOCKER_IMAGE_TAG := ${DOCKER_IMAGE_TAG}-fips
 DOCKER_FILE := ${DOCKER_FILE}.FIPS
 else
 ENABLE_FEATURES += openssl-vendored

--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,19 @@ ENABLE_FEATURES += cloud-gcp
 ENABLE_FEATURES += cloud-azure
 endif
 
+export DOCKER_FILE ?= Dockerfile
+export DOCKER_IMAGE_NAME ?= pingcap/tikv
+export DOCKER_IMAGE_TAG ?= latest
+export DEV_DOCKER_IMAGE_NAME ?= pingcap/tikv_dev
+export ENABLE_FIPS ?= 0
+
+ifeq ($(ENABLE_FIPS),1)
+DOCKER_IMAGE_NAME := ${DOCKER_IMAGE_NAME}-fips
+DOCKER_FILE := ${DOCKER_FILE}.FIPS
+else
+ENABLE_FEATURES += openssl-vendored
+endif
+
 PROJECT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
 BIN_PATH = $(CURDIR)/bin
@@ -134,18 +147,6 @@ export TIKV_BUILD_RUSTC_TARGET := $(shell rustc -vV | awk '/host/ { print $$2 }'
 export TIKV_BUILD_GIT_HASH ?= $(shell git rev-parse HEAD 2> /dev/null || echo ${BUILD_INFO_GIT_FALLBACK})
 export TIKV_BUILD_GIT_TAG ?= $(shell git describe --tag || echo ${BUILD_INFO_GIT_FALLBACK})
 export TIKV_BUILD_GIT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD 2> /dev/null || echo ${BUILD_INFO_GIT_FALLBACK})
-
-export DOCKER_FILE ?= Dockerfile
-export DOCKER_IMAGE_NAME ?= pingcap/tikv
-export DOCKER_IMAGE_TAG ?= latest
-export DEV_DOCKER_IMAGE_NAME ?= pingcap/tikv_dev
-export ENABLE_FIPS ?= 0
-ifeq ($(ENABLE_FIPS),1)
-DOCKER_IMAGE_NAME := ${DOCKER_IMAGE_NAME}-fips
-DOCKER_FILE := ${DOCKER_FILE}.FIPS
-else
-ENABLE_FEATURES += openssl-vendored
-endif
 
 # Turn on cargo pipelining to add more build parallelism. This has shown decent
 # speedups in TiKV.

--- a/Makefile
+++ b/Makefile
@@ -135,9 +135,17 @@ export TIKV_BUILD_GIT_HASH ?= $(shell git rev-parse HEAD 2> /dev/null || echo ${
 export TIKV_BUILD_GIT_TAG ?= $(shell git describe --tag || echo ${BUILD_INFO_GIT_FALLBACK})
 export TIKV_BUILD_GIT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD 2> /dev/null || echo ${BUILD_INFO_GIT_FALLBACK})
 
-export DOCKER_IMAGE_NAME ?= "pingcap/tikv"
-export DOCKER_IMAGE_TAG ?= "latest"
-export DEV_DOCKER_IMAGE_NAME ?= "pingcap/tikv_dev"
+export DOCKER_FILE ?= Dockerfile
+export DOCKER_IMAGE_NAME ?= pingcap/tikv
+export DOCKER_IMAGE_TAG ?= latest
+export DEV_DOCKER_IMAGE_NAME ?= pingcap/tikv_dev
+export ENABLE_FIPS ?= 0
+ifeq ($(ENABLE_FIPS),1)
+DOCKER_IMAGE_NAME := ${DOCKER_IMAGE_NAME}-fips
+DOCKER_FILE := ${DOCKER_FILE}.FIPS
+else
+ENABLE_FEATURES += openssl-vendored
+endif
 
 # Turn on cargo pipelining to add more build parallelism. This has shown decent
 # speedups in TiKV.
@@ -153,6 +161,12 @@ export CARGO_BUILD_PIPELINING=true
 #      https://bugzilla.redhat.com/show_bug.cgi?id=1830472
 ifeq ($(TIKV_BUILD_RUSTC_TARGET),aarch64-unknown-linux-gnu)
 export RUSTFLAGS := $(RUSTFLAGS) -Ctarget-feature=-outline-atomics
+endif
+
+ifeq ($(shell basename $(shell which python 2>/dev/null)),python)
+PY := python
+else
+PY := python3
 endif
 
 # Almost all the rules in this Makefile are PHONY
@@ -248,7 +262,7 @@ dist_release:
 	@mkdir -p ${BIN_PATH}
 	@cp -f ${CARGO_TARGET_DIR}/release/tikv-ctl ${CARGO_TARGET_DIR}/release/tikv-server ${BIN_PATH}/
 ifeq ($(shell uname),Linux) # Macs binary isn't elf format
-	@python scripts/check-bins.py --features "${ENABLE_FEATURES}" --check-release ${BIN_PATH}/tikv-ctl ${BIN_PATH}/tikv-server
+	$(PY) scripts/check-bins.py --features "${ENABLE_FEATURES}" --check-release ${BIN_PATH}/tikv-ctl ${BIN_PATH}/tikv-server
 endif
 
 # Build with release flag as if it were for distribution, but without
@@ -393,6 +407,7 @@ error-code: etc/error_code.toml
 docker:
 	docker build \
 		-t ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} \
+		-f ${DOCKER_FILE} \
 		--build-arg GIT_HASH=${TIKV_BUILD_GIT_HASH} \
 		--build-arg GIT_TAG=${TIKV_BUILD_GIT_TAG} \
 		--build-arg GIT_BRANCH=${TIKV_BUILD_GIT_BRANCH} \

--- a/cmd/tikv-ctl/Cargo.toml
+++ b/cmd/tikv-ctl/Cargo.toml
@@ -24,6 +24,7 @@ cloud-gcp = [
 cloud-azure = [
   "encryption_export/cloud-azure",
 ]
+openssl-vendored = ["tikv/openssl-vendored"]
 test-engine-kv-rocksdb = [
   "tikv/test-engine-kv-rocksdb"
 ]

--- a/cmd/tikv-server/Cargo.toml
+++ b/cmd/tikv-server/Cargo.toml
@@ -18,6 +18,7 @@ failpoints = ["server/failpoints"]
 cloud-aws = ["server/cloud-aws"]
 cloud-gcp = ["server/cloud-gcp"]
 cloud-azure = ["server/cloud-azure"]
+openssl-vendored = ["tikv/openssl-vendored"]
 test-engine-kv-rocksdb = [
   "server/test-engine-kv-rocksdb"
 ]

--- a/components/backup-stream/Cargo.toml
+++ b/components/backup-stream/Cargo.toml
@@ -41,7 +41,7 @@ engine_traits = { workspace = true }
 error_code = { workspace = true }
 # We cannot update the etcd-client to latest version because of the cyclic requirement.
 # Also we need wait until https://github.com/etcdv3/etcd-client/pull/43/files to be merged.
-etcd-client = { git = "https://github.com/pingcap/etcd-client", rev = "41d393c32a7a7c728550cee1d9a138dafe6f3e27", features = ["pub-response-field", "tls-openssl-vendored"], optional = true }
+etcd-client = { git = "https://github.com/pingcap/etcd-client", rev = "41d393c32a7a7c728550cee1d9a138dafe6f3e27", features = ["pub-response-field", "tls-openssl"], optional = true }
 external_storage = { workspace = true }
 fail = "0.5"
 file_system = { workspace = true }

--- a/components/encryption/Cargo.toml
+++ b/components/encryption/Cargo.toml
@@ -6,6 +6,9 @@ publish = false
 
 [features]
 failpoints = ["fail/failpoints"]
+# openssl/vendored is necssary in order to conditionally building SM4 encryption
+# support, as SM4 is disabled on various openssl distributions, such as Rocky Linux 9.
+sm4 = ["openssl/vendored"]
 
 [dependencies]
 async-trait = "0.1"

--- a/components/encryption/export/Cargo.toml
+++ b/components/encryption/export/Cargo.toml
@@ -9,6 +9,7 @@ default = ["cloud-aws", "cloud-gcp", "cloud-azure"]
 cloud-aws = ["aws"]
 cloud-gcp = []
 cloud-azure = ["azure"]
+sm4 = ["encryption/sm4"]
 
 [dependencies]
 async-trait = "0.1"

--- a/components/encryption/src/io.rs
+++ b/components/encryption/src/io.rs
@@ -390,7 +390,19 @@ pub fn create_aes_ctr_crypter(
         EncryptionMethod::Aes128Ctr => OCipher::aes_128_ctr(),
         EncryptionMethod::Aes192Ctr => OCipher::aes_192_ctr(),
         EncryptionMethod::Aes256Ctr => OCipher::aes_256_ctr(),
-        EncryptionMethod::Sm4Ctr => OCipher::sm4_ctr(),
+        EncryptionMethod::Sm4Ctr => {
+            return Err(box_err!(
+                "sm4-ctr is not supported when dynamic link openssl"
+            ));
+
+            // #[cfg(feature = "openssl-dylib")]
+            // {
+            //     return Err(box_err!(
+            //         "sm4-ctr is not supported when dynamic link openssl"
+            //     ));
+            // }
+            // OCipher::sm4_ctr()
+        }
     };
     let crypter = OCrypter::new(cipher, mode, key, Some(iv.as_slice()))?;
     Ok((cipher, crypter))

--- a/components/encryption/src/io.rs
+++ b/components/encryption/src/io.rs
@@ -391,17 +391,16 @@ pub fn create_aes_ctr_crypter(
         EncryptionMethod::Aes192Ctr => OCipher::aes_192_ctr(),
         EncryptionMethod::Aes256Ctr => OCipher::aes_256_ctr(),
         EncryptionMethod::Sm4Ctr => {
-            return Err(box_err!(
-                "sm4-ctr is not supported when dynamic link openssl"
-            ));
-
-            // #[cfg(feature = "openssl-dylib")]
-            // {
-            //     return Err(box_err!(
-            //         "sm4-ctr is not supported when dynamic link openssl"
-            //     ));
-            // }
-            // OCipher::sm4_ctr()
+            #[cfg(feature = "sm4")]
+            {
+                OCipher::sm4_ctr()
+            }
+            #[cfg(not(feature = "sm4"))]
+            {
+                return Err(box_err!(
+                    "sm4-ctr is not supported by dynamically linked openssl"
+                ));
+            }
         }
     };
     let crypter = OCrypter::new(cipher, mode, key, Some(iv.as_slice()))?;

--- a/components/engine_rocks/Cargo.toml
+++ b/components/engine_rocks/Cargo.toml
@@ -60,6 +60,8 @@ txn_types = { workspace = true }
 git = "https://github.com/tikv/rust-rocksdb.git"
 package = "rocksdb"
 features = ["encryption"]
+branch = "dyn-openssl"
+# features = ["encryption", "static_libcpp"]
 
 [dev-dependencies]
 rand = "0.8"

--- a/components/engine_rocks/Cargo.toml
+++ b/components/engine_rocks/Cargo.toml
@@ -60,8 +60,6 @@ txn_types = { workspace = true }
 git = "https://github.com/tikv/rust-rocksdb.git"
 package = "rocksdb"
 features = ["encryption"]
-branch = "dyn-openssl"
-# features = ["encryption", "static_libcpp"]
 
 [dev-dependencies]
 rand = "0.8"

--- a/scripts/check-bins.py
+++ b/scripts/check-bins.py
@@ -21,6 +21,22 @@ JEMALLOC_SYMBOL = ["je_arena_boot", " malloc"]
 
 SYS_LIB = ["libstdc++"]
 
+def ensure_link(args, require_static, libs):
+    p = os.popen("uname")
+    if "Linux" not in p.readline():
+        return
+    for bin in args:
+        p = os.popen("ldd " + bin)
+        requires = set(l.split()[0] for l in p.readlines())
+        for lib in libs:
+            if any(lib in r for r in requires):
+                if require_static:
+                    pr("error: %s should not requires dynamic library %s\n" % (bin, lib))
+                    sys.exit(1)
+            elif not require_static:
+                    pr("error: %s should requires dynamic library %s\n" % (bin, lib))
+                    sys.exit(1)
+
 def pr(s):
     if sys.stdout.isatty():
         sys.stdout.write("\x1b[2K\r" + s)
@@ -72,6 +88,22 @@ def check_sse(executable):
             print("fix this by building tikv with ROCKSDB_SYS_SSE=1")
             sys.exit(1)
 
+def is_openssl_vendored_enabled(features):
+    return "openssl-vendored" in features
+
+def check_openssl(executable, is_static_link):
+    openssl_libs = ["libcrypto", "libssl"]
+    ensure_link([executable], is_static_link, openssl_libs)
+    openssl_symbol = "EVP_EncryptInit"
+    if not is_static_link:
+        p = os.popen("nm %s | grep %s" % (executable, openssl_symbol))
+        lines = p.readlines()
+        text_symbol = "T "+openssl_symbol
+        finds = [l for l in lines if text_symbol in l]
+        if len(finds) != 0:
+            pr("error: %s contains OpenSSL symbol %s in text section\n" % (executable, openssl_symbol))
+            sys.exit(1)
+
 def check_tests(features):
     if not is_jemalloc_enabled(features):
         print("jemalloc not enabled, skip check!")
@@ -98,25 +130,18 @@ def check_tests(features):
     pr("")
     print("Done, takes %.2fs." % (time.time() - start))
 
-def ensure_link(args):
-    p = os.popen("uname")
-    if "Linux" not in p.readline():
-        return
-    for bin in args:
-        p = os.popen("ldd " + bin)
-        requires = set(l.split()[0] for l in p.readlines())
-        for lib in SYS_LIB:
-            if any(lib in r for r in requires):
-                pr("error: %s should not requires dynamic library %s\n" % (bin, lib))
-                sys.exit(1)
-
 def check_release(enabled_features, args):
-    ensure_link(args)
+    # Ensure statically link SYS_LIB.
+    ensure_link(args, True, SYS_LIB)
     checked_features = []
     if is_jemalloc_enabled(enabled_features):
         checked_features.append("jemalloc")
     if is_sse_enabled(enabled_features):
         checked_features.append("SSE4.2")
+    if is_openssl_vendored_enabled(enabled_features):
+        checked_features.append("static-link-openssl")
+    else:
+        checked_features.append("dynamic-link-openssl")
     if not checked_features:
         print("Both jemalloc and SSE4.2 are disabled, skip check")
         return
@@ -127,7 +152,8 @@ def check_release(enabled_features, args):
             check_jemalloc(arg)
         if is_sse_enabled(enabled_features):
             check_sse(arg)
-        pr("%s %s \033[32menabled\033[0m\n" % (arg, " ".join(checked_features)))
+        check_openssl(arg, is_openssl_vendored_enabled(enabled_features))
+        pr("%s [%s] \033[32menabled\033[0m\n" % (arg, " ".join(checked_features)))
 
 def main():
     argv = sys.argv

--- a/scripts/check-bins.py
+++ b/scripts/check-bins.py
@@ -127,6 +127,7 @@ def check_tests(features):
 
         pr("Checking binary %s" % name)
         check_jemalloc(executable)
+        check_openssl(executable, True)
     pr("")
     print("Done, takes %.2fs." % (time.time() - start))
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,8 +79,12 @@ pub fn tikv_version_info(build_time: Option<&str>) -> String {
 }
 
 /// return the build version of tikv-server
-pub fn tikv_build_version() -> &'static str {
-    env!("CARGO_PKG_VERSION")
+pub fn tikv_build_version() -> String {
+    if option_env!("ENABLE_FIPS").map_or(false, |v| v == "1") {
+        format!("{}-{}", env!("CARGO_PKG_VERSION"), "fips")
+    } else {
+        env!("CARGO_PKG_VERSION").to_owned()
+    }
 }
 
 /// Prints the tikv version information to the standard output.


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #15943

Requires https://github.com/tikv/rust-rocksdb/pull/774

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Currently, TiKV binaries are statically linked to the OpenSSL library,
preventing the use of the host system's OpenSSL.

This commit adds an option to build TiKV with dynamic linking of the
OpenSSL library, enabling TiKV to utilize the host system's OpenSSL.
This is particularly useful in FIPS scenarios where TiKV needs to
delegate cryptographic operations to the host FIPS OpenSSL.

By default, this option is disabled, and TiKV continues to statically
link the OpenSSL library.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

`ENABLE_FIPS=0 make docker`

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
none
```
