### PR TITLE
test: do not capture test output in make test_with_nextest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,7 +316,7 @@ test:
 
 # Run tests with nextest.
 ifndef CUSTOM_TEST_COMMAND
-test_with_nextest: export CUSTOM_TEST_COMMAND=nextest run
+test_with_nextest: export CUSTOM_TEST_COMMAND=nextest run --nocapture
 endif
 test_with_nextest: export RUSTDOCFLAGS="-Z unstable-options --persist-doctests"
 test_with_nextest:


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref  #15967

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```
Because `cargo test` won't fail the test when a background thread panic,
do not capture the test output can at least make it easier to reason
about some unexpected behavior such as timeout caused by panic.
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
- No code

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
