### PR TITLE
fips: enable OpenSSL FIPS mode on TiKV start if it's eligible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1867,6 +1867,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fips"
+version = "0.0.1"
+dependencies = [
+ "openssl",
+ "openssl-sys",
+ "slog",
+ "slog-global",
+]
+
+[[package]]
 name = "fix-hidden-lifetime-bug"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6317,6 +6327,7 @@ dependencies = [
  "example_coprocessor_plugin",
  "fail",
  "file_system",
+ "fips",
  "flate2",
  "futures 0.3.15",
  "futures-executor",
@@ -6433,6 +6444,7 @@ dependencies = [
  "engine_traits",
  "error_code",
  "file_system",
+ "fips",
  "futures 0.3.15",
  "gag",
  "grpcio",
@@ -6509,6 +6521,7 @@ dependencies = [
  "clap 2.33.0",
  "encryption_export",
  "engine_traits",
+ "fips",
  "keys",
  "kvproto",
  "raft-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ engine_traits_tests = { workspace = true }
 error_code = { workspace = true }
 fail = "0.5"
 file_system = { workspace = true }
+fips = { workspace = true }
 flate2 = { version = "1.0", default-features = false, features = ["zlib"] }
 futures = { version = "0.3", features = ["thread-pool", "compat"] }
 futures-executor = "0.3.1"
@@ -111,7 +112,7 @@ notify = "4"
 num-traits = "0.2.14"
 num_cpus = "1"
 online_config = { workspace = true }
-openssl = "0.10"
+openssl = { workspace = true }
 parking_lot = "0.12"
 paste = "1.0"
 pd_client = { workspace = true }
@@ -249,6 +250,7 @@ members = [
   "components/error_code",
   "components/external_storage",
   "components/file_system",
+  "components/fips",
   "components/into_other",
   "components/keys",
   "components/log_wrappers",
@@ -323,6 +325,7 @@ engine_traits_tests = { path = "components/engine_traits_tests", default-feature
 error_code = { path = "components/error_code" }
 external_storage = { path = "components/external_storage" }
 file_system = { path = "components/file_system" }
+fips = { path = "components/fips" }
 gcp = { path = "components/cloud/gcp" }
 into_other = { path = "components/into_other" }
 keys = { path = "components/keys" }
@@ -378,6 +381,8 @@ tokio-timer = { git = "https://github.com/tikv/tokio", branch = "tokio-timer-hot
 tokio-executor = { git = "https://github.com/tikv/tokio", branch = "tokio-timer-hotfix" }
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }
+openssl = "0.10"
+openssl-sys = "0.9"
 
 [profile.dev.package.grpcio-sys]
 debug = false

--- a/cmd/tikv-ctl/Cargo.toml
+++ b/cmd/tikv-ctl/Cargo.toml
@@ -54,6 +54,7 @@ engine_rocks = { workspace = true }
 engine_traits = { workspace = true }
 error_code = { workspace = true }
 file_system = { workspace = true }
+fips = { workspace = true }
 futures = "0.3"
 gag = "1.0"
 grpcio = { workspace = true }

--- a/cmd/tikv-ctl/src/main.rs
+++ b/cmd/tikv-ctl/src/main.rs
@@ -61,10 +61,16 @@ mod fork_readonly_tikv;
 mod util;
 
 fn main() {
+    // OpenSSL FIPS mode should be enabled at the very start.
+    fips::maybe_enable();
+
     let opt = Opt::from_args();
 
     // Initialize logger.
     init_ctl_logger(&opt.log_level);
+
+    // Print OpenSSL FIPS mode status.
+    fips::log_status();
 
     // Initialize configuration and security manager.
     let cfg_path = opt.config.as_ref();

--- a/cmd/tikv-server/Cargo.toml
+++ b/cmd/tikv-server/Cargo.toml
@@ -36,6 +36,7 @@ pprof-fp = ["tikv/pprof-fp"]
 clap = "2.32"
 encryption_export = { workspace = true }
 engine_traits = { workspace = true }
+fips = { workspace = true }
 keys = { workspace = true }
 kvproto = { workspace = true }
 raft-engine = { git = "https://github.com/tikv/raft-engine.git" }

--- a/cmd/tikv-server/src/main.rs
+++ b/cmd/tikv-server/src/main.rs
@@ -13,6 +13,9 @@ use tikv::{
 };
 
 fn main() {
+    // OpenSSL FIPS mode should be enabled at the very start.
+    fips::maybe_enable();
+
     let build_timestamp = option_env!("TIKV_BUILD_TIME");
     let version_info = tikv::tikv_version_info(build_timestamp);
 
@@ -216,6 +219,17 @@ fn main() {
         println!("invalid storage.engine configuration: {}", e);
         process::exit(1)
     }
+
+    // Sets the global logger ASAP.
+    // It is okay to use the config w/o `validate()`,
+    // because `initial_logger()` handles various conditions.
+    server::setup::initial_logger(&config);
+
+    // Print version information.
+    tikv::log_tikv_info(build_timestamp);
+
+    // Print OpenSSL FIPS mode status.
+    fips::log_status();
 
     // Init memory related settings.
     config.memory.init();

--- a/components/backup-stream/Cargo.toml
+++ b/components/backup-stream/Cargo.toml
@@ -49,7 +49,7 @@ kvproto = { workspace = true }
 lazy_static = "1.4"
 log_wrappers = { workspace = true }
 online_config = { workspace = true }
-openssl = "0.10"
+openssl = { workspace = true }
 pd_client = { workspace = true }
 pin-project = "1.0"
 prometheus = { version = "0.13", default-features = false, features = ["nightly"] }

--- a/components/cloud/Cargo.toml
+++ b/components/cloud/Cargo.toml
@@ -11,7 +11,7 @@ error_code = { workspace = true }
 futures-io = "0.3"
 kvproto = { workspace = true }
 lazy_static = "1.3"
-openssl = "0.10"
+openssl = { workspace = true }
 prometheus = { version = "0.13", default-features = false, features = ["nightly"] }
 protobuf = { version = "2.8", features = ["bytes"] }
 rusoto_core = "0.46.0"

--- a/components/cloud/azure/Cargo.toml
+++ b/components/cloud/azure/Cargo.toml
@@ -21,7 +21,7 @@ futures = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["io"] }
 kvproto = { workspace = true }
 oauth2 = { version = "4.0.0", default-features = false }
-openssl = { version = "0.10.50" }
+openssl = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 slog = { workspace = true }

--- a/components/encryption/Cargo.toml
+++ b/components/encryption/Cargo.toml
@@ -28,7 +28,7 @@ hex = "0.4.2"
 kvproto = { workspace = true }
 lazy_static = "1.3"
 online_config = { workspace = true }
-openssl = "0.10"
+openssl = { workspace = true }
 prometheus = { version = "0.13", features = ["nightly"] }
 protobuf = { version = "2.8", features = ["bytes"] }
 rand = "0.8"

--- a/components/encryption/export/Cargo.toml
+++ b/components/encryption/export/Cargo.toml
@@ -21,7 +21,7 @@ encryption = { workspace = true }
 error_code = { workspace = true }
 file_system = { workspace = true }
 kvproto = { workspace = true }
-openssl = "0.10"
+openssl = { workspace = true }
 protobuf = { version = "2.8", features = ["bytes"] }
 slog = { workspace = true }
 # better to not use slog-global, but pass in the logger

--- a/components/external_storage/Cargo.toml
+++ b/components/external_storage/Cargo.toml
@@ -19,7 +19,7 @@ futures-util = { version = "0.3", default-features = false, features = ["io"] }
 gcp = { workspace = true }
 kvproto = { workspace = true }
 lazy_static = "1.3"
-openssl = "0.10"
+openssl = { workspace = true }
 prometheus = { version = "0.13", default-features = false, features = ["nightly", "push"] }
 rand = "0.8"
 slog = { workspace = true }

--- a/components/file_system/Cargo.toml
+++ b/components/file_system/Cargo.toml
@@ -15,7 +15,7 @@ fs2 = "0.4"
 lazy_static = "1.3"
 libc = "0.2"
 online_config = { workspace = true }
-openssl = "0.10"
+openssl = { workspace = true }
 parking_lot = "0.12"
 prometheus = { version = "0.13", features = ["nightly"] }
 prometheus-static-metric = "0.5"

--- a/components/fips/Cargo.toml
+++ b/components/fips/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "fips"
+version = "0.0.1"
+edition = "2021"
+publish = false
+
+[dependencies]
+openssl = { workspace = true }
+openssl-sys = { workspace = true }
+slog = { workspace = true }
+# better to not use slog-global, but pass in the logger
+slog-global = { workspace = true }

--- a/components/fips/build.rs
+++ b/components/fips/build.rs
@@ -1,0 +1,32 @@
+// Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::env;
+
+fn main() {
+    if !option_env!("ENABLE_FIPS").map_or(false, |v| v == "1") {
+        println!("cargo:rustc-cfg=disable_fips");
+        return;
+    }
+    if let Ok(version) = env::var("DEP_OPENSSL_VERSION_NUMBER") {
+        let version = u64::from_str_radix(&version, 16).unwrap();
+
+        #[allow(clippy::unusual_byte_groupings)]
+        // Follow OpenSSL numeric release version identifier style:
+        // MNNFFPPS: major minor fix patch status
+        // See https://github.com/openssl/openssl/blob/OpenSSL_1_0_0-stable/crypto/opensslv.h
+        if version >= 0x3_00_00_00_0 {
+            println!("cargo:rustc-cfg=ossl3");
+        } else {
+            println!("cargo:rustc-cfg=ossl1");
+        }
+    } else {
+        panic!(
+            "
+
+The DEP_OPENSSL_VERSION_NUMBER environment variable is not found.
+Please make sure \"openssl-sys\" is in fips's dependencies.
+
+"
+        )
+    }
+}

--- a/components/fips/src/lib.rs
+++ b/components/fips/src/lib.rs
@@ -1,0 +1,44 @@
+// Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static FIPS_VERSION: AtomicUsize = AtomicUsize::new(0);
+
+/// Enable OpenSSL FIPS mode if `can_enable` returns true.
+/// It should be called at the very start of a program.
+pub fn maybe_enable() {
+    if !can_enable() {
+        return;
+    }
+    #[cfg(ossl1)]
+    {
+        openssl::fips::enable(true).unwrap();
+        FIPS_VERSION.store(1, Ordering::SeqCst);
+        return;
+    }
+    #[cfg(ossl3)]
+    {
+        std::mem::forget(openssl::provider::Provider::load(None, "fips").unwrap());
+        FIPS_VERSION.store(3, Ordering::SeqCst);
+        return;
+    }
+    #[allow(unreachable_code)]
+    {
+        slog_global::warn!("OpenSSL FIPS mode is disabled unexpectedly");
+    }
+}
+
+/// Return true if it is built for FIPS mode.
+pub fn can_enable() -> bool {
+    !cfg!(disable_fips)
+}
+
+/// Prints OpenSSL FIPS mode status.
+pub fn log_status() {
+    let ver = FIPS_VERSION.load(Ordering::SeqCst);
+    if ver == 0 {
+        slog_global::info!("OpenSSL FIPS mode is disabled");
+    } else {
+        slog_global::info!("OpenSSL FIPS mode is enabled"; "openssl_major_version" => ver);
+    }
+}

--- a/components/raftstore/Cargo.toml
+++ b/components/raftstore/Cargo.toml
@@ -59,7 +59,7 @@ log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug
 log_wrappers = { workspace = true }
 memory_trace_macros = { workspace = true }
 online_config = { workspace = true }
-openssl = "0.10"
+openssl = { workspace = true }
 ordered-float = "2.6"
 parking_lot = "0.12"
 pd_client = { workspace = true }

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -198,15 +198,6 @@ pub fn run_tikv(
     service_event_tx: TikvMpsc::Sender<ServiceEvent>,
     service_event_rx: TikvMpsc::Receiver<ServiceEvent>,
 ) {
-    // Sets the global logger ASAP.
-    // It is okay to use the config w/o `validate()`,
-    // because `initial_logger()` handles various conditions.
-    initial_logger(&config);
-
-    // Print version information.
-    let build_timestamp = option_env!("TIKV_BUILD_TIME");
-    tikv::log_tikv_info(build_timestamp);
-
     // Print resource quota.
     SysQuota::log_quota();
     CPU_CORES_QUOTA_GAUGE.set(SysQuota::cpu_cores_quota());

--- a/components/server/src/server2.rs
+++ b/components/server/src/server2.rs
@@ -194,15 +194,6 @@ pub fn run_tikv(
     service_event_tx: TikvMpsc::Sender<ServiceEvent>,
     service_event_rx: TikvMpsc::Receiver<ServiceEvent>,
 ) {
-    // Sets the global logger ASAP.
-    // It is okay to use the config w/o `validate()`,
-    // because `initial_logger()` handles various conditions.
-    initial_logger(&config);
-
-    // Print version information.
-    let build_timestamp = option_env!("TIKV_BUILD_TIME");
-    tikv::log_tikv_info(build_timestamp);
-
     // Print resource quota.
     SysQuota::log_quota();
     CPU_CORES_QUOTA_GAUGE.set(SysQuota::cpu_cores_quota());

--- a/components/server/src/setup.rs
+++ b/components/server/src/setup.rs
@@ -74,7 +74,6 @@ fn make_engine_log_path(path: &str, sub_path: &str, filename: &str) -> String {
     })
 }
 
-#[allow(dead_code)]
 pub fn initial_logger(config: &TikvConfig) {
     fail::fail_point!("mock_force_uninitial_logger", |_| {
         LOG_INITIALIZED.store(false, Ordering::SeqCst);

--- a/components/sst_importer/Cargo.toml
+++ b/components/sst_importer/Cargo.toml
@@ -39,7 +39,7 @@ kvproto = { workspace = true }
 lazy_static = "1.3"
 log_wrappers = { workspace = true }
 online_config = { workspace = true }
-openssl = "0.10"
+openssl = { workspace = true }
 prometheus = { version = "0.13", default-features = false }
 protobuf = { version = "2.8", features = ["bytes"] }
 rand = "0.8"

--- a/components/tidb_query_expr/Cargo.toml
+++ b/components/tidb_query_expr/Cargo.toml
@@ -17,7 +17,7 @@ log_wrappers = { workspace = true }
 match-template = "0.0.1"
 num = { version = "0.3", default-features = false }
 num-traits = "0.2"
-openssl = { version = "0.10" }
+openssl = { workspace = true }
 protobuf = "2"
 rand = "0.8.3"
 regex = "1.1"

--- a/components/tikv_util/Cargo.toml
+++ b/components/tikv_util/Cargo.toml
@@ -37,7 +37,7 @@ nix = "0.24"
 num-traits = "0.2"
 num_cpus = "1"
 online_config = { workspace = true }
-openssl = "0.10"
+openssl = { workspace = true }
 parking_lot_core = "0.9.1"
 pin-project = "1.0"
 prometheus = { version = "0.13", features = ["nightly"] }

--- a/scripts/check-bins.py
+++ b/scripts/check-bins.py
@@ -14,7 +14,7 @@ WHITE_LIST = {
     "online_config", "online_config_derive", "tidb_query_codegen",
     "panic_hook", "fuzz", "fuzzer_afl", "fuzzer_honggfuzz", "fuzzer_libfuzzer",
     "coprocessor_plugin_api", "example_coprocessor_plugin", "memory_trace_macros", "case_macros",
-    "tracker", "test_raftstore_macro"
+    "tracker", "test_raftstore_macro", "fips"
 }
 
 JEMALLOC_SYMBOL = ["je_arena_boot", " malloc"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ pub fn tikv_version_info(build_time: Option<&str>) -> String {
 
 /// return the build version of tikv-server
 pub fn tikv_build_version() -> String {
-    if option_env!("ENABLE_FIPS").map_or(false, |v| v == "1") {
+    if fips::can_enable() {
         format!("{}-{}", env!("CARGO_PKG_VERSION"), "fips")
     } else {
         env!("CARGO_PKG_VERSION").to_owned()


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #15982

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
In this commit, a new crate, "fips", is introduced. This crate includes
utilities designed to enable OpenSSL FIPS mode, catering to various OpenSSL
releases. This commit ensures that TiKV starts with OpenSSL FIPS mode
enabled if it is built with an environment variable "ENABLE_FIPS=1".
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test

```sh
# Test link with openssl 1.1.1
ENABLE_FIPS=1 make docker

# Test link with openssl 3.0.7
cd tikv
docker run --name rock9 -v $(pwd):/tikv -v ~/.cargo:/root/.cargo -v ~/.rustup/:/root/.rustup -d rockylinux:9 bash -c "tail -f -"
dnf install -y openssl-devel gcc gcc-c++ make cmake perl git
ENABLE_FIPS=1 make build
```

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
