### PR TITLE
raftstore: make full compaction incremental, pause when load is high

### DIFF
--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -1625,7 +1625,7 @@ impl<EK: KvEngine, ER: RaftEngine> RaftBatchSystem<EK, ER> {
         } else {
             None
         };
-
+        let bgworker_remote = background_worker.remote();
         let workers = Workers {
             pd_worker,
             background_worker,
@@ -1663,7 +1663,7 @@ impl<EK: KvEngine, ER: RaftEngine> RaftBatchSystem<EK, ER> {
             ReadRunner::new(self.router.clone(), engines.raft.clone()),
         );
 
-        let compact_runner = CompactRunner::new(engines.kv.clone());
+        let compact_runner = CompactRunner::new(engines.kv.clone(), bgworker_remote);
         let cleanup_sst_runner = CleanupSstRunner::new(Arc::clone(&importer));
         let gc_snapshot_runner = GcSnapshotRunner::new(
             meta.get_id(),

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -126,7 +126,7 @@ pub const MULTI_FILES_SNAPSHOT_FEATURE: Feature = Feature::require(6, 1, 0); // 
 const PERIODIC_FULL_COMPACT_TICK_INTERVAL_DURATION: Duration = Duration::from_secs(30 * 60);
 // If periodic full compaction is enabled (`periodic_full_compact_start_times`
 // is set), sample load metrics every 30 seconds.
-const LOAD_METRICS_WINDOW_DURATION: Duration = Duration::from_secs(30);
+const LOAD_STATS_WINDOW_DURATION: Duration = Duration::from_secs(30);
 
 pub struct StoreInfo<EK, ER> {
     pub kv_engine: EK,
@@ -2464,7 +2464,7 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
         // enabled.
         if !self.ctx.cfg.periodic_full_compact_start_times.is_empty() {
             self.ctx
-                .schedule_store_tick(StoreTick::LoadMetricsWindow, LOAD_METRICS_WINDOW_DURATION)
+                .schedule_store_tick(StoreTick::LoadMetricsWindow, LOAD_STATS_WINDOW_DURATION)
         }
     }
 

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -2515,7 +2515,7 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
         let ranges = self.ranges_for_full_compact();
 
         let compact_load_controller =
-            FullCompactController::new(1, 15 * 60, Some(Box::new(compact_predicate_fn)));
+            FullCompactController::new(1, 15 * 60, Box::new(compact_predicate_fn));
 
         // Attempt executing a periodic full compaction.
         // Note that full compaction will not run if another full compact tasks has

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -2537,10 +2537,9 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
     /// Use ranges assigned to each region as increments for full compaction.
     fn ranges_for_full_compact(&self) -> Vec<(Vec<u8>, Vec<u8>)> {
         let meta = self.ctx.store_meta.lock().unwrap();
-        let mut ranges = Vec::with_capacity(meta.region_ranges.len());
+        let mut ranges = Vec::with_capacity(meta.regions.len());
 
-        for region_id in meta.region_ranges.values() {
-            let region = &meta.regions[region_id];
+        for region in meta.regions.values() {
             let start_key = keys::enc_start_key(region);
             let end_key = keys::enc_end_key(region);
             ranges.push((start_key, end_key))

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -125,8 +125,8 @@ pub const MULTI_FILES_SNAPSHOT_FEATURE: Feature = Feature::require(6, 1, 0); // 
 // setting `periodic_full_compact_start_times` to be changed dynamically.
 const PERIODIC_FULL_COMPACT_TICK_INTERVAL_DURATION: Duration = Duration::from_secs(30 * 60);
 // If periodic full compaction is enabled (`periodic_full_compact_start_times`
-// is set), sample load metrics every 30 seconds.
-const LOAD_STATS_WINDOW_DURATION: Duration = Duration::from_secs(30);
+// is set), sample load metrics every 10 minutes.
+const LOAD_STATS_WINDOW_DURATION: Duration = Duration::from_secs(10 * 60);
 
 pub struct StoreInfo<EK, ER> {
     pub kv_engine: EK,

--- a/components/raftstore/src/store/metrics.rs
+++ b/components/raftstore/src/store/metrics.rs
@@ -215,6 +215,7 @@ make_static_metric! {
     pub label_enum RaftEventDurationType {
         compact_check,
         periodic_full_compact,
+        load_metrics_window,
         pd_store_heartbeat,
         snap_gc,
         compact_lock_cf,

--- a/components/raftstore/src/store/mod.rs
+++ b/components/raftstore/src/store/mod.rs
@@ -86,9 +86,9 @@ pub use self::{
     worker::{
         metrics as worker_metrics, need_compact, AutoSplitController, BatchComponent, Bucket,
         BucketRange, BucketStatsInfo, CachedReadDelegate, CheckLeaderRunner, CheckLeaderTask,
-        CompactThreshold, FlowStatistics, FlowStatsReporter, KeyEntry, LocalReadContext,
-        LocalReader, LocalReaderCore, PdStatsMonitor, PdTask, ReadDelegate, ReadExecutor,
-        ReadExecutorProvider, ReadProgress, ReadStats, RefreshConfigTask, RegionTask,
+        CompactThreshold, FlowStatistics, FlowStatsReporter, FullCompactController, KeyEntry,
+        LocalReadContext, LocalReader, LocalReaderCore, PdStatsMonitor, PdTask, ReadDelegate,
+        ReadExecutor, ReadExecutorProvider, ReadProgress, ReadStats, RefreshConfigTask, RegionTask,
         SplitCheckRunner, SplitCheckTask, SplitConfig, SplitConfigManager, SplitInfo,
         StoreMetaDelegate, StoreStatsReporter, TrackVer, WriteStats, WriterContoller,
         BIG_REGION_CPU_OVERLOAD_THRESHOLD_RATIO, DEFAULT_BIG_REGION_BYTE_THRESHOLD,

--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -436,6 +436,7 @@ impl PeerTick {
 pub enum StoreTick {
     CompactCheck,
     PeriodicFullCompact,
+    LoadMetricsWindow,
     PdStoreHeartbeat,
     SnapGc,
     CompactLockCf,
@@ -454,6 +455,7 @@ impl StoreTick {
             StoreTick::CompactLockCf => RaftEventDurationType::compact_lock_cf,
             StoreTick::ConsistencyCheck => RaftEventDurationType::consistency_check,
             StoreTick::CleanupImportSst => RaftEventDurationType::cleanup_import_sst,
+            StoreTick::LoadMetricsWindow => RaftEventDurationType::load_metrics_window,
         }
     }
 }

--- a/components/raftstore/src/store/worker/compact.rs
+++ b/components/raftstore/src/store/worker/compact.rs
@@ -155,7 +155,7 @@ impl Display for Task {
                             .map(|k| log_wrappers::Value::key(k.1.as_slice())),
                     ),
                 )
-                .field("coompact_load_controller", compact_load_controller)
+                .field("compact_load_controller", compact_load_controller)
                 .finish(),
             Task::Compact {
                 ref cf_name,
@@ -343,6 +343,9 @@ where
                 ranges,
                 compact_load_controller,
             } => {
+                // Since periodic full compaction is submitted as a task to the background
+                // worker pool, verify we will not start full compaction if
+                // another full compaction is running in the background.
                 if FULL_COMPACTION_IN_PROCESS.load(Ordering::SeqCst)
                     || FULL_COMPACTION_IN_PROCESS.swap(true, Ordering::SeqCst)
                 {

--- a/components/raftstore/src/store/worker/compact.rs
+++ b/components/raftstore/src/store/worker/compact.rs
@@ -262,9 +262,10 @@ where
                 "finished incremental range full compaction";
                 "remaining" => ranges.len(),
             );
-            // If `predicate_fn` is set and we have more ranges remaining, evaluate
-            // `predicate_fn`. If `true`, proceed to next range; otherwise, pause this task
-            // (see `FullCompactController::pause` for details) until `predicate_fn`
+            // If there is at least one range remaining in `ranges` remaining, evaluate
+            // `compact_controller.incremental_compaction_pred`. If `true`, proceed to next
+            // range; otherwise, pause this task
+            // (see `FullCompactController::pause` for details) until predicate
             // evaluates to true.
             if let Some(next_range) = ranges.front() {
                 if !(compact_controller.incremental_compaction_pred)() {

--- a/components/raftstore/src/store/worker/compact.rs
+++ b/components/raftstore/src/store/worker/compact.rs
@@ -269,7 +269,7 @@ where
             // evaluates to true.
             if let Some(next_range) = ranges.front() {
                 if !(compact_controller.incremental_compaction_pred)() {
-                    warn!("pausing full compaction before next increment";
+                    info!("pausing full compaction before next increment";
                     "finished_start_key" => ?range.0.map(log_wrappers::Value::key),
                     "finished_end_key" => ?range.1.map(log_wrappers::Value::key),
                     "next_range_start_key" => ?next_range.0.map(log_wrappers::Value::key),

--- a/components/raftstore/src/store/worker/metrics.rs
+++ b/components/raftstore/src/store/worker/metrics.rs
@@ -165,6 +165,16 @@ lazy_static! {
         "Bucketed histogram of full compaction for the storage."
     )
     .unwrap();
+    pub static ref FULL_COMPACT_INCREMENTAL: Histogram = register_histogram!(
+        "tikv_storage_full_compact_increment_duration_seconds",
+        "Bucketed histogram of full compaction increments for the storage."
+    )
+    .unwrap();
+    pub static ref FULL_COMPACT_PAUSE: Histogram = register_histogram!(
+        "tikv_storage_full_compact_pause_duration_seconds",
+        "Bucketed histogram of full compaction pauses for the storage."
+    )
+    .unwrap();
     pub static ref REGION_HASH_HISTOGRAM: Histogram = register_histogram!(
         "tikv_raftstore_hash_duration_seconds",
         "Bucketed histogram of raftstore hash computation duration"

--- a/components/raftstore/src/store/worker/metrics.rs
+++ b/components/raftstore/src/store/worker/metrics.rs
@@ -175,6 +175,11 @@ lazy_static! {
         "Bucketed histogram of full compaction pauses for the storage."
     )
     .unwrap();
+    pub static ref PROCESS_STAT_CPU_USAGE: Gauge = register_gauge!(
+        "tikv_storage_process_stat_cpu_usage",
+        "CPU usage measured over a 30 second window",
+    )
+    .unwrap();
     pub static ref REGION_HASH_HISTOGRAM: Histogram = register_histogram!(
         "tikv_raftstore_hash_duration_seconds",
         "Bucketed histogram of raftstore hash computation duration"

--- a/components/raftstore/src/store/worker/mod.rs
+++ b/components/raftstore/src/store/worker/mod.rs
@@ -23,7 +23,10 @@ pub use self::{
     cleanup::{Runner as CleanupRunner, Task as CleanupTask},
     cleanup_snapshot::{Runner as GcSnapshotRunner, Task as GcSnapshotTask},
     cleanup_sst::{Runner as CleanupSstRunner, Task as CleanupSstTask},
-    compact::{need_compact, CompactThreshold, Runner as CompactRunner, Task as CompactTask},
+    compact::{
+        need_compact, CompactThreshold, FullCompactController, Runner as CompactRunner,
+        Task as CompactTask,
+    },
     consistency_check::{Runner as ConsistencyCheckRunner, Task as ConsistencyCheckTask},
     pd::{
         new_change_peer_v2_request, FlowStatistics, FlowStatsReporter, HeartbeatTask,

--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -19288,6 +19288,406 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 67
+          },
+          "hiddenSeries": false,
+          "id": 24763574239,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.11",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": false,
+              "expr": "histogram_quantile(0.95, sum(rate(tikv_storage_full_compact_duration_seconds_bucket[5m])) by (le))",
+              "instant": false,
+              "interval": "",
+              "legendFormat": "",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Full compaction duration seconds",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:86",
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:87",
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          },
+          "timeFrom": null,
+          "timeShift": null
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 75
+          },
+          "hiddenSeries": false,
+          "id": 24763574241,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.11",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": false,
+              "expr": "histogram_quantile(0.95, sum(rate(tikv_storage_full_compact_pause_duration_seconds_bucket[5m])) by (le))",
+              "instant": false,
+              "interval": "",
+              "legendFormat": "",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Full compaction pause duration ",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:86",
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:87",
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 75
+          },
+          "hiddenSeries": false,
+          "id": 24763574240,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.11",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": false,
+              "expr": "histogram_quantile(0.95, sum(rate(tikv_storage_full_compact_increment_duration_seconds_bucket[5m])) by (le))",
+              "instant": false,
+              "interval": "",
+              "legendFormat": "",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Full compaction per-increment duration ",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:86",
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:87",
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 67
+          },
+          "hiddenSeries": false,
+          "id": 24763574242,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.11",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": false,
+              "expr": "tikv_storage_process_stat_cpu_usage",
+              "instant": false,
+              "interval": "",
+              "legendFormat": "",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Process Stat Cpu Usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:86",
+              "format": "percentunit",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:87",
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
           "description": "The storage async write duration",
           "fieldConfig": {
             "defaults": {},


### PR DESCRIPTION
Issue Number: ref tikv/tikv#15271

```commit-message
Makes full compaction incremental, by range. Currently regions' ranges are used as increments.

Run a predicate ("load-check") function before starting full compaction and between each incremental
range.  If the function evaluates to false, pause with exponential backoff (up to a maximum duration)
until it evaluates to  true. 

If periodic full compaction is enabled, poll process CPU stats every 30 seconds to determine usage for the
"load-check"  function. If usage exceeds a certain threshold before full compaction starts, compaction will
 not be started, and if started, full compaction will be paused. This cpu usage is also exported as
``tikv_storage_process_stat_cpu_usage`` gauge metric.
```

### Testing
* Manual tests.
* Unit test in `compact.rs`


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Adds experimental support for periodic full compaction. Periodic full compaction ensures that SSTables are 
compactedat all levels, including the bottommost (L6.) This ensures compaction filters that purge deleted data
are able to run.  Since full compaction can impact live serving, periodic full compaction should only run during
times at which the load  is likely to low. As an additional precaution, periodic full compaction will not start (or if?
started, will be paused) if CPU usage exceeds a specified threshold.

Example tikv.toml configuration:
[raftstore]
periodic-full-compact-start-max-cpu = 0.33 
periodic-full-compact-start-times = ["03:00", "23:00"] 
```
