### PR TITLE
resolved_ts: use smaller timeout when do check_leader

### DIFF
--- a/components/backup-stream/src/subscription_manager.rs
+++ b/components/backup-stream/src/subscription_manager.rs
@@ -485,7 +485,7 @@ where
                             "take" => ?now.saturating_elapsed(), "timedout" => %timedout);
                     }
                     let regions = leader_checker
-                        .resolve(self.subs.current_regions(), min_ts)
+                        .resolve(self.subs.current_regions(), min_ts, None)
                         .await;
                     let cps = self.subs.resolve_with(min_ts, regions);
                     let min_region = cps.iter().min_by_key(|rs| rs.checkpoint);

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -1069,7 +1069,7 @@ impl<T: 'static + RaftStoreRouter<E>, E: KvEngine> Endpoint<T, E> {
             let regions =
                 if hibernate_regions_compatible && gate.can_enable(FEATURE_RESOLVED_TS_STORE) {
                     CDC_RESOLVED_TS_ADVANCE_METHOD.set(1);
-                    leader_resolver.resolve(regions, min_ts).await
+                    leader_resolver.resolve(regions, min_ts, None).await
                 } else {
                     CDC_RESOLVED_TS_ADVANCE_METHOD.set(0);
                     leader_resolver

--- a/components/resolved_ts/src/advance.rs
+++ b/components/resolved_ts/src/advance.rs
@@ -369,8 +369,9 @@ impl LeadershipResolver {
             .map_or(0, |req| req.regions[0].compute_size());
         let store_count = store_req_map.len();
         let mut check_leader_rpcs = Vec::with_capacity(store_req_map.len());
-        let timeout = timeout.unwrap_or(DEFAULT_CHECK_LEADER_TIMEOUT_DURATION)
-        .min(DEFAULT_CHECK_LEADER_TIMEOUT_DURATION);
+        let timeout = timeout
+            .unwrap_or(DEFAULT_CHECK_LEADER_TIMEOUT_DURATION)
+            .min(DEFAULT_CHECK_LEADER_TIMEOUT_DURATION);
 
         for (store_id, req) in store_req_map {
             if req.regions.is_empty() {

--- a/components/resolved_ts/src/advance.rs
+++ b/components/resolved_ts/src/advance.rs
@@ -129,7 +129,9 @@ impl AdvanceTsWorker {
                 }
             }
 
-            let regions = leader_resolver.resolve(regions, min_ts, None).await;
+            let regions = leader_resolver
+                .resolve(regions, min_ts, Some(advance_ts_interval))
+                .await;
             if !regions.is_empty() {
                 if let Err(e) = scheduler.schedule(Task::ResolvedTsAdvanced {
                     regions,

--- a/components/resolved_ts/src/advance.rs
+++ b/components/resolved_ts/src/advance.rs
@@ -369,10 +369,9 @@ impl LeadershipResolver {
             .map_or(0, |req| req.regions[0].compute_size());
         let store_count = store_req_map.len();
         let mut check_leader_rpcs = Vec::with_capacity(store_req_map.len());
-        let timeout = match timeout {
-            Some(v) => cmp::min(DEFAULT_CHECK_LEADER_TIMEOUT_DURATION, v),
-            None => DEFAULT_CHECK_LEADER_TIMEOUT_DURATION,
-        };
+        let timeout = timeout.unwrap_or(DEFAULT_CHECK_LEADER_TIMEOUT_DURATION)
+        .min(DEFAULT_CHECK_LEADER_TIMEOUT_DURATION);
+
         for (store_id, req) in store_req_map {
             if req.regions.is_empty() {
                 continue;

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -943,19 +943,6 @@ impl<E: Engine, L: LockManager, F: KvFormat> Tikv for Service<E, L, F> {
         let (cb, resp) = paired_future_callback();
         let check_leader_scheduler = self.check_leader_scheduler.clone();
         let task = async move {
-            let delay = (|| -> u64 {
-                fail_point!("check_leader_slow", |x| {
-                    x.map_or(0, |s| s.parse::<u64>().unwrap_or(0))
-                });
-                0
-            })();
-            if delay > 0 {
-                let dur = std::time::Duration::from_millis(delay);
-                let _ = tikv_util::timer::SteadyTimer::default()
-                    .delay(dur)
-                    .compat()
-                    .await;
-            }
             check_leader_scheduler
                 .schedule(CheckLeaderTask::CheckLeader { leaders, cb })
                 .map_err(|e| Error::Other(format!("{}", e).into()))?;


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #15999

What's Changed:
- use smaller timeout when do check_leader, to to reduce the impact of a single TiKV slowing down on the advance resolve_ts of other TiKVs

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

**Before**

![image](https://github.com/tikv/tikv/assets/26020263/c3750655-ef23-45bf-924c-4dbfc1b787d4)

![image](https://github.com/tikv/tikv/assets/26020263/0e7c8509-5862-40c7-9c9f-3bdafd71e4f2)


**This PR**

![image](https://github.com/tikv/tikv/assets/26020263/1d731217-a3df-4566-9e5c-4f1e364c19c0)

![image](https://github.com/tikv/tikv/assets/26020263/7214944c-c248-4201-9ab9-d156774d2f74)


Side effects

- N/A

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None.
```
