### PR TITLE
resource_control: do not force set override priority at handle gRPC request

### DIFF
--- a/components/resource_control/src/resource_group.rs
+++ b/components/resource_control/src/resource_group.rs
@@ -1433,4 +1433,20 @@ pub(crate) mod tests {
             &mgr.priority_limiters[1]
         ));
     }
+
+    #[test]
+    fn test_task_priority() {
+        use TaskPriority::*;
+        let cases = [
+            (0, Medium),
+            (1, Low),
+            (7, Medium),
+            (8, Medium),
+            (15, High),
+            (16, High),
+        ];
+        for (value, priority) in cases {
+            assert_eq!(TaskPriority::from(value), priority);
+        }
+    }
 }

--- a/components/resource_control/src/resource_group.rs
+++ b/components/resource_control/src/resource_group.rs
@@ -77,7 +77,10 @@ impl TaskPriority {
 impl From<u32> for TaskPriority {
     fn from(value: u32) -> Self {
         // map the resource group priority value (1,8,16) to (Low,Medium,High)
-        if value < 6 {
+        // 0 means the priority is not set, so map it to medium by default.
+        if value == 0 {
+            Self::Medium
+        } else if value < 6 {
             Self::Low
         } else if value < 11 {
             Self::Medium

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -192,14 +192,14 @@ macro_rules! handle_request {
         handle_request!($fn_name, $future_name, $req_ty, $resp_ty, no_time_detail);
     };
     ($fn_name: ident, $future_name: ident, $req_ty: ident, $resp_ty: ident, $time_detail: tt) => {
-        fn $fn_name(&mut self, ctx: RpcContext<'_>, mut req: $req_ty, sink: UnarySink<$resp_ty>) {
+        fn $fn_name(&mut self, ctx: RpcContext<'_>, req: $req_ty, sink: UnarySink<$resp_ty>) {
             forward_unary!(self.proxy, $fn_name, ctx, req, sink);
             let begin_instant = Instant::now();
 
             let source = req.get_context().get_request_source().to_owned();
-            let resource_control_ctx = req.mut_context().mut_resource_control_context();
+            let resource_control_ctx = req.get_context().get_resource_control_context();
             if let Some(resource_manager) = &self.resource_manager {
-                consume_penalty_and_set_priority(resource_manager, resource_control_ctx);
+                resource_manager.consume_penalty(resource_control_ctx);
             }
             GRPC_RESOURCE_GROUP_COUNTER_VEC
                     .with_label_values(&[resource_control_ctx.get_resource_group_name()])
@@ -226,20 +226,6 @@ macro_rules! handle_request {
 
             ctx.spawn(task);
         }
-    }
-}
-
-// consume resource group penalty and set explicit group priority
-// We override the override_priority here to make handling tasks easier.
-fn consume_penalty_and_set_priority(
-    resource_manager: &Arc<ResourceGroupManager>,
-    resource_control_ctx: &mut ResourceControlContext,
-) {
-    resource_manager.consume_penalty(resource_control_ctx);
-    if resource_control_ctx.get_override_priority() == 0 {
-        let prioirty = resource_manager
-            .get_resource_group_priority(resource_control_ctx.get_resource_group_name());
-        resource_control_ctx.override_priority = prioirty as u64;
     }
 }
 
@@ -490,12 +476,12 @@ impl<E: Engine, L: LockManager, F: KvFormat> Tikv for Service<E, L, F> {
         ctx.spawn(task);
     }
 
-    fn coprocessor(&mut self, ctx: RpcContext<'_>, mut req: Request, sink: UnarySink<Response>) {
+    fn coprocessor(&mut self, ctx: RpcContext<'_>, req: Request, sink: UnarySink<Response>) {
         forward_unary!(self.proxy, coprocessor, ctx, req, sink);
         let source = req.get_context().get_request_source().to_owned();
-        let resource_control_ctx = req.mut_context().mut_resource_control_context();
+        let resource_control_ctx = req.get_context().get_resource_control_context();
         if let Some(resource_manager) = &self.resource_manager {
-            consume_penalty_and_set_priority(resource_manager, resource_control_ctx);
+            resource_manager.consume_penalty(resource_control_ctx);
         }
         GRPC_RESOURCE_GROUP_COUNTER_VEC
             .with_label_values(&[resource_control_ctx.get_resource_group_name()])
@@ -527,13 +513,13 @@ impl<E: Engine, L: LockManager, F: KvFormat> Tikv for Service<E, L, F> {
     fn raw_coprocessor(
         &mut self,
         ctx: RpcContext<'_>,
-        mut req: RawCoprocessorRequest,
+        req: RawCoprocessorRequest,
         sink: UnarySink<RawCoprocessorResponse>,
     ) {
         let source = req.get_context().get_request_source().to_owned();
-        let resource_control_ctx = req.mut_context().mut_resource_control_context();
+        let resource_control_ctx = req.get_context().get_resource_control_context();
         if let Some(resource_manager) = &self.resource_manager {
-            consume_penalty_and_set_priority(resource_manager, resource_control_ctx);
+            resource_manager.consume_penalty(resource_control_ctx);
         }
         GRPC_RESOURCE_GROUP_COUNTER_VEC
             .with_label_values(&[resource_control_ctx.get_resource_group_name()])
@@ -616,13 +602,13 @@ impl<E: Engine, L: LockManager, F: KvFormat> Tikv for Service<E, L, F> {
     fn coprocessor_stream(
         &mut self,
         ctx: RpcContext<'_>,
-        mut req: Request,
+        req: Request,
         mut sink: ServerStreamingSink<Response>,
     ) {
         let begin_instant = Instant::now();
-        let resource_control_ctx = req.mut_context().mut_resource_control_context();
+        let resource_control_ctx = req.get_context().get_resource_control_context();
         if let Some(resource_manager) = &self.resource_manager {
-            consume_penalty_and_set_priority(resource_manager, resource_control_ctx);
+            resource_manager.consume_penalty(resource_control_ctx);
         }
         GRPC_RESOURCE_GROUP_COUNTER_VEC
             .with_label_values(&[resource_control_ctx.get_resource_group_name()])
@@ -1162,10 +1148,10 @@ fn handle_batch_commands_request<E: Engine, L: LockManager, F: KvFormat>(
                     let resp = future::ok(batch_commands_response::Response::default());
                     response_batch_commands_request(id, resp, tx.clone(), begin_instant, GrpcTypeKind::invalid, String::default());
                 },
-                Some(batch_commands_request::request::Cmd::Get(mut req)) => {
-                    let resource_control_ctx = req.mut_context().mut_resource_control_context();
+                Some(batch_commands_request::request::Cmd::Get(req)) => {
+                    let resource_control_ctx = req.get_context().get_resource_control_context();
                     if let Some(resource_manager) = resource_manager {
-                        consume_penalty_and_set_priority(resource_manager, resource_control_ctx);
+                        resource_manager.consume_penalty(resource_control_ctx);
                     }
                     GRPC_RESOURCE_GROUP_COUNTER_VEC
                         .with_label_values(&[resource_control_ctx.get_resource_group_name()])
@@ -1183,10 +1169,10 @@ fn handle_batch_commands_request<E: Engine, L: LockManager, F: KvFormat>(
                         response_batch_commands_request(id, resp, tx.clone(), begin_instant, GrpcTypeKind::kv_get, source);
                     }
                 },
-                Some(batch_commands_request::request::Cmd::RawGet(mut req)) => {
-                    let resource_control_ctx = req.mut_context().mut_resource_control_context();
+                Some(batch_commands_request::request::Cmd::RawGet(req)) => {
+                    let resource_control_ctx = req.get_context().get_resource_control_context();
                     if let Some(resource_manager) = resource_manager {
-                        consume_penalty_and_set_priority(resource_manager, resource_control_ctx);
+                        resource_manager.consume_penalty(resource_control_ctx);
                     }
                     GRPC_RESOURCE_GROUP_COUNTER_VEC
                     .with_label_values(&[resource_control_ctx.get_resource_group_name()])
@@ -1204,10 +1190,10 @@ fn handle_batch_commands_request<E: Engine, L: LockManager, F: KvFormat>(
                         response_batch_commands_request(id, resp, tx.clone(), begin_instant, GrpcTypeKind::raw_get, source);
                     }
                 },
-                Some(batch_commands_request::request::Cmd::Coprocessor(mut req)) => {
-                    let resource_control_ctx = req.mut_context().mut_resource_control_context();
+                Some(batch_commands_request::request::Cmd::Coprocessor(req)) => {
+                    let resource_control_ctx = req.get_context().get_resource_control_context();
                     if let Some(resource_manager) = resource_manager {
-                        consume_penalty_and_set_priority(resource_manager, resource_control_ctx);
+                        resource_manager.consume_penalty(resource_control_ctx);
                     }
                     GRPC_RESOURCE_GROUP_COUNTER_VEC
                         .with_label_values(&[resource_control_ctx.get_resource_group_name()])
@@ -1238,10 +1224,10 @@ fn handle_batch_commands_request<E: Engine, L: LockManager, F: KvFormat>(
                         String::default(),
                     );
                 }
-                $(Some(batch_commands_request::request::Cmd::$cmd(mut req)) => {
-                    let resource_control_ctx = req.mut_context().mut_resource_control_context();
+                $(Some(batch_commands_request::request::Cmd::$cmd(req)) => {
+                    let resource_control_ctx = req.get_context().get_resource_control_context();
                     if let Some(resource_manager) = resource_manager {
-                        consume_penalty_and_set_priority(resource_manager, resource_control_ctx);
+                        resource_manager.consume_penalty(resource_control_ctx);
                     }
                     GRPC_RESOURCE_GROUP_COUNTER_VEC
                         .with_label_values(&[resource_control_ctx.get_resource_group_name()])


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #15994

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```
Revert get and set resource_control_context.override_priority at handle gRPC request to avoid performance regression. We move this logic to client-go side so the overall logic keeps the same.
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


Side effects


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
