### PR TITLE
Dockerfile: update base image

### DIFF
--- a/Dockerfile.FIPS
+++ b/Dockerfile.FIPS
@@ -1,21 +1,22 @@
 # This Docker image contains a minimal build environment for a FIPS compliant TiKV.
 
-FROM redhat/ubi8-minimal:8.6 as builder
+FROM rockylinux:9 as builder
 
-RUN microdnf install -y openssl-devel
+RUN dnf install -y openssl-devel
 
-RUN microdnf install -y \
+RUN dnf install -y \
       gcc \
       gcc-c++ \
-      libstdc++-static \
       make \
       cmake \
       perl \
       git \
       findutils \
       curl \
-      python3 && \
-    microdnf clean all
+      python3 --allowerasing && \
+    dnf --enablerepo=crb install -y \
+      libstdc++-static && \
+    dnf clean all
 
 # Install Rustup
 RUN curl https://sh.rustup.rs -sSf | sh -s -- --no-modify-path --default-toolchain none -y
@@ -32,11 +33,12 @@ ENV ENABLE_FIPS 1
 RUN make build_dist_release
 
 # Export to a clean image
-FROM redhat/ubi8-minimal:8.6
-COPY --from=builder /tikv/target/release/tikv-server /tikv-server
-COPY --from=builder /tikv/target/release/tikv-ctl /tikv-ctl
+FROM rockylinux:9-minimal
 
 RUN microdnf install -y openssl
+
+COPY --from=builder /tikv/target/release/tikv-server /tikv-server
+COPY --from=builder /tikv/target/release/tikv-ctl /tikv-ctl
 
 EXPOSE 20160 20180
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #16032

What's Changed:

Use rocklinux:9 as base image. Because it has fewer security issues than ubi 8.6.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
