### PR TITLE
update default value of region_compact_redundant_rows_percent

### DIFF
--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -440,7 +440,7 @@ impl Default for Config {
             region_compact_min_tombstones: 10000,
             region_compact_tombstones_percent: 30,
             region_compact_min_redundant_rows: 50000,
-            region_compact_redundant_rows_percent: None,
+            region_compact_redundant_rows_percent: Some(20),
             pd_heartbeat_tick_interval: ReadableDuration::minutes(1),
             pd_store_heartbeat_tick_interval: ReadableDuration::secs(10),
             // Disable periodic full compaction by default.
@@ -627,15 +627,6 @@ impl Config {
                 self.region_compact_check_step = Some(5);
             } else {
                 self.region_compact_check_step = Some(100);
-            }
-        }
-
-        if self.region_compact_redundant_rows_percent.is_none() {
-            if raft_kv_v2 {
-                self.region_compact_redundant_rows_percent = Some(20);
-            } else {
-                // Disable redundant rows check in default for v1.
-                self.region_compact_redundant_rows_percent = Some(100);
             }
         }
 

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -456,7 +456,7 @@
 ## It should be set between 1 and 100. Manual compaction is only triggered when the number of
 ## duplicated MVCC keys exceeds `region-compact-min-redundant-rows` and the percentage of duplicated MVCC keys
 ## exceeds `region-compact-redundant-rows-percent`.
-# region-compact-redundant-rows-percent = 100
+# region-compact-redundant-rows-percent = 20
 
 ## Interval to check whether to start a manual compaction for Lock Column Family.
 ## If written bytes reach `lock-cf-compact-bytes-threshold` for Lock Column Family, TiKV will

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -7058,7 +7058,7 @@ mod tests {
             cfg.raft_store
                 .region_compact_redundant_rows_percent
                 .unwrap(),
-            100
+            20
         );
 
         let content = r#"


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #15282

What's Changed:

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
Change the default value of raftstore.redundant-rows-percent-threshold to 20 from 100. 
This would triggers a compaction when a region has 20% entries as stale MVCC versions. 
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Set default value of raftstore.redundant-rows-percent-threshold to 20
```
