### PR TITLE
cdc: return server_is_busy to cdc clients if necessary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2715,7 +2715,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#87bebcc0d071a18cbbd94a4fc02de9c4988af815"
+source = "git+https://github.com/hicqu/kvproto?branch=cdc-server-is-busy#65f7789a4230aa9add2f14f1a6af0055eb6e2f1e"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2715,7 +2715,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/hicqu/kvproto?branch=cdc-server-is-busy#65f7789a4230aa9add2f14f1a6af0055eb6e2f1e"
+source = "git+https://github.com/pingcap/kvproto.git#96c40585233f176393213dbd4c04d76259bad8f9"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,8 +212,8 @@ procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "7693954bd1dd86e
 # When you modify TiKV cooperatively with kvproto, this will be useful to submit the PR to TiKV and the PR to
 # kvproto at the same time.
 # After the PR to kvproto is merged, remember to comment this out and run `cargo update -p kvproto`.
-[patch.'https://github.com/pingcap/kvproto']
-kvproto = { git = "https://github.com/hicqu/kvproto", branch = "cdc-server-is-busy" }
+# [patch.'https://github.com/pingcap/kvproto']
+# kvproto = { git = "https://github.com/your_github_id/kvproto", branch = "your_branch" }
 #
 # After the PR to rust-rocksdb is merged, remember to comment this out and run `cargo update -p rocksdb`.
 # [patch.'https://github.com/tikv/rust-rocksdb']

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,8 +212,8 @@ procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "7693954bd1dd86e
 # When you modify TiKV cooperatively with kvproto, this will be useful to submit the PR to TiKV and the PR to
 # kvproto at the same time.
 # After the PR to kvproto is merged, remember to comment this out and run `cargo update -p kvproto`.
-# [patch.'https://github.com/pingcap/kvproto']
-# kvproto = { git = "https://github.com/your_github_id/kvproto", branch = "your_branch" }
+[patch.'https://github.com/pingcap/kvproto']
+kvproto = { git = "https://github.com/hicqu/kvproto", branch = "cdc-server-is-busy" }
 #
 # After the PR to rust-rocksdb is merged, remember to comment this out and run `cargo update -p rocksdb`.
 # [patch.'https://github.com/tikv/rust-rocksdb']

--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -206,6 +206,12 @@ impl Downstream {
         self.sink_error_event(region_id, err_event)
     }
 
+    pub fn sink_server_is_busy(&self, region_id: u64) -> Result<()> {
+        let mut err_event = EventError::default();
+        err_event.mut_server_is_busy().reason = "too many pending incremental scans".to_owned();
+        self.sink_error_event(region_id, err_event)
+    }
+
     pub fn set_sink(&mut self, sink: Sink) {
         self.sink = Some(sink);
     }

--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -206,9 +206,9 @@ impl Downstream {
         self.sink_error_event(region_id, err_event)
     }
 
-    pub fn sink_server_is_busy(&self, region_id: u64) -> Result<()> {
+    pub fn sink_server_is_busy(&self, region_id: u64, reason: String) -> Result<()> {
         let mut err_event = EventError::default();
-        err_event.mut_server_is_busy().reason = "too many pending incremental scans".to_owned();
+        err_event.mut_server_is_busy().reason = reason;
         self.sink_error_event(region_id, err_event)
     }
 

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -2125,7 +2125,7 @@ mod tests {
             let event = e.event.take().unwrap();
             match event {
                 Event_oneof_event::Error(err) => {
-                    assert!(err.has_region_not_found());
+                    assert!(err.has_server_is_busy());
                 }
                 other => panic!("unknown event {:?}", other),
             }

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -742,7 +742,8 @@ impl<T: 'static + CdcHandle<E>, E: KvEngine, S: StoreRegionMeta> Endpoint<T, E, 
             );
             // To avoid OOM (e.g., https://github.com/tikv/tikv/issues/16035),
             // TiKV needs to reject and return error immediately.
-            let _ = downstream.sink_server_is_busy(region_id);
+            let _ = downstream
+                .sink_server_is_busy(region_id, "too many pending incremental scans".to_owned());
             return;
         }
 

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -742,10 +742,7 @@ impl<T: 'static + CdcHandle<E>, E: KvEngine, S: StoreRegionMeta> Endpoint<T, E, 
             );
             // To avoid OOM (e.g., https://github.com/tikv/tikv/issues/16035),
             // TiKV needs to reject and return error immediately.
-            //
-            // TODO: TiKV is supposed to return a "busy" error, but for the sake
-            // of compatibility, it returns a "region not found" error.
-            let _ = downstream.sink_region_not_found(region_id);
+            let _ = downstream.sink_server_is_busy(region_id);
             return;
         }
 


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Ref #16035 

What's Changed:

```commit-message
return server_is_busy to cdc clients if necessary
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
None
```
