### PR TITLE
collections: print key when hashmap index fails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1004,6 +1004,7 @@ name = "collections"
 version = "0.1.0"
 dependencies = [
  "fxhash",
+ "serde",
  "tikv_alloc",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,6 +480,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "chrono",
+ "collections",
  "concurrency_manager",
  "crossbeam",
  "crossbeam-channel",
@@ -1413,6 +1414,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "cloud",
+ "collections",
  "crc32fast",
  "crossbeam",
  "derive_more",
@@ -3389,6 +3391,7 @@ name = "online_config"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "collections",
  "online_config_derive",
  "serde",
  "serde_derive",
@@ -3399,6 +3402,7 @@ dependencies = [
 name = "online_config_derive"
 version = "0.1.0"
 dependencies = [
+ "collections",
  "proc-macro2",
  "quote",
  "syn 1.0.103",
@@ -6169,6 +6173,7 @@ dependencies = [
  "byteorder",
  "chrono",
  "codec",
+ "collections",
  "file_system",
  "flate2",
  "hex 0.4.2",

--- a/Makefile
+++ b/Makefile
@@ -363,6 +363,7 @@ clippy: pre-clippy
 	@./scripts/check-dashboards
 	@./scripts/check-docker-build
 	@./scripts/check-license
+	@./scripts/check-collections
 	@./scripts/clippy-all
 
 pre-audit:

--- a/components/backup-stream/Cargo.toml
+++ b/components/backup-stream/Cargo.toml
@@ -29,6 +29,7 @@ async-compression = { version = "0.3.14", features = ["tokio", "zstd"] }
 async-trait = { version = "0.1" }
 bytes = "1"
 chrono = "0.4"
+collections = { workspace = true }
 concurrency_manager = { workspace = true }
 crossbeam = "0.8"
 crossbeam-channel = "0.5"

--- a/components/backup-stream/src/checkpoint_manager.rs
+++ b/components/backup-stream/src/checkpoint_manager.rs
@@ -1,7 +1,8 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{cell::RefCell, collections::HashMap, sync::Arc, time::Duration};
+use std::{cell::RefCell, sync::Arc, time::Duration};
 
+use collections::HashMap;
 use futures::{
     channel::mpsc::{self as async_mpsc, Receiver, Sender},
     future::BoxFuture,
@@ -553,11 +554,11 @@ where
 pub mod tests {
     use std::{
         assert_matches,
-        collections::HashMap,
         sync::{Arc, Mutex, RwLock},
         time::Duration,
     };
 
+    use collections::HashMap;
     use futures::{future::ok, Sink};
     use grpcio::{RpcStatus, RpcStatusCode};
     use kvproto::{logbackuppb::SubscribeFlushEventResponse, metapb::*};

--- a/components/backup-stream/src/metadata/client.rs
+++ b/components/backup-stream/src/metadata/client.rs
@@ -1,7 +1,8 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{cmp::Ordering, collections::HashMap, fmt::Debug, path::Path, sync::Arc};
+use std::{cmp::Ordering, fmt::Debug, path::Path, sync::Arc};
 
+use collections::HashMap;
 use dashmap::DashMap;
 use kvproto::{
     brpb::{StreamBackupError, StreamBackupTaskInfo},

--- a/components/backup-stream/src/metadata/store/slash_etc.rs
+++ b/components/backup-stream/src/metadata/store/slash_etc.rs
@@ -1,13 +1,9 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{
-    cell::Cell,
-    collections::{BTreeMap, HashMap},
-    ops::Bound,
-    sync::Arc,
-};
+use std::{cell::Cell, collections::BTreeMap, ops::Bound, sync::Arc};
 
 use async_trait::async_trait;
+use collections::HashMap;
 use tokio::sync::{
     mpsc::{self, Sender},
     Mutex,

--- a/components/backup-stream/src/router.rs
+++ b/components/backup-stream/src/router.rs
@@ -2,7 +2,6 @@
 
 use std::{
     borrow::Borrow,
-    collections::HashMap,
     fmt::Display,
     path::{Path, PathBuf},
     result,
@@ -13,6 +12,7 @@ use std::{
     time::Duration,
 };
 
+use collections::HashMap;
 use engine_traits::{CfName, CF_DEFAULT, CF_LOCK, CF_WRITE};
 use external_storage::{create_storage, BackendConfig, ExternalStorage, UnpinReader};
 use futures::io::Cursor;

--- a/components/backup-stream/src/tempfiles.rs
+++ b/components/backup-stream/src/tempfiles.rs
@@ -3,7 +3,6 @@
 //! log backup.
 
 use std::{
-    collections::HashMap,
     convert::identity,
     fs::File as SyncOsFile,
     path::{Path, PathBuf},
@@ -15,6 +14,7 @@ use std::{
     task::{ready, Context, Poll},
 };
 
+use collections::HashMap;
 use futures::TryFutureExt;
 use kvproto::brpb::CompressionType;
 use tikv_util::warn;

--- a/components/backup-stream/src/utils.rs
+++ b/components/backup-stream/src/utils.rs
@@ -4,7 +4,7 @@ use core::pin::Pin;
 use std::{
     borrow::Borrow,
     cell::RefCell,
-    collections::{hash_map::RandomState, BTreeMap, HashMap},
+    collections::BTreeMap,
     ops::{Bound, RangeBounds},
     path::Path,
     sync::{
@@ -16,6 +16,7 @@ use std::{
 };
 
 use async_compression::{tokio::write::ZstdEncoder, Level};
+use collections::HashMap;
 use engine_rocks::ReadPerfInstant;
 use engine_traits::{CfName, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
 use futures::{ready, task::Poll, FutureExt};
@@ -99,7 +100,7 @@ pub type Slot<T> = Mutex<T>;
 
 /// SlotMap is a trivial concurrent map which sharding over each key.
 /// NOTE: Maybe we can use dashmap for replacing the RwLock.
-pub type SlotMap<K, V, S = RandomState> = RwLock<HashMap<K, Slot<V>, S>>;
+pub type SlotMap<K, V> = RwLock<HashMap<K, Slot<V>>>;
 
 /// Like `..=val`(a.k.a. `RangeToInclusive`), but allows `val` being a reference
 /// to DSTs.
@@ -768,7 +769,7 @@ impl<'a> slog::KV for SlogRegion<'a> {
 }
 
 /// A shortcut for making an opaque future type for return type or argument
-/// type, which is sendable and not borrowing any variables.  
+/// type, which is sendable and not borrowing any variables.
 ///
 /// `future![T]` == `impl Future<Output = T> + Send + 'static`
 #[macro_export]

--- a/components/backup-stream/tests/suite.rs
+++ b/components/backup-stream/tests/suite.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashSet,
     fmt::Display,
     path::{Path, PathBuf},
     sync::Arc,
@@ -21,6 +21,7 @@ use backup_stream::{
     utils, BackupStreamResolver, Endpoint, GetCheckpointResult, RegionCheckpointOperation,
     RegionSet, Service, Task,
 };
+use collections::HashMap;
 use futures::{executor::block_on, AsyncWriteExt, Future, Stream, StreamExt};
 use grpcio::{ChannelBuilder, Server, ServerBuilder};
 use kvproto::{

--- a/components/collections/Cargo.toml
+++ b/components/collections/Cargo.toml
@@ -6,4 +6,5 @@ publish = false
 
 [dependencies]
 fxhash = "0.2.1"
+serde = { version = "1.0" }
 tikv_alloc = { workspace = true }

--- a/components/collections/src/lib.rs
+++ b/components/collections/src/lib.rs
@@ -298,3 +298,18 @@ where
         Ok(HashMap { base })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_index_panic() {
+        let map: HashMap<String, usize> = HashMap::new();
+        let result = std::panic::catch_unwind(|| {
+            let _ = map["KeyNotFound;&="];
+        });
+        let panic_msg = result.unwrap_err().downcast::<String>().unwrap();
+        assert!(panic_msg.contains("KeyNotFound;&="), "{:?}", panic_msg);
+    }
+}

--- a/components/collections/src/lib.rs
+++ b/components/collections/src/lib.rs
@@ -181,6 +181,10 @@ where
 }
 
 impl<K, V> HashMap<K, V> {
+    pub fn new() -> HashMap<K, V> {
+        HashMap::default()
+    }
+
     pub fn is_empty(&self) -> bool {
         self.base.is_empty()
     }

--- a/components/collections/src/lib.rs
+++ b/components/collections/src/lib.rs
@@ -1,15 +1,296 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
+#![feature(hash_drain_filter)]
+
 #[allow(unused_extern_crates)]
 extern crate tikv_alloc;
 
-use std::{cmp::Eq, hash::Hash};
+use std::{
+    borrow::Borrow,
+    cmp::Eq,
+    collections,
+    fmt::{self, Debug},
+    hash::{self, Hash},
+    ops::Index,
+};
 
-pub type HashMap<K, V> =
-    std::collections::HashMap<K, V, std::hash::BuildHasherDefault<fxhash::FxHasher>>;
-pub type HashSet<T> = std::collections::HashSet<T, std::hash::BuildHasherDefault<fxhash::FxHasher>>;
-pub use std::collections::hash_map::Entry as HashMapEntry;
+type HashBuilder = hash::BuildHasherDefault<fxhash::FxHasher>;
+pub struct HashMap<K, V> {
+    base: collections::HashMap<K, V, HashBuilder>,
+}
+pub type HashSet<T> = collections::HashSet<T, HashBuilder>;
+pub use collections::hash_map::Entry as HashMapEntry;
 
 pub fn hash_set_with_capacity<T: Hash + Eq>(capacity: usize) -> HashSet<T> {
     HashSet::with_capacity_and_hasher(capacity, fxhash::FxBuildHasher::default())
+}
+
+impl<K, Q: ?Sized, V> Index<&Q> for HashMap<K, V>
+where
+    K: Eq + Hash + Borrow<Q>,
+    Q: Eq + Hash + Debug,
+{
+    type Output = V;
+
+    fn index(&self, key: &Q) -> &V {
+        self.base
+            .get(key)
+            .expect(&format!("no entry found for key: {:?}", key))
+    }
+}
+
+impl<K, V> Debug for HashMap<K, V>
+where
+    K: Debug,
+    V: Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.base.fmt(f)
+    }
+}
+
+impl<K, V> Clone for HashMap<K, V>
+where
+    K: Clone,
+    V: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            base: self.base.clone(),
+        }
+    }
+
+    fn clone_from(&mut self, other: &Self) {
+        self.base.clone_from(&other.base);
+    }
+}
+
+impl<K, V> PartialEq for HashMap<K, V>
+where
+    K: Eq + Hash,
+    V: PartialEq,
+{
+    fn eq(&self, other: &HashMap<K, V>) -> bool {
+        self.base.eq(&other.base)
+    }
+}
+
+impl<K, V> Default for HashMap<K, V> {
+    /// Creates an empty `HashMap<K, V>`, with the `Default` value for the
+    /// hasher.
+    fn default() -> HashMap<K, V> {
+        HashMap {
+            base: collections::HashMap::with_hasher(fxhash::FxBuildHasher::default()),
+        }
+    }
+}
+
+impl<K, V> HashMap<K, V>
+where
+    K: Eq + Hash,
+{
+    fn extend<T: IntoIterator<Item = (K, V)>>(&mut self, iter: T) {
+        self.base.extend(iter)
+    }
+
+    pub fn contains_key<Q: ?Sized>(&self, k: &Q) -> bool
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        self.base.contains_key(k)
+    }
+
+    pub fn get<Q: ?Sized>(&self, k: &Q) -> Option<&V>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        self.base.get(k)
+    }
+
+    pub fn get_mut<Q: ?Sized>(&mut self, k: &Q) -> Option<&mut V>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        self.base.get_mut(k)
+    }
+
+    pub fn remove<Q: ?Sized>(&mut self, k: &Q) -> Option<V>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        self.base.remove(k)
+    }
+
+    pub fn insert(&mut self, k: K, v: V) -> Option<V> {
+        self.base.insert(k, v)
+    }
+
+    pub fn retain<F>(&mut self, f: F)
+    where
+        F: FnMut(&K, &mut V) -> bool,
+    {
+        self.base.retain(f)
+    }
+
+    pub fn entry(&mut self, key: K) -> collections::hash_map::Entry<'_, K, V> {
+        self.base.entry(key)
+    }
+
+    pub fn get_key_value<Q: ?Sized>(&self, k: &Q) -> Option<(&K, &V)>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        self.base.get_key_value(k)
+    }
+
+    pub fn remove_entry<Q: ?Sized>(&mut self, k: &Q) -> Option<(K, V)>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        self.base.remove_entry(k)
+    }
+
+    pub fn iter(&self) -> collections::hash_map::Iter<'_, K, V> {
+        self.base.iter()
+    }
+
+    pub fn iter_mut(&mut self) -> collections::hash_map::IterMut<'_, K, V> {
+        self.base.iter_mut()
+    }
+
+    pub fn shrink_to_fit(&mut self) {
+        self.base.shrink_to_fit();
+    }
+
+    pub fn shrink_to(&mut self, min_capacity: usize) {
+        self.base.shrink_to(min_capacity);
+    }
+
+    pub fn drain_filter<F>(&mut self, pred: F) -> collections::hash_map::DrainFilter<'_, K, V, F>
+    where
+        F: FnMut(&K, &mut V) -> bool,
+    {
+        self.base.drain_filter(pred)
+    }
+}
+
+impl<K, V> HashMap<K, V> {
+    pub fn is_empty(&self) -> bool {
+        self.base.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.base.len()
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.base.capacity()
+    }
+
+    pub fn clear(&mut self) {
+        self.base.clear();
+    }
+
+    pub fn keys(&self) -> collections::hash_map::Keys<'_, K, V> {
+        self.base.keys()
+    }
+
+    pub fn into_keys(self) -> collections::hash_map::IntoKeys<K, V> {
+        self.base.into_keys()
+    }
+
+    pub fn values(&self) -> collections::hash_map::Values<'_, K, V> {
+        self.base.values()
+    }
+
+    pub fn values_mut(&mut self) -> collections::hash_map::ValuesMut<'_, K, V> {
+        self.base.values_mut()
+    }
+
+    pub fn into_values(self) -> collections::hash_map::IntoValues<K, V> {
+        self.base.into_values()
+    }
+
+    pub fn with_capacity(capacity: usize) -> HashMap<K, V> {
+        HashMap {
+            base: collections::HashMap::with_capacity_and_hasher(capacity, Default::default()),
+        }
+    }
+
+    pub fn drain(&mut self) -> collections::hash_map::Drain<'_, K, V> {
+        self.base.drain()
+    }
+}
+
+impl<'a, K, V> IntoIterator for &'a HashMap<K, V> {
+    type Item = (&'a K, &'a V);
+    type IntoIter = collections::hash_map::Iter<'a, K, V>;
+
+    fn into_iter(self) -> collections::hash_map::Iter<'a, K, V> {
+        self.base.iter()
+    }
+}
+
+impl<'a, K, V> IntoIterator for &'a mut HashMap<K, V> {
+    type Item = (&'a K, &'a mut V);
+    type IntoIter = collections::hash_map::IterMut<'a, K, V>;
+
+    fn into_iter(self) -> collections::hash_map::IterMut<'a, K, V> {
+        self.base.iter_mut()
+    }
+}
+
+impl<K, V> IntoIterator for HashMap<K, V> {
+    type Item = (K, V);
+    type IntoIter = collections::hash_map::IntoIter<K, V>;
+
+    fn into_iter(self) -> collections::hash_map::IntoIter<K, V> {
+        self.base.into_iter()
+    }
+}
+
+impl<K, V> FromIterator<(K, V)> for HashMap<K, V>
+where
+    K: Eq + Hash,
+{
+    fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> HashMap<K, V> {
+        let mut map = HashMap::default();
+        map.extend(iter);
+        map
+    }
+}
+
+impl<K, V> serde::Serialize for HashMap<K, V>
+where
+    K: serde::Serialize + Eq + Hash,
+    V: serde::Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.base.serialize(serializer)
+    }
+}
+
+impl<'de, K, V> serde::Deserialize<'de> for HashMap<K, V>
+where
+    K: serde::Deserialize<'de> + Eq + Hash,
+    V: serde::Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let base = <collections::HashMap<K, V, HashBuilder> as serde::Deserialize>::deserialize(
+            deserializer,
+        )?;
+        Ok(HashMap { base })
+    }
 }

--- a/components/collections/src/lib.rs
+++ b/components/collections/src/lib.rs
@@ -35,7 +35,7 @@ where
     fn index(&self, key: &Q) -> &V {
         self.base
             .get(key)
-            .expect(&format!("no entry found for key: {:?}", key))
+            .unwrap_or_else(|| panic!("no entry found for key: {:?}", key))
     }
 }
 

--- a/components/encryption/Cargo.toml
+++ b/components/encryption/Cargo.toml
@@ -15,6 +15,7 @@ async-trait = "0.1"
 byteorder = "1.2"
 bytes = "1.0"
 cloud = { workspace = true }
+collections = { workspace = true }
 crc32fast = "1.2"
 crossbeam = "0.8"
 derive_more = "0.99.3"

--- a/components/encryption/src/master_key/mod.rs
+++ b/components/encryption/src/master_key/mod.rs
@@ -70,8 +70,9 @@ impl Backend for PlaintextBackend {
 
 #[cfg(test)]
 pub mod tests {
-    use std::{collections::HashMap, sync::Mutex};
+    use std::sync::Mutex;
 
+    use collections::HashMap;
     use lazy_static::lazy_static;
 
     use super::{Backend, *};

--- a/components/online_config/Cargo.toml
+++ b/components/online_config/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [dependencies]
 chrono = "0.4"
+collections = { workspace = true }
 online_config_derive = { path = "./online_config_derive" }
 serde = { version = "1.0", features = ["derive"] }
 

--- a/components/online_config/online_config_derive/Cargo.toml
+++ b/components/online_config/online_config_derive/Cargo.toml
@@ -11,3 +11,4 @@ proc-macro = true
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "1", features = ["extra-traits", "full"] }
+collections = { workspace = true }

--- a/components/online_config/online_config_derive/src/lib.rs
+++ b/components/online_config/online_config_derive/src/lib.rs
@@ -240,7 +240,7 @@ fn diff(fields: &Punctuated<Field, Comma>, crate_name: &Ident) -> Result<TokenSt
     Ok(quote! {
         #[allow(clippy::float_cmp)]
         fn diff(&self, mut #incoming: &Self) -> #crate_name::ConfigChange {
-            let mut #diff_ident = std::collections::HashMap::default();
+            let mut #diff_ident = collections::HashMap::default();
             #(#diff_fields)*
             #diff_ident
         }
@@ -281,7 +281,7 @@ fn typed(fields: &Punctuated<Field, Comma>, crate_name: &Ident) -> Result<TokenS
     }
     Ok(quote! {
         fn typed(&self) -> #crate_name::ConfigChange {
-            let mut #typed_ident = std::collections::HashMap::default();
+            let mut #typed_ident = collections::HashMap::default();
             #(#typed_fields)*
             #typed_ident
         }

--- a/components/online_config/src/lib.rs
+++ b/components/online_config/src/lib.rs
@@ -1,11 +1,9 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{
-    collections::HashMap,
-    fmt::{self, Debug, Display, Formatter},
-};
+use std::fmt::{self, Debug, Display, Formatter};
 
 use chrono::{FixedOffset, NaiveTime};
+use collections::HashMap;
 pub use online_config_derive::*;
 
 pub type ConfigChange = HashMap<String, ConfigValue>;

--- a/components/pd_client/src/client_v2.rs
+++ b/components/pd_client/src/client_v2.rs
@@ -12,7 +12,6 @@
 //! connection subscribe changes instead of altering it themselves.
 
 use std::{
-    collections::HashMap,
     fmt::Debug,
     pin::Pin,
     sync::{
@@ -23,6 +22,7 @@ use std::{
     u64,
 };
 
+use collections::HashMap;
 use fail::fail_point;
 use futures::{
     compat::{Compat, Future01CompatExt},

--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -1,8 +1,9 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{cmp::min, collections::HashMap, sync::Arc, time::Duration, u64};
+use std::{cmp::min, sync::Arc, time::Duration, u64};
 
 use batch_system::Config as BatchSystemConfig;
+use collections::HashMap;
 use engine_traits::{perf_level_serde, PerfLevel};
 use lazy_static::lazy_static;
 use online_config::{ConfigChange, ConfigManager, ConfigValue, OnlineConfig};

--- a/components/raftstore/src/store/region_meta.rs
+++ b/components/raftstore/src/store/region_meta.rs
@@ -1,7 +1,6 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::collections::HashMap;
-
+use collections::HashMap;
 use kvproto::{
     metapb::{self, PeerRole},
     raft_serverpb,

--- a/components/raftstore/src/store/snap/io.rs
+++ b/components/raftstore/src/store/snap/io.rs
@@ -302,8 +302,9 @@ pub fn get_decrypter_reader(
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, path::PathBuf};
+    use std::path::PathBuf;
 
+    use collections::HashMap;
     use engine_test::kv::KvTestEngine;
     use engine_traits::CF_DEFAULT;
     use tempfile::Builder;

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -3,7 +3,7 @@
 // #[PerformanceCriticalPath]
 use std::{
     cmp,
-    collections::{HashMap, VecDeque},
+    collections::VecDeque,
     fmt,
     fmt::{Debug, Display},
     option::Option,
@@ -14,7 +14,7 @@ use std::{
     u64,
 };
 
-use collections::HashSet;
+use collections::{HashMap, HashSet};
 use engine_traits::KvEngine;
 use kvproto::{
     kvrpcpb::{self, KeyRange, LeaderInfo},

--- a/components/raftstore/src/store/worker/split_controller.rs
+++ b/components/raftstore/src/store/worker/split_controller.rs
@@ -2,12 +2,13 @@
 
 use std::{
     cmp::{min, Ordering},
-    collections::{BinaryHeap, HashMap, HashSet},
+    collections::{BinaryHeap, HashSet},
     slice::{Iter, IterMut},
     sync::{mpsc::Receiver, Arc},
     time::{Duration, SystemTime},
 };
 
+use collections::HashMap;
 use kvproto::{
     kvrpcpb::KeyRange,
     metapb::{self, Peer},

--- a/components/resolved_ts/src/endpoint.rs
+++ b/components/resolved_ts/src/endpoint.rs
@@ -2,13 +2,13 @@
 
 use std::{
     cmp::min,
-    collections::HashMap,
     fmt,
     marker::PhantomData,
     sync::{Arc, Mutex, MutexGuard},
     time::Duration,
 };
 
+use collections::HashMap;
 use concurrency_manager::ConcurrencyManager;
 use engine_traits::KvEngine;
 use futures::channel::oneshot::{channel, Receiver, Sender};

--- a/components/resolved_ts/tests/mod.rs
+++ b/components/resolved_ts/tests/mod.rs
@@ -115,7 +115,7 @@ impl TestSuite {
 
     pub fn must_change_advance_ts_interval(&self, store_id: u64, new_interval: Duration) {
         let change = {
-            let mut c = std::collections::HashMap::default();
+            let mut c = HashMap::default();
             c.insert(
                 "advance_ts_interval".to_owned(),
                 ConfigValue::Duration(new_interval.as_millis() as u64),
@@ -127,7 +127,7 @@ impl TestSuite {
 
     pub fn must_change_memory_quota(&self, store_id: u64, bytes: u64) {
         let change = {
-            let mut c = std::collections::HashMap::default();
+            let mut c = HashMap::default();
             c.insert("memory_quota".to_owned(), ConfigValue::Size(bytes));
             c
         };

--- a/components/resource_control/src/service.rs
+++ b/components/resource_control/src/service.rs
@@ -1,11 +1,8 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-    time::Duration,
-};
+use std::{collections::HashSet, sync::Arc, time::Duration};
 
+use collections::HashMap;
 use futures::{compat::Future01CompatExt, StreamExt};
 use kvproto::{
     pdpb::EventType,

--- a/components/resource_control/src/worker.rs
+++ b/components/resource_control/src/worker.rs
@@ -1,13 +1,8 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{
-    array,
-    collections::{HashMap, HashSet},
-    io::Result as IoResult,
-    sync::Arc,
-    time::Duration,
-};
+use std::{array, collections::HashSet, io::Result as IoResult, sync::Arc, time::Duration};
 
+use collections::HashMap;
 use file_system::{fetch_io_bytes, IoBytes, IoType};
 use prometheus::Histogram;
 use strum::EnumCount;
@@ -447,9 +442,9 @@ impl<R: ResourceStatsProvider> PriorityLimiterAdjustWorker<R> {
             limits[i - 1] = limit;
             expect_cpu_time_total -= level_expected[i];
         }
-        debug!("adjsut cpu limiter by priority"; "cpu_quota" => process_cpu_stats.total_quota, 
+        debug!("adjsut cpu limiter by priority"; "cpu_quota" => process_cpu_stats.total_quota,
             "process_cpu" => process_cpu_stats.current_used, "expected_cpu" => ?level_expected,
-            "cpu_costs" => ?cpu_duration, "limits" => ?limits, 
+            "cpu_costs" => ?cpu_duration, "limits" => ?limits,
             "limit_cpu_total" => expect_pool_cpu_total, "pool_cpu_cost" => real_cpu_total);
     }
 }

--- a/components/server/src/common.rs
+++ b/components/server/src/common.rs
@@ -2,9 +2,7 @@
 //! This mod is exported to make convenience for creating TiKV-like servers.
 
 use std::{
-    cmp,
-    collections::HashMap,
-    env, fmt,
+    cmp, env, fmt,
     net::SocketAddr,
     path::{Path, PathBuf},
     sync::{
@@ -15,6 +13,7 @@ use std::{
     u64,
 };
 
+use collections::HashMap;
 use encryption_export::{data_key_manager_from_config, DataKeyManager};
 use engine_rocks::{
     flush_engine_statistics,

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -13,7 +13,6 @@
 
 use std::{
     cmp,
-    collections::HashMap,
     convert::TryFrom,
     path::{Path, PathBuf},
     str::FromStr,
@@ -29,6 +28,7 @@ use backup_stream::{
 };
 use causal_ts::CausalTsProviderImpl;
 use cdc::CdcConfigManager;
+use collections::HashMap;
 use concurrency_manager::ConcurrencyManager;
 use engine_rocks::{from_rocks_compression_type, RocksEngine, RocksStatistics};
 use engine_rocks_helper::sst_recovery::{RecoveryRunner, DEFAULT_CHECK_INTERVAL};
@@ -1616,8 +1616,9 @@ fn pre_start() {
 
 #[cfg(test)]
 mod test {
-    use std::{collections::HashMap, sync::Arc};
+    use std::sync::Arc;
 
+    use collections::HashMap;
     use engine_rocks::raw::Env;
     use engine_traits::{
         FlowControlFactorsExt, MiscExt, SyncMutable, TabletContext, TabletRegistry, CF_DEFAULT,

--- a/components/server/src/server2.rs
+++ b/components/server/src/server2.rs
@@ -13,7 +13,6 @@
 
 use std::{
     cmp,
-    collections::HashMap,
     marker::PhantomData,
     path::{Path, PathBuf},
     str::FromStr,
@@ -33,6 +32,7 @@ use backup_stream::{
 };
 use causal_ts::CausalTsProviderImpl;
 use cdc::CdcConfigManager;
+use collections::HashMap;
 use concurrency_manager::ConcurrencyManager;
 use engine_rocks::{from_rocks_compression_type, RocksEngine, RocksStatistics};
 use engine_traits::{Engines, KvEngine, MiscExt, RaftEngine, TabletRegistry, CF_DEFAULT, CF_WRITE};
@@ -1566,8 +1566,9 @@ fn pre_start() {
 
 #[cfg(test)]
 mod test {
-    use std::{collections::HashMap, sync::Arc};
+    use std::sync::Arc;
 
+    use collections::HashMap;
     use engine_rocks::raw::Env;
     use engine_traits::{
         FlowControlFactorsExt, MiscExt, SyncMutable, TabletContext, TabletRegistry, CF_DEFAULT,

--- a/components/sst_importer/src/import_file.rs
+++ b/components/sst_importer/src/import_file.rs
@@ -1,7 +1,6 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::{
-    collections::HashMap,
     fmt,
     io::{self, Write},
     marker::PhantomData,
@@ -11,6 +10,7 @@ use std::{
 };
 
 use api_version::api_v2::TIDB_RANGES_COMPLEMENT;
+use collections::HashMap;
 use encryption::{DataKeyManager, EncrypterWriter};
 use engine_traits::{iter_option, Iterator, KvEngine, RefIterable, SstMetaInfo, SstReader};
 use file_system::{sync_dir, File, OpenOptions};

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -2,7 +2,6 @@
 
 use std::{
     borrow::Cow,
-    collections::HashMap,
     fs::File,
     io::{self, BufReader, ErrorKind, Read},
     ops::Bound,
@@ -14,7 +13,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use collections::HashSet;
+use collections::{HashMap, HashSet};
 use dashmap::{mapref::entry::Entry, DashMap};
 use encryption::{DataKeyManager, FileEncryptionInfo};
 use engine_traits::{

--- a/components/test_pd/src/mocker/etcd.rs
+++ b/components/test_pd/src/mocker/etcd.rs
@@ -1,12 +1,8 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{
-    cell::Cell,
-    collections::{BTreeMap, HashMap},
-    ops::Bound,
-    sync::Arc,
-};
+use std::{cell::Cell, collections::BTreeMap, ops::Bound, sync::Arc};
 
+use collections::HashMap;
 use futures::lock::Mutex;
 use tokio::sync::mpsc::{self, Sender};
 use tokio_stream::wrappers::ReceiverStream;

--- a/components/tidb_query_datatype/src/codec/table.rs
+++ b/components/tidb_query_datatype/src/codec/table.rs
@@ -325,7 +325,7 @@ pub fn decode_row(
     if values.len() & 1 == 1 {
         return Err(box_err!("decoded row values' length should be even!"));
     }
-    let mut row = HashMap::with_capacity_and_hasher(cols.len(), Default::default());
+    let mut row = HashMap::with_capacity(cols.len());
     let mut drain = values.drain(..);
     loop {
         let id = match drain.next() {
@@ -439,7 +439,7 @@ pub fn cut_row(
 /// Cuts a non-empty row in row format v1.
 fn cut_row_v1(data: Vec<u8>, cols: &HashSet<i64>) -> Result<RowColsDict> {
     let meta_map = {
-        let mut meta_map = HashMap::with_capacity_and_hasher(cols.len(), Default::default());
+        let mut meta_map = HashMap::with_capacity(cols.len());
         let length = data.len();
         let mut tmp_data: &[u8] = data.as_ref();
         while !tmp_data.is_empty() && meta_map.len() < cols.len() {
@@ -463,7 +463,7 @@ fn cut_row_v2(data: Vec<u8>, cols: Arc<[ColumnInfo]>) -> Result<RowColsDict> {
         row::v2::{RowSlice, V1CompatibleEncoder},
     };
 
-    let mut meta_map = HashMap::with_capacity_and_hasher(cols.len(), Default::default());
+    let mut meta_map = HashMap::with_capacity(cols.len());
     let mut result = Vec::with_capacity(data.len() + cols.len() * 8);
 
     let row_slice = RowSlice::from_bytes(&data)?;
@@ -495,8 +495,7 @@ fn cut_row_v2(data: Vec<u8>, cols: Arc<[ColumnInfo]>) -> Result<RowColsDict> {
 
 /// `cut_idx_key` cuts the encoded index key into RowColsDict and handle .
 pub fn cut_idx_key(key: Vec<u8>, col_ids: &[i64]) -> Result<(RowColsDict, Option<i64>)> {
-    let mut meta_map: HashMap<i64, RowColMeta> =
-        HashMap::with_capacity_and_hasher(col_ids.len(), Default::default());
+    let mut meta_map: HashMap<i64, RowColMeta> = HashMap::with_capacity(col_ids.len());
     let handle = {
         let mut tmp_data: &[u8] = &key[PREFIX_LEN + ID_LEN..];
         let length = key.len();

--- a/components/tidb_query_datatype/src/codec/table.rs
+++ b/components/tidb_query_datatype/src/codec/table.rs
@@ -594,7 +594,7 @@ mod tests {
     }
 
     fn to_hash_map(row: &RowColsDict) -> HashMap<i64, Vec<u8>> {
-        let mut data = HashMap::with_capacity_and_hasher(row.cols.len(), Default::default());
+        let mut data = HashMap::with_capacity(row.cols.len());
         if row.is_empty() {
             return data;
         }

--- a/components/tidb_query_expr/Cargo.toml
+++ b/components/tidb_query_expr/Cargo.toml
@@ -10,6 +10,7 @@ base64 = "0.13"
 bstr = "0.2.8"
 byteorder = "1.2"
 codec = { workspace = true }
+collections = { workspace = true }
 file_system = { workspace = true }
 flate2 = { version = "=1.0.11", default-features = false, features = ["zlib"] }
 hex = "0.4"

--- a/components/tidb_query_expr/src/impl_compare_in.rs
+++ b/components/tidb_query_expr/src/impl_compare_in.rs
@@ -1,12 +1,12 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::{
-    collections::HashMap,
     hash::Hash,
     marker::{PhantomData, Send, Sized},
 };
 
 use codec::prelude::NumberDecoder;
+use collections::HashMap;
 use tidb_query_codegen::rpn_fn;
 use tidb_query_common::{Error, Result};
 use tidb_query_datatype::{

--- a/components/tikv_alloc/src/jemalloc.rs
+++ b/components/tikv_alloc/src/jemalloc.rs
@@ -3,13 +3,13 @@
 // The implementation of this crate when jemalloc is turned on
 
 use std::{
-    collections::HashMap,
     ptr::{self, NonNull},
     slice,
     sync::Mutex,
     thread,
 };
 
+use collections::HashMap;
 use libc::{self, c_char, c_void};
 use tikv_jemalloc_ctl::{epoch, stats, Error};
 use tikv_jemalloc_sys::malloc_stats_print;

--- a/components/tikv_alloc/src/jemalloc.rs
+++ b/components/tikv_alloc/src/jemalloc.rs
@@ -3,13 +3,13 @@
 // The implementation of this crate when jemalloc is turned on
 
 use std::{
+    collections::HashMap,
     ptr::{self, NonNull},
     slice,
     sync::Mutex,
     thread,
 };
 
-use collections::HashMap;
 use libc::{self, c_char, c_void};
 use tikv_jemalloc_ctl::{epoch, stats, Error};
 use tikv_jemalloc_sys::malloc_stats_print;

--- a/components/tikv_util/src/config.rs
+++ b/components/tikv_util/src/config.rs
@@ -1345,7 +1345,7 @@ impl<T> Tracker<T> {
     }
 }
 
-use std::collections::HashMap;
+use collections::HashMap;
 
 /// TomlLine use to parse one line content of a toml file
 #[derive(Debug)]

--- a/components/tikv_util/src/metrics/mod.rs
+++ b/components/tikv_util/src/metrics/mod.rs
@@ -1,7 +1,8 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{collections::HashMap, io::Write};
+use std::io::Write;
 
+use collections::HashMap;
 use kvproto::pdpb;
 use lazy_static::lazy_static;
 use prometheus::{proto::MetricType, *};

--- a/components/tikv_util/src/sys/cgroup.rs
+++ b/components/tikv_util/src/sys/cgroup.rs
@@ -1,13 +1,14 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashSet,
     fs::read_to_string,
     mem::MaybeUninit,
     num::IntErrorKind,
     path::{Path, PathBuf},
 };
 
+use collections::HashMap;
 use num_traits::Bounded;
 use procfs::process::{MountInfo, Process};
 

--- a/components/tikv_util/src/sys/ioload.rs
+++ b/components/tikv_util/src/sys/ioload.rs
@@ -1,6 +1,8 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{collections::HashMap, fs::File, io::Read};
+use std::{fs::File, io::Read};
+
+use collections::HashMap;
 
 /// IoLoad represents current system block devices IO statistics
 #[derive(Debug)]

--- a/scripts/check-collections
+++ b/scripts/check-collections
@@ -13,7 +13,8 @@ rules=(
 )
 
 # rocksdb properties are std hashmap.
-allow_list="engine_rocks.*properties.rs|test_sst_importer"
+# collections depends on tikv_alloc
+allow_list="engine_rocks.*properties.rs|test_sst_importer|tikv_alloc"
 
 for rule in "${rules[@]}"; do
     if grep -r -n --color=always \

--- a/scripts/check-collections
+++ b/scripts/check-collections
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# This script checks if collection types in TiKV.
+set -euo pipefail
+
+function error_msg() {
+    echo "Prefer collections::HashMap" >&2
+}
+
+rules=(
+    "\{collections::.*HashMap[^<:E]"
+    " {2,}collections::.*HashMap[^<:E]"
+    "std::collections::.*HashMap[^<:E]"
+)
+
+# rocksdb properties are std hashmap.
+allow_list="engine_rocks.*properties.rs|test_sst_importer"
+
+for rule in "${rules[@]}"; do
+    if grep -r -n --color=always \
+        -E "$rule" \
+        --include \*.rs \
+        --exclude-dir target . \
+        | grep -v -E "$allow_list";
+    then
+        error_msg
+        exit 1
+    fi
+done
+
+echo "Collection type check passed."

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -5809,10 +5809,11 @@ mod tests {
             "normal",
             "read-only",
         ] {
-            let change = HashMap::from([(
+            let mut change = HashMap::new();
+            change.insert(
                 "rocksdb.defaultcf.titan.blob-run-mode".to_string(),
                 run_mode.to_string(),
-            )]);
+            );
             cfg_controller.update_without_persist(change).unwrap();
         }
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -9,7 +9,7 @@ mod configurable;
 
 use std::{
     cmp,
-    collections::{HashMap, HashSet},
+    collections::HashSet,
     convert::TryFrom,
     error::Error,
     fs, i32,
@@ -22,6 +22,7 @@ use std::{
 
 use api_version::ApiV1Ttl;
 use causal_ts::Config as CausalTsConfig;
+use collections::HashMap;
 pub use configurable::{loop_registry, ConfigRes, ConfigurableDb};
 use encryption_export::DataKeyManager;
 use engine_rocks::{

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -1209,7 +1209,7 @@ impl AnalyzeMixedResult {
 
 #[cfg(test)]
 mod tests {
-    use ::std::collections::HashMap;
+    use collections::HashMap;
     use tidb_query_datatype::codec::{datum, datum::Datum};
 
     use super::*;

--- a/src/coprocessor_v2/plugin_registry.rs
+++ b/src/coprocessor_v2/plugin_registry.rs
@@ -1,7 +1,7 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashSet,
     ffi::{OsStr, OsString},
     ops::Range,
     path::{Path, PathBuf},
@@ -10,6 +10,7 @@ use std::{
     time::Duration,
 };
 
+use collections::HashMap;
 use coprocessor_plugin_api::{allocator::HostAllocatorPtr, util::*, *};
 use libloading::{Error as DylibError, Library, Symbol};
 use notify::{DebouncedEvent, RecursiveMode, Watcher};

--- a/src/import/raft_writer.rs
+++ b/src/import/raft_writer.rs
@@ -2,11 +2,9 @@
 //! This module contains types for asynchronously applying the write batches
 //! into the storage.
 
-use std::{
-    collections::HashMap,
-    sync::{Arc, Mutex},
-};
+use std::sync::{Arc, Mutex};
 
+use collections::HashMap;
 use futures::{Future, Stream, StreamExt};
 use kvproto::kvrpcpb::Context;
 use sst_importer::metrics::{APPLIER_ENGINE_REQUEST_DURATION, APPLIER_EVENT, IMPORTER_APPLY_BYTES};

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -1,7 +1,7 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::{
-    collections::{HashMap, HashSet, VecDeque},
+    collections::{HashSet, VecDeque},
     convert::identity,
     future::Future,
     path::PathBuf,
@@ -12,6 +12,7 @@ use std::{
     time::Duration,
 };
 
+use collections::HashMap;
 use engine_traits::{CompactExt, MiscExt, CF_DEFAULT, CF_WRITE};
 use file_system::{set_io_type, IoType};
 use futures::{sink::SinkExt, stream::TryStreamExt, FutureExt, TryFutureExt};
@@ -184,8 +185,8 @@ impl RequestCollector {
     }
 
     fn accept_kv(&mut self, cf: &str, is_delete: bool, k: Vec<u8>, v: Vec<u8>) {
-        debug!("Accepting KV."; "cf" => %cf, 
-            "key" => %log_wrappers::Value::key(&k), 
+        debug!("Accepting KV."; "cf" => %cf,
+            "key" => %log_wrappers::Value::key(&k),
             "value" => %log_wrappers::Value::key(&v));
         // Need to skip the empty key/value that could break the transaction or cause
         // data corruption. see details at https://github.com/pingcap/tiflow/issues/5468.
@@ -1408,7 +1409,7 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
             ctx.spawn(async move {
                 send_rpc_response!(Err(Error::Io(
                     std::io::Error::new(std::io::ErrorKind::InvalidInput,
-                        format!("you are going to suspend the import RPCs too long. (for {} seconds, max acceptable duration is {} seconds)", 
+                        format!("you are going to suspend the import RPCs too long. (for {} seconds, max acceptable duration is {} seconds)",
                         req.get_duration_in_secs(), SUSPEND_REQUEST_MAX_SECS)))), sink, label, timer);
             });
             return;
@@ -1479,8 +1480,7 @@ fn write_needs_restore(write: &[u8]) -> bool {
 
 #[cfg(test)]
 mod test {
-    use std::collections::HashMap;
-
+    use collections::HashMap;
     use engine_traits::{CF_DEFAULT, CF_WRITE};
     use kvproto::{
         kvrpcpb::Context,

--- a/src/server/service/diagnostics/sys.rs
+++ b/src/server/service/diagnostics/sys.rs
@@ -1,7 +1,8 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{collections::HashMap, string::ToString};
+use std::string::ToString;
 
+use collections::HashMap;
 use kvproto::diagnosticspb::{ServerInfoItem, ServerInfoPair};
 use tikv_util::sys::{cpu_time::LinuxStyleCpuTime, ioload, SysQuota, *};
 use walkdir::WalkDir;

--- a/src/server/status_server/mod.rs
+++ b/src/server/status_server/mod.rs
@@ -1151,10 +1151,10 @@ fn client_accept_gzip(req: &Request<Body>) -> bool {
 // Decode different type of json value to string value
 fn decode_json(
     data: &[u8],
-) -> std::result::Result<std::collections::HashMap<String, String>, Box<dyn std::error::Error>> {
+) -> std::result::Result<HashMap<String, String>, Box<dyn std::error::Error>> {
     let json: Value = serde_json::from_slice(data)?;
     if let Value::Object(map) = json {
-        let mut dst = std::collections::HashMap::new();
+        let mut dst = HashMap::new();
         for (k, v) in map.into_iter() {
             let v = match v {
                 Value::Bool(v) => format!("{}", v),

--- a/tests/integrations/config/dynamic/gc_worker.rs
+++ b/tests/integrations/config/dynamic/gc_worker.rs
@@ -77,7 +77,7 @@ fn test_gc_worker_config_update() {
 
     // Update gc worker config
     let change = {
-        let mut change = std::collections::HashMap::new();
+        let mut change = collections::HashMap::new();
         change.insert("gc.ratio-threshold".to_owned(), "1.23".to_owned());
         change.insert("gc.batch-keys".to_owned(), "1234".to_owned());
         change.insert("gc.max-write-bytes-per-sec".to_owned(), "1KB".to_owned());

--- a/tests/integrations/config/dynamic/raftstore.rs
+++ b/tests/integrations/config/dynamic/raftstore.rs
@@ -1,11 +1,11 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::{
-    iter::FromIterator,
     sync::{atomic::AtomicU64, mpsc, Arc, Mutex},
     time::Duration,
 };
 
+use collections::HashMap;
 use concurrency_manager::ConcurrencyManager;
 use engine_rocks::RocksEngine;
 use engine_traits::{Engines, ALL_CFS, CF_DEFAULT};
@@ -144,11 +144,10 @@ where
     rx.recv_timeout(Duration::from_secs(3)).unwrap();
 }
 
-fn new_changes(cfgs: Vec<(&str, &str)>) -> std::collections::HashMap<String, String> {
-    std::collections::HashMap::from_iter(
-        cfgs.into_iter()
-            .map(|kv| (kv.0.to_owned(), kv.1.to_owned())),
-    )
+fn new_changes(cfgs: Vec<(&str, &str)>) -> HashMap<String, String> {
+    cfgs.into_iter()
+        .map(|kv| (kv.0.to_owned(), kv.1.to_owned()))
+        .collect()
 }
 
 #[test]

--- a/tests/integrations/config/dynamic/snap.rs
+++ b/tests/integrations/config/dynamic/snap.rs
@@ -5,6 +5,7 @@ use std::{
     time::Duration,
 };
 
+use collections::HashMap;
 use engine_rocks::RocksEngine;
 use grpcio::{EnvBuilder, ResourceQuota};
 use raft_log_engine::RaftLogEngine;
@@ -93,7 +94,7 @@ fn test_update_server_config() {
     let mut svr_cfg = config.server.clone();
     // dispatch updated config
     let change = {
-        let mut m = std::collections::HashMap::new();
+        let mut m = HashMap::new();
         m.insert(
             "server.snap-io-max-bytes-per-sec".to_owned(),
             "512MB".to_owned(),

--- a/tests/integrations/config/dynamic/split_check.rs
+++ b/tests/integrations/config/dynamic/split_check.rs
@@ -6,6 +6,7 @@ use std::{
     time::Duration,
 };
 
+use collections::HashMap;
 use engine_rocks::RocksEngine;
 use engine_traits::CF_DEFAULT;
 use raftstore::{
@@ -78,7 +79,7 @@ fn test_update_split_check_config() {
     });
 
     let change = {
-        let mut m = std::collections::HashMap::new();
+        let mut m = HashMap::new();
         m.insert(
             "coprocessor.split_region_on_table".to_owned(),
             "true".to_owned(),

--- a/tests/integrations/config/test_config_client.rs
+++ b/tests/integrations/config/test_config_client.rs
@@ -1,12 +1,12 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::{
-    collections::HashMap,
     fs::File,
     io::{Read, Write},
     sync::{Arc, Mutex},
 };
 
+use collections::HashMap;
 use online_config::{ConfigChange, OnlineConfig};
 use raftstore::store::Config as RaftstoreConfig;
 use tikv::config::*;
@@ -105,12 +105,12 @@ fn test_write_update_to_file() {
 block-cache-size = "10GB"
 
 [rocksdb.lockcf]
-## this config will not update even it has the same last 
+## this config will not update even it has the same last
 ## name as `rocksdb.defaultcf.block-cache-size`
 block-cache-size = "512MB"
 
 [coprocessor]
-## the update to `coprocessor.region-split-keys`, which do not show up 
+## the update to `coprocessor.region-split-keys`, which do not show up
 ## as key-value pair after [coprocessor], will be written at the end of [coprocessor]
 
 [gc]
@@ -167,12 +167,12 @@ pd-heartbeat-tick-interval = "1h"
 block-cache-size = "1GB"
 
 [rocksdb.lockcf]
-## this config will not update even it has the same last 
+## this config will not update even it has the same last
 ## name as `rocksdb.defaultcf.block-cache-size`
 block-cache-size = "512MB"
 
 [coprocessor]
-## the update to `coprocessor.region-split-keys`, which do not show up 
+## the update to `coprocessor.region-split-keys`, which do not show up
 ## as key-value pair after [coprocessor], will be written at the end of [coprocessor]
 
 region-split-keys = 10000

--- a/tests/integrations/raftstore/test_replica_read.rs
+++ b/tests/integrations/raftstore/test_replica_read.rs
@@ -1,7 +1,6 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::{
-    collections::HashMap,
     mem,
     sync::{
         atomic::AtomicBool,
@@ -12,6 +11,7 @@ use std::{
     time::Duration,
 };
 
+use collections::HashMap;
 use futures::executor::block_on;
 use kvproto::raft_serverpb::RaftMessage;
 use pd_client::PdClient;

--- a/tests/integrations/raftstore/test_scale_pool.rs
+++ b/tests/integrations/raftstore/test_scale_pool.rs
@@ -1,11 +1,11 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::{
-    collections::HashMap,
     sync::{mpsc::sync_channel, Mutex},
     time::Duration,
 };
 
+use collections::HashMap;
 use engine_traits::{MiscExt, Peekable};
 use raft::prelude::MessageType;
 use test_raftstore::*;

--- a/tests/integrations/resource_metering/test_suite/mod.rs
+++ b/tests/integrations/resource_metering/test_suite/mod.rs
@@ -3,8 +3,9 @@
 mod mock_pubsub;
 mod mock_receiver_server;
 
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
+use collections::HashMap;
 use crossbeam::channel::{unbounded, Receiver, Sender};
 use futures::{channel::oneshot, select, FutureExt};
 use grpcio::{ChannelBuilder, ClientSStreamReceiver, Environment};


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #15990
ref #16111

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
When a key was not found in the HashMap during an index operation,
the panic message simply stated "no entry found for key" without
specifying the actual key. This lack of information made debugging
challenging.
This commit improves the HashMap panic message by including the key
when an index panic occurs. Now, developers will have more insightful
information to aid in debugging.
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
