### PR TITLE
In-memory Engine: integrate hybrid engine with TiKV

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2447,6 +2447,7 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 name = "hybrid_engine"
 version = "0.0.1"
 dependencies = [
+ "engine_rocks",
  "engine_traits",
  "tikv_util",
  "txn_types",
@@ -4440,6 +4441,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
+name = "region_cache_memory_engine"
+version = "0.0.1"
+dependencies = [
+ "collections",
+ "engine_traits",
+ "skiplist-rs",
+]
+
+[[package]]
 name = "remove_dir_all"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5104,6 +5114,7 @@ dependencies = [
  "grpcio",
  "grpcio-health",
  "hex 0.4.2",
+ "hybrid_engine",
  "keys",
  "kvproto",
  "libc 0.2.146",
@@ -5116,6 +5127,7 @@ dependencies = [
  "raft_log_engine",
  "raftstore",
  "raftstore-v2",
+ "region_cache_memory_engine",
  "resolved_ts",
  "resource_control",
  "resource_metering",
@@ -5194,6 +5206,16 @@ name = "siphasher"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa8f3741c7372e75519bd9346068370c9cdaabcc1f9599cbcf2a2719352286b7"
+
+[[package]]
+name = "skiplist-rs"
+version = "0.1.0"
+source = "git+https://github.com/tikv/skiplist-rs.git?branch=main#618af619d9348ef89eaa71c5f6fbddbd9a5c09bf"
+dependencies = [
+ "bytes",
+ "rand 0.8.5",
+ "slog",
+]
 
 [[package]]
 name = "slab"
@@ -6290,6 +6312,7 @@ dependencies = [
  "raftstore-v2",
  "rand 0.7.3",
  "regex",
+ "region_cache_memory_engine",
  "reqwest",
  "resource_control",
  "resource_metering",
@@ -6821,7 +6844,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,7 @@ raftstore = { workspace = true, features = ["engine_rocks"] }
 raftstore-v2 = { workspace = true }
 rand = "0.7.3"
 regex = "1.3"
+region_cache_memory_engine = { workspace = true }
 resource_control = { workspace = true }
 resource_metering = { workspace = true }
 rev_lines = "0.2.1"
@@ -321,6 +322,7 @@ encryption_export = { path = "components/encryption/export" }
 engine_panic = { path = "components/engine_panic" }
 engine_rocks = { path = "components/engine_rocks" }
 hybrid_engine = { path = "components/hybrid_engine" }
+region_cache_memory_engine = { path = "components/region_cache_memory_engine" }
 engine_rocks_helper = { path = "components/engine_rocks_helper" }
 engine_test = { path = "components/engine_test", default-features = false }
 engine_traits = { path = "components/engine_traits" }

--- a/components/engine_panic/src/misc.rs
+++ b/components/engine_panic/src/misc.rs
@@ -129,4 +129,9 @@ impl MiscExt for PanicEngine {
     fn get_accumulated_flush_count_cf(cf: &str) -> Result<u64> {
         panic!()
     }
+
+    type DiskEngine = PanicEngine;
+    fn get_disk_engine(&self) -> &Self::DiskEngine {
+        panic!()
+    }
 }

--- a/components/engine_rocks/src/misc.rs
+++ b/components/engine_rocks/src/misc.rs
@@ -448,6 +448,11 @@ impl MiscExt for RocksEngine {
             .get();
         Ok(n)
     }
+
+    type DiskEngine = RocksEngine;
+    fn get_disk_engine(&self) -> &Self::DiskEngine {
+        self
+    }
 }
 
 #[cfg(test)]

--- a/components/engine_traits/src/misc.rs
+++ b/components/engine_traits/src/misc.rs
@@ -178,4 +178,7 @@ pub trait MiscExt: CfNamesExt + FlowControlFactorsExt + WriteBatchExt {
         }
         Ok(n)
     }
+
+    type DiskEngine;
+    fn get_disk_engine(&self) -> &Self::DiskEngine;
 }

--- a/components/hybrid_engine/Cargo.toml
+++ b/components/hybrid_engine/Cargo.toml
@@ -11,3 +11,4 @@ testexport = []
 engine_traits = { workspace = true }
 txn_types = { workspace = true }
 tikv_util = { workspace = true }
+engine_rocks = { workspace = true }

--- a/components/hybrid_engine/src/engine.rs
+++ b/components/hybrid_engine/src/engine.rs
@@ -42,6 +42,19 @@ where
     }
 }
 
+impl<EK, EC> HybridEngine<EK, EC>
+where
+    EK: KvEngine,
+    EC: RegionCacheEngine,
+{
+    pub fn new(disk_engine: EK, region_cache_engine: EC) -> Self {
+        Self {
+            disk_engine,
+            region_cache_engine,
+        }
+    }
+}
+
 // todo: implement KvEngine methods as well as it's super traits.
 impl<EK, EC> KvEngine for HybridEngine<EK, EC>
 where

--- a/components/hybrid_engine/src/lib.rs
+++ b/components/hybrid_engine/src/lib.rs
@@ -22,3 +22,5 @@ mod sst;
 mod table_properties;
 mod ttl_properties;
 mod write_batch;
+
+pub use engine::HybridEngine;

--- a/components/hybrid_engine/src/misc.rs
+++ b/components/hybrid_engine/src/misc.rs
@@ -124,4 +124,9 @@ where
     fn get_accumulated_flush_count_cf(cf: &str) -> Result<u64> {
         unimplemented!()
     }
+
+    type DiskEngine = EK::DiskEngine;
+    fn get_disk_engine(&self) -> &Self::DiskEngine {
+        self.disk_engine().get_disk_engine()
+    }
 }

--- a/components/raftstore/src/compacted_event_sender.rs
+++ b/components/raftstore/src/compacted_event_sender.rs
@@ -1,18 +1,26 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 use std::sync::Mutex;
 
-use engine_rocks::{CompactedEventSender, RocksCompactedEvent, RocksEngine};
-use engine_traits::RaftEngine;
+use engine_rocks::{CompactedEventSender, RocksCompactedEvent};
+use engine_traits::{KvEngine, RaftEngine};
 use tikv_util::error_unknown;
 
 use crate::store::{fsm::store::RaftRouter, StoreMsg};
 
 // raftstore v1's implementation
-pub struct RaftRouterCompactedEventSender<ER: RaftEngine> {
-    pub router: Mutex<RaftRouter<RocksEngine, ER>>,
+pub struct RaftRouterCompactedEventSender<EK, ER>
+where
+    EK: KvEngine,
+    ER: RaftEngine,
+{
+    pub router: Mutex<RaftRouter<EK, ER>>,
 }
 
-impl<ER: RaftEngine> CompactedEventSender for RaftRouterCompactedEventSender<ER> {
+impl<EK, ER> CompactedEventSender for RaftRouterCompactedEventSender<EK, ER>
+where
+    EK: KvEngine<CompactedEvent = RocksCompactedEvent>,
+    ER: RaftEngine,
+{
     fn send(&self, event: RocksCompactedEvent) {
         let router = self.router.lock().unwrap();
         let event = StoreMsg::CompactedEvent(event);

--- a/components/region_cache_memory_engine/Cargo.toml
+++ b/components/region_cache_memory_engine/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "region_cache_memory_engine"
+version = "0.0.1"
+edition = "2021"
+publish = false
+
+[features]
+testexport = []
+
+[dependencies]
+engine_traits = { workspace = true }
+collections = { workspace = true }
+skiplist-rs = { git = "https://github.com/tikv/skiplist-rs.git", branch = "main" }

--- a/components/region_cache_memory_engine/src/engine.rs
+++ b/components/region_cache_memory_engine/src/engine.rs
@@ -1,0 +1,307 @@
+// Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::{
+    collections::BTreeMap,
+    fmt::{self, Debug},
+    ops::Deref,
+    sync::{Arc, Mutex},
+};
+
+use collections::HashMap;
+use engine_traits::{
+    CfNamesExt, DbVector, IterOptions, Iterable, Iterator, Mutable, Peekable, ReadOptions,
+    RegionCacheEngine, Result, Snapshot, SnapshotMiscExt, WriteBatch, WriteBatchExt, WriteOptions,
+};
+use skiplist_rs::{ByteWiseComparator, IterRef, Skiplist};
+
+/// RegionMemoryEngine stores data for a specific cached region
+///
+/// todo: The skiplist used here currently is for test purpose. Replace it
+/// with a formal implementation.
+#[derive(Clone)]
+pub struct RegionMemoryEngine {
+    data: [Arc<Skiplist<ByteWiseComparator>>; 3],
+}
+
+impl Debug for RegionMemoryEngine {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        unimplemented!()
+    }
+}
+
+type SnapshotList = BTreeMap<u64, u64>;
+
+#[derive(Default)]
+pub struct RegionMemoryMeta {
+    // It records the snapshots that have been granted previsously with specific snapshot_ts. We
+    // should guarantee that the data visible to any one of the snapshot in it will not be removed.
+    snapshots: SnapshotList,
+    // It indicates whether the region is readable. False means integrity of the data in this
+    // cached region is not satisfied due to being evicted for instance.
+    can_read: bool,
+    // Request with read_ts below it is not eligible for granting snapshot.
+    // Note: different region can have different safe_ts.
+    safe_ts: u64,
+}
+
+#[derive(Default)]
+pub struct RegionCacheMemoryEngineCore {
+    engine: HashMap<u64, RegionMemoryEngine>,
+    region_metats: HashMap<u64, RegionMemoryMeta>,
+}
+
+/// The RegionCacheMemoryEngine serves as a region cache, storing hot regions in
+/// the leaders' store. Incoming writes that are written to disk engine (now,
+/// RocksDB) are also written to the RegionCacheMemoryEngine, leading to a
+/// mirrored data set in the cached regions with the disk engine.
+///
+/// A load/evict unit manages the memory, deciding which regions should be
+/// evicted when the memory used by the RegionCacheMemoryEngine reaches a
+/// certain limit, and determining which regions should be loaded when there is
+/// spare memory capacity.
+///
+/// The safe point lifetime differs between RegionCacheMemoryEngine and the disk
+/// engine, often being much shorter in RegionCacheMemoryEngine. This means that
+/// RegionCacheMemoryEngine may filter out some keys that still exist in the
+/// disk engine, thereby improving read performance as fewer duplicated keys
+/// will be read. If there's a need to read keys that may have been filtered by
+/// RegionCacheMemoryEngine (as indicated by read_ts and safe_point of the
+/// cached region), we resort to using a the disk engine's snapshot instead.
+#[derive(Clone, Default)]
+pub struct RegionCacheMemoryEngine {
+    core: Arc<Mutex<RegionCacheMemoryEngineCore>>,
+}
+
+impl Debug for RegionCacheMemoryEngine {
+    fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
+        unimplemented!()
+    }
+}
+
+impl RegionCacheMemoryEngine {
+    pub fn new() -> Self {
+        RegionCacheMemoryEngine::default()
+    }
+}
+
+impl RegionCacheEngine for RegionCacheMemoryEngine {
+    type Snapshot = RegionCacheSnapshot;
+
+    fn snapshot(&self, region_id: u64, read_ts: u64) -> Option<Self::Snapshot> {
+        unimplemented!()
+    }
+}
+
+// todo: fill fields needed
+pub struct RegionCacheWriteBatch;
+
+impl WriteBatchExt for RegionCacheMemoryEngine {
+    type WriteBatch = RegionCacheWriteBatch;
+    // todo: adjust it
+    const WRITE_BATCH_MAX_KEYS: usize = 256;
+
+    fn write_batch(&self) -> Self::WriteBatch {
+        RegionCacheWriteBatch {}
+    }
+
+    fn write_batch_with_cap(&self, _: usize) -> Self::WriteBatch {
+        RegionCacheWriteBatch {}
+    }
+}
+
+pub struct RegionCacheIterator {
+    valid: bool,
+    prefix_same_as_start: bool,
+    prefix: Option<Vec<u8>>,
+    iter: IterRef<Skiplist<ByteWiseComparator>, ByteWiseComparator>,
+    lower_bound: Option<Vec<u8>>,
+    upper_bound: Option<Vec<u8>>,
+}
+
+impl Iterable for RegionCacheMemoryEngine {
+    type Iterator = RegionCacheIterator;
+
+    fn iterator(&self, cf: &str) -> Result<Self::Iterator> {
+        unimplemented!()
+    }
+
+    fn iterator_opt(&self, cf: &str, opts: IterOptions) -> Result<Self::Iterator> {
+        unimplemented!()
+    }
+}
+
+impl Iterator for RegionCacheIterator {
+    fn key(&self) -> &[u8] {
+        unimplemented!()
+    }
+
+    fn value(&self) -> &[u8] {
+        unimplemented!()
+    }
+
+    fn next(&mut self) -> Result<bool> {
+        unimplemented!()
+    }
+
+    fn prev(&mut self) -> Result<bool> {
+        unimplemented!()
+    }
+
+    fn seek(&mut self, key: &[u8]) -> Result<bool> {
+        unimplemented!()
+    }
+
+    fn seek_for_prev(&mut self, key: &[u8]) -> Result<bool> {
+        unimplemented!()
+    }
+
+    fn seek_to_first(&mut self) -> Result<bool> {
+        unimplemented!()
+    }
+
+    fn seek_to_last(&mut self) -> Result<bool> {
+        unimplemented!()
+    }
+
+    fn valid(&self) -> Result<bool> {
+        unimplemented!()
+    }
+}
+
+impl WriteBatch for RegionCacheWriteBatch {
+    fn write_opt(&mut self, _: &WriteOptions) -> Result<u64> {
+        unimplemented!()
+    }
+
+    fn data_size(&self) -> usize {
+        unimplemented!()
+    }
+
+    fn count(&self) -> usize {
+        unimplemented!()
+    }
+
+    fn is_empty(&self) -> bool {
+        unimplemented!()
+    }
+
+    fn should_write_to_engine(&self) -> bool {
+        unimplemented!()
+    }
+
+    fn clear(&mut self) {
+        unimplemented!()
+    }
+
+    fn set_save_point(&mut self) {
+        unimplemented!()
+    }
+
+    fn pop_save_point(&mut self) -> Result<()> {
+        unimplemented!()
+    }
+
+    fn rollback_to_save_point(&mut self) -> Result<()> {
+        unimplemented!()
+    }
+
+    fn merge(&mut self, _: Self) -> Result<()> {
+        unimplemented!()
+    }
+}
+
+impl Mutable for RegionCacheWriteBatch {
+    fn put(&mut self, _: &[u8], _: &[u8]) -> Result<()> {
+        unimplemented!()
+    }
+
+    fn put_cf(&mut self, _: &str, _: &[u8], _: &[u8]) -> Result<()> {
+        unimplemented!()
+    }
+
+    fn delete(&mut self, _: &[u8]) -> Result<()> {
+        unimplemented!()
+    }
+
+    fn delete_cf(&mut self, _: &str, _: &[u8]) -> Result<()> {
+        unimplemented!()
+    }
+
+    fn delete_range(&mut self, _: &[u8], _: &[u8]) -> Result<()> {
+        unimplemented!()
+    }
+
+    fn delete_range_cf(&mut self, _: &str, _: &[u8], _: &[u8]) -> Result<()> {
+        unimplemented!()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct RegionCacheSnapshot {
+    region_id: u64,
+    snapshot_ts: u64,
+    engine: RegionMemoryEngine,
+}
+
+impl Snapshot for RegionCacheSnapshot {}
+
+impl Iterable for RegionCacheSnapshot {
+    type Iterator = RegionCacheIterator;
+
+    fn iterator(&self, cf: &str) -> Result<Self::Iterator> {
+        unimplemented!()
+    }
+
+    fn iterator_opt(&self, cf: &str, opts: IterOptions) -> Result<Self::Iterator> {
+        unimplemented!()
+    }
+}
+
+impl Peekable for RegionCacheSnapshot {
+    type DbVector = RegionCacheDbVector;
+
+    fn get_value_opt(&self, opts: &ReadOptions, key: &[u8]) -> Result<Option<Self::DbVector>> {
+        unimplemented!()
+    }
+
+    fn get_value_cf_opt(
+        &self,
+        opts: &ReadOptions,
+        cf: &str,
+        key: &[u8],
+    ) -> Result<Option<Self::DbVector>> {
+        unimplemented!()
+    }
+}
+
+impl CfNamesExt for RegionCacheSnapshot {
+    fn cf_names(&self) -> Vec<&str> {
+        unimplemented!()
+    }
+}
+
+impl SnapshotMiscExt for RegionCacheSnapshot {
+    fn sequence_number(&self) -> u64 {
+        self.snapshot_ts
+    }
+}
+
+// todo: fill fields needed
+#[derive(Debug)]
+pub struct RegionCacheDbVector;
+
+impl Deref for RegionCacheDbVector {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        unimplemented!()
+    }
+}
+
+impl DbVector for RegionCacheDbVector {}
+
+impl<'a> PartialEq<&'a [u8]> for RegionCacheDbVector {
+    fn eq(&self, rhs: &&[u8]) -> bool {
+        unimplemented!()
+    }
+}

--- a/components/region_cache_memory_engine/src/lib.rs
+++ b/components/region_cache_memory_engine/src/lib.rs
@@ -1,0 +1,7 @@
+// Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
+
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
+mod engine;
+pub use engine::RegionCacheMemoryEngine;

--- a/components/server/Cargo.toml
+++ b/components/server/Cargo.toml
@@ -56,6 +56,7 @@ futures = "0.3"
 grpcio = { workspace = true }
 grpcio-health = { workspace = true }
 hex = "0.4"
+hybrid_engine = { workspace = true }
 keys = { workspace = true }
 kvproto = { workspace = true }
 libc = "0.2"
@@ -68,6 +69,7 @@ raft = { workspace = true }
 raft_log_engine = { workspace = true }
 raftstore = { workspace = true, features = ["engine_rocks"] }
 raftstore-v2 = { workspace = true }
+region_cache_memory_engine = { workspace = true }
 resolved_ts = { workspace = true }
 resource_control = { workspace = true }
 resource_metering = { workspace = true }

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -30,16 +30,19 @@ use backup_stream::{
 use causal_ts::CausalTsProviderImpl;
 use cdc::CdcConfigManager;
 use concurrency_manager::ConcurrencyManager;
-use engine_rocks::{from_rocks_compression_type, RocksEngine, RocksStatistics};
+use engine_rocks::{
+    from_rocks_compression_type, RocksCompactedEvent, RocksEngine, RocksStatistics,
+};
 use engine_rocks_helper::sst_recovery::{RecoveryRunner, DEFAULT_CHECK_INTERVAL};
 use engine_traits::{
-    Engines, KvEngine, MiscExt, RaftEngine, SingletonFactory, TabletContext, TabletRegistry,
-    CF_DEFAULT, CF_WRITE,
+    Engines, KvEngine, RaftEngine, SingletonFactory, TabletContext, TabletRegistry, CF_DEFAULT,
+    CF_WRITE,
 };
 use file_system::{get_io_rate_limiter, BytesFetcher, MetricsManager as IoMetricsManager};
 use futures::executor::block_on;
 use grpcio::{EnvBuilder, Environment};
 use grpcio_health::HealthService;
+use hybrid_engine::HybridEngine;
 use kvproto::{
     brpb::create_backup, cdcpb::create_change_data, deadlock::create_deadlock,
     debugpb::create_debug, diagnosticspb::create_diagnostics, import_sstpb::create_import_sst,
@@ -69,6 +72,7 @@ use raftstore::{
     },
     RaftRouterCompactedEventSender,
 };
+use region_cache_memory_engine::RegionCacheMemoryEngine;
 use resolved_ts::{LeadershipResolver, Task};
 use resource_control::ResourceGroupManager;
 use security::SecurityManager;
@@ -110,7 +114,7 @@ use tikv::{
 use tikv_alloc::{add_thread_memory_accessor, remove_thread_memory_accessor};
 use tikv_util::{
     check_environment_variables,
-    config::VersionTrack,
+    config::{ReadableSize, VersionTrack},
     memory::MemoryQuota,
     mpsc as TikvMpsc,
     quota_limiter::{QuotaLimitConfigManager, QuotaLimiter},
@@ -124,7 +128,10 @@ use tikv_util::{
 use tokio::runtime::Builder;
 
 use crate::{
-    common::{ConfiguredRaftEngine, EngineMetricsManager, EnginesResourceInfo, TikvServerCore},
+    common::{
+        ConfiguredRaftEngine, EngineMetricsManager, EnginesResourceInfo, KvEngineBuilder,
+        TikvServerCore,
+    },
     memory::*,
     setup::*,
     signal_handler,
@@ -132,12 +139,16 @@ use crate::{
 };
 
 #[inline]
-fn run_impl<CER: ConfiguredRaftEngine, F: KvFormat>(
+fn run_impl<EK, CER, F>(
     config: TikvConfig,
     service_event_tx: TikvMpsc::Sender<ServiceEvent>,
     service_event_rx: TikvMpsc::Receiver<ServiceEvent>,
-) {
-    let mut tikv = TikvServer::<CER, F>::init(config, service_event_tx.clone());
+) where
+    EK: KvEngine<CompactedEvent = RocksCompactedEvent, DiskEngine = RocksEngine> + KvEngineBuilder,
+    CER: ConfiguredRaftEngine,
+    F: KvFormat,
+{
+    let mut tikv = TikvServer::<EK, CER, F>::init(config, service_event_tx.clone());
     // Must be called after `TikvServer::init`.
     let memory_limit = tikv.core.config.memory_usage_limit.unwrap().0;
     let high_water = (tikv.core.config.memory_usage_high_water * memory_limit as f64) as u64;
@@ -209,9 +220,33 @@ pub fn run_tikv(
 
     dispatch_api_version!(config.storage.api_version(), {
         if !config.raft_engine.enable {
-            run_impl::<RocksEngine, API>(config, service_event_tx, service_event_rx)
+            if config.region_cache_memory_limit == ReadableSize(0) {
+                run_impl::<RocksEngine, RocksEngine, API>(
+                    config,
+                    service_event_tx,
+                    service_event_rx,
+                )
+            } else {
+                run_impl::<HybridEngine<RocksEngine, RegionCacheMemoryEngine>, RocksEngine, API>(
+                    config,
+                    service_event_tx,
+                    service_event_rx,
+                )
+            }
         } else {
-            run_impl::<RaftLogEngine, API>(config, service_event_tx, service_event_rx)
+            if config.region_cache_memory_limit == ReadableSize(0) {
+                run_impl::<RocksEngine, RaftLogEngine, API>(
+                    config,
+                    service_event_tx,
+                    service_event_rx,
+                )
+            } else {
+                run_impl::<HybridEngine<RocksEngine, RegionCacheMemoryEngine>, RaftLogEngine, API>(
+                    config,
+                    service_event_tx,
+                    service_event_rx,
+                )
+            }
         }
     })
 }
@@ -221,21 +256,26 @@ const DEFAULT_MEMTRACE_FLUSH_INTERVAL: Duration = Duration::from_millis(1_000);
 const DEFAULT_STORAGE_STATS_INTERVAL: Duration = Duration::from_secs(1);
 
 /// A complete TiKV server.
-struct TikvServer<ER: RaftEngine, F: KvFormat> {
+struct TikvServer<EK, ER, F>
+where
+    EK: KvEngine,
+    ER: RaftEngine,
+    F: KvFormat,
+{
     core: TikvServerCore,
     cfg_controller: Option<ConfigController>,
     security_mgr: Arc<SecurityManager>,
     pd_client: Arc<RpcClient>,
-    router: RaftRouter<RocksEngine, ER>,
-    system: Option<RaftBatchSystem<RocksEngine, ER>>,
+    router: RaftRouter<EK, ER>,
+    system: Option<RaftBatchSystem<EK, ER>>,
     resolver: Option<resolve::PdStoreAddrResolver>,
     snap_mgr: Option<SnapManager>, // Will be filled in `init_servers`.
-    engines: Option<TikvEngines<RocksEngine, ER>>,
+    engines: Option<TikvEngines<EK, ER>>,
     kv_statistics: Option<Arc<RocksStatistics>>,
     raft_statistics: Option<Arc<RocksStatistics>>,
-    servers: Option<Servers<RocksEngine, ER, F>>,
+    servers: Option<Servers<EK, ER, F>>,
     region_info_accessor: RegionInfoAccessor,
-    coprocessor_host: Option<CoprocessorHost<RocksEngine>>,
+    coprocessor_host: Option<CoprocessorHost<EK>>,
     concurrency_manager: ConcurrencyManager,
     env: Arc<Environment>,
     check_leader_worker: Worker,
@@ -270,12 +310,13 @@ struct Servers<EK: KvEngine, ER: RaftEngine, F: KvFormat> {
 type LocalServer<EK, ER> = Server<resolve::PdStoreAddrResolver, LocalRaftKv<EK, ER>>;
 type LocalRaftKv<EK, ER> = RaftKv<EK, ServerRaftStoreRouter<EK, ER>>;
 
-impl<ER, F> TikvServer<ER, F>
+impl<EK, ER, F> TikvServer<EK, ER, F>
 where
+    EK: KvEngine<DiskEngine = RocksEngine>,
     ER: RaftEngine,
     F: KvFormat,
 {
-    fn init(mut config: TikvConfig, tx: TikvMpsc::Sender<ServiceEvent>) -> TikvServer<ER, F> {
+    fn init(mut config: TikvConfig, tx: TikvMpsc::Sender<ServiceEvent>) -> TikvServer<EK, ER, F> {
         tikv_util::thread_group::set_properties(Some(GroupProperties::default()));
         // It is okay use pd config and security config before `init_config`,
         // because these configs must be provided by command line, and only
@@ -436,7 +477,7 @@ where
         }
     }
 
-    fn init_engines(&mut self, engines: Engines<RocksEngine, ER>) {
+    fn init_engines(&mut self, engines: Engines<EK, ER>) {
         let store_meta = Arc::new(Mutex::new(StoreMeta::new(PENDING_MSG_CAP)));
         let engine = RaftKv::new(
             ServerRaftStoreRouter::new(
@@ -458,9 +499,7 @@ where
         });
     }
 
-    fn init_gc_worker(
-        &mut self,
-    ) -> GcWorker<RaftKv<RocksEngine, ServerRaftStoreRouter<RocksEngine, ER>>> {
+    fn init_gc_worker(&mut self) -> GcWorker<RaftKv<EK, ServerRaftStoreRouter<EK, ER>>> {
         let engines = self.engines.as_ref().unwrap();
         let gc_worker = GcWorker::new(
             engines.engine.clone(),
@@ -526,7 +565,7 @@ where
 
         if let Some(sst_worker) = &mut self.sst_worker {
             let sst_runner = RecoveryRunner::new(
-                engines.engines.kv.clone(),
+                engines.engines.kv.get_disk_engine().clone(),
                 engines.store_meta.clone(),
                 self.core
                     .config
@@ -1041,7 +1080,10 @@ where
 
         // Create Debugger.
         let mut debugger = DebuggerImpl::new(
-            engines.engines.clone(),
+            Engines::new(
+                engines.engines.kv.get_disk_engine().clone(),
+                engines.engines.raft.clone(),
+            ),
             self.cfg_controller.as_ref().unwrap().clone(),
             Some(storage),
         );
@@ -1163,7 +1205,7 @@ where
         let mut backup_worker = Box::new(self.core.background_worker.lazy_build("backup-endpoint"));
         let backup_scheduler = backup_worker.scheduler();
         let backup_service =
-            backup::Service::<RocksEngine, ER>::with_router(backup_scheduler, self.router.clone());
+            backup::Service::<EK, ER>::with_router(backup_scheduler, self.router.clone());
         if servers
             .server
             .register_service(create_backup(backup_service))
@@ -1282,7 +1324,7 @@ where
         );
     }
 
-    fn init_storage_stats_task(&self, engines: Engines<RocksEngine, ER>) {
+    fn init_storage_stats_task(&self, engines: Engines<EK, ER>) {
         let config_disk_capacity: u64 = self.core.config.raft_store.capacity.0;
         let data_dir = self.core.config.storage.data_dir.clone();
         let store_path = self.core.store_path.clone();
@@ -1509,11 +1551,16 @@ where
     }
 }
 
-impl<CER: ConfiguredRaftEngine, F: KvFormat> TikvServer<CER, F> {
+impl<EK, CER, F> TikvServer<EK, CER, F>
+where
+    EK: KvEngine<DiskEngine = RocksEngine, CompactedEvent = RocksCompactedEvent> + KvEngineBuilder,
+    CER: ConfiguredRaftEngine,
+    F: KvFormat,
+{
     fn init_raw_engines(
         &mut self,
         flow_listener: engine_rocks::FlowListener,
-    ) -> (Engines<RocksEngine, CER>, Arc<EnginesResourceInfo>) {
+    ) -> (Engines<EK, CER>, Arc<EnginesResourceInfo>) {
         let block_cache = self.core.config.storage.block_cache.build_shared_cache();
         let env = self
             .core
@@ -1547,23 +1594,24 @@ impl<CER: ConfiguredRaftEngine, F: KvFormat> TikvServer<CER, F> {
         .sst_recovery_sender(self.init_sst_recovery_sender())
         .flow_listener(flow_listener);
         let factory = Box::new(builder.build());
-        let kv_engine = factory
+        let disk_engine = factory
             .create_shared_db(&self.core.store_path)
             .unwrap_or_else(|s| fatal!("failed to create kv engine: {}", s));
+        let kv_engine: EK = KvEngineBuilder::build(disk_engine.clone());
         self.kv_statistics = Some(factory.rocks_statistics());
-        let engines = Engines::new(kv_engine.clone(), raft_engine);
+        let engines = Engines::new(kv_engine, raft_engine);
 
         let cfg_controller = self.cfg_controller.as_mut().unwrap();
         cfg_controller.register(
             tikv::config::Module::Rocksdb,
             Box::new(DbConfigManger::new(
                 cfg_controller.get_current().rocksdb,
-                kv_engine.clone(),
+                disk_engine.clone(),
                 DbType::Kv,
             )),
         );
         let reg = TabletRegistry::new(
-            Box::new(SingletonFactory::new(kv_engine)),
+            Box::new(SingletonFactory::new(disk_engine)),
             &self.core.store_path,
         )
         .unwrap();

--- a/components/snap_recovery/src/init_cluster.rs
+++ b/components/snap_recovery/src/init_cluster.rs
@@ -3,8 +3,8 @@
 use std::{cmp, error::Error as StdError, i32, result, sync::Arc, thread, time::Duration};
 
 use encryption_export::data_key_manager_from_config;
-use engine_rocks::{util::new_engine_opt, RocksEngine};
-use engine_traits::{Engines, Error as EngineError, Peekable, RaftEngine, SyncMutable};
+use engine_rocks::util::new_engine_opt;
+use engine_traits::{Engines, Error as EngineError, KvEngine, RaftEngine};
 use kvproto::{metapb, raft_serverpb::StoreIdent};
 use pd_client::{Error as PdError, PdClient};
 use raft_log_engine::RaftLogEngine;
@@ -251,21 +251,21 @@ pub trait LocalEngineService {
 }
 
 // init engine and read local engine info
-pub struct LocalEngines<ER: RaftEngine> {
-    engines: Engines<RocksEngine, ER>,
+pub struct LocalEngines<EK: KvEngine, ER: RaftEngine> {
+    engines: Engines<EK, ER>,
 }
 
-impl<ER: RaftEngine> LocalEngines<ER> {
-    pub fn new(engines: Engines<RocksEngine, ER>) -> LocalEngines<ER> {
+impl<EK: KvEngine, ER: RaftEngine> LocalEngines<EK, ER> {
+    pub fn new(engines: Engines<EK, ER>) -> LocalEngines<EK, ER> {
         LocalEngines { engines }
     }
 
-    pub fn get_engine(&self) -> &Engines<RocksEngine, ER> {
+    pub fn get_engine(&self) -> &Engines<EK, ER> {
         &self.engines
     }
 }
 
-impl<ER: RaftEngine> LocalEngineService for LocalEngines<ER> {
+impl<EK: KvEngine, ER: RaftEngine> LocalEngineService for LocalEngines<EK, ER> {
     fn set_cluster_id(&self, cluster_id: u64) {
         let res = self
             .get_engine()

--- a/components/snap_recovery/src/services.rs
+++ b/components/snap_recovery/src/services.rs
@@ -19,7 +19,7 @@ use engine_rocks::{
     util::get_cf_handle,
     RocksEngine,
 };
-use engine_traits::{CfNamesExt, CfOptionsExt, Engines, Peekable, RaftEngine};
+use engine_traits::{CfNamesExt, CfOptionsExt, Engines, KvEngine, RaftEngine};
 use futures::{
     channel::mpsc,
     executor::{ThreadPool, ThreadPoolBuilder},
@@ -67,11 +67,16 @@ pub enum Error {
     #[error("{0:?}")]
     Other(#[from] Box<dyn StdError + Sync + Send>),
 }
+
 /// Service handles the recovery messages from backup restore.
 #[derive(Clone)]
-pub struct RecoveryService<ER: RaftEngine> {
-    engines: Engines<RocksEngine, ER>,
-    router: RaftRouter<RocksEngine, ER>,
+pub struct RecoveryService<EK, ER>
+where
+    EK: KvEngine<DiskEngine = RocksEngine>,
+    ER: RaftEngine,
+{
+    engines: Engines<EK, ER>,
+    router: RaftRouter<EK, ER>,
     threads: ThreadPool,
 
     /// The handle to last call of recover region RPC.
@@ -113,13 +118,14 @@ impl RecoverRegionState {
     }
 }
 
-impl<ER: RaftEngine> RecoveryService<ER> {
+impl<EK, ER> RecoveryService<EK, ER>
+where
+    EK: KvEngine<DiskEngine = RocksEngine>,
+    ER: RaftEngine,
+{
     /// Constructs a new `Service` with `Engines`, a `RaftStoreRouter` and a
     /// `thread pool`.
-    pub fn new(
-        engines: Engines<RocksEngine, ER>,
-        router: RaftRouter<RocksEngine, ER>,
-    ) -> RecoveryService<ER> {
+    pub fn new(engines: Engines<EK, ER>, router: RaftRouter<EK, ER>) -> RecoveryService<EK, ER> {
         let props = tikv_util::thread_group::current_properties();
         let threads = ThreadPoolBuilder::new()
             .pool_size(4)
@@ -136,7 +142,7 @@ impl<ER: RaftEngine> RecoveryService<ER> {
         // config rocksdb l0 to optimize the restore
         // also for massive data applied during the restore, it easy to reach the write
         // stop
-        let db = engines.kv.clone();
+        let db: &RocksEngine = engines.kv.get_disk_engine();
         for cf_name in db.cf_names() {
             Self::set_db_options(cf_name, db.clone()).expect("set db option failure");
         }
@@ -218,7 +224,7 @@ impl<ER: RaftEngine> RecoveryService<ER> {
     // a new wait apply syncer share with all regions,
     // when all region reached the target index, share reference decreased to 0,
     // trigger closure to send finish info back.
-    pub fn wait_apply_last(router: RaftRouter<RocksEngine, ER>, sender: SyncSender<u64>) {
+    pub fn wait_apply_last(router: RaftRouter<EK, ER>, sender: SyncSender<u64>) {
         let wait_apply = SnapshotRecoveryWaitApplySyncer::new(0, sender);
         router.broadcast_normal(|| {
             PeerMsg::SignificantMsg(SignificantMsg::SnapshotRecoveryWaitApply(
@@ -261,7 +267,11 @@ fn compact(engine: RocksEngine) -> Result<()> {
     Ok(())
 }
 
-impl<ER: RaftEngine> RecoverData for RecoveryService<ER> {
+impl<EK, ER> RecoverData for RecoveryService<EK, ER>
+where
+    EK: KvEngine<DiskEngine = RocksEngine>,
+    ER: RaftEngine,
+{
     // 1. br start to ready region meta
     fn read_region_meta(
         &mut self,
@@ -444,10 +454,14 @@ impl<ER: RaftEngine> RecoverData for RecoveryService<ER> {
         // implement a resolve/delete data funciton
         let resolved_ts = req.get_resolved_ts();
         let (tx, rx) = mpsc::unbounded();
-        let resolver = DataResolverManager::new(self.engines.kv.clone(), tx, resolved_ts.into());
+        let resolver = DataResolverManager::new(
+            self.engines.kv.get_disk_engine().clone(),
+            tx,
+            resolved_ts.into(),
+        );
         info!("start to resolve kv data");
         resolver.start();
-        let db = self.engines.kv.clone();
+        let db = self.engines.kv.get_disk_engine().clone();
         let store_id = self.get_store_id();
         let send_task = async move {
             let id = store_id?;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3400,6 +3400,9 @@ pub struct TikvConfig {
     #[online_config(skip)]
     pub memory_usage_high_water: f64,
 
+    // Memory quota used for in-memory engine. 0 means not enable it.
+    pub region_cache_memory_limit: ReadableSize,
+
     #[online_config(submodule)]
     pub log: LogConfig,
 
@@ -3499,6 +3502,7 @@ impl Default for TikvConfig {
             abort_on_panic: false,
             memory_usage_limit: None,
             memory_usage_high_water: 0.9,
+            region_cache_memory_limit: ReadableSize::mb(0),
             log: LogConfig::default(),
             memory: MemoryConfig::default(),
             quota: QuotaConfig::default(),


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref #16141

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Integrate hybrid engine with TiKV. User can choose to use hybrid engine by set `memory_engine_enabled` in TiKV config.
```
This PR refactors some parts mainly in component/server to replace RocksEngine by generic type implementing KvEngine.
So we can make `HybridEngine` as a specific type that implements KvEngine be used by TiKV server, RaftKv, raftstore and so on.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
