### PR TITLE
raftstore: clean up destroyed_region_for_snap when a peer is destroyed

### DIFF
--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -3849,6 +3849,7 @@ where
                     .get_mut(&target_region_id)
                     .unwrap()
                     .remove(&region_id);
+                meta.destroyed_region_for_snap.remove(&region_id);
                 info!("peer has destroyed, clean up for incoming overlapped snapshot";
                     "region_id" => region_id,
                     "peer_id" => self.fsm.peer_id(),


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref https://github.com/tikv/tikv/issues/16111

Address comment: https://github.com/tikv/tikv/pull/16112#discussion_r1413779674

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->

Cleanup `destroyed_region_for_snap`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Integration test

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
