### PR TITLE
revert "cdc: limit pending scan tasks (#16048) (#16054)"

### DIFF
--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -5,10 +5,7 @@ use std::{
     cmp::{Ord, Ordering as CmpOrdering, PartialOrd, Reverse},
     collections::BinaryHeap,
     fmt,
-    sync::{
-        atomic::{AtomicIsize, Ordering},
-        Arc, Mutex as StdMutex,
-    },
+    sync::{Arc, Mutex as StdMutex},
     time::Duration,
 };
 
@@ -338,8 +335,6 @@ pub struct Endpoint<T, E> {
 
     // Incremental scan
     workers: Runtime,
-    // The total number of scan tasks including running and pending.
-    scan_task_counter: Arc<AtomicIsize>,
     scan_concurrency_semaphore: Arc<Semaphore>,
     scan_speed_limiter: Limiter,
     fetch_speed_limiter: Limiter,
@@ -434,7 +429,6 @@ impl<T: 'static + RaftStoreRouter<E>, E: KvEngine> Endpoint<T, E> {
             pd_client,
             tso_worker,
             timer: SteadyTimer::default(),
-            scan_task_counter: Arc::default(),
             scan_speed_limiter,
             fetch_speed_limiter,
             max_scan_batch_bytes,
@@ -665,27 +659,6 @@ impl<T: 'static + RaftStoreRouter<E>, E: KvEngine> Endpoint<T, E> {
             return;
         }
 
-        let scan_task_counter = self.scan_task_counter.clone();
-        let scan_task_count = scan_task_counter.fetch_add(1, Ordering::Relaxed);
-        let release_scan_task_counter = tikv_util::DeferContext::new(move || {
-            scan_task_counter.fetch_sub(1, Ordering::Relaxed);
-        });
-        if scan_task_count + 1 > self.config.incremental_scan_concurrency_limit as isize {
-            debug!("cdc rejects registration, too many scan tasks";
-                "region_id" => region_id,
-                "conn_id" => ?conn_id,
-                "scan_task_count" => scan_task_count,
-                "incremental_scan_concurrency_limit" => self.config.incremental_scan_concurrency_limit,
-            );
-            // To avoid OOM (e.g., https://github.com/tikv/tikv/issues/16035),
-            // TiKV needs to reject and return error immediately.
-            //
-            // TODO: TiKV is supposed to return a "busy" error, but for the sake
-            // of compatibility, it returns a "region not found" error.
-            let _ = downstream.sink_region_not_found(region_id);
-            return;
-        }
-
         let txn_extra_op = match self.store_meta.lock().unwrap().readers.get(&region_id) {
             Some(reader) => reader.txn_extra_op.clone(),
             None => {
@@ -804,7 +777,6 @@ impl<T: 'static + RaftStoreRouter<E>, E: KvEngine> Endpoint<T, E> {
                     init.deregister_downstream(e)
                 }
             }
-            drop(release_scan_task_counter);
         });
     }
 
@@ -1949,96 +1921,6 @@ mod tests {
             }
             other => panic!("unexpected task {:?}", other),
         }
-    }
-
-    #[test]
-    fn test_too_many_scan_tasks() {
-        let cfg = CdcConfig {
-            min_ts_interval: ReadableDuration(Duration::from_secs(60)),
-            incremental_scan_concurrency: 1,
-            incremental_scan_concurrency_limit: 1,
-            ..Default::default()
-        };
-        let mut suite = mock_endpoint(&cfg, None, ApiVersion::V1);
-
-        // Pause scan task runtime.
-        suite.endpoint.workers = Builder::new_multi_thread()
-            .worker_threads(1)
-            .build()
-            .unwrap();
-        let (pause_tx, pause_rx) = std::sync::mpsc::channel::<()>();
-        suite.endpoint.workers.spawn(async move {
-            let _ = pause_rx.recv();
-        });
-
-        suite.add_region(1, 100);
-        let quota = MemoryQuota::new(usize::MAX);
-        let (tx, mut rx) = channel::channel(1, quota);
-        let mut rx = rx.drain();
-
-        let conn = Conn::new(tx, String::new());
-        let conn_id = conn.get_id();
-        suite.run(Task::OpenConn { conn });
-
-        // Enable batch resolved ts in the test.
-        let version = FeatureGate::batch_resolved_ts();
-
-        let mut req_header = Header::default();
-        req_header.set_cluster_id(0);
-        let mut req = ChangeDataRequest::default();
-        req.set_region_id(1);
-        req.set_request_id(1);
-        let region_epoch = req.get_region_epoch().clone();
-        let downstream = Downstream::new(
-            "".to_string(),
-            region_epoch.clone(),
-            1,
-            conn_id,
-            ChangeDataRequestKvApi::TiDb,
-            false,
-        );
-        suite.run(Task::Register {
-            request: req.clone(),
-            downstream,
-            conn_id,
-            version: version.clone(),
-        });
-        assert_eq!(suite.endpoint.capture_regions.len(), 1);
-
-        // Test too many scan tasks error.
-        req.set_request_id(2);
-        let downstream = Downstream::new(
-            "".to_string(),
-            region_epoch,
-            2,
-            conn_id,
-            ChangeDataRequestKvApi::TiDb,
-            false,
-        );
-        suite.run(Task::Register {
-            request: req.clone(),
-            downstream,
-            conn_id,
-            version,
-        });
-        let cdc_event = channel::recv_timeout(&mut rx, Duration::from_millis(500))
-            .unwrap()
-            .unwrap();
-        if let CdcEvent::Event(mut e) = cdc_event.0 {
-            assert_eq!(e.region_id, 1);
-            assert_eq!(e.request_id, 2);
-            let event = e.event.take().unwrap();
-            match event {
-                Event_oneof_event::Error(err) => {
-                    assert!(err.has_region_not_found());
-                }
-                other => panic!("unknown event {:?}", other),
-            }
-        } else {
-            panic!("unknown cdc event {:?}", cdc_event);
-        }
-
-        drop(pause_tx);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -2530,12 +2530,7 @@ pub struct CdcConfig {
     // TODO(hi-rustin): Consider resizing the thread pool based on `incremental_scan_threads`.
     #[online_config(skip)]
     pub incremental_scan_threads: usize,
-    // The number of scan tasks that is allowed to run concurrently.
     pub incremental_scan_concurrency: usize,
-    // The number of scan tasks that is allowed to be created. In other words,
-    // there will be at most `incremental_scan_concurrency_limit - incremental_scan_concurrency`
-    // number of scan tasks that is waitting to run.
-    pub incremental_scan_concurrency_limit: usize,
     /// Limit scan speed based on disk I/O traffic.
     pub incremental_scan_speed_limit: ReadableSize,
     /// Limit scan speed based on memory accesing traffic.
@@ -2576,8 +2571,6 @@ impl Default for CdcConfig {
             incremental_scan_threads: 4,
             // At most 6 concurrent running tasks.
             incremental_scan_concurrency: 6,
-            // At most 10000 tasks can exist simultaneously.
-            incremental_scan_concurrency_limit: 10000,
             // TiCDC requires a SSD, the typical write speed of SSD
             // is more than 500MB/s, so 128MB/s is enough.
             incremental_scan_speed_limit: ReadableSize::mb(128),
@@ -2618,14 +2611,6 @@ impl CdcConfig {
                 self.incremental_scan_threads
             );
             self.incremental_scan_concurrency = self.incremental_scan_threads
-        }
-        if self.incremental_scan_concurrency_limit < self.incremental_scan_concurrency {
-            warn!(
-                "cdc.incremental-scan-concurrency-limit must be larger than cdc.incremental-scan-concurrency,
-                change it to {}",
-                self.incremental_scan_concurrency
-            );
-            self.incremental_scan_concurrency_limit = self.incremental_scan_concurrency
         }
         if self.incremental_scan_ts_filter_ratio < 0.0
             || self.incremental_scan_ts_filter_ratio > 1.0
@@ -5570,15 +5555,6 @@ mod tests {
         "#;
         let mut cfg: TikvConfig = toml::from_str(content).unwrap();
         cfg.validate().unwrap();
-
-        let content = r#"
-            [cdc]
-            incremental-scan-concurrency = 6
-            incremental-scan-concurrency-limit = 0
-        "#;
-        let mut cfg: TikvConfig = toml::from_str(content).unwrap();
-        cfg.validate().unwrap();
-        assert!(cfg.cdc.incremental_scan_concurrency_limit >= cfg.cdc.incremental_scan_concurrency);
     }
 
     #[test]

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -788,7 +788,6 @@ fn test_serde_custom_tikv_config() {
         hibernate_regions_compatible: false,
         incremental_scan_threads: 3,
         incremental_scan_concurrency: 4,
-        incremental_scan_concurrency_limit: 5,
         incremental_scan_speed_limit: ReadableSize(7),
         incremental_fetch_speed_limit: ReadableSize(8),
         incremental_scan_ts_filter_ratio: 0.7,

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -655,7 +655,6 @@ old-value-cache-size = 0
 hibernate-regions-compatible = false
 incremental-scan-threads = 3
 incremental-scan-concurrency = 4
-incremental-scan-concurrency-limit = 5
 incremental-scan-speed-limit = 7
 incremental-fetch-speed-limit = 8
 incremental-scan-ts-filter-ratio = 0.7


### PR DESCRIPTION
This reverts commit 22d397b4e6908e520743a256c7b312a190be1d4b.

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #xxx

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
