### PR TITLE
server: observe read index durations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,7 +307,7 @@ dependencies = [
  "tikv_util",
  "tokio",
  "url",
- "uuid 0.8.2",
+ "uuid 1.6.1",
 ]
 
 [[package]]
@@ -575,7 +575,7 @@ dependencies = [
  "tonic",
  "txn_types",
  "url",
- "uuid 0.8.2",
+ "uuid 1.6.1",
  "walkdir",
  "yatp",
 ]
@@ -1404,7 +1404,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
- "uuid 1.2.1",
+ "uuid 1.6.1",
 ]
 
 [[package]]
@@ -4435,7 +4435,7 @@ dependencies = [
  "tokio",
  "tracker",
  "txn_types",
- "uuid 0.8.2",
+ "uuid 1.6.1",
  "yatp",
 ]
 
@@ -5619,7 +5619,7 @@ dependencies = [
  "tikv_util",
  "tokio",
  "txn_types",
- "uuid 0.8.2",
+ "uuid 1.6.1",
 ]
 
 [[package]]
@@ -5746,7 +5746,7 @@ dependencies = [
  "debugid",
  "memmap2",
  "stable_deref_trait",
- "uuid 1.2.1",
+ "uuid 1.6.1",
 ]
 
 [[package]]
@@ -6033,7 +6033,7 @@ dependencies = [
  "engine_traits",
  "keys",
  "kvproto",
- "uuid 0.8.2",
+ "uuid 1.6.1",
 ]
 
 [[package]]
@@ -6154,7 +6154,7 @@ dependencies = [
  "toml",
  "tracker",
  "txn_types",
- "uuid 0.8.2",
+ "uuid 1.6.1",
 ]
 
 [[package]]
@@ -6351,7 +6351,7 @@ dependencies = [
  "tipb",
  "tipb_helper",
  "twoway",
- "uuid 0.8.2",
+ "uuid 1.6.1",
 ]
 
 [[package]]
@@ -6476,7 +6476,7 @@ dependencies = [
  "tracker",
  "txn_types",
  "url",
- "uuid 0.8.2",
+ "uuid 1.6.1",
  "walkdir",
  "yatp",
  "zipf",
@@ -7144,14 +7144,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "getrandom 0.2.3",
- "serde",
 ]
 
 [[package]]
 name = "uuid"
-version = "1.2.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb41e78f93363bb2df8b0e86a2ca30eed7806ea16ea0c790d757cf93f79be83"
+checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
+dependencies = [
+ "atomic",
+ "getrandom 0.2.3",
+ "serde",
+]
 
 [[package]]
 name = "valgrind_request"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,7 +174,7 @@ toml = "0.5"
 tracker = { workspace = true }
 txn_types = { workspace = true }
 url = "2"
-uuid = { version = "0.8.1", features = ["serde", "v4"] }
+uuid = { version = "1.6.1", features = ["serde", "v4", "v7"] }
 walkdir = "2"
 yatp = { workspace = true }
 

--- a/components/backup-stream/Cargo.toml
+++ b/components/backup-stream/Cargo.toml
@@ -72,10 +72,10 @@ tikv_kv = { workspace = true }
 tikv_util = { workspace = true }
 tokio = { version = "1.5", features = ["rt-multi-thread", "macros", "time", "sync"] }
 tokio-stream = "0.1"
-tokio-util = { version = "0.7", features = ["compat"] } 
+tokio-util = { version = "0.7", features = ["compat"] }
 tonic = "0.8"
 txn_types = { workspace = true }
-uuid = "0.8"
+uuid = { version = "1.6.1", features = ["serde", "v4", "v7"] }
 yatp = { workspace = true }
 
 [dev-dependencies]

--- a/components/cloud/aws/Cargo.toml
+++ b/components/cloud/aws/Cargo.toml
@@ -38,7 +38,7 @@ tikv_util = { workspace = true }
 # better to not use slog-global, but pass in the logger
 tokio = { version = "1.5", features = ["time"] }
 url = "2.0"
-uuid = { version = "0.8", features = ["v4"] }
+uuid = { version = "1.6.1", features = ["serde", "v4", "v7"] }
 
 [dev-dependencies]
 futures = "0.3"

--- a/components/raftstore/Cargo.toml
+++ b/components/raftstore/Cargo.toml
@@ -89,7 +89,7 @@ time = "0.1"
 tokio = { version = "1.5", features = ["sync", "rt-multi-thread"] }
 tracker = { workspace = true }
 txn_types = { workspace = true }
-uuid = { version = "0.8.1", features = ["serde", "v4"] }
+uuid = { version = "1.6.1", features = ["serde", "v4", "v7"] }
 yatp = { workspace = true }
 
 [dev-dependencies]

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -68,7 +68,10 @@ use tikv_util::{
 use time::{Duration as TimeDuration, Timespec};
 use tracker::GLOBAL_TRACKERS;
 use txn_types::{TimeStamp, WriteBatchFlags};
-use uuid::Uuid;
+use uuid::{
+    timestamp::{context::NoContext, Timestamp},
+    Uuid,
+};
 
 use super::{
     cmd_resp,
@@ -581,7 +584,7 @@ pub fn propose_read_index<T: raft::Storage>(
     let last_pending_read_count = raft_group.raft.pending_read_count();
     let last_ready_read_count = raft_group.raft.ready_read_count();
 
-    let id = Uuid::new_v4();
+    let id = Uuid::new_v7(Timestamp::now(NoContext));
     raft_group.read_index(ReadIndexContext::fields_to_bytes(id, request, locked));
 
     let pending_read_count = raft_group.raft.pending_read_count();

--- a/components/sst_importer/Cargo.toml
+++ b/components/sst_importer/Cargo.toml
@@ -46,7 +46,7 @@ tikv_alloc = { workspace = true }
 tikv_util = { workspace = true }
 tokio = { version = "1.5", features = ["time", "rt-multi-thread", "macros"] }
 txn_types = { workspace = true }
-uuid = { version = "0.8.1", features = ["serde", "v4"] }
+uuid = { version = "1.6.1", features = ["serde", "v4", "v7"] }
 
 [dev-dependencies]
 engine_test = { workspace = true }

--- a/components/sst_importer/src/import_file.rs
+++ b/components/sst_importer/src/import_file.rs
@@ -461,7 +461,7 @@ const SST_SUFFIX: &str = ".sst";
 pub fn sst_meta_to_path(meta: &SstMeta) -> Result<PathBuf> {
     Ok(PathBuf::from(format!(
         "{}_{}_{}_{}_{}{}",
-        UuidBuilder::from_slice(meta.get_uuid())?.build(),
+        UuidBuilder::from_slice(meta.get_uuid())?.into_uuid(),
         meta.get_region_id(),
         meta.get_region_epoch().get_conf_ver(),
         meta.get_region_epoch().get_version(),

--- a/components/test_sst_importer/Cargo.toml
+++ b/components/test_sst_importer/Cargo.toml
@@ -14,4 +14,4 @@ engine_rocks = { workspace = true }
 engine_traits = { workspace = true }
 keys = { workspace = true }
 kvproto = { workspace = true }
-uuid = { version = "0.8.1", features = ["serde", "v4"] }
+uuid = { version = "1.6.1", features = ["serde", "v4", "v7"] }

--- a/components/tidb_query_expr/Cargo.toml
+++ b/components/tidb_query_expr/Cargo.toml
@@ -32,7 +32,7 @@ tikv_util = { workspace = true }
 time = "0.1"
 tipb = { workspace = true }
 twoway = "0.2.0"
-uuid = { version = "0.8.1", features = ["v4"] }
+uuid = { version = "1.6.1", features = ["serde", "v4", "v7"] }
 
 [dev-dependencies]
 bstr = "0.2.8"

--- a/components/tidb_query_expr/src/impl_miscellaneous.rs
+++ b/components/tidb_query_expr/src/impl_miscellaneous.rs
@@ -189,8 +189,8 @@ pub fn is_ipv6(addr: Option<BytesRef>) -> Result<Option<Int>> {
 #[inline]
 pub fn uuid() -> Result<Option<Bytes>> {
     let result = Uuid::new_v4();
-    let mut buf = vec![0; uuid::adapter::Hyphenated::LENGTH];
-    result.to_hyphenated().encode_lower(&mut buf);
+    let mut buf = vec![0; uuid::fmt::Hyphenated::LENGTH];
+    uuid::fmt::Hyphenated::from_uuid(result).encode_lower(&mut buf);
     Ok(Some(buf))
 }
 

--- a/src/server/metrics.rs
+++ b/src/server/metrics.rs
@@ -440,6 +440,20 @@ lazy_static! {
         &["type"],
     )
     .unwrap();
+    pub static ref READ_INDEX_SEND_HEARTBEAT_DURATION: HistogramVec = register_histogram_vec!(
+        "tikv_server_read_index_send_heartbeat_duration_seconds",
+        "Duration of sending raft heartbeat with read index context",
+        &["store"],
+        exponential_buckets(0.002, 2.0, 18).unwrap()
+    )
+    .unwrap();
+    pub static ref READ_INDEX_RECV_HEARTBEAT_DURATION: HistogramVec = register_histogram_vec!(
+        "tikv_server_read_index_recv_heartbeat_duration_seconds",
+        "Duration of receiving raft heartbeat with read index context",
+        &["store"],
+        exponential_buckets(0.005, 2.0, 18).unwrap()
+    )
+    .unwrap();
 }
 
 make_auto_flush_static_metric! {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -26,6 +26,7 @@ pub mod ttl;
 
 pub use engine_factory::{KvEngineFactory, KvEngineFactoryBuilder};
 
+pub(crate) use self::raft_client::observe_read_index_duration;
 #[cfg(any(test, feature = "testexport"))]
 pub use self::server::test_router::TestRaftStoreRouter;
 pub use self::{

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -112,7 +112,7 @@ tipb = { workspace = true }
 toml = "0.5"
 tracker = { workspace = true }
 txn_types = { workspace = true }
-uuid = { version = "0.8.1", features = ["serde", "v4"] }
+uuid = { version = "1.6.1", features = ["serde", "v4", "v7"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "6599eb9dca74229b2c1fcc44118bef7eff127128" }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #xxx

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Use UUIDv7 as the read index context so that the following durations can be observed:
1. the duration it takes for a heartbeat request to be sent to the follower
2. the duration it takes for the heartbeat response to be received by the leader
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note

```
