### PR TITLE
txn: change memory pessimsitic lock to btree map and support scan

### DIFF
--- a/components/raftstore/src/store/txn_ext.rs
+++ b/components/raftstore/src/store/txn_ext.rs
@@ -1,16 +1,16 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::{
+    collections::{BTreeMap, Bound},
     fmt,
     sync::atomic::{AtomicU64, Ordering},
 };
 
-use collections::HashMap;
 use kvproto::metapb;
 use lazy_static::lazy_static;
 use parking_lot::RwLock;
 use prometheus::{register_int_gauge, IntGauge};
-use txn_types::{Key, PessimisticLock};
+use txn_types::{Key, Lock, PessimisticLock};
 
 /// Transaction extensions related to a peer.
 #[derive(Default)]
@@ -106,7 +106,7 @@ pub struct PeerPessimisticLocks {
     ///   skipped because of version mismatch. So, no lock should be deleted.
     ///   It's correct that we include the locks that are marked deleted in the
     ///   commit merge request.
-    map: HashMap<Key, (PessimisticLock, bool)>,
+    map: BTreeMap<Key, (PessimisticLock, bool)>,
     /// Status of the pessimistic lock map.
     /// The map is writable only in the Normal state.
     pub status: LocksStatus,
@@ -143,7 +143,7 @@ impl fmt::Debug for PeerPessimisticLocks {
 impl Default for PeerPessimisticLocks {
     fn default() -> Self {
         PeerPessimisticLocks {
-            map: HashMap::default(),
+            map: BTreeMap::default(),
             status: LocksStatus::Normal,
             term: 0,
             version: 0,
@@ -192,7 +192,7 @@ impl PeerPessimisticLocks {
     }
 
     pub fn clear(&mut self) {
-        self.map = HashMap::default();
+        self.map = BTreeMap::default();
         GLOBAL_MEM_SIZE.sub(self.memory_size as i64);
         self.memory_size = 0;
     }
@@ -244,12 +244,20 @@ impl PeerPessimisticLocks {
         // Locks that are marked deleted still need to be moved to the new regions,
         // and the deleted mark should also be cleared.
         // Refer to the comment in `PeerPessimisticLocks` for details.
-        let removed_locks = self.map.drain_filter(|key, _| {
-            let key = &**key.as_encoded();
+        // There is no drain_filter for BtreeMap, so extra clone are needed.
+        let mut removed_locks = Vec::new();
+        self.map.retain(|key, value| {
+            let encoded_key = &**key.as_encoded();
             let (start_key, end_key) = (derived.get_start_key(), derived.get_end_key());
-            key < start_key || (!end_key.is_empty() && key >= end_key)
+            if encoded_key < start_key || (!end_key.is_empty() && encoded_key >= end_key) {
+                removed_locks.push((key.clone(), value.clone()));
+                false
+            } else {
+                true
+            }
         });
-        for (key, (lock, _)) in removed_locks {
+
+        for (key, (lock, _)) in removed_locks.into_iter() {
             let idx = match regions
                 .binary_search_by_key(&&**key.as_encoded(), |region| region.get_start_key())
             {
@@ -262,6 +270,39 @@ impl PeerPessimisticLocks {
             res[idx].memory_size += size;
         }
         res
+    }
+
+    /// Scan and return locks in the current pessimistic lock map, the map
+    /// should be locked first before calling this method.
+    pub fn scan_locks<F>(
+        &self,
+        start: Option<&Key>,
+        end: Option<&Key>,
+        filter: F,
+        limit: usize,
+    ) -> (Vec<(Key, Lock)>, bool)
+    where
+        F: Fn(&Key, &PessimisticLock) -> bool,
+    {
+        if let (Some(start_key), Some(end_key)) = (start, end) {
+            assert!(end_key >= start_key);
+        }
+        let mut locks = Vec::with_capacity(limit);
+        let mut iter = self.map.range((
+            start.map_or(Bound::Unbounded, |k| Bound::Included(k)),
+            end.map_or(Bound::Unbounded, |k| Bound::Excluded(k)),
+        ));
+        let mut remaining_limit = limit;
+        while let Some((key, (lock, _))) = iter.next() {
+            if filter(key, lock) {
+                locks.push((key.clone(), lock.clone().into_lock()));
+                remaining_limit -= 1;
+            }
+            if remaining_limit == 0 {
+                return (locks, iter.next().is_some());
+            }
+        }
+        (locks, false)
     }
 
     #[cfg(test)]
@@ -277,7 +318,7 @@ impl PeerPessimisticLocks {
 
 impl<'a> IntoIterator for &'a PeerPessimisticLocks {
     type Item = (&'a Key, &'a (PessimisticLock, bool));
-    type IntoIter = std::collections::hash_map::Iter<'a, Key, (PessimisticLock, bool)>;
+    type IntoIter = std::collections::btree_map::Iter<'a, Key, (PessimisticLock, bool)>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.map.iter()
@@ -329,6 +370,24 @@ mod tests {
             last_change: LastChange::make_exist(105.into(), 2),
             is_locked_with_conflict: false,
         }
+    }
+
+    fn lock_with_key(key: &[u8], deleted: bool) -> (Key, (PessimisticLock, bool)) {
+        (
+            Key::from_raw(key),
+            (
+                PessimisticLock {
+                    primary: key.to_vec().into_boxed_slice(),
+                    start_ts: 10.into(),
+                    ttl: 1000,
+                    for_update_ts: 10.into(),
+                    min_commit_ts: 20.into(),
+                    last_change: LastChange::make_exist(5.into(), 2),
+                    is_locked_with_conflict: false,
+                },
+                deleted,
+            ),
+        )
     }
 
     #[test]
@@ -418,23 +477,6 @@ mod tests {
 
     #[test]
     fn test_group_locks_by_regions() {
-        fn lock(key: &[u8], deleted: bool) -> (Key, (PessimisticLock, bool)) {
-            (
-                Key::from_raw(key),
-                (
-                    PessimisticLock {
-                        primary: key.to_vec().into_boxed_slice(),
-                        start_ts: 10.into(),
-                        ttl: 1000,
-                        for_update_ts: 10.into(),
-                        min_commit_ts: 20.into(),
-                        last_change: LastChange::make_exist(5.into(), 2),
-                        is_locked_with_conflict: false,
-                    },
-                    deleted,
-                ),
-            )
-        }
         fn region(start_key: &[u8], end_key: &[u8]) -> metapb::Region {
             let mut region = metapb::Region::default();
             region.set_start_key(start_key.to_vec());
@@ -445,11 +487,11 @@ mod tests {
         defer!(GLOBAL_MEM_SIZE.set(0));
 
         let mut original = PeerPessimisticLocks::from_locks(vec![
-            lock(b"a", true),
-            lock(b"c", false),
-            lock(b"e", true),
-            lock(b"g", false),
-            lock(b"i", false),
+            lock_with_key(b"a", true),
+            lock_with_key(b"c", false),
+            lock_with_key(b"e", true),
+            lock_with_key(b"g", false),
+            lock_with_key(b"i", false),
         ]);
         let regions = vec![
             region(b"", b"b"),  // test leftmost region
@@ -460,10 +502,10 @@ mod tests {
         ];
         let output = original.group_by_regions(&regions, &regions[4]);
         let expected: Vec<_> = vec![
-            vec![lock(b"a", false)],
+            vec![lock_with_key(b"a", false)],
             vec![],
-            vec![lock(b"c", false)],
-            vec![lock(b"e", false), lock(b"g", false)],
+            vec![lock_with_key(b"c", false)],
+            vec![lock_with_key(b"e", false), lock_with_key(b"g", false)],
             vec![], // the position of the derived region is empty
         ]
         .into_iter()
@@ -473,7 +515,158 @@ mod tests {
         // The lock that belongs to the derived region is kept in the original map.
         assert_eq!(
             original,
-            PeerPessimisticLocks::from_locks(vec![lock(b"i", false)])
+            PeerPessimisticLocks::from_locks(vec![lock_with_key(b"i", false)])
         );
+    }
+
+    #[test]
+    fn test_scan_memory_lock() {
+        // Create a sample PeerPessimisticLocks instance with some locks.
+        let peer_locks = PeerPessimisticLocks::from_locks(vec![
+            lock_with_key(b"key1", false),
+            lock_with_key(b"key2", false),
+            lock_with_key(b"key3", false),
+        ]);
+
+        fn txn_lock(key: &[u8], deleted: bool) -> Lock {
+            let (_, (pessimistic_lock, _)) = lock_with_key(key, deleted);
+            pessimistic_lock.into_lock()
+        }
+
+        let filter_pass_all = |_key: &Key, _lock: &PessimisticLock| true;
+        let filter_pass_key2 =
+            |key: &Key, _lock: &PessimisticLock| key.as_encoded().starts_with(b"key2");
+
+        // start_key, end_key, filter, expected results, limit, has more.
+        type LockFilter = fn(&Key, &PessimisticLock) -> bool;
+        let cases: [(
+            Option<Key>,
+            Option<Key>,
+            LockFilter,
+            usize,
+            Vec<(Key, Lock)>,
+            bool,
+        ); 12] = [
+            (
+                None,
+                None,
+                filter_pass_all,
+                1,
+                vec![(Key::from_raw(b"key1"), txn_lock(b"key1", false))],
+                true,
+            ),
+            (
+                None,
+                None,
+                filter_pass_all,
+                10,
+                vec![
+                    (Key::from_raw(b"key1"), txn_lock(b"key1", false)),
+                    (Key::from_raw(b"key2"), txn_lock(b"key2", false)),
+                    (Key::from_raw(b"key3"), txn_lock(b"key3", false)),
+                ],
+                false,
+            ),
+            (
+                Some(Key::from_raw(b"key0")),
+                Some(Key::from_raw(b"key1")),
+                filter_pass_all,
+                10,
+                vec![],
+                false,
+            ),
+            (
+                Some(Key::from_raw(b"key0")),
+                Some(Key::from_raw(b"key2")),
+                filter_pass_all,
+                10,
+                vec![(Key::from_raw(b"key1"), txn_lock(b"key1", false))],
+                false,
+            ),
+            (
+                Some(Key::from_raw(b"key1")),
+                Some(Key::from_raw(b"key3")),
+                filter_pass_all,
+                10,
+                vec![
+                    (Key::from_raw(b"key1"), txn_lock(b"key1", false)),
+                    (Key::from_raw(b"key2"), txn_lock(b"key2", false)),
+                ],
+                false,
+            ),
+            (
+                Some(Key::from_raw(b"key1")),
+                Some(Key::from_raw(b"key4")),
+                filter_pass_all,
+                2,
+                vec![
+                    (Key::from_raw(b"key1"), txn_lock(b"key1", false)),
+                    (Key::from_raw(b"key2"), txn_lock(b"key2", false)),
+                ],
+                true,
+            ),
+            (
+                Some(Key::from_raw(b"key1")),
+                Some(Key::from_raw(b"key4")),
+                filter_pass_all,
+                10,
+                vec![
+                    (Key::from_raw(b"key1"), txn_lock(b"key1", false)),
+                    (Key::from_raw(b"key2"), txn_lock(b"key2", false)),
+                    (Key::from_raw(b"key3"), txn_lock(b"key3", false)),
+                ],
+                false,
+            ),
+            (
+                Some(Key::from_raw(b"key2")),
+                Some(Key::from_raw(b"key4")),
+                filter_pass_all,
+                10,
+                vec![
+                    (Key::from_raw(b"key2"), txn_lock(b"key2", false)),
+                    (Key::from_raw(b"key3"), txn_lock(b"key3", false)),
+                ],
+                false,
+            ),
+            (
+                Some(Key::from_raw(b"key4")),
+                Some(Key::from_raw(b"key4")),
+                filter_pass_all,
+                10,
+                vec![],
+                false,
+            ),
+            (
+                None,
+                None,
+                filter_pass_key2,
+                10,
+                vec![(Key::from_raw(b"key2"), txn_lock(b"key2", false))],
+                false,
+            ),
+            (
+                Some(Key::from_raw(b"key2")),
+                None,
+                filter_pass_key2,
+                1,
+                vec![(Key::from_raw(b"key2"), txn_lock(b"key2", false))],
+                true,
+            ),
+            (
+                None,
+                Some(Key::from_raw(b"key2")),
+                filter_pass_key2,
+                1,
+                vec![],
+                false,
+            ),
+        ];
+
+        for (start_key, end_key, filter, limit, expected_locks, expected_has_more) in cases {
+            let (locks, has_more) =
+                peer_locks.scan_locks(start_key.as_ref(), end_key.as_ref(), filter, limit);
+            assert_eq!(locks, expected_locks);
+            assert_eq!(has_more, expected_has_more);
+        }
     }
 }

--- a/components/raftstore/src/store/txn_ext.rs
+++ b/components/raftstore/src/store/txn_ext.rs
@@ -535,7 +535,8 @@ mod tests {
         let filter_pass_key2 =
             |key: &Key, _lock: &PessimisticLock| key.as_encoded().starts_with(b"key2");
 
-        // start_key, end_key, filter, expected results, limit, has more.
+        // Case parameter: start_key, end_key, filter, limit, expected results, expected
+        // has more.
         type LockFilter = fn(&Key, &PessimisticLock) -> bool;
         let cases: [(
             Option<Key>,

--- a/components/raftstore/src/store/txn_ext.rs
+++ b/components/raftstore/src/store/txn_ext.rs
@@ -247,7 +247,7 @@ impl PeerPessimisticLocks {
         // There is no drain_filter for BtreeMap, so extra clone are needed.
         let mut removed_locks = Vec::new();
         self.map.retain(|key, value| {
-            let encoded_key = &**key.as_encoded();
+            let encoded_key = key.as_encoded().as_slice();
             let (start_key, end_key) = (derived.get_start_key(), derived.get_end_key());
             if encoded_key < start_key || (!end_key.is_empty() && encoded_key >= end_key) {
                 removed_locks.push((key.clone(), value.clone()));

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1468,7 +1468,6 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                         )
                         .map_err(txn::Error::from);
                     let (memory_lock_kv_pairs, _) = memory_locks?;
-
                     let result = reader
                         .scan_locks(
                             start_key.as_ref(),
@@ -1479,6 +1478,9 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                         .map_err(txn::Error::from);
                     statistics.add(&reader.statistics);
                     let (kv_pairs, _) = result?;
+
+                    // Merge the results from in-memory pessimistic locks and the lock cf.
+                    // The result order is decided by the key.
                     let memory_lock_iter = memory_lock_kv_pairs.into_iter();
                     let lock_iter = kv_pairs.into_iter();
                     let merged_iter = memory_lock_iter

--- a/src/storage/mvcc/metrics.rs
+++ b/src/storage/mvcc/metrics.rs
@@ -36,6 +36,11 @@ make_static_metric! {
         write_not_loaded_skip
     }
 
+    pub label_enum ScanLockReadTimeSource {
+        resolve_lock,
+        pessimistic_rollback,
+    }
+
     pub struct MvccConflictCounterVec: IntCounter {
         "type" => MvccConflictKind,
     }
@@ -57,6 +62,10 @@ make_static_metric! {
             non_retry_req,
             retry_req,
         },
+    }
+
+    pub struct ScanLockReadTimeVec: Histogram {
+        "type" => ScanLockReadTimeSource,
     }
 }
 
@@ -120,4 +129,12 @@ lazy_static! {
         )
         .unwrap()
     };
+    pub static ref SCAN_LOCK_READ_TIME_VEC: ScanLockReadTimeVec = register_static_histogram_vec!(
+        ScanLockReadTimeVec,
+        "tikv_storage_mvcc_scan_lock_read_duration_seconds",
+        "Bucketed histogram of memory lock read lock hold for scan lock",
+        &["type"],
+        exponential_buckets(0.00001, 2.0, 20).unwrap()
+    )
+    .unwrap();
 }

--- a/tests/integrations/server/kv_service.rs
+++ b/tests/integrations/server/kv_service.rs
@@ -2790,7 +2790,7 @@ fn test_mvcc_scan_memory_and_cf_locks() {
         }
     }
 
-    // Scan lock, the pessimistic and prewrite
+    // Scan lock, the pessimistic and prewrite results are returned.
     for scan_limit in [0, 512, num_keys, num_keys * 2] {
         let scan_ts = 20;
         let scan_lock_max_version = scan_ts;
@@ -2828,7 +2828,7 @@ fn test_mvcc_scan_memory_and_cf_locks() {
     assert!(!scan_lock_resp.has_region_error());
     assert_eq!(scan_lock_resp.locks.len(), 0);
 
-    // Rollback the prewrite locks.
+    // Roll back the prewrite locks.
     let rollback_start_version = start_ts;
     let mut rollback_req = BatchRollbackRequest::default();
     rollback_req.set_context(ctx.clone());
@@ -2854,7 +2854,7 @@ fn test_mvcc_scan_memory_and_cf_locks() {
         assert_eq!(lock_info.lock_type, Op::PessimisticLock);
     }
 
-    // Pessimistic rollback all the locsk.
+    // Pessimistic rollabck all the locks. Scan lock should return empty result.
     let mut pessimsitic_rollback_req = PessimisticRollbackRequest::default();
     pessimsitic_rollback_req.start_version = start_ts;
     pessimsitic_rollback_req.for_update_ts = start_ts;


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref #15066 #16158 

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Change in-memory pessimsitic locks from hash map to btree map, support collecting pessimistic locks for scan lock command.
Then:
1. GC could collect expired pessimistic locks.
2. Pessimistic rollback could use read scan first and then clean up expired pessimistic locks at one time.
```

# Benchmark Test

## Local Sysbench
From the sysbench `oltp_write_only` tests, there are not much performance difference
PR:
Throughput:
    events/s (eps):                      5082.2634
    time elapsed:                        600.0055s
    total number of events:              3049386

Master:
Throughput:
    events/s (eps):                      4971.9635
    time elapsed:                        600.0060s
    total number of events:              2983208


## Heavy Lock Workload
Besides @zyguan has helped to verify that in lock heavy workloads there could be a **3% regression**, see the comments below for details. 


### Related changes

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [x] Performance regression: Consumes more CPU
- [x] Performance regression: Consumes more Memory

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
