### PR TITLE
tidb_query_datatype: fix timezone conversion by upgrading chrono-tz

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -891,9 +891,9 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0e430fad0384e4defc3dc6b1223d1b886087a8bf9b7080e5ae027f73851ea15"
+checksum = "2554a3155fec064362507487171dcc4edc3df60cb10f3a1fb10ed8094822b120"
 dependencies = [
  "chrono",
  "parse-zoneinfo",
@@ -3569,9 +3569,9 @@ dependencies = [
 
 [[package]]
 name = "parse-zoneinfo"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "089a398ccdcdd77b8c38909d5a1e4b67da1bc4c9dbfe6d5b536c828eddb779e5"
+checksum = "c705f256449c60da65e11ff6626e0c16a0a0b96aaa348de61376b249bc340f41"
 dependencies = [
  "regex",
 ]

--- a/components/tidb_query_datatype/src/codec/mysql/time/mod.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/time/mod.rs
@@ -2401,15 +2401,19 @@ mod tests {
 
     #[test]
     fn test_parse_time_with_tz() -> Result<()> {
-        let ctx_with_tz = |tz: &str| {
+        let ctx_with_tz = |tz: &str, by_offset: bool| {
             let mut cfg = EvalConfig::default();
-            let raw = tz.as_bytes();
-            // brutally turn timezone in format +08:00 into offset in minute
-            let offset = if raw[0] == b'-' { -1 } else { 1 }
-                * ((raw[1] - b'0') as i64 * 10 + (raw[2] - b'0') as i64)
-                * 60
-                + ((raw[4] - b'0') as i64 * 10 + (raw[5] - b'0') as i64);
-            cfg.set_time_zone_by_offset(offset * 60).unwrap();
+            if by_offset {
+                let raw = tz.as_bytes();
+                // brutally turn timezone in format +08:00 into offset in minute
+                let offset = if raw[0] == b'-' { -1 } else { 1 }
+                    * ((raw[1] - b'0') as i64 * 10 + (raw[2] - b'0') as i64)
+                    * 60
+                    + ((raw[4] - b'0') as i64 * 10 + (raw[5] - b'0') as i64);
+                cfg.set_time_zone_by_offset(offset * 60).unwrap();
+            } else {
+                cfg.set_time_zone_by_name(tz).unwrap();
+            }
             let warnings = cfg.new_eval_warnings();
             EvalContext {
                 cfg: Arc::new(cfg),
@@ -2418,6 +2422,7 @@ mod tests {
         };
         struct Case {
             tz: &'static str,
+            by_offset: bool,
             t: &'static str,
             r: Option<&'static str>,
             tp: TimeType,
@@ -2425,60 +2430,70 @@ mod tests {
         let cases = vec![
             Case {
                 tz: "+00:00",
+                by_offset: true,
                 t: "2020-10-10T10:10:10Z",
                 r: Some("2020-10-10 10:10:10.000000"),
                 tp: TimeType::DateTime,
             },
             Case {
                 tz: "+00:00",
+                by_offset: true,
                 t: "2020-10-10T10:10:10+",
                 r: None,
                 tp: TimeType::DateTime,
             },
             Case {
                 tz: "+00:00",
+                by_offset: true,
                 t: "2020-10-10T10:10:10+14:01",
                 r: None,
                 tp: TimeType::DateTime,
             },
             Case {
                 tz: "+00:00",
+                by_offset: true,
                 t: "2020-10-10T10:10:10-00:00",
                 r: None,
                 tp: TimeType::DateTime,
             },
             Case {
                 tz: "-08:00",
+                by_offset: true,
                 t: "2020-10-10T10:10:10-08",
                 r: Some("2020-10-10 10:10:10.000000"),
                 tp: TimeType::DateTime,
             },
             Case {
                 tz: "+08:00",
+                by_offset: true,
                 t: "2020-10-10T10:10:10+08:00",
                 r: Some("2020-10-10 10:10:10.000000"),
                 tp: TimeType::DateTime,
             },
             Case {
                 tz: "+08:00",
+                by_offset: true,
                 t: "2020-10-10T10:10:10+08:00",
                 r: Some("2020-10-10 10:10:10.000000"),
                 tp: TimeType::Timestamp,
             },
             Case {
                 tz: "+08:00",
+                by_offset: true,
                 t: "2022-06-02T10:10:10Z",
                 r: Some("2022-06-02 18:10:10.000000"),
                 tp: TimeType::DateTime,
             },
             Case {
                 tz: "-08:00",
+                by_offset: true,
                 t: "2022-06-02T10:10:10Z",
                 r: Some("2022-06-02 02:10:10.000000"),
                 tp: TimeType::DateTime,
             },
             Case {
                 tz: "+06:30",
+                by_offset: true,
                 t: "2022-06-02T10:10:10-05:00",
                 r: Some("2022-06-02 21:40:10.000000"),
                 tp: TimeType::DateTime,
@@ -2486,26 +2501,45 @@ mod tests {
             // Time with fraction
             Case {
                 tz: "+08:00",
+                by_offset: true,
                 t: "2022-06-02T10:10:10.123Z",
                 r: Some("2022-06-02 18:10:10.123000"),
                 tp: TimeType::DateTime,
             },
             Case {
                 tz: "-08:00",
+                by_offset: true,
                 t: "2022-06-02T10:10:10.123Z",
                 r: Some("2022-06-02 02:10:10.123000"),
                 tp: TimeType::DateTime,
             },
             Case {
                 tz: "+06:30",
+                by_offset: true,
                 t: "2022-06-02T10:10:10.654321-05:00",
                 r: Some("2022-06-02 21:40:10.654321"),
                 tp: TimeType::DateTime,
             },
+            Case {
+                // Note: this case may fail if Brazil observes DST again.
+                // See https://github.com/pingcap/tidb/issues/49586
+                tz: "Brazil/East",
+                by_offset: false,
+                t: "2023-11-30T17:02:00.654321+00:00",
+                r: Some("2023-11-30 14:02:00.654321"),
+                tp: TimeType::DateTime,
+            },
         ];
         let mut result: Vec<Option<String>> = vec![];
-        for Case { tz, t, r: _, tp } in &cases {
-            let mut ctx = ctx_with_tz(tz);
+        for Case {
+            tz,
+            by_offset,
+            t,
+            r: _,
+            tp,
+        } in &cases
+        {
+            let mut ctx = ctx_with_tz(tz, *by_offset);
             let parsed = Time::parse(&mut ctx, t, *tp, 6, true);
             match parsed {
                 Ok(p) => result.push(Some(p.to_string())),


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #16220 Close pingcap/tidb#49586

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Brazil no longer observes DST since 2020[1]. Updating chrono-tz from
0.5.1 to 0.5.2 bumps the timezone database from 2018i to 2020a, which
includes this change, thus fixes the issue.

[1]: https://en.wikipedia.org/wiki/Daylight_saving_time_in_Brazil
```

### Related changes

- [x] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fix an issue about some timezone conversion including Brazil and Egypt.
```
