### PR TITLE
cdc: incremental scans use correct specified ranges

### DIFF
--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -1164,8 +1164,8 @@ fn decode_default(value: Vec<u8>, row: &mut EventRow, has_value: &mut bool) {
 /// Observed key range.
 #[derive(Clone, Default)]
 pub struct ObservedRange {
-    start_key_encoded: Vec<u8>,
-    end_key_encoded: Vec<u8>,
+    pub(crate) start_key_encoded: Vec<u8>,
+    pub(crate) end_key_encoded: Vec<u8>,
     start_key_raw: Vec<u8>,
     end_key_raw: Vec<u8>,
     pub(crate) all_key_covered: bool,

--- a/components/cdc/src/initializer.rs
+++ b/components/cdc/src/initializer.rs
@@ -216,13 +216,13 @@ impl<E: KvEngine> Initializer<E> {
 
         // Be compatible with old TiCDC clients, which won't give `observed_range`.
         let (start_key, end_key): (Key, Key);
-        if self.observed_range.start_key_encoded < region.start_key {
+        if self.observed_range.start_key_encoded <= region.start_key {
             start_key = Key::from_encoded_slice(&region.start_key);
         } else {
             start_key = Key::from_encoded_slice(&self.observed_range.start_key_encoded);
         }
         if self.observed_range.end_key_encoded.is_empty()
-            || self.observed_range.end_key_encoded > region.end_key && !region.end_key.is_empty()
+            || self.observed_range.end_key_encoded >= region.end_key && !region.end_key.is_empty()
         {
             end_key = Key::from_encoded_slice(&region.end_key);
         } else {
@@ -251,11 +251,17 @@ impl<E: KvEngine> Initializer<E> {
                 let dc = new_old_value_cursor(&snap, CF_DEFAULT);
                 old_value_cursors = Some(OldValueCursors::new(wc, dc));
             }
+            let upper_boundary = if end_key.as_encoded().is_empty() {
+                // Region upper boundary could be an empty slice.
+                None
+            } else {
+                Some(end_key)
+            };
 
             // Time range: (checkpoint_ts, max]
             let txnkv_scanner = ScannerBuilder::new(snap, TimeStamp::max())
                 .fill_cache(false)
-                .range(Some(start_key), Some(end_key))
+                .range(Some(start_key), upper_boundary)
                 .hint_min_ts(hint_min_ts)
                 .build_delta_scanner(self.checkpoint_ts, TxnExtraOp::ReadOldValue)
                 .unwrap();

--- a/components/cdc/src/initializer.rs
+++ b/components/cdc/src/initializer.rs
@@ -734,12 +734,14 @@ mod tests {
             total_bytes += v.len();
             let ts = TimeStamp::new(i as _);
             must_prewrite_put(&mut engine, k, v, k, ts);
-            let txn_locks = expected_locks.entry(ts).or_insert_with(|| {
-                let mut txn_locks = TxnLocks::default();
-                txn_locks.sample_lock = Some(k.to_vec().into());
-                txn_locks
-            });
-            txn_locks.lock_count += 1;
+            if i < 90 {
+                let txn_locks = expected_locks.entry(ts).or_insert_with(|| {
+                    let mut txn_locks = TxnLocks::default();
+                    txn_locks.sample_lock = Some(k.to_vec().into());
+                    txn_locks
+                });
+                txn_locks.lock_count += 1;
+            }
         }
 
         let region = Region::default();

--- a/components/tikv_util/src/config.rs
+++ b/components/tikv_util/src/config.rs
@@ -625,7 +625,7 @@ fn parse_offset(offset_str: &str) -> Result<FixedOffset, String> {
 
 impl fmt::Display for ReadableOffsetTime {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} {}", self.0, self.1)
+        write!(f, "{} {}", self.0.format("%H:%M"), self.1)
     }
 }
 
@@ -2022,12 +2022,27 @@ mod tests {
                 )
             });
             assert_eq!(actual, expected);
+            let actual = format!("{}", expected)
+                .parse::<ReadableOffsetTime>()
+                .unwrap();
+            assert_eq!(actual, expected);
         }
+        let (encoded, actual) = (
+            "23:00 +00:00",
+            ReadableOffsetTime(
+                NaiveTime::from_hms_opt(23, 00, 00).unwrap(),
+                FixedOffset::east_opt(0).unwrap(),
+            ),
+        );
+        let actual = format!("{}", actual);
+        let expected = encoded.to_owned();
+        assert_eq!(actual, expected);
+
         let time = ReadableOffsetTime(
             NaiveTime::from_hms_opt(9, 30, 00).unwrap(),
             FixedOffset::west_opt(0).unwrap(),
         );
-        assert_eq!(format!("{}", time), "09:30:00 +00:00");
+        assert_eq!(format!("{}", time), "09:30 +00:00");
         let dt = DateTime::parse_from_rfc3339("2023-10-27T09:39:57-00:00").unwrap();
         assert!(time.hour_matches(&dt));
         assert!(!time.hour_minutes_matches(&dt));


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Close #16362 

What's Changed:

* make incremental scans use correct ranges instead of snapshot boundaries;
* make timstamp filter of incremental scans use correct ranges instead of snapshot boundaries.

```commit-message

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
None
```
