### PR TITLE
raftstore: batch ingest sst files during committed entries apply.

### DIFF
--- a/components/backup-stream/src/observer.rs
+++ b/components/backup-stream/src/observer.rs
@@ -6,13 +6,12 @@ use engine_traits::KvEngine;
 use kvproto::metapb::Region;
 use raft::StateRole;
 use raftstore::coprocessor::*;
-use tikv_util::{worker::Scheduler, HandyRwLock};
+use tikv_util::{worker::Scheduler, HandyRwLock, range::SegmentSet};
 
 use crate::{
     debug,
     endpoint::{ObserveOp, Task},
     try_send,
-    utils::SegmentSet,
 };
 
 /// An Observer for Backup Stream.

--- a/components/backup-stream/src/observer.rs
+++ b/components/backup-stream/src/observer.rs
@@ -6,7 +6,7 @@ use engine_traits::KvEngine;
 use kvproto::metapb::Region;
 use raft::StateRole;
 use raftstore::coprocessor::*;
-use tikv_util::{worker::Scheduler, HandyRwLock, range::SegmentSet};
+use tikv_util::{range::SegmentSet, worker::Scheduler, HandyRwLock};
 
 use crate::{
     debug,

--- a/components/backup-stream/src/router.rs
+++ b/components/backup-stream/src/router.rs
@@ -34,6 +34,7 @@ use tikv_util::{
     codec::stream_event::EventEncoder,
     config::ReadableSize,
     error, info,
+    range::SegmentMap,
     time::{Instant, Limiter},
     warn,
     worker::Scheduler,
@@ -58,7 +59,7 @@ use crate::{
     subscription_track::TwoPhaseResolver,
     tempfiles::{self, TempFilePool},
     try_send,
-    utils::{self, CompressionWriter, FilesReader, SegmentMap, SlotMap, StopWatch},
+    utils::{self, CompressionWriter, FilesReader, SlotMap, StopWatch},
 };
 
 const FLUSH_FAILURE_BECOME_FATAL_THRESHOLD: usize = 30;

--- a/components/backup-stream/src/utils.rs
+++ b/components/backup-stream/src/utils.rs
@@ -99,7 +99,6 @@ pub type Slot<T> = Mutex<T>;
 /// NOTE: Maybe we can use dashmap for replacing the RwLock.
 pub type SlotMap<K, V, S = RandomState> = RwLock<HashMap<K, Slot<V>, S>>;
 
-
 /// transform a [`RaftCmdRequest`] to `(key, value, cf)` triple.
 /// once it contains a write request, extract it, and return `Left((key, value,
 /// cf))`, otherwise return the request itself via `Right`.
@@ -652,6 +651,7 @@ mod test {
     use futures::executor::block_on;
     use kvproto::metapb::{Region, RegionEpoch};
     use tokio::io::{AsyncWriteExt, BufReader};
+
     use crate::utils::{is_in_range, CallbackWaitGroup};
 
     #[test]

--- a/components/backup-stream/src/utils.rs
+++ b/components/backup-stream/src/utils.rs
@@ -2,10 +2,8 @@
 
 use core::pin::Pin;
 use std::{
-    borrow::Borrow,
     cell::RefCell,
-    collections::{hash_map::RandomState, BTreeMap, HashMap},
-    ops::{Bound, RangeBounds},
+    collections::{hash_map::RandomState, HashMap},
     path::Path,
     sync::{
         atomic::{AtomicUsize, Ordering},
@@ -101,163 +99,6 @@ pub type Slot<T> = Mutex<T>;
 /// NOTE: Maybe we can use dashmap for replacing the RwLock.
 pub type SlotMap<K, V, S = RandomState> = RwLock<HashMap<K, Slot<V>, S>>;
 
-/// Like `..=val`(a.k.a. `RangeToInclusive`), but allows `val` being a reference
-/// to DSTs.
-struct RangeToInclusiveRef<'a, T: ?Sized>(&'a T);
-
-impl<'a, T: ?Sized> RangeBounds<T> for RangeToInclusiveRef<'a, T> {
-    fn start_bound(&self) -> Bound<&T> {
-        Bound::Unbounded
-    }
-
-    fn end_bound(&self) -> Bound<&T> {
-        Bound::Included(self.0)
-    }
-}
-
-struct RangeToExclusiveRef<'a, T: ?Sized>(&'a T);
-
-impl<'a, T: ?Sized> RangeBounds<T> for RangeToExclusiveRef<'a, T> {
-    fn start_bound(&self) -> Bound<&T> {
-        Bound::Unbounded
-    }
-
-    fn end_bound(&self) -> Bound<&T> {
-        Bound::Excluded(self.0)
-    }
-}
-#[derive(Default, Debug, Clone)]
-pub struct SegmentMap<K: Ord, V>(BTreeMap<K, SegmentValue<K, V>>);
-
-#[derive(Clone, Debug)]
-pub struct SegmentValue<R, T> {
-    pub range_end: R,
-    pub item: T,
-}
-
-/// A container for holding ranges without overlapping.
-/// supports fast(`O(log(n))`) query of overlapping and points in segments.
-///
-/// Maybe replace it with extended binary search tree or the real segment tree?
-/// So it can contains overlapping segments.
-pub type SegmentSet<T> = SegmentMap<T, ()>;
-
-impl<K: Ord, V: Default> SegmentMap<K, V> {
-    /// Try to add a element into the segment tree, with default value.
-    /// (This is useful when using the segment tree as a `Set`, i.e.
-    /// `SegmentMap<T, ()>`)
-    ///
-    /// - If no overlapping, insert the range into the tree and returns `true`.
-    /// - If overlapping detected, do nothing and return `false`.
-    pub fn add(&mut self, (start, end): (K, K)) -> bool {
-        self.insert((start, end), V::default())
-    }
-}
-
-impl<K: Ord, V> SegmentMap<K, V> {
-    /// Remove all records in the map.
-    pub fn clear(&mut self) {
-        self.0.clear();
-    }
-
-    /// Like `add`, but insert a value associated to the key.
-    pub fn insert(&mut self, (start, end): (K, K), value: V) -> bool {
-        if self.is_overlapping((&start, &end)) {
-            return false;
-        }
-        self.0.insert(
-            start,
-            SegmentValue {
-                range_end: end,
-                item: value,
-            },
-        );
-        true
-    }
-
-    /// Find a segment with its associated value by the point.
-    pub fn get_by_point<R>(&self, point: &R) -> Option<(&K, &K, &V)>
-    where
-        K: Borrow<R>,
-        R: Ord + ?Sized,
-    {
-        self.0
-            .range(RangeToInclusiveRef(point))
-            .next_back()
-            .filter(|(_, end)| <K as Borrow<R>>::borrow(&end.range_end) > point)
-            .map(|(k, v)| (k, &v.range_end, &v.item))
-    }
-
-    /// Like `get_by_point`, but omit the segment.
-    pub fn get_value_by_point<R>(&self, point: &R) -> Option<&V>
-    where
-        K: Borrow<R>,
-        R: Ord + ?Sized,
-    {
-        self.get_by_point(point).map(|(_, _, v)| v)
-    }
-
-    /// Like `get_by_point`, but omit the segment.
-    pub fn get_interval_by_point<R>(&self, point: &R) -> Option<(&K, &K)>
-    where
-        K: Borrow<R>,
-        R: Ord + ?Sized,
-    {
-        self.get_by_point(point).map(|(k, v, _)| (k, v))
-    }
-
-    pub fn find_overlapping<R>(&self, range: (&R, &R)) -> Option<(&K, &K, &V)>
-    where
-        K: Borrow<R>,
-        R: Ord + ?Sized,
-    {
-        // o: The Start Key.
-        // e: The End Key.
-        // +: The Boundary of Candidate Range.
-        // |------+-s----+----e----|
-        // Firstly, we check whether the start point is in some range.
-        // if true, it must be overlapping.
-        if let Some(overlap_with_start) = self.get_by_point(range.0) {
-            return Some(overlap_with_start);
-        }
-        // |--s----+-----+----e----|
-        // Otherwise, the possibility of being overlapping would be there are some sub
-        // range of the queried range...
-        // |--s----+----e----+-----|
-        // ...Or the end key is contained by some Range.
-        // For faster query, we merged the two cases together.
-        let covered_by_the_range = self
-             .0
-             // When querying possibility of overlapping by end key,
-             // we don't want the range [end key, ...) become a candidate.
-             // (which is impossible to overlapping with the range)
-             .range(RangeToExclusiveRef(range.1))
-             .next_back()
-             .filter(|(start, end)| {
-                 <K as Borrow<R>>::borrow(&end.range_end) > range.1
-                     || <K as Borrow<R>>::borrow(start) > range.0
-             });
-        covered_by_the_range.map(|(k, v)| (k, &v.range_end, &v.item))
-    }
-
-    /// Check whether the range is overlapping with any range in the segment
-    /// tree.
-    pub fn is_overlapping<R>(&self, range: (&R, &R)) -> bool
-    where
-        K: Borrow<R>,
-        R: Ord + ?Sized,
-    {
-        self.find_overlapping(range).is_some()
-    }
-
-    pub fn get_inner(&mut self) -> &mut BTreeMap<K, SegmentValue<K, V>> {
-        &mut self.0
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-}
 
 /// transform a [`RaftCmdRequest`] to `(key, value, cf)` triple.
 /// once it contains a write request, extract it, and return `Left((key, value,
@@ -811,8 +652,7 @@ mod test {
     use futures::executor::block_on;
     use kvproto::metapb::{Region, RegionEpoch};
     use tokio::io::{AsyncWriteExt, BufReader};
-
-    use crate::utils::{is_in_range, CallbackWaitGroup, SegmentMap};
+    use crate::utils::{is_in_range, CallbackWaitGroup};
 
     #[test]
     fn test_redact() {
@@ -887,29 +727,6 @@ mod test {
                 case
             );
         }
-    }
-
-    #[test]
-    fn test_segment_tree() {
-        let mut tree = SegmentMap::default();
-        assert!(tree.add((1, 4)));
-        assert!(tree.add((4, 8)));
-        assert!(tree.add((42, 46)));
-        assert!(!tree.add((3, 8)));
-        assert!(tree.insert((47, 88), "hello".to_owned()));
-        assert_eq!(
-            tree.get_value_by_point(&49).map(String::as_str),
-            Some("hello")
-        );
-        assert_eq!(tree.get_interval_by_point(&3), Some((&1, &4)));
-        assert_eq!(tree.get_interval_by_point(&7), Some((&4, &8)));
-        assert_eq!(tree.get_interval_by_point(&90), None);
-        assert!(tree.is_overlapping((&1, &3)));
-        assert!(tree.is_overlapping((&7, &9)));
-        assert!(!tree.is_overlapping((&8, &42)));
-        assert!(!tree.is_overlapping((&9, &10)));
-        assert!(tree.is_overlapping((&2, &10)));
-        assert!(tree.is_overlapping((&0, &9999999)));
     }
 
     #[test]

--- a/components/engine_traits/src/sst.rs
+++ b/components/engine_traits/src/sst.rs
@@ -7,7 +7,7 @@ use kvproto::import_sstpb::SstMeta;
 
 use crate::{errors::Result, RefIterable};
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Default, Debug)]
 pub struct SstMetaInfo {
     pub total_bytes: u64,
     pub total_kvs: u64,

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -2039,8 +2039,8 @@ where
                     .pending_ssts
                     .insert((start.to_vec(), end.to_vec()), meta_info.clone())
                 {
-                    // even if we had a check during handle_raft_committed_entry
-                    // it still has possibility that multiple ssts are overlapped in one apply entry.
+                    // we had a check during handle_raft_committed_entry
+                    // so this error is unreachable, due to there is no batched ingest ssts.
                     error!("ingest overlapped";
                         "region_id" => self.region_id(),
                         "peer_id" => self.id(),

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -1410,7 +1410,6 @@ where
 
         apply_ctx.host.pre_apply(&self.region, &req);
         let (mut cmd, exec_result, should_write) = self.apply_raft_cmd(apply_ctx, index, term, req);
-        println!("process raft cmd: {}", should_write);
         if let ApplyResult::WaitMergeSource(_) = exec_result {
             return exec_result;
         }

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -5242,7 +5242,7 @@ mod tests {
         // Delet range command
         let mut req = Request::default();
         req.set_cmd_type(CmdType::DeleteRange);
-        req.set_delete_range(DeleteRange::default());
+        req.set_delete_range(DeleteRangeRequest::default());
         let mut cmd = RaftCmdRequest::default();
         cmd.mut_requests().push(req);
         assert_eq!(should_write_to_engine(&cmd), true);

--- a/components/tikv_util/src/lib.rs
+++ b/components/tikv_util/src/lib.rs
@@ -53,6 +53,7 @@ pub mod memory;
 pub mod metrics;
 pub mod mpsc;
 pub mod quota_limiter;
+pub mod range;
 pub mod resource_control;
 pub mod store;
 pub mod stream;

--- a/components/tikv_util/src/range.rs
+++ b/components/tikv_util/src/range.rs
@@ -1,0 +1,194 @@
+// Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
+
+/// This mod provide some utility types and functions for resource control.
+
+use std::borrow::Borrow;
+use std::collections::BTreeMap;
+use std::ops::{Bound,RangeBounds};
+
+/// Like `..=val`(a.k.a. `RangeToInclusive`), but allows `val` being a reference
+/// to DSTs.
+struct RangeToInclusiveRef<'a, T: ?Sized>(&'a T);
+
+impl<'a, T: ?Sized> RangeBounds<T> for RangeToInclusiveRef<'a, T> {
+    fn start_bound(&self) -> Bound<&T> {
+        Bound::Unbounded
+    }
+
+    fn end_bound(&self) -> Bound<&T> {
+        Bound::Included(self.0)
+    }
+}
+
+struct RangeToExclusiveRef<'a, T: ?Sized>(&'a T);
+
+impl<'a, T: ?Sized> RangeBounds<T> for RangeToExclusiveRef<'a, T> {
+    fn start_bound(&self) -> Bound<&T> {
+        Bound::Unbounded
+    }
+
+    fn end_bound(&self) -> Bound<&T> {
+        Bound::Excluded(self.0)
+    }
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct SegmentMap<K: Ord, V>(BTreeMap<K, SegmentValue<K, V>>);
+
+#[derive(Clone, Debug)]
+pub struct SegmentValue<R, T> {
+    pub range_end: R,
+    pub item: T,
+}
+
+/// A container for holding ranges without overlapping.
+/// supports fast(`O(log(n))`) query of overlapping and points in segments.
+///
+/// Maybe replace it with extended binary search tree or the real segment tree?
+/// So it can contains overlapping segments.
+pub type SegmentSet<T> = SegmentMap<T, ()>;
+
+impl<K: Ord, V: Default> SegmentMap<K, V> {
+    /// Try to add a element into the segment tree, with default value.
+    /// (This is useful when using the segment tree as a `Set`, i.e.
+    /// `SegmentMap<T, ()>`)
+    ///
+    /// - If no overlapping, insert the range into the tree and returns `true`.
+    /// - If overlapping detected, do nothing and return `false`.
+    pub fn add(&mut self, (start, end): (K, K)) -> bool {
+        self.insert((start, end), V::default())
+    }
+}
+
+impl<K: Ord, V> SegmentMap<K, V> {
+    /// Remove all records in the map.
+    pub fn clear(&mut self) {
+        self.0.clear();
+    }
+
+    /// Like `add`, but insert a value associated to the key.
+    pub fn insert(&mut self, (start, end): (K, K), value: V) -> bool {
+        if self.is_overlapping((&start, &end)) {
+            return false;
+        }
+        self.0.insert(
+            start,
+            SegmentValue {
+                range_end: end,
+                item: value,
+            },
+        );
+        true
+    }
+
+    /// Find a segment with its associated value by the point.
+    pub fn get_by_point<R>(&self, point: &R) -> Option<(&K, &K, &V)>
+    where
+        K: Borrow<R>,
+        R: Ord + ?Sized,
+    {
+        self.0
+            .range(RangeToInclusiveRef(point))
+            .next_back()
+            .filter(|(_, end)| <K as Borrow<R>>::borrow(&end.range_end) > point)
+            .map(|(k, v)| (k, &v.range_end, &v.item))
+    }
+
+    /// Like `get_by_point`, but omit the segment.
+    pub fn get_value_by_point<R>(&self, point: &R) -> Option<&V>
+    where
+        K: Borrow<R>,
+        R: Ord + ?Sized,
+    {
+        self.get_by_point(point).map(|(_, _, v)| v)
+    }
+
+    /// Like `get_by_point`, but omit the segment.
+    pub fn get_interval_by_point<R>(&self, point: &R) -> Option<(&K, &K)>
+    where
+        K: Borrow<R>,
+        R: Ord + ?Sized,
+    {
+        self.get_by_point(point).map(|(k, v, _)| (k, v))
+    }
+
+    pub fn find_overlapping<R>(&self, range: (&R, &R)) -> Option<(&K, &K, &V)>
+    where
+        K: Borrow<R>,
+        R: Ord + ?Sized,
+    {
+        // o: The Start Key.
+        // e: The End Key.
+        // +: The Boundary of Candidate Range.
+        // |------+-s----+----e----|
+        // Firstly, we check whether the start point is in some range.
+        // if true, it must be overlapping.
+        if let Some(overlap_with_start) = self.get_by_point(range.0) {
+            return Some(overlap_with_start);
+        }
+        // |--s----+-----+----e----|
+        // Otherwise, the possibility of being overlapping would be there are some sub
+        // range of the queried range...
+        // |--s----+----e----+-----|
+        // ...Or the end key is contained by some Range.
+        // For faster query, we merged the two cases together.
+        let covered_by_the_range = self
+             .0
+             // When querying possibility of overlapping by end key,
+             // we don't want the range [end key, ...) become a candidate.
+             // (which is impossible to overlapping with the range)
+             .range(RangeToExclusiveRef(range.1))
+             .next_back()
+             .filter(|(start, end)| {
+                 <K as Borrow<R>>::borrow(&end.range_end) > range.1
+                     || <K as Borrow<R>>::borrow(start) > range.0
+             });
+        covered_by_the_range.map(|(k, v)| (k, &v.range_end, &v.item))
+    }
+
+    /// Check whether the range is overlapping with any range in the segment
+    /// tree.
+    pub fn is_overlapping<R>(&self, range: (&R, &R)) -> bool
+    where
+        K: Borrow<R>,
+        R: Ord + ?Sized,
+    {
+        self.find_overlapping(range).is_some()
+    }
+
+    pub fn get_inner(&mut self) -> &mut BTreeMap<K, SegmentValue<K, V>> {
+        &mut self.0
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+
+
+#[cfg(test)]
+mod tests{
+#[test]
+fn test_segment_tree() {
+    let mut tree = SegmentMap::default();
+    assert!(tree.add((1, 4)));
+    assert!(tree.add((4, 8)));
+    assert!(tree.add((42, 46)));
+    assert!(!tree.add((3, 8)));
+    assert!(tree.insert((47, 88), "hello".to_owned()));
+    assert_eq!(
+        tree.get_value_by_point(&49).map(String::as_str),
+        Some("hello")
+    );
+    assert_eq!(tree.get_interval_by_point(&3), Some((&1, &4)));
+    assert_eq!(tree.get_interval_by_point(&7), Some((&4, &8)));
+    assert_eq!(tree.get_interval_by_point(&90), None);
+    assert!(tree.is_overlapping((&1, &3)));
+    assert!(tree.is_overlapping((&7, &9)));
+    assert!(!tree.is_overlapping((&8, &42)));
+    assert!(!tree.is_overlapping((&9, &10)));
+    assert!(tree.is_overlapping((&2, &10)));
+    assert!(tree.is_overlapping((&0, &9999999)));
+}
+}

--- a/components/tikv_util/src/range.rs
+++ b/components/tikv_util/src/range.rs
@@ -107,7 +107,11 @@ impl<K: Ord, V: Clone> SegmentMap<K, V> {
 
     // get_vaules retrive and clone the value into a vector.
     pub fn get_values(&self) -> Vec<V> {
-        self.0.values().map(|v| &v.item).cloned().collect::<Vec<V>>()
+        self.0
+            .values()
+            .map(|v| &v.item)
+            .cloned()
+            .collect::<Vec<V>>()
     }
 
     /// Like `get_by_point`, but omit the segment.
@@ -150,6 +154,7 @@ impl<K: Ord, V: Clone> SegmentMap<K, V> {
                  <K as Borrow<R>>::borrow(&end.range_end) > range.1
                      || <K as Borrow<R>>::borrow(start) > range.0
              });
+
         covered_by_the_range.map(|(k, v)| (k, &v.range_end, &v.item))
     }
 

--- a/components/tikv_util/src/range.rs
+++ b/components/tikv_util/src/range.rs
@@ -107,7 +107,7 @@ impl<K: Ord, V: Clone> SegmentMap<K, V> {
 
     // get_vaules retrive and clone the value into a vector.
     pub fn get_values(&self) -> Vec<V> {
-        self.0.values().map(|v| v.item).cloned().collect::<Vec<V>>()
+        self.0.values().map(|v| &v.item).cloned().collect::<Vec<V>>()
     }
 
     /// Like `get_by_point`, but omit the segment.

--- a/components/tikv_util/src/range.rs
+++ b/components/tikv_util/src/range.rs
@@ -206,11 +206,9 @@ mod tests {
     #[test]
     fn test_values() {
         let mut tree = SegmentMap::default();
-        assert!(tree.add((1, 4)));
-        assert!(tree.add((4, 8)));
         assert!(tree.add((42, 46)));
-        assert!(!tree.add((3, 8)));
+        assert!(!tree.add((3, 43)));
         assert!(tree.insert((47, 88), "hello".to_owned()));
-        assert_eq!(tree.get_values(), vec!["hello"])
+        assert_eq!(tree.get_values(), vec!["", "hello"])
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: close https://github.com/tikv/tikv/issues/16267
https://github.com/tikv/tikv/pull/9686 didn't implement batch ingest totally.the batch-size of pending_ssts is too small to take benefits from batch ingest. this PR tried to complete it.

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:
1. move SegmentMap from `backup_stream` component to `tikv_util` components
2. check pending ssts is overlapped with new ingest commands.

```commit-message
raftstore: batch apply ingest sst files when there is no overlapped pending ssts.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note

```
