### PR TITLE
raftstore: batch ingest ssts if there is no pending writes during apply

### DIFF
--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -6226,16 +6226,14 @@ mod tests {
         // nomral put command, so the first apple_res.exec_res should be empty.
         let apply_res = fetch_apply_res(&rx);
         assert!(apply_res.exec_res.is_empty());
-        // The region was rescheduled low-priority becasuee of ingest command,
+        // The region was rescheduled low-priority because of ingest command,
         // only put entry has been applied;
         let apply_res = fetch_apply_res(&rx);
         assert_eq!(apply_res.applied_term, 3);
         assert_eq!(apply_res.apply_state.get_applied_index(), 9);
         // The region will yield after timeout.
-        let apply_res = fetch_apply_res(&rx);
-        assert_eq!(apply_res.applied_term, 3);
-        assert_eq!(apply_res.apply_state.get_applied_index(), 10);
-        // The third entry should be applied now.
+        // The second and third entry should be applied now. because we batch ingest ssts.
+        // so apply result notifier will trigger once. and the apply index should be 11.
         let apply_res = fetch_apply_res(&rx);
         assert_eq!(apply_res.applied_term, 3);
         assert_eq!(apply_res.apply_state.get_applied_index(), 11);
@@ -6577,10 +6575,8 @@ mod tests {
         assert_eq!(apply_res.applied_term, 3);
         assert_eq!(apply_res.apply_state.get_applied_index(), 9);
         // The region will yield after timeout.
-        let apply_res = fetch_apply_res(&rx);
-        assert_eq!(apply_res.applied_term, 3);
-        assert_eq!(apply_res.apply_state.get_applied_index(), 10);
-        // The third entry should be applied now.
+        // The second and third entry should be applied now. because we batch ingest ssts.
+        // so apply result notifier will trigger once. and the apply index should be 11.
         let apply_res = fetch_apply_res(&rx);
         assert_eq!(apply_res.applied_term, 3);
         assert_eq!(apply_res.apply_state.get_applied_index(), 11);

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -6232,8 +6232,9 @@ mod tests {
         assert_eq!(apply_res.applied_term, 3);
         assert_eq!(apply_res.apply_state.get_applied_index(), 9);
         // The region will yield after timeout.
-        // The second and third entry should be applied now. because we batch ingest ssts.
-        // so apply result notifier will trigger once. and the apply index should be 11.
+        // The second and third entry should be applied now. because we batch ingest
+        // ssts. so apply result notifier will trigger once. and the apply index
+        // should be 11.
         let apply_res = fetch_apply_res(&rx);
         assert_eq!(apply_res.applied_term, 3);
         assert_eq!(apply_res.apply_state.get_applied_index(), 11);
@@ -6575,8 +6576,9 @@ mod tests {
         assert_eq!(apply_res.applied_term, 3);
         assert_eq!(apply_res.apply_state.get_applied_index(), 9);
         // The region will yield after timeout.
-        // The second and third entry should be applied now. because we batch ingest ssts.
-        // so apply result notifier will trigger once. and the apply index should be 11.
+        // The second and third entry should be applied now. because we batch ingest
+        // ssts. so apply result notifier will trigger once. and the apply index
+        // should be 11.
         let apply_res = fetch_apply_res(&rx);
         assert_eq!(apply_res.applied_term, 3);
         assert_eq!(apply_res.apply_state.get_applied_index(), 11);


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close https://github.com/tikv/tikv/issues/16267

Current implementation would not batch too many ingest ssts.  because `apply_ctx.commit()` every time when entry has an ingest sst request. and ingest sst requests are not batched into one entry.

This PR try batch ingeset ssts if there is no pending writes. to increase the performance during bulk ingest workloads.

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
raftstore: batch ingest ssts if there is no pending writes during apply
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [x] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Increase the performance in bulk ingest workloads.
```
