### PR TITLE
txn: try to fix the possible deadlock caused by scan lock

### DIFF
--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -395,16 +395,16 @@ impl<S: EngineSnapshot> MvccReader<S> {
     {
         if let Some(txn_ext) = self.snapshot.ext().get_txn_ext() {
             let begin_instant = Instant::now();
-            let res = match self.check_term_version_status(&txn_ext.pessimistic_locks.read()) {
+            let pessimistic_locks_guard = txn_ext.pessimistic_locks.read();
+            let res = match self.check_term_version_status(&pessimistic_locks_guard) {
                 Ok(_) => {
-                    // Scan locks within the specified range and filter by max_ts.
-                    Ok(txn_ext
-                        .pessimistic_locks
-                        .read()
-                        .scan_locks(start_key, end_key, filter, scan_limit))
+                    // Scan locks within the specified range and filter.
+                    Ok(pessimistic_locks_guard.scan_locks(start_key, end_key, filter, scan_limit))
                 }
                 Err(e) => Err(e),
             };
+            drop(pessimistic_locks_guard);
+
             let elapsed = begin_instant.saturating_elapsed();
             SCAN_LOCK_READ_TIME_VEC
                 .get(source)


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref #16340

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Try to fix the possible deadlock caused by scan lock.
```

### Related changes



### Check List

Tests <!-- At least one of them must be included. -->


- [ ] Manual test (add detailed scripts or steps below)
```rust
#[test]
fn test_rw_lock() {
    fn test_check_term_version_status(locks: &PeerPessimisticLocks) -> Result<(), ()> {
        let version = locks.version;
        Ok(())
    }
    let peer_locks = PeerPessimisticLocks::from_locks(vec![
        lock_with_key(b"key1", false),
        lock_with_key(b"key2", false),
        lock_with_key(b"key3", false),
    ]);
    let lock = std::sync::Arc::new(RwLock::new(peer_locks));
    let running = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
    let l_read = lock.clone();
    let r = running.clone();
    let t0 = std::thread::spawn(move || {
        while r.load(Ordering::SeqCst) {
            // Impl 1.
            // let res = match test_check_term_version_status(&l_read.read()) {
            //     Ok(_) => {
            //         // Scan locks within the specified range and filter by max_ts.
            //         Ok(l_read
            //             .read()
            //             .scan_locks(None, None, |_, _ |true, 0))
            //     }
            //     Err(e) => Err(e),
            // };
            /// Impl 2.
            let pessimistic_locks_guard = l_read.read();
            let res = match test_check_term_version_status(&pessimistic_locks_guard) {
                Ok(_) => {
                    // Scan locks within the specified range and filter by max_ts.
                    Ok(pessimistic_locks_guard.scan_locks(None, None, |_,_| true, 0))
                }
                Err(e) => Err(e),
            };
        }
    });
    let l_write = lock.clone();
    let r = running.clone();
    let t1 = std::thread::spawn(move || {
        while r.load(Ordering::SeqCst) {
            let mut a = l_write.write();
            a.version += 1;
        }
    });
    std::thread::sleep(std::time::Duration::from_millis(1000));
    running.store(false, Ordering::SeqCst);
    t0.join().unwrap();
    t1.join().unwrap();
}
```

The `Impl 1` which executes like https://github.com/tikv/tikv/blob/master/src/storage/mvcc/reader/reader.rs#L398-L404 would cause deadlock, while `Impl 2` would not

```
The read thread
#0  syscall () at ../sysdeps/unix/sysv/linux/x86_64/syscall.S:38
#1  0x0000555557aceb97 in parking_lot_core::thread_parker::imp::ThreadParker::futex_wait (self=0x7ffff6ffe560, ts=...)
    at parking_lot_core-0.9.1/src/thread_parker/linux.rs:112
#2  0x0000555557ace9c4 in parking_lot_core::thread_parker::imp::{impl#0}::park (self=0x7ffff6ffe560)
    at parking_lot_core-0.9.1/src/thread_parker/linux.rs:66
#3  0x0000555557ac36ea in parking_lot_core::parking_lot::park::{closure#0}<parking_lot::raw_rwlock::{impl#10}::lock_common::{closure_env#0}<parking_lot::raw_rwlock::{impl#10}::lock_shared_slow::{closure_env#0}>, parking_lot::raw_rwlock::{impl#10}::lock_common::{closure_env#1}<parking_lot::raw_rwlock::{impl#10}::lock_shared_slow::{closure_env#0}>, parking_lot::raw_rwlock::{impl#10}::lock_common::{closure_env#2}<parking_lot::raw_rwlock::{impl#10}::lock_shared_slow::{closure_env#0}>> (
    thread_data=0x7ffff6ffe540) at parking_lot_core-0.9.1/src/parking_lot.rs:635
#4  0x0000555557ac1ceb in parking_lot_core::parking_lot::with_thread_data<parking_lot_core::parking_lot::ParkResult, parking_lot_core::parking_lot::park::{closure_env#0}<parking_lot::raw_rwlock::{impl#10}::lock_common::{closure_env#0}<parking_lot::raw_rwlock::{impl#10}::lock_shared_slow::{closure_env#0}>, parking_lot::raw_rwlock::{impl#10}::lock_common::{closure_env#1}<parking_lot::raw_rwlock::{impl#10}::lock_shared_slow::{closure_env#0}>, parking_lot::raw_rwlock::{impl#10}::lock_common::{closure_env#2}<parking_lot::raw_rwlock::{impl#10}::lock_shared_slow::{closure_env#0}>>> (f=...)
    at parking_lot_core-0.9.1/src/parking_lot.rs:207
#5  parking_lot_core::parking_lot::park<parking_lot::raw_rwlock::{impl#10}::lock_common::{closure_env#0}<parking_lot::raw_rwlock::{impl#10}::lock_shared_slow::{closure_env#0}>, parking_lot::raw_rwlock::{impl#10}::lock_common::{closure_env#1}<parking_lot::raw_rwlock::{impl#10}::lock_shared_slow::{closure_env#0}>, parking_lot::raw_rwlock::{impl#10}::lock_common::{closure_env#2}<parking_lot::raw_rwlock::{impl#10}::lock_shared_slow::{closure_env#0}>> (key=140737219925040, validate=..., 
    before_sleep=..., timed_out=..., park_token=..., timeout=...)
    at parking_lot_core-0.9.1/src/parking_lot.rs:600
#6  0x0000555557ac620d in parking_lot::raw_rwlock::RawRwLock::lock_common<parking_lot::raw_rwlock::{impl#10}::lock_shared_slow::{closure_env#0}> (

The write thread
#0  syscall () at ../sysdeps/unix/sysv/linux/x86_64/syscall.S:38
#1  0x0000555557aceb97 in parking_lot_core::thread_parker::imp::ThreadParker::futex_wait (self=0x7ffff6dfd560, ts=...)
    at parking_lot_core-0.9.1/src/thread_parker/linux.rs:112
#2  0x0000555557ace9c4 in parking_lot_core::thread_parker::imp::{impl#0}::park (self=0x7ffff6dfd560)
    at parking_lot_core-0.9.1/src/thread_parker/linux.rs:66
#3  0x0000555557ac3f36 in parking_lot_core::parking_lot::park::{closure#0}<parking_lot::raw_rwlock::{impl#10}::wait_for_readers::{closure_env#0}, parking_lot::raw_rwlock::{impl#10}::wait_for_readers::{closure_env#1}, parking_lot::raw_rwlock::{impl#10}::wait_for_readers::{closure_env#2}> (thread_data=0x7ffff6dfd540)
    at parking_lot_core-0.9.1/src/parking_lot.rs:635
#4  0x0000555557ac2255 in parking_lot_core::parking_lot::with_thread_data<parking_lot_core::parking_lot::ParkResult, parking_lot_core::parking_lot::park::{closure_env#0}<parking_lot::raw_rwlock::{impl#10}::wait_for_readers::{closure_env#0}, parking_lot::raw_rwlock::{impl#10}::wait_for_readers::{closure_env#1}, parking_lot::raw_rwlock::{impl#10}::wait_for_readers::{closure_env#2}>> (f=...)
    at parking_lot_core-0.9.1/src/parking_lot.rs:207
#5  parking_lot_core::parking_lot::park<parking_lot::raw_rwlock::{impl#10}::wait_for_readers::{closure_env#0}, parking_lot::raw_rwlock::{impl#10}::wait_for_readers::{closure_env#1}, parking_lot::raw_rwlock::{impl#10}::wait_for_readers::{closure_env#2}> (key=140737219925041, validate=..., before_sleep=..., timed_out=..., 
    park_token=..., timeout=...) at parking_lot_core-0.9.1/src/parking_lot.rs:600
#6  0x0000555557ac5b23 in parking_lot::raw_rwlock::RawRwLock::wait_for_readers (self=0x7ffff0001430, timeout=..., prev_value=0) at src/raw_rwlock.rs:1013
#7  0x0000555557ac5035 in parking_lot::raw_rwlock::RawRwLock::lock_exclusive_slow 
```

Side effects



### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
