### PR TITLE
test: fix unstable test test_limit_concurrency

### DIFF
--- a/src/coprocessor/interceptors/concurrency_limiter.rs
+++ b/src/coprocessor/interceptors/concurrency_limiter.rs
@@ -4,6 +4,7 @@ use std::{
     future::Future,
     marker::PhantomData,
     pin::Pin,
+    sync::atomic::{AtomicBool, Ordering},
     task::{Context, Poll},
     time::Duration,
 };
@@ -162,11 +163,15 @@ mod tests {
         // than t1, it starts with t1
         smp.add_permits(1);
         let smp2 = smp.clone();
-        let mut t1 =
-            tokio::spawn(
-                async move { limit_concurrency(work(8), &smp2, Duration::default()).await },
-            )
-            .fuse();
+
+        let t1_finished = Arc::new(AtomicBool::new(false));
+
+        let t1_finished_cloned = t1_finished.clone();
+        let mut t1 = tokio::spawn(async move {
+            limit_concurrency(work(8), &smp2, Duration::default()).await;
+            t1_finished_cloned.store(true, Ordering::Release);
+        })
+        .fuse();
 
         sleep(Duration::from_millis(100)).await;
         let smp2 = smp.clone();
@@ -178,14 +183,11 @@ mod tests {
 
         let deadline = sleep(Duration::from_millis(1500)).fuse();
         futures::pin_mut!(deadline);
-        let mut t1_finished = false;
         loop {
             futures_util::select! {
-                _ = t1 => {
-                    t1_finished = true;
-                },
+                _ = t1 => {},
                 _ = t2 => {
-                    if t1_finished {
+                    if t1_finished.load(Ordering::Acquire) {
                         return;
                     } else {
                         panic!("t2 should finish later than t1");

--- a/src/coprocessor/interceptors/concurrency_limiter.rs
+++ b/src/coprocessor/interceptors/concurrency_limiter.rs
@@ -4,7 +4,6 @@ use std::{
     future::Future,
     marker::PhantomData,
     pin::Pin,
-    sync::atomic::{AtomicBool, Ordering},
     task::{Context, Poll},
     time::Duration,
 };
@@ -127,7 +126,13 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::{sync::Arc, thread};
+    use std::{
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        },
+        thread,
+    };
 
     use futures::future::FutureExt;
     use tokio::{


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #15990

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
The original test use select! to check t1 is finished before t2, but this is unstable when the select! is called when both t1 and t2 is finished. From the rust doc we can see " If multiple futures are ready, one will be pseudo-randomly selected at runtime."
which means if both future is ready, which is polled first is not determined. So this PR uses a atomic value to determine t1's complete to make the result stable.
```

In my local test, I add an extra sleep to emulate `select!` call delay in which case both future are ready.
```
        ...
        let deadline = sleep(Duration::from_millis(1500)).fuse();
        futures::pin_mut!(deadline);
        
        // manual add a extra sleep to wait both future ready.
        sleep(Duration::from_millis(1000)).await;

        loop {
            futures_util::select! {
       ...
```
After add the extra sleep, the original case always fail(due to the pseudo-randomly), the fixed logic can still pass.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
