### PR TITLE
In-Memory Engine: WriteBatch implementation.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2342,9 +2342,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",
@@ -6957,7 +6957,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "static_assertions",
 ]
 

--- a/components/hybrid_engine/src/write_batch.rs
+++ b/components/hybrid_engine/src/write_batch.rs
@@ -50,65 +50,75 @@ impl<EK: KvEngine> WriteBatch for HybridEngineWriteBatch<EK> {
     }
 
     fn data_size(&self) -> usize {
-        unimplemented!()
+        self.disk_write_batch.data_size()
     }
 
     fn count(&self) -> usize {
-        unimplemented!()
+        self.disk_write_batch.count()
     }
 
     fn is_empty(&self) -> bool {
-        unimplemented!()
+        self.disk_write_batch.is_empty()
     }
 
     fn should_write_to_engine(&self) -> bool {
-        unimplemented!()
+        self.disk_write_batch.should_write_to_engine()
     }
 
     fn clear(&mut self) {
-        unimplemented!()
+        self.disk_write_batch.clear();
+        self.cache_write_batch.clear()
     }
 
     fn set_save_point(&mut self) {
-        unimplemented!()
+        self.disk_write_batch.set_save_point();
+        self.cache_write_batch.set_save_point()
     }
 
     fn pop_save_point(&mut self) -> Result<()> {
-        unimplemented!()
+        self.disk_write_batch.pop_save_point()?;
+        self.cache_write_batch.pop_save_point()
     }
 
     fn rollback_to_save_point(&mut self) -> Result<()> {
-        unimplemented!()
+        self.disk_write_batch.rollback_to_save_point()?;
+        self.cache_write_batch.rollback_to_save_point()
     }
 
-    fn merge(&mut self, _other: Self) -> Result<()> {
-        unimplemented!()
+    fn merge(&mut self, other: Self) -> Result<()> {
+        self.disk_write_batch.merge(other.disk_write_batch)?;
+        self.cache_write_batch.merge(other.cache_write_batch)
     }
 }
 
 impl<EK: KvEngine> Mutable for HybridEngineWriteBatch<EK> {
-    fn put(&mut self, _key: &[u8], _value: &[u8]) -> Result<()> {
-        unimplemented!()
+    fn put(&mut self, key: &[u8], value: &[u8]) -> Result<()> {
+        self.disk_write_batch.put(key, value)?;
+        self.cache_write_batch.put(key, value)
     }
 
-    fn put_cf(&mut self, _cf: &str, _key: &[u8], _value: &[u8]) -> Result<()> {
-        unimplemented!()
+    fn put_cf(&mut self, cf: &str, key: &[u8], value: &[u8]) -> Result<()> {
+        self.disk_write_batch.put_cf(cf, key, value)?;
+        self.cache_write_batch.put_cf(cf, key, value)
     }
 
-    fn delete(&mut self, _key: &[u8]) -> Result<()> {
-        unimplemented!()
+    fn delete(&mut self, key: &[u8]) -> Result<()> {
+        self.disk_write_batch.delete(key)?;
+        self.cache_write_batch.delete(key)
     }
 
-    fn delete_cf(&mut self, _cf: &str, _key: &[u8]) -> Result<()> {
-        unimplemented!()
+    fn delete_cf(&mut self, cf: &str, key: &[u8]) -> Result<()> {
+        self.disk_write_batch.delete_cf(cf, key)?;
+        self.cache_write_batch.delete_cf(cf, key)
     }
 
-    fn delete_range(&mut self, _begin_key: &[u8], _end_key: &[u8]) -> Result<()> {
-        unimplemented!()
+    fn delete_range(&mut self, begin_key: &[u8], end_key: &[u8]) -> Result<()> {
+        self.disk_write_batch.delete_range(begin_key, end_key)
     }
 
-    fn delete_range_cf(&mut self, _cf: &str, _begin_key: &[u8], _end_key: &[u8]) -> Result<()> {
-        unimplemented!()
+    fn delete_range_cf(&mut self, cf: &str, begin_key: &[u8], end_key: &[u8]) -> Result<()> {
+        self.disk_write_batch
+            .delete_range_cf(cf, begin_key, end_key)
     }
 }
 

--- a/components/region_cache_memory_engine/src/engine.rs
+++ b/components/region_cache_memory_engine/src/engine.rs
@@ -23,7 +23,7 @@ use crate::keys::{
     VALUE_TYPE_FOR_SEEK, VALUE_TYPE_FOR_SEEK_FOR_PREV,
 };
 
-fn cf_to_id(cf: &str) -> usize {
+pub(crate) fn cf_to_id(cf: &str) -> usize {
     match cf {
         CF_DEFAULT => 0,
         CF_LOCK => 1,
@@ -38,7 +38,7 @@ fn cf_to_id(cf: &str) -> usize {
 /// with a formal implementation.
 #[derive(Clone)]
 pub struct RegionMemoryEngine {
-    data: [Arc<Skiplist<InternalKeyComparator>>; 3],
+    pub(crate) data: [Arc<Skiplist<InternalKeyComparator>>; 3],
 }
 
 impl RegionMemoryEngine {

--- a/components/region_cache_memory_engine/src/engine.rs
+++ b/components/region_cache_memory_engine/src/engine.rs
@@ -106,10 +106,10 @@ pub struct RegionMemoryMeta {
     snapshot_list: SnapshotList,
     // It indicates whether the region is readable. False means integrity of the data in this
     // cached region is not satisfied due to being evicted for instance.
-    can_read: bool,
+    pub(crate) can_read: bool,
     // Request with read_ts below it is not eligible for granting snapshot.
     // Note: different region can have different safe_ts.
-    safe_ts: u64,
+    pub(crate) safe_ts: u64,
 }
 
 impl RegionMemoryMeta {
@@ -124,8 +124,8 @@ impl RegionMemoryMeta {
 
 #[derive(Default)]
 pub struct RegionCacheMemoryEngineCore {
-    engine: HashMap<u64, RegionMemoryEngine>,
-    region_metas: HashMap<u64, RegionMemoryMeta>,
+    pub(crate) engine: HashMap<u64, RegionMemoryEngine>,
+    pub(crate) region_metas: HashMap<u64, RegionMemoryMeta>,
 }
 
 impl RegionCacheMemoryEngineCore {
@@ -153,7 +153,7 @@ impl RegionCacheMemoryEngineCore {
 /// cached region), we resort to using a the disk engine's snapshot instead.
 #[derive(Clone, Default)]
 pub struct RegionCacheMemoryEngine {
-    core: Arc<Mutex<RegionCacheMemoryEngineCore>>,
+    pub(crate) core: Arc<Mutex<RegionCacheMemoryEngineCore>>,
 }
 
 impl RegionCacheMemoryEngine {

--- a/components/region_cache_memory_engine/src/write_batch.rs
+++ b/components/region_cache_memory_engine/src/write_batch.rs
@@ -273,7 +273,7 @@ mod tests {
         wb.set_save_point();
         wb.put(b"aaa", b"ccc").unwrap();
         wb.put(b"ccc", b"ddd").unwrap();
-        let _ = wb.rollback_to_save_point().unwrap();
+        wb.rollback_to_save_point().unwrap();
         wb.set_sequence_number(1).unwrap();
         assert_eq!(wb.write().unwrap(), 1);
         let sl = engine.data[cf_to_id(CF_DEFAULT)].clone();


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref #16323 


<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Basic WriteBatch implementation for In-Memory Engine.

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
