### PR TITLE
In-memory Engine: refactor from region based to range based

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5228,11 +5228,13 @@ checksum = "fa8f3741c7372e75519bd9346068370c9cdaabcc1f9599cbcf2a2719352286b7"
 [[package]]
 name = "skiplist-rs"
 version = "0.1.0"
-source = "git+https://github.com/tikv/skiplist-rs.git?branch=main#618af619d9348ef89eaa71c5f6fbddbd9a5c09bf"
+source = "git+https://github.com/tikv/skiplist-rs.git?branch=main#3cc4da483c1ed8c5cdf71c49d52e4216fc0257d2"
 dependencies = [
  "bytes",
  "rand 0.8.5",
  "slog",
+ "tikv-jemalloc-ctl",
+ "tikv-jemallocator",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5228,7 +5228,7 @@ checksum = "fa8f3741c7372e75519bd9346068370c9cdaabcc1f9599cbcf2a2719352286b7"
 [[package]]
 name = "skiplist-rs"
 version = "0.1.0"
-source = "git+https://github.com/tikv/skiplist-rs.git?branch=main#3cc4da483c1ed8c5cdf71c49d52e4216fc0257d2"
+source = "git+https://github.com/tikv/skiplist-rs.git?branch=main#b1e1d4ff0ae0603df1f18a63888cbd6c3fac991a"
 dependencies = [
  "bytes",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6969,7 +6969,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2342,9 +2342,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",
@@ -6969,7 +6969,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5228,7 +5228,7 @@ checksum = "fa8f3741c7372e75519bd9346068370c9cdaabcc1f9599cbcf2a2719352286b7"
 [[package]]
 name = "skiplist-rs"
 version = "0.1.0"
-source = "git+https://github.com/tikv/skiplist-rs.git?branch=main#b1e1d4ff0ae0603df1f18a63888cbd6c3fac991a"
+source = "git+https://github.com/tikv/skiplist-rs.git?branch=main#79280c29c3d309189fc39b2d8df48c67ccc998bf"
 dependencies = [
  "bytes",
  "rand 0.8.5",

--- a/components/engine_traits/src/engine.rs
+++ b/components/engine_traits/src/engine.rs
@@ -84,6 +84,13 @@ pub trait KvEngine:
 
 #[derive(Debug, Clone)]
 pub struct SnapshotContext {
-    pub range: CacheRange,
+    pub range: Option<CacheRange>,
     pub read_ts: u64,
+}
+
+impl SnapshotContext {
+    pub fn set_range(&mut self, range: CacheRange) {
+        assert!(self.range.is_none());
+        self.range = Some(range);
+    }
 }

--- a/components/engine_traits/src/errors.rs
+++ b/components/engine_traits/src/errors.rs
@@ -149,7 +149,7 @@ pub enum Error {
     EntriesUnavailable,
     #[error("The entries of region is compacted")]
     EntriesCompacted,
-    #[error("Iterator of RegionCacheSnapshot is only supported with boundary set")]
+    #[error("Iterator of RangeCaheSnapshot is only supported with boundary set")]
     BoundaryNotSet,
 }
 

--- a/components/engine_traits/src/errors.rs
+++ b/components/engine_traits/src/errors.rs
@@ -149,7 +149,7 @@ pub enum Error {
     EntriesUnavailable,
     #[error("The entries of region is compacted")]
     EntriesCompacted,
-    #[error("Iterator of RangeCaheSnapshot is only supported with boundary set")]
+    #[error("Iterator of RangeCacheSnapshot is only supported with boundary set")]
     BoundaryNotSet,
 }
 

--- a/components/engine_traits/src/lib.rs
+++ b/components/engine_traits/src/lib.rs
@@ -312,7 +312,7 @@ pub use crate::table_properties::*;
 mod checkpoint;
 pub use crate::checkpoint::*;
 mod memory_engine;
-pub use memory_engine::RegionCacheEngine;
+pub use memory_engine::{CacheRange, RangeCacheEngine};
 
 // These modules contain more general traits, some of which may be implemented
 // by multiple types.

--- a/components/engine_traits/src/memory_engine.rs
+++ b/components/engine_traits/src/memory_engine.rs
@@ -70,16 +70,16 @@ impl Ord for CacheRange {
 
 impl CacheRange {
     // todo: need to consider ""?
-    pub fn contains(&self, other: &CacheRange) -> bool {
+    pub fn contains_range(&self, other: &CacheRange) -> bool {
         self.start <= other.start && self.end >= other.end
+    }
+
+    pub fn contains_key(&self, key: &[u8]) -> bool {
+        self.start <= key && key < self.end
     }
 
     pub fn overlaps(&self, other: &CacheRange) -> bool {
         self.start < other.end && other.start < self.end
-    }
-
-    pub fn is_sibling(&self, other: &CacheRange) -> bool {
-        self.start == other.end || self.end == other.start
     }
 
     pub fn split_off(&self, key: &CacheRange) -> (Option<CacheRange>, Option<CacheRange>) {

--- a/components/engine_traits/src/memory_engine.rs
+++ b/components/engine_traits/src/memory_engine.rs
@@ -7,16 +7,16 @@ use kvproto::metapb;
 
 use crate::{Iterable, Snapshot, WriteBatchExt};
 
-/// RangeCaheEngine works as a range cache caching some ranges (in Memory or
+/// RangeCacheEngine works as a range cache caching some ranges (in Memory or
 /// NVME for instance) to improve the read performance.
 pub trait RangeCacheEngine:
     WriteBatchExt + Iterable + Debug + Clone + Unpin + Send + Sync + 'static
 {
     type Snapshot: Snapshot;
 
-    // If None is returned, the RangeCaheEngine is currently not readable for this
+    // If None is returned, the RangeCacheEngine is currently not readable for this
     // region or read_ts.
-    // Sequence number is shared between RangeCaheEngine and disk KvEnigne to
+    // Sequence number is shared between RangeCacheEngine and disk KvEnigne to
     // provide atomic write
     fn snapshot(&self, range: CacheRange, read_ts: u64, seq_num: u64) -> Option<Self::Snapshot>;
 }

--- a/components/engine_traits/src/memory_engine.rs
+++ b/components/engine_traits/src/memory_engine.rs
@@ -75,7 +75,7 @@ impl CacheRange {
     }
 
     pub fn contains_key(&self, key: &[u8]) -> bool {
-        self.start <= key && key < self.end
+        self.start.as_slice() <= key && key < self.end.as_slice()
     }
 
     pub fn overlaps(&self, other: &CacheRange) -> bool {

--- a/components/engine_traits/src/memory_engine.rs
+++ b/components/engine_traits/src/memory_engine.rs
@@ -2,6 +2,9 @@
 
 use std::{cmp, fmt::Debug};
 
+use keys::{enc_end_key, enc_start_key};
+use kvproto::metapb;
+
 use crate::{Iterable, Snapshot, WriteBatchExt};
 
 /// RegionCacheEngine works as a region cache caching some regions (in Memory or
@@ -28,6 +31,13 @@ impl CacheRange {
     pub fn new(start: Vec<u8>, end: Vec<u8>) -> Self {
         Self { start, end }
     }
+
+    pub fn from_region(region: &metapb::Region) -> Self {
+        Self {
+            start: enc_start_key(region),
+            end: enc_end_key(region),
+        }
+    }
 }
 
 impl PartialOrd for CacheRange {
@@ -44,7 +54,7 @@ impl PartialOrd for CacheRange {
             return Some(cmp::Ordering::Equal);
         }
 
-        return None;
+        None
     }
 }
 

--- a/components/engine_traits/src/memory_engine.rs
+++ b/components/engine_traits/src/memory_engine.rs
@@ -97,7 +97,6 @@ impl CacheRange {
 
     // r1 and r2 should be unoverlap
     pub fn merge(r1: CacheRange, r2: CacheRange) -> CacheRange {
-        assert!(!r1.overlaps(&r2));
         assert!(r1.is_sibling(&r2));
         let CacheRange { start: s1, end: e1 } = r1;
         let CacheRange { start: s2, end: e2 } = r2;

--- a/components/engine_traits/src/memory_engine.rs
+++ b/components/engine_traits/src/memory_engine.rs
@@ -1,12 +1,12 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::fmt::Debug;
+use std::{cmp, fmt::Debug};
 
 use crate::{Iterable, Snapshot, WriteBatchExt};
 
 /// RegionCacheEngine works as a region cache caching some regions (in Memory or
 /// NVME for instance) to improve the read performance.
-pub trait RegionCacheEngine:
+pub trait RangeCacheEngine:
     WriteBatchExt + Iterable + Debug + Clone + Unpin + Send + Sync + 'static
 {
     type Snapshot: Snapshot;
@@ -15,5 +15,86 @@ pub trait RegionCacheEngine:
     // region or read_ts.
     // Sequence number is shared between RegionCacheEngine and disk KvEnigne to
     // provide atomic write
-    fn snapshot(&self, region_id: u64, read_ts: u64, seq_num: u64) -> Option<Self::Snapshot>;
+    fn snapshot(&self, range: CacheRange, read_ts: u64, seq_num: u64) -> Option<Self::Snapshot>;
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CacheRange {
+    pub start: Vec<u8>,
+    pub end: Vec<u8>,
+}
+
+impl CacheRange {
+    pub fn new(start: Vec<u8>, end: Vec<u8>) -> Self {
+        Self { start, end }
+    }
+}
+
+impl PartialOrd for CacheRange {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        if self.end <= other.start {
+            return Some(cmp::Ordering::Less);
+        }
+
+        if other.end <= self.start {
+            return Some(cmp::Ordering::Greater);
+        }
+
+        if self == other {
+            return Some(cmp::Ordering::Equal);
+        }
+
+        return None;
+    }
+}
+
+impl Ord for CacheRange {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        let c = self.start.cmp(&other.start);
+        if !c.is_eq() {
+            return c;
+        }
+        self.end.cmp(&other.end)
+    }
+}
+
+impl CacheRange {
+    // todo: need to consider ""?
+    pub fn contains(&self, other: &CacheRange) -> bool {
+        self.start <= other.start && self.end >= other.end
+    }
+
+    pub fn overlaps(&self, other: &CacheRange) -> bool {
+        self.start < other.end && other.start < self.end
+    }
+
+    pub fn is_sibling(&self, other: &CacheRange) -> bool {
+        self.start == other.end || self.end == other.start
+    }
+
+    pub fn split_off(&self, key: &CacheRange) -> (CacheRange, CacheRange) {
+        (
+            CacheRange {
+                start: self.start.clone(),
+                end: key.start.clone(),
+            },
+            CacheRange {
+                start: key.end.clone(),
+                end: self.end.clone(),
+            },
+        )
+    }
+
+    // r1 and r2 should be unoverlap
+    pub fn merge(r1: CacheRange, r2: CacheRange) -> CacheRange {
+        assert!(!r1.overlaps(&r2));
+        assert!(r1.is_sibling(&r2));
+        let CacheRange { start: s1, end: e1 } = r1;
+        let CacheRange { start: s2, end: e2 } = r2;
+        if s1 < s2 {
+            CacheRange { start: s1, end: e2 }
+        } else {
+            CacheRange { start: s2, end: e1 }
+        }
+    }
 }

--- a/components/engine_traits/src/memory_engine.rs
+++ b/components/engine_traits/src/memory_engine.rs
@@ -82,28 +82,24 @@ impl CacheRange {
         self.start == other.end || self.end == other.start
     }
 
-    pub fn split_off(&self, key: &CacheRange) -> (CacheRange, CacheRange) {
-        (
-            CacheRange {
+    pub fn split_off(&self, key: &CacheRange) -> (Option<CacheRange>, Option<CacheRange>) {
+        let left = if self.start != key.start {
+            Some(CacheRange {
                 start: self.start.clone(),
                 end: key.start.clone(),
-            },
-            CacheRange {
+            })
+        } else {
+            None
+        };
+        let right = if self.end != key.end {
+            Some(CacheRange {
                 start: key.end.clone(),
                 end: self.end.clone(),
-            },
-        )
-    }
-
-    // r1 and r2 should be unoverlap
-    pub fn merge(r1: CacheRange, r2: CacheRange) -> CacheRange {
-        assert!(r1.is_sibling(&r2));
-        let CacheRange { start: s1, end: e1 } = r1;
-        let CacheRange { start: s2, end: e2 } = r2;
-        if s1 < s2 {
-            CacheRange { start: s1, end: e2 }
+            })
         } else {
-            CacheRange { start: s2, end: e1 }
-        }
+            None
+        };
+
+        (left, right)
     }
 }

--- a/components/engine_traits/src/memory_engine.rs
+++ b/components/engine_traits/src/memory_engine.rs
@@ -7,7 +7,7 @@ use kvproto::metapb;
 
 use crate::{Iterable, Snapshot, WriteBatchExt};
 
-/// RangeCaheEngine works as a region cache caching some regions (in Memory or
+/// RangeCaheEngine works as a range cache caching some ranges (in Memory or
 /// NVME for instance) to improve the read performance.
 pub trait RangeCacheEngine:
     WriteBatchExt + Iterable + Debug + Clone + Unpin + Send + Sync + 'static

--- a/components/engine_traits/src/memory_engine.rs
+++ b/components/engine_traits/src/memory_engine.rs
@@ -7,16 +7,16 @@ use kvproto::metapb;
 
 use crate::{Iterable, Snapshot, WriteBatchExt};
 
-/// RegionCacheEngine works as a region cache caching some regions (in Memory or
+/// RangeCaheEngine works as a region cache caching some regions (in Memory or
 /// NVME for instance) to improve the read performance.
 pub trait RangeCacheEngine:
     WriteBatchExt + Iterable + Debug + Clone + Unpin + Send + Sync + 'static
 {
     type Snapshot: Snapshot;
 
-    // If None is returned, the RegionCacheEngine is currently not readable for this
+    // If None is returned, the RangeCaheEngine is currently not readable for this
     // region or read_ts.
-    // Sequence number is shared between RegionCacheEngine and disk KvEnigne to
+    // Sequence number is shared between RangeCaheEngine and disk KvEnigne to
     // provide atomic write
     fn snapshot(&self, range: CacheRange, read_ts: u64, seq_num: u64) -> Option<Self::Snapshot>;
 }

--- a/components/hybrid_engine/src/cf_names.rs
+++ b/components/hybrid_engine/src/cf_names.rs
@@ -1,13 +1,13 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_traits::{CfNamesExt, KvEngine, RegionCacheEngine};
+use engine_traits::{CfNamesExt, KvEngine, RangeCacheEngine};
 
 use crate::engine::HybridEngine;
 
 impl<EK, EC> CfNamesExt for HybridEngine<EK, EC>
 where
     EK: KvEngine,
-    EC: RegionCacheEngine,
+    EC: RangeCacheEngine,
 {
     fn cf_names(&self) -> Vec<&str> {
         self.disk_engine().cf_names()

--- a/components/hybrid_engine/src/cf_options.rs
+++ b/components/hybrid_engine/src/cf_options.rs
@@ -1,13 +1,13 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_traits::{CfOptionsExt, KvEngine, RegionCacheEngine, Result};
+use engine_traits::{CfOptionsExt, KvEngine, RangeCacheEngine, Result};
 
 use crate::engine::HybridEngine;
 
 impl<EK, EC> CfOptionsExt for HybridEngine<EK, EC>
 where
     EK: KvEngine,
-    EC: RegionCacheEngine,
+    EC: RangeCacheEngine,
 {
     type CfOptions = EK::CfOptions;
 

--- a/components/hybrid_engine/src/checkpoint.rs
+++ b/components/hybrid_engine/src/checkpoint.rs
@@ -1,13 +1,13 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_traits::{Checkpointable, KvEngine, RegionCacheEngine, Result};
+use engine_traits::{Checkpointable, KvEngine, RangeCacheEngine, Result};
 
 use crate::engine::HybridEngine;
 
 impl<EK, EC> Checkpointable for HybridEngine<EK, EC>
 where
     EK: KvEngine,
-    EC: RegionCacheEngine,
+    EC: RangeCacheEngine,
 {
     type Checkpointer = EK::Checkpointer;
 

--- a/components/hybrid_engine/src/compact.rs
+++ b/components/hybrid_engine/src/compact.rs
@@ -1,13 +1,13 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_traits::{CompactExt, KvEngine, RegionCacheEngine, Result};
+use engine_traits::{CompactExt, KvEngine, RangeCacheEngine, Result};
 
 use crate::engine::HybridEngine;
 
 impl<EK, EC> CompactExt for HybridEngine<EK, EC>
 where
     EK: KvEngine,
-    EC: RegionCacheEngine,
+    EC: RangeCacheEngine,
 {
     type CompactedEvent = EK::CompactedEvent;
 

--- a/components/hybrid_engine/src/db_options.rs
+++ b/components/hybrid_engine/src/db_options.rs
@@ -1,13 +1,13 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_traits::{DbOptionsExt, KvEngine, RegionCacheEngine, Result};
+use engine_traits::{DbOptionsExt, KvEngine, RangeCacheEngine, Result};
 
 use crate::engine::HybridEngine;
 
 impl<EK, EC> DbOptionsExt for HybridEngine<EK, EC>
 where
     EK: KvEngine,
-    EC: RegionCacheEngine,
+    EC: RangeCacheEngine,
 {
     type DbOptions = EK::DbOptions;
 

--- a/components/hybrid_engine/src/engine.rs
+++ b/components/hybrid_engine/src/engine.rs
@@ -70,8 +70,11 @@ where
     fn snapshot(&self, ctx: Option<SnapshotContext>) -> Self::Snapshot {
         let disk_snap = self.disk_engine.snapshot(ctx.clone());
         let region_cache_snap = if let Some(ctx) = ctx {
-            self.region_cache_engine
-                .snapshot(ctx.range, ctx.read_ts, disk_snap.sequence_number())
+            self.region_cache_engine.snapshot(
+                ctx.range.unwrap(),
+                ctx.read_ts,
+                disk_snap.sequence_number(),
+            )
         } else {
             None
         };
@@ -150,7 +153,7 @@ mod tests {
     use std::sync::Arc;
 
     use engine_rocks::util::new_engine;
-    use engine_traits::{KvEngine, SnapshotContext, CF_DEFAULT, CF_LOCK, CF_WRITE, CacheRange};
+    use engine_traits::{CacheRange, KvEngine, SnapshotContext, CF_DEFAULT, CF_LOCK, CF_WRITE};
     use region_cache_memory_engine::RangeCacheMemoryEngine;
     use tempfile::Builder;
 
@@ -179,7 +182,7 @@ mod tests {
 
         let mut snap_ctx = SnapshotContext {
             read_ts: 15,
-            range: range.clone(),
+            range: Some(range.clone()),
         };
         let s = hybrid_engine.snapshot(Some(snap_ctx.clone()));
         assert!(s.region_cache_snapshot_available());

--- a/components/hybrid_engine/src/engine.rs
+++ b/components/hybrid_engine/src/engine.rs
@@ -1,7 +1,7 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
 use engine_traits::{
-    KvEngine, Peekable, ReadOptions, RegionCacheEngine, Result, SnapshotContext, SnapshotMiscExt,
+    KvEngine, Peekable, ReadOptions, RangeCacheEngine, Result, SnapshotContext, SnapshotMiscExt,
     SyncMutable,
 };
 
@@ -17,7 +17,7 @@ use crate::snapshot::HybridEngineSnapshot;
 pub struct HybridEngine<EK, EC>
 where
     EK: KvEngine,
-    EC: RegionCacheEngine,
+    EC: RangeCacheEngine,
 {
     disk_engine: EK,
     region_cache_engine: EC,
@@ -26,7 +26,7 @@ where
 impl<EK, EC> HybridEngine<EK, EC>
 where
     EK: KvEngine,
-    EC: RegionCacheEngine,
+    EC: RangeCacheEngine,
 {
     pub fn disk_engine(&self) -> &EK {
         &self.disk_engine
@@ -48,7 +48,7 @@ where
 impl<EK, EC> HybridEngine<EK, EC>
 where
     EK: KvEngine,
-    EC: RegionCacheEngine,
+    EC: RangeCacheEngine,
 {
     pub fn new(disk_engine: EK, region_cache_engine: EC) -> Self {
         Self {
@@ -62,7 +62,7 @@ where
 impl<EK, EC> KvEngine for HybridEngine<EK, EC>
 where
     EK: KvEngine,
-    EC: RegionCacheEngine,
+    EC: RangeCacheEngine,
 {
     type Snapshot = HybridEngineSnapshot<EK, EC>;
 
@@ -97,7 +97,7 @@ where
 impl<EK, EC> Peekable for HybridEngine<EK, EC>
 where
     EK: KvEngine,
-    EC: RegionCacheEngine,
+    EC: RangeCacheEngine,
 {
     type DbVector = EK::DbVector;
 
@@ -120,7 +120,7 @@ where
 impl<EK, EC> SyncMutable for HybridEngine<EK, EC>
 where
     EK: KvEngine,
-    EC: RegionCacheEngine,
+    EC: RangeCacheEngine,
 {
     fn put(&self, key: &[u8], value: &[u8]) -> Result<()> {
         unimplemented!()
@@ -151,7 +151,7 @@ where
 mod tests {
     use engine_rocks::util::new_engine;
     use engine_traits::{KvEngine, SnapshotContext, CF_DEFAULT, CF_LOCK, CF_WRITE};
-    use region_cache_memory_engine::RegionCacheMemoryEngine;
+    use region_cache_memory_engine::RangeCacheMemoryEngine;
     use tempfile::Builder;
 
     use crate::HybridEngine;
@@ -164,7 +164,7 @@ mod tests {
             &[CF_DEFAULT, CF_LOCK, CF_WRITE],
         )
         .unwrap();
-        let memory_engine = RegionCacheMemoryEngine::default();
+        let memory_engine = RangeCacheMemoryEngine::default();
         memory_engine.new_region(1);
         {
             let mut core = memory_engine.core().lock().unwrap();

--- a/components/hybrid_engine/src/engine_iterator.rs
+++ b/components/hybrid_engine/src/engine_iterator.rs
@@ -1,12 +1,12 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_traits::{Iterator, KvEngine, RegionCacheEngine, Result};
+use engine_traits::{Iterator, KvEngine, RangeCacheEngine, Result};
 use tikv_util::Either;
 
 pub struct HybridEngineIterator<EK, EC>
 where
     EK: KvEngine,
-    EC: RegionCacheEngine,
+    EC: RangeCacheEngine,
 {
     iter: Either<EK::Iterator, EC::Iterator>,
 }
@@ -14,7 +14,7 @@ where
 impl<EK, EC> HybridEngineIterator<EK, EC>
 where
     EK: KvEngine,
-    EC: RegionCacheEngine,
+    EC: RangeCacheEngine,
 {
     pub fn disk_engine_iterator(iter: EK::Iterator) -> Self {
         Self {
@@ -32,7 +32,7 @@ where
 impl<EK, EC> Iterator for HybridEngineIterator<EK, EC>
 where
     EK: KvEngine,
-    EC: RegionCacheEngine,
+    EC: RangeCacheEngine,
 {
     fn seek(&mut self, key: &[u8]) -> Result<bool> {
         match self.iter {

--- a/components/hybrid_engine/src/flow_control_factors.rs
+++ b/components/hybrid_engine/src/flow_control_factors.rs
@@ -1,13 +1,13 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_traits::{FlowControlFactorsExt, KvEngine, RegionCacheEngine, Result};
+use engine_traits::{FlowControlFactorsExt, KvEngine, RangeCacheEngine, Result};
 
 use crate::engine::HybridEngine;
 
 impl<EK, EC> FlowControlFactorsExt for HybridEngine<EK, EC>
 where
     EK: KvEngine,
-    EC: RegionCacheEngine,
+    EC: RangeCacheEngine,
 {
     fn get_cf_num_files_at_level(&self, cf: &str, level: usize) -> Result<Option<u64>> {
         self.disk_engine().get_cf_num_files_at_level(cf, level)

--- a/components/hybrid_engine/src/hybrid_metrics.rs
+++ b/components/hybrid_engine/src/hybrid_metrics.rs
@@ -1,6 +1,6 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_traits::{KvEngine, RegionCacheEngine, StatisticsReporter};
+use engine_traits::{KvEngine, RangeCacheEngine, StatisticsReporter};
 
 use crate::engine::HybridEngine;
 
@@ -9,7 +9,7 @@ pub struct HybridEngineStatisticsReporter {}
 impl<EK, EC> StatisticsReporter<HybridEngine<EK, EC>> for HybridEngineStatisticsReporter
 where
     EK: KvEngine,
-    EC: RegionCacheEngine,
+    EC: RangeCacheEngine,
 {
     fn new(name: &str) -> Self {
         unimplemented!()

--- a/components/hybrid_engine/src/import.rs
+++ b/components/hybrid_engine/src/import.rs
@@ -1,13 +1,13 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_traits::{ImportExt, KvEngine, RegionCacheEngine};
+use engine_traits::{ImportExt, KvEngine, RangeCacheEngine};
 
 use crate::engine::HybridEngine;
 
 impl<EK, EC> ImportExt for HybridEngine<EK, EC>
 where
     EK: KvEngine,
-    EC: RegionCacheEngine,
+    EC: RangeCacheEngine,
 {
     type IngestExternalFileOptions = EK::IngestExternalFileOptions;
 

--- a/components/hybrid_engine/src/iterable.rs
+++ b/components/hybrid_engine/src/iterable.rs
@@ -1,13 +1,13 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_traits::{IterOptions, Iterable, KvEngine, RegionCacheEngine, Result};
+use engine_traits::{IterOptions, Iterable, KvEngine, RangeCacheEngine, Result};
 
 use crate::{engine::HybridEngine, engine_iterator::HybridEngineIterator};
 
 impl<EK, EC> Iterable for HybridEngine<EK, EC>
 where
     EK: KvEngine,
-    EC: RegionCacheEngine,
+    EC: RangeCacheEngine,
 {
     type Iterator = HybridEngineIterator<EK, EC>;
 

--- a/components/hybrid_engine/src/misc.rs
+++ b/components/hybrid_engine/src/misc.rs
@@ -1,13 +1,13 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_traits::{KvEngine, MiscExt, RegionCacheEngine, Result};
+use engine_traits::{KvEngine, MiscExt, RangeCacheEngine, Result};
 
 use crate::{engine::HybridEngine, hybrid_metrics::HybridEngineStatisticsReporter};
 
 impl<EK, EC> MiscExt for HybridEngine<EK, EC>
 where
     EK: KvEngine,
-    EC: RegionCacheEngine,
+    EC: RangeCacheEngine,
 {
     type StatisticsReporter = HybridEngineStatisticsReporter;
 

--- a/components/hybrid_engine/src/mvcc_properties.rs
+++ b/components/hybrid_engine/src/mvcc_properties.rs
@@ -1,6 +1,6 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_traits::{KvEngine, MvccProperties, MvccPropertiesExt, RegionCacheEngine};
+use engine_traits::{KvEngine, MvccProperties, MvccPropertiesExt, RangeCacheEngine};
 use txn_types::TimeStamp;
 
 use crate::engine::HybridEngine;
@@ -8,7 +8,7 @@ use crate::engine::HybridEngine;
 impl<EK, EC> MvccPropertiesExt for HybridEngine<EK, EC>
 where
     EK: KvEngine,
-    EC: RegionCacheEngine,
+    EC: RangeCacheEngine,
 {
     fn get_mvcc_properties_cf(
         &self,

--- a/components/hybrid_engine/src/perf_context.rs
+++ b/components/hybrid_engine/src/perf_context.rs
@@ -1,13 +1,13 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_traits::{KvEngine, PerfContextExt, PerfContextKind, RegionCacheEngine};
+use engine_traits::{KvEngine, PerfContextExt, PerfContextKind, RangeCacheEngine};
 
 use crate::engine::HybridEngine;
 
 impl<EK, EC> PerfContextExt for HybridEngine<EK, EC>
 where
     EK: KvEngine,
-    EC: RegionCacheEngine,
+    EC: RangeCacheEngine,
 {
     type PerfContext = EK::PerfContext;
 

--- a/components/hybrid_engine/src/range_properties.rs
+++ b/components/hybrid_engine/src/range_properties.rs
@@ -1,13 +1,13 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_traits::{KvEngine, Range, RangePropertiesExt, RegionCacheEngine, Result};
+use engine_traits::{KvEngine, Range, RangePropertiesExt, RangeCacheEngine, Result};
 
 use crate::engine::HybridEngine;
 
 impl<EK, EC> RangePropertiesExt for HybridEngine<EK, EC>
 where
     EK: KvEngine,
-    EC: RegionCacheEngine,
+    EC: RangeCacheEngine,
 {
     fn get_range_approximate_keys(&self, range: Range<'_>, large_threshold: u64) -> Result<u64> {
         self.disk_engine()

--- a/components/hybrid_engine/src/range_properties.rs
+++ b/components/hybrid_engine/src/range_properties.rs
@@ -1,6 +1,6 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_traits::{KvEngine, Range, RangePropertiesExt, RangeCacheEngine, Result};
+use engine_traits::{KvEngine, Range, RangeCacheEngine, RangePropertiesExt, Result};
 
 use crate::engine::HybridEngine;
 

--- a/components/hybrid_engine/src/snapshot.rs
+++ b/components/hybrid_engine/src/snapshot.rs
@@ -3,7 +3,7 @@
 use std::fmt::{self, Debug, Formatter};
 
 use engine_traits::{
-    CfNamesExt, IterOptions, Iterable, KvEngine, Peekable, ReadOptions, RegionCacheEngine, Result,
+    CfNamesExt, IterOptions, Iterable, KvEngine, Peekable, ReadOptions, RangeCacheEngine, Result,
     Snapshot, SnapshotMiscExt,
 };
 
@@ -12,7 +12,7 @@ use crate::engine_iterator::HybridEngineIterator;
 pub struct HybridEngineSnapshot<EK, EC>
 where
     EK: KvEngine,
-    EC: RegionCacheEngine,
+    EC: RangeCacheEngine,
 {
     disk_snap: EK::Snapshot,
     region_cache_snap: Option<EC::Snapshot>,
@@ -21,7 +21,7 @@ where
 impl<EK, EC> HybridEngineSnapshot<EK, EC>
 where
     EK: KvEngine,
-    EC: RegionCacheEngine,
+    EC: RangeCacheEngine,
 {
     pub fn new(disk_snap: EK::Snapshot, region_cache_snap: Option<EC::Snapshot>) -> Self {
         HybridEngineSnapshot {
@@ -38,14 +38,14 @@ where
 impl<EK, EC> Snapshot for HybridEngineSnapshot<EK, EC>
 where
     EK: KvEngine,
-    EC: RegionCacheEngine,
+    EC: RangeCacheEngine,
 {
 }
 
 impl<EK, EC> Debug for HybridEngineSnapshot<EK, EC>
 where
     EK: KvEngine,
-    EC: RegionCacheEngine,
+    EC: RangeCacheEngine,
 {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
         write!(fmt, "Hybrid Engine Snapshot Impl")
@@ -55,7 +55,7 @@ where
 impl<EK, EC> Iterable for HybridEngineSnapshot<EK, EC>
 where
     EK: KvEngine,
-    EC: RegionCacheEngine,
+    EC: RangeCacheEngine,
 {
     type Iterator = HybridEngineIterator<EK, EC>;
 
@@ -67,7 +67,7 @@ where
 impl<EK, EC> Peekable for HybridEngineSnapshot<EK, EC>
 where
     EK: KvEngine,
-    EC: RegionCacheEngine,
+    EC: RangeCacheEngine,
 {
     type DbVector = EK::DbVector;
 
@@ -88,7 +88,7 @@ where
 impl<EK, EC> CfNamesExt for HybridEngineSnapshot<EK, EC>
 where
     EK: KvEngine,
-    EC: RegionCacheEngine,
+    EC: RangeCacheEngine,
 {
     fn cf_names(&self) -> Vec<&str> {
         self.disk_snap.cf_names()
@@ -98,7 +98,7 @@ where
 impl<EK, EC> SnapshotMiscExt for HybridEngineSnapshot<EK, EC>
 where
     EK: KvEngine,
-    EC: RegionCacheEngine,
+    EC: RangeCacheEngine,
 {
     fn sequence_number(&self) -> u64 {
         self.disk_snap.sequence_number()

--- a/components/hybrid_engine/src/snapshot.rs
+++ b/components/hybrid_engine/src/snapshot.rs
@@ -3,7 +3,7 @@
 use std::fmt::{self, Debug, Formatter};
 
 use engine_traits::{
-    CfNamesExt, IterOptions, Iterable, KvEngine, Peekable, ReadOptions, RangeCacheEngine, Result,
+    CfNamesExt, IterOptions, Iterable, KvEngine, Peekable, RangeCacheEngine, ReadOptions, Result,
     Snapshot, SnapshotMiscExt,
 };
 

--- a/components/hybrid_engine/src/sst.rs
+++ b/components/hybrid_engine/src/sst.rs
@@ -1,7 +1,7 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
 use engine_traits::{
-    KvEngine, RegionCacheEngine, Result, SstCompressionType, SstExt, SstWriterBuilder,
+    KvEngine, RangeCacheEngine, Result, SstCompressionType, SstExt, SstWriterBuilder,
 };
 
 use crate::engine::HybridEngine;
@@ -11,7 +11,7 @@ pub struct HybridEngineSstWriteBuilder {}
 impl<EK, EC> SstExt for HybridEngine<EK, EC>
 where
     EK: KvEngine,
-    EC: RegionCacheEngine,
+    EC: RangeCacheEngine,
 {
     type SstReader = EK::SstReader;
     type SstWriter = EK::SstWriter;
@@ -21,7 +21,7 @@ where
 impl<EK, EC> SstWriterBuilder<HybridEngine<EK, EC>> for HybridEngineSstWriteBuilder
 where
     EK: KvEngine,
-    EC: RegionCacheEngine,
+    EC: RangeCacheEngine,
 {
     fn new() -> Self {
         unimplemented!()

--- a/components/hybrid_engine/src/table_properties.rs
+++ b/components/hybrid_engine/src/table_properties.rs
@@ -1,13 +1,13 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_traits::{KvEngine, Range, RegionCacheEngine, Result, TablePropertiesExt};
+use engine_traits::{KvEngine, Range, RangeCacheEngine, Result, TablePropertiesExt};
 
 use crate::engine::HybridEngine;
 
 impl<EK, EC> TablePropertiesExt for HybridEngine<EK, EC>
 where
     EK: KvEngine,
-    EC: RegionCacheEngine,
+    EC: RangeCacheEngine,
 {
     type TablePropertiesCollection = EK::TablePropertiesCollection;
 

--- a/components/hybrid_engine/src/ttl_properties.rs
+++ b/components/hybrid_engine/src/ttl_properties.rs
@@ -1,13 +1,13 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_traits::{KvEngine, RegionCacheEngine, Result, TtlProperties, TtlPropertiesExt};
+use engine_traits::{KvEngine, RangeCacheEngine, Result, TtlProperties, TtlPropertiesExt};
 
 use crate::engine::HybridEngine;
 
 impl<EK, EC> TtlPropertiesExt for HybridEngine<EK, EC>
 where
     EK: KvEngine,
-    EC: RegionCacheEngine,
+    EC: RangeCacheEngine,
 {
     fn get_range_ttl_properties_cf(
         &self,

--- a/components/hybrid_engine/src/write_batch.rs
+++ b/components/hybrid_engine/src/write_batch.rs
@@ -1,13 +1,13 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
 use engine_traits::{KvEngine, Mutable, Result, WriteBatch, WriteBatchExt, WriteOptions};
-use region_cache_memory_engine::{RangeCacheMemoryEngine, RegionCacheWriteBatch};
+use region_cache_memory_engine::{RangeCacheMemoryEngine, RangeCacheWriteBatch};
 
 use crate::engine::HybridEngine;
 
 pub struct HybridEngineWriteBatch<EK: KvEngine> {
     disk_write_batch: EK::WriteBatch,
-    cache_write_batch: RegionCacheWriteBatch,
+    cache_write_batch: RangeCacheWriteBatch,
 }
 
 impl<EK> WriteBatchExt for HybridEngine<EK, RangeCacheMemoryEngine>

--- a/components/hybrid_engine/src/write_batch.rs
+++ b/components/hybrid_engine/src/write_batch.rs
@@ -1,7 +1,7 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
 use engine_traits::{
-    KvEngine, Mutable, RegionCacheEngine, Result, WriteBatch, WriteBatchExt, WriteOptions,
+    KvEngine, Mutable, RangeCacheEngine, Result, WriteBatch, WriteBatchExt, WriteOptions,
 };
 
 use crate::engine::HybridEngine;
@@ -14,7 +14,7 @@ pub struct HybridEngineWriteBatch<EK: KvEngine> {
 impl<EK, EC> WriteBatchExt for HybridEngine<EK, EC>
 where
     EK: KvEngine,
-    EC: RegionCacheEngine,
+    EC: RangeCacheEngine,
 {
     type WriteBatch = HybridEngineWriteBatch<EK>;
     const WRITE_BATCH_MAX_KEYS: usize = EK::WRITE_BATCH_MAX_KEYS;

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -19,7 +19,7 @@ use bytes::Bytes;
 use collections::{HashMap, HashSet};
 use crossbeam::{atomic::AtomicCell, channel::TrySendError};
 use engine_traits::{
-    Engines, KvEngine, PerfContext, RaftEngine, Snapshot, SnapshotContext, WriteBatch,
+    CacheRange, Engines, KvEngine, PerfContext, RaftEngine, Snapshot, SnapshotContext, WriteBatch,
     WriteOptions, CF_DEFAULT, CF_LOCK, CF_WRITE,
 };
 use error_code::ErrorCodeExt;
@@ -4861,7 +4861,7 @@ where
 
         let snap_ctx = if let Ok(read_ts) = decode_u64(&mut req.get_header().get_flag_data()) {
             Some(SnapshotContext {
-                region_id: self.region_id,
+                range: Some(CacheRange::from_region(&region)),
                 read_ts,
             })
         } else {

--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -1292,7 +1292,7 @@ mod tests {
     use engine_traits::{MiscExt, Peekable, SyncMutable, ALL_CFS};
     use hybrid_engine::{HybridEngine, HybridEngineSnapshot};
     use kvproto::{metapb::RegionEpoch, raft_cmdpb::*};
-    use region_cache_memory_engine::RegionCacheMemoryEngine;
+    use region_cache_memory_engine::RangeCacheMemoryEngine;
     use tempfile::{Builder, TempDir};
     use tikv_util::{codec::number::NumberEncoder, time::monotonic_raw_now};
     use time::Duration;
@@ -2418,8 +2418,8 @@ mod tests {
         );
     }
 
-    type HybridTestEnigne = HybridEngine<KvTestEngine, RegionCacheMemoryEngine>;
-    type HybridEngineTestSnapshot = HybridEngineSnapshot<KvTestEngine, RegionCacheMemoryEngine>;
+    type HybridTestEnigne = HybridEngine<KvTestEngine, RangeCacheMemoryEngine>;
+    type HybridEngineTestSnapshot = HybridEngineSnapshot<KvTestEngine, RangeCacheMemoryEngine>;
 
     struct HybridEngineMockRouter {
         p_router: SyncSender<RaftCommand<HybridEngineTestSnapshot>>,
@@ -2470,13 +2470,13 @@ mod tests {
         TempDir,
         LocalReader<HybridTestEnigne, HybridEngineMockRouter>,
         Receiver<RaftCommand<HybridEngineTestSnapshot>>,
-        RegionCacheMemoryEngine,
+        RangeCacheMemoryEngine,
     ) {
         let path = Builder::new().prefix(path).tempdir().unwrap();
         let disk_engine =
             engine_test::kv::new_engine(path.path().to_str().unwrap(), ALL_CFS).unwrap();
         let (ch, rx, _) = HybridEngineMockRouter::new();
-        let memory_engine = RegionCacheMemoryEngine::default();
+        let memory_engine = RangeCacheMemoryEngine::default();
         let engine = HybridEngine::new(disk_engine, memory_engine.clone());
         let mut reader = LocalReader::new(
             engine.clone(),

--- a/components/region_cache_memory_engine/src/engine.rs
+++ b/components/region_cache_memory_engine/src/engine.rs
@@ -1719,7 +1719,7 @@ mod tests {
     fn test_skiplist_engine_evict_range() {
         let sl_engine = SkiplistEngine::new(Arc::default());
         sl_engine.data.iter().for_each(|sl| {
-            fill_data_in_skiplist(sl.clone(), (1..60).step_by(1 as usize), 1..2, 1);
+            fill_data_in_skiplist(sl.clone(), (1..60).step_by(1), 1..2, 1);
         });
 
         let evict_range = CacheRange::new(construct_user_key(20), construct_user_key(40));
@@ -1788,7 +1788,7 @@ mod tests {
         iter_opt.set_lower_bound(&lower_bound, 0);
         let mut iter = snap_left.iterator_opt("write", iter_opt.clone()).unwrap();
         iter.seek_to_first().unwrap();
-        verify_key_values(&mut iter, (0..10).step_by(1 as usize), 10..11, true, true);
+        verify_key_values(&mut iter, (0..10).step_by(1), 10..11, true, true);
 
         let lower_bound = construct_user_key(20);
         let upper_bound = construct_user_key(30);
@@ -1796,7 +1796,7 @@ mod tests {
         iter_opt.set_lower_bound(&lower_bound, 0);
         let mut iter = snap_left.iterator_opt("write", iter_opt).unwrap();
         iter.seek_to_first().unwrap();
-        verify_key_values(&mut iter, (20..30).step_by(1 as usize), 10..11, true, true);
+        verify_key_values(&mut iter, (20..30).step_by(1), 10..11, true, true);
     }
 
     #[test]

--- a/components/region_cache_memory_engine/src/engine.rs
+++ b/components/region_cache_memory_engine/src/engine.rs
@@ -165,22 +165,22 @@ impl RangeCacheMemoryEngineCore {
     }
 }
 
-/// The RangeCaheMemoryEngine serves as a range cache, storing hot ranges in
+/// The RangeCacheMemoryEngine serves as a range cache, storing hot ranges in
 /// the leaders' store. Incoming writes that are written to disk engine (now,
-/// RocksDB) are also written to the RangeCaheMemoryEngine, leading to a
+/// RocksDB) are also written to the RangeCacheMemoryEngine, leading to a
 /// mirrored data set in the cached ranges with the disk engine.
 ///
 /// A load/evict unit manages the memory, deciding which ranges should be
-/// evicted when the memory used by the RangeCaheMemoryEngine reaches a
+/// evicted when the memory used by the RangeCacheMemoryEngine reaches a
 /// certain limit, and determining which ranges should be loaded when there is
 /// spare memory capacity.
 ///
-/// The safe point lifetime differs between RangeCaheMemoryEngine and the disk
-/// engine, often being much shorter in RangeCaheMemoryEngine. This means that
-/// RangeCaheMemoryEngine may filter out some keys that still exist in the
+/// The safe point lifetime differs between RangeCacheMemoryEngine and the disk
+/// engine, often being much shorter in RangeCacheMemoryEngine. This means that
+/// RangeCacheMemoryEngine may filter out some keys that still exist in the
 /// disk engine, thereby improving read performance as fewer duplicated keys
 /// will be read. If there's a need to read keys that may have been filtered by
-/// RangeCaheMemoryEngine (as indicated by read_ts and safe_point of the
+/// RangeCacheMemoryEngine (as indicated by read_ts and safe_point of the
 /// cached region), we resort to using a the disk engine's snapshot instead.
 #[derive(Clone)]
 pub struct RangeCacheMemoryEngine {
@@ -521,7 +521,7 @@ impl Iterator for RangeCacheIterator {
 pub struct RangeCacheSnapshot {
     range: CacheRange,
     snapshot_ts: u64,
-    // Sequence number is shared between RangeCaheEngine and disk KvEnigne to
+    // Sequence number is shared between RangeCacheEngine and disk KvEnigne to
     // provide atomic write
     sequence_number: u64,
     skiplist_engine: SkiplistEngine,
@@ -596,7 +596,7 @@ impl Iterable for RangeCacheSnapshot {
 }
 
 impl Peekable for RangeCacheSnapshot {
-    type DbVector = RangeCaheDbVector;
+    type DbVector = RangeCacheDbVector;
 
     fn get_value_opt(&self, opts: &ReadOptions, key: &[u8]) -> Result<Option<Self::DbVector>> {
         self.get_value_cf_opt(opts, CF_DEFAULT, key)
@@ -622,7 +622,7 @@ impl Peekable for RangeCacheSnapshot {
                 user_key,
                 v_type: ValueType::Value,
                 ..
-            } if user_key == key => Ok(Some(RangeCaheDbVector(iter.value().clone()))),
+            } if user_key == key => Ok(Some(RangeCacheDbVector(iter.value().clone()))),
             _ => Ok(None),
         }
     }
@@ -641,9 +641,9 @@ impl SnapshotMiscExt for RangeCacheSnapshot {
 }
 
 #[derive(Debug)]
-pub struct RangeCaheDbVector(Bytes);
+pub struct RangeCacheDbVector(Bytes);
 
-impl Deref for RangeCaheDbVector {
+impl Deref for RangeCacheDbVector {
     type Target = [u8];
 
     fn deref(&self) -> &[u8] {
@@ -651,9 +651,9 @@ impl Deref for RangeCaheDbVector {
     }
 }
 
-impl DbVector for RangeCaheDbVector {}
+impl DbVector for RangeCacheDbVector {}
 
-impl<'a> PartialEq<&'a [u8]> for RangeCaheDbVector {
+impl<'a> PartialEq<&'a [u8]> for RangeCacheDbVector {
     fn eq(&self, rhs: &&[u8]) -> bool {
         self.0.as_slice() == *rhs
     }

--- a/components/region_cache_memory_engine/src/engine.rs
+++ b/components/region_cache_memory_engine/src/engine.rs
@@ -1562,14 +1562,15 @@ mod tests {
                 core.engine.get_mut(&1).unwrap().data[cf_to_id("write")].clone()
             };
 
+            let mut s = 1;
             for seq in 2..50 {
-                put_key_val(&sl, "a", "val", 10, 1);
+                put_key_val(&sl, "a", "val", 10, s + 1);
                 for i in 2..50 {
                     let v = construct_value(i, i);
-                    put_key_val(&sl, "b", v.as_str(), 10, i);
+                    put_key_val(&sl, "b", v.as_str(), 10, s + i);
                 }
 
-                let snapshot = engine.snapshot(1, 10, seq).unwrap();
+                let snapshot = engine.snapshot(1, 10, s + seq).unwrap();
                 let mut iter = snapshot.iterator_opt("write", iter_opt.clone()).unwrap();
                 assert!(iter.seek_to_last().unwrap());
                 let k = construct_mvcc_key("b", 10);
@@ -1583,6 +1584,7 @@ mod tests {
                 assert_eq!(iter.value(), b"val");
                 assert!(!iter.prev().unwrap());
                 assert!(!iter.valid().unwrap());
+                s += 100;
             }
         }
 
@@ -1597,13 +1599,14 @@ mod tests {
                 core.engine.get_mut(&1).unwrap().data[cf_to_id("write")].clone()
             };
 
+            let mut s = 1;
             for seq in 2..50 {
-                put_key_val(&sl, "a", "val", 10, 1);
+                put_key_val(&sl, "a", "val", 10, s + 1);
                 for i in 2..50 {
-                    delete_key(&sl, "b", 10, i);
+                    delete_key(&sl, "b", 10, s + i);
                 }
 
-                let snapshot = engine.snapshot(1, 10, seq).unwrap();
+                let snapshot = engine.snapshot(1, 10, s + seq).unwrap();
                 let mut iter = snapshot.iterator_opt("write", iter_opt.clone()).unwrap();
                 assert!(iter.seek_to_last().unwrap());
                 let k = construct_mvcc_key("a", 10);
@@ -1611,6 +1614,7 @@ mod tests {
                 assert_eq!(iter.value(), b"val");
                 assert!(!iter.prev().unwrap());
                 assert!(!iter.valid().unwrap());
+                s += 100;
             }
         }
 
@@ -1656,20 +1660,23 @@ mod tests {
                 core.region_metas.get_mut(&1).unwrap().safe_ts = 5;
                 core.engine.get_mut(&1).unwrap().data[cf_to_id("write")].clone()
             };
+            let mut s = 1;
             for seq in 2..50 {
                 for i in 2..50 {
-                    delete_key(&sl, "b", 10, i);
+                    delete_key(&sl, "b", 10, s + i);
                 }
                 let v = construct_value(50, 50);
-                put_key_val(&sl, "b", v.as_str(), 10, 50);
+                put_key_val(&sl, "b", v.as_str(), 10, s + 50);
 
-                let snapshot = engine.snapshot(1, 10, seq).unwrap();
+                let snapshot = engine.snapshot(1, 10, s + seq).unwrap();
                 let mut iter = snapshot.iterator_opt("write", iter_opt.clone()).unwrap();
                 assert!(!iter.seek_to_first().unwrap());
                 assert!(!iter.valid().unwrap());
 
                 assert!(!iter.seek_to_last().unwrap());
                 assert!(!iter.valid().unwrap());
+
+                s += 100;
             }
         }
     }

--- a/components/region_cache_memory_engine/src/engine.rs
+++ b/components/region_cache_memory_engine/src/engine.rs
@@ -106,13 +106,7 @@ impl SkiplistEngine {
     }
 
     fn evict_range(&self, range: &CacheRange) {
-        // self.data.iter().map(|sl| {
-        //     let iter = sl.iter();
-        //     iter.seek(&range.start);
-        //     while iter.valid() && iter.key() < &range.end {
-        //         sl.remove(iter.key());
-        //     }
-        // })
+        unimplemented!()
     }
 }
 
@@ -145,6 +139,10 @@ impl SnapshotList {
 
     pub(crate) fn is_empty(&self) -> bool {
         self.0.is_empty()
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.0.keys().len()
     }
 }
 
@@ -237,8 +235,7 @@ impl RangeCacheMemoryEngine {
     }
 
     pub fn evict_range(&mut self, range: &CacheRange) {
-        let mut core = self.core.lock().unwrap();
-        core.range_manager.evict_range(range);
+        unimplemented!()
     }
 }
 
@@ -589,9 +586,8 @@ impl Drop for RangeCacheSnapshot {
         let mut core = self.engine.core.lock().unwrap();
         core.range_manager
             .remove_range_snapshot(&self.range, self.snapshot_ts);
-        if core.range_manager.range_evictable(&self.range) {
-            core.range_manager.evict_range(&self.range);
-        }
+
+        // todo: may evict range
     }
 }
 

--- a/components/region_cache_memory_engine/src/engine.rs
+++ b/components/region_cache_memory_engine/src/engine.rs
@@ -104,7 +104,6 @@ impl SkiplistEngine {
         }
     }
 
-    // todo(SpadeA): do it asychronously
     fn delete_range(&self, range: &CacheRange) {
         self.data.iter().for_each(|d| {
             let mut key_buffer: Vec<Bytes> = vec![];
@@ -227,7 +226,6 @@ impl RangeCacheMemoryEngine {
 
     pub fn new_range(&self, range: CacheRange) {
         let mut core = self.core.lock().unwrap();
-        assert!(!core.range_manager.overlap_with_range(&range));
         core.range_manager.new_range(range);
     }
 
@@ -603,6 +601,7 @@ impl Drop for RangeCacheSnapshot {
             .range_manager
             .remove_range_snapshot(&self.snapshot_meta)
         {
+            // todo: schedule it to a separate thread
             core.engine.delete_range(&self.snapshot_meta.range);
         }
     }

--- a/components/region_cache_memory_engine/src/engine.rs
+++ b/components/region_cache_memory_engine/src/engine.rs
@@ -67,6 +67,12 @@ impl AllocationRecorder for GlobalMemoryLimiter {
     }
 }
 
+impl Drop for GlobalMemoryLimiter {
+    fn drop(&mut self) {
+        assert!(self.recorder.lock().unwrap().is_empty());
+    }
+}
+
 /// RegionMemoryEngine stores data for a specific cached region
 ///
 /// todo: The skiplist used here currently is for test purpose. Replace it
@@ -74,11 +80,11 @@ impl AllocationRecorder for GlobalMemoryLimiter {
 #[derive(Clone)]
 pub struct RegionMemoryEngine {
     data: [Arc<Skiplist<InternalKeyComparator, GlobalMemoryLimiter>>; 3],
-    global_limiter: GlobalMemoryLimiter,
+    global_limiter: Arc<GlobalMemoryLimiter>,
 }
 
 impl RegionMemoryEngine {
-    pub fn new(global_limiter: GlobalMemoryLimiter) -> Self {
+    pub fn new(global_limiter: Arc<GlobalMemoryLimiter>) -> Self {
         RegionMemoryEngine {
             data: [
                 Arc::new(Skiplist::new(
@@ -191,7 +197,7 @@ impl RegionCacheMemoryEngineCore {
 #[derive(Clone, Default)]
 pub struct RegionCacheMemoryEngine {
     core: Arc<Mutex<RegionCacheMemoryEngineCore>>,
-    memory_limiter: GlobalMemoryLimiter,
+    memory_limiter: Arc<GlobalMemoryLimiter>,
 }
 
 impl RegionCacheMemoryEngine {

--- a/components/region_cache_memory_engine/src/engine.rs
+++ b/components/region_cache_memory_engine/src/engine.rs
@@ -196,22 +196,22 @@ impl RangeCacheMemoryEngineCore {
     }
 }
 
-/// The RegionCacheMemoryEngine serves as a region cache, storing hot regions in
+/// The RangeCaheMemoryEngine serves as a region cache, storing hot regions in
 /// the leaders' store. Incoming writes that are written to disk engine (now,
-/// RocksDB) are also written to the RegionCacheMemoryEngine, leading to a
+/// RocksDB) are also written to the RangeCaheMemoryEngine, leading to a
 /// mirrored data set in the cached regions with the disk engine.
 ///
 /// A load/evict unit manages the memory, deciding which regions should be
-/// evicted when the memory used by the RegionCacheMemoryEngine reaches a
+/// evicted when the memory used by the RangeCaheMemoryEngine reaches a
 /// certain limit, and determining which regions should be loaded when there is
 /// spare memory capacity.
 ///
-/// The safe point lifetime differs between RegionCacheMemoryEngine and the disk
-/// engine, often being much shorter in RegionCacheMemoryEngine. This means that
-/// RegionCacheMemoryEngine may filter out some keys that still exist in the
+/// The safe point lifetime differs between RangeCaheMemoryEngine and the disk
+/// engine, often being much shorter in RangeCaheMemoryEngine. This means that
+/// RangeCaheMemoryEngine may filter out some keys that still exist in the
 /// disk engine, thereby improving read performance as fewer duplicated keys
 /// will be read. If there's a need to read keys that may have been filtered by
-/// RegionCacheMemoryEngine (as indicated by read_ts and safe_point of the
+/// RangeCaheMemoryEngine (as indicated by read_ts and safe_point of the
 /// cached region), we resort to using a the disk engine's snapshot instead.
 #[derive(Clone)]
 pub struct RangeCacheMemoryEngine {
@@ -552,7 +552,7 @@ impl Iterator for RangeCacheIterator {
 pub struct RangeCacheSnapshot {
     range: CacheRange,
     snapshot_ts: u64,
-    // Sequence number is shared between RegionCacheEngine and disk KvEnigne to
+    // Sequence number is shared between RangeCaheEngine and disk KvEnigne to
     // provide atomic write
     sequence_number: u64,
     skiplist_engine: SkiplistEngine,
@@ -627,7 +627,7 @@ impl Iterable for RangeCacheSnapshot {
 }
 
 impl Peekable for RangeCacheSnapshot {
-    type DbVector = RegionCacheDbVector;
+    type DbVector = RangeCaheDbVector;
 
     fn get_value_opt(&self, opts: &ReadOptions, key: &[u8]) -> Result<Option<Self::DbVector>> {
         self.get_value_cf_opt(opts, CF_DEFAULT, key)
@@ -653,7 +653,7 @@ impl Peekable for RangeCacheSnapshot {
                 user_key,
                 v_type: ValueType::Value,
                 ..
-            } if user_key == key => Ok(Some(RegionCacheDbVector(iter.value().clone()))),
+            } if user_key == key => Ok(Some(RangeCaheDbVector(iter.value().clone()))),
             _ => Ok(None),
         }
     }
@@ -672,9 +672,9 @@ impl SnapshotMiscExt for RangeCacheSnapshot {
 }
 
 #[derive(Debug)]
-pub struct RegionCacheDbVector(Bytes);
+pub struct RangeCaheDbVector(Bytes);
 
-impl Deref for RegionCacheDbVector {
+impl Deref for RangeCaheDbVector {
     type Target = [u8];
 
     fn deref(&self) -> &[u8] {
@@ -682,9 +682,9 @@ impl Deref for RegionCacheDbVector {
     }
 }
 
-impl DbVector for RegionCacheDbVector {}
+impl DbVector for RangeCaheDbVector {}
 
-impl<'a> PartialEq<&'a [u8]> for RegionCacheDbVector {
+impl<'a> PartialEq<&'a [u8]> for RangeCaheDbVector {
     fn eq(&self, rhs: &&[u8]) -> bool {
         self.0.as_slice() == *rhs
     }

--- a/components/region_cache_memory_engine/src/engine.rs
+++ b/components/region_cache_memory_engine/src/engine.rs
@@ -696,7 +696,7 @@ impl<'a> PartialEq<&'a [u8]> for RegionCacheDbVector {
 
 #[cfg(test)]
 mod tests {
-    use core::{ops::Range, slice::SlicePattern};
+    use core::ops::Range;
     use std::{iter, iter::StepBy, ops::Deref, sync::Arc};
 
     use bytes::{BufMut, Bytes};

--- a/components/region_cache_memory_engine/src/engine.rs
+++ b/components/region_cache_memory_engine/src/engine.rs
@@ -20,8 +20,8 @@ use skiplist_rs::{AllocationRecorder, IterRef, MemoryLimiter, Node, Skiplist, MI
 
 use crate::{
     keys::{
-        decode_key, encode_seek_key, InternalKey, InternalKeyComparator, ValueType,
-        VALUE_TYPE_FOR_SEEK, VALUE_TYPE_FOR_SEEK_FOR_PREV, encode_key_for_eviction,
+        decode_key, encode_key_for_eviction, encode_seek_key, InternalKey, InternalKeyComparator,
+        ValueType, VALUE_TYPE_FOR_SEEK, VALUE_TYPE_FOR_SEEK_FOR_PREV,
     },
     range_manager::RangeManager,
 };
@@ -232,7 +232,10 @@ impl RangeCacheMemoryEngine {
     }
 
     pub fn evict_range(&mut self, range: &CacheRange) {
-        unimplemented!()
+        let mut core = self.core.lock().unwrap();
+        if core.range_manager.evict_range(range) {
+            core.engine.delete_range(range);
+        }
     }
 }
 
@@ -706,7 +709,7 @@ impl<'a> PartialEq<&'a [u8]> for RangeCacheDbVector {
 
 #[cfg(test)]
 mod tests {
-    use core::ops::Range;
+    use core::{ops::Range, slice::SlicePattern};
     use std::{iter, iter::StepBy, ops::Deref, sync::Arc};
 
     use bytes::{BufMut, Bytes};
@@ -715,9 +718,9 @@ mod tests {
     };
     use skiplist_rs::Skiplist;
 
-    use super::{cf_to_id, GlobalMemoryLimiter, RangeCacheIterator};
+    use super::{cf_to_id, GlobalMemoryLimiter, RangeCacheIterator, SkiplistEngine};
     use crate::{
-        keys::{encode_key, InternalKeyComparator, ValueType},
+        keys::{decode_key, encode_key, InternalKeyComparator, ValueType},
         RangeCacheMemoryEngine,
     };
 
@@ -897,6 +900,7 @@ mod tests {
         key_range: I,
         mvcc_range: J,
         foward: bool,
+        ended: bool,
     ) {
         for i in key_range {
             for mvcc in mvcc_range.clone() {
@@ -910,7 +914,10 @@ mod tests {
                 }
             }
         }
-        assert!(!iter.valid().unwrap());
+
+        if ended {
+            assert!(!iter.valid().unwrap());
+        }
     }
 
     #[test]
@@ -1034,6 +1041,7 @@ mod tests {
                 (1..100).step_by(step as usize),
                 (1..10).rev(),
                 true,
+                true,
             );
 
             // seek key that is in the skiplist
@@ -1044,6 +1052,7 @@ mod tests {
                 (11..100).step_by(step as usize),
                 (1..10).rev(),
                 true,
+                true,
             );
 
             // seek key that is not in the skiplist
@@ -1053,6 +1062,7 @@ mod tests {
                 &mut iter,
                 (13..100).step_by(step as usize),
                 (1..10).rev(),
+                true,
                 true,
             );
         }
@@ -1066,6 +1076,7 @@ mod tests {
                 &mut iter,
                 (63..100).step_by(step as usize),
                 (1..10).rev(),
+                true,
                 true,
             );
 
@@ -1111,6 +1122,7 @@ mod tests {
                 (21..40).step_by(step as usize),
                 (1..10).rev(),
                 true,
+                true,
             );
 
             // seek a key that is below the lower bound is the same with seek_to_first
@@ -1120,6 +1132,7 @@ mod tests {
                 &mut iter,
                 (21..40).step_by(step as usize),
                 (1..10).rev(),
+                true,
                 true,
             );
 
@@ -1134,6 +1147,7 @@ mod tests {
                 &mut iter,
                 (33..40).step_by(step as usize),
                 (1..10).rev(),
+                true,
                 true,
             );
         }
@@ -1203,6 +1217,7 @@ mod tests {
                 (1..100).step_by(step as usize).rev(),
                 1..10,
                 false,
+                true,
             );
 
             // seek key that is in the skiplist
@@ -1213,6 +1228,7 @@ mod tests {
                 (1..82).step_by(step as usize).rev(),
                 1..10,
                 false,
+                true,
             );
 
             // seek key that is in the skiplist
@@ -1223,6 +1239,7 @@ mod tests {
                 (1..80).step_by(step as usize).rev(),
                 1..10,
                 false,
+                true,
             );
         }
 
@@ -1240,6 +1257,7 @@ mod tests {
                 (21..38).step_by(step as usize).rev(),
                 1..10,
                 false,
+                true,
             );
 
             // seek a key that is above the upper bound is the same with seek_to_last
@@ -1250,6 +1268,7 @@ mod tests {
                 (21..38).step_by(step as usize).rev(),
                 1..10,
                 false,
+                true,
             );
 
             // seek a key that is less than the lower bound won't get any key
@@ -1264,6 +1283,7 @@ mod tests {
                 (21..26).step_by(step as usize).rev(),
                 1..10,
                 false,
+                true,
             );
         }
     }
@@ -1692,6 +1712,149 @@ mod tests {
                 iter.prev().unwrap();
             }
             assert_eq!(start, 20);
+        }
+    }
+
+    #[test]
+    fn test_skiplist_engine_evict_range() {
+        let sl_engine = SkiplistEngine::new(Arc::default());
+        sl_engine.data.iter().for_each(|sl| {
+            fill_data_in_skiplist(sl.clone(), (1..60).step_by(1 as usize), 1..2, 1);
+        });
+
+        let evict_range = CacheRange::new(construct_user_key(20), construct_user_key(40));
+        sl_engine.delete_range(&evict_range);
+        sl_engine.data.iter().for_each(|sl| {
+            let mut iter = sl.iter();
+            iter.seek_to_first();
+            for i in 1..20 {
+                let internal_key = decode_key(iter.key());
+                let expected_key = construct_key(i, 1);
+                assert_eq!(internal_key.user_key, &expected_key);
+                iter.next();
+            }
+
+            for i in 40..60 {
+                let internal_key = decode_key(iter.key());
+                let expected_key = construct_key(i, 1);
+                assert_eq!(internal_key.user_key, &expected_key);
+                iter.next();
+            }
+            assert!(!iter.valid());
+        });
+    }
+
+    #[test]
+    fn test_evict_range_without_snapshot() {
+        let mut engine = RangeCacheMemoryEngine::new(Arc::default());
+        let range = CacheRange::new(construct_user_key(0), construct_user_key(30));
+        let evict_range = CacheRange::new(construct_user_key(10), construct_user_key(20));
+        engine.new_range(range.clone());
+
+        {
+            let mut core = engine.core.lock().unwrap();
+            core.range_manager.set_range_readable(&range, true);
+            core.range_manager.set_safe_ts(&range, 5);
+            let sl = core.engine.data[cf_to_id("write")].clone();
+            for i in 0..30 {
+                let user_key = construct_key(i, 10);
+                let internal_key = encode_key(&user_key, 10, ValueType::Value);
+                let v = construct_value(i, 10);
+                sl.put(internal_key.clone(), v.clone());
+            }
+        }
+
+        engine.evict_range(&evict_range);
+        assert!(engine.snapshot(range.clone(), 10, 200).is_none());
+        assert!(engine.snapshot(evict_range, 10, 200).is_none());
+
+        {
+            let removed = engine.memory_limiter.removed.lock().unwrap();
+            for i in 10..20 {
+                let user_key = construct_key(i, 10);
+                let internal_key = encode_key(&user_key, 10, ValueType::Value);
+                assert!(removed.contains(internal_key.as_slice()));
+            }
+        }
+
+        let r_left = CacheRange::new(construct_user_key(0), construct_user_key(10));
+        let r_right = CacheRange::new(construct_user_key(20), construct_user_key(30));
+        let snap_left = engine.snapshot(r_left, 10, 200).unwrap();
+
+        let mut iter_opt = IterOptions::default();
+        let lower_bound = construct_user_key(0);
+        let upper_bound = construct_user_key(10);
+        iter_opt.set_upper_bound(&upper_bound, 0);
+        iter_opt.set_lower_bound(&lower_bound, 0);
+        let mut iter = snap_left.iterator_opt("write", iter_opt.clone()).unwrap();
+        iter.seek_to_first().unwrap();
+        verify_key_values(&mut iter, (0..10).step_by(1 as usize), 10..11, true, true);
+
+        let lower_bound = construct_user_key(20);
+        let upper_bound = construct_user_key(30);
+        iter_opt.set_upper_bound(&upper_bound, 0);
+        iter_opt.set_lower_bound(&lower_bound, 0);
+        let mut iter = snap_left.iterator_opt("write", iter_opt).unwrap();
+        iter.seek_to_first().unwrap();
+        verify_key_values(&mut iter, (20..30).step_by(1 as usize), 10..11, true, true);
+    }
+
+    #[test]
+    fn test_evict_range_with_snapshot() {
+        let mut engine = RangeCacheMemoryEngine::new(Arc::default());
+        let range = CacheRange::new(construct_user_key(0), construct_user_key(30));
+        let evict_range = CacheRange::new(construct_user_key(10), construct_user_key(20));
+        engine.new_range(range.clone());
+        {
+            let mut core = engine.core.lock().unwrap();
+            core.range_manager.set_range_readable(&range, true);
+            core.range_manager.set_safe_ts(&range, 5);
+            let sl = core.engine.data[cf_to_id("write")].clone();
+            for i in 0..30 {
+                let user_key = construct_key(i, 10);
+                let internal_key = encode_key(&user_key, 10, ValueType::Value);
+                let v = construct_value(i, 10);
+                sl.put(internal_key.clone(), v.clone());
+            }
+        }
+
+        let s1 = engine.snapshot(range.clone(), 10, 10);
+        let s2 = engine.snapshot(range, 20, 20);
+        engine.evict_range(&evict_range);
+        let range_left = CacheRange::new(construct_user_key(0), construct_user_key(10));
+        let s3 = engine.snapshot(range_left, 20, 20).unwrap();
+        let range_right = CacheRange::new(construct_user_key(20), construct_user_key(30));
+        let s4 = engine.snapshot(range_right, 20, 20).unwrap();
+
+        drop(s3);
+        let range_left_eviction = CacheRange::new(construct_user_key(0), construct_user_key(5));
+        engine.evict_range(&range_left_eviction);
+
+        {
+            let removed = engine.memory_limiter.removed.lock().unwrap();
+            assert!(removed.is_empty());
+        }
+
+        drop(s1);
+        {
+            let removed = engine.memory_limiter.removed.lock().unwrap();
+            for i in 10..20 {
+                let user_key = construct_key(i, 10);
+                let internal_key = encode_key(&user_key, 10, ValueType::Value);
+                assert!(!removed.contains(internal_key.as_slice()));
+            }
+        }
+
+        drop(s2);
+        // s2 is dropped, so the range of `evict_range` is removed. The snapshot of s3
+        // and s4 does not prevent it as they are not overlapped.
+        {
+            let removed = engine.memory_limiter.removed.lock().unwrap();
+            for i in 10..20 {
+                let user_key = construct_key(i, 10);
+                let internal_key = encode_key(&user_key, 10, ValueType::Value);
+                assert!(removed.contains(internal_key.as_slice()));
+            }
         }
     }
 }

--- a/components/region_cache_memory_engine/src/keys.rs
+++ b/components/region_cache_memory_engine/src/keys.rs
@@ -3,7 +3,9 @@
 use std::cmp;
 
 use bytes::{BufMut, Bytes, BytesMut};
+use engine_traits::CacheRange;
 use skiplist_rs::KeyComparator;
+use tikv_util::codec::number::NumberEncoder;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ValueType {
@@ -104,6 +106,25 @@ pub fn encode_key(key: &[u8], seq: u64, v_type: ValueType) -> Bytes {
 #[inline]
 pub fn encode_seek_key(key: &[u8], seq: u64, v_type: ValueType) -> Vec<u8> {
     encode_key_internal::<Vec<_>>(key, seq, v_type, Vec::with_capacity)
+}
+
+// range keys deos not contain mvcc version and sequence number
+#[inline]
+pub fn encode_key_for_eviction(range: &CacheRange) -> (Vec<u8>, Vec<u8>) {
+    // Both encoded_start and encoded_end should be the smallest key in the
+    // respective of user key, so that the eviction covers all versions of the range
+    // start and covers nothing of range end.
+    let mut encoded_start = Vec::with_capacity(range.start.len() + 16);
+    encoded_start.extend_from_slice(&range.start);
+    encoded_start.encode_u64_desc(u64::MAX).unwrap();
+    encoded_start.put_u64((u64::MAX << 8) | VALUE_TYPE_FOR_SEEK as u64);
+
+    let mut encoded_end = Vec::with_capacity(range.end.len() + 16);
+    encoded_end.extend_from_slice(&range.end);
+    encoded_end.encode_u64_desc(u64::MAX).unwrap();
+    encoded_end.put_u64((u64::MAX << 8) | VALUE_TYPE_FOR_SEEK as u64);
+
+    (encoded_start, encoded_end)
 }
 
 #[derive(Default, Debug, Clone, Copy)]

--- a/components/region_cache_memory_engine/src/lib.rs
+++ b/components/region_cache_memory_engine/src/lib.rs
@@ -7,4 +7,5 @@
 
 mod engine;
 pub mod keys;
-pub use engine::RegionCacheMemoryEngine;
+pub use engine::RangeCacheMemoryEngine;
+pub mod range_manager;

--- a/components/region_cache_memory_engine/src/lib.rs
+++ b/components/region_cache_memory_engine/src/lib.rs
@@ -10,4 +10,4 @@ pub mod keys;
 pub use engine::RangeCacheMemoryEngine;
 pub mod range_manager;
 mod write_batch;
-pub use write_batch::RegionCacheWriteBatch;
+pub use write_batch::RangeCacheWriteBatch;

--- a/components/region_cache_memory_engine/src/range_manager.rs
+++ b/components/region_cache_memory_engine/src/range_manager.rs
@@ -28,7 +28,7 @@ impl RangeMeta {
 
     pub(crate) fn set_range_readable(&mut self, range: &CacheRange, set_readable: bool) {
         if set_readable {
-            assert!(self.ranges_unreadable.remove(&range));
+            assert!(self.ranges_unreadable.remove(range));
         } else {
             self.ranges_unreadable.insert(range.clone());
         }
@@ -184,33 +184,28 @@ impl RangeManager {
         let mut meta = self.ranges.remove(&range_key).unwrap();
 
         let range_snapshot_list2 = meta.range_snapshot_list.split_off(&range_key);
-        // range overlap assertion check
-        range_snapshot_list2
-            .keys()
-            .into_iter()
-            .next()
-            .map(|r| assert!(!r.overlaps(range)));
-        meta.range_snapshot_list
-            .keys()
-            .last()
-            .map(|r| assert!(!r.overlaps(range)));
         let evicted2 = meta.ranges_evcited.split_off(&range_key);
-        // range overlap assertion check
-        evicted2.iter().next().map(|r| assert!(!r.overlaps(&range)));
-        meta.ranges_evcited
-            .iter()
-            .last()
-            .map(|r| assert!(!r.overlaps(range)));
         let unreadable2 = meta.ranges_unreadable.split_off(&range_key);
+
         // range overlap assertion check
-        unreadable2
-            .iter()
-            .next()
-            .map(|r| assert!(!r.overlaps(&range)));
-        meta.ranges_unreadable
-            .iter()
-            .last()
-            .map(|r| assert!(!r.overlaps(range)));
+        if let Some(r) = range_snapshot_list2.keys().next() {
+            assert!(!r.overlaps(range));
+        }
+        if let Some(r) = meta.range_snapshot_list.keys().last() {
+            assert!(!r.overlaps(range));
+        }
+        if let Some(r) = evicted2.iter().next() {
+            assert!(!r.overlaps(range));
+        }
+        if let Some(r) = meta.ranges_evcited.iter().last() {
+            assert!(!r.overlaps(range));
+        }
+        if let Some(r) = unreadable2.iter().next() {
+            assert!(!r.overlaps(range));
+        }
+        if let Some(r) = meta.ranges_unreadable.iter().last() {
+            assert!(!r.overlaps(range));
+        }
 
         let (r1, r2) = range_key.split_off(range);
         let safe_ts = meta.safe_ts;

--- a/components/region_cache_memory_engine/src/range_manager.rs
+++ b/components/region_cache_memory_engine/src/range_manager.rs
@@ -9,7 +9,7 @@ use crate::engine::SnapshotList;
 #[derive(Debug, Default)]
 pub struct RangeMeta {
     range_snapshot_list: BTreeMap<CacheRange, SnapshotList>,
-    ranges_evcited: BTreeSet<CacheRange>,
+    ranges_evicted: BTreeSet<CacheRange>,
     ranges_unreadable: BTreeSet<CacheRange>,
     safe_ts: u64,
 }
@@ -22,7 +22,7 @@ impl RangeMeta {
     pub(crate) fn merge_meta(&mut self, mut other: RangeMeta) {
         self.range_snapshot_list
             .append(&mut other.range_snapshot_list);
-        self.ranges_evcited.append(&mut other.ranges_evcited);
+        self.ranges_evicted.append(&mut other.ranges_evicted);
         self.ranges_unreadable.append(&mut other.ranges_unreadable);
 
         // merge safe_ts to the min of them if not 0
@@ -117,7 +117,7 @@ impl RangeManager {
             return false;
         }
 
-        if meta.ranges_evcited.iter().any(|r| r.overlaps(range)) {
+        if meta.ranges_evicted.iter().any(|r| r.overlaps(range)) {
             return false;
         }
 

--- a/components/region_cache_memory_engine/src/range_manager.rs
+++ b/components/region_cache_memory_engine/src/range_manager.rs
@@ -6,6 +6,23 @@ use engine_traits::CacheRange;
 
 use crate::engine::SnapshotList;
 
+//  RangeManager: range [k1-k10]
+//  range_snapshot_list: [k1-k10]
+//
+//  batch split k1-k5 k5-k10
+// 
+//  RangeManager: range [k1-k10]
+//  range_snapshot_list: [k1-k10, k1-k5]
+//  
+// 
+//  RangeManager: range [ k1-k5,        k5-k10 -- evict ]
+//  k1-k5 range_snapshot_list: [k1-k10, k1-k5]
+// 
+// 
+// range_snapshot_list: [k1-k10, k1-k3, k3-k5]
+// ranges_evicted: [k3-k5]
+// 
+//  k1-k3  
 #[derive(Debug, Default)]
 pub struct RangeMeta {
     range_snapshot_list: BTreeMap<CacheRange, SnapshotList>,

--- a/components/region_cache_memory_engine/src/range_manager.rs
+++ b/components/region_cache_memory_engine/src/range_manager.rs
@@ -85,7 +85,7 @@ impl RangeManager {
 
     pub fn set_range_readable(&mut self, range: &CacheRange, set_readable: bool) {
         let meta = self.ranges.get_mut(range).unwrap();
-        meta.can_read = true;
+        meta.can_read = set_readable;
     }
 
     pub fn set_safe_ts(&mut self, range: &CacheRange, safe_ts: u64) -> bool {

--- a/components/region_cache_memory_engine/src/range_manager.rs
+++ b/components/region_cache_memory_engine/src/range_manager.rs
@@ -177,6 +177,8 @@ mod tests {
         range_mgr.set_safe_ts(&r1, 5);
         assert!(!range_mgr.range_snapshot(&r1, 5));
         assert!(range_mgr.range_snapshot(&r1, 8));
+        let tmp_r = CacheRange::new(b"k00".to_vec(), b"k04".to_vec());
+        assert!(!range_mgr.range_snapshot(&tmp_r, 8));
         assert!(range_mgr.range_snapshot(&r1, 10));
         range_mgr.set_range_readable(&r1_1, false);
         assert!(!range_mgr.range_snapshot(&r1_1, 10));

--- a/components/region_cache_memory_engine/src/range_manager.rs
+++ b/components/region_cache_memory_engine/src/range_manager.rs
@@ -1,0 +1,231 @@
+// Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use engine_traits::CacheRange;
+
+use crate::engine::SnapshotList;
+
+#[derive(Debug, Default)]
+pub struct RangeMeta {
+    range_snapshot_list: BTreeMap<CacheRange, SnapshotList>,
+    ranges_evcited: BTreeSet<CacheRange>,
+    ranges_unreadable: BTreeSet<CacheRange>,
+    safe_ts: u64,
+}
+
+impl RangeMeta {
+    pub(crate) fn range_snapshot_list(&self) -> &BTreeMap<CacheRange, SnapshotList> {
+        &self.range_snapshot_list
+    }
+
+    pub(crate) fn merge_meta(&mut self, mut other: RangeMeta) {
+        self.range_snapshot_list
+            .append(&mut other.range_snapshot_list);
+        self.ranges_evcited.append(&mut other.ranges_evcited);
+        self.ranges_unreadable.append(&mut other.ranges_unreadable);
+    }
+
+    pub(crate) fn set_range_readable(&mut self, range: &CacheRange, set_readable: bool) {
+        if set_readable {
+            assert!(self.ranges_unreadable.remove(&range));
+        } else {
+            self.ranges_unreadable.insert(range.clone());
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct RangeManager {
+    // the range reflects the range of data that is accessable.
+    ranges: BTreeMap<CacheRange, RangeMeta>,
+}
+
+impl RangeManager {
+    pub(crate) fn ranges(&self) -> &BTreeMap<CacheRange, RangeMeta> {
+        &self.ranges
+    }
+
+    pub(crate) fn new_range(&mut self, range: CacheRange) {
+        if let Some(sibling) = self.ranges.keys().find(|r| r.is_sibling(&range)).cloned() {
+            let left_sib = sibling < range;
+            let mut sib_meta = self.ranges.remove(&sibling).unwrap();
+            sib_meta.ranges_unreadable.insert(range.clone());
+            let range = CacheRange::merge(sibling, range);
+
+            // if sibling found above is the left sibling of the range, there could be a
+            // right sibling
+            if left_sib {
+                if let Some(right_sibling) =
+                    self.ranges.keys().find(|r| r.is_sibling(&range)).cloned()
+                {
+                    let right_sib_meta = self.ranges.remove(&right_sibling).unwrap();
+                    sib_meta.merge_meta(right_sib_meta);
+                }
+            }
+            self.ranges.insert(range, sib_meta);
+        } else {
+            let mut range_meta = RangeMeta::default();
+            range_meta.ranges_unreadable.insert(range.clone());
+            self.ranges.insert(range, range_meta);
+        }
+    }
+
+    pub(crate) fn set_range_readable(&mut self, range: &CacheRange, set_readable: bool) {
+        let range_key = self
+            .ranges
+            .keys()
+            .find(|&r| r.contains(range))
+            .unwrap()
+            .clone();
+        let meta = self.ranges.get_mut(&range_key).unwrap();
+        meta.set_range_readable(range, set_readable);
+    }
+
+    pub(crate) fn set_safe_ts(&mut self, range: &CacheRange, safe_ts: u64) -> bool {
+        if let Some(meta) = self.ranges.get_mut(range) {
+            meta.safe_ts = safe_ts;
+            true
+        } else {
+            false
+        }
+    }
+
+    pub(crate) fn overlap_with_range(&self, range: &CacheRange) -> bool {
+        false
+    }
+
+    pub(crate) fn range_readable(&self, range: &CacheRange, read_ts: u64) -> bool {
+        let Some(range_key) = self.ranges.keys().find(|&r| r.contains(range)) else {
+            return false;
+        };
+        let meta = self.ranges.get(range_key).unwrap();
+
+        if read_ts <= meta.safe_ts {
+            // todo(SpadeA): add metrics for it
+            return false;
+        }
+
+        if meta.ranges_evcited.iter().any(|r| r.overlaps(range)) {
+            return false;
+        }
+
+        if meta.ranges_unreadable.iter().any(|r| r.overlaps(range)) {
+            return false;
+        }
+
+        true
+    }
+
+    pub(crate) fn range_snapshot(&mut self, range: &CacheRange, read_ts: u64) -> bool {
+        let Some(range_key) = self.ranges.keys().find(|&r| r.contains(range)) else {
+            return false;
+        };
+        let meta = self.ranges.get(range_key).unwrap();
+
+        if read_ts <= meta.safe_ts {
+            // todo(SpadeA): add metrics for it
+            return false;
+        }
+
+        if meta.ranges_evcited.iter().any(|r| r.overlaps(range)) {
+            return false;
+        }
+
+        if meta.ranges_unreadable.iter().any(|r| r.overlaps(range)) {
+            return false;
+        }
+
+        let meta = self.ranges.get_mut(&range_key.clone()).unwrap();
+        meta.range_snapshot_list
+            .entry(range.clone())
+            .or_default()
+            .new_snapshot(read_ts);
+        true
+    }
+
+    pub(crate) fn remove_range_snapshot(&mut self, range: &CacheRange, read_ts: u64) {
+        let range_key = self
+            .ranges
+            .keys()
+            .find(|&r| r.contains(range))
+            .unwrap()
+            .clone();
+        let meta = self.ranges.get_mut(&range_key).unwrap();
+        let snap_list = meta.range_snapshot_list.get_mut(range).unwrap();
+        snap_list.remove_snapshot(read_ts);
+        if snap_list.is_empty() {
+            meta.range_snapshot_list.remove(range).unwrap();
+        }
+    }
+
+    // A range is evictable if:
+    // 1. it is marked as evicted (so it's in the ranges_evicted)
+    // 2. there's no snapshot whose range overlap with it
+    pub(crate) fn range_evictable(&self, range: &CacheRange) -> bool {
+        let range_key = self.ranges.keys().find(|&r| r.contains(range)).unwrap();
+        let meta = self.ranges.get(range_key).unwrap();
+        if meta.ranges_evcited.get(range).is_none() {
+            return false;
+        }
+
+        return !meta.range_snapshot_list.keys().any(|r| r.overlaps(range));
+    }
+
+    // Evict a range which results in a split of the range containing it. Meta
+    // should also be splitted.
+    pub(crate) fn evict_range(&mut self, range: &CacheRange) {
+        let range_key = self
+            .ranges
+            .keys()
+            .find(|&r| r.contains(range))
+            .unwrap()
+            .clone();
+        let mut meta = self.ranges.remove(&range_key).unwrap();
+
+        let range_snapshot_list2 = meta.range_snapshot_list.split_off(&range_key);
+        // range overlap assertion check
+        range_snapshot_list2
+            .keys()
+            .into_iter()
+            .next()
+            .map(|r| assert!(!r.overlaps(range)));
+        meta.range_snapshot_list
+            .keys()
+            .last()
+            .map(|r| assert!(!r.overlaps(range)));
+        let evicted2 = meta.ranges_evcited.split_off(&range_key);
+        // range overlap assertion check
+        evicted2.iter().next().map(|r| assert!(!r.overlaps(&range)));
+        meta.ranges_evcited
+            .iter()
+            .last()
+            .map(|r| assert!(!r.overlaps(range)));
+        let unreadable2 = meta.ranges_unreadable.split_off(&range_key);
+        // range overlap assertion check
+        unreadable2
+            .iter()
+            .next()
+            .map(|r| assert!(!r.overlaps(&range)));
+        meta.ranges_unreadable
+            .iter()
+            .last()
+            .map(|r| assert!(!r.overlaps(range)));
+
+        let (r1, r2) = range_key.split_off(range);
+        let safe_ts = meta.safe_ts;
+        self.ranges.insert(r1, meta);
+        self.ranges.insert(
+            r2,
+            RangeMeta {
+                range_snapshot_list: range_snapshot_list2,
+                ranges_evcited: evicted2,
+                ranges_unreadable: unreadable2,
+                safe_ts,
+            },
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {}

--- a/components/region_cache_memory_engine/src/range_manager.rs
+++ b/components/region_cache_memory_engine/src/range_manager.rs
@@ -103,7 +103,7 @@ impl RangeManager {
     }
 
     pub(crate) fn overlap_with_range(&self, range: &CacheRange) -> bool {
-        self.ranges.keys().any(|r| r.overlaps(&range))
+        self.ranges.keys().any(|r| r.overlaps(range))
     }
 
     pub(crate) fn range_snapshot(&mut self, range: &CacheRange, read_ts: u64) -> bool {

--- a/components/region_cache_memory_engine/src/range_manager.rs
+++ b/components/region_cache_memory_engine/src/range_manager.rs
@@ -4,64 +4,60 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use engine_traits::CacheRange;
 
-use crate::engine::SnapshotList;
+use crate::engine::{RagneCacheSnapshotMeta, SnapshotList};
 
-//  RangeManager: range [k1-k10]
-//  range_snapshot_list: [k1-k10]
-//
-//  batch split k1-k5 k5-k10
-// 
-//  RangeManager: range [k1-k10]
-//  range_snapshot_list: [k1-k10, k1-k5]
-//  
-// 
-//  RangeManager: range [ k1-k5,        k5-k10 -- evict ]
-//  k1-k5 range_snapshot_list: [k1-k10, k1-k5]
-// 
-// 
-// range_snapshot_list: [k1-k10, k1-k3, k3-k5]
-// ranges_evicted: [k3-k5]
-// 
-//  k1-k3  
 #[derive(Debug, Default)]
 pub struct RangeMeta {
-    range_snapshot_list: BTreeMap<CacheRange, SnapshotList>,
-    ranges_evicted: BTreeSet<CacheRange>,
-    ranges_unreadable: BTreeSet<CacheRange>,
+    id: u64,
+    range_snapshot_list: SnapshotList,
+    evicted: bool,
+    can_read: bool,
     safe_ts: u64,
 }
 
 impl RangeMeta {
-    pub(crate) fn range_snapshot_list(&self) -> &BTreeMap<CacheRange, SnapshotList> {
+    fn new(id: u64) -> Self {
+        Self {
+            id,
+            range_snapshot_list: SnapshotList::default(),
+            evicted: false,
+            can_read: false,
+            safe_ts: 0,
+        }
+    }
+
+    fn derive_from(id: u64, r: &RangeMeta) -> Self {
+        Self {
+            id,
+            range_snapshot_list: SnapshotList::default(),
+            evicted: false,
+            can_read: r.can_read,
+            safe_ts: r.safe_ts,
+        }
+    }
+
+    pub(crate) fn range_snapshot_list(&self) -> &SnapshotList {
         &self.range_snapshot_list
-    }
-
-    pub(crate) fn merge_meta(&mut self, mut other: RangeMeta) {
-        self.range_snapshot_list
-            .append(&mut other.range_snapshot_list);
-        self.ranges_evicted.append(&mut other.ranges_evicted);
-        self.ranges_unreadable.append(&mut other.ranges_unreadable);
-
-        // merge safe_ts to the min of them if not 0
-        if self.safe_ts != 0 && other.safe_ts != 0 {
-            self.safe_ts = u64::min(self.safe_ts, other.safe_ts);
-        } else if other.safe_ts != 0 {
-            self.safe_ts = other.safe_ts;
-        }
-    }
-
-    pub(crate) fn set_range_readable(&mut self, range: &CacheRange, set_readable: bool) {
-        if set_readable {
-            assert!(self.ranges_unreadable.remove(range));
-        } else {
-            self.ranges_unreadable.insert(range.clone());
-        }
     }
 }
 
 #[derive(Default)]
+struct IdAllocator(u64);
+
+impl IdAllocator {
+    fn allocate_id(&mut self) -> u64 {
+        self.0 += 1;
+        self.0
+    }
+}
+
+/// RangeManger manges the ranges for RangeCacheMemoryEngine.
+#[derive(Default)]
 pub struct RangeManager {
-    // the range reflects the range of data that is accessable.
+    // Each new range will increment it by one.
+    id_allocator: IdAllocator,
+    historical_ranges: BTreeMap<CacheRange, RangeMeta>,
+    evicted_ranges: BTreeSet<CacheRange>,
     ranges: BTreeMap<CacheRange, RangeMeta>,
 }
 
@@ -71,44 +67,18 @@ impl RangeManager {
     }
 
     pub(crate) fn new_range(&mut self, range: CacheRange) {
-        if let Some(sibling) = self.ranges.keys().find(|r| r.is_sibling(&range)).cloned() {
-            let left_sib = sibling < range;
-            let mut sib_meta = self.ranges.remove(&sibling).unwrap();
-            sib_meta.ranges_unreadable.insert(range.clone());
-            let mut range = CacheRange::merge(sibling, range);
-
-            // if sibling found above is the left sibling of the range, there could be a
-            // right sibling
-            if left_sib {
-                if let Some(right_sibling) =
-                    self.ranges.keys().find(|r| r.is_sibling(&range)).cloned()
-                {
-                    let right_sib_meta = self.ranges.remove(&right_sibling).unwrap();
-                    sib_meta.merge_meta(right_sib_meta);
-                    range = CacheRange::merge(range, right_sibling);
-                }
-            }
-            self.ranges.insert(range, sib_meta);
-        } else {
-            let mut range_meta = RangeMeta::default();
-            range_meta.ranges_unreadable.insert(range.clone());
-            self.ranges.insert(range, range_meta);
-        }
+        let range_meta = RangeMeta::new(self.id_allocator.allocate_id());
+        self.ranges.insert(range, range_meta);
     }
 
     pub fn set_range_readable(&mut self, range: &CacheRange, set_readable: bool) {
-        let range_key = self
-            .ranges
-            .keys()
-            .find(|&r| r.contains(range))
-            .unwrap()
-            .clone();
-        let meta = self.ranges.get_mut(&range_key).unwrap();
-        meta.set_range_readable(range, set_readable);
+        if let Some(meta) = self.ranges.get_mut(&range) {
+            meta.can_read = true;
+        }
     }
 
     pub fn set_safe_ts(&mut self, range: &CacheRange, safe_ts: u64) -> bool {
-        if let Some(meta) = self.ranges.get_mut(range) {
+        if let Some(meta) = self.ranges.get_mut(&range) {
             if meta.safe_ts > safe_ts {
                 return false;
             }
@@ -123,56 +93,102 @@ impl RangeManager {
         self.ranges.keys().any(|r| r.overlaps(range))
     }
 
-    pub(crate) fn range_snapshot(&mut self, range: &CacheRange, read_ts: u64) -> bool {
-        let Some(range_key) = self.ranges.keys().find(|&r| r.contains(range)) else {
-            return false;
+    // Acquire a snapshot of the `range` with `reaed_ts`. If the range is not
+    // accessable, None will be returned. Otherwise, the range id will be returned.
+    pub(crate) fn range_snapshot(&mut self, range: &CacheRange, read_ts: u64) -> Option<u64> {
+        let Some(range_key) = self.ranges.keys().find(|&r| r.contains(range)).cloned() else {
+            return None;
         };
-        let meta = self.ranges.get(range_key).unwrap();
+        let meta = self.ranges.get_mut(&range_key).unwrap();
 
-        if read_ts <= meta.safe_ts {
+        if read_ts <= meta.safe_ts || meta.evicted || !meta.can_read {
             // todo(SpadeA): add metrics for it
-            return false;
+            return None;
         }
 
-        if meta.ranges_evicted.iter().any(|r| r.overlaps(range)) {
-            return false;
-        }
-
-        if meta.ranges_unreadable.iter().any(|r| r.overlaps(range)) {
-            return false;
-        }
-
-        let meta = self.ranges.get_mut(&range_key.clone()).unwrap();
-        meta.range_snapshot_list
-            .entry(range.clone())
-            .or_default()
-            .new_snapshot(read_ts);
-        true
+        meta.range_snapshot_list.new_snapshot(read_ts);
+        Some(meta.id)
     }
 
-    pub(crate) fn remove_range_snapshot(&mut self, range: &CacheRange, read_ts: u64) {
+    // If the snapshot is the last one in the snapshot list of one cache range in
+    // historical_ranges, it means one or some evicted_ranges may be ready to be
+    // removed physically.
+    // So, here, we return a vector of ranges to denote the ranges that are ready to
+    // be removed.
+    pub(crate) fn remove_range_snapshot(
+        &mut self,
+        snapshot_meta: &RagneCacheSnapshotMeta,
+    ) -> Vec<CacheRange> {
+        if let Some(range_key) = self
+            .historical_ranges
+            .iter()
+            .find(|&(range, meta)| {
+                range.contains(&snapshot_meta.range) && meta.id == snapshot_meta.range_id
+            })
+            .map(|(r, _)| r.clone())
+        {
+            let meta = self.historical_ranges.get_mut(&range_key).unwrap();
+            meta.range_snapshot_list
+                .remove_snapshot(snapshot_meta.snapshot_ts);
+            if meta.range_snapshot_list.is_empty() {
+                self.historical_ranges.remove(&range_key);
+            }
+
+            return self
+                .evicted_ranges
+                .iter()
+                .filter(|evicted_range| {
+                    !self
+                        .historical_ranges
+                        .keys()
+                        .any(|r| r.overlaps(&evicted_range))
+                })
+                .map(|r| r.clone())
+                .collect();
+        }
+
+        // It must belong to the `self.ranges` if not found in `self.historical_ranges`
         let range_key = self
             .ranges
-            .keys()
-            .find(|&r| r.contains(range))
-            .unwrap()
-            .clone();
+            .iter()
+            .find(|&(range, meta)| {
+                range.contains(&snapshot_meta.range) && meta.id == snapshot_meta.range_id
+            })
+            .map(|(r, _)| r.clone())
+            .unwrap();
         let meta = self.ranges.get_mut(&range_key).unwrap();
-        let snap_list = meta.range_snapshot_list.get_mut(range).unwrap();
-        snap_list.remove_snapshot(read_ts);
-        if snap_list.is_empty() {
-            meta.range_snapshot_list.remove(range).unwrap();
-        }
+        meta.range_snapshot_list
+            .remove_snapshot(snapshot_meta.snapshot_ts);
+        vec![]
     }
 
     pub(crate) fn range_evictable(&self, range: &CacheRange) -> bool {
         unimplemented!()
     }
 
-    // Evict a range which results in a split of the range containing it. Meta
-    // should also be splitted.
     pub(crate) fn evict_range(&mut self, range: &CacheRange) {
-        unimplemented!()
+        let range_key = self
+            .ranges
+            .keys()
+            .find(|&r| r.contains(range))
+            .unwrap()
+            .clone();
+        let meta = self.ranges.remove(&range_key).unwrap();
+        let (left_range, right_range) = range_key.split_off(&range);
+        assert!((left_range.is_some() || right_range.is_some()) || &range_key == range);
+
+        if let Some(left_range) = left_range {
+            let left_meta = RangeMeta::derive_from(self.id_allocator.allocate_id(), &meta);
+            self.ranges.insert(left_range, left_meta);
+        }
+
+        if let Some(right_range) = right_range {
+            let right_meta = RangeMeta::derive_from(self.id_allocator.allocate_id(), &meta);
+            self.ranges.insert(right_range, right_meta);
+        }
+
+        self.evicted_ranges.insert(range.clone());
+        self.historical_ranges.insert(range_key, meta);
     }
 }
 
@@ -185,44 +201,35 @@ mod tests {
     #[test]
     fn test_range_manager() {
         let mut range_mgr = RangeManager::default();
-        let r1 = CacheRange::new(b"k00".to_vec(), b"k03".to_vec());
-        let r1_1 = CacheRange::new(b"k00".to_vec(), b"k01".to_vec());
-        let r1_2 = CacheRange::new(b"k01".to_vec(), b"k02".to_vec());
+        let r1 = CacheRange::new(b"k00".to_vec(), b"k10".to_vec());
 
         range_mgr.new_range(r1.clone());
         range_mgr.set_range_readable(&r1, true);
         range_mgr.set_safe_ts(&r1, 5);
-        assert!(!range_mgr.range_snapshot(&r1, 5));
-        assert!(range_mgr.range_snapshot(&r1, 8));
-        let tmp_r = CacheRange::new(b"k00".to_vec(), b"k04".to_vec());
-        assert!(!range_mgr.range_snapshot(&tmp_r, 8));
-        assert!(range_mgr.range_snapshot(&r1, 10));
-        range_mgr.set_range_readable(&r1_1, false);
-        assert!(!range_mgr.range_snapshot(&r1_1, 10));
-        range_mgr.set_range_readable(&r1_2, false);
-        assert!(!range_mgr.range_snapshot(&r1_2, 10));
+        assert!(range_mgr.range_snapshot(&r1, 5).is_none());
+        assert!(range_mgr.range_snapshot(&r1, 8).is_some());
+        assert!(range_mgr.range_snapshot(&r1, 10).is_some());
+        let tmp_r = CacheRange::new(b"k08".to_vec(), b"k15".to_vec());
+        assert!(range_mgr.range_snapshot(&tmp_r, 8).is_none());
+        let tmp_r = CacheRange::new(b"k10".to_vec(), b"k11".to_vec());
+        assert!(range_mgr.range_snapshot(&tmp_r, 8).is_none());
 
-        let r2 = CacheRange::new(b"k05".to_vec(), b"k10".to_vec());
-        let r2_1 = CacheRange::new(b"k05".to_vec(), b"k07".to_vec());
-        let r2_2 = CacheRange::new(b"k07".to_vec(), b"k08".to_vec());
-        range_mgr.new_range(r2.clone());
-        range_mgr.set_range_readable(&r2, true);
-        range_mgr.set_safe_ts(&r2, 3);
-        assert!(range_mgr.range_snapshot(&r2, 10));
-        range_mgr.set_range_readable(&r2_1, false);
-        range_mgr.set_range_readable(&r2_2, false);
+        let r_evict = CacheRange::new(b"k03".to_vec(), b"k06".to_vec());
+        let r_left = CacheRange::new(b"k00".to_vec(), b"k03".to_vec());
+        let r_right = CacheRange::new(b"k06".to_vec(), b"k10".to_vec());
+        range_mgr.evict_range(&r_evict);
+        let meta1 = range_mgr.historical_ranges.get(&r1).unwrap();
+        assert!(range_mgr.evicted_ranges.contains(&r_evict));
+        assert!(range_mgr.ranges.get(&r1).is_none());
+        let meta2 = range_mgr.ranges.get(&r_left).unwrap();
+        let meta3 = range_mgr.ranges.get(&r_right).unwrap();
+        assert!(meta1.safe_ts == meta2.safe_ts && meta1.safe_ts == meta3.safe_ts);
+        assert!(meta2.can_read && meta3.can_read);
 
-        let r3 = CacheRange::new(b"k03".to_vec(), b"k05".to_vec());
-        // it makes all ranges merged
-        range_mgr.new_range(r3.clone());
-        range_mgr.set_range_readable(&r3, true);
-        let r = CacheRange::new(b"k00".to_vec(), b"k10".to_vec());
-        assert_eq!(range_mgr.ranges.len(), 1);
-        let meta = range_mgr.ranges.get(&r).unwrap();
-        assert_eq!(meta.safe_ts, 3);
-        assert_eq!(meta.ranges_unreadable.len(), 4);
-        assert_eq!(meta.range_snapshot_list.len(), 2);
-        assert_eq!(meta.range_snapshot_list.get(&r1).unwrap().len(), 2);
-        assert_eq!(meta.range_snapshot_list.get(&r2).unwrap().len(), 1);
+        // evict a range with accurate match
+        range_mgr.evict_range(&r_left);
+        assert!(range_mgr.historical_ranges.get(&r_left).is_some());
+        assert!(range_mgr.evicted_ranges.contains(&r_left));
+        assert!(range_mgr.ranges.get(&r_left).is_none());
     }
 }

--- a/components/region_cache_memory_engine/src/range_manager.rs
+++ b/components/region_cache_memory_engine/src/range_manager.rs
@@ -86,13 +86,13 @@ impl RangeManager {
     }
 
     pub fn set_range_readable(&mut self, range: &CacheRange, set_readable: bool) {
-        if let Some(meta) = self.ranges.get_mut(&range) {
+        if let Some(meta) = self.ranges.get_mut(range) {
             meta.can_read = true;
         }
     }
 
     pub fn set_safe_ts(&mut self, range: &CacheRange, safe_ts: u64) -> bool {
-        if let Some(meta) = self.ranges.get_mut(&range) {
+        if let Some(meta) = self.ranges.get_mut(range) {
             if meta.safe_ts > safe_ts {
                 return false;
             }
@@ -155,10 +155,10 @@ impl RangeManager {
                     !self
                         .historical_ranges
                         .keys()
-                        .any(|r| r.overlaps(&evicted_range))
+                        .any(|r| r.overlaps(evicted_range))
                 })
-                .map(|r| r.clone())
-                .collect();
+                .cloned()
+                .collect::<Vec<_>>();
         }
 
         // It must belong to the `self.ranges` if not found in `self.historical_ranges`
@@ -185,7 +185,7 @@ impl RangeManager {
             .unwrap()
             .clone();
         let meta = self.ranges.remove(&range_key).unwrap();
-        let (left_range, right_range) = range_key.split_off(&evict_range);
+        let (left_range, right_range) = range_key.split_off(evict_range);
         assert!((left_range.is_some() || right_range.is_some()) || &range_key == evict_range);
 
         if let Some(left_range) = left_range {

--- a/components/region_cache_memory_engine/src/write_batch.rs
+++ b/components/region_cache_memory_engine/src/write_batch.rs
@@ -4,7 +4,7 @@ use tikv_util::box_err;
 
 use crate::RangeCacheMemoryEngine;
 
-/// RangeCaheWriteBatch maintains its own in-memory buffer.
+/// RangeCacheWriteBatch maintains its own in-memory buffer.
 #[derive(Default, Clone, Debug)]
 pub struct RangeCacheWriteBatch {
     buffer: Vec<RangeCacheWriteBatchEntry>,

--- a/components/region_cache_memory_engine/src/write_batch.rs
+++ b/components/region_cache_memory_engine/src/write_batch.rs
@@ -4,7 +4,7 @@ use tikv_util::box_err;
 
 use crate::RangeCacheMemoryEngine;
 
-/// RegionCacheWriteBatch maintains its own in-memory buffer.
+/// RangeCaheWriteBatch maintains its own in-memory buffer.
 #[derive(Default, Clone, Debug)]
 pub struct RangeCacheWriteBatch {
     buffer: Vec<RangeCacheWriteBatchEntry>,

--- a/components/region_cache_memory_engine/src/write_batch.rs
+++ b/components/region_cache_memory_engine/src/write_batch.rs
@@ -6,12 +6,12 @@ use crate::RangeCacheMemoryEngine;
 
 /// RegionCacheWriteBatch maintains its own in-memory buffer.
 #[derive(Default, Clone, Debug)]
-pub struct RegionCacheWriteBatch {
-    buffer: Vec<RegionCacheWriteBatchEntry>,
+pub struct RangeCacheWriteBatch {
+    buffer: Vec<RangeCacheWriteBatchEntry>,
     sequence_number: Option<u64>,
 }
 
-impl RegionCacheWriteBatch {
+impl RangeCacheWriteBatch {
     pub fn with_capacity(cap: usize) -> Self {
         Self {
             buffer: Vec::with_capacity(cap),
@@ -31,27 +31,27 @@ impl RegionCacheWriteBatch {
 }
 
 #[derive(Clone, Debug)]
-struct RegionCacheWriteBatchEntry {
+struct RangeCacheWriteBatchEntry {
     cf: String,
     key: Bytes,
     mutation: (), // TODO,
 }
 
 impl WriteBatchExt for RangeCacheMemoryEngine {
-    type WriteBatch = RegionCacheWriteBatch;
+    type WriteBatch = RangeCacheWriteBatch;
     // todo: adjust it
     const WRITE_BATCH_MAX_KEYS: usize = 256;
 
     fn write_batch(&self) -> Self::WriteBatch {
-        RegionCacheWriteBatch::default()
+        RangeCacheWriteBatch::default()
     }
 
     fn write_batch_with_cap(&self, cap: usize) -> Self::WriteBatch {
-        RegionCacheWriteBatch::with_capacity(cap)
+        RangeCacheWriteBatch::with_capacity(cap)
     }
 }
 
-impl WriteBatch for RegionCacheWriteBatch {
+impl WriteBatch for RangeCacheWriteBatch {
     fn write_opt(&mut self, _: &WriteOptions) -> Result<u64> {
         unimplemented!()
     }
@@ -93,7 +93,7 @@ impl WriteBatch for RegionCacheWriteBatch {
     }
 }
 
-impl Mutable for RegionCacheWriteBatch {
+impl Mutable for RangeCacheWriteBatch {
     fn put(&mut self, _: &[u8], _: &[u8]) -> Result<()> {
         unimplemented!()
     }

--- a/components/server/src/common.rs
+++ b/components/server/src/common.rs
@@ -31,7 +31,7 @@ use grpcio::Environment;
 use hybrid_engine::HybridEngine;
 use pd_client::{PdClient, RpcClient};
 use raft_log_engine::RaftLogEngine;
-use region_cache_memory_engine::RegionCacheMemoryEngine;
+use region_cache_memory_engine::RangeCacheMemoryEngine;
 use security::SecurityManager;
 use tikv::{
     config::{ConfigController, DbConfigManger, DbType, TikvConfig},
@@ -709,7 +709,7 @@ impl KvEngineBuilder for RocksEngine {
     }
 }
 
-impl KvEngineBuilder for HybridEngine<RocksEngine, RegionCacheMemoryEngine> {
+impl KvEngineBuilder for HybridEngine<RocksEngine, RangeCacheMemoryEngine> {
     fn build(_disk_engine: RocksEngine) -> Self {
         unimplemented!()
     }

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -224,7 +224,7 @@ pub fn run_tikv(
             if cfg!(feature = "memory-engine")
                 && config.region_cache_memory_limit != ReadableSize(0)
             {
-                run_impl::<HybridEngine<RocksEngine, RegionCacheMemoryEngine>, RocksEngine, API>(
+                run_impl::<HybridEngine<RocksEngine, RangeCacheMemoryEngine>, RocksEngine, API>(
                     config,
                     service_event_tx,
                     service_event_rx,
@@ -240,7 +240,7 @@ pub fn run_tikv(
             if cfg!(feature = "memory-engine")
                 && config.region_cache_memory_limit != ReadableSize(0)
             {
-                run_impl::<HybridEngine<RocksEngine, RegionCacheMemoryEngine>, RaftLogEngine, API>(
+                run_impl::<HybridEngine<RocksEngine, RangeCacheMemoryEngine>, RaftLogEngine, API>(
                     config,
                     service_event_tx,
                     service_event_rx,

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -72,7 +72,7 @@ use raftstore::{
     },
     RaftRouterCompactedEventSender,
 };
-use region_cache_memory_engine::RegionCacheMemoryEngine;
+use region_cache_memory_engine::RangeCacheMemoryEngine;
 use resolved_ts::{LeadershipResolver, Task};
 use resource_control::ResourceGroupManager;
 use security::SecurityManager;
@@ -227,7 +227,7 @@ pub fn run_tikv(
                     service_event_rx,
                 )
             } else {
-                run_impl::<HybridEngine<RocksEngine, RegionCacheMemoryEngine>, RocksEngine, API>(
+                run_impl::<HybridEngine<RocksEngine, RangeCacheMemoryEngine>, RocksEngine, API>(
                     config,
                     service_event_tx,
                     service_event_rx,
@@ -241,7 +241,7 @@ pub fn run_tikv(
                     service_event_rx,
                 )
             } else {
-                run_impl::<HybridEngine<RocksEngine, RegionCacheMemoryEngine>, RaftLogEngine, API>(
+                run_impl::<HybridEngine<RocksEngine, RangeCacheMemoryEngine>, RaftLogEngine, API>(
                     config,
                     service_event_tx,
                     service_event_rx,

--- a/components/test_raftstore/src/node.rs
+++ b/components/test_raftstore/src/node.rs
@@ -526,7 +526,7 @@ pub fn new_node_cluster(id: u64, count: usize) -> Cluster<RocksEngine, NodeClust
 }
 
 // the hybrid engine with disk engine "RocksEngine" and region cache engine
-// "RegionCacheMemoryEngine" is used in the node cluster.
+// "RangeCaheMemoryEngine" is used in the node cluster.
 pub fn new_node_cluster_with_hybrid_engine(
     id: u64,
     count: usize,

--- a/components/test_raftstore/src/node.rs
+++ b/components/test_raftstore/src/node.rs
@@ -526,7 +526,7 @@ pub fn new_node_cluster(id: u64, count: usize) -> Cluster<RocksEngine, NodeClust
 }
 
 // the hybrid engine with disk engine "RocksEngine" and region cache engine
-// "RangeCaheMemoryEngine" is used in the node cluster.
+// "RangeCacheMemoryEngine" is used in the node cluster.
 pub fn new_node_cluster_with_hybrid_engine(
     id: u64,
     count: usize,

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -868,7 +868,7 @@ pub fn new_server_cluster(
 }
 
 // the hybrid engine with disk engine "RocksEngine" and region cache engine
-// "RangeCaheMemoryEngine" is used in the server cluster.
+// "RangeCacheMemoryEngine" is used in the server cluster.
 pub fn new_server_cluster_with_hybrid_engine(
     id: u64,
     count: usize,

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -868,7 +868,7 @@ pub fn new_server_cluster(
 }
 
 // the hybrid engine with disk engine "RocksEngine" and region cache engine
-// "RegionCacheMemoryEngine" is used in the server cluster.
+// "RangeCaheMemoryEngine" is used in the server cluster.
 pub fn new_server_cluster_with_hybrid_engine(
     id: u64,
     count: usize,

--- a/components/test_raftstore/src/util.rs
+++ b/components/test_raftstore/src/util.rs
@@ -47,7 +47,7 @@ use raftstore::{
     RaftRouterCompactedEventSender, Result,
 };
 use rand::{seq::SliceRandom, RngCore};
-use region_cache_memory_engine::RegionCacheMemoryEngine;
+use region_cache_memory_engine::RangeCacheMemoryEngine;
 use server::common::{ConfiguredRaftEngine, KvEngineBuilder};
 use tempfile::TempDir;
 use test_pd_client::TestPdClient;
@@ -67,7 +67,7 @@ use txn_types::Key;
 
 use crate::{Cluster, Config, KvEngineWithRocks, RawEngine, ServerCluster, Simulator};
 
-pub type HybridEngineImpl = HybridEngine<RocksEngine, RegionCacheMemoryEngine>;
+pub type HybridEngineImpl = HybridEngine<RocksEngine, RangeCacheMemoryEngine>;
 
 pub fn must_get<EK: KvEngine>(
     engine: &impl RawEngine<EK>,

--- a/src/server/raftkv/mod.rs
+++ b/src/server/raftkv/mod.rs
@@ -648,7 +648,7 @@ where
 
         let snap_ctx = ctx.start_ts.map(|ts| SnapshotContext {
             read_ts: ts.into_inner(),
-            region_id: ctx.pb_ctx.get_region_id(),
+            range: None,
         });
 
         if res.is_ok() {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref #16141

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
refactor from region based to range based
```

This PR refactors region based in-memory engine to range based in-memory engine to decouple in-memory engine with raftstore as much as possible. It means in-memory engine is ignorant about admin commands such as batch split and merge.
This PR provides a `RangeManager` which manages the ranges cached.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
