### PR TITLE
logger: fix thread_id in log

### DIFF
--- a/components/tikv_util/src/logger/mod.rs
+++ b/components/tikv_util/src/logger/mod.rs
@@ -6,7 +6,6 @@ mod formatter;
 use std::{
     env, fmt,
     io::{self, BufWriter},
-    num::NonZeroU64,
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicUsize, Ordering},
@@ -16,10 +15,7 @@ use std::{
 };
 
 use log::{self, SetLoggerError};
-use slog::{
-    self, slog_o, Drain, FnValue, Key, OwnedKV, OwnedKVList, PushFnValue, Record,
-    SendSyncRefUnwindSafeKV, KV,
-};
+use slog::{self, slog_o, Drain, FnValue, Key, OwnedKVList, PushFnValue, Record, KV};
 pub use slog::{FilterFn, Level};
 use slog_async::{Async, AsyncGuard, OverflowStrategy};
 use slog_term::{Decorator, PlainDecorator, RecordDecorator};
@@ -76,6 +72,28 @@ where
         }
     };
 
+    fn build_log_drain<I>(
+        drain: I,
+        threshold: u64,
+        filter: impl FilterFn,
+    ) -> impl Drain<Ok = (), Err = slog::Never>
+    where
+        I: Drain<Ok = (), Err = slog::Never>,
+    {
+        let drain = SlowLogFilter {
+            threshold,
+            inner: drain,
+        };
+        let filtered = GlobalLevelFilter::new(drain.filter(filter).fuse());
+        // ThreadIDrain discards all previous `slog::OwnedKVList`, it should be
+        // placed as the first Drain that receives `slog::Record`.
+        //
+        // NB: slog macros (slog::info!() and others) only produce one
+        // `slog::Record`, `slog::OwnedKVList` are provided by `slog::Drain` and
+        // `slog::Logger`.
+        ThreadIDrain(filtered)
+    }
+
     let (logger, guard) = if use_async {
         let (async_log, guard) = Async::new(LogAndFuse(drain))
             .chan_size(SLOG_CHANNEL_SIZE)
@@ -83,21 +101,12 @@ where
             .thread_name(thd_name!("slogger"))
             .build_with_guard();
         let drain = async_log.fuse();
-        let drain = SlowLogFilter {
-            threshold: slow_threshold,
-            inner: drain,
-        };
-        let filtered = GlobalLevelFilter::new(drain.filter(filter).fuse());
-
-        (slog::Logger::root(filtered, get_values()), Some(guard))
+        let drain = build_log_drain(drain, slow_threshold, filter);
+        (slog::Logger::root(drain, slog_o!()), Some(guard))
     } else {
         let drain = LogAndFuse(Mutex::new(drain));
-        let drain = SlowLogFilter {
-            threshold: slow_threshold,
-            inner: drain,
-        };
-        let filtered = GlobalLevelFilter::new(drain.filter(filter).fuse());
-        (slog::Logger::root(filtered, get_values()), None)
+        let drain = build_log_drain(drain, slow_threshold, filter);
+        (slog::Logger::root(drain, slog_o!()), None)
     };
 
     set_global_logger(level, init_stdlog, logger, guard)
@@ -632,16 +641,20 @@ fn write_log_fields(
     Ok(())
 }
 
-fn format_thread_id(thread_id: NonZeroU64) -> String {
-    format!("{:#0x}", thread_id)
-}
+struct ThreadIDrain<D: Drain>(pub D);
 
-fn get_values() -> OwnedKV<impl SendSyncRefUnwindSafeKV> {
-    slog_o!(
-        "thread_id" => FnValue(|_| {
-            format_thread_id(std::thread::current().id().as_u64())
-        })
-    )
+impl<D> Drain for ThreadIDrain<D>
+where
+    D: Drain,
+{
+    type Ok = D::Ok;
+    type Err = D::Err;
+    fn log(&self, record: &Record<'_>, _: &OwnedKVList) -> Result<Self::Ok, Self::Err> {
+        self.0.log(
+            record,
+            &OwnedKVList::from(slog::o!("thread_id" => std::thread::current().id().as_u64().get())),
+        )
+    }
 }
 
 struct Serializer<'a> {
@@ -695,7 +708,7 @@ impl<'a> slog::Serializer for Serializer<'a> {
 
 #[cfg(test)]
 mod tests {
-    use std::{cell::RefCell, io, io::Write, str::from_utf8, sync::RwLock, time::Duration};
+    use std::{cell::RefCell, io, io::Write, str::from_utf8, sync::Arc, time::Duration};
 
     use chrono::DateTime;
     use regex::Regex;
@@ -704,19 +717,13 @@ mod tests {
 
     use super::*;
 
-    // Due to the requirements of `Logger::root*` on a writer with a 'static
-    // lifetime we need to make a Thread Local,
-    // and implement a custom writer.
-    thread_local! {
-        static BUFFER: RefCell<Vec<u8>> = RefCell::new(Vec::new());
-    }
-    struct TestWriter;
+    struct TestWriter(Arc<Mutex<Vec<u8>>>);
     impl Write for TestWriter {
         fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-            BUFFER.with(|buffer| buffer.borrow_mut().write(buf))
+            self.0.lock().unwrap().write(buf)
         }
         fn flush(&mut self) -> io::Result<()> {
-            BUFFER.with(|buffer| buffer.borrow_mut().flush())
+            self.0.lock().unwrap().flush()
         }
     }
 
@@ -775,13 +782,15 @@ mod tests {
 
     #[test]
     fn test_log_format_text() {
-        let decorator = PlainSyncDecorator::new(TestWriter);
+        let buffer: Arc<Mutex<Vec<u8>>> = Arc::default();
+        let decorator = PlainSyncDecorator::new(TestWriter(buffer.clone()));
         let drain = TikvFormat::new(decorator, true).fuse();
-        let logger = slog::Logger::root_typed(drain, get_values()).into_erased();
+        let drain = ThreadIDrain(drain);
+        let logger = slog::Logger::root_typed(drain, slog_o!()).into_erased();
 
         log_format_cases(logger);
 
-        let thread_id = format_thread_id(std::thread::current().id().as_u64());
+        let thread_id = std::thread::current().id().as_u64();
         let expect = format!(
             r#"[2019/01/15 13:40:39.619 +08:00] [INFO] [mod.rs:469] [] [thread_id={0}]
 [2019/01/15 13:40:39.619 +08:00] [INFO] [mod.rs:469] [Welcome] [thread_id={0}]
@@ -797,43 +806,48 @@ mod tests {
             thread_id
         );
 
-        BUFFER.with(|buffer| {
-            let mut buffer = buffer.borrow_mut();
-            let output = from_utf8(&buffer).unwrap();
-            assert_eq!(output.lines().count(), expect.lines().count());
+        let buffer = buffer.lock().unwrap();
+        let output = from_utf8(&buffer).unwrap();
+        assert_eq!(
+            output.lines().count(),
+            expect.lines().count(),
+            "{}\n===\n{}",
+            output,
+            expect
+        );
 
-            let re = Regex::new(r"(?P<datetime>\[.*?\])\s(?P<level>\[.*?\])\s(?P<source_file>\[.*?\])\s(?P<msg>\[.*?\])\s?(?P<kvs>\[.*\])?").unwrap();
+        let re = Regex::new(r"(?P<datetime>\[.*?\])\s(?P<level>\[.*?\])\s(?P<source_file>\[.*?\])\s(?P<msg>\[.*?\])\s?(?P<kvs>\[.*\])?").unwrap();
 
-            for (output_line, expect_line) in output.lines().zip(expect.lines()) {
-                let expect_segments = re.captures(expect_line).unwrap();
-                let output_segments = re.captures(output_line).unwrap();
+        for (output_line, expect_line) in output.lines().zip(expect.lines()) {
+            let expect_segments = re.captures(expect_line).unwrap();
+            let output_segments = re.captures(output_line).unwrap();
 
-                validate_log_datetime(peel(&output_segments["datetime"]));
+            validate_log_datetime(peel(&output_segments["datetime"]));
 
-                assert!(validate_log_source_file(
-                    peel(&expect_segments["source_file"]),
-                    peel(&output_segments["source_file"])
-                ));
-                assert_eq!(expect_segments["level"], output_segments["level"]);
-                assert_eq!(expect_segments["msg"], output_segments["msg"]);
-                assert_eq!(
-                    expect_segments.name("kvs").map(|s| s.as_str()),
-                    output_segments.name("kvs").map(|s| s.as_str())
-                );
-            }
-            buffer.clear();
-        });
+            assert!(validate_log_source_file(
+                peel(&expect_segments["source_file"]),
+                peel(&output_segments["source_file"])
+            ));
+            assert_eq!(expect_segments["level"], output_segments["level"]);
+            assert_eq!(expect_segments["msg"], output_segments["msg"]);
+            assert_eq!(
+                expect_segments.name("kvs").map(|s| s.as_str()),
+                output_segments.name("kvs").map(|s| s.as_str())
+            );
+        }
     }
 
     #[test]
     fn test_log_format_json() {
         use serde_json::{from_str, Value};
-        let drain = Mutex::new(json_format(TestWriter, true)).map(slog::Fuse);
-        let logger = slog::Logger::root_typed(drain, get_values()).into_erased();
+        let buffer: Arc<Mutex<Vec<u8>>> = Arc::default();
+        let drain = Mutex::new(json_format(TestWriter(buffer.clone()), true)).map(slog::Fuse);
+        let drain = ThreadIDrain(drain);
+        let logger = slog::Logger::root_typed(drain, slog_o!()).into_erased();
 
         log_format_cases(logger);
 
-        let thread_id = format_thread_id(std::thread::current().id().as_u64());
+        let thread_id = std::thread::current().id().as_u64();
         let expect = format!(
             r#"{{"time":"2020/05/16 15:49:52.449 +08:00","level":"INFO","caller":"mod.rs:469","message":"","thread_id":"{0}"}}
 {{"time":"2020/05/16 15:49:52.450 +08:00","level":"INFO","caller":"mod.rs:469","message":"Welcome","thread_id":"{0}"}}
@@ -849,47 +863,42 @@ mod tests {
             thread_id
         );
 
-        BUFFER.with(|buffer| {
-            let mut buffer = buffer.borrow_mut();
-            let output = from_utf8(&buffer).unwrap();
-            assert_eq!(output.lines().count(), expect.lines().count());
+        let buffer = buffer.lock().unwrap();
+        let output = from_utf8(&buffer).unwrap();
+        assert_eq!(output.lines().count(), expect.lines().count());
 
-            for (output_line, expect_line) in output.lines().zip(expect.lines()) {
-                let mut expect_json = from_str::<Value>(expect_line).unwrap();
-                let mut output_json = from_str::<Value>(output_line).unwrap();
+        for (output_line, expect_line) in output.lines().zip(expect.lines()) {
+            let mut expect_json = from_str::<Value>(expect_line).unwrap();
+            let mut output_json = from_str::<Value>(output_line).unwrap();
 
-                validate_log_datetime(output_json["time"].take().as_str().unwrap());
-                // Remove time field to bypass timestamp mismatch.
-                let _ = expect_json["time"].take();
+            validate_log_datetime(output_json["time"].take().as_str().unwrap());
+            // Remove time field to bypass timestamp mismatch.
+            let _ = expect_json["time"].take();
 
-                validate_log_source_file(
-                    output_json["caller"].take().as_str().unwrap(),
-                    expect_json["caller"].take().as_str().unwrap(),
-                );
+            validate_log_source_file(
+                output_json["caller"].take().as_str().unwrap(),
+                expect_json["caller"].take().as_str().unwrap(),
+            );
 
-                assert_eq!(expect_json, output_json);
-            }
-            buffer.clear();
-        });
+            assert_eq!(expect_json, output_json);
+        }
     }
 
     #[test]
     fn test_global_level_filter() {
-        let decorator = PlainSyncDecorator::new(TestWriter);
+        let buffer: Arc<Mutex<Vec<u8>>> = Arc::default();
+        let decorator = PlainSyncDecorator::new(TestWriter(buffer.clone()));
         let drain = TikvFormat::new(decorator, true).fuse();
         let logger =
             slog::Logger::root_typed(GlobalLevelFilter::new(drain), slog_o!()).into_erased();
 
         let expected = "[2019/01/15 13:40:39.619 +08:00] [INFO] [mod.rs:871] [Welcome]\n";
         let check_log = |log: &str| {
-            BUFFER.with(|buffer| {
-                let mut buffer = buffer.borrow_mut();
-                let output = from_utf8(&buffer).unwrap();
-                // only check the log len here as some field like timestamp, location may
-                // change.
-                assert_eq!(output.len(), log.len());
-                buffer.clear();
-            });
+            let buffer = buffer.lock().unwrap();
+            let output = from_utf8(&buffer).unwrap();
+            // only check the log len here as some field like timestamp, location may
+            // change.
+            assert_eq!(output.len(), log.len());
         };
 
         set_log_level(Level::Info);
@@ -1095,49 +1104,5 @@ mod tests {
                 );
             }
         });
-    }
-
-    static THREAD_SAFE_BUFFER: RwLock<Vec<u8>> = RwLock::new(Vec::new());
-
-    struct ThreadSafeWriter;
-    impl Write for ThreadSafeWriter {
-        fn write(&mut self, data: &[u8]) -> io::Result<usize> {
-            let mut buffer = THREAD_SAFE_BUFFER.write().unwrap();
-            buffer.write(data)
-        }
-
-        fn flush(&mut self) -> io::Result<()> {
-            let mut buffer = THREAD_SAFE_BUFFER.write().unwrap();
-            buffer.flush()
-        }
-    }
-
-    #[test]
-    fn test_threadid() {
-        let drain = TikvFormat::new(PlainSyncDecorator::new(ThreadSafeWriter), true).fuse();
-        let logger = slog::Logger::root_typed(drain, get_values()).into_erased();
-
-        slog_info!(logger, "Hello from the first thread");
-        let this_threadid = thread::current().id().as_u64();
-        let this_threadid = format_thread_id(this_threadid);
-
-        let handle = thread::spawn(move || {
-            slog_info!(logger, "Hello from the second thread");
-        });
-        let other_threadid = handle.thread().id().as_u64();
-        let other_threadid = format_thread_id(other_threadid);
-        handle.join().unwrap();
-
-        let expected = vec![this_threadid, other_threadid];
-
-        let re = Regex::new(r"\[thread_id=(.*?)\]").unwrap();
-        let buffer = THREAD_SAFE_BUFFER.read().unwrap();
-        let output = from_utf8(&buffer).unwrap();
-        let actual: Vec<&str> = output
-            .lines()
-            .map(|line| re.captures(line).unwrap())
-            .map(|captures| captures.get(1).unwrap().as_str())
-            .collect();
-        assert_eq!(expected, actual);
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #16398 

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
The current "thread_id" in the log is always 0x5. This is because:
1)TiKV logs asynchronously by sending all log records to a dedicated
thread called "slogger", which is the fifth thread spawned by TiKV;
and 2) "thread_id" is evaluated lazily by the "slogger" thread.
To fix this issue, this commit obtains the "thread_id" before sending
it to the "slogger" thread.
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Manual test (add detailed scripts or steps below)

<details><summary>Logs on master branch</summary>
<p>

```log
[2024/01/03 15:11:49.005 +08:00] [INFO] [lib.rs:88] ["Welcome to TiKV"] [thread_id=0x5]
[2024/01/03 15:11:49.006 +08:00] [INFO] [lib.rs:93] ["Release Version:   7.6.0-alpha"] [thread_id=0x5]
[2024/01/03 15:11:49.006 +08:00] [INFO] [lib.rs:93] ["Edition:           Community"] [thread_id=0x5]
[2024/01/03 15:11:49.006 +08:00] [INFO] [lib.rs:93] ["Git Commit Hash:   78d835d91b07fb5c18e1158c21841fd43116bc02"] [thread_id=0x5]
[2024/01/03 15:11:49.006 +08:00] [INFO] [lib.rs:93] ["Git Commit Branch: heads/refs/tags/v7.6.0-alpha"] [thread_id=0x5]
[2024/01/03 15:11:49.006 +08:00] [INFO] [lib.rs:93] ["UTC Build Time:    Unknown (env var does not exist when building)"] [thread_id=0x5]
[2024/01/03 15:11:49.006 +08:00] [INFO] [lib.rs:93] ["Rust Version:      rustc 1.67.0-nightly (96ddd32c4 2022-11-14)"] [thread_id=0x5]
[2024/01/03 15:11:49.006 +08:00] [INFO] [lib.rs:93] ["Enable Features:   pprof-fp jemalloc mem-profiling portable sse test-engine-kv-rocksdb test-engine-raft-raft-engine cloud-aws cloud-gcp cloud-azure"] [thread_id=0x5]
[2024/01/03 15:11:49.006 +08:00] [INFO] [lib.rs:93] ["Profile:           dist_release"] [thread_id=0x5]
[2024/01/03 15:11:49.006 +08:00] [INFO] [mod.rs:80] ["cgroup quota: memory=Some(9223372036854771712), cpu=None, cores={2, 3, 5, 7, 4, 0, 1, 6}"] [thread_id=0x5]
[2024/01/03 15:11:49.006 +08:00] [INFO] [mod.rs:87] ["memory limit in bytes: 34770685952, cpu cores quota: 8"] [thread_id=0x5]
[2024/01/03 15:11:49.006 +08:00] [WARN] [lib.rs:557] ["environment variable `TZ` is missing, using `/etc/localtime`"] [thread_id=0x5]
[2024/01/03 15:11:49.006 +08:00] [WARN] [server.rs:1615] ["check: kernel"] [err="kernel parameters net.core.somaxconn got 128, expect 32768"] [thread_id=0x5]
[2024/01/03 15:11:49.006 +08:00] [WARN] [server.rs:1615] ["check: kernel"] [err="kernel parameters net.ipv4.tcp_syncookies got 1, expect 0"] [thread_id=0x5]
[2024/01/03 15:11:49.006 +08:00] [WARN] [server.rs:1615] ["check: kernel"] [err="kernel parameters vm.swappiness got 30, expect 0"] [thread_id=0x5]
[2024/01/03 15:11:49.009 +08:00] [INFO] [util.rs:638] ["connecting to PD endpoint"] [endpoints=127.0.0.1:3379] [thread_id=0x5]
[2024/01/03 15:11:49.011 +08:00] [INFO] [<unknown>] ["TCP_USER_TIMEOUT is available. TCP_USER_TIMEOUT will be used thereafter"] [thread_id=0x5]
[2024/01/03 15:11:51.011 +08:00] [INFO] [util.rs:600] ["PD failed to respond"] [err="Grpc(RpcFailure(RpcStatus { code: 4-DEADLINE_EXCEEDED, message: \"Deadline Exceeded\", details: [] }))"] [endpoints=127.0.0.1:3379] [thread_id=0x5]
[2024/01/03 15:11:51.011 +08:00] [WARN] [client.rs:169] ["validate PD endpoints failed"] [err="Other(\"[components/pd_client/src/util.rs:633]: PD cluster failed to respond\")"] [thread_id=0x5]
[2024/01/03 15:11:51.312 +08:00] [INFO] [util.rs:638] ["connecting to PD endpoint"] [endpoints=127.0.0.1:3379] [thread_id=0x5]
[2024/01/03 15:11:51.738 +08:00] [INFO] [util.rs:638] ["connecting to PD endpoint"] [endpoints=127.0.0.1:3379] [thread_id=0x5]
[2024/01/03 15:11:51.745 +08:00] [INFO] [util.rs:638] ["connecting to PD endpoint"] [endpoints=https://127.0.0.1:3379] [thread_id=0x5]
[2024/01/03 15:11:51.751 +08:00] [INFO] [util.rs:638] ["connecting to PD endpoint"] [endpoints=https://127.0.0.1:3379] [thread_id=0x5]
[2024/01/03 15:11:51.757 +08:00] [INFO] [util.rs:807] ["connected to PD member"] [endpoints=https://127.0.0.1:3379] [thread_id=0x5]
[2024/01/03 15:11:51.757 +08:00] [INFO] [util.rs:630] ["all PD endpoints are consistent"] [endpoints="[\"127.0.0.1:3379\"]"] [thread_id=0x5]
[2024/01/03 15:11:51.757 +08:00] [INFO] [common.rs:327] ["connect to PD cluster"] [cluster_id=7296781250045487992] [thread_id=0x5]
[2024/01/03 15:11:51.758 +08:00] [INFO] [mod.rs:2538] ["readpool.storage.use-unified-pool is not set, set to true by default"] [thread_id=0x5]
[2024/01/03 15:11:51.758 +08:00] [INFO] [mod.rs:2561] ["readpool.coprocessor.use-unified-pool is not set, set to true by default"] [thread_id=0x5]
[2024/01/03 15:11:51.759 +08:00] [WARN] [config.rs:668] ["Election timeout ticks needs to be same across all the cluster, otherwise it may lead to inconsistency."] [thread_id=0x5]
[2024/01/03 15:11:51.762 +08:00] [WARN] [config.rs:668] ["Election timeout ticks needs to be same across all the cluster, otherwise it may lead to inconsistency."] [thread_id=0x5]
[2024/01/03 15:11:51.762 +08:00] [INFO] [common.rs:447] ["beginning system configuration check"] [thread_id=0x5]
[2024/01/03 15:11:51.762 +08:00] [INFO] [config.rs:1077] ["data dir"] [mount_fs="FsInfo { tp: \"ext4\", opts: \"rw,relatime\", mnt_dir: \"/\", fsname: \"/dev/vda3\" }"] [data_path=/home/stn/stash/cluster/mini-insecure/tidb-data/tikv-21160] [thread_id=0x5]
[2024/01/03 15:11:51.762 +08:00] [WARN] [config.rs:1080] ["not on SSD device"] [data_path=/home/stn/stash/cluster/mini-insecure/tidb-data/tikv-21160] [thread_id=0x5]
[2024/01/03 15:11:51.762 +08:00] [INFO] [config.rs:1077] ["data dir"] [mount_fs="FsInfo { tp: \"ext4\", opts: \"rw,relatime\", mnt_dir: \"/\", fsname: \"/dev/vda3\" }"] [data_path=/home/stn/stash/cluster/mini-insecure/tidb-data/tikv-21160/raft] [thread_id=0x5]
[2024/01/03 15:11:51.762 +08:00] [WARN] [config.rs:1080] ["not on SSD device"] [data_path=/home/stn/stash/cluster/mini-insecure/tidb-data/tikv-21160/raft] [thread_id=0x5]
...
[2024/01/03 15:11:52.081 +08:00] [INFO] [store.rs:1323] ["start store"] [takes=2.812964ms] [merge_count=0] [applying_count=0] [tombstone_count=0] [region_count=60] [store_id=1] [thread_id=0x5]
[2024/01/03 15:11:52.081 +08:00] [INFO] [store.rs:1379] ["cleans up garbage data"] [takes=28.839<C2><B5>s] [garbage_range_count=61] [store_id=1] [thread_id=0x5]
[2024/01/03 15:11:52.083 +08:00] [INFO] [peer.rs:5401] ["require updating max ts"] [initial_status=47244640264] [region_id=2] [thread_id=0x5]
[2024/01/03 15:11:52.083 +08:00] [INFO] [peer.rs:5401] ["require updating max ts"] [initial_status=47244640262] [region_id=4] [thread_id=0x5]
[2024/01/03 15:11:52.083 +08:00] [INFO] [peer.rs:5401] ["require updating max ts"] [initial_status=47244640264] [region_id=6] [thread_id=0x5]
[2024/01/03 15:11:52.083 +08:00] [INFO] [peer.rs:5401] ["require updating max ts"] [initial_status=47244640266] [region_id=8] [thread_id=0x5]
[2024/01/03 15:11:52.083 +08:00] [INFO] [peer.rs:5401] ["require updating max ts"] [initial_status=47244640268] [region_id=10] [thread_id=0x5]
[2024/01/03 15:11:52.083 +08:00] [INFO] [peer.rs:5401] ["require updating max ts"] [initial_status=47244640270] [region_id=12] [thread_id=0x5]
[2024/01/03 15:11:52.083 +08:00] [INFO] [peer.rs:5401] ["require updating max ts"] [initial_status=47244640276] [region_id=16] [thread_id=0x5]
```

</p>
</details> 

<details><summary>Logs on this PR</summary>
<p>

```log
[2024/01/17 15:21:13.728 +08:00] [INFO] [lib.rs:89] ["Welcome to TiKV"] [thread_id=1]
[2024/01/17 15:21:13.730 +08:00] [INFO] [lib.rs:94] ["Release Version:   8.0.0-alpha"] [thread_id=1]
[2024/01/17 15:21:13.730 +08:00] [INFO] [lib.rs:94] ["Edition:           Community"] [thread_id=1]
[2024/01/17 15:21:13.730 +08:00] [INFO] [lib.rs:94] ["Git Commit Hash:   14996c6fc9e0993ba766f8a9d6b682e09c7e998e"] [thread_id=1]
[2024/01/17 15:21:13.730 +08:00] [INFO] [lib.rs:94] ["Git Commit Branch: fix-log-thread-id"] [thread_id=1]
[2024/01/17 15:21:13.730 +08:00] [INFO] [lib.rs:94] ["UTC Build Time:    2024-01-17 07:06:55"] [thread_id=1]
[2024/01/17 15:21:13.730 +08:00] [INFO] [lib.rs:94] ["Rust Version:      rustc 1.76.0-nightly (06e02d5b2 2023-12-09)"] [thread_id=1]
[2024/01/17 15:21:13.730 +08:00] [INFO] [lib.rs:94] ["Enable Features:   pprof-fp jemalloc mem-profiling portable sse test-engine-kv-rocksdb test-engine-raft-raft-engine cloud-aws cloud-gcp cloud-azure trace-async-tasks openssl-vendored"] [thread_id=1]
[2024/01/17 15:21:13.730 +08:00] [INFO] [lib.rs:94] ["Profile:           debug"] [thread_id=1]
[2024/01/17 15:21:13.730 +08:00] [INFO] [fips.rs:40] ["OpenSSL FIPS mode is disabled"] [thread_id=1]
[2024/01/17 15:21:13.731 +08:00] [INFO] [mod.rs:78] ["cgroup quota: memory=Some(9223372036854771712), cpu=None, cores={5, 1, 3, 6, 2, 7, 4, 0}"] [thread_id=1]
[2024/01/17 15:21:13.731 +08:00] [INFO] [mod.rs:85] ["memory limit in bytes: 34770685952, cpu cores quota: 8"] [thread_id=1]
[2024/01/17 15:21:13.731 +08:00] [WARN] [lib.rs:525] ["environment variable `TZ` is missing, using `/etc/localtime`"] [thread_id=1]
[2024/01/17 15:21:13.731 +08:00] [WARN] [server.rs:1675] ["check: kernel"] [err="kernel parameters net.core.somaxconn got 128, expect 32768"] [thread_id=1]
[2024/01/17 15:21:13.731 +08:00] [WARN] [server.rs:1675] ["check: kernel"] [err="kernel parameters net.ipv4.tcp_syncookies got 1, expect 0"] [thread_id=1]
[2024/01/17 15:21:13.731 +08:00] [WARN] [server.rs:1675] ["check: kernel"] [err="kernel parameters vm.swappiness got 30, expect 0"] [thread_id=1]
[2024/01/17 15:21:13.749 +08:00] [INFO] [util.rs:638] ["connecting to PD endpoint"] [endpoints=127.0.0.1:3379] [thread_id=1]
[2024/01/17 15:21:13.752 +08:00] [INFO] [<unknown>] ["TCP_USER_TIMEOUT is available. TCP_USER_TIMEOUT will be used thereafter"] [thread_id=1]
[2024/01/17 15:21:13.764 +08:00] [INFO] [util.rs:638] ["connecting to PD endpoint"] [endpoints=https://127.0.0.1:3379] [thread_id=1]
[2024/01/17 15:21:13.771 +08:00] [INFO] [util.rs:638] ["connecting to PD endpoint"] [endpoints=https://127.0.0.1:3379] [thread_id=1]
[2024/01/17 15:21:13.779 +08:00] [INFO] [util.rs:807] ["connected to PD member"] [endpoints=https://127.0.0.1:3379] [thread_id=1]
[2024/01/17 15:21:13.781 +08:00] [INFO] [util.rs:630] ["all PD endpoints are consistent"] [endpoints="[\"127.0.0.1:3379\"]"] [thread_id=1]
[2024/01/17 15:21:13.786 +08:00] [INFO] [common.rs:329] ["connect to PD cluster"] [cluster_id=7296781250045487992] [thread_id=1]
[2024/01/17 15:21:13.789 +08:00] [INFO] [mod.rs:2566] ["readpool.storage.use-unified-pool is not set, set to true by default"] [thread_id=1]
[2024/01/17 15:21:13.789 +08:00] [INFO] [mod.rs:2589] ["readpool.coprocessor.use-unified-pool is not set, set to true by default"] [thread_id=1]
[2024/01/17 15:21:13.793 +08:00] [WARN] [config.rs:667] ["Election timeout ticks needs to be same across all the cluster, otherwise it may lead to inconsistency."] [thread_id=1]
[2024/01/17 15:21:13.816 +08:00] [WARN] [config.rs:667] ["Election timeout ticks needs to be same across all the cluster, otherwise it may lead to inconsistency."] [thread_id=1]
[2024/01/17 15:21:13.824 +08:00] [INFO] [common.rs:449] ["beginning system configuration check"] [thread_id=1]
[2024/01/17 15:21:13.824 +08:00] [INFO] [config.rs:1077] ["data dir"] [mount_fs="FsInfo { tp: \"ext4\", opts: \"rw,relatime\", mnt_dir: \"/\", fsname: \"/dev/vda3\" }"] [data_path=/home/stn/stash/cluster/mini-insecure/tidb-data/tikv-21160] [thread_id=1]
[2024/01/17 15:21:13.824 +08:00] [WARN] [config.rs:1080] ["not on SSD device"] [data_path=/home/stn/stash/cluster/mini-insecure/tidb-data/tikv-21160] [thread_id=1]
[2024/01/17 15:21:13.824 +08:00] [INFO] [config.rs:1077] ["data dir"] [mount_fs="FsInfo { tp: \"ext4\", opts: \"rw,relatime\", mnt_dir: \"/\", fsname: \"/dev/vda3\" }"] [data_path=/home/stn/stash/cluster/mini-insecure/tidb-data/tikv-21160/raft] [thread_id=1]
[2024/01/17 15:21:13.824 +08:00] [WARN] [config.rs:1080] ["not on SSD device"] [data_path=/home/stn/stash/cluster/mini-insecure/tidb-data/tikv-21160/raft] [thread_id=1]
...
[2024/01/17 15:21:17.755 +08:00] [INFO] [store.rs:1345] ["start store"] [takes=39.416589ms] [merge_count=0] [applying_count=0] [tombstone_count=0] [region_count=60] [store_id=1] [thread_id=1]
[2024/01/17 15:21:17.755 +08:00] [INFO] [store.rs:1401] ["cleans up garbage data"] [takes=313.176<C2><B5>s] [garbage_range_count=61] [store_id=1] [thread_id=1]
[2024/01/17 15:21:17.764 +08:00] [INFO] [peer.rs:5583] ["require updating max ts"] [initial_status=51539607560] [region_id=2] [thread_id=99]
[2024/01/17 15:21:17.764 +08:00] [INFO] [peer.rs:5583] ["require updating max ts"] [initial_status=51539607558] [region_id=4] [thread_id=100]
[2024/01/17 15:21:17.765 +08:00] [INFO] [peer.rs:5583] ["require updating max ts"] [initial_status=51539607562] [region_id=8] [thread_id=99]
[2024/01/17 15:21:17.765 +08:00] [INFO] [peer.rs:5583] ["require updating max ts"] [initial_status=51539607560] [region_id=6] [thread_id=100]
[2024/01/17 15:21:17.765 +08:00] [INFO] [peer.rs:5583] ["require updating max ts"] [initial_status=51539607564] [region_id=10] [thread_id=100]
[2024/01/17 15:21:17.765 +08:00] [INFO] [peer.rs:5583] ["require updating max ts"] [initial_status=51539607566] [region_id=12] [thread_id=99]

```

</p>
</details> 

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
