### PR TITLE
[cherry-pick-v6.5] raftstore: address the corner case on WakeUp hibernate regions. (#16408)

### DIFF
--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -2145,6 +2145,11 @@ where
             self.fsm.hibernate_state.group_state() == GroupState::Idle,
             |_| {}
         );
+        fail_point!(
+            "on_raft_base_tick_chaos",
+            self.fsm.hibernate_state.group_state() == GroupState::Chaos,
+            |_| {}
+        );
 
         if self.fsm.peer.pending_remove {
             self.fsm.peer.mut_store().flush_entry_cache_metrics();
@@ -2743,18 +2748,19 @@ where
     fn on_extra_message(&mut self, mut msg: RaftMessage) {
         match msg.get_extra_msg().get_type() {
             ExtraMessageType::MsgRegionWakeUp | ExtraMessageType::MsgCheckStalePeer => {
-                if self.fsm.hibernate_state.group_state() == GroupState::Idle {
-                    if msg.get_extra_msg().forcely_awaken {
-                        // Forcely awaken this region by manually setting this GroupState
-                        // into Chaos to trigger a new voting in this RaftGroup.
-                        self.reset_raft_tick(if !self.fsm.peer.is_leader() {
-                            GroupState::Chaos
-                        } else {
-                            GroupState::Ordered
-                        });
+                if msg.get_extra_msg().forcely_awaken {
+                    // Forcely awaken this region by manually setting the GroupState
+                    // into `Chaos` to trigger a new voting in the Raft Group.
+                    // Meanwhile, it avoids the peer entering the `PreChaos` state,
+                    // which would wait for another long tick to enter the `Chaos` state.
+                    self.reset_raft_tick(if !self.fsm.peer.is_leader() {
+                        GroupState::Chaos
                     } else {
-                        self.reset_raft_tick(GroupState::Ordered);
-                    }
+                        GroupState::Ordered
+                    });
+                }
+                if self.fsm.hibernate_state.group_state() == GroupState::Idle {
+                    self.reset_raft_tick(GroupState::Ordered);
                 }
                 if msg.get_extra_msg().get_type() == ExtraMessageType::MsgRegionWakeUp
                     && self.fsm.peer.is_leader()

--- a/tests/failpoints/cases/test_hibernate.rs
+++ b/tests/failpoints/cases/test_hibernate.rs
@@ -144,7 +144,7 @@ fn test_forcely_awaken_hibenrate_regions() {
     // stable.
     cluster.cfg.raft_store.raft_min_election_timeout_ticks = 10;
     cluster.cfg.raft_store.raft_max_election_timeout_ticks = 11;
-    configure_for_hibernate(&mut cluster.cfg);
+    configure_for_hibernate(&mut cluster);
     cluster.pd_client.disable_default_operator();
     let r = cluster.run_conf_change();
     cluster.pd_client.must_add_peer(r, new_peer(2, 2));

--- a/tests/failpoints/cases/test_hibernate.rs
+++ b/tests/failpoints/cases/test_hibernate.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use kvproto::raft_serverpb::RaftMessage;
+use kvproto::raft_serverpb::{ExtraMessage, ExtraMessageType, RaftMessage};
 use raft::eraftpb::MessageType;
 use raftstore::store::{PeerMsg, PeerTick};
 use test_raftstore::*;
@@ -131,4 +131,59 @@ fn test_store_disconnect_with_hibernate() {
     thread::sleep(Duration::from_millis(base_tick_ms * 30));
     must_get_equal(&cluster.get_engine(2), b"k2", b"v2");
     must_get_equal(&cluster.get_engine(3), b"k2", b"v2");
+}
+
+#[test]
+fn test_forcely_awaken_hibenrate_regions() {
+    let mut cluster = new_node_cluster(0, 3);
+    let base_tick_ms = 50;
+    cluster.cfg.raft_store.raft_base_tick_interval = ReadableDuration::millis(base_tick_ms);
+    cluster.cfg.raft_store.raft_heartbeat_ticks = 2;
+    cluster.cfg.raft_store.raft_election_timeout_ticks = 10;
+    // So the random election timeout will always be 10, which makes the case more
+    // stable.
+    cluster.cfg.raft_store.raft_min_election_timeout_ticks = 10;
+    cluster.cfg.raft_store.raft_max_election_timeout_ticks = 11;
+    configure_for_hibernate(&mut cluster.cfg);
+    cluster.pd_client.disable_default_operator();
+    let r = cluster.run_conf_change();
+    cluster.pd_client.must_add_peer(r, new_peer(2, 2));
+    cluster.pd_client.must_add_peer(r, new_peer(3, 3));
+
+    cluster.must_put(b"k1", b"v1");
+    must_get_equal(&cluster.get_engine(2), b"k1", b"v1");
+    must_get_equal(&cluster.get_engine(3), b"k1", b"v1");
+
+    // Wait until all peers of region 1 hibernate.
+    thread::sleep(Duration::from_millis(base_tick_ms * 30));
+
+    // Firstly, send `CheckPeerStaleState` message to trigger the check.
+    let router = cluster.sim.rl().get_router(3).unwrap();
+    router
+        .send(1, PeerMsg::Tick(PeerTick::CheckPeerStaleState))
+        .unwrap();
+
+    // Secondly, forcely send `MsgRegionWakeUp` message for awakening hibernated
+    // regions.
+    let (tx, rx) = mpsc::sync_channel(128);
+    fail::cfg_callback("on_raft_base_tick_chaos", move || {
+        tx.send(base_tick_ms).unwrap()
+    })
+    .unwrap();
+    let mut message = RaftMessage::default();
+    message.region_id = 1;
+    message.set_from_peer(new_peer(3, 3));
+    message.set_to_peer(new_peer(3, 3));
+    message.mut_region_epoch().version = 1;
+    message.mut_region_epoch().conf_ver = 3;
+    let mut msg = ExtraMessage::default();
+    msg.set_type(ExtraMessageType::MsgRegionWakeUp);
+    msg.forcely_awaken = true;
+    message.set_extra_msg(msg);
+    router.send_raft_message(message).unwrap();
+    assert_eq!(
+        rx.recv_timeout(Duration::from_secs(1)).unwrap(),
+        base_tick_ms
+    );
+    fail::remove("on_raft_base_tick_chaos");
 }


### PR DESCRIPTION
This is a manul cherry-pick of #16408.

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close https://github.com/tikv/tikv/issues/16368

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
This pull request addresses a corner case where `WakeUp` messages were being
ignored during I/O hang scenarios.
```

Previously, in the nightly branch, there was a possibility of Peers entering the `PreChaos` state by `on_check_peer_stale_state_tick` scheduler before handling `WakeUp` messages. In such cases,
these Peers would ignore `WakeUp` messages triggered by the "awaken hibernate regions" mechanism. 
Consequently, the recovery duration would last longer than expected.

In this pull request, when the `raftstore` forcibly receives `WakeUp` messages -- indicating the presence of I/O hang problems in the cluster -- the relevant `raftstore` will promptly notify the affected Peers to directly enter the `Chaos` state. 

This facilitates the re-election of new leaders in a shorter duration as expected.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code



| - | Nightly version (Exists Bugs) | **This PR (BugFix)** |
| ---- | ---- | ---- |
| Leaders Distribution | ![image](https://github.com/tikv/tikv/assets/18441614/562c644f-6c2c-452e-9fbb-f0fa73be32c8) | ![image](https://github.com/tikv/tikv/assets/18441614/64022f61-d6d1-4c76-8135-e3e9830098be) |
| Peers state | ![image](https://github.com/tikv/tikv/assets/18441614/646ddea0-e64d-4fa6-9095-bb0975dce7be) | ![image](https://github.com/tikv/tikv/assets/18441614/5678fdfb-b1eb-44c9-a687-079804edab6f) |

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None.
```
