### PR TITLE
statistics: use std from trait

### DIFF
--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -103,13 +103,13 @@ impl<S: Snapshot, F: KvFormat> AnalyzeContext<S, F> {
         let (col_res, idx_res) = builder.collect_columns_stats().await?;
 
         let res_data = {
-            let resp = AnalyzeMixedResult::new(
+            let resp: tipb::AnalyzeMixedResp = AnalyzeMixedResult::new(
                 col_res,
                 idx_res.ok_or_else(|| {
                     Error::Other("Mixed analyze type should have index response.".into())
                 })?,
             )
-            .into_proto();
+            .into();
             box_try!(resp.write_to_bytes())
         };
         Ok(res_data)
@@ -118,7 +118,7 @@ impl<S: Snapshot, F: KvFormat> AnalyzeContext<S, F> {
     async fn handle_full_sampling(builder: &mut RowSampleBuilder<S, F>) -> Result<Vec<u8>> {
         let sample_res = builder.collect_column_stats().await?;
         let res_data = {
-            let res = sample_res.into_proto();
+            let res: tipb::AnalyzeColumnsResp = sample_res.into();
             box_try!(res.write_to_bytes())
         };
         Ok(res_data)
@@ -597,7 +597,7 @@ impl BaseRowSampleCollector {
         proto_collector.set_count(self.count as i64);
         let pb_fm_sketches = mem::take(&mut self.fm_sketches)
             .into_iter()
-            .map(|fm_sketch| fm_sketch.into_proto())
+            .map(|fm_sketch| fm_sketch.into())
             .collect();
         proto_collector.set_fm_sketch(pb_fm_sketches);
         proto_collector.set_total_size(self.total_sizes.clone());
@@ -1097,10 +1097,10 @@ impl From<SampleCollector> for tipb::SampleCollector {
         let mut s = tipb::SampleCollector::default();
         s.set_null_count(collector.null_count as i64);
         s.set_count(collector.count as i64);
-        s.set_fm_sketch(collector.fm_sketch.into_proto());
+        s.set_fm_sketch(collector.fm_sketch.into());
         s.set_samples(collector.samples.into());
         if let Some(c) = collector.cm_sketch {
-            s.set_cm_sketch(c.into_proto())
+            s.set_cm_sketch(c.into())
         }
         s.set_total_size(collector.total_size as i64);
         s
@@ -1117,9 +1117,11 @@ impl AnalyzeSamplingResult {
             row_sample_collector,
         }
     }
+}
 
-    fn into_proto(mut self) -> tipb::AnalyzeColumnsResp {
-        let pb_collector = self.row_sample_collector.to_proto();
+impl From<AnalyzeSamplingResult> for tipb::AnalyzeColumnsResp {
+    fn from(mut result: AnalyzeSamplingResult) -> tipb::AnalyzeColumnsResp {
+        let pb_collector = result.row_sample_collector.to_proto();
         let mut res = tipb::AnalyzeColumnsResp::default();
         res.set_row_collector(pb_collector);
         res
@@ -1182,11 +1184,11 @@ impl From<AnalyzeIndexResult> for tipb::AnalyzeIndexResp {
         let mut res = tipb::AnalyzeIndexResp::default();
         res.set_hist(result.hist.into());
         if let Some(c) = result.cms {
-            res.set_cms(c.into_proto());
+            res.set_cms(c.into());
         }
         if let Some(f) = result.fms {
             let mut s = tipb::SampleCollector::default();
-            s.set_fm_sketch(f.into_proto());
+            s.set_fm_sketch(f.into());
             res.set_collector(s);
         }
         res
@@ -1204,11 +1206,13 @@ impl AnalyzeMixedResult {
     fn new(col_res: AnalyzeColumnsResult, idx_res: AnalyzeIndexResult) -> AnalyzeMixedResult {
         AnalyzeMixedResult { col_res, idx_res }
     }
+}
 
-    fn into_proto(self) -> tipb::AnalyzeMixedResp {
+impl From<AnalyzeMixedResult> for tipb::AnalyzeMixedResp {
+    fn from(result: AnalyzeMixedResult) -> tipb::AnalyzeMixedResp {
         let mut res = tipb::AnalyzeMixedResp::default();
-        res.set_index_resp(self.idx_res.into());
-        res.set_columns_resp(self.col_res.into());
+        res.set_index_resp(result.idx_res.into());
+        res.set_columns_resp(result.col_res.into());
         res
     }
 }

--- a/src/coprocessor/statistics/cmsketch.rs
+++ b/src/coprocessor/statistics/cmsketch.rs
@@ -58,10 +58,12 @@ impl CmSketch {
     pub fn push_to_top_n(&mut self, b: Vec<u8>, cnt: u64) {
         self.top_n.push((b, cnt))
     }
+}
 
-    pub fn into_proto(self) -> tipb::CmSketch {
+impl From<CmSketch> for tipb::CmSketch {
+    fn from(cm: CmSketch) -> tipb::CmSketch {
         let mut proto = tipb::CmSketch::default();
-        let rows = self
+        let rows = cm
             .table
             .into_iter()
             .map(|row| {
@@ -71,7 +73,7 @@ impl CmSketch {
             })
             .collect();
         proto.set_rows(rows);
-        let top_n_data = self
+        let top_n_data = cm
             .top_n
             .into_iter()
             .map(|(item, cnt)| {

--- a/src/coprocessor/statistics/fmsketch.rs
+++ b/src/coprocessor/statistics/fmsketch.rs
@@ -27,14 +27,6 @@ impl FmSketch {
         self.insert_hash_value(hash);
     }
 
-    pub fn into_proto(self) -> tipb::FmSketch {
-        let mut proto = tipb::FmSketch::default();
-        proto.set_mask(self.mask);
-        let hash = self.hash_set.into_iter().collect();
-        proto.set_hashset(hash);
-        proto
-    }
-
     pub fn insert_hash_value(&mut self, hash_val: u64) {
         if (hash_val & self.mask) != 0 {
             return;
@@ -45,6 +37,16 @@ impl FmSketch {
             self.hash_set.retain(|&x| x & mask == 0);
             self.mask = mask;
         }
+    }
+}
+
+impl From<FmSketch> for tipb::FmSketch {
+    fn from(fm: FmSketch) -> tipb::FmSketch {
+        let mut proto = tipb::FmSketch::default();
+        proto.set_mask(fm.mask);
+        let hash = fm.hash_set.into_iter().collect();
+        proto.set_hashset(hash);
+        proto
     }
 }
 

--- a/src/coprocessor/statistics/histogram.rs
+++ b/src/coprocessor/statistics/histogram.rs
@@ -48,15 +48,17 @@ impl Bucket {
             self.ndv += 1;
         }
     }
+}
 
-    fn into_proto(self) -> tipb::Bucket {
-        let mut bucket = tipb::Bucket::default();
-        bucket.set_repeats(self.repeats as i64);
-        bucket.set_count(self.count as i64);
-        bucket.set_lower_bound(self.lower_bound);
-        bucket.set_upper_bound(self.upper_bound);
-        bucket.set_ndv(self.ndv as i64);
-        bucket
+impl From<Bucket> for tipb::Bucket {
+    fn from(bucket: Bucket) -> tipb::Bucket {
+        let mut b = tipb::Bucket::default();
+        b.set_repeats(bucket.repeats as i64);
+        b.set_count(bucket.count as i64);
+        b.set_lower_bound(bucket.lower_bound);
+        b.set_upper_bound(bucket.upper_bound);
+        b.set_ndv(bucket.ndv as i64);
+        b
     }
 }
 
@@ -80,18 +82,6 @@ impl Histogram {
             buckets_num,
             ..Default::default()
         }
-    }
-
-    pub fn into_proto(self) -> tipb::Histogram {
-        let mut hist = tipb::Histogram::default();
-        hist.set_ndv(self.ndv as i64);
-        let buckets: Vec<tipb::Bucket> = self
-            .buckets
-            .into_iter()
-            .map(|bucket| bucket.into_proto())
-            .collect();
-        hist.set_buckets(buckets.into());
-        hist
     }
 
     // insert a data bigger than or equal to the max value in current histogram.
@@ -170,6 +160,20 @@ impl Histogram {
         }
         self.buckets.drain(bucket_num..);
         self.per_bucket_limit *= 2;
+    }
+}
+
+impl From<Histogram> for tipb::Histogram {
+    fn from(hist: Histogram) -> tipb::Histogram {
+        let mut h = tipb::Histogram::default();
+        h.set_ndv(hist.ndv as i64);
+        let buckets: Vec<tipb::Bucket> = hist
+            .buckets
+            .into_iter()
+            .map(|bucket| bucket.into())
+            .collect();
+        h.set_buckets(buckets.into());
+        h
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref https://github.com/tikv/tikv/issues/16463

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Use the standard from and into traits.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
