### PR TITLE
Engine: add basic proptest for titan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,6 +641,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bit_field"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1545,6 +1560,7 @@ dependencies = [
  "online_config",
  "prometheus",
  "prometheus-static-metric",
+ "proptest",
  "protobuf",
  "raft",
  "rand 0.8.5",
@@ -2876,6 +2892,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
 name = "libmimalloc-sys"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3420,6 +3442,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -4017,6 +4040,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.4.1",
+ "lazy_static",
+ "num-traits",
+ "rand 0.8.5",
+ "rand_chacha 0.3.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "protobuf"
 version = "2.8.0"
 source = "git+https://github.com/pingcap/rust-protobuf?branch=v2.8#6642ebaae4352ea01bf00e160480d8da966d3109"
@@ -4067,6 +4110,12 @@ checksum = "c7ac8852baeb3cc6fb83b93646fb93c0ffe5d14bf138c945ceb4b9948ee0e3c1"
 dependencies = [
  "autotools",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
@@ -4947,6 +4996,18 @@ name = "rustversion"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5d2a036dc6d2d8fd16fde3498b04306e29bd193bf306a57427019b823d5acd"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -7024,6 +7085,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unchecked-index"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7143,6 +7210,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc 0.2.151",
+]
 
 [[package]]
 name = "waker-fn"

--- a/components/engine_rocks/Cargo.toml
+++ b/components/engine_rocks/Cargo.toml
@@ -65,3 +65,4 @@ features = ["encryption"]
 [dev-dependencies]
 rand = "0.8"
 toml = "0.5"
+proptest = "1.0.0"

--- a/components/engine_rocks/src/engine.rs
+++ b/components/engine_rocks/src/engine.rs
@@ -277,6 +277,8 @@ impl SyncMutable for RocksEngine {
 mod tests {
     use engine_traits::{Iterable, KvEngine, Peekable, SyncMutable, CF_DEFAULT};
     use kvproto::metapb::Region;
+    use proptest::prelude::*;
+    use rocksdb::{DBOptions, SeekKey, TitanDBOptions, Writable, DB};
     use tempfile::Builder;
 
     use crate::{util, RocksSnapshot};
@@ -408,5 +410,130 @@ mod tests {
         .unwrap();
 
         assert_eq!(data.len(), 2);
+    }
+
+    #[derive(Clone, Debug)]
+    enum Operation {
+        Put(Vec<u8>, Vec<u8>),
+        Get(Vec<u8>),
+        Delete(Vec<u8>),
+        Scan(Vec<u8>, usize),
+        DeleteRange(Vec<u8>, Vec<u8>),
+    }
+
+    fn gen_operations(value_size: usize) -> impl Strategy<Value = Vec<Operation>> {
+        let key_size: usize = 16;
+        prop::collection::vec(
+            prop_oneof![
+                (
+                    prop::collection::vec(prop::num::u8::ANY, 0..key_size),
+                    prop::collection::vec(prop::num::u8::ANY, 0..value_size)
+                )
+                    .prop_map(|(k, v)| Operation::Put(k, v)),
+                prop::collection::vec(prop::num::u8::ANY, 0..key_size)
+                    .prop_map(|k| Operation::Get(k)),
+                prop::collection::vec(prop::num::u8::ANY, 0..key_size)
+                    .prop_map(|k| Operation::Delete(k)),
+                (
+                    prop::collection::vec(prop::num::u8::ANY, 0..key_size),
+                    0..10usize
+                )
+                    .prop_map(|(k, v)| Operation::Scan(k, v)),
+                (
+                    prop::collection::vec(prop::num::u8::ANY, 0..key_size),
+                    prop::collection::vec(prop::num::u8::ANY, 0..key_size)
+                )
+                    .prop_map(|(k1, k2)| Operation::DeleteRange(k1, k2)),
+            ],
+            0..100,
+        )
+    }
+
+    fn scan_kvs(db: &DB, start: &[u8], limit: usize) -> Vec<(Vec<u8>, Vec<u8>)> {
+        let mut iter = db.iter();
+        iter.seek(SeekKey::Key(start)).unwrap();
+        let mut num = 0;
+        let mut res = vec![];
+        while num < limit {
+            if iter.valid().unwrap() {
+                let k = iter.key().to_vec();
+                let v = iter.value().to_vec();
+
+                res.push((k, v));
+                num += 1;
+            } else {
+                break;
+            }
+            iter.next().unwrap();
+        }
+        res
+    }
+
+    fn test_rocks_titan_basic_operations(operations: Vec<Operation>, min_blob_size: u64) {
+        let path_rocks = Builder::new()
+            .prefix("test_rocks_titan_basic_operations_rocks")
+            .tempdir()
+            .unwrap();
+        let path_titan = Builder::new()
+            .prefix("test_rocks_titan_basic_operations_titan")
+            .tempdir()
+            .unwrap();
+        let mut tdb_opts = TitanDBOptions::new();
+        tdb_opts.set_min_blob_size(min_blob_size);
+        let mut opts = DBOptions::new();
+        opts.set_titandb_options(&tdb_opts);
+        opts.create_if_missing(true);
+
+        let db_titan = DB::open(opts, path_titan.path().to_str().unwrap()).unwrap();
+
+        opts = DBOptions::new();
+        opts.create_if_missing(true);
+
+        let db_rocks = DB::open(opts, path_rocks.path().to_str().unwrap()).unwrap();
+
+        for op in operations {
+            match op {
+                Operation::Put(k, v) => {
+                    db_rocks.put(&k, &v).unwrap();
+                    db_titan.put(&k, &v).unwrap();
+                }
+                Operation::Get(k) => {
+                    let res_rocks = db_rocks.get(&k).unwrap();
+                    let res_titan = db_titan.get(&k).unwrap();
+                    assert_eq!(res_rocks.as_deref(), res_titan.as_deref());
+                }
+                Operation::Delete(k) => {
+                    db_rocks.delete(&k).unwrap();
+                    db_titan.delete(&k).unwrap();
+                }
+                Operation::Scan(k, limit) => {
+                    let res_rocks = scan_kvs(&db_rocks, &k, limit);
+                    let res_titan = scan_kvs(&db_titan, &k, limit);
+                    assert_eq!(res_rocks, res_titan);
+                }
+                Operation::DeleteRange(k1, k2) => {
+                    if k1 <= k2 {
+                        db_rocks.delete_range(&k1, &k2).unwrap();
+                        db_titan.delete_range(&k1, &k2).unwrap();
+                    } else {
+                        db_rocks.delete_range(&k2, &k1).unwrap();
+                        db_titan.delete_range(&k2, &k1).unwrap();
+                    }
+                }
+            }
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn test_rocks_titan_basic_ops(operations in gen_operations(1000)) {
+            test_rocks_titan_basic_operations(operations.clone(), 8);
+        }
+
+        #[test]
+        fn test_rocks_titan_basic_ops_large_min_blob_size(operations in gen_operations(1000)) {
+            // titan actually is not enabled
+            test_rocks_titan_basic_operations(operations, 1024);
+        }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref #16259

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Add property test for titan's basic operations: get/put/delete/scan/delete_range
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
