### PR TITLE
raftstore: use force in compact_range triggered by no valid split key

### DIFF
--- a/components/engine_panic/src/compact.rs
+++ b/components/engine_panic/src/compact.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeMap;
 
-use engine_traits::{CompactExt, CompactedEvent, Result};
+use engine_traits::{CompactExt, CompactedEvent, ManualCompactionOptions, Result};
 
 use crate::engine::PanicEngine;
 
@@ -18,9 +18,7 @@ impl CompactExt for PanicEngine {
         cf: &str,
         start_key: Option<&[u8]>,
         end_key: Option<&[u8]>,
-        exclusive_manual: bool,
-        max_subcompactions: u32,
-        bottommost_level_force: bool,
+        compaction_option: ManualCompactionOptions,
     ) -> Result<()> {
         panic!()
     }

--- a/components/engine_panic/src/compact.rs
+++ b/components/engine_panic/src/compact.rs
@@ -20,6 +20,7 @@ impl CompactExt for PanicEngine {
         end_key: Option<&[u8]>,
         exclusive_manual: bool,
         max_subcompactions: u32,
+        bottommost_level_force: bool,
     ) -> Result<()> {
         panic!()
     }

--- a/components/engine_rocks/src/compact.rs
+++ b/components/engine_rocks/src/compact.rs
@@ -2,7 +2,7 @@
 
 use std::cmp;
 
-use engine_traits::{CfNamesExt, CompactExt, Result};
+use engine_traits::{CfNamesExt, CompactExt, ManualCompactionOptions, Result};
 use rocksdb::{CompactOptions, CompactionOptions, DBBottommostLevelCompaction, DBCompressionType};
 
 use crate::{engine::RocksEngine, r2e, util};
@@ -29,18 +29,16 @@ impl CompactExt for RocksEngine {
         cf: &str,
         start_key: Option<&[u8]>,
         end_key: Option<&[u8]>,
-        exclusive_manual: bool,
-        max_subcompactions: u32,
-        bottommost_level_force: bool,
+        option: ManualCompactionOptions,
     ) -> Result<()> {
         let db = self.as_inner();
         let handle = util::get_cf_handle(db, cf)?;
         let mut compact_opts = CompactOptions::new();
         // `exclusive_manual == false` means manual compaction can
         // concurrently run with other background compactions.
-        compact_opts.set_exclusive_manual_compaction(exclusive_manual);
-        compact_opts.set_max_subcompactions(max_subcompactions as i32);
-        if bottommost_level_force {
+        compact_opts.set_exclusive_manual_compaction(option.exclusive_manual);
+        compact_opts.set_max_subcompactions(option.max_subcompactions as i32);
+        if option.bottommost_level_force {
             compact_opts.set_bottommost_level_compaction(DBBottommostLevelCompaction::Force);
         }
         db.compact_range_cf_opt(handle, &compact_opts, start_key, end_key);

--- a/components/engine_rocks/src/compact.rs
+++ b/components/engine_rocks/src/compact.rs
@@ -3,7 +3,7 @@
 use std::cmp;
 
 use engine_traits::{CfNamesExt, CompactExt, Result};
-use rocksdb::{CompactOptions, CompactionOptions, DBCompressionType};
+use rocksdb::{CompactOptions, CompactionOptions, DBBottommostLevelCompaction, DBCompressionType};
 
 use crate::{engine::RocksEngine, r2e, util};
 
@@ -31,6 +31,7 @@ impl CompactExt for RocksEngine {
         end_key: Option<&[u8]>,
         exclusive_manual: bool,
         max_subcompactions: u32,
+        bottommost_level_force: bool,
     ) -> Result<()> {
         let db = self.as_inner();
         let handle = util::get_cf_handle(db, cf)?;
@@ -39,6 +40,9 @@ impl CompactExt for RocksEngine {
         // concurrently run with other background compactions.
         compact_opts.set_exclusive_manual_compaction(exclusive_manual);
         compact_opts.set_max_subcompactions(max_subcompactions as i32);
+        // if bottommost_level_force {
+        //     compact_opts.set_bottommost_level_compaction(DBBottommostLevelCompaction::Force);
+        // }
         db.compact_range_cf_opt(handle, &compact_opts, start_key, end_key);
         Ok(())
     }

--- a/components/engine_rocks/src/compact.rs
+++ b/components/engine_rocks/src/compact.rs
@@ -40,9 +40,9 @@ impl CompactExt for RocksEngine {
         // concurrently run with other background compactions.
         compact_opts.set_exclusive_manual_compaction(exclusive_manual);
         compact_opts.set_max_subcompactions(max_subcompactions as i32);
-        // if bottommost_level_force {
-        //     compact_opts.set_bottommost_level_compaction(DBBottommostLevelCompaction::Force);
-        // }
+        if bottommost_level_force {
+            compact_opts.set_bottommost_level_compaction(DBBottommostLevelCompaction::Force);
+        }
         db.compact_range_cf_opt(handle, &compact_opts, start_key, end_key);
         Ok(())
     }

--- a/components/engine_rocks/src/file_system.rs
+++ b/components/engine_rocks/src/file_system.rs
@@ -97,6 +97,7 @@ mod tests {
             None,  // end_key
             false, // exclusive_manual
             1,     // max_subcompactions
+            false,
         )
         .unwrap();
         assert!(stats.fetch(IoType::LevelZeroCompaction, IoOp::Read) > value_size * 4);

--- a/components/engine_rocks/src/file_system.rs
+++ b/components/engine_rocks/src/file_system.rs
@@ -42,7 +42,7 @@ impl<T: FileSystemInspector> DBFileSystemInspector for WrappedFileSystemInspecto
 mod tests {
     use std::sync::Arc;
 
-    use engine_traits::{CompactExt, MiscExt, SyncMutable, CF_DEFAULT};
+    use engine_traits::{CompactExt, ManualCompactionOptions, MiscExt, SyncMutable, CF_DEFAULT};
     use file_system::{IoOp, IoRateLimiter, IoRateLimiterStatistics, IoType};
     use keys::data_key;
     use tempfile::Builder;
@@ -93,11 +93,10 @@ mod tests {
         assert!(stats.fetch(IoType::Flush, IoOp::Write) < value_size * 2 + amplification_bytes);
         stats.reset();
         db.compact_range_cf(
-            CF_DEFAULT, None,  // start_key
-            None,  // end_key
-            false, // exclusive_manual
-            1,     // max_subcompactions
-            false,
+            CF_DEFAULT,
+            None, // start_key
+            None, // end_key
+            ManualCompactionOptions::new(false, 1, false),
         )
         .unwrap();
         assert!(stats.fetch(IoType::LevelZeroCompaction, IoOp::Read) > value_size * 4);

--- a/components/engine_rocks/src/misc.rs
+++ b/components/engine_rocks/src/misc.rs
@@ -455,8 +455,8 @@ impl MiscExt for RocksEngine {
 #[cfg(test)]
 mod tests {
     use engine_traits::{
-        CompactExt, DeleteStrategy, Iterable, Iterator, Mutable, SyncMutable, WriteBatchExt,
-        ALL_CFS,
+        CompactExt, DeleteStrategy, Iterable, Iterator, ManualCompactionOptions, Mutable,
+        SyncMutable, WriteBatchExt, ALL_CFS,
     };
     use tempfile::Builder;
 
@@ -773,8 +773,13 @@ mod tests {
         ];
         assert_eq!(sst_range, expected);
 
-        db.compact_range_cf(cf, None, None, false, 1, false)
-            .unwrap();
+        db.compact_range_cf(
+            cf,
+            None,
+            None,
+            ManualCompactionOptions::new(false, 1, false),
+        )
+        .unwrap();
         let sst_range = db.get_sst_key_ranges(cf, 0).unwrap();
         assert_eq!(sst_range.len(), 0);
         let sst_range = db.get_sst_key_ranges(cf, 1).unwrap();

--- a/components/engine_rocks/src/misc.rs
+++ b/components/engine_rocks/src/misc.rs
@@ -773,7 +773,8 @@ mod tests {
         ];
         assert_eq!(sst_range, expected);
 
-        db.compact_range_cf(cf, None, None, false, 1).unwrap();
+        db.compact_range_cf(cf, None, None, false, 1, false)
+            .unwrap();
         let sst_range = db.get_sst_key_ranges(cf, 0).unwrap();
         assert_eq!(sst_range.len(), 0);
         let sst_range = db.get_sst_key_ranges(cf, 1).unwrap();

--- a/components/engine_rocks_helper/src/sst_recovery.rs
+++ b/components/engine_rocks_helper/src/sst_recovery.rs
@@ -227,7 +227,7 @@ mod tests {
         db.put(b"z2", b"val").unwrap();
         db.put(b"z7", b"val").unwrap();
         // generate SST file.
-        db.compact_range_cf(CF_DEFAULT, None, None, false, 1)
+        db.compact_range_cf(CF_DEFAULT, None, None, false, 1, false)
             .unwrap();
 
         let files = db.as_inner().get_live_files();

--- a/components/engine_rocks_helper/src/sst_recovery.rs
+++ b/components/engine_rocks_helper/src/sst_recovery.rs
@@ -210,7 +210,7 @@ mod tests {
     use std::{collections::BTreeMap, sync::Arc};
 
     use engine_rocks::util;
-    use engine_traits::{CompactExt, SyncMutable, CF_DEFAULT};
+    use engine_traits::{CompactExt, ManualCompactionOptions, SyncMutable, CF_DEFAULT};
     use kvproto::metapb::{Peer, Region};
     use tempfile::Builder;
 
@@ -227,8 +227,13 @@ mod tests {
         db.put(b"z2", b"val").unwrap();
         db.put(b"z7", b"val").unwrap();
         // generate SST file.
-        db.compact_range_cf(CF_DEFAULT, None, None, false, 1, false)
-            .unwrap();
+        db.compact_range_cf(
+            CF_DEFAULT,
+            None,
+            None,
+            ManualCompactionOptions::new(false, 1, false),
+        )
+        .unwrap();
 
         let files = db.as_inner().get_live_files();
         assert_eq!(files.get_smallestkey(0), b"z2");

--- a/components/engine_traits/src/compact.rs
+++ b/components/engine_traits/src/compact.rs
@@ -19,9 +19,17 @@ pub trait CompactExt: CfNamesExt {
         end_key: Option<&[u8]>,
         exclusive_manual: bool,
         max_subcompactions: u32,
+        bottommost_level_force: bool,
     ) -> Result<()> {
         for cf in self.cf_names() {
-            self.compact_range_cf(cf, start_key, end_key, exclusive_manual, max_subcompactions)?;
+            self.compact_range_cf(
+                cf,
+                start_key,
+                end_key,
+                exclusive_manual,
+                max_subcompactions,
+                bottommost_level_force,
+            )?;
         }
         Ok(())
     }
@@ -34,6 +42,7 @@ pub trait CompactExt: CfNamesExt {
         end_key: Option<&[u8]>,
         exclusive_manual: bool,
         max_subcompactions: u32,
+        bottommost_level_force: bool,
     ) -> Result<()>;
 
     /// Compacts files in the range and above the output level.

--- a/components/engine_traits/src/compact.rs
+++ b/components/engine_traits/src/compact.rs
@@ -6,6 +6,27 @@ use std::collections::BTreeMap;
 
 use crate::{errors::Result, CfNamesExt};
 
+#[derive(Clone)]
+pub struct ManualCompactionOptions {
+    pub exclusive_manual: bool,
+    pub max_subcompactions: u32,
+    pub bottommost_level_force: bool,
+}
+
+impl ManualCompactionOptions {
+    pub fn new(
+        exclusive_manual: bool,
+        max_subcompactions: u32,
+        bottommost_level_force: bool,
+    ) -> Self {
+        Self {
+            exclusive_manual,
+            max_subcompactions,
+            bottommost_level_force,
+        }
+    }
+}
+
 pub trait CompactExt: CfNamesExt {
     type CompactedEvent: CompactedEvent;
 
@@ -17,19 +38,10 @@ pub trait CompactExt: CfNamesExt {
         &self,
         start_key: Option<&[u8]>,
         end_key: Option<&[u8]>,
-        exclusive_manual: bool,
-        max_subcompactions: u32,
-        bottommost_level_force: bool,
+        compaction_option: ManualCompactionOptions,
     ) -> Result<()> {
         for cf in self.cf_names() {
-            self.compact_range_cf(
-                cf,
-                start_key,
-                end_key,
-                exclusive_manual,
-                max_subcompactions,
-                bottommost_level_force,
-            )?;
+            self.compact_range_cf(cf, start_key, end_key, compaction_option.clone())?;
         }
         Ok(())
     }
@@ -40,9 +52,7 @@ pub trait CompactExt: CfNamesExt {
         cf: &str,
         start_key: Option<&[u8]>,
         end_key: Option<&[u8]>,
-        exclusive_manual: bool,
-        max_subcompactions: u32,
-        bottommost_level_force: bool,
+        compaction_option: ManualCompactionOptions,
     ) -> Result<()>;
 
     /// Compacts files in the range and above the output level.

--- a/components/engine_traits/src/compact.rs
+++ b/components/engine_traits/src/compact.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeMap;
 
 use crate::{errors::Result, CfNamesExt};
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ManualCompactionOptions {
     pub exclusive_manual: bool,
     pub max_subcompactions: u32,

--- a/components/hybrid_engine/src/compact.rs
+++ b/components/hybrid_engine/src/compact.rs
@@ -1,6 +1,6 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_traits::{CompactExt, KvEngine, RangeCacheEngine, Result};
+use engine_traits::{CompactExt, KvEngine, ManualCompactionOptions, RangeCacheEngine, Result};
 
 use crate::engine::HybridEngine;
 
@@ -20,18 +20,10 @@ where
         cf: &str,
         start_key: Option<&[u8]>,
         end_key: Option<&[u8]>,
-        exclusive_manual: bool,
-        max_subcompactions: u32,
-        bottommost_level_force: bool,
+        compaction_option: ManualCompactionOptions,
     ) -> Result<()> {
-        self.disk_engine().compact_range_cf(
-            cf,
-            start_key,
-            end_key,
-            exclusive_manual,
-            max_subcompactions,
-            bottommost_level_force,
-        )
+        self.disk_engine()
+            .compact_range_cf(cf, start_key, end_key, compaction_option)
     }
 
     fn compact_files_in_range_cf(

--- a/components/hybrid_engine/src/compact.rs
+++ b/components/hybrid_engine/src/compact.rs
@@ -22,6 +22,7 @@ where
         end_key: Option<&[u8]>,
         exclusive_manual: bool,
         max_subcompactions: u32,
+        bottommost_level_force: bool,
     ) -> Result<()> {
         self.disk_engine().compact_range_cf(
             cf,
@@ -29,6 +30,7 @@ where
             end_key,
             exclusive_manual,
             max_subcompactions,
+            bottommost_level_force,
         )
     }
 

--- a/components/raftstore-v2/src/worker/cleanup/compact.rs
+++ b/components/raftstore-v2/src/worker/cleanup/compact.rs
@@ -104,9 +104,10 @@ where
                             continue;
                         };
                         for cf in &cf_names {
-                            if let Err(e) =
-                                tablet.compact_range_cf(cf, None, None, false, 1 /* threads */)
-                            {
+                            if let Err(e) = tablet.compact_range_cf(
+                                cf, None, None, false, 1, // threads
+                                false,
+                            ) {
                                 error!(
                                     self.logger,
                                     "compact range failed";

--- a/components/raftstore-v2/src/worker/cleanup/compact.rs
+++ b/components/raftstore-v2/src/worker/cleanup/compact.rs
@@ -5,7 +5,7 @@ use std::{
     fmt::{self, Display, Formatter},
 };
 
-use engine_traits::{KvEngine, TabletRegistry, CF_WRITE};
+use engine_traits::{KvEngine, ManualCompactionOptions, TabletRegistry, CF_WRITE};
 use fail::fail_point;
 use keys::{DATA_MAX_KEY, DATA_MIN_KEY};
 use raftstore::store::{need_compact, CompactThreshold};
@@ -105,8 +105,10 @@ where
                         };
                         for cf in &cf_names {
                             if let Err(e) = tablet.compact_range_cf(
-                                cf, None, None, false, 1, // threads
-                                false,
+                                cf,
+                                None,
+                                None,
+                                ManualCompactionOptions::new(false, 1, false),
                             ) {
                                 error!(
                                     self.logger,

--- a/components/raftstore-v2/src/worker/tablet.rs
+++ b/components/raftstore-v2/src/worker/tablet.rs
@@ -303,7 +303,7 @@ impl<EK: KvEngine> Runner<EK> {
                 for r in [range1, range2] {
                     // When compaction filter is present, trivial move is disallowed.
                     if let Err(e) =
-                        tablet.compact_range(Some(r.start_key), Some(r.end_key), false, 1)
+                        tablet.compact_range(Some(r.start_key), Some(r.end_key), false, 1, false)
                     {
                         if e.to_string().contains("Manual compaction paused") {
                             info!(

--- a/components/raftstore-v2/tests/failpoints/test_basic_write.rs
+++ b/components/raftstore-v2/tests/failpoints/test_basic_write.rs
@@ -200,7 +200,7 @@ fn test_delete_range_does_not_block_flushed_index() {
     cached
         .latest()
         .unwrap()
-        .compact_range_cf(CF_DEFAULT, Some(b"A"), Some(b"{"), false, 1)
+        .compact_range_cf(CF_DEFAULT, Some(b"A"), Some(b"{"), false, 1, false)
         .unwrap();
     // delete range by files.
     let header = Box::new(router.new_request_for(2).take_header());

--- a/components/raftstore-v2/tests/failpoints/test_basic_write.rs
+++ b/components/raftstore-v2/tests/failpoints/test_basic_write.rs
@@ -3,7 +3,8 @@
 use std::{assert_matches::assert_matches, time::Duration};
 
 use engine_traits::{
-    CompactExt, DbOptionsExt, MiscExt, Peekable, RaftEngineReadOnly, CF_DEFAULT, CF_RAFT, CF_WRITE,
+    CompactExt, DbOptionsExt, ManualCompactionOptions, MiscExt, Peekable, RaftEngineReadOnly,
+    CF_DEFAULT, CF_RAFT, CF_WRITE,
 };
 use futures::executor::block_on;
 use raftstore_v2::{router::PeerMsg, SimpleWriteEncoder};
@@ -200,7 +201,12 @@ fn test_delete_range_does_not_block_flushed_index() {
     cached
         .latest()
         .unwrap()
-        .compact_range_cf(CF_DEFAULT, Some(b"A"), Some(b"{"), false, 1, false)
+        .compact_range_cf(
+            CF_DEFAULT,
+            Some(b"A"),
+            Some(b"{"),
+            ManualCompactionOptions::new(false, 1, false),
+        )
         .unwrap();
     // delete range by files.
     let header = Box::new(router.new_request_for(2).take_header());

--- a/components/raftstore/src/store/compaction_guard.rs
+++ b/components/raftstore/src/store/compaction_guard.rs
@@ -610,6 +610,7 @@ mod tests {
             None,  // end_key
             false, // exclusive_manual
             1,     // max_subcompactions
+            false,
         )
         .unwrap();
 
@@ -697,7 +698,7 @@ mod tests {
         assert_eq!(level_1.len(), 1, "{:?}", level_1);
         assert_eq!(level_1[0].smallestkey, b"za0", "{:?}", level_1);
         assert_eq!(level_1[0].largestkey, b"za9", "{:?}", level_1);
-        db.compact_range(None, None, false, 1).unwrap();
+        db.compact_range(None, None, false, 1, false).unwrap();
 
         // So... the next-level size will be almost 1024 * 15, which should reach the
         // limit.

--- a/components/raftstore/src/store/compaction_guard.rs
+++ b/components/raftstore/src/store/compaction_guard.rs
@@ -275,7 +275,8 @@ mod tests {
         RocksCfOptions, RocksDbOptions, RocksEngine, RocksSstPartitionerFactory, RocksSstReader,
     };
     use engine_traits::{
-        CompactExt, IterOptions, Iterator, MiscExt, RefIterable, SstReader, SyncMutable, CF_DEFAULT,
+        CompactExt, IterOptions, Iterator, ManualCompactionOptions, MiscExt, RefIterable,
+        SstReader, SyncMutable, CF_DEFAULT,
     };
     use keys::DATA_PREFIX_KEY;
     use kvproto::metapb::Region;
@@ -606,11 +607,10 @@ mod tests {
         db.put(b"zc6", &value).unwrap();
         db.flush_cfs(&[], true /* wait */).unwrap();
         db.compact_range_cf(
-            CF_DEFAULT, None,  // start_key
-            None,  // end_key
-            false, // exclusive_manual
-            1,     // max_subcompactions
-            false,
+            CF_DEFAULT,
+            None, // start_key
+            None, // end_key
+            ManualCompactionOptions::new(false, 1, false),
         )
         .unwrap();
 
@@ -698,7 +698,8 @@ mod tests {
         assert_eq!(level_1.len(), 1, "{:?}", level_1);
         assert_eq!(level_1[0].smallestkey, b"za0", "{:?}", level_1);
         assert_eq!(level_1[0].largestkey, b"za9", "{:?}", level_1);
-        db.compact_range(None, None, false, 1, false).unwrap();
+        db.compact_range(None, None, ManualCompactionOptions::new(false, 1, false))
+            .unwrap();
 
         // So... the next-level size will be almost 1024 * 15, which should reach the
         // limit.

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -2923,6 +2923,7 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
                 cf_name: String::from(CF_LOCK),
                 start_key: None,
                 end_key: None,
+                bottommost_level_force: false,
             };
             if let Err(e) = self
                 .ctx

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -4309,6 +4309,7 @@ where
                             cf_name: String::from(cf),
                             start_key: Some(start_key.clone()),
                             end_key: Some(end_key.clone()),
+                            bottommost_level_force: true,
                         };
 
                         if let Err(e) = poll_ctx

--- a/components/raftstore/src/store/worker/compact.rs
+++ b/components/raftstore/src/store/worker/compact.rs
@@ -539,6 +539,7 @@ mod tests {
             cf_name: String::from(CF_DEFAULT),
             start_key: None,
             end_key: None,
+            bottommost_level_force: false,
         });
         sleep(Duration::from_secs(5));
 

--- a/components/raftstore/src/store/worker/compact.rs
+++ b/components/raftstore/src/store/worker/compact.rs
@@ -8,7 +8,7 @@ use std::{
     time::Duration,
 };
 
-use engine_traits::{KvEngine, RangeStats, CF_WRITE};
+use engine_traits::{KvEngine, ManualCompactionOptions, RangeStats, CF_WRITE};
 use fail::fail_point;
 use futures_util::compat::Future01CompatExt;
 use thiserror::Error;
@@ -256,10 +256,9 @@ where
              );
             let incremental_timer = FULL_COMPACT_INCREMENTAL.start_coarse_timer();
             box_try!(engine.compact_range(
-                range.0, range.1, // Compact the entire key range.
-                false,   // non-exclusive
-                1,       // number of threads threads
-                false,   // force bottommost level compaction
+                range.0,
+                range.1, // Compact the entire key range.
+                ManualCompactionOptions::new(false, 1, false),
             ));
             incremental_timer.observe_duration();
             debug!(
@@ -316,9 +315,7 @@ where
             cf_name,
             start_key,
             end_key,
-            false,
-            1, // threads
-            bottommost_level_force
+            ManualCompactionOptions::new(false, 1, bottommost_level_force),
         ));
         compact_range_timer.observe_duration();
         info!(

--- a/components/raftstore/src/store/worker/compact.rs
+++ b/components/raftstore/src/store/worker/compact.rs
@@ -311,11 +311,12 @@ where
         let compact_range_timer = COMPACT_RANGE_CF
             .with_label_values(&[cf_name])
             .start_coarse_timer();
+        let compact_options = ManualCompactionOptions::new(false, 1, bottommost_level_force);
         box_try!(self.engine.compact_range_cf(
             cf_name,
             start_key,
             end_key,
-            ManualCompactionOptions::new(false, 1, bottommost_level_force),
+            compact_options.clone()
         ));
         compact_range_timer.observe_duration();
         info!(
@@ -324,6 +325,7 @@ where
             "range_end" => end_key.map(::log_wrappers::Value::key),
             "cf" => cf_name,
             "time_takes" => ?timer.saturating_elapsed(),
+            "compact_options" => ?compact_options,
         );
         Ok(())
     }

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -327,7 +327,7 @@ where
     pub fn compact_data(&self) {
         for engine in self.engines.values() {
             let db = &engine.kv;
-            db.compact_range_cf(CF_DEFAULT, None, None, false, 1)
+            db.compact_range_cf(CF_DEFAULT, None, None, false, 1, false)
                 .unwrap();
         }
     }

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -19,8 +19,8 @@ use encryption_export::DataKeyManager;
 use engine_rocks::{RocksCompactedEvent, RocksEngine, RocksStatistics};
 use engine_test::raft::RaftTestEngine;
 use engine_traits::{
-    Engines, Iterable, KvEngine, Mutable, Peekable, RaftEngineReadOnly, SnapshotContext,
-    SyncMutable, WriteBatch, CF_DEFAULT, CF_RAFT,
+    Engines, Iterable, KvEngine, ManualCompactionOptions, Mutable, Peekable, RaftEngineReadOnly,
+    SnapshotContext, SyncMutable, WriteBatch, CF_DEFAULT, CF_RAFT,
 };
 use file_system::IoRateLimiter;
 use futures::{self, channel::oneshot, executor::block_on, future::BoxFuture, StreamExt};
@@ -327,8 +327,13 @@ where
     pub fn compact_data(&self) {
         for engine in self.engines.values() {
             let db = &engine.kv;
-            db.compact_range_cf(CF_DEFAULT, None, None, false, 1, false)
-                .unwrap();
+            db.compact_range_cf(
+                CF_DEFAULT,
+                None,
+                None,
+                ManualCompactionOptions::new(false, 1, false),
+            )
+            .unwrap();
         }
     }
 

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -1216,7 +1216,9 @@ pub mod tests {
 
         pub fn compact(&mut self) {
             for cf in ALL_CFS {
-                self.db.compact_range_cf(cf, None, None, false, 1).unwrap();
+                self.db
+                    .compact_range_cf(cf, None, None, false, 1, false)
+                    .unwrap();
             }
         }
     }

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -951,8 +951,8 @@ pub mod tests {
         RocksSnapshot,
     };
     use engine_traits::{
-        CompactExt, IterOptions, MiscExt, Mutable, SyncMutable, WriteBatch, WriteBatchExt, ALL_CFS,
-        CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE,
+        CompactExt, IterOptions, ManualCompactionOptions, MiscExt, Mutable, SyncMutable,
+        WriteBatch, WriteBatchExt, ALL_CFS, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE,
     };
     use kvproto::{
         kvrpcpb::{AssertionLevel, Context, PrewriteRequestPessimisticAction::*},
@@ -1217,7 +1217,12 @@ pub mod tests {
         pub fn compact(&mut self) {
             for cf in ALL_CFS {
                 self.db
-                    .compact_range_cf(cf, None, None, false, 1, false)
+                    .compact_range_cf(
+                        cf,
+                        None,
+                        None,
+                        ManualCompactionOptions::new(false, 1, false),
+                    )
                     .unwrap();
             }
         }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #15282

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
use option bottommost_level_compaction = force in the compact_range scheduled by no_valid_split_key.
```
In no_valid_split_key senario, we schedule a compact range for the given region. We shoud also set bottommost_level_compaction = force to avoid the trivial move in the bottommost level so that tombstones can be removed..

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
