### PR TITLE
raftstore: fix store_heartbeat incorrectly reporting store.is_busy == true.

### DIFF
--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -6602,7 +6602,9 @@ where
             {
                 let mut meta = self.ctx.store_meta.lock().unwrap();
                 meta.busy_apply_peers.remove(&peer_id);
-                meta.completed_apply_peers_count += 1;
+                if let Some(count) = meta.completed_apply_peers_count.as_mut() {
+                    *count += 1;
+                }
             }
             debug!(
                 "peer completes applying logs";

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -6579,6 +6579,12 @@ where
         // If the peer is newly added or created, no need to check the apply status.
         if last_idx <= RAFT_INIT_LOG_INDEX {
             self.fsm.peer.busy_on_apply = None;
+            // And it should be recorded in the `completed_apply_peers_count`.
+            let mut meta = self.ctx.store_meta.lock().unwrap();
+            meta.busy_apply_peers.remove(&peer_id);
+            if let Some(count) = meta.completed_apply_peers_count.as_mut() {
+                *count += 1;
+            }
             return;
         }
         assert!(self.fsm.peer.busy_on_apply.is_some());

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -2733,7 +2733,6 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
         if completed_apply_peers_count.is_none() || region_count == 0 {
             return false;
         }
-        assert!(completed_apply_peers_count.is_some());
 
         let completed_apply_peers_count = completed_apply_peers_count.unwrap();
         let during_starting_stage = {

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -2784,7 +2784,7 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
                 let damaged_regions_id = meta.get_all_damaged_region_ids().into_iter().collect();
                 stats.set_damaged_regions_id(damaged_regions_id);
             }
-            completed_apply_peers_count = meta.completed_apply_peers_count.clone();
+            completed_apply_peers_count = meta.completed_apply_peers_count;
             busy_apply_peers_count = meta.busy_apply_peers.len() as u64;
         }
 

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -2746,7 +2746,7 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
         // regarded as the candidate for balancing leaders.
         if during_starting_stage {
             let completed_target_count = (|| {
-                fail_point!("on_mock_store_completed_target_count", |_| 0);
+                fail_point!("on_mock_store_completed_target_count", |_| 100);
                 std::cmp::max(
                     1,
                     STORE_CHECK_COMPLETE_APPLY_REGIONS_PERCENT * region_count / 100,
@@ -2761,7 +2761,7 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
                     self.ctx.cfg.min_pending_apply_region_count,
                     region_count.saturating_sub(completed_target_count),
                 );
-                busy_apply_peers_count >= pending_target_count
+                pending_target_count > 0 && busy_apply_peers_count >= pending_target_count
             }
         } else {
             // Already started for a fairy long time.

--- a/tests/failpoints/cases/test_pending_peers.rs
+++ b/tests/failpoints/cases/test_pending_peers.rs
@@ -133,6 +133,12 @@ fn test_on_check_busy_on_apply_peers() {
     must_get_equal(&cluster.get_engine(2), b"k1", b"v1");
     must_get_equal(&cluster.get_engine(3), b"k1", b"v1");
 
+    // Check the start status for peer 1003.
+    cluster.must_send_store_heartbeat(3);
+    sleep_ms(100);
+    let stats = cluster.pd_client.get_store_stats(3).unwrap();
+    assert!(!stats.is_busy);
+
     // Pause peer 1003 on applying logs to make it pending.
     let before_apply_stat = cluster.apply_state(r1, 3);
     cluster.stop_node(3);
@@ -149,11 +155,13 @@ fn test_on_check_busy_on_apply_peers() {
     cluster.run_node(3).unwrap();
     let after_apply_stat = cluster.apply_state(r1, 3);
     assert!(after_apply_stat.applied_index == before_apply_stat.applied_index);
+
     // Case 1: no completed regions.
     cluster.must_send_store_heartbeat(3);
     sleep_ms(100);
     let stats = cluster.pd_client.get_store_stats(3).unwrap();
     assert!(stats.is_busy);
+
     // Case 2: completed_apply_peers_count > completed_target_count but
     //        there exists busy peers.
     fail::cfg("on_mock_store_completed_target_count", "return").unwrap();
@@ -165,6 +173,7 @@ fn test_on_check_busy_on_apply_peers() {
     fail::remove("on_mock_store_completed_target_count");
     fail::remove("on_handle_apply_1003");
     sleep_ms(100);
+
     // After peer 1003 is recovered, store should not be marked with busy.
     let stats = cluster.pd_client.get_store_stats(3).unwrap();
     assert!(!stats.is_busy);

--- a/tests/failpoints/cases/test_pending_peers.rs
+++ b/tests/failpoints/cases/test_pending_peers.rs
@@ -156,25 +156,26 @@ fn test_on_check_busy_on_apply_peers() {
     let after_apply_stat = cluster.apply_state(r1, 3);
     assert!(after_apply_stat.applied_index == before_apply_stat.applied_index);
 
-    // Case 1: no completed regions.
-    cluster.must_send_store_heartbeat(3);
-    sleep_ms(100);
-    let stats = cluster.pd_client.get_store_stats(3).unwrap();
-    assert!(stats.is_busy);
-
-    // Case 2: completed_apply_peers_count > completed_target_count but
-    //        there exists busy peers.
+    // Case 1: completed regions < target count.
     fail::cfg("on_mock_store_completed_target_count", "return").unwrap();
     sleep_ms(100);
     cluster.must_send_store_heartbeat(3);
     sleep_ms(100);
     let stats = cluster.pd_client.get_store_stats(3).unwrap();
-    assert!(!stats.is_busy);
+    assert!(stats.is_busy);
     fail::remove("on_mock_store_completed_target_count");
-    fail::remove("on_handle_apply_1003");
     sleep_ms(100);
 
-    // After peer 1003 is recovered, store should not be marked with busy.
+    // Case 2: completed_apply_peers_count > completed_target_count but
+    //        there exists no busy peers.
+    cluster.must_send_store_heartbeat(3);
+    sleep_ms(100);
+    let stats = cluster.pd_client.get_store_stats(3).unwrap();
+    assert!(!stats.is_busy);
+
+    // After peer 1003 is recovered, store also should not be marked with busy.
+    fail::remove("on_handle_apply_1003");
+    sleep_ms(100);
     let stats = cluster.pd_client.get_store_stats(3).unwrap();
     assert!(!stats.is_busy);
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #16491

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

This pr is used to fix the issue when starting from no regions (new node from empty), store_heartbeat incorrectly reports `store.is_busy == true`.
Meanwhile, the related codes when reporting `store.is_busy` has been polished.

```commit-message

In this pr, `completed_apply_peers_count` is replaced with `Option<u64>` from `u64`.

When initializing, `completed_apply_peers_count` will be set with `Some(0)`. If the check finds
that the store already finishes its `busy_on_apply` check  with `false` or starting from empty regions, this value
will be reset with `None` to mark the check is finished and no need to keep the check anymore next time.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

After bugfix:
![image](https://github.com/tikv/tikv/assets/18441614/a35bda89-1b86-4b0e-9422-0ab37b3cfebb)

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None.
```
