### PR TITLE
*: fix issue of stale peer block resolve-ts cause by ignore gc message

### DIFF
--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -3175,11 +3175,12 @@ where
             return;
         }
 
-        if self.fsm.peer.peer != *msg.get_to_peer() {
+        if self.fsm.peer.peer.get_id() != msg.get_to_peer().get_id() {
             info!(
                 "receive stale gc message, ignore.";
                 "region_id" => self.fsm.region_id(),
                 "peer_id" => self.fsm.peer_id(),
+                "to_peer_id" => msg.get_to_peer().get_id(),
             );
             self.ctx.raft_metrics.message_dropped.stale_msg.inc();
             return;

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -1372,8 +1372,7 @@ where
                     .get_region()
                     .get_peers()
                     .iter()
-                    .filter(|p| p.get_id() == peer_id)
-                    .next()
+                    .find(|p| p.get_id() == peer_id)
                     .unwrap();
                 if peer.role == role {
                     return;

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -1358,6 +1358,35 @@ where
         );
     }
 
+    pub fn wait_peer_role(&self, region_id: u64, store_id: u64, peer_id: u64, role: PeerRole) {
+        for _ in 0..100 {
+            if let Some(state) = self
+                .get_engine(store_id)
+                .get_msg_cf::<RegionLocalState>(
+                    engine_traits::CF_RAFT,
+                    &keys::region_state_key(region_id),
+                )
+                .unwrap()
+            {
+                let peer = state
+                    .get_region()
+                    .get_peers()
+                    .iter()
+                    .filter(|p| p.get_id() == peer_id)
+                    .next()
+                    .unwrap();
+                if peer.role == role {
+                    return;
+                }
+            }
+            sleep_ms(10);
+        }
+        panic!(
+            "[region {}] peer state still not reach {:?}",
+            region_id, role
+        );
+    }
+
     pub fn wait_last_index(
         &mut self,
         region_id: u64,

--- a/tests/integrations/raftstore/test_life.rs
+++ b/tests/integrations/raftstore/test_life.rs
@@ -5,9 +5,16 @@ use std::{
     time::Duration,
 };
 
-use kvproto::raft_serverpb::{ExtraMessageType, PeerState, RaftMessage};
+use kvproto::{
+    metapb::PeerRole::Learner,
+    raft_serverpb::{ExtraMessageType, PeerState, RaftMessage},
+};
+use raft::{eraftpb::ConfChangeType, prelude::MessageType};
 use raftstore::errors::Result;
-use test_raftstore::{new_learner_peer, new_peer, Filter, FilterFactory, Simulator as S1};
+use test_raftstore::{
+    new_admin_request, new_change_peer_request, new_learner_peer, new_peer, Direction, Filter,
+    FilterFactory, RegionPacketFilter, Simulator as S1,
+};
 use test_raftstore_v2::Simulator as S2;
 use tikv_util::{config::ReadableDuration, time::Instant, HandyRwLock};
 
@@ -204,4 +211,77 @@ fn test_gc_removed_peer() {
         new_learner_peer(2, 4),
         Duration::from_millis(200)
     ));
+}
+
+#[test]
+fn test_gc_peer_with_conf_change() {
+    let mut cluster = test_raftstore::new_node_cluster(0, 5);
+    let pd_client = Arc::clone(&cluster.pd_client);
+    pd_client.disable_default_operator();
+
+    let region_id = cluster.run_conf_change();
+    pd_client.must_add_peer(region_id, new_peer(2, 2));
+    pd_client.must_add_peer(region_id, new_peer(3, 3));
+    cluster.must_transfer_leader(region_id, new_peer(1, 1));
+    cluster.must_put(b"k1", b"v1");
+    let mut region_epoch = cluster.get_region_epoch(region_id);
+
+    // Create a learner peer 4 on store 4.
+    let extra_store_id = 4;
+    let extra_peer_id = 4;
+    let cc = new_change_peer_request(
+        ConfChangeType::AddLearnerNode,
+        new_learner_peer(extra_store_id, extra_peer_id),
+    );
+    let req = new_admin_request(region_id, &region_epoch, cc);
+    let res = cluster
+        .call_command_on_leader(req, Duration::from_secs(3))
+        .unwrap();
+    assert!(!res.get_header().has_error(), "{:?}", res);
+    region_epoch.conf_ver += 1;
+    cluster.wait_peer_state(region_id, 4, PeerState::Normal);
+
+    // Isolate peer 4 from other region peers.
+    let left_filter = RegionPacketFilter::new(region_id, extra_store_id)
+        .direction(Direction::Recv)
+        .skip(MessageType::MsgHup);
+    cluster
+        .sim
+        .wl()
+        .add_recv_filter(extra_store_id, Box::new(left_filter));
+
+    // Change peer 4 to voter.
+    let cc = new_change_peer_request(
+        ConfChangeType::AddNode,
+        new_peer(extra_store_id, extra_peer_id),
+    );
+    let req = new_admin_request(region_id, &region_epoch, cc);
+    let res = cluster
+        .call_command_on_leader(req, Duration::from_secs(3))
+        .unwrap();
+    assert!(!res.get_header().has_error(), "{:?}", res);
+    region_epoch.conf_ver += 1;
+
+    // Remove peer 4 from region 1.
+    let cc = new_change_peer_request(
+        ConfChangeType::RemoveNode,
+        new_peer(extra_store_id, extra_peer_id),
+    );
+    let req = new_admin_request(region_id, &region_epoch, cc);
+    let res = cluster
+        .call_command_on_leader(req, Duration::from_secs(3))
+        .unwrap();
+    assert!(!res.get_header().has_error(), "{:?}", res);
+    region_epoch.conf_ver += 1;
+
+    // GC peer 4 using Voter peer state, peer 4 is learner because it's isolated.
+    cluster.wait_peer_role(region_id, extra_store_id, extra_peer_id, Learner);
+    let mut gc_msg = RaftMessage::default();
+    gc_msg.set_region_id(region_id);
+    gc_msg.set_from_peer(new_peer(1, 1));
+    gc_msg.set_to_peer(new_peer(4, 4));
+    gc_msg.set_region_epoch(region_epoch);
+    gc_msg.set_is_tombstone(true);
+    cluster.send_raft_msg(gc_msg).unwrap();
+    cluster.wait_peer_state(region_id, 4, PeerState::Tombstone);
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #16504

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Fix issue of stale peer block resolve-ts cause by ignore gc message.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [x] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fix issue of stale peer block resolve-ts caused by ignore gc message.
```
