### PR TITLE
In-Memory Engine: region stats manager.

### DIFF
--- a/components/pd_client/src/lib.rs
+++ b/components/pd_client/src/lib.rs
@@ -39,7 +39,7 @@ pub use self::{
 pub type Key = Vec<u8>;
 pub type PdFuture<T> = BoxFuture<'static, Result<T>>;
 
-#[derive(Default, Clone)]
+#[derive(Default, Clone, Debug)]
 pub struct RegionStat {
     pub down_peers: Vec<pdpb::PeerStats>,
     pub pending_peers: Vec<metapb::Peer>,

--- a/components/raftstore/src/coprocessor/config.rs
+++ b/components/raftstore/src/coprocessor/config.rs
@@ -56,7 +56,6 @@ pub struct Config {
     // The region_bucket_merge_size_ratio * region_bucket_size is threshold to merge with its left
     // neighbor bucket
     pub region_bucket_merge_size_ratio: f64,
-    // TODO: add enable_region_stats_mgr? auto set it to true if hybrid engine is enabled?
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/components/raftstore/src/coprocessor/config.rs
+++ b/components/raftstore/src/coprocessor/config.rs
@@ -56,6 +56,7 @@ pub struct Config {
     // The region_bucket_merge_size_ratio * region_bucket_size is threshold to merge with its left
     // neighbor bucket
     pub region_bucket_merge_size_ratio: f64,
+    // TODO: add enable_region_stats_mgr? auto set it to true if hybrid engine is enabled?
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/components/raftstore/src/coprocessor/mod.rs
+++ b/components/raftstore/src/coprocessor/mod.rs
@@ -19,6 +19,7 @@ use kvproto::{
     },
     raft_serverpb::RaftApplyState,
 };
+use pd_client::RegionStat;
 use raft::{eraftpb, StateRole};
 
 pub mod config;
@@ -350,6 +351,9 @@ pub trait RegionChangeObserver: Coprocessor {
     fn pre_write_apply_state(&self, _: &mut ObserverContext<'_>) -> bool {
         true
     }
+}
+pub trait RegionHeartbeatObserver: Coprocessor {
+    fn on_region_heartbeat(&self, _: &mut ObserverContext<'_>, _: &RegionStat) {}
 }
 
 pub trait MessageObserver: Coprocessor {

--- a/components/raftstore/src/coprocessor/region_info_accessor.rs
+++ b/components/raftstore/src/coprocessor/region_info_accessor.rs
@@ -511,7 +511,13 @@ impl RegionCollector {
 
     pub fn handle_get_top_regions(&self, count: usize, callback: Callback<Vec<Region>>) {
         if count == 0 {
-            callback(self.regions.values().into_iter().map(|ri| ri.region.clone()).collect::<Vec<_>>())
+            callback(
+                self.regions
+                    .values()
+                    .into_iter()
+                    .map(|ri| ri.region.clone())
+                    .collect::<Vec<_>>(),
+            )
         } else {
             unimplemented!()
         }
@@ -893,7 +899,8 @@ impl RegionInfoProvider for MockRegionInfoProvider {
         let mut regions = Vec::new();
         let (tx, rx) = mpsc::channel();
 
-        self.seek_region(b"",
+        self.seek_region(
+            b"",
             Box::new(move |iter| {
                 for region_info in iter {
                     tx.send(region_info.region.clone()).unwrap();

--- a/components/raftstore/src/coprocessor/region_info_accessor.rs
+++ b/components/raftstore/src/coprocessor/region_info_accessor.rs
@@ -104,9 +104,13 @@ impl RegionInfo {
     }
 }
 
+/// Region activity data. Used by in-memory cache.
 #[derive(Clone, Debug)]
 pub struct RegionActivity {
     pub region_stat: RegionStat,
+    // TODO: add region's MVCC version/tombestone count to measure effectiveness of the in-memory
+    // cache for that region's data. This information could be collected from rocksdb, see:
+    // collection_regions_to_compact.
 }
 
 type RegionsMap = HashMap<u64, RegionInfo>;

--- a/components/raftstore/src/coprocessor/region_info_accessor.rs
+++ b/components/raftstore/src/coprocessor/region_info_accessor.rs
@@ -554,6 +554,7 @@ impl RegionCollector {
         let top_regions = if count == 0 {
             self.regions
                 .values()
+                .filter(|ri| ri.role == StateRole::Leader)
                 .map(|ri| ri.region.clone())
                 .collect::<Vec<_>>()
         } else {

--- a/components/raftstore/src/coprocessor/region_info_accessor.rs
+++ b/components/raftstore/src/coprocessor/region_info_accessor.rs
@@ -290,6 +290,9 @@ pub struct RegionCollector {
     regions: RegionsMap,
     // BTreeMap: data_end_key -> region_id
     region_ranges: RegionRangesMap,
+    // HashMap: region_id -> RegionActivity
+    // TODO: add BinaryHeap to keep track of top N regions. Wrap the HashMap and BinaryHeap
+    // together in a struct exposing add, delete, and get_top_regions methods.
     region_activity: RegionActivityMap,
     region_leaders: Arc<RwLock<HashSet<u64>>>,
 }

--- a/components/raftstore/src/coprocessor/region_info_accessor.rs
+++ b/components/raftstore/src/coprocessor/region_info_accessor.rs
@@ -547,7 +547,6 @@ impl RegionCollector {
         let top_regions = if count == 0 {
             self.regions
                 .values()
-                .into_iter()
                 .map(|ri| ri.region.clone())
                 .collect::<Vec<_>>()
         } else {
@@ -560,7 +559,7 @@ impl RegionCollector {
                     b.cmp(&a)
                 })
                 .take(count)
-                .flat_map(|(id, _)| self.regions.get(&id).map(|ri| ri.region.clone()))
+                .flat_map(|(id, _)| self.regions.get(id).map(|ri| ri.region.clone()))
                 .collect::<Vec<_>>()
         };
         callback(top_regions)

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -1114,7 +1114,6 @@ where
             .region_keys_read
             .observe(region_stat.read_keys as f64);
 
-        // TODO: this should only be done if enabled in config.
         self.coprocessor_host
             .on_region_heartbeat(&region, &region_stat);
         let resp = self.pd_client.region_heartbeat(

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -1114,6 +1114,9 @@ where
             .region_keys_read
             .observe(region_stat.read_keys as f64);
 
+        // TODO: this should only be done if enabled in config.
+        self.coprocessor_host
+            .on_region_heartbeat(&region, &region_stat);
         let resp = self.pd_client.region_heartbeat(
             term,
             region.clone(),

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -410,9 +410,13 @@ where
             config.coprocessor.clone(),
         ));
 
+        // Region stats manager collects region heartbeat for use by in-memory engine.
+        let enable_region_stats_manager =
+            cfg!(feature = "memory-engine") && config.region_cache_memory_limit != ReadableSize(0);
+
         let region_info_accessor = RegionInfoAccessor::new(
             coprocessor_host.as_mut().unwrap(),
-            false, // TODO: change this.
+            enable_region_stats_manager,
         );
 
         // Initialize concurrency manager

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -410,7 +410,10 @@ where
             config.coprocessor.clone(),
         ));
 
-        let region_info_accessor = RegionInfoAccessor::new(coprocessor_host.as_mut().unwrap());
+        let region_info_accessor = RegionInfoAccessor::new(
+            coprocessor_host.as_mut().unwrap(),
+            false, // TODO: change this.
+        );
 
         // Initialize concurrency manager
         let latest_ts = block_on(pd_client.get_tso()).expect("failed to get timestamp from PD");

--- a/components/server/src/server2.rs
+++ b/components/server/src/server2.rs
@@ -1515,8 +1515,10 @@ impl<CER: ConfiguredRaftEngine> TikvServer<CER> {
             router.store_router().clone(),
             self.core.config.coprocessor.clone(),
         );
-        let region_info_accessor =
-            RegionInfoAccessor::new(&mut coprocessor_host, false /* TODO: change this */);
+        let region_info_accessor = RegionInfoAccessor::new(
+            &mut coprocessor_host,
+            Arc::new(|| false), // Not applicable to v2.
+        );
 
         let cdc_worker = Box::new(LazyWorker::new("cdc"));
         let cdc_scheduler = cdc_worker.scheduler();

--- a/components/server/src/server2.rs
+++ b/components/server/src/server2.rs
@@ -1515,7 +1515,8 @@ impl<CER: ConfiguredRaftEngine> TikvServer<CER> {
             router.store_router().clone(),
             self.core.config.coprocessor.clone(),
         );
-        let region_info_accessor = RegionInfoAccessor::new(&mut coprocessor_host);
+        let region_info_accessor =
+            RegionInfoAccessor::new(&mut coprocessor_host, false /* TODO: change this */);
 
         let cdc_worker = Box::new(LazyWorker::new("cdc"));
         let cdc_scheduler = cdc_worker.scheduler();

--- a/components/test_raftstore-v2/src/server.rs
+++ b/components/test_raftstore-v2/src/server.rs
@@ -419,7 +419,8 @@ impl<EK: KvEngine> ServerCluster<EK> {
         let mut coprocessor_host =
             CoprocessorHost::new(raft_router.store_router().clone(), cfg.coprocessor.clone());
 
-        let region_info_accessor = RegionInfoAccessor::new(&mut coprocessor_host);
+        let region_info_accessor =
+            RegionInfoAccessor::new(&mut coprocessor_host, false /* TODO: change this */);
 
         let sim_router = SimulateTransport::new(raft_router.clone());
         let mut raft_kv_v2 = TestRaftKv2::new(

--- a/components/test_raftstore-v2/src/server.rs
+++ b/components/test_raftstore-v2/src/server.rs
@@ -419,8 +419,10 @@ impl<EK: KvEngine> ServerCluster<EK> {
         let mut coprocessor_host =
             CoprocessorHost::new(raft_router.store_router().clone(), cfg.coprocessor.clone());
 
-        let region_info_accessor =
-            RegionInfoAccessor::new(&mut coprocessor_host, false /* TODO: change this */);
+        let region_info_accessor = RegionInfoAccessor::new(
+            &mut coprocessor_host,
+            Arc::new(|| false), // Not applicable to v2
+        );
 
         let sim_router = SimulateTransport::new(raft_router.clone());
         let mut raft_kv_v2 = TestRaftKv2::new(

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -296,7 +296,8 @@ impl<EK: KvEngineWithRocks> ServerCluster<EK> {
 
         // Create coprocessor.
         let mut coprocessor_host = CoprocessorHost::new(router.clone(), cfg.coprocessor.clone());
-        let region_info_accessor = RegionInfoAccessor::new(&mut coprocessor_host);
+        let region_info_accessor =
+            RegionInfoAccessor::new(&mut coprocessor_host, false /* TODO: change this */);
 
         let raft_router = ServerRaftStoreRouter::new(router.clone(), local_reader);
         let sim_router = SimulateTransport::new(raft_router.clone());

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -1867,7 +1867,7 @@ mod tests {
 
         let sp_provider = MockSafePointProvider(200);
         let mut host = CoprocessorHost::<RocksEngine>::default();
-        let ri_provider = RegionInfoAccessor::new(&mut host);
+        let ri_provider = RegionInfoAccessor::new(&mut host, false);
 
         let mut gc_config = GcConfig::default();
         gc_config.num_threads = 2;
@@ -1982,7 +1982,7 @@ mod tests {
         r1.mut_peers()[0].set_store_id(store_id);
 
         let mut host = CoprocessorHost::<RocksEngine>::default();
-        let ri_provider = RegionInfoAccessor::new(&mut host);
+        let ri_provider = RegionInfoAccessor::new(&mut host, false);
         host.on_region_changed(&r1, RegionChangeEvent::Create, StateRole::Leader);
 
         let db = engine.kv_engine().unwrap().as_inner().clone();
@@ -2046,7 +2046,7 @@ mod tests {
         r1.mut_peers()[0].set_store_id(store_id);
 
         let mut host = CoprocessorHost::<RocksEngine>::default();
-        let ri_provider = Arc::new(RegionInfoAccessor::new(&mut host));
+        let ri_provider = Arc::new(RegionInfoAccessor::new(&mut host, false));
         host.on_region_changed(&r1, RegionChangeEvent::Create, StateRole::Leader);
         // Init env end...
 
@@ -2147,7 +2147,7 @@ mod tests {
         r1.mut_peers()[0].set_store_id(1);
 
         let mut host = CoprocessorHost::<RocksEngine>::default();
-        let ri_provider = Arc::new(RegionInfoAccessor::new(&mut host));
+        let ri_provider = Arc::new(RegionInfoAccessor::new(&mut host, false));
         host.on_region_changed(&r1, RegionChangeEvent::Create, StateRole::Leader);
 
         let db = engine.kv_engine().unwrap().as_inner().clone();

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -1867,7 +1867,7 @@ mod tests {
 
         let sp_provider = MockSafePointProvider(200);
         let mut host = CoprocessorHost::<RocksEngine>::default();
-        let ri_provider = RegionInfoAccessor::new(&mut host, false);
+        let ri_provider = RegionInfoAccessor::new(&mut host, Arc::new(|| false));
 
         let mut gc_config = GcConfig::default();
         gc_config.num_threads = 2;
@@ -1982,7 +1982,7 @@ mod tests {
         r1.mut_peers()[0].set_store_id(store_id);
 
         let mut host = CoprocessorHost::<RocksEngine>::default();
-        let ri_provider = RegionInfoAccessor::new(&mut host, false);
+        let ri_provider = RegionInfoAccessor::new(&mut host, Arc::new(|| false));
         host.on_region_changed(&r1, RegionChangeEvent::Create, StateRole::Leader);
 
         let db = engine.kv_engine().unwrap().as_inner().clone();
@@ -2046,7 +2046,7 @@ mod tests {
         r1.mut_peers()[0].set_store_id(store_id);
 
         let mut host = CoprocessorHost::<RocksEngine>::default();
-        let ri_provider = Arc::new(RegionInfoAccessor::new(&mut host, false));
+        let ri_provider = Arc::new(RegionInfoAccessor::new(&mut host, Arc::new(|| false)));
         host.on_region_changed(&r1, RegionChangeEvent::Create, StateRole::Leader);
         // Init env end...
 
@@ -2147,7 +2147,7 @@ mod tests {
         r1.mut_peers()[0].set_store_id(1);
 
         let mut host = CoprocessorHost::<RocksEngine>::default();
-        let ri_provider = Arc::new(RegionInfoAccessor::new(&mut host, false));
+        let ri_provider = Arc::new(RegionInfoAccessor::new(&mut host, Arc::new(|| false)));
         host.on_region_changed(&r1, RegionChangeEvent::Create, StateRole::Leader);
 
         let db = engine.kv_engine().unwrap().as_inner().clone();

--- a/tests/failpoints/cases/test_gc_metrics.rs
+++ b/tests/failpoints/cases/test_gc_metrics.rs
@@ -158,7 +158,7 @@ fn test_txn_gc_keys_handled() {
 
     let sp_provider = MockSafePointProvider(200);
     let mut host = CoprocessorHost::<RocksEngine>::default();
-    let ri_provider = RegionInfoAccessor::new(&mut host);
+    let ri_provider = RegionInfoAccessor::new(&mut host, false);
     let auto_gc_cfg = AutoGcConfig::new(sp_provider, ri_provider, 1);
     let safe_point = Arc::new(AtomicU64::new(500));
 
@@ -303,7 +303,7 @@ fn test_raw_gc_keys_handled() {
 
     let sp_provider = MockSafePointProvider(200);
     let mut host = CoprocessorHost::<RocksEngine>::default();
-    let ri_provider = RegionInfoAccessor::new(&mut host);
+    let ri_provider = RegionInfoAccessor::new(&mut host, false);
     let auto_gc_cfg = AutoGcConfig::new(sp_provider, ri_provider, store_id);
     let safe_point = Arc::new(AtomicU64::new(500));
 

--- a/tests/failpoints/cases/test_gc_metrics.rs
+++ b/tests/failpoints/cases/test_gc_metrics.rs
@@ -158,7 +158,7 @@ fn test_txn_gc_keys_handled() {
 
     let sp_provider = MockSafePointProvider(200);
     let mut host = CoprocessorHost::<RocksEngine>::default();
-    let ri_provider = RegionInfoAccessor::new(&mut host, false);
+    let ri_provider = RegionInfoAccessor::new(&mut host, Arc::new(|| false));
     let auto_gc_cfg = AutoGcConfig::new(sp_provider, ri_provider, 1);
     let safe_point = Arc::new(AtomicU64::new(500));
 
@@ -303,7 +303,7 @@ fn test_raw_gc_keys_handled() {
 
     let sp_provider = MockSafePointProvider(200);
     let mut host = CoprocessorHost::<RocksEngine>::default();
-    let ri_provider = RegionInfoAccessor::new(&mut host, false);
+    let ri_provider = RegionInfoAccessor::new(&mut host, Arc::new(|| false));
     let auto_gc_cfg = AutoGcConfig::new(sp_provider, ri_provider, store_id);
     let safe_point = Arc::new(AtomicU64::new(500));
 

--- a/tests/integrations/raftstore/test_region_info_accessor.rs
+++ b/tests/integrations/raftstore/test_region_info_accessor.rs
@@ -188,7 +188,7 @@ fn test_node_cluster_region_info_accessor() {
         .wl()
         .post_create_coprocessor_host(Box::new(move |id, host| {
             if id == 1 {
-                let c = RegionInfoAccessor::new(host, false);
+                let c = RegionInfoAccessor::new(host, Arc::new(|| false));
                 tx.send(c).unwrap();
             }
         }));

--- a/tests/integrations/raftstore/test_region_info_accessor.rs
+++ b/tests/integrations/raftstore/test_region_info_accessor.rs
@@ -188,7 +188,7 @@ fn test_node_cluster_region_info_accessor() {
         .wl()
         .post_create_coprocessor_host(Box::new(move |id, host| {
             if id == 1 {
-                let c = RegionInfoAccessor::new(host);
+                let c = RegionInfoAccessor::new(host, false);
                 tx.send(c).unwrap();
             }
         }));

--- a/tests/integrations/storage/test_region_info_accessor.rs
+++ b/tests/integrations/storage/test_region_info_accessor.rs
@@ -181,6 +181,36 @@ fn test_region_collection_get_regions_in_range() {
 }
 
 #[test]
+fn test_region_collection_get_top_regions() {
+    let mut cluster = new_node_cluster(0, 3);
+
+    let (tx, rx) = channel();
+    cluster
+        .sim
+        .wl()
+        .post_create_coprocessor_host(Box::new(move |id, host| {
+            let p = RegionInfoAccessor::new(host);
+            tx.send((id, p)).unwrap()
+        }));
+
+    cluster.run();
+    let region_info_providers: HashMap<_, _> = rx.try_iter().collect();
+    assert_eq!(region_info_providers.len(), 3);
+    let regions = prepare_cluster(&mut cluster);
+
+    for node_id in cluster.get_node_ids() {
+        let engine = &region_info_providers[&node_id];
+
+        let result = engine.get_top_regions(0).unwrap();
+        assert_eq!(result, regions);
+    }
+
+    for  (_, p) in region_info_providers {
+        p.stop();
+    }
+}
+
+#[test]
 fn test_region_collection_find_region_by_key() {
     let mut cluster = new_node_cluster(0, 3);
 

--- a/tests/integrations/storage/test_region_info_accessor.rs
+++ b/tests/integrations/storage/test_region_info_accessor.rs
@@ -197,15 +197,23 @@ fn test_region_collection_get_top_regions() {
     let region_info_providers: HashMap<_, _> = rx.try_iter().collect();
     assert_eq!(region_info_providers.len(), 3);
     let regions = prepare_cluster(&mut cluster);
+    let mut regions = regions.into_iter().map(|r| r.get_id()).collect::<Vec<_>>();
+    regions.sort();
 
     for node_id in cluster.get_node_ids() {
         let engine = &region_info_providers[&node_id];
 
-        let result = engine.get_top_regions(0).unwrap();
+        let mut result = engine
+            .get_top_regions(0)
+            .unwrap()
+            .into_iter()
+            .map(|r| r.get_id())
+            .collect::<Vec<_>>();
+        result.sort();
         assert_eq!(result, regions);
     }
 
-    for  (_, p) in region_info_providers {
+    for (_, p) in region_info_providers {
         p.stop();
     }
 }

--- a/tests/integrations/storage/test_region_info_accessor.rs
+++ b/tests/integrations/storage/test_region_info_accessor.rs
@@ -70,7 +70,7 @@ fn test_region_collection_seek_region() {
         .sim
         .wl()
         .post_create_coprocessor_host(Box::new(move |id, host| {
-            let p = RegionInfoAccessor::new(host);
+            let p = RegionInfoAccessor::new(host, false);
             tx.send((id, p)).unwrap()
         }));
 
@@ -144,7 +144,7 @@ fn test_region_collection_get_regions_in_range() {
         .sim
         .wl()
         .post_create_coprocessor_host(Box::new(move |id, host| {
-            let p = RegionInfoAccessor::new(host);
+            let p = RegionInfoAccessor::new(host, false);
             tx.send((id, p)).unwrap()
         }));
 
@@ -189,7 +189,7 @@ fn test_region_collection_get_top_regions() {
         .sim
         .wl()
         .post_create_coprocessor_host(Box::new(move |id, host| {
-            let p = RegionInfoAccessor::new(host);
+            let p = RegionInfoAccessor::new(host, false);
             tx.send((id, p)).unwrap()
         }));
 
@@ -227,7 +227,7 @@ fn test_region_collection_find_region_by_key() {
         .sim
         .wl()
         .post_create_coprocessor_host(Box::new(move |id, host| {
-            let p = RegionInfoAccessor::new(host);
+            let p = RegionInfoAccessor::new(host, false);
             tx.send((id, p)).unwrap()
         }));
 

--- a/tests/integrations/storage/test_region_info_accessor.rs
+++ b/tests/integrations/storage/test_region_info_accessor.rs
@@ -5,6 +5,7 @@ use std::{sync::mpsc::channel, thread, time::Duration};
 use collections::HashMap;
 use engine_rocks::RocksEngine;
 use kvproto::metapb::Region;
+use more_asserts::{assert_gt, assert_le};
 use raftstore::coprocessor::{RegionInfoAccessor, RegionInfoProvider};
 use test_raftstore::*;
 use tikv_util::HandyRwLock;
@@ -189,29 +190,46 @@ fn test_region_collection_get_top_regions() {
         .sim
         .wl()
         .post_create_coprocessor_host(Box::new(move |id, host| {
-            let p = RegionInfoAccessor::new(host, false);
+            let p = RegionInfoAccessor::new(host, true);
             tx.send((id, p)).unwrap()
         }));
-
     cluster.run();
     let region_info_providers: HashMap<_, _> = rx.try_iter().collect();
     assert_eq!(region_info_providers.len(), 3);
     let regions = prepare_cluster(&mut cluster);
     let mut regions = regions.into_iter().map(|r| r.get_id()).collect::<Vec<_>>();
     regions.sort();
-
+    let mut all_results = Vec::<u64>::new();
     for node_id in cluster.get_node_ids() {
         let engine = &region_info_providers[&node_id];
 
-        let mut result = engine
+        let result = engine
+            .get_top_regions(10)
+            .unwrap()
+            .into_iter()
+            .map(|r| r.get_id())
+            .collect::<Vec<_>>();
+
+        for region_id in &result {
+            assert!(regions.contains(region_id));
+        }
+        let len = result.len();
+        if engine.region_leaders().read().unwrap().contains(&node_id) {
+            // Assert that top regions are populated on a leader.
+            assert_gt!(len, 0);
+            assert_le!(len, 10);
+        }
+        // All the regions for which this node is the leader.
+        let result = engine
             .get_top_regions(0)
             .unwrap()
             .into_iter()
             .map(|r| r.get_id())
             .collect::<Vec<_>>();
-        result.sort();
-        assert_eq!(result, regions);
+        all_results.extend(result.iter());
     }
+    all_results.sort();
+    assert_eq!(all_results, regions);
 
     for (_, p) in region_info_providers {
         p.stop();

--- a/tests/integrations/storage/test_region_info_accessor.rs
+++ b/tests/integrations/storage/test_region_info_accessor.rs
@@ -1,6 +1,10 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{sync::mpsc::channel, thread, time::Duration};
+use std::{
+    sync::{mpsc::channel, Arc},
+    thread,
+    time::Duration,
+};
 
 use collections::HashMap;
 use engine_rocks::RocksEngine;
@@ -71,7 +75,7 @@ fn test_region_collection_seek_region() {
         .sim
         .wl()
         .post_create_coprocessor_host(Box::new(move |id, host| {
-            let p = RegionInfoAccessor::new(host, false);
+            let p = RegionInfoAccessor::new(host, Arc::new(|| false));
             tx.send((id, p)).unwrap()
         }));
 
@@ -145,7 +149,7 @@ fn test_region_collection_get_regions_in_range() {
         .sim
         .wl()
         .post_create_coprocessor_host(Box::new(move |id, host| {
-            let p = RegionInfoAccessor::new(host, false);
+            let p = RegionInfoAccessor::new(host, Arc::new(|| false));
             tx.send((id, p)).unwrap()
         }));
 
@@ -190,7 +194,7 @@ fn test_region_collection_get_top_regions() {
         .sim
         .wl()
         .post_create_coprocessor_host(Box::new(move |id, host| {
-            let p = RegionInfoAccessor::new(host, true);
+            let p = RegionInfoAccessor::new(host, Arc::new(|| true));
             tx.send((id, p)).unwrap()
         }));
     cluster.run();
@@ -245,7 +249,7 @@ fn test_region_collection_find_region_by_key() {
         .sim
         .wl()
         .post_create_coprocessor_host(Box::new(move |id, host| {
-            let p = RegionInfoAccessor::new(host, false);
+            let p = RegionInfoAccessor::new(host, Arc::new(|| false));
             tx.send((id, p)).unwrap()
         }));
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #16141, ref #16417,  close #16507 

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Add basic load eviction manager for in-memory engine.

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [X] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
