### PR TITLE
log_backup: abort the task when the lag grows too huge

### DIFF
--- a/components/backup-stream/tests/integration/mod.rs
+++ b/components/backup-stream/tests/integration/mod.rs
@@ -176,7 +176,7 @@ mod all {
 
         assert!(
             safepoints.iter().any(|sp| {
-                sp.serivce.contains(&format!("{}", victim))
+                sp.service.contains(&format!("{}", victim))
                     && sp.ttl >= Duration::from_secs(60 * 60 * 24)
                     && sp.safepoint.into_inner() == checkpoint - 1
             }),

--- a/components/test_pd_client/src/pd.rs
+++ b/components/test_pd_client/src/pd.rs
@@ -928,7 +928,7 @@ pub struct TestPdClient {
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct GcSafePoint {
-    pub serivce: String,
+    pub service: String,
     pub ttl: Duration,
     pub safepoint: TimeStamp,
 }
@@ -1939,7 +1939,7 @@ impl PdClient for TestPdClient {
     ) -> PdFuture<()> {
         if ttl.as_secs() > 0 {
             self.gc_safepoints.wl().push(GcSafePoint {
-                serivce: name,
+                service: name,
                 ttl,
                 safepoint,
             });

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2880,6 +2880,8 @@ pub struct BackupStreamConfig {
     #[online_config(skip)]
     pub initial_scan_rate_limit: ReadableSize,
     pub initial_scan_concurrency: usize,
+
+    pub checkpoint_max_gap: ReadableDuration,
 }
 
 impl BackupStreamConfig {
@@ -2939,6 +2941,7 @@ impl Default for BackupStreamConfig {
             initial_scan_rate_limit: ReadableSize::mb(60),
             initial_scan_concurrency: 6,
             temp_file_memory_quota: cache_size,
+            checkpoint_max_gap: ReadableDuration::days(1),
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #16510



<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
This PR added a new config for log backup: `checkpoint_max_gap`, default `1d`.
Once the checkpoint lag of log backup grows exceeds this, we will abort the log backup task with a fatal error.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Now, log backup tasks will be aborted once the checkpoint lag is too huge.
```
