### PR TITLE
disk_snapshot_backup: pause raft log GC while backing up

### DIFF
--- a/components/raftstore/src/store/snapshot_backup.rs
+++ b/components/raftstore/src/store/snapshot_backup.rs
@@ -233,11 +233,9 @@ impl AdminObserver for Arc<PrepareDiskSnapObserver> {
         if self.allowed() {
             return Ok(());
         }
-        // NOTE: We should disable `CompactLog` here because if the log get truncated,
+        // NOTE: We have disabled `CompactLog` here because if the log get truncated,
         // we may take a long time to send snapshots during restoring.
-        //
-        // However it may impact the TP workload if we are preparing for a long time.
-        // With this risk, we need more evidence of its adventage to reject CompactLogs.
+        // Also note it may impact the TP workload if we are preparing for a long time.
         let should_reject = matches!(
             admin.get_cmd_type(),
             AdminCmdType::Split |
@@ -249,7 +247,8 @@ impl AdminObserver for Arc<PrepareDiskSnapObserver> {
             AdminCmdType::PrepareMerge |
             AdminCmdType::ChangePeer |
             AdminCmdType::ChangePeerV2 |
-            AdminCmdType::BatchSwitchWitness
+            AdminCmdType::BatchSwitchWitness |
+            AdminCmdType::CompactLog
         );
         if should_reject {
             metrics::SNAP_BR_SUSPEND_COMMAND_TYPE


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #16518

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
This PR will pause the `CompactLog` admin command during backing up.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
The code change is small but the impact would be relatively huge.
We have tested this before which shows there wouldn't be snapshot sent during restoring.
We have disabled GC manually for minutes and see there isn't huge impact to TP workloads (But I guess not for every scenario.).
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Speeded up the restoration for newly generated backups.
```
