### PR TITLE
copr: Fix panic when there is illegal push down

### DIFF
--- a/components/tidb_query_aggr/src/impl_avg.rs
+++ b/components/tidb_query_aggr/src/impl_avg.rs
@@ -38,7 +38,7 @@ impl super::AggrDefinitionParser for AggrFnDefinitionParserAvg {
         let col_sum_et = box_try!(EvalType::try_from(col_sum_ft.as_accessor().tp()));
 
         // Rewrite expression to insert CAST() if needed.
-        super::util::rewrite_exp_for_sum_avg(src_schema, &mut exp).unwrap();
+        super::util::rewrite_exp_for_sum_avg(src_schema, &mut exp)?;
 
         let rewritten_eval_type =
             EvalType::try_from(exp.ret_field_type(src_schema).as_accessor().tp()).unwrap();

--- a/components/tidb_query_aggr/src/impl_bit_op.rs
+++ b/components/tidb_query_aggr/src/impl_bit_op.rs
@@ -75,7 +75,7 @@ impl<T: BitOp> super::AggrDefinitionParser for AggrFnDefinitionParserBitOp<T> {
         // bit operation outputs one column.
         out_schema.push(root_expr.take_field_type());
 
-        super::util::rewrite_exp_for_bit_op(src_schema, &mut exp).unwrap();
+        super::util::rewrite_exp_for_bit_op(src_schema, &mut exp)?;
         out_exp.push(exp);
 
         Ok(Box::new(AggrFnBitOp::<T>(std::marker::PhantomData)))

--- a/components/tidb_query_aggr/src/impl_sum.rs
+++ b/components/tidb_query_aggr/src/impl_sum.rs
@@ -34,8 +34,8 @@ impl super::parser::AggrDefinitionParser for AggrFnDefinitionParserSum {
         let out_ft = root_expr.take_field_type();
         let out_et = box_try!(EvalType::try_from(out_ft.as_accessor().tp()));
 
-        // The rewrite should always succeed.
-        super::util::rewrite_exp_for_sum_avg(src_schema, &mut exp).unwrap();
+        // Rewrite expression to insert CAST() if needed.
+        super::util::rewrite_exp_for_sum_avg(src_schema, &mut exp)?;
 
         let rewritten_eval_type =
             EvalType::try_from(exp.ret_field_type(src_schema).as_accessor().tp()).unwrap();


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close https://github.com/tikv/tikv/issues/16531

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Fix possible panic when there is illegal push down to Coprocessor related with data type and aggregation.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
