### PR TITLE
raftstore: use force in compact_range triggered by no valid split key

### DIFF
--- a/components/engine_panic/src/compact.rs
+++ b/components/engine_panic/src/compact.rs
@@ -18,8 +18,7 @@ impl CompactExt for PanicEngine {
         cf: &str,
         start_key: Option<&[u8]>,
         end_key: Option<&[u8]>,
-        exclusive_manual: bool,
-        max_subcompactions: u32,
+        compaction_option: ManualCompactionOptions,
     ) -> Result<()> {
         panic!()
     }

--- a/components/engine_rocks/src/compact.rs
+++ b/components/engine_rocks/src/compact.rs
@@ -2,7 +2,7 @@
 
 use std::cmp;
 
-use engine_traits::{CfNamesExt, CompactExt, Result};
+use engine_traits::{CfNamesExt, CompactExt, ManualCompactionOptions, Result};
 use rocksdb::{CompactOptions, CompactionOptions, DBCompressionType};
 
 use crate::{engine::RocksEngine, r2e, util};
@@ -29,16 +29,18 @@ impl CompactExt for RocksEngine {
         cf: &str,
         start_key: Option<&[u8]>,
         end_key: Option<&[u8]>,
-        exclusive_manual: bool,
-        max_subcompactions: u32,
+        option: ManualCompactionOptions,
     ) -> Result<()> {
         let db = self.as_inner();
         let handle = util::get_cf_handle(db, cf)?;
         let mut compact_opts = CompactOptions::new();
         // `exclusive_manual == false` means manual compaction can
         // concurrently run with other background compactions.
-        compact_opts.set_exclusive_manual_compaction(exclusive_manual);
-        compact_opts.set_max_subcompactions(max_subcompactions as i32);
+        compact_opts.set_exclusive_manual_compaction(option.exclusive_manual);
+        compact_opts.set_max_subcompactions(option.max_subcompactions as i32);
+        if option.bottommost_level_force {
+            compact_opts.set_bottommost_level_compaction(DBBottommostLevelCompaction::Force);
+        }
         db.compact_range_cf_opt(handle, &compact_opts, start_key, end_key);
         Ok(())
     }

--- a/components/engine_traits/src/compact.rs
+++ b/components/engine_traits/src/compact.rs
@@ -6,6 +6,27 @@ use std::collections::BTreeMap;
 
 use crate::errors::Result;
 
+#[derive(Clone, Debug)]
+pub struct ManualCompactionOptions {
+    pub exclusive_manual: bool,
+    pub max_subcompactions: u32,
+    pub bottommost_level_force: bool,
+}
+
+impl ManualCompactionOptions {
+    pub fn new(
+        exclusive_manual: bool,
+        max_subcompactions: u32,
+        bottommost_level_force: bool,
+    ) -> Self {
+        Self {
+            exclusive_manual,
+            max_subcompactions,
+            bottommost_level_force,
+        }
+    }
+}
+
 pub trait CompactExt {
     type CompactedEvent: CompactedEvent;
 
@@ -19,8 +40,7 @@ pub trait CompactExt {
         cf: &str,
         start_key: Option<&[u8]>,
         end_key: Option<&[u8]>,
-        exclusive_manual: bool,
-        max_subcompactions: u32,
+        compaction_option: ManualCompactionOptions,
     ) -> Result<()>;
 
     /// Compacts files in the range and above the output level.

--- a/components/raftstore/src/store/worker/compact.rs
+++ b/components/raftstore/src/store/worker/compact.rs
@@ -139,10 +139,13 @@ where
         let compact_range_timer = COMPACT_RANGE_CF
             .with_label_values(&[cf_name])
             .start_coarse_timer();
+
+        let compact_options = ManualCompactionOptions::new(false, 1, bottommost_level_force);
         box_try!(
             self.engine
-                .compact_range(cf_name, start_key, end_key, false, 1 /* threads */,)
+                .compact_range(cf_name, start_key, end_key, compact_options.clone())
         );
+
         compact_range_timer.observe_duration();
         info!(
             "compact range finished";
@@ -150,6 +153,7 @@ where
             "range_end" => end_key.map(::log_wrappers::Value::key),
             "cf" => cf_name,
             "time_takes" => ?timer.saturating_elapsed(),
+            "compact_options" => ?compact_options,
         );
         Ok(())
     }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #15282

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
use option bottommost_level_compaction = force in the compact_range scheduled by no_valid_split_key.
```
cherry-pick https://github.com/tikv/tikv/pull/16493


### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
