### PR TITLE
Config, Security: Allow dynamic configuration for "security.redact_info_log"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3921,6 +3921,7 @@ version = "0.0.1"
 dependencies = [
  "atomic",
  "hex 0.4.3",
+ "online_config",
  "protobuf",
  "serde",
  "slog",
@@ -5963,9 +5964,13 @@ dependencies = [
  "encryption",
  "grpcio",
  "log_wrappers",
+ "online_config",
  "serde",
  "serde_derive",
+ "slog",
+ "slog-global",
  "tempfile",
+ "tikv_util",
 ]
 
 [[package]]

--- a/components/backup-stream/src/utils.rs
+++ b/components/backup-stream/src/utils.rs
@@ -828,7 +828,7 @@ mod test {
 
     #[test]
     fn test_redact() {
-        log_wrappers::set_redact_info_log(RedactOption::Flag(true));
+        log_wrappers::set_redact_info_log(RedactOption::On);
         let mut region = Region::default();
         region.set_id(42);
         region.set_start_key(b"TiDB".to_vec());

--- a/components/log_wrappers/Cargo.toml
+++ b/components/log_wrappers/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 [dependencies]
 atomic = "0.5"
 hex = "0.4"
+online_config = { workspace = true }
 protobuf = { version = "2.8", features = ["bytes"] }
 serde = { version = "1.0", features = ["derive"] }
 slog = "2.3"

--- a/components/log_wrappers/src/lib.rs
+++ b/components/log_wrappers/src/lib.rs
@@ -113,7 +113,7 @@ impl TryFrom<ConfigValue> for RedactOption {
             ConfigValue::Bool(false) => Ok(RedactOption::Off),
             ConfigValue::String(s) => RedactOption::from_str(&s),
             _ => Err(format!(
-                "expect: marker, marker | on | off | true | false, got: {value:?}"
+                "expect: marker | on | off | true | false, got: {value:?}"
             )),
         }
     }

--- a/components/log_wrappers/src/lib.rs
+++ b/components/log_wrappers/src/lib.rs
@@ -12,6 +12,7 @@ pub mod hex;
 use std::{fmt, str::FromStr, sync::atomic::Ordering};
 
 use atomic::Atomic;
+use online_config::ConfigValue;
 use protobuf::atomic_flags::{
     set_redact_level as proto_set_redact_level, RedactLevel, DEFAULT_REDACT_MARKER_HEAD,
     DEFAULT_REDACT_MARKER_TAIL,
@@ -86,6 +87,26 @@ impl FromStr for RedactOption {
             "off" | "OFF" => Ok(RedactOption::Flag(false)),
             "marker" | "MARKER" => Ok(RedactOption::Marker),
             s => Err(format!("expect: marker, on | off, got: {:?}", s)),
+        }
+    }
+}
+
+impl TryFrom<ConfigValue> for RedactOption {
+    type Error = String;
+    fn try_from(value: ConfigValue) -> Result<Self, Self::Error> {
+        match value {
+            ConfigValue::Bool(flag) => Ok(RedactOption::Flag(flag)),
+            ConfigValue::String(s) => RedactOption::from_str(&s),
+            _ => Err(format!("expect: marker, on | off, got: {:?}", value)),
+        }
+    }
+}
+
+impl From<RedactOption> for ConfigValue {
+    fn from(option: RedactOption) -> Self {
+        match option {
+            RedactOption::Flag(flag) => ConfigValue::Bool(flag),
+            RedactOption::Marker => ConfigValue::String("marker".to_owned()),
         }
     }
 }

--- a/components/log_wrappers/src/lib.rs
+++ b/components/log_wrappers/src/lib.rs
@@ -120,7 +120,6 @@ impl From<RedactOption> for ConfigValue {
     }
 }
 
-
 impl Serialize for RedactOption {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/components/log_wrappers/src/lib.rs
+++ b/components/log_wrappers/src/lib.rs
@@ -78,6 +78,15 @@ impl Default for RedactOption {
     }
 }
 
+impl fmt::Display for RedactOption {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Flag(flag) => write!(f, "{}", if *flag { "on" } else { "off" }),
+            Self::Marker => write!(f, "marker"),
+        }
+    }
+}
+
 impl FromStr for RedactOption {
     type Err = String;
     fn from_str(s: &str) -> Result<RedactOption, String> {
@@ -110,6 +119,7 @@ impl From<RedactOption> for ConfigValue {
         }
     }
 }
+
 
 impl Serialize for RedactOption {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/components/online_config/src/lib.rs
+++ b/components/online_config/src/lib.rs
@@ -7,7 +7,6 @@ use std::{
 
 use chrono::{FixedOffset, NaiveTime};
 pub use online_config_derive::*;
-
 pub type ConfigChange = HashMap<String, ConfigValue>;
 pub type OffsetTime = (NaiveTime, FixedOffset);
 pub type Schedule = Vec<OffsetTime>;

--- a/components/security/Cargo.toml
+++ b/components/security/Cargo.toml
@@ -10,8 +10,12 @@ collections = { workspace = true }
 encryption = { workspace = true }
 grpcio = { workspace = true }
 log_wrappers = { workspace = true }
+online_config = { workspace = true }
 serde = "1.0"
 serde_derive = "1.0"
+slog = { workspace = true }
+slog-global = { workspace = true }
+tikv_util = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/components/security/src/lib.rs
+++ b/components/security/src/lib.rs
@@ -19,20 +19,28 @@ use grpcio::{
     ServerCredentialsFetcher,
 };
 use log_wrappers::RedactOption;
+use online_config::{ConfigChange, ConfigManager, OnlineConfig, Result as CfgResult};
+use tikv_util::info;
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Default)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Default, OnlineConfig)]
 #[serde(default)]
 #[serde(rename_all = "kebab-case")]
 pub struct SecurityConfig {
     // SSL configs.
+    #[online_config(skip)]
     pub ca_path: String,
+    #[online_config(skip)]
     pub cert_path: String,
+    #[online_config(skip)]
     pub key_path: String,
     // Test purpose only.
     #[serde(skip)]
+    #[online_config(skip)]
     pub override_ssl_target: String,
+    #[online_config(skip)]
     pub cert_allowed_cn: HashSet<String>,
     pub redact_info_log: RedactOption,
+    #[online_config(skip)]
     pub encryption: EncryptionConfig,
 }
 
@@ -124,6 +132,19 @@ impl SecurityConfig {
         }
         *last = Some(this);
         Ok(true)
+    }
+}
+
+pub struct SecurityConfigManager;
+
+impl ConfigManager for SecurityConfigManager {
+    fn dispatch(&mut self, changes: ConfigChange) -> CfgResult<()> {
+        // update log redaction config
+        if let Some(v) = changes.get("redact_info_log") {
+            log_wrappers::set_redact_info_log(RedactOption::try_from(v.clone())?);
+        }
+        info!("update security config"; "config" => ?changes);
+        Ok(())
     }
 }
 

--- a/components/security/src/lib.rs
+++ b/components/security/src/lib.rs
@@ -39,7 +39,7 @@ pub struct SecurityConfig {
     pub override_ssl_target: String,
     #[online_config(skip)]
     pub cert_allowed_cn: HashSet<String>,
-    pub redact_info_log: RedactOption,
+    pub redact_info_log: String,
     #[online_config(skip)]
     pub encryption: EncryptionConfig,
 }

--- a/components/security/src/lib.rs
+++ b/components/security/src/lib.rs
@@ -39,7 +39,7 @@ pub struct SecurityConfig {
     pub override_ssl_target: String,
     #[online_config(skip)]
     pub cert_allowed_cn: HashSet<String>,
-    pub redact_info_log: String,
+    pub redact_info_log: RedactOption,
     #[online_config(skip)]
     pub encryption: EncryptionConfig,
 }

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -82,7 +82,7 @@ use raftstore::{
 };
 use resolved_ts::{LeadershipResolver, Task};
 use resource_control::{config::ResourceContrlCfgMgr, ResourceGroupManager};
-use security::SecurityManager;
+use security::{SecurityConfigManager, SecurityManager};
 use service::{service_event::ServiceEvent, service_manager::GrpcServiceManager};
 use snap_recovery::RecoveryService;
 use tikv::{
@@ -555,7 +555,10 @@ where
 
         cfg_controller.register(tikv::config::Module::Log, Box::new(LogConfigManager));
         cfg_controller.register(tikv::config::Module::Memory, Box::new(MemoryConfigManager));
-
+        cfg_controller.register(
+            tikv::config::Module::Security,
+            Box::new(SecurityConfigManager),
+        );
         // Create cdc.
         let cdc_memory_quota = Arc::new(MemoryQuota::new(
             self.core.config.cdc.sink_memory_quota.0 as _,

--- a/components/server/src/server2.rs
+++ b/components/server/src/server2.rs
@@ -70,7 +70,7 @@ use raftstore_v2::{
 };
 use resolved_ts::Task;
 use resource_control::{config::ResourceContrlCfgMgr, ResourceGroupManager};
-use security::SecurityManager;
+use security::{SecurityConfigManager, SecurityManager};
 use service::{service_event::ServiceEvent, service_manager::GrpcServiceManager};
 use tikv::{
     config::{
@@ -466,7 +466,10 @@ where
 
         cfg_controller.register(tikv::config::Module::Log, Box::new(LogConfigManager));
         cfg_controller.register(tikv::config::Module::Memory, Box::new(MemoryConfigManager));
-
+        cfg_controller.register(
+            tikv::config::Module::Security,
+            Box::new(SecurityConfigManager),
+        );
         let lock_mgr = LockManager::new(&self.core.config.pessimistic_txn);
         cfg_controller.register(
             tikv::config::Module::PessimisticTxn,

--- a/components/server/src/setup.rs
+++ b/components/server/src/setup.rs
@@ -4,7 +4,6 @@ use std::{
     borrow::ToOwned,
     io,
     path::{Path, PathBuf},
-    str::FromStr,
     sync::atomic::{AtomicBool, Ordering},
 };
 
@@ -219,9 +218,7 @@ pub fn initial_logger(config: &TikvConfig) {
     }
 
     // Set redact_info_log.
-    log_wrappers::set_redact_info_log(
-        log_wrappers::RedactOption::from_str(&config.security.redact_info_log).unwrap(),
-    );
+    log_wrappers::set_redact_info_log(config.security.redact_info_log.clone());
 
     LOG_INITIALIZED.store(true, Ordering::SeqCst);
 }

--- a/components/server/src/setup.rs
+++ b/components/server/src/setup.rs
@@ -4,7 +4,7 @@ use std::{
     borrow::ToOwned,
     io,
     path::{Path, PathBuf},
-    sync::atomic::{AtomicBool, Ordering},
+    sync::atomic::{AtomicBool, Ordering}, str::FromStr,
 };
 
 use chrono::Local;
@@ -218,7 +218,7 @@ pub fn initial_logger(config: &TikvConfig) {
     }
 
     // Set redact_info_log.
-    log_wrappers::set_redact_info_log(config.security.redact_info_log.clone());
+    log_wrappers::set_redact_info_log(log_wrappers::RedactOption::from_str(&config.security.redact_info_log,).unwrap());
 
     LOG_INITIALIZED.store(true, Ordering::SeqCst);
 }

--- a/components/server/src/setup.rs
+++ b/components/server/src/setup.rs
@@ -4,7 +4,8 @@ use std::{
     borrow::ToOwned,
     io,
     path::{Path, PathBuf},
-    sync::atomic::{AtomicBool, Ordering}, str::FromStr,
+    str::FromStr,
+    sync::atomic::{AtomicBool, Ordering},
 };
 
 use chrono::Local;
@@ -218,7 +219,9 @@ pub fn initial_logger(config: &TikvConfig) {
     }
 
     // Set redact_info_log.
-    log_wrappers::set_redact_info_log(log_wrappers::RedactOption::from_str(&config.security.redact_info_log,).unwrap());
+    log_wrappers::set_redact_info_log(
+        log_wrappers::RedactOption::from_str(&config.security.redact_info_log).unwrap(),
+    );
 
     LOG_INITIALIZED.store(true, Ordering::SeqCst);
 }

--- a/components/test_util/src/security.rs
+++ b/components/test_util/src/security.rs
@@ -16,7 +16,7 @@ pub fn new_security_cfg(cn: Option<HashSet<String>>) -> SecurityConfig {
         override_ssl_target: "".to_owned(),
         cert_allowed_cn: cn.unwrap_or_default(),
         encryption: EncryptionConfig::default(),
-        redact_info_log: log_wrappers::RedactOption::Flag(true),
+        redact_info_log: log_wrappers::RedactOption::On,
     }
 }
 

--- a/components/test_util/src/security.rs
+++ b/components/test_util/src/security.rs
@@ -16,7 +16,7 @@ pub fn new_security_cfg(cn: Option<HashSet<String>>) -> SecurityConfig {
         override_ssl_target: "".to_owned(),
         cert_allowed_cn: cn.unwrap_or_default(),
         encryption: EncryptionConfig::default(),
-        redact_info_log: log_wrappers::RedactOption::Flag(true).to_string(),
+        redact_info_log: log_wrappers::RedactOption::Flag(true),
     }
 }
 

--- a/components/test_util/src/security.rs
+++ b/components/test_util/src/security.rs
@@ -16,7 +16,7 @@ pub fn new_security_cfg(cn: Option<HashSet<String>>) -> SecurityConfig {
         override_ssl_target: "".to_owned(),
         cert_allowed_cn: cn.unwrap_or_default(),
         encryption: EncryptionConfig::default(),
-        redact_info_log: log_wrappers::RedactOption::Flag(true),
+        redact_info_log: log_wrappers::RedactOption::Flag(true).to_string(),
     }
 }
 

--- a/components/txn_types/src/lock.rs
+++ b/components/txn_types/src/lock.rs
@@ -1217,9 +1217,9 @@ mod tests {
             generation: 0 \
             }"
         );
-        log_wrappers::set_redact_info_log(log_wrappers::RedactOption::Flag(true));
+        log_wrappers::set_redact_info_log(log_wrappers::RedactOption::On);
         let redact_result = format!("{:?}", lock);
-        log_wrappers::set_redact_info_log(log_wrappers::RedactOption::Flag(false));
+        log_wrappers::set_redact_info_log(log_wrappers::RedactOption::Off);
         assert_eq!(
             redact_result,
             "Lock { \
@@ -1241,9 +1241,9 @@ mod tests {
             }"
         );
 
-        log_wrappers::set_redact_info_log(log_wrappers::RedactOption::Mode("marker".to_string()));
+        log_wrappers::set_redact_info_log(log_wrappers::RedactOption::Marker);
         let redact_result = format!("{:?}", lock);
-        log_wrappers::set_redact_info_log(log_wrappers::RedactOption::Flag(false));
+        log_wrappers::set_redact_info_log(log_wrappers::RedactOption::Off);
         assert_eq!(
             redact_result,
             "Lock { \
@@ -1289,9 +1289,9 @@ mod tests {
             generation: 10 \
             }"
         );
-        log_wrappers::set_redact_info_log(log_wrappers::RedactOption::Flag(true));
+        log_wrappers::set_redact_info_log(log_wrappers::RedactOption::On);
         let redact_result = format!("{:?}", lock);
-        log_wrappers::set_redact_info_log(log_wrappers::RedactOption::Flag(false));
+        log_wrappers::set_redact_info_log(log_wrappers::RedactOption::Off);
         assert_eq!(
             redact_result,
             "Lock { \
@@ -1365,9 +1365,9 @@ mod tests {
             last_change: Exist { last_change_ts: TimeStamp(8), estimated_versions_to_last_change: 2 }\
             , is_locked_with_conflict: false }"
         );
-        log_wrappers::set_redact_info_log(log_wrappers::RedactOption::Flag(true));
+        log_wrappers::set_redact_info_log(log_wrappers::RedactOption::On);
         let redact_result = format!("{:?}", pessimistic_lock);
-        log_wrappers::set_redact_info_log(log_wrappers::RedactOption::Flag(false));
+        log_wrappers::set_redact_info_log(log_wrappers::RedactOption::Off);
         assert_eq!(
             redact_result,
             "PessimisticLock { primary_key: ?, start_ts: TimeStamp(5), ttl: 1000, \

--- a/components/txn_types/src/lock.rs
+++ b/components/txn_types/src/lock.rs
@@ -1241,7 +1241,7 @@ mod tests {
             }"
         );
 
-        log_wrappers::set_redact_info_log(log_wrappers::RedactOption::Marker);
+        log_wrappers::set_redact_info_log(log_wrappers::RedactOption::Mode("marker".to_string()));
         let redact_result = format!("{:?}", lock);
         log_wrappers::set_redact_info_log(log_wrappers::RedactOption::Flag(false));
         assert_eq!(

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -5522,7 +5522,7 @@ mod tests {
         incoming.gc.max_write_bytes_per_sec = ReadableSize::mb(100);
         incoming.rocksdb.defaultcf.block_cache_size = Some(ReadableSize::mb(500));
         incoming.storage.io_rate_limit.import_priority = file_system::IoPriority::High;
-        incoming.security.redact_info_log = log_wrappers::RedactOption::Mode("marker".to_owned());
+        incoming.security.redact_info_log = log_wrappers::RedactOption::Marker;
         let diff = old.diff(&incoming);
         let mut change = HashMap::new();
         change.insert(

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3499,7 +3499,7 @@ pub struct TikvConfig {
     #[online_config(skip)]
     pub raft_engine: RaftEngineConfig,
 
-    #[online_config(skip)]
+    #[online_config(submodule)]
     pub security: SecurityConfig,
 
     #[online_config(submodule)]
@@ -5522,6 +5522,7 @@ mod tests {
         incoming.gc.max_write_bytes_per_sec = ReadableSize::mb(100);
         incoming.rocksdb.defaultcf.block_cache_size = Some(ReadableSize::mb(500));
         incoming.storage.io_rate_limit.import_priority = file_system::IoPriority::High;
+        incoming.security.redact_info_log = log_wrappers::RedactOption::Marker.to_string();
         let diff = old.diff(&incoming);
         let mut change = HashMap::new();
         change.insert(
@@ -5536,6 +5537,10 @@ mod tests {
         change.insert(
             "storage.io-rate-limit.import-priority".to_owned(),
             "high".to_owned(),
+        );
+        change.insert(
+            "security.redact-info-log".to_owned(),
+            "marker".to_owned(),
         );
         let res = to_config_change(change).unwrap();
         assert_eq!(diff, res);
@@ -7067,7 +7072,7 @@ mod tests {
             default_cfg.raft_engine.config().batch_compression_threshold,
             RaftEngineReadableSize::kb(4)
         );
-        default_cfg.security.redact_info_log = log_wrappers::RedactOption::default();
+        default_cfg.security.redact_info_log = log_wrappers::RedactOption::default().to_string();
         default_cfg.coprocessor.region_max_size = Some(default_cfg.coprocessor.region_max_size());
         default_cfg.coprocessor.region_max_keys = Some(default_cfg.coprocessor.region_max_keys());
         default_cfg.coprocessor.region_split_keys =

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -5538,10 +5538,7 @@ mod tests {
             "storage.io-rate-limit.import-priority".to_owned(),
             "high".to_owned(),
         );
-        change.insert(
-            "security.redact-info-log".to_owned(),
-            "marker".to_owned(),
-        );
+        change.insert("security.redact-info-log".to_owned(), "marker".to_owned());
         let res = to_config_change(change).unwrap();
         assert_eq!(diff, res);
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -5522,7 +5522,7 @@ mod tests {
         incoming.gc.max_write_bytes_per_sec = ReadableSize::mb(100);
         incoming.rocksdb.defaultcf.block_cache_size = Some(ReadableSize::mb(500));
         incoming.storage.io_rate_limit.import_priority = file_system::IoPriority::High;
-        incoming.security.redact_info_log = log_wrappers::RedactOption::Marker.to_string();
+        incoming.security.redact_info_log = log_wrappers::RedactOption::Mode("marker".to_owned());
         let diff = old.diff(&incoming);
         let mut change = HashMap::new();
         change.insert(
@@ -7069,7 +7069,7 @@ mod tests {
             default_cfg.raft_engine.config().batch_compression_threshold,
             RaftEngineReadableSize::kb(4)
         );
-        default_cfg.security.redact_info_log = log_wrappers::RedactOption::default().to_string();
+        default_cfg.security.redact_info_log = log_wrappers::RedactOption::default();
         default_cfg.coprocessor.region_max_size = Some(default_cfg.coprocessor.region_max_size());
         default_cfg.coprocessor.region_max_keys = Some(default_cfg.coprocessor.region_max_keys());
         default_cfg.coprocessor.region_split_keys =

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -810,7 +810,7 @@ fn test_serde_custom_tikv_config() {
         key_path: "invalid path".to_owned(),
         override_ssl_target: "".to_owned(),
         cert_allowed_cn,
-        redact_info_log: log_wrappers::RedactOption::Flag(true),
+        redact_info_log: log_wrappers::RedactOption::On,
         encryption: EncryptionConfig {
             data_encryption_method: EncryptionMethod::Aes128Ctr,
             data_key_rotation_period: ReadableDuration::days(14),

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -810,7 +810,7 @@ fn test_serde_custom_tikv_config() {
         key_path: "invalid path".to_owned(),
         override_ssl_target: "".to_owned(),
         cert_allowed_cn,
-        redact_info_log: log_wrappers::RedactOption::Flag(true),
+        redact_info_log: log_wrappers::RedactOption::Flag(true).to_string(),
         encryption: EncryptionConfig {
             data_encryption_method: EncryptionMethod::Aes128Ctr,
             data_key_rotation_period: ReadableDuration::days(14),

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -810,7 +810,7 @@ fn test_serde_custom_tikv_config() {
         key_path: "invalid path".to_owned(),
         override_ssl_target: "".to_owned(),
         cert_allowed_cn,
-        redact_info_log: log_wrappers::RedactOption::Flag(true).to_string(),
+        redact_info_log: log_wrappers::RedactOption::Flag(true),
         encryption: EncryptionConfig {
             data_encryption_method: EncryptionMethod::Aes128Ctr,
             data_key_rotation_period: ReadableDuration::days(14),


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #16568 

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:
Allow dynamic(online) configuration for "security.redact_info_log"

**OUTDATED:**
Add 'allow-dynamic-security-config' config switch to allow online changes to security configurations(e.g. security.redact-info-log)

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->
```release-note
Allow dynamic(online) configuration for "security.redact_info_log"
```


**OUTDATED:**
Add 'allow-dynamic-security-config' config switch to allow online changes to security configurations(e.g. security.redact-info-log)
