### PR TITLE
rocksdb: Expose track-and-verify-wals-in-manifest config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2828,7 +2828,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-6.5#ef9b4fcf7489584d469723ba894644714b406c0d"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-6.5#915404ebbb3523be07eba95f7cad22c2310d4e88"
 dependencies = [
  "bindgen 0.57.0",
  "bzip2-sys",
@@ -2847,7 +2847,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-6.5#ef9b4fcf7489584d469723ba894644714b406c0d"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-6.5#915404ebbb3523be07eba95f7cad22c2310d4e88"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -4680,7 +4680,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-6.5#ef9b4fcf7489584d469723ba894644714b406c0d"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-6.5#915404ebbb3523be07eba95f7cad22c2310d4e88"
 dependencies = [
  "libc 0.2.139",
  "librocksdb_sys",

--- a/components/engine_panic/src/db_options.rs
+++ b/components/engine_panic/src/db_options.rs
@@ -47,6 +47,10 @@ impl DbOptions for PanicDbOptions {
     fn set_titandb_options(&mut self, opts: &Self::TitanDbOptions) {
         panic!()
     }
+
+    fn set_track_and_verify_wals_in_manifest(&mut self, v: bool) {
+        panic!()
+    }
 }
 
 pub struct PanicTitanDbOptions;

--- a/components/engine_rocks/src/db_options.rs
+++ b/components/engine_rocks/src/db_options.rs
@@ -88,6 +88,10 @@ impl DbOptions for RocksDbOptions {
     fn set_titandb_options(&mut self, opts: &Self::TitanDbOptions) {
         self.0.set_titandb_options(opts.as_raw())
     }
+
+    fn set_track_and_verify_wals_in_manifest(&mut self, v: bool) {
+        self.0.set_track_and_verify_wals_in_manifest(v)
+    }
 }
 
 pub struct RocksTitanDbOptions(RawTitanDBOptions);

--- a/components/engine_traits/src/db_options.rs
+++ b/components/engine_traits/src/db_options.rs
@@ -21,6 +21,7 @@ pub trait DbOptions {
     fn get_rate_limiter_auto_tuned(&self) -> Option<bool>;
     fn set_rate_limiter_auto_tuned(&mut self, rate_limiter_auto_tuned: bool) -> Result<()>;
     fn set_titandb_options(&mut self, opts: &Self::TitanDbOptions);
+    fn set_track_and_verify_wals_in_manifest(&mut self, v: bool);
 }
 
 /// Titan-specefic options

--- a/src/config.rs
+++ b/src/config.rs
@@ -1093,6 +1093,8 @@ pub struct DbConfig {
     pub enable_multi_batch_write: bool,
     #[online_config(skip)]
     pub enable_unordered_write: bool,
+    #[online_config(skip)]
+    pub track_and_verify_wals_in_manifest: bool,
     #[online_config(submodule)]
     pub defaultcf: DefaultCfConfig,
     #[online_config(submodule)]
@@ -1144,6 +1146,7 @@ impl Default for DbConfig {
             enable_pipelined_write: false,
             enable_multi_batch_write: true, // deprecated
             enable_unordered_write: false,
+            track_and_verify_wals_in_manifest: false,
             defaultcf: DefaultCfConfig::default(),
             writecf: WriteCfConfig::default(),
             lockcf: LockCfConfig::default(),
@@ -1210,6 +1213,7 @@ impl DbConfig {
         if self.titan.enabled {
             opts.set_titandb_options(&self.titan.build_opts());
         }
+        opts.set_track_and_verify_wals_in_manifest(self.track_and_verify_wals_in_manifest);
         opts
     }
 

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -315,6 +315,7 @@ fn test_serde_custom_tikv_config() {
         enable_pipelined_write: false,
         enable_multi_batch_write: true,
         enable_unordered_write: true,
+        track_and_verify_wals_in_manifest: false,
         defaultcf: DefaultCfConfig {
             block_size: ReadableSize::kb(12),
             block_cache_size: ReadableSize::gb(12),


### PR DESCRIPTION
This is a manual cherry-pick of #16546
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref #16549

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Expose track-and-verify-wals-in-manifest config.

For further investigating corrupted WAL issue happened during EBS restore process.

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
