### PR TITLE
sst_importer: use start_ts for duplicate detect. 

### DIFF
--- a/src/import/duplicate_detect.rs
+++ b/src/import/duplicate_detect.rs
@@ -416,6 +416,7 @@ mod tests {
             }
             base += data.len();
         }
+
         assert_eq!(base, expected_kvs.len(), "{:?}", &expected_kvs[base..]);
     }
 
@@ -426,21 +427,21 @@ mod tests {
             .unwrap();
         let mut data = vec![];
         for i in 0..1000 {
-            let key = format!("{}", i);
-            let value = format!("{}", i);
+            let key = format!("{:03}", i);
+            let value = format!("{:03}", i);
             data.push((key.as_bytes().to_vec(), value.as_bytes().to_vec()))
         }
         write_data(&storage, data, 3);
         let mut data = vec![];
         let big_value = vec![1u8; 300];
         for i in 0..1000 {
-            let key = format!("{}", i * 2);
+            let key = format!("{:03}", i * 2);
             data.push((key.as_bytes().to_vec(), big_value.clone()))
         }
         write_data(&storage, data, 5);
         // We have to do the prewrite manually so that the mem locks don't get released.
         let snapshot = storage.get_snapshot();
-        let start = format!("{}", 0);
+        let start = format!("{:03}", 0);
         let end = format!("{}", 800);
         let detector = DuplicateDetector::new(
             snapshot,
@@ -452,8 +453,8 @@ mod tests {
         .unwrap();
         let mut expected_kvs = vec![];
         for i in 0..400 {
-            let key = format!("{}", i * 2);
-            let value = format!("{}", i * 2);
+            let key = format!("{:03}", i * 2);
+            let value = format!("{:03}", i * 2);
             expected_kvs.push((key.as_bytes().to_vec(), big_value.clone(), 5));
             expected_kvs.push((key.as_bytes().to_vec(), value.as_bytes().to_vec(), 3));
         }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref #16533, Close #16582

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:
This PR will use `start_ts` (instead of `commit_ts`) for duplicate detect in the `import` service.
That is: 
```commit-message
Writes with the same `start_ts` won't be treated as duplicated in `duplicate_detect` RPC.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Breaking backward compatibility
Now, lightning is possible to import two write records with the same `start_ts`. This may break some potential promises of  the transaction model.

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
