### PR TITLE
sst_importer: add ingest mediator and observer

### DIFF
--- a/components/sst_importer/src/lib.rs
+++ b/components/sst_importer/src/lib.rs
@@ -2,6 +2,8 @@
 
 //! Importing RocksDB SST files into TiKV
 #![feature(min_specialization)]
+#![feature(let_chains)]
+#![feature(assert_matches)]
 
 #[macro_use]
 extern crate lazy_static;
@@ -21,6 +23,7 @@ mod util;
 pub mod import_mode;
 mod caching;
 pub mod import_mode2;
+mod mediate;
 pub mod metrics;
 pub mod sst_importer;
 
@@ -29,6 +32,7 @@ pub use self::{
     errors::{error_inc, Error, Result},
     import_file::{sst_meta_to_path, API_VERSION_2},
     import_mode2::range_overlaps,
+    mediate::{periodic_gc_mediator, IngestMediator, IngestObserver, Mediator, Observer},
     sst_importer::SstImporter,
     sst_writer::{RawSstWriter, TxnSstWriter},
     util::{copy_sst_for_ingestion, prepare_sst_for_ingestion},

--- a/components/sst_importer/src/mediate/mod.rs
+++ b/components/sst_importer/src/mediate/mod.rs
@@ -1,0 +1,231 @@
+// Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
+
+//! This module contains the implementation of the mediator pattern for the
+//! sst_importer component in TiKV. It provides the `Mediator` trait and the
+//! `IngestMediator` struct, which act as a central hub for communication
+//! between different observers. Observers can register with the mediator and
+//! receive events through the `Observer` trait.
+//! Together, they resolves the compatibility issue between the sst_importer
+//! and resolved_ts.
+
+use std::{
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, Weak,
+    },
+    time::{Duration, Instant},
+};
+
+use futures::compat::Future01CompatExt;
+use uuid::Uuid;
+
+mod observer;
+pub use observer::IngestObserver;
+
+/// The event type that the mediator can send to observers.
+#[derive(Clone)]
+pub enum Event {
+    Acquire {
+        region_id: u64,
+        uuid: Uuid,
+        deadline: Instant,
+    },
+    Release {
+        region_id: u64,
+        uuid: Uuid,
+    },
+}
+
+#[derive(Debug)]
+struct LeaseState {
+    deadline: Instant,
+    ref_count: Arc<AtomicU64>,
+}
+
+impl LeaseState {
+    fn ref_(&self) -> LeaseRef {
+        self.ref_count.fetch_add(1, Ordering::SeqCst);
+        LeaseRef {
+            lease: LeaseState {
+                deadline: self.deadline,
+                ref_count: self.ref_count.clone(),
+            },
+        }
+    }
+
+    fn has_ref(&self) -> bool {
+        self.ref_count.load(Ordering::SeqCst) != 0
+    }
+
+    fn expire(&mut self) {
+        self.deadline = Instant::now() - Duration::from_secs(1);
+    }
+
+    fn is_expired(&self) -> bool {
+        Instant::now() > self.deadline
+    }
+}
+
+/// A reference to a lease. It should be hold when a long time import RPC is in
+/// progress.
+#[derive(Debug)]
+pub struct LeaseRef {
+    lease: LeaseState,
+}
+
+impl LeaseRef {
+    /// Checks if the lease is expired.
+    pub fn is_expired(&self) -> bool {
+        self.lease.is_expired()
+    }
+}
+
+impl Drop for LeaseRef {
+    fn drop(&mut self) {
+        self.lease.ref_count.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+pub trait Observer: Sync + Send {
+    fn update(&self, event: Event);
+    /// Returns a lease specified by region_id and uuid if the lease is valid.
+    fn get_lease(&self, region_id: u64, uuid: &Uuid) -> Option<LeaseRef>;
+    /// Returns a valid lease uuid for a region.
+    /// Called by Resolver before advancing resolved_ts.
+    fn get_region_lease(&self, region_id: u64) -> Option<Uuid>;
+    /// Garbage collection and it should never block.
+    fn gc(&self);
+}
+
+pub trait Mediator: Sync + Send {
+    fn acquire(&self, region_id: u64, uuid: Uuid, deadline: Instant);
+    fn release(&self, region_id: u64, uuid: Uuid);
+    fn register(&mut self, comp: Arc<dyn Observer>);
+    fn gc(&self);
+}
+
+#[derive(Default)]
+pub struct IngestMediator {
+    comps: Vec<Arc<dyn Observer>>,
+}
+
+impl Mediator for IngestMediator {
+    fn acquire(&self, region_id: u64, uuid: Uuid, deadline: Instant) {
+        let event = Event::Acquire {
+            region_id,
+            uuid,
+            deadline,
+        };
+        for comp in &self.comps {
+            comp.update(event.clone())
+        }
+    }
+
+    fn release(&self, region_id: u64, uuid: Uuid) {
+        let event = Event::Release { region_id, uuid };
+        for comp in &self.comps {
+            comp.update(event.clone())
+        }
+    }
+
+    fn register(&mut self, comp: Arc<dyn Observer>) {
+        self.comps.push(comp)
+    }
+
+    fn gc(&self) {
+        for comp in &self.comps {
+            comp.gc();
+        }
+    }
+}
+
+/// Periodically triggers garbage collection on the mediator.
+pub async fn periodic_gc_mediator(mediator: Weak<dyn Mediator>, duration: Duration) {
+    loop {
+        let Some(m) = mediator.upgrade() else {
+            return;
+        };
+        m.gc();
+        let _ = tikv_util::timer::GLOBAL_TIMER_HANDLE
+            .delay(Instant::now() + duration)
+            .compat()
+            .await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{thread, time::Duration};
+
+    use futures::executor::block_on;
+
+    use super::*;
+
+    #[test]
+    fn test_lease_ref_is_expired() {
+        let ttl = Duration::from_millis(200);
+        let lease = LeaseState {
+            deadline: Instant::now() + ttl,
+            ref_count: Arc::default(),
+        };
+        let ref_ = lease.ref_();
+        assert!(!ref_.is_expired());
+        std::thread::sleep(2 * ttl);
+        assert!(ref_.is_expired());
+    }
+
+    #[test]
+    fn test_lease_ref_count() {
+        let lease = LeaseState {
+            deadline: Instant::now(),
+            ref_count: Arc::default(),
+        };
+        assert!(!lease.has_ref());
+
+        let ref1 = lease.ref_();
+        assert!(lease.has_ref());
+        let ref2 = lease.ref_();
+        assert_eq!(lease.ref_count.load(Ordering::SeqCst), 2);
+
+        drop(ref1);
+        assert_eq!(lease.ref_count.load(Ordering::SeqCst), 1);
+        drop(ref2);
+        assert_eq!(lease.ref_count.load(Ordering::SeqCst), 0);
+        assert!(!lease.has_ref());
+    }
+
+    #[test]
+    fn test_gc() {
+        struct Mock {
+            gc_count: AtomicU64,
+        }
+        impl Observer for Mock {
+            fn update(&self, _: Event) {}
+            fn get_lease(&self, _: u64, _: &Uuid) -> Option<LeaseRef> {
+                None
+            }
+            fn get_region_lease(&self, _: u64) -> Option<Uuid> {
+                None
+            }
+            fn gc(&self) {
+                self.gc_count.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        let mock = Arc::new(Mock {
+            gc_count: AtomicU64::new(0),
+        });
+        let mut mediator = IngestMediator::default();
+        mediator.register(mock.clone());
+        let mediator = Arc::new(mediator);
+        let mediator_weak = Arc::downgrade(&mediator);
+        thread::spawn(move || {
+            block_on(periodic_gc_mediator(
+                mediator_weak,
+                Duration::from_millis(100),
+            ))
+        });
+        thread::sleep(Duration::from_millis(500));
+        assert!(mock.gc_count.load(Ordering::SeqCst) > 2);
+    }
+}

--- a/components/sst_importer/src/mediate/observer.rs
+++ b/components/sst_importer/src/mediate/observer.rs
@@ -1,0 +1,335 @@
+// Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::{
+    sync::{Arc, RwLock},
+    time::Instant,
+};
+
+use collections::{HashMap, HashMapEntry};
+use uuid::Uuid;
+
+use super::*;
+
+const MIN_SHRINK_CAP: usize = 1024;
+
+// region_id -> (uuid -> deadline)
+#[derive(Default)]
+struct SstLeases(HashMap<u64, HashMap<Uuid, LeaseState>>);
+
+impl SstLeases {
+    fn upsert_lease(&mut self, region_id: u64, uuid: Uuid, deadline: Instant) {
+        let ssts = &mut self.0;
+        let region_leases = ssts.entry(region_id).or_default();
+        match region_leases.entry(uuid) {
+            HashMapEntry::Vacant(e) => {
+                e.insert(LeaseState {
+                    deadline,
+                    ref_count: Arc::default(),
+                });
+            }
+            HashMapEntry::Occupied(mut e) => {
+                // Update deadline and keep ref_count as it is.
+                e.get_mut().deadline = deadline;
+            }
+        };
+    }
+    fn expire_lease(&mut self, region_id: u64, uuid: &Uuid) {
+        let ssts = &mut self.0;
+        if let HashMapEntry::Occupied(mut leases) = ssts.entry(region_id) {
+            if let Some(lease) = leases.get_mut().get_mut(uuid) {
+                if lease.has_ref() {
+                    // Do not remove a lease that has refs.
+                    lease.expire();
+                } else {
+                    leases.get_mut().remove(uuid);
+                }
+            }
+            if leases.get().is_empty() {
+                leases.remove();
+            }
+        } else {
+            warn!("sst lease not found"; "region_id" => region_id, "uuid" => ?uuid);
+        };
+    }
+
+    fn gc(&mut self) {
+        let ssts = &mut self.0;
+        let mut empty_regions = vec![];
+        for (region_id, leases) in ssts.iter_mut() {
+            leases.retain(|_, lease| {
+                // Remove a lease that has expired and no ref.
+                lease.has_ref() || !lease.is_expired()
+            });
+            if leases.is_empty() {
+                empty_regions.push(*region_id);
+            }
+        }
+        // Remove regions that have no lease.
+        for region_id in empty_regions {
+            ssts.remove(&region_id);
+        }
+        if ssts.capacity() > MIN_SHRINK_CAP && ssts.capacity() > ssts.len() * 2 {
+            ssts.shrink_to(MIN_SHRINK_CAP);
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct IngestObserver {
+    sst_leases: RwLock<SstLeases>,
+}
+
+impl Observer for IngestObserver {
+    fn update(&self, event: Event) {
+        match event {
+            Event::Acquire {
+                region_id,
+                uuid,
+                deadline,
+            } => {
+                self.upsert_lease(region_id, uuid, deadline);
+            }
+            Event::Release { region_id, uuid } => {
+                self.expire_lease(region_id, &uuid);
+            }
+        }
+    }
+
+    fn get_lease(&self, region_id: u64, uuid: &Uuid) -> Option<LeaseRef> {
+        let ssts = self.sst_leases.read().unwrap();
+        let Some(leases) = ssts.0.get(&region_id) else {
+            return None;
+        };
+        leases.get(uuid).map(|lease| lease.ref_())
+    }
+
+    fn get_region_lease(&self, region_id: u64) -> Option<Uuid> {
+        let ssts = self.sst_leases.read().unwrap();
+        let leases = ssts.0.get(&region_id)?;
+        for (uuid, lease) in leases {
+            if !lease.is_expired() || lease.has_ref() {
+                return Some(*uuid);
+            }
+        }
+        None
+    }
+
+    fn gc(&self) {
+        let Ok(mut leases) = self.sst_leases.try_write() else {
+            return;
+        };
+        leases.gc()
+    }
+}
+
+impl IngestObserver {
+    fn upsert_lease(&self, region_id: u64, uuid: Uuid, deadline: Instant) {
+        let mut ssts = self.sst_leases.write().unwrap();
+        ssts.upsert_lease(region_id, uuid, deadline)
+    }
+    fn expire_lease(&self, region_id: u64, uuid: &Uuid) {
+        let mut ssts = self.sst_leases.write().unwrap();
+        ssts.expire_lease(region_id, uuid)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{assert_matches::assert_matches, sync::mpsc::channel, thread, time::Duration};
+
+    use super::*;
+
+    #[test]
+    fn test_observer_get_region_lease() {
+        let observer = IngestObserver::default();
+        let region_id = 1;
+        assert!(observer.get_region_lease(region_id).is_none());
+
+        let uuid = Uuid::new_v4();
+        let deadline = Instant::now() + Duration::from_secs(60);
+        observer.update(Event::Acquire {
+            region_id,
+            uuid,
+            deadline,
+        });
+        assert_eq!(observer.get_region_lease(region_id).unwrap(), uuid);
+
+        observer.update(Event::Release { region_id, uuid });
+        assert!(observer.get_region_lease(region_id).is_none());
+
+        observer.update(Event::Acquire {
+            region_id,
+            uuid,
+            deadline: Instant::now(),
+        });
+        thread::sleep(Duration::from_millis(200));
+        assert!(observer.get_region_lease(region_id).is_none());
+    }
+
+    #[test]
+    fn test_observer_upsert_lease() {
+        let observer = IngestObserver::default();
+        let region_id = 1;
+        let uuid1 = Uuid::new_v4();
+        let deadline1 = Instant::now();
+        let uuid2 = Uuid::new_v4();
+        let deadline2 = Instant::now();
+        observer.update(Event::Acquire {
+            region_id,
+            uuid: uuid1,
+            deadline: deadline1,
+        });
+        observer.update(Event::Acquire {
+            region_id,
+            uuid: uuid2,
+            deadline: deadline2,
+        });
+
+        let assert_ref_count = |uuid, count: u64| {
+            assert_eq!(
+                observer.sst_leases.read().unwrap().0[&region_id][&uuid]
+                    .ref_count
+                    .load(Ordering::SeqCst),
+                count,
+            );
+        };
+
+        let ref1 = observer.get_lease(region_id, &uuid1).unwrap();
+        assert_eq!(ref1.lease.deadline, deadline1);
+        assert_ref_count(uuid1, 1);
+        let ref2 = observer.get_lease(region_id, &uuid2).unwrap();
+        assert_eq!(ref2.lease.deadline, deadline2);
+
+        // Make sure upsert does not overwrite ref_count.
+        let deadline3 = Instant::now();
+        observer.update(Event::Acquire {
+            region_id,
+            uuid: uuid1,
+            deadline: deadline3,
+        });
+        let ref3 = observer.get_lease(region_id, &uuid1).unwrap();
+        assert_eq!(ref3.lease.deadline, deadline3);
+        assert_ref_count(uuid1, 2);
+    }
+
+    #[test]
+    fn test_observer_expire_lease() {
+        let observer = IngestObserver::default();
+        let region_id = 1;
+        let uuid1 = Uuid::new_v4();
+        let deadline1 = Instant::now();
+        let uuid2 = Uuid::new_v4();
+        let deadline2 = Instant::now();
+        observer.update(Event::Acquire {
+            region_id,
+            uuid: uuid1,
+            deadline: deadline1,
+        });
+        observer.update(Event::Acquire {
+            region_id,
+            uuid: uuid2,
+            deadline: deadline2,
+        });
+
+        // Hold a ref to uuid1.
+        let ref1 = observer.get_lease(region_id, &uuid1).unwrap();
+        assert_eq!(ref1.lease.deadline, deadline1);
+
+        observer.update(Event::Release {
+            region_id,
+            uuid: uuid1,
+        });
+        observer.update(Event::Release {
+            region_id,
+            uuid: uuid2,
+        });
+
+        // Make sure expire does not remove a lease that has refs.
+        let ref11 = observer.get_lease(region_id, &uuid1).unwrap();
+        // Make sure the unremoved lease is indeed expired.
+        assert!(ref11.is_expired());
+
+        assert_matches!(observer.get_lease(region_id, &uuid2), None);
+    }
+
+    #[test]
+    fn test_observer_gc() {
+        let observer = IngestObserver::default();
+
+        let region_id1 = 1;
+        let uuid11 = Uuid::new_v4();
+        let deadline11 = Instant::now() + Duration::from_secs(60);
+        let uuid12 = Uuid::new_v4();
+        let deadline12 = Instant::now() + Duration::from_secs(60);
+        observer.update(Event::Acquire {
+            region_id: region_id1,
+            uuid: uuid11,
+            deadline: deadline11,
+        });
+        observer.update(Event::Acquire {
+            region_id: region_id1,
+            uuid: uuid12,
+            deadline: deadline12,
+        });
+
+        let region_id2 = 2;
+        let uuid2 = Uuid::new_v4();
+        let deadline2 = Instant::now() + Duration::from_secs(60);
+        observer.update(Event::Acquire {
+            region_id: region_id2,
+            uuid: uuid2,
+            deadline: deadline2,
+        });
+
+        // Gc does not remove valid leases.
+        observer.gc();
+        observer.get_lease(region_id1, &uuid11).unwrap();
+        observer.get_lease(region_id1, &uuid12).unwrap();
+        observer.get_lease(region_id2, &uuid2).unwrap();
+
+        // Gc does not remove leases that have refs.
+        let ref2 = observer.get_lease(region_id2, &uuid2).unwrap();
+        observer.update(Event::Release {
+            region_id: region_id2,
+            uuid: uuid2,
+        });
+        observer.gc();
+        observer.get_lease(region_id2, &uuid2).unwrap();
+
+        // Gc does remove regions that has no valid lease.
+        drop(ref2);
+        observer.gc();
+        assert!(observer.get_lease(region_id2, &uuid2).is_none());
+
+        // Gc can handle concurrent leases.
+        observer.update(Event::Release {
+            region_id: region_id1,
+            uuid: uuid12,
+        });
+        observer.gc();
+        observer.get_lease(region_id1, &uuid11).unwrap();
+        assert!(observer.get_lease(region_id1, &uuid12).is_none());
+
+        // Gc reclaims memory.
+        observer
+            .sst_leases
+            .write()
+            .unwrap()
+            .0
+            .reserve(MIN_SHRINK_CAP * 2);
+        observer.gc();
+        let cap = observer.sst_leases.write().unwrap().0.capacity();
+        assert!(cap < MIN_SHRINK_CAP * 2);
+
+        // Gc never block.
+        let observer = Arc::new(observer);
+        let _guard = observer.sst_leases.write().unwrap();
+        let observer_ = observer.clone();
+        let (tx, rx) = channel();
+        thread::spawn(move || {
+            observer_.gc();
+            tx.send(()).unwrap();
+        });
+        rx.recv_timeout(Duration::from_secs(5)).unwrap();
+    }
+}


### PR DESCRIPTION
### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref https://github.com/tikv/tikv/issues/16533

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Introducing `IngestMediator` and `IngestObserver` as fundamental
components to address compatibility concerns between `sst_importer`
and `resolved_ts`.

`IngestMediator` facilitates the publication of ingest events by
`sst_importer`, while `IngestObserver` is responsible for receiving
these events and, if required, halting the advancement of resolved ts.
```

This PR is extracted from #16596 

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
