### PR TITLE
txn: check should_not_exist flag for Flush

### DIFF
--- a/src/storage/txn/actions/prewrite.rs
+++ b/src/storage/txn/actions/prewrite.rs
@@ -449,7 +449,7 @@ impl<'a> PrewriteMutation<'a> {
         // A key can be flushed multiple times for a Pipelined-DML transaction.
         // A latter flush with `should_not_exist` should return error if a previous
         // flush of the key writes a value
-        if self.should_not_exist && matches!(lock.lock_type, LockType::Put) {
+        if lock.generation > 0 && self.should_not_exist && matches!(lock.lock_type, LockType::Put) {
             return Err(ErrorInner::AlreadyExist {
                 key: self.key.to_raw()?,
             }

--- a/src/storage/txn/actions/prewrite.rs
+++ b/src/storage/txn/actions/prewrite.rs
@@ -446,6 +446,16 @@ impl<'a> PrewriteMutation<'a> {
             .into());
         }
 
+        // A key can be flushed multiple times for a Pipelined-DML transaction.
+        // A latter flush with `should_not_exist` should return error if a previous
+        // flush of the key writes a value
+        if self.should_not_exist && matches!(lock.lock_type, LockType::Put) {
+            return Err(ErrorInner::AlreadyExist {
+                key: self.key.to_raw()?,
+            }
+            .into());
+        }
+
         // Duplicated command. No need to overwrite the lock and data.
         MVCC_DUPLICATE_CMD_COUNTER_VEC.prewrite.inc();
         let min_commit_ts = if lock.use_async_commit {

--- a/src/storage/txn/commands/flush.rs
+++ b/src/storage/txn/commands/flush.rs
@@ -224,7 +224,10 @@ mod tests {
 
     use crate::storage::{
         lock_manager::MockLockManager,
-        mvcc::tests::{must_get, must_locked},
+        mvcc::{
+            tests::{must_get, must_locked},
+            Error as MvccError, ErrorInner as MvccErrorInner,
+        },
         txn,
         txn::{
             commands::{Flush, WriteContext, WriteResult},
@@ -245,13 +248,18 @@ mod tests {
         pk: impl Into<Vec<u8>>,
         start_ts: impl Into<TimeStamp>,
         generation: u64,
+        should_not_exist: bool,
     ) -> txn::Result<WriteResult> {
         let key = Key::from_raw(key);
         let start_ts = start_ts.into();
         let cmd = Flush::new(
             start_ts,
             pk.into(),
-            vec![Mutation::make_put(key, value.into())],
+            vec![if should_not_exist {
+                Mutation::make_insert(key, value.into())
+            } else {
+                Mutation::make_put(key, value.into())
+            }],
             generation,
             3000,
             AssertionLevel::Strict,
@@ -280,7 +288,7 @@ mod tests {
         start_ts: impl Into<TimeStamp>,
         generation: u64,
     ) {
-        let res = flush_put_impl(engine, key, value, pk, start_ts, generation);
+        let res = flush_put_impl(engine, key, value, pk, start_ts, generation, false);
         assert!(res.is_ok());
         let res = res.unwrap();
         let to_be_write = res.to_be_write;
@@ -298,7 +306,7 @@ mod tests {
         start_ts: impl Into<TimeStamp>,
         generation: u64,
     ) {
-        let res = flush_put_impl(engine, key, value, pk, start_ts, generation).unwrap();
+        let res = flush_put_impl(engine, key, value, pk, start_ts, generation, false).unwrap();
         if let ProcessResult::MultiRes { results } = res.pr {
             assert!(!results.is_empty());
         } else {
@@ -315,7 +323,20 @@ mod tests {
         start_ts: impl Into<TimeStamp>,
         generation: u64,
     ) -> txn::Error {
-        let res = flush_put_impl(engine, key, value, pk, start_ts, generation);
+        let res = flush_put_impl(engine, key, value, pk, start_ts, generation, false);
+        assert!(res.is_err());
+        res.err().unwrap()
+    }
+
+    pub fn must_flush_insert_err<E: Engine>(
+        engine: &mut E,
+        key: &[u8],
+        value: impl Into<Vec<u8>>,
+        pk: impl Into<Vec<u8>>,
+        start_ts: impl Into<TimeStamp>,
+        generation: u64,
+    ) -> txn::Error {
+        let res = flush_put_impl(engine, key, value, pk, start_ts, generation, true);
         assert!(res.is_err());
         res.err().unwrap()
     }
@@ -390,5 +411,18 @@ mod tests {
         must_locked(&mut engine, k, 1);
         must_commit(&mut engine, k, 1, 2);
         must_get(&mut engine, k, 3, v);
+    }
+
+    #[test]
+    fn test_flushed_existence_check() {
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+        let k = b"key";
+        let v = b"value";
+        must_flush_put(&mut engine, k, *v, k, 1, 1);
+        must_locked(&mut engine, k, 1);
+        assert_matches!(
+            must_flush_insert_err(&mut engine, k, *v, k, 1, 2),
+            Error(box ErrorInner::Mvcc(MvccError(box MvccErrorInner::AlreadyExist { key }))) if key == k
+        );
     }
 }


### PR DESCRIPTION

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #16291

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Check should_not_exist flag for Flush, even when the lock is written by current transaction itself.

This is for the case:
TiDB flush key K.
TiDB do membuffer.CheckMemExist(K) and gets ErrNotFound because the key is flushed to TiKV. 
In vanilla TiDB it is able to know that the key has been written by membuffer.Get(K), 
but for pipelined DML it is too expensive to do a membuffer.Get because it involves a RPC.

To compensate, in this case we let TiDB attach a PresumeNotExist flag to the mutation.
In the next Flush, the should_not_exist flag is attached, 
and during the Flush we detect that the value is written before and return an AlreadyExist error.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
