### PR TITLE
txn: skip assertion checks for pipelined-dml

### DIFF
--- a/src/storage/txn/actions/check_txn_status.rs
+++ b/src/storage/txn/actions/check_txn_status.rs
@@ -322,8 +322,23 @@ pub fn rollback_lock(
         txn.delete_value(key.clone(), lock.ts);
     }
 
-    // Only the primary key of a pessimistic transaction needs to be protected.
-    let protected: bool = is_pessimistic_txn && key.is_encoded_from(&lock.primary);
+    // (1) The primary key of a pessimistic transaction needs to be protected.
+    //
+    // (2) If the lock belongs to a pipelined-DML transaction, it must be protected.
+    //
+    // This is for avoiding false positive of assertion failures.
+    // Consider the sequence of events happening on a same key:
+    // 1. T0 commits at commit_ts=10
+    // 2. T1(pipelined-DML) with start_ts=10 flushes, and assert exist. The
+    //    assertion passes.
+    // 3. T2 rolls back T1. The lock is removed, if this is not protected, there's
+    //    no clue left that indicates T1 is rolled back.
+    // 4. T1 flushes again, and assert not exist. It observes T0's commit and
+    //    assertion failed.
+    // If the lock is protected, the second flush will detect the conflict and
+    // return a write conflict error.
+    let protected: bool =
+        (is_pessimistic_txn && key.is_encoded_from(&lock.primary)) || (lock.generation > 0);
     if let Some(write) = make_rollback(reader.start_ts, protected, overlapped_write) {
         txn.put_write(key.clone(), reader.start_ts, write.as_ref().to_bytes());
     }

--- a/src/storage/txn/actions/prewrite.rs
+++ b/src/storage/txn/actions/prewrite.rs
@@ -94,6 +94,9 @@ pub fn prewrite_with_generation<S: Snapshot>(
             mutation.check_lock(lock, pessimistic_action, expected_for_update_ts, generation)?
         }
         None if matches!(pessimistic_action, DoPessimisticCheck) => {
+            // pipelined DML can't go into this. Otherwise, assertions may need to be
+            // skipped for non-first flushes.
+            assert_eq!(generation, 0);
             amend_pessimistic_lock(&mut mutation, reader)?;
             lock_amended = true;
             LockStatus::None
@@ -125,7 +128,14 @@ pub fn prewrite_with_generation<S: Snapshot>(
     //   assertion here introduces too much overhead. However, we'll do it anyway if
     //   `assertion_level` is set to `Strict` level.
     // Assertion level will be checked within the `check_assertion` function.
-    if !lock_amended {
+    //
+    // By design, each key can be asserted only once in a transaction. For
+    // pipelined-DML, a key may be flushed multiple times. Once a mutation with an
+    // assertion is flushed and dropped from client buffer, the following execution
+    // can set a different assertion for the same key. We only check the first
+    // assertion here, ignoring the rest.
+    let is_subsequent_flush = generation > 0 && matches!(lock_status, LockStatus::Locked(_));
+    if !lock_amended && !is_subsequent_flush {
         let (reloaded_prev_write, reloaded) =
             mutation.check_assertion(reader, &prev_write, prev_write_loaded)?;
         if reloaded {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #16291

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Skip assertion checks for pipelined-dml if the lock is already locked by itself.

By design, each key can be asserted only once in a transaction. For
pipelined-DML, a key may be flushed multiple times. Once a mutation with an
assertion is flushed and dropped from client buffer, the following execution
can set a different assertion for the same key. We only check the first
assertion, ignoring the rest.

In addition, we enforce protecting rollbacks of pipelined-DML locks, 
to avoid corner cases where t0.commit_ts = t1.start_ts. 
See comments for details.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
