### PR TITLE
raftstore: enable async-io by default.

### DIFF
--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -500,7 +500,7 @@ impl Default for Config {
             local_read_batch_size: 1024,
             apply_batch_system: BatchSystemConfig::default(),
             store_batch_system: BatchSystemConfig::default(),
-            store_io_pool_size: 0,
+            store_io_pool_size: 1,
             store_io_notify_capacity: 40960,
             future_poll_size: 1,
             hibernate_regions: true,

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -481,7 +481,7 @@
 
 ## Use how many threads to handle raft io tasks
 ## If it is 0, it means io tasks are handled in store threads.
-# store-io-pool-size = 0
+# store-io-pool-size = 1
 
 ## When the size of raft db writebatch exceeds this value, write will be triggered.
 # raft-write-size-limit = "1MB"

--- a/tests/integrations/config/dynamic/raftstore.rs
+++ b/tests/integrations/config/dynamic/raftstore.rs
@@ -237,6 +237,7 @@ fn test_update_raftstore_io_config() {
     // Start from SYNC mode.
     {
         let (mut resize_config, _dir) = TikvConfig::with_tmp().unwrap();
+        resize_config.raft_store.store_io_pool_size = 0; // SYNC mode
         resize_config.validate().unwrap();
         let (cfg_controller, _, _, mut system) = start_raftstore(resize_config, &_dir);
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

In previous works, we've introduce [raftstore.store-io-pool-size](https://docs.pingcap.com/tidb/v5.3/tikv-configuration-file) to flush raft logs asynchronously.

Compared with default setting(sync-io), enabling async-io:
- Async-IO costs more CPU usages on TiKV side.
- About performance:
  - Introducing async-io, there is no obvious performance regression on READ workloads (YCSB-WORKLOADD, OLTP_READ_ONLY and OLTP_READ_WRITE) both on On-premise and DBaas envs.
  - For DBaas env, performance improvements are impressive and significant on Write intensive workloads with up to ~21% improvements to E2E QPS.
  - For On-Premise env, performance improvements affected by async-io are not apparent as the I/O operations on Disk are fast, CPU.usage costs make more effecst to E2E performance.
    - And as expected, also mentioned in [tune-tikv-thread-performance](https://docs.pingcap.com/tidb/v5.3/tune-tikv-thread-performance), when CPU is busy (CPU.Usage > 80%) in TiKV nodes, async-io feedbacks with worse latency on P99 / AVG as expected.(E2E performance loss < ~3.5%)
    - When CPU is not busy (CPU.Usage < 80%) in TiKV nodes, async-io will bring obvious improvements on throughputs(16c on YCSB-WORKLOADA, E2E performance improvments ~6.3%)

Currently, with plenty of tests and practical proofs, it's appropriate to enable this feature by default.

Issue Number: Close #16614 , Ref https://github.com/pingcap/tidb/issues/51585

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Enable `async-io` by default with changing the setting `raftstore.store-io-pool-size` from 0 to 1.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [x] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility



Taking `ycsb` workloads as example, using 8 cores setting for deploying TiKV nodes,
| CPU Usage | QPS |
| --- | --- |
| ![image](https://github.com/tikv/tikv/assets/18441614/88e23a30-df5b-4f0c-b62f-feb43d29613a) | ![image](https://github.com/tikv/tikv/assets/18441614/d2128425-ee61-4872-adb7-bfb5caf636fa) |
### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Enable `async-io` by default with changing the setting `raftstore.store-io-pool-size` from 0 to 1.
```
