### PR TITLE
copr: don't resize binary opaque when the type flen is unspecified

### DIFF
--- a/components/tidb_query_expr/src/impl_cast.rs
+++ b/components/tidb_query_expr/src/impl_cast.rs
@@ -1385,8 +1385,9 @@ fn cast_string_as_json(
                 let mut vec;
                 if typ.tp() == FieldTypeTp::String {
                     vec = (*val).to_owned();
-                    // the `flen` of string is always greater than zero
-                    vec.resize(typ.flen().try_into().unwrap(), 0);
+                    if typ.flen() > 0 {
+                        vec.resize(typ.flen().try_into().unwrap(), 0);
+                    }
                     buf = &vec;
                 }
 
@@ -7015,6 +7016,17 @@ mod tests {
                 FieldTypeBuilder::new()
                     .tp(FieldTypeTp::VarChar)
                     .flen(256)
+                    .charset(CHARSET_BIN)
+                    .collation(Collation::Binary)
+                    .build(),
+                "a".to_string(),
+                Json::from_opaque(FieldTypeTp::String, &[97]).unwrap(),
+                true,
+            ),
+            (
+                FieldTypeBuilder::new()
+                    .tp(FieldTypeTp::VarChar)
+                    .flen(UNSPECIFIED_LENGTH)
                     .charset(CHARSET_BIN)
                     .collation(Collation::Binary)
                     .build(),


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Close #16616

What's Changed:

If the `flen` is unspecified (-1), don't resize the string to try to produce extra zero. ref https://github.com/pingcap/tidb/pull/51586

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [x] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
None
```
