### PR TITLE
txn: Fix the issue that CheckTxnStatus didn't make rollback on optimistic transaction's primary protected, which may break transaction atomicity

### DIFF
--- a/src/storage/txn/actions/check_txn_status.rs
+++ b/src/storage/txn/actions/check_txn_status.rs
@@ -322,8 +322,10 @@ pub fn rollback_lock(
         txn.delete_value(key.clone(), lock.ts);
     }
 
-    // Only the primary key of a pessimistic transaction needs to be protected.
-    let protected: bool = is_pessimistic_txn && key.is_encoded_from(&lock.primary);
+    // Only the primary key needs to be protected.
+    // The primary keys of optimistic transactions must also be protected, see:
+    // (TODO: github issue link here)
+    let protected: bool = key.is_encoded_from(&lock.primary);
     if let Some(write) = make_rollback(reader.start_ts, protected, overlapped_write) {
         txn.put_write(key.clone(), reader.start_ts, write.as_ref().to_bytes());
     }

--- a/src/storage/txn/commands/check_txn_status.rs
+++ b/src/storage/txn/commands/check_txn_status.rs
@@ -164,7 +164,9 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for CheckTxnStatus {
 #[cfg(test)]
 pub mod tests {
     use concurrency_manager::ConcurrencyManager;
-    use kvproto::kvrpcpb::{self, Context, LockInfo, PrewriteRequestPessimisticAction::*};
+    use kvproto::kvrpcpb::{
+        self, Context, LockInfo, PrewriteRequestPessimisticAction::*, WriteConflictReason,
+    };
     use tikv_util::deadline::Deadline;
     use txn_types::{Key, LastChange, WriteType};
 
@@ -173,7 +175,7 @@ pub mod tests {
         kv::Engine,
         lock_manager::MockLockManager,
         mvcc,
-        mvcc::tests::*,
+        mvcc::{tests::*, ErrorInner},
         txn::{
             self,
             actions::acquire_pessimistic_lock::tests::acquire_pessimistic_lock_allow_lock_with_conflict,
@@ -229,7 +231,12 @@ pub mod tests {
             )
             .unwrap();
         if let ProcessResult::TxnStatus { txn_status } = result.pr {
-            assert!(status_pred(txn_status));
+            let formatted_txn_status = format!("{:?}", txn_status);
+            assert!(
+                status_pred(txn_status),
+                "txn_status returned by check_txn_status ({}) doesn't pass the check",
+                formatted_txn_status
+            );
         } else {
             unreachable!();
         }
@@ -834,6 +841,7 @@ pub mod tests {
             ts(20, 0),
             WriteType::Rollback,
         );
+        must_get_rollback_protected(&mut engine, k, ts(20, 0), true);
 
         // Push the min_commit_ts of pessimistic locks.
         must_acquire_pessimistic_lock_for_large_txn(&mut engine, k, k, ts(4, 0), ts(130, 0), 200);
@@ -1441,5 +1449,62 @@ pub mod tests {
             10,
         )
         .unwrap_err();
+    }
+
+    #[test]
+    fn test_check_txn_status_rollback_optimistic() {
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+        let k = b"k1";
+        let (v1, v2) = (b"v1", b"v2");
+
+        let ts = TimeStamp::compose;
+
+        must_prewrite_put_async_commit(&mut engine, k, v1, k, &Some(vec![]), ts(1, 0), ts(1, 1));
+        must_commit(&mut engine, k, ts(1, 0), ts(2, 0));
+
+        must_prewrite_put(&mut engine, k, v2, k, ts(2, 0));
+        assert!(!must_have_write(&mut engine, k, ts(2, 0)).has_overlapped_rollback);
+
+        must_success(
+            &mut engine,
+            k,
+            ts(2, 0),
+            ts(3, 0),
+            ts(3, 0),
+            true,
+            false,
+            false,
+            |s| s == TtlExpire,
+        );
+        must_get_overlapped_rollback(
+            &mut engine,
+            k,
+            ts(2, 0),
+            ts(1, 0),
+            WriteType::Put,
+            Some(0.into()),
+        );
+
+        let e = must_prewrite_put_err(&mut engine, k, v2, k, ts(2, 0));
+        match &*e.0 {
+            ErrorInner::WriteConflict {
+                start_ts,
+                conflict_start_ts,
+                conflict_commit_ts,
+                key,
+                primary,
+                reason,
+            } => {
+                assert_eq!(*start_ts, ts(2, 0));
+                assert_eq!(*conflict_start_ts, ts(1, 0));
+                assert_eq!(*conflict_commit_ts, ts(2, 0));
+                assert_eq!(key.as_slice(), k);
+                assert_eq!(primary.as_slice(), k);
+                assert_eq!(*reason, WriteConflictReason::SelfRolledBack);
+            }
+            e => {
+                panic!("unexpected error: {:?}", e);
+            }
+        }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #16620

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Fix the issue that CheckTxnStatus didn't make rollback on optimistic transaction's primary protected, which may break transaction atomicity
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fix the issue that CheckTxnStatus didn't make rollback on optimistic transaction's primary protected, which may break transaction atomicity.
```
