### PR TITLE
log_backup: store pending region info when giving up retry

### DIFF
--- a/components/backup-stream/src/subscription_manager.rs
+++ b/components/backup-stream/src/subscription_manager.rs
@@ -252,6 +252,19 @@ async fn scan_executor_loop(init: impl InitialScan, mut cmds: Receiver<ScanCmd>)
     }
 }
 
+/// spawn the executors to some runtime.
+#[cfg(test)]
+fn spawn_executors_to(
+    init: impl InitialScan + Send + Sync + 'static,
+    handle: &tokio::runtime::Handle,
+) -> ScanPoolHandle {
+    let (tx, rx) = tokio::sync::mpsc::channel(MESSAGE_BUFFER_SIZE);
+    handle.spawn(async move {
+        scan_executor_loop(init, rx).await;
+    });
+    ScanPoolHandle { tx }
+}
+
 /// spawn the executors in the scan pool.
 fn spawn_executors(
     init: impl InitialScan + Send + Sync + 'static,
@@ -477,10 +490,11 @@ where
                 return;
             }
             Some(err) => {
+                self.subs
+                    .set_pending_if(&region, |sub, _| sub.handle.id == handle.id);
                 if !should_retry(&err) {
                     self.failure_count.remove(&region.id);
-                    self.subs
-                        .deregister_region_if(&region, |sub, _| sub.handle.id == handle.id);
+                    // The pending record will be cleaned up by `Stop` command.
                     return;
                 }
                 err
@@ -542,7 +556,7 @@ where
         }
         let tx = tx.unwrap();
         // tikv_util::Instant cannot be converted to std::time::Instant :(
-        let start = std::time::Instant::now();
+        let start = tokio::time::Instant::now();
         debug!("Scheduing subscription."; utils::slog_region(&region), "after" => ?backoff, "handle" => ?handle);
         let scheduled = async move {
             tokio::time::sleep_until((start + backoff).into()).await;
@@ -820,7 +834,7 @@ mod test {
             atomic::{AtomicBool, Ordering},
             Arc, Mutex,
         },
-        time::{Duration, Instant},
+        time::Duration,
     };
 
     use engine_test::{kv::KvTestEngine, raft::RaftTestEngine};
@@ -834,11 +848,11 @@ mod test {
         RegionInfo,
     };
     use tikv::{config::BackupStreamConfig, storage::Statistics};
-    use tikv_util::{info, memory::MemoryQuota, worker::dummy_scheduler};
+    use tikv_util::{box_err, info, memory::MemoryQuota, worker::dummy_scheduler};
     use tokio::{sync::mpsc::Sender, task::JoinHandle};
     use txn_types::TimeStamp;
 
-    use super::{spawn_executors, InitialScan, RegionSubscriptionManager};
+    use super::{spawn_executors_to, InitialScan, RegionSubscriptionManager};
     use crate::{
         errors::Error,
         metadata::{store::SlashEtcStore, MetadataClient, StreamTask},
@@ -1018,6 +1032,7 @@ mod test {
             let task_name = "test";
             let task_start_ts = TimeStamp::new(42);
             let pool = tokio::runtime::Builder::new_current_thread()
+                .start_paused(true)
                 .enable_all()
                 .build()
                 .unwrap();
@@ -1057,7 +1072,7 @@ mod test {
                 failure_count: Default::default(),
                 memory_manager,
                 messenger: tx.downgrade(),
-                scan_pool_handle: spawn_executors(init, 2),
+                scan_pool_handle: spawn_executors_to(init, pool.handle()),
                 scans: CallbackWaitGroup::new(),
             };
             let events = Arc::new(Mutex::new(vec![]));
@@ -1176,20 +1191,30 @@ mod test {
                 .unwrap();
         }
 
+        fn sync(&self) {
+            self.rt.block_on(async {
+                let (tx, rx) = tokio::sync::oneshot::channel();
+                self.handle
+                    .as_ref()
+                    .unwrap()
+                    .send(ObserveOp::ResolveRegions {
+                        callback: Box::new(move |_result| {
+                            tx.send(()).unwrap();
+                        }),
+                        min_ts: self.task_start_ts.next(),
+                    })
+                    .await
+                    .unwrap();
+                rx.await.unwrap();
+            })
+        }
+
         #[track_caller]
         fn wait_initial_scan_all_finish(&self, expected_region: usize) {
             info!("[TEST] Start waiting initial scanning finish.");
             self.rt.block_on(async move {
-                let max_wait = Duration::from_secs(1);
-                let start = Instant::now();
-                loop {
+                for _ in 0..200 {
                     let (tx, rx) = tokio::sync::oneshot::channel();
-                    if start.elapsed() > max_wait {
-                        panic!(
-                            "wait initial scan takes too long! events = {:?}",
-                            self.events
-                        );
-                    }
                     self.handle
                         .as_ref()
                         .unwrap()
@@ -1212,6 +1237,10 @@ mod test {
                     // Advance the global timer in case of someone is waiting for timer.
                     tokio::time::advance(Duration::from_secs(16)).await;
                 }
+                panic!(
+                    "wait initial scan takes too long! events = {:?}",
+                    self.events
+                );
             })
         }
 
@@ -1223,7 +1252,6 @@ mod test {
 
     #[test]
     fn test_basic_retry() {
-        test_util::init_log_for_test();
         use ObserveEvent::*;
         let failed = Arc::new(AtomicBool::new(false));
         let mut suite = Suite::new(FuncInitialScan(move |r, _, _| {
@@ -1234,7 +1262,6 @@ mod test {
             Err(Error::OutOfQuota { region_id: r.id })
         }));
         let _guard = suite.rt.enter();
-        tokio::time::pause();
         suite.insert_and_start_region(suite.region(1, 1, 1, b"a", b"b"));
         suite.insert_and_start_region(suite.region(2, 1, 1, b"b", b"c"));
         suite.wait_initial_scan_all_finish(2);
@@ -1256,10 +1283,9 @@ mod test {
     fn test_on_high_mem() {
         let mut suite = Suite::new(FuncInitialScan(|_, _, _| Ok(Statistics::default())));
         let _guard = suite.rt.enter();
-        tokio::time::pause();
         suite.insert_and_start_region(suite.region(1, 1, 1, b"a", b"b"));
         suite.insert_and_start_region(suite.region(2, 1, 1, b"b", b"c"));
-        suite.advance_ms(0);
+        suite.sync();
         let mut rs = suite.subs.current_regions();
         rs.sort();
         assert_eq!(rs, [1, 2]);
@@ -1293,10 +1319,8 @@ mod test {
 
     #[test]
     fn test_region_split_inflight() {
-        test_util::init_log_for_test();
         let mut suite = Suite::new(FuncInitialScan(|_, _, _| Ok(Statistics::default())));
         let _guard = suite.rt.enter();
-        tokio::time::pause();
         suite.insert_region(suite.region(1, 1, 1, b"a", b"b"));
         // Region split..?
         suite.insert_region(suite.region(1, 2, 1, b"a", b"az"));
@@ -1311,5 +1335,78 @@ mod test {
             &*suite.events.lock().unwrap(),
             &[Start(1), RefreshObs(1), StartResult(1, true)]
         );
+    }
+
+    #[test]
+    fn test_unretryable_failure() {
+        let mut suite = Suite::new(FuncInitialScan(move |region, _, _| {
+            if region.get_region_epoch().get_version() != 2 {
+                let mut r2 = region.clone();
+                r2.mut_region_epoch().version = 2;
+                *r2.mut_end_key() = b"az".to_vec();
+                Err(Error::RaftStore(raftstore::Error::EpochNotMatch(
+                    "Testing Testing".to_string(),
+                    vec![r2],
+                )))
+            } else {
+                Ok(Statistics::default())
+            }
+        }));
+        suite.insert_and_start_region(suite.region(1, 1, 1, b"a", b"b"));
+        suite.sync();
+        // The region has been updated!
+        suite.insert_region(suite.region(1, 2, 1, b"a", b"az"));
+        suite.run(ObserveOp::RefreshResolver {
+            region: suite.region(1, 2, 1, b"a", b"az"),
+        });
+        suite.wait_initial_scan_all_finish(1);
+        suite.wait_shutdown();
+        use ObserveEvent::*;
+        assert_eq!(
+            *suite.events.lock().unwrap(),
+            [
+                Start(1),
+                StartResult(1, false),
+                RefreshObs(1),
+                StartResult(1, true)
+            ]
+        );
+    }
+
+    #[test]
+    fn test_always_failure_initial_scan() {
+        let start_time = tokio::time::Instant::now();
+        let target = start_time + Duration::from_secs(300);
+        let init = FuncInitialScan(move |_, _, _| {
+            let now = tokio::time::Instant::now();
+            if now < target {
+                return Err(Error::Other(box_err!(
+                    "work in progress now... please wait more {:?}",
+                    target - now
+                )));
+            }
+            Ok(Statistics::default())
+        });
+        let mut suite = Suite::new(init);
+        let _g = suite.rt.enter();
+        suite.insert_region(suite.region(1, 1, 1, b"a", b"b"));
+        suite.start_region(suite.region(1, 1, 1, b"a", b"b"));
+        suite.wait_initial_scan_all_finish(1);
+        suite.wait_shutdown();
+        fn consume_many<'a, T: Eq>(mut slice: &'a [T], pat: &[T]) -> (&'a [T], usize) {
+            assert!(!pat.is_empty());
+            let mut n = 0;
+            while slice.starts_with(pat) {
+                slice = &slice[pat.len()..];
+                n += 1;
+            }
+            (slice, n)
+        }
+        let events_lock = suite.events.lock().unwrap();
+        let events = events_lock.as_slice();
+        use ObserveEvent::*;
+        let (rem, count) = consume_many(events, &[Start(1), StartResult(1, false)]);
+        assert!(count > 0);
+        assert_eq!(rem, [Start(1), StartResult(1, true)]);
     }
 }

--- a/components/backup-stream/src/subscription_manager.rs
+++ b/components/backup-stream/src/subscription_manager.rs
@@ -559,7 +559,7 @@ where
         let start = tokio::time::Instant::now();
         debug!("Scheduing subscription."; utils::slog_region(&region), "after" => ?backoff, "handle" => ?handle);
         let scheduled = async move {
-            tokio::time::sleep_until((start + backoff).into()).await;
+            tokio::time::sleep_until(start + backoff).await;
             let handle = handle.unwrap_or_else(|| ObserveHandle::new());
             if let Err(err) = tx.send(ObserveOp::Start { region, handle }).await {
                 warn!("log backup failed to schedule start observe."; "err" => %err);

--- a/components/backup-stream/src/subscription_track.rs
+++ b/components/backup-stream/src/subscription_track.rs
@@ -171,6 +171,17 @@ impl SubscriptionTracer {
     /// there are still tiny impure things need to do. (e.g. getting the
     /// checkpoint of this region.)
     ///
+    /// A typical state machine of a region:
+    ///
+    /// ```text
+    ///                             +-----[Start(Err)]------+
+    ///                             +----+   +--------------+
+    ///                                  v   |
+    ///   Absent --------[Start]------> Pending --[Start(OK)]--> Active
+    ///    ^                                |                       |
+    ///    +-------------[Stop]-------------+--------[Stop]---------+
+    /// ```
+    ///
     /// This state is a placeholder for those regions: once they failed in the
     /// impure operations, this would be the evidence proofing they were here.
     ///
@@ -261,6 +272,38 @@ impl SubscriptionTracer {
             }
             })
             .collect()
+    }
+
+    pub fn set_pending_if(
+        &self,
+        region: &Region,
+        if_cond: impl FnOnce(&ActiveSubscription, &Region) -> bool,
+    ) -> bool {
+        let region_id = region.get_id();
+        let remove_result = self.0.entry(region_id);
+        match remove_result {
+            Entry::Vacant(_) => false,
+            Entry::Occupied(mut o) => match o.get_mut() {
+                SubscribeState::Pending(r) => {
+                    info!("remove pending subscription"; "region_id"=> %region_id, utils::slog_region(r));
+
+                    o.remove();
+                    true
+                }
+                SubscribeState::Running(s) => {
+                    if if_cond(s, region) {
+                        let r = s.meta.clone();
+                        TRACK_REGION.dec();
+                        s.stop();
+                        info!("stop listen stream from store"; "observer" => ?s, "region_id"=> %region_id);
+
+                        *o.get_mut() = SubscribeState::Pending(r);
+                        return true;
+                    }
+                    false
+                }
+            },
+        }
     }
 
     /// try to mark a region no longer be tracked by this observer.

--- a/components/backup-stream/src/subscription_track.rs
+++ b/components/backup-stream/src/subscription_track.rs
@@ -284,12 +284,7 @@ impl SubscriptionTracer {
         match remove_result {
             Entry::Vacant(_) => false,
             Entry::Occupied(mut o) => match o.get_mut() {
-                SubscribeState::Pending(r) => {
-                    info!("remove pending subscription"; "region_id"=> %region_id, utils::slog_region(r));
-
-                    o.remove();
-                    true
-                }
+                SubscribeState::Pending(_) => true,
                 SubscribeState::Running(s) => {
                     if if_cond(s, region) {
                         let r = s.meta.clone();

--- a/components/backup-stream/src/subscription_track.rs
+++ b/components/backup-stream/src/subscription_track.rs
@@ -295,7 +295,7 @@ impl SubscriptionTracer {
                         let r = s.meta.clone();
                         TRACK_REGION.dec();
                         s.stop();
-                        info!("stop listen stream from store"; "observer" => ?s, "region_id"=> %region_id);
+                        info!("Inactivating subscription."; "observer" => ?s, "region_id"=> %region_id);
 
                         *o.get_mut() = SubscribeState::Pending(r);
                         return true;


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #16469, Ref #16554 

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:
This PR rearranged the lifetime of a observed region.
For now, we will try to keep it in subscription tracker from `Start` until `End`, even the start itself is failed.
So the `RefreshObserver` will be able to find and start its observe as expected.

This also added a test case for verifying #16554 has been fixed in master.

```commit-message

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fixed a bug that may cause PiTR failed to observe the region.
```
