### PR TITLE
backup-stream: Fix backup-stream make test failure due to race condition

### DIFF
--- a/components/backup-stream/src/tempfiles.rs
+++ b/components/backup-stream/src/tempfiles.rs
@@ -696,6 +696,7 @@ mod test {
 
     use async_compression::tokio::bufread::ZstdDecoder;
     use kvproto::brpb::CompressionType;
+    use rand::random;
     use tempfile::tempdir;
     use tokio::io::{AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader};
     use walkdir::WalkDir;
@@ -716,7 +717,7 @@ mod test {
             cache_size: AtomicUsize::new(100000),
             swap_files: std::env::temp_dir().join(format!(
                 "backup_stream::tempfiles::test::{}",
-                std::process::id()
+                random::<u64>()
             )),
             content_compression: CompressionType::Unknown,
             minimal_swap_out_file_size: 8192,


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #16632

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Using random generated id to separate test dirs for `backup-stream::tempfiles::test`.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

Test only

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
