### PR TITLE
txn: reduce allocation for scan lock

### DIFF
--- a/components/raftstore/src/store/txn_ext.rs
+++ b/components/raftstore/src/store/txn_ext.rs
@@ -258,12 +258,9 @@ impl PeerPessimisticLocks {
         });
 
         for (key, (lock, _)) in removed_locks.into_iter() {
-            let idx = match regions
+            let idx = regions
                 .binary_search_by_key(&&**key.as_encoded(), |region| region.get_start_key())
-            {
-                Ok(idx) => idx,
-                Err(idx) => idx - 1,
-            };
+                .unwrap_or_else(|idx| idx - 1);
             let size = key.len() + lock.memory_size();
             self.memory_size -= size;
             res[idx].map.insert(key, (lock, false));
@@ -287,7 +284,7 @@ impl PeerPessimisticLocks {
         if let (Some(start_key), Some(end_key)) = (start, end) {
             assert!(end_key >= start_key);
         }
-        let mut locks = Vec::with_capacity(limit);
+        let mut locks = Vec::new();
         let mut iter = self.map.range((
             start.map_or(Bound::Unbounded, |k| Bound::Included(k)),
             end.map_or(Bound::Unbounded, |k| Bound::Excluded(k)),


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref #16158

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:
The memory lock scan would be called by `scan_lock` api used by GC and pessimistic lock rollback read stage, there should be only a few keys in most cases so it's unnecessary to allocate `limit`(256 by default) slots every time it is called.

```commit-message
Reduce memory allocation for scan lock.
```


### Related changes



### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test


Side effects



### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
