### PR TITLE
In-memory Engine: remove allow dead_code and unused_variables

### DIFF
--- a/components/region_cache_memory_engine/src/background.rs
+++ b/components/region_cache_memory_engine/src/background.rs
@@ -372,10 +372,7 @@ struct Filter {
     default_cf_handle: Arc<SkipList<InternalBytes, InternalBytes>>,
     write_cf_handle: Arc<SkipList<InternalBytes, InternalBytes>>,
 
-    // the total size of the keys buffered, when it exceeds the limit, all keys in the buffer will
-    // be removed
-    filtered_write_key_size: usize,
-    filtered_write_key_buffer: Vec<Vec<u8>>,
+    // When delete some key, we should delete the latest one last to avoid the older version appear
     cached_delete_key: Option<Vec<u8>>,
 
     versions: usize,
@@ -410,8 +407,6 @@ impl Filter {
             default_cf_handle,
             write_cf_handle,
             unique_key: 0,
-            filtered_write_key_size: 0,
-            filtered_write_key_buffer: Vec::with_capacity(100),
             mvcc_key_prefix: vec![],
             delete_versions: 0,
             versions: 0,
@@ -763,7 +758,6 @@ pub mod tests {
         worker.core.gc_range(&range, 17);
         assert_eq!(1, element_count(&default));
         assert_eq!(1, element_count(&write));
-        let guard = &epoch::pin();
         let key = encode_key(b"key1", TimeStamp::new(15));
         let guard = &epoch::pin();
         assert!(key_exist(&write, &key, guard));

--- a/components/region_cache_memory_engine/src/background.rs
+++ b/components/region_cache_memory_engine/src/background.rs
@@ -372,7 +372,8 @@ struct Filter {
     default_cf_handle: Arc<SkipList<InternalBytes, InternalBytes>>,
     write_cf_handle: Arc<SkipList<InternalBytes, InternalBytes>>,
 
-    // When delete some key, we should delete the latest one last to avoid the older version appear
+    // When deleting some keys, the latest one should be deleted at last to avoid the older
+    // version appears.
     cached_delete_key: Option<Vec<u8>>,
 
     versions: usize,

--- a/components/region_cache_memory_engine/src/engine.rs
+++ b/components/region_cache_memory_engine/src/engine.rs
@@ -20,7 +20,7 @@ use engine_traits::{
 use parking_lot::{lock_api::RwLockUpgradableReadGuard, RwLock, RwLockWriteGuard};
 use skiplist_rs::{base::OwnedIter, SkipList};
 use slog_global::error;
-use tikv_util::{box_err, config::MIB};
+use tikv_util::box_err;
 
 use crate::{
     background::{BackgroundTask, BgWorkManager},
@@ -31,8 +31,6 @@ use crate::{
     range_manager::RangeManager,
     write_batch::{group_write_batch_entries, RangeCacheWriteBatchEntry},
 };
-
-pub(crate) const EVICTION_KEY_BUFFER_LIMIT: usize = 5 * MIB as usize;
 
 pub(crate) fn cf_to_id(cf: &str) -> usize {
     match cf {
@@ -121,10 +119,6 @@ impl SnapshotList {
 
     pub(crate) fn is_empty(&self) -> bool {
         self.0.is_empty()
-    }
-
-    pub(crate) fn len(&self) -> usize {
-        self.0.keys().len()
     }
 }
 
@@ -393,7 +387,6 @@ enum Direction {
 }
 
 pub struct RangeCacheIterator {
-    cf: String,
     valid: bool,
     iter: OwnedIter<Arc<SkipList<InternalBytes, InternalBytes>>, InternalBytes, InternalBytes>,
     // The lower bound is inclusive while the upper bound is exclusive if set
@@ -420,7 +413,8 @@ pub struct RangeCacheIterator {
 impl Iterable for RangeCacheMemoryEngine {
     type Iterator = RangeCacheIterator;
 
-    fn iterator_opt(&self, cf: &str, opts: IterOptions) -> Result<Self::Iterator> {
+    fn iterator_opt(&self, _: &str, _: IterOptions) -> Result<Self::Iterator> {
+        // This engine does not support creating iterator directly by the engine
         unimplemented!()
     }
 }
@@ -774,7 +768,6 @@ impl Iterable for RangeCacheSnapshot {
         }
 
         Ok(RangeCacheIterator {
-            cf: String::from(cf),
             valid: false,
             prefix: None,
             lower_bound,
@@ -803,7 +796,6 @@ impl Peekable for RangeCacheSnapshot {
         key: &[u8],
     ) -> Result<Option<Self::DbVector>> {
         fail::fail_point!("on_range_cache_get_value");
-        let seq = self.sequence_number();
         let mut iter = self.skiplist_engine.data[cf_to_id(cf)].owned_iter();
         let seek_key = encode_seek_key(key, self.sequence_number());
 
@@ -1445,7 +1437,6 @@ mod tests {
         let engine = RangeCacheMemoryEngine::new(Duration::from_secs(1));
         let range = CacheRange::new(b"".to_vec(), b"z".to_vec());
         engine.new_range(range.clone());
-        let step: i32 = 2;
 
         {
             let mut core = engine.core.write();
@@ -1978,7 +1969,7 @@ mod tests {
         let range_left = CacheRange::new(construct_user_key(0), construct_user_key(10));
         let s3 = engine.snapshot(range_left, 20, 20).unwrap();
         let range_right = CacheRange::new(construct_user_key(20), construct_user_key(30));
-        let s4 = engine.snapshot(range_right, 20, 20).unwrap();
+        let _s4 = engine.snapshot(range_right, 20, 20).unwrap();
 
         drop(s3);
         let range_left_eviction = CacheRange::new(construct_user_key(0), construct_user_key(5));

--- a/components/region_cache_memory_engine/src/engine.rs
+++ b/components/region_cache_memory_engine/src/engine.rs
@@ -414,7 +414,7 @@ impl Iterable for RangeCacheMemoryEngine {
     type Iterator = RangeCacheIterator;
 
     fn iterator_opt(&self, _: &str, _: IterOptions) -> Result<Self::Iterator> {
-        // This engine does not support creating iterator directly by the engine
+        // This engine does not support creating iterators directly by the engine.
         unimplemented!()
     }
 }

--- a/components/region_cache_memory_engine/src/lib.rs
+++ b/components/region_cache_memory_engine/src/lib.rs
@@ -1,7 +1,5 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
-#![allow(dead_code)]
-#![allow(unused_variables)]
 #![feature(let_chains)]
 #![feature(slice_pattern)]
 

--- a/components/region_cache_memory_engine/src/range_manager.rs
+++ b/components/region_cache_memory_engine/src/range_manager.rs
@@ -304,10 +304,6 @@ impl RangeManager {
         self.pending_ranges.push(cache_range);
         Ok(())
     }
-
-    pub(crate) fn has_range_to_cache_write(&self) -> bool {
-        !self.pending_ranges_loading_data.is_empty()
-    }
 }
 
 #[derive(Debug, PartialEq)]

--- a/components/region_cache_memory_engine/src/region_label.rs
+++ b/components/region_cache_memory_engine/src/region_label.rs
@@ -82,7 +82,7 @@ pub type RuleFilterFn = Arc<dyn Fn(&LabelRule) -> bool + Send + Sync>;
 #[derive(Clone)]
 pub struct RegionLabelService {
     manager: Arc<RegionLabelRulesManager>,
-    pd_client: Arc<RpcClient>,
+    _pd_client: Arc<RpcClient>,
     meta_client: Checked<Sourced<Arc<RpcClient>>>,
     revision: i64,
     cluster_id: u64,
@@ -132,7 +132,7 @@ impl RegionLabelServiceBuilder {
                 Arc::clone(&self.pd_client.clone()),
                 pd_client::meta_storage::Source::RegionLabel,
             )),
-            pd_client: self.pd_client,
+            _pd_client: self.pd_client,
             path_suffix: self.path_suffix,
             rule_filter_fn: self.rule_filter_fn,
         })

--- a/components/region_cache_memory_engine/src/write_batch.rs
+++ b/components/region_cache_memory_engine/src/write_batch.rs
@@ -172,11 +172,6 @@ impl RangeCacheWriteBatchEntry {
     }
 
     #[inline]
-    pub fn should_write_to_memory(&self, range_manager: &RangeManager) -> bool {
-        range_manager.contains(&self.key)
-    }
-
-    #[inline]
     pub fn write_to_memory(
         &self,
         skiplist_engine: &SkiplistEngine,


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref #16141

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
remove allow dead_code and unused_variables
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
