### PR TITLE
In-memory Engine: make range delete be handled in background

### DIFF
--- a/components/region_cache_memory_engine/src/engine.rs
+++ b/components/region_cache_memory_engine/src/engine.rs
@@ -71,7 +71,7 @@ impl SkiplistEngine {
         self.data[cf_to_id(cf)].clone()
     }
 
-    fn delete_range(&self, range: &CacheRange) {
+    pub fn delete_range(&self, range: &CacheRange) {
         self.data.iter().for_each(|d| {
             let (start, end) = encode_key_for_eviction(range);
             let mut iter = d.owned_iter();
@@ -232,19 +232,20 @@ impl RangeCacheMemoryEngine {
     }
 
     pub fn evict_range(&mut self, range: &CacheRange) {
-        let mut skiplist_engine = None;
-        {
-            let mut core = self.core.write();
-            if core.range_manager.evict_range(range) {
-                // The range can be delete directly.
-                skiplist_engine = Some(core.engine().clone());
+        let mut core = self.core.write();
+        if core.range_manager.evict_range(range) {
+            drop(core);
+            // The range can be delete directly.
+            if let Err(e) = self
+                .bg_worker_manager()
+                .schedule_task(BackgroundTask::DeleteRange(vec![range.clone()]))
+            {
+                error!(
+                    "schedule delete range failed";
+                    "err" => ?e,
+                );
+                assert!(tikv_util::thread_group::is_shutdown(!cfg!(test)));
             }
-        };
-        if let Some(skiplist_engine) = skiplist_engine {
-            // todo(SpadeA): do it in background
-            skiplist_engine.delete_range(range);
-            let mut core = self.core.write();
-            core.mut_range_manager().on_delete_range(range);
         }
     }
 
@@ -306,7 +307,7 @@ impl RangeCacheMemoryEngine {
 
         if let Err(e) = self
             .bg_worker_manager()
-            .schedule_task(BackgroundTask::LoadTask)
+            .schedule_task(BackgroundTask::LoadRange)
         {
             error!(
                 "schedule range load failed";
@@ -721,21 +722,22 @@ impl RangeCacheSnapshot {
 
 impl Drop for RangeCacheSnapshot {
     fn drop(&mut self) {
-        let (ranges_removable, skiplist_engine) = {
-            let mut core = self.engine.core.write();
-            let ranges_removable = core
-                .range_manager
-                .remove_range_snapshot(&self.snapshot_meta);
-            (ranges_removable, core.engine().clone())
-        };
-        for range_removable in &ranges_removable {
-            // todo: schedule it to a separate thread
-            skiplist_engine.delete_range(range_removable);
-        }
+        let mut core = self.engine.core.write();
+        let ranges_removable = core
+            .range_manager
+            .remove_range_snapshot(&self.snapshot_meta);
         if !ranges_removable.is_empty() {
-            let mut core = self.engine.core.write();
-            for range_removable in &ranges_removable {
-                core.mut_range_manager().on_delete_range(range_removable);
+            drop(core);
+            if let Err(e) = self
+                .engine
+                .bg_worker_manager()
+                .schedule_task(BackgroundTask::DeleteRange(ranges_removable))
+            {
+                error!(
+                    "schedule delete range failed";
+                    "err" => ?e,
+                );
+                assert!(tikv_util::thread_group::is_shutdown(!cfg!(test)));
             }
         }
     }
@@ -876,7 +878,7 @@ mod tests {
     use crate::{
         keys::{
             construct_key, construct_user_key, construct_value, decode_key, encode_key,
-            InternalBytes, ValueType,
+            encode_seek_key, InternalBytes, ValueType,
         },
         RangeCacheMemoryEngine,
     };
@@ -1893,6 +1895,32 @@ mod tests {
         });
     }
 
+    fn verify_evict_range_deleted(engine: &RangeCacheMemoryEngine, range: &CacheRange) {
+        let mut wait = 0;
+        while wait < 10 {
+            wait += 1;
+            if !engine
+                .core
+                .read()
+                .range_manager()
+                .evicted_ranges()
+                .is_empty()
+            {
+                std::thread::sleep(Duration::from_millis(200));
+            } else {
+                break;
+            }
+        }
+        let write_handle = engine.core.read().engine.cf_handle("write");
+        let start_key = encode_seek_key(&range.start, u64::MAX);
+        let mut iter = write_handle.owned_iter();
+
+        let guard = &epoch::pin();
+        iter.seek(&start_key, guard);
+        let end = encode_seek_key(&range.end, u64::MAX);
+        assert!(iter.key() > &end || !iter.valid());
+    }
+
     #[test]
     fn test_evict_range_without_snapshot() {
         let mut engine = RangeCacheMemoryEngine::new(Duration::from_secs(1));
@@ -1921,7 +1949,7 @@ mod tests {
 
         engine.evict_range(&evict_range);
         assert!(engine.snapshot(range.clone(), 10, 200).is_none());
-        assert!(engine.snapshot(evict_range, 10, 200).is_none());
+        assert!(engine.snapshot(evict_range.clone(), 10, 200).is_none());
 
         let r_left = CacheRange::new(construct_user_key(0), construct_user_key(10));
         let r_right = CacheRange::new(construct_user_key(20), construct_user_key(30));
@@ -1944,6 +1972,9 @@ mod tests {
         let mut iter = snap_right.iterator_opt("write", iter_opt).unwrap();
         iter.seek_to_first().unwrap();
         verify_key_values(&mut iter, (20..30).step_by(1), 10..11, true, true);
+
+        // verify the key, values are delete
+        verify_evict_range_deleted(&engine, &evict_range);
     }
 
     #[test]
@@ -1984,34 +2015,36 @@ mod tests {
         let range_left_eviction = CacheRange::new(construct_user_key(0), construct_user_key(5));
         engine.evict_range(&range_left_eviction);
 
-        // todo(SpadeA): use memory limiter to check the removal of the node
-        // {
-        //     let removed = engine.memory_limiter.removed.lock().unwrap();
-        //     assert!(removed.is_empty());
-        // }
+        // todo(SpadeA): memory limiter
+        {
+            // evict_range is not eligible for delete
+            assert!(
+                engine
+                    .core
+                    .read()
+                    .range_manager()
+                    .evicted_ranges()
+                    .contains(&evict_range)
+            );
+        }
 
         drop(s1);
-        // todo(SpadeA): use memory limiter to check the removal of the node
-        // {
-        //     let removed = engine.memory_limiter.removed.lock().unwrap();
-        //     for i in 10..20 {
-        //         let user_key = construct_key(i, 10);
-        //         let internal_key = encode_key(&user_key, 10, ValueType::Value);
-        //         assert!(!removed.contains(internal_key.as_slice()));
-        //     }
-        // }
-
+        {
+            // evict_range is still not eligible for delete
+            assert!(
+                engine
+                    .core
+                    .read()
+                    .range_manager()
+                    .evicted_ranges()
+                    .contains(&evict_range)
+            );
+        }
         drop(s2);
-        // todo(SpadeA): use memory limiter to check the removal of the node
-        // s2 is dropped, so the range of `evict_range` is removed. The snapshot
-        // of s3 and s4 does not prevent it as they are not overlapped.
-        // {
-        //     let removed = engine.memory_limiter.removed.lock().unwrap();
-        //     for i in 10..20 {
-        //         let user_key = construct_key(i, 10);
-        //         let internal_key = encode_key(&user_key, 10,
-        // ValueType::Value);         assert!(removed.
-        // contains(internal_key.as_slice()));     }
-        // }
+        // Now, all snapshots before evicting `evict_range` are released
+        verify_evict_range_deleted(&engine, &evict_range);
+
+        drop(s4);
+        verify_evict_range_deleted(&engine, &range_left_eviction);
     }
 }

--- a/components/region_cache_memory_engine/src/range_manager.rs
+++ b/components/region_cache_memory_engine/src/range_manager.rs
@@ -279,16 +279,22 @@ impl RangeManager {
             .any(|r| r.overlaps(evict_range))
     }
 
-    pub fn on_delete_range(&mut self, range: &CacheRange) {
-        self.evicted_ranges.remove(range);
+    pub fn on_delete_ranges(&mut self, ranges: &[CacheRange]) {
+        for r in ranges {
+            self.evicted_ranges.remove(r);
+        }
+    }
+
+    pub fn has_ranges_in_gc(&self) -> bool {
+        !self.ranges_in_gc.is_empty()
     }
 
     pub fn set_ranges_in_gc(&mut self, ranges_in_gc: BTreeSet<CacheRange>) {
         self.ranges_in_gc = ranges_in_gc;
     }
 
-    pub fn clear_ranges_in_gc(&mut self) {
-        self.ranges_in_gc = BTreeSet::default();
+    pub fn on_gc_finished(&mut self, range: BTreeSet<CacheRange>) {
+        assert_eq!(range, std::mem::take(&mut self.ranges_in_gc));
     }
 
     pub fn load_range(&mut self, cache_range: CacheRange) -> Result<(), LoadFailedReason> {
@@ -307,6 +313,10 @@ impl RangeManager {
 
     pub(crate) fn has_range_to_cache_write(&self) -> bool {
         !self.pending_ranges_loading_data.is_empty()
+    }
+
+    pub(crate) fn evicted_ranges(&self) -> &BTreeSet<CacheRange> {
+        &self.evicted_ranges
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref #16141

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
make range delete be handled in background
```
Now, we have background worker, so if the range is evicted and eligible to be removed, delete the range in the background worker.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
