### PR TITLE
test: enhance unstable test test_pool_available_deadline

### DIFF
--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -2307,24 +2307,18 @@ mod tests {
     fn test_pool_available_deadline() {
         let (scheduler, _) = new_test_scheduler();
 
-        // Spawn a task that sleeps for 500ms to occupy the pool. The next request
-        // cannot run within 500ms.
-        scheduler
-            .get_sched_pool()
-            .spawn(TaskMetadata::default(), CommandPri::Normal, async {
-                thread::sleep(Duration::from_millis(500))
-            })
-            .unwrap();
-
         let mut req = BatchRollbackRequest::default();
         req.mut_context().max_execution_duration_ms = 100;
         req.set_keys(vec![b"a".to_vec(), b"b".to_vec(), b"c".to_vec()].into());
-
         let cmd: TypedCommand<()> = req.into();
+
+        // wait to let the cmd timeout.
+        std::thread::sleep(Duration::from_millis(120));
+
         let (cb, f) = paired_future_callback();
         scheduler.run_cmd(cmd.cmd, StorageCallback::Boolean(cb));
 
-        // But the max execution duration is 100ms, so the deadline is exceeded.
+        // the max execution duration is 100ms, so the deadline is exceeded.
         assert!(matches!(
             block_on(f).unwrap(),
             Err(StorageError(box StorageErrorInner::DeadlineExceeded))

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -2312,13 +2312,13 @@ mod tests {
         req.set_keys(vec![b"a".to_vec(), b"b".to_vec(), b"c".to_vec()].into());
         let cmd: TypedCommand<()> = req.into();
 
-        // wait to let the cmd timeout.
+        // Wait enough time to let the cmd timeout.
         std::thread::sleep(Duration::from_millis(120));
 
         let (cb, f) = paired_future_callback();
         scheduler.run_cmd(cmd.cmd, StorageCallback::Boolean(cb));
 
-        // the max execution duration is 100ms, so the deadline is exceeded.
+        // The max execution duration is 100ms, so the deadline is exceeded.
         assert!(matches!(
             block_on(f).unwrap(),
             Err(StorageError(box StorageErrorInner::DeadlineExceeded))


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #16442

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Enhance unstable test test_pool_available_deadline.

The original logica has 2 factors that makes it not stable:
- Thread scheduling. If the 2nd cmd is scheduled 500ms later than the 1st cmd, then the 2nd task won't meet deadline error.
- Threadpool thread count. The yatp's active thread count is not always ensured, it only ensure that within finite duration, the active thread count will reach the target number. Thus if the 2nd thread is scheduled when there are more than 1 active threads, it won't meet deadline error.

I found there is no easy way to ensure that the active thread number is 1 so just let the cmd timeout before it is scheduled to always trigger the deadline error.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
