### PR TITLE
raftstore: optimize AutoSplitController memory usage

### DIFF
--- a/components/collections/src/lib.rs
+++ b/components/collections/src/lib.rs
@@ -10,10 +10,6 @@ pub type HashMap<K, V> =
 pub type HashSet<T> = std::collections::HashSet<T, std::hash::BuildHasherDefault<fxhash::FxHasher>>;
 pub use std::collections::hash_map::Entry as HashMapEntry;
 
-pub fn hash_map_with_capacity<K: Hash + Eq, V>(capacity: usize) -> HashMap<K, V> {
-    HashMap::with_capacity_and_hasher(capacity, fxhash::FxBuildHasher::default())
-}
-
 pub fn hash_set_with_capacity<T: Hash + Eq>(capacity: usize) -> HashSet<T> {
     HashSet::with_capacity_and_hasher(capacity, fxhash::FxBuildHasher::default())
 }

--- a/components/collections/src/lib.rs
+++ b/components/collections/src/lib.rs
@@ -10,6 +10,10 @@ pub type HashMap<K, V> =
 pub type HashSet<T> = std::collections::HashSet<T, std::hash::BuildHasherDefault<fxhash::FxHasher>>;
 pub use std::collections::hash_map::Entry as HashMapEntry;
 
+pub fn hash_map_with_capacity<K: Hash + Eq, V>(capacity: usize) -> HashMap<K, V> {
+    HashMap::with_capacity_and_hasher(capacity, fxhash::FxBuildHasher::default())
+}
+
 pub fn hash_set_with_capacity<T: Hash + Eq>(capacity: usize) -> HashSet<T> {
     HashSet::with_capacity_and_hasher(capacity, fxhash::FxBuildHasher::default())
 }

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -7,7 +7,7 @@ use std::{
     io, mem,
     sync::{
         atomic::Ordering,
-        mpsc::{self, Receiver, Sender},
+        mpsc::{self, Receiver, Sender, SyncSender},
         Arc, Mutex,
     },
     thread::{Builder, JoinHandle},
@@ -575,8 +575,8 @@ where
     reporter: T,
     handle: Option<JoinHandle<()>>,
     timer: Option<Sender<bool>>,
-    read_stats_sender: Option<Sender<ReadStats>>,
-    cpu_stats_sender: Option<Sender<Arc<RawRecords>>>,
+    read_stats_sender: Option<SyncSender<ReadStats>>,
+    cpu_stats_sender: Option<SyncSender<Arc<RawRecords>>>,
     collect_store_infos_interval: Duration,
     load_base_split_check_interval: Duration,
     collect_tick_interval: Duration,
@@ -641,10 +641,10 @@ where
         let (timer_tx, timer_rx) = mpsc::channel();
         self.timer = Some(timer_tx);
 
-        let (read_stats_sender, read_stats_receiver) = mpsc::channel();
+        let (read_stats_sender, read_stats_receiver) = mpsc::sync_channel(128);
         self.read_stats_sender = Some(read_stats_sender);
 
-        let (cpu_stats_sender, cpu_stats_receiver) = mpsc::channel();
+        let (cpu_stats_sender, cpu_stats_receiver) = mpsc::sync_channel(128);
         self.cpu_stats_sender = Some(cpu_stats_sender);
 
         let reporter = self.reporter.clone();
@@ -775,7 +775,7 @@ where
     pub fn maybe_send_read_stats(&self, read_stats: ReadStats) {
         if let Some(sender) = &self.read_stats_sender {
             if sender.send(read_stats).is_err() {
-                warn!("send read_stats failed, are we shutting down?")
+                debug!("send read_stats failed, are we shutting down?")
             }
         }
     }
@@ -784,7 +784,7 @@ where
     pub fn maybe_send_cpu_stats(&self, cpu_stats: &Arc<RawRecords>) {
         if let Some(sender) = &self.cpu_stats_sender {
             if sender.send(cpu_stats.clone()).is_err() {
-                warn!("send region cpu info failed, are we shutting down?")
+                debug!("send region cpu info failed, are we shutting down?")
             }
         }
     }

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -642,11 +642,14 @@ where
         let (timer_tx, timer_rx) = mpsc::channel();
         self.timer = Some(timer_tx);
 
-        let stats_limit = 128;
-        let (read_stats_sender, read_stats_receiver) = mpsc::sync_channel(stats_limit);
+        // The upper bound of buffer stats messages.
+        // It prevents unexpected memory buildup when AutoSplitController
+        // runs slowly.
+        const STATS_LIMIT: usize = 128;
+        let (read_stats_sender, read_stats_receiver) = mpsc::sync_channel(STATS_LIMIT);
         self.read_stats_sender = Some(read_stats_sender);
 
-        let (cpu_stats_sender, cpu_stats_receiver) = mpsc::sync_channel(stats_limit);
+        let (cpu_stats_sender, cpu_stats_receiver) = mpsc::sync_channel(STATS_LIMIT);
         self.cpu_stats_sender = Some(cpu_stats_sender);
 
         let reporter = self.reporter.clone();
@@ -665,7 +668,7 @@ where
                 let mut collect_store_infos_thread_stats = ThreadInfoStatistics::new();
                 let mut load_base_split_thread_stats = ThreadInfoStatistics::new();
                 let mut region_cpu_records_collector = None;
-                let mut auto_split_controller_ctx = AutoSplitControllerContext::new(stats_limit);
+                let mut auto_split_controller_ctx = AutoSplitControllerContext::new(STATS_LIMIT);
                 // Register the region CPU records collector.
                 if auto_split_controller
                     .cfg

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -744,10 +744,16 @@ where
         let mut read_stats_vec = vec![];
         while let Ok(read_stats) = read_stats_receiver.try_recv() {
             read_stats_vec.push(read_stats);
+            if read_stats_vec.len() == 128 {
+                break;
+            }
         }
         let mut cpu_stats_vec = vec![];
         while let Ok(cpu_stats) = cpu_stats_receiver.try_recv() {
             cpu_stats_vec.push(cpu_stats);
+            if cpu_stats_vec.len() == 128 {
+                break;
+            }
         }
         thread_stats.record();
         let (top_qps, split_infos) = auto_split_controller.flush(

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -642,7 +642,7 @@ where
         let (timer_tx, timer_rx) = mpsc::channel();
         self.timer = Some(timer_tx);
 
-        // The upper bound of buffer stats messages.
+        // The upper bound of buffered stats messages.
         // It prevents unexpected memory buildup when AutoSplitController
         // runs slowly.
         const STATS_LIMIT: usize = 128;

--- a/components/raftstore/src/store/worker/split_controller.rs
+++ b/components/raftstore/src/store/worker/split_controller.rs
@@ -22,6 +22,7 @@ use tikv_util::{
     debug, info,
     metrics::ThreadInfoStatistics,
     store::{is_read_query, QueryStats},
+    time::Instant,
     warn,
 };
 
@@ -648,11 +649,15 @@ impl AutoSplitController {
 
     // collect the read stats from read_stats_vec and dispatch them to a Region
     // HashMap.
-    fn collect_read_stats(read_stats_vec: Vec<ReadStats>) -> HashMap<u64, Vec<RegionInfo>> {
+    fn collect_read_stats(
+        ctx: &mut AutoSplitControllerContext,
+        read_stats_receiver: &Receiver<ReadStats>,
+    ) -> HashMap<u64, Vec<RegionInfo>> {
+        let read_stats_vec = ctx.batch_recv_read_stats(read_stats_receiver);
         // RegionID -> Vec<RegionInfo>, collect the RegionInfo from different threads.
         let mut region_infos_map = HashMap::default();
         let capacity = read_stats_vec.len();
-        for read_stats in read_stats_vec {
+        for read_stats in read_stats_vec.drain(..) {
             for (region_id, region_info) in read_stats.region_infos {
                 let region_infos = region_infos_map
                     .entry(region_id)
@@ -665,19 +670,24 @@ impl AutoSplitController {
 
     // collect the CPU stats from cpu_stats_vec and dispatch them to a Region
     // HashMap.
-    fn collect_cpu_stats(
+    fn collect_cpu_stats<'c>(
         &mut self,
-        cpu_stats_vec: Vec<Arc<RawRecords>>,
-        region_cpu_map: &mut HashMap<u64, (f64, Option<KeyRange>)>,
-        hottest_key_range_cpu_time_map: &mut HashMap<u64, u32>,
-    ) {
+        ctx: &'c mut AutoSplitControllerContext,
+        cpu_stats_receiver: &Receiver<Arc<RawRecords>>,
+    ) -> &'c HashMap<u64, (f64, Option<KeyRange>)> {
         // RegionID -> (CPU usage, Hottest Key Range), calculate the CPU usage and its
         // hottest key range.
-        region_cpu_map.clear();
-        hottest_key_range_cpu_time_map.clear();
         if !self.should_check_region_cpu() {
-            return;
+            return ctx.empty_region_cpu_map();
         }
+
+        let (
+            cpu_stats_vec,
+            CpuStatsCache {
+                region_cpu_map,
+                hottest_key_range_cpu_time_map,
+            },
+        ) = ctx.batch_recv_cpu_stats(cpu_stats_receiver);
         // Calculate the Region CPU usage.
         let mut collect_interval_ms = 0;
         let mut region_key_range_cpu_time_map = HashMap::default();
@@ -723,6 +733,7 @@ impl AutoSplitController {
                     *hottest_key_range_cpu_time = *cpu_time;
                 }
             });
+        region_cpu_map
     }
 
     fn collect_thread_usage(thread_stats: &ThreadInfoStatistics, name: &str) -> f64 {
@@ -741,21 +752,17 @@ impl AutoSplitController {
     // be split according to all the stats info the recorder has collected before.
     pub fn flush(
         &mut self,
-        read_stats_vec: Vec<ReadStats>,
-        cpu_stats_vec: Vec<Arc<RawRecords>>,
-        thread_stats: &ThreadInfoStatistics,
-        region_cpu_map: &mut HashMap<u64, (f64, Option<KeyRange>)>,
-        hottest_key_range_cpu_time_map: &mut HashMap<u64, u32>,
+        ctx: &mut AutoSplitControllerContext,
+        read_stats_receiver: &Receiver<ReadStats>,
+        cpu_stats_receiver: &Receiver<Arc<RawRecords>>,
+        thread_stats: &mut ThreadInfoStatistics,
     ) -> (Vec<usize>, Vec<SplitInfo>) {
         let mut top_cpu_usage = vec![];
         let mut top_qps = BinaryHeap::with_capacity(TOP_N);
-        let region_infos_map = Self::collect_read_stats(read_stats_vec);
-        self.collect_cpu_stats(
-            cpu_stats_vec,
-            region_cpu_map,
-            hottest_key_range_cpu_time_map,
-        );
+        let region_infos_map = Self::collect_read_stats(ctx, read_stats_receiver);
+        let region_cpu_map = self.collect_cpu_stats(ctx, cpu_stats_receiver);
         // Prepare some diagnostic info.
+        thread_stats.record();
         let (grpc_thread_usage, unified_read_pool_thread_usage) = (
             Self::collect_thread_usage(thread_stats, "grpc-server"),
             Self::collect_thread_usage(thread_stats, "unified-read-po"),
@@ -946,8 +953,89 @@ impl AutoSplitController {
     }
 }
 
-#[cfg(skip)]
+#[derive(Default)]
+pub struct CpuStatsCache {
+    region_cpu_map: HashMap<u64, (f64, Option<KeyRange>)>,
+    hottest_key_range_cpu_time_map: HashMap<u64, u32>,
+}
+
+pub struct AutoSplitControllerContext {
+    read_stats_vec: Vec<ReadStats>,
+    cpu_stats_vec: Vec<Arc<RawRecords>>,
+    cpu_stats_cache: CpuStatsCache,
+    batch_recv_len: usize,
+
+    last_gc_time: Instant,
+    gc_duration: Duration,
+}
+
+impl AutoSplitControllerContext {
+    pub fn new(batch_recv_len: usize) -> Self {
+        AutoSplitControllerContext {
+            read_stats_vec: Vec::default(),
+            cpu_stats_vec: Vec::default(),
+            cpu_stats_cache: CpuStatsCache::default(),
+            batch_recv_len,
+            last_gc_time: Instant::now_coarse(),
+            // 30 seconds is a balance between efficient memory usage and
+            // maintaining performance under load.
+            gc_duration: Duration::from_secs(30),
+        }
+    }
+
+    pub fn batch_recv_read_stats(
+        &mut self,
+        read_stats_receiver: &Receiver<ReadStats>,
+    ) -> &mut Vec<ReadStats> {
+        self.read_stats_vec.clear();
+
+        while let Ok(read_stats) = read_stats_receiver.try_recv() {
+            self.read_stats_vec.push(read_stats);
+            if self.read_stats_vec.len() == self.batch_recv_len {
+                break;
+            }
+        }
+        &mut self.read_stats_vec
+    }
+
+    pub fn batch_recv_cpu_stats(
+        &mut self,
+        cpu_stats_receiver: &Receiver<Arc<RawRecords>>,
+    ) -> (&mut Vec<Arc<RawRecords>>, &mut CpuStatsCache) {
+        self.cpu_stats_vec.clear();
+        self.cpu_stats_cache.region_cpu_map.clear();
+        self.cpu_stats_cache.hottest_key_range_cpu_time_map.clear();
+
+        while let Ok(cpu_stats) = cpu_stats_receiver.try_recv() {
+            self.cpu_stats_vec.push(cpu_stats);
+            if self.cpu_stats_vec.len() == self.batch_recv_len {
+                break;
+            }
+        }
+        (&mut self.cpu_stats_vec, &mut self.cpu_stats_cache)
+    }
+
+    pub fn empty_region_cpu_map(&mut self) -> &HashMap<u64, (f64, Option<KeyRange>)> {
+        self.cpu_stats_cache.region_cpu_map.clear();
+        &self.cpu_stats_cache.region_cpu_map
+    }
+
+    pub fn maybe_gc(&mut self) {
+        let now = Instant::now_coarse();
+        if now.saturating_duration_since(self.last_gc_time) > self.gc_duration {
+            self.read_stats_vec = Vec::default();
+            self.cpu_stats_vec = Vec::default();
+            self.cpu_stats_cache = CpuStatsCache::default();
+
+            self.last_gc_time = now;
+        }
+    }
+}
+
+#[cfg(test)]
 mod tests {
+    use std::sync::mpsc::{self, TryRecvError};
+
     use online_config::{ConfigChange, ConfigManager, ConfigValue};
     use resource_metering::{RawRecord, TagInfos};
     use tikv_util::config::{ReadableSize, VersionTrack};
@@ -1197,6 +1285,30 @@ mod tests {
         fail::remove("mock_region_is_busy");
     }
 
+    fn new_auto_split_controller_ctx(
+        read_stats: Vec<ReadStats>,
+        cpu_stats: Vec<Arc<RawRecords>>,
+    ) -> (
+        AutoSplitControllerContext,
+        Receiver<ReadStats>,
+        Receiver<Arc<RawRecords>>,
+    ) {
+        let len = std::cmp::max(read_stats.len(), cpu_stats.len());
+        let (read_stats_sender, read_stats_receiver) = mpsc::sync_channel(len);
+        let (cpu_stats_sender, cpu_stats_receiver) = mpsc::sync_channel(len);
+        for s in cpu_stats {
+            cpu_stats_sender.send(s).unwrap();
+        }
+        for s in read_stats {
+            read_stats_sender.send(s).unwrap();
+        }
+        (
+            AutoSplitControllerContext::new(len),
+            read_stats_receiver,
+            cpu_stats_receiver,
+        )
+    }
+
     fn check_split_key(mode: &[u8], qps_stats: Vec<ReadStats>, split_keys: Vec<&[u8]>) {
         let mode = String::from_utf8(Vec::from(mode)).unwrap();
         let mut hub = AutoSplitController::default();
@@ -1204,8 +1316,14 @@ mod tests {
         hub.cfg.sample_threshold = 0;
 
         for i in 0..10 {
-            let (_, split_infos) =
-                hub.flush(qps_stats.clone(), vec![], &ThreadInfoStatistics::default());
+            let (mut ctx, read_stats_receiver, cpu_stats_receiver) =
+                new_auto_split_controller_ctx(qps_stats.clone(), vec![]);
+            let (_, split_infos) = hub.flush(
+                &mut ctx,
+                &read_stats_receiver,
+                &cpu_stats_receiver,
+                &mut ThreadInfoStatistics::default(),
+            );
             if (i + 1) % hub.cfg.detect_times != 0 {
                 continue;
             }
@@ -1237,10 +1355,13 @@ mod tests {
         hub.cfg.sample_threshold = 0;
 
         for i in 0..10 {
+            let (mut ctx, read_stats_receiver, cpu_stats_receiver) =
+                new_auto_split_controller_ctx(qps_stats.clone(), cpu_stats.clone());
             let (_, split_infos) = hub.flush(
-                qps_stats.clone(),
-                cpu_stats.clone(),
-                &ThreadInfoStatistics::default(),
+                &mut ctx,
+                &read_stats_receiver,
+                &cpu_stats_receiver,
+                &mut ThreadInfoStatistics::default(),
             );
             if (i + 1) % hub.cfg.detect_times != 0 {
                 continue;
@@ -1325,7 +1446,15 @@ mod tests {
                 );
             }
             qps_stats_vec.push(qps_stats);
-            hub.flush(qps_stats_vec, vec![], &ThreadInfoStatistics::default());
+
+            let (mut ctx, read_stats_receiver, cpu_stats_receiver) =
+                new_auto_split_controller_ctx(qps_stats_vec.clone(), vec![]);
+            hub.flush(
+                &mut ctx,
+                &read_stats_receiver,
+                &cpu_stats_receiver,
+                &mut ThreadInfoStatistics::default(),
+            );
         }
 
         // Test the empty key ranges.
@@ -1338,7 +1467,15 @@ mod tests {
             qps_stats.add_query_num(1, &Peer::default(), KeyRange::default(), QueryKind::Get);
         }
         qps_stats_vec.push(qps_stats);
-        hub.flush(qps_stats_vec, vec![], &ThreadInfoStatistics::default());
+
+        let (mut ctx, read_stats_receiver, cpu_stats_receiver) =
+            new_auto_split_controller_ctx(qps_stats_vec, vec![]);
+        hub.flush(
+            &mut ctx,
+            &read_stats_receiver,
+            &cpu_stats_receiver,
+            &mut ThreadInfoStatistics::default(),
+        );
     }
 
     fn check_sample_length(key_ranges: Vec<Vec<KeyRange>>) {
@@ -1686,7 +1823,9 @@ mod tests {
     #[test]
     fn test_collect_cpu_stats() {
         let mut auto_split_controller = AutoSplitController::default();
-        let region_cpu_map = auto_split_controller.collect_cpu_stats(vec![]);
+
+        let (mut ctx, _, cpu_stats_receiver) = new_auto_split_controller_ctx(vec![], vec![]);
+        let region_cpu_map = auto_split_controller.collect_cpu_stats(&mut ctx, &cpu_stats_receiver);
         assert!(region_cpu_map.is_empty());
 
         let ab_key_range_tag = Arc::new(TagInfos {
@@ -1774,8 +1913,11 @@ mod tests {
                     write_keys: 0,
                 },
             );
+
+            let (mut ctx, _, cpu_stats_receiver) =
+                new_auto_split_controller_ctx(vec![], vec![Arc::new(raw_records)]);
             let region_cpu_map =
-                auto_split_controller.collect_cpu_stats(vec![Arc::new(raw_records)]);
+                auto_split_controller.collect_cpu_stats(&mut ctx, &cpu_stats_receiver);
             assert_eq!(
                 region_cpu_map.len(),
                 1,
@@ -1876,12 +2018,21 @@ mod tests {
         for _i in 0..10 {
             other_qps_stats.push(default_qps_stats());
         }
+        let (read_stats_sender, read_stats_receiver) = mpsc::sync_channel(other_qps_stats.len());
+        let (_, cpu_stats_receiver) = mpsc::sync_channel(other_qps_stats.len());
+        let mut ctx = AutoSplitControllerContext::new(other_qps_stats.len());
+        let mut threads = ThreadInfoStatistics::default();
+
         b.iter(|| {
             let mut hub = AutoSplitController::default();
+            for s in other_qps_stats.clone() {
+                read_stats_sender.send(s).unwrap();
+            }
             hub.flush(
-                other_qps_stats.clone(),
-                vec![],
-                &ThreadInfoStatistics::default(),
+                &mut ctx,
+                &read_stats_receiver,
+                &cpu_stats_receiver,
+                &mut threads,
             );
         });
     }
@@ -1921,5 +2072,100 @@ mod tests {
                 QueryKind::Get,
             );
         });
+    }
+
+    #[test]
+    fn test_auto_split_controller_ctx_batch_recv() {
+        let batch_limit = 3;
+        let mut ctx = AutoSplitControllerContext::new(batch_limit);
+        for len in [0, 2, 3, 5, 6] {
+            let (read_stats_sender, read_stats_receiver) = mpsc::sync_channel(len);
+            let (cpu_stats_sender, cpu_stats_receiver) = mpsc::sync_channel(len);
+
+            let read_stats = ReadStats::default();
+            let cpu_stats = Arc::new(RawRecords::default());
+            for _ in 0..len {
+                read_stats_sender.send(read_stats.clone()).unwrap();
+                cpu_stats_sender.send(cpu_stats.clone()).unwrap();
+            }
+            loop {
+                let batch = ctx.batch_recv_read_stats(&read_stats_receiver);
+                if batch.is_empty() {
+                    break;
+                }
+                assert!(
+                    batch.len() == batch_limit || batch.len() == len % batch_limit,
+                    "{:?}",
+                    (len, batch.len())
+                );
+            }
+            assert_eq!(
+                read_stats_receiver.try_recv().unwrap_err(),
+                TryRecvError::Empty
+            );
+
+            loop {
+                let (batch, cache) = ctx.batch_recv_cpu_stats(&cpu_stats_receiver);
+                if batch.is_empty() {
+                    break;
+                }
+                assert!(
+                    batch.len() == batch_limit || batch.len() == len % batch_limit,
+                    "{:?}",
+                    (len, batch.len())
+                );
+                assert!(cache.region_cpu_map.is_empty());
+                assert!(cache.hottest_key_range_cpu_time_map.is_empty());
+                // The cache should be empty after the batch_recv_cpu_stats.
+                cache.region_cpu_map.insert(1, (0.0, None));
+                cache.hottest_key_range_cpu_time_map.insert(1, 1);
+            }
+            assert_eq!(
+                read_stats_receiver.try_recv().unwrap_err(),
+                TryRecvError::Empty
+            );
+        }
+    }
+
+    #[test]
+    fn test_auto_split_controller_empty_region_cpu_map() {
+        let mut ctx = AutoSplitControllerContext::new(1);
+        ctx.cpu_stats_cache.region_cpu_map.insert(1, (0.0, None));
+        assert!(ctx.empty_region_cpu_map().is_empty());
+    }
+
+    #[test]
+    fn test_auto_split_controller_empty_gc() {
+        let mut ctx = AutoSplitControllerContext::new(1);
+        ctx.cpu_stats_cache.region_cpu_map.insert(1, (0.0, None));
+        ctx.cpu_stats_cache
+            .hottest_key_range_cpu_time_map
+            .insert(1, 1);
+        ctx.cpu_stats_vec.push(Arc::new(RawRecords::default()));
+        ctx.read_stats_vec.push(ReadStats::default());
+
+        ctx.last_gc_time = Instant::now_coarse();
+        ctx.maybe_gc();
+
+        assert!(!ctx.cpu_stats_cache.region_cpu_map.is_empty());
+        assert!(
+            !ctx.cpu_stats_cache
+                .hottest_key_range_cpu_time_map
+                .is_empty()
+        );
+        assert!(!ctx.cpu_stats_vec.is_empty());
+        assert!(!ctx.read_stats_vec.is_empty());
+
+        ctx.last_gc_time = Instant::now_coarse() - 2 * ctx.gc_duration;
+        ctx.maybe_gc();
+
+        assert!(ctx.cpu_stats_cache.region_cpu_map.is_empty());
+        assert!(
+            ctx.cpu_stats_cache
+                .hottest_key_range_cpu_time_map
+                .is_empty()
+        );
+        assert!(ctx.cpu_stats_vec.is_empty());
+        assert!(ctx.read_stats_vec.is_empty());
     }
 }

--- a/components/raftstore/src/store/worker/split_controller.rs
+++ b/components/raftstore/src/store/worker/split_controller.rs
@@ -2,12 +2,13 @@
 
 use std::{
     cmp::{min, Ordering},
-    collections::{BinaryHeap, HashMap, HashSet},
+    collections::{BinaryHeap, HashSet},
     slice::{Iter, IterMut},
     sync::{mpsc::Receiver, Arc},
     time::{Duration, SystemTime},
 };
 
+use collections::HashMap;
 use kvproto::{
     kvrpcpb::KeyRange,
     metapb::{self, Peer},
@@ -665,18 +666,21 @@ impl AutoSplitController {
     // collect the CPU stats from cpu_stats_vec and dispatch them to a Region
     // HashMap.
     fn collect_cpu_stats(
-        &self,
+        &mut self,
         cpu_stats_vec: Vec<Arc<RawRecords>>,
-    ) -> HashMap<u64, (f64, Option<KeyRange>)> {
+        region_cpu_map: &mut HashMap<u64, (f64, Option<KeyRange>)>,
+        hottest_key_range_cpu_time_map: &mut HashMap<u64, u32>,
+    ) {
         // RegionID -> (CPU usage, Hottest Key Range), calculate the CPU usage and its
         // hottest key range.
-        let mut region_cpu_map = HashMap::default();
+        region_cpu_map.clear();
+        hottest_key_range_cpu_time_map.clear();
         if !self.should_check_region_cpu() {
-            return region_cpu_map;
+            return;
         }
         // Calculate the Region CPU usage.
         let mut collect_interval_ms = 0;
-        let mut region_key_range_cpu_time_map = HashMap::new();
+        let mut region_key_range_cpu_time_map = HashMap::default();
         cpu_stats_vec.iter().for_each(|cpu_stats| {
             cpu_stats.records.iter().for_each(|(tag, record)| {
                 // Calculate the Region ID -> CPU Time.
@@ -703,7 +707,6 @@ impl AutoSplitController {
             }
         });
         // Choose the hottest key range for each Region.
-        let mut hottest_key_range_cpu_time_map = HashMap::with_capacity(region_cpu_map.len());
         region_key_range_cpu_time_map
             .iter()
             .for_each(|((region_id, key_range), cpu_time)| {
@@ -720,7 +723,6 @@ impl AutoSplitController {
                     *hottest_key_range_cpu_time = *cpu_time;
                 }
             });
-        region_cpu_map
     }
 
     fn collect_thread_usage(thread_stats: &ThreadInfoStatistics, name: &str) -> f64 {
@@ -742,11 +744,17 @@ impl AutoSplitController {
         read_stats_vec: Vec<ReadStats>,
         cpu_stats_vec: Vec<Arc<RawRecords>>,
         thread_stats: &ThreadInfoStatistics,
+        region_cpu_map: &mut HashMap<u64, (f64, Option<KeyRange>)>,
+        hottest_key_range_cpu_time_map: &mut HashMap<u64, u32>,
     ) -> (Vec<usize>, Vec<SplitInfo>) {
         let mut top_cpu_usage = vec![];
         let mut top_qps = BinaryHeap::with_capacity(TOP_N);
         let region_infos_map = Self::collect_read_stats(read_stats_vec);
-        let region_cpu_map = self.collect_cpu_stats(cpu_stats_vec);
+        self.collect_cpu_stats(
+            cpu_stats_vec,
+            region_cpu_map,
+            hottest_key_range_cpu_time_map,
+        );
         // Prepare some diagnostic info.
         let (grpc_thread_usage, unified_read_pool_thread_usage) = (
             Self::collect_thread_usage(thread_stats, "grpc-server"),
@@ -938,7 +946,7 @@ impl AutoSplitController {
     }
 }
 
-#[cfg(test)]
+#[cfg(skip)]
 mod tests {
     use online_config::{ConfigChange, ConfigManager, ConfigValue};
     use resource_metering::{RawRecord, TagInfos};
@@ -1677,7 +1685,7 @@ mod tests {
 
     #[test]
     fn test_collect_cpu_stats() {
-        let auto_split_controller = AutoSplitController::default();
+        let mut auto_split_controller = AutoSplitController::default();
         let region_cpu_map = auto_split_controller.collect_cpu_stats(vec![]);
         assert!(region_cpu_map.is_empty());
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!
 
If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #16653

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
raftstore: optimize AutoSplitController memory usage

* Replaced unbounded channels with bounded channels to prevent unexpected
  memory buildup when AutoSplitController runs slowly.
* Implemented reusability of temporary vectors and maps during CPU stats
  handling to reduce memory allocation and deallocation overhead, saving
  about 10% CPU.
```

Tests shows that it saves about 10% CPU, and memory usage is much stable.

| Header | 2024-03-20 nightly | With this PR |
|--------|--------|--------|
| CPU | ![image](https://github.com/tikv/tikv/assets/2150711/4a7b867e-34ef-4d7a-a086-471d3722d7da)| ![image](https://github.com/tikv/tikv/assets/2150711/9c6a9547-073e-4e5b-8c8a-7ec7944afd6f) |
| Memory\* | ![image](https://github.com/tikv/tikv/assets/2150711/b270dd31-173e-4bbf-9648-52ba62262001) <br/> OOM frequently | ![image](https://github.com/tikv/tikv/assets/2150711/df3d1a20-13f6-42dd-9b4b-912691f045ac)|

The memory test is conducted with PR #16662.

### Check List

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
