### PR TITLE
In-memory Engine: decouple load with split and fix a bug

### DIFF
--- a/components/hybrid_engine/src/snapshot.rs
+++ b/components/hybrid_engine/src/snapshot.rs
@@ -133,6 +133,7 @@ mod tests {
         CacheRange, IterOptions, Iterable, Iterator, KvEngine, Mutable, SnapshotContext,
         WriteBatch, WriteBatchExt, CF_DEFAULT,
     };
+    use region_cache_memory_engine::range_manager::RangeCacheStatus;
 
     use crate::util::hybrid_engine_for_tests;
 
@@ -161,7 +162,9 @@ mod tests {
             assert!(!iter.seek_to_first().unwrap());
         }
         let mut write_batch = hybrid_engine.write_batch();
-        write_batch.cache_write_batch.set_range_in_cache(true);
+        write_batch
+            .cache_write_batch
+            .set_range_cache_status(RangeCacheStatus::Cached);
         write_batch.put(b"hello", b"world").unwrap();
         let seq = write_batch.write().unwrap();
         assert!(seq > 0);

--- a/components/hybrid_engine/src/write_batch.rs
+++ b/components/hybrid_engine/src/write_batch.rs
@@ -138,6 +138,7 @@ mod tests {
     use engine_traits::{
         CacheRange, KvEngine, Mutable, Peekable, SnapshotContext, WriteBatch, WriteBatchExt,
     };
+    use region_cache_memory_engine::range_manager::RangeCacheStatus;
 
     use crate::util::hybrid_engine_for_tests;
 
@@ -157,7 +158,9 @@ mod tests {
             })
             .unwrap();
         let mut write_batch = hybrid_engine.write_batch();
-        write_batch.cache_write_batch.set_range_in_cache(true);
+        write_batch
+            .cache_write_batch
+            .set_range_cache_status(RangeCacheStatus::Cached);
         write_batch.put(b"hello", b"world").unwrap();
         let seq = write_batch.write().unwrap();
         assert!(seq > 0);

--- a/components/region_cache_memory_engine/src/engine.rs
+++ b/components/region_cache_memory_engine/src/engine.rs
@@ -228,7 +228,8 @@ impl RangeCacheMemoryEngine {
 
     /// Load the range in the in-memory engine.
     // This method only push the range in the `pending_range` where sometime
-    // later, the range will be scheduled to load snapshot data into engine.
+    // later in `prepare_for_apply`, the range will be scheduled to load snapshot
+    // data into engine.
     pub fn load_range(&self, range: CacheRange) -> result::Result<(), LoadFailedReason> {
         let mut core = self.core.write();
         core.mut_range_manager().load_range(range)

--- a/components/region_cache_memory_engine/src/engine.rs
+++ b/components/region_cache_memory_engine/src/engine.rs
@@ -5,6 +5,7 @@ use std::{
     collections::BTreeMap,
     fmt::{self, Debug},
     ops::Deref,
+    result,
     sync::Arc,
     time::Duration,
 };
@@ -228,7 +229,7 @@ impl RangeCacheMemoryEngine {
     /// Load the range in the in-memory engine.
     // This method only push the range in the `pending_range` where sometime
     // later, the range will be scheduled to load snapshot data into engine.
-    pub fn load_range(&self, range: CacheRange) -> Result<(), LoadFailedReason> {
+    pub fn load_range(&self, range: CacheRange) -> result::Result<(), LoadFailedReason> {
         let mut core = self.core.write();
         core.mut_range_manager().load_range(range)
     }
@@ -1887,7 +1888,7 @@ mod tests {
 
     #[test]
     fn test_evict_range_without_snapshot() {
-        let mut engine = RangeCacheMemoryEngine::new(Duration::from_secs(1));
+        let engine = RangeCacheMemoryEngine::new(Duration::from_secs(1));
         let range = CacheRange::new(construct_user_key(0), construct_user_key(30));
         let evict_range = CacheRange::new(construct_user_key(10), construct_user_key(20));
         engine.new_range(range.clone());
@@ -1940,7 +1941,7 @@ mod tests {
 
     #[test]
     fn test_evict_range_with_snapshot() {
-        let mut engine = RangeCacheMemoryEngine::new(Duration::from_secs(1));
+        let engine = RangeCacheMemoryEngine::new(Duration::from_secs(1));
         let range = CacheRange::new(construct_user_key(0), construct_user_key(30));
         let evict_range = CacheRange::new(construct_user_key(10), construct_user_key(20));
         engine.new_range(range.clone());

--- a/components/region_cache_memory_engine/src/range_manager.rs
+++ b/components/region_cache_memory_engine/src/range_manager.rs
@@ -100,11 +100,11 @@ pub struct RangeManager {
     // further write batch being cached. We must ensure the cached write batch is empty at the time
     // the range becoming accessable range.
     //
-    // Note: the region with range equaling to the range in the `pending_range`
-    // may have been splited. This is fine, we just let the first child region that
-    // calls the prepare_for_apply to schedule it. We should cache writes for all child regions,
-    // and the load task completes as long as the snapshot has been loaded and the cached write
-    // batches for this super range have all been consumed.
+    // Note: the region with range equaling to the range in the `pending_range` may have been
+    // split. This is fine, we just let the first child region that calls the prepare_for_apply
+    // to schedule it. We should cache writes for all child regions, and the load task
+    // completes as long as the snapshot has been loaded and the cached write batches for this
+    // super range have all been consumed.
     pub(crate) pending_ranges: Vec<CacheRange>,
     pub(crate) pending_ranges_loading_data: VecDeque<(CacheRange, Arc<RocksSnapshot>)>,
 

--- a/components/region_cache_memory_engine/src/range_manager.rs
+++ b/components/region_cache_memory_engine/src/range_manager.rs
@@ -100,9 +100,11 @@ pub struct RangeManager {
     // further write batch being cached. We must ensure the cached write batch is empty at the time
     // the range becoming accessable range.
     //
-    // Note: the range transferred from pending_range *must be* performed by the peer whose region
-    // range equals to it. If split happened, the first noticed peer should first split the range
-    // in the pending_range and then only handles its part.
+    // Note: the region with range equaling to the range in the `pending_range`
+    // may have been splited. This is fine, we just let the first child region that
+    // calls the prepare_for_apply to schedule it. We should cache writes for all child regions,
+    // and the load task completes as long as the snapshot has been loaded and the cached write
+    // batches for this super range have all been consumed.
     pub(crate) pending_ranges: Vec<CacheRange>,
     pub(crate) pending_ranges_loading_data: VecDeque<(CacheRange, Arc<RocksSnapshot>)>,
 

--- a/components/region_cache_memory_engine/src/range_manager.rs
+++ b/components/region_cache_memory_engine/src/range_manager.rs
@@ -326,6 +326,12 @@ pub enum LoadFailedReason {
     Evicted,
 }
 
+pub(crate) enum RangeCacheStatus {
+    NotInCache,
+    Cached,
+    Loading,
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeSet;

--- a/components/region_cache_memory_engine/src/range_manager.rs
+++ b/components/region_cache_memory_engine/src/range_manager.rs
@@ -326,7 +326,7 @@ pub enum LoadFailedReason {
     Evicted,
 }
 
-pub(crate) enum RangeCacheStatus {
+pub enum RangeCacheStatus {
     NotInCache,
     Cached,
     Loading,

--- a/components/region_cache_memory_engine/src/write_batch.rs
+++ b/components/region_cache_memory_engine/src/write_batch.rs
@@ -13,8 +13,8 @@ use crate::{
 };
 
 // `prepare_for_range` should be called before raft command apply for each peer
-// delegate. It sets `range_in_cache` and `pending_range_in_loading` which are
-// used to determine whether the writes of this peer should be buffered.
+// delegate. It sets `range_cache_status` which is used to determine whether the
+// writes of this peer should be buffered.
 pub struct RangeCacheWriteBatch {
     // `range_cache_status` indicates whether the range is cached, loading data, or not cached. If
     // it is cached, we should buffer the write in `buffer` which is consumed during the write
@@ -89,7 +89,7 @@ impl RangeCacheWriteBatch {
     }
 
     #[inline]
-    pub(crate) fn set_range_cache_status(&mut self, range_cache_status: RangeCacheStatus) {
+    pub fn set_range_cache_status(&mut self, range_cache_status: RangeCacheStatus) {
         self.range_cache_status = range_cache_status;
     }
 

--- a/tests/failpoints/cases/test_range_cache_engine.rs
+++ b/tests/failpoints/cases/test_range_cache_engine.rs
@@ -453,5 +453,5 @@ fn test_load_with_eviction() {
         .get_cf_with_snap_ctx(CF_DEFAULT, b"k15", snap_ctx.clone())
         .unwrap();
     assert_eq!(&val, b"v");
-    assert!(rx.try_recv().is_err());
+    rx.try_recv().unwrap_err();
 }

--- a/tests/failpoints/cases/test_range_cache_engine.rs
+++ b/tests/failpoints/cases/test_range_cache_engine.rs
@@ -1,8 +1,16 @@
-use std::{sync::mpsc::sync_channel, time::Duration};
+use std::{
+    sync::{mpsc::sync_channel, Arc, Mutex},
+    time::Duration,
+};
 
-use engine_traits::{CacheRange, SnapshotContext, CF_WRITE};
+use engine_traits::{CacheRange, RangeCacheEngine, SnapshotContext, CF_DEFAULT, CF_WRITE};
 use keys::{data_key, DATA_MAX_KEY, DATA_MIN_KEY};
-use test_raftstore::new_node_cluster_with_hybrid_engine;
+use kvproto::raft_cmdpb::RaftCmdRequest;
+use test_raftstore::{
+    make_cb, new_node_cluster_with_hybrid_engine, new_put_cmd, new_request, Cluster,
+    HybridEngineImpl, NodeCluster, Simulator,
+};
+use tikv_util::HandyRwLock;
 use txn_types::Key;
 
 #[test]
@@ -97,9 +105,15 @@ fn test_load() {
             cluster.must_put_cf(CF_WRITE, &encoded_key, b"val-write");
         }
 
-        rx.recv_timeout(Duration::from_secs(5)).unwrap();
-        rx.recv_timeout(Duration::from_secs(5)).unwrap();
-        rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        if concurrent_with_split {
+            // The range is not splitted at the time of becoming pending
+            rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        } else {
+            // ensure the snapshot is loaded
+            rx.recv_timeout(Duration::from_secs(5)).unwrap();
+            rx.recv_timeout(Duration::from_secs(5)).unwrap();
+            rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        }
 
         for i in (1..30).step_by(2) {
             let key = format!("key-{:04}", i);
@@ -246,4 +260,198 @@ fn test_write_batch_cache_during_load() {
         // verify it's read from range cache engine
         assert!(rx2.try_recv().unwrap());
     }
+}
+
+#[test]
+// It tests that after we schedule the pending range to load snapshot, the range
+// splits.
+fn test_load_with_split() {
+    let mut cluster = new_node_cluster_with_hybrid_engine(0, 1);
+    cluster.cfg.raft_store.apply_batch_system.pool_size = 2;
+    cluster.run();
+
+    for i in (0..30).step_by(2) {
+        let key = format!("key-{:04}", i);
+        let encoded_key = Key::from_raw(key.as_bytes())
+            .append_ts(20.into())
+            .into_encoded();
+        cluster.must_put(&encoded_key, b"val-default");
+        cluster.must_put_cf(CF_WRITE, &encoded_key, b"val-write");
+    }
+
+    let (tx, rx) = sync_channel(0);
+    // let channel to make load process block at finishing loading snapshot
+    let (tx2, rx2) = sync_channel(0);
+    let rx2 = Arc::new(Mutex::new(rx2));
+    fail::cfg_callback("on_snapshot_loaded", move || {
+        tx.send(true).unwrap();
+        let _ = rx2.lock().unwrap().recv().unwrap();
+    })
+    .unwrap();
+
+    // load range
+    {
+        let range_cache_engine = cluster.get_range_cache_engine(1);
+        let mut core = range_cache_engine.core().write();
+        // Load the whole range as if it is not splitted. Loading process should handle
+        // it correctly.
+        let cache_range = CacheRange::new(DATA_MIN_KEY.to_vec(), DATA_MAX_KEY.to_vec());
+        core.mut_range_manager().load_range(cache_range).unwrap();
+    }
+
+    rx.recv_timeout(Duration::from_secs(5)).unwrap();
+    // Now, the snapshot load is finished, and blocked before consuming cached
+    // write batches. Let split the range.
+
+    let r = cluster.get_region(b"");
+    let split_key1 = format!("key-{:04}", 10).into_bytes();
+    cluster.must_split(&r, &split_key1);
+    let r = cluster.get_region(&split_key1);
+    let split_key2 = format!("key-{:04}", 20).into_bytes();
+    cluster.must_split(&r, &split_key2);
+    // Now, we have 3 regions: [min, 10), [10, 20), [20, max)
+
+    for i in (1..30).step_by(2) {
+        let key = format!("key-{:04}", i);
+        let encoded_key = Key::from_raw(key.as_bytes())
+            .append_ts(20.into())
+            .into_encoded();
+        cluster.must_put(&encoded_key, b"val-default");
+        cluster.must_put_cf(CF_WRITE, &encoded_key, b"val-write");
+    }
+
+    // unblock loading task
+    tx2.send(true).unwrap();
+
+    let (tx, rx) = sync_channel(1);
+    fail::cfg_callback("on_range_cache_get_value", move || {
+        tx.send(true).unwrap();
+    })
+    .unwrap();
+
+    let snap_ctx = SnapshotContext {
+        read_ts: 20,
+        range: None,
+    };
+
+    for i in 0..30 {
+        let key = format!("key-{:04}", i);
+        let encoded_key = Key::from_raw(key.as_bytes())
+            .append_ts(20.into())
+            .into_encoded();
+        let val = cluster
+            .get_cf_with_snap_ctx(CF_WRITE, &encoded_key, snap_ctx.clone())
+            .unwrap();
+        assert_eq!(&val, b"val-write");
+        // verify it's read from range cache engine
+        assert!(rx.try_recv().unwrap());
+
+        let val = cluster
+            .get_with_snap_ctx(&encoded_key, snap_ctx.clone())
+            .unwrap();
+        assert_eq!(&val, b"val-default");
+        // verify it's read from range cache engine
+        assert!(rx.try_recv().unwrap());
+    }
+}
+
+fn make_write_req(
+    cluster: &mut Cluster<HybridEngineImpl, NodeCluster<HybridEngineImpl>>,
+    k: &[u8],
+) -> RaftCmdRequest {
+    let r = cluster.get_region(k);
+    let mut req = new_request(
+        r.get_id(),
+        r.get_region_epoch().clone(),
+        vec![new_put_cmd(k, b"v")],
+        false,
+    );
+    let leader = cluster.leader_of_region(r.get_id()).unwrap();
+    req.mut_header().set_peer(leader);
+    req
+}
+
+#[test]
+// It tests that for a apply delete, at the time it prepares to apply something,
+// the range of it is in pending range. When it begins to write the write batch
+// to engine, the range has finished the loading, became a normal range, and
+// even been evicted.
+fn test_load_with_eviction() {
+    let mut cluster = new_node_cluster_with_hybrid_engine(0, 1);
+    cluster.run();
+    // load range
+    {
+        let range_cache_engine = cluster.get_range_cache_engine(1);
+        let mut core = range_cache_engine.core().write();
+        // Load the whole range as if it is not splitted. Loading process should handle
+        // it correctly.
+        let cache_range = CacheRange::new(DATA_MIN_KEY.to_vec(), DATA_MAX_KEY.to_vec());
+        core.mut_range_manager().load_range(cache_range).unwrap();
+    }
+
+    let r = cluster.get_region(b"");
+    cluster.must_split(&r, b"k10");
+
+    fail::cfg("on_write_impl", "pause").unwrap();
+    let write_req = make_write_req(&mut cluster, b"k01");
+    let (cb, mut cb_rx) = make_cb::<HybridEngineImpl>(&write_req);
+    cluster
+        .sim
+        .rl()
+        .async_command_on_node(1, write_req, cb)
+        .unwrap();
+
+    let write_req = make_write_req(&mut cluster, b"k15");
+    let (cb, mut cb_rx2) = make_cb::<HybridEngineImpl>(&write_req);
+    cluster
+        .sim
+        .rl()
+        .async_command_on_node(1, write_req, cb)
+        .unwrap();
+
+    {
+        let range_cache_engine = cluster.get_range_cache_engine(1);
+        let mut tried_count = 0;
+        while range_cache_engine
+            .snapshot(
+                CacheRange::new(DATA_MIN_KEY.to_vec(), DATA_MAX_KEY.to_vec()),
+                u64::MAX,
+                u64::MAX,
+            )
+            .is_none()
+            && tried_count < 5
+        {
+            std::thread::sleep(Duration::from_millis(100));
+            tried_count += 1;
+        }
+        // Now, the range (DATA_MIN_KEY, DATA_MAX_KEY) should be cached
+        let range = CacheRange::new(data_key(b"k10"), DATA_MAX_KEY.to_vec());
+        range_cache_engine.evict_range(&range);
+    }
+
+    fail::remove("on_write_impl");
+    let _ = cb_rx.recv_timeout(Duration::from_secs(5));
+    let _ = cb_rx2.recv_timeout(Duration::from_secs(5));
+
+    let (tx, rx) = sync_channel(1);
+    fail::cfg_callback("on_range_cache_get_value", move || {
+        tx.send(true).unwrap();
+    })
+    .unwrap();
+
+    let snap_ctx = SnapshotContext {
+        read_ts: u64::MAX,
+        range: None,
+    };
+    let val = cluster
+        .get_cf_with_snap_ctx(CF_DEFAULT, b"k01", snap_ctx.clone())
+        .unwrap();
+    assert_eq!(&val, b"v");
+    assert!(rx.try_recv().unwrap());
+
+    let val = cluster
+        .get_cf_with_snap_ctx(CF_DEFAULT, b"k15", snap_ctx.clone())
+        .unwrap();
+    assert_eq!(&val, b"v");
+    assert!(rx.try_recv().is_err());
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref #16141

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
simplify load and fix a bug
```
Currently, when the region of the range in `pending_range` splits, the range will also be splitted and scheduled to loading snapshot separately by each splited regions. 
This is unnecessary. **We can guarantee the data completeness as long as the snapshot is loaded and all the writes of the range after the acquirement of the snapshot are consumed, regardless of whether the range has been splitted or not**.

This PR also fixes a bug:
in `group_write_batch_entries`, we should also consider that the range may be evicted. This is to say that the range is loading data at the begin of apply entries. During the apply, the range has finished the load, and even been evicted.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
