### PR TITLE
raftstore: Avoid snapshot IO in raftstore thread

### DIFF
--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -3222,7 +3222,7 @@ where
             // No need to get snapshot for witness, as witness's empty snapshot bypass
             // snapshot manager.
             let key = SnapKey::from_region_snap(region_id, snap);
-            self.ctx.snap_mgr.check_snapshot_meta_file_exist(&key)?;
+            self.ctx.snap_mgr.meta_file_exist(&key)?;
             Some(key)
         } else {
             None

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -3222,7 +3222,7 @@ where
             // No need to get snapshot for witness, as witness's empty snapshot bypass
             // snapshot manager.
             let key = SnapKey::from_region_snap(region_id, snap);
-            self.ctx.snap_mgr.get_snapshot_for_applying(&key)?;
+            self.ctx.snap_mgr.check_snapshot_meta_file_exist(&key)?;
             Some(key)
         } else {
             None

--- a/components/raftstore/src/store/snap.rs
+++ b/components/raftstore/src/store/snap.rs
@@ -1710,6 +1710,20 @@ impl SnapManager {
         Ok(Box::new(s))
     }
 
+    pub fn check_snapshot_meta_file_exist(&self, key: &SnapKey) -> RaftStoreResult<()> {
+        let _lock = self.core.registry.rl();
+        let base = &self.core.base;
+        // Use CheckPolicy::None to avoid reading meta file 
+        let s = Snapshot::new(base, key, false, CheckPolicy::None, &self.core)?;
+        if !file_exists(&s.meta_file.path) {
+            return Err(RaftStoreError::Other(From::from(format!(
+                "snapshot of {:?} not exists.",
+                key
+            ))));
+        }
+        Ok(())
+    }
+
     /// Get the approximate size of snap file exists in snap directory.
     ///
     /// Return value is not guaranteed to be accurate.

--- a/components/raftstore/src/store/snap.rs
+++ b/components/raftstore/src/store/snap.rs
@@ -718,21 +718,11 @@ impl Snapshot {
                     ));
                 }
                 if meta.get_size() != 0 {
-                    let file_path = self.cf_files[cf_idx].add_file_with_size_checksum(
+                    let _ = self.cf_files[cf_idx].add_file_with_size_checksum(
                         file_idx,
                         meta.get_size(),
                         meta.get_checksum(),
                     );
-                    if file_exists(&file_path) {
-                        let mgr = self.mgr.encryption_key_manager.as_ref();
-                        let file_path = Path::new(&file_path);
-                        let (_, size) = calc_checksum_and_size(file_path, mgr)?;
-                        check_file_size(
-                            size,
-                            *(self.cf_files[cf_idx].size.last().unwrap()),
-                            file_path,
-                        )?;
-                    }
                 }
                 file_idx += 1;
                 if file_idx >= cf_file_count_from_meta[cf_idx] {

--- a/components/raftstore/src/store/snap.rs
+++ b/components/raftstore/src/store/snap.rs
@@ -1705,7 +1705,7 @@ impl SnapManager {
         let base = &self.core.base;
         // Use CheckPolicy::None to avoid reading meta file
         let s = Snapshot::new(base, key, false, CheckPolicy::None, &self.core)?;
-        if !file_exists(&s.meta_file.path) {
+        if !file_exists(s.meta_file.path.as_path()) {
             return Err(RaftStoreError::Other(From::from(format!(
                 "snapshot of {:?} not exists.",
                 key

--- a/components/raftstore/src/store/snap.rs
+++ b/components/raftstore/src/store/snap.rs
@@ -1700,10 +1700,10 @@ impl SnapManager {
         Ok(Box::new(s))
     }
 
-    pub fn check_snapshot_meta_file_exist(&self, key: &SnapKey) -> RaftStoreResult<()> {
+    pub fn meta_file_exist(&self, key: &SnapKey) -> RaftStoreResult<()> {
         let _lock = self.core.registry.rl();
         let base = &self.core.base;
-        // Use CheckPolicy::None to avoid reading meta file 
+        // Use CheckPolicy::None to avoid reading meta file
         let s = Snapshot::new(base, key, false, CheckPolicy::None, &self.core)?;
         if !file_exists(&s.meta_file.path) {
             return Err(RaftStoreError::Other(From::from(format!(

--- a/components/raftstore/src/store/snap.rs
+++ b/components/raftstore/src/store/snap.rs
@@ -2776,26 +2776,6 @@ pub mod tests {
         assert!(s2.exists());
     }
 
-    // Make all the snapshot in the specified dir corrupted to have incorrect size.
-    fn corrupt_snapshot_size_in<T: Into<PathBuf>>(dir: T) {
-        let dir_path = dir.into();
-        let read_dir = file_system::read_dir(dir_path).unwrap();
-        for p in read_dir {
-            if p.is_ok() {
-                let e = p.as_ref().unwrap();
-                if !e
-                    .file_name()
-                    .into_string()
-                    .unwrap()
-                    .ends_with(META_FILE_SUFFIX)
-                {
-                    let mut f = OpenOptions::new().append(true).open(e.path()).unwrap();
-                    f.write_all(b"xxxxx").unwrap();
-                }
-            }
-        }
-    }
-
     // Make all the snapshot in the specified dir corrupted to have incorrect
     // checksum.
     fn corrupt_snapshot_checksum_in<T: Into<PathBuf>>(dir: T) -> Vec<SnapshotMeta> {
@@ -2896,7 +2876,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_snap_corruption_on_size_or_checksum() {
+    fn test_snap_corruption_on_checksum() {
         let region_id = 1;
         let region = gen_test_region(region_id, 1, 1);
         let db_dir = Builder::new()
@@ -2915,21 +2895,10 @@ pub mod tests {
         let mut s1 = Snapshot::new_for_building(dir.path(), &key, &mgr_core).unwrap();
         assert!(!s1.exists());
 
-        let _ = s1
+        let snap_data = s1
             .build(&db, &snapshot, &region, true, false, UnixSecs::now())
             .unwrap();
         assert!(s1.exists());
-
-        corrupt_snapshot_size_in(dir.path());
-
-        Snapshot::new_for_sending(dir.path(), &key, &mgr_core).unwrap_err();
-
-        let mut s2 = Snapshot::new_for_building(dir.path(), &key, &mgr_core).unwrap();
-        assert!(!s2.exists());
-        let snap_data = s2
-            .build(&db, &snapshot, &region, true, false, UnixSecs::now())
-            .unwrap();
-        assert!(s2.exists());
 
         let dst_dir = Builder::new()
             .prefix("test-snap-corruption-dst")
@@ -2943,12 +2912,11 @@ pub mod tests {
             snap_data.get_meta().clone(),
         );
 
-        let mut metas = corrupt_snapshot_checksum_in(dst_dir.path());
+        let metas = corrupt_snapshot_checksum_in(dst_dir.path());
         assert_eq!(1, metas.len());
-        let snap_meta = metas.pop().unwrap();
 
-        let mut s5 = Snapshot::new_for_applying(dst_dir.path(), &key, &mgr_core).unwrap();
-        assert!(s5.exists());
+        let mut s2 = Snapshot::new_for_applying(dst_dir.path(), &key, &mgr_core).unwrap();
+        assert!(s2.exists());
 
         let dst_db_dir = Builder::new()
             .prefix("test-snap-corruption-dst-db")
@@ -2963,11 +2931,7 @@ pub mod tests {
             coprocessor_host: CoprocessorHost::<KvTestEngine>::default(),
             ingest_copy_symlink: false,
         };
-        s5.apply(options).unwrap_err();
-
-        corrupt_snapshot_size_in(dst_dir.path());
-        Snapshot::new_for_receiving(dst_dir.path(), &key, &mgr_core, snap_meta).unwrap_err();
-        Snapshot::new_for_applying(dst_dir.path(), &key, &mgr_core).unwrap_err();
+        s2.apply(options).unwrap_err();
     }
 
     #[test]


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close https://github.com/tikv/tikv/issues/16564

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Avoid snapshot IO in raftstore thread
```
This PR does:
- Only check snapshot meta file existence when receiving snapshot message so that don't need to read meta file content 
- Don't calculate checksum when loading snapshot meta, because it would check in `validate`

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [x] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Avoid snapshot IO in raftstore thread
```
