### PR TITLE
In-Memory: implement hybrid snapshot iter

### DIFF
--- a/components/engine_traits/src/iterable.rs
+++ b/components/engine_traits/src/iterable.rs
@@ -109,44 +109,6 @@ pub trait Iterator: Send {
     fn valid(&self) -> Result<bool>;
 }
 
-impl<T: Iterator + ?Sized> Iterator for Box<T> {
-    fn seek(&mut self, key: &[u8]) -> Result<bool> {
-        (**self).seek(key)
-    }
-
-    fn seek_for_prev(&mut self, key: &[u8]) -> Result<bool> {
-        (**self).seek_for_prev(key)
-    }
-
-    fn seek_to_first(&mut self) -> Result<bool> {
-        (**self).seek_to_first()
-    }
-
-    fn seek_to_last(&mut self) -> Result<bool> {
-        (**self).seek_to_last()
-    }
-
-    fn prev(&mut self) -> Result<bool> {
-        (**self).prev()
-    }
-
-    fn next(&mut self) -> Result<bool> {
-        (**self).next()
-    }
-
-    fn key(&self) -> &[u8] {
-        (**self).key()
-    }
-
-    fn value(&self) -> &[u8] {
-        (**self).value()
-    }
-
-    fn valid(&self) -> Result<bool> {
-        (**self).valid()
-    }
-}
-
 pub trait RefIterable {
     type Iterator<'a>: Iterator
     where

--- a/components/engine_traits/src/iterable.rs
+++ b/components/engine_traits/src/iterable.rs
@@ -109,6 +109,44 @@ pub trait Iterator: Send {
     fn valid(&self) -> Result<bool>;
 }
 
+impl<T: Iterator + ?Sized> Iterator for Box<T> {
+    fn seek(&mut self, key: &[u8]) -> Result<bool> {
+        (**self).seek(key)
+    }
+
+    fn seek_for_prev(&mut self, key: &[u8]) -> Result<bool> {
+        (**self).seek_for_prev(key)
+    }
+
+    fn seek_to_first(&mut self) -> Result<bool> {
+        (**self).seek_to_first()
+    }
+
+    fn seek_to_last(&mut self) -> Result<bool> {
+        (**self).seek_to_last()
+    }
+
+    fn prev(&mut self) -> Result<bool> {
+        (**self).prev()
+    }
+
+    fn next(&mut self) -> Result<bool> {
+        (**self).next()
+    }
+
+    fn key(&self) -> &[u8] {
+        (**self).key()
+    }
+
+    fn value(&self) -> &[u8] {
+        (**self).value()
+    }
+
+    fn valid(&self) -> Result<bool> {
+        (**self).valid()
+    }
+}
+
 pub trait RefIterable {
     type Iterator<'a>: Iterator
     where

--- a/components/hybrid_engine/src/db_vector.rs
+++ b/components/hybrid_engine/src/db_vector.rs
@@ -1,0 +1,91 @@
+// Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::{
+    fmt::{self, Debug, Formatter},
+    ops::Deref,
+};
+
+use engine_traits::{DbVector, KvEngine, Peekable, RangeCacheEngine, ReadOptions, Result};
+use tikv_util::Either;
+
+pub struct HybridDbVector<EK, EC>
+where
+    EK: KvEngine,
+    EC: RangeCacheEngine,
+{
+    db_vec: Either<<EK::Snapshot as Peekable>::DbVector, <EC::Snapshot as Peekable>::DbVector>,
+}
+
+impl<EK, EC> DbVector for HybridDbVector<EK, EC>
+where
+    EK: KvEngine,
+    EC: RangeCacheEngine,
+{
+}
+
+impl<EK, EC> HybridDbVector<EK, EC>
+where
+    EK: KvEngine,
+    EC: RangeCacheEngine,
+{
+    pub fn try_from_disk_snap(
+        snap: &EK::Snapshot,
+        opts: &ReadOptions,
+        cf: &str,
+        key: &[u8],
+    ) -> Result<Option<Self>> {
+        Ok(snap
+            .get_value_cf_opt(opts, cf, key)?
+            .map(|e| HybridDbVector {
+                db_vec: Either::Left(e),
+            }))
+    }
+
+    pub fn try_from_cache_snap(
+        snap: &EC::Snapshot,
+        opts: &ReadOptions,
+        cf: &str,
+        key: &[u8],
+    ) -> Result<Option<Self>> {
+        Ok(snap
+            .get_value_cf_opt(opts, cf, key)?
+            .map(|e| HybridDbVector {
+                db_vec: Either::Right(e),
+            }))
+    }
+}
+
+impl<EK, EC> Deref for HybridDbVector<EK, EC>
+where
+    EK: KvEngine,
+    EC: RangeCacheEngine,
+{
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        match self.db_vec {
+            Either::Left(ref db_vec) => db_vec,
+            Either::Right(ref db_vec) => db_vec,
+        }
+    }
+}
+
+impl<EK, EC> Debug for HybridDbVector<EK, EC>
+where
+    EK: KvEngine,
+    EC: RangeCacheEngine,
+{
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{:?}", &**self)
+    }
+}
+
+impl<'a, EK, EC> PartialEq<&'a [u8]> for HybridDbVector<EK, EC>
+where
+    EK: KvEngine,
+    EC: RangeCacheEngine,
+{
+    fn eq(&self, rhs: &&[u8]) -> bool {
+        **rhs == **self
+    }
+}

--- a/components/hybrid_engine/src/engine_iterator.rs
+++ b/components/hybrid_engine/src/engine_iterator.rs
@@ -1,6 +1,6 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_traits::{Iterator, KvEngine, RangeCacheEngine, Result};
+use engine_traits::{Iterable, Iterator, KvEngine, RangeCacheEngine, Result};
 use tikv_util::Either;
 
 pub struct HybridEngineIterator<EK, EC>
@@ -8,7 +8,7 @@ where
     EK: KvEngine,
     EC: RangeCacheEngine,
 {
-    iter: Either<EK::Iterator, EC::Iterator>,
+    iter: Either<<EK::Snapshot as Iterable>::Iterator, <EC::Snapshot as Iterable>::Iterator>,
 }
 
 impl<EK, EC> HybridEngineIterator<EK, EC>
@@ -16,13 +16,13 @@ where
     EK: KvEngine,
     EC: RangeCacheEngine,
 {
-    pub fn disk_engine_iterator(iter: EK::Iterator) -> Self {
+    pub fn disk_engine_iterator(iter: <EK::Snapshot as Iterable>::Iterator) -> Self {
         Self {
             iter: Either::Left(iter),
         }
     }
 
-    pub fn region_cache_engine_iterator(iter: EC::Iterator) -> Self {
+    pub fn region_cache_engine_iterator(iter: <EC::Snapshot as Iterable>::Iterator) -> Self {
         Self {
             iter: Either::Right(iter),
         }

--- a/components/hybrid_engine/src/iterable.rs
+++ b/components/hybrid_engine/src/iterable.rs
@@ -2,20 +2,18 @@
 
 use engine_traits::{IterOptions, Iterable, KvEngine, RangeCacheEngine, Result};
 
-use crate::{engine::HybridEngine, engine_iterator::HybridEngineIterator};
+use crate::engine::HybridEngine;
 
 impl<EK, EC> Iterable for HybridEngine<EK, EC>
 where
     EK: KvEngine,
     EC: RangeCacheEngine,
 {
-    type Iterator = HybridEngineIterator<EK, EC>;
+    type Iterator = EK::Iterator;
 
     fn iterator_opt(&self, cf: &str, opts: IterOptions) -> Result<Self::Iterator> {
         // Iterator of region cache engine should only be created from the
         // snapshot of it
-        self.disk_engine()
-            .iterator_opt(cf, opts)
-            .map(|iter| HybridEngineIterator::disk_engine_iterator(iter))
+        self.disk_engine().iterator_opt(cf, opts)
     }
 }

--- a/components/hybrid_engine/src/lib.rs
+++ b/components/hybrid_engine/src/lib.rs
@@ -7,6 +7,7 @@ mod cf_options;
 mod checkpoint;
 mod compact;
 mod db_options;
+mod db_vector;
 mod engine;
 mod engine_iterator;
 mod flow_control_factors;

--- a/components/hybrid_engine/src/write_batch.rs
+++ b/components/hybrid_engine/src/write_batch.rs
@@ -11,7 +11,7 @@ use crate::engine::HybridEngine;
 
 pub struct HybridEngineWriteBatch<EK: KvEngine> {
     disk_write_batch: EK::WriteBatch,
-    cache_write_batch: RangeCacheWriteBatch,
+    pub(crate) cache_write_batch: RangeCacheWriteBatch,
 }
 
 impl<EK> WriteBatchExt for HybridEngine<EK, RangeCacheMemoryEngine>


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref #16141 Close #16684

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Implements an iterator for HybridEngineSnapshot and fixes a bug in HybridEngineSnapshot::get_value_opt (memory-engine only supports the data cfs.)
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)
Tested during TPCC runs in a separate branch.
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
None
-->

```release-note
None

```
