### PR TITLE
Add a metrics for cdc to observe the region count that use too long to do incremental scan

### DIFF
--- a/components/cdc/src/initializer.rs
+++ b/components/cdc/src/initializer.rs
@@ -270,14 +270,14 @@ impl<E: KvEngine> Initializer<E> {
 
         while !done {
             // Add metrics to observe long time incremental scan region count
-            if (!scan_long_time) && start.saturating_elapsed() > Duration::from_secs(60) {
+            if !scan_long_time && start.saturating_elapsed() > Duration::from_secs(60) {
                 CDC_SCAN_LONG_DURATION_REGIONS.inc();
                 defer!(CDC_SCAN_LONG_DURATION_REGIONS.dec());
-        
+
                 scan_long_time = true;
                 warn!("cdc incremental scan takes too long"; "region_id" => region_id, "conn_id" => ?self.conn_id, 
                       "downstream_id" => ?self.downstream_id, "takes" => ?start.saturating_elapsed());
-            } 
+            }
             // When downstream_state is Stopped, it means the corresponding
             // delegate is stopped. The initialization can be safely canceled.
             if self.downstream_state.load() == DownstreamState::Stopped {

--- a/components/cdc/src/initializer.rs
+++ b/components/cdc/src/initializer.rs
@@ -266,7 +266,14 @@ impl<E: KvEngine> Initializer<E> {
             DownstreamState::Initializing | DownstreamState::Stopped
         ));
 
+        let mut scan_long_time = false;
         while !done {
+            // Add metrics to observe long time incremental scan region count
+            if (!scan_long_time) && start.saturating_elapsed() > Duration::from_secs(60) {
+                CDC_SCAN_LONG_DURATION_REGIONS.inc();
+                scan_long_time = true;
+                warn!("cdc incremental scan takes too long"; "region_id" => region_id, "conn_id" => ?self.conn_id, "downstream_id" => ?self.downstream_id, "takes" => ?start.saturating_elapsed());
+            } 
             // When downstream_state is Stopped, it means the corresponding
             // delegate is stopped. The initialization can be safely canceled.
             if self.downstream_state.load() == DownstreamState::Stopped {
@@ -300,6 +307,10 @@ impl<E: KvEngine> Initializer<E> {
 
         if let Some(resolver) = resolver {
             self.finish_building_resolver(resolver, region);
+        }
+
+        if scan_long_time {
+            CDC_SCAN_LONG_DURATION_REGIONS.dec();
         }
 
         CDC_SCAN_DURATION_HISTOGRAM.observe(takes.as_secs_f64());

--- a/components/cdc/src/metrics.rs
+++ b/components/cdc/src/metrics.rs
@@ -96,7 +96,7 @@ lazy_static! {
     pub static ref CDC_SCAN_LONG_DURATION_REGIONS : IntGauge = register_int_gauge!(
         "tikv_cdc_scan_long_duration_region",
         "The number of regions that take a long time to scan"
-    ).unwrap()
+    ).unwrap();
     pub static ref CDC_SCAN_BYTES: IntCounter = register_int_counter!(
         "tikv_cdc_scan_bytes_total",
         "Total fetched bytes of CDC incremental scan"

--- a/components/cdc/src/metrics.rs
+++ b/components/cdc/src/metrics.rs
@@ -93,6 +93,10 @@ lazy_static! {
         "Bucketed histogram of cdc async scan sink time duration",
     )
     .unwrap();
+    pub static ref CDC_SCAN_LONG_DURATION_REGIONS : IntGauge = register_int_gauge!(
+        "tikv_cdc_scan_long_duration_region",
+        "The number of regions that take a long time to scan"
+    ).unwrap()
     pub static ref CDC_SCAN_BYTES: IntCounter = register_int_counter!(
         "tikv_cdc_scan_bytes_total",
         "Total fetched bytes of CDC incremental scan"


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref https://github.com/tikv/tikv/issues/12592

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:
Add a new metrics called tikv_cdc_scan_long_duration_region to observe the region count that use too long to do incremental scan.

```commit-message

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
