### PR TITLE
In-memory engine: make integration tests reusable for hybrid engine

### DIFF
--- a/components/hybrid_engine/src/engine.rs
+++ b/components/hybrid_engine/src/engine.rs
@@ -235,7 +235,6 @@ mod tests {
         memory_engine.new_range(range.clone());
         {
             let mut core = memory_engine.core().write();
-            core.mut_range_manager().set_range_readable(&range, true);
             core.mut_range_manager().set_safe_point(&range, 10);
         }
 
@@ -250,17 +249,6 @@ mod tests {
         let s = hybrid_engine.snapshot(Some(snap_ctx.clone()));
         assert!(s.region_cache_snapshot_available());
 
-        {
-            let mut core = memory_engine.core().write();
-            core.mut_range_manager().set_range_readable(&range, false);
-        }
-        let s = hybrid_engine.snapshot(Some(snap_ctx.clone()));
-        assert!(!s.region_cache_snapshot_available());
-
-        {
-            let mut core = memory_engine.core().write();
-            core.mut_range_manager().set_range_readable(&range, true);
-        }
         snap_ctx.read_ts = 5;
         let s = hybrid_engine.snapshot(Some(snap_ctx));
         assert!(!s.region_cache_snapshot_available());

--- a/components/hybrid_engine/src/import.rs
+++ b/components/hybrid_engine/src/import.rs
@@ -12,6 +12,6 @@ where
     type IngestExternalFileOptions = EK::IngestExternalFileOptions;
 
     fn ingest_external_file_cf(&self, cf: &str, files: &[&str]) -> engine_traits::Result<()> {
-        unimplemented!()
+        self.disk_engine().ingest_external_file_cf(cf, files)
     }
 }

--- a/components/hybrid_engine/src/snapshot.rs
+++ b/components/hybrid_engine/src/snapshot.rs
@@ -150,8 +150,6 @@ mod tests {
                 memory_engine.new_range(range_clone.clone());
                 {
                     let mut core = memory_engine.core().write();
-                    core.mut_range_manager()
-                        .set_range_readable(&range_clone, true);
                     core.mut_range_manager().set_safe_point(&range_clone, 5);
                 }
             })

--- a/components/hybrid_engine/src/sst.rs
+++ b/components/hybrid_engine/src/sst.rs
@@ -6,7 +6,7 @@ use engine_traits::{
 
 use crate::engine::HybridEngine;
 
-pub struct HybridEngineSstWriteBuilder {}
+pub struct HybridEngineSstWriteBuilder<EK: SstExt>(EK::SstWriterBuilder);
 
 impl<EK, EC> SstExt for HybridEngine<EK, EC>
 where
@@ -15,39 +15,39 @@ where
 {
     type SstReader = EK::SstReader;
     type SstWriter = EK::SstWriter;
-    type SstWriterBuilder = HybridEngineSstWriteBuilder;
+    type SstWriterBuilder = HybridEngineSstWriteBuilder<EK>;
 }
 
-impl<EK, EC> SstWriterBuilder<HybridEngine<EK, EC>> for HybridEngineSstWriteBuilder
+impl<EK, EC> SstWriterBuilder<HybridEngine<EK, EC>> for HybridEngineSstWriteBuilder<EK>
 where
     EK: KvEngine,
     EC: RangeCacheEngine,
 {
     fn new() -> Self {
-        unimplemented!()
+        HybridEngineSstWriteBuilder(EK::SstWriterBuilder::new())
     }
 
-    fn set_db(self, _db: &HybridEngine<EK, EC>) -> Self {
-        unimplemented!()
+    fn set_db(self, db: &HybridEngine<EK, EC>) -> Self {
+        HybridEngineSstWriteBuilder(self.0.set_db(db.disk_engine()))
     }
 
-    fn set_cf(self, _cf: &str) -> Self {
-        unimplemented!()
+    fn set_cf(self, cf: &str) -> Self {
+        HybridEngineSstWriteBuilder(self.0.set_cf(cf))
     }
 
-    fn set_in_memory(self, _in_memory: bool) -> Self {
-        unimplemented!()
+    fn set_in_memory(self, in_memory: bool) -> Self {
+        HybridEngineSstWriteBuilder(self.0.set_in_memory(in_memory))
     }
 
-    fn set_compression_type(self, _compression: Option<SstCompressionType>) -> Self {
-        unimplemented!()
+    fn set_compression_type(self, compression: Option<SstCompressionType>) -> Self {
+        HybridEngineSstWriteBuilder(self.0.set_compression_type(compression))
     }
 
     fn set_compression_level(self, level: i32) -> Self {
-        unimplemented!()
+        HybridEngineSstWriteBuilder(self.0.set_compression_level(level))
     }
 
-    fn build(self, _path: &str) -> Result<<HybridEngine<EK, EC> as SstExt>::SstWriter> {
-        unimplemented!()
+    fn build(self, path: &str) -> Result<<HybridEngine<EK, EC> as SstExt>::SstWriter> {
+        self.0.build(path)
     }
 }

--- a/components/hybrid_engine/src/write_batch.rs
+++ b/components/hybrid_engine/src/write_batch.rs
@@ -156,8 +156,6 @@ mod tests {
                 memory_engine.new_range(range_clone.clone());
                 {
                     let mut core = memory_engine.core().write();
-                    core.mut_range_manager()
-                        .set_range_readable(&range_clone, true);
                     core.mut_range_manager().set_safe_point(&range_clone, 5);
                 }
             })
@@ -197,7 +195,6 @@ mod tests {
                 memory_engine.new_range(range.clone());
                 {
                     let mut core = memory_engine.core().write();
-                    core.mut_range_manager().set_range_readable(&range, true);
                     core.mut_range_manager().set_safe_point(&range, 10);
                 }
             })

--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -2540,7 +2540,6 @@ mod tests {
         memory_engine.new_range(range.clone());
         {
             let mut core = memory_engine.core().write();
-            core.mut_range_manager().set_range_readable(&range, true);
             core.mut_range_manager().set_safe_point(&range, 1);
         }
         let kv = (&[DATA_PREFIX, b'a'], b"b");
@@ -2588,11 +2587,10 @@ mod tests {
 
         {
             let mut core = memory_engine.core().write();
-            core.mut_range_manager().set_range_readable(&range, true);
             core.mut_range_manager().set_safe_point(&range, 10);
         }
 
-        let mut snap_ctx = SnapshotContext {
+        let snap_ctx = SnapshotContext {
             read_ts: 15,
             range: None,
         };
@@ -2600,19 +2598,5 @@ mod tests {
         let s = get_snapshot(Some(snap_ctx.clone()), &mut reader, cmd.clone(), &rx);
         assert!(s.region_cache_snapshot_available());
         assert_eq!(s.get_value(kv.0).unwrap().unwrap(), kv.1);
-
-        {
-            let mut core = memory_engine.core().write();
-            core.mut_range_manager().set_range_readable(&range, false);
-        }
-        let s = get_snapshot(Some(snap_ctx.clone()), &mut reader, cmd.clone(), &rx);
-        assert!(!s.region_cache_snapshot_available());
-
-        {
-            let mut core = memory_engine.core().write();
-            core.mut_range_manager().set_range_readable(&range, true);
-        }
-        snap_ctx.read_ts = 5;
-        assert!(!s.region_cache_snapshot_available());
     }
 }

--- a/components/region_cache_memory_engine/src/background.rs
+++ b/components/region_cache_memory_engine/src/background.rs
@@ -808,9 +808,7 @@ pub mod tests {
         let range = CacheRange::new(b"".to_vec(), b"z".to_vec());
         engine.new_range(range.clone());
         let (write, default) = {
-            let mut core = engine.core().write();
-            let skiplist_engine = core.engine();
-            core.mut_range_manager().set_range_readable(&range, true);
+            let skiplist_engine = engine.core().write().engine();
             (
                 skiplist_engine.cf_handle(CF_WRITE),
                 skiplist_engine.cf_handle(CF_DEFAULT),
@@ -864,9 +862,7 @@ pub mod tests {
         let range = CacheRange::new(b"".to_vec(), b"z".to_vec());
         engine.new_range(range.clone());
         let (write, default) = {
-            let mut core = engine.core().write();
-            let skiplist_engine = core.engine();
-            core.mut_range_manager().set_range_readable(&range, true);
+            let skiplist_engine = engine.core().write().engine();
             (
                 skiplist_engine.cf_handle(CF_WRITE),
                 skiplist_engine.cf_handle(CF_DEFAULT),

--- a/components/region_cache_memory_engine/src/engine.rs
+++ b/components/region_cache_memory_engine/src/engine.rs
@@ -183,7 +183,6 @@ impl RangeCacheMemoryEngineCore {
             .0;
         assert_eq!(&r, range);
         range_manager.new_range(r);
-        range_manager.set_range_readable(range, true);
     }
 }
 
@@ -912,10 +911,6 @@ mod tests {
             }
         };
 
-        {
-            let mut core = engine.core.write();
-            core.range_manager.set_range_readable(&range, true);
-        }
         let s1 = engine.snapshot(range.clone(), 5, u64::MAX).unwrap();
 
         {
@@ -1077,7 +1072,6 @@ mod tests {
 
         {
             let mut core = engine.core.write();
-            core.range_manager.set_range_readable(&range, true);
             core.range_manager.set_safe_point(&range, 5);
             let sl = core.engine.data[cf_to_id("write")].clone();
             fill_data_in_skiplist(sl.clone(), (1..10).step_by(1), 1..50, 1);
@@ -1157,7 +1151,6 @@ mod tests {
 
         {
             let mut core = engine.core.write();
-            core.range_manager.set_range_readable(&range, true);
             core.range_manager.set_safe_point(&range, 5);
             let sl = core.engine.data[cf_to_id("write")].clone();
             fill_data_in_skiplist(sl.clone(), (1..100).step_by(step as usize), 1..10, 1);
@@ -1343,7 +1336,6 @@ mod tests {
 
         {
             let mut core = engine.core.write();
-            core.range_manager.set_range_readable(&range, true);
             core.range_manager.set_safe_point(&range, 5);
             let sl = core.engine.data[cf_to_id("write")].clone();
             fill_data_in_skiplist(sl.clone(), (1..100).step_by(step as usize), 1..10, 1);
@@ -1445,7 +1437,6 @@ mod tests {
 
         {
             let mut core = engine.core.write();
-            core.range_manager.set_range_readable(&range, true);
             core.range_manager.set_safe_point(&range, 5);
             let sl = core.engine.data[cf_to_id("write")].clone();
 
@@ -1567,7 +1558,6 @@ mod tests {
 
         {
             let mut core = engine.core.write();
-            core.range_manager.set_range_readable(&range, true);
             core.range_manager.set_safe_point(&range, 5);
             let sl = core.engine.data[cf_to_id("write")].clone();
 
@@ -1667,7 +1657,6 @@ mod tests {
             engine.new_range(range.clone());
             let sl = {
                 let mut core = engine.core.write();
-                core.range_manager.set_range_readable(&range, true);
                 core.range_manager.set_safe_point(&range, 5);
                 core.engine.data[cf_to_id("write")].clone()
             };
@@ -1704,7 +1693,6 @@ mod tests {
             engine.new_range(range.clone());
             let sl = {
                 let mut core = engine.core.write();
-                core.range_manager.set_range_readable(&range, true);
                 core.range_manager.set_safe_point(&range, 5);
                 core.engine.data[cf_to_id("write")].clone()
             };
@@ -1734,7 +1722,6 @@ mod tests {
             engine.new_range(range.clone());
             let sl = {
                 let mut core = engine.core.write();
-                core.range_manager.set_range_readable(&range, true);
                 core.range_manager.set_safe_point(&range, 5);
                 core.engine.data[cf_to_id("write")].clone()
             };
@@ -1766,7 +1753,6 @@ mod tests {
             engine.new_range(range.clone());
             let sl = {
                 let mut core = engine.core.write();
-                core.range_manager.set_range_readable(&range, true);
                 core.range_manager.set_safe_point(&range, 5);
                 core.engine.data[cf_to_id("write")].clone()
             };
@@ -1799,7 +1785,6 @@ mod tests {
 
         {
             let mut core = engine.core.write();
-            core.range_manager.set_range_readable(&range, true);
             core.range_manager.set_safe_point(&range, 5);
             let sl = core.engine.data[cf_to_id("write")].clone();
 
@@ -1925,7 +1910,6 @@ mod tests {
         let guard = &epoch::pin();
         {
             let mut core = engine.core.write();
-            core.range_manager.set_range_readable(&range, true);
             core.range_manager.set_safe_point(&range, 5);
             let sl = core.engine.data[cf_to_id("write")].clone();
             for i in 0..30 {
@@ -1987,7 +1971,6 @@ mod tests {
         let guard = &epoch::pin();
         {
             let mut core = engine.core.write();
-            core.range_manager.set_range_readable(&range, true);
             core.range_manager.set_safe_point(&range, 5);
             let sl = core.engine.data[cf_to_id("write")].clone();
             for i in 0..30 {

--- a/components/region_cache_memory_engine/src/range_manager.rs
+++ b/components/region_cache_memory_engine/src/range_manager.rs
@@ -15,7 +15,6 @@ use crate::engine::{RagneCacheSnapshotMeta, SnapshotList};
 pub struct RangeMeta {
     id: u64,
     range_snapshot_list: SnapshotList,
-    can_read: bool,
     safe_point: u64,
 }
 
@@ -24,7 +23,6 @@ impl RangeMeta {
         Self {
             id,
             range_snapshot_list: SnapshotList::default(),
-            can_read: false,
             safe_point: 0,
         }
     }
@@ -42,7 +40,6 @@ impl RangeMeta {
         Self {
             id,
             range_snapshot_list: SnapshotList::default(),
-            can_read: r.can_read,
             safe_point: r.safe_point,
         }
     }
@@ -123,11 +120,6 @@ impl RangeManager {
         self.ranges.insert(range, range_meta);
     }
 
-    pub fn set_range_readable(&mut self, range: &CacheRange, set_readable: bool) {
-        let meta = self.ranges.get_mut(range).unwrap();
-        meta.can_read = set_readable;
-    }
-
     pub fn mut_range_meta(&mut self, range: &CacheRange) -> Option<&mut RangeMeta> {
         self.ranges.get_mut(range)
     }
@@ -189,8 +181,7 @@ impl RangeManager {
         };
         let meta = self.ranges.get_mut(&range_key).unwrap();
 
-        if read_ts <= meta.safe_point || !meta.can_read {
-            // todo(SpadeA): add metrics for it
+        if read_ts <= meta.safe_point {
             return Err(FailedReason::TooOldRead);
         }
 
@@ -352,7 +343,6 @@ mod tests {
         let r1 = CacheRange::new(b"k00".to_vec(), b"k10".to_vec());
 
         range_mgr.new_range(r1.clone());
-        range_mgr.set_range_readable(&r1, true);
         range_mgr.set_safe_point(&r1, 5);
         assert_eq!(
             range_mgr.range_snapshot(&r1, 5).unwrap_err(),
@@ -381,7 +371,6 @@ mod tests {
         let meta2 = range_mgr.ranges.get(&r_left).unwrap();
         let meta3 = range_mgr.ranges.get(&r_right).unwrap();
         assert!(meta1.safe_point == meta2.safe_point && meta1.safe_point == meta3.safe_point);
-        assert!(meta2.can_read && meta3.can_read);
 
         // evict a range with accurate match
         let _ = range_mgr.range_snapshot(&r_left, 10);

--- a/components/region_cache_memory_engine/src/write_batch.rs
+++ b/components/region_cache_memory_engine/src/write_batch.rs
@@ -383,7 +383,6 @@ mod tests {
         engine.new_range(r.clone());
         {
             let mut core = engine.core.write();
-            core.mut_range_manager().set_range_readable(&r, true);
             core.mut_range_manager().set_safe_point(&r, 10);
         }
         let mut wb = RangeCacheWriteBatch::from(&engine);
@@ -404,7 +403,6 @@ mod tests {
         engine.new_range(r.clone());
         {
             let mut core = engine.core.write();
-            core.mut_range_manager().set_range_readable(&r, true);
             core.mut_range_manager().set_safe_point(&r, 10);
         }
         let mut wb = RangeCacheWriteBatch::from(&engine);
@@ -430,7 +428,6 @@ mod tests {
         engine.new_range(r.clone());
         {
             let mut core = engine.core.write();
-            core.mut_range_manager().set_range_readable(&r, true);
             core.mut_range_manager().set_safe_point(&r, 10);
         }
         let mut wb = RangeCacheWriteBatch::from(&engine);
@@ -467,7 +464,6 @@ mod tests {
         {
             engine.new_range(r1.clone());
             let mut core = engine.core.write();
-            core.mut_range_manager().set_range_readable(&r1, true);
             core.mut_range_manager().set_safe_point(&r1, 10);
 
             let snap = Arc::new(rocks_engine.snapshot(None));

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -1007,44 +1007,74 @@ where
     }
 
     pub fn get(&mut self, key: &[u8]) -> Option<Vec<u8>> {
-        self.get_cf(CF_DEFAULT, key)
+        if !self.range_cache_engine_enabled_with_whole_range {
+            self.get_impl(CF_DEFAULT, key, false)
+        } else {
+            let ctx = SnapshotContext {
+                read_ts: u64::MAX,
+                range: Some(CacheRange::new(
+                    DATA_MIN_KEY.to_vec(),
+                    DATA_MAX_KEY.to_vec(),
+                )),
+            };
+            self.get_cf_with_snap_ctx(CF_DEFAULT, key, true, ctx)
+        }
     }
 
     pub fn get_cf(&mut self, cf: &str, key: &[u8]) -> Option<Vec<u8>> {
-        let ctx = if self.range_cache_engine_enabled_with_whole_range {
-            Some(SnapshotContext {
+        if !self.range_cache_engine_enabled_with_whole_range {
+            self.get_impl(cf, key, false)
+        } else {
+            let ctx = SnapshotContext {
                 read_ts: u64::MAX,
                 range: Some(CacheRange::new(
                     DATA_MIN_KEY.to_vec(),
                     DATA_MAX_KEY.to_vec(),
                 )),
-            })
-        } else {
-            None
-        };
-        self.get_cf_with_snap_ctx(cf, key, false, ctx)
+            };
+            self.get_cf_with_snap_ctx(cf, key, true, ctx)
+        }
     }
 
     pub fn must_get(&mut self, key: &[u8]) -> Option<Vec<u8>> {
-        let ctx = if self.range_cache_engine_enabled_with_whole_range {
-            Some(SnapshotContext {
+        if !self.range_cache_engine_enabled_with_whole_range {
+            self.get_impl(CF_DEFAULT, key, true)
+        } else {
+            let ctx = SnapshotContext {
                 read_ts: u64::MAX,
                 range: Some(CacheRange::new(
                     DATA_MIN_KEY.to_vec(),
                     DATA_MAX_KEY.to_vec(),
                 )),
-            })
+            };
+            self.get_cf_with_snap_ctx(CF_DEFAULT, key, true, ctx)
+        }
+    }
+
+    fn get_impl(&mut self, cf: &str, key: &[u8], read_quorum: bool) -> Option<Vec<u8>> {
+        let mut resp = self.request(
+            key,
+            vec![new_get_cf_cmd(cf, key)],
+            read_quorum,
+            Duration::from_secs(5),
+        );
+        if resp.get_header().has_error() {
+            panic!("response {:?} has error", resp);
+        }
+        assert_eq!(resp.get_responses().len(), 1);
+        assert_eq!(resp.get_responses()[0].get_cmd_type(), CmdType::Get);
+        if resp.get_responses()[0].has_get() {
+            Some(resp.mut_responses()[0].mut_get().take_value())
         } else {
             None
-        };
-        self.get_cf_with_snap_ctx(CF_DEFAULT, key, true, ctx)
+        }
     }
 
     pub fn get_with_snap_ctx(
         &mut self,
         key: &[u8],
         read_quorum: bool,
-        snap_ctx: Option<SnapshotContext>,
+        snap_ctx: SnapshotContext,
     ) -> Option<Vec<u8>> {
         self.get_cf_with_snap_ctx(CF_DEFAULT, key, read_quorum, snap_ctx)
     }
@@ -1055,10 +1085,8 @@ where
         cf: &str,
         key: &[u8],
         read_quorum: bool,
-        snap_ctx: Option<SnapshotContext>,
+        snap_ctx: SnapshotContext,
     ) -> Option<Vec<u8>> {
-        // If whole range cache is enabled, we use a failpoint to verify the key is got
-        // from the range cache.
         let rx = if self.range_cache_engine_enabled_with_whole_range {
             fail::remove("on_range_cache_get_value");
             let (tx, rx) = sync_channel(1);
@@ -1076,7 +1104,7 @@ where
             vec![new_get_cf_cmd(cf, key)],
             read_quorum,
             Duration::from_secs(5),
-            snap_ctx,
+            Some(snap_ctx),
         );
         if resp.get_header().has_error() {
             panic!("response {:?} has error", resp);

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -5,7 +5,7 @@ use std::{
     error::Error as StdError,
     result,
     sync::{
-        mpsc::{self},
+        mpsc::{self, sync_channel},
         Arc, Mutex, RwLock,
     },
     thread,
@@ -19,11 +19,12 @@ use encryption_export::DataKeyManager;
 use engine_rocks::{RocksCompactedEvent, RocksEngine, RocksStatistics};
 use engine_test::raft::RaftTestEngine;
 use engine_traits::{
-    Engines, Iterable, KvEngine, ManualCompactionOptions, Mutable, Peekable, RaftEngineReadOnly,
-    SnapshotContext, SyncMutable, WriteBatch, CF_DEFAULT, CF_RAFT,
+    CacheRange, Engines, Iterable, KvEngine, ManualCompactionOptions, Mutable, Peekable,
+    RaftEngineReadOnly, SnapshotContext, SyncMutable, WriteBatch, CF_DEFAULT, CF_RAFT,
 };
 use file_system::IoRateLimiter;
 use futures::{self, channel::oneshot, executor::block_on, future::BoxFuture, StreamExt};
+use keys::{DATA_MAX_KEY, DATA_MIN_KEY};
 use kvproto::{
     errorpb::Error as PbError,
     kvrpcpb::{ApiVersion, Context, DiskFullOpt},
@@ -64,11 +65,13 @@ use tikv_util::{
 };
 use txn_types::WriteBatchFlags;
 
+use self::range_cache_engine::RangCacheEngineExt;
 use super::*;
 use crate::Config;
 
-pub trait KvEngineWithRocks =
-    KvEngine<DiskEngine = RocksEngine, CompactedEvent = RocksCompactedEvent> + KvEngineBuilder;
+pub trait KvEngineWithRocks = KvEngine<DiskEngine = RocksEngine, CompactedEvent = RocksCompactedEvent>
+    + KvEngineBuilder
+    + RangCacheEngineExt;
 
 // We simulate 3 or 5 nodes, each has a store.
 // Sometimes, we use fixed id to test, which means the id
@@ -188,6 +191,8 @@ pub struct Cluster<EK: KvEngineWithRocks, T: Simulator<EK>> {
     pub sim: Arc<RwLock<T>>,
     pub pd_client: Arc<TestPdClient>,
     resource_manager: Option<Arc<ResourceGroupManager>>,
+
+    range_cache_engine_enabled: bool,
 }
 
 impl<EK, T> Cluster<EK, T>
@@ -228,6 +233,7 @@ where
             resource_manager: Some(Arc::new(ResourceGroupManager::default())),
             kv_statistics: vec![],
             raft_statistics: vec![],
+            range_cache_engine_enabled: false,
         }
     }
 
@@ -352,6 +358,11 @@ where
         self.create_engines();
         self.bootstrap_region().unwrap();
         self.start().unwrap();
+        if self.range_cache_engine_enabled {
+            self.engines
+                .iter()
+                .for_each(|(_, engines)| engines.kv.cache_all());
+        }
     }
 
     // Bootstrap the store with fixed ID (like 1, 2, .. 5) and
@@ -993,15 +1004,48 @@ where
     }
 
     pub fn get(&mut self, key: &[u8]) -> Option<Vec<u8>> {
-        self.get_impl(CF_DEFAULT, key, false)
+        if !self.range_cache_engine_enabled {
+            self.get_impl(CF_DEFAULT, key, false)
+        } else {
+            let ctx = SnapshotContext {
+                read_ts: u64::MAX,
+                range: Some(CacheRange::new(
+                    DATA_MIN_KEY.to_vec(),
+                    DATA_MAX_KEY.to_vec(),
+                )),
+            };
+            self.get_cf_with_snap_ctx(CF_DEFAULT, key, true, ctx)
+        }
     }
 
     pub fn get_cf(&mut self, cf: &str, key: &[u8]) -> Option<Vec<u8>> {
-        self.get_impl(cf, key, false)
+        if !self.range_cache_engine_enabled {
+            self.get_impl(cf, key, false)
+        } else {
+            let ctx = SnapshotContext {
+                read_ts: u64::MAX,
+                range: Some(CacheRange::new(
+                    DATA_MIN_KEY.to_vec(),
+                    DATA_MAX_KEY.to_vec(),
+                )),
+            };
+            self.get_cf_with_snap_ctx(cf, key, true, ctx)
+        }
     }
 
     pub fn must_get(&mut self, key: &[u8]) -> Option<Vec<u8>> {
-        self.get_impl(CF_DEFAULT, key, true)
+        if !self.range_cache_engine_enabled {
+            self.get_impl(CF_DEFAULT, key, true)
+        } else {
+            let ctx = SnapshotContext {
+                read_ts: u64::MAX,
+                range: Some(CacheRange::new(
+                    DATA_MIN_KEY.to_vec(),
+                    DATA_MAX_KEY.to_vec(),
+                )),
+            };
+            self.get_cf_with_snap_ctx(CF_DEFAULT, key, true, ctx)
+        }
     }
 
     fn get_impl(&mut self, cf: &str, key: &[u8], read_quorum: bool) -> Option<Vec<u8>> {
@@ -1021,6 +1065,52 @@ where
         } else {
             None
         }
+    }
+
+    pub fn get_with_snap_ctx(
+        &mut self,
+        key: &[u8],
+        read_quorum: bool,
+        snap_ctx: SnapshotContext,
+    ) -> Option<Vec<u8>> {
+        self.get_cf_with_snap_ctx(CF_DEFAULT, key, read_quorum, snap_ctx)
+    }
+
+    // called by range cache engine only
+    pub fn get_cf_with_snap_ctx(
+        &mut self,
+        cf: &str,
+        key: &[u8],
+        read_quorum: bool,
+        snap_ctx: SnapshotContext,
+    ) -> Option<Vec<u8>> {
+        fail::remove("on_range_cache_get_value");
+        let (tx, rx) = sync_channel(1);
+        fail::cfg_callback("on_range_cache_get_value", move || {
+            tx.send(true).unwrap();
+        })
+        .unwrap();
+
+        let mut resp = self.request_with_snap_ctx(
+            key,
+            vec![new_get_cf_cmd(cf, key)],
+            read_quorum,
+            Duration::from_secs(5),
+            Some(snap_ctx),
+        );
+        if resp.get_header().has_error() {
+            panic!("response {:?} has error", resp);
+        }
+        assert_eq!(resp.get_responses().len(), 1);
+        assert_eq!(resp.get_responses()[0].get_cmd_type(), CmdType::Get);
+        let res = if resp.get_responses()[0].has_get() {
+            rx.recv_timeout(Duration::from_secs(5)).unwrap();
+            Some(resp.mut_responses()[0].mut_get().take_value())
+        } else {
+            None
+        };
+        fail::remove("on_range_cache_get_value");
+        res
     }
 
     pub fn async_request(
@@ -2021,6 +2111,10 @@ where
 
         Ok(())
     }
+
+    pub fn set_range_cache_engine_enabled(&mut self, v: bool) {
+        self.range_cache_engine_enabled = v;
+    }
 }
 
 impl<EK: KvEngineWithRocks, T: Simulator<EK>> Drop for Cluster<EK, T> {
@@ -2033,6 +2127,10 @@ impl<EK: KvEngineWithRocks, T: Simulator<EK>> Drop for Cluster<EK, T> {
 pub trait RawEngine<EK: engine_traits::KvEngine>:
     Peekable<DbVector = EK::DbVector> + SyncMutable
 {
+    fn range_cache_engine(&self) -> bool {
+        false
+    }
+
     fn region_local_state(&self, region_id: u64)
     -> engine_traits::Result<Option<RegionLocalState>>;
 
@@ -2058,6 +2156,30 @@ impl RawEngine<RocksEngine> for RocksEngine {
     }
 }
 
+impl RawEngine<RocksEngine> for HybridEngineImpl {
+    fn range_cache_engine(&self) -> bool {
+        true
+    }
+
+    fn region_local_state(
+        &self,
+        region_id: u64,
+    ) -> engine_traits::Result<Option<RegionLocalState>> {
+        self.disk_engine()
+            .get_msg_cf(CF_RAFT, &keys::region_state_key(region_id))
+    }
+
+    fn raft_apply_state(&self, region_id: u64) -> engine_traits::Result<Option<RaftApplyState>> {
+        self.disk_engine()
+            .get_msg_cf(CF_RAFT, &keys::apply_state_key(region_id))
+    }
+
+    fn raft_local_state(&self, region_id: u64) -> engine_traits::Result<Option<RaftLocalState>> {
+        self.disk_engine()
+            .get_msg_cf(CF_RAFT, &keys::raft_state_key(region_id))
+    }
+}
+
 impl<T: Simulator<HybridEngineImpl>> Cluster<HybridEngineImpl, T> {
     pub fn get_range_cache_engine(&self, node_id: u64) -> RangeCacheMemoryEngine {
         self.engines
@@ -2066,34 +2188,5 @@ impl<T: Simulator<HybridEngineImpl>> Cluster<HybridEngineImpl, T> {
             .kv
             .region_cache_engine()
             .clone()
-    }
-
-    pub fn get_with_snap_ctx(&mut self, key: &[u8], snap_ctx: SnapshotContext) -> Option<Vec<u8>> {
-        self.get_cf_with_snap_ctx(CF_DEFAULT, key, snap_ctx)
-    }
-
-    pub fn get_cf_with_snap_ctx(
-        &mut self,
-        cf: &str,
-        key: &[u8],
-        snap_ctx: SnapshotContext,
-    ) -> Option<Vec<u8>> {
-        let mut resp = self.request_with_snap_ctx(
-            key,
-            vec![new_get_cf_cmd(cf, key)],
-            false,
-            Duration::from_secs(5),
-            Some(snap_ctx),
-        );
-        if resp.get_header().has_error() {
-            panic!("response {:?} has error", resp);
-        }
-        assert_eq!(resp.get_responses().len(), 1);
-        assert_eq!(resp.get_responses()[0].get_cmd_type(), CmdType::Get);
-        if resp.get_responses()[0].has_get() {
-            Some(resp.mut_responses()[0].mut_get().take_value())
-        } else {
-            None
-        }
     }
 }

--- a/components/test_raftstore/src/lib.rs
+++ b/components/test_raftstore/src/lib.rs
@@ -11,6 +11,7 @@ extern crate tikv_util;
 mod cluster;
 mod config;
 mod node;
+pub mod range_cache_engine;
 mod router;
 mod server;
 mod transport_simulate;

--- a/components/test_raftstore/src/node.rs
+++ b/components/test_raftstore/src/node.rs
@@ -522,8 +522,17 @@ pub fn new_node_cluster_with_hybrid_engine(
     let pd_client = Arc::new(TestPdClient::new(id, false));
     let sim = Arc::new(RwLock::new(NodeCluster::new(Arc::clone(&pd_client))));
     let mut cluster = Cluster::new(id, count, sim, pd_client, ApiVersion::V1);
-    cluster.set_range_cache_engine_enabled(true);
+    cluster.range_cache_engine_enabled_with_whole_range(true);
     cluster
+}
+
+pub fn new_node_cluster_with_hybrid_engine_with_no_range_cache(
+    id: u64,
+    count: usize,
+) -> Cluster<HybridEngineImpl, NodeCluster<HybridEngineImpl>> {
+    let pd_client = Arc::new(TestPdClient::new(id, false));
+    let sim = Arc::new(RwLock::new(NodeCluster::new(Arc::clone(&pd_client))));
+    Cluster::new(id, count, sim, pd_client, ApiVersion::V1)
 }
 
 // This cluster does not support batch split, we expect it to transfer the

--- a/components/test_raftstore/src/node.rs
+++ b/components/test_raftstore/src/node.rs
@@ -521,7 +521,9 @@ pub fn new_node_cluster_with_hybrid_engine(
 ) -> Cluster<HybridEngineImpl, NodeCluster<HybridEngineImpl>> {
     let pd_client = Arc::new(TestPdClient::new(id, false));
     let sim = Arc::new(RwLock::new(NodeCluster::new(Arc::clone(&pd_client))));
-    Cluster::new(id, count, sim, pd_client, ApiVersion::V1)
+    let mut cluster = Cluster::new(id, count, sim, pd_client, ApiVersion::V1);
+    cluster.set_range_cache_engine_enabled(true);
+    cluster
 }
 
 // This cluster does not support batch split, we expect it to transfer the

--- a/components/test_raftstore/src/range_cache_engine.rs
+++ b/components/test_raftstore/src/range_cache_engine.rs
@@ -1,0 +1,24 @@
+// Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
+
+use engine_rocks::RocksEngine;
+use engine_traits::CacheRange;
+use keys::{DATA_MAX_KEY, DATA_MIN_KEY};
+
+use crate::HybridEngineImpl;
+
+pub trait RangCacheEngineExt {
+    fn cache_all(&self);
+}
+
+impl RangCacheEngineExt for HybridEngineImpl {
+    fn cache_all(&self) {
+        self.region_cache_engine().new_range(CacheRange::new(
+            DATA_MIN_KEY.to_vec(),
+            DATA_MAX_KEY.to_vec(),
+        ));
+    }
+}
+
+impl RangCacheEngineExt for RocksEngine {
+    fn cache_all(&self) {}
+}

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -889,7 +889,7 @@ pub fn new_server_cluster_with_hybrid_engine(
     let pd_client = Arc::new(TestPdClient::new(id, false));
     let sim = Arc::new(RwLock::new(ServerCluster::new(Arc::clone(&pd_client))));
     let mut cluster = Cluster::new(id, count, sim, pd_client, ApiVersion::V1);
-    cluster.set_range_cache_engine_enabled(true);
+    cluster.range_cache_engine_enabled_with_whole_range(true);
     cluster
 }
 

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -888,7 +888,9 @@ pub fn new_server_cluster_with_hybrid_engine(
 ) -> Cluster<HybridEngineImpl, ServerCluster<HybridEngineImpl>> {
     let pd_client = Arc::new(TestPdClient::new(id, false));
     let sim = Arc::new(RwLock::new(ServerCluster::new(Arc::clone(&pd_client))));
-    Cluster::new(id, count, sim, pd_client, ApiVersion::V1)
+    let mut cluster = Cluster::new(id, count, sim, pd_client, ApiVersion::V1);
+    cluster.set_range_cache_engine_enabled(true);
+    cluster
 }
 
 pub fn new_server_cluster_with_api_ver(

--- a/components/test_raftstore/src/util.rs
+++ b/components/test_raftstore/src/util.rs
@@ -5,7 +5,7 @@ use std::{
     path::Path,
     str::FromStr,
     sync::{
-        mpsc::{self, sync_channel},
+        mpsc::{self},
         Arc, Mutex,
     },
     thread,
@@ -78,22 +78,8 @@ pub fn must_get<EK: KvEngine>(
     key: &[u8],
     value: Option<&[u8]>,
 ) {
-    let rx = if engine.range_cache_engine() {
-        fail::remove("on_range_cache_get_value");
-        let (tx, rx) = sync_channel(1);
-        fail::cfg_callback("on_range_cache_get_value", move || {
-            tx.send(true).unwrap();
-        })
-        .unwrap();
-        Some(rx)
-    } else {
-        None
-    };
     for _ in 1..300 {
         let res = engine.get_value_cf(cf, &keys::data_key(key)).unwrap();
-        if let Some(ref rx) = rx {
-            rx.recv_timeout(Duration::from_secs(5)).unwrap();
-        }
         if let (Some(value), Some(res)) = (value, res.as_ref()) {
             assert_eq!(value, &res[..]);
             return;

--- a/tests/failpoints/cases/test_range_cache_engine.rs
+++ b/tests/failpoints/cases/test_range_cache_engine.rs
@@ -39,9 +39,7 @@ fn test_basic_put_get() {
     })
     .unwrap();
 
-    let val = cluster
-        .get_with_snap_ctx(b"k05", false, Some(snap_ctx))
-        .unwrap();
+    let val = cluster.get_with_snap_ctx(b"k05", false, snap_ctx).unwrap();
     assert_eq!(&val, b"val");
 
     // verify it's read from range cache engine
@@ -141,14 +139,14 @@ fn test_load() {
                 .append_ts(20.into())
                 .into_encoded();
             let val = cluster
-                .get_cf_with_snap_ctx(CF_WRITE, &encoded_key, false, Some(snap_ctx.clone()))
+                .get_cf_with_snap_ctx(CF_WRITE, &encoded_key, false, snap_ctx.clone())
                 .unwrap();
             assert_eq!(&val, b"val-write");
             // verify it's read from range cache engine
             assert!(rx.try_recv().unwrap());
 
             let val = cluster
-                .get_with_snap_ctx(&encoded_key, false, Some(snap_ctx.clone()))
+                .get_with_snap_ctx(&encoded_key, false, snap_ctx.clone())
                 .unwrap();
             assert_eq!(&val, b"val-default");
             // verify it's read from range cache engine
@@ -223,7 +221,7 @@ fn test_write_batch_cache_during_load() {
                 .append_ts(20.into())
                 .into_encoded();
             let val = cluster
-                .get_cf_with_snap_ctx(CF_WRITE, &encoded_key, false, Some(snap_ctx.clone()))
+                .get_cf_with_snap_ctx(CF_WRITE, &encoded_key, false, snap_ctx.clone())
                 .unwrap();
             assert_eq!(&val, b"val-write");
             // We should not read the value in the memory engine at this phase.
@@ -247,14 +245,14 @@ fn test_write_batch_cache_during_load() {
             .append_ts(20.into())
             .into_encoded();
         let val = cluster
-            .get_cf_with_snap_ctx(CF_WRITE, &encoded_key, false, Some(snap_ctx.clone()))
+            .get_cf_with_snap_ctx(CF_WRITE, &encoded_key, false, snap_ctx.clone())
             .unwrap();
         assert_eq!(&val, b"val-write");
         // verify it's read from range cache engine
         assert!(rx2.try_recv().unwrap());
 
         let val = cluster
-            .get_with_snap_ctx(&encoded_key, false, Some(snap_ctx.clone()))
+            .get_with_snap_ctx(&encoded_key, false, snap_ctx.clone())
             .unwrap();
         assert_eq!(&val, b"val-default");
         // verify it's read from range cache engine
@@ -340,14 +338,14 @@ fn test_load_with_split() {
             .append_ts(20.into())
             .into_encoded();
         let val = cluster
-            .get_cf_with_snap_ctx(CF_WRITE, &encoded_key, false, Some(snap_ctx.clone()))
+            .get_cf_with_snap_ctx(CF_WRITE, &encoded_key, false, snap_ctx.clone())
             .unwrap();
         assert_eq!(&val, b"val-write");
         // verify it's read from range cache engine
         assert!(rx.try_recv().unwrap());
 
         let val = cluster
-            .get_with_snap_ctx(&encoded_key, false, Some(snap_ctx.clone()))
+            .get_with_snap_ctx(&encoded_key, false, snap_ctx.clone())
             .unwrap();
         assert_eq!(&val, b"val-default");
         // verify it's read from range cache engine
@@ -444,13 +442,13 @@ fn test_load_with_eviction() {
         range: None,
     };
     let val = cluster
-        .get_cf_with_snap_ctx(CF_DEFAULT, b"k01", false, Some(snap_ctx.clone()))
+        .get_cf_with_snap_ctx(CF_DEFAULT, b"k01", false, snap_ctx.clone())
         .unwrap();
     assert_eq!(&val, b"v");
     assert!(rx.try_recv().unwrap());
 
     let val = cluster
-        .get_cf_with_snap_ctx(CF_DEFAULT, b"k15", false, Some(snap_ctx.clone()))
+        .get_cf_with_snap_ctx(CF_DEFAULT, b"k15", false, snap_ctx.clone())
         .unwrap();
     assert_eq!(&val, b"v");
     rx.try_recv().unwrap_err();

--- a/tests/failpoints/cases/test_range_cache_engine.rs
+++ b/tests/failpoints/cases/test_range_cache_engine.rs
@@ -139,14 +139,14 @@ fn test_load() {
                 .append_ts(20.into())
                 .into_encoded();
             let val = cluster
-                .get_cf_with_snap_ctx(CF_WRITE, &encoded_key, false, snap_ctx.clone())
+                .get_cf_with_snap_ctx(CF_WRITE, &encoded_key, false, Some(snap_ctx.clone()))
                 .unwrap();
             assert_eq!(&val, b"val-write");
             // verify it's read from range cache engine
             assert!(rx.try_recv().unwrap());
 
             let val = cluster
-                .get_with_snap_ctx(&encoded_key, false, snap_ctx.clone())
+                .get_with_snap_ctx(&encoded_key, false, Some(snap_ctx.clone()))
                 .unwrap();
             assert_eq!(&val, b"val-default");
             // verify it's read from range cache engine

--- a/tests/failpoints/cases/test_range_cache_engine.rs
+++ b/tests/failpoints/cases/test_range_cache_engine.rs
@@ -7,15 +7,15 @@ use engine_traits::{CacheRange, RangeCacheEngine, SnapshotContext, CF_DEFAULT, C
 use keys::{data_key, DATA_MAX_KEY, DATA_MIN_KEY};
 use kvproto::raft_cmdpb::RaftCmdRequest;
 use test_raftstore::{
-    make_cb, new_node_cluster_with_hybrid_engine, new_put_cmd, new_request, Cluster,
-    HybridEngineImpl, NodeCluster, Simulator,
+    make_cb, new_node_cluster_with_hybrid_engine_with_no_range_cache, new_put_cmd, new_request,
+    Cluster, HybridEngineImpl, NodeCluster, Simulator,
 };
 use tikv_util::HandyRwLock;
 use txn_types::Key;
 
 #[test]
 fn test_basic_put_get() {
-    let mut cluster = new_node_cluster_with_hybrid_engine(0, 1);
+    let mut cluster = new_node_cluster_with_hybrid_engine_with_no_range_cache(0, 1);
     cluster.cfg.raft_store.apply_batch_system.pool_size = 1;
     cluster.run();
 
@@ -49,7 +49,7 @@ fn test_basic_put_get() {
 #[test]
 fn test_load() {
     let test_load = |concurrent_with_split: bool| {
-        let mut cluster = new_node_cluster_with_hybrid_engine(0, 1);
+        let mut cluster = new_node_cluster_with_hybrid_engine_with_no_range_cache(0, 1);
         cluster.cfg.raft_store.apply_batch_system.pool_size = 2;
         cluster.run();
 
@@ -159,7 +159,7 @@ fn test_load() {
 
 #[test]
 fn test_write_batch_cache_during_load() {
-    let mut cluster = new_node_cluster_with_hybrid_engine(0, 1);
+    let mut cluster = new_node_cluster_with_hybrid_engine_with_no_range_cache(0, 1);
     cluster.cfg.raft_store.apply_batch_system.pool_size = 2;
     cluster.run();
 
@@ -264,7 +264,7 @@ fn test_write_batch_cache_during_load() {
 // It tests that after we schedule the pending range to load snapshot, the range
 // splits.
 fn test_load_with_split() {
-    let mut cluster = new_node_cluster_with_hybrid_engine(0, 1);
+    let mut cluster = new_node_cluster_with_hybrid_engine_with_no_range_cache(0, 1);
     cluster.cfg.raft_store.apply_batch_system.pool_size = 2;
     cluster.run();
 
@@ -375,7 +375,7 @@ fn make_write_req(
 // to engine, the range has finished the loading, became a normal range, and
 // even been evicted.
 fn test_load_with_eviction() {
-    let mut cluster = new_node_cluster_with_hybrid_engine(0, 1);
+    let mut cluster = new_node_cluster_with_hybrid_engine_with_no_range_cache(0, 1);
     cluster.run();
     // load range
     {

--- a/tests/failpoints/cases/test_range_cache_engine.rs
+++ b/tests/failpoints/cases/test_range_cache_engine.rs
@@ -39,7 +39,9 @@ fn test_basic_put_get() {
     })
     .unwrap();
 
-    let val = cluster.get_with_snap_ctx(b"k05", false, snap_ctx).unwrap();
+    let val = cluster
+        .get_with_snap_ctx(b"k05", false, Some(snap_ctx))
+        .unwrap();
     assert_eq!(&val, b"val");
 
     // verify it's read from range cache engine
@@ -221,7 +223,7 @@ fn test_write_batch_cache_during_load() {
                 .append_ts(20.into())
                 .into_encoded();
             let val = cluster
-                .get_cf_with_snap_ctx(CF_WRITE, &encoded_key, false, snap_ctx.clone())
+                .get_cf_with_snap_ctx(CF_WRITE, &encoded_key, false, Some(snap_ctx.clone()))
                 .unwrap();
             assert_eq!(&val, b"val-write");
             // We should not read the value in the memory engine at this phase.
@@ -245,14 +247,14 @@ fn test_write_batch_cache_during_load() {
             .append_ts(20.into())
             .into_encoded();
         let val = cluster
-            .get_cf_with_snap_ctx(CF_WRITE, &encoded_key, false, snap_ctx.clone())
+            .get_cf_with_snap_ctx(CF_WRITE, &encoded_key, false, Some(snap_ctx.clone()))
             .unwrap();
         assert_eq!(&val, b"val-write");
         // verify it's read from range cache engine
         assert!(rx2.try_recv().unwrap());
 
         let val = cluster
-            .get_with_snap_ctx(&encoded_key, false, snap_ctx.clone())
+            .get_with_snap_ctx(&encoded_key, false, Some(snap_ctx.clone()))
             .unwrap();
         assert_eq!(&val, b"val-default");
         // verify it's read from range cache engine
@@ -338,14 +340,14 @@ fn test_load_with_split() {
             .append_ts(20.into())
             .into_encoded();
         let val = cluster
-            .get_cf_with_snap_ctx(CF_WRITE, &encoded_key, false, snap_ctx.clone())
+            .get_cf_with_snap_ctx(CF_WRITE, &encoded_key, false, Some(snap_ctx.clone()))
             .unwrap();
         assert_eq!(&val, b"val-write");
         // verify it's read from range cache engine
         assert!(rx.try_recv().unwrap());
 
         let val = cluster
-            .get_with_snap_ctx(&encoded_key, false, snap_ctx.clone())
+            .get_with_snap_ctx(&encoded_key, false, Some(snap_ctx.clone()))
             .unwrap();
         assert_eq!(&val, b"val-default");
         // verify it's read from range cache engine
@@ -442,13 +444,13 @@ fn test_load_with_eviction() {
         range: None,
     };
     let val = cluster
-        .get_cf_with_snap_ctx(CF_DEFAULT, b"k01", false, snap_ctx.clone())
+        .get_cf_with_snap_ctx(CF_DEFAULT, b"k01", false, Some(snap_ctx.clone()))
         .unwrap();
     assert_eq!(&val, b"v");
     assert!(rx.try_recv().unwrap());
 
     let val = cluster
-        .get_cf_with_snap_ctx(CF_DEFAULT, b"k15", false, snap_ctx.clone())
+        .get_cf_with_snap_ctx(CF_DEFAULT, b"k15", false, Some(snap_ctx.clone()))
         .unwrap();
     assert_eq!(&val, b"v");
     rx.try_recv().unwrap_err();

--- a/tests/integrations/raftstore/test_single.rs
+++ b/tests/integrations/raftstore/test_single.rs
@@ -15,6 +15,8 @@ use tikv_util::{config::*, time::Instant};
 #[test_case(test_raftstore::new_server_cluster)]
 #[test_case(test_raftstore_v2::new_node_cluster)]
 #[test_case(test_raftstore_v2::new_server_cluster)]
+#[test_case(test_raftstore::new_node_cluster_with_hybrid_engine)]
+#[test_case(test_raftstore::new_server_cluster_with_hybrid_engine)]
 fn test_put() {
     let mut cluster = new_cluster(0, 1);
     cluster.run();
@@ -63,6 +65,8 @@ fn test_put() {
 #[test_case(test_raftstore::new_server_cluster)]
 #[test_case(test_raftstore_v2::new_node_cluster)]
 #[test_case(test_raftstore_v2::new_server_cluster)]
+#[test_case(test_raftstore::new_node_cluster_with_hybrid_engine)]
+#[test_case(test_raftstore::new_server_cluster_with_hybrid_engine)]
 fn test_delete() {
     let mut cluster = new_cluster(0, 1);
     cluster.run();
@@ -117,6 +121,8 @@ fn test_node_not_use_delete_range() {
 #[test_case(test_raftstore::new_server_cluster)]
 #[test_case(test_raftstore_v2::new_node_cluster)]
 #[test_case(test_raftstore_v2::new_server_cluster)]
+#[test_case(test_raftstore::new_node_cluster_with_hybrid_engine)]
+#[test_case(test_raftstore::new_server_cluster_with_hybrid_engine)]
 fn test_wrong_store_id() {
     let mut cluster = new_cluster(0, 1);
     cluster.run();
@@ -146,6 +152,8 @@ fn test_wrong_store_id() {
 #[test_case(test_raftstore::new_server_cluster)]
 #[test_case(test_raftstore_v2::new_node_cluster)]
 #[test_case(test_raftstore_v2::new_server_cluster)]
+#[test_case(test_raftstore::new_node_cluster_with_hybrid_engine)]
+#[test_case(test_raftstore::new_server_cluster_with_hybrid_engine)]
 fn test_put_large_entry() {
     let mut cluster = new_cluster(0, 1);
     let max_size: usize = 1024;

--- a/tests/integrations/raftstore/test_split_region.rs
+++ b/tests/integrations/raftstore/test_split_region.rs
@@ -35,6 +35,7 @@ pub const REGION_SPLIT_SIZE: u64 = 30000;
 
 #[test_case(test_raftstore::new_server_cluster)]
 #[test_case(test_raftstore_v2::new_server_cluster)]
+#[test_case(test_raftstore::new_server_cluster_with_hybrid_engine)]
 fn test_server_base_split_region() {
     let test_base_split_region = |right_derive| {
         let count = 5;
@@ -107,6 +108,7 @@ fn test_server_base_split_region() {
 
 #[test_case(test_raftstore::new_server_cluster)]
 #[test_case(test_raftstore_v2::new_server_cluster)]
+#[test_case(test_raftstore::new_server_cluster_with_hybrid_engine)]
 fn test_server_split_region_twice() {
     let count = 5;
     let mut cluster = new_cluster(0, count);
@@ -158,6 +160,8 @@ fn test_server_split_region_twice() {
 #[test_case(test_raftstore::new_incompatible_node_cluster)]
 #[test_case(test_raftstore_v2::new_node_cluster)]
 #[test_case(test_raftstore_v2::new_server_cluster)]
+#[test_case(test_raftstore::new_node_cluster_with_hybrid_engine)]
+#[test_case(test_raftstore::new_server_cluster_with_hybrid_engine)]
 fn test_auto_split_region() {
     let count = 5;
     let mut cluster = new_cluster(0, count);
@@ -293,6 +297,7 @@ macro_rules! check_cluster {
 /// sure broadcast commit is disabled when split.
 #[test_case(test_raftstore::new_server_cluster)]
 #[test_case(test_raftstore_v2::new_server_cluster)]
+#[test_case(test_raftstore::new_server_cluster_with_hybrid_engine)]
 fn test_delay_split_region() {
     let mut cluster = new_cluster(0, 3);
     cluster.cfg.raft_store.raft_log_gc_count_limit = Some(500);
@@ -349,6 +354,8 @@ fn test_delay_split_region() {
 #[test_case(test_raftstore::new_server_cluster)]
 #[test_case(test_raftstore_v2::new_node_cluster)]
 #[test_case(test_raftstore_v2::new_server_cluster)]
+#[test_case(test_raftstore::new_node_cluster_with_hybrid_engine)]
+#[test_case(test_raftstore::new_server_cluster_with_hybrid_engine)]
 fn test_node_split_overlap_snapshot() {
     let mut cluster = new_cluster(0, 3);
     // We use three nodes([1, 2, 3]) for this test.
@@ -405,6 +412,8 @@ fn test_node_split_overlap_snapshot() {
 #[test_case(test_raftstore::new_server_cluster)]
 #[test_case(test_raftstore_v2::new_node_cluster)]
 #[test_case(test_raftstore_v2::new_server_cluster)]
+#[test_case(test_raftstore::new_node_cluster_with_hybrid_engine)]
+#[test_case(test_raftstore::new_server_cluster_with_hybrid_engine)]
 fn test_apply_new_version_snapshot() {
     let mut cluster = new_cluster(0, 3);
     // truncate the log quickly so that we can force sending snapshot.
@@ -461,6 +470,7 @@ fn test_apply_new_version_snapshot() {
 
 #[test_case(test_raftstore::new_server_cluster)]
 #[test_case(test_raftstore_v2::new_server_cluster)]
+#[test_case(test_raftstore::new_server_cluster_with_hybrid_engine)]
 fn test_server_split_with_stale_peer() {
     let mut cluster = new_cluster(0, 3);
     // disable raft log gc.
@@ -534,6 +544,8 @@ fn test_server_split_with_stale_peer() {
 #[test_case(test_raftstore::new_server_cluster)]
 #[test_case(test_raftstore_v2::new_node_cluster)]
 #[test_case(test_raftstore_v2::new_server_cluster)]
+#[test_case(test_raftstore::new_node_cluster_with_hybrid_engine)]
+#[test_case(test_raftstore::new_server_cluster_with_hybrid_engine)]
 fn test_split_region_diff_check() {
     let count = 1;
     let mut cluster = new_cluster(0, count);
@@ -587,6 +599,7 @@ fn test_split_region_diff_check() {
 // verify the region is splitted.
 #[test_case(test_raftstore::new_server_cluster)]
 #[test_case(test_raftstore_v2::new_server_cluster)]
+#[test_case(test_raftstore::new_server_cluster_with_hybrid_engine)]
 fn test_node_split_region_after_reboot_with_config_change() {
     let count = 1;
     let mut cluster = new_cluster(0, count);
@@ -731,6 +744,8 @@ fn test_node_split_epoch_not_match_right_derive() {
 #[test_case(test_raftstore::new_server_cluster)]
 #[test_case(test_raftstore_v2::new_node_cluster)]
 #[test_case(test_raftstore_v2::new_server_cluster)]
+#[test_case(test_raftstore::new_node_cluster_with_hybrid_engine)]
+#[test_case(test_raftstore::new_server_cluster_with_hybrid_engine)]
 fn test_node_quick_election_after_split() {
     let mut cluster = new_cluster(0, 3);
 
@@ -769,6 +784,8 @@ fn test_node_quick_election_after_split() {
 #[test_case(test_raftstore::new_server_cluster)]
 #[test_case(test_raftstore_v2::new_node_cluster)]
 #[test_case(test_raftstore_v2::new_server_cluster)]
+#[test_case(test_raftstore::new_node_cluster_with_hybrid_engine)]
+#[test_case(test_raftstore::new_server_cluster_with_hybrid_engine)]
 fn test_node_split_region() {
     let count = 5;
     let mut cluster = new_cluster(0, count);
@@ -809,6 +826,7 @@ fn test_node_split_region() {
 
 #[test_case(test_raftstore::new_node_cluster)]
 #[test_case(test_raftstore_v2::new_node_cluster)]
+#[test_case(test_raftstore::new_node_cluster_with_hybrid_engine)]
 fn test_node_split_update_region_right_derive() {
     let mut cluster = new_cluster(0, 3);
     // Election timeout and max leader lease is 1s.
@@ -864,6 +882,7 @@ fn test_node_split_update_region_right_derive() {
 
 #[test_case(test_raftstore::new_server_cluster)]
 #[test_case(test_raftstore_v2::new_server_cluster)]
+#[test_case(test_raftstore::new_server_cluster_with_hybrid_engine)]
 fn test_split_with_epoch_not_match() {
     let mut cluster = new_cluster(0, 3);
     let pd_client = Arc::clone(&cluster.pd_client);
@@ -899,6 +918,7 @@ fn test_split_with_epoch_not_match() {
 
 #[test_case(test_raftstore::new_server_cluster)]
 #[test_case(test_raftstore_v2::new_server_cluster)]
+#[test_case(test_raftstore::new_server_cluster_with_hybrid_engine)]
 fn test_split_with_in_memory_pessimistic_locks() {
     let mut cluster = new_cluster(0, 3);
     let pd_client = Arc::clone(&cluster.pd_client);
@@ -1240,6 +1260,7 @@ fn test_gen_split_check_bucket_ranges() {
 
 #[test_case(test_raftstore::new_server_cluster)]
 #[test_case(test_raftstore_v2::new_server_cluster)]
+#[test_case(test_raftstore::new_server_cluster_with_hybrid_engine)]
 fn test_catch_up_peers_after_split() {
     let mut cluster = new_cluster(0, 3);
     let pd_client = Arc::clone(&cluster.pd_client);
@@ -1273,6 +1294,7 @@ fn test_catch_up_peers_after_split() {
 }
 
 #[test_case(test_raftstore_v2::new_node_cluster)]
+#[test_case(test_raftstore::new_node_cluster_with_hybrid_engine)]
 fn test_split_region_keep_records() {
     let mut cluster = new_cluster(0, 3);
     let pd_client = Arc::clone(&cluster.pd_client);
@@ -1310,6 +1332,7 @@ fn test_split_region_keep_records() {
 
 #[test_case(test_raftstore::new_node_cluster)]
 #[test_case(test_raftstore_v2::new_node_cluster)]
+#[test_case(test_raftstore::new_node_cluster_with_hybrid_engine)]
 fn test_node_slow_split_does_not_cause_snapshot() {
     // We use three nodes([1, 2, 3]) for this test.
     let mut cluster = new_cluster(0, 3);

--- a/tests/integrations/raftstore/test_split_region.rs
+++ b/tests/integrations/raftstore/test_split_region.rs
@@ -1294,7 +1294,6 @@ fn test_catch_up_peers_after_split() {
 }
 
 #[test_case(test_raftstore_v2::new_node_cluster)]
-#[test_case(test_raftstore::new_node_cluster_with_hybrid_engine)]
 fn test_split_region_keep_records() {
     let mut cluster = new_cluster(0, 3);
     let pd_client = Arc::clone(&cluster.pd_client);


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref #16141

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
make integration tests reusable for hybrid engine
```
This PR makes integration tests reusable (maybe part of, and with small modification) by in-memory engine by using the procedure macro `test_case` .
This PR makes the tests in `test_single.rs`, `test_lease_read.rs`, and `test_split_region.rs` using in-memory engine.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
