### PR TITLE
[Bugfix] raftstore: fix the bug when the channel is full in AutoSplitController.

### DIFF
--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -778,8 +778,8 @@ where
     #[inline]
     pub fn maybe_send_read_stats(&self, read_stats: ReadStats) {
         if let Some(sender) = &self.read_stats_sender {
-            if sender.send(read_stats).is_err() {
-                debug!("send read_stats failed, are we shutting down?")
+            if sender.try_send(read_stats).is_err() {
+                debug!("send read_stats failed, are we shutting down or channel is full?")
             }
         }
     }
@@ -787,8 +787,8 @@ where
     #[inline]
     pub fn maybe_send_cpu_stats(&self, cpu_stats: &Arc<RawRecords>) {
         if let Some(sender) = &self.cpu_stats_sender {
-            if sender.send(cpu_stats.clone()).is_err() {
-                debug!("send region cpu info failed, are we shutting down?")
+            if sender.try_send(cpu_stats.clone()).is_err() {
+                debug!("send region cpu info failed, are we shutting down or channel is full?")
             }
         }
     }

--- a/components/raftstore/src/store/worker/split_controller.rs
+++ b/components/raftstore/src/store/worker/split_controller.rs
@@ -2026,7 +2026,7 @@ mod tests {
         b.iter(|| {
             let mut hub = AutoSplitController::default();
             for s in other_qps_stats.clone() {
-                read_stats_sender.try_send(s).unwrap();
+                read_stats_sender.send(s).unwrap();
             }
             hub.flush(
                 &mut ctx,
@@ -2085,8 +2085,8 @@ mod tests {
             let read_stats = ReadStats::default();
             let cpu_stats = Arc::new(RawRecords::default());
             for _ in 0..len {
-                read_stats_sender.send(read_stats.clone()).unwrap();
-                cpu_stats_sender.send(cpu_stats.clone()).unwrap();
+                read_stats_sender.try_send(read_stats.clone()).unwrap();
+                cpu_stats_sender.try_send(cpu_stats.clone()).unwrap();
             }
             // If channel is full, should return error.
             assert!(read_stats_sender.try_send(read_stats.clone()).is_err());

--- a/components/raftstore/src/store/worker/split_controller.rs
+++ b/components/raftstore/src/store/worker/split_controller.rs
@@ -1297,10 +1297,10 @@ mod tests {
         let (read_stats_sender, read_stats_receiver) = mpsc::sync_channel(len);
         let (cpu_stats_sender, cpu_stats_receiver) = mpsc::sync_channel(len);
         for s in cpu_stats {
-            cpu_stats_sender.send(s).unwrap();
+            cpu_stats_sender.try_send(s).unwrap();
         }
         for s in read_stats {
-            read_stats_sender.send(s).unwrap();
+            read_stats_sender.try_send(s).unwrap();
         }
         (
             AutoSplitControllerContext::new(len),
@@ -2026,7 +2026,7 @@ mod tests {
         b.iter(|| {
             let mut hub = AutoSplitController::default();
             for s in other_qps_stats.clone() {
-                read_stats_sender.send(s).unwrap();
+                read_stats_sender.try_send(s).unwrap();
             }
             hub.flush(
                 &mut ctx,
@@ -2088,6 +2088,9 @@ mod tests {
                 read_stats_sender.send(read_stats.clone()).unwrap();
                 cpu_stats_sender.send(cpu_stats.clone()).unwrap();
             }
+            // If channel is full, should return error.
+            assert!(read_stats_sender.try_send(read_stats.clone()).is_err());
+            assert!(cpu_stats_sender.try_send(cpu_stats.clone()).is_err());
             loop {
                 let batch = ctx.batch_recv_read_stats(&read_stats_receiver);
                 if batch.is_empty() {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #16716

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Fix the bug when the channel is full in `AutoSplitController`.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
