### PR TITLE
raftstore: supply extra ut for testing non-blocking channel.

### DIFF
--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -76,6 +76,10 @@ use crate::{
 };
 
 pub const NUM_COLLECT_STORE_INFOS_PER_HEARTBEAT: u32 = 2;
+/// The upper bound of buffered stats messages.
+/// It prevents unexpected memory buildup when AutoSplitController
+/// runs slowly.
+const STATS_CHANNEL_CAPACITY_LIMIT: usize = 128;
 
 type RecordPairVec = Vec<pdpb::RecordPair>;
 
@@ -642,14 +646,12 @@ where
         let (timer_tx, timer_rx) = mpsc::channel();
         self.timer = Some(timer_tx);
 
-        // The upper bound of buffered stats messages.
-        // It prevents unexpected memory buildup when AutoSplitController
-        // runs slowly.
-        const STATS_LIMIT: usize = 128;
-        let (read_stats_sender, read_stats_receiver) = mpsc::sync_channel(STATS_LIMIT);
+        let (read_stats_sender, read_stats_receiver) =
+            mpsc::sync_channel(STATS_CHANNEL_CAPACITY_LIMIT);
         self.read_stats_sender = Some(read_stats_sender);
 
-        let (cpu_stats_sender, cpu_stats_receiver) = mpsc::sync_channel(STATS_LIMIT);
+        let (cpu_stats_sender, cpu_stats_receiver) =
+            mpsc::sync_channel(STATS_CHANNEL_CAPACITY_LIMIT);
         self.cpu_stats_sender = Some(cpu_stats_sender);
 
         let reporter = self.reporter.clone();
@@ -668,7 +670,8 @@ where
                 let mut collect_store_infos_thread_stats = ThreadInfoStatistics::new();
                 let mut load_base_split_thread_stats = ThreadInfoStatistics::new();
                 let mut region_cpu_records_collector = None;
-                let mut auto_split_controller_ctx = AutoSplitControllerContext::new(STATS_LIMIT);
+                let mut auto_split_controller_ctx =
+                    AutoSplitControllerContext::new(STATS_CHANNEL_CAPACITY_LIMIT);
                 // Register the region CPU records collector.
                 if auto_split_controller
                     .cfg
@@ -2479,8 +2482,10 @@ mod tests {
 
     use kvproto::{kvrpcpb, pdpb::QueryKind};
     use pd_client::{new_bucket_stats, BucketMeta};
+    use tikv_util::worker::LazyWorker;
 
     use super::*;
+    use crate::store::util::build_key_range;
 
     const DEFAULT_TEST_STORE_ID: u64 = 1;
 
@@ -2490,7 +2495,6 @@ mod tests {
         use std::{sync::Mutex, time::Instant};
 
         use engine_test::{kv::KvTestEngine, raft::RaftTestEngine};
-        use tikv_util::worker::LazyWorker;
 
         struct RunnerTest {
             store_stat: Arc<Mutex<StoreStat>>,
@@ -2743,5 +2747,65 @@ mod tests {
         assert_eq!(cap, 444);
         assert_eq!(used, 111);
         assert_eq!(avail, 333);
+    }
+
+    #[test]
+    fn test_pd_worker_send_stats_on_read_and_cpu() {
+        let mut pd_worker: LazyWorker<Task<KvTestEngine, RaftTestEngine>> =
+            LazyWorker::new("test-pd-worker-collect-stats");
+        // Set the interval long enough for mocking the channel full state.
+        let interval = 600_u64;
+        let mut stats_monitor = StatsMonitor::new(
+            Duration::from_secs(interval),
+            Duration::from_secs(interval),
+            WrappedScheduler(pd_worker.scheduler()),
+        );
+        stats_monitor
+            .start(
+                AutoSplitController::default(),
+                CollectorRegHandle::new_for_test(),
+            )
+            .unwrap();
+        // Add some read stats and cpu stats to the stats monitor.
+        {
+            for _ in 0..=STATS_CHANNEL_CAPACITY_LIMIT + 10 {
+                let mut read_stats = ReadStats::with_sample_num(1);
+                read_stats.add_query_num(
+                    1,
+                    &Peer::default(),
+                    build_key_range(b"a", b"b", false),
+                    QueryKind::Get,
+                );
+                stats_monitor.maybe_send_read_stats(read_stats);
+            }
+
+            let raw_records = Arc::new(RawRecords {
+                begin_unix_time_secs: UnixSecs::now().into_inner(),
+                duration: Duration::default(),
+                records: {
+                    let mut records = HashMap::default();
+                    records.insert(
+                        Arc::new(TagInfos {
+                            store_id: 0,
+                            region_id: 1,
+                            peer_id: 0,
+                            key_ranges: vec![],
+                            extra_attachment: b"a".to_vec(),
+                        }),
+                        RawRecord {
+                            cpu_time: 111,
+                            read_keys: 1,
+                            write_keys: 0,
+                        },
+                    );
+                    records
+                },
+            });
+            for _ in 0..=STATS_CHANNEL_CAPACITY_LIMIT + 10 {
+                stats_monitor.maybe_send_cpu_stats(&raw_records);
+            }
+        }
+
+        pd_worker.stop();
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #16716, derived from #16726

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Add an extra ut to test the non-blocking channel in pd_worker for sending collected ReadStats and CPU statistics.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
