### PR TITLE
log_backup: fix flaky test `subscription_manager::*`

### DIFF
--- a/components/backup-stream/src/router.rs
+++ b/components/backup-stream/src/router.rs
@@ -896,7 +896,9 @@ impl StreamTaskInfo {
         temp_pool_cfg: tempfiles::Config,
     ) -> Result<Self> {
         let temp_dir = &temp_pool_cfg.swap_files;
-        tokio::fs::create_dir_all(temp_dir).await?;
+        tokio::fs::create_dir_all(temp_dir)
+            .await
+            .context(format_args!("creating {}", temp_dir.display()))?;
         let storage = Arc::from(create_storage(
             task.info.get_storage(),
             BackendConfig::default(),
@@ -916,7 +918,9 @@ impl StreamTaskInfo {
             flush_fail_count: AtomicUsize::new(0),
             global_checkpoint_ts: AtomicU64::new(start_ts),
             merged_file_size_limit,
-            temp_file_pool: Arc::new(TempFilePool::new(temp_pool_cfg)?),
+            temp_file_pool: Arc::new(
+                TempFilePool::new(temp_pool_cfg).context("creating temp file pool")?,
+            ),
         })
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #16736

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

We will ignore the error while removing the old dir.
Also, this added more context to errors we have encountered while creating `TempFile`.

```commit-message
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
```fish
for i in (seq 100)
    if ! cargo test --package backup-stream --lib -- subscription_manager::test --nocapture
        break
    end
end
```
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note

```
