### PR TITLE
[cherry-pick-7.5] server: stop manual compaction jobs in engines before shutdown

### DIFF
--- a/components/engine_panic/src/misc.rs
+++ b/components/engine_panic/src/misc.rs
@@ -75,6 +75,14 @@ impl MiscExt for PanicEngine {
         panic!()
     }
 
+    fn disable_manual_compaction(&self) -> Result<()> {
+        panic!()
+    }
+
+    fn enable_manual_compaction(&self) -> Result<()> {
+        panic!()
+    }
+
     fn pause_background_work(&self) -> Result<()> {
         panic!()
     }

--- a/components/engine_rocks/src/misc.rs
+++ b/components/engine_rocks/src/misc.rs
@@ -334,16 +334,26 @@ impl MiscExt for RocksEngine {
         self.as_inner().sync_wal().map_err(r2e)
     }
 
+    fn disable_manual_compaction(&self) -> Result<()> {
+        self.as_inner().disable_manual_compaction();
+        Ok(())
+    }
+
+    fn enable_manual_compaction(&self) -> Result<()> {
+        self.as_inner().enable_manual_compaction();
+        Ok(())
+    }
+
     fn pause_background_work(&self) -> Result<()> {
         // This will make manual compaction return error instead of waiting. In practice
         // we might want to identify this case by parsing error message.
-        self.as_inner().disable_manual_compaction();
+        self.disable_manual_compaction()?;
         self.as_inner().pause_bg_work();
         Ok(())
     }
 
     fn continue_background_work(&self) -> Result<()> {
-        self.as_inner().enable_manual_compaction();
+        self.enable_manual_compaction()?;
         self.as_inner().continue_bg_work();
         Ok(())
     }

--- a/components/engine_traits/src/misc.rs
+++ b/components/engine_traits/src/misc.rs
@@ -121,6 +121,12 @@ pub trait MiscExt: CfNamesExt + FlowControlFactorsExt + WriteBatchExt {
 
     fn sync_wal(&self) -> Result<()>;
 
+    /// Disable manual compactions, some on-going manual compactions may be
+    /// aborted.
+    fn disable_manual_compaction(&self) -> Result<()>;
+
+    fn enable_manual_compaction(&self) -> Result<()>;
+
     /// Depending on the implementation, some on-going manual compactions may be
     /// aborted.
     fn pause_background_work(&self) -> Result<()>;

--- a/components/raftstore/src/store/worker/compact.rs
+++ b/components/raftstore/src/store/worker/compact.rs
@@ -277,7 +277,7 @@ mod tests {
         kv::{new_engine, new_engine_opt, KvTestEngine},
     };
     use engine_traits::{
-        MiscExt, Mutable, SyncMutable, WriteBatch, WriteBatchExt, CF_DEFAULT, CF_LOCK, CF_RAFT,
+        CompactExt, MiscExt, Mutable, SyncMutable, WriteBatch, WriteBatchExt, CF_DEFAULT, CF_LOCK, CF_RAFT,
         CF_WRITE,
     };
     use keys::data_key;
@@ -285,6 +285,73 @@ mod tests {
     use txn_types::{Key, TimeStamp, Write, WriteType};
 
     use super::*;
+
+    #[test]
+    fn test_disable_manual_compaction() {
+        let path = Builder::new()
+            .prefix("test_disable_manual_compaction")
+            .tempdir()
+            .unwrap();
+        let db = new_engine(path.path().to_str().unwrap(), &[CF_DEFAULT]).unwrap();
+
+        // Generate the first SST file.
+        let mut wb = db.write_batch();
+        for i in 0..1000 {
+            let k = format!("key_{}", i);
+            wb.put_cf(CF_DEFAULT, k.as_bytes(), b"whatever content")
+                .unwrap();
+        }
+        wb.write().unwrap();
+        db.flush_cf(CF_DEFAULT, true).unwrap();
+
+        // Generate another SST file has the same content with first SST file.
+        let mut wb = db.write_batch();
+        for i in 0..1000 {
+            let k = format!("key_{}", i);
+            wb.put_cf(CF_DEFAULT, k.as_bytes(), b"whatever content")
+                .unwrap();
+        }
+        wb.write().unwrap();
+        db.flush_cf(CF_DEFAULT, true).unwrap();
+
+        // Get the total SST files size.
+        let old_sst_files_size = db.get_total_sst_files_size_cf(CF_DEFAULT).unwrap().unwrap();
+
+        // Stop the assistant.
+        {
+            let _ = db.disable_manual_compaction();
+
+            // Manually compact range.
+            let _ = db.compact_range_cf(
+                CF_DEFAULT,
+                None,
+                None,
+                false,
+                1,
+            );
+
+            // Get the total SST files size after compact range.
+            let new_sst_files_size = db.get_total_sst_files_size_cf(CF_DEFAULT).unwrap().unwrap();
+            assert_eq!(old_sst_files_size, new_sst_files_size);
+        }
+        // Restart the assistant.
+        {
+            let _ = db.enable_manual_compaction();
+
+            // Manually compact range.
+            let _ = db.compact_range_cf(
+                CF_DEFAULT,
+                None,
+                None,
+                false,
+                1,
+            );
+
+            // Get the total SST files size after compact range.
+            let new_sst_files_size = db.get_total_sst_files_size_cf(CF_DEFAULT).unwrap().unwrap();
+            assert!(old_sst_files_size > new_sst_files_size);
+        }
+    }
 
     #[test]
     fn test_compact_range() {

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -1492,8 +1492,18 @@ where
         }
     }
 
+    fn prepare_stop(&self) {
+        if let Some(engines) = self.engines.as_ref() {
+            // Disable manul compaction jobs before shutting down the engines. And it
+            // will stop the compaction thread in advance, so it won't block the
+            // cleanup thread when exiting.
+            let _ = engines.engines.kv.disable_manual_compaction();
+        }
+    }
+
     fn stop(self) {
         tikv_util::thread_group::mark_shutdown();
+        self.prepare_stop();
         let mut servers = self.servers.unwrap();
         servers
             .server


### PR DESCRIPTION
Cherry-pick from #16700.

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #xxx

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
None.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None.
```
