### PR TITLE
enlarge default region size from 96MB to 256MB

### DIFF
--- a/components/raftstore/src/coprocessor/config.rs
+++ b/components/raftstore/src/coprocessor/config.rs
@@ -70,17 +70,17 @@ pub enum ConsistencyCheckMethod {
 }
 
 /// Default region split size.
-pub const SPLIT_SIZE: ReadableSize = ReadableSize::mb(96);
+pub const SPLIT_SIZE: ReadableSize = ReadableSize::mb(256);
 pub const RAFTSTORE_V2_SPLIT_SIZE: ReadableSize = ReadableSize::gb(10);
 
 /// Default batch split limit.
 pub const BATCH_SPLIT_LIMIT: u64 = 10;
 
 // A bucket will be split only when its size is larger than 2x of
-// DEFAULT_BUCKET_SIZE So the avg of the actual bucket size is 75MB, which is
-// slightly less than region size We don't use 48MB size because it will enable
-// the automatic bucket under default 96MB region size.
-pub const DEFAULT_BUCKET_SIZE: ReadableSize = ReadableSize::mb(50);
+// DEFAULT_BUCKET_SIZE So the avg of the actual bucket size is 200MB, which is
+// slightly less than region size. We don't use 48MB size because it will enable
+// the automatic bucket under default 256MB region size.
+pub const DEFAULT_BUCKET_SIZE: ReadableSize = ReadableSize::mb(133);
 
 pub const DEFAULT_REGION_BUCKET_MERGE_SIZE_RATIO: f64 = 0.33;
 

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -502,14 +502,14 @@
 ## When Region [a,e) size exceeds `region_max_size`, it will be split into several Regions [a,b),
 ## [b,c), [c,d), [d,e) and the size of [a,b), [b,c), [c,d) will be `region_split_size` (or a
 ## little larger).
-# region-max-size = "144MB"
-# region-split-size = "96MB"
+# region-max-size = "384MB"
+# region-split-size = "256MB"
 
 ## When the number of keys in Region [a,e) exceeds the `region_max_keys`, it will be split into
 ## several Regions [a,b), [b,c), [c,d), [d,e) and the number of keys in [a,b), [b,c), [c,d) will be
 ## `region_split_keys`.
-# region-max-keys = 1440000
-# region-split-keys = 960000
+# region-max-keys = 3840000
+# region-split-keys = 2560000
 
 ## Set to "mvcc" to do consistency check for MVCC data, or "raw" for raw data.
 # consistency-check-method = "mvcc"


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close https://github.com/tikv/tikv/issues/16732

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Change the default region size from 96MB to 256MB to reduce TiKV meta memory usage and PD meta management pressure.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Change the default region size from 96MB to 256MB to reduce TiKV meta memory usage and PD meta management pressure.
```
