### PR TITLE
In-memory engine: fix problems of sub range scheduling load task of the whole range

### DIFF
--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -1824,6 +1824,7 @@ where
     EK: KvEngine,
 {
     fn handle_put(&mut self, ctx: &mut ApplyContext<EK>, req: &Request) -> Result<()> {
+        fail::fail_point!("on_handle_put");
         PEER_WRITE_CMD_COUNTER.put.inc();
         let (key, value) = (req.get_put().get_key(), req.get_put().get_value());
         // region key range has no data prefix, so we must use origin key to check.

--- a/components/region_cache_memory_engine/src/engine.rs
+++ b/components/region_cache_memory_engine/src/engine.rs
@@ -322,6 +322,9 @@ impl RangeCacheMemoryEngine {
             .enumerate()
             .find_map(|(idx, r)| {
                 if r.contains_range(range) {
+                    // The `range` may be a proper subset of `r` and we should split it in this case
+                    // and push the rest back to `pending_range` so that each range only schedules
+                    // load task of its own.
                     Some((idx, r.split_off(range)))
                 } else if range.contains_range(r) {
                     // todo(SpadeA): merge occurs

--- a/components/region_cache_memory_engine/src/engine.rs
+++ b/components/region_cache_memory_engine/src/engine.rs
@@ -316,13 +316,13 @@ impl RangeCacheMemoryEngine {
 
         // check whether the range is in pending_range and we can schedule load task if
         // it is
-        if let Some((idx, pending_range)) = range_manager
+        if let Some((idx, (left_range, right_range))) = range_manager
             .pending_ranges
             .iter()
             .enumerate()
             .find_map(|(idx, r)| {
                 if r.contains_range(range) {
-                    Some((idx, r.clone()))
+                    Some((idx, r.split_off(range)))
                 } else if range.contains_range(r) {
                     // todo(SpadeA): merge occurs
                     unimplemented!()
@@ -332,6 +332,16 @@ impl RangeCacheMemoryEngine {
             })
         {
             let mut core = RwLockUpgradableReadGuard::upgrade(core);
+
+            let range_manager = core.mut_range_manager();
+            if let Some(left_range) = left_range {
+                range_manager.pending_ranges.push(left_range);
+            }
+
+            if let Some(right_range) = right_range {
+                range_manager.pending_ranges.push(right_range);
+            }
+
             let range_manager = core.mut_range_manager();
             range_manager.pending_ranges.swap_remove(idx);
             let rocks_snap = Arc::new(self.rocks_engine.as_ref().unwrap().snapshot(None));
@@ -339,7 +349,7 @@ impl RangeCacheMemoryEngine {
             // the region may be splitted.
             range_manager
                 .pending_ranges_loading_data
-                .push_back((pending_range, rocks_snap, false));
+                .push_back((range.clone(), rocks_snap, false));
             if let Err(e) = self
                 .bg_worker_manager()
                 .schedule_task(BackgroundTask::LoadRange)

--- a/tests/failpoints/cases/test_range_cache_engine.rs
+++ b/tests/failpoints/cases/test_range_cache_engine.rs
@@ -103,15 +103,10 @@ fn test_load() {
             cluster.must_put_cf(CF_WRITE, &encoded_key, b"val-write");
         }
 
-        if concurrent_with_split {
-            // The range is not splitted at the time of becoming pending
-            rx.recv_timeout(Duration::from_secs(5)).unwrap();
-        } else {
-            // ensure the snapshot is loaded
-            rx.recv_timeout(Duration::from_secs(5)).unwrap();
-            rx.recv_timeout(Duration::from_secs(5)).unwrap();
-            rx.recv_timeout(Duration::from_secs(5)).unwrap();
-        }
+        // ensure the snapshot is loaded
+        rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        rx.recv_timeout(Duration::from_secs(5)).unwrap();
 
         for i in (1..30).step_by(2) {
             let key = format!("key-{:04}", i);


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref #16141

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
fix problems of sub range scheduling load task of the whole range
```
This PR fixes a race of sub range scheluding load task of whole range. Say we are to load k1-k10 and k1-k5, and k5-k10 are ranges of two separete regions.
Now, the first one who calls `prepare_for_apply` will schedule the load of k1-k10 which can cause loss of data:
![image](https://github.com/tikv/tikv/assets/71589810/de002736-73ba-4dac-af7b-b83e685e1608)
We can see `k1` has not been written in rocksdb before acquiring snapshot and will not be written or cached in the in-memory engine. So it will be lost.

To fix it:
We should split the range of k1-k10 into k1-k5 and k5-k10 and only schedule k5-k10 in apply thread 2.
When k1-k5 calls `prepare_for_apply` again, it schedules the remaining k1-k5. Furthermore, k1-k5 may be splitted before next `prepare_for_apply`, and each child region is responsible for it's own range similarlly.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
