### PR TITLE
rocksdb: Expose track-and-verify-wals-in-manifest config (#16546)

### DIFF
--- a/components/engine_panic/src/db_options.rs
+++ b/components/engine_panic/src/db_options.rs
@@ -59,6 +59,10 @@ impl DbOptions for PanicDbOptions {
     fn set_titandb_options(&mut self, opts: &Self::TitanDbOptions) {
         panic!()
     }
+
+    fn set_track_and_verify_wals_in_manifest(&mut self, v: bool) {
+        panic!()
+    }
 }
 
 pub struct PanicTitanDbOptions;

--- a/components/engine_rocks/src/db_options.rs
+++ b/components/engine_rocks/src/db_options.rs
@@ -120,6 +120,10 @@ impl DbOptions for RocksDbOptions {
     fn set_titandb_options(&mut self, opts: &Self::TitanDbOptions) {
         self.0.set_titandb_options(opts.as_raw())
     }
+
+    fn set_track_and_verify_wals_in_manifest(&mut self, v: bool) {
+        self.0.set_track_and_verify_wals_in_manifest(v)
+    }
 }
 
 pub struct RocksTitanDbOptions(RawTitanDBOptions);

--- a/components/engine_traits/src/db_options.rs
+++ b/components/engine_traits/src/db_options.rs
@@ -24,6 +24,7 @@ pub trait DbOptions {
     fn get_flush_size(&self) -> Result<u64>;
     fn set_flush_oldest_first(&mut self, f: bool) -> Result<()>;
     fn set_titandb_options(&mut self, opts: &Self::TitanDbOptions);
+    fn set_track_and_verify_wals_in_manifest(&mut self, v: bool);
 }
 
 /// Titan-specefic options

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1362,7 +1362,7 @@ impl Default for DbConfig {
             write_buffer_limit: None,
             write_buffer_stall_ratio: 0.0,
             write_buffer_flush_oldest_first: true,
-            track_and_verify_wals_in_manifest: true,
+            track_and_verify_wals_in_manifest: false,
             paranoid_checks: None,
             defaultcf: DefaultCfConfig::default(),
             writecf: WriteCfConfig::default(),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1296,6 +1296,8 @@ pub struct DbConfig {
     #[doc(hidden)]
     #[serde(skip_serializing)]
     pub write_buffer_flush_oldest_first: bool,
+    #[online_config(skip)]
+    pub track_and_verify_wals_in_manifest: bool,
     // Dangerous option only for programming use.
     #[online_config(skip)]
     #[serde(skip)]
@@ -1360,6 +1362,7 @@ impl Default for DbConfig {
             write_buffer_limit: None,
             write_buffer_stall_ratio: 0.0,
             write_buffer_flush_oldest_first: true,
+            track_and_verify_wals_in_manifest: true,
             paranoid_checks: None,
             defaultcf: DefaultCfConfig::default(),
             writecf: WriteCfConfig::default(),
@@ -1536,6 +1539,7 @@ impl DbConfig {
             // Historical stats are not used.
             opts.set_stats_persist_period_sec(0);
         }
+        opts.set_track_and_verify_wals_in_manifest(self.track_and_verify_wals_in_manifest);
         opts
     }
 


### PR DESCRIPTION
This is a manual cherry-pick of #16546
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref #16549

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Expose track-and-verify-wals-in-manifest config.

For further investigating corrupted WAL issue happened during EBS restore process.

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
