### PR TITLE
tests: Fix flaky test_raw_put_key_guard

### DIFF
--- a/tests/failpoints/cases/test_rawkv.rs
+++ b/tests/failpoints/cases/test_rawkv.rs
@@ -290,7 +290,8 @@ fn test_raw_put_key_guard() {
     let region_id = region.get_id();
     let client = suite.get_client(region_id);
     let ctx = suite.get_context(region_id);
-    let node_id = region.get_peers()[0].get_id();
+    let leader = suite.cluster.leader_of_region(region_id).unwrap();
+    let node_id = leader.get_id();
     let leader_cm = suite.cluster.sim.rl().get_concurrency_manager(node_id);
     let ts_provider = suite.get_causal_ts_provider(node_id).unwrap();
     let ts = block_on(ts_provider.async_get_ts()).unwrap();
@@ -305,9 +306,10 @@ fn test_raw_put_key_guard() {
     // Wait for global_min_lock_ts.
     sleep_ms(500);
     let start = Instant::now();
-    while leader_cm.global_min_lock_ts().is_none()
-        && start.saturating_elapsed() < Duration::from_secs(5)
-    {
+    while leader_cm.global_min_lock_ts().is_none() {
+        if start.saturating_elapsed() > Duration::from_secs(5) {
+            panic!("wait for global_min_lock_ts timeout");
+        }
         sleep_ms(200);
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #16825

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Fix flaky test_raw_put_key_guard.
```

The issue is caused by peer `0` would not be the leader of region.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
