### PR TITLE
tests,storage: Fix flaky test_rawkv::test_leader_transfer

### DIFF
--- a/components/test_raftstore/src/util.rs
+++ b/components/test_raftstore/src/util.rs
@@ -64,7 +64,12 @@ use tikv::{
 };
 pub use tikv_util::store::{find_peer, new_learner_peer, new_peer};
 use tikv_util::{
-    config::*, escape, mpsc::future, time::ThreadReadId, worker::LazyWorker, HandyRwLock,
+    config::*,
+    escape,
+    mpsc::future,
+    time::{Instant, ThreadReadId},
+    worker::LazyWorker,
+    HandyRwLock,
 };
 use txn_types::Key;
 
@@ -1511,17 +1516,33 @@ pub fn must_raw_put(client: &TikvClient, ctx: Context, key: Vec<u8>, value: Vec<
     put_req.set_context(ctx);
     put_req.key = key;
     put_req.value = value;
-    let put_resp = client.raw_put(&put_req).unwrap();
-    assert!(
-        !put_resp.has_region_error(),
-        "{:?}",
-        put_resp.get_region_error()
-    );
-    assert!(
-        put_resp.get_error().is_empty(),
-        "{:?}",
-        put_resp.get_error()
-    );
+
+    let retryable = |err: &kvproto::errorpb::Error| -> bool { err.has_max_timestamp_not_synced() };
+    let start = Instant::now_coarse();
+    loop {
+        let put_resp = client.raw_put(&put_req).unwrap();
+        if put_resp.has_region_error() {
+            let err = put_resp.get_region_error();
+            if retryable(err) && start.saturating_elapsed() < Duration::from_secs(5) {
+                debug!("must_raw_put meet region error"; "err" => ?err);
+                sleep_ms(100);
+                continue;
+            }
+            panic!(
+                "must_raw_put meet region error: {:?}, ctx: {:?}, key: {}, value {}",
+                err,
+                put_req.get_context(),
+                tikv_util::escape(&put_req.key),
+                tikv_util::escape(&put_req.value),
+            );
+        }
+        assert!(
+            put_resp.get_error().is_empty(),
+            "must_raw_put meet error: {:?}",
+            put_resp.get_error()
+        );
+        return;
+    }
 }
 
 pub fn must_raw_get(client: &TikvClient, ctx: Context, key: Vec<u8>) -> Option<Vec<u8>> {

--- a/src/storage/errors.rs
+++ b/src/storage/errors.rs
@@ -279,11 +279,12 @@ pub fn extract_region_error_from_error(e: &Error) -> Option<errorpb::Error> {
         | Error(box ErrorInner::Txn(TxnError(box TxnErrorInner::Mvcc(MvccError(
             box MvccErrorInner::Kv(KvError(box KvErrorInner::Request(ref e))),
         ))))) => Some(e.to_owned()),
-        Error(box ErrorInner::Txn(TxnError(box TxnErrorInner::MaxTimestampNotSynced {
-            ..
-        }))) => {
+        Error(box ErrorInner::Txn(
+            e @ TxnError(box TxnErrorInner::MaxTimestampNotSynced { .. }),
+        )) => {
             let mut err = errorpb::Error::default();
             err.set_max_timestamp_not_synced(Default::default());
+            err.set_message(format!("Max timestamp not synced: {}", e));
             Some(err)
         }
         Error(box ErrorInner::Txn(TxnError(box TxnErrorInner::FlashbackNotPrepared(

--- a/src/storage/errors.rs
+++ b/src/storage/errors.rs
@@ -279,12 +279,19 @@ pub fn extract_region_error_from_error(e: &Error) -> Option<errorpb::Error> {
         | Error(box ErrorInner::Txn(TxnError(box TxnErrorInner::Mvcc(MvccError(
             box MvccErrorInner::Kv(KvError(box KvErrorInner::Request(ref e))),
         ))))) => Some(e.to_owned()),
+        Error(box ErrorInner::Txn(TxnError(box TxnErrorInner::MaxTimestampNotSynced {
+            ..
+        }))) => {
+            let mut err = errorpb::Error::default();
+            err.set_max_timestamp_not_synced(Default::default());
+            Some(err)
+        }
         Error(box ErrorInner::Txn(
-            e @ TxnError(box TxnErrorInner::MaxTimestampNotSynced { .. }),
+            e @ TxnError(box TxnErrorInner::RawKvMaxTimestampNotSynced { .. }),
         )) => {
             let mut err = errorpb::Error::default();
             err.set_max_timestamp_not_synced(Default::default());
-            err.set_message(format!("Max timestamp not synced: {}", e));
+            err.set_message(format!("{}", e));
             Some(err)
         }
         Error(box ErrorInner::Txn(TxnError(box TxnErrorInner::FlashbackNotPrepared(

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -2242,9 +2242,8 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                     SCHED_STAGE_COUNTER_VEC.get(tag).snapshot_ok.inc();
                     if !snapshot.ext().is_max_ts_synced() {
                         return Err(Error::from(txn::Error::from(
-                            TxnErrorInner::MaxTimestampNotSynced {
+                            TxnErrorInner::RawKvMaxTimestampNotSynced {
                                 region_id: ctx.get_region_id(),
-                                start_ts: TimeStamp::zero(),
                             },
                         )));
                     }

--- a/src/storage/txn/mod.rs
+++ b/src/storage/txn/mod.rs
@@ -144,6 +144,9 @@ pub enum ErrorInner {
     )]
     MaxTimestampNotSynced { region_id: u64, start_ts: TimeStamp },
 
+    #[error("RawKV write fails due to potentially stale max timestamp, region_id: {region_id}")]
+    RawKvMaxTimestampNotSynced { region_id: u64 },
+
     #[error("region {0} not prepared the flashback")]
     FlashbackNotPrepared(u64),
 }
@@ -179,6 +182,9 @@ impl ErrorInner {
                 region_id,
                 start_ts,
             }),
+            ErrorInner::RawKvMaxTimestampNotSynced { region_id } => {
+                Some(ErrorInner::RawKvMaxTimestampNotSynced { region_id })
+            }
             ErrorInner::FlashbackNotPrepared(region_id) => {
                 Some(ErrorInner::FlashbackNotPrepared(region_id))
             }
@@ -230,6 +236,9 @@ impl ErrorCodeExt for Error {
             ErrorInner::InvalidTxnTso { .. } => error_code::storage::INVALID_TXN_TSO,
             ErrorInner::InvalidReqRange { .. } => error_code::storage::INVALID_REQ_RANGE,
             ErrorInner::MaxTimestampNotSynced { .. } => {
+                error_code::storage::MAX_TIMESTAMP_NOT_SYNCED
+            }
+            ErrorInner::RawKvMaxTimestampNotSynced { .. } => {
                 error_code::storage::MAX_TIMESTAMP_NOT_SYNCED
             }
             ErrorInner::FlashbackNotPrepared(_) => error_code::storage::FLASHBACK_NOT_PREPARED,

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -1953,9 +1953,8 @@ pub async fn get_raw_ext(
         match cmd {
             Command::RawCompareAndSwap(_) | Command::RawAtomicStore(_) => {
                 if !max_ts_synced {
-                    return Err(ErrorInner::MaxTimestampNotSynced {
+                    return Err(ErrorInner::RawKvMaxTimestampNotSynced {
                         region_id: cmd.ctx().get_region_id(),
-                        start_ts: TimeStamp::zero(),
                     }
                     .into());
                 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #16789 

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Add RawKvMaxTimestampNotSynced error and set message to errorpb.Error.max_ts_not_synced to provide more information.
Retry on max_ts_not_synced error for must_raw_put.
```

The debug string of "max timestamp not synced" region error will be, e.g, `message: "RawKV write fails due to potentially stale max timestamp, region_id: 1"`.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Add RawKvMaxTimestampNotSynced error and set message to errorpb.Error.max_ts_not_synced to provide more information.
Retry on max_ts_not_synced error for must_raw_put.
```
