### PR TITLE
raftstore: enable apply committed log before persistence by default

### DIFF
--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -445,7 +445,7 @@ impl Default for Config {
             raft_log_gc_threshold: 50,
             raft_log_gc_count_limit: None,
             raft_log_gc_size_limit: None,
-            max_apply_unpersisted_log_limit: 0,
+            max_apply_unpersisted_log_limit: 1024,
             follower_read_max_log_gap: 100,
             raft_log_reserve_max_ticks: 6,
             raft_engine_purge_interval: ReadableDuration::secs(10),

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -1182,7 +1182,7 @@ where
     #[inline]
     pub fn maybe_update_apply_unpersisted_log_state(&mut self, applied_index: u64) {
         if self.min_safe_index_for_unpersisted_apply > 0
-            && self.min_safe_index_for_unpersisted_apply < applied_index
+            && self.min_safe_index_for_unpersisted_apply <= applied_index
         {
             if self.max_apply_unpersisted_log_limit > 0
                 && self

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6908,7 +6908,6 @@ mod tests {
         cfg.raftdb.titan.max_background_gc = default_cfg.raftdb.titan.max_background_gc;
         cfg.backup.num_threads = default_cfg.backup.num_threads;
         cfg.log_backup.num_threads = default_cfg.log_backup.num_threads;
-        cfg.raft_store.cmd_batch_concurrent_ready_max_count = 1;
 
         // There is another set of config values that we can't directly compare:
         // When the default values are `None`, but are then resolved to `Some(_)` later

--- a/tests/failpoints/cases/test_async_fetch.rs
+++ b/tests/failpoints/cases/test_async_fetch.rs
@@ -122,10 +122,7 @@ fn test_node_async_fetch() {
 fn test_persist_delay_block_log_compaction() {
     let mut cluster = new_node_cluster(0, 3);
 
-    cluster.cfg.raft_store.cmd_batch_concurrent_ready_max_count = 0;
     cluster.cfg.raft_store.store_io_pool_size = 1;
-    cluster.cfg.raft_store.max_apply_unpersisted_log_limit = 10000;
-
     cluster.cfg.raft_store.raft_log_gc_count_limit = Some(100000);
     cluster.cfg.raft_store.raft_log_gc_threshold = 50;
     cluster.cfg.raft_store.raft_log_gc_size_limit = Some(ReadableSize::mb(20));

--- a/tests/failpoints/cases/test_async_io.rs
+++ b/tests/failpoints/cases/test_async_io.rs
@@ -19,6 +19,7 @@ fn test_async_io_commit_without_leader_persist() {
     let mut cluster = new_cluster(0, 3);
     cluster.cfg.raft_store.cmd_batch_concurrent_ready_max_count = 0;
     cluster.cfg.raft_store.store_io_pool_size = 2;
+    cluster.cfg.raft_store.max_apply_unpersisted_log_limit = 0;
     let pd_client = Arc::clone(&cluster.pd_client);
     pd_client.disable_default_operator();
 

--- a/tests/failpoints/cases/test_async_io.rs
+++ b/tests/failpoints/cases/test_async_io.rs
@@ -52,9 +52,7 @@ fn test_async_io_commit_without_leader_persist() {
 #[test]
 fn test_async_io_apply_without_leader_persist() {
     let mut cluster = new_node_cluster(0, 3);
-    cluster.cfg.raft_store.cmd_batch_concurrent_ready_max_count = 0;
     cluster.cfg.raft_store.store_io_pool_size = 1;
-    cluster.cfg.raft_store.max_apply_unpersisted_log_limit = 10000;
     let pd_client = Arc::clone(&cluster.pd_client);
     pd_client.disable_default_operator();
 
@@ -92,6 +90,50 @@ fn test_async_io_apply_without_leader_persist() {
     for i in 1..=3 {
         must_get_equal(&cluster.get_engine(i), b"k1", b"v2");
     }
+}
+
+#[test]
+fn test_async_io_apply_conf_change_without_leader_persist() {
+    let mut cluster = new_node_cluster(0, 4);
+    cluster.cfg.raft_store.store_io_pool_size = 1;
+    let pd_client = Arc::clone(&cluster.pd_client);
+    pd_client.disable_default_operator();
+
+    let r1 = cluster.run_conf_change();
+
+    pd_client.must_add_peer(r1, new_peer(2, 2));
+    pd_client.must_add_peer(r1, new_peer(3, 3));
+
+    cluster.must_put(b"k1", b"v1");
+
+    let raft_before_save_on_store_1_fp = "raft_before_persist_on_store_1";
+    // Skip persisting to simulate raft log persist lag but not block node restart.
+    fail::cfg(raft_before_save_on_store_1_fp, "return").unwrap();
+
+    for i in 2..10 {
+        let _ = cluster
+            .async_put(format!("k{}", i).as_bytes(), b"v1")
+            .unwrap();
+    }
+    must_get_equal(&cluster.get_engine(1), b"k9", b"v1");
+
+    pd_client.must_add_peer(r1, new_peer(4, 4));
+    pd_client.remove_peer(r1, new_peer(3, 3));
+
+    cluster.must_put(b"k1", b"v2");
+    for i in [1, 2, 4] {
+        eventually_get_equal(&cluster.get_engine(i), b"k1", b"v2");
+    }
+    must_get_none(&cluster.get_engine(3), b"k1");
+
+    cluster.stop_node(1);
+    fail::remove(raft_before_save_on_store_1_fp);
+
+    // Node 1 can recover successfully.
+    cluster.run_node(1).unwrap();
+
+    cluster.must_put(b"k1", b"v3");
+    eventually_get_equal(&cluster.get_engine(1), b"k1", b"v3");
 }
 
 /// Test if the leader delays its destroy after applying conf change to

--- a/tests/failpoints/cases/test_early_apply.rs
+++ b/tests/failpoints/cases/test_early_apply.rs
@@ -41,6 +41,7 @@ fn test_multi_early_apply() {
     let mut cluster = new_cluster(0, 3);
     cluster.pd_client.disable_default_operator();
     cluster.cfg.raft_store.store_batch_system.pool_size = 1;
+    cluster.cfg.raft_store.max_apply_unpersisted_log_limit = 0;
     // So compact log will not be triggered automatically.
     configure_for_request_snapshot(&mut cluster.cfg);
 

--- a/tests/failpoints/cases/test_unsafe_recovery.rs
+++ b/tests/failpoints/cases/test_unsafe_recovery.rs
@@ -559,9 +559,7 @@ fn test_unsafe_recovery_rollback_merge() {
 fn test_unsafe_recovery_apply_before_persist() {
     let mut cluster = new_node_cluster(0, 5);
     cluster.cfg.raft_store.raft_store_max_leader_lease = ReadableDuration::millis(40);
-    cluster.cfg.raft_store.cmd_batch_concurrent_ready_max_count = 0;
     cluster.cfg.raft_store.store_io_pool_size = 1;
-    cluster.cfg.raft_store.max_apply_unpersisted_log_limit = 10000;
     cluster.run();
     assert_eq!(cluster.get_node_ids().len(), 5);
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #16717

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Change the default value of `raftstore.max_apply_unpersisted_log_limit` from 0 to 1024 to enable apply committed log before persistence by default.
```

In our internal benchmark, with 3*8c tikv instances, when running sysbench oltp_write_only workload with 100 threads, the performance is almost the same when this feature is enabled/disabled. The result matches our expectation that this feature won't bring any performance impact.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
