### PR TITLE
In-memory engine: fix missing memory record when snapshot loading

### DIFF
--- a/components/engine_traits/src/range_cache_engine.rs
+++ b/components/engine_traits/src/range_cache_engine.rs
@@ -63,7 +63,7 @@ impl Debug for CacheRange {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CacheRange")
             .field("range_start", &log_wrappers::Value(&self.start))
-            .field("value", &log_wrappers::Value(&self.end))
+            .field("range_end", &log_wrappers::Value(&self.end))
             .finish()
     }
 }

--- a/components/region_cache_memory_engine/src/background.rs
+++ b/components/region_cache_memory_engine/src/background.rs
@@ -630,6 +630,7 @@ impl Runnable for BackgroundRunner {
 
                         let start = Instant::now();
                         if !snapshot_load() {
+                            // snapshot load failed, we should clear the dirty data
                             core.delete_ranges(&[range.clone()]);
                             core.on_snapshot_load_canceled(range);
                             continue;
@@ -896,7 +897,7 @@ pub mod tests {
         let guard = &epoch::pin();
         let _ = mem_controller.acquire(RangeCacheWriteBatchEntry::calc_put_entry_size(
             &raw_write_k,
-            &val.as_bytes(),
+            val.as_bytes(),
         ));
         write_cf.insert(write_k, val, guard);
 
@@ -910,7 +911,7 @@ pub mod tests {
             val.set_memory_controller(mem_controller.clone());
             let _ = mem_controller.acquire(RangeCacheWriteBatchEntry::calc_put_entry_size(
                 &raw_default_k,
-                &val.as_bytes(),
+                val.as_bytes(),
             ));
             default_cf.insert(default_k, val, guard);
         }
@@ -934,7 +935,7 @@ pub mod tests {
         let guard = &epoch::pin();
         let _ = mem_controller.acquire(RangeCacheWriteBatchEntry::calc_put_entry_size(
             &raw_write_k,
-            &val.as_bytes(),
+            val.as_bytes(),
         ));
         write_cf.insert(write_k, val, guard);
     }
@@ -957,7 +958,7 @@ pub mod tests {
         let guard = &epoch::pin();
         let _ = mem_controller.acquire(RangeCacheWriteBatchEntry::calc_put_entry_size(
             &raw_write_k,
-            &val.as_bytes(),
+            val.as_bytes(),
         ));
         write_cf.insert(write_k, val, guard);
     }

--- a/components/region_cache_memory_engine/src/background.rs
+++ b/components/region_cache_memory_engine/src/background.rs
@@ -587,8 +587,8 @@ impl Runnable for BackgroundRunner {
                                     Ok(mut iter) => {
                                         iter.seek_to_first().unwrap();
                                         while iter.valid().unwrap() {
-                                            // use 0 sequence number here as the kv is clearly
-                                            // visible
+                                            // use the sequence number from RocksDB snapshot here as
+                                            // the kv is clearly visible
                                             let mut encoded_key =
                                                 encode_key(iter.key(), seq, ValueType::Value);
                                             let mut val =

--- a/components/region_cache_memory_engine/src/background.rs
+++ b/components/region_cache_memory_engine/src/background.rs
@@ -463,7 +463,9 @@ pub(crate) fn flush_epoch() {
         let guard = &epoch::pin();
         guard.flush();
     }
-    // local epoch tries to advance the global epoch every 128 pins.
+    // local epoch tries to advance the global epoch every 128 pins. When global
+    // epoch advances, the operations(here, means delete) in the older epoch can be
+    // executed.
     for _ in 0..128 {
         let _ = &epoch::pin();
     }

--- a/components/region_cache_memory_engine/src/background.rs
+++ b/components/region_cache_memory_engine/src/background.rs
@@ -1695,7 +1695,7 @@ pub mod tests {
 
         let verify = |range: CacheRange, exist, expect_count| {
             if exist {
-                let snap = engine.snapshot(range.clone(), 10, 10).unwrap();
+                let snap = engine.snapshot(range.clone(), 10, u64::MAX).unwrap();
                 let mut count = 0;
                 for cf in DATA_CFS {
                     let mut iter = IterOptions::default();

--- a/components/region_cache_memory_engine/src/background.rs
+++ b/components/region_cache_memory_engine/src/background.rs
@@ -456,9 +456,6 @@ impl BackgroundRunnerCore {
 // flush epoch and pin enough times to make the delayed operations be executed
 #[cfg(test)]
 pub(crate) fn flush_epoch() {
-    // Epoch is global unique, so sleep a while to mitigate the influence of unpined
-    // guard in other concurrent test cases.
-    std::thread::sleep(Duration::from_secs(2));
     {
         let guard = &epoch::pin();
         guard.flush();

--- a/components/region_cache_memory_engine/src/background.rs
+++ b/components/region_cache_memory_engine/src/background.rs
@@ -453,14 +453,14 @@ impl BackgroundRunnerCore {
     }
 }
 
-// flush epoch and pin enough times to make the delayed operations be executed
+// Flush epoch and pin enough times to make the delayed operations be executed
 #[cfg(test)]
 pub(crate) fn flush_epoch() {
     {
         let guard = &epoch::pin();
         guard.flush();
     }
-    // local epoch tries to advance the global epoch every 128 pins. When global
+    // Local epoch tries to advance the global epoch every 128 pins. When global
     // epoch advances, the operations(here, means delete) in the older epoch can be
     // executed.
     for _ in 0..128 {

--- a/components/region_cache_memory_engine/src/background.rs
+++ b/components/region_cache_memory_engine/src/background.rs
@@ -26,7 +26,7 @@ use yatp::Remote;
 use crate::{
     engine::{RangeCacheMemoryEngineCore, SkiplistHandle},
     keys::{decode_key, encode_key, encoding_for_filter, InternalBytes, InternalKey, ValueType},
-    memory_controller::MemoryController,
+    memory_controller::{MemoryController, MemoryUsage},
     metrics::{
         GC_FILTERED_STATIC, RANGE_CACHE_MEMORY_USAGE, RANGE_GC_TIME_HISTOGRAM,
         RANGE_LOAD_TIME_HISTOGRAM,
@@ -35,6 +35,7 @@ use crate::{
     region_label::{
         LabelRule, RegionLabelAddedCb, RegionLabelRulesManager, RegionLabelServiceBuilder,
     },
+    write_batch::RangeCacheWriteBatchEntry,
 };
 
 /// Try to extract the key and `u64` timestamp from `encoded_key`.
@@ -446,6 +447,23 @@ impl BackgroundRunnerCore {
             .write()
             .mut_range_manager()
             .on_delete_ranges(ranges);
+        #[cfg(test)]
+        flush_epoch();
+    }
+}
+
+// flush epoch and pin enough times to make the delayed operations be executed
+#[cfg(test)]
+pub(crate) fn flush_epoch() {
+    // Epoch is global unique, so sleep a while to mitigate the influence of unpined
+    // guard in other concurrent test cases.
+    std::thread::sleep(Duration::from_secs(2));
+    {
+        let guard = &epoch::pin();
+        guard.flush();
+    }
+    for _ in 0..128 {
+        let _ = &epoch::pin();
     }
 }
 
@@ -513,6 +531,10 @@ impl Runnable for BackgroundRunner {
     fn run(&mut self, task: Self::Task) {
         match task {
             BackgroundTask::Gc(t) => {
+                info!(
+                    "start a new round of gc for range cache engine";
+                    "safe_point" => t.safe_point,
+                );
                 let mut core = self.core.clone();
                 if let Some(ranges) = core.ranges_for_gc() {
                     let f = async move {
@@ -547,35 +569,72 @@ impl Runnable for BackgroundRunner {
                         }
 
                         if canceled {
+                            info!(
+                                "snapshot load canceled due to memory reaching soft limit";
+                                "range" => ?range,
+                            );
                             core.on_snapshot_load_canceled(range);
                             continue;
                         }
-                        let start = Instant::now();
-                        for &cf in DATA_CFS {
-                            let guard = &epoch::pin();
-                            let handle = skiplist_engine.cf_handle(cf);
-                            match snap.iterator_opt(cf, iter_opt.clone()) {
-                                Ok(mut iter) => {
-                                    iter.seek_to_first().unwrap();
-                                    while iter.valid().unwrap() {
-                                        // use 0 sequence number here as the kv is clearly
-                                        // visible
-                                        let mut encoded_key =
-                                            encode_key(iter.key(), 0, ValueType::Value);
-                                        let mut val =
-                                            InternalBytes::from_vec(iter.value().to_vec());
-                                        encoded_key
-                                            .set_memory_controller(core.memory_controller.clone());
-                                        val.set_memory_controller(core.memory_controller.clone());
-                                        handle.insert(encoded_key, val, guard);
-                                        iter.next().unwrap();
+
+                        let snapshot_load = || -> bool {
+                            for &cf in DATA_CFS {
+                                let handle = skiplist_engine.cf_handle(cf);
+                                let guard = &epoch::pin();
+                                match snap.iterator_opt(cf, iter_opt.clone()) {
+                                    Ok(mut iter) => {
+                                        iter.seek_to_first().unwrap();
+                                        while iter.valid().unwrap() {
+                                            // use 0 sequence number here as the kv is clearly
+                                            // visible
+                                            let mut encoded_key =
+                                                encode_key(iter.key(), 0, ValueType::Value);
+                                            let mut val =
+                                                InternalBytes::from_vec(iter.value().to_vec());
+
+                                            let mem_size =
+                                                RangeCacheWriteBatchEntry::calc_put_entry_size(
+                                                    iter.key(),
+                                                    val.as_bytes(),
+                                                );
+
+                                            if let MemoryUsage::HardLimitReached(n) =
+                                                core.memory_controller.acquire(mem_size)
+                                            {
+                                                warn!(
+                                                    "stop loading snapshot due to memory reaching hard limit";
+                                                    "range" => ?range,
+                                                    "memory_usage(MB)" => ReadableSize(n as u64).as_mb_f64(),
+                                                );
+                                                return false;
+                                            }
+
+                                            encoded_key.set_memory_controller(
+                                                core.memory_controller.clone(),
+                                            );
+                                            val.set_memory_controller(
+                                                core.memory_controller.clone(),
+                                            );
+                                            handle.insert(encoded_key, val, guard);
+                                            iter.next().unwrap();
+                                        }
+                                    }
+                                    Err(e) => {
+                                        error!("creating rocksdb iterator failed"; "cf" => cf, "err" => %e);
+                                        return false;
                                     }
                                 }
-                                Err(e) => {
-                                    error!("creating rocksdb iterator failed"; "cf" => cf, "err" => %e);
-                                }
                             }
+                            true
+                        };
+
+                        let start = Instant::now();
+                        if !snapshot_load() {
+                            core.delete_ranges(&[range.clone()]);
+                            core.on_snapshot_load_canceled(range);
+                            continue;
                         }
+
                         if core.on_snapshot_load_finished(range.clone()) {
                             let duration = start.saturating_elapsed();
                             RANGE_LOAD_TIME_HISTOGRAM.observe(duration.as_secs_f64());
@@ -781,12 +840,13 @@ pub mod tests {
     use crossbeam::epoch;
     use engine_rocks::util::new_engine;
     use engine_traits::{
-        CacheRange, RangeCacheEngine, SyncMutable, CF_DEFAULT, CF_WRITE, DATA_CFS,
+        CacheRange, IterOptions, Iterable, Iterator, RangeCacheEngine, SyncMutable, CF_DEFAULT,
+        CF_LOCK, CF_WRITE, DATA_CFS,
     };
     use keys::{data_key, DATA_MAX_KEY, DATA_MIN_KEY};
     use pd_client::PdClient;
     use tempfile::Builder;
-    use tikv_util::config::ReadableDuration;
+    use tikv_util::config::{ReadableDuration, ReadableSize};
     use txn_types::{Key, TimeStamp, Write, WriteType};
 
     use super::{Filter, PdRangeHintService};
@@ -794,14 +854,15 @@ pub mod tests {
         background::BackgroundRunner,
         engine::{SkiplistEngine, SkiplistHandle},
         keys::{
-            construct_key, construct_value, encode_key, encode_seek_key, encoding_for_filter,
-            InternalBytes, ValueType,
+            construct_key, construct_user_key, construct_value, encode_key, encode_seek_key,
+            encoding_for_filter, InternalBytes, ValueType,
         },
         memory_controller::MemoryController,
         region_label::{
             region_label_meta_client,
             tests::{add_region_label_rule, new_region_label_rule, new_test_server_and_client},
         },
+        write_batch::RangeCacheWriteBatchEntry,
         RangeCacheEngineConfig, RangeCacheMemoryEngine,
     };
 
@@ -816,10 +877,10 @@ pub mod tests {
         write_cf: &SkiplistHandle,
         mem_controller: Arc<MemoryController>,
     ) {
-        let write_k = Key::from_raw(key)
+        let raw_write_k = Key::from_raw(key)
             .append_ts(TimeStamp::new(commit_ts))
             .into_encoded();
-        let mut write_k = encode_key(&write_k, seq_num, ValueType::Value);
+        let mut write_k = encode_key(&raw_write_k, seq_num, ValueType::Value);
         write_k.set_memory_controller(mem_controller.clone());
         let write_v = Write::new(
             WriteType::Put,
@@ -833,16 +894,24 @@ pub mod tests {
         let mut val = InternalBytes::from_vec(write_v.as_ref().to_bytes());
         val.set_memory_controller(mem_controller.clone());
         let guard = &epoch::pin();
+        let _ = mem_controller.acquire(RangeCacheWriteBatchEntry::calc_put_entry_size(
+            &raw_write_k,
+            &val.as_bytes(),
+        ));
         write_cf.insert(write_k, val, guard);
 
         if !short_value {
-            let default_k = Key::from_raw(key)
+            let raw_default_k = Key::from_raw(key)
                 .append_ts(TimeStamp::new(start_ts))
                 .into_encoded();
-            let mut default_k = encode_key(&default_k, seq_num + 1, ValueType::Value);
+            let mut default_k = encode_key(&raw_default_k, seq_num + 1, ValueType::Value);
             default_k.set_memory_controller(mem_controller.clone());
             let mut val = InternalBytes::from_vec(value.to_vec());
-            val.set_memory_controller(mem_controller);
+            val.set_memory_controller(mem_controller.clone());
+            let _ = mem_controller.acquire(RangeCacheWriteBatchEntry::calc_put_entry_size(
+                &raw_default_k,
+                &val.as_bytes(),
+            ));
             default_cf.insert(default_k, val, guard);
         }
     }
@@ -854,15 +923,19 @@ pub mod tests {
         write_cf: &SkiplistHandle,
         mem_controller: Arc<MemoryController>,
     ) {
-        let write_k = Key::from_raw(key)
+        let raw_write_k = Key::from_raw(key)
             .append_ts(TimeStamp::new(ts))
             .into_encoded();
-        let mut write_k = encode_key(&write_k, seq_num, ValueType::Value);
+        let mut write_k = encode_key(&raw_write_k, seq_num, ValueType::Value);
         write_k.set_memory_controller(mem_controller.clone());
         let write_v = Write::new(WriteType::Delete, TimeStamp::new(ts), None);
         let mut val = InternalBytes::from_vec(write_v.as_ref().to_bytes());
-        val.set_memory_controller(mem_controller);
+        val.set_memory_controller(mem_controller.clone());
         let guard = &epoch::pin();
+        let _ = mem_controller.acquire(RangeCacheWriteBatchEntry::calc_put_entry_size(
+            &raw_write_k,
+            &val.as_bytes(),
+        ));
         write_cf.insert(write_k, val, guard);
     }
 
@@ -873,15 +946,19 @@ pub mod tests {
         write_cf: &SkiplistHandle,
         mem_controller: Arc<MemoryController>,
     ) {
-        let write_k = Key::from_raw(key)
+        let raw_write_k = Key::from_raw(key)
             .append_ts(TimeStamp::new(ts))
             .into_encoded();
-        let mut write_k = encode_key(&write_k, seq_num, ValueType::Value);
+        let mut write_k = encode_key(&raw_write_k, seq_num, ValueType::Value);
         write_k.set_memory_controller(mem_controller.clone());
         let write_v = Write::new(WriteType::Rollback, TimeStamp::new(ts), None);
         let mut val = InternalBytes::from_vec(write_v.as_ref().to_bytes());
-        val.set_memory_controller(mem_controller);
+        val.set_memory_controller(mem_controller.clone());
         let guard = &epoch::pin();
+        let _ = mem_controller.acquire(RangeCacheWriteBatchEntry::calc_put_entry_size(
+            &raw_write_k,
+            &val.as_bytes(),
+        ));
         write_cf.insert(write_k, val, guard);
     }
 
@@ -1527,5 +1604,111 @@ pub mod tests {
         }
 
         pd_server.stop();
+    }
+
+    #[test]
+    fn test_snapshot_load_reaching_limit() {
+        let mut config = RangeCacheEngineConfig::config_for_test();
+        config.soft_limit_threshold = Some(ReadableSize(1000));
+        config.hard_limit_threshold = Some(ReadableSize(1500));
+        let mut engine = RangeCacheMemoryEngine::new(&config);
+        let path = Builder::new()
+            .prefix("test_snapshot_load_reaching_limit")
+            .tempdir()
+            .unwrap();
+        let path_str = path.path().to_str().unwrap();
+        let rocks_engine = new_engine(path_str, DATA_CFS).unwrap();
+        engine.set_disk_engine(rocks_engine.clone());
+        let mem_controller = engine.memory_controller();
+
+        let range1 = CacheRange::new(construct_user_key(1), construct_user_key(3));
+        // Memory for one put is 17(key) + 3(val) + 8(Seqno) + 16(Memory controller in
+        // key and val) + 96(Node overhead) = 140
+        let key = construct_key(1, 10);
+        rocks_engine.put_cf(CF_DEFAULT, &key, b"val").unwrap();
+        rocks_engine.put_cf(CF_LOCK, &key, b"val").unwrap();
+        rocks_engine.put_cf(CF_WRITE, &key, b"val").unwrap();
+
+        let key = construct_key(2, 10);
+        rocks_engine.put_cf(CF_DEFAULT, &key, b"val").unwrap();
+        rocks_engine.put_cf(CF_LOCK, &key, b"val").unwrap();
+        rocks_engine.put_cf(CF_WRITE, &key, b"val").unwrap();
+        // After loading range1, the memory usage should be 140*6=840
+
+        let range2 = CacheRange::new(construct_user_key(3), construct_user_key(5));
+        let key = construct_key(3, 10);
+        rocks_engine.put_cf(CF_DEFAULT, &key, b"val").unwrap();
+        rocks_engine.put_cf(CF_LOCK, &key, b"val").unwrap();
+        rocks_engine.put_cf(CF_WRITE, &key, b"val").unwrap();
+
+        let key = construct_key(4, 10);
+        rocks_engine.put_cf(CF_DEFAULT, &key, b"val").unwrap();
+        rocks_engine.put_cf(CF_LOCK, &key, b"val").unwrap();
+        rocks_engine.put_cf(CF_WRITE, &key, b"val").unwrap();
+        // 840*2 > hard limit 1500, so the load will fail and the loaded keys should be
+        // removed
+
+        let range3 = CacheRange::new(construct_user_key(5), construct_user_key(6));
+        let key = construct_key(5, 10);
+        rocks_engine.put_cf(CF_DEFAULT, &key, b"val").unwrap();
+        rocks_engine.put_cf(CF_LOCK, &key, b"val").unwrap();
+        rocks_engine.put_cf(CF_WRITE, &key, b"val").unwrap();
+        // Memory usage reaches 1260
+
+        let range4 = CacheRange::new(construct_user_key(6), construct_user_key(7));
+        let key = construct_key(6, 10);
+        rocks_engine.put_cf(CF_DEFAULT, &key, b"val").unwrap();
+        rocks_engine.put_cf(CF_LOCK, &key, b"val").unwrap();
+        // Although the memory is enough for loading range4, it is alreay reaching soft
+        // limit at begin.
+
+        for r in [&range1, &range2, &range3, &range4] {
+            engine.load_range(r.clone()).unwrap();
+            engine.prepare_for_apply(r);
+        }
+
+        // ensure all ranges are finshed
+        {
+            let mut count = 0;
+            while count < 20 {
+                {
+                    let core = engine.core.read();
+                    let range_manager = core.range_manager();
+                    if range_manager.pending_ranges.is_empty()
+                        && range_manager.pending_ranges_loading_data.is_empty()
+                    {
+                        break;
+                    }
+                }
+                std::thread::sleep(Duration::from_millis(100));
+                count += 1;
+            }
+        }
+
+        let verify = |range: CacheRange, exist, expect_count| {
+            if exist {
+                let snap = engine.snapshot(range.clone(), 10, 10).unwrap();
+                let mut count = 0;
+                for cf in DATA_CFS {
+                    let mut iter = IterOptions::default();
+                    iter.set_lower_bound(&range.start, 0);
+                    iter.set_upper_bound(&range.end, 0);
+                    let mut iter = snap.iterator_opt(cf, iter).unwrap();
+                    let _ = iter.seek_to_first();
+                    while iter.valid().unwrap() {
+                        let _ = iter.next();
+                        count += 1;
+                    }
+                }
+                assert_eq!(count, expect_count);
+            } else {
+                engine.snapshot(range, 10, 10).unwrap_err();
+            }
+        };
+        verify(range1, true, 6);
+        verify(range2, false, 0);
+        verify(range3, true, 3);
+        verify(range4, false, 0);
+        assert_eq!(mem_controller.mem_usage(), 1260);
     }
 }

--- a/components/region_cache_memory_engine/src/range_manager.rs
+++ b/components/region_cache_memory_engine/src/range_manager.rs
@@ -112,9 +112,8 @@ pub struct RangeManager {
     // Range before an eviction. It is recorded due to some undropped snapshot, which block the
     // evicted range deleting the relevant data.
     historical_ranges: BTreeMap<CacheRange, RangeMeta>,
-    // `ranges_being_deleted` contains two types of ranges: 1. the range is evicted and not finish
-    // the delete(or even not start to delete due to ongoing snapshot), 2. the range is loading
-    // data but memory acquirement is rejected.
+    // `ranges_being_deleted` contains ranges that are evicted but not finished the delete (or even
+    // not start to delete due to ongoing snapshot)
     pub(crate) ranges_being_deleted: BTreeSet<CacheRange>,
     // ranges that are cached now
     ranges: BTreeMap<CacheRange, RangeMeta>,


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref #16141

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
fix missing memory record when snapshot loading
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
