### PR TITLE
In-memory engine: delete lock physically rather than writting tombstone

### DIFF
--- a/components/region_cache_memory_engine/src/engine.rs
+++ b/components/region_cache_memory_engine/src/engine.rs
@@ -41,7 +41,7 @@ pub(crate) fn cf_to_id(cf: &str) -> usize {
     }
 }
 
-pub(crate) fn id_to_cf(id: usize) -> &str {
+pub(crate) fn id_to_cf(id: usize) -> &'static str {
     match id {
         0 => CF_DEFAULT,
         1 => CF_LOCK,

--- a/components/region_cache_memory_engine/src/engine.rs
+++ b/components/region_cache_memory_engine/src/engine.rs
@@ -3,6 +3,7 @@
 use std::{
     collections::BTreeMap,
     fmt::{self, Debug},
+    ops::Bound,
     result,
     sync::Arc,
 };
@@ -60,6 +61,19 @@ impl SkiplistHandle {
         guard: &'g Guard,
     ) -> Option<Entry<'a, 'g, InternalBytes, InternalBytes>> {
         self.0.get(key, guard)
+    }
+
+    pub fn get_with_user_key<'a: 'g, 'g>(
+        &'a self,
+        key: &InternalBytes,
+        guard: &'g Guard,
+    ) -> Option<Entry<'a, 'g, InternalBytes, InternalBytes>> {
+        let n = self.0.lower_bound(Bound::Included(key), guard)?;
+        if n.key().same_user_key_with(key) {
+            Some(n)
+        } else {
+            None
+        }
     }
 
     pub fn insert(&self, key: InternalBytes, value: InternalBytes, guard: &Guard) {

--- a/components/region_cache_memory_engine/src/engine.rs
+++ b/components/region_cache_memory_engine/src/engine.rs
@@ -14,7 +14,10 @@ use engine_traits::{
     CF_DEFAULT, CF_LOCK, CF_WRITE, DATA_CFS,
 };
 use parking_lot::{lock_api::RwLockUpgradableReadGuard, RwLock, RwLockWriteGuard};
-use skiplist_rs::{base::OwnedIter, SkipList};
+use skiplist_rs::{
+    base::{Entry, OwnedIter},
+    SkipList,
+};
 use slog_global::error;
 use tikv_util::info;
 
@@ -37,11 +40,28 @@ pub(crate) fn cf_to_id(cf: &str) -> usize {
     }
 }
 
+pub(crate) fn id_to_cf(id: usize) -> &str {
+    match id {
+        0 => CF_DEFAULT,
+        1 => CF_LOCK,
+        2 => CF_WRITE,
+        _ => panic!("unrecognized id {}", id),
+    }
+}
+
 // A wrapper for skiplist to provide some check and clean up worker
 #[derive(Clone)]
 pub struct SkiplistHandle(Arc<SkipList<InternalBytes, InternalBytes>>);
 
 impl SkiplistHandle {
+    pub fn get<'a: 'g, 'g>(
+        &'a self,
+        key: &InternalBytes,
+        guard: &'g Guard,
+    ) -> Option<Entry<'a, 'g, InternalBytes, InternalBytes>> {
+        self.0.get(key, guard)
+    }
+
     pub fn insert(&self, key: InternalBytes, value: InternalBytes, guard: &Guard) {
         assert!(key.memory_controller_set() && value.memory_controller_set());
         self.0.insert(key, value, guard).release(guard);


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref #16141

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
delete lock physically rather than writting tombstone
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
