### PR TITLE
rocksdb: Expose track-and-verify-wals-in-manifest config 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2817,7 +2817,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-7.1#f9615d673d416c219163588d2e24e3ee254b83d7"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-7.1#2a127d084abb239a6c53e1e82e695325cf66bbce"
 dependencies = [
  "bindgen 0.57.0",
  "bzip2-sys",
@@ -2836,7 +2836,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-7.1#f9615d673d416c219163588d2e24e3ee254b83d7"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-7.1#2a127d084abb239a6c53e1e82e695325cf66bbce"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -4710,7 +4710,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-7.1#f9615d673d416c219163588d2e24e3ee254b83d7"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-7.1#2a127d084abb239a6c53e1e82e695325cf66bbce"
 dependencies = [
  "libc 0.2.139",
  "librocksdb_sys",

--- a/components/engine_panic/src/db_options.rs
+++ b/components/engine_panic/src/db_options.rs
@@ -47,6 +47,10 @@ impl DbOptions for PanicDbOptions {
     fn set_titandb_options(&mut self, opts: &Self::TitanDbOptions) {
         panic!()
     }
+
+    fn set_track_and_verify_wals_in_manifest(&mut self, v: bool) {
+        panic!()
+    }
 }
 
 pub struct PanicTitanDbOptions;

--- a/components/engine_rocks/src/db_options.rs
+++ b/components/engine_rocks/src/db_options.rs
@@ -94,6 +94,10 @@ impl DbOptions for RocksDbOptions {
     fn set_titandb_options(&mut self, opts: &Self::TitanDbOptions) {
         self.0.set_titandb_options(opts.as_raw())
     }
+
+    fn set_track_and_verify_wals_in_manifest(&mut self, v: bool) {
+        self.0.set_track_and_verify_wals_in_manifest(v)
+    }
 }
 
 pub struct RocksTitanDbOptions(RawTitanDBOptions);

--- a/components/engine_traits/src/db_options.rs
+++ b/components/engine_traits/src/db_options.rs
@@ -21,6 +21,7 @@ pub trait DbOptions {
     fn get_rate_limiter_auto_tuned(&self) -> Option<bool>;
     fn set_rate_limiter_auto_tuned(&mut self, rate_limiter_auto_tuned: bool) -> Result<()>;
     fn set_titandb_options(&mut self, opts: &Self::TitanDbOptions);
+    fn set_track_and_verify_wals_in_manifest(&mut self, v: bool);
 }
 
 /// Titan-specefic options

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1237,6 +1237,8 @@ pub struct DbConfig {
     #[doc(hidden)]
     #[serde(skip_serializing)]
     pub write_buffer_flush_oldest_first: bool,
+    #[online_config(skip)]
+    pub track_and_verify_wals_in_manifest: bool,
     // Dangerous option only for programming use.
     #[online_config(skip)]
     #[serde(skip)]
@@ -1305,6 +1307,7 @@ impl Default for DbConfig {
             write_buffer_limit: None,
             write_buffer_stall_ratio: 0.0,
             write_buffer_flush_oldest_first: false,
+            track_and_verify_wals_in_manifest: false,
             paranoid_checks: None,
             defaultcf: DefaultCfConfig::default(),
             writecf: WriteCfConfig::default(),
@@ -1433,6 +1436,7 @@ impl DbConfig {
             // Historical stats are not used.
             opts.set_stats_persist_period_sec(0);
         }
+        opts.set_track_and_verify_wals_in_manifest(self.track_and_verify_wals_in_manifest);
         opts
     }
 

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -326,6 +326,7 @@ fn test_serde_custom_tikv_config() {
         write_buffer_limit: Some(ReadableSize::gb(1)),
         write_buffer_stall_ratio: 0.0,
         write_buffer_flush_oldest_first: false,
+        track_and_verify_wals_in_manifest: false,
         defaultcf: DefaultCfConfig {
             block_size: ReadableSize::kb(12),
             block_cache_size: ReadableSize::gb(12),


### PR DESCRIPTION
This is a manual cherry-pick of #16546
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref #16549

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Expose track-and-verify-wals-in-manifest config.

For further investigating corrupted WAL issue happened during EBS restore process.

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
