### PR TITLE
In-memory engine: remove out of date pending ranges

### DIFF
--- a/components/engine_traits/src/range_cache_engine.rs
+++ b/components/engine_traits/src/range_cache_engine.rs
@@ -63,7 +63,7 @@ pub struct CacheRange {
 impl Debug for CacheRange {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CacheRange")
-            .field("tag", &log_wrappers::Value(&self.tag))
+            .field("tag", &self.tag)
             .field("range_start", &log_wrappers::Value(&self.start))
             .field("range_end", &log_wrappers::Value(&self.end))
             .finish()

--- a/components/region_cache_memory_engine/src/engine.rs
+++ b/components/region_cache_memory_engine/src/engine.rs
@@ -321,6 +321,7 @@ impl RangeCacheMemoryEngine {
             return RangeCacheStatus::Cached;
         }
 
+        let mut overlapped = false;
         // check whether the range is in pending_range and we can schedule load task if
         // it is
         if let Some((idx, (left_range, right_range))) = range_manager
@@ -333,15 +334,27 @@ impl RangeCacheMemoryEngine {
                     // and push the rest back to `pending_range` so that each range only schedules
                     // load task of its own.
                     Some((idx, r.split_off(range)))
-                } else if range.contains_range(r) {
-                    // todo(SpadeA): merge occurs
-                    unimplemented!()
+                } else if range.overlaps(r) {
+                    // Pending range `range` does not contains the applying range `r` but overlap
+                    // with it, which means the pending range is out dated, we remove it directly.
+                    info!(
+                        "out of date pending ranges";
+                        "applying_range" => ?range,
+                        "pending_range" => ?r,
+                    );
+                    overlapped = true;
+                    Some((idx, (None, None)))
                 } else {
                     None
                 }
             })
         {
             let mut core = RwLockUpgradableReadGuard::upgrade(core);
+
+            if overlapped {
+                core.mut_range_manager().pending_ranges.swap_remove(idx);
+                return RangeCacheStatus::NotInCache;
+            }
 
             let range_manager = core.mut_range_manager();
             if let Some(left_range) = left_range {
@@ -466,5 +479,46 @@ impl Iterable for RangeCacheMemoryEngine {
     fn iterator_opt(&self, _: &str, _: IterOptions) -> Result<Self::Iterator> {
         // This engine does not support creating iterators directly by the engine.
         panic!("iterator_opt is not supported on creating by RangeCacheMemoryEngine directly")
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use engine_traits::CacheRange;
+
+    use crate::{RangeCacheEngineConfig, RangeCacheMemoryEngine};
+
+    #[test]
+    fn test_overlap_with_pending() {
+        let engine = RangeCacheMemoryEngine::new(&RangeCacheEngineConfig::config_for_test());
+        let range1 = CacheRange::new(b"k1".to_vec(), b"k3".to_vec());
+        engine.load_range(range1).unwrap();
+
+        let range2 = CacheRange::new(b"k1".to_vec(), b"k5".to_vec());
+        engine.prepare_for_apply(&range2);
+        assert!(
+            engine.core.read().range_manager().pending_ranges.is_empty()
+                && engine
+                    .core
+                    .read()
+                    .range_manager()
+                    .pending_ranges_loading_data
+                    .is_empty()
+        );
+
+        let range1 = CacheRange::new(b"k1".to_vec(), b"k3".to_vec());
+        engine.load_range(range1).unwrap();
+
+        let range2 = CacheRange::new(b"k2".to_vec(), b"k5".to_vec());
+        engine.prepare_for_apply(&range2);
+        assert!(
+            engine.core.read().range_manager().pending_ranges.is_empty()
+                && engine
+                    .core
+                    .read()
+                    .range_manager()
+                    .pending_ranges_loading_data
+                    .is_empty()
+        );
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref #16141

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
remove out of date pending ranges
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
