### PR TITLE
test: use a temp dir to store the test cluster configuration

### DIFF
--- a/components/test_raftstore-v2/src/cluster.rs
+++ b/components/test_raftstore-v2/src/cluster.rs
@@ -56,7 +56,7 @@ use test_raftstore::{
     new_tikv_config_with_api_ver, new_transfer_leader_cmd, sleep_ms, Config, Filter, FilterFactory,
     PartitionFilterFactory, RawEngine,
 };
-use tikv::{server::Result as ServerResult, storage::config::EngineType};
+use tikv::{config::TikvConfig, server::Result as ServerResult, storage::config::EngineType};
 use tikv_util::{
     box_err, box_try, debug, error,
     future::block_on_timeout,
@@ -405,10 +405,7 @@ impl<T: Simulator<EK>, EK: KvEngine> Cluster<T, EK> {
         let mut tikv_cfg = new_tikv_config_with_api_ver(id, api_version);
         tikv_cfg.storage.engine = EngineType::RaftKv2;
         Cluster {
-            cfg: Config {
-                tikv: tikv_cfg,
-                prefer_mem: true,
-            },
+            cfg: Config::new(tikv_cfg, true),
             count,
             tablet_registries: HashMap::default(),
             key_managers_map: HashMap::default(),
@@ -429,6 +426,11 @@ impl<T: Simulator<EK>, EK: KvEngine> Cluster<T, EK> {
             pd_client,
             engine_creator,
         }
+    }
+
+    pub fn set_cfg(&mut self, mut cfg: TikvConfig) {
+        cfg.cfg_path = self.cfg.tikv.cfg_path.clone();
+        self.cfg.tikv = cfg;
     }
 
     pub fn id(&self) -> u64 {

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -56,7 +56,7 @@ use region_cache_memory_engine::RangeCacheMemoryEngine;
 use resource_control::ResourceGroupManager;
 use tempfile::TempDir;
 use test_pd_client::TestPdClient;
-use tikv::server::Result as ServerResult;
+use tikv::{config::TikvConfig, server::Result as ServerResult};
 use tikv_util::{
     thread_group::GroupProperties,
     time::{Instant, ThreadReadId},
@@ -214,10 +214,7 @@ where
         // TODO: In the future, maybe it's better to test both case where
         // `use_delete_range` is true and false
         Cluster {
-            cfg: Config {
-                tikv: new_tikv_config_with_api_ver(id, api_version),
-                prefer_mem: true,
-            },
+            cfg: Config::new(new_tikv_config_with_api_ver(id, api_version), true),
             leaders: HashMap::default(),
             count,
             paths: vec![],
@@ -238,6 +235,11 @@ where
             raft_statistics: vec![],
             range_cache_engine_enabled_with_whole_range: false,
         }
+    }
+
+    pub fn set_cfg(&mut self, mut cfg: TikvConfig) {
+        cfg.cfg_path = self.cfg.tikv.cfg_path.clone();
+        self.cfg.tikv = cfg;
     }
 
     // To destroy temp dir later.

--- a/components/test_raftstore/src/config.rs
+++ b/components/test_raftstore/src/config.rs
@@ -4,10 +4,35 @@ use std::ops::{Deref, DerefMut};
 
 use tikv::config::TikvConfig;
 
-#[derive(Clone)]
 pub struct Config {
+    // temp dir to store the persisted configuration.
+    // We use a temp dir to ensure the original `common-test.toml` won't be
+    // changed by online config.
+    _cfg_dir: Option<tempfile::TempDir>,
     pub tikv: TikvConfig,
     pub prefer_mem: bool,
+}
+
+impl Config {
+    pub fn new(mut tikv: TikvConfig, prefer_mem: bool) -> Self {
+        let cfg_dir = test_util::temp_dir("test-cfg", prefer_mem);
+        tikv.cfg_path = cfg_dir.path().join("tikv.toml").display().to_string();
+        Self {
+            _cfg_dir: Some(cfg_dir),
+            tikv,
+            prefer_mem,
+        }
+    }
+}
+
+impl Clone for Config {
+    fn clone(&self) -> Self {
+        Self {
+            _cfg_dir: None,
+            tikv: self.tikv.clone(),
+            prefer_mem: self.prefer_mem,
+        }
+    }
 }
 
 impl Deref for Config {

--- a/tests/integrations/import/util.rs
+++ b/tests/integrations/import/util.rs
@@ -16,10 +16,7 @@ const CLEANUP_SST_MILLIS: u64 = 10;
 pub fn new_cluster(cfg: TikvConfig) -> (Cluster<RocksEngine, ServerCluster<RocksEngine>>, Context) {
     let count = 1;
     let mut cluster = new_server_cluster(0, count);
-    cluster.cfg = Config {
-        tikv: cfg,
-        prefer_mem: true,
-    };
+    cluster.set_cfg(cfg);
     cluster.run();
 
     let region_id = 1;
@@ -41,10 +38,7 @@ pub fn new_cluster_v2(
 ) {
     let count = 1;
     let mut cluster = test_raftstore_v2::new_server_cluster(0, count);
-    cluster.cfg = Config {
-        tikv: cfg,
-        prefer_mem: true,
-    };
+    cluster.set_cfg(cfg);
     cluster.run();
 
     let region_id = 1;


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #16871

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Always create a temp dir as the test cluster's config path. This can avoid the online configs change the "common-test.toml" file which can impact other test cases.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
