### PR TITLE
txn: use start_ts + 1 as Flush's min_commit_ts

### DIFF
--- a/src/storage/txn/commands/flush.rs
+++ b/src/storage/txn/commands/flush.rs
@@ -123,7 +123,8 @@ impl Flush {
             // txn_size is unknown, set it to max to avoid unexpected resolve_lock_lite
             txn_size: u64::MAX,
             lock_ttl: self.lock_ttl,
-            min_commit_ts: TimeStamp::zero(),
+            // min_commit_ts == 0 will disallow readers pushing it
+            min_commit_ts: self.start_ts.next(),
             need_old_value: extra_op == ExtraOp::ReadOldValue, // FIXME?
             is_retry_request: self.ctx.is_retry_request,
             assertion_level: self.assertion_level,

--- a/tests/integrations/server/kv_service.rs
+++ b/tests/integrations/server/kv_service.rs
@@ -21,7 +21,7 @@ use grpcio_health::{proto::HealthCheckRequest, *};
 use kvproto::{
     coprocessor::*,
     debugpb,
-    kvrpcpb::{PrewriteRequestPessimisticAction::*, *},
+    kvrpcpb::{Action::MinCommitTsPushed, PrewriteRequestPessimisticAction::*, *},
     metapb, raft_serverpb,
     raft_serverpb::*,
     tikvpb::*,
@@ -3309,7 +3309,8 @@ fn test_pipelined_dml_read_write_conflict() {
     let (_cluster, client, ctx) = new_cluster();
     let (k, v) = (b"key".to_vec(), b"value".to_vec());
 
-    // flushed lock can be observed by another read
+    // flushed lock can be observed by another read, and its min_commit_ts can be
+    // pushed
     let mut req = FlushRequest::default();
     req.set_mutations(
         vec![Mutation {
@@ -3335,6 +3336,18 @@ fn test_pipelined_dml_read_write_conflict() {
     let resp = client.kv_get(&req).unwrap();
     assert!(!resp.has_region_error());
     assert!(resp.get_error().has_locked());
+
+    // reader pushing the lock's min_commit_ts
+    let mut req = CheckTxnStatusRequest::default();
+    req.set_context(ctx.clone());
+    req.set_primary_key(k.clone());
+    req.set_lock_ts(1);
+    req.set_caller_start_ts(2);
+    req.set_current_ts(2);
+    let resp = client.kv_check_txn_status(&req).unwrap();
+    assert!(!resp.has_region_error());
+    assert!(!resp.has_error());
+    assert_eq!(resp.get_action(), MinCommitTsPushed);
 }
 
 #[test_case(test_raftstore::must_new_cluster_and_kv_client)]


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #16880

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
The PR fixes the problem that locks written by pipelined-dml block reads.
Now min_commit_ts was set to start_ts + 1 for Flush commands. 
Previously it was set to 0, which disallows pushing min_commit_ts.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
