### PR TITLE
(release-8.1) txn: use u64::MAX as txn_size for Flush commands (#16811)

### DIFF
--- a/src/storage/txn/commands/flush.rs
+++ b/src/storage/txn/commands/flush.rs
@@ -120,7 +120,8 @@ impl Flush {
             kind: TransactionKind::Optimistic(false),
             commit_kind: CommitKind::TwoPc,
             primary: &self.primary,
-            txn_size: 0, // txn_size is unknown
+            // txn_size is unknown, set it to max to avoid unexpected resolve_lock_lite
+            txn_size: u64::MAX,
             lock_ttl: self.lock_ttl,
             min_commit_ts: TimeStamp::zero(),
             need_old_value: extra_op == ExtraOp::ReadOldValue, // FIXME?


### PR DESCRIPTION
ref tikv/tikv#16810

Cherry picking #16811 

fix: use u64::MAX as txn_size for Flush commands to avoid unexpected resolve_lock_lite

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #xxx

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
