### PR TITLE
WIP: In-Memory Engine Algorithmic load and eviction.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4610,6 +4610,7 @@ dependencies = [
  "pd_client",
  "prometheus",
  "prometheus-static-metric",
+ "raftstore",
  "security",
  "serde",
  "serde_derive",

--- a/components/region_cache_memory_engine/Cargo.toml
+++ b/components/region_cache_memory_engine/Cargo.toml
@@ -20,6 +20,7 @@ txn_types = { workspace = true }
 kvproto = { workspace = true }
 log_wrappers = { workspace = true }
 pd_client = { workspace = true }
+raftstore = { workspace = true }
 dashmap = "5.1"
 security = { workspace = true }
 serde = "1.0"

--- a/components/region_cache_memory_engine/src/background.rs
+++ b/components/region_cache_memory_engine/src/background.rs
@@ -608,8 +608,9 @@ impl BackgroundRunner {
             .thread_count(1)
             .create();
         let gc_range_remote = delete_range_worker.remote();
+        let num_regions_to_cache = memory_controller.soft_limit_threshold() / 96_000_000;
         let range_stats_manager =
-            region_info_provider.map(|r_i_p| RangeStatsManager::new(NUM_REGIONS_FOR_CACHE, r_i_p));
+            region_info_provider.map(|r_i_p| RangeStatsManager::new(num_regions_to_cache, r_i_p));
         Self {
             core: BackgroundRunnerCore {
                 engine,

--- a/components/region_cache_memory_engine/src/background.rs
+++ b/components/region_cache_memory_engine/src/background.rs
@@ -621,7 +621,7 @@ impl Drop for BackgroundRunner {
     }
 }
 
-pub const NUM_REGIONS_FOR_CACHE: usize = 1000;
+//pub const NUM_REGIONS_FOR_CACHE: usize = 1000;
 impl BackgroundRunner {
     pub fn new(
         engine: Arc<RwLock<RangeCacheMemoryEngineCore>>,

--- a/components/region_cache_memory_engine/src/background.rs
+++ b/components/region_cache_memory_engine/src/background.rs
@@ -302,7 +302,7 @@ impl Clone for RangeStatsManager {
             num_regions: self.num_regions,
             info_provider: self.info_provider.clone(),
             prev_top_regions: self.prev_top_regions.clone(),
-            checking_top_regions: AtomicBoolean::new(
+            checking_top_regions: AtomicBool::new(
                 self.checking_top_regions.load(Ordering::Relaxed),
             ),
         }
@@ -332,7 +332,7 @@ impl RangeStatsManager {
         ranges_added_out: &mut Vec<CacheRange>,
         ranges_removed_out: &mut Vec<CacheRange>,
     ) {
-        info!("collect_changed_ranges", "num_regions" => num_regions);
+        info!("collect_changed_ranges"; "num_regions" => self.num_regions);
         // TODO (afeinberg): Error handling here.
         let curr_top_regions = self
             .info_provider
@@ -564,10 +564,7 @@ impl BackgroundRunnerCore {
 
         let mut ranges_to_add = Vec::<CacheRange>::with_capacity(256);
         let mut ranges_to_remove = Vec::<CacheRange>::with_capacity(256);
-        self.range_stats_manager
-            .as_ref()
-            .unwrap()
-            .collect_changed_ranges(&mut ranges_to_add, &mut ranges_to_remove);
+        range_stats_manager.collect_changed_ranges(&mut ranges_to_add, &mut ranges_to_remove);
         info!("load_evict"; "ranges_to_add" => ?&ranges_to_add, "ranges_to_remove" => ?&ranges_to_remove);
         for cache_range in ranges_to_add {
             let mut core = self.engine.write();
@@ -579,7 +576,7 @@ impl BackgroundRunnerCore {
             let _ = core.mut_range_manager().evict_range(&evict_range);
         }
         range_stats_manager.set_checking_top_regions(false);
-        info("load_evict complete");
+        info!("load_evict complete");
     }
 }
 
@@ -621,7 +618,7 @@ impl Drop for BackgroundRunner {
     }
 }
 
-//pub const NUM_REGIONS_FOR_CACHE: usize = 1000;
+// pub const NUM_REGIONS_FOR_CACHE: usize = 1000;
 impl BackgroundRunner {
     pub fn new(
         engine: Arc<RwLock<RangeCacheMemoryEngineCore>>,

--- a/components/region_cache_memory_engine/src/background.rs
+++ b/components/region_cache_memory_engine/src/background.rs
@@ -535,11 +535,13 @@ impl BackgroundRunnerCore {
             .as_ref()
             .unwrap()
             .collect_changed_ranges(&mut ranges_to_add, &mut ranges_to_remove);
+        info!("load_evict"; "ranges_to_add" => ?&ranges_to_add, "ranges_to_remove" => ?&ranges_to_remove);
         for cache_range in ranges_to_add {
             let mut core = self.engine.write();
             let _ = core.mut_range_manager().load_range(cache_range);
         }
         for evict_range in ranges_to_remove {
+            // TODO: check when last loaded, do not evict unless there is a miniminum time.
             let mut core = self.engine.write();
             let _ = core.mut_range_manager().evict_range(&evict_range);
         }

--- a/components/region_cache_memory_engine/src/background.rs
+++ b/components/region_cache_memory_engine/src/background.rs
@@ -579,16 +579,15 @@ impl BackgroundRunnerCore {
             }
             cmp::Ordering::Greater => {
                 let to_shrink_by = curr_memory_usage - threshold;
-                if to_shrink_by >= EXPECTED_AVERAGE_REGION_SIZE {
-                    let curr_num_regions = range_stats_manager.num_regions();
-                    let next_num_regions =
-                        curr_num_regions - to_shrink_by / EXPECTED_AVERAGE_REGION_SIZE;
-                    info!("decreasing number of top regions to cache";
-                        "from" => curr_num_regions,
-                        "to" => next_num_regions,
-                    );
-                    range_stats_manager.set_num_regions(next_num_regions);
-                }
+                let curr_num_regions = range_stats_manager.num_regions();
+                let next_num_regions = curr_num_regions
+                    .checked_sub(1.max(to_shrink_by / EXPECTED_AVERAGE_REGION_SIZE))
+                    .unwrap_or(1);
+                info!("decreasing number of top regions to cache";
+                    "from" => curr_num_regions,
+                    "to" => next_num_regions,
+                );
+                range_stats_manager.set_num_regions(next_num_regions);
             }
             _ => (),
         };

--- a/components/region_cache_memory_engine/src/background.rs
+++ b/components/region_cache_memory_engine/src/background.rs
@@ -330,7 +330,7 @@ impl RangeStatsManager {
         ranges_out.extend(
             all_regions
                 .iter()
-                .map(|r| (CacheRange::from_region(r), r.cached_size.get() as usize)),
+                .map(|r| (CacheRange::from_region(r), 45_000_000usize)),
         );
     }
 
@@ -603,6 +603,7 @@ impl BackgroundRunnerCore {
 
     fn evict_on_soft_limit_reached(&mut self) {
         if self.range_stats_manager.is_none() {
+            warn!("range stats manager is not initialized, cannot evict on soft limit reached");
             return;
         }
         let range_stats_manager = self.range_stats_manager.as_ref().unwrap();

--- a/components/region_cache_memory_engine/src/background.rs
+++ b/components/region_cache_memory_engine/src/background.rs
@@ -76,7 +76,7 @@ pub enum BackgroundTask {
     LoadRange,
     MemoryCheckAndEvict,
     DeleteRange(Vec<CacheRange>),
-    CheckTopRegions,
+    TopRegionsLoadEvict,
 }
 
 impl Display for BackgroundTask {
@@ -88,7 +88,7 @@ impl Display for BackgroundTask {
             BackgroundTask::DeleteRange(ref r) => {
                 f.debug_struct("DeleteRange").field("range", r).finish()
             }
-            BackgroundTask::CheckTopRegions => f.debug_struct("CheckTopRegions").finish(),
+            BackgroundTask::TopRegionsLoadEvict => f.debug_struct("CheckTopRegions").finish(),
         }
     }
 }
@@ -520,7 +520,7 @@ impl BackgroundRunnerCore {
         flush_epoch();
     }
 
-    fn find_top_regions(&mut self) {
+    fn top_regions_load_evict(&mut self) {
         let mut ranges_to_add = Vec::<CacheRange>::with_capacity(NUM_REGIONS_FOR_CACHE / 2);
         let mut ranges_to_remove = Vec::<CacheRange>::with_capacity(NUM_REGIONS_FOR_CACHE / 2);
         self.range_stats_manager
@@ -761,9 +761,9 @@ impl Runnable for BackgroundRunner {
                 let f = async move { core.delete_ranges(&ranges) };
                 self.delete_range_remote.spawn(f);
             }
-            BackgroundTask::CheckTopRegions => {
+            BackgroundTask::TopRegionsLoadEvict => {
                 let mut core = self.core.clone();
-                core.find_top_regions()
+                core.top_regions_load_evict()
             }
         }
     }

--- a/components/region_cache_memory_engine/src/engine.rs
+++ b/components/region_cache_memory_engine/src/engine.rs
@@ -255,7 +255,10 @@ impl RangeCacheMemoryEngine {
         RangeCacheMemoryEngine::with_region_info_provider(config, None)
     }
 
-    pub fn with_region_info_provider(config: Arc<VersionTrack<RangeCacheEngineConfig>>, region_info_provider: Option<Arc<dyn RegionInfoProvider>>) -> Self {
+    pub fn with_region_info_provider(
+        config: Arc<VersionTrack<RangeCacheEngineConfig>>,
+        region_info_provider: Option<Arc<dyn RegionInfoProvider>>,
+    ) -> Self {
         info!("init range cache memory engine";);
         let core = Arc::new(RwLock::new(RangeCacheMemoryEngineCore::new()));
         let skiplist_engine = { core.read().engine().clone() };

--- a/components/region_cache_memory_engine/src/engine.rs
+++ b/components/region_cache_memory_engine/src/engine.rs
@@ -261,6 +261,7 @@ impl RangeCacheMemoryEngine {
             core.clone(),
             config.value().gc_interval.0,
             memory_controller.clone(),
+            None,
         ));
 
         Self {

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -1674,6 +1674,7 @@ where
             range_cache_engine_config.clone(),
             disk_engine.clone(),
             Some(self.pd_client.clone()),
+            Some(Arc::new(self.region_info_accessor.clone())),
         );
         let range_cache_config_manager = RangeCacheConfigManager(range_cache_engine_config);
         self.kv_statistics = Some(factory.rocks_statistics());

--- a/components/test_raftstore/src/util.rs
+++ b/components/test_raftstore/src/util.rs
@@ -718,7 +718,7 @@ where
     let factory = builder.build();
     let disk_engine = factory.create_shared_db(dir.path()).unwrap();
     let config = Arc::new(VersionTrack::new(cfg.tikv.range_cache_engine.clone()));
-    let kv_engine: EK = KvEngineBuilder::build(config, disk_engine, None);
+    let kv_engine: EK = KvEngineBuilder::build(config, disk_engine, None, None);
     let engines = Engines::new(kv_engine, raft_engine);
     (
         engines,


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref #16764 Ref #16141 

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
In-Memory Engine: Algorithmic Load and Eviction

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None

```
