### PR TITLE
In-memory engine: manually implement partial_eq for CacheRange to avoid the consideration of tag

### DIFF
--- a/components/engine_traits/src/range_cache_engine.rs
+++ b/components/engine_traits/src/range_cache_engine.rs
@@ -57,11 +57,17 @@ pub trait RangeCacheEngine:
 /// as it continues to evolve to handle eviction, using stats.
 pub trait RangeHintService: Send + Sync {}
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, Eq)]
 pub struct CacheRange {
     pub start: Vec<u8>,
     pub end: Vec<u8>,
     pub tag: String,
+}
+
+impl PartialEq for CacheRange {
+    fn eq(&self, other: &Self) -> bool {
+        self.start == other.start && self.end == other.end
+    }
 }
 
 impl Debug for CacheRange {
@@ -156,5 +162,45 @@ impl CacheRange {
         };
 
         (left, right)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cmp::Ordering;
+
+    use crate::CacheRange;
+
+    #[test]
+    fn test_cache_range_eq() {
+        let r1 = CacheRange::new(b"k1".to_vec(), b"k2".to_vec());
+        let mut r2 = CacheRange::new(b"k1".to_vec(), b"k2".to_vec());
+        r2.tag = "Something".to_string();
+        assert_eq!(r1, r2);
+    }
+
+    #[test]
+    fn test_cache_range_partial_cmp() {
+        let r1 = CacheRange::new(b"k1".to_vec(), b"k2".to_vec());
+        let r2 = CacheRange::new(b"k2".to_vec(), b"k3".to_vec());
+        let r3 = CacheRange::new(b"k2".to_vec(), b"k4".to_vec());
+        assert_eq!(r1.partial_cmp(&r2).unwrap(), Ordering::Less);
+        assert_eq!(r2.partial_cmp(&r1).unwrap(), Ordering::Greater);
+        assert!(r2.partial_cmp(&r3).is_none());
+    }
+
+    #[test]
+    fn test_split_off() {
+        let r1 = CacheRange::new(b"k1".to_vec(), b"k6".to_vec());
+        let r2 = CacheRange::new(b"k2".to_vec(), b"k4".to_vec());
+
+        let r3 = CacheRange::new(b"k1".to_vec(), b"k2".to_vec());
+        let r4 = CacheRange::new(b"k4".to_vec(), b"k6".to_vec());
+
+        let (left, right) = r1.split_off(&r1);
+        assert!(left.is_none() && right.is_none());
+        let (left, right) = r1.split_off(&r2);
+        assert_eq!(left.unwrap(), r3);
+        assert_eq!(right.unwrap(), r4);
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref #16141

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
manually implement partial_eq for CacheRange to avoid the consideration of tag
```
Manually implement partial_eq for CacheRange to avoid the consideration of tag.
In addition, add some tests.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
