### PR TITLE
[test] In-memory engine: load whole range hack

### DIFF
--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -383,6 +383,7 @@ impl BackupRange {
             Default::default(),
             Default::default(),
             false,
+            false,
         );
         let start_key = self.start_key.clone();
         let end_key = self.end_key.clone();

--- a/components/engine_traits/src/engine.rs
+++ b/components/engine_traits/src/engine.rs
@@ -80,6 +80,8 @@ pub trait KvEngine:
     /// full release of engine.
     #[cfg(feature = "testexport")]
     fn inner_refcount(&self) -> usize;
+
+    fn evict_range(&self, range: CacheRange) {}
 }
 
 #[derive(Debug, Clone)]

--- a/components/engine_traits/src/range_cache_engine.rs
+++ b/components/engine_traits/src/range_cache_engine.rs
@@ -47,6 +47,8 @@ pub trait RangeCacheEngine:
     fn enabled(&self) -> bool {
         false
     }
+
+    fn evict_range(&self, range: CacheRange);
 }
 
 /// A service that should run in the background to retrieve and apply cache

--- a/components/engine_traits/src/snapshot.rs
+++ b/components/engine_traits/src/snapshot.rs
@@ -13,4 +13,7 @@ where
     Self:
         'static + Peekable + Iterable + CfNamesExt + SnapshotMiscExt + Send + Sync + Sized + Debug,
 {
+    fn range_cache_engine_snap(&self) -> bool {
+        false
+    }
 }

--- a/components/hybrid_engine/src/engine.rs
+++ b/components/hybrid_engine/src/engine.rs
@@ -123,6 +123,10 @@ where
     fn inner_refcount(&self) -> usize {
         self.disk_engine.inner_refcount()
     }
+
+    fn evict_range(&self, range: engine_traits::CacheRange) {
+        self.region_cache_engine.evict_range(range);
+    }
 }
 
 impl<EK, EC> Peekable for HybridEngine<EK, EC>

--- a/components/hybrid_engine/src/snapshot.rs
+++ b/components/hybrid_engine/src/snapshot.rs
@@ -48,6 +48,9 @@ where
     EK: KvEngine,
     EC: RangeCacheEngine,
 {
+    fn range_cache_engine_snap(&self) -> bool {
+        self.region_cache_snapshot_available()
+    }
 }
 
 impl<EK, EC> Debug for HybridEngineSnapshot<EK, EC>

--- a/components/hybrid_engine/src/write_batch.rs
+++ b/components/hybrid_engine/src/write_batch.rs
@@ -127,11 +127,14 @@ impl<EK: KvEngine> Mutable for HybridEngineWriteBatch<EK> {
     }
 
     fn delete_range(&mut self, begin_key: &[u8], end_key: &[u8]) -> Result<()> {
-        self.disk_write_batch.delete_range(begin_key, end_key)
+        self.disk_write_batch.delete_range(begin_key, end_key)?;
+        self.cache_write_batch.delete_range(begin_key, end_key)
     }
 
     fn delete_range_cf(&mut self, cf: &str, begin_key: &[u8], end_key: &[u8]) -> Result<()> {
         self.disk_write_batch
+            .delete_range_cf(cf, begin_key, end_key);
+        self.cache_write_batch
             .delete_range_cf(cf, begin_key, end_key)
     }
 }

--- a/components/raftstore/src/store/async_io/write.rs
+++ b/components/raftstore/src/store/async_io/write.rs
@@ -733,16 +733,12 @@ where
                 write_opts.set_sync(true);
                 // TODO: Add perf context
                 let tag = &self.tag;
-                let seq = kv_wb.write_opt(&write_opts).unwrap_or_else(|e| {
+                kv_wb.write_opt(&write_opts).unwrap_or_else(|e| {
                     panic!(
                         "store {}: {} failed to write to kv engine: {:?}",
                         store_id, tag, e
                     );
                 });
-                let snap = self.kv_engine.as_ref().unwrap().snapshot(None);
-                let latest_seq = snap.sequence_number();
-                assert!(seq <= latest_seq);
-
                 if kv_wb.data_size() > KV_WB_SHRINK_SIZE {
                     *kv_wb = self
                         .kv_engine

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -1913,7 +1913,7 @@ where
     ) -> Result<()> {
         PEER_WRITE_CMD_COUNTER.delete.inc();
         let key = req.get_delete().get_key();
-        let cf = req.get_put().get_cf();
+        let cf = req.get_delete().get_cf();
         info!(
             "handle delete";
             "region_id" => self.region.get_id(),

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -1240,6 +1240,7 @@ where
                         simple_write_decoder.to_raft_cmd_request()
                     }
                 };
+
                 if apply_ctx.yield_high_latency_operation && has_high_latency_operation(&cmd) {
                     self.priority = Priority::Low;
                 }
@@ -1762,6 +1763,13 @@ where
             }
         );
 
+        let flag_data = req.get_header().get_flag_data();
+        let start_ts = if flag_data.len() == 8 {
+            u64::from_le_bytes(flag_data.try_into().unwrap())
+        } else {
+            0
+        };
+
         let requests = req.get_requests();
 
         let mut ranges = vec![];
@@ -1769,12 +1777,16 @@ where
         for req in requests {
             let cmd_type = req.get_cmd_type();
             match cmd_type {
-                CmdType::Put => self.handle_put(ctx, req),
-                CmdType::Delete => self.handle_delete(ctx, req),
-                CmdType::DeleteRange => {
-                    self.handle_delete_range(&ctx.engine, req, &mut ranges, ctx.use_delete_range)
-                }
-                CmdType::IngestSst => self.handle_ingest_sst(ctx, req, &mut ssts),
+                CmdType::Put => self.handle_put(ctx, req, start_ts),
+                CmdType::Delete => self.handle_delete(ctx, req, start_ts),
+                CmdType::DeleteRange => self.handle_delete_range(
+                    &ctx.engine,
+                    req,
+                    &mut ranges,
+                    ctx.use_delete_range,
+                    start_ts,
+                ),
+                CmdType::IngestSst => self.handle_ingest_sst(ctx, req, &mut ssts, start_ts),
                 // Readonly commands are handled in raftstore directly.
                 // Don't panic here in case there are old entries need to be applied.
                 // It's also safe to skip them here, because a restart must have happened,
@@ -1827,10 +1839,27 @@ impl<EK> ApplyDelegate<EK>
 where
     EK: KvEngine,
 {
-    fn handle_put(&mut self, ctx: &mut ApplyContext<EK>, req: &Request) -> Result<()> {
+    fn handle_put(
+        &mut self,
+        ctx: &mut ApplyContext<EK>,
+        req: &Request,
+        start_ts: u64,
+    ) -> Result<()> {
         fail::fail_point!("on_handle_put");
         PEER_WRITE_CMD_COUNTER.put.inc();
         let (key, value) = (req.get_put().get_key(), req.get_put().get_value());
+        let cf = req.get_put().get_cf();
+
+        info!(
+            "handle put";
+            "region_id" => self.region.get_id(),
+            "cf" => ?cf,
+            "start_ts" => ?start_ts,
+            "key" => log_wrappers::hex_encode_upper(key),
+            "value" => log_wrappers::hex_encode_upper(value),
+            "index" => ctx.exec_log_index,
+        );
+
         // region key range has no data prefix, so we must use origin key to check.
         util::check_key_in_region(key, &self.region)?;
         if let Some(s) = self.buckets.as_mut() {
@@ -1876,9 +1905,24 @@ where
         Ok(())
     }
 
-    fn handle_delete(&mut self, ctx: &mut ApplyContext<EK>, req: &Request) -> Result<()> {
+    fn handle_delete(
+        &mut self,
+        ctx: &mut ApplyContext<EK>,
+        req: &Request,
+        start_ts: u64,
+    ) -> Result<()> {
         PEER_WRITE_CMD_COUNTER.delete.inc();
         let key = req.get_delete().get_key();
+        let cf = req.get_put().get_cf();
+        info!(
+            "handle delete";
+            "region_id" => self.region.get_id(),
+            "cf" => ?cf,
+            "start_ts" => ?start_ts,
+            "key" => log_wrappers::hex_encode_upper(key),
+            "index" => ctx.exec_log_index,
+        );
+
         // region key range has no data prefix, so we must use origin key to check.
         util::check_key_in_region(key, &self.region)?;
         if let Some(s) = self.buckets.as_mut() {
@@ -1930,10 +1974,21 @@ where
         req: &Request,
         ranges: &mut Vec<Range>,
         use_delete_range: bool,
+        start_ts: u64,
     ) -> Result<()> {
         PEER_WRITE_CMD_COUNTER.delete_range.inc();
         let s_key = req.get_delete_range().get_start_key();
         let e_key = req.get_delete_range().get_end_key();
+        let cf = req.get_put().get_cf();
+        info!(
+            "handle delete range";
+            "region_id" => self.region.get_id(),
+            "cf" => ?cf,
+            "start_ts" => ?start_ts,
+            "start_key" => log_wrappers::hex_encode_upper(s_key),
+            "end_key" => log_wrappers::hex_encode_upper(e_key),
+        );
+
         let notify_only = req.get_delete_range().get_notify_only();
         if !e_key.is_empty() && s_key >= e_key {
             return Err(box_err!(
@@ -2003,9 +2058,17 @@ where
         ctx: &mut ApplyContext<EK>,
         req: &Request,
         ssts: &mut Vec<SstMetaInfo>,
+        start_ts: u64,
     ) -> Result<()> {
         PEER_WRITE_CMD_COUNTER.ingest_sst.inc();
         let sst = req.get_ingest_sst().get_sst();
+
+        info!(
+            "handle ingest sst";
+            "region_id" => self.region.get_id(),
+            "start_ts" => ?start_ts,
+            "index" => ctx.exec_log_index,
+        );
 
         if let Err(e) = check_sst_for_ingestion(sst, &self.region) {
             error!(?e;

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -4121,6 +4121,10 @@ where
                     // We only care remove itself now.
                     if self.store_id() == store_id {
                         let range = CacheRange::from_region(self.fsm.peer.region());
+                        info!(
+                            "evict range due to remove node";
+                            "range" => ?range,
+                        );
                         self.ctx.engines.kv.evict_range(range);
                         if self.fsm.peer.peer_id() == peer_id {
                             remove_self = true;

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -19,7 +19,8 @@ use std::{
 use batch_system::{BasicMailbox, Fsm};
 use collections::{HashMap, HashSet};
 use engine_traits::{
-    Engines, KvEngine, RaftEngine, RaftLogBatch, SstMetaInfo, WriteBatchExt, CF_LOCK, CF_RAFT,
+    CacheRange, Engines, KvEngine, RaftEngine, RaftLogBatch, SstMetaInfo, WriteBatchExt, CF_LOCK,
+    CF_RAFT,
 };
 use error_code::ErrorCodeExt;
 use fail::fail_point;
@@ -4119,6 +4120,8 @@ where
                     self.fsm.peer.remove_peer_from_cache(peer_id);
                     // We only care remove itself now.
                     if self.store_id() == store_id {
+                        let range = CacheRange::from_region(self.fsm.peer.region());
+                        self.ctx.engines.kv.evict_range(range);
                         if self.fsm.peer.peer_id() == peer_id {
                             remove_self = true;
                         } else {

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -2418,11 +2418,11 @@ where
         fail_point!("on_apply_res", |_| {});
         match res {
             ApplyTaskRes::Apply(mut res) => {
-                debug!(
+                info!(
                     "async apply finish";
                     "region_id" => self.region_id(),
                     "peer_id" => self.fsm.peer_id(),
-                    "res" => ?res,
+                    "res" => ?res.apply_state,
                 );
                 if self.fsm.peer.wait_data {
                     return;

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -4965,7 +4965,9 @@ where
             }
         }
 
-        let snap_ctx = if let Ok(read_ts) = decode_u64(&mut req.get_header().get_flag_data()) {
+        let snap_ctx = if let Ok(read_ts) = decode_u64(&mut req.get_header().get_flag_data())
+            && !req.get_header().get_replica_read()
+        {
             Some(SnapshotContext {
                 range: Some(CacheRange::from_region(&region)),
                 read_ts,

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -4966,7 +4966,7 @@ where
         }
 
         let snap_ctx = if let Ok(read_ts) = decode_u64(&mut req.get_header().get_flag_data())
-            && !req.get_header().get_replica_read()
+        // && !req.get_header().get_replica_read()
         {
             Some(SnapshotContext {
                 range: Some(CacheRange::from_region(&region)),

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -4081,6 +4081,13 @@ where
             .filter(|req| req.has_read_index())
             .map(|req| req.take_read_index());
         let (id, dropped) = self.propose_read_index(request.as_ref());
+        info!(
+            "*** propose read index";
+            "start_ts" => ?request.as_ref().map(|r| r.get_start_ts()),
+            "is_leader" => self.is_leader(),
+            "uuid" => ?id,
+            "dropped" => dropped,
+        );
         if dropped && self.is_leader() {
             // The message gets dropped silently, can't be handled anymore.
             apply::notify_stale_req(self.term(), cb);

--- a/components/raftstore/src/store/read_queue.rs
+++ b/components/raftstore/src/store/read_queue.rs
@@ -12,7 +12,7 @@ use protobuf::Message;
 use tikv_util::{
     box_err,
     codec::number::{NumberEncoder, MAX_VAR_U64_LEN},
-    debug, error,
+    debug, error, info,
     memory::HeapSize,
     time::{duration_to_sec, monotonic_raw_now},
     MustConsumeVec,
@@ -275,6 +275,13 @@ impl<C: ErrorCallback> ReadIndexQueue<C> {
                         continue;
                     }
                 }
+                info!(
+                    "*** advance_replica_reads";
+                    // "start_ts" => self.reads[offset].start_ts,
+                    "uuid" => ?uuid,
+                    "read_index" => index,
+                    "offset" => offset
+                );
                 self.reads[offset].read_index = Some(index);
                 min_changed_offset = cmp::min(min_changed_offset, offset);
                 max_changed_offset = cmp::max(max_changed_offset, offset);

--- a/components/raftstore/src/store/region_snapshot.rs
+++ b/components/raftstore/src/store/region_snapshot.rs
@@ -103,6 +103,10 @@ where
         }
     }
 
+    pub fn sequence_number(&self) -> u64 {
+        self.snap.sequence_number()
+    }
+
     #[inline]
     pub fn set_apply_index(&self, apply_index: u64) {
         self.apply_index.store(apply_index, Ordering::SeqCst);

--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -1007,6 +1007,13 @@ where
     ) -> Option<ReadResponse<E::Snapshot>> {
         let mut local_read_ctx = LocalReadContext::new(&mut self.snap_cache, read_id);
 
+        if snap_ctx.is_some() {
+            // When `snap_ctx` is some, it means we want to acquire the range cache engine
+            // snapshot which cannot be used across different regions. So we don't use
+            // cache.
+            local_read_ctx.read_id.take();
+        }
+
         (*snap_updated) = local_read_ctx.maybe_update_snapshot(
             delegate.get_tablet(),
             snap_ctx.clone(),

--- a/components/raftstore/src/store/worker/region.rs
+++ b/components/raftstore/src/store/worker/region.rs
@@ -460,7 +460,12 @@ where
         let mut region_state = self.region_state(region_id)?;
         let region = region_state.get_region().clone();
 
-        self.engine.evict_range(CacheRange::from_region(&region));
+        let range = CacheRange::from_region(&region);
+        info!(
+            "evict range due to apply snap";
+            "range" => ?range,
+        );
+        self.engine.evict_range(range);
 
         let start_key = keys::enc_start_key(&region);
         let end_key = keys::enc_end_key(&region);

--- a/components/raftstore/src/store/worker/region.rs
+++ b/components/raftstore/src/store/worker/region.rs
@@ -18,7 +18,8 @@ use std::{
 
 use collections::HashMap;
 use engine_traits::{
-    DeleteStrategy, KvEngine, Mutable, Range, WriteBatch, WriteOptions, CF_LOCK, CF_RAFT,
+    CacheRange, DeleteStrategy, KvEngine, Mutable, Range, WriteBatch, WriteOptions, CF_LOCK,
+    CF_RAFT,
 };
 use fail::fail_point;
 use file_system::{IoType, WithIoType};
@@ -458,6 +459,9 @@ where
 
         let mut region_state = self.region_state(region_id)?;
         let region = region_state.get_region().clone();
+
+        self.engine.evict_range(CacheRange::from_region(&region));
+
         let start_key = keys::enc_start_key(&region);
         let end_key = keys::enc_end_key(&region);
         check_abort(&abort)?;

--- a/components/region_cache_memory_engine/src/background.rs
+++ b/components/region_cache_memory_engine/src/background.rs
@@ -68,6 +68,7 @@ pub enum BackgroundTask {
     LoadRange,
     MemoryCheckAndEvict,
     DeleteRange(Vec<CacheRange>),
+    CleanLockTombstone(u64),
 }
 
 impl Display for BackgroundTask {
@@ -79,6 +80,10 @@ impl Display for BackgroundTask {
             BackgroundTask::DeleteRange(ref r) => {
                 f.debug_struct("DeleteRange").field("range", r).finish()
             }
+            BackgroundTask::CleanLockTombstone(s) => f
+                .debug_struct("CleanLockTombstone")
+                .field("seqno", s)
+                .finish(),
         }
     }
 }
@@ -482,6 +487,11 @@ pub struct BackgroundRunner {
 
     gc_range_remote: Remote<yatp::task::future::TaskCell>,
     gc_range_worker: Worker,
+
+    lock_cleanup_remote: Remote<yatp::task::future::TaskCell>,
+    lock_cleanup_worker: Worker,
+
+    last_seqno: u64,
 }
 
 impl Drop for BackgroundRunner {
@@ -489,6 +499,7 @@ impl Drop for BackgroundRunner {
         self.range_load_worker.stop();
         self.delete_range_worker.stop();
         self.gc_range_worker.stop();
+        self.lock_cleanup_worker.stop();
     }
 }
 
@@ -507,6 +518,9 @@ impl BackgroundRunner {
         let delete_range_worker = Worker::new("background-delete-range_worker");
         let delete_range_remote = delete_range_worker.remote();
 
+        let lock_cleanup_worker = Worker::new("lock-cleanup-worker");
+        let lock_cleanup_remote = lock_cleanup_worker.remote();
+
         let gc_range_worker = Builder::new("background-range-load-worker")
             // Gc must also use exactly one thread to handle it.
             .thread_count(1)
@@ -523,6 +537,9 @@ impl BackgroundRunner {
             delete_range_remote,
             gc_range_worker,
             gc_range_remote,
+            lock_cleanup_remote,
+            lock_cleanup_worker,
+            last_seqno: 0,
         }
     }
 }
@@ -671,6 +688,76 @@ impl Runnable for BackgroundRunner {
                 let mut core = self.core.clone();
                 let f = async move { core.delete_ranges(&ranges) };
                 self.delete_range_remote.spawn(f);
+            }
+            BackgroundTask::CleanLockTombstone(snapshot_seqno) => {
+                if snapshot_seqno < self.last_seqno {
+                    return;
+                }
+                let core = self.core.clone();
+
+                let f = async move {
+                    let mut last_user_key = vec![];
+                    let mut remove_rest = false;
+                    let mut cached_to_remove: Option<Vec<u8>> = None;
+
+                    let mut removed = 0;
+                    let mut total = 0;
+                    let now = Instant::now();
+                    let lock_handle = core.engine.read().engine().cf_handle("lock");
+                    let guard = &epoch::pin();
+                    let mut iter = lock_handle.iterator();
+                    iter.seek_to_first(guard);
+                    while iter.valid() {
+                        total += 1;
+                        let InternalKey {
+                            user_key,
+                            v_type,
+                            sequence,
+                        } = decode_key(iter.key().as_bytes());
+                        if user_key != last_user_key {
+                            if let Some(remove) = cached_to_remove.take() {
+                                removed += 1;
+                                lock_handle.remove(&InternalBytes::from_vec(remove), guard);
+                            }
+                            last_user_key = user_key.to_vec();
+                            if sequence >= snapshot_seqno {
+                                remove_rest = false;
+                            } else {
+                                remove_rest = true;
+                                if v_type == ValueType::Deletion {
+                                    cached_to_remove = Some(iter.key().as_bytes().to_vec());
+                                }
+                            }
+                        } else if remove_rest {
+                            assert!(sequence < snapshot_seqno);
+                            removed += 1;
+                            lock_handle.remove(iter.key(), guard);
+                        } else if sequence < snapshot_seqno {
+                            remove_rest = true;
+                            if v_type == ValueType::Deletion {
+                                assert!(cached_to_remove.is_none());
+                                cached_to_remove = Some(iter.key().as_bytes().to_vec());
+                            }
+                        }
+
+                        iter.next(guard);
+                    }
+                    if let Some(remove) = cached_to_remove.take() {
+                        removed += 1;
+                        lock_handle.remove(&InternalBytes::from_vec(remove), guard);
+                    }
+
+                    info!(
+                        "cleanup lock tombstone";
+                        "seqno" => snapshot_seqno,
+                        "total" => total,
+                        "removed" => removed,
+                        "duration" => ?now.saturating_elapsed(),
+                        "current_count" => lock_handle.count(),
+                    );
+                };
+
+                self.lock_cleanup_remote.spawn(f);
             }
         }
     }

--- a/components/region_cache_memory_engine/src/background.rs
+++ b/components/region_cache_memory_engine/src/background.rs
@@ -533,6 +533,7 @@ impl Runnable for BackgroundRunner {
     fn run(&mut self, task: Self::Task) {
         match task {
             BackgroundTask::Gc(t) => {
+                return;
                 info!(
                     "start a new round of gc for range cache engine";
                     "safe_point" => t.safe_point,

--- a/components/region_cache_memory_engine/src/background.rs
+++ b/components/region_cache_memory_engine/src/background.rs
@@ -533,7 +533,6 @@ impl Runnable for BackgroundRunner {
     fn run(&mut self, task: Self::Task) {
         match task {
             BackgroundTask::Gc(t) => {
-                return;
                 info!(
                     "start a new round of gc for range cache engine";
                     "safe_point" => t.safe_point,

--- a/components/region_cache_memory_engine/src/engine.rs
+++ b/components/region_cache_memory_engine/src/engine.rs
@@ -412,7 +412,7 @@ impl RangeCacheMemoryEngine {
     // cached and which writes should be written directly.
     pub(crate) fn handle_pending_range_in_loading_buffer(
         &self,
-        seq: u64,
+        seq: &mut u64,
         pending_range_in_loading_buffer: Vec<RangeCacheWriteBatchEntry>,
     ) -> (Vec<RangeCacheWriteBatchEntry>, SkiplistEngine) {
         if !pending_range_in_loading_buffer.is_empty() {
@@ -426,7 +426,11 @@ impl RangeCacheMemoryEngine {
                     core.cached_write_batch
                         .entry(range)
                         .or_default()
-                        .extend(write_batches.into_iter().map(|e| (seq, e)));
+                        .extend(write_batches.into_iter().map(|e| {
+                            let cur = *seq;
+                            *seq += 1;
+                            (cur, e)
+                        }));
                 }
             }
             (entries_to_write, engine)

--- a/components/region_cache_memory_engine/src/engine.rs
+++ b/components/region_cache_memory_engine/src/engine.rs
@@ -14,6 +14,7 @@ use engine_traits::{
     CacheRange, FailedReason, IterOptions, Iterable, KvEngine, RangeCacheEngine, Result,
     CF_DEFAULT, CF_LOCK, CF_WRITE, DATA_CFS,
 };
+use keys::{DATA_MAX_KEY, DATA_MIN_KEY};
 use parking_lot::{lock_api::RwLockUpgradableReadGuard, RwLock, RwLockWriteGuard};
 use skiplist_rs::{
     base::{Entry, OwnedIter},
@@ -263,13 +264,20 @@ impl RangeCacheMemoryEngine {
             memory_controller.clone(),
         ));
 
-        Self {
+        let engine = Self {
             core,
             rocks_engine: None,
             bg_work_manager,
             memory_controller,
             config,
-        }
+        };
+        engine
+            .load_range(CacheRange::new(
+                DATA_MIN_KEY.to_vec(),
+                DATA_MAX_KEY.to_vec(),
+            ))
+            .unwrap();
+        engine
     }
 
     pub fn new_range(&self, range: CacheRange) {

--- a/components/region_cache_memory_engine/src/engine.rs
+++ b/components/region_cache_memory_engine/src/engine.rs
@@ -488,6 +488,10 @@ impl RangeCacheEngine for RangeCacheMemoryEngine {
     fn enabled(&self) -> bool {
         self.config.value().enabled
     }
+
+    fn evict_range(&self, range: CacheRange) {
+        self.evict_range(&range);
+    }
 }
 
 impl Iterable for RangeCacheMemoryEngine {

--- a/components/region_cache_memory_engine/src/engine.rs
+++ b/components/region_cache_memory_engine/src/engine.rs
@@ -299,12 +299,12 @@ impl RangeCacheMemoryEngine {
     /// immediately due to some ongoing snapshots.
     pub fn evict_range(&self, range: &CacheRange) {
         let mut core = self.core.write();
-        if core.range_manager.evict_range(range) {
+        if let Some(evict_range) = core.range_manager.evict_range(range) {
             drop(core);
             // The range can be deleted directly.
             if let Err(e) = self
                 .bg_worker_manager()
-                .schedule_task(BackgroundTask::DeleteRange(vec![range.clone()]))
+                .schedule_task(BackgroundTask::DeleteRange(vec![evict_range]))
             {
                 error!(
                     "schedule delete range failed";

--- a/components/region_cache_memory_engine/src/lib.rs
+++ b/components/region_cache_memory_engine/src/lib.rs
@@ -46,7 +46,7 @@ impl Default for RangeCacheEngineConfig {
     fn default() -> Self {
         Self {
             enabled: false,
-            gc_interval: ReadableDuration(Duration::from_secs(180)),
+            gc_interval: ReadableDuration(Duration::from_secs(60)),
             soft_limit_threshold: None,
             hard_limit_threshold: None,
         }

--- a/components/region_cache_memory_engine/src/range_manager.rs
+++ b/components/region_cache_memory_engine/src/range_manager.rs
@@ -295,7 +295,7 @@ impl RangeManager {
     }
 
     // return whether the range can be already removed
-    pub(crate) fn evict_range(&mut self, evict_range: &CacheRange) -> bool {
+    pub(crate) fn evict_range(&mut self, evict_range: &CacheRange) -> Option<CacheRange> {
         let Some(range_key) = self
             .ranges
             .keys()
@@ -309,17 +309,22 @@ impl RangeManager {
                 .cloned()
             {
                 info!(
-                    "evict range and overlap";
+                    "evict range that overlaps";
                     "evicted_range" => ?evict_range,
                     "overlapped_range" => ?range_key,
                 );
-                panic!();
+                let meta = self.ranges.remove(&range_key).unwrap();
+                if !meta.range_snapshot_list.is_empty() {
+                    self.historical_ranges.insert(range_key, meta);
+                    return None;
+                }
+                return Some(range_key);
             }
             info!(
                 "evict a range that is not cached";
                 "range" => ?evict_range,
             );
-            return false;
+            return None;
         };
 
         info!(
@@ -355,14 +360,19 @@ impl RangeManager {
 
         if !meta.range_snapshot_list.is_empty() {
             self.historical_ranges.insert(range_key, meta);
-            return false;
+            return None;
         }
 
         // we also need to check with previous historical_ranges
-        !self
+        if !self
             .historical_ranges
             .keys()
             .any(|r| r.overlaps(evict_range))
+        {
+            Some(evict_range.clone())
+        } else {
+            None
+        }
     }
 
     pub fn has_ranges_in_gc(&self) -> bool {

--- a/components/region_cache_memory_engine/src/range_manager.rs
+++ b/components/region_cache_memory_engine/src/range_manager.rs
@@ -476,7 +476,6 @@ mod tests {
         assert!(range_mgr.ranges_being_deleted.contains(&r_left));
         assert!(range_mgr.ranges.get(&r_left).is_none());
 
-        assert!(!range_mgr.evict_range(&r_right));
         assert!(range_mgr.historical_ranges.get(&r_right).is_none());
     }
 

--- a/components/region_cache_memory_engine/src/range_manager.rs
+++ b/components/region_cache_memory_engine/src/range_manager.rs
@@ -319,6 +319,20 @@ impl RangeManager {
                     return None;
                 }
                 return Some(range_key);
+            } else if let Some((range_key, _, canceled)) =
+                self.pending_ranges_loading_data.iter_mut().find(|(r, ..)| {
+                    evict_range.overlaps(r)
+                        || evict_range.contains_range(r)
+                        || r.contains_range(evict_range)
+                })
+            {
+                // The range may be loading now
+                info!(
+                    "evict range that overlaps with loading range";
+                    "evicted_range" => ?evict_range,
+                    "overlapped_range" => ?range_key,
+                );
+                *canceled = true;
             }
             info!(
                 "evict a range that is not cached";

--- a/components/region_cache_memory_engine/src/write_batch.rs
+++ b/components/region_cache_memory_engine/src/write_batch.rs
@@ -360,14 +360,11 @@ impl RangeCacheWriteBatchEntry {
         guard: &epoch::Guard,
     ) -> Result<()> {
         let handle = skiplist_engine.cf_handle(id_to_cf(self.cf));
-        if is_lock_cf(self.cf) && matches!(self.inner, WriteBatchEntryInternal::Deletion) {
-            self.delete_in_lock_cf(seq, &handle, guard);
-        } else {
-            let (mut key, mut value) = self.encode(seq);
-            key.set_memory_controller(memory_controller.clone());
-            value.set_memory_controller(memory_controller);
-            handle.insert(key, value, guard);
-        }
+
+        let (mut key, mut value) = self.encode(seq);
+        key.set_memory_controller(memory_controller.clone());
+        value.set_memory_controller(memory_controller);
+        handle.insert(key, value, guard);
 
         Ok(())
     }

--- a/components/region_cache_memory_engine/src/write_batch.rs
+++ b/components/region_cache_memory_engine/src/write_batch.rs
@@ -570,12 +570,16 @@ impl Mutable for RangeCacheWriteBatch {
         Ok(())
     }
 
-    fn delete_range(&mut self, _: &[u8], _: &[u8]) -> Result<()> {
-        unimplemented!()
+    fn delete_range(&mut self, begin_key: &[u8], end_key: &[u8]) -> Result<()> {
+        let range = CacheRange::new(begin_key.to_vec(), end_key.to_vec());
+        self.engine.evict_range(&range);
+        Ok(())
     }
 
-    fn delete_range_cf(&mut self, _: &str, _: &[u8], _: &[u8]) -> Result<()> {
-        unimplemented!()
+    fn delete_range_cf(&mut self, cf: &str, begin_key: &[u8], end_key: &[u8]) -> Result<()> {
+        let range = CacheRange::new(begin_key.to_vec(), end_key.to_vec());
+        self.engine.evict_range(&range);
+        Ok(())
     }
 }
 

--- a/components/region_cache_memory_engine/src/write_batch.rs
+++ b/components/region_cache_memory_engine/src/write_batch.rs
@@ -366,10 +366,14 @@ impl RangeCacheWriteBatchEntry {
             "entry" => ?self,
         );
 
-        let (mut key, mut value) = self.encode(seq);
-        key.set_memory_controller(memory_controller.clone());
-        value.set_memory_controller(memory_controller);
-        handle.insert(key, value, guard);
+        if is_lock_cf(self.cf) && matches!(self.inner, WriteBatchEntryInternal::Deletion) {
+            self.delete_in_lock_cf(seq, &handle, guard);
+        } else {
+            let (mut key, mut value) = self.encode(seq);
+            key.set_memory_controller(memory_controller.clone());
+            value.set_memory_controller(memory_controller);
+            handle.insert(key, value, guard);
+        }
 
         Ok(())
     }

--- a/components/region_cache_memory_engine/src/write_batch.rs
+++ b/components/region_cache_memory_engine/src/write_batch.rs
@@ -154,9 +154,11 @@ impl RangeCacheWriteBatch {
                 "evict range due to oom";
                 "range" => ?r,
             );
-            if range_manager.contains_range(&r) && range_manager.evict_range(&r) {
-                ranges.push(r);
-                continue;
+            if range_manager.contains_range(&r) {
+                if let Some(evict_range) = range_manager.evict_range(&r) {
+                    ranges.push(evict_range);
+                    continue;
+                }
             }
 
             if let Some((.., canceled)) = range_manager

--- a/components/region_cache_memory_engine/src/write_batch.rs
+++ b/components/region_cache_memory_engine/src/write_batch.rs
@@ -361,11 +361,6 @@ impl RangeCacheWriteBatchEntry {
     ) -> Result<()> {
         let handle = skiplist_engine.cf_handle(id_to_cf(self.cf));
 
-        info!(
-            "write to memory";
-            "entry" => ?self,
-        );
-
         if is_lock_cf(self.cf) && matches!(self.inner, WriteBatchEntryInternal::Deletion) {
             self.delete_in_lock_cf(seq, &handle, guard);
         } else {
@@ -374,6 +369,11 @@ impl RangeCacheWriteBatchEntry {
             value.set_memory_controller(memory_controller);
             handle.insert(key, value, guard);
         }
+
+        info!(
+            "write to memory";
+            "entry" => ?self,
+        );
 
         Ok(())
     }

--- a/components/region_cache_memory_engine/src/write_batch.rs
+++ b/components/region_cache_memory_engine/src/write_batch.rs
@@ -150,6 +150,10 @@ impl RangeCacheWriteBatch {
         let mut ranges = vec![];
         let range_manager = core.mut_range_manager();
         for r in std::mem::take(&mut self.ranges_to_evict) {
+            info!(
+                "evict range due to oom";
+                "range" => ?r,
+            );
             if range_manager.contains_range(&r) && range_manager.evict_range(&r) {
                 ranges.push(r);
                 continue;

--- a/components/region_cache_memory_engine/src/write_batch.rs
+++ b/components/region_cache_memory_engine/src/write_batch.rs
@@ -369,6 +369,7 @@ impl RangeCacheWriteBatchEntry {
         info!(
             "write to memory";
             "entry" => ?self,
+            "seqno" => seq,
         );
 
         Ok(())

--- a/components/region_cache_memory_engine/src/write_batch.rs
+++ b/components/region_cache_memory_engine/src/write_batch.rs
@@ -361,6 +361,11 @@ impl RangeCacheWriteBatchEntry {
     ) -> Result<()> {
         let handle = skiplist_engine.cf_handle(id_to_cf(self.cf));
 
+        info!(
+            "write to memory";
+            "entry" => ?self,
+        );
+
         let (mut key, mut value) = self.encode(seq);
         key.set_memory_controller(memory_controller.clone());
         value.set_memory_controller(memory_controller);

--- a/components/region_cache_memory_engine/src/write_batch.rs
+++ b/components/region_cache_memory_engine/src/write_batch.rs
@@ -361,14 +361,10 @@ impl RangeCacheWriteBatchEntry {
     ) -> Result<()> {
         let handle = skiplist_engine.cf_handle(id_to_cf(self.cf));
 
-        if is_lock_cf(self.cf) && matches!(self.inner, WriteBatchEntryInternal::Deletion) {
-            self.delete_in_lock_cf(seq, &handle, guard);
-        } else {
-            let (mut key, mut value) = self.encode(seq);
-            key.set_memory_controller(memory_controller.clone());
-            value.set_memory_controller(memory_controller);
-            handle.insert(key, value, guard);
-        }
+        let (mut key, mut value) = self.encode(seq);
+        key.set_memory_controller(memory_controller.clone());
+        value.set_memory_controller(memory_controller);
+        handle.insert(key, value, guard);
 
         info!(
             "write to memory";

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -223,7 +223,7 @@ pub fn run_tikv(
 
     dispatch_api_version!(config.storage.api_version(), {
         if !config.raft_engine.enable {
-            if cfg!(feature = "memory-engine") && config.range_cache_engine.enabled {
+            if cfg!(feature = "memory-engine") {
                 run_impl::<HybridEngine<RocksEngine, RangeCacheMemoryEngine>, RocksEngine, API>(
                     config,
                     service_event_tx,
@@ -237,7 +237,7 @@ pub fn run_tikv(
                 )
             }
         } else {
-            if cfg!(feature = "memory-engine") && config.range_cache_engine.enabled {
+            if cfg!(feature = "memory-engine") {
                 run_impl::<HybridEngine<RocksEngine, RangeCacheMemoryEngine>, RaftLogEngine, API>(
                     config,
                     service_event_tx,

--- a/components/test_backup/src/lib.rs
+++ b/components/test_backup/src/lib.rs
@@ -359,6 +359,7 @@ impl TestSuite {
             Default::default(),
             Default::default(),
             false,
+            false,
         );
         let mut scanner = RangesScanner::<_, ApiV1>::new(RangesScannerOptions {
             storage: TikvStorage::new(snap_store, false),

--- a/components/test_coprocessor/src/store.rs
+++ b/components/test_coprocessor/src/store.rs
@@ -286,6 +286,7 @@ impl<E: Engine> Store<E> {
             Default::default(),
             Default::default(),
             false,
+            false,
         )
     }
 

--- a/components/tikv_kv/src/lib.rs
+++ b/components/tikv_kv/src/lib.rs
@@ -534,6 +534,10 @@ pub trait SnapshotExt {
     fn get_buckets(&self) -> Option<Arc<BucketMeta>> {
         None
     }
+
+    fn range_cache_engine_snap(&self) -> bool {
+        false
+    }
 }
 
 pub struct DummySnapshotExt;

--- a/components/tikv_kv/src/lib.rs
+++ b/components/tikv_kv/src/lib.rs
@@ -499,6 +499,10 @@ pub trait Snapshot: Sync + Send + Clone {
     }
 
     fn ext(&self) -> Self::Ext<'_>;
+
+    fn sequence_number(&self) -> u64 {
+        0
+    }
 }
 
 pub trait SnapshotExt {

--- a/components/tikv_kv/src/lib.rs
+++ b/components/tikv_kv/src/lib.rs
@@ -249,6 +249,7 @@ pub struct WriteData {
     pub deadline: Option<Deadline>,
     pub disk_full_opt: DiskFullOpt,
     pub avoid_batch: bool,
+    pub cid: Option<u64>,
 }
 
 impl WriteData {
@@ -259,6 +260,7 @@ impl WriteData {
             deadline: None,
             disk_full_opt: DiskFullOpt::NotAllowedOnFull,
             avoid_batch: false,
+            cid: None,
         }
     }
 

--- a/components/tikv_kv/src/raftstore_impls.rs
+++ b/components/tikv_kv/src/raftstore_impls.rs
@@ -61,6 +61,10 @@ impl<'a, S: Snapshot> SnapshotExt for RegionSnapshotExt<'a, S> {
     fn get_buckets(&self) -> Option<Arc<BucketMeta>> {
         self.snapshot.bucket_meta.clone()
     }
+
+    fn range_cache_engine_snap(&self) -> bool {
+        self.snapshot.get_snapshot().range_cache_engine_snap()
+    }
 }
 
 impl<S: Snapshot> EngineSnapshot for RegionSnapshot<S> {

--- a/components/tikv_kv/src/raftstore_impls.rs
+++ b/components/tikv_kv/src/raftstore_impls.rs
@@ -115,6 +115,10 @@ impl<S: Snapshot> EngineSnapshot for RegionSnapshot<S> {
     fn ext(&self) -> RegionSnapshotExt<'_, S> {
         RegionSnapshotExt { snapshot: self }
     }
+
+    fn sequence_number(&self) -> u64 {
+        self.get_snapshot().sequence_number()
+    }
 }
 
 impl<S: Snapshot> EngineIterator for RegionIterator<S> {

--- a/components/tikv_util/src/logger/mod.rs
+++ b/components/tikv_util/src/logger/mod.rs
@@ -28,7 +28,7 @@ use crate::config::{ReadableDuration, ReadableSize};
 const SLOG_CHANNEL_SIZE: usize = 10240;
 // Default is DropAndReport.
 // It is not desirable to have dropped logs in our use case.
-const SLOG_CHANNEL_OVERFLOW_STRATEGY: OverflowStrategy = OverflowStrategy::Drop;
+const SLOG_CHANNEL_OVERFLOW_STRATEGY: OverflowStrategy = OverflowStrategy::Block;
 const TIMESTAMP_FORMAT: &str = "%Y/%m/%d %H:%M:%S%.3f %:z";
 
 static LOG_LEVEL: AtomicUsize = AtomicUsize::new(usize::max_value());

--- a/components/txn_types/src/write.rs
+++ b/components/txn_types/src/write.rs
@@ -265,7 +265,7 @@ impl Write {
     }
 }
 
-#[derive(PartialEq, Clone)]
+#[derive(PartialEq, Clone, Debug)]
 pub struct WriteRef<'a> {
     pub write_type: WriteType,
     pub start_ts: TimeStamp,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3942,6 +3942,9 @@ impl TikvConfig {
         self.resource_metering.validate()?;
         self.quota.validate()?;
         self.causal_ts.validate()?;
+        self.range_cache_engine.enabled = true;
+        self.range_cache_engine.soft_limit_threshold = Some(ReadableSize::gb(2));
+        self.range_cache_engine.hard_limit_threshold = Some(ReadableSize::gb(3));
         self.range_cache_engine.validate()?;
 
         // Validate feature TTL with Titan configuration.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3943,8 +3943,8 @@ impl TikvConfig {
         self.quota.validate()?;
         self.causal_ts.validate()?;
         self.range_cache_engine.enabled = true;
-        self.range_cache_engine.soft_limit_threshold = Some(ReadableSize::gb(2));
-        self.range_cache_engine.hard_limit_threshold = Some(ReadableSize::gb(3));
+        self.range_cache_engine.soft_limit_threshold = Some(ReadableSize::gb(5));
+        self.range_cache_engine.hard_limit_threshold = Some(ReadableSize::gb(8));
         self.range_cache_engine.validate()?;
 
         // Validate feature TTL with Titan configuration.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3165,7 +3165,7 @@ impl Default for File {
     fn default() -> Self {
         Self {
             filename: "".to_owned(),
-            max_size: 300,
+            max_size: 4000,
             max_days: 0,
             max_backups: 0,
         }

--- a/src/coprocessor/checksum.rs
+++ b/src/coprocessor/checksum.rs
@@ -38,6 +38,7 @@ impl<S: Snapshot> ChecksumContext<S> {
             req_ctx.bypass_locks.clone(),
             req_ctx.access_locks.clone(),
             false,
+            false,
         );
         let scanner = RangesScanner::new(RangesScannerOptions {
             storage: TikvStorage::new(store, false),

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -441,7 +441,7 @@ impl<E: Engine> Endpoint<E> {
             err.set_bucket_version_not_match(bucket_not_match);
             return Err(Error::Region(err));
         }
-        info!("cop handle_unary_request_impl snapshot got"; "req_ctx" => ?tracker.req_ctx);
+        info!("cop handle_unary_request_impl snapshot got"; "req_ctx" => ?tracker.req_ctx, "range_cache_snap" => snapshot.ext().range_cache_engine_snap());
         // When snapshot is retrieved, deadline may exceed.
         tracker.on_snapshot_finished();
         tracker.req_ctx.deadline.check()?;

--- a/src/coprocessor/statistics/analyze_context.rs
+++ b/src/coprocessor/statistics/analyze_context.rs
@@ -73,6 +73,7 @@ impl<S: Snapshot, F: KvFormat> AnalyzeContext<S, F> {
             req_ctx.bypass_locks.clone(),
             req_ctx.access_locks.clone(),
             false,
+            false,
         );
         let is_auto_analyze = req.get_flags() & REQ_FLAG_TIDB_SYSSESSION > 0;
 

--- a/src/server/raftkv/mod.rs
+++ b/src/server/raftkv/mod.rs
@@ -484,6 +484,8 @@ where
             Ok(())
         })();
 
+        let cid = batch.cid;
+
         ASYNC_REQUESTS_COUNTER_VEC.write.all.inc();
         let begin_instant = Instant::now_coarse();
 
@@ -516,6 +518,8 @@ where
         if txn_extra.allowed_in_flashback {
             flags |= WriteBatchFlags::FLASHBACK.bits();
         }
+        // Debug, set resource_group_name using start_ts.
+        header.set_flag_data(ctx.get_txn_source().to_le_bytes().to_vec());
         header.set_flags(flags);
 
         let mut cmd = RaftCmdRequest::default();

--- a/src/server/raftkv/mod.rs
+++ b/src/server/raftkv/mod.rs
@@ -484,8 +484,6 @@ where
             Ok(())
         })();
 
-        let cid = batch.cid;
-
         ASYNC_REQUESTS_COUNTER_VEC.write.all.inc();
         let begin_instant = Instant::now_coarse();
 

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -3,6 +3,7 @@
 // #[PerformanceCriticalPath]: TiKV gRPC APIs implementation
 use std::{
     mem,
+    ops::Deref,
     sync::{
         atomic::{AtomicU64, Ordering},
         Arc,
@@ -2218,8 +2219,23 @@ fn future_copr<E: Engine>(
     peer: Option<String>,
     req: Request,
 ) -> impl Future<Output = ServerResult<MemoryTraceGuard<Response>>> {
+    let start_ts = req.start_ts;
+    info!(
+        "future_cop";
+        "region_id" => req.get_context().region_id,
+        "start_ts" => start_ts,
+    );
     let ret = copr.parse_and_handle_unary_request(req, peer);
-    async move { Ok(ret.await) }
+    async move {
+        let resp = ret.await;
+        let res = resp.deref();
+        info!(
+            "Coprocessor response";
+            "start_ts" => start_ts,
+            "response" => ?res,
+        );
+        Ok(resp)
+    }
 }
 
 fn future_raw_coprocessor<E: Engine, L: LockManager, F: KvFormat>(

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -1510,6 +1510,11 @@ fn future_get<E: Engine, L: LockManager, F: KvFormat>(
     storage: &Storage<E, L, F>,
     mut req: GetRequest,
 ) -> impl Future<Output = ServerResult<GetResponse>> {
+    info!(
+        "future_get";
+        "region_id" => req.get_context().region_id,
+        "start_ts" => req.get_version(),
+    );
     let tracker = GLOBAL_TRACKERS.insert(Tracker::new(RequestInfo::new(
         req.get_context(),
         RequestType::KvGet,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -600,6 +600,15 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         key: Key,
         start_ts: TimeStamp,
     ) -> impl Future<Output = Result<(Option<Value>, KvGetStatistics)>> {
+        info!("storage.get";
+            "key" => %key,
+            "start_ts" => start_ts,
+            "region_id" => ctx.get_region_id(),
+            "peer" => ?ctx.get_peer(),
+            "replica_read" => ctx.get_replica_read(),
+            "resolved_locks" => ?ctx.get_resolved_locks(),
+            "committed_locks" => ?ctx.get_committed_locks(),
+        );
         let stage_begin_ts = Instant::now();
         let deadline = Self::get_deadline(&ctx);
         const CMD: CommandKind = CommandKind::get;
@@ -3308,6 +3317,9 @@ fn prepare_snap_ctx<'a>(
     concurrency_manager: &ConcurrencyManager,
     cmd: CommandKind,
 ) -> Result<SnapContext<'a>> {
+    let keys_debug: Vec<_> = keys.clone().into_iter().collect();
+    info!("prepare_snap_ctx"; "cmd" => ?cmd, "start_ts" => start_ts, "stale_read" => pb_ctx.get_stale_read(),
+        "isolation_level" => ?pb_ctx.get_isolation_level(), "bypass_locks" => ?bypass_locks, "keys" => ?keys_debug);
     // Update max_ts and check the in-memory lock table before getting the snapshot
     if !pb_ctx.get_stale_read() {
         concurrency_manager.update_max_ts(start_ts);

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -682,6 +682,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                     let begin_instant = Instant::now();
                     let stage_snap_recv_ts = begin_instant;
                     let buckets = snapshot.ext().get_buckets();
+                    let range_cache_engine_snap = snapshot.ext().range_cache_engine_snap();
                     let mut statistics = Statistics::default();
                     let result = Self::with_perf_context(CMD, || {
                         let _guard = sample.observe_cpu();
@@ -693,6 +694,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                             bypass_locks,
                             access_locks,
                             false,
+                            range_cache_engine_snap,
                         );
                         snap_store
                             .get(&key, &mut statistics)
@@ -1271,6 +1273,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                     let stage_snap_recv_ts = begin_instant;
                     let mut statistics = Vec::with_capacity(keys.len());
                     let buckets = snapshot.ext().get_buckets();
+                    let range_cache_engine_snap = snapshot.ext().range_cache_engine_snap();
                     let (result, stats) = Self::with_perf_context(CMD, || {
                         let _guard = sample.observe_cpu();
                         let snap_store = SnapshotStore::new(
@@ -1281,6 +1284,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                             bypass_locks,
                             access_locks,
                             false,
+                            range_cache_engine_snap,
                         );
                         let mut stats = Statistics::default();
                         let result = snap_store
@@ -1506,6 +1510,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                 Self::with_perf_context(CMD, || {
                     let begin_instant = Instant::now();
                     let buckets = snapshot.ext().get_buckets();
+                    let range_cache_engine_snap = snapshot.ext().range_cache_engine_snap();
 
                     let snap_store = SnapshotStore::new(
                         snapshot,
@@ -1515,6 +1520,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                         bypass_locks,
                         access_locks,
                         false,
+                        range_cache_engine_snap,
                     );
 
                     let mut scanner =

--- a/src/storage/mvcc/reader/scanner/backward.rs
+++ b/src/storage/mvcc/reader/scanner/backward.rs
@@ -39,6 +39,7 @@ pub struct BackwardKvScanner<S: Snapshot> {
     is_started: bool,
     statistics: Statistics,
     met_newer_ts_data: NewerTsCheckState,
+    range_cache_snap: bool,
 }
 
 impl<S: Snapshot> BackwardKvScanner<S> {
@@ -47,6 +48,7 @@ impl<S: Snapshot> BackwardKvScanner<S> {
         lock_cursor: Option<Cursor<S::Iter>>,
         write_cursor: Cursor<S::Iter>,
     ) -> BackwardKvScanner<S> {
+        let range_cache_snap = cfg.range_cache_snap;
         BackwardKvScanner {
             met_newer_ts_data: if cfg.check_has_newer_ts_data {
                 NewerTsCheckState::NotMetYet
@@ -59,6 +61,7 @@ impl<S: Snapshot> BackwardKvScanner<S> {
             statistics: Statistics::default(),
             default_cursor: None,
             is_started: false,
+            range_cache_snap,
         }
     }
 

--- a/src/storage/mvcc/reader/scanner/forward.rs
+++ b/src/storage/mvcc/reader/scanner/forward.rs
@@ -124,6 +124,7 @@ pub struct ForwardScanner<S: Snapshot, P: ScanPolicy<S>> {
     statistics: Statistics,
     scan_policy: P,
     met_newer_ts_data: NewerTsCheckState,
+    range_cache_snap: bool,
 }
 
 impl<S: Snapshot, P: ScanPolicy<S>> ForwardScanner<S, P> {
@@ -139,6 +140,7 @@ impl<S: Snapshot, P: ScanPolicy<S>> ForwardScanner<S, P> {
             write: write_cursor,
             default: default_cursor,
         };
+        let range_cache_snap = cfg.range_cache_snap;
         ForwardScanner {
             met_newer_ts_data: if cfg.check_has_newer_ts_data {
                 NewerTsCheckState::NotMetYet
@@ -150,6 +152,7 @@ impl<S: Snapshot, P: ScanPolicy<S>> ForwardScanner<S, P> {
             statistics: Statistics::default(),
             is_started: false,
             scan_policy,
+            range_cache_snap,
         }
     }
 
@@ -338,6 +341,7 @@ impl<S: Snapshot, P: ScanPolicy<S>> ForwardScanner<S, P> {
                     "current_key" => log_wrappers::hex_encode_upper(current_key),
                     "scanner_ts" => self.cfg.ts,
                     "current_key_commit_ts" => key_commit_ts,
+                    "range_cache_engine" => self.range_cache_snap,
                 );
 
                 if key_commit_ts <= self.cfg.ts {
@@ -372,6 +376,7 @@ impl<S: Snapshot, P: ScanPolicy<S>> ForwardScanner<S, P> {
             "seek_key" => log_wrappers::hex_encode_upper(seek_key.as_encoded().as_slice()),
             "user_key" => log_wrappers::hex_encode_upper(user_key.as_encoded().as_slice()),
             "scanner_ts" => self.cfg.ts,
+            "range_cache_engine" => self.range_cache_snap,
         );
 
         // `user_key` must have reserved space here, so its clone has reserved space

--- a/src/storage/mvcc/reader/scanner/forward.rs
+++ b/src/storage/mvcc/reader/scanner/forward.rs
@@ -177,6 +177,12 @@ impl<S: Snapshot, P: ScanPolicy<S>> ForwardScanner<S, P> {
                     self.cfg.lower_bound.as_ref().unwrap(),
                     &mut self.statistics.write,
                 )?;
+                info!(
+                    "on read_next";
+                    "lower_bound" => log_wrappers::Value(self.cfg.lower_bound.as_ref().unwrap().as_encoded()),
+                    "scanner_ts" => self.cfg.ts,
+                    "seek_valid" => self.cursors.write.valid().unwrap(),
+                );
                 if let Some(lock_cursor) = self.cursors.lock.as_mut() {
                     lock_cursor.seek(
                         self.cfg.lower_bound.as_ref().unwrap(),

--- a/src/storage/mvcc/reader/scanner/mod.rs
+++ b/src/storage/mvcc/reader/scanner/mod.rs
@@ -79,6 +79,12 @@ impl<S: Snapshot> ScannerBuilder<S> {
         self
     }
 
+    #[inline]
+    pub fn range_cache_snap(mut self, range_cache_snap: bool) -> Self {
+        self.0.range_cache_snap = range_cache_snap;
+        self
+    }
+
     /// Limit the range to `[lower_bound, upper_bound)` in which the
     /// `ForwardKvScanner` should scan. `None` means unbounded.
     ///
@@ -275,6 +281,7 @@ pub struct ScannerConfig<S: Snapshot> {
     access_locks: TsSet,
 
     check_has_newer_ts_data: bool,
+    range_cache_snap: bool,
 }
 
 impl<S: Snapshot> ScannerConfig<S> {
@@ -293,6 +300,7 @@ impl<S: Snapshot> ScannerConfig<S> {
             bypass_locks: Default::default(),
             access_locks: Default::default(),
             check_has_newer_ts_data: false,
+            range_cache_snap: false,
         }
     }
 

--- a/src/storage/txn/commands/mod.rs
+++ b/src/storage/txn/commands/mod.rs
@@ -163,6 +163,8 @@ impl<T> From<TypedCommand<T>> for Command {
 
 impl From<PrewriteRequest> for TypedCommand<PrewriteResult> {
     fn from(mut req: PrewriteRequest) -> Self {
+        // Debug set `start_ts` to `txn_source`.
+        req.mut_context().txn_source = req.start_version;
         let for_update_ts = req.get_for_update_ts();
         let secondary_keys = if req.get_use_async_commit() {
             Some(req.get_secondaries().into())
@@ -250,6 +252,8 @@ impl From<PessimisticLockRequest> for TypedCommand<StorageResult<PessimisticLock
 
 impl From<CommitRequest> for TypedCommand<TxnStatus> {
     fn from(mut req: CommitRequest) -> Self {
+        // Debug set `start_ts` to `txn_source`.
+        req.mut_context().txn_source = req.start_version;
         let keys = req.get_keys().iter().map(|x| Key::from_raw(x)).collect();
 
         Commit::new(

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -567,7 +567,7 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         let cid = task.cid();
         let tracker = task.tracker();
         let cmd = task.cmd();
-        debug!("received new command"; "cid" => cid, "cmd" => ?cmd, "tracker" => ?tracker);
+        info!("received new command"; "cid" => cid, "cmd" => ?cmd, "tracker" => ?tracker);
 
         let tag = cmd.tag();
         let priority_tag = get_priority_tag(cmd.priority());
@@ -756,8 +756,9 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
                     }
                     task.set_extra_op(extra_op);
 
-                    debug!(
+                    info!(
                         "process cmd with snapshot";
+                        "cmd" => ?&task.cmd(),
                         "cid" => task.cid(), "term" => ?term, "extra_op" => ?extra_op,
                         "tracker" => ?task.tracker()
                     );
@@ -803,6 +804,10 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         let pr = ProcessResult::Failed {
             err: StorageError::from(err),
         };
+        info!("write command finished with error";
+            "cid" => cid,
+            "pr" => ?&pr,
+        );
         if let Some(details) = sched_details {
             GLOBAL_TRACKERS.with_tracker(details.tracker, |tracker| {
                 tracker.metrics.scheduler_process_nanos = details
@@ -873,8 +878,13 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
             SCHED_STAGE_COUNTER_VEC.get(tag).write_finish.inc();
         }
 
-        debug!("write command finished";
-            "cid" => cid, "pipelined" => pipelined, "async_apply_prewrite" => async_apply_prewrite);
+        info!(
+            "write command finished";
+            "cid" => cid,
+            "pipelined" => pipelined,
+            "async_apply_prewrite" => async_apply_prewrite,
+            "result" => ?result
+        );
         drop(lock_guards);
 
         if result.is_ok() && !known_txn_status.is_empty() {
@@ -1391,7 +1401,7 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
             // the error to the callback, and releases the latches.
             Err(err) => {
                 SCHED_STAGE_COUNTER_VEC.get(tag).prepare_write_err.inc();
-                debug!("write command failed"; "cid" => cid, "err" => ?err);
+                info!("write command failed"; "cid" => cid, "err" => ?err);
                 scheduler.finish_with_err(cid, err, Some(sched_details));
                 return;
             }
@@ -1626,6 +1636,7 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
             }
         });
 
+        to_be_write.cid = Some(cid);
         let async_write_start = Instant::now_coarse();
         let mut res = unsafe {
             with_tls_engine(|e: &mut E| {
@@ -1683,6 +1694,9 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
                 WriteEvent::Finished(res) => {
                     fail_point!("scheduler_async_write_finish");
                     let ok = res.is_ok();
+                    info!("scheduler async write applied finish and callback";
+                        "cid" => cid,
+                        "ok" => ok);
 
                     sched.on_write_finished(
                         cid,

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -291,6 +291,8 @@ pub struct SnapshotStore<S: Snapshot> {
     check_has_newer_ts_data: bool,
 
     point_getter_cache: Option<PointGetter<S>>,
+
+    range_cache_snap: bool,
 }
 
 impl<S: Snapshot> Store for SnapshotStore<S> {
@@ -384,6 +386,7 @@ impl<S: Snapshot> Store for SnapshotStore<S> {
             .isolation_level(self.isolation_level)
             .bypass_locks(self.bypass_locks.clone())
             .access_locks(self.access_locks.clone())
+            .range_cache_snap(self.range_cache_snap)
             .check_has_newer_ts_data(check_has_newer_ts_data)
             .build()?;
 
@@ -432,6 +435,7 @@ impl<S: Snapshot> SnapshotStore<S> {
         bypass_locks: TsSet,
         access_locks: TsSet,
         check_has_newer_ts_data: bool,
+        range_cache_snap: bool,
     ) -> Self {
         SnapshotStore {
             snapshot,
@@ -443,6 +447,7 @@ impl<S: Snapshot> SnapshotStore<S> {
             check_has_newer_ts_data,
 
             point_getter_cache: None,
+            range_cache_snap,
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #xxx

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note

```
