### PR TITLE
In-memory engine: fix seek does not set self.valid properly

### DIFF
--- a/components/region_cache_memory_engine/src/read.rs
+++ b/components/region_cache_memory_engine/src/read.rs
@@ -824,12 +824,14 @@ mod tests {
 
         let key = construct_mvcc_key("b", 10);
         iter.seek(&key).unwrap();
+        assert_eq!(iter.value(), b"val");
         let key = construct_mvcc_key("d", 10);
         iter.seek(&key).unwrap();
         assert!(!iter.valid().unwrap());
 
         let key = construct_mvcc_key("b", 10);
         iter.seek_for_prev(&key).unwrap();
+        assert_eq!(iter.value(), b"val");
         let key = construct_mvcc_key("a", 10);
         iter.seek_for_prev(&key).unwrap();
         assert!(!iter.valid().unwrap());

--- a/components/region_cache_memory_engine/src/read.rs
+++ b/components/region_cache_memory_engine/src/read.rs
@@ -312,6 +312,8 @@ impl RangeCacheIterator {
         self.iter.seek(key, guard);
         if self.iter.valid() {
             self.find_next_visible_key(false, guard);
+        } else {
+            self.valid = false;
         }
     }
 
@@ -795,6 +797,42 @@ mod tests {
         if ended {
             assert!(!iter.valid().unwrap());
         }
+    }
+
+    #[test]
+    fn test_seek() {
+        let engine = RangeCacheMemoryEngine::new(RangeCacheEngineContext::new(Arc::new(
+            VersionTrack::new(RangeCacheEngineConfig::config_for_test()),
+        )));
+        let range = CacheRange::new(b"".to_vec(), b"z".to_vec());
+        engine.new_range(range.clone());
+
+        {
+            let mut core = engine.core.write();
+            core.range_manager.set_safe_point(&range, 5);
+            let sl = core.engine.data[cf_to_id("write")].clone();
+
+            put_key_val(&sl, "b", "val", 10, 5);
+            put_key_val(&sl, "c", "vall", 10, 5);
+        }
+
+        let snapshot = engine.snapshot(range.clone(), u64::MAX, 100).unwrap();
+        let mut iter_opt = IterOptions::default();
+        iter_opt.set_upper_bound(&range.end, 0);
+        iter_opt.set_lower_bound(&range.start, 0);
+        let mut iter = snapshot.iterator_opt("write", iter_opt.clone()).unwrap();
+
+        let key = construct_mvcc_key("b", 10);
+        iter.seek(&key).unwrap();
+        let key = construct_mvcc_key("d", 10);
+        iter.seek(&key).unwrap();
+        assert!(!iter.valid().unwrap());
+
+        let key = construct_mvcc_key("b", 10);
+        iter.seek_for_prev(&key).unwrap();
+        let key = construct_mvcc_key("a", 10);
+        iter.seek_for_prev(&key).unwrap();
+        assert!(!iter.valid().unwrap());
     }
 
     #[test]


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref #16141

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
fix seek does not set self.valid properly
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
