### PR TITLE
statistics: remove unreachable code

### DIFF
--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -534,6 +534,8 @@ pub(crate) struct SampleBuilder<S: Snapshot, F: KvFormat> {
     cm_sketch_depth: usize,
     cm_sketch_width: usize,
     columns_info: Vec<tipb::ColumnInfo>,
+    // NOTE: The field is currently used only when mixed analyze requests are received,
+    // which happens exclusively when the statistics version is 1.
     analyze_common_handle: bool,
     common_handle_col_ids: Vec<i64>,
 }

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -535,8 +535,6 @@ pub(crate) struct SampleBuilder<S: Snapshot, F: KvFormat> {
     max_fm_sketch_size: usize,
     cm_sketch_depth: usize,
     cm_sketch_width: usize,
-    stats_version: AnalyzeVersion,
-    top_n_size: usize,
     columns_info: Vec<tipb::ColumnInfo>,
     analyze_common_handle: bool,
     common_handle_col_ids: Vec<i64>,
@@ -574,16 +572,6 @@ impl<S: Snapshot, F: KvFormat> SampleBuilder<S, F> {
             max_sample_size: req.get_sample_size() as usize,
             cm_sketch_depth: req.get_cmsketch_depth() as usize,
             cm_sketch_width: req.get_cmsketch_width() as usize,
-            stats_version: common_handle_req.as_ref().map_or_else(
-                || AnalyzeVersion::V1,
-                |req| match req.has_version() {
-                    true => req.get_version().into(),
-                    _ => AnalyzeVersion::V1,
-                },
-            ),
-            top_n_size: common_handle_req
-                .as_ref()
-                .map_or_else(|| 0_usize, |req| req.get_top_n_size() as usize),
             common_handle_col_ids: common_handle_ids,
             columns_info,
             analyze_common_handle: common_handle_req.is_some(),

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -26,9 +26,7 @@ use tipb::{self, AnalyzeColumnsReq};
 
 use super::{cmsketch::CmSketch, fmsketch::FmSketch, histogram::Histogram};
 use crate::{
-    coprocessor::{
-        dag::TikvStorage, statistics::analyze_context::AnalyzeVersion, MEMTRACE_ANALYZE, *,
-    },
+    coprocessor::{dag::TikvStorage, MEMTRACE_ANALYZE, *},
     storage::{Snapshot, SnapshotStore},
 };
 

--- a/src/coprocessor/statistics/analyze_context.rs
+++ b/src/coprocessor/statistics/analyze_context.rs
@@ -102,6 +102,7 @@ impl<S: Snapshot, F: KvFormat> AnalyzeContext<S, F> {
 
     // Handle mixed request, it would build histograms for common handle and columns
     // by scan table rows once.
+    // NOTE: Mixed requests are only sent when the statistics version is set to 1.
     async fn handle_mixed(builder: &mut SampleBuilder<S, F>) -> Result<Vec<u8>> {
         let (col_res, idx_res) = builder.collect_columns_stats().await?;
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

Removed some unreachable code. The code is now unreachable as TiDB no longer sends mixed analyze requests to TiKV if the statistics version is set to 2.

You can only find one reference of the mixed request type in TiDB.

<img width="1862" alt="image" src="https://github.com/tikv/tikv/assets/29879298/89cd2a73-06da-424c-862e-2cc454fc62d9">

You can find it here: https://github.com/pingcap/tidb/blob/12b37d88dceb4eb4da6fe316fb4d0af2024ab58b/pkg/executor/builder.go#L2706

But for version 2, we use `buildAnalyzeSamplingPushdown` to build the analysis task.

<img width="832" alt="image" src="https://github.com/tikv/tikv/assets/29879298/4e1c36d7-3fc7-4ddf-80b3-121a5592d3f3">


Issue Number: Ref https://github.com/tikv/tikv/issues/16463

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
statistics: remove unreachable code

The code is now unreachable as TiDB no longer
sends mixed analyze requests to TiKV if the
statistics version is set to 2.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
