### PR TITLE
Revert "raftstore: bugfix of the calculation on the log gap between leader and peer when restart. (#16738) (#16961)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2841,7 +2841,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#4fa2b26b2d8003523908b124ab6e70580023eee6"
+source = "git+https://github.com/pingcap/kvproto.git#c699538f7aa18394ae5e09cd1291209079b391d6"
 dependencies = [
  "futures 0.3.15",
  "grpcio",
@@ -7079,7 +7079,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,10 @@ edition = "2021"
 publish = false
 
 [features]
-default = ["test-engine-kv-rocksdb", "test-engine-raft-raft-engine"]
+default = [
+  "test-engine-kv-rocksdb",
+  "test-engine-raft-raft-engine",
+]
 trace-tablet-lifetime = ["engine_rocks/trace-lifetime"]
 tcmalloc = ["tikv_alloc/tcmalloc"]
 jemalloc = ["tikv_alloc/jemalloc", "engine_rocks/jemalloc"]

--- a/components/raftstore/src/store/metrics.rs
+++ b/components/raftstore/src/store/metrics.rs
@@ -324,20 +324,6 @@ make_static_metric! {
     pub struct LoadBaseSplitEventCounterVec: IntCounter {
         "type" => LoadBaseSplitEventType,
     }
-
-    pub struct StoreBusyOnApplyRegionsGaugeVec: IntGauge {
-        "type" => {
-            busy_apply_peers,
-            completed_apply_peers,
-        },
-    }
-
-    pub struct StoreBusyStateGaugeVec: IntGauge {
-        "type" => {
-            raftstore_busy,
-            applystore_busy,
-        },
-    }
 }
 
 lazy_static! {
@@ -985,20 +971,4 @@ lazy_static! {
         "The events of the lease to denying new admin commands being proposed by snapshot br.",
         &["event"]
     ).unwrap();
-
-    pub static ref STORE_BUSY_ON_APPLY_REGIONS_GAUGE_VEC: StoreBusyOnApplyRegionsGaugeVec =
-        register_static_int_gauge_vec!(
-            StoreBusyOnApplyRegionsGaugeVec,
-            "tikv_raftstore_busy_on_apply_region_total",
-            "Total number of regions busy on apply or complete apply.",
-            &["type"]
-        ).unwrap();
-
-    pub static ref STORE_PROCESS_BUSY_GAUGE_VEC: StoreBusyStateGaugeVec =
-        register_static_int_gauge_vec!(
-            StoreBusyStateGaugeVec,
-            "tikv_raftstore_process_busy",
-            "Is raft process busy or not",
-            &["type"]
-        ).unwrap();
 }

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -917,10 +917,6 @@ where
     /// * `Some(false)` => initial state, not be recorded.
     /// * `Some(true)` => busy on apply, and already recorded.
     pub busy_on_apply: Option<bool>,
-    /// The index of last commited idx in the leader. It's used to check whether
-    /// this peer has raft log gaps and whether should be marked busy on
-    /// apply.
-    pub last_leader_committed_idx: Option<u64>,
 }
 
 impl<EK, ER> Peer<EK, ER>
@@ -1071,7 +1067,6 @@ where
             unsafe_recovery_state: None,
             snapshot_recovery_state: None,
             busy_on_apply: Some(false),
-            last_leader_committed_idx: None,
         };
 
         // If this region has only one peer and I am the one, campaign directly.
@@ -5326,37 +5321,6 @@ where
                 self.snapshot_recovery_state = None;
             }
         }
-    }
-
-    pub fn update_last_leader_committed_idx(&mut self, committed_index: u64) {
-        if self.is_leader() {
-            // Ignore.
-            return;
-        }
-
-        let local_committed_index = self.get_store().commit_index();
-        if committed_index < local_committed_index {
-            warn!(
-                "stale committed index";
-                "region_id" => self.region().get_id(),
-                "peer_id" => self.peer_id(),
-                "last_committed_index" => committed_index,
-                "local_index" => local_committed_index,
-            );
-        } else {
-            self.last_leader_committed_idx = Some(committed_index);
-            debug!(
-                "update last committed index from leader";
-                "region_id" => self.region().get_id(),
-                "peer_id" => self.peer_id(),
-                "last_committed_index" => committed_index,
-                "local_index" => local_committed_index,
-            );
-        }
-    }
-
-    pub fn needs_update_last_leader_committed_idx(&self) -> bool {
-        self.busy_on_apply.is_some() && self.last_leader_committed_idx.is_none()
     }
 }
 

--- a/deny.toml
+++ b/deny.toml
@@ -83,7 +83,15 @@ unlicensed = "deny"
 copyleft = "deny"
 private = { ignore = false }
 # Allow licenses in Category A
-allow = ["0BSD", "Apache-2.0", "BSD-3-Clause", "CC0-1.0", "ISC", "MIT", "Zlib"]
+allow = [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-3-Clause",
+    "CC0-1.0",
+    "ISC",
+    "MIT",
+    "Zlib",
+]
 exceptions = [
     # unicode-ident includes data generated from Unicode Character Database
     # which is licensed under Unicode-DFS-2016.

--- a/metrics/grafana/tikv_details.dashboard.py
+++ b/metrics/grafana/tikv_details.dashboard.py
@@ -490,13 +490,6 @@ Full""",
                         ),
                         legend_format=r"store-write-channelfull-{{instance}}",
                     ),
-                    target(
-                        expr=expr_sum(
-                            "tikv_raftstore_process_busy",
-                            by_labels=["instance", "type"],
-                        ),
-                        legend_format=r"{{instance}}-{{type}}",
-                    ),
                 ],
             ),
             graph_panel(

--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -2474,21 +2474,6 @@
               "refId": "",
               "step": 10,
               "target": ""
-            },
-            {
-              "datasource": "${DS_TEST-CLUSTER}",
-              "expr": "sum((\n    tikv_raftstore_process_busy\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (instance, type) ",
-              "format": "time_series",
-              "hide": false,
-              "instant": false,
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "{{instance}}-{{type}}",
-              "metric": "",
-              "query": "sum((\n    tikv_raftstore_process_busy\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (instance, type) ",
-              "refId": "",
-              "step": 10,
-              "target": ""
             }
           ],
           "thresholds": [],

--- a/metrics/grafana/tikv_details.json.sha256
+++ b/metrics/grafana/tikv_details.json.sha256
@@ -1,1 +1,1 @@
-062b2e4f7d24f23967cd378efd78c8ba5277a4855d6733585ca12b081fb7b3c5  ./metrics/grafana/tikv_details.json
+08adf24e602cbd911af7a5df64a21358876cbd2569b12bedc1d415350b97ffac  ./metrics/grafana/tikv_details.json

--- a/tests/failpoints/cases/test_pending_peers.rs
+++ b/tests/failpoints/cases/test_pending_peers.rs
@@ -1,10 +1,7 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
-use crossbeam::channel;
-use kvproto::raft_serverpb::RaftMessage;
-use raft::eraftpb::MessageType;
 use test_raftstore::*;
 use tikv_util::{config::*, time::Instant};
 
@@ -154,73 +151,30 @@ fn test_on_check_busy_on_apply_peers() {
     must_get_equal(&cluster.get_engine(2), b"k2", b"v2");
 
     // Restart peer 1003 and make it busy for applying pending logs.
-    fail::cfg("on_handle_apply_1003", "pause").unwrap();
-    // Case 1: check the leader committed index comes from MsgAppend and
-    // MsgReadIndexResp is valid.
-    let (read_tx, read_rx) = channel::unbounded::<RaftMessage>();
-    let (append_tx, append_rx) = channel::unbounded::<RaftMessage>();
-    cluster.add_send_filter_on_node(
-        1,
-        Box::new(
-            RegionPacketFilter::new(r1, 1)
-                .direction(Direction::Send)
-                .msg_type(MessageType::MsgReadIndexResp)
-                .set_msg_callback(Arc::new(move |msg: &RaftMessage| {
-                    read_tx.send(msg.clone()).unwrap();
-                })),
-        ),
-    );
-    cluster.add_send_filter_on_node(
-        1,
-        Box::new(
-            RegionPacketFilter::new(r1, 1)
-                .direction(Direction::Send)
-                .msg_type(MessageType::MsgAppend)
-                .set_msg_callback(Arc::new(move |msg: &RaftMessage| {
-                    append_tx.send(msg.clone()).unwrap();
-                })),
-        ),
-    );
-    let leader_apply_state = cluster.apply_state(r1, 1);
+    fail::cfg("on_handle_apply_1003", "return").unwrap();
     cluster.run_node(3).unwrap();
-    let append_msg = append_rx.recv_timeout(Duration::from_secs(2)).unwrap();
-    assert_eq!(
-        append_msg.get_message().get_commit(),
-        leader_apply_state.applied_index
-    );
-    let read_msg = read_rx.recv_timeout(Duration::from_secs(2)).unwrap();
-    assert_eq!(
-        read_msg.get_message().get_index(),
-        leader_apply_state.applied_index
-    );
-    cluster.clear_send_filter_on_node(1);
-
-    // Case 2: completed regions < target count.
     let after_apply_stat = cluster.apply_state(r1, 3);
     assert!(after_apply_stat.applied_index == before_apply_stat.applied_index);
-    sleep_ms(100);
-    cluster.must_send_store_heartbeat(3);
-    sleep_ms(100);
-    let stats = cluster.pd_client.get_store_stats(3).unwrap();
-    assert!(stats.is_busy);
-    sleep_ms(100);
 
-    // Case 3: completed_apply_peers_count > completed_target_count but
-    //        there exists busy peers.
+    // Case 1: completed regions < target count.
     fail::cfg("on_mock_store_completed_target_count", "return").unwrap();
+    sleep_ms(100);
     cluster.must_send_store_heartbeat(3);
     sleep_ms(100);
     let stats = cluster.pd_client.get_store_stats(3).unwrap();
     assert!(stats.is_busy);
     fail::remove("on_mock_store_completed_target_count");
+    sleep_ms(100);
+
+    // Case 2: completed_apply_peers_count > completed_target_count but
+    //        there exists no busy peers.
+    cluster.must_send_store_heartbeat(3);
+    sleep_ms(100);
+    let stats = cluster.pd_client.get_store_stats(3).unwrap();
+    assert!(!stats.is_busy);
+
     // After peer 1003 is recovered, store also should not be marked with busy.
     fail::remove("on_handle_apply_1003");
-    sleep_ms(100);
-    must_get_equal(&cluster.get_engine(3), b"k2", b"v2");
-    sleep_ms(100);
-    let after_apply_stat = cluster.apply_state(r1, 3);
-    assert!(after_apply_stat.applied_index > before_apply_stat.applied_index);
-    cluster.must_send_store_heartbeat(3);
     sleep_ms(100);
     let stats = cluster.pd_client.get_store_stats(3).unwrap();
     assert!(!stats.is_busy);


### PR DESCRIPTION
This reverts commit 5aed80452ad64bf756950b3b1d61666a8f1155c7.

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #xxx

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note

```
