### PR TITLE
log_backup: fix panic when encountered error during resuming

### DIFF
--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -760,7 +760,7 @@ where
             Err(err) => {
                 err.report(format!("failed to resume backup stream task {}", task_name));
                 let sched = self.scheduler.clone();
-                tokio::task::spawn(root!("retry_resume"; async move {
+                self.pool.spawn(root!("retry_resume"; async move {
                     tokio::time::sleep(Duration::from_secs(5)).await;
                     sched
                         .schedule(Task::WatchTask(TaskOp::ResumeTask(task_name)))

--- a/components/backup-stream/src/metadata/client.rs
+++ b/components/backup-stream/src/metadata/client.rs
@@ -331,6 +331,13 @@ impl<Store: MetaStore> MetadataClient<Store> {
             .await
     }
 
+    /// resume a task.
+    pub async fn resume(&self, name: &str) -> Result<()> {
+        self.meta_store
+            .delete(Keys::Key(MetaKey::pause_of(name)))
+            .await
+    }
+
     pub async fn get_tasks_pause_status(&self) -> Result<HashMap<Vec<u8>, bool>> {
         let kvs = self
             .meta_store
@@ -354,6 +361,11 @@ impl<Store: MetaStore> MetadataClient<Store> {
         defer! {
             super::metrics::METADATA_OPERATION_LATENCY.with_label_values(&["task_get"]).observe(now.saturating_elapsed().as_secs_f64())
         }
+        fail::fail_point!("failed_to_get_task", |_| {
+            Err(Error::MalformedMetadata(
+                "failed to connect etcd client".to_string(),
+            ))
+        });
         let items = self
             .meta_store
             .get_latest(Keys::Key(MetaKey::task_of(name)))
@@ -376,7 +388,7 @@ impl<Store: MetaStore> MetadataClient<Store> {
         }
         fail::fail_point!("failed_to_get_tasks", |_| {
             Err(Error::MalformedMetadata(
-                "faild to connect etcd client".to_string(),
+                "failed to connect etcd client".to_string(),
             ))
         });
         let kvs = self

--- a/components/backup-stream/tests/failpoints/mod.rs
+++ b/components/backup-stream/tests/failpoints/mod.rs
@@ -402,7 +402,7 @@ mod all {
 
     #[test]
     fn failed_to_get_task_when_pausing() {
-        let mut suite = SuiteBuilder::new_named("resume_error").nodes(1).build();
+        let suite = SuiteBuilder::new_named("resume_error").nodes(1).build();
         suite.must_register_task(1, "resume_error");
         let mcli = suite.get_meta_cli();
         run_async_test(mcli.pause("resume_error")).unwrap();

--- a/components/backup-stream/tests/failpoints/mod.rs
+++ b/components/backup-stream/tests/failpoints/mod.rs
@@ -399,4 +399,18 @@ mod all {
             std::iter::once(enc_key.as_encoded().as_slice()),
         )
     }
+
+    #[test]
+    fn failed_to_get_task_when_pausing() {
+        let mut suite = SuiteBuilder::new_named("resume_error").nodes(1).build();
+        suite.must_register_task(1, "resume_error");
+        let mcli = suite.get_meta_cli();
+        run_async_test(mcli.pause("resume_error")).unwrap();
+        suite.sync();
+        fail::cfg("failed_to_get_task", "1*return").unwrap();
+        run_async_test(mcli.resume("resume_error")).unwrap();
+        suite.sync();
+        // Make sure our suite doesn't panic.
+        suite.sync();
+    }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #17020
<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Spawn thread from the thread pool directly. (Instead of the thread local runtime handle.)
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fixed a bug that might cause TiKV panic when resuming a PiTR task and the connection to PD isn't stable enought.
```
