### PR TITLE
resolved_ts: refactor log for the unexpected path

### DIFF
--- a/components/resolved_ts/src/cmd.rs
+++ b/components/resolved_ts/src/cmd.rs
@@ -1,5 +1,7 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::fmt::{Debug, Formatter};
+
 use collections::HashMap;
 use engine_traits::{CF_DEFAULT, CF_LOCK, CF_WRITE};
 use kvproto::{
@@ -173,10 +175,25 @@ pub(crate) fn decode_lock(key: &[u8], value: &[u8]) -> Option<Lock> {
     }
 }
 
-#[derive(Debug)]
 enum KeyOp {
     Put(Option<TimeStamp>, Vec<u8>),
     Delete,
+}
+
+impl Debug for KeyOp {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            KeyOp::Put(ts, value) => {
+                write!(
+                    f,
+                    "Put(ts:{:?}, value:{:?})",
+                    ts,
+                    log_wrappers::Value(value)
+                )
+            }
+            KeyOp::Delete => write!(f, "Delete"),
+        }
+    }
 }
 
 impl KeyOp {
@@ -220,12 +237,25 @@ fn group_row_changes(requests: Vec<Request>) -> (HashMap<Key, RowChange>, bool) 
                         }
                     }
                     CF_LOCK => {
-                        let row = changes.entry(key).or_default();
-                        if let Some(lock) = &row.lock {
-                            error!("there is already lock={:?} on row={:?}", lock, row);
-                        }
-                        assert!(row.lock.is_none());
-                        row.lock = Some(KeyOp::Put(None, value));
+                        match changes.entry(key) {
+                            std::collections::hash_map::Entry::Occupied(mut occupied_entry) => {
+                                if occupied_entry.get().lock.is_some() {
+                                    error!(
+                                        "there is already row={:?} with same key processing key={:?} value={:?}",
+                                        occupied_entry.get(),
+                                        log_wrappers::Value::key(occupied_entry.key().as_encoded()),
+                                        log_wrappers::Value::value(&value),
+                                    );
+                                }
+                                assert!(occupied_entry.get().lock.is_none());
+                                occupied_entry.get_mut().lock = Some(KeyOp::Put(None, value));
+                            }
+                            std::collections::hash_map::Entry::Vacant(vacant_entry) => {
+                                let mut row_change = RowChange::default();
+                                row_change.lock = Some(KeyOp::Put(None, value));
+                                vacant_entry.insert(row_change);
+                            }
+                        };
                     }
                     "" | CF_DEFAULT => {
                         if let Ok(ts) = key.decode_ts() {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref #16818


<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:


```commit-message
Refactor logs for the unexpected path, print both the exsiting row and input key/value.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
