### PR TITLE
raftstore: fix online config change panic for periodic-full-compact-start-time

### DIFF
--- a/components/online_config/src/lib.rs
+++ b/components/online_config/src/lib.rs
@@ -24,7 +24,8 @@ pub enum ConfigValue {
     Bool(bool),
     String(String),
     Module(ConfigChange),
-    OffsetTime(OffsetTime),
+    // We cannot use Schedule(ReadableSchedule) directly as the module defining `ReadableSchedule`
+    // imports the current module
     Schedule(Vec<String>),
     Skip,
     None,
@@ -43,7 +44,6 @@ impl Display for ConfigValue {
             ConfigValue::Bool(v) => write!(f, "{}", v),
             ConfigValue::String(v) => write!(f, "{}", v),
             ConfigValue::Module(v) => write!(f, "{:?}", v),
-            ConfigValue::OffsetTime((t, o)) => write!(f, "{} {}", t, o),
             ConfigValue::Schedule(v) => write!(f, "{:?}", v),
             ConfigValue::Skip => write!(f, "ConfigValue::Skip"),
             ConfigValue::None => write!(f, ""),

--- a/components/online_config/src/lib.rs
+++ b/components/online_config/src/lib.rs
@@ -25,7 +25,7 @@ pub enum ConfigValue {
     String(String),
     Module(ConfigChange),
     OffsetTime(OffsetTime),
-    Schedule(Schedule),
+    Schedule(Vec<String>),
     Skip,
     None,
 }

--- a/components/tikv_util/src/config.rs
+++ b/components/tikv_util/src/config.rs
@@ -530,22 +530,6 @@ impl<'de> Deserialize<'de> for ReadableDuration {
 #[derive(Clone, Debug, Copy, PartialEq)]
 pub struct ReadableOffsetTime(pub NaiveTime, pub FixedOffset);
 
-impl From<ReadableOffsetTime> for ConfigValue {
-    fn from(ot: ReadableOffsetTime) -> ConfigValue {
-        ConfigValue::OffsetTime((ot.0, ot.1))
-    }
-}
-
-impl From<ConfigValue> for ReadableOffsetTime {
-    fn from(c: ConfigValue) -> ReadableOffsetTime {
-        if let ConfigValue::OffsetTime(ot) = c {
-            ReadableOffsetTime(ot.0, ot.1)
-        } else {
-            panic!("expect: ConfigValue::OffsetTime, got: {:?}", c)
-        }
-    }
-}
-
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct ReadableSchedule(pub Vec<ReadableOffsetTime>);
 
@@ -2114,6 +2098,40 @@ mod tests {
         assert!(!schedule.is_scheduled_this_hour_minute(&time_b));
         assert!(!schedule.is_scheduled_this_hour_minute(&time_c));
         assert!(!schedule.is_scheduled_this_hour_minute(&time_e));
+    }
+
+    #[test]
+    fn test_readable_schedule_parse() {
+        let check_parse = |vec_strs: Vec<String>, strs| {
+            let schedule = ReadableSchedule(
+                vec_strs
+                    .iter()
+                    .flat_map(|s| ReadableOffsetTime::from_str(s.as_str()))
+                    .collect::<Vec<_>>(),
+            );
+
+            let schedule2 = ReadableSchedule::from_str(strs).unwrap();
+            assert_eq!(schedule, schedule2);
+
+            let ConfigValue::Schedule(config_value) = ConfigValue::from(schedule) else {
+                unreachable!()
+            };
+            assert_eq!(config_value, vec_strs);
+            assert_eq!(
+                ReadableSchedule::from(ConfigValue::Schedule(config_value)),
+                schedule2
+            );
+        };
+
+        check_parse(
+            vec!["09:30 +00:00".to_owned(), "23:00 +00:00".to_owned()],
+            "[\"09:30 +00:00\", \"23:00 +00:00\"]",
+        );
+
+        check_parse(
+            vec!["11:30 +02:00".to_owned(), "13:00 +02:00".to_owned()],
+            "[\"11:30 +02:00\", \"13:00 +02:00\"]",
+        );
     }
 
     #[test]

--- a/components/tikv_util/src/lib.rs
+++ b/components/tikv_util/src/lib.rs
@@ -5,6 +5,7 @@
 #![feature(box_patterns)]
 #![feature(vec_into_raw_parts)]
 #![feature(let_chains)]
+#![feature(iterator_try_collect)]
 
 #[cfg(test)]
 extern crate test;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -69,7 +69,8 @@ use serde::{
 use serde_json::{to_value, Map, Value};
 use tikv_util::{
     config::{
-        self, LogFormat, RaftDataStateMachine, ReadableDuration, ReadableSize, TomlWriter, MIB,
+        self, LogFormat, RaftDataStateMachine, ReadableDuration, ReadableSchedule, ReadableSize,
+        TomlWriter, MIB,
     },
     logger::{get_level_by_string, get_string_by_level, set_log_level},
     sys::SysQuota,
@@ -4651,6 +4652,10 @@ fn to_change_value(v: &str, typed: &ConfigValue) -> CfgResult<ConfigValue> {
         ConfigValue::Usize(_) => ConfigValue::from(v.parse::<usize>()?),
         ConfigValue::Bool(_) => ConfigValue::from(v.parse::<bool>()?),
         ConfigValue::String(_) => ConfigValue::String(v.to_owned()),
+        ConfigValue::Schedule(_) => {
+            let schedule = v.parse::<ReadableSchedule>()?;
+            ConfigValue::from(schedule)
+        }
         _ => unreachable!(),
     };
     Ok(res)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4656,7 +4656,7 @@ fn to_change_value(v: &str, typed: &ConfigValue) -> CfgResult<ConfigValue> {
             let schedule = v.parse::<ReadableSchedule>()?;
             ConfigValue::from(schedule)
         }
-        _ => unreachable!(),
+        ConfigValue::Skip | ConfigValue::None | ConfigValue::Module(_) => unreachable!(),
     };
     Ok(res)
 }

--- a/tests/integrations/config/test_config_client.rs
+++ b/tests/integrations/config/test_config_client.rs
@@ -4,13 +4,14 @@ use std::{
     collections::HashMap,
     fs::File,
     io::{Read, Write},
+    str::FromStr,
     sync::{Arc, Mutex},
 };
 
 use online_config::{ConfigChange, OnlineConfig};
 use raftstore::store::Config as RaftstoreConfig;
 use tikv::config::*;
-use tikv_util::config::ReadableSize;
+use tikv_util::config::{ReadableOffsetTime, ReadableSchedule, ReadableSize};
 
 fn change(name: &str, value: &str) -> HashMap<String, String> {
     let mut m = HashMap::new();
@@ -24,6 +25,29 @@ fn test_update_config() {
     cfg.validate().unwrap();
     let cfg_controller = ConfigController::new(cfg);
     let mut cfg = cfg_controller.get_current();
+
+    cfg_controller
+        .update(change(
+            "raftstore.periodic-full-compact-start-times",
+            "[\"12:00 +0800\",\"14:00 +0800\"]",
+        ))
+        .unwrap();
+    cfg.raft_store.periodic_full_compact_start_times = ReadableSchedule(vec![
+        ReadableOffsetTime::from_str("12:00 +0800").unwrap(),
+        ReadableOffsetTime::from_str("14:00 +0800").unwrap(),
+    ]);
+    assert_eq!(cfg_controller.get_current(), cfg);
+
+    cfg_controller
+        .update(change(
+            "raftstore.periodic-full-compact-start-times",
+            "[\"12:00\",\"14:00\"]",
+        ))
+        .unwrap();
+    cfg.raft_store.periodic_full_compact_start_times = ReadableSchedule(vec![
+        ReadableOffsetTime::from_str("12:00").unwrap(),
+        ReadableOffsetTime::from_str("14:00").unwrap(),
+    ]);
 
     // normal update
     cfg_controller


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #17066

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
fix online config change panic for periodic-full-compact-start-time
```
![image](https://github.com/tikv/tikv/assets/71589810/aedb49d3-5401-414c-91ec-b8e64c8bc8ea)



### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
