### PR TITLE
Dockerfile: fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,13 +58,10 @@ ENV PATH /usr/local/bin/:$PATH
 # Install Rustup
 RUN curl https://sh.rustup.rs -sSf | sh -s -- --no-modify-path --default-toolchain none -y
 ENV PATH /root/.cargo/bin/:$PATH
+RUN rustup self update
 
-# Install the Rust toolchain
 WORKDIR /tikv
-COPY rust-toolchain ./
-RUN rustup self update \
-  && rustup set profile minimal \
-  && rustup default $(cat "rust-toolchain")
+COPY rust-toolchain.toml ./
 
 # For cargo
 COPY scripts ./scripts

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -44,13 +44,10 @@ ENV PATH /usr/local/bin/:$PATH
 # Install Rustup
 RUN curl https://sh.rustup.rs -sSf | sh -s -- --no-modify-path --default-toolchain none -y
 ENV PATH /root/.cargo/bin/:$PATH
+RUN rustup self update
 
-# Install the Rust toolchain
 WORKDIR /tikv
-COPY rust-toolchain ./
-RUN rustup self update \
-  && rustup set profile minimal \
-  && rustup default $(cat "rust-toolchain")
+COPY rust-toolchain.toml ./
 
 RUN cargo install cargo-nextest --locked
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "nightly-2023-12-28"
 components = ["rustfmt", "clippy", "rust-src", "rust-analyzer"]
+profile = "minimal"


### PR DESCRIPTION
Fix `make docker` and `make docker_test`.

<!-- 
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #17075

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:
Fixed a problem where it was trying to read a non-existent `rust-toolchain` file.

```commit-message
Fix `make docker` and `make docker_test`.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
