### PR TITLE
config: test +HHMM offset in ReadableSchedule

### DIFF
--- a/components/tikv_util/src/config.rs
+++ b/components/tikv_util/src/config.rs
@@ -2068,8 +2068,9 @@ mod tests {
 
     #[test]
     fn test_readable_schedule() {
+        // Tests HHMM offsets for timezones.
         let schedule = ReadableSchedule(
-            vec!["09:30 +0000", "11:15 +05:30", "23:00 +00:00"] // Both HH:MM and HHMM offsets are supported.
+            vec!["09:30 +0000", "11:15 +0530", "23:00 +0000"]
                 .into_iter()
                 .flat_map(ReadableOffsetTime::from_str)
                 .collect::<Vec<_>>(),
@@ -2101,6 +2102,28 @@ mod tests {
         assert!(!schedule.is_scheduled_this_hour_minute(&time_b));
         assert!(!schedule.is_scheduled_this_hour_minute(&time_c));
         assert!(!schedule.is_scheduled_this_hour_minute(&time_e));
+    }
+
+    #[test]
+    fn test_readable_schedule_col_separated_offsets() {
+        // Test that HH:MM offsets are supported.
+        let schedule = ReadableSchedule(
+            vec!["09:30 +00:00", "11:15 +05:30", "23:00 +00:00"]
+                .into_iter()
+                .flat_map(ReadableOffsetTime::from_str)
+                .collect::<Vec<_>>(),
+        );
+
+        let time_a = DateTime::parse_from_rfc3339("2023-10-27T09:30:57-00:00").unwrap();
+        let time_b = DateTime::parse_from_rfc3339("2023-10-27T23:00:00-00:00").unwrap();
+        let time_c = DateTime::parse_from_rfc3339("2024-05-29T05:45:00-00:00").unwrap();
+        let time_d = DateTime::parse_from_rfc3339("2023-10-27T20:00:00-00:00").unwrap();
+
+        assert!(schedule.is_scheduled_this_hour(&time_a));
+        assert!(schedule.is_scheduled_this_hour(&time_b));
+        assert!(schedule.is_scheduled_this_hour(&time_c));
+        assert!(schedule.is_scheduled_this_hour_minute(&time_c));
+        assert!(!schedule.is_scheduled_this_hour_minute(&time_d));
     }
 
     #[test]

--- a/components/tikv_util/src/config.rs
+++ b/components/tikv_util/src/config.rs
@@ -2069,7 +2069,7 @@ mod tests {
     #[test]
     fn test_readable_schedule() {
         let schedule = ReadableSchedule(
-            vec!["09:30 +00:00", "23:00 +00:00"]
+            vec!["09:30 +0000", "23:00 +00:00"]
                 .into_iter()
                 .flat_map(ReadableOffsetTime::from_str)
                 .collect::<Vec<_>>(),

--- a/components/tikv_util/src/config.rs
+++ b/components/tikv_util/src/config.rs
@@ -2069,7 +2069,7 @@ mod tests {
     #[test]
     fn test_readable_schedule() {
         let schedule = ReadableSchedule(
-            vec!["09:30 +0000", "23:00 +00:00"]
+            vec!["09:30 +0000", "11:15 +05:30", "23:00 +00:00"] // Both HH:MM and HHMM offsets are supported.
                 .into_iter()
                 .flat_map(ReadableOffsetTime::from_str)
                 .collect::<Vec<_>>(),
@@ -2080,12 +2080,14 @@ mod tests {
         let time_c = DateTime::parse_from_rfc3339("2023-10-27T23:15:00-00:00").unwrap();
         let time_d = DateTime::parse_from_rfc3339("2023-10-27T23:00:00-00:00").unwrap();
         let time_e = DateTime::parse_from_rfc3339("2023-10-27T20:00:00-00:00").unwrap();
+        let time_f = DateTime::parse_from_rfc3339("2024-05-29T05:45:00-00:00").unwrap();
 
         // positives for schedule by hour
         assert!(schedule.is_scheduled_this_hour(&time_a));
         assert!(schedule.is_scheduled_this_hour(&time_b));
         assert!(schedule.is_scheduled_this_hour(&time_c));
         assert!(schedule.is_scheduled_this_hour(&time_d));
+        assert!(schedule.is_scheduled_this_hour(&time_f));
 
         // negatives for schedule by hour
         assert!(!schedule.is_scheduled_this_hour(&time_e));
@@ -2093,6 +2095,7 @@ mod tests {
         // positives for schedule by hour and minute
         assert!(schedule.is_scheduled_this_hour_minute(&time_a));
         assert!(schedule.is_scheduled_this_hour_minute(&time_d));
+        assert!(schedule.is_scheduled_this_hour_minute(&time_f));
 
         // negatives for schedule by hour and minute
         assert!(!schedule.is_scheduled_this_hour_minute(&time_b));


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #17080

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
* Test both formats +HHMM offsets and as well as +HH:MM for ReadableSchedule.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
