### PR TITLE
In-memory engine: mvcc keys with different sequence number should only be handled once in GC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4619,6 +4619,7 @@ dependencies = [
  "tempfile",
  "test_pd",
  "test_pd_client",
+ "test_util",
  "thiserror",
  "tikv_util",
  "txn_types",

--- a/components/region_cache_memory_engine/Cargo.toml
+++ b/components/region_cache_memory_engine/Cargo.toml
@@ -7,6 +7,12 @@ license = "Apache-2.0"
 
 [features]
 testexport = []
+failpoints = ["fail/failpoints"]
+
+[[test]]
+name = "failpoints"
+path = "tests/failpoints/mod.rs"
+required-features = ["failpoints"]
 
 [dependencies]
 engine_traits = { workspace = true }
@@ -45,3 +51,4 @@ rand = "0.8"
 tempfile = "3.0"
 test_pd = { workspace = true }
 test_pd_client = { workspace = true }
+test_util = { workspace = true }

--- a/components/region_cache_memory_engine/src/background.rs
+++ b/components/region_cache_memory_engine/src/background.rs
@@ -581,6 +581,7 @@ impl Runnable for BackgroundRunner {
                         }
                         core.on_gc_finished(ranges);
                         metrics.flush();
+                        fail::fail_point!("in_memory_engine_gc_finish");
                     };
                     self.gc_range_remote.spawn(f);
                 }

--- a/components/region_cache_memory_engine/src/background.rs
+++ b/components/region_cache_memory_engine/src/background.rs
@@ -7,10 +7,10 @@ use crossbeam::{
     channel::{bounded, tick, Sender},
     epoch, select,
 };
-use engine_rocks::RocksSnapshot;
+use engine_rocks::{RocksEngine, RocksSnapshot};
 use engine_traits::{
-    CacheRange, IterOptions, Iterable, Iterator, RangeHintService, SnapshotMiscExt, CF_DEFAULT,
-    CF_WRITE, DATA_CFS,
+    CacheRange, IterOptions, Iterable, Iterator, MiscExt, RangeHintService, SnapshotMiscExt,
+    CF_DEFAULT, CF_WRITE, DATA_CFS,
 };
 use parking_lot::RwLock;
 use pd_client::RpcClient;
@@ -68,6 +68,7 @@ pub enum BackgroundTask {
     LoadRange,
     MemoryCheckAndEvict,
     DeleteRange(Vec<CacheRange>),
+    SetRocksEngine(RocksEngine),
 }
 
 impl Display for BackgroundTask {
@@ -79,6 +80,7 @@ impl Display for BackgroundTask {
             BackgroundTask::DeleteRange(ref r) => {
                 f.debug_struct("DeleteRange").field("range", r).finish()
             }
+            BackgroundTask::SetRocksEngine(_) => f.debug_struct("SetDiskEngine").finish(),
         }
     }
 }
@@ -289,7 +291,7 @@ impl BackgroundRunnerCore {
         Some(ranges)
     }
 
-    fn gc_range(&self, range: &CacheRange, safe_point: u64) -> FilterMetrics {
+    fn gc_range(&self, range: &CacheRange, safe_point: u64, oldest_seqno: u64) -> FilterMetrics {
         let (skiplist_engine, safe_ts) = {
             let mut core = self.engine.write();
             let Some(range_meta) = core.mut_range_manager().mut_range_meta(range) else {
@@ -324,7 +326,12 @@ impl BackgroundRunnerCore {
         let start = Instant::now();
         let write_cf_handle = skiplist_engine.cf_handle(CF_WRITE);
         let default_cf_handle = skiplist_engine.cf_handle(CF_DEFAULT);
-        let mut filter = Filter::new(safe_ts, default_cf_handle, write_cf_handle.clone());
+        let mut filter = Filter::new(
+            safe_ts,
+            oldest_seqno,
+            default_cf_handle,
+            write_cf_handle.clone(),
+        );
 
         let mut iter = write_cf_handle.iterator();
         let guard = &epoch::pin();
@@ -481,6 +488,9 @@ pub struct BackgroundRunner {
 
     gc_range_remote: Remote<yatp::task::future::TaskCell>,
     gc_range_worker: Worker,
+
+    // RocksEngine is used to get the oldest snapshot no.
+    rocks_engine: Option<RocksEngine>,
 }
 
 impl Drop for BackgroundRunner {
@@ -522,6 +532,7 @@ impl BackgroundRunner {
             delete_range_remote,
             gc_range_worker,
             gc_range_remote,
+            rocks_engine: None,
         }
     }
 }
@@ -531,17 +542,41 @@ impl Runnable for BackgroundRunner {
 
     fn run(&mut self, task: Self::Task) {
         match task {
+            BackgroundTask::SetRocksEngine(rocks_engine) => {
+                self.rocks_engine = Some(rocks_engine);
+            }
             BackgroundTask::Gc(t) => {
+                let seqno = (|| {
+                    fail::fail_point!("oldest_seqno_ingest", |t| {
+                        Some(t.unwrap().parse::<u64>().unwrap())
+                    });
+
+                    let Some(ref rocks_engine) = self.rocks_engine else {
+                        return None;
+                    };
+                    let latest_seqno = rocks_engine.get_latest_sequence_number();
+                    Some(
+                        rocks_engine
+                            .get_oldest_snapshot_sequence_number()
+                            .unwrap_or(latest_seqno),
+                    )
+                })();
+
+                let Some(seqno) = seqno else {
+                    return;
+                };
+
                 info!(
                     "start a new round of gc for range cache engine";
                     "safe_point" => t.safe_point,
+                    "oldest_sequence" => seqno,
                 );
                 let mut core = self.core.clone();
                 if let Some(ranges) = core.ranges_for_gc() {
                     let f = async move {
                         let mut metrics = FilterMetrics::default();
                         for range in &ranges {
-                            let m = core.gc_range(range, t.safe_point);
+                            let m = core.gc_range(range, t.safe_point, seqno);
                             metrics.merge(&m);
                         }
                         core.on_gc_finished(ranges);
@@ -739,6 +774,7 @@ impl FilterMetrics {
 
 struct Filter {
     safe_point: u64,
+    oldest_seqno: u64,
     mvcc_key_prefix: Vec<u8>,
     remove_older: bool,
 
@@ -751,6 +787,8 @@ struct Filter {
     cached_skiplist_delete_key: Option<Vec<u8>>,
 
     metrics: FilterMetrics,
+
+    last_user_key: Vec<u8>,
 }
 
 impl Drop for Filter {
@@ -771,11 +809,13 @@ impl Drop for Filter {
 impl Filter {
     fn new(
         safe_point: u64,
+        oldest_seqno: u64,
         default_cf_handle: SkiplistHandle,
         write_cf_handle: SkiplistHandle,
     ) -> Self {
         Self {
             safe_point,
+            oldest_seqno,
             default_cf_handle,
             write_cf_handle,
             mvcc_key_prefix: vec![],
@@ -783,14 +823,22 @@ impl Filter {
             cached_skiplist_delete_key: None,
             remove_older: false,
             metrics: FilterMetrics::default(),
+            last_user_key: vec![],
         }
     }
 
     fn filter(&mut self, key: &Bytes, value: &Bytes) -> Result<(), String> {
         self.metrics.total += 1;
         let InternalKey {
-            user_key, v_type, ..
+            user_key,
+            v_type,
+            sequence,
         } = decode_key(key);
+
+        if sequence > self.oldest_seqno {
+            // skip those under read by some snapshots
+            return Ok(());
+        }
 
         let (mvcc_key_prefix, commit_ts) = split_ts(user_key)?;
         if commit_ts > self.safe_point {
@@ -835,6 +883,16 @@ impl Filter {
         }
 
         let guard = &epoch::pin();
+        // Also, we only handle the same user_key once (user_key here refers to refers
+        // to the key with MVCC version but without sequence number).
+        if user_key != self.last_user_key {
+            self.last_user_key = user_key.to_vec();
+        } else {
+            self.write_cf_handle
+                .remove(&InternalBytes::from_bytes(key.clone()), guard);
+            return Ok(());
+        }
+
         self.metrics.versions += 1;
         if self.mvcc_key_prefix != mvcc_key_prefix {
             self.metrics.unique_key += 1;
@@ -937,56 +995,6 @@ pub mod tests {
         write_batch::RangeCacheWriteBatchEntry,
         RangeCacheEngineConfig, RangeCacheEngineContext, RangeCacheMemoryEngine,
     };
-
-    fn put_data(
-        key: &[u8],
-        value: &[u8],
-        start_ts: u64,
-        commit_ts: u64,
-        seq_num: u64,
-        short_value: bool,
-        default_cf: &SkiplistHandle,
-        write_cf: &SkiplistHandle,
-        mem_controller: Arc<MemoryController>,
-    ) {
-        let raw_write_k = Key::from_raw(key)
-            .append_ts(TimeStamp::new(commit_ts))
-            .into_encoded();
-        let mut write_k = encode_key(&raw_write_k, seq_num, ValueType::Value);
-        write_k.set_memory_controller(mem_controller.clone());
-        let write_v = Write::new(
-            WriteType::Put,
-            TimeStamp::new(start_ts),
-            if short_value {
-                Some(value.to_vec())
-            } else {
-                None
-            },
-        );
-        let mut val = InternalBytes::from_vec(write_v.as_ref().to_bytes());
-        val.set_memory_controller(mem_controller.clone());
-        let guard = &epoch::pin();
-        let _ = mem_controller.acquire(RangeCacheWriteBatchEntry::calc_put_entry_size(
-            &raw_write_k,
-            val.as_bytes(),
-        ));
-        write_cf.insert(write_k, val, guard);
-
-        if !short_value {
-            let raw_default_k = Key::from_raw(key)
-                .append_ts(TimeStamp::new(start_ts))
-                .into_encoded();
-            let mut default_k = encode_key(&raw_default_k, seq_num + 1, ValueType::Value);
-            default_k.set_memory_controller(mem_controller.clone());
-            let mut val = InternalBytes::from_vec(value.to_vec());
-            val.set_memory_controller(mem_controller.clone());
-            let _ = mem_controller.acquire(RangeCacheWriteBatchEntry::calc_put_entry_size(
-                &raw_default_k,
-                val.as_bytes(),
-            ));
-            default_cf.insert(default_k, val, guard);
-        }
-    }
 
     fn delete_data(
         key: &[u8],
@@ -1175,7 +1183,7 @@ pub mod tests {
         assert_eq!(7, element_count(&default));
         assert_eq!(8, element_count(&write));
 
-        let mut filter = Filter::new(50, default.clone(), write.clone());
+        let mut filter = Filter::new(50, 100, default.clone(), write.clone());
         let mut count = 0;
         let mut iter = write.iterator();
         let guard = &epoch::pin();
@@ -1292,7 +1300,7 @@ pub mod tests {
         iter_opts.set_upper_bound(&range.end, 0);
 
         let worker = BackgroundRunner::new(engine.core.clone(), memory_controller.clone());
-        worker.core.gc_range(&range, 40);
+        worker.core.gc_range(&range, 40, 100);
 
         let mut iter = snap.iterator_opt("write", iter_opts).unwrap();
         iter.seek_to_first().unwrap();
@@ -1363,17 +1371,17 @@ pub mod tests {
         let worker = BackgroundRunner::new(engine.core.clone(), memory_controller.clone());
 
         // gc will not remove the latest mvcc put below safe point
-        worker.core.gc_range(&range, 14);
+        worker.core.gc_range(&range, 14, 100);
         assert_eq!(2, element_count(&default));
         assert_eq!(2, element_count(&write));
 
-        worker.core.gc_range(&range, 16);
+        worker.core.gc_range(&range, 16, 100);
         assert_eq!(1, element_count(&default));
         assert_eq!(1, element_count(&write));
 
         // rollback will not make the first older version be filtered
         rollback_data(b"key1", 17, 16, &write, memory_controller.clone());
-        worker.core.gc_range(&range, 17);
+        worker.core.gc_range(&range, 17, 100);
         assert_eq!(1, element_count(&default));
         assert_eq!(1, element_count(&write));
         let key = encode_key(b"key1", TimeStamp::new(15));
@@ -1385,9 +1393,48 @@ pub mod tests {
         // unlike in WriteCompactionFilter, the latest mvcc delete below safe point will
         // be filtered
         delete_data(b"key1", 19, 18, &write, memory_controller.clone());
-        worker.core.gc_range(&range, 19);
+        worker.core.gc_range(&range, 19, 100);
         assert_eq!(0, element_count(&write));
         assert_eq!(0, element_count(&default));
+    }
+
+    #[test]
+    fn test_gc_for_overwrite_write() {
+        let engine = RangeCacheMemoryEngine::new(RangeCacheEngineContext::new(Arc::new(
+            VersionTrack::new(RangeCacheEngineConfig::config_for_test()),
+        )));
+        let memory_controller = engine.memory_controller();
+        let range = CacheRange::new(b"".to_vec(), b"z".to_vec());
+        engine.new_range(range.clone());
+        let (write, default) = {
+            let skiplist_engine = engine.core().write().engine();
+            (
+                skiplist_engine.cf_handle(CF_WRITE),
+                skiplist_engine.cf_handle(CF_DEFAULT),
+            )
+        };
+
+        put_data_with_overwrite(
+            b"key1",
+            b"value1",
+            10,
+            11,
+            100,
+            101,
+            false,
+            &default,
+            &write,
+            memory_controller.clone(),
+        );
+
+        assert_eq!(1, element_count(&default));
+        assert_eq!(2, element_count(&write));
+
+        let worker = BackgroundRunner::new(engine.core.clone(), memory_controller.clone());
+
+        worker.core.gc_range(&range, 20, 200);
+        assert_eq!(1, element_count(&default));
+        assert_eq!(1, element_count(&write));
     }
 
     #[test]
@@ -1481,117 +1528,24 @@ pub mod tests {
         let s3 = engine.snapshot(range.clone(), 20, u64::MAX);
 
         // nothing will be removed due to snapshot 5
-        worker.core.gc_range(&range, 30);
+        worker.core.gc_range(&range, 30, 100);
         assert_eq!(6, element_count(&default));
         assert_eq!(6, element_count(&write));
 
         drop(s1);
-        worker.core.gc_range(&range, 30);
+        worker.core.gc_range(&range, 30, 100);
         assert_eq!(5, element_count(&default));
         assert_eq!(5, element_count(&write));
 
         drop(s2);
-        worker.core.gc_range(&range, 30);
+        worker.core.gc_range(&range, 30, 100);
         assert_eq!(4, element_count(&default));
         assert_eq!(4, element_count(&write));
 
         drop(s3);
-        worker.core.gc_range(&range, 30);
+        worker.core.gc_range(&range, 30, 100);
         assert_eq!(3, element_count(&default));
         assert_eq!(3, element_count(&write));
-    }
-
-    #[test]
-    fn test_gc_worker() {
-        let mut config = RangeCacheEngineConfig::config_for_test();
-        config.gc_interval = ReadableDuration(Duration::from_secs(1));
-        let engine = RangeCacheMemoryEngine::new(RangeCacheEngineContext::new(Arc::new(
-            VersionTrack::new(config),
-        )));
-        let memory_controller = engine.memory_controller();
-        let (write, default) = {
-            let mut core = engine.core.write();
-            core.mut_range_manager()
-                .new_range(CacheRange::new(b"".to_vec(), b"z".to_vec()));
-            let engine = core.engine();
-            (engine.cf_handle(CF_WRITE), engine.cf_handle(CF_DEFAULT))
-        };
-
-        let start_ts = TimeStamp::physical_now() - Duration::from_secs(10).as_millis() as u64;
-        let commit_ts1 = TimeStamp::physical_now() - Duration::from_secs(9).as_millis() as u64;
-        put_data(
-            b"k",
-            b"v1",
-            start_ts,
-            commit_ts1,
-            100,
-            false,
-            &default,
-            &write,
-            memory_controller.clone(),
-        );
-
-        let start_ts = TimeStamp::physical_now() - Duration::from_secs(8).as_millis() as u64;
-        let commit_ts2 = TimeStamp::physical_now() - Duration::from_secs(7).as_millis() as u64;
-        put_data(
-            b"k",
-            b"v2",
-            start_ts,
-            commit_ts2,
-            110,
-            false,
-            &default,
-            &write,
-            memory_controller.clone(),
-        );
-
-        let start_ts = TimeStamp::physical_now() - Duration::from_secs(6).as_millis() as u64;
-        let commit_ts3 = TimeStamp::physical_now() - Duration::from_secs(5).as_millis() as u64;
-        put_data(
-            b"k",
-            b"v3",
-            start_ts,
-            commit_ts3,
-            110,
-            false,
-            &default,
-            &write,
-            memory_controller.clone(),
-        );
-
-        let start_ts = TimeStamp::physical_now() - Duration::from_secs(4).as_millis() as u64;
-        let commit_ts4 = TimeStamp::physical_now() - Duration::from_secs(3).as_millis() as u64;
-        put_data(
-            b"k",
-            b"v4",
-            start_ts,
-            commit_ts4,
-            110,
-            false,
-            &default,
-            &write,
-            memory_controller.clone(),
-        );
-
-        let guard = &epoch::pin();
-        for &ts in &[commit_ts1, commit_ts2, commit_ts3] {
-            let key = Key::from_raw(b"k");
-            let key = encoding_for_filter(key.as_encoded(), TimeStamp::new(ts));
-
-            assert!(key_exist(&write, &key, guard));
-        }
-
-        std::thread::sleep(Duration::from_secs_f32(1.5));
-
-        let key = Key::from_raw(b"k");
-        // now, the outdated mvcc versions should be gone
-        for &ts in &[commit_ts1, commit_ts2, commit_ts3] {
-            let key = encoding_for_filter(key.as_encoded(), TimeStamp::new(ts));
-            assert!(!key_exist(&write, &key, guard));
-        }
-
-        let key = encoding_for_filter(key.as_encoded(), TimeStamp::new(commit_ts4));
-        assert!(key_exist(&write, &key, guard));
     }
 
     #[test]

--- a/components/region_cache_memory_engine/src/background.rs
+++ b/components/region_cache_memory_engine/src/background.rs
@@ -883,8 +883,8 @@ impl Filter {
         }
 
         let guard = &epoch::pin();
-        // Also, we only handle the same user_key once (user_key here refers to refers
-        // to the key with MVCC version but without sequence number).
+        // Also, we only handle the same user_key once (user_key here refers to the key
+        // with MVCC version but without sequence number).
         if user_key != self.last_user_key {
             self.last_user_key = user_key.to_vec();
         } else {

--- a/components/region_cache_memory_engine/src/background.rs
+++ b/components/region_cache_memory_engine/src/background.rs
@@ -489,7 +489,7 @@ pub struct BackgroundRunner {
     gc_range_remote: Remote<yatp::task::future::TaskCell>,
     gc_range_worker: Worker,
 
-    // RocksEngine is used to get the oldest snapshot no.
+    // RocksEngine is used to get the oldest snapshot sequence number.
     rocks_engine: Option<RocksEngine>,
 }
 
@@ -547,7 +547,7 @@ impl Runnable for BackgroundRunner {
             }
             BackgroundTask::Gc(t) => {
                 let seqno = (|| {
-                    fail::fail_point!("oldest_seqno_ingest", |t| {
+                    fail::fail_point!("in_memry_engine_gc_oldest_seqno", |t| {
                         Some(t.unwrap().parse::<u64>().unwrap())
                     });
 

--- a/components/region_cache_memory_engine/src/background.rs
+++ b/components/region_cache_memory_engine/src/background.rs
@@ -992,6 +992,7 @@ pub mod tests {
             region_label_meta_client,
             tests::{add_region_label_rule, new_region_label_rule, new_test_server_and_client},
         },
+        test_util::{put_data, put_data_with_overwrite},
         write_batch::RangeCacheWriteBatchEntry,
         RangeCacheEngineConfig, RangeCacheEngineContext, RangeCacheMemoryEngine,
     };
@@ -1369,6 +1370,11 @@ pub mod tests {
         assert_eq!(3, element_count(&write));
 
         let worker = BackgroundRunner::new(engine.core.clone(), memory_controller.clone());
+
+        // gc should not hanlde keys with larger seqno than oldest seqno
+        worker.core.gc_range(&range, 13, 10);
+        assert_eq!(3, element_count(&default));
+        assert_eq!(3, element_count(&write));
 
         // gc will not remove the latest mvcc put below safe point
         worker.core.gc_range(&range, 14, 100);

--- a/components/region_cache_memory_engine/src/engine.rs
+++ b/components/region_cache_memory_engine/src/engine.rs
@@ -437,11 +437,11 @@ impl RangeCacheMemoryEngine {
         &self.bg_work_manager
     }
 
-    pub(crate) fn memory_controller(&self) -> Arc<MemoryController> {
+    pub fn memory_controller(&self) -> Arc<MemoryController> {
         self.memory_controller.clone()
     }
 
-    pub(crate) fn statistics(&self) -> Arc<Statistics> {
+    pub fn statistics(&self) -> Arc<Statistics> {
         self.statistics.clone()
     }
 }

--- a/components/region_cache_memory_engine/src/lib.rs
+++ b/components/region_cache_memory_engine/src/lib.rs
@@ -23,10 +23,12 @@ mod range_manager;
 mod read;
 mod region_label;
 mod statistics;
+pub mod test_util;
 mod write_batch;
 
 pub use background::{BackgroundRunner, GcTask};
-pub use engine::RangeCacheMemoryEngine;
+pub use engine::{RangeCacheMemoryEngine, SkiplistHandle};
+pub use keys::{encoding_for_filter, InternalBytes};
 pub use metrics::flush_range_cache_engine_statistics;
 pub use range_manager::RangeCacheStatus;
 pub use statistics::Statistics as RangeCacheMemoryEngineStatistics;

--- a/components/region_cache_memory_engine/src/test_util.rs
+++ b/components/region_cache_memory_engine/src/test_util.rs
@@ -1,0 +1,126 @@
+// Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::sync::Arc;
+
+use crossbeam::epoch;
+use txn_types::{Key, TimeStamp, Write, WriteType};
+
+use crate::{
+    engine::SkiplistHandle,
+    keys::{encode_key, InternalBytes, ValueType},
+    memory_controller::MemoryController,
+    write_batch::RangeCacheWriteBatchEntry,
+};
+
+// Put data with write cf and related start cf
+pub fn put_data(
+    key: &[u8],
+    value: &[u8],
+    start_ts: u64,
+    commit_ts: u64,
+    seq_num: u64,
+    short_value: bool,
+    default_cf: &SkiplistHandle,
+    write_cf: &SkiplistHandle,
+    mem_controller: Arc<MemoryController>,
+) {
+    put_data_impl(
+        key,
+        value,
+        start_ts,
+        commit_ts,
+        seq_num,
+        None,
+        short_value,
+        default_cf,
+        write_cf,
+        mem_controller,
+    )
+}
+
+// Put data with write cf and related start cf and overwrite the write cf with
+// sequence number `seq_num2` which also points to the prevous default cf
+pub fn put_data_with_overwrite(
+    key: &[u8],
+    value: &[u8],
+    start_ts: u64,
+    commit_ts: u64,
+    seq_num: u64,
+    seq_num2: u64,
+    short_value: bool,
+    default_cf: &SkiplistHandle,
+    write_cf: &SkiplistHandle,
+    mem_controller: Arc<MemoryController>,
+) {
+    put_data_impl(
+        key,
+        value,
+        start_ts,
+        commit_ts,
+        seq_num,
+        Some(seq_num2),
+        short_value,
+        default_cf,
+        write_cf,
+        mem_controller,
+    )
+}
+
+fn put_data_impl(
+    key: &[u8],
+    value: &[u8],
+    start_ts: u64,
+    commit_ts: u64,
+    seq_num: u64,
+    overwrite_seq_num: Option<u64>,
+    short_value: bool,
+    default_cf: &SkiplistHandle,
+    write_cf: &SkiplistHandle,
+    mem_controller: Arc<MemoryController>,
+) {
+    let raw_write_k = Key::from_raw(key)
+        .append_ts(TimeStamp::new(commit_ts))
+        .into_encoded();
+    let mut write_k = encode_key(&raw_write_k, seq_num, ValueType::Value);
+    write_k.set_memory_controller(mem_controller.clone());
+    let write_v = Write::new(
+        WriteType::Put,
+        TimeStamp::new(start_ts),
+        if short_value {
+            Some(value.to_vec())
+        } else {
+            None
+        },
+    );
+    let mut val = InternalBytes::from_vec(write_v.as_ref().to_bytes());
+    val.set_memory_controller(mem_controller.clone());
+    let guard = &epoch::pin();
+    let _ = mem_controller.acquire(RangeCacheWriteBatchEntry::calc_put_entry_size(
+        &raw_write_k,
+        val.as_bytes(),
+    ));
+    write_cf.insert(write_k, val, guard);
+
+    if let Some(seq) = overwrite_seq_num {
+        let mut write_k = encode_key(&raw_write_k, seq, ValueType::Value);
+        write_k.set_memory_controller(mem_controller.clone());
+        let mut val = InternalBytes::from_vec(write_v.as_ref().to_bytes());
+        val.set_memory_controller(mem_controller.clone());
+        write_cf.insert(write_k, val, guard);
+    }
+
+    if !short_value {
+        let raw_default_k = Key::from_raw(key)
+            .append_ts(TimeStamp::new(start_ts))
+            .into_encoded();
+        let mut default_k = encode_key(&raw_default_k, seq_num + 1, ValueType::Value);
+        default_k.set_memory_controller(mem_controller.clone());
+        let mut val = InternalBytes::from_vec(value.to_vec());
+        val.set_memory_controller(mem_controller.clone());
+        let _ = mem_controller.acquire(RangeCacheWriteBatchEntry::calc_put_entry_size(
+            &raw_default_k,
+            val.as_bytes(),
+        ));
+        default_cf.insert(default_k, val, guard);
+    }
+}

--- a/components/region_cache_memory_engine/src/test_util.rs
+++ b/components/region_cache_memory_engine/src/test_util.rs
@@ -39,7 +39,7 @@ pub fn put_data(
 }
 
 // Put data with write cf and related start cf and overwrite the write cf with
-// sequence number `seq_num2` which also points to the prevous default cf
+// sequence number `seq_num2` which also points to the previous default cf.
 pub fn put_data_with_overwrite(
     key: &[u8],
     value: &[u8],

--- a/components/region_cache_memory_engine/tests/failpoints/mod.rs
+++ b/components/region_cache_memory_engine/tests/failpoints/mod.rs
@@ -1,1 +1,3 @@
+// Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
+
 mod test_gc;

--- a/components/region_cache_memory_engine/tests/failpoints/mod.rs
+++ b/components/region_cache_memory_engine/tests/failpoints/mod.rs
@@ -1,0 +1,1 @@
+mod test_gc;

--- a/components/region_cache_memory_engine/tests/failpoints/test_gc.rs
+++ b/components/region_cache_memory_engine/tests/failpoints/test_gc.rs
@@ -38,7 +38,7 @@ fn test_gc_worker() {
         (engine.cf_handle(CF_WRITE), engine.cf_handle(CF_DEFAULT))
     };
 
-    fail::cfg("oldest_seqno_ingest", "return(1000)").unwrap();
+    fail::cfg("in_memry_engine_gc_oldest_seqno", "return(1000)").unwrap();
 
     let start_ts = TimeStamp::physical_now() - Duration::from_secs(10).as_millis() as u64;
     let commit_ts1 = TimeStamp::physical_now() - Duration::from_secs(9).as_millis() as u64;

--- a/components/region_cache_memory_engine/tests/failpoints/test_gc.rs
+++ b/components/region_cache_memory_engine/tests/failpoints/test_gc.rs
@@ -1,0 +1,118 @@
+// Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::{sync::Arc, time::Duration};
+
+use crossbeam::epoch;
+use engine_traits::{CacheRange, CF_DEFAULT, CF_WRITE};
+use region_cache_memory_engine::{
+    encoding_for_filter, test_util::put_data, InternalBytes, RangeCacheEngineConfig,
+    RangeCacheEngineContext, RangeCacheMemoryEngine, SkiplistHandle,
+};
+use tikv_util::config::{ReadableDuration, VersionTrack};
+use txn_types::{Key, TimeStamp};
+
+// We should not use skiplist.get directly as we only cares keys without
+// sequence number suffix
+fn key_exist(sl: &SkiplistHandle, key: &InternalBytes, guard: &epoch::Guard) -> bool {
+    let mut iter = sl.iterator();
+    iter.seek(key, guard);
+    if iter.valid() && iter.key().same_user_key_with(key) {
+        return true;
+    }
+    false
+}
+
+#[test]
+fn test_gc_worker() {
+    let mut config = RangeCacheEngineConfig::config_for_test();
+    config.gc_interval = ReadableDuration(Duration::from_secs(1));
+    let engine = RangeCacheMemoryEngine::new(RangeCacheEngineContext::new(Arc::new(
+        VersionTrack::new(config),
+    )));
+    let memory_controller = engine.memory_controller();
+    let (write, default) = {
+        let mut core = engine.core().write();
+        core.mut_range_manager()
+            .new_range(CacheRange::new(b"".to_vec(), b"z".to_vec()));
+        let engine = core.engine();
+        (engine.cf_handle(CF_WRITE), engine.cf_handle(CF_DEFAULT))
+    };
+
+    fail::cfg("oldest_seqno_ingest", "return(1000)").unwrap();
+
+    let start_ts = TimeStamp::physical_now() - Duration::from_secs(10).as_millis() as u64;
+    let commit_ts1 = TimeStamp::physical_now() - Duration::from_secs(9).as_millis() as u64;
+    put_data(
+        b"k",
+        b"v1",
+        start_ts,
+        commit_ts1,
+        100,
+        false,
+        &default,
+        &write,
+        memory_controller.clone(),
+    );
+
+    let start_ts = TimeStamp::physical_now() - Duration::from_secs(8).as_millis() as u64;
+    let commit_ts2 = TimeStamp::physical_now() - Duration::from_secs(7).as_millis() as u64;
+    put_data(
+        b"k",
+        b"v2",
+        start_ts,
+        commit_ts2,
+        110,
+        false,
+        &default,
+        &write,
+        memory_controller.clone(),
+    );
+
+    let start_ts = TimeStamp::physical_now() - Duration::from_secs(6).as_millis() as u64;
+    let commit_ts3 = TimeStamp::physical_now() - Duration::from_secs(5).as_millis() as u64;
+    put_data(
+        b"k",
+        b"v3",
+        start_ts,
+        commit_ts3,
+        110,
+        false,
+        &default,
+        &write,
+        memory_controller.clone(),
+    );
+
+    let start_ts = TimeStamp::physical_now() - Duration::from_secs(4).as_millis() as u64;
+    let commit_ts4 = TimeStamp::physical_now() - Duration::from_secs(3).as_millis() as u64;
+    put_data(
+        b"k",
+        b"v4",
+        start_ts,
+        commit_ts4,
+        110,
+        false,
+        &default,
+        &write,
+        memory_controller.clone(),
+    );
+
+    let guard = &epoch::pin();
+    for &ts in &[commit_ts1, commit_ts2, commit_ts3] {
+        let key = Key::from_raw(b"k");
+        let key = encoding_for_filter(key.as_encoded(), TimeStamp::new(ts));
+
+        assert!(key_exist(&write, &key, guard));
+    }
+
+    std::thread::sleep(Duration::from_secs_f32(1.5));
+
+    let key = Key::from_raw(b"k");
+    // now, the outdated mvcc versions should be gone
+    for &ts in &[commit_ts1, commit_ts2, commit_ts3] {
+        let key = encoding_for_filter(key.as_encoded(), TimeStamp::new(ts));
+        assert!(!key_exist(&write, &key, guard));
+    }
+
+    let key = encoding_for_filter(key.as_encoded(), TimeStamp::new(commit_ts4));
+    assert!(key_exist(&write, &key, guard));
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #17060 Ref #16141

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
mvcc keys with different sequen number should only be handled once in GC
```
Without the patch, the default not found can occur:
If one key in write cf is overwritten, GC can delete the default cf incorrectly, e.g.
safe-point is 10, and there is only one k1 with commit ts less than 10, ex: k1_5_100 (5 is the commit ts, 100 is the seqno)
Now the overwrite happens, k1_5_200.
So now it's k1_5_200, k1_5_100.

The GC will leave the latest put under the safe-point
Here, k1_5_100 was mistakenly GC'd, and the corresponding default cf was deleted where key of this default cf is also the one pointed to by k1_5_200.


### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
