### PR TITLE
In-memory engine: enable compaction filter for HybridEngine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6119,6 +6119,7 @@ dependencies = [
  "api_version",
  "collections",
  "engine_rocks",
+ "engine_traits",
  "futures 0.3.15",
  "kvproto",
  "pd_client",

--- a/components/engine_traits/src/misc.rs
+++ b/components/engine_traits/src/misc.rs
@@ -7,7 +7,7 @@
 
 use crate::{
     cf_names::CfNamesExt, errors::Result, flow_control_factors::FlowControlFactorsExt,
-    range::Range, WriteBatchExt, WriteOptions,
+    range::Range, KvEngine, WriteBatchExt, WriteOptions,
 };
 
 #[derive(Clone, Debug)]
@@ -185,6 +185,6 @@ pub trait MiscExt: CfNamesExt + FlowControlFactorsExt + WriteBatchExt {
         Ok(n)
     }
 
-    type DiskEngine;
+    type DiskEngine: KvEngine;
     fn get_disk_engine(&self) -> &Self::DiskEngine;
 }

--- a/components/test_storage/Cargo.toml
+++ b/components/test_storage/Cargo.toml
@@ -25,6 +25,7 @@ test-engines-panic = [
 api_version = { workspace = true }
 collections = { workspace = true }
 engine_rocks = { workspace = true }
+engine_traits = { workspace = true }
 futures = "0.3"
 kvproto = { workspace = true }
 pd_client = { workspace = true }

--- a/components/test_storage/src/lib.rs
+++ b/components/test_storage/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
 
 #![feature(box_patterns)]
+#![feature(associated_type_bounds)]
 
 #[macro_use]
 extern crate tikv_util;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@
 #![allow(incomplete_features)]
 #![feature(core_io_borrowed_buf)]
 #![feature(assert_matches)]
+#![feature(associated_type_bounds)]
 
 #[macro_use(fail_point)]
 extern crate fail;

--- a/src/server/gc_worker/compaction_filter.rs
+++ b/src/server/gc_worker/compaction_filter.rs
@@ -147,7 +147,7 @@ where
         safe_point: Arc<AtomicU64>,
         cfg_tracker: GcWorkerConfigManager,
         feature_gate: FeatureGate,
-        gc_scheduler: Scheduler<GcTask<EK>>,
+        gc_scheduler: Scheduler<GcTask<<EK as MiscExt>::DiskEngine>>,
         region_info_provider: Arc<dyn RegionInfoProvider>,
     );
 }
@@ -162,7 +162,7 @@ where
         _safe_point: Arc<AtomicU64>,
         _cfg_tracker: GcWorkerConfigManager,
         _feature_gate: FeatureGate,
-        _gc_scheduler: Scheduler<GcTask<EK>>,
+        _gc_scheduler: Scheduler<GcTask<<EK as MiscExt>::DiskEngine>>,
         _region_info_provider: Arc<dyn RegionInfoProvider>,
     ) {
         info!("Compaction filter is not supported for this engine.");

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -1206,7 +1206,10 @@ impl<E: Engine> Drop for GcWorker<E> {
     }
 }
 
-impl<E: Engine<Local: KvEngine<DiskEngine = RocksEngine>>> GcWorker<E> {
+impl<E> GcWorker<E>
+where
+    E: Engine<Local: KvEngine<DiskEngine = RocksEngine>>,
+{
     pub fn start_auto_gc<S: GcSafePointProvider, R: RegionInfoProvider + Clone + 'static>(
         &self,
         cfg: AutoGcConfig<S, R>,

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -15,7 +15,7 @@ use std::{
 use api_version::{ApiV2, KvFormat};
 use collections::HashMap;
 use concurrency_manager::ConcurrencyManager;
-use engine_rocks::FlowInfo;
+use engine_rocks::{FlowInfo, RocksEngine};
 use engine_traits::{
     raw_ttl::ttl_current_ts, DeleteStrategy, Error as EngineError, KvEngine, MiscExt, Range,
     WriteBatch, WriteOptions, CF_DEFAULT, CF_LOCK, CF_WRITE,
@@ -938,7 +938,7 @@ impl<E: Engine> GcRunnerCore<E> {
     }
 
     #[inline]
-    fn run(&mut self, task: GcTask<E::Local>) {
+    fn run(&mut self, task: GcTask<<E::Local as MiscExt>::DiskEngine>) {
         let _io_type_guard = WithIoType::new(IoType::Gc);
         let enum_label = task.get_enum_label();
         GC_GCTASK_COUNTER_STATIC.get(enum_label).inc();
@@ -1088,10 +1088,10 @@ impl<E: Engine> GcRunner<E> {
 }
 
 impl<E: Engine> Runnable for GcRunner<E> {
-    type Task = GcTask<E::Local>;
+    type Task = GcTask<<E::Local as MiscExt>::DiskEngine>;
 
     #[inline]
-    fn run(&mut self, task: GcTask<E::Local>) {
+    fn run(&mut self, task: GcTask<<E::Local as MiscExt>::DiskEngine>) {
         // Refresh config before handle task
         self.inner.refresh_cfg();
 
@@ -1164,8 +1164,8 @@ where
     /// How many strong references. The worker will be stopped
     /// once there are no more references.
     refs: Arc<AtomicUsize>,
-    worker: Arc<Mutex<LazyWorker<GcTask<E::Local>>>>,
-    worker_scheduler: Scheduler<GcTask<E::Local>>,
+    worker: Arc<Mutex<LazyWorker<GcTask<<E::Local as MiscExt>::DiskEngine>>>>,
+    worker_scheduler: Scheduler<GcTask<<E::Local as MiscExt>::DiskEngine>>,
 
     gc_manager_handle: Arc<Mutex<Option<GcManagerHandle>>>,
     feature_gate: FeatureGate,
@@ -1206,6 +1206,49 @@ impl<E: Engine> Drop for GcWorker<E> {
     }
 }
 
+impl<E: Engine<Local: KvEngine<DiskEngine = RocksEngine>>> GcWorker<E> {
+    pub fn start_auto_gc<S: GcSafePointProvider, R: RegionInfoProvider + Clone + 'static>(
+        &self,
+        cfg: AutoGcConfig<S, R>,
+        safe_point: Arc<AtomicU64>, // Store safe point here.
+    ) -> Result<()> {
+        assert!(
+            cfg.self_store_id > 0,
+            "AutoGcConfig::self_store_id shouldn't be 0"
+        );
+
+        info!("initialize compaction filter to perform GC when necessary");
+        let disk_engine = self.engine.kv_engine().map(|e| e.get_disk_engine().clone());
+        disk_engine.init_compaction_filter(
+            cfg.self_store_id,
+            safe_point.clone(),
+            self.config_manager.clone(),
+            self.feature_gate.clone(),
+            self.scheduler(),
+            Arc::new(cfg.region_info_provider.clone()),
+        );
+
+        let mut handle = self.gc_manager_handle.lock().unwrap();
+        assert!(handle.is_none());
+
+        let new_handle = GcManager::new(
+            cfg,
+            safe_point,
+            self.scheduler(),
+            self.config_manager.clone(),
+            self.feature_gate.clone(),
+            self.config_manager.value().num_threads,
+        )
+        .start()?;
+        *handle = Some(new_handle);
+        Ok(())
+    }
+
+    pub fn scheduler(&self) -> Scheduler<GcTask<<E::Local as MiscExt>::DiskEngine>> {
+        self.worker_scheduler.clone()
+    }
+}
+
 impl<E: Engine> GcWorker<E> {
     pub fn new(
         engine: E,
@@ -1235,42 +1278,6 @@ impl<E: Engine> GcWorker<E> {
         }
     }
 
-    pub fn start_auto_gc<S: GcSafePointProvider, R: RegionInfoProvider + Clone + 'static>(
-        &self,
-        cfg: AutoGcConfig<S, R>,
-        safe_point: Arc<AtomicU64>, // Store safe point here.
-    ) -> Result<()> {
-        assert!(
-            cfg.self_store_id > 0,
-            "AutoGcConfig::self_store_id shouldn't be 0"
-        );
-
-        info!("initialize compaction filter to perform GC when necessary");
-        self.engine.kv_engine().init_compaction_filter(
-            cfg.self_store_id,
-            safe_point.clone(),
-            self.config_manager.clone(),
-            self.feature_gate.clone(),
-            self.scheduler(),
-            Arc::new(cfg.region_info_provider.clone()),
-        );
-
-        let mut handle = self.gc_manager_handle.lock().unwrap();
-        assert!(handle.is_none());
-
-        let new_handle = GcManager::new(
-            cfg,
-            safe_point,
-            self.scheduler(),
-            self.config_manager.clone(),
-            self.feature_gate.clone(),
-            self.config_manager.value().num_threads,
-        )
-        .start()?;
-        *handle = Some(new_handle);
-        Ok(())
-    }
-
     pub fn start(&mut self, store_id: u64) -> Result<()> {
         let mut worker = self.worker.lock().unwrap();
         let runner = GcRunner::new(
@@ -1297,10 +1304,6 @@ impl<E: Engine> GcWorker<E> {
         // Stop self.
         self.worker.lock().unwrap().stop();
         Ok(())
-    }
-
-    pub fn scheduler(&self) -> Scheduler<GcTask<E::Local>> {
-        self.worker_scheduler.clone()
     }
 
     /// Only for tests.


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #17086 Ref #16141

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
enable compaction filter for HybridEngine
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
