### PR TITLE
In-memory engine: clean lock cf tombstone in a background worker

### DIFF
--- a/components/region_cache_memory_engine/src/background.rs
+++ b/components/region_cache_memory_engine/src/background.rs
@@ -68,6 +68,7 @@ pub enum BackgroundTask {
     LoadRange,
     MemoryCheckAndEvict,
     DeleteRange(Vec<CacheRange>),
+    CleanLockTombstone(u64),
 }
 
 impl Display for BackgroundTask {
@@ -79,6 +80,10 @@ impl Display for BackgroundTask {
             BackgroundTask::DeleteRange(ref r) => {
                 f.debug_struct("DeleteRange").field("range", r).finish()
             }
+            BackgroundTask::CleanLockTombstone(ref r) => f
+                .debug_struct("CleanLockTombstone")
+                .field("seqno", r)
+                .finish(),
         }
     }
 }
@@ -481,6 +486,12 @@ pub struct BackgroundRunner {
 
     gc_range_remote: Remote<yatp::task::future::TaskCell>,
     gc_range_worker: Worker,
+
+    lock_cleanup_remote: Remote<yatp::task::future::TaskCell>,
+    lock_cleanup_worker: Worker,
+
+    // The last sequence number for the lock cf tombstone cleanup
+    last_seqno: u64,
 }
 
 impl Drop for BackgroundRunner {
@@ -488,6 +499,7 @@ impl Drop for BackgroundRunner {
         self.range_load_worker.stop();
         self.delete_range_worker.stop();
         self.gc_range_worker.stop();
+        self.lock_cleanup_worker.stop();
     }
 }
 
@@ -506,6 +518,9 @@ impl BackgroundRunner {
         let delete_range_worker = Worker::new("background-delete-range_worker");
         let delete_range_remote = delete_range_worker.remote();
 
+        let lock_cleanup_worker = Worker::new("lock-cleanup-worker");
+        let lock_cleanup_remote = lock_cleanup_worker.remote();
+
         let gc_range_worker = Builder::new("background-range-load-worker")
             // Gc must also use exactly one thread to handle it.
             .thread_count(1)
@@ -522,6 +537,9 @@ impl BackgroundRunner {
             delete_range_remote,
             gc_range_worker,
             gc_range_remote,
+            lock_cleanup_remote,
+            lock_cleanup_worker,
+            last_seqno: 0,
         }
     }
 }
@@ -670,6 +688,83 @@ impl Runnable for BackgroundRunner {
                 let mut core = self.core.clone();
                 let f = async move { core.delete_ranges(&ranges) };
                 self.delete_range_remote.spawn(f);
+            }
+            BackgroundTask::CleanLockTombstone(snapshot_seqno) => {
+                if snapshot_seqno < self.last_seqno {
+                    return;
+                }
+                let core = self.core.clone();
+
+                let f = async move {
+                    info!(
+                        "begin lock tombstone";
+                        "seqno" => snapshot_seqno,
+                    );
+
+                    let mut last_user_key = vec![];
+                    let mut remove_rest = false;
+                    let mut cached_to_remove: Option<Vec<u8>> = None;
+
+                    let mut removed = 0;
+                    let mut total = 0;
+                    let now = Instant::now();
+                    let lock_handle = core.engine.read().engine().cf_handle("lock");
+                    let guard = &epoch::pin();
+                    let mut iter = lock_handle.iterator();
+                    iter.seek_to_first(guard);
+                    while iter.valid() {
+                        total += 1;
+                        let InternalKey {
+                            user_key,
+                            v_type,
+                            sequence,
+                        } = decode_key(iter.key().as_bytes());
+                        if user_key != last_user_key {
+                            if let Some(remove) = cached_to_remove.take() {
+                                removed += 1;
+                                lock_handle.remove(&InternalBytes::from_vec(remove), guard);
+                            }
+                            last_user_key = user_key.to_vec();
+                            if sequence >= snapshot_seqno {
+                                remove_rest = false;
+                            } else {
+                                remove_rest = true;
+                                if v_type == ValueType::Deletion {
+                                    cached_to_remove = Some(iter.key().as_bytes().to_vec());
+                                }
+                            }
+                        } else if remove_rest {
+                            assert!(sequence < snapshot_seqno);
+                            removed += 1;
+                            lock_handle.remove(iter.key(), guard);
+                        } else if sequence < snapshot_seqno {
+                            remove_rest = true;
+                            if v_type == ValueType::Deletion {
+                                assert!(cached_to_remove.is_none());
+                                cached_to_remove = Some(iter.key().as_bytes().to_vec());
+                            }
+                        }
+
+                        iter.next(guard);
+                    }
+                    if let Some(remove) = cached_to_remove.take() {
+                        removed += 1;
+                        lock_handle.remove(&InternalBytes::from_vec(remove), guard);
+                    }
+
+                    info!(
+                        "cleanup lock tombstone";
+                        "seqno" => snapshot_seqno,
+                        "total" => total,
+                        "removed" => removed,
+                        "duration" => ?now.saturating_elapsed(),
+                        "current_count" => lock_handle.len(),
+                    );
+
+                    fail::fail_point!("clean_lock_tombstone_done");
+                };
+
+                self.lock_cleanup_remote.spawn(f);
             }
         }
     }
@@ -910,8 +1005,8 @@ pub mod tests {
     use crossbeam::epoch;
     use engine_rocks::util::new_engine;
     use engine_traits::{
-        CacheRange, IterOptions, Iterable, Iterator, RangeCacheEngine, SyncMutable, CF_DEFAULT,
-        CF_LOCK, CF_WRITE, DATA_CFS,
+        CacheRange, IterOptions, Iterable, Iterator, MiscExt, Mutable, RangeCacheEngine,
+        SyncMutable, WriteBatch, WriteBatchExt, CF_DEFAULT, CF_LOCK, CF_WRITE, DATA_CFS,
     };
     use keys::{data_key, DATA_MAX_KEY, DATA_MIN_KEY};
     use online_config::{ConfigChange, ConfigManager, ConfigValue};
@@ -920,7 +1015,7 @@ pub mod tests {
     use tikv_util::config::{ReadableDuration, ReadableSize, VersionTrack};
     use txn_types::{Key, TimeStamp, Write, WriteType};
 
-    use super::{Filter, PdRangeHintService};
+    use super::{BackgroundTask, Filter, PdRangeHintService};
     use crate::{
         background::BackgroundRunner,
         config::RangeCacheConfigManager,
@@ -1990,5 +2085,47 @@ pub mod tests {
         verify(range1, true, 6);
         verify(range2, true, 6);
         assert_eq!(mem_controller.mem_usage(), 1680);
+    }
+
+    #[test]
+    fn test_clean_up_tombstone() {
+        let config = Arc::new(VersionTrack::new(RangeCacheEngineConfig::config_for_test()));
+        let engine = RangeCacheMemoryEngine::new(RangeCacheEngineContext::new(config.clone()));
+        let range = CacheRange::new(b"".to_vec(), b"z".to_vec());
+        engine.new_range(range.clone());
+        let mut wb = engine.write_batch();
+        wb.prepare_for_range(range.clone());
+        wb.put_cf("lock", b"k", b"val").unwrap();
+        wb.put_cf("lock", b"k1", b"val").unwrap();
+        wb.put_cf("lock", b"k2", b"val").unwrap();
+        wb.delete_cf("lock", b"k").unwrap();
+        wb.delete_cf("lock", b"k1").unwrap();
+        wb.delete_cf("lock", b"k2").unwrap();
+        wb.put_cf("lock", b"k", b"val2").unwrap();
+        wb.set_sequence_number(100).unwrap();
+        wb.write().unwrap();
+
+        let mut wb = engine.write_batch();
+        wb.prepare_for_range(range.clone());
+        wb.put_cf("lock", b"k", b"val").unwrap();
+        wb.put_cf("lock", b"k1", b"val").unwrap();
+        wb.put_cf("lock", b"k2", b"val").unwrap();
+        wb.delete_cf("lock", b"k").unwrap();
+        wb.delete_cf("lock", b"k1").unwrap();
+        wb.delete_cf("lock", b"k2").unwrap();
+        wb.set_sequence_number(120).unwrap();
+        wb.write().unwrap();
+
+        let lock_handle = engine.core.read().engine().cf_handle("lock");
+        assert_eq!(lock_handle.len(), 12);
+
+        engine
+            .bg_worker_manager()
+            .schedule_task(BackgroundTask::CleanLockTombstone(110))
+            .unwrap();
+
+        std::thread::sleep(Duration::from_secs(1));
+
+        assert_eq!(lock_handle.len(), 6);
     }
 }

--- a/components/region_cache_memory_engine/src/background.rs
+++ b/components/region_cache_memory_engine/src/background.rs
@@ -733,7 +733,7 @@ impl Runnable for BackgroundRunner {
 
                 let f = async move {
                     info!(
-                        "begin lock tombstone";
+                        "begin to cleanup tombstones in lock cf";
                         "seqno" => snapshot_seqno,
                     );
 
@@ -789,7 +789,7 @@ impl Runnable for BackgroundRunner {
                     }
 
                     info!(
-                        "cleanup lock tombstone";
+                        "cleanup tombstones in lock cf";
                         "seqno" => snapshot_seqno,
                         "total" => total,
                         "removed" => removed,

--- a/components/region_cache_memory_engine/src/engine.rs
+++ b/components/region_cache_memory_engine/src/engine.rs
@@ -258,8 +258,9 @@ pub struct RangeCacheMemoryEngine {
     statistics: Arc<Statistics>,
     config: Arc<VersionTrack<RangeCacheEngineConfig>>,
 
-    // The increment amout of the lock cf. When reaching to a certain amount, a CleanLockTombstone
-    // task will be scheduled to clean lock cf tombstones.
+    // The increment amount of tombstones in the lock cf.
+    // When reaching to the threshold, a CleanLockTombstone task will be scheduled to clean lock cf
+    // tombstones.
     pub(crate) lock_modification_bytes: Arc<AtomicU64>,
 }
 

--- a/components/region_cache_memory_engine/src/engine.rs
+++ b/components/region_cache_memory_engine/src/engine.rs
@@ -5,7 +5,7 @@ use std::{
     fmt::{self, Debug},
     ops::Bound,
     result,
-    sync::Arc,
+    sync::{atomic::AtomicU64, Arc},
 };
 
 use crossbeam::epoch::{self, default_collector, Guard};
@@ -101,6 +101,10 @@ impl SkiplistHandle {
         &self,
     ) -> OwnedIter<Arc<SkipList<InternalBytes, InternalBytes>>, InternalBytes, InternalBytes> {
         self.0.owned_iter()
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
     }
 }
 
@@ -249,6 +253,10 @@ pub struct RangeCacheMemoryEngine {
     memory_controller: Arc<MemoryController>,
     statistics: Arc<Statistics>,
     config: Arc<VersionTrack<RangeCacheEngineConfig>>,
+
+    // The increment amout of the lock cf. When reaching to a certain amount, a CleanLockTombstone
+    // task will be scheduled to clean lock cf tombstones.
+    pub(crate) lock_modification_bytes: Arc<AtomicU64>,
 }
 
 impl RangeCacheMemoryEngine {
@@ -274,6 +282,7 @@ impl RangeCacheMemoryEngine {
             memory_controller,
             statistics,
             config,
+            lock_modification_bytes: Arc::default(),
         }
     }
 

--- a/components/region_cache_memory_engine/src/engine.rs
+++ b/components/region_cache_memory_engine/src/engine.rs
@@ -106,6 +106,10 @@ impl SkiplistHandle {
     pub fn len(&self) -> usize {
         self.0.len()
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }
 
 /// A single global set of skiplists shared by all cached ranges

--- a/components/region_cache_memory_engine/src/lib.rs
+++ b/components/region_cache_memory_engine/src/lib.rs
@@ -26,7 +26,7 @@ mod statistics;
 pub mod test_util;
 mod write_batch;
 
-pub use background::{BackgroundRunner, GcTask};
+pub use background::{BackgroundRunner, BackgroundTask, GcTask};
 pub use engine::{RangeCacheMemoryEngine, SkiplistHandle};
 pub use keys::{decode_key, encoding_for_filter, InternalBytes, InternalKey, ValueType};
 pub use metrics::flush_range_cache_engine_statistics;

--- a/components/region_cache_memory_engine/src/write_batch.rs
+++ b/components/region_cache_memory_engine/src/write_batch.rs
@@ -98,7 +98,7 @@ impl RangeCacheWriteBatch {
     }
 
     /// Trigger a CleanLockTombstone task if the accumulated lock cf
-    /// modification exceeds the threshold, by default, 16MB.
+    /// modification exceeds the threshold (16MB).
     ///
     /// NB: It need to acquire RocksDB mutex to get oldest snapshot, so do not
     ///     call it on any RocksDB's callback, e.g., write batch callback.

--- a/components/region_cache_memory_engine/src/write_batch.rs
+++ b/components/region_cache_memory_engine/src/write_batch.rs
@@ -106,8 +106,9 @@ impl RangeCacheWriteBatch {
     /// Trigger a CleanLockTombstone task if the accumulated lock cf
     /// modification exceeds the threshold (16MB).
     ///
-    /// NB: It need to acquire RocksDB mutex to get oldest snapshot, so do not
-    ///     call it on any RocksDB's callback, e.g., write batch callback.
+    /// NB: Acquiring the RocksDB mutex is necessary to get the oldest snapshot,
+    ///     so avoid calling this in any RocksDB callback (e.g., write batch
+    ///     callback) to prevent potential deadlocks.
     pub fn maybe_compact_lock_cf(&self) {
         if self.engine.lock_modification_bytes.load(Ordering::Relaxed) > AMOUNT_TO_CLEAN_TOMBSTONE {
             // Use `swap` to only allow one schedule when multiple writers reaches the limit

--- a/components/region_cache_memory_engine/src/write_batch.rs
+++ b/components/region_cache_memory_engine/src/write_batch.rs
@@ -28,6 +28,12 @@ pub(crate) const NODE_OVERHEAD_SIZE_EXPECTATION: usize = 96;
 // As every key/value holds a Arc<MemoryController>, this overhead should be
 // taken into consideration.
 pub(crate) const MEM_CONTROLLER_OVERHEAD: usize = 8;
+// A threshold that when the lock cf increment bytes exceed it, a
+// CleanLockTombstone will be scheduled to cleanup the lock tombstones.
+// It's somewhat like RocksDB flush memtables when the memtable reaches to a
+// certain bytes so that the compactions may cleanup some tombstones. By
+// default, the memtable size for lock cf is 32MB. As not all ranges will be
+// cached in the memory, just use half of it here.
 const AMOUNT_TO_CLEAN_TOMBSTONE: u64 = ReadableSize::mb(16).0;
 
 // `prepare_for_range` should be called before raft command apply for each peer

--- a/components/region_cache_memory_engine/src/write_batch.rs
+++ b/components/region_cache_memory_engine/src/write_batch.rs
@@ -586,13 +586,12 @@ impl Mutable for RangeCacheWriteBatch {
 
 #[cfg(test)]
 mod tests {
-    use core::slice::SlicePattern;
     use std::{sync::Arc, time::Duration};
 
     use engine_rocks::util::new_engine;
     use engine_traits::{
-        CacheRange, FailedReason, KvEngine, Peekable, RangeCacheEngine, WriteBatch, CF_LOCK,
-        CF_WRITE, DATA_CFS,
+        CacheRange, FailedReason, KvEngine, Peekable, RangeCacheEngine, WriteBatch, CF_WRITE,
+        DATA_CFS,
     };
     use online_config::{ConfigChange, ConfigManager, ConfigValue};
     use skiplist_rs::SkipList;
@@ -601,8 +600,8 @@ mod tests {
 
     use super::*;
     use crate::{
-        background::flush_epoch, config::RangeCacheConfigManager, keys::encode_seek_key,
-        RangeCacheEngineConfig, RangeCacheEngineContext,
+        background::flush_epoch, config::RangeCacheConfigManager, RangeCacheEngineConfig,
+        RangeCacheEngineContext,
     };
 
     // We should not use skiplist.get directly as we only cares keys without

--- a/components/region_cache_memory_engine/src/write_batch.rs
+++ b/components/region_cache_memory_engine/src/write_batch.rs
@@ -1,4 +1,3 @@
-use core::slice::SlicePattern;
 use std::{
     collections::BTreeSet,
     sync::{atomic::Ordering, Arc},
@@ -15,7 +14,7 @@ use tikv_util::{box_err, config::ReadableSize, error, info, time::Instant, warn}
 use crate::{
     background::BackgroundTask,
     engine::{cf_to_id, id_to_cf, is_lock_cf, SkiplistEngine},
-    keys::{encode_key, encode_seek_key, InternalBytes, ValueType, ENC_KEY_SEQ_LENGTH},
+    keys::{encode_key, InternalBytes, ValueType, ENC_KEY_SEQ_LENGTH},
     memory_controller::{MemoryController, MemoryUsage},
     metrics::WRITE_DURATION_HISTOGRAM,
     range_manager::{RangeCacheStatus, RangeManager},
@@ -579,6 +578,7 @@ impl Mutable for RangeCacheWriteBatch {
 
 #[cfg(test)]
 mod tests {
+    use core::slice::SlicePattern;
     use std::{sync::Arc, time::Duration};
 
     use engine_rocks::util::new_engine;
@@ -593,8 +593,8 @@ mod tests {
 
     use super::*;
     use crate::{
-        background::flush_epoch, config::RangeCacheConfigManager, RangeCacheEngineConfig,
-        RangeCacheEngineContext,
+        background::flush_epoch, config::RangeCacheConfigManager, keys::encode_seek_key,
+        RangeCacheEngineConfig, RangeCacheEngineContext,
     };
 
     // We should not use skiplist.get directly as we only cares keys without

--- a/components/region_cache_memory_engine/tests/failpoints/mod.rs
+++ b/components/region_cache_memory_engine/tests/failpoints/mod.rs
@@ -1,3 +1,3 @@
 // Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
 
-mod test_gc;
+mod test_memory_engine;

--- a/components/region_cache_memory_engine/tests/failpoints/test_memory_engine.rs
+++ b/components/region_cache_memory_engine/tests/failpoints/test_memory_engine.rs
@@ -6,10 +6,11 @@ use std::{
 };
 
 use crossbeam::epoch;
-use engine_traits::{CacheRange, CF_DEFAULT, CF_WRITE};
+use engine_traits::{CacheRange, Mutable, WriteBatch, WriteBatchExt, CF_DEFAULT, CF_WRITE};
 use region_cache_memory_engine::{
-    encoding_for_filter, test_util::put_data, InternalBytes, RangeCacheEngineConfig,
-    RangeCacheEngineContext, RangeCacheMemoryEngine, SkiplistHandle,
+    decode_key, encoding_for_filter, test_util::put_data, BackgroundTask, InternalBytes,
+    InternalKey, RangeCacheEngineConfig, RangeCacheEngineContext, RangeCacheMemoryEngine,
+    SkiplistHandle, ValueType,
 };
 use tikv_util::config::{ReadableDuration, VersionTrack};
 use txn_types::{Key, TimeStamp};
@@ -124,4 +125,82 @@ fn test_gc_worker() {
 
     let key = encoding_for_filter(key.as_encoded(), TimeStamp::new(commit_ts4));
     assert!(key_exist(&write, &key, guard));
+}
+
+#[test]
+fn test_clean_up_tombstone() {
+    let config = Arc::new(VersionTrack::new(RangeCacheEngineConfig::config_for_test()));
+    let engine = RangeCacheMemoryEngine::new(RangeCacheEngineContext::new(config.clone()));
+    let range = CacheRange::new(b"".to_vec(), b"z".to_vec());
+
+    let (tx, rx) = sync_channel(0);
+    fail::cfg_callback("clean_lock_tombstone_done", move || {
+        tx.send(true).unwrap();
+    })
+    .unwrap();
+
+    engine.new_range(range.clone());
+    let mut wb = engine.write_batch();
+    wb.prepare_for_range(range.clone());
+    wb.put_cf("lock", b"k", b"val").unwrap();
+    wb.put_cf("lock", b"k1", b"val").unwrap();
+    wb.put_cf("lock", b"k2", b"val").unwrap();
+    wb.delete_cf("lock", b"k").unwrap();
+    wb.delete_cf("lock", b"k1").unwrap();
+    wb.delete_cf("lock", b"k2").unwrap();
+    wb.put_cf("lock", b"k", b"val2").unwrap(); // seq 107
+    wb.set_sequence_number(100).unwrap();
+    wb.write().unwrap();
+
+    let mut wb = engine.write_batch();
+    wb.prepare_for_range(range.clone());
+    wb.put_cf("lock", b"k", b"val").unwrap(); // seq 120
+    wb.put_cf("lock", b"k1", b"val").unwrap(); // seq 121
+    wb.put_cf("lock", b"k2", b"val").unwrap(); // seq 122
+    wb.delete_cf("lock", b"k").unwrap(); // seq 123
+    wb.delete_cf("lock", b"k1").unwrap(); // seq 124
+    wb.delete_cf("lock", b"k2").unwrap(); // seq 125
+    wb.set_sequence_number(120).unwrap();
+    wb.write().unwrap();
+
+    let lock_handle = engine.core().read().engine().cf_handle("lock");
+    assert_eq!(lock_handle.len(), 13);
+
+    engine
+        .bg_worker_manager()
+        .schedule_task(BackgroundTask::CleanLockTombstone(107))
+        .unwrap();
+
+    rx.recv_timeout(Duration::from_secs(5)).unwrap();
+
+    let mut iter = engine.core().read().engine().cf_handle("lock").iterator();
+
+    let mut first = true;
+    let guard = &epoch::pin();
+    for (k, seq, ty) in [
+        (b"k".to_vec(), 123, ValueType::Deletion),
+        (b"k".to_vec(), 120, ValueType::Value),
+        (b"k".to_vec(), 106, ValueType::Value),
+        (b"k1".to_vec(), 124, ValueType::Deletion),
+        (b"k1".to_vec(), 121, ValueType::Value),
+        (b"k2".to_vec(), 125, ValueType::Deletion),
+        (b"k2".to_vec(), 122, ValueType::Value),
+    ] {
+        if first {
+            iter.seek_to_first(guard);
+            first = false;
+        } else {
+            iter.next(guard);
+        }
+
+        let key = iter.key();
+        let InternalKey {
+            user_key,
+            sequence,
+            v_type,
+        } = decode_key(key.as_bytes());
+        assert_eq!(sequence, seq);
+        assert_eq!(user_key, &k);
+        assert_eq!(v_type, ty);
+    }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #17127 Ref #16141

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
clean lock cf tombstone in a background worker
```

This PR replace the in-place delete of the lock cf with writing tombstones just like what does in rocksdb.
This PR also adds a background task to clean these tombstones to avoid the performance regression.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
