### PR TITLE
In-memory engine: evict range should consider loading range

### DIFF
--- a/components/region_cache_memory_engine/src/engine.rs
+++ b/components/region_cache_memory_engine/src/engine.rs
@@ -259,9 +259,9 @@ impl RangeCacheMemoryEngineCore {
 /// cached region), we resort to using a the disk engine's snapshot instead.
 #[derive(Clone)]
 pub struct RangeCacheMemoryEngine {
+    bg_work_manager: Arc<BgWorkManager>,
     pub(crate) core: Arc<RwLock<RangeCacheMemoryEngineCore>>,
     pub(crate) rocks_engine: Option<RocksEngine>,
-    bg_work_manager: Arc<BgWorkManager>,
     memory_controller: Arc<MemoryController>,
     statistics: Arc<Statistics>,
     config: Arc<VersionTrack<RangeCacheEngineConfig>>,

--- a/components/region_cache_memory_engine/src/range_manager.rs
+++ b/components/region_cache_memory_engine/src/range_manager.rs
@@ -318,6 +318,7 @@ impl RangeManager {
             "evict_range" => ?evict_range,
         );
 
+        // cancel loading ranges overlapped with `evict_range`
         self.pending_ranges_loading_data
             .iter_mut()
             .for_each(|(r, _, canceled)| {

--- a/components/region_cache_memory_engine/src/range_manager.rs
+++ b/components/region_cache_memory_engine/src/range_manager.rs
@@ -318,6 +318,19 @@ impl RangeManager {
             "evict_range" => ?evict_range,
         );
 
+        self.pending_ranges_loading_data
+            .iter_mut()
+            .for_each(|(r, _, canceled)| {
+                if evict_range.overlaps(r) {
+                    info!(
+                        "evict range that overlaps with loading range";
+                        "evicted_range" => ?evict_range,
+                        "overlapped_range" => ?r,
+                    );
+                    *canceled = true;
+                }
+            });
+
         let mut overlapped_ranges = vec![];
         for r in self.ranges.keys() {
             if r.contains_range(evict_range) {

--- a/components/region_cache_memory_engine/tests/failpoints/test_memory_engine.rs
+++ b/components/region_cache_memory_engine/tests/failpoints/test_memory_engine.rs
@@ -268,8 +268,4 @@ fn test_evict_with_loading_range() {
     engine.snapshot(range1, 100, 100).unwrap_err();
     engine.snapshot(range2, 100, 100).unwrap_err();
     engine.snapshot(range3, 100, 100).unwrap();
-
-    drop(engine);
-
-    std::thread::sleep(Duration::from_secs(1));
 }

--- a/components/region_cache_memory_engine/tests/failpoints/test_memory_engine.rs
+++ b/components/region_cache_memory_engine/tests/failpoints/test_memory_engine.rs
@@ -6,12 +6,17 @@ use std::{
 };
 
 use crossbeam::epoch;
-use engine_traits::{CacheRange, Mutable, WriteBatch, WriteBatchExt, CF_DEFAULT, CF_WRITE};
+use engine_rocks::util::new_engine;
+use engine_traits::{
+    CacheRange, Mutable, RangeCacheEngine, WriteBatch, WriteBatchExt, CF_DEFAULT, CF_WRITE,
+    DATA_CFS,
+};
 use region_cache_memory_engine::{
     decode_key, encoding_for_filter, test_util::put_data, BackgroundTask, InternalBytes,
     InternalKey, RangeCacheEngineConfig, RangeCacheEngineContext, RangeCacheMemoryEngine,
     SkiplistHandle, ValueType,
 };
+use tempfile::Builder;
 use tikv_util::config::{ReadableDuration, VersionTrack};
 use txn_types::{Key, TimeStamp};
 
@@ -204,4 +209,67 @@ fn test_clean_up_tombstone() {
         assert_eq!(user_key, &k);
         assert_eq!(v_type, ty);
     }
+}
+
+#[test]
+fn test_evict_with_loading_range() {
+    let path = Builder::new().prefix("test").tempdir().unwrap();
+    let path_str = path.path().to_str().unwrap();
+    let rocks_engine = new_engine(path_str, DATA_CFS).unwrap();
+
+    let config = RangeCacheEngineConfig::config_for_test();
+    let mut engine = RangeCacheMemoryEngine::new(RangeCacheEngineContext::new_for_tests(Arc::new(
+        VersionTrack::new(config),
+    )));
+    engine.set_disk_engine(rocks_engine);
+
+    let range1 = CacheRange::new(b"k00".to_vec(), b"k10".to_vec());
+    let range2 = CacheRange::new(b"k20".to_vec(), b"k30".to_vec());
+    let range3 = CacheRange::new(b"k40".to_vec(), b"k50".to_vec());
+    let (snapshot_load_tx, snapshot_load_rx) = sync_channel(0);
+    fail::cfg_callback("on_snapshot_load_finished", move || {
+        let _ = snapshot_load_tx.send(true);
+    })
+    .unwrap();
+
+    let (loading_complete_tx, loading_complete_rx) = sync_channel(0);
+    fail::cfg_callback("on_pending_range_completes_loading", move || {
+        let _ = loading_complete_tx.send(true);
+    })
+    .unwrap();
+
+    engine.load_range(range1.clone()).unwrap();
+    engine.load_range(range2.clone()).unwrap();
+    engine.load_range(range3.clone()).unwrap();
+
+    let mut wb = engine.write_batch();
+    // prepare range to trigger loading
+    wb.prepare_for_range(range1.clone());
+    wb.prepare_for_range(range2.clone());
+    wb.prepare_for_range(range3.clone());
+    wb.set_sequence_number(10).unwrap();
+    wb.write().unwrap();
+
+    // range1 and range2 will be evicted
+    let r = CacheRange::new(b"k05".to_vec(), b"k25".to_vec());
+    engine.evict_range(&r);
+
+    snapshot_load_rx
+        .recv_timeout(Duration::from_secs(5))
+        .unwrap();
+    snapshot_load_rx
+        .recv_timeout(Duration::from_secs(5))
+        .unwrap();
+
+    loading_complete_rx
+        .recv_timeout(Duration::from_secs(5))
+        .unwrap();
+
+    assert!(engine.snapshot(range1, 100, 100).is_err());
+    assert!(engine.snapshot(range2, 100, 100).is_err());
+    assert!(engine.snapshot(range3, 100, 100).is_ok());
+
+    drop(engine);
+
+    std::thread::sleep(Duration::from_secs(1));
 }

--- a/components/region_cache_memory_engine/tests/failpoints/test_memory_engine.rs
+++ b/components/region_cache_memory_engine/tests/failpoints/test_memory_engine.rs
@@ -265,9 +265,9 @@ fn test_evict_with_loading_range() {
         .recv_timeout(Duration::from_secs(5))
         .unwrap();
 
-    assert!(engine.snapshot(range1, 100, 100).is_err());
-    assert!(engine.snapshot(range2, 100, 100).is_err());
-    assert!(engine.snapshot(range3, 100, 100).is_ok());
+    engine.snapshot(range1, 100, 100).unwrap_err();
+    engine.snapshot(range2, 100, 100).unwrap_err();
+    engine.snapshot(range3, 100, 100).unwrap();
 
     drop(engine);
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #17153

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
evict range should consider loading range
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
