### PR TITLE
In-memory engine: clear write batch when range load failed

### DIFF
--- a/components/region_cache_memory_engine/src/engine.rs
+++ b/components/region_cache_memory_engine/src/engine.rs
@@ -210,15 +210,36 @@ impl RangeCacheMemoryEngineCore {
         &mut self.range_manager
     }
 
-    pub(crate) fn has_cached_write_batch(&self, cache_range: &CacheRange) -> bool {
-        self.cached_write_batch.contains_key(cache_range)
+    // `cached_range` must not exist in the `cached_write_batch`
+    pub fn init_cached_write_batch(&mut self, cache_range: &CacheRange) {
+        assert!(
+            self.cached_write_batch
+                .insert(cache_range.clone(), vec![])
+                .is_none()
+        );
     }
 
-    pub(crate) fn take_cache_write_batch(
+    pub fn has_cached_write_batch(&self, cache_range: &CacheRange) -> bool {
+        self.cached_write_batch
+            .get(cache_range)
+            .map_or(false, |entries| !entries.is_empty())
+    }
+
+    pub(crate) fn take_cached_write_batch_entries(
         &mut self,
         cache_range: &CacheRange,
-    ) -> Option<Vec<(u64, RangeCacheWriteBatchEntry)>> {
-        self.cached_write_batch.remove(cache_range)
+    ) -> Vec<(u64, RangeCacheWriteBatchEntry)> {
+        std::mem::take(self.cached_write_batch.get_mut(cache_range).unwrap())
+    }
+
+    pub fn remove_cached_write_batch(&mut self, cache_range: &CacheRange) {
+        self.cached_write_batch.remove(cache_range).expect(
+            format!(
+                "range cannot be found in cached_write_batch: {:?}",
+                cache_range
+            )
+            .as_str(),
+        );
     }
 
     // ensure that the transfer from `pending_ranges_loading_data` to
@@ -259,9 +280,9 @@ impl RangeCacheMemoryEngineCore {
 /// cached region), we resort to using a the disk engine's snapshot instead.
 #[derive(Clone)]
 pub struct RangeCacheMemoryEngine {
+    bg_work_manager: Arc<BgWorkManager>,
     pub(crate) core: Arc<RwLock<RangeCacheMemoryEngineCore>>,
     pub(crate) rocks_engine: Option<RocksEngine>,
-    bg_work_manager: Arc<BgWorkManager>,
     memory_controller: Arc<MemoryController>,
     statistics: Arc<Statistics>,
     config: Arc<VersionTrack<RangeCacheEngineConfig>>,
@@ -424,6 +445,10 @@ impl RangeCacheMemoryEngine {
                 "Cached" => range_manager.ranges().len(),
                 "Pending" => range_manager.pending_ranges_loading_data.len(),
             );
+
+            // init cached write batch to cache the writes before loading complete
+            core.init_cached_write_batch(range);
+
             if let Err(e) = self
                 .bg_worker_manager()
                 .schedule_task(BackgroundTask::LoadRange)

--- a/components/region_cache_memory_engine/tests/failpoints/test_memory_engine.rs
+++ b/components/region_cache_memory_engine/tests/failpoints/test_memory_engine.rs
@@ -6,13 +6,18 @@ use std::{
 };
 
 use crossbeam::epoch;
-use engine_traits::{CacheRange, Mutable, WriteBatch, WriteBatchExt, CF_DEFAULT, CF_WRITE};
+use engine_rocks::util::new_engine;
+use engine_traits::{
+    CacheRange, Mutable, RangeCacheEngine, WriteBatch, WriteBatchExt, CF_DEFAULT, CF_WRITE,
+    DATA_CFS,
+};
 use region_cache_memory_engine::{
     decode_key, encoding_for_filter, test_util::put_data, BackgroundTask, InternalBytes,
     InternalKey, RangeCacheEngineConfig, RangeCacheEngineContext, RangeCacheMemoryEngine,
     SkiplistHandle, ValueType,
 };
-use tikv_util::config::{ReadableDuration, VersionTrack};
+use tempfile::Builder;
+use tikv_util::config::{ReadableDuration, ReadableSize, VersionTrack};
 use txn_types::{Key, TimeStamp};
 
 // We should not use skiplist.get directly as we only cares keys without
@@ -204,4 +209,60 @@ fn test_clean_up_tombstone() {
         assert_eq!(user_key, &k);
         assert_eq!(v_type, ty);
     }
+}
+
+#[test]
+fn test_cached_write_batch_cleared_when_load_failed() {
+    let path = Builder::new().prefix("test").tempdir().unwrap();
+    let path_str = path.path().to_str().unwrap();
+    let rocks_engine = new_engine(path_str, DATA_CFS).unwrap();
+
+    let mut config = RangeCacheEngineConfig::config_for_test();
+    config.soft_limit_threshold = Some(ReadableSize(20));
+    config.hard_limit_threshold = Some(ReadableSize(40));
+    let config = Arc::new(VersionTrack::new(config));
+    let mut engine =
+        RangeCacheMemoryEngine::new(RangeCacheEngineContext::new_for_tests(config.clone()));
+    engine.set_disk_engine(rocks_engine);
+
+    let (tx, rx) = sync_channel(0);
+    fail::cfg_callback("on_snapshot_load_finished", move || {
+        let _ = tx.send(true);
+    })
+    .unwrap();
+
+    fail::cfg("on_snapshot_load_finished2", "pause").unwrap();
+
+    // range1 will be canceled in on_snapshot_load_finished whereas range2 will be
+    // canceled at begin
+    let range1 = CacheRange::new(b"k00".to_vec(), b"k10".to_vec());
+    let range2 = CacheRange::new(b"k20".to_vec(), b"k30".to_vec());
+    engine.load_range(range1.clone()).unwrap();
+    engine.load_range(range2.clone()).unwrap();
+
+    let mut wb = engine.write_batch();
+    // range1 starts to load
+    wb.prepare_for_range(range1.clone());
+    rx.recv_timeout(Duration::from_secs(5)).unwrap();
+
+    wb.put(b"k05", b"val").unwrap();
+    wb.put(b"k06", b"val").unwrap();
+    wb.prepare_for_range(range2.clone());
+    wb.put(b"k25", b"val").unwrap();
+    wb.set_sequence_number(100).unwrap();
+    wb.write().unwrap();
+
+    fail::remove("on_snapshot_load_finished2");
+
+    let mut tried = 0;
+    while tried < 20 {
+        if !engine.core().read().has_cached_write_batch(&range1)
+            && !engine.core().read().has_cached_write_batch(&range2)
+        {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+        tried += 1;
+    }
+    panic!("write batches are not cleared");
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #17103 Ref #16141

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
clear write batch when range load failed
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
