### PR TITLE
In-memory engine: set disk engine when start

### DIFF
--- a/components/region_cache_memory_engine/src/background.rs
+++ b/components/region_cache_memory_engine/src/background.rs
@@ -805,6 +805,7 @@ impl Runnable for BackgroundRunner {
         match task {
             BackgroundTask::SetRocksEngine(rocks_engine) => {
                 self.rocks_engine = Some(rocks_engine);
+                fail::fail_point!("in_memory_engine_set_rocks_engine");
             }
             BackgroundTask::Gc(t) => {
                 let seqno = (|| {

--- a/components/region_cache_memory_engine/src/engine.rs
+++ b/components/region_cache_memory_engine/src/engine.rs
@@ -563,6 +563,16 @@ impl RangeCacheEngine for RangeCacheMemoryEngine {
     type DiskEngine = RocksEngine;
     fn set_disk_engine(&mut self, disk_engine: Self::DiskEngine) {
         self.rocks_engine = Some(disk_engine);
+        if let Err(e) = self
+            .bg_worker_manager()
+            .schedule_task(BackgroundTask::SetRocksEngine(disk_engine))
+        {
+            error!(
+                "schedule set rocks_engine failed";
+                "err" => ?e,
+            );
+            assert!(tikv_util::thread_group::is_shutdown(!cfg!(test)));
+        }
     }
 
     type RangeHintService = PdRangeHintService;

--- a/components/region_cache_memory_engine/src/engine.rs
+++ b/components/region_cache_memory_engine/src/engine.rs
@@ -562,7 +562,7 @@ impl RangeCacheEngine for RangeCacheMemoryEngine {
 
     type DiskEngine = RocksEngine;
     fn set_disk_engine(&mut self, disk_engine: Self::DiskEngine) {
-        self.rocks_engine = Some(disk_engine);
+        self.rocks_engine = Some(disk_engine.clone());
         if let Err(e) = self
             .bg_worker_manager()
             .schedule_task(BackgroundTask::SetRocksEngine(disk_engine))


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref #16141

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
set disk engine when start
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
