### PR TITLE
In-memory engine: `filter` plus one when any key is removed during GC

### DIFF
--- a/components/region_cache_memory_engine/src/background.rs
+++ b/components/region_cache_memory_engine/src/background.rs
@@ -1655,7 +1655,7 @@ pub mod tests {
             iter.next(guard);
         }
         assert_eq!(count, 8);
-        assert_eq!(4, filter.metrics.filtered);
+        assert_eq!(5, filter.metrics.filtered);
         drop(filter);
 
         assert_eq!(2, element_count(&write));

--- a/components/region_cache_memory_engine/src/read.rs
+++ b/components/region_cache_memory_engine/src/read.rs
@@ -30,6 +30,8 @@ use crate::{
     RangeCacheMemoryEngine,
 };
 
+// The max snapshot number that can exist in the RocksDB. This is typically used
+// for search.
 pub const MAX_SEQUENCE_NUMBER: u64 = (1 << 56) - 1;
 
 #[derive(PartialEq)]

--- a/components/region_cache_memory_engine/tests/failpoints/test_memory_engine.rs
+++ b/components/region_cache_memory_engine/tests/failpoints/test_memory_engine.rs
@@ -400,7 +400,7 @@ fn test_concurrency_between_delete_range_and_write_to_memory() {
     let range1_clone = range1.clone();
     let range2_clone = range2.clone();
     let range3_clone = range3.clone();
-    let _ = std::thread::spawn(move || {
+    let handle = std::thread::spawn(move || {
         let mut wb = engine_clone.write_batch();
         wb.prepare_for_range(range1_clone);
         wb.put_cf(CF_LOCK, b"k02", b"val").unwrap();
@@ -494,4 +494,6 @@ fn test_concurrency_between_delete_range_and_write_to_memory() {
         .recv_timeout(Duration::from_secs(5))
         .unwrap();
     verify_data(&range3, 0);
+
+    let _ = handle.join();
 }

--- a/components/region_cache_memory_engine/tests/failpoints/test_memory_engine.rs
+++ b/components/region_cache_memory_engine/tests/failpoints/test_memory_engine.rs
@@ -495,5 +495,5 @@ fn test_concurrency_between_delete_range_and_write_to_memory() {
         .unwrap();
     verify_data(&range3, 0);
 
-    let _ = handle.join();
+    let _ = handle.join().unwrap();
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref #16141

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
filter plus one when any key is removed during GC
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
