### PR TITLE
In-memory engine: correct under-estimate memory size usage of delete entries.

### DIFF
--- a/components/region_cache_memory_engine/src/keys.rs
+++ b/components/region_cache_memory_engine/src/keys.rs
@@ -78,6 +78,9 @@ impl InternalBytes {
         user_key == other_user_key
     }
 
+    // The IntervalBytes that has been written in the in-memory engine have set the
+    // `memory_controller`, so the memory usage of it is the memory usage of bytes +
+    // 8 bytes (the size of Arc).
     #[inline]
     pub fn memory_size_required(bytes_size: usize) -> usize {
         bytes_size + MEM_CONTROLLER_OVERHEAD
@@ -158,6 +161,7 @@ pub struct InternalKey<'a> {
     pub sequence: u64,
 }
 
+// The size of sequence number suffix
 pub const ENC_KEY_SEQ_LENGTH: usize = std::mem::size_of::<u64>();
 
 impl<'a> From<&'a [u8]> for InternalKey<'a> {

--- a/components/region_cache_memory_engine/src/keys.rs
+++ b/components/region_cache_memory_engine/src/keys.rs
@@ -24,7 +24,7 @@ pub struct InternalBytes {
 
 impl Drop for InternalBytes {
     fn drop(&mut self) {
-        let size = InternalBytes::memory_size_required(&self.bytes);
+        let size = InternalBytes::memory_size_required(self.bytes.len());
         let controller = self.memory_controller.take();
         if let Some(controller) = controller {
             // Reclaim the memory though the bytes have not been drop. This time
@@ -79,8 +79,8 @@ impl InternalBytes {
     }
 
     #[inline]
-    pub fn memory_size_required(bytes: &[u8]) -> usize {
-        bytes.len() + MEM_CONTROLLER_OVERHEAD
+    pub fn memory_size_required(bytes_size: usize) -> usize {
+        bytes_size + MEM_CONTROLLER_OVERHEAD
     }
 }
 

--- a/components/region_cache_memory_engine/src/keys.rs
+++ b/components/region_cache_memory_engine/src/keys.rs
@@ -24,7 +24,7 @@ pub struct InternalBytes {
 
 impl Drop for InternalBytes {
     fn drop(&mut self) {
-        let size = self.bytes.len() + MEM_CONTROLLER_OVERHEAD;
+        let size = InternalBytes::memory_size_required(&self.bytes);
         let controller = self.memory_controller.take();
         if let Some(controller) = controller {
             // Reclaim the memory though the bytes have not been drop. This time
@@ -76,6 +76,11 @@ impl InternalBytes {
             ..
         } = decode_key(other.as_slice());
         user_key == other_user_key
+    }
+
+    #[inline]
+    pub fn memory_size_required(bytes: &[u8]) -> usize {
+        bytes.len() + MEM_CONTROLLER_OVERHEAD
     }
 }
 

--- a/components/region_cache_memory_engine/src/write_batch.rs
+++ b/components/region_cache_memory_engine/src/write_batch.rs
@@ -38,7 +38,7 @@ pub(crate) const MEM_CONTROLLER_OVERHEAD: usize = 8;
 const AMOUNT_TO_CLEAN_TOMBSTONE: u64 = ReadableSize::mb(16).0;
 // The value of the delete entry in the in-memory engine. It's just a emptry
 // slice.
-const DELETE_ENTRY_VAL: &'statc [u8] = b"";
+const DELETE_ENTRY_VAL: &'static [u8] = b"";
 
 // `prepare_for_range` should be called before raft command apply for each peer
 // delegate. It sets `range_cache_status` which is used to determine whether the

--- a/components/region_cache_memory_engine/src/write_batch.rs
+++ b/components/region_cache_memory_engine/src/write_batch.rs
@@ -405,7 +405,8 @@ impl RangeCacheWriteBatchEntry {
     }
 
     fn memory_size_required_for_key_value(key: &[u8], value: &[u8]) -> usize {
-        key.len() + value.len() + ENC_KEY_SEQ_LENGTH + 2 * MEM_CONTROLLER_OVERHEAD /* one for key and one for value */
+        InternalBytes::memory_size_required(key.len() + ENC_KEY_SEQ_LENGTH)
+            + InternalBytes::memory_size_required(value.len())
     }
 
     pub fn data_size(&self) -> usize {

--- a/components/region_cache_memory_engine/src/write_batch.rs
+++ b/components/region_cache_memory_engine/src/write_batch.rs
@@ -396,11 +396,16 @@ impl RangeCacheWriteBatchEntry {
     }
 
     pub fn calc_put_entry_size(key: &[u8], value: &[u8]) -> usize {
-        key.len() + value.len() + ENC_KEY_SEQ_LENGTH + 2 * MEM_CONTROLLER_OVERHEAD /* one for key and one for value */
+        RangeCacheWriteBatchEntry::memory_size_required_for_key_value(key, value)
     }
 
     pub fn cal_delete_entry_size(key: &[u8]) -> usize {
-        key.len() + ENC_KEY_SEQ_LENGTH
+        // delete also has value which is an empty bytes
+        RangeCacheWriteBatchEntry::memory_size_required_for_key_value(key, b"")
+    }
+
+    fn memory_size_required_for_key_value(key: &[u8], value: &[u8]) -> usize {
+        key.len() + value.len() + ENC_KEY_SEQ_LENGTH + 2 * MEM_CONTROLLER_OVERHEAD /* one for key and one for value */
     }
 
     pub fn data_size(&self) -> usize {
@@ -864,12 +869,12 @@ mod tests {
         let engine = RangeCacheMemoryEngine::new(RangeCacheEngineContext::new_for_tests(Arc::new(
             VersionTrack::new(config),
         )));
-        let r1 = CacheRange::new(b"kk00".to_vec(), b"kk10".to_vec());
-        let r2 = CacheRange::new(b"kk10".to_vec(), b"kk20".to_vec());
-        let r3 = CacheRange::new(b"kk20".to_vec(), b"kk30".to_vec());
-        let r4 = CacheRange::new(b"kk30".to_vec(), b"kk40".to_vec());
-        let r5 = CacheRange::new(b"kk40".to_vec(), b"kk50".to_vec());
-        for r in [&r1, &r2, &r3, &r4, &r5] {
+        let range1 = CacheRange::new(b"kk00".to_vec(), b"kk10".to_vec());
+        let range2 = CacheRange::new(b"kk10".to_vec(), b"kk20".to_vec());
+        let range3 = CacheRange::new(b"kk20".to_vec(), b"kk30".to_vec());
+        let range4 = CacheRange::new(b"kk30".to_vec(), b"kk40".to_vec());
+        let range5 = CacheRange::new(b"kk40".to_vec(), b"kk50".to_vec());
+        for r in [&range1, &range2, &range3, &range4, &range5] {
             engine.new_range(r.clone());
             {
                 let mut core = engine.core.write();
@@ -880,66 +885,72 @@ mod tests {
 
         let val1: Vec<u8> = (0..150).map(|_| 0).collect();
         let mut wb = RangeCacheWriteBatch::from(&engine);
-        wb.prepare_for_range(r1.clone());
+        wb.prepare_for_range(range1.clone());
         // memory required:
         // 4(key) + 8(sequencen number) + 150(value) + 16(2 Arc<MemoryController) = 178
         wb.put(b"kk01", &val1).unwrap();
-        wb.prepare_for_range(r2.clone());
+        wb.prepare_for_range(range2.clone());
         // Now, 356
         wb.put(b"kk11", &val1).unwrap();
-        wb.prepare_for_range(r3.clone());
+        wb.prepare_for_range(range3.clone());
         // Now, 534
         wb.put(b"kk21", &val1).unwrap();
+        // memory required:
+        // 4(key) + 8(sequence number) + 16(2 Arc<MemoryController>) = 28
+        // Now, 562
+        wb.delete(b"kk21").unwrap();
         let val2: Vec<u8> = (0..500).map(|_| 2).collect();
         // The memory will fail to acquire
         wb.put(b"kk22", &val2).unwrap();
 
-        // The memory capacity is enough the the following two inserts
+        // The memory capacity is enough for the following two inserts
         let val3: Vec<u8> = (0..150).map(|_| 3).collect();
-        wb.prepare_for_range(r4.clone());
-        // Now, 712
+        wb.prepare_for_range(range4.clone());
+        // Now, 740
         wb.put(b"kk32", &val3).unwrap();
 
+        // The memory will fail to acquire
         let val4: Vec<u8> = (0..300).map(|_| 3).collect();
-        wb.prepare_for_range(r5.clone());
+        wb.prepare_for_range(range5.clone());
         wb.put(b"kk41", &val4).unwrap();
 
         let memory_controller = engine.memory_controller();
-        // We should have allocated 896 as calculated above
-        assert_eq!(712, memory_controller.mem_usage());
+        // We should have allocated 740 as calculated above
+        assert_eq!(740, memory_controller.mem_usage());
         wb.write_impl(1000).unwrap();
-        // We dont count the node overhead in write batch, so after they are written
-        // into the engine, the mem usage can even exceed the hard limit. But this
-        // should be fine as this amount should be at most MB level.
-        assert_eq!(1096, memory_controller.mem_usage());
+        // We dont count the node overhead (96 bytes for each node) in write batch, so
+        // after they are written into the engine, the mem usage can even exceed
+        // the hard limit. But this should be fine as this amount should be at
+        // most MB level.
+        assert_eq!(1220, memory_controller.mem_usage());
 
-        let snap1 = engine.snapshot(r1.clone(), 1000, 1010).unwrap();
+        let snap1 = engine.snapshot(range1.clone(), 1000, 1010).unwrap();
         assert_eq!(snap1.get_value(b"kk01").unwrap().unwrap(), &val1);
-        let snap2 = engine.snapshot(r2.clone(), 1000, 1010).unwrap();
+        let snap2 = engine.snapshot(range2.clone(), 1000, 1010).unwrap();
         assert_eq!(snap2.get_value(b"kk11").unwrap().unwrap(), &val1);
 
         assert_eq!(
-            engine.snapshot(r3.clone(), 1000, 1000).unwrap_err(),
+            engine.snapshot(range3.clone(), 1000, 1000).unwrap_err(),
             FailedReason::NotCached
         );
 
-        let snap4 = engine.snapshot(r4.clone(), 1000, 1010).unwrap();
+        let snap4 = engine.snapshot(range4.clone(), 1000, 1010).unwrap();
         assert_eq!(snap4.get_value(b"kk32").unwrap().unwrap(), &val3);
 
         assert_eq!(
-            engine.snapshot(r5.clone(), 1000, 1010).unwrap_err(),
+            engine.snapshot(range5.clone(), 1000, 1010).unwrap_err(),
             FailedReason::NotCached
         );
 
-        // For range 3, one write is buffered but the other is rejected, so the range 3
-        // is evicted and the keys of it are deleted. After flush the epoch, we should
-        // get 1096-178(kv)-96(node overhead) = 822 memory usage.
+        // For range3, one write is buffered but others is rejected, so the range3 is
+        // evicted and the keys of it are deleted. After flush the epoch, we should
+        // get 1220-178-28(kv)-96*2(node overhead) = 822 memory usage.
         flush_epoch();
         wait_evict_done(&engine);
         assert_eq!(822, memory_controller.mem_usage());
 
         drop(snap1);
-        engine.evict_range(&r1);
+        engine.evict_range(&range1);
         flush_epoch();
         wait_evict_done(&engine);
         assert_eq!(548, memory_controller.mem_usage());

--- a/components/region_cache_memory_engine/src/write_batch.rs
+++ b/components/region_cache_memory_engine/src/write_batch.rs
@@ -38,7 +38,7 @@ pub(crate) const MEM_CONTROLLER_OVERHEAD: usize = 8;
 const AMOUNT_TO_CLEAN_TOMBSTONE: u64 = ReadableSize::mb(16).0;
 // The value of the delete entry in the in-memory engine. It's just a emptry
 // slice.
-const DELETE_ENTRY_VAL: &'static [u8] = b"";
+const DELETE_ENTRY_VAL: &[u8] = b"";
 
 // `prepare_for_range` should be called before raft command apply for each peer
 // delegate. It sets `range_cache_status` which is used to determine whether the


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #17106

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
fix under-estimate memory size usage of delete entry
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
