### PR TITLE
cdc: add `RegionId` type to make code more clear

### DIFF
--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -352,7 +352,7 @@ impl ResolvedRegionHeap {
 #[derive(Default, Debug)]
 pub(crate) struct Advance {
     // multiplexing means one region can be subscribed multiple times in one `Conn`,
-    // in which case progresses are grouped by (ConnId, request_id).
+    // in which case progresses are grouped by (ConnId, RequestId).
     pub(crate) multiplexing: HashMap<(ConnId, RequestId), ResolvedRegionHeap>,
 
     // exclusive means one region can only be subscribed one time in one `Conn`,
@@ -361,7 +361,7 @@ pub(crate) struct Advance {
 
     // To be compatible with old TiCDC client before v4.0.8.
     // TODO(qupeng): we can deprecate support for too old TiCDC clients.
-    // map[(ConnId, region_id)]->request_id.
+    // map[(ConnId, RegionId)] -> RequestId.
     pub(crate) dispersed: HashMap<(ConnId, RegionId), RequestId>,
 
     pub(crate) scan_finished: usize,

--- a/components/cdc/src/errors.rs
+++ b/components/cdc/src/errors.rs
@@ -13,7 +13,7 @@ use tikv::storage::{
 use tikv_util::memory::MemoryQuotaExceeded;
 use txn_types::Error as TxnTypesError;
 
-use crate::channel::SendError;
+use crate::{channel::SendError, service::RegionId};
 
 /// The error type for cdc.
 #[derive(Debug, Error)]
@@ -97,7 +97,7 @@ impl Error {
         }
     }
 
-    pub fn into_error_event(self, region_id: u64) -> ErrorEvent {
+    pub fn into_error_event(self, region_id: RegionId) -> ErrorEvent {
         let mut err_event = ErrorEvent::default();
         let mut err = self.extract_region_error();
         if err.has_not_leader() {
@@ -109,7 +109,7 @@ impl Error {
         } else {
             // TODO: Add more errors to the cdc protocol
             let mut region_not_found = errorpb::RegionNotFound::default();
-            region_not_found.set_region_id(region_id);
+            region_not_found.set_region_id(region_id.0);
             err_event.set_region_not_found(region_not_found);
         }
         err_event

--- a/components/cdc/src/lib.rs
+++ b/components/cdc/src/lib.rs
@@ -12,7 +12,7 @@ mod initializer;
 pub mod metrics;
 mod observer;
 mod old_value;
-mod service;
+pub mod service;
 mod txn_source;
 
 pub use channel::{recv_timeout, CdcEvent};

--- a/components/cdc/src/service.rs
+++ b/components/cdc/src/service.rs
@@ -40,6 +40,11 @@ pub struct RequestId(pub u64);
 
 #[derive(Default, Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub struct RegionId(pub u64);
+impl Debug for RegionId {
+  fn fmt(self, f) -> Result() {
+    write!(f, "{}", self.0)
+  }
+}
 
 impl ConnId {
     pub fn new() -> ConnId {

--- a/components/cdc/tests/failpoints/test_memory_quota.rs
+++ b/components/cdc/tests/failpoints/test_memory_quota.rs
@@ -2,7 +2,7 @@
 
 use std::{sync::*, time::Duration};
 
-use cdc::{Task, Validate};
+use cdc::{service::RegionId, Task, Validate};
 use futures::{executor::block_on, SinkExt};
 use grpcio::WriteFlags;
 use kvproto::{cdcpb::*, kvrpcpb::*};
@@ -88,7 +88,7 @@ fn test_resolver_track_lock_memory_quota_exceeded() {
     let (tx, rx) = mpsc::channel();
     scheduler
         .schedule(Task::Validate(Validate::Region(
-            1,
+            RegionId(1),
             Box::new(move |delegate| {
                 tx.send(delegate.is_none()).unwrap();
             }),
@@ -140,7 +140,7 @@ fn test_pending_on_region_ready_memory_quota_exceeded() {
     let (tx, rx) = mpsc::channel();
     scheduler
         .schedule(Task::Validate(Validate::Region(
-            1,
+            RegionId(1),
             Box::new(move |delegate| {
                 tx.send(delegate.is_none()).unwrap();
             }),
@@ -204,7 +204,7 @@ fn test_pending_push_lock_memory_quota_exceeded() {
     let (tx, rx) = mpsc::channel();
     scheduler
         .schedule(Task::Validate(Validate::Region(
-            1,
+            RegionId(1),
             Box::new(move |delegate| {
                 tx.send(delegate.is_none()).unwrap();
             }),
@@ -263,7 +263,7 @@ fn test_scan_lock_memory_quota_exceeded() {
     let (tx, rx) = mpsc::channel();
     scheduler
         .schedule(Task::Validate(Validate::Region(
-            1,
+            RegionId(1),
             Box::new(move |delegate| {
                 tx.send(delegate.is_none()).unwrap();
             }),

--- a/components/cdc/tests/integrations/test_flow_control.rs
+++ b/components/cdc/tests/integrations/test_flow_control.rs
@@ -2,7 +2,7 @@
 
 use std::{sync::*, time::Duration};
 
-use cdc::{Task, Validate};
+use cdc::{service::RegionId, Task, Validate};
 use futures::{executor::block_on, SinkExt};
 use grpcio::WriteFlags;
 use kvproto::{cdcpb::*, kvrpcpb::*};
@@ -85,7 +85,7 @@ fn test_cdc_congest() {
     let (tx, rx) = mpsc::channel();
     scheduler
         .schedule(Task::Validate(Validate::Region(
-            1,
+            RegionId(1),
             Box::new(move |delegate| {
                 tx.send(delegate.is_none()).unwrap();
             }),

--- a/components/cdc/tests/mod.rs
+++ b/components/cdc/tests/mod.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use causal_ts::CausalTsProvider;
-use cdc::{recv_timeout, CdcObserver, Delegate, FeatureGate, Task, Validate};
+use cdc::{recv_timeout, service::RegionId, CdcObserver, Delegate, FeatureGate, Task, Validate};
 use collections::HashMap;
 use concurrency_manager::ConcurrencyManager;
 use engine_rocks::RocksEngine;
@@ -610,7 +610,7 @@ impl TestSuite {
             };
             scheduler
                 .schedule(Task::Validate(Validate::Region(
-                    region_id,
+                    RegionId(region_id),
                     Box::new(checker),
                 )))
                 .unwrap();


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #17225 

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
cdc introduce new data type `RegionId` to replace the `u64`, makes the code more easier to read.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
