### PR TITLE
raftstore:added metrics in follower reads

### DIFF
--- a/components/raftstore/src/store/local_metrics.rs
+++ b/components/raftstore/src/store/local_metrics.rs
@@ -155,6 +155,9 @@ pub struct RaftMetrics {
     pub propose: RaftProposalCounterVec,
     pub invalid_proposal: RaftInvalidProposalCounterVec,
     pub raft_log_gc_skipped: RaftLogGcSkippedCounterVec,
+    pub read_indx_coal: LocalIntCounter,
+    pub read_indx_retry: LocalIntCounter,
+    pub read_indx_retry_coal: LocalIntCounter,
 
     // local histogram
     pub store_time: LocalHistogram,
@@ -192,6 +195,9 @@ impl RaftMetrics {
         Self {
             ready: RaftReadyCounterVec::from(&STORE_RAFT_READY_COUNTER_VEC),
             send_message: RaftSendMessageMetrics::default(),
+            read_indx_coal: READ_INDX_COAL_COUNTER.local(),
+            read_indx_retry: READ_INDX_RETRY_COUNTER.local(),
+            read_indx_retry_coal: READ_INDX_RETRY_COAL_COUNTER.local(),
             message_dropped: RaftDroppedMessageCounterVec::from(
                 &STORE_RAFT_DROPPED_MESSAGE_COUNTER_VEC,
             ),
@@ -235,6 +241,9 @@ impl RaftMetrics {
 
         self.ready.flush();
         self.send_message.flush();
+        self.read_indx_coal.flush();
+        self.read_indx_retry_coal.flush();
+        self.read_indx_retry.flush();
         self.message_dropped.flush();
         self.propose.flush();
         self.invalid_proposal.flush();

--- a/components/raftstore/src/store/local_metrics.rs
+++ b/components/raftstore/src/store/local_metrics.rs
@@ -155,9 +155,9 @@ pub struct RaftMetrics {
     pub propose: RaftProposalCounterVec,
     pub invalid_proposal: RaftInvalidProposalCounterVec,
     pub raft_log_gc_skipped: RaftLogGcSkippedCounterVec,
-    pub read_indx_coal: LocalIntCounter,
-    pub read_indx_retry: LocalIntCounter,
-    pub read_indx_retry_coal: LocalIntCounter,
+    pub read_index_dedup: LocalIntCounter,
+    pub read_index_retry: LocalIntCounter,
+    pub read_index_retry_dedup: LocalIntCounter,
 
     // local histogram
     pub store_time: LocalHistogram,
@@ -195,9 +195,9 @@ impl RaftMetrics {
         Self {
             ready: RaftReadyCounterVec::from(&STORE_RAFT_READY_COUNTER_VEC),
             send_message: RaftSendMessageMetrics::default(),
-            read_indx_coal: READ_INDX_COAL_COUNTER.local(),
-            read_indx_retry: READ_INDX_RETRY_COUNTER.local(),
-            read_indx_retry_coal: READ_INDX_RETRY_COAL_COUNTER.local(),
+            read_index_dedup: READ_INDEX_DEDUP_COUNTER.local(),
+            read_index_retry: READ_INDEX_RETRY_COUNTER.local(),
+            read_index_retry_dedup: READ_INDEX_RETRY_DEDUP_COUNTER.local(),
             message_dropped: RaftDroppedMessageCounterVec::from(
                 &STORE_RAFT_DROPPED_MESSAGE_COUNTER_VEC,
             ),
@@ -241,9 +241,9 @@ impl RaftMetrics {
 
         self.ready.flush();
         self.send_message.flush();
-        self.read_indx_coal.flush();
-        self.read_indx_retry_coal.flush();
-        self.read_indx_retry.flush();
+        self.read_index_dedup.flush();
+        self.read_index_retry_dedup.flush();
+        self.read_index_retry.flush();
         self.message_dropped.flush();
         self.propose.flush();
         self.invalid_proposal.flush();

--- a/components/raftstore/src/store/metrics.rs
+++ b/components/raftstore/src/store/metrics.rs
@@ -714,6 +714,21 @@ lazy_static! {
             "Total number of leader missed region."
         ).unwrap();
 
+    pub static ref READ_INDX_COAL_COUNTER: IntCounter = register_int_counter!(
+        "tikv_readIndex_coal",
+        "Total number of read index messages coalesced."
+    ).unwrap();
+
+    pub static ref READ_INDX_RETRY_COUNTER: IntCounter = register_int_counter!(
+        "tikv_readIndex_retry",
+        "Total number of read index messages retried."
+    ).unwrap();
+
+    pub static ref READ_INDX_RETRY_COAL_COUNTER: IntCounter = register_int_counter!(
+        "tikv_readIndex_retry_coal",
+        "Total number of retry read index messages coalesced."
+    ).unwrap();
+
     pub static ref CHECK_STALE_PEER_COUNTER: IntCounter = register_int_counter!(
         "tikv_raftstore_check_stale_peer",
         "Total number of checking stale peers."

--- a/components/raftstore/src/store/metrics.rs
+++ b/components/raftstore/src/store/metrics.rs
@@ -714,19 +714,19 @@ lazy_static! {
             "Total number of leader missed region."
         ).unwrap();
 
-    pub static ref READ_INDX_COAL_COUNTER: IntCounter = register_int_counter!(
-        "tikv_readIndex_coal",
-        "Total number of read index messages coalesced."
+    pub static ref READ_INDEX_DEDUP_COUNTER: IntCounter = register_int_counter!(
+        "tikv_read_index_dedup",
+        "Total number of read index messages deduped."
     ).unwrap();
 
-    pub static ref READ_INDX_RETRY_COUNTER: IntCounter = register_int_counter!(
-        "tikv_readIndex_retry",
+    pub static ref READ_INDEX_RETRY_COUNTER: IntCounter = register_int_counter!(
+        "tikv_read_index_retry",
         "Total number of read index messages retried."
     ).unwrap();
 
-    pub static ref READ_INDX_RETRY_COAL_COUNTER: IntCounter = register_int_counter!(
-        "tikv_readIndex_retry_coal",
-        "Total number of retry read index messages coalesced."
+    pub static ref READ_INDEX_RETRY_DEDUP_COUNTER: IntCounter = register_int_counter!(
+        "tikv_read_index_retry_dedup",
+        "Total number of retry read index messages deduped."
     ).unwrap();
 
     pub static ref CHECK_STALE_PEER_COUNTER: IntCounter = register_int_counter!(

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -1887,6 +1887,7 @@ where
         if msg_type == MessageType::MsgReadIndex {
             fail_point!("on_step_read_index_msg");
             let mut start_ts: u64 = 0;
+            assert_eq!(m.get_entries().len(), 1);
             let mut rctx = ReadIndexContext::parse(m.get_entries()[0].get_data()).unwrap();
             if let Some(request) = rctx.request.take() {
                 start_ts = request.get_start_ts();

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -1888,9 +1888,11 @@ where
             fail_point!("on_step_read_index_msg");
             let mut start_ts: u64 = 0;
             assert_eq!(m.get_entries().len(), 1);
-            let mut rctx = ReadIndexContext::parse(m.get_entries()[0].get_data()).unwrap();
-            if let Some(request) = rctx.request.take() {
-                start_ts = request.get_start_ts();
+            {
+                let mut rctx = ReadIndexContext::parse(m.get_entries()[0].get_data()).unwrap();
+                if let Some(request) = rctx.request.take() {
+                    start_ts = request.get_start_ts().into();
+                }
             }
             ctx.coprocessor_host
                 .on_step_read_index(&mut m, self.get_role());

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -1896,7 +1896,7 @@ where
             let mut start_ts: u64 = 0;
             let mut rctx = ReadIndexContext::parse(m.get_entries()[0].get_data()).unwrap();
             if let Some(request) = rctx.request.take() {
-                start_ts = request.get_start_ts().into();
+                start_ts = request.get_start_ts();
             }
 
             // Check if the log term of this index is equal to current term, if so,

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -1887,11 +1887,10 @@ where
         if msg_type == MessageType::MsgReadIndex {
             fail_point!("on_step_read_index_msg");
             let mut start_ts: u64 = 0;
-            assert_eq!(m.get_entries().len(), 1);
-            {
+            if m.get_entries().len() > 0 && !m.get_entries()[0].get_data().is_empty() {
                 let mut rctx = ReadIndexContext::parse(m.get_entries()[0].get_data()).unwrap();
                 if let Some(request) = rctx.request.take() {
-                    start_ts = request.get_start_ts().into();
+                    start_ts = request.get_start_ts();
                 }
             }
             ctx.coprocessor_host

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -1912,7 +1912,7 @@ where
                     if val.is_some() && *val.unwrap() == start_ts {
                         // this message can be dedupd with the last one
                         ctx.raft_metrics.read_index_dedup.inc();
-                    } else if self.next_proposal_index() > self.get_store().applied_index() {
+                    } else if self.next_proposal_index() - self.get_store().applied_index() == 1 {
                         // there are no pending proposals
                         self.read_index_resp.insert(m.from, start_ts);
                     }

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -1899,7 +1899,6 @@ where
             // For more details, see the annotations above `on_leader_commit_idx_changed`.
             let index = self.get_store().commit_index();
 
-
             // Check if the log term of this index is equal to current term, if so,
             // this index can be used to reply the read index request if the leader holds
             // the lease. Please also take a look at raft-rs.

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -3517,8 +3517,8 @@ where
             }
         }
         if retry_reqs != 0 {
-            ctx.raft_metrics.read_indx_retry.inc();
-            ctx.raft_metrics.read_indx_retry_coal.inc();
+            ctx.raft_metrics.read_indx_retry.inc_by(retry_reqs);
+            ctx.raft_metrics.read_indx_retry_coal.inc_by(retry_reqs - 1);
         }
     }
 

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -1887,7 +1887,7 @@ where
         if msg_type == MessageType::MsgReadIndex {
             fail_point!("on_step_read_index_msg");
             let mut start_ts: u64 = 0;
-            if m.get_entries().len() > 0 && !m.get_entries()[0].get_data().is_empty() {
+            if !m.get_entries().is_empty() && !m.get_entries()[0].get_data().is_empty() {
                 let mut rctx = ReadIndexContext::parse(m.get_entries()[0].get_data()).unwrap();
                 if let Some(request) = rctx.request.take() {
                     start_ts = request.get_start_ts();


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number:  #17058

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:
I added 3 metrics to see which approach is more efficient to coalesce the read index messages. 
**read_indx_coal** : it increments this counter if there are no pending proposals at the time of read index message received. It gives us the indication that how many times memory locks check is required
**read_indx_retry** : It is incremented when the request is retried
**read_indx_retry_coal** : This counter indicated the number of messages that can be coalesced during retry. 

```commit-message

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note

```
