### PR TITLE
cdc: count locks for partial subscriped regions correctly

### DIFF
--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -912,7 +912,7 @@ impl Delegate {
         Ok(())
     }
 
-    fn sink_downstream_tidb(&mut self, mut entries: Vec<(EventRow, isize)>) -> Result<()> {
+    fn sink_downstream_tidb(&mut self, entries: Vec<(EventRow, isize)>) -> Result<()> {
         let mut downstreams = Vec::with_capacity(self.downstreams.len());
         for d in &mut self.downstreams {
             if d.kv_api == ChangeDataRequestKvApi::TiDb && d.state.load().ready_for_change_events()

--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -637,6 +637,11 @@ impl Delegate {
             }
             advance.scan_finished += 1;
 
+            if downstream.kv_api == ChangeDataRequestKvApi::RawKv {
+                downstream.advanced_to = min_ts;
+                return Some(downstream.advanced_to);
+            }
+
             if downstream.lock_heap.is_none() {
                 let mut lock_heap = BTreeMap::<TimeStamp, isize>::new();
                 for (_, lock) in locks.range(downstream.observed_range.to_range()) {

--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -951,7 +951,7 @@ impl Delegate {
                     }
                 }
 
-                if TxnSource::is_lossy_ddl_reorg_source_set(x.txn_source)
+                if TxnSource::is_lossy_ddl_reorg_source_set(entry.txn_source)
                     || downstream.filter_loop
                         && TxnSource::is_cdc_write_source_set(entry.txn_source)
                 {

--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -1145,8 +1145,6 @@ impl Delegate {
         self.txn_extra_op.store(TxnExtraOp::Noop);
     }
 }
-    // suite.must_kv_prewrite_with_source(rid, vec![mutation], k.clone(), start_tso,
-    // 1);
 
 #[derive(Default)]
 struct RowsBuilder {

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -897,7 +897,7 @@ impl<T: 'static + CdcHandle<E>, E: KvEngine, S: StoreRegionMeta> Endpoint<T, E, 
         let event_error_handle = downstream.get_event_error_handle();
         let sched = self.scheduler.clone();
 
-        if let Err((err, mut downstream)) = delegate.subscribe(downstream) {
+        if let Err((err, downstream)) = delegate.subscribe(downstream) {
             let error_event = err.into_error_event(region_id);
             let _ = downstream.sink_error_event(region_id, error_event);
             conn.unsubscribe(request_id, region_id);

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -891,6 +891,7 @@ impl<T: 'static + CdcHandle<E>, E: KvEngine, S: StoreRegionMeta> Endpoint<T, E, 
 
         let observed_range = downstream.observed_range.clone();
         let downstream_state = downstream.get_state();
+        let event_error_handle = downstream.get_event_error_handle();
         let sched = self.scheduler.clone();
 
         if let Err((err, downstream)) = delegate.subscribe(downstream) {
@@ -927,6 +928,7 @@ impl<T: 'static + CdcHandle<E>, E: KvEngine, S: StoreRegionMeta> Endpoint<T, E, 
             observe_handle: delegate.handle.clone(),
             downstream_id,
             downstream_state,
+            event_error_handle,
 
             tablet: self.tablets.get(region_id).map(|t| t.into_owned()),
             sched,

--- a/components/cdc/src/initializer.rs
+++ b/components/cdc/src/initializer.rs
@@ -763,6 +763,7 @@ mod tests {
             observe_handle: ObserveHandle::new(),
             downstream_id: DownstreamId::new(),
             downstream_state,
+            event_error_handle: Arc::new(Mutex::new(Default::default())),
 
             tablet: engine.or_else(|| {
                 TestEngineBuilder::new()

--- a/components/cdc/src/initializer.rs
+++ b/components/cdc/src/initializer.rs
@@ -208,6 +208,7 @@ impl<E: KvEngine> Initializer<E> {
                 if !handle.sent_out && handle.event_error.is_some() {
                     let error = handle.event_error.take().unwrap();
                     handle.sent_out = true;
+                    handle.initializer_stopped = true;
                     drop(handle);
 
                     let mut change_data_event = Event::default();
@@ -228,6 +229,9 @@ impl<E: KvEngine> Initializer<E> {
                                   "conn_id" => ?conn_id, "downstream_id" => ?downstream_id, "req_id" => ?request_id);
                         }
                     }
+                } else {
+                    handle.initializer_stopped = true;
+                    drop(handle);
                 }
             }
 

--- a/components/cdc/tests/failpoints/test_endpoint.rs
+++ b/components/cdc/tests/failpoints/test_endpoint.rs
@@ -15,7 +15,7 @@ use kvproto::{cdcpb::*, kvrpcpb::*, tikvpb_grpc::TikvClient};
 use pd_client::PdClient;
 use test_raftstore::*;
 use tikv_util::{debug, worker::Scheduler, HandyRwLock};
-use txn_types::{TimeStamp, Key};
+use txn_types::{Key, TimeStamp};
 
 use crate::{new_event_feed, new_event_feed_v2, ClientReceiver, TestSuite, TestSuiteBuilder};
 
@@ -594,71 +594,6 @@ fn test_cdc_notify_pending_regions() {
         Some(Event_oneof_event::Error(ref e)) if e.has_region_not_found(),
     );
     fail::remove("cdc_before_initialize");
-}
-
-#[test]
-fn test_cdc_partial_subscriptions() {
-    let mut cluster = new_server_cluster(0, 1);
-    configure_for_lease_read(&mut cluster.cfg, Some(100), Some(10));
-    cluster.pd_client.disable_default_operator();
-    let mut suite = TestSuiteBuilder::new().cluster(cluster).build();
-    let region = suite.cluster.get_region(&[]);
-    let rid = region.id;
-    let cf_tso = block_on(suite.cluster.pd_client.get_tso()).unwrap();
-
-    let start_tso = cf_tso.next();
-    let k = b"key".to_vec();
-    let v = vec![b'x'; 16 * 1024];
-    let mut mutation = Mutation::default();
-    mutation.set_op(Op::Put);
-    mutation.key = k.clone();
-    mutation.value = v;
-    suite.must_kv_prewrite(rid, vec![mutation], k.clone(), start_tso);
-
-    fail::cfg("before_post_incremental_scan", "1*pause").unwrap();
-
-    let (mut req_tx_1, _, receive_event_1) = new_event_feed_v2(suite.get_region_cdc_client(rid));
-    let mut req = suite.new_changedata_request(rid);
-    req.request_id = 100;
-    req.checkpoint_ts = cf_tso.into_inner();
-    req.set_start_key(Key::from_raw(b"a").into_encoded());
-    req.set_end_key(Key::from_raw(b"z").into_encoded());
-    block_on(req_tx_1.send((req, WriteFlags::default()))).unwrap();
-
-    let (mut req_tx_2, _, receive_event_2) = new_event_feed_v2(suite.get_region_cdc_client(rid));
-    let mut req = suite.new_changedata_request(rid);
-    req.request_id = 200;
-    req.checkpoint_ts = cf_tso.into_inner();
-    req.set_start_key(Key::from_raw(b"b").into_encoded());
-    req.set_end_key(Key::from_raw(b"x").into_encoded());
-    block_on(req_tx_2.send((req, WriteFlags::default()))).unwrap();
-
-    let cdc_event = receive_event_1(false);
-    'WaitInit: for event in cdc_event.get_events() {
-        for entry in event.get_entries().get_entries() {
-            match entry.get_type() {
-                EventLogType::Prewrite => {}
-                EventLogType::Initialized => break 'WaitInit,
-                _ => unreachable!(),
-            }
-        }
-    }
-
-    let cdc_event = receive_event_2(false);
-    'WaitInit: for event in cdc_event.get_events() {
-        for entry in event.get_entries().get_entries() {
-            match entry.get_type() {
-                EventLogType::Prewrite => {}
-                EventLogType::Initialized => break 'WaitInit,
-                _ => unreachable!(),
-            }
-        }
-    }
-
-    suite.must_kv_rollback(rid, vec![k.clone()], start_tso);
-
-    std::thread::park();
-    fail::remove("before_post_incremental_scan");
 }
 
 #[test]

--- a/components/cdc/tests/mod.rs
+++ b/components/cdc/tests/mod.rs
@@ -475,6 +475,26 @@ impl TestSuite {
         );
     }
 
+    pub fn must_release_pessimistic_lock(
+        &mut self,
+        region_id: u64,
+        pk: Vec<u8>,
+        start_ts: TimeStamp,
+        for_update_ts: TimeStamp,
+    ) {
+        let mut req = PessimisticRollbackRequest::default();
+        req.set_context(self.get_context(region_id));
+        req.start_version = start_ts.into_inner();
+        req.for_update_ts = for_update_ts.into_inner();
+        req.set_keys(vec![pk].into_iter().collect());
+        let resp = self
+            .get_tikv_client(region_id)
+            .kv_pessimistic_rollback(&req)
+            .unwrap();
+        assert!(!resp.has_region_error(), "{:?}", resp.get_region_error());
+        assert!(resp.errors.is_empty(), "{:?}", resp.get_errors());
+    }
+
     pub fn must_kv_pessimistic_prewrite(
         &mut self,
         region_id: u64,


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Close #17211 

The bug is introduced in #17210 .

What's Changed:

```commit-message
cdc: count locks for partial subscriped regions correctly
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
None
```
