### PR TITLE
metrics: fix incorrect statistics on `Ingest SST duration seconds`.

### DIFF
--- a/components/engine_rocks/src/import.rs
+++ b/components/engine_rocks/src/import.rs
@@ -21,23 +21,23 @@ impl ImportExt for RocksEngine {
         let now = Instant::now_coarse();
         // This is calling a specially optimized version of
         // ingest_external_file_cf. In cases where the memtable needs to be
-        // flushed it avoids blocking writers while doing the flush. The unused
+        // flushed it avoids blocking writers while doing the flush. The
         // return value here just indicates whether the fallback path requiring
         // the manual memtable flush was taken.
-        let did_nonblocking_memtable_flush = self
+        let did_blocking_memtable_flush = self
             .as_inner()
             .ingest_external_file_optimized(cf, &opts.0, files)
             .map_err(r2e)?;
         let time_cost = now.saturating_elapsed_secs();
-        if did_nonblocking_memtable_flush {
+        if did_blocking_memtable_flush {
             INGEST_EXTERNAL_FILE_TIME_HISTOGRAM
                 .get(cf_name.into())
-                .non_block
+                .block
                 .observe(time_cost);
         } else {
             INGEST_EXTERNAL_FILE_TIME_HISTOGRAM
                 .get(cf_name.into())
-                .block
+                .non_block
                 .observe(time_cost);
         }
         Ok(())


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref https://github.com/tikv/tikv/issues/17239

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
This pr is used to fix the incorrect metrics on `Ingest SST duration seconds`, introduced in #17070 
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
