### PR TITLE
Revert "raftstore: handle region destroy in a separate thread pool (#17121)"

### DIFF
--- a/components/raftstore/src/store/worker/region.rs
+++ b/components/raftstore/src/store/worker/region.rs
@@ -10,7 +10,7 @@ use std::{
     sync::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
         mpsc::SyncSender,
-        Arc, Mutex,
+        Arc,
     },
     time::Duration,
     u64,
@@ -341,12 +341,22 @@ where
     }
 }
 
-struct RegionCleaner<EK>
+pub struct Runner<EK, R, T>
 where
     EK: KvEngine,
+    T: PdClient + 'static,
 {
+    batch_size: usize,
     use_delete_range: bool,
-    engine: EK,
+    ingest_copy_symlink: bool,
+    clean_stale_tick: usize,
+    clean_stale_check_interval: Duration,
+    clean_stale_ranges_tick: usize,
+
+    tiflash_stores: HashMap<u64, bool>,
+    // we may delay some apply tasks if level 0 files to write stall threshold,
+    // pending_applies records all delayed apply task, and will check again later
+    pending_applies: VecDeque<Task<EK::Snapshot>>,
     // Ranges that have been logically destroyed at a specific sequence number. We can
     // assume there will be no reader (engine snapshot) newer than that sequence number. Therefore,
     // they can be physically deleted with `DeleteFiles` when we're sure there is no older
@@ -356,13 +366,206 @@ where
     // The sole purpose of maintaining this list is to optimize deletion with `DeleteFiles`
     // whenever we can. Errors while processing them can be ignored.
     pending_delete_ranges: PendingDeleteRanges,
+
+    engine: EK,
     mgr: SnapManager,
+    coprocessor_host: CoprocessorHost<EK>,
+    router: R,
+    pd_client: Option<Arc<T>>,
+    pool: FuturePool,
 }
 
-impl<EK> RegionCleaner<EK>
+impl<EK, R, T> Runner<EK, R, T>
 where
     EK: KvEngine,
+    R: CasualRouter<EK>,
+    T: PdClient + 'static,
 {
+    pub fn new(
+        engine: EK,
+        mgr: SnapManager,
+        cfg: Arc<VersionTrack<Config>>,
+        coprocessor_host: CoprocessorHost<EK>,
+        router: R,
+        pd_client: Option<Arc<T>>,
+    ) -> Runner<EK, R, T> {
+        Runner {
+            batch_size: cfg.value().snap_apply_batch_size.0 as usize,
+            use_delete_range: cfg.value().use_delete_range,
+            ingest_copy_symlink: cfg.value().snap_apply_copy_symlink,
+            clean_stale_tick: 0,
+            clean_stale_check_interval: Duration::from_millis(
+                cfg.value().region_worker_tick_interval.as_millis(),
+            ),
+            clean_stale_ranges_tick: cfg.value().clean_stale_ranges_tick,
+            tiflash_stores: HashMap::default(),
+            pending_applies: VecDeque::new(),
+            pending_delete_ranges: PendingDeleteRanges::default(),
+            engine,
+            mgr,
+            coprocessor_host,
+            router,
+            pd_client,
+            pool: YatpPoolBuilder::new(DefaultTicker::default())
+                .name_prefix("snap-generator")
+                .thread_count(
+                    1,
+                    cfg.value().snap_generator_pool_size,
+                    SNAP_GENERATOR_MAX_POOL_SIZE,
+                )
+                .build_future_pool(),
+        }
+    }
+
+    pub fn snap_generator_pool(&self) -> FuturePool {
+        self.pool.clone()
+    }
+
+    fn region_state(&self, region_id: u64) -> Result<RegionLocalState> {
+        let region_key = keys::region_state_key(region_id);
+        let region_state: RegionLocalState =
+            match box_try!(self.engine.get_msg_cf(CF_RAFT, &region_key)) {
+                Some(state) => state,
+                None => {
+                    return Err(box_err!(
+                        "failed to get region_state from {}",
+                        log_wrappers::Value::key(&region_key)
+                    ));
+                }
+            };
+        Ok(region_state)
+    }
+
+    fn apply_state(&self, region_id: u64) -> Result<RaftApplyState> {
+        let state_key = keys::apply_state_key(region_id);
+        let apply_state: RaftApplyState =
+            match box_try!(self.engine.get_msg_cf(CF_RAFT, &state_key)) {
+                Some(state) => state,
+                None => {
+                    return Err(box_err!(
+                        "failed to get apply_state from {}",
+                        log_wrappers::Value::key(&state_key)
+                    ));
+                }
+            };
+        Ok(apply_state)
+    }
+
+    /// Applies snapshot data of the Region.
+    fn apply_snap(&mut self, region_id: u64, peer_id: u64, abort: Arc<AtomicUsize>) -> Result<()> {
+        info!("begin apply snap data"; "region_id" => region_id, "peer_id" => peer_id);
+        fail_point!("region_apply_snap", |_| { Ok(()) });
+        fail_point!("region_apply_snap_io_err", |_| {
+            Err(crate::store::SnapError::Other(box_err!("io error")))
+        });
+        check_abort(&abort)?;
+
+        let mut region_state = self.region_state(region_id)?;
+        let region = region_state.get_region().clone();
+
+        let start_key = keys::enc_start_key(&region);
+        let end_key = keys::enc_end_key(&region);
+        check_abort(&abort)?;
+        self.clean_overlap_ranges(start_key, end_key)?;
+        check_abort(&abort)?;
+        fail_point!("apply_snap_cleanup_range");
+
+        // apply snapshot
+        let apply_state = self.apply_state(region_id)?;
+        let term = apply_state.get_truncated_state().get_term();
+        let idx = apply_state.get_truncated_state().get_index();
+        let snap_key = SnapKey::new(region_id, term, idx);
+        self.mgr.register(snap_key.clone(), SnapEntry::Applying);
+        defer!({
+            self.mgr.deregister(&snap_key, &SnapEntry::Applying);
+        });
+        let mut s = box_try!(self.mgr.get_snapshot_for_applying(&snap_key));
+        if !s.exists() {
+            return Err(box_err!("missing snapshot file {}", s.path()));
+        }
+        check_abort(&abort)?;
+        let timer = Instant::now();
+        let options = ApplyOptions {
+            db: self.engine.clone(),
+            region: region.clone(),
+            abort: Arc::clone(&abort),
+            write_batch_size: self.batch_size,
+            coprocessor_host: self.coprocessor_host.clone(),
+            ingest_copy_symlink: self.ingest_copy_symlink,
+        };
+        s.apply(options)?;
+        self.coprocessor_host
+            .post_apply_snapshot(&region, peer_id, &snap_key, Some(&s));
+
+        // delete snapshot state.
+        let mut wb = self.engine.write_batch();
+        region_state.set_state(PeerState::Normal);
+        box_try!(wb.put_msg_cf(CF_RAFT, &keys::region_state_key(region_id), &region_state));
+        box_try!(wb.delete_cf(CF_RAFT, &keys::snapshot_raft_state_key(region_id)));
+        wb.write().unwrap_or_else(|e| {
+            panic!("{} failed to save apply_snap result: {:?}", region_id, e);
+        });
+        info!(
+            "apply new data";
+            "region_id" => region_id,
+            "time_takes" => ?timer.saturating_elapsed(),
+        );
+        Ok(())
+    }
+
+    /// Tries to apply the snapshot of the specified Region. It calls
+    /// `apply_snap` to do the actual work.
+    fn handle_apply(&mut self, region_id: u64, peer_id: u64, status: Arc<AtomicUsize>) {
+        let _ = status.compare_exchange(
+            JOB_STATUS_PENDING,
+            JOB_STATUS_RUNNING,
+            Ordering::SeqCst,
+            Ordering::SeqCst,
+        );
+        SNAP_COUNTER.apply.start.inc();
+
+        let start = Instant::now();
+
+        let tombstone = match self.apply_snap(region_id, peer_id, Arc::clone(&status)) {
+            Ok(()) => {
+                status.swap(JOB_STATUS_FINISHED, Ordering::SeqCst);
+                SNAP_COUNTER.apply.success.inc();
+                false
+            }
+            Err(Error::Abort) => {
+                warn!("applying snapshot is aborted"; "region_id" => region_id);
+                self.coprocessor_host
+                    .cancel_apply_snapshot(region_id, peer_id);
+                assert_eq!(
+                    status.swap(JOB_STATUS_CANCELLED, Ordering::SeqCst),
+                    JOB_STATUS_CANCELLING
+                );
+                SNAP_COUNTER.apply.abort.inc();
+                // The snapshot is applied abort, it's not necessary to tombstone the peer.
+                false
+            }
+            Err(e) => {
+                warn!("failed to apply snap!!!"; "region_id" => region_id, "err" => %e);
+                self.coprocessor_host
+                    .cancel_apply_snapshot(region_id, peer_id);
+                status.swap(JOB_STATUS_FAILED, Ordering::SeqCst);
+                SNAP_COUNTER.apply.fail.inc();
+                // As the snapshot failed, the related peer should be marked tombstone.
+                // And as for the abnormal snapshot, it will be automatically cleaned up by
+                // the CleanupWorker later.
+                true
+            }
+        };
+
+        SNAP_HISTOGRAM
+            .apply
+            .observe(start.saturating_elapsed_secs());
+        let _ = self.router.send(
+            region_id,
+            CasualMessage::SnapshotApplied { peer_id, tombstone },
+        );
+    }
+
     /// Tries to clean up files in pending ranges overlapping with the given
     /// bounds. These pending ranges will be removed. Returns an updated range
     /// that also includes these ranges. Caller must ensure the remaining keys
@@ -529,262 +732,30 @@ where
         let wopts = WriteOptions::default();
         for cf in self.engine.cf_names() {
             // CF_LOCK usually contains fewer keys than other CFs, so we delete them by key.
-            let strategy = if cf == CF_LOCK {
-                DeleteStrategy::DeleteByKey
-            } else if self.use_delete_range {
-                DeleteStrategy::DeleteByRange
-            } else {
-                DeleteStrategy::DeleteByWriter {
-                    sst_path: self.mgr.get_temp_path_for_ingest(),
-                }
-            };
-            box_try!(self.engine.delete_ranges_cf(&wopts, cf, strategy, ranges));
-        }
-        Ok(())
-    }
-}
-
-pub struct Runner<EK, R, T>
-where
-    EK: KvEngine,
-    T: PdClient + 'static,
-{
-    batch_size: usize,
-    ingest_copy_symlink: bool,
-    clean_stale_tick: usize,
-    clean_stale_check_interval: Duration,
-    clean_stale_ranges_tick: usize,
-
-    tiflash_stores: HashMap<u64, bool>,
-    // we may delay some apply tasks if level 0 files to write stall threshold,
-    // pending_applies records all delayed apply task, and will check again later
-    pending_applies: VecDeque<Task<EK::Snapshot>>,
-
-    engine: EK,
-    mgr: SnapManager,
-    coprocessor_host: CoprocessorHost<EK>,
-    router: R,
-    pd_client: Option<Arc<T>>,
-    snap_gen_pool: FuturePool,
-    region_cleanup_pool: FuturePool,
-    region_cleaner: Arc<Mutex<RegionCleaner<EK>>>,
-}
-
-impl<EK, R, T> Runner<EK, R, T>
-where
-    EK: KvEngine,
-    R: CasualRouter<EK>,
-    T: PdClient + 'static,
-{
-    pub fn new(
-        engine: EK,
-        mgr: SnapManager,
-        cfg: Arc<VersionTrack<Config>>,
-        coprocessor_host: CoprocessorHost<EK>,
-        router: R,
-        pd_client: Option<Arc<T>>,
-    ) -> Runner<EK, R, T> {
-        Runner {
-            batch_size: cfg.value().snap_apply_batch_size.0 as usize,
-            ingest_copy_symlink: cfg.value().snap_apply_copy_symlink,
-            clean_stale_tick: 0,
-            clean_stale_check_interval: Duration::from_millis(
-                cfg.value().region_worker_tick_interval.as_millis(),
-            ),
-            clean_stale_ranges_tick: cfg.value().clean_stale_ranges_tick,
-            tiflash_stores: HashMap::default(),
-            pending_applies: VecDeque::new(),
-            engine: engine.clone(),
-            mgr: mgr.clone(),
-            coprocessor_host,
-            router,
-            pd_client,
-            snap_gen_pool: YatpPoolBuilder::new(DefaultTicker::default())
-                .name_prefix("snap-generator")
-                .thread_count(
-                    1,
-                    cfg.value().snap_generator_pool_size,
-                    SNAP_GENERATOR_MAX_POOL_SIZE,
+            let (strategy, observer) = if cf == CF_LOCK {
+                (
+                    DeleteStrategy::DeleteByKey,
+                    &CLEAR_OVERLAP_REGION_DURATION.by_key,
                 )
-                .build_future_pool(),
-            region_cleanup_pool: YatpPoolBuilder::new(DefaultTicker::default())
-                .name_prefix("region-cleanup")
-                .thread_count(1, 1, 1)
-                .build_future_pool(),
-            region_cleaner: Arc::new(Mutex::new(RegionCleaner {
-                use_delete_range: cfg.value().use_delete_range,
-                engine,
-                pending_delete_ranges: PendingDeleteRanges::default(),
-                mgr,
-            })),
-        }
-    }
-
-    pub fn snap_generator_pool(&self) -> FuturePool {
-        self.snap_gen_pool.clone()
-    }
-
-    fn region_state(&self, region_id: u64) -> Result<RegionLocalState> {
-        let region_key = keys::region_state_key(region_id);
-        let region_state: RegionLocalState =
-            match box_try!(self.engine.get_msg_cf(CF_RAFT, &region_key)) {
-                Some(state) => state,
-                None => {
-                    return Err(box_err!(
-                        "failed to get region_state from {}",
-                        log_wrappers::Value::key(&region_key)
-                    ));
-                }
+            } else if self.use_delete_range {
+                (
+                    DeleteStrategy::DeleteByRange,
+                    &CLEAR_OVERLAP_REGION_DURATION.by_range,
+                )
+            } else {
+                (
+                    DeleteStrategy::DeleteByWriter {
+                        sst_path: self.mgr.get_temp_path_for_ingest(),
+                    },
+                    &CLEAR_OVERLAP_REGION_DURATION.by_ingest_files,
+                )
             };
-        Ok(region_state)
-    }
-
-    fn apply_state(&self, region_id: u64) -> Result<RaftApplyState> {
-        let state_key = keys::apply_state_key(region_id);
-        let apply_state: RaftApplyState =
-            match box_try!(self.engine.get_msg_cf(CF_RAFT, &state_key)) {
-                Some(state) => state,
-                None => {
-                    return Err(box_err!(
-                        "failed to get apply_state from {}",
-                        log_wrappers::Value::key(&state_key)
-                    ));
-                }
-            };
-        Ok(apply_state)
-    }
-
-    /// Applies snapshot data of the Region.
-    fn apply_snap(&mut self, region_id: u64, peer_id: u64, abort: Arc<AtomicUsize>) -> Result<()> {
-        info!("begin apply snap data"; "region_id" => region_id, "peer_id" => peer_id);
-        fail_point!("region_apply_snap", |_| { Ok(()) });
-        fail_point!("region_apply_snap_io_err", |_| {
-            Err(crate::store::SnapError::Other(box_err!("io error")))
-        });
-        check_abort(&abort)?;
-
-        let mut region_state = self.region_state(region_id)?;
-        let region = region_state.get_region().clone();
-
-        let start_key = keys::enc_start_key(&region);
-        let end_key = keys::enc_end_key(&region);
-        check_abort(&abort)?;
-        {
-            let mut region_cleaner = self.region_cleaner.lock().unwrap();
-            region_cleaner.clean_overlap_ranges(start_key, end_key)?;
+            let start = Instant::now();
+            box_try!(self.engine.delete_ranges_cf(&wopts, cf, strategy, ranges));
+            observer.observe(start.saturating_elapsed_secs());
         }
-        check_abort(&abort)?;
-        fail_point!("apply_snap_cleanup_range");
 
-        // apply snapshot
-        let apply_state = self.apply_state(region_id)?;
-        let term = apply_state.get_truncated_state().get_term();
-        let idx = apply_state.get_truncated_state().get_index();
-        let snap_key = SnapKey::new(region_id, term, idx);
-        self.mgr.register(snap_key.clone(), SnapEntry::Applying);
-        defer!({
-            self.mgr.deregister(&snap_key, &SnapEntry::Applying);
-        });
-        let mut s = box_try!(self.mgr.get_snapshot_for_applying(&snap_key));
-        if !s.exists() {
-            return Err(box_err!("missing snapshot file {}", s.path()));
-        }
-        check_abort(&abort)?;
-        let timer = Instant::now();
-        let options = ApplyOptions {
-            db: self.engine.clone(),
-            region: region.clone(),
-            abort: Arc::clone(&abort),
-            write_batch_size: self.batch_size,
-            coprocessor_host: self.coprocessor_host.clone(),
-            ingest_copy_symlink: self.ingest_copy_symlink,
-        };
-        s.apply(options)?;
-        self.coprocessor_host
-            .post_apply_snapshot(&region, peer_id, &snap_key, Some(&s));
-
-        // delete snapshot state.
-        let mut wb = self.engine.write_batch();
-        region_state.set_state(PeerState::Normal);
-        box_try!(wb.put_msg_cf(CF_RAFT, &keys::region_state_key(region_id), &region_state));
-        box_try!(wb.delete_cf(CF_RAFT, &keys::snapshot_raft_state_key(region_id)));
-        wb.write().unwrap_or_else(|e| {
-            panic!("{} failed to save apply_snap result: {:?}", region_id, e);
-        });
-        info!(
-            "apply new data";
-            "region_id" => region_id,
-            "time_takes" => ?timer.saturating_elapsed(),
-        );
         Ok(())
-    }
-
-    /// Tries to apply the snapshot of the specified Region. It calls
-    /// `apply_snap` to do the actual work.
-    fn handle_apply(&mut self, region_id: u64, peer_id: u64, status: Arc<AtomicUsize>) {
-        let _ = status.compare_exchange(
-            JOB_STATUS_PENDING,
-            JOB_STATUS_RUNNING,
-            Ordering::SeqCst,
-            Ordering::SeqCst,
-        );
-        SNAP_COUNTER.apply.start.inc();
-
-        let start = Instant::now();
-
-        let tombstone = match self.apply_snap(region_id, peer_id, Arc::clone(&status)) {
-            Ok(()) => {
-                status.swap(JOB_STATUS_FINISHED, Ordering::SeqCst);
-                SNAP_COUNTER.apply.success.inc();
-                false
-            }
-            Err(Error::Abort) => {
-                warn!("applying snapshot is aborted"; "region_id" => region_id);
-                self.coprocessor_host
-                    .cancel_apply_snapshot(region_id, peer_id);
-                assert_eq!(
-                    status.swap(JOB_STATUS_CANCELLED, Ordering::SeqCst),
-                    JOB_STATUS_CANCELLING
-                );
-                SNAP_COUNTER.apply.abort.inc();
-                // The snapshot is applied abort, it's not necessary to tombstone the peer.
-                false
-            }
-            Err(e) => {
-                warn!("failed to apply snap!!!"; "region_id" => region_id, "err" => %e);
-                self.coprocessor_host
-                    .cancel_apply_snapshot(region_id, peer_id);
-                status.swap(JOB_STATUS_FAILED, Ordering::SeqCst);
-                SNAP_COUNTER.apply.fail.inc();
-                // As the snapshot failed, the related peer should be marked tombstone.
-                // And as for the abnormal snapshot, it will be automatically cleaned up by
-                // the CleanupWorker later.
-                true
-            }
-        };
-
-        SNAP_HISTOGRAM
-            .apply
-            .observe(start.saturating_elapsed_secs());
-        let _ = self.router.send(
-            region_id,
-            CasualMessage::SnapshotApplied { peer_id, tombstone },
-        );
-    }
-
-    /// Checks the number of files at level 0 to avoid write stall after
-    /// ingesting sst. Returns true if the ingestion causes write stall.
-    fn ingest_maybe_stall(&self) -> bool {
-        for cf in SNAPSHOT_CFS {
-            // no need to check lock cf
-            if plain_file_used(cf) {
-                continue;
-            }
-            if self.engine.ingest_maybe_slowdown_writes(cf).expect("cf") {
-                return true;
-            }
-        }
-        false
     }
 
     /// Calls observer `pre_apply_snapshot` for every task.
@@ -920,7 +891,7 @@ where
                     start: UnixSecs::now(),
                 };
                 let scheduled_time = Instant::now_coarse();
-                self.snap_gen_pool.spawn(async move {
+                self.pool.spawn(async move {
                     SNAP_GEN_WAIT_DURATION_HISTOGRAM
                         .observe(scheduled_time.saturating_elapsed_secs());
 
@@ -961,19 +932,11 @@ where
                 start_key,
                 end_key,
             } => {
-                let region_cleaner = self.region_cleaner.clone();
-                self.region_cleanup_pool
-                    .spawn(async move {
-                        fail_point!("on_region_worker_destroy", region_id == 1000, |_| {});
-                        let mut region_cleaner = region_cleaner.lock().unwrap();
-                        // try to delay the range deletion because
-                        // there might be a coprocessor request related to this range
-                        region_cleaner.insert_pending_delete_range(region_id, start_key, end_key);
-                        region_cleaner.clean_stale_ranges();
-                    })
-                    .unwrap_or_else(|e| {
-                        error!("failed to destroy region"; "region_id" => region_id, "err" => ?e);
-                    });
+                fail_point!("on_region_worker_destroy", true, |_| {});
+                // try to delay the range deletion because
+                // there might be a coprocessor request related to this range
+                self.insert_pending_delete_range(region_id, start_key, end_key);
+                self.clean_stale_ranges();
             }
         }
     }
@@ -989,7 +952,7 @@ where
         self.handle_pending_applies(true);
         self.clean_stale_tick += 1;
         if self.clean_stale_tick >= self.clean_stale_ranges_tick {
-            self.region_cleaner.lock().unwrap().clean_stale_ranges();
+            self.clean_stale_ranges();
             self.clean_stale_tick = 0;
         }
     }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #17258

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
This reverts commit 273ec868a794cf4637c9c8c5a2d8bb462d701217.

The previous commit introduced a bug that could result in data loss. 
Specifically, the region worker might delete data from a range where a 
snapshot has just been applied.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

I manually checked that the outputs of the two commands are the same, which means all changes made after the commit are untouched:
1. git diff 273ec86 HEAD^ components/raftstore/src/store/worker/region.rs
2. git diff 273ec86^ HEAD components/raftstore/src/store/worker/region.rs


Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
