### PR TITLE
Revert "metrics: fix incorrect unit of grpc source requests' duration(#17279)"

### DIFF
--- a/metrics/grafana/tikv_details.dashboard.py
+++ b/metrics/grafana/tikv_details.dashboard.py
@@ -1096,9 +1096,7 @@ def gRPC() -> RowPanel:
             graph_panel(
                 title="gRPC request sources duration",
                 description="The duration of different sources of gRPC request",
-                yaxes=yaxes(
-                    left_format=UNITS.NANO_SECONDS, right_format=UNITS.NANO_SECONDS
-                ),
+                yaxes=yaxes(left_format=UNITS.MICRO_SECONDS),
                 lines=False,
                 stack=True,
                 targets=[

--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -7755,7 +7755,7 @@
           "yaxes": [
             {
               "decimals": null,
-              "format": "ns",
+              "format": "\u00b5s",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -7764,7 +7764,7 @@
             },
             {
               "decimals": null,
-              "format": "ns",
+              "format": "short",
               "label": null,
               "logBase": 1,
               "max": null,

--- a/metrics/grafana/tikv_details.json.sha256
+++ b/metrics/grafana/tikv_details.json.sha256
@@ -1,1 +1,1 @@
-573466dbc2466856b440e7a2cdc239ca35bc655321544e5c607dae2d67cf6a63  ./metrics/grafana/tikv_details.json
+4a5b360a219dfd53a3589809cd51bd94afe5333dcf9b3388b2b460fed58c4b7d  ./metrics/grafana/tikv_details.json


### PR DESCRIPTION
This reverts commit 254ceaaa654a70d78919ee5d85f5b4cbe3c444a3.

As it duplicates with previous pr #17133 and the unit should be `microseconds` rather than `nanoseconds`.

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #16265

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Revert duplicated changes.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
