### PR TITLE
Prepare the external storage interface for compacting log backup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -953,6 +953,7 @@ dependencies = [
  "async-trait",
  "derive_more",
  "error_code",
+ "futures 0.3.15",
  "futures-io",
  "kvproto",
  "lazy_static",
@@ -961,6 +962,7 @@ dependencies = [
  "thiserror",
  "tikv_util",
  "url",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -1701,6 +1703,7 @@ dependencies = [
  "async-trait",
  "aws",
  "azure",
+ "chrono",
  "cloud",
  "encryption",
  "file_system",
@@ -1714,6 +1717,8 @@ dependencies = [
  "prometheus",
  "rand 0.8.5",
  "rust-ini",
+ "serde",
+ "serde_json",
  "slog",
  "slog-global",
  "structopt",
@@ -1723,6 +1728,8 @@ dependencies = [
  "tokio",
  "tokio-util",
  "url",
+ "uuid 0.8.2",
+ "walkdir",
 ]
 
 [[package]]

--- a/components/cloud/Cargo.toml
+++ b/components/cloud/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 async-trait = "0.1"
 derive_more = "0.99.3"
 error_code = { workspace = true }
+futures = "0.3"
 futures-io = "0.3"
 kvproto = { workspace = true }
 lazy_static = "1.3"
@@ -17,5 +18,6 @@ protobuf = { version = "2.8", features = ["bytes"] }
 thiserror = "1.0"
 tikv_util = { workspace = true }
 url = "2.0"
+uuid = { version = "0.8", features = ["v4"] }
 
 [dev-dependencies]

--- a/components/cloud/aws/src/s3.rs
+++ b/components/cloud/aws/src/s3.rs
@@ -2,17 +2,22 @@
 use std::{
     error::Error as StdError,
     io,
+    pin::Pin,
     time::{Duration, SystemTime},
 };
 
 use async_trait::async_trait;
 use cloud::{
-    blob::{none_to_empty, BlobConfig, BlobStorage, BucketConf, PutResource, StringNonEmpty},
+    blob::{
+        none_to_empty, BlobConfig, BlobObject, BlobStorage, BucketConf, DeletableStorage,
+        IterableStorage, PutResource, StringNonEmpty,
+    },
     metrics::CLOUD_REQUEST_HISTOGRAM_VEC,
 };
 use fail::fail_point;
+use futures::stream::{self, Stream};
 use futures_util::{
-    future::FutureExt,
+    future::{FutureExt, LocalBoxFuture},
     io::{AsyncRead, AsyncReadExt},
     stream::TryStreamExt,
 };
@@ -29,6 +34,7 @@ use crate::util::{self, retry_and_count};
 
 const CONNECTION_TIMEOUT: Duration = Duration::from_secs(900);
 pub const STORAGE_VENDOR_NAME_AWS: &str = "aws";
+const DEFAULT_SEP: char = '/';
 
 #[derive(Clone)]
 pub struct AccessKeyPair {
@@ -236,9 +242,20 @@ impl S3Storage {
 
     fn maybe_prefix_key(&self, key: &str) -> String {
         if let Some(prefix) = &self.config.bucket.prefix {
-            return format!("{}/{}", *prefix, key);
+            return format!("{}{}{}", *prefix, DEFAULT_SEP, key);
         }
         key.to_owned()
+    }
+
+    fn strip_prefix_if_needed(&self, key: String) -> String {
+        if let Some(prefix) = &self.config.bucket.prefix {
+            if key.starts_with(prefix.as_str()) {
+                return key[prefix.len()..]
+                    .trim_start_matches(DEFAULT_SEP)
+                    .to_owned();
+            }
+        }
+        key
     }
 
     fn get_range(&self, name: &str, range: Option<String>) -> cloud::blob::BlobStream<'_> {
@@ -595,7 +612,7 @@ impl BlobStorage for S3Storage {
     async fn put(
         &self,
         name: &str,
-        mut reader: PutResource,
+        mut reader: PutResource<'_>,
         content_length: u64,
     ) -> io::Result<()> {
         let key = self.maybe_prefix_key(name);
@@ -626,6 +643,103 @@ impl BlobStorage for S3Storage {
     }
 }
 
+struct S3PrefixIter<'cli> {
+    cli: &'cli S3Storage,
+    finished: bool,
+    cont_token: Option<String>,
+    prefix: String,
+}
+
+impl<'cli> S3PrefixIter<'cli> {
+    async fn next_page(&mut self) -> io::Result<Option<Vec<BlobObject>>> {
+        if self.finished {
+            return Ok(None);
+        }
+        let mut input = ListObjectsV2Request::default();
+        input.bucket = String::clone(&self.cli.config.bucket.bucket);
+        input.prefix = Some(self.cli.maybe_prefix_key(&self.prefix));
+        input.continuation_token = self.cont_token.clone();
+        let now = Instant::now();
+        let res = retry_and_count(
+            || self.cli.client.list_objects_v2(input.clone()),
+            "get_one_page",
+        )
+        .await
+        .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+        CLOUD_REQUEST_HISTOGRAM_VEC
+            .with_label_values(&["s3", "list_objects_v2"])
+            .observe(now.saturating_elapsed().as_secs_f64());
+
+        self.finished = !res.is_truncated.ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "no IsTruncated in response")
+        })? || res.next_continuation_token.is_none();
+        self.cont_token = res.next_continuation_token;
+        let data = res
+            .contents
+            .unwrap_or_default()
+            .into_iter()
+            .map(|data| BlobObject {
+                key: self
+                    .cli
+                    .strip_prefix_if_needed(data.key.unwrap_or_default()),
+            })
+            .collect::<Vec<_>>();
+        Ok(Some(data))
+    }
+}
+
+impl DeletableStorage for S3Storage {
+    fn delete(&self, name: &str) -> LocalBoxFuture<'_, io::Result<()>> {
+        let key = self.maybe_prefix_key(name);
+        async move {
+            let now = Instant::now();
+            let res = retry_and_count(
+                || {
+                    self.client.delete_object(DeleteObjectRequest {
+                        bucket: self.config.bucket.bucket.to_string(),
+                        key: key.clone(),
+                        ..Default::default()
+                    })
+                },
+                "delete_object",
+            )
+            .await;
+            CLOUD_REQUEST_HISTOGRAM_VEC
+                .with_label_values(&["s3", "delete_object"])
+                .observe(now.saturating_elapsed().as_secs_f64());
+            match res {
+                Ok(_) => Ok(()),
+                Err(e) => Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("failed to delete object {}", e),
+                )),
+            }
+        }
+        .boxed_local()
+    }
+}
+
+impl IterableStorage for S3Storage {
+    fn iter_prefix(
+        &self,
+        prefix: &str,
+    ) -> Pin<Box<dyn Stream<Item = std::result::Result<BlobObject, io::Error>> + '_>> {
+        let walker = S3PrefixIter {
+            cli: self,
+            finished: false,
+            cont_token: None,
+            prefix: prefix.to_owned(),
+        };
+        let s = stream::try_unfold(walker, |mut w| async move {
+            let res = w.next_page().await?;
+            io::Result::Ok(res.map(|v| (v, w)))
+        })
+        .map_ok(|data| stream::iter(data.into_iter().map(Ok)))
+        .try_flatten();
+        Box::pin(s)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::assert_matches::assert_matches;
@@ -635,6 +749,128 @@ mod tests {
     use tikv_util::stream::block_on_external_io;
 
     use super::*;
+
+    fn make_list_bucket_result(
+        name: &str,
+        pfx: &str,
+        next_cont_token: Option<&str>,
+        is_truncated: bool,
+        max_keys: u64,
+        items: impl IntoIterator<Item = String>,
+    ) -> MockRequestDispatcher {
+        let items = items.into_iter().collect::<Vec<_>>();
+        let mut s = format!(
+            r#"
+        <?xml version="1.0" encoding="UTF-8"?>
+        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+            <Name>{}</Name>
+            <Prefix>{}</Prefix>
+            <NextContinuationToken>{}</NextContinuationToken>
+            <KeyCount>{}</KeyCount>
+            <MaxKeys>{}</MaxKeys>
+            <IsTruncated>{}</IsTruncated>"#,
+            name,
+            pfx,
+            next_cont_token.unwrap_or(""),
+            items.len(),
+            max_keys,
+            is_truncated
+        );
+        for item in items {
+            s.push_str(&format!(
+                r#"
+            <Contents>
+                <Key>{}</Key>
+                <StorageClass>STANDARD</StorageClass>
+            </Contents>"#,
+                item
+            ));
+        }
+        s.push_str("\n</ListBucketResult>");
+        MockRequestDispatcher::with_status(200).with_body(&s)
+    }
+
+    #[tokio::test]
+    async fn test_list_objects() {
+        const BUCKET: &str = "breeze";
+        const PREFIX: &str = "/my/great/prefix";
+
+        let bucket_name = StringNonEmpty::required(BUCKET.to_string()).unwrap();
+        let bucket = BucketConf::default(bucket_name);
+        let mut config = Config::default(bucket);
+        let multi_part_size = 2;
+        // set multi_part_size to use upload_part function
+        config.multi_part_size = multi_part_size;
+
+        let check_cont_tok = |cont: Option<String>| {
+            move |r: &SignedRequest| {
+                assert_eq!(
+                    r.params.get("continuation-token").and_then(|v| v.as_ref()),
+                    cont.as_ref()
+                );
+            }
+        };
+
+        let files = |pfx, max| {
+            let mut i = 0;
+            std::iter::repeat_with(move || {
+                i += 1;
+                format!("{}-{}", pfx, i)
+            })
+            .take(max)
+        };
+
+        // split magic_contents into 3 parts, so we mock 5 requests here(1 begin + 3
+        // part + 1 complete)
+        let dispatcher = MultipleMockRequestDispatcher::new(vec![
+            make_list_bucket_result(BUCKET, PREFIX, Some("foo"), true, 16, files("foo", 16))
+                .with_request_checker(check_cont_tok(None)),
+            make_list_bucket_result(BUCKET, PREFIX, Some("bar"), true, 16, files("bar", 16))
+                .with_request_checker(check_cont_tok(Some("foo".to_owned()))),
+            make_list_bucket_result(BUCKET, PREFIX, None, false, 16, files("quux", 8))
+                .with_request_checker(check_cont_tok(Some("bar".to_owned()))),
+            MockRequestDispatcher::with_status(400).with_request_checker(|req| {
+                panic!("Walk haven't stopped. The last request is {:?}", req)
+            }),
+        ]);
+
+        let credentials_provider = StaticProvider::new_minimal(String::new(), String::new());
+        let s = S3Storage::new_creds_dispatcher(config, dispatcher, credentials_provider).unwrap();
+        assert_eq!(
+            s.iter_prefix(PREFIX)
+                .map_ok(|v| v.key)
+                .try_collect::<Vec<_>>()
+                .await
+                .unwrap(),
+            files("foo", 16)
+                .chain(files("bar", 16))
+                .chain(files("quux", 8))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    #[ignore]
+    fn test_somewhat() {
+        let mut bucket = BucketConf::default(StringNonEmpty::opt("astro".to_owned()).unwrap());
+        bucket.endpoint = StringNonEmpty::opt("http://10.2.7.193:9000".to_owned());
+        let s3 = Config::default(bucket);
+        let s3 = Config {
+            access_key_pair: Some(AccessKeyPair {
+                access_key: StringNonEmpty::opt("minioadmin".to_owned()).unwrap(),
+                secret_access_key: StringNonEmpty::opt("minioadmin".to_owned()).unwrap(),
+                session_token: None,
+            }),
+            force_path_style: true,
+            ..s3
+        };
+
+        let storage = S3Storage::new(s3).unwrap();
+        let s = storage.iter_prefix("tpcc-1000-incr-with-crc64/v1/backupmeta");
+        let items = block_on_external_io(TryStreamExt::try_collect::<Vec<_>>(s));
+        println!("{:?}", items);
+        println!("{}", items.unwrap().len());
+    }
 
     #[test]
     fn test_s3_get_content_md5() {

--- a/components/cloud/gcp/src/lib.rs
+++ b/components/cloud/gcp/src/lib.rs
@@ -14,9 +14,11 @@ pub use kms::GcpKms;
 pub const STORAGE_VENDOR_NAME_GCP: &str = "gcp";
 
 pub mod utils {
-    use std::future::Future;
+    use std::{future::Future, io};
 
     use cloud::metrics;
+    use hyper::{body::Bytes, Body};
+    use tame_gcs::ApiResponse;
     use tikv_util::stream::{retry_ext, RetryError, RetryExt};
     pub async fn retry<G, T, F, E>(action: G, name: &'static str) -> Result<T, E>
     where
@@ -28,5 +30,18 @@ pub mod utils {
             warn!("gcp request meet error."; "err" => ?err, "retry?" => %err.is_retryable(), "context" => %name);
             metrics::CLOUD_ERROR_VEC.with_label_values(&["gcp", name]).inc();
         })).await
+    }
+
+    pub async fn read_from_http_body<M: ApiResponse<Bytes>>(
+        b: http::Response<Body>,
+    ) -> io::Result<M> {
+        use crate::gcs::ResultExt;
+        let (headers, body) = b.into_parts();
+        let bytes = hyper::body::to_bytes(body).await.or_io_error(format_args!(
+            "cannot read bytes from http response {:?}",
+            headers
+        ))?;
+        let cached_resp = http::Response::from_parts(headers, bytes);
+        M::try_from_parts(cached_resp).or_invalid_input(format_args!("invalid response format"))
     }
 }

--- a/components/cloud/src/blob.rs
+++ b/components/cloud/src/blob.rs
@@ -1,8 +1,9 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{io, marker::Unpin, pin::Pin, task::Poll};
+use std::{fmt::Display, io, marker::Unpin, panic::Location, pin::Pin, task::Poll};
 
 use async_trait::async_trait;
+use futures::{future::LocalBoxFuture, stream::Stream};
 use futures_io::AsyncRead;
 
 pub trait BlobConfig: 'static + Send + Sync {
@@ -16,11 +17,11 @@ pub trait BlobConfig: 'static + Send + Sync {
 ///
 /// See the documentation of [external_storage::UnpinReader] for why those
 /// wrappers exists.
-pub struct PutResource(pub Box<dyn AsyncRead + Send + Unpin>);
+pub struct PutResource<'a>(pub Box<dyn AsyncRead + Send + Unpin + 'a>);
 
 pub type BlobStream<'a> = Box<dyn AsyncRead + Unpin + Send + 'a>;
 
-impl AsyncRead for PutResource {
+impl<'a> AsyncRead for PutResource<'a> {
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
@@ -30,8 +31,8 @@ impl AsyncRead for PutResource {
     }
 }
 
-impl From<Box<dyn AsyncRead + Send + Unpin>> for PutResource {
-    fn from(s: Box<dyn AsyncRead + Send + Unpin>) -> Self {
+impl<'a> From<Box<dyn AsyncRead + Send + Unpin + 'a>> for PutResource<'a> {
+    fn from(s: Box<dyn AsyncRead + Send + Unpin + 'a>) -> Self {
         Self(s)
     }
 }
@@ -43,13 +44,50 @@ pub trait BlobStorage: 'static + Send + Sync {
     fn config(&self) -> Box<dyn BlobConfig>;
 
     /// Write all contents of the read to the given path.
-    async fn put(&self, name: &str, reader: PutResource, content_length: u64) -> io::Result<()>;
+    async fn put(&self, name: &str, reader: PutResource<'_>, content_length: u64)
+    -> io::Result<()>;
 
     /// Read all contents of the given path.
     fn get(&self, name: &str) -> BlobStream<'_>;
 
     /// Read part of contents of the given path.
     fn get_part(&self, name: &str, off: u64, len: u64) -> BlobStream<'_>;
+}
+
+pub trait DeletableStorage {
+    fn delete(&self, name: &str) -> LocalBoxFuture<'_, io::Result<()>>;
+}
+
+#[track_caller]
+pub fn unimplemented() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::Unsupported,
+        format!(
+            "this method isn't supported, check more details at {:?}",
+            Location::caller()
+        ),
+    )
+}
+
+#[derive(Debug)]
+pub struct BlobObject {
+    pub key: String,
+}
+
+impl Display for BlobObject {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.key)
+    }
+}
+
+/// An storage that its content can be enumerated by prefix.
+pub trait IterableStorage {
+    /// Walk the prefix of the blob storage.
+    /// It returns the stream of items.
+    fn iter_prefix(
+        &self,
+        prefix: &str,
+    ) -> Pin<Box<dyn Stream<Item = std::result::Result<BlobObject, io::Error>> + '_>>;
 }
 
 impl BlobConfig for dyn BlobStorage {
@@ -68,7 +106,12 @@ impl BlobStorage for Box<dyn BlobStorage> {
         (**self).config()
     }
 
-    async fn put(&self, name: &str, reader: PutResource, content_length: u64) -> io::Result<()> {
+    async fn put(
+        &self,
+        name: &str,
+        reader: PutResource<'_>,
+        content_length: u64,
+    ) -> io::Result<()> {
         let fut = (**self).put(name, reader, content_length);
         fut.await
     }

--- a/components/engine_panic/src/sst.rs
+++ b/components/engine_panic/src/sst.rs
@@ -4,8 +4,8 @@ use std::{marker::PhantomData, path::PathBuf, sync::Arc};
 
 use ::encryption::DataKeyManager;
 use engine_traits::{
-    CfName, ExternalSstFileInfo, IterOptions, Iterable, Iterator, RefIterable, Result,
-    SstCompressionType, SstExt, SstReader, SstWriter, SstWriterBuilder,
+    CfName, ExternalSstFileInfo, ExternalSstFileReader, IterOptions, Iterable, Iterator,
+    RefIterable, Result, SstCompressionType, SstExt, SstReader, SstWriter, SstWriterBuilder,
 };
 
 use crate::engine::PanicEngine;
@@ -154,6 +154,12 @@ impl ExternalSstFileInfo for PanicExternalSstFileInfo {
 }
 
 pub struct PanicExternalSstFileReader;
+
+impl ExternalSstFileReader for PanicExternalSstFileReader {
+    fn reset(&mut self) -> Result<()> {
+        panic!()
+    }
+}
 
 impl std::io::Read for PanicExternalSstFileReader {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {

--- a/components/engine_traits/src/sst.rs
+++ b/components/engine_traits/src/sst.rs
@@ -1,6 +1,6 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{path::PathBuf, sync::Arc};
+use std::{path::PathBuf, str::FromStr, sync::Arc};
 
 use encryption::DataKeyManager;
 use kvproto::import_sstpb::SstMeta;
@@ -30,7 +30,7 @@ pub trait SstReader: RefIterable + Sized + Send {
 /// SstWriter is used to create sst files that can be added to database later.
 pub trait SstWriter: Send {
     type ExternalSstFileInfo: ExternalSstFileInfo;
-    type ExternalSstFileReader: std::io::Read + Send;
+    type ExternalSstFileReader: ExternalSstFileReader;
 
     /// Add key, value to currently opened file
     /// REQUIRES: key is after any previously added key according to comparator.
@@ -50,12 +50,29 @@ pub trait SstWriter: Send {
     fn finish_read(self) -> Result<(Self::ExternalSstFileInfo, Self::ExternalSstFileReader)>;
 }
 
+pub trait ExternalSstFileReader: std::io::Read + Send {
+    fn reset(&mut self) -> Result<()>;
+}
+
 // compression type used for write sst file
 #[derive(Copy, Clone)]
 pub enum SstCompressionType {
     Lz4,
     Snappy,
     Zstd,
+}
+
+impl FromStr for SstCompressionType {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "lz4" => Ok(Self::Lz4),
+            "snappy" => Ok(Self::Snappy),
+            "zstd" => Ok(Self::Zstd),
+            otherwise => Err(format!("{} isn't a valid compression method", otherwise)),
+        }
+    }
 }
 
 /// A builder builds a SstWriter.

--- a/components/external_storage/Cargo.toml
+++ b/components/external_storage/Cargo.toml
@@ -10,6 +10,7 @@ async-compression = { version = "0.4.12", features = ["futures-io", "zstd"] }
 async-trait = "0.1"
 aws = { workspace = true }
 azure = { workspace = true }
+chrono = { workspace = true }
 cloud = { workspace = true }
 encryption = { workspace = true }
 file_system = { workspace = true }
@@ -22,6 +23,8 @@ lazy_static = "1.3"
 openssl = { workspace = true }
 prometheus = { version = "0.13", default-features = false, features = ["nightly", "push"] }
 rand = "0.8"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 slog = { workspace = true }
 # better to not use slog-global, but pass in the logger
 slog-global = { workspace = true }
@@ -30,6 +33,8 @@ tikv_util = { workspace = true }
 tokio = { version = "1.5", features = ["time", "fs", "process"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 url = "2.0"
+uuid = { version = "0.8", features = ["v4", "serde"] }
+walkdir = "2"
 
 [dev-dependencies]
 rust-ini = "0.14.0"

--- a/components/external_storage/src/locking.rs
+++ b/components/external_storage/src/locking.rs
@@ -1,0 +1,416 @@
+//! This mod allows you to create a "lock" in the external storage.
+//!
+//! In a storage that PUT and LIST is strong consistent (both AWS S3, GCP GCS
+//! supports this), an atomic lock can be reterived: that is, if there are many
+//! clients racing for locking one file, at most one of them can eventually
+//! reterive the lock.
+//!
+//! The atomic was implmentated by a "Write-and-verify" protocol, that is:
+//!
+//! - Before writing a file `f`, we will write an intention file
+//!   `f.INTENT.{txn_id}`. Where `txn_id` is an unique ID generated in each
+//!   write.
+//! - Then, it double checks whether there are other intention files. If there
+//!   were, there must be other clients trying lock this file, we will delete
+//!   our intention file and return failure now.
+//!
+//! For now, there isn't internal retry when failed to locking a file. We may
+//! encounter live locks when there are too many clients racing for the same
+//! lock.
+
+use std::io;
+
+use chrono::Utc;
+use futures_util::{
+    future::{ok, FutureExt, LocalBoxFuture},
+    io::AsyncReadExt,
+    stream::TryStreamExt,
+};
+use tikv_util::sys::{
+    hostname,
+    thread::{process_id, Pid},
+};
+use uuid::Uuid;
+
+use crate::{ExternalStorage, UnpinReader};
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct LockMeta {
+    locked_at: chrono::DateTime<Utc>,
+    locker_host: String,
+    locker_pid: Pid,
+    txn_id: Uuid,
+    hint: String,
+}
+
+impl LockMeta {
+    fn new(txn_id: Uuid, hint: String) -> Self {
+        Self {
+            locked_at: Utc::now(),
+            locker_host: hostname().unwrap_or_else(|| "an_unknown_tikv_node".to_owned()),
+            locker_pid: process_id(),
+            txn_id,
+            hint,
+        }
+    }
+
+    fn to_json(&self) -> io::Result<Vec<u8>> {
+        serde_json::ser::to_vec(self).map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
+    }
+}
+
+#[derive(Debug)]
+pub struct RemoteLock {
+    txn_id: uuid::Uuid,
+    path: String,
+}
+
+impl RemoteLock {
+    /// Unlock this lock.
+    ///
+    /// If the lock was modified, this may return an error.
+    pub async fn unlock(&self, st: &dyn ExternalStorage) -> io::Result<()> {
+        let mut buf = vec![];
+        st.read(&self.path).read_to_end(&mut buf).await?;
+        let meta = serde_json::from_slice::<LockMeta>(&buf)?;
+        if meta.txn_id != self.txn_id {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "TXN ID mismatch, remote {} ours {}",
+                    meta.txn_id, self.txn_id
+                ),
+            ));
+        }
+
+        st.delete(&self.path).await
+    }
+}
+
+/// The [`ExclusiveWriteTxn`] instance for putting a read lock for a path.
+struct PutRLock {
+    basic_path: String,
+    lock_path: String,
+    hint: String,
+}
+
+impl PutRLock {
+    fn new(path: &str, hint: String) -> Self {
+        Self {
+            basic_path: path.to_string(),
+            lock_path: format!("{}.READ.{:016x}", path, rand::random::<u64>()),
+            hint,
+        }
+    }
+}
+
+impl ExclusiveWriteTxn for PutRLock {
+    fn path(&self) -> &str {
+        &self.lock_path
+    }
+
+    fn content(&self, cx: ExclusiveWriteCtx<'_>) -> io::Result<Vec<u8>> {
+        LockMeta::new(cx.txn_id(), self.hint.clone()).to_json()
+    }
+
+    fn verify<'cx: 'ret, 's: 'ret, 'ret>(
+        &'s self,
+        cx: ExclusiveWriteCtx<'cx>,
+    ) -> LocalBoxFuture<'ret, io::Result<()>> {
+        // We need capture `cx` here, or rustc complains that we are returning a future
+        // reference to a local variable. (Yes indeed.)
+        async move {
+            cx.check_files_of_prefix(&format!("{}.WRIT", self.basic_path), requirements::nothing)
+                .await
+        }
+        .boxed_local()
+    }
+}
+
+/// The [`ExclusiveWriteTxn`] instance for putting a write lock for a path.
+struct PutWLock {
+    basic_path: String,
+    lock_path: String,
+    hint: String,
+}
+
+impl PutWLock {
+    fn new(path: &str, hint: String) -> Self {
+        Self {
+            basic_path: path.to_owned(),
+            lock_path: format!("{}.WRIT", path),
+            hint,
+        }
+    }
+}
+
+impl ExclusiveWriteTxn for PutWLock {
+    fn path(&self) -> &str {
+        &self.lock_path
+    }
+
+    fn content(&self, cx: ExclusiveWriteCtx<'_>) -> io::Result<Vec<u8>> {
+        LockMeta::new(cx.txn_id(), self.hint.clone()).to_json()
+    }
+
+    fn verify<'cx: 'ret, 's: 'ret, 'ret>(
+        &'s self,
+        cx: ExclusiveWriteCtx<'cx>,
+    ) -> LocalBoxFuture<'ret, io::Result<()>> {
+        async move {
+            cx.check_files_of_prefix(&self.basic_path, requirements::only(&cx.intent_file_name()))
+                .await
+        }
+        .boxed_local()
+    }
+}
+
+/// LockExt allows you to create lock at some path.
+#[allow(async_fn_in_trait)]
+pub trait LockExt {
+    /// Create a read lock at the given path.
+    /// If there are write locks at that path, this will fail.
+    ///
+    /// The hint will be saved as readable text in the lock file.
+    /// Will generate a lock file at `$path.READ.{random_hex_u64}`.
+    async fn lock_for_read(&self, path: &str, hint: String) -> io::Result<RemoteLock>;
+
+    /// Create a write lock at the given path.
+    /// If there is any read lock or write lock at that path, this will fail.
+    ///
+    /// The hint will be saved as readable text in the lock file.
+    /// Will generate a lock file at `$path.READ.WRIT`.
+    async fn lock_for_write(&self, path: &str, hint: String) -> io::Result<RemoteLock>;
+}
+
+impl<S: ExclusiveWriteExt + ?Sized> LockExt for S {
+    async fn lock_for_read(&self, path: &str, hint: String) -> io::Result<RemoteLock> {
+        let w = PutRLock::new(path, hint);
+        let path = w.lock_path.clone();
+        let id = self.exclusive_write(&w).await?;
+        Ok(RemoteLock { txn_id: id, path })
+    }
+
+    async fn lock_for_write(&self, path: &str, hint: String) -> io::Result<RemoteLock> {
+        let w = PutWLock::new(path, hint);
+        let path = w.lock_path.clone();
+        let id = self.exclusive_write(&w).await?;
+        Ok(RemoteLock { txn_id: id, path })
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct ExclusiveWriteCtx<'a> {
+    file: &'a str,
+    txn_id: uuid::Uuid,
+    storage: &'a dyn ExternalStorage,
+}
+
+pub mod requirements {
+    use std::io;
+
+    pub fn only(expect: &str) -> impl (Fn(&str) -> io::Result<()>) + '_ {
+        move |v| {
+            if v != expect {
+                Err(io::Error::new(
+                    io::ErrorKind::AlreadyExists,
+                    format!("there is a file {}", v),
+                ))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    pub fn nothing(v: &str) -> io::Result<()> {
+        Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            format!("there is a file {}", v),
+        ))
+    }
+}
+
+impl<'a> ExclusiveWriteCtx<'a> {
+    pub fn txn_id(&self) -> uuid::Uuid {
+        self.txn_id
+    }
+
+    pub async fn check_files_of_prefix(
+        &self,
+        prefix: &str,
+        mut requires: impl FnMut(&str) -> io::Result<()>,
+    ) -> io::Result<()> {
+        self.storage
+            .iter_prefix(prefix)
+            .try_for_each(|v| futures::future::ready(requires(&v.key)))
+            .await
+    }
+
+    pub async fn verify_only_my_intent(&self) -> io::Result<()> {
+        self.check_files_of_prefix(self.file, requirements::only(&self.intent_file_name()))
+            .await
+    }
+
+    pub fn intent_file_name(&self) -> String {
+        format!("{}.INTENT.{:032X}", self.file, self.txn_id)
+    }
+}
+
+#[allow(async_fn_in_trait)]
+pub trait ExclusiveWriteTxn {
+    fn path(&self) -> &str;
+    fn content(&self, cx: ExclusiveWriteCtx<'_>) -> io::Result<Vec<u8>>;
+    fn verify<'cx: 'ret, 's: 'ret, 'ret>(
+        &'s self,
+        _cx: ExclusiveWriteCtx<'cx>,
+    ) -> LocalBoxFuture<'ret, io::Result<()>> {
+        ok(()).boxed_local()
+    }
+}
+
+/// An storage that supports atomically write a file if the file not exists.
+pub trait ExclusiveWriteExt {
+    fn exclusive_write<'s: 'ret, 'txn: 'ret, 'ret>(
+        &'s self,
+        w: &'txn dyn ExclusiveWriteTxn,
+    ) -> LocalBoxFuture<'ret, io::Result<uuid::Uuid>>;
+}
+
+// In fact this can be implemented for all types that are `ExternalStorage`.
+//
+// But we cannot replace this implementation with:
+// ```no-run
+// impl<T: ExternalStorage + ?Sized> ExclusiveWriteExt for T
+// ```
+// Because for some T is a blob storage, &T isn't a blob storage: which means,
+// we cannot downcast T (i.e. we have a &T, but we cannot cast it to `&dyn
+// ExternalStorage`, even T itself is `impl ExternalStorage`)! So we cannot
+// construct the `ExclusiveWriteCtx` here.
+//
+// We may remove the `?Sized` hence &T can be dereferenced and then downcasted.
+// But here `dyn ExternalStorage`, trait object of our universal storage
+// interface, isn't a [`ExclusiveWriteExt`] more -- it is simply `!Sized`.
+//
+// Writing a blank implementation for the types is also not helpful, because
+// `ExternalStorage` requires `'static`... (Which was required by
+// `async_trait`...)
+//
+// Can we make the `ExclusiveWriteCtx` contains a `&T` instead of a `&dyn ...`?
+// Perhaps. I have tried it. Eventually blocked by something like "cyclic
+// dependiencies" in query system. I have no idea how to solve it. I gave up.
+//
+// Hence, as a workaround, we directly implement this extension for the trait
+// object of the universal external storage interface.
+impl ExclusiveWriteExt for dyn ExternalStorage {
+    fn exclusive_write<'s: 'ret, 'txn: 'ret, 'ret>(
+        &'s self,
+        w: &'txn dyn ExclusiveWriteTxn,
+    ) -> LocalBoxFuture<'ret, io::Result<uuid::Uuid>> {
+        async move {
+            let txn_id = Uuid::new_v4();
+            let cx = ExclusiveWriteCtx {
+                file: w.path(),
+                txn_id,
+                storage: self,
+            };
+            futures::future::try_join(cx.verify_only_my_intent(), w.verify(cx)).await?;
+            let target = cx.intent_file_name();
+            self.write(&target, UnpinReader(Box::new(futures::io::empty())), 0)
+                .await?;
+
+            let result = async {
+                futures::future::try_join(cx.verify_only_my_intent(), w.verify(cx)).await?;
+                let content = w.content(cx)?;
+                self.write(
+                    w.path(),
+                    UnpinReader(Box::new(futures::io::Cursor::new(&content))),
+                    content.len() as _,
+                )
+                .await?;
+                io::Result::Ok(txn_id)
+            }
+            .await;
+
+            let _ = self.delete(&target).await;
+            result
+        }
+        .boxed_local()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use uuid::Uuid;
+
+    use super::LockExt;
+    use crate::{ExternalStorage, LocalStorage};
+
+    #[tokio::test]
+    async fn test_read_blocks_write() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path();
+        let ls = LocalStorage::new(path).unwrap();
+        let ls = &ls as &dyn ExternalStorage;
+
+        let res = ls
+            .lock_for_read("my_lock", String::from("testing lock"))
+            .await;
+        let l1 = res.unwrap();
+        let res = ls
+            .lock_for_read("my_lock", String::from("testing lock"))
+            .await;
+        let l2 = res.unwrap();
+
+        let res = ls
+            .lock_for_write("my_lock", String::from("testing lock"))
+            .await;
+        res.unwrap_err();
+
+        l1.unlock(ls).await.unwrap();
+        l2.unlock(ls).await.unwrap();
+        let res = ls
+            .lock_for_write("my_lock", String::from("testing lock"))
+            .await;
+        res.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_write_blocks_read() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path();
+        let ls = LocalStorage::new(path).unwrap();
+        let ls = &ls as &dyn ExternalStorage;
+
+        let res = ls
+            .lock_for_write("my_lock", String::from("testing lock"))
+            .await;
+        let l1 = res.unwrap();
+
+        let res = ls
+            .lock_for_read("my_lock", String::from("testing lock"))
+            .await;
+        res.unwrap_err();
+
+        l1.unlock(ls).await.unwrap();
+        let res = ls
+            .lock_for_read("my_lock", String::from("testing lock"))
+            .await;
+        res.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_dont_unlock_others() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path();
+        let ls = LocalStorage::new(path).unwrap();
+        let ls = &ls as &dyn ExternalStorage;
+
+        let mut l1 = ls
+            .lock_for_read("my_lock", String::from("test"))
+            .await
+            .unwrap();
+        l1.txn_id = Uuid::new_v4();
+
+        l1.unlock(ls).await.unwrap_err();
+    }
+}

--- a/components/tikv_util/src/stream.rs
+++ b/components/tikv_util/src/stream.rs
@@ -14,9 +14,11 @@ use bytes::Bytes;
 use futures::stream::{self, Stream};
 use futures_util::io::AsyncRead;
 use http::status::StatusCode;
-use rand::{thread_rng, Rng};
 use rusoto_core::{request::HttpDispatchError, RusotoError};
-use tokio::{runtime::Builder, time::sleep};
+use tokio::runtime::Builder;
+
+const MAX_RETRY_DELAY: Duration = Duration::from_secs(32);
+const MAX_RETRY_TIMES: usize = 14;
 
 /// Wrapper of an `AsyncRead` instance, exposed as a `Sync` `Stream` of `Bytes`.
 pub struct AsyncReadAsSyncStreamOfBytes<R> {
@@ -107,10 +109,9 @@ where
 
 /// The extra configuration for retry.
 pub struct RetryExt<E> {
-    // NOTE: we can move `MAX_RETRY_DELAY` and `MAX_RETRY_TIMES`
-    // to here, for making the retry more configurable.
-    // However those are constant for now and no place for configure them.
-    on_failure: Option<Box<dyn FnMut(&E) + Send + Sync + 'static>>,
+    pub on_failure: Option<Box<dyn FnMut(&E) + Send + Sync + 'static>>,
+    pub max_retry_times: usize,
+    pub max_retry_delay: Duration,
 }
 
 impl<E> RetryExt<E> {
@@ -122,6 +123,18 @@ impl<E> RetryExt<E> {
         self.on_failure = Some(Box::new(f));
         self
     }
+
+    /// Attaches the maximum retry times to the ext.
+    pub fn with_max_retry_times(mut self, max_retry_times: usize) -> Self {
+        self.max_retry_times = max_retry_times;
+        self
+    }
+
+    /// Attaches the maximum retry delay to the ext.
+    pub fn with_max_retry_delay(mut self, max_retry_delay: Duration) -> Self {
+        self.max_retry_delay = max_retry_delay;
+        self
+    }
 }
 
 // If we use the default derive macro, it would complain that `E` isn't
@@ -130,8 +143,96 @@ impl<E> Default for RetryExt<E> {
     fn default() -> Self {
         Self {
             on_failure: Default::default(),
+            max_retry_times: MAX_RETRY_TIMES,
+            max_retry_delay: MAX_RETRY_DELAY,
         }
     }
+}
+
+#[doc(hidden)]
+pub mod __macro_helper {
+    #[doc(hidden)]
+    pub use rand::thread_rng as __thread_rng;
+    #[doc(hidden)]
+    pub use rand::Rng as __rand_Rng;
+    #[doc(hidden)]
+    pub use tokio::time::sleep as __tokio_sleep;
+}
+
+/// JustRetry wraps an error to [`RetryError`] which will always be retryed.
+#[derive(Debug, derive_more::Deref, derive_more::DerefMut, derive_more::Display)]
+pub struct JustRetry<E>(pub E);
+
+impl<E> RetryError for JustRetry<E> {
+    fn is_retryable(&self) -> bool {
+        true
+    }
+}
+
+/// retry_expr! make a future that evaluates the expression and retry when it
+/// evaluated to an `Err`. The expression will be evaluated multi-times.
+///
+/// This would be useful when your action cannot be sealed into a `FnMut`, say,
+/// the action captures some local variables, rustc will complain that `FnMut`
+/// cannot return reference to things it captures.
+///
+/// When possible, prefer using `retry_ext`, which is a normal function. Normal
+/// functions are more friendly to static analysis.
+#[macro_export]
+macro_rules! retry_expr {
+    ($action:expr) => {
+        $crate::retry_expr!($action, $crate::stream::RetryExt::default())
+    };
+    ($action:expr, $ext:expr) => {
+        async {
+            use $crate::stream::{RetryError, __macro_helper};
+
+            let mut ext: $crate::stream::RetryExt<_> = $ext;
+            let max_retry_times = ext.max_retry_times;
+            let mut retry_wait_dur = ::std::time::Duration::from_secs(1);
+            let mut retry_time = 0;
+            loop {
+                match { $action }.await {
+                    Ok(r) => return Ok(r),
+                    Err(e) => {
+                        if let Some(ref mut f) = ext.on_failure {
+                            f(&e);
+                        }
+                        if !RetryError::is_retryable(&e) {
+                            return Err(e);
+                        }
+                        retry_time += 1;
+                        if retry_time > max_retry_times {
+                            return Err(e);
+                        }
+                    }
+                }
+                use __macro_helper::__rand_Rng;
+                let backoff = __macro_helper::__thread_rng().gen_range(0..1000);
+                __macro_helper::__tokio_sleep(
+                    retry_wait_dur + ::std::time::Duration::from_millis(backoff),
+                )
+                .await;
+                retry_wait_dur = ext.max_retry_delay.min(retry_wait_dur * 2);
+            }
+        }
+    };
+}
+
+/// Retires a future execution. Comparing to `retry`, this version allows more
+/// configurations.
+pub async fn retry_all_ext<'a, G, T, F, E>(
+    mut action: G,
+    ext: RetryExt<JustRetry<E>>,
+) -> Result<T, E>
+where
+    G: FnMut() -> F,
+    F: Future<Output = Result<T, E>>,
+{
+    use futures::TryFutureExt;
+    retry_expr!(action().map_err(JustRetry), ext)
+        .await
+        .map_err(|err| err.0)
 }
 
 /// Retires a future execution. Comparing to `retry`, this version allows more
@@ -142,38 +243,14 @@ where
     F: Future<Output = Result<T, E>>,
     E: RetryError,
 {
-    const MAX_RETRY_DELAY: Duration = Duration::from_secs(32);
-    const MAX_RETRY_TIMES: usize = 14;
-    let max_retry_times = (|| {
+    ext.max_retry_times = (|| {
         fail::fail_point!("retry_count", |t| t
             .and_then(|v| v.parse::<usize>().ok())
-            .unwrap_or(MAX_RETRY_TIMES));
-        MAX_RETRY_TIMES
+            .unwrap_or(ext.max_retry_times));
+        ext.max_retry_times
     })();
 
-    let mut retry_wait_dur = Duration::from_secs(1);
-    let mut retry_time = 0;
-    loop {
-        match action().await {
-            Ok(r) => return Ok(r),
-            Err(e) => {
-                if let Some(ref mut f) = ext.on_failure {
-                    f(&e);
-                }
-                if !e.is_retryable() {
-                    return Err(e);
-                }
-                retry_time += 1;
-                if retry_time > max_retry_times {
-                    return Err(e);
-                }
-            }
-        }
-
-        let backoff = thread_rng().gen_range(0..1000);
-        sleep(retry_wait_dur + Duration::from_millis(backoff)).await;
-        retry_wait_dur = MAX_RETRY_DELAY.min(retry_wait_dur * 2);
-    }
+    retry_expr!(action(), ext).await
 }
 
 // Return an error if the future does not finish by the timeout


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #17284

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
- Added `WalkBlobStorage` and implemented it for S3 and GCS.
- Allow the `Read` of the `write` call to borrow local variables.
- Added a new macro `retry_expr!` for retrying.
- Added `Reset` for the reader that generated by `SstWriter`.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
The `WalkBlobStorage` was tested by the following code:
```rust
#[test]
#[ignore]
fn test_somewhat() {
    let mut bucket = BucketConf::default(StringNonEmpty::opt("astro".to_owned()).unwrap());
    bucket.endpoint = StringNonEmpty::opt("http://minio:9000/".to_owned());
    let s3 = Config::default(bucket);
    let s3 = Config {
        access_key_pair: Some(AccessKeyPair {
            access_key: StringNonEmpty::opt("minioadmin".to_owned()).unwrap(),
            secret_access_key: StringNonEmpty::opt("minioadmin".to_owned()).unwrap(),
            session_token: None,
        }),
        force_path_style: true,
        ..s3
    };

    let storage = S3Storage::new(s3).unwrap();
    let s = storage.walk("tpcc-1000-incr-with-crc64/v1/backupmeta");
    let items = block_on_external_io(TryStreamExt::try_collect::<Vec<_>>(s));
    println!("{:?}", items);
    println!("{}", items.unwrap().len());
}
```

The GCP walk implementation was tested by:
```rust
#[tokio::test]
#[ignore = "manual test"]
async fn gcloud() {
    let mut backend = StorageBackend::new();
    let mut gcs = Gcs::new();
    gcs.bucket = "br-datasets".to_owned();
    gcs.prefix = "pitr-compaction-test/log".to_owned();
    gcs.credentials_blob = String::from_utf8(
        std::fs::read("/root/.config/gcloud/application_default_credentials.json").unwrap(),
    )
    .unwrap();
    backend.set_gcs(gcs);
    let storage =
        external_storage::create_full_featured_storage(&backend, BackendConfig::default()).unwrap();

    let now = Instant::now();
    let mut ext = LoadFromExt::default();
    ext.max_concurrent_fetch = 128;
    let meta = StreamyMetaStorage::load_from_ext(storage.as_ref(), ext);
    let stream = meta.flat_map(|file| match file {
        Ok(file) => stream::iter(file.into_logs()).map(Ok).left_stream(),
        Err(err) => stream::once(futures::future::err(err)).right_stream(),
    });
    let mut coll = CollectSubcompaction::new(
        stream,
        CollectSubcompactionConfig {
            compact_from_ts: 0,
            compact_to_ts: u64::MAX,
            compaction_size_threshold: ReadableSize::mb(128).0,
        },
    );
    let compaction = coll.try_next().await;
    println!("{:?}", compaction);
    println!("{:?}", now.elapsed());
    let c_ext = SubcompactExt {
        max_load_concurrency: 32,
        ..Default::default()
    };
    drop(coll);
    let arc_store: Arc<dyn FullFeaturedStorage> = Arc::from(storage);
    let compact_worker =
        SubcompactionExec::<RocksEngine>::default_config(Arc::clone(&arc_store) as _);
    let result = compact_worker
        .run(compaction.unwrap().unwrap(), c_ext)
        .await
        .unwrap();
    println!("{:?}\n{:?}", result.load_stat, result.compact_stat);
}
```

- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
