### PR TITLE
Add Vector data type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2848,7 +2848,7 @@ dependencies = [
  "futures 0.3.15",
  "grpcio",
  "protobuf",
- "protobuf-build",
+ "protobuf-build 0.15.1",
  "raft-proto",
 ]
 
@@ -4070,6 +4070,18 @@ dependencies = [
 
 [[package]]
 name = "protobuf-build"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2be70fa994657539e3c872cc54363c9bf28b0d7a7f774df70e9fd760df3bc4"
+dependencies = [
+ "bitflags 1.3.2",
+ "protobuf",
+ "protobuf-codegen",
+ "regex",
+]
+
+[[package]]
+name = "protobuf-build"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c852d9625b912c3e50480cdc701f60f49890b5d7ad46198dd583600f15e7c6ec"
@@ -4210,7 +4222,7 @@ source = "git+https://github.com/tikv/raft-rs?branch=master#a76fb6ef2cbd002ec10d
 dependencies = [
  "bytes",
  "protobuf",
- "protobuf-build",
+ "protobuf-build 0.15.1",
 ]
 
 [[package]]
@@ -6856,12 +6868,12 @@ dependencies = [
 [[package]]
 name = "tipb"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/tipb.git#87f5b80908ab561fb7875c88114488cad15727b1"
+source = "git+https://github.com/pingcap/tipb.git#955fbdc879517f16b7a2f5967f143b92a6ab03dd"
 dependencies = [
  "futures 0.3.15",
  "grpcio",
  "protobuf",
- "protobuf-build",
+ "protobuf-build 0.13.0",
 ]
 
 [[package]]

--- a/components/tidb_query_aggr/src/impl_first.rs
+++ b/components/tidb_query_aggr/src/impl_first.rs
@@ -62,6 +62,7 @@ impl super::AggrDefinitionParser for AggrFnDefinitionParserFirst {
                 Bytes => BytesRef<'static>,
                 Enum => EnumRef<'static>,
                 Set => SetRef<'static>,
+                VectorFloat32 => VectorFloat32Ref<'static>,
             ],
             match eval_type {
                 EvalType::TT => Ok(Box::new(AggrFnFirst::<TT>::new())),

--- a/components/tidb_query_aggr/src/impl_max_min.rs
+++ b/components/tidb_query_aggr/src/impl_max_min.rs
@@ -92,6 +92,7 @@ impl<E: Extremum> super::AggrDefinitionParser for AggrFnDefinitionParserExtremum
                 Decimal => &'static Decimal,
                 DateTime => &'static DateTime,
                 Json => JsonRef<'static>,
+                VectorFloat32 => VectorFloat32Ref<'static>,
             ],
             match eval_type {
                 EvalType::T => Ok(Box::new(AggFnExtremum::<T, E>::new())),

--- a/components/tidb_query_aggr/src/lib.rs
+++ b/components/tidb_query_aggr/src/lib.rs
@@ -76,6 +76,7 @@ pub trait AggrFunctionState:
     + AggrFunctionStateUpdatePartial<JsonRef<'static>>
     + AggrFunctionStateUpdatePartial<EnumRef<'static>>
     + AggrFunctionStateUpdatePartial<SetRef<'static>>
+    + AggrFunctionStateUpdatePartial<VectorFloat32Ref<'static>>
 {
     // TODO: A better implementation is to specialize different push result targets.
     // However current aggregation executor cannot utilize it.

--- a/components/tidb_query_datatype/src/codec/data_type/chunked_vec_vector_float32.rs
+++ b/components/tidb_query_datatype/src/codec/data_type/chunked_vec_vector_float32.rs
@@ -1,0 +1,135 @@
+// Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
+
+use super::{
+    bit_vec::BitVec, ChunkRef, ChunkedVec, UnsafeRefInto, VectorFloat32, VectorFloat32Ref,
+};
+use crate::{
+    codec::mysql::{VectorFloat32Decoder, VectorFloat32Encoder},
+    impl_chunked_vec_common,
+};
+
+/// A vector storing `Option<VectorFloat32>` with a compact layout.
+///
+/// Inside `ChunkedVecVectorFloat32`, `bitmap` indicates if an element at given
+/// index is null, and `data` stores actual data. VectorFloat32 data are stored
+/// adjacent to each other in `data`. If element at a given index is null, then
+/// it takes no space in `data`. Otherwise, a variable size VectorFloat32 data
+/// is stored in `data`, and `var_offset` indicates the starting position of
+/// each element.
+#[derive(Debug, PartialEq, Clone)]
+pub struct ChunkedVecVectorFloat32 {
+    data: Vec<u8>,
+    bitmap: BitVec,
+    length: usize,
+    var_offset: Vec<usize>,
+}
+
+impl ChunkedVecVectorFloat32 {
+    #[inline]
+    pub fn get(&self, idx: usize) -> Option<VectorFloat32Ref<'_>> {
+        assert!(idx < self.len());
+        if self.bitmap.get(idx) {
+            let mut sliced_data = &self.data[self.var_offset[idx]..self.var_offset[idx + 1]];
+            let v: VectorFloat32Ref<'_> = sliced_data.read_vector_float32_ref().unwrap();
+            unsafe {
+                let v_with_static_lifetime = v.unsafe_into();
+                Some(v_with_static_lifetime)
+            }
+        } else {
+            None
+        }
+    }
+}
+
+impl ChunkedVec<VectorFloat32> for ChunkedVecVectorFloat32 {
+    impl_chunked_vec_common! { VectorFloat32 }
+
+    fn with_capacity(capacity: usize) -> Self {
+        Self {
+            data: Vec::with_capacity(capacity),
+            bitmap: BitVec::with_capacity(capacity),
+            var_offset: vec![0],
+            length: 0,
+        }
+    }
+
+    #[inline]
+    fn push_data(&mut self, value: VectorFloat32) {
+        self.bitmap.push(true);
+        self.data.write_vector_float32(value.as_ref()).unwrap();
+        self.var_offset.push(self.data.len());
+        self.length += 1;
+    }
+
+    #[inline]
+    fn push_null(&mut self) {
+        self.bitmap.push(false);
+        self.var_offset.push(self.data.len());
+        self.length += 1;
+    }
+
+    fn len(&self) -> usize {
+        self.length
+    }
+
+    fn truncate(&mut self, len: usize) {
+        if len < self.len() {
+            self.data.truncate(self.var_offset[len]);
+            self.bitmap.truncate(len);
+            self.var_offset.truncate(len + 1);
+            self.length = len;
+        }
+    }
+
+    fn capacity(&self) -> usize {
+        self.data.capacity().max(self.length)
+    }
+
+    fn append(&mut self, other: &mut Self) {
+        self.data.append(&mut other.data);
+        self.bitmap.append(&mut other.bitmap);
+        let var_offset_last = *self.var_offset.last().unwrap();
+        for i in 1..other.var_offset.len() {
+            self.var_offset.push(other.var_offset[i] + var_offset_last);
+        }
+        self.length += other.length;
+        other.var_offset = vec![0];
+        other.length = 0;
+    }
+
+    fn to_vec(&self) -> Vec<Option<VectorFloat32>> {
+        let mut x = Vec::with_capacity(self.len());
+        for i in 0..self.len() {
+            x.push(self.get(i).map(|x| x.to_owned()));
+        }
+        x
+    }
+}
+
+impl<'a> ChunkRef<'a, VectorFloat32Ref<'a>> for &'a ChunkedVecVectorFloat32 {
+    #[inline]
+    fn get_option_ref(self, idx: usize) -> Option<VectorFloat32Ref<'a>> {
+        self.get(idx)
+    }
+
+    fn get_bit_vec(self) -> &'a BitVec {
+        &self.bitmap
+    }
+
+    #[inline]
+    fn phantom_data(self) -> Option<VectorFloat32Ref<'a>> {
+        None
+    }
+}
+
+impl From<Vec<Option<VectorFloat32>>> for ChunkedVecVectorFloat32 {
+    fn from(v: Vec<Option<VectorFloat32>>) -> ChunkedVecVectorFloat32 {
+        ChunkedVecVectorFloat32::from_vec(v)
+    }
+}
+
+impl<'a> UnsafeRefInto<&'static ChunkedVecVectorFloat32> for &'a ChunkedVecVectorFloat32 {
+    unsafe fn unsafe_into(self) -> &'static ChunkedVecVectorFloat32 {
+        std::mem::transmute(self)
+    }
+}

--- a/components/tidb_query_datatype/src/codec/data_type/mod.rs
+++ b/components/tidb_query_datatype/src/codec/data_type/mod.rs
@@ -7,6 +7,7 @@ mod chunked_vec_enum;
 mod chunked_vec_json;
 mod chunked_vec_set;
 mod chunked_vec_sized;
+mod chunked_vec_vector_float32;
 mod logical_rows;
 mod scalar;
 mod vector;
@@ -17,10 +18,10 @@ pub use logical_rows::{LogicalRows, BATCH_MAX_SIZE, IDENTICAL_LOGICAL_ROWS};
 macro_rules! match_template_evaltype {
     ($t:tt, $($tail:tt)*) => {{
         #[allow(unused_imports)]
-        use $crate::codec::data_type::{Int, Real, Decimal, Bytes, DateTime, Duration, Json, Set, Enum};
+        use $crate::codec::data_type::{Int, Real, Decimal, Bytes, DateTime, Duration, Json, Set, Enum, VectorFloat32};
 
         match_template::match_template! {
-            $t = [Int, Real, Decimal, Bytes, DateTime, Duration, Json, Set, Enum],
+            $t = [Int, Real, Decimal, Bytes, DateTime, Duration, Json, Set, Enum, VectorFloat32],
             $($tail)*
         }}
     }
@@ -38,6 +39,7 @@ pub use chunked_vec_enum::ChunkedVecEnum;
 pub use chunked_vec_json::ChunkedVecJson;
 pub use chunked_vec_set::ChunkedVecSet;
 pub use chunked_vec_sized::ChunkedVecSized;
+pub use chunked_vec_vector_float32::ChunkedVecVectorFloat32;
 
 // Dynamic eval types.
 pub use self::{
@@ -47,6 +49,7 @@ pub use self::{
 use super::Result;
 pub use crate::codec::mysql::{
     json::JsonRef, Decimal, Duration, Enum, EnumRef, Json, JsonType, Set, SetRef, Time as DateTime,
+    VectorFloat32, VectorFloat32Ref,
 };
 use crate::{codec::convert::ConvertTo, expr::EvalContext, EvalType};
 
@@ -104,9 +107,21 @@ where
     }
 }
 
+impl AsMySqlBool for VectorFloat32 {
+    fn as_mysql_bool(&self, _context: &mut EvalContext) -> Result<bool> {
+        Ok(!self.as_ref().is_empty())
+    }
+}
+
 impl<'a> AsMySqlBool for JsonRef<'a> {
     fn as_mysql_bool(&self, _context: &mut EvalContext) -> Result<bool> {
         Ok(!self.is_zero())
+    }
+}
+
+impl<'a> AsMySqlBool for VectorFloat32Ref<'a> {
+    fn as_mysql_bool(&self, _context: &mut EvalContext) -> Result<bool> {
+        Ok(!self.is_empty())
     }
 }
 
@@ -132,6 +147,15 @@ impl<'a> AsMySqlBool for Option<BytesRef<'a>> {
 }
 
 impl<'a> AsMySqlBool for Option<JsonRef<'a>> {
+    fn as_mysql_bool(&self, context: &mut EvalContext) -> Result<bool> {
+        match self {
+            None => Ok(false),
+            Some(ref v) => v.as_mysql_bool(context),
+        }
+    }
+}
+
+impl<'a> AsMySqlBool for Option<VectorFloat32Ref<'a>> {
     fn as_mysql_bool(&self, context: &mut EvalContext) -> Result<bool> {
         match self {
             None => Ok(false),
@@ -355,6 +379,7 @@ impl_evaluable_ret! { Duration, ChunkedVecSized<Self> }
 impl_evaluable_ret! { Json, ChunkedVecJson }
 impl_evaluable_ret! { Enum, ChunkedVecEnum }
 impl_evaluable_ret! { Set, ChunkedVecSet }
+impl_evaluable_ret! { VectorFloat32, ChunkedVecVectorFloat32 }
 
 pub trait EvaluableRef<'a>: Clone + std::fmt::Debug + Send + Sync {
     const EVAL_TYPE: EvalType;
@@ -501,6 +526,12 @@ impl<'a> UnsafeRefInto<SetRef<'static>> for SetRef<'a> {
     }
 }
 
+impl<'a> UnsafeRefInto<VectorFloat32Ref<'static>> for VectorFloat32Ref<'a> {
+    unsafe fn unsafe_into(self) -> VectorFloat32Ref<'static> {
+        std::mem::transmute(self)
+    }
+}
+
 impl<'a> EvaluableRef<'a> for JsonRef<'a> {
     const EVAL_TYPE: EvalType = EvalType::Json;
     type EvaluableType = Json;
@@ -549,6 +580,58 @@ impl<'a> EvaluableRef<'a> for JsonRef<'a> {
 
     #[inline]
     fn from_owned_value(value: &'a Json) -> Self {
+        value.as_ref()
+    }
+}
+
+impl<'a> EvaluableRef<'a> for VectorFloat32Ref<'a> {
+    const EVAL_TYPE: EvalType = EvalType::VectorFloat32;
+    type EvaluableType = VectorFloat32;
+    type ChunkedType = &'a ChunkedVecVectorFloat32;
+
+    #[inline]
+    fn borrow_scalar_value(v: &'a ScalarValue) -> Option<Self> {
+        match v {
+            ScalarValue::VectorFloat32(x) => x.as_ref().map(|x| x.as_ref()),
+            other => panic!(
+                "Cannot cast {} scalar value into {}",
+                other.eval_type(),
+                stringify!(VectorFloat32),
+            ),
+        }
+    }
+
+    #[inline]
+    fn borrow_scalar_value_ref(v: ScalarValueRef<'a>) -> Option<Self> {
+        match v {
+            ScalarValueRef::VectorFloat32(x) => x,
+            other => panic!(
+                "Cannot cast {} scalar value into {}",
+                other.eval_type(),
+                stringify!(VectorFloat32),
+            ),
+        }
+    }
+
+    #[inline]
+    fn borrow_vector_value(v: &VectorValue) -> &ChunkedVecVectorFloat32 {
+        match v {
+            VectorValue::VectorFloat32(x) => x,
+            other => panic!(
+                "Cannot cast {} scalar value into {}",
+                other.eval_type(),
+                stringify!(VectorFloat32),
+            ),
+        }
+    }
+
+    #[inline]
+    fn into_owned_value(self) -> Self::EvaluableType {
+        self.to_owned()
+    }
+
+    #[inline]
+    fn from_owned_value(value: &'a VectorFloat32) -> Self {
         value.as_ref()
     }
 }

--- a/components/tidb_query_datatype/src/codec/data_type/scalar.rs
+++ b/components/tidb_query_datatype/src/codec/data_type/scalar.rs
@@ -37,6 +37,7 @@ pub enum ScalarValue {
     Json(Option<super::Json>),
     Enum(Option<super::Enum>),
     Set(Option<super::Set>),
+    VectorFloat32(Option<super::VectorFloat32>),
 }
 
 impl ScalarValue {
@@ -61,6 +62,9 @@ impl ScalarValue {
             ScalarValue::Json(x) => ScalarValueRef::Json(x.as_ref().map(|x| x.as_ref())),
             ScalarValue::Enum(x) => ScalarValueRef::Enum(x.as_ref().map(|x| x.as_ref())),
             ScalarValue::Set(x) => ScalarValueRef::Set(x.as_ref().map(|x| x.as_ref())),
+            ScalarValue::VectorFloat32(x) => {
+                ScalarValueRef::VectorFloat32(x.as_ref().map(|x| x.as_ref()))
+            }
         }
     }
 
@@ -193,6 +197,7 @@ pub enum ScalarValueRef<'a> {
     Json(Option<JsonRef<'a>>),
     Enum(Option<EnumRef<'a>>),
     Set(Option<SetRef<'a>>),
+    VectorFloat32(Option<VectorFloat32Ref<'a>>),
 }
 
 impl<'a> ScalarValueRef<'a> {
@@ -209,6 +214,7 @@ impl<'a> ScalarValueRef<'a> {
             ScalarValueRef::Json(x) => ScalarValue::Json(x.map(|x| x.to_owned())),
             ScalarValueRef::Enum(x) => ScalarValue::Enum(x.map(|x| x.to_owned())),
             ScalarValueRef::Set(x) => ScalarValue::Set(x.map(|x| x.to_owned())),
+            ScalarValueRef::VectorFloat32(x) => ScalarValue::VectorFloat32(x.map(|x| x.to_owned())),
         }
     }
 
@@ -310,6 +316,17 @@ impl<'a> ScalarValueRef<'a> {
                 }
                 Ok(())
             }
+            ScalarValueRef::VectorFloat32(val) => {
+                match val {
+                    None => {
+                        output.write_evaluable_datum_null()?;
+                    }
+                    Some(val) => {
+                        output.write_evaluable_datum_vector_float32(*val)?;
+                    }
+                }
+                Ok(())
+            }
             // TODO: we should implement enum/set encode
             ScalarValueRef::Enum(_) => unimplemented!(),
             ScalarValueRef::Set(_) => unimplemented!(),
@@ -352,7 +369,7 @@ impl<'a> ScalarValueRef<'a> {
         field_type: &FieldType,
     ) -> crate::codec::Result<Ordering> {
         Ok(match_template! {
-            TT = [Real, Decimal, DateTime, Duration, Json, Enum],
+            TT = [Real, Decimal, DateTime, Duration, Json, Enum, VectorFloat32],
             match (self, other) {
                 (ScalarValueRef::TT(v1), ScalarValueRef::TT(v2)) => v1.cmp(v2),
                 (ScalarValueRef::Int(v1), ScalarValueRef::Int(v2)) => compare_int(&v1.cloned(), &v2.cloned(), field_type),
@@ -442,11 +459,21 @@ impl ScalarValue {
     pub fn as_json(&self) -> Option<JsonRef<'_>> {
         EvaluableRef::borrow_scalar_value(self)
     }
+
+    #[inline]
+    pub fn as_vector_float32(&self) -> Option<VectorFloat32Ref<'_>> {
+        EvaluableRef::borrow_scalar_value(self)
+    }
 }
 
 impl<'a> ScalarValueRef<'a> {
     #[inline]
     pub fn as_json(&'a self) -> Option<JsonRef<'a>> {
+        EvaluableRef::borrow_scalar_value_ref(*self)
+    }
+
+    #[inline]
+    pub fn as_vector_float32(&'a self) -> Option<VectorFloat32Ref<'a>> {
         EvaluableRef::borrow_scalar_value_ref(*self)
     }
 }

--- a/components/tidb_query_datatype/src/codec/datum_codec.rs
+++ b/components/tidb_query_datatype/src/codec/datum_codec.rs
@@ -13,7 +13,7 @@ use crate::{
         datum,
         mysql::{
             DecimalDecoder, DecimalEncoder, DurationDecoder, EnumDecoder, EnumEncoder, JsonDecoder,
-            JsonEncoder, TimeDecoder,
+            JsonEncoder, TimeDecoder, VectorFloat32Decoder, VectorFloat32Encoder,
         },
         Error, Result,
     },
@@ -33,6 +33,7 @@ pub trait DatumPayloadDecoder:
     + DecimalDecoder
     + JsonDecoder
     + EnumDecoder
+    + VectorFloat32Decoder
 {
     #[inline]
     fn read_datum_payload_i64(&mut self) -> Result<i64> {
@@ -131,6 +132,13 @@ pub trait DatumPayloadDecoder:
     }
 
     #[inline]
+    fn read_datum_payload_vector_float32(&mut self) -> Result<VectorFloat32> {
+        self.read_vector_float32().map_err(|_| {
+            Error::InvalidDataType("Failed to decode datum payload as vectorFloat32".to_owned())
+        })
+    }
+
+    #[inline]
     fn read_datum_payload_enum_compact_bytes(&mut self, field_type: &FieldType) -> Result<Enum> {
         self.read_enum_compact_bytes(field_type).map_err(|_| {
             Error::InvalidDataType("Failed to decode datum payload as enum".to_owned())
@@ -158,7 +166,12 @@ impl<T: BufferReader> DatumPayloadDecoder for T {}
 ///
 /// The types this encoder accepts are not fully 1:1 mapping to evaluable types.
 pub trait DatumPayloadEncoder:
-    NumberEncoder + CompactByteEncoder + JsonEncoder + DecimalEncoder + EnumEncoder
+    NumberEncoder
+    + CompactByteEncoder
+    + JsonEncoder
+    + DecimalEncoder
+    + EnumEncoder
+    + VectorFloat32Encoder
 {
     #[inline]
     fn write_datum_payload_i64(&mut self, v: i64) -> Result<()> {
@@ -208,6 +221,13 @@ pub trait DatumPayloadEncoder:
     fn write_datum_payload_json(&mut self, v: JsonRef<'_>) -> Result<()> {
         self.write_json(v).map_err(|_| {
             Error::InvalidDataType("Failed to encode datum payload from json".to_owned())
+        })
+    }
+
+    #[inline]
+    fn write_datum_payload_vector_float32(&mut self, v: VectorFloat32Ref<'_>) -> Result<()> {
+        self.write_vector_float32(v).map_err(|_| {
+            Error::InvalidDataType("Failed to encode datum payload from vectorFloat32".to_owned())
         })
     }
 
@@ -290,6 +310,12 @@ pub trait DatumFlagAndPayloadEncoder: BufferWriter + DatumPayloadEncoder {
         Ok(())
     }
 
+    fn write_datum_vector_float32(&mut self, val: VectorFloat32Ref<'_>) -> Result<()> {
+        self.write_u8(datum::VECTOR_FLOAT32_FLAG)?;
+        self.write_datum_payload_vector_float32(val)?;
+        Ok(())
+    }
+
     fn write_datum_enum_uint(&mut self, val: EnumRef<'_>) -> Result<()> {
         self.write_u8(datum::UINT_FLAG)?;
         self.write_datum_payload_enum_uint(val)?;
@@ -346,6 +372,11 @@ pub trait EvaluableDatumEncoder: DatumFlagAndPayloadEncoder {
     #[inline]
     fn write_evaluable_datum_json(&mut self, val: JsonRef<'_>) -> Result<()> {
         self.write_datum_json(val)
+    }
+
+    #[inline]
+    fn write_evaluable_datum_vector_float32(&mut self, val: VectorFloat32Ref<'_>) -> Result<()> {
+        self.write_datum_vector_float32(val)
     }
 
     #[inline]
@@ -529,6 +560,24 @@ pub fn decode_json_datum(mut raw_datum: &[u8]) -> Result<Option<Json>> {
     }
 }
 
+pub fn decode_vector_float32_datum(mut raw_datum: &[u8]) -> Result<Option<VectorFloat32>> {
+    if raw_datum.is_empty() {
+        return Err(Error::InvalidDataType(
+            "Failed to decode datum flag".to_owned(),
+        ));
+    }
+    let flag = raw_datum[0];
+    raw_datum = &raw_datum[1..];
+    match flag {
+        datum::NIL_FLAG => Ok(None),
+        datum::VECTOR_FLOAT32_FLAG => Ok(Some(raw_datum.read_datum_payload_vector_float32()?)),
+        _ => Err(Error::InvalidDataType(format!(
+            "Unsupported datum flag {} for VectorFloat32 vector",
+            flag
+        ))),
+    }
+}
+
 pub fn decode_enum_datum(mut raw_datum: &[u8], field_type: &FieldType) -> Result<Option<Enum>> {
     if raw_datum.is_empty() {
         return Err(Error::InvalidDataType(
@@ -596,6 +645,16 @@ impl<'a> RawDatumDecoder<Duration> for &'a [u8] {
 impl<'a> RawDatumDecoder<Json> for &'a [u8] {
     fn decode(self, _field_type: &FieldType, _ctx: &mut EvalContext) -> Result<Option<Json>> {
         decode_json_datum(self)
+    }
+}
+
+impl<'a> RawDatumDecoder<VectorFloat32> for &'a [u8] {
+    fn decode(
+        self,
+        _field_type: &FieldType,
+        _ctx: &mut EvalContext,
+    ) -> Result<Option<VectorFloat32>> {
+        decode_vector_float32_datum(self)
     }
 }
 

--- a/components/tidb_query_datatype/src/codec/mysql/mod.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/mod.rs
@@ -33,6 +33,7 @@ pub mod enums;
 pub mod json;
 pub mod set;
 pub mod time;
+pub mod vector;
 
 pub use self::{
     decimal::{dec_encoded_len, Decimal, DecimalDecoder, DecimalEncoder, Res, RoundMode},
@@ -44,4 +45,5 @@ pub use self::{
     },
     set::{Set, SetRef},
     time::{Time, TimeDecoder, TimeEncoder, TimeType, Tz},
+    vector::{VectorFloat32, VectorFloat32Decoder, VectorFloat32Encoder, VectorFloat32Ref},
 };

--- a/components/tidb_query_datatype/src/codec/mysql/vector.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/vector.rs
@@ -1,0 +1,211 @@
+// Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
+
+use codec::prelude::*;
+use ordered_float::OrderedFloat;
+
+use crate::codec::Result;
+
+// TODO: Implement generic version
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct VectorFloat32 {
+    pub value: Vec<OrderedFloat<f32>>,
+}
+
+impl VectorFloat32 {
+    pub fn new(value: Vec<OrderedFloat<f32>>) -> Self {
+        Self { value }
+    }
+
+    pub fn as_ref(&self) -> VectorFloat32Ref<'_> {
+        VectorFloat32Ref {
+            value: self.value.as_slice(),
+        }
+    }
+}
+
+impl std::fmt::Display for VectorFloat32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_ref())
+    }
+}
+
+impl std::fmt::Debug for VectorFloat32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_ref())
+    }
+}
+
+pub trait VectorFloat32DatumPayloadChunkEncoder: BufferWriter {
+    fn write_vector_float32_to_chunk_by_datum_payload(&mut self, src_payload: &[u8]) -> Result<()> {
+        // VectorFloat32's chunk format is same as binary format.
+        self.write_bytes(src_payload)?;
+        Ok(())
+    }
+}
+
+impl<T: BufferWriter> VectorFloat32DatumPayloadChunkEncoder for T {}
+
+impl<T: BufferWriter> VectorFloat32Encoder for T {}
+
+pub trait VectorFloat32Decoder: NumberDecoder {
+    // `read_vector_float32_ref` decodes value encoded by `write_vector_float32`
+    // before.
+    fn read_vector_float32_ref(&mut self) -> Result<VectorFloat32Ref<'_>> {
+        if !cfg!(target_endian = "little") {
+            return Err(box_err!("VectorFloat32 only support Little Endian"));
+        }
+
+        if self.bytes().is_empty() {
+            return Ok(VectorFloat32Ref::new(&[]));
+        }
+        let n = self.read_u32_le()? as usize;
+        let data_size = n * 4;
+        let data = self.read_bytes(data_size)?;
+        let data_in_f32 =
+            unsafe { std::slice::from_raw_parts(data.as_ptr() as *const OrderedFloat<f32>, n) };
+        Ok(VectorFloat32Ref::new(data_in_f32))
+    }
+
+    // `read_vector_float32` decodes value encoded by `write_vector_float32` before.
+    fn read_vector_float32(&mut self) -> Result<VectorFloat32> {
+        let r = self.read_vector_float32_ref()?;
+        Ok(r.to_owned())
+    }
+}
+
+impl<T: BufferReader> VectorFloat32Decoder for T {}
+
+/// Represents a reference of VectorFloat32 value aiming to reduce memory copy.
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct VectorFloat32Ref<'a> {
+    // Referred value
+    value: &'a [OrderedFloat<f32>],
+}
+
+impl<'a> VectorFloat32Ref<'a> {
+    pub fn new(value: &[OrderedFloat<f32>]) -> VectorFloat32Ref<'_> {
+        VectorFloat32Ref { value }
+    }
+
+    pub fn encoded_len(&self) -> usize {
+        self.value.len() * 4 + 4
+    }
+
+    pub fn to_owned(&self) -> VectorFloat32 {
+        VectorFloat32 {
+            value: self.value.to_owned(),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.value.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+pub trait VectorFloat32Encoder: NumberEncoder {
+    fn write_vector_float32(&mut self, data: VectorFloat32Ref<'_>) -> Result<()> {
+        if !cfg!(target_endian = "little") {
+            return Err(box_err!("VectorFloat32 only support Little Endian"));
+        }
+
+        self.write_u32_le(data.value.len() as u32)?;
+        unsafe {
+            let data_in_bytes =
+                std::slice::from_raw_parts(data.value.as_ptr() as *const u8, data.value.len() * 4);
+            self.write_bytes(data_in_bytes)?;
+        }
+        Ok(())
+    }
+}
+
+impl std::fmt::Display for VectorFloat32Ref<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[")?;
+        for (i, v) in self.value.iter().enumerate() {
+            if i > 0 {
+                write!(f, ",")?;
+            }
+            write!(f, "{}", v)?;
+        }
+        write!(f, "]")?;
+        Ok(())
+    }
+}
+
+impl std::fmt::Debug for VectorFloat32Ref<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
+impl ToString for VectorFloat32Ref<'_> {
+    fn to_string(&self) -> String {
+        format!("{}", self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_to_string() {
+        let v = VectorFloat32::new(vec![OrderedFloat(1.0), OrderedFloat(2.0)]);
+        assert_eq!("[1,2]", v.to_string());
+
+        let v = VectorFloat32::new(vec![OrderedFloat(1.1), OrderedFloat(2.2)]);
+        assert_eq!("[1.1,2.2]", v.to_string());
+
+        let v = VectorFloat32::new(vec![]);
+        assert_eq!("[]", v.to_string());
+    }
+
+    #[test]
+    fn test_encode() {
+        let v = VectorFloat32::new(vec![OrderedFloat(1.1), OrderedFloat(2.2)]);
+        let mut encoded = Vec::new();
+        encoded.write_vector_float32(v.as_ref()).unwrap();
+        assert_eq!(
+            encoded,
+            vec![
+                0x02, 0x00, 0x00, 0x00, // Length = 0x02
+                0xcd, 0xcc, 0x8c, 0x3f, // Element 1 = 0x3f8ccccd
+                0xcd, 0xcc, 0x0c, 0x40, // Element 2 = 0x400ccccd
+            ]
+        );
+        assert_eq!(v.as_ref().encoded_len(), 12);
+    }
+
+    #[test]
+    fn test_decode() {
+        let buf: Vec<u8> = vec![
+            0x02, 0x00, 0x00, 0x00, // Length = 0x02
+            0xcd, 0xcc, 0x8c, 0x3f, // Element 1 = 0x3f8ccccd
+            0xcd, 0xcc, 0x0c, 0x40, // Element 2 = 0x400ccccd
+            0xff, // Remaining dummy data
+        ];
+
+        let mut buf_slice = &buf[..];
+        let v = buf_slice.read_vector_float32_ref().unwrap();
+        assert_eq!(v.len(), 2);
+        assert_eq!(v.to_string(), "[1.1,2.2]");
+        assert_eq!(buf_slice.len(), 1);
+        assert_eq!(buf_slice, &[0xff]);
+
+        buf_slice.read_vector_float32_ref().unwrap_err();
+        assert_eq!(buf_slice.len(), 1);
+        assert_eq!(buf_slice, &[0xff]);
+
+        buf_slice = &[];
+        let v = buf_slice.read_vector_float32_ref().unwrap();
+        assert_eq!(v.len(), 0);
+        assert_eq!(v.to_string(), "[]");
+        let mut encode_buf = Vec::new();
+        encode_buf.write_vector_float32(v).unwrap();
+        assert_eq!(encode_buf, vec![0x00, 0x00, 0x00, 0x00]);
+    }
+}

--- a/components/tidb_query_datatype/src/codec/row/v2/compat_v1.rs
+++ b/components/tidb_query_datatype/src/codec/row/v2/compat_v1.rs
@@ -108,6 +108,10 @@ pub trait V1CompatibleEncoder: DatumFlagAndPayloadEncoder {
                 // Copy datum payload as it is
                 self.write_bytes(src)?;
             }
+            FieldTypeTp::TiDbVectorFloat32 => {
+                self.write_u8(datum::VECTOR_FLOAT32_FLAG)?;
+                self.write_bytes(src)?;
+            }
             FieldTypeTp::Null => {
                 self.write_u8(datum::NIL_FLAG)?;
             }

--- a/components/tidb_query_datatype/src/codec/table.rs
+++ b/components/tidb_query_datatype/src/codec/table.rs
@@ -291,6 +291,7 @@ fn unflatten(
                     FieldTypeTp::String,
                     FieldTypeTp::NewDecimal,
                     FieldTypeTp::Json,
+                    FieldTypeTp::TiDbVectorFloat32,
                 ]
                 .contains(&t),
                 "unknown type {} {}",

--- a/components/tidb_query_datatype/src/def/eval_type.rs
+++ b/components/tidb_query_datatype/src/def/eval_type.rs
@@ -18,6 +18,7 @@ pub enum EvalType {
     Json,
     Enum,
     Set,
+    VectorFloat32,
 }
 
 impl EvalType {
@@ -36,6 +37,7 @@ impl EvalType {
             EvalType::Json => crate::FieldTypeTp::Json,
             EvalType::Enum => crate::FieldTypeTp::Enum,
             EvalType::Set => crate::FieldTypeTp::Set,
+            EvalType::VectorFloat32 => crate::FieldTypeTp::TiDbVectorFloat32,
         }
     }
 }
@@ -67,6 +69,7 @@ impl std::convert::TryFrom<crate::FieldTypeTp> for EvalType {
             | crate::FieldTypeTp::DateTime => EvalType::DateTime,
             crate::FieldTypeTp::Duration => EvalType::Duration,
             crate::FieldTypeTp::Json => EvalType::Json,
+            crate::FieldTypeTp::TiDbVectorFloat32 => EvalType::VectorFloat32,
             crate::FieldTypeTp::VarChar
             | crate::FieldTypeTp::TinyBlob
             | crate::FieldTypeTp::MediumBlob

--- a/components/tidb_query_datatype/src/def/field_type.rs
+++ b/components/tidb_query_datatype/src/def/field_type.rs
@@ -47,12 +47,14 @@ pub enum FieldTypeTp {
     VarString = 0xfd,
     String = 0xfe,
     Geometry = 0xff,
+    TiDbVectorFloat32 = 0xe1,
 }
 
 impl FieldTypeTp {
     pub fn from_i32(i: i32) -> Option<FieldTypeTp> {
         if (i >= FieldTypeTp::Unspecified as i32 && i <= FieldTypeTp::Bit as i32)
             || (i >= FieldTypeTp::Json as i32 && i <= FieldTypeTp::Geometry as i32)
+            || (i == FieldTypeTp::TiDbVectorFloat32 as i32)
         {
             Some(unsafe { ::std::mem::transmute::<i32, FieldTypeTp>(i) })
         } else {

--- a/components/tidb_query_executors/src/fast_hash_aggr_executor.rs
+++ b/components/tidb_query_executors/src/fast_hash_aggr_executor.rs
@@ -27,7 +27,7 @@ use crate::{
 macro_rules! match_template_hashable {
     ($t:tt, $($tail:tt)*) => {{
         match_template::match_template! {
-            $t = [Int, Real, Bytes, Duration, Decimal, DateTime, Enum],
+            $t = [Int, Real, Bytes, Duration, Decimal, DateTime, Enum, VectorFloat32],
             $($tail)*
         }
     }}
@@ -96,7 +96,8 @@ impl BatchFastHashAggregationExecutor<Box<dyn BatchExecutor<StorageStats = ()>>>
             | EvalType::Bytes
             | EvalType::Duration
             | EvalType::Decimal
-            | EvalType::DateTime => {}
+            | EvalType::DateTime
+            | EvalType::VectorFloat32 => {}
             _ => return Err(other_err!("Eval type {} is not supported", eval_type)),
         }
 
@@ -209,6 +210,7 @@ enum Groups {
     Decimal(HashMap<Option<Decimal>, usize>),
     DateTime(HashMap<Option<DateTime>, usize>),
     Enum(HashMap<Option<Enum>, usize>),
+    VectorFloat32(HashMap<Option<VectorFloat32>, usize>),
 }
 
 impl Groups {
@@ -267,7 +269,7 @@ impl<Src: BatchExecutor> AggregationExecutorImpl<Src> for FastHashAggregationImp
         match group_by_result {
             RpnStackNode::Scalar { value, .. } => {
                 match_template::match_template! {
-                    TT = [Int, Bytes, Real, Duration, Decimal, DateTime, Enum],
+                    TT = [Int, Bytes, Real, Duration, Decimal, DateTime, Enum, VectorFloat32],
                     match value {
                         ScalarValue::TT(v) => {
                             if let Groups::TT(group) = &mut self.groups {
@@ -292,7 +294,7 @@ impl<Src: BatchExecutor> AggregationExecutorImpl<Src> for FastHashAggregationImp
                 let group_by_logical_rows = value.logical_rows_struct();
 
                 match_template::match_template! {
-                    TT = [Int, Real, Duration, Decimal, DateTime, Enum],
+                    TT = [Int, Real, Duration, Decimal, DateTime, Enum, VectorFloat32],
                     match group_by_physical_vec {
                         VectorValue::TT(v) => {
                             if let Groups::TT(group) = &mut self.groups {

--- a/components/tidb_query_executors/src/runner.rs
+++ b/components/tidb_query_executors/src/runner.rs
@@ -163,6 +163,9 @@ impl BatchExecutorsRunner<()> {
                 ExecType::TypeExpand2 => {
                     return Err(other_err!("Expand2 executor not implemented"));
                 }
+                ExecType::TypeExpand2 => {
+                    other_err!("Expand2 executor not implemented");
+                }
             }
         }
 

--- a/components/tidb_query_executors/src/util/top_n_heap.rs
+++ b/components/tidb_query_executors/src/util/top_n_heap.rs
@@ -92,6 +92,7 @@ impl TopNHeap {
                             Json => JsonRef,
                             Enum => EnumRef,
                             Set => SetRef,
+                            VectorFloat32 => VectorFloat32Ref,
                         ],
                         match dest_vector_value {
                             VectorValue::TT(dest_column) => {

--- a/components/tidb_query_expr/src/impl_cast.rs
+++ b/components/tidb_query_expr/src/impl_cast.rs
@@ -145,6 +145,7 @@ fn get_cast_fn_rpn_meta(
         (EvalType::Duration, EvalType::Bytes) => cast_any_as_string_fn_meta::<Duration>(),
         (EvalType::Json, EvalType::Bytes) => cast_json_as_bytes_fn_meta(),
         (EvalType::Enum, EvalType::Bytes) => cast_enum_as_bytes_fn_meta(),
+        (EvalType::VectorFloat32, EvalType::Bytes) => cast_vector_float32_as_bytes_fn_meta(),
 
         // any as decimal
         (EvalType::Int, EvalType::Decimal) => {
@@ -218,6 +219,11 @@ fn get_cast_fn_rpn_meta(
         (EvalType::Duration, EvalType::Json) => cast_any_as_json_fn_meta::<Duration>(),
         (EvalType::Json, EvalType::Json) => cast_json_as_json_fn_meta(),
         (EvalType::Enum, EvalType::Json) => cast_enum_as_json_fn_meta(),
+
+        // any as VectorFloat32
+        (EvalType::VectorFloat32, EvalType::VectorFloat32) => {
+            cast_vector_float32_as_vector_float32_fn_meta()
+        }
 
         _ => return Err(other_err!("Unsupported cast from {} to {}", from, to)),
     };
@@ -1421,6 +1427,12 @@ fn cast_json_as_json(val: Option<JsonRef>) -> Result<Option<Json>> {
     }
 }
 
+#[rpn_fn]
+#[inline]
+fn cast_vector_float32_as_vector_float32(val: VectorFloat32Ref) -> Result<Option<VectorFloat32>> {
+    Ok(Some(val.to_owned()))
+}
+
 #[rpn_fn(nullable, capture = [ctx])]
 #[inline]
 fn cast_any_as_any<From: ConvertTo<To> + Evaluable + EvaluableRet, To: Evaluable + EvaluableRet>(
@@ -1491,6 +1503,12 @@ fn cast_json_as_bytes(ctx: &mut EvalContext, val: Option<JsonRef>) -> Result<Opt
             Ok(Some(val))
         }
     }
+}
+
+#[rpn_fn]
+#[inline]
+fn cast_vector_float32_as_bytes(val: VectorFloat32Ref) -> Result<Option<Bytes>> {
+    Ok(Some(val.to_string().into_bytes()))
 }
 
 #[rpn_fn(nullable, capture = [ctx])]

--- a/components/tidb_query_expr/src/impl_compare.rs
+++ b/components/tidb_query_expr/src/impl_compare.rs
@@ -33,6 +33,19 @@ pub fn compare_json<F: CmpOp>(lhs: Option<JsonRef>, rhs: Option<JsonRef>) -> Res
 
 #[rpn_fn(nullable)]
 #[inline]
+pub fn compare_vector_float32<F: CmpOp>(
+    lhs: Option<VectorFloat32Ref>,
+    rhs: Option<VectorFloat32Ref>,
+) -> Result<Option<i64>> {
+    Ok(match (lhs, rhs) {
+        (None, None) => F::compare_null(),
+        (None, _) | (_, None) => F::compare_partial_null(),
+        (Some(lhs), Some(rhs)) => Some(F::compare_order(lhs.cmp(&rhs)) as i64),
+    })
+}
+
+#[rpn_fn(nullable)]
+#[inline]
 pub fn compare_bytes<C: Collator, F: CmpOp>(
     lhs: Option<BytesRef>,
     rhs: Option<BytesRef>,

--- a/components/tidb_query_expr/src/impl_miscellaneous.rs
+++ b/components/tidb_query_expr/src/impl_miscellaneous.rs
@@ -40,6 +40,18 @@ pub fn any_value_json(args: &[Option<JsonRef>]) -> Result<Option<Json>> {
 
 #[rpn_fn(nullable, varg)]
 #[inline]
+pub fn any_value_vector_float32(
+    args: &[Option<VectorFloat32Ref>],
+) -> Result<Option<VectorFloat32>> {
+    if let Some(arg) = args.first() {
+        Ok(arg.map(|x| x.to_owned()))
+    } else {
+        Ok(None)
+    }
+}
+
+#[rpn_fn(nullable, varg)]
+#[inline]
 pub fn any_value_bytes(args: &[Option<BytesRef>]) -> Result<Option<Bytes>> {
     if let Some(arg) = args.first() {
         Ok(arg.map(|x| x.to_vec()))

--- a/components/tidb_query_expr/src/impl_op.rs
+++ b/components/tidb_query_expr/src/impl_op.rs
@@ -137,6 +137,12 @@ pub fn is_null_json(arg: Option<JsonRef>) -> Result<Option<i64>> {
 
 #[rpn_fn(nullable)]
 #[inline]
+pub fn is_null_vector_float32(arg: Option<VectorFloat32Ref>) -> Result<Option<i64>> {
+    is_null_ref(arg)
+}
+
+#[rpn_fn(nullable)]
+#[inline]
 pub fn bit_and(lhs: Option<&Int>, rhs: Option<&Int>) -> Result<Option<Int>> {
     Ok(match (lhs, rhs) {
         (Some(lhs), Some(rhs)) => Some(lhs & rhs),

--- a/components/tidb_query_expr/src/impl_vec.rs
+++ b/components/tidb_query_expr/src/impl_vec.rs
@@ -1,0 +1,17 @@
+// Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
+
+use tidb_query_codegen::rpn_fn;
+use tidb_query_common::Result;
+use tidb_query_datatype::codec::data_type::*;
+
+#[rpn_fn(writer)]
+#[inline]
+fn vec_as_text(a: VectorFloat32Ref, writer: BytesWriter) -> Result<BytesGuard> {
+    Ok(writer.write(Some(Bytes::from(a.to_string()))))
+}
+
+#[rpn_fn]
+#[inline]
+fn vec_dims(arg: VectorFloat32Ref) -> Result<Option<Int>> {
+    Ok(Some(arg.len() as Int))
+}

--- a/components/tidb_query_expr/src/lib.rs
+++ b/components/tidb_query_expr/src/lib.rs
@@ -41,6 +41,7 @@ pub mod impl_other;
 pub mod impl_regexp;
 pub mod impl_string;
 pub mod impl_time;
+pub mod impl_vec;
 
 use tidb_query_common::Result;
 use tidb_query_datatype::{
@@ -57,7 +58,7 @@ pub use self::types::*;
 use self::{
     impl_arithmetic::*, impl_cast::*, impl_compare::*, impl_compare_in::*, impl_control::*,
     impl_encryption::*, impl_json::*, impl_like::*, impl_math::*, impl_miscellaneous::*,
-    impl_op::*, impl_other::*, impl_regexp::*, impl_string::*, impl_time::*,
+    impl_op::*, impl_other::*, impl_regexp::*, impl_string::*, impl_time::*, impl_vec::*,
 };
 
 fn map_to_binary_fn_sig(expr: &Expr) -> Result<RpnFnMeta> {
@@ -436,7 +437,7 @@ fn map_expr_node_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
         ScalarFuncSig::ModIntUnsignedSigned => arithmetic_fn_meta::<UintIntMod>(),
         ScalarFuncSig::ModIntSignedUnsigned => arithmetic_fn_meta::<IntUintMod>(),
         ScalarFuncSig::ModIntSignedSigned => arithmetic_fn_meta::<IntIntMod>(),
-                
+
         // impl_cast
         ScalarFuncSig::CastIntAsInt |
         ScalarFuncSig::CastIntAsReal |
@@ -486,7 +487,9 @@ fn map_expr_node_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
         ScalarFuncSig::CastJsonAsDecimal |
         ScalarFuncSig::CastJsonAsTime |
         ScalarFuncSig::CastJsonAsDuration |
-        ScalarFuncSig::CastJsonAsJson => map_cast_func(expr)?,
+        ScalarFuncSig::CastJsonAsJson |
+        ScalarFuncSig::CastVectorFloat32AsString |
+        ScalarFuncSig::CastVectorFloat32AsVectorFloat32 => map_cast_func(expr)?,
         ScalarFuncSig::ToBinary => map_to_binary_fn_sig(expr)?,
         ScalarFuncSig::FromBinary => map_from_binary_fn_sig(expr)?,
 
@@ -498,6 +501,7 @@ fn map_expr_node_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
         ScalarFuncSig::LtTime => compare_fn_meta::<BasicComparer<DateTime, CmpOpLt>>(),
         ScalarFuncSig::LtDuration => compare_fn_meta::<BasicComparer<Duration, CmpOpLt>>(),
         ScalarFuncSig::LtJson => compare_json_fn_meta::<CmpOpLt>(),
+        ScalarFuncSig::LtVectorFloat32 => compare_vector_float32_fn_meta::<CmpOpLt>(),
         ScalarFuncSig::LeInt => map_int_sig(value, children, compare_mapper::<CmpOpLe>)?,
         ScalarFuncSig::LeReal => compare_fn_meta::<BasicComparer<Real, CmpOpLe>>(),
         ScalarFuncSig::LeDecimal => compare_fn_meta::<BasicComparer<Decimal, CmpOpLe>>(),
@@ -505,6 +509,7 @@ fn map_expr_node_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
         ScalarFuncSig::LeTime => compare_fn_meta::<BasicComparer<DateTime, CmpOpLe>>(),
         ScalarFuncSig::LeDuration => compare_fn_meta::<BasicComparer<Duration, CmpOpLe>>(),
         ScalarFuncSig::LeJson => compare_json_fn_meta::<CmpOpLe>(),
+        ScalarFuncSig::LeVectorFloat32 => compare_vector_float32_fn_meta::<CmpOpLe>(),
         ScalarFuncSig::GreatestInt => greatest_int_fn_meta(),
         ScalarFuncSig::GreatestDecimal => greatest_decimal_fn_meta(),
         ScalarFuncSig::GreatestString => greatest_string_fn_meta(),
@@ -532,6 +537,7 @@ fn map_expr_node_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
         ScalarFuncSig::GtTime => compare_fn_meta::<BasicComparer<DateTime, CmpOpGt>>(),
         ScalarFuncSig::GtDuration => compare_fn_meta::<BasicComparer<Duration, CmpOpGt>>(),
         ScalarFuncSig::GtJson => compare_json_fn_meta::<CmpOpGt>(),
+        ScalarFuncSig::GtVectorFloat32 => compare_vector_float32_fn_meta::<CmpOpGt>(),
         ScalarFuncSig::GeInt => map_int_sig(value, children, compare_mapper::<CmpOpGe>)?,
         ScalarFuncSig::GeReal => compare_fn_meta::<BasicComparer<Real, CmpOpGe>>(),
         ScalarFuncSig::GeDecimal => compare_fn_meta::<BasicComparer<Decimal, CmpOpGe>>(),
@@ -539,6 +545,7 @@ fn map_expr_node_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
         ScalarFuncSig::GeTime => compare_fn_meta::<BasicComparer<DateTime, CmpOpGe>>(),
         ScalarFuncSig::GeDuration => compare_fn_meta::<BasicComparer<Duration, CmpOpGe>>(),
         ScalarFuncSig::GeJson => compare_json_fn_meta::<CmpOpGe>(),
+        ScalarFuncSig::GeVectorFloat32 => compare_vector_float32_fn_meta::<CmpOpGe>(),
         ScalarFuncSig::NeInt => map_int_sig(value, children, compare_mapper::<CmpOpNe>)?,
         ScalarFuncSig::NeReal => compare_fn_meta::<BasicComparer<Real, CmpOpNe>>(),
         ScalarFuncSig::NeDecimal => compare_fn_meta::<BasicComparer<Decimal, CmpOpNe>>(),
@@ -546,6 +553,7 @@ fn map_expr_node_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
         ScalarFuncSig::NeTime => compare_fn_meta::<BasicComparer<DateTime, CmpOpNe>>(),
         ScalarFuncSig::NeDuration => compare_fn_meta::<BasicComparer<Duration, CmpOpNe>>(),
         ScalarFuncSig::NeJson => compare_json_fn_meta::<CmpOpNe>(),
+        ScalarFuncSig::NeVectorFloat32 => compare_vector_float32_fn_meta::<CmpOpNe>(),
         ScalarFuncSig::EqInt => map_int_sig(value, children, compare_mapper::<CmpOpEq>)?,
         ScalarFuncSig::EqReal => compare_fn_meta::<BasicComparer<Real, CmpOpEq>>(),
         ScalarFuncSig::EqDecimal => compare_fn_meta::<BasicComparer<Decimal, CmpOpEq>>(),
@@ -553,6 +561,7 @@ fn map_expr_node_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
         ScalarFuncSig::EqTime => compare_fn_meta::<BasicComparer<DateTime, CmpOpEq>>(),
         ScalarFuncSig::EqDuration => compare_fn_meta::<BasicComparer<Duration, CmpOpEq>>(),
         ScalarFuncSig::EqJson => compare_json_fn_meta::<CmpOpEq>(),
+        ScalarFuncSig::EqVectorFloat32 => compare_vector_float32_fn_meta::<CmpOpEq>(),
         ScalarFuncSig::NullEqInt => map_int_sig(value, children, compare_mapper::<CmpOpNullEq>)?,
         ScalarFuncSig::NullEqReal => compare_fn_meta::<BasicComparer<Real, CmpOpNullEq>>(),
         ScalarFuncSig::NullEqDecimal => compare_fn_meta::<BasicComparer<Decimal, CmpOpNullEq>>(),
@@ -560,6 +569,7 @@ fn map_expr_node_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
         ScalarFuncSig::NullEqTime => compare_fn_meta::<BasicComparer<DateTime, CmpOpNullEq>>(),
         ScalarFuncSig::NullEqDuration => compare_fn_meta::<BasicComparer<Duration, CmpOpNullEq>>(),
         ScalarFuncSig::NullEqJson => compare_json_fn_meta::<CmpOpNullEq>(),
+        ScalarFuncSig::NullEqVectorFloat32 => compare_vector_float32_fn_meta::<CmpOpNullEq>(),
         ScalarFuncSig::CoalesceInt => coalesce_fn_meta::<Int>(),
         ScalarFuncSig::CoalesceReal => coalesce_fn_meta::<Real>(),
         ScalarFuncSig::CoalesceString => coalesce_bytes_fn_meta(),
@@ -629,6 +639,9 @@ fn map_expr_node_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
         ScalarFuncSig::JsonMemberOfSig => member_of_fn_meta(),
         ScalarFuncSig::JsonArrayAppendSig => json_array_append_fn_meta(),
         ScalarFuncSig::JsonMergePatchSig => json_merge_patch_fn_meta(),
+        // impl_vec
+        ScalarFuncSig::VecAsTextSig => vec_as_text_fn_meta(),
+        ScalarFuncSig::VecDimsSig => vec_dims_fn_meta(),
         // impl_like
         ScalarFuncSig::LikeSig => map_like_sig(ft, children)?,
         // impl_regexp
@@ -692,6 +705,7 @@ fn map_expr_node_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
         ScalarFuncSig::DurationAnyValue => any_value_fn_meta::<Duration>(),
         ScalarFuncSig::IntAnyValue => any_value_fn_meta::<Int>(),
         ScalarFuncSig::JsonAnyValue => any_value_json_fn_meta(),
+        ScalarFuncSig::VectorFloat32AnyValue => any_value_vector_float32_fn_meta(),
         ScalarFuncSig::RealAnyValue => any_value_fn_meta::<Real>(),
         ScalarFuncSig::StringAnyValue => any_value_bytes_fn_meta(),
         ScalarFuncSig::TimeAnyValue => any_value_fn_meta::<DateTime>(),
@@ -712,6 +726,7 @@ fn map_expr_node_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
         ScalarFuncSig::TimeIsNull => is_null_fn_meta::<DateTime>(),
         ScalarFuncSig::DurationIsNull => is_null_fn_meta::<Duration>(),
         ScalarFuncSig::JsonIsNull => is_null_json_fn_meta(),
+        ScalarFuncSig::VectorFloat32IsNull => is_null_vector_float32_fn_meta(),
         ScalarFuncSig::IntIsTrue => int_is_true_fn_meta::<KeepNullOff>(),
         ScalarFuncSig::IntIsTrueWithNull => int_is_true_fn_meta::<KeepNullOn>(),
         ScalarFuncSig::RealIsTrue => real_is_true_fn_meta::<KeepNullOff>(),

--- a/components/tidb_query_expr/src/types/expr.rs
+++ b/components/tidb_query_expr/src/types/expr.rs
@@ -57,6 +57,7 @@ impl RpnExpressionNode {
                 EvalType::Real => ExprType::Float64,
                 EvalType::Enum => ExprType::MysqlEnum,
                 EvalType::Set => ExprType::MysqlSet,
+                EvalType::VectorFloat32 => ExprType::TiDbVectorFloat32,
             },
             RpnExpressionNode::ColumnRef { .. } => ExprType::ColumnRef,
         }

--- a/components/tidb_query_expr/src/types/function.rs
+++ b/components/tidb_query_expr/src/types/function.rs
@@ -345,6 +345,9 @@ thread_local! {
     pub static VARG_PARAM_BUF_JSON_REF: std::cell::RefCell<Vec<Option<JsonRef<'static>>>> =
         std::cell::RefCell::new(Vec::with_capacity(20));
 
+    pub static VARG_PARAM_BUF_VECTOR_FLOAT32_REF: std::cell::RefCell<Vec<Option<VectorFloat32Ref<'static>>>> =
+        std::cell::RefCell::new(Vec::with_capacity(20));
+
     pub static RAW_VARG_PARAM_BUF: std::cell::RefCell<Vec<ScalarValueRef<'static>>> =
         std::cell::RefCell::new(Vec::with_capacity(20));
 }


### PR DESCRIPTION
### What is changed and how it works?
ref: _
Support reading table data contains Vector data type, introduced by _

This PR should be merged before TiDB. Otherwise TiDB cannot read out the table containing Vector data through TiKV Coprocessor.

What's Changed:
The VectorFloat32's Datum / Chunk / Memory (in TiDB) layouts are identical, as follows:
<img width="660" alt="截屏2024-07-22 11 24 54" src="https://github.com/user-attachments/assets/0e2fb8f6-ffee-49f4-9f51-4982f4adca81">
The VectorFloat32 is simply defined as follows in Rust:
`pub struct VectorFloat32 {
    pub value: Vec<OrderedFloat<f32>>,
}

pub struct VectorFloat32Ref<'a> {
    // Referred value
    value: &'a [OrderedFloat<f32>],
}`

See:  _

Detailed tech design: _

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note

```
