### PR TITLE
*: ignore unsound `openssl::bio::MemBio::get_buf`

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -51,5 +51,36 @@ reason = """
 X509StoreRef::objects is unsound, see RUSTSEC-2020-0071
 """
 
+# See more about RUSTSEC-2024-0357 in deny.toml.
+[[disallowed-types]]
+path = "openssl::bio::MemBio"
+reason = """
+openssl::bio::MemBio::get_buf is unsound, see RUSTSEC-2024-0357
+"""
+[[disallowed-types]]
+path = "openssl::pkcs7::Pkcs7"
+reason = """
+openssl::pkcs7::Pkcs7 may call openssl::bio::MemBio::get_buf, \
+see RUSTSEC-2024-0357
+"""
+[[disallowed-types]]
+path = "openssl::pkey::PKeyRef"
+reason = """
+openssl::pkey::PKeyRef may call openssl::bio::MemBio::get_buf, \
+see RUSTSEC-2024-0357
+"""
+[[disallowed-types]]
+path = "openssl::cms::CmsContentInfoRef"
+reason = """
+openssl::cms::CmsContentInfoRef may call openssl::bio::MemBio::get_buf, \
+see RUSTSEC-2024-0357
+"""
+[[disallowed-types]]
+path = "openssl::asn1::Asn1GeneralizedTimeRef"
+reason = """
+openssl::asn1::Asn1GeneralizedTimeRef may call openssl::bio::MemBio::get_buf, \
+see RUSTSEC-2024-0357
+"""
+
 avoid-breaking-exported-api = false
 upper-case-acronyms-aggressive = true

--- a/deny.toml
+++ b/deny.toml
@@ -55,13 +55,18 @@ ignore = [
     # are required by TiKV.
     # See https://github.com/time-rs/time/blob/8067540c/CHANGELOG.md#L703
     "RUSTSEC-2020-0071",
-    # Ignore RUSTSEC-2023-0072 as we bans the unsound `X509StoreRef::objects`.
+    # Ignore RUSTSEC-2023-0072 as we ban the unsound `X509StoreRef::objects`.
     #
     # NB: Upgrading rust-openssl the latest version do fix the issue but it
     # also upgrade the OpenSSL to v3.x which causes performance degradation.
     # See https://github.com/openssl/openssl/issues/17064
     "RUSTSEC-2023-0072",
-    # Ignore RUSTSEC-2023-0072 (unsound issue of "atty" crate) as it only
+    # Ignore RUSTSEC-2024-0357 as there is no `MemBio::get_buf` in TiKV, also
+    # we ban all openssl (Rust) APIs that call `MemBio::get_buf`.
+    #
+    # See https://github.com/sfackler/rust-openssl/pull/2266
+    "RUSTSEC-2024-0357",
+    # Ignore RUSTSEC-2021-0145 (unsound issue of "atty" crate) as it only
     # affects Windows plaform which is not supported offically by TiKV, and 2)
     # we have disabled the clap feature "color" so that the "atty" crate is not
     # included in production code.


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close https://github.com/tikv/tikv/issues/17291

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Ignore RUSTSEC-2024-0357 (unsound `openssl::bio::MemBio::get_buf`) as we
have banned relevant APIs in the TiKV codebase.

Also, TiKV temporarily pins OpenSSL 1.1.1 because OpenSSL 3.0.0 has
performance regressions. See details in deny.toml.
```

### Related changes

- Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- No code

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
