### PR TITLE
batch-system: Reduce the memory usage of peers' message channel 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -419,7 +419,7 @@ raft-engine = { git = "https://github.com/tikv/raft-engine.git", features = [
 ] }
 raft-engine-ctl = { git = "https://github.com/tikv/raft-engine.git" }
 grpcio = { version = "0.10.4", default-features = false, features = [
-  "openssl-vendored",
+  "openssl",
   "protobuf-codec",
   "nightly",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -419,7 +419,7 @@ raft-engine = { git = "https://github.com/tikv/raft-engine.git", features = [
 ] }
 raft-engine-ctl = { git = "https://github.com/tikv/raft-engine.git" }
 grpcio = { version = "0.10.4", default-features = false, features = [
-  "openssl",
+  "openssl-vendored",
   "protobuf-codec",
   "nightly",
 ] }

--- a/components/raftstore/src/router.rs
+++ b/components/raftstore/src/router.rs
@@ -92,7 +92,10 @@ where
     /// Report a `StoreResolved` event to all Raft groups.
     fn report_resolved(&self, store_id: u64, group_id: u64) {
         self.broadcast_normal(|| {
-            PeerMsg::SignificantMsg(SignificantMsg::StoreResolved { store_id, group_id })
+            PeerMsg::SignificantMsg(Box::new(SignificantMsg::StoreResolved {
+                store_id,
+                group_id,
+            }))
         })
     }
 }

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -930,6 +930,7 @@ where
     /// All of messages that need to continue to be handled after
     /// the source peer has applied its logs and pending entries
     /// are all handled.
+    #[allow(clippy::vec_box)]
     pending_msgs: Vec<Box<Msg<EK>>>,
 
     /// Cache heap size for itself.
@@ -4412,6 +4413,7 @@ where
         ctx.finish_for(&mut self.delegate, result);
     }
 
+    #[allow(clippy::vec_box)]
     fn handle_tasks(&mut self, apply_ctx: &mut ApplyContext<EK>, msgs: &mut Vec<Box<Msg<EK>>>) {
         let mut drainer = msgs.drain(..);
         let mut batch_apply = None;
@@ -4623,6 +4625,7 @@ pub struct ApplyPoller<EK>
 where
     EK: KvEngine,
 {
+    #[allow(clippy::vec_box)]
     msg_buf: Vec<Box<Msg<EK>>>,
     apply_ctx: ApplyContext<EK>,
     messages_per_tick: usize,

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -210,7 +210,7 @@ where
         while let Ok(msg) = self.receiver.try_recv() {
             let callback = match msg {
                 PeerMsg::RaftCommand(cmd) => cmd.callback,
-                PeerMsg::CasualMessage(CasualMessage::SplitRegion { callback, .. }) => callback,
+                PeerMsg::CasualMessage(box CasualMessage::SplitRegion { callback, .. }) => callback,
                 PeerMsg::RaftMessage(im, _) => {
                     raft_messages_size += im.heap_size;
                     continue;
@@ -684,7 +684,7 @@ where
                         && !self.fsm.peer.disk_full_peers.majority())
                         || cmd.extra_opts.disk_full_opt == DiskFullOpt::NotAllowedOnFull)
                     {
-                        self.fsm.batch_req_builder.add(cmd, req_size);
+                        self.fsm.batch_req_builder.add(*cmd, req_size);
                         if self.fsm.batch_req_builder.should_finish(&self.ctx.cfg) {
                             self.propose_pending_batch_raft_command();
                         }
@@ -697,7 +697,7 @@ where
                     }
                 }
                 PeerMsg::Tick(tick) => self.on_tick(tick),
-                PeerMsg::ApplyRes { res } => {
+                PeerMsg::ApplyRes(res) => {
                     self.on_apply_res(res);
                 }
                 PeerMsg::SignificantMsg(msg) => self.on_significant_msg(msg),
@@ -1129,8 +1129,8 @@ where
         }
     }
 
-    fn on_casual_msg(&mut self, msg: CasualMessage<EK>) {
-        match msg {
+    fn on_casual_msg(&mut self, msg: Box<CasualMessage<EK>>) {
+        match *msg {
             CasualMessage::SplitRegion {
                 region_epoch,
                 split_keys,
@@ -1491,8 +1491,8 @@ where
         );
     }
 
-    fn on_significant_msg(&mut self, msg: SignificantMsg<EK::Snapshot>) {
-        match msg {
+    fn on_significant_msg(&mut self, msg: Box<SignificantMsg<EK::Snapshot>>) {
+        match *msg {
             SignificantMsg::SnapshotStatus {
                 to_peer_id, status, ..
             } => {
@@ -1873,7 +1873,7 @@ where
             // follower state
             let _ = self.ctx.router.send(
                 self.region_id(),
-                PeerMsg::CasualMessage(CasualMessage::Campaign),
+                PeerMsg::CasualMessage(Box::new(CasualMessage::Campaign)),
             );
         }
         self.fsm.has_ready = true;
@@ -2440,9 +2440,9 @@ where
         }
     }
 
-    fn on_apply_res(&mut self, res: ApplyTaskRes<EK::Snapshot>) {
+    fn on_apply_res(&mut self, res: Box<ApplyTaskRes<EK::Snapshot>>) {
         fail_point!("on_apply_res", |_| {});
-        match res {
+        match *res {
             ApplyTaskRes::Apply(mut res) => {
                 debug!(
                     "async apply finish";
@@ -2613,8 +2613,8 @@ where
         }
     }
 
-    fn on_raft_message(&mut self, msg: InspectedRaftMessage) -> Result<()> {
-        let InspectedRaftMessage { heap_size, mut msg } = msg;
+    fn on_raft_message(&mut self, m: Box<InspectedRaftMessage>) -> Result<()> {
+        let InspectedRaftMessage { heap_size, mut msg } = *m;
         let peer_disk_usage = msg.disk_usage;
         let stepped = Cell::new(false);
         let memtrace_raft_entries = &mut self.fsm.peer.memtrace_raft_entries as *mut usize;
@@ -3199,10 +3199,10 @@ where
                         );
                         if self.handle_destroy_peer(job) {
                             // It's not frequent, so use 0 as `heap_size` is ok.
-                            let store_msg = StoreMsg::RaftMessage(InspectedRaftMessage {
+                            let store_msg = StoreMsg::RaftMessage(Box::new(InspectedRaftMessage {
                                 heap_size: 0,
                                 msg: msg.clone(),
-                            });
+                            }));
                             if let Err(e) = self.ctx.router.send_control(store_msg) {
                                 info!(
                                     "failed to send back store message, are we shutting down?";
@@ -3537,7 +3537,7 @@ where
                 // may has been merged/splitted already.
                 let _ = self.ctx.router.force_send(
                     exist_region.get_id(),
-                    PeerMsg::CasualMessage(CasualMessage::RegionOverlapped),
+                    PeerMsg::CasualMessage(Box::new(CasualMessage::RegionOverlapped)),
                 );
             }
         }
@@ -3615,11 +3615,11 @@ where
                 .router
                 .force_send(
                     source_region_id,
-                    PeerMsg::SignificantMsg(SignificantMsg::MergeResult {
+                    PeerMsg::SignificantMsg(Box::new(SignificantMsg::MergeResult {
                         target_region_id: self.fsm.region_id(),
                         target: self.fsm.peer.peer.clone(),
                         result,
-                    }),
+                    })),
                 )
                 .unwrap();
         }
@@ -3847,9 +3847,9 @@ where
             )
             .flush()
             .when_done(move || {
-                if let Err(e) =
-                    mb.force_send(PeerMsg::SignificantMsg(SignificantMsg::RaftLogGcFlushed))
-                {
+                if let Err(e) = mb.force_send(PeerMsg::SignificantMsg(Box::new(
+                    SignificantMsg::RaftLogGcFlushed,
+                ))) {
                     if tikv_util::thread_group::is_shutdown(!cfg!(test)) {
                         return;
                     }
@@ -4534,7 +4534,7 @@ where
                     .swap_remove_front(|m| m.get_to_peer() == &meta_peer)
                 {
                     let peer_msg = PeerMsg::RaftMessage(
-                        InspectedRaftMessage { heap_size: 0, msg },
+                        Box::new(InspectedRaftMessage { heap_size: 0, msg }),
                         Some(TiInstant::now()),
                     );
                     if let Err(e) = self.ctx.router.force_send(new_region_id, peer_msg) {
@@ -4765,14 +4765,14 @@ where
             .router
             .force_send(
                 target_id,
-                PeerMsg::RaftCommand(RaftCommand::new_ext(
+                PeerMsg::RaftCommand(Box::new(RaftCommand::new_ext(
                     request,
                     Callback::None,
                     RaftCmdExtraOpts {
                         deadline: None,
                         disk_full_opt: DiskFullOpt::AllowedOnAlmostFull,
                     },
-                )),
+                ))),
             )
             .map_err(|_| Error::RegionNotFound(target_id))
     }
@@ -5029,11 +5029,11 @@ where
         }
         if let Err(e) = self.ctx.router.force_send(
             source.get_id(),
-            PeerMsg::SignificantMsg(SignificantMsg::MergeResult {
+            PeerMsg::SignificantMsg(Box::new(SignificantMsg::MergeResult {
                 target_region_id: self.fsm.region_id(),
                 target: self.fsm.peer.peer.clone(),
                 result: MergeResultKind::FromTargetLog,
-            }),
+            })),
         ) {
             panic!(
                 "{} failed to send merge result(FromTargetLog) to source region {}, err {}",
@@ -5307,11 +5307,11 @@ where
         for r in &persist_res.destroy_regions {
             if let Err(e) = self.ctx.router.force_send(
                 r.get_id(),
-                PeerMsg::SignificantMsg(SignificantMsg::MergeResult {
+                PeerMsg::SignificantMsg(Box::new(SignificantMsg::MergeResult {
                     target_region_id: self.fsm.region_id(),
                     target: self.fsm.peer.peer.clone(),
                     result: MergeResultKind::FromTargetSnapshotStep2,
-                }),
+                })),
             ) {
                 panic!(
                     "{} failed to send merge result(FromTargetSnapshotStep2) to source region {}, err {}",

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -384,9 +384,7 @@ where
             let region_id = r.region_id;
             if let Err(e) = self.router.force_send(
                 region_id,
-                PeerMsg::ApplyRes {
-                    res: ApplyTaskRes::Apply(r),
-                },
+                PeerMsg::ApplyRes(Box::new(ApplyTaskRes::Apply(r))),
             ) {
                 error!("failed to send apply result"; "region_id" => region_id, "err" => ?e);
             }
@@ -423,7 +421,7 @@ where
             heap_size += bytes_capacity(&e.data) + bytes_capacity(&e.context);
         }
         let peer_msg = PeerMsg::RaftMessage(
-            InspectedRaftMessage { heap_size, msg },
+            Box::new(InspectedRaftMessage { heap_size, msg }),
             Some(TiInstant::now()),
         );
         let event = TraceEvent::Add(heap_size);
@@ -468,10 +466,10 @@ where
         cmd: RaftCommand<EK::Snapshot>,
     ) -> std::result::Result<(), TrySendError<RaftCommand<EK::Snapshot>>> {
         let region_id = cmd.request.get_header().get_region_id();
-        match self.send(region_id, PeerMsg::RaftCommand(cmd)) {
+        match self.send(region_id, PeerMsg::RaftCommand(Box::new(cmd))) {
             Ok(()) => Ok(()),
-            Err(TrySendError::Full(PeerMsg::RaftCommand(cmd))) => Err(TrySendError::Full(cmd)),
-            Err(TrySendError::Disconnected(PeerMsg::RaftCommand(cmd))) => {
+            Err(TrySendError::Full(PeerMsg::RaftCommand(box cmd))) => Err(TrySendError::Full(cmd)),
+            Err(TrySendError::Disconnected(PeerMsg::RaftCommand(box cmd))) => {
                 Err(TrySendError::Disconnected(cmd))
             }
             _ => unreachable!(),
@@ -480,7 +478,7 @@ where
 
     fn report_unreachable(&self, store_id: u64) {
         self.broadcast_normal(|| {
-            PeerMsg::SignificantMsg(SignificantMsg::StoreUnreachable { store_id })
+            PeerMsg::SignificantMsg(Box::new(SignificantMsg::StoreUnreachable { store_id }))
         });
     }
 
@@ -491,7 +489,10 @@ where
     /// Broadcasts resolved result to all regions.
     pub fn report_resolved(&self, store_id: u64, group_id: u64) {
         self.broadcast_normal(|| {
-            PeerMsg::SignificantMsg(SignificantMsg::StoreResolved { store_id, group_id })
+            PeerMsg::SignificantMsg(Box::new(SignificantMsg::StoreResolved {
+                store_id,
+                group_id,
+            }))
         })
     }
 
@@ -1074,12 +1075,7 @@ impl<EK: KvEngine, ER: RaftEngine, T: Transport> PollHandler<PeerFsm<EK, ER>, St
                     fail_point!(
                         "pause_on_peer_destroy_res",
                         peer.peer_id() == 1
-                            && matches!(
-                                msg,
-                                PeerMsg::ApplyRes {
-                                    res: ApplyTaskRes::Destroy { .. },
-                                }
-                            ),
+                            && matches!(msg, PeerMsg::ApplyRes(box ApplyTaskRes::Destroy { .. })),
                         |_| unreachable!()
                     );
                     self.peer_msg_buf.push(msg);
@@ -1679,7 +1675,9 @@ impl<EK: KvEngine, ER: RaftEngine> RaftBatchSystem<EK, ER> {
                         for region_id in regions {
                             let _ = router_clone.send(
                                 region_id,
-                                PeerMsg::CasualMessage(CasualMessage::ForceCompactRaftLogs),
+                                PeerMsg::CasualMessage(Box::new(
+                                    CasualMessage::ForceCompactRaftLogs,
+                                )),
                             );
                         }
                     }
@@ -2143,7 +2141,7 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
         Ok(CheckMsgStatus::NewPeer)
     }
 
-    fn on_raft_message(&mut self, msg: InspectedRaftMessage) -> Result<()> {
+    fn on_raft_message(&mut self, msg: Box<InspectedRaftMessage>) -> Result<()> {
         let (heap_size, forwarded) = (msg.heap_size, Cell::new(false));
         defer!(if !forwarded.get() {
             MEMTRACE_RAFT_MESSAGES.trace(TraceEvent::Sub(heap_size));
@@ -2234,8 +2232,10 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
                     check_msg_status == CheckMsgStatus::NewPeerFirst,
                 )? {
                     // Peer created, send the message again.
-                    let peer_msg =
-                        PeerMsg::RaftMessage(InspectedRaftMessage { heap_size, msg }, None);
+                    let peer_msg = PeerMsg::RaftMessage(
+                        Box::new(InspectedRaftMessage { heap_size, msg }),
+                        None,
+                    );
                     if self.ctx.router.send(region_id, peer_msg).is_ok() {
                         forwarded.set(true);
                     }
@@ -2258,7 +2258,8 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
                 store_meta.pending_msgs.push(msg);
             } else {
                 drop(store_meta);
-                let peer_msg = PeerMsg::RaftMessage(InspectedRaftMessage { heap_size, msg }, None);
+                let peer_msg =
+                    PeerMsg::RaftMessage(Box::new(InspectedRaftMessage { heap_size, msg }), None);
                 if let Err(e) = self.ctx.router.force_send(region_id, peer_msg) {
                     warn!("handle first request failed"; "region_id" => region_id, "error" => ?e);
                 } else {
@@ -2423,7 +2424,7 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
                 // region may has been merged/splitted already.
                 let _ = self.ctx.router.force_send(
                     exist_region.get_id(),
-                    PeerMsg::CasualMessage(CasualMessage::RegionOverlapped),
+                    PeerMsg::CasualMessage(Box::new(CasualMessage::RegionOverlapped)),
                 );
             }
         }
@@ -2438,11 +2439,11 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
                 .router
                 .force_send(
                     id,
-                    PeerMsg::SignificantMsg(SignificantMsg::MergeResult {
+                    PeerMsg::SignificantMsg(Box::new(SignificantMsg::MergeResult {
                         target_region_id: region_id,
                         target: target.clone(),
                         result: MergeResultKind::Stale,
-                    }),
+                    })),
                 )
                 .unwrap();
         }
@@ -2510,9 +2511,9 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
         for (region_id, declined_bytes) in region_declined_bytes.drain(..) {
             let _ = self.ctx.router.send(
                 region_id,
-                PeerMsg::CasualMessage(CasualMessage::CompactionDeclinedBytes {
+                PeerMsg::CasualMessage(Box::new(CasualMessage::CompactionDeclinedBytes {
                     bytes: declined_bytes,
-                }),
+                })),
             );
         }
     }
@@ -3201,7 +3202,7 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
 
         let _ = self.ctx.router.send(
             target_region_id,
-            PeerMsg::RaftCommand(RaftCommand::new(request, Callback::None)),
+            PeerMsg::RaftCommand(Box::new(RaftCommand::new(request, Callback::None))),
         );
     }
 
@@ -3239,7 +3240,7 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
         for region_id in regions {
             let _ = self.ctx.router.send(
                 region_id,
-                PeerMsg::CasualMessage(CasualMessage::ClearRegionSize),
+                PeerMsg::CasualMessage(Box::new(CasualMessage::ClearRegionSize)),
             );
         }
     }

--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -1007,17 +1007,11 @@ mod tests {
     fn test_msg_size() {
         use std::mem;
 
-        use engine_rocks::{RocksCompactedEvent, RocksEngine};
-        use engine_traits::KvEngine;
-        use kvproto::raft_serverpb::RaftMessage;
+        use engine_rocks::RocksEngine;
 
         use super::*;
-        use crate::store::fsm::apply::TaskRes;
 
+        // make sure the msg is small enough
         assert_eq!(mem::size_of::<PeerMsg<RocksEngine>>(), 32);
-        // println!("{}", mem::size_of::<RocksCompactedEvent>());
-        // println!("{}", mem::size_of::<metapb::Store>());
-        // println!("{}", mem::size_of::<pdpb::StoreReport>());
-        assert_eq!(mem::size_of::<StoreMsg<RocksEngine>>(), 224);
     }
 }

--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -1007,13 +1007,17 @@ mod tests {
     fn test_msg_size() {
         use std::mem;
 
+        use engine_rocks::{RocksCompactedEvent, RocksEngine};
         use engine_traits::KvEngine;
         use kvproto::raft_serverpb::RaftMessage;
 
         use super::*;
         use crate::store::fsm::apply::TaskRes;
 
-        assert_eq!(mem::size_of::<PeerMsg<RocksEngine>>(), 48);
-        assert_eq!(mem::size_of::<StoreMsg<RocksEngine>>(), 48);
+        assert_eq!(mem::size_of::<PeerMsg<RocksEngine>>(), 32);
+        // println!("{}", mem::size_of::<RocksCompactedEvent>());
+        // println!("{}", mem::size_of::<metapb::Store>());
+        // println!("{}", mem::size_of::<pdpb::StoreReport>());
+        assert_eq!(mem::size_of::<StoreMsg<RocksEngine>>(), 224);
     }
 }

--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -795,28 +795,25 @@ impl fmt::Debug for InspectedRaftMessage {
 }
 
 /// Message that can be sent to a peer.
-#[allow(clippy::large_enum_variant)]
 #[derive(EnumCount, EnumVariantNames)]
 pub enum PeerMsg<EK: KvEngine> {
     /// Raft message is the message sent between raft nodes in the same
     /// raft group. Messages need to be redirected to raftstore if target
     /// peer doesn't exist.
-    RaftMessage(InspectedRaftMessage, Option<Instant>),
+    RaftMessage(Box<InspectedRaftMessage>, Option<Instant>),
     /// Raft command is the command that is expected to be proposed by the
     /// leader of the target raft group. If it's failed to be sent, callback
     /// usually needs to be called before dropping in case of resource leak.
-    RaftCommand(RaftCommand<EK::Snapshot>),
+    RaftCommand(Box<RaftCommand<EK::Snapshot>>),
     /// Tick is periodical task. If target peer doesn't exist there is a
     /// potential that the raft node will not work anymore.
     Tick(PeerTick),
     /// Result of applying committed entries. The message can't be lost.
-    ApplyRes {
-        res: ApplyTaskRes<EK::Snapshot>,
-    },
+    ApplyRes(Box<ApplyTaskRes<EK::Snapshot>>),
     /// Message that can't be lost but rarely created. If they are lost, real
     /// bad things happen like some peers will be considered dead in the
     /// group.
-    SignificantMsg(SignificantMsg<EK::Snapshot>),
+    SignificantMsg(Box<SignificantMsg<EK::Snapshot>>),
     /// Start the FSM.
     Start,
     /// A message only used to notify a peer.
@@ -826,7 +823,7 @@ pub enum PeerMsg<EK: KvEngine> {
         ready_number: u64,
     },
     /// Message that is not important and can be dropped occasionally.
-    CasualMessage(CasualMessage<EK>),
+    CasualMessage(Box<CasualMessage<EK>>),
     /// Ask region to report a heartbeat to PD.
     HeartbeatPd,
     /// Asks region to change replication mode.
@@ -849,7 +846,7 @@ impl<EK: KvEngine> fmt::Debug for PeerMsg<EK> {
                 tick
             },
             PeerMsg::SignificantMsg(msg) => write!(fmt, "{:?}", msg),
-            PeerMsg::ApplyRes { res } => write!(fmt, "ApplyRes {:?}", res),
+            PeerMsg::ApplyRes(res) => write!(fmt, "ApplyRes {:?}", res),
             PeerMsg::Start => write!(fmt, "Startup"),
             PeerMsg::Noop => write!(fmt, "Noop"),
             PeerMsg::Persisted {
@@ -892,7 +889,7 @@ impl<EK: KvEngine> PeerMsg<EK> {
     pub fn is_send_failure_ignorable(&self) -> bool {
         matches!(
             self,
-            PeerMsg::SignificantMsg(SignificantMsg::CaptureChange { .. })
+            PeerMsg::SignificantMsg(box SignificantMsg::CaptureChange { .. })
         )
     }
 }
@@ -902,7 +899,7 @@ pub enum StoreMsg<EK>
 where
     EK: KvEngine,
 {
-    RaftMessage(InspectedRaftMessage),
+    RaftMessage(Box<InspectedRaftMessage>),
 
     // Clear region size and keys for all regions in the range, so we can force them to
     // re-calculate their size later.
@@ -1001,5 +998,22 @@ impl<EK: KvEngine> StoreMsg<EK> {
             #[cfg(any(test, feature = "testexport"))]
             StoreMsg::Validate(_) => 12, // Please keep this always be the last one.
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_msg_size() {
+        use std::mem;
+
+        use engine_traits::KvEngine;
+        use kvproto::raft_serverpb::RaftMessage;
+
+        use super::*;
+        use crate::store::fsm::apply::TaskRes;
+
+        assert_eq!(mem::size_of::<PeerMsg<RocksEngine>>(), 48);
+        assert_eq!(mem::size_of::<StoreMsg<RocksEngine>>(), 48);
     }
 }

--- a/components/raftstore/src/store/snapshot_backup.rs
+++ b/components/raftstore/src/store/snapshot_backup.rs
@@ -75,7 +75,7 @@ impl<EK: KvEngine, ER: RaftEngine> SnapshotBrHandle for Arc<Mutex<RaftRouter<EK,
     fn broadcast_wait_apply(&self, req: SnapshotBrWaitApplyRequest) -> crate::Result<()> {
         let msg_gen = || {
             metrics::SNAP_BR_WAIT_APPLY_EVENT.sent.inc();
-            PeerMsg::SignificantMsg(SignificantMsg::SnapshotBrWaitApply(req.clone()))
+            PeerMsg::SignificantMsg(Box::new(SignificantMsg::SnapshotBrWaitApply(req.clone())))
         };
         self.lock().unwrap().broadcast_normal(msg_gen);
         Ok(())
@@ -86,7 +86,7 @@ impl<EK: KvEngine, ER: RaftEngine> SnapshotBrHandle for Arc<Mutex<RaftRouter<EK,
         tx: UnboundedSender<CheckAdminResponse>,
     ) -> crate::Result<()> {
         self.lock().unwrap().broadcast_normal(|| {
-            PeerMsg::SignificantMsg(SignificantMsg::CheckPendingAdmin(tx.clone()))
+            PeerMsg::SignificantMsg(Box::new(SignificantMsg::CheckPendingAdmin(tx.clone())))
         });
         Ok(())
     }

--- a/components/raftstore/src/store/transport.rs
+++ b/components/raftstore/src/store/transport.rs
@@ -78,7 +78,10 @@ where
 {
     #[inline]
     fn send(&self, region_id: u64, msg: CasualMessage<EK>) -> Result<()> {
-        match self.router.send(region_id, PeerMsg::CasualMessage(msg)) {
+        match self
+            .router
+            .send(region_id, PeerMsg::CasualMessage(Box::new(msg)))
+        {
             Ok(()) => Ok(()),
             Err(TrySendError::Full(_)) => Err(Error::Transport(DiscardReason::Full)),
             Err(TrySendError::Disconnected(_)) => Err(Error::RegionNotFound(region_id)),
@@ -102,7 +105,7 @@ where
     fn significant_send(&self, region_id: u64, msg: SignificantMsg<EK::Snapshot>) -> Result<()> {
         if let Err(SendError(msg)) = self
             .router
-            .force_send(region_id, PeerMsg::SignificantMsg(msg))
+            .force_send(region_id, PeerMsg::SignificantMsg(Box::new(msg)))
         {
             // TODO: panic here once we can detect system is shutting down reliably.
 

--- a/components/raftstore/src/store/unsafe_recovery.rs
+++ b/components/raftstore/src/store/unsafe_recovery.rs
@@ -80,7 +80,9 @@ impl<EK: KvEngine, ER: RaftEngine> UnsafeRecoveryHandle for Mutex<RaftRouter<EK,
 
     fn broadcast_exit_force_leader(&self) {
         let router = self.lock().unwrap();
-        router.broadcast_normal(|| PeerMsg::SignificantMsg(SignificantMsg::ExitForceLeaderState));
+        router.broadcast_normal(|| {
+            PeerMsg::SignificantMsg(Box::new(SignificantMsg::ExitForceLeaderState))
+        });
     }
 
     fn send_create_peer(
@@ -130,14 +132,18 @@ impl<EK: KvEngine, ER: RaftEngine> UnsafeRecoveryHandle for Mutex<RaftRouter<EK,
     fn broadcast_wait_apply(&self, syncer: UnsafeRecoveryWaitApplySyncer) {
         let router = self.lock().unwrap();
         router.broadcast_normal(|| {
-            PeerMsg::SignificantMsg(SignificantMsg::UnsafeRecoveryWaitApply(syncer.clone()))
+            PeerMsg::SignificantMsg(Box::new(SignificantMsg::UnsafeRecoveryWaitApply(
+                syncer.clone(),
+            )))
         });
     }
 
     fn broadcast_fill_out_report(&self, syncer: UnsafeRecoveryFillOutReportSyncer) {
         let router = self.lock().unwrap();
         router.broadcast_normal(|| {
-            PeerMsg::SignificantMsg(SignificantMsg::UnsafeRecoveryFillOutReport(syncer.clone()))
+            PeerMsg::SignificantMsg(Box::new(SignificantMsg::UnsafeRecoveryFillOutReport(
+                syncer.clone(),
+            )))
         });
     }
 

--- a/components/raftstore/src/store/worker/cleanup_snapshot.rs
+++ b/components/raftstore/src/store/worker/cleanup_snapshot.rs
@@ -70,12 +70,12 @@ where
                 "region_id" => region_id,
             );
 
-            let gc_snap = PeerMsg::CasualMessage(CasualMessage::GcSnap { snaps });
+            let gc_snap = PeerMsg::CasualMessage(Box::new(CasualMessage::GcSnap { snaps }));
             match (*self.router).send(region_id, gc_snap) {
                 Ok(()) => Ok(()),
                 Err(TrySendError::Disconnected(_)) if self.router.is_shutdown() => Ok(()),
                 Err(TrySendError::Disconnected(PeerMsg::CasualMessage(
-                    CasualMessage::GcSnap { snaps },
+                    box CasualMessage::GcSnap { snaps },
                 ))) => {
                     // The snapshot exists because MsgAppend has been rejected. So the
                     // peer must have been exist. But now it's disconnected, so the peer

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -1547,7 +1547,7 @@ where
                             cb: Callback::None,
                         }
                     };
-                    if let Err(e) = router.send(region_id, PeerMsg::CasualMessage(msg)) {
+                    if let Err(e) = router.send(region_id, PeerMsg::CasualMessage(Box::new(msg))) {
                         error!("send halfsplit request failed"; "region_id" => region_id, "err" => ?e);
                     }
                 } else if resp.has_merge() {
@@ -1737,7 +1737,7 @@ where
             match resp.await {
                 Ok(Some((region, leader))) => {
                     if leader.get_store_id() != 0 {
-                        let msg = CasualMessage::QueryRegionLeaderResp { region, leader };
+                        let msg = Box::new(CasualMessage::QueryRegionLeaderResp { region, leader });
                         if let Err(e) = router.send(region_id, PeerMsg::CasualMessage(msg)) {
                             error!("send region info message failed"; "region_id" => region_id, "err" => ?e);
                         }
@@ -1991,14 +1991,14 @@ where
                             let start_key = split_info.start_key.unwrap();
                             let end_key = split_info.end_key.unwrap();
                             let region_id = region.get_id();
-                            let msg = CasualMessage::HalfSplitRegion {
+                            let msg = Box::new(CasualMessage::HalfSplitRegion {
                                 region_epoch: region.get_region_epoch().clone(),
                                 start_key: Some(start_key.clone()),
                                 end_key: Some(end_key.clone()),
                                 policy: pdpb::CheckPolicy::Scan,
                                 source: "auto_split",
                                 cb: Callback::None,
-                            };
+                            });
                             if let Err(e) = router.send(region_id, PeerMsg::CasualMessage(msg)) {
                                 error!("send auto half split request failed";
                                     "region_id" => region_id,

--- a/components/snap_recovery/src/services.rs
+++ b/components/snap_recovery/src/services.rs
@@ -228,9 +228,9 @@ where
     pub fn wait_apply_last(router: RaftRouter<EK, ER>, sender: Sender<SyncReport>) {
         let wait_apply = SnapshotBrWaitApplySyncer::new(0, sender);
         router.broadcast_normal(|| {
-            PeerMsg::SignificantMsg(SignificantMsg::SnapshotBrWaitApply(
+            PeerMsg::SignificantMsg(Box::new(SignificantMsg::SnapshotBrWaitApply(
                 SnapshotBrWaitApplyRequest::relaxed(wait_apply.clone()),
-            ))
+            )))
         });
     }
 }

--- a/components/test_raftstore/src/router.rs
+++ b/components/test_raftstore/src/router.rs
@@ -60,7 +60,7 @@ impl CasualRouter<RocksEngine> for MockRaftStoreRouter {
     fn send(&self, region_id: u64, msg: CasualMessage<RocksEngine>) -> RaftStoreResult<()> {
         let mut senders = self.senders.lock().unwrap();
         if let Some(tx) = senders.get_mut(&region_id) {
-            tx.try_send(PeerMsg::CasualMessage(msg))
+            tx.try_send(PeerMsg::CasualMessage(Box::new(msg)))
                 .map_err(|e| handle_send_error(region_id, e))
         } else {
             Err(RaftStoreError::RegionNotFound(region_id))
@@ -76,7 +76,8 @@ impl SignificantRouter<RocksEngine> for MockRaftStoreRouter {
     ) -> RaftStoreResult<()> {
         let mut senders = self.senders.lock().unwrap();
         if let Some(tx) = senders.get_mut(&region_id) {
-            tx.force_send(PeerMsg::SignificantMsg(msg)).unwrap();
+            tx.force_send(PeerMsg::SignificantMsg(Box::new(msg)))
+                .unwrap();
             Ok(())
         } else {
             error!("failed to send significant msg"; "msg" => ?msg);

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -481,14 +481,18 @@ pub mod test_router {
             cmd: RaftCommand<RocksSnapshot>,
         ) -> std::result::Result<(), crossbeam::channel::TrySendError<RaftCommand<RocksSnapshot>>>
         {
-            let _ = self.tx.send(Either::Left(PeerMsg::RaftCommand(cmd)));
+            let _ = self
+                .tx
+                .send(Either::Left(PeerMsg::RaftCommand(Box::new(cmd))));
             Ok(())
         }
     }
 
     impl CasualRouter<RocksEngine> for TestRaftStoreRouter {
         fn send(&self, _: u64, msg: CasualMessage<RocksEngine>) -> RaftStoreResult<()> {
-            let _ = self.tx.send(Either::Left(PeerMsg::CasualMessage(msg)));
+            let _ = self
+                .tx
+                .send(Either::Left(PeerMsg::CasualMessage(Box::new(msg))));
             Ok(())
         }
     }
@@ -507,7 +511,7 @@ pub mod test_router {
     impl RaftStoreRouter<RocksEngine> for TestRaftStoreRouter {
         fn send_raft_msg(&self, msg: RaftMessage) -> RaftStoreResult<()> {
             let _ = self.tx.send(Either::Left(PeerMsg::RaftMessage(
-                InspectedRaftMessage { heap_size: 0, msg },
+                Box::new(InspectedRaftMessage { heap_size: 0, msg }),
                 Some(TiInstant::now()),
             )));
             Ok(())

--- a/tests/integrations/raftstore/test_snap_recovery.rs
+++ b/tests/integrations/raftstore/test_snap_recovery.rs
@@ -101,9 +101,9 @@ fn test_snap_wait_apply() {
     let (tx, rx) = oneshot::channel();
     let syncer = SnapshotBrWaitApplySyncer::new(1, tx);
     router.broadcast_normal(|| {
-        PeerMsg::SignificantMsg(SignificantMsg::SnapshotBrWaitApply(
+        PeerMsg::SignificantMsg(Box::new(SignificantMsg::SnapshotBrWaitApply(
             SnapshotBrWaitApplyRequest::relaxed(syncer.clone()),
-        ))
+        )))
     });
 
     // we expect recv timeout because the leader peer on store 1 cannot finished the
@@ -119,9 +119,9 @@ fn test_snap_wait_apply() {
     let (tx, rx) = oneshot::channel();
     let syncer = SnapshotBrWaitApplySyncer::new(1, tx);
     router.broadcast_normal(|| {
-        PeerMsg::SignificantMsg(SignificantMsg::SnapshotBrWaitApply(
+        PeerMsg::SignificantMsg(Box::new(SignificantMsg::SnapshotBrWaitApply(
             SnapshotBrWaitApplyRequest::relaxed(syncer.clone()),
-        ))
+        )))
     });
     drop(syncer);
 

--- a/tests/integrations/raftstore/test_snap_recovery.rs
+++ b/tests/integrations/raftstore/test_snap_recovery.rs
@@ -45,7 +45,7 @@ fn test_check_pending_admin() {
 
     let (tx, mut rx) = futures::channel::mpsc::unbounded();
     router.broadcast_normal(|| {
-        PeerMsg::SignificantMsg(SignificantMsg::CheckPendingAdmin(tx.clone()))
+        PeerMsg::SignificantMsg(Box::new(SignificantMsg::CheckPendingAdmin(tx.clone())))
     });
     futures::executor::block_on(async {
         let r = rx.next().await;
@@ -61,7 +61,7 @@ fn test_check_pending_admin() {
 
     let (tx, mut rx) = futures::channel::mpsc::unbounded();
     router.broadcast_normal(|| {
-        PeerMsg::SignificantMsg(SignificantMsg::CheckPendingAdmin(tx.clone()))
+        PeerMsg::SignificantMsg(Box::new(SignificantMsg::CheckPendingAdmin(tx.clone())))
     });
     futures::executor::block_on(async {
         let r = rx.next().await;


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close https://github.com/tikv/tikv/issues/16229

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Reduce the memory usage of peers' message channel 
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Test with 100k regions, the total memory usage reduce 40% compared to master
- patched: 
  - <img width="723" alt="img_v3_02da_f6018662-1da3-4be4-9ddb-14ce1e963adg" src="https://github.com/user-attachments/assets/f2d23596-4205-4eec-af87-fdbfd83e82e5">
- master:
  - <img width="718" alt="img_v3_02da_4785f9d6-1845-4699-b2eb-78163f9e39cg" src="https://github.com/user-attachments/assets/1395b1ea-0cca-492c-b81d-d401ccd286fb">

Gain 2% performance improvement on oltp_write_only 
![a5caebbe-8ab2-4197-929d-0a4d64503d24](https://github.com/user-attachments/assets/871caa33-9bd0-41a2-b683-0c3a31d72284)


Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Reduce considerable memory usage when there are lots of regions on one TiKV instance
```
