### PR TITLE
In-Memory-Engine: move from range-base to region-base

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2551,6 +2551,7 @@ dependencies = [
  "slog",
  "slog-global",
  "tempfile",
+ "test_util",
  "tikv_util",
  "txn_types",
 ]
@@ -6202,6 +6203,7 @@ dependencies = [
  "raftstore-v2",
  "rand 0.8.5",
  "rand_xorshift",
+ "range_cache_memory_engine",
  "resource_control",
  "resource_metering",
  "security",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2542,6 +2542,7 @@ dependencies = [
  "fail",
  "kvproto",
  "lazy_static",
+ "log_wrappers",
  "online_config",
  "prometheus",
  "prometheus-static-metric",

--- a/components/backup-stream/src/tempfiles.rs
+++ b/components/backup-stream/src/tempfiles.rs
@@ -59,7 +59,7 @@ pub struct Config {
     /// Prevent files with size less than this being swapped out.
     /// We perfer to swap larger files for reducing IOps.
     pub minimal_swap_out_file_size: usize,
-    /// The buffer size for writting swap files.
+    /// The buffer size for writing swap files.
     /// Even some of files has been swapped out, when new content appended,
     /// those content would be kept in memory before they reach a threshold.
     /// This would help us to reduce the I/O system calls.
@@ -334,7 +334,7 @@ impl TempFilePool {
         self.current.load(Ordering::Acquire)
     }
 
-    /// Create a file for writting.
+    /// Create a file for writing.
     /// This function is synchronous so we can call it easier in the polling
     /// context. (Anyway, it is really hard to call an async function in the
     /// polling context.)

--- a/components/engine_panic/src/range_cache_engine.rs
+++ b/components/engine_panic/src/range_cache_engine.rs
@@ -1,6 +1,6 @@
 // Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_traits::RangeCacheEngineExt;
+use engine_traits::{RangeCacheEngineExt, RegionEvent};
 
 use crate::PanicEngine;
 
@@ -9,7 +9,7 @@ impl RangeCacheEngineExt for PanicEngine {
         panic!()
     }
 
-    fn evict_range(&self, range: &engine_traits::CacheRange) {
+    fn on_region_event(&self, event: RegionEvent) {
         panic!()
     }
 }

--- a/components/engine_rocks/src/range_cache_engine.rs
+++ b/components/engine_rocks/src/range_cache_engine.rs
@@ -1,6 +1,6 @@
 // Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_traits::RangeCacheEngineExt;
+use engine_traits::{RangeCacheEngineExt, RegionEvent};
 
 use crate::RocksEngine;
 
@@ -10,5 +10,5 @@ impl RangeCacheEngineExt for RocksEngine {
     }
 
     #[inline]
-    fn evict_range(&self, _: &engine_traits::CacheRange) {}
+    fn on_region_event(&self, _: RegionEvent) {}
 }

--- a/components/engine_rocks/src/range_cache_engine.rs
+++ b/components/engine_rocks/src/range_cache_engine.rs
@@ -1,6 +1,6 @@
 // Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_traits::{RangeCacheEngineExt, EvictReason, RegionEvent};
+use engine_traits::{RangeCacheEngineExt, RegionEvent};
 
 use crate::RocksEngine;
 

--- a/components/engine_traits/src/engine.rs
+++ b/components/engine_traits/src/engine.rs
@@ -86,6 +86,10 @@ pub trait KvEngine:
 #[derive(Debug, Clone)]
 pub struct SnapshotContext {
     pub range: Option<CacheRange>,
+    pub region_id: u64,
+    // the version of region epoch.
+    pub epoch_version: u64,
+
     pub read_ts: u64,
 }
 

--- a/components/engine_traits/src/flush.rs
+++ b/components/engine_traits/src/flush.rs
@@ -217,7 +217,7 @@ impl PersistenceListener {
             })
         })();
         // The correctness relies on the assumption that there will be only one
-        // thread writting to the DB and increasing apply index.
+        // thread writing to the DB and increasing apply index.
         // Apply index will be set within DB lock, so it's correct even with manual
         // flush.
         let offset = data_cf_offset(&cf);

--- a/components/engine_traits/src/range_cache_engine.rs
+++ b/components/engine_traits/src/range_cache_engine.rs
@@ -16,7 +16,7 @@ pub enum FailedReason {
     TooOldRead,
     // while we always get rocksdb's snapshot first and then get IME's snapshot.
     // epoch is first checked in get rocksdb's snaphsot by raftstore.
-    // But bacuse we update IME's epoch in apply batch, and update raft local reader's
+    // But because we update IME's epoch in apply batch, and update raft local reader's
     // epoch after ApplyRes is returned, so it's possible that IME's region epoch is
     // newer than raftstore's, so we still need to check epoch again in IME snapshot.
     EpochNotMatch,
@@ -65,7 +65,7 @@ pub trait RangeCacheEngine:
     // provide atomic write
     fn snapshot(
         &self,
-        reigon_id: u64,
+        region_id: u64,
         region_epoch: u64,
         range: CacheRange,
         read_ts: u64,

--- a/components/engine_traits/src/range_cache_engine.rs
+++ b/components/engine_traits/src/range_cache_engine.rs
@@ -172,7 +172,12 @@ impl CacheRange {
     }
 
     pub fn overlaps_with_region(&self, region: &Region) -> bool {
-        self.start < region.end_key && region.start_key < self.end
+        &self.start[1..] < region.end_key.as_slice() && region.start_key.as_slice() < &self.end[1..]
+    }
+
+    pub fn equals_with_region(&self, region: &Region) -> bool {
+        &self.start[1..] == region.start_key.as_slice()
+            && &self.end[1..] == region.end_key.as_slice()
     }
 
     pub fn split_off(&self, range: &CacheRange) -> (Option<CacheRange>, Option<CacheRange>) {

--- a/components/engine_traits/src/range_cache_engine.rs
+++ b/components/engine_traits/src/range_cache_engine.rs
@@ -14,6 +14,11 @@ use crate::{Iterable, KvEngine, Snapshot, WriteBatchExt};
 pub enum FailedReason {
     NotCached,
     TooOldRead,
+    // while we always get rocksdb's snapshot first and then get IME's snapshot.
+    // epoch is first checked in get rocksdb's snaphsot by raftstore.
+    // But bacuse we update IME's epoch in apply batch, and update raft local reader's
+    // epoch after ApplyRes is returned, so it's possible that IME's region epoch is
+    // newer than raftstore's, so we still need to check epoch again in IME snapshot.
     EpochNotMatch,
 }
 
@@ -44,7 +49,7 @@ pub enum EvictReason {
     AutoEvict,
     DeleteRange,
     Merge,
-    InMemoryEngineDisabled,
+    Disabled,
 }
 
 /// RangeCacheEngine works as a range cache caching some ranges (in Memory or

--- a/components/engine_traits/src/range_cache_engine.rs
+++ b/components/engine_traits/src/range_cache_engine.rs
@@ -171,15 +171,6 @@ impl CacheRange {
         self.start < other.end && other.start < self.end
     }
 
-    pub fn overlaps_with_region(&self, region: &Region) -> bool {
-        &self.start[1..] < region.end_key.as_slice() && region.start_key.as_slice() < &self.end[1..]
-    }
-
-    pub fn equals_with_region(&self, region: &Region) -> bool {
-        &self.start[1..] == region.start_key.as_slice()
-            && &self.end[1..] == region.end_key.as_slice()
-    }
-
     pub fn split_off(&self, range: &CacheRange) -> (Option<CacheRange>, Option<CacheRange>) {
         assert!(self.contains_range(range));
         let left = if self.start != range.start {

--- a/components/engine_traits/src/range_cache_engine.rs
+++ b/components/engine_traits/src/range_cache_engine.rs
@@ -15,6 +15,7 @@ use crate::{Iterable, KvEngine, Snapshot, WriteBatchExt};
 pub enum FailedReason {
     NotCached,
     TooOldRead,
+    EpochNotMatch,
 }
 
 pub enum RegionEvent {

--- a/components/engine_traits/src/range_cache_engine.rs
+++ b/components/engine_traits/src/range_cache_engine.rs
@@ -145,18 +145,7 @@ impl CacheRange {
 
 #[cfg(test)]
 mod tests {
-    use std::cmp::Ordering;
-
     use super::CacheRange;
-    #[test]
-    fn test_cache_range_partial_cmp() {
-        let r1 = CacheRange::new(b"k1".to_vec(), b"k2".to_vec());
-        let r2 = CacheRange::new(b"k2".to_vec(), b"k3".to_vec());
-        let r3 = CacheRange::new(b"k2".to_vec(), b"k4".to_vec());
-        assert_eq!(r1.partial_cmp(&r2).unwrap(), Ordering::Less);
-        assert_eq!(r2.partial_cmp(&r1).unwrap(), Ordering::Greater);
-        assert!(r2.partial_cmp(&r3).is_none());
-    }
 
     #[test]
     fn test_overlap() {

--- a/components/engine_traits/src/range_cache_engine.rs
+++ b/components/engine_traits/src/range_cache_engine.rs
@@ -25,6 +25,8 @@ pub enum RegionEvent {
     Eviction {
         region: Region,
     },
+    // range eviction triggered by delte_range
+    // we should evict all cache regions that overlaps with this range
     EvictByRange {
         range: CacheRange,
     },

--- a/components/engine_traits/src/range_cache_engine.rs
+++ b/components/engine_traits/src/range_cache_engine.rs
@@ -26,7 +26,7 @@ pub enum RegionEvent {
     Eviction {
         region: Region,
     },
-    // range eviction triggered by delte_range
+    // range eviction triggered by delete_range
     // we should evict all cache regions that overlaps with this range
     EvictByRange {
         range: CacheRange,

--- a/components/engine_traits/src/write_batch.rs
+++ b/components/engine_traits/src/write_batch.rs
@@ -1,6 +1,8 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use crate::{errors::Result, options::WriteOptions, CacheRange};
+use kvproto::metapb::Region;
+
+use crate::{errors::Result, options::WriteOptions};
 
 /// Engines that can create write batches
 pub trait WriteBatchExt: Sized {
@@ -125,6 +127,6 @@ pub trait WriteBatch: Mutable {
     fn merge(&mut self, src: Self) -> Result<()>;
 
     /// It declares that the following consecutive write will be within this
-    /// range.
-    fn prepare_for_range(&mut self, _: CacheRange) {}
+    /// region.
+    fn prepare_for_region(&mut self, _: &Region) {}
 }

--- a/components/hybrid_engine/Cargo.toml
+++ b/components/hybrid_engine/Cargo.toml
@@ -35,3 +35,4 @@ kvproto = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3.0"
+test_util = { workspace = true }

--- a/components/hybrid_engine/Cargo.toml
+++ b/components/hybrid_engine/Cargo.toml
@@ -19,6 +19,7 @@ engine_traits = { workspace = true }
 txn_types = { workspace = true }
 tikv_util = { workspace = true }
 engine_rocks = { workspace = true }
+log_wrappers = { workspace = true }
 online_config = { workspace = true }
 range_cache_memory_engine = { workspace = true }
 slog = { workspace = true }

--- a/components/hybrid_engine/src/engine.rs
+++ b/components/hybrid_engine/src/engine.rs
@@ -214,16 +214,15 @@ mod tests {
 
     use engine_rocks::util::new_engine;
     use engine_traits::{CacheRange, KvEngine, SnapshotContext, CF_DEFAULT, CF_LOCK, CF_WRITE};
-    use kvproto::metapb::Region;
     use online_config::{ConfigChange, ConfigManager, ConfigValue};
     use range_cache_memory_engine::{
-        config::RangeCacheConfigManager, RangeCacheEngineConfig, RangeCacheEngineContext,
-        RangeCacheMemoryEngine,
+        config::RangeCacheConfigManager, test_util::new_region, RangeCacheEngineConfig,
+        RangeCacheEngineContext, RangeCacheMemoryEngine,
     };
     use tempfile::Builder;
     use tikv_util::config::VersionTrack;
 
-    use crate::{misc::tests::new_region, HybridEngine};
+    use crate::HybridEngine;
 
     #[test]
     fn test_engine() {

--- a/components/hybrid_engine/src/engine.rs
+++ b/components/hybrid_engine/src/engine.rs
@@ -120,6 +120,12 @@ where
                         .inc();
                     None
                 }
+                Err(FailedReason::EpochNotMatch) => {
+                    RANGE_CACHEN_SNAPSHOT_ACQUIRE_FAILED_REASON_COUNT_STAIC
+                        .epoch_not_match
+                        .inc();
+                    None
+                }
             }
         } else {
             RANGE_CACHEN_SNAPSHOT_ACQUIRE_FAILED_REASON_COUNT_STAIC

--- a/components/hybrid_engine/src/metrics.rs
+++ b/components/hybrid_engine/src/metrics.rs
@@ -18,6 +18,7 @@ make_auto_flush_static_metric! {
         no_read_ts,
         not_cached,
         too_old_read,
+        epoch_not_match,
     }
 
     pub struct FailedReasonCountVec: LocalIntCounter {

--- a/components/hybrid_engine/src/observer.rs
+++ b/components/hybrid_engine/src/observer.rs
@@ -13,7 +13,7 @@ use raftstore::coprocessor::{
 
 #[derive(Clone)]
 pub struct Observer {
-    // observer is per thread so ther is no need to use mutex here,
+    // observer is per thread so there is no need to use mutex here,
     // but current inteface only provides `&self` but not `&mut self`,
     // so we use mutex to workaround this restriction.
     // TODO: change Observer's interface to `&mut self`.

--- a/components/hybrid_engine/src/observer.rs
+++ b/components/hybrid_engine/src/observer.rs
@@ -91,6 +91,7 @@ impl Observer {
                     region: ctx.region().clone(),
                 });
         }
+        // there are new_regions, this must be a split event.
         if !state.new_regions.is_empty() {
             let cmd_type = cmd.request.get_admin_request().get_cmd_type();
             assert!(cmd_type == AdminCmdType::BatchSplit || cmd_type == AdminCmdType::Split);

--- a/components/hybrid_engine/src/observer.rs
+++ b/components/hybrid_engine/src/observer.rs
@@ -138,8 +138,8 @@ impl Observer {
            "evict region due to leader step down";
            "region_id" => region.get_id(),
            "epoch" => ?region.get_region_epoch(),
-           "start_key" => ?region.start_key,
-           "end_key" => ?region.end_key,
+           "start_key" => ?log_wrappers::Value(&region.start_key),
+           "end_key" => ?log_wrappers::Value(&region.end_key),
         );
         self.pending_events
             .lock()

--- a/components/hybrid_engine/src/range_cache_engine.rs
+++ b/components/hybrid_engine/src/range_cache_engine.rs
@@ -1,6 +1,6 @@
 // Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_traits::{CacheRange, KvEngine, RangeCacheEngine, RangeCacheEngineExt, RegionEvent};
+use engine_traits::{KvEngine, RangeCacheEngine, RangeCacheEngineExt, RegionEvent};
 
 use crate::HybridEngine;
 

--- a/components/hybrid_engine/src/range_cache_engine.rs
+++ b/components/hybrid_engine/src/range_cache_engine.rs
@@ -1,6 +1,6 @@
 // Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_traits::{CacheRange, KvEngine, RangeCacheEngine, RangeCacheEngineExt};
+use engine_traits::{CacheRange, KvEngine, RangeCacheEngine, RangeCacheEngineExt, RegionEvent};
 
 use crate::HybridEngine;
 
@@ -14,7 +14,7 @@ where
     }
 
     #[inline]
-    fn evict_range(&self, range: &CacheRange) {
-        self.range_cache_engine().evict_range(range);
+    fn on_region_event(&self, event: RegionEvent) {
+        self.range_cache_engine().on_region_event(event);
     }
 }

--- a/components/hybrid_engine/src/snapshot.rs
+++ b/components/hybrid_engine/src/snapshot.rs
@@ -162,7 +162,7 @@ mod tests {
             assert!(!iter.seek_to_first().unwrap());
         }
         let mut write_batch = hybrid_engine.write_batch();
-        write_batch.prepare_for_range(range.clone());
+        write_batch.prepare_for_region(range.clone());
         write_batch
             .cache_write_batch
             .set_range_cache_status(RangeCacheStatus::Cached);

--- a/components/hybrid_engine/src/snapshot.rs
+++ b/components/hybrid_engine/src/snapshot.rs
@@ -135,16 +135,19 @@ mod tests {
         CacheRange, IterOptions, Iterable, Iterator, KvEngine, Mutable, SnapshotContext,
         WriteBatch, WriteBatchExt, CF_DEFAULT,
     };
-    use range_cache_memory_engine::{RangeCacheEngineConfig, RangeCacheStatus};
+    use range_cache_memory_engine::{
+        test_util::new_region, RangeCacheEngineConfig, RangeCacheStatus,
+    };
 
-    use crate::{misc::tests::new_region, util::hybrid_engine_for_tests};
+    use crate::util::hybrid_engine_for_tests;
 
     #[test]
     fn test_iterator() {
         let region = new_region(1, b"", b"z");
+        let range = CacheRange::from_region(&region);
         let mut iter_opt = IterOptions::default();
-        iter_opt.set_upper_bound(&region.end_key, 0);
-        iter_opt.set_lower_bound(&region.start_key, 0);
+        iter_opt.set_upper_bound(&range.end, 0);
+        iter_opt.set_lower_bound(&range.start, 0);
 
         let region_clone = region.clone();
         let (_path, hybrid_engine) = hybrid_engine_for_tests(
@@ -169,7 +172,7 @@ mod tests {
         write_batch
             .cache_write_batch
             .set_range_cache_status(RangeCacheStatus::Cached);
-        write_batch.put(b"hello", b"world").unwrap();
+        write_batch.put(b"zhello", b"world").unwrap();
         let seq = write_batch.write().unwrap();
         assert!(seq > 0);
         let ctx = SnapshotContext {
@@ -184,7 +187,7 @@ mod tests {
             assert!(iter.seek_to_first().unwrap());
             let actual_key = iter.key();
             let actual_value = iter.value();
-            assert_eq!(actual_key, b"hello");
+            assert_eq!(actual_key, b"zhello");
             assert_eq!(actual_value, b"world");
         }
     }

--- a/components/hybrid_engine/src/util.rs
+++ b/components/hybrid_engine/src/util.rs
@@ -20,11 +20,17 @@ use crate::HybridEngine;
 /// ```
 /// use hybrid_engine::util::hybrid_engine_for_tests;
 /// let (_path, _hybrid_engine) = hybrid_engine_for_tests("temp", |memory_engine| {
-///     let range = engine_traits::CacheRange::new(b"k00".to_vec(), b"k10".to_vec());
-///     memory_engine.new_range(range.clone());
+///     let region = {
+///         let mut r = kvproto::metapb::Region::default();
+///         r.id = 1;
+///         r.start_key = b"".into();
+///         r.end_key = b"z".into();
+///         r
+///     };
+///     memory_engine.new_region(region.clone());
 ///     {
 ///         let mut core = memory_engine.core().write().unwrap();
-///         core.mut_range_manager().set_range_readable(&range, true);
+///         core.mut_range_manager().set_region_readable(&region, true);
 ///         core.mut_range_manager().set_safe_ts(&range, 10);
 ///     }
 /// })

--- a/components/hybrid_engine/src/util.rs
+++ b/components/hybrid_engine/src/util.rs
@@ -19,20 +19,19 @@ use crate::HybridEngine;
 ///
 /// ```
 /// use hybrid_engine::util::hybrid_engine_for_tests;
-/// let (_path, _hybrid_engine) = hybrid_engine_for_tests("temp", |memory_engine| {
+/// use range_cache_memory_engine::RangeCacheEngineConfig;
+/// let mut config = RangeCacheEngineConfig::default();
+/// config.enabled = true;
+/// let (_path, _hybrid_engine) = hybrid_engine_for_tests("temp", config, |memory_engine| {
 ///     let region = {
 ///         let mut r = kvproto::metapb::Region::default();
 ///         r.id = 1;
 ///         r.start_key = b"".into();
 ///         r.end_key = b"z".into();
+///         r.mut_peers().push(kvproto::metapb::Peer::default());
 ///         r
 ///     };
 ///     memory_engine.new_region(region.clone());
-///     {
-///         let mut core = memory_engine.core().write().unwrap();
-///         core.mut_range_manager().set_region_readable(&region, true);
-///         core.mut_range_manager().set_safe_ts(&range, 10);
-///     }
 /// })
 /// .unwrap();
 /// ```

--- a/components/hybrid_engine/src/util.rs
+++ b/components/hybrid_engine/src/util.rs
@@ -19,19 +19,12 @@ use crate::HybridEngine;
 ///
 /// ```
 /// use hybrid_engine::util::hybrid_engine_for_tests;
-/// use range_cache_memory_engine::RangeCacheEngineConfig;
+/// use range_cache_memory_engine::{test_util::new_region, RangeCacheEngineConfig};
 /// let mut config = RangeCacheEngineConfig::default();
 /// config.enabled = true;
 /// let (_path, _hybrid_engine) = hybrid_engine_for_tests("temp", config, |memory_engine| {
-///     let region = {
-///         let mut r = kvproto::metapb::Region::default();
-///         r.id = 1;
-///         r.start_key = b"".into();
-///         r.end_key = b"z".into();
-///         r.mut_peers().push(kvproto::metapb::Peer::default());
-///         r
-///     };
-///     memory_engine.new_region(region.clone());
+///     let region = new_region(1, b"", b"z");
+///     memory_engine.new_region(region);
 /// })
 /// .unwrap();
 /// ```

--- a/components/hybrid_engine/tests/failpoints/test_write_batch.rs
+++ b/components/hybrid_engine/tests/failpoints/test_write_batch.rs
@@ -15,20 +15,26 @@ fn test_sequence_number_unique() {
         hybrid_engine_for_tests("temp", RangeCacheEngineConfig::config_for_test(), |_| {}).unwrap();
 
     let (tx, rx) = sync_channel(0);
-    fail::cfg_callback("pending_range_completes_loading", move || {
-        fail::cfg("on_snapshot_load_finished", "pause").unwrap();
+    fail::cfg_callback("on_completes_batch_loading", move || {
+        fail::cfg("on_start_loading_region", "pause").unwrap();
         tx.send(true).unwrap();
     })
     .unwrap();
 
+    // first write some data, these data should be handled by batch loading.
+    let mut wb = hybrid_engine.write_batch();
+    wb.put(b"zk5", b"val").unwrap(); // seq 1
+    wb.put(b"zk7", b"val").unwrap(); // seq 2
+
     let engine = hybrid_engine.range_cache_engine().clone();
     let r = new_region(1, b"k", b"k5");
     engine.new_region(r.clone());
+    wb.write().unwrap();
 
     // Mock that we have a loading range, and there are some keys written in it
     // during the load
-    let r2 = new_region(1, b"k5", b"k7");
-    let r3 = new_region(1, b"k7", b"k9");
+    let r2 = new_region(2, b"k5", b"k7");
+    let r3 = new_region(3, b"k7", b"k9");
 
     engine.load_region(r2.clone()).unwrap();
     engine.load_region(r3.clone()).unwrap();
@@ -37,27 +43,26 @@ fn test_sequence_number_unique() {
     // if a delete and a put of the same key occurs in the same write batch,
     // the delete will be hidden by the put even the delete is performed
     // after the put.
+    // while we block the batch loading of region3, it's new KVs are still directly
+    // written into the skiplist.
     let mut wb = hybrid_engine.write_batch();
     wb.prepare_for_region(&r);
-    wb.put(b"k", b"val").unwrap(); // seq 6
-    wb.delete(b"k").unwrap(); // seq 7
-    wb.put(b"k2", b"val").unwrap(); // seq 8
+    wb.put(b"zk", b"val").unwrap(); // seq 3
+    wb.delete(b"zk").unwrap(); // seq 4
+    wb.put(b"zk2", b"val").unwrap(); // seq 5
 
     wb.prepare_for_region(&r2);
-    wb.put(b"k6", b"val").unwrap(); // seq 3
-    wb.put(b"k5", b"val").unwrap(); // seq 4
-    wb.delete(b"k5").unwrap(); // seq 5
+    wb.put(b"zk6", b"val").unwrap(); // seq 6
+    wb.delete(b"zk5").unwrap(); // seq 7
+    wb.put(b"zk5", b"val2").unwrap(); // seq 8
 
     wb.prepare_for_region(&r3);
-    wb.put(b"k8", b"val").unwrap(); // seq 1
-    wb.put(b"k7", b"val").unwrap(); // seq 2
+    wb.put(b"zk8", b"val").unwrap(); // seq 9
+    wb.put(b"zk7", b"val2").unwrap(); // seq 10
 
     rx.recv().unwrap();
     wb.write().unwrap();
 
-    // For sequence number increment, the loading range get increment first, the
-    // loading range that completes the loading before consuming the write batch get
-    // increment second, and the cached range get increment last.
     let mut iter = engine
         .core()
         .read()
@@ -68,13 +73,19 @@ fn test_sequence_number_unique() {
 
     let mut first = true;
 
-    for (k, seq, ty) in [
-        (b"k".to_vec(), 7, ValueType::Deletion),
-        (b"k".to_vec(), 6, ValueType::Value),
-        (b"k2".to_vec(), 8, ValueType::Value),
-        (b"k5".to_vec(), 5, ValueType::Deletion),
-        (b"k5".to_vec(), 4, ValueType::Value),
-        (b"k6".to_vec(), 3, ValueType::Value),
+    for (k, sequence, v_type) in [
+        (b"zk".to_vec(), 4, ValueType::Deletion),
+        (b"zk".to_vec(), 3, ValueType::Value),
+        (b"zk2".to_vec(), 5, ValueType::Value),
+        (b"zk5".to_vec(), 8, ValueType::Value),
+        (b"zk5".to_vec(), 7, ValueType::Deletion),
+        // NOTE: for batch loading, we always use the current seq number
+        // to write all the keys.
+        (b"zk5".to_vec(), 2, ValueType::Value),
+        (b"zk6".to_vec(), 6, ValueType::Value),
+        (b"zk7".to_vec(), 10, ValueType::Value),
+        // "zk7" with seq 2 is block, so invisible here.
+        (b"zk8".to_vec(), 9, ValueType::Value),
     ] {
         if first {
             iter.seek_to_first(guard);
@@ -83,14 +94,13 @@ fn test_sequence_number_unique() {
             iter.next(guard);
         }
 
-        let key = iter.key();
-        let InternalKey {
-            user_key,
-            sequence,
+        let expected_key = InternalKey {
+            user_key: k.as_slice(),
             v_type,
-        } = decode_key(key.as_bytes());
-        assert_eq!(sequence, seq);
-        assert_eq!(user_key, &k);
-        assert_eq!(v_type, ty);
+            sequence,
+        };
+        let key = iter.key();
+        let got_key = decode_key(key.as_bytes());
+        assert_eq!(expected_key, got_key);
     }
 }

--- a/components/hybrid_engine/tests/failpoints/test_write_batch.rs
+++ b/components/hybrid_engine/tests/failpoints/test_write_batch.rs
@@ -3,9 +3,11 @@
 use std::sync::mpsc::sync_channel;
 
 use crossbeam::epoch;
-use engine_traits::{CacheRange, Mutable, WriteBatch, WriteBatchExt};
-use hybrid_engine::{misc::tests::new_region, util::hybrid_engine_for_tests};
-use range_cache_memory_engine::{decode_key, InternalKey, RangeCacheEngineConfig, ValueType};
+use engine_traits::{Mutable, WriteBatch, WriteBatchExt};
+use hybrid_engine::util::hybrid_engine_for_tests;
+use range_cache_memory_engine::{
+    decode_key, test_util::new_region, InternalKey, RangeCacheEngineConfig, ValueType,
+};
 
 #[test]
 fn test_sequence_number_unique() {

--- a/components/hybrid_engine/tests/failpoints/test_write_batch.rs
+++ b/components/hybrid_engine/tests/failpoints/test_write_batch.rs
@@ -36,17 +36,17 @@ fn test_sequence_number_unique() {
     // the delete will be hidden by the put even the delete is performed
     // after the put.
     let mut wb = hybrid_engine.write_batch();
-    wb.prepare_for_range(r.clone());
+    wb.prepare_for_region(r.clone());
     wb.put(b"k", b"val").unwrap(); // seq 6
     wb.delete(b"k").unwrap(); // seq 7
     wb.put(b"k2", b"val").unwrap(); // seq 8
 
-    wb.prepare_for_range(r2.clone());
+    wb.prepare_for_region(r2.clone());
     wb.put(b"k6", b"val").unwrap(); // seq 3
     wb.put(b"k5", b"val").unwrap(); // seq 4
     wb.delete(b"k5").unwrap(); // seq 5
 
-    wb.prepare_for_range(r3.clone());
+    wb.prepare_for_region(r3.clone());
     wb.put(b"k8", b"val").unwrap(); // seq 1
     wb.put(b"k7", b"val").unwrap(); // seq 2
 

--- a/components/keys/src/lib.rs
+++ b/components/keys/src/lib.rs
@@ -228,16 +228,16 @@ pub fn origin_key(key: &[u8]) -> &[u8] {
 /// Get the `start_key` of current region in encoded form.
 pub fn enc_start_key(region: &Region) -> Vec<u8> {
     // only initialized region's start_key can be encoded, otherwise there must be
-    // bugs somewhere. Here we only the region id for test convenience.
-    assert!(region.id > 0);
+    // bugs somewhere.
+    assert!(!region.get_peers().is_empty());
     data_key(region.get_start_key())
 }
 
 /// Get the `end_key` of current region in encoded form.
 pub fn enc_end_key(region: &Region) -> Vec<u8> {
     // only initialized region's end_key can be encoded, otherwise there must be
-    // bugs somewhere. Here we only the region id for test convenience.
-    assert!(region.id > 0);
+    // bugs somewhere.
+    assert!(!region.get_peers().is_empty());
     data_end_key(region.get_end_key())
 }
 

--- a/components/keys/src/lib.rs
+++ b/components/keys/src/lib.rs
@@ -228,16 +228,16 @@ pub fn origin_key(key: &[u8]) -> &[u8] {
 /// Get the `start_key` of current region in encoded form.
 pub fn enc_start_key(region: &Region) -> Vec<u8> {
     // only initialized region's start_key can be encoded, otherwise there must be
-    // bugs somewhere.
-    assert!(!region.get_peers().is_empty());
+    // bugs somewhere. Here we only the region id for test convenience.
+    assert!(region.id > 0);
     data_key(region.get_start_key())
 }
 
 /// Get the `end_key` of current region in encoded form.
 pub fn enc_end_key(region: &Region) -> Vec<u8> {
     // only initialized region's end_key can be encoded, otherwise there must be
-    // bugs somewhere.
-    assert!(!region.get_peers().is_empty());
+    // bugs somewhere. Here we only the region id for test convenience.
+    assert!(region.id > 0);
     data_end_key(region.get_end_key())
 }
 

--- a/components/raftstore/src/coprocessor/mod.rs
+++ b/components/raftstore/src/coprocessor/mod.rs
@@ -87,6 +87,7 @@ pub struct RegionState {
     pub peer_id: u64,
     pub pending_remove: bool,
     pub modified_region: Option<Region>,
+    pub new_regions: Vec<Region>,
 }
 
 /// Context for exec observers of mutation to be applied to ApplyContext.

--- a/components/raftstore/src/coprocessor/region_info_accessor.rs
+++ b/components/raftstore/src/coprocessor/region_info_accessor.rs
@@ -817,7 +817,7 @@ pub trait RegionInfoProvider: Send + Sync {
 
     fn find_region_by_id(
         &self,
-        _reigon_id: u64,
+        _region_id: u64,
         _callback: Callback<Option<RegionInfo>>,
     ) -> Result<()> {
         unimplemented!()

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -1511,9 +1511,9 @@ where
 
         let (modified_region, new_regions, mut pending_handle_ssts) = match &exec_result {
             ApplyResult::Res(e) => match e {
-                ExecResult::SplitRegion {
-                    derived, regions, ..
-                } => (Some(derived.clone()), regions.clone(), None),
+                ExecResult::SplitRegion { regions, .. } => {
+                    (Some(self.region.clone()), regions.clone(), None)
+                }
                 ExecResult::PrepareMerge { region, .. } => (Some(region.clone()), vec![], None),
                 ExecResult::CommitMerge { region, .. } => (Some(region.clone()), vec![], None),
                 ExecResult::RollbackMerge { region, .. } => (Some(region.clone()), vec![], None),

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -7423,7 +7423,7 @@ mod tests {
         let cmd_batch = cmdbatch_rx.recv_timeout(Duration::from_secs(3)).unwrap();
         assert_eq!(2, cmd_batch.len());
 
-        // Stop observer regoin 1.
+        // Stop observer region 1.
         observe_handle.stop_observing();
 
         let observe_handle = ObserveHandle::new();

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -2627,7 +2627,7 @@ where
             MEMTRACE_RAFT_MESSAGES.trace(TraceEvent::Sub(heap_size));
             if stepped.get() {
                 unsafe {
-                    // It could be less than exact for entry overwritting.
+                    // It could be less than exact for entry overwriting.
                     *memtrace_raft_entries += heap_size;
                     MEMTRACE_RAFT_ENTRIES.trace(TraceEvent::Add(heap_size));
                 }
@@ -3806,7 +3806,7 @@ where
         if self.fsm.peer.has_unpersisted_ready() {
             assert!(self.ctx.sync_write_worker.is_none());
             // The destroy must be delayed if there are some unpersisted readies.
-            // Otherwise there is a race of writting kv db and raft db between here
+            // Otherwise there is a race of writing kv db and raft db between here
             // and write worker.
             return Some(DelayReason::UnPersistedReady);
         }

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -5009,6 +5009,8 @@ where
         let snap_ctx = if let Ok(read_ts) = decode_u64(&mut req.get_header().get_flag_data()) {
             Some(SnapshotContext {
                 range: Some(CacheRange::from_region(&region)),
+                region_id: region.id,
+                epoch_version: region.get_region_epoch().version,
                 read_ts,
             })
         } else {

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -424,7 +424,7 @@ pub fn check_term(header: &RaftRequestHeader, term: u64) -> Result<()> {
     if header.get_term() == 0 || term <= header.get_term() + 1 {
         Ok(())
     } else {
-        // If header's term is 2 verions behind current term,
+        // If header's term is 2 versions behind current term,
         // leadership may have been changed away.
         Err(Error::StaleCommand)
     }
@@ -2304,7 +2304,7 @@ mod tests {
         header.set_term(7);
         check_term(&header, 7).unwrap();
         check_term(&header, 8).unwrap();
-        // If header's term is 2 verions behind current term,
+        // If header's term is 2 versions behind current term,
         // leadership may have been changed away.
         check_term(&header, 9).unwrap_err();
         check_term(&header, 10).unwrap_err();

--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -1300,7 +1300,7 @@ mod tests {
 
     use crossbeam::channel::TrySendError;
     use engine_test::kv::{KvTestEngine, KvTestSnapshot};
-    use engine_traits::{CacheRange, MiscExt, Peekable, SyncMutable, ALL_CFS};
+    use engine_traits::{MiscExt, Peekable, SyncMutable, ALL_CFS};
     use hybrid_engine::{HybridEngine, HybridEngineSnapshot};
     use keys::DATA_PREFIX;
     use kvproto::{metapb::RegionEpoch, raft_cmdpb::*};
@@ -2551,7 +2551,7 @@ mod tests {
         memory_engine.new_region(region1.clone());
         {
             let mut core = memory_engine.core().write();
-            core.mut_range_manager().set_safe_point(reigon1.id, 1);
+            core.mut_range_manager().set_safe_point(region1.id, 1);
         }
         let kv = (&[DATA_PREFIX, b'a'], b"b");
         reader.kv_engine.put(kv.0, kv.1).unwrap();
@@ -2686,6 +2686,8 @@ mod tests {
         let snap_ctx = SnapshotContext {
             read_ts: 15,
             range: None,
+            region_id: 0,
+            epoch_version: 0,
         };
         reader.propose_raft_command(Some(snap_ctx), read_id, task.request, task.callback);
         assert_eq!(rx.try_recv().unwrap_err(), TryRecvError::Empty);

--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -2548,11 +2548,10 @@ mod tests {
         };
         let leader2 = prs[0].clone();
         region1.set_region_epoch(epoch13.clone());
-        let range = CacheRange::from_region(&region1);
-        memory_engine.new_range(range.clone());
+        memory_engine.new_region(region1.clone());
         {
             let mut core = memory_engine.core().write();
-            core.mut_range_manager().set_safe_point(&range, 1);
+            core.mut_range_manager().set_safe_point(reigon1.id, 1);
         }
         let kv = (&[DATA_PREFIX, b'a'], b"b");
         reader.kv_engine.put(kv.0, kv.1).unwrap();
@@ -2599,10 +2598,12 @@ mod tests {
 
         {
             let mut core = memory_engine.core().write();
-            core.mut_range_manager().set_safe_point(&range, 10);
+            core.mut_range_manager().set_safe_point(region1.id, 10);
         }
 
         let snap_ctx = SnapshotContext {
+            region_id: 0,
+            epoch_version: 0,
             read_ts: 15,
             range: None,
         };

--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -1071,6 +1071,8 @@ where
         match self.pre_propose_raft_command(&req) {
             Ok(Some((mut delegate, policy))) => {
                 if let Some(ref mut ctx) = snap_ctx {
+                    ctx.region_id = delegate.region.id;
+                    ctx.epoch_version = delegate.region.get_region_epoch().version;
                     ctx.set_range(CacheRange::from_region(&delegate.region))
                 }
 

--- a/components/range_cache_memory_engine/src/background.rs
+++ b/components/range_cache_memory_engine/src/background.rs
@@ -2580,7 +2580,7 @@ pub mod tests {
             .snapshot(
                 region2.id,
                 0,
-                CacheRange::from_region(&region1),
+                CacheRange::from_region(&region2),
                 u64::MAX,
                 u64::MAX,
             )

--- a/components/range_cache_memory_engine/src/background.rs
+++ b/components/range_cache_memory_engine/src/background.rs
@@ -1573,6 +1573,7 @@ pub mod tests {
             encoding_for_filter, InternalBytes, ValueType,
         },
         memory_controller::MemoryController,
+        range_manager::RegionState::*,
         region_label::{
             region_label_meta_client,
             tests::{add_region_label_rule, new_region_label_rule, new_test_server_and_client},
@@ -2842,7 +2843,7 @@ pub mod tests {
                 .range_manager()
                 .regions()
                 .values()
-                .any(|m| m.get_state() <= RegionState::Loading)
+                .any(|m| matches!(m.get_state(), Pending | ReadyToLoad | Loading))
         });
 
         let verify = |region: &Region, exist, expect_count| {
@@ -2949,7 +2950,7 @@ pub mod tests {
                 .range_manager()
                 .regions()
                 .values()
-                .any(|m| m.get_state() <= RegionState::Loading)
+                .any(|m| matches!(m.get_state(), Pending | ReadyToLoad | Loading))
         });
 
         let verify = |r: &Region, exist, expect_count| {

--- a/components/range_cache_memory_engine/src/background.rs
+++ b/components/range_cache_memory_engine/src/background.rs
@@ -518,6 +518,8 @@ impl BackgroundRunnerCore {
                     on_region_meta(meta);
                 });
         }
+        drop(core);
+
         if !remove_regions.is_empty() {
             fail::fail_point!("in_memory_engine_snapshot_load_canceled");
 
@@ -534,9 +536,7 @@ impl BackgroundRunnerCore {
             return false;
         }
 
-        drop(core);
-
-        fail::fail_point!("pending_range_completes_loading");
+        fail::fail_point!("on_completes_batch_loading");
         true
     }
 
@@ -908,6 +908,7 @@ impl Runnable for BackgroundRunner {
                 let pd_client = self.pd_client.clone();
                 let gc_interval = self.gc_interval;
                 let f = async move {
+                    fail::fail_point!("on_start_loading_region");
                     let mut is_canceled = false;
                     let region_range = CacheRange::from_region(&region);
                     let skiplist_engine = {

--- a/components/range_cache_memory_engine/src/background.rs
+++ b/components/range_cache_memory_engine/src/background.rs
@@ -2952,7 +2952,7 @@ pub mod tests {
         };
         let safe_point = TimeStamp::from(safe_point);
         // Make sure it is a reasonable timestamp.
-        assert!(safe_point > start_time, "{safe_point}, {start_time}");
+        assert!(safe_point >= start_time, "{safe_point}, {start_time}");
         let now = TimeStamp::compose(TimeStamp::physical_now(), 0);
         assert!(safe_point < now, "{safe_point}, {now}");
         // Must get ts from PD.

--- a/components/range_cache_memory_engine/src/background.rs
+++ b/components/range_cache_memory_engine/src/background.rs
@@ -2776,15 +2776,13 @@ pub mod tests {
 
         // ensure all ranges are finshed
         test_util::eventually(Duration::from_millis(100), Duration::from_secs(2), || {
-            let count = engine
+            !engine
                 .core
                 .read()
                 .range_manager()
                 .regions()
                 .values()
-                .filter(|m| m.get_state() <= RegionState::Loading)
-                .count();
-            count == 0
+                .any(|m| m.get_state() <= RegionState::Loading)
         });
 
         let verify = |region: &Region, exist, expect_count| {
@@ -2885,15 +2883,13 @@ pub mod tests {
 
         // ensure all ranges are finshed
         test_util::eventually(Duration::from_millis(100), Duration::from_secs(2), || {
-            let count = engine
+            !engine
                 .core
                 .read()
                 .range_manager()
                 .regions()
                 .values()
-                .filter(|m| m.get_state() <= RegionState::Loading)
-                .count();
-            count == 0
+                .any(|m| m.get_state() <= RegionState::Loading)
         });
 
         let verify = |r: &Region, exist, expect_count| {

--- a/components/range_cache_memory_engine/src/engine.rs
+++ b/components/range_cache_memory_engine/src/engine.rs
@@ -339,7 +339,7 @@ impl RangeCacheMemoryEngine {
     ) -> RangeCacheStatus {
         let mut core = self.core.write();
         let range_manager = core.mut_range_manager();
-        let Some(mut region_state) = range_manager.check_region_status(region) else {
+        let Some(mut region_state) = range_manager.check_region_state(region) else {
             return RangeCacheStatus::NotInCache;
         };
 
@@ -370,7 +370,7 @@ impl RangeCacheMemoryEngine {
             || region_state == RegionState::Loading
             || region_state == RegionState::Active
         {
-            range_manager.record_in_region_being_written(write_batch_id, range, region.id);
+            range_manager.record_in_region_being_written(write_batch_id, range);
             if region_state == RegionState::Active {
                 result = RangeCacheStatus::Cached;
             } else {

--- a/components/range_cache_memory_engine/src/engine.rs
+++ b/components/range_cache_memory_engine/src/engine.rs
@@ -521,7 +521,7 @@ pub mod tests {
     use crate::{
         keys::{construct_key, construct_user_key, encode_key},
         memory_controller::MemoryController,
-        range_manager::{RangeMeta, RegionManager, RegionState},
+        range_manager::{RangeMeta, RegionManager, RegionState, RegionState::*},
         test_util::new_region,
         InternalBytes, RangeCacheEngineConfig, RangeCacheEngineContext, RangeCacheMemoryEngine,
         ValueType,
@@ -543,7 +543,7 @@ pub mod tests {
         engine.prepare_for_apply(1, CacheRange::from_region(&region2), &region2);
         assert_eq!(
             count_region(engine.core.read().range_manager(), |m| {
-                m.get_state() <= RegionState::Loading
+                matches!(m.get_state(), Pending | ReadyToLoad | Loading)
             }),
             0
         );
@@ -556,7 +556,7 @@ pub mod tests {
         engine.prepare_for_apply(1, CacheRange::from_region(&region2), &region2);
         assert_eq!(
             count_region(engine.core.read().range_manager(), |m| {
-                m.get_state() <= RegionState::Loading
+                matches!(m.get_state(), Pending | ReadyToLoad | Loading)
             }),
             0
         );

--- a/components/range_cache_memory_engine/src/engine.rs
+++ b/components/range_cache_memory_engine/src/engine.rs
@@ -521,7 +521,7 @@ pub mod tests {
     use crate::{
         keys::{construct_key, construct_user_key, encode_key},
         memory_controller::MemoryController,
-        range_manager::{RangeMeta, RegionManager, RegionState, RegionState::*},
+        range_manager::{RangeMeta, RegionManager, RegionState::*},
         test_util::new_region,
         InternalBytes, RangeCacheEngineConfig, RangeCacheEngineContext, RangeCacheMemoryEngine,
         ValueType,

--- a/components/range_cache_memory_engine/src/engine.rs
+++ b/components/range_cache_memory_engine/src/engine.rs
@@ -32,7 +32,7 @@ use crate::{
         encode_key_for_boundary_with_mvcc, encode_key_for_boundary_without_mvcc, InternalBytes,
     },
     memory_controller::MemoryController,
-    range_manager::{RangeCacheStatus, RegionManager, RegionState, LoadFailedReason},
+    range_manager::{LoadFailedReason, RangeCacheStatus, RegionManager, RegionState},
     read::{RangeCacheIterator, RangeCacheSnapshot},
     statistics::Statistics,
     RangeCacheEngineConfig, RangeCacheEngineContext,

--- a/components/range_cache_memory_engine/src/engine.rs
+++ b/components/range_cache_memory_engine/src/engine.rs
@@ -1,7 +1,6 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::{
-    borrow::Borrow,
     fmt::{self, Debug},
     ops::Bound,
     result,
@@ -97,11 +96,7 @@ impl SkiplistHandle {
         self.0.insert(key, value, guard).release(guard);
     }
 
-    pub fn remove<Q>(&self, key: &Q, guard: &Guard)
-    where
-        InternalBytes: Borrow<Q>,
-        Q: Ord + ?Sized,
-    {
+    pub fn remove(&self, key: &InternalBytes, guard: &Guard) {
         if let Some(entry) = self.0.remove(key, guard) {
             entry.release(guard);
         }

--- a/components/range_cache_memory_engine/src/keys.rs
+++ b/components/range_cache_memory_engine/src/keys.rs
@@ -268,13 +268,13 @@ pub fn encoding_for_filter(mvcc_prefix: &[u8], start_ts: TimeStamp) -> InternalB
 
 #[cfg(test)]
 pub fn construct_user_key(i: u64) -> Vec<u8> {
-    let k = format!("k{:08}", i);
+    let k = format!("zk{:08}", i);
     k.as_bytes().to_owned()
 }
 
 #[cfg(test)]
 pub fn construct_key(i: u64, ts: u64) -> Vec<u8> {
-    let k = format!("k{:08}", i);
+    let k = format!("zk{:08}", i);
     Key::from_encoded(k.as_bytes().to_vec())
         .append_ts(TimeStamp::new(ts))
         .into_encoded()

--- a/components/range_cache_memory_engine/src/keys.rs
+++ b/components/range_cache_memory_engine/src/keys.rs
@@ -2,7 +2,6 @@
 
 use core::slice::SlicePattern;
 use std::{
-    borrow::Borrow,
     cmp::{self, Ordering},
     fmt,
     sync::Arc,
@@ -117,26 +116,13 @@ impl Ord for InternalBytes {
                 .unwrap(),
         );
 
-        #[allow(clippy::comparison_chain)]
-        if n1 < n2 {
-            Ordering::Greater
-        } else if n1 > n2 {
-            Ordering::Less
-        } else {
-            Ordering::Equal
-        }
+        n2.cmp(&n1)
     }
 }
 
 impl PartialOrd for InternalBytes {
     fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
         Some(self.cmp(other))
-    }
-}
-
-impl Borrow<[u8]> for InternalBytes {
-    fn borrow(&self) -> &[u8] {
-        &self.bytes
     }
 }
 

--- a/components/range_cache_memory_engine/src/keys.rs
+++ b/components/range_cache_memory_engine/src/keys.rs
@@ -168,7 +168,9 @@ impl<'a> fmt::Debug for InternalKey<'a> {
         write!(
             f,
             "(key: {:?}, type: {:?}, seq: {})",
-            self.user_key, self.v_type, self.sequence
+            log_wrappers::Value(self.user_key),
+            self.v_type,
+            self.sequence
         )
     }
 }

--- a/components/range_cache_memory_engine/src/keys.rs
+++ b/components/range_cache_memory_engine/src/keys.rs
@@ -2,6 +2,7 @@
 
 use core::slice::SlicePattern;
 use std::{
+    borrow::Borrow,
     cmp::{self, Ordering},
     fmt,
     sync::Arc,
@@ -130,6 +131,12 @@ impl Ord for InternalBytes {
 impl PartialOrd for InternalBytes {
     fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
         Some(self.cmp(other))
+    }
+}
+
+impl Borrow<[u8]> for InternalBytes {
+    fn borrow(&self) -> &[u8] {
+        &self.bytes
     }
 }
 

--- a/components/range_cache_memory_engine/src/keys.rs
+++ b/components/range_cache_memory_engine/src/keys.rs
@@ -3,6 +3,7 @@
 use core::slice::SlicePattern;
 use std::{
     cmp::{self, Ordering},
+    fmt,
     sync::Arc,
 };
 
@@ -154,11 +155,22 @@ impl TryFrom<u8> for ValueType {
     }
 }
 
+#[derive(PartialEq)]
 pub struct InternalKey<'a> {
     // key with mvcc version in memory comparable format
     pub user_key: &'a [u8],
     pub v_type: ValueType,
     pub sequence: u64,
+}
+
+impl<'a> fmt::Debug for InternalKey<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "(key: {:?}, type: {:?}, seq: {})",
+            self.user_key, self.v_type, self.sequence
+        )
+    }
 }
 
 // The size of sequence number suffix

--- a/components/range_cache_memory_engine/src/keys.rs
+++ b/components/range_cache_memory_engine/src/keys.rs
@@ -273,6 +273,12 @@ pub fn construct_user_key(i: u64) -> Vec<u8> {
 }
 
 #[cfg(test)]
+pub fn construct_region_key(i: u64) -> Vec<u8> {
+    let k = format!("k{:08}", i);
+    k.as_bytes().to_owned()
+}
+
+#[cfg(test)]
 pub fn construct_key(i: u64, ts: u64) -> Vec<u8> {
     let k = format!("zk{:08}", i);
     Key::from_encoded(k.as_bytes().to_vec())

--- a/components/range_cache_memory_engine/src/lib.rs
+++ b/components/range_cache_memory_engine/src/lib.rs
@@ -38,7 +38,7 @@ pub use keys::{
     InternalKey, ValueType,
 };
 pub use metrics::flush_range_cache_engine_statistics;
-pub use range_manager::RangeCacheStatus;
+pub use range_manager::{RangeCacheStatus, RegionState};
 pub use statistics::Statistics as RangeCacheMemoryEngineStatistics;
 use txn_types::TimeStamp;
 pub use write_batch::RangeCacheWriteBatch;

--- a/components/range_cache_memory_engine/src/lib.rs
+++ b/components/range_cache_memory_engine/src/lib.rs
@@ -1,5 +1,6 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
+#![feature(assert_matches)]
 #![feature(let_chains)]
 #![allow(internal_features)]
 #![feature(core_intrinsics)]

--- a/components/range_cache_memory_engine/src/lib.rs
+++ b/components/range_cache_memory_engine/src/lib.rs
@@ -65,10 +65,8 @@ impl Default for RangeCacheEngineConfig {
         Self {
             enabled: false,
             gc_interval: ReadableDuration(Duration::from_secs(180)),
-            load_evict_interval: ReadableDuration(Duration::from_secs(300)), /* Each load/evict
-                                                                              * operation should
-                                                                              * run within five
-                                                                              * minutes. */
+            // Each load/evict operation should run within five minutes.
+            load_evict_interval: ReadableDuration(Duration::from_secs(300)),
             soft_limit_threshold: None,
             hard_limit_threshold: None,
             expected_region_size: None,

--- a/components/range_cache_memory_engine/src/memory_controller.rs
+++ b/components/range_cache_memory_engine/src/memory_controller.rs
@@ -96,8 +96,9 @@ impl MemoryController {
     }
 
     #[inline]
-    pub(crate) fn set_memory_checking(&self, v: bool) {
-        self.memory_checking.store(v, Ordering::Relaxed);
+    // return the previous status.
+    pub(crate) fn set_memory_checking(&self, v: bool) -> bool {
+        self.memory_checking.swap(v, Ordering::Relaxed)
     }
 
     #[inline]

--- a/components/range_cache_memory_engine/src/metrics.rs
+++ b/components/range_cache_memory_engine/src/metrics.rs
@@ -201,6 +201,8 @@ pub(crate) fn observe_eviction_duration(secs: f64, evict_reason: EvictReason) {
             .memory_limit_reached
             .observe(secs),
         EvictReason::Merge => RANGE_EVICTION_DURATION_HISTOGRAM_STATIC.merge.observe(secs),
-        EvictReason::InMemoryEngineDisabled => RANGE_EVICTION_DURATION_HISTOGRAM_STATIC.in_memory_engine_disabled.observe(secs),
+        EvictReason::InMemoryEngineDisabled => RANGE_EVICTION_DURATION_HISTOGRAM_STATIC
+            .in_memory_engine_disabled
+            .observe(secs),
     }
 }

--- a/components/range_cache_memory_engine/src/metrics.rs
+++ b/components/range_cache_memory_engine/src/metrics.rs
@@ -39,7 +39,7 @@ make_auto_flush_static_metric! {
         delete_range,
         become_follower,
         memory_limit_reached,
-        in_memory_engine_disabled,
+        disabled,
     }
 
     pub struct GcFilteredCountVec: LocalIntCounter {
@@ -201,8 +201,8 @@ pub(crate) fn observe_eviction_duration(secs: f64, evict_reason: EvictReason) {
             .memory_limit_reached
             .observe(secs),
         EvictReason::Merge => RANGE_EVICTION_DURATION_HISTOGRAM_STATIC.merge.observe(secs),
-        EvictReason::InMemoryEngineDisabled => RANGE_EVICTION_DURATION_HISTOGRAM_STATIC
-            .in_memory_engine_disabled
+        EvictReason::Disabled => RANGE_EVICTION_DURATION_HISTOGRAM_STATIC
+            .disabled
             .observe(secs),
     }
 }

--- a/components/range_cache_memory_engine/src/range_manager.rs
+++ b/components/range_cache_memory_engine/src/range_manager.rs
@@ -100,7 +100,7 @@ impl RangeMeta {
     }
 
     #[inline]
-    pub(crate) fn region(&self) -> &Region {
+    pub fn region(&self) -> &Region {
         &self.region
     }
 
@@ -129,7 +129,7 @@ impl RangeMeta {
         self.safe_point = safe_point;
     }
 
-    pub(crate) fn get_range(&self) -> &CacheRange {
+    pub fn get_range(&self) -> &CacheRange {
         &self.range
     }
 
@@ -804,7 +804,7 @@ pub enum LoadFailedReason {
     Evicting,
 }
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Debug)]
 pub enum RangeCacheStatus {
     NotInCache,
     Cached,

--- a/components/range_cache_memory_engine/src/range_manager.rs
+++ b/components/range_cache_memory_engine/src/range_manager.rs
@@ -734,10 +734,6 @@ impl RegionManager {
         }
     }
 
-    pub fn add_pinned_range(&mut self, _cache_range: CacheRange) {
-        // TODO: handle pinned range later
-    }
-
     pub fn load_region(&mut self, region: Region) -> Result<(), LoadFailedReason> {
         use RegionState::*;
         if let Some(state) = self.check_overlap_with_region(&region) {

--- a/components/range_cache_memory_engine/src/range_manager.rs
+++ b/components/range_cache_memory_engine/src/range_manager.rs
@@ -23,8 +23,8 @@ pub enum RegionState {
     // target region in raftstore.
     #[default]
     Pending,
-    // Region is ready to do batch load. In this state, apply thread
-    // will directly write new kv into the skiplist.
+    // Region is ready to do batch load but not started. In this state,
+    // apply thread starts directly write new KVs into the skiplist.
     ReadyToLoad,
     // Region is handling batch loading from rocksdb snapshot.
     Loading,

--- a/components/range_cache_memory_engine/src/range_stats.rs
+++ b/components/range_cache_memory_engine/src/range_stats.rs
@@ -252,7 +252,6 @@ impl RangeStatsManager {
 
 #[cfg(test)]
 pub mod tests {
-    use engine_traits::CacheRange;
     use kvproto::metapb::Peer;
     use raftstore::coprocessor::{self, region_info_accessor::TopRegions, RegionInfoProvider};
     use tikv_util::box_err;

--- a/components/range_cache_memory_engine/src/range_stats.rs
+++ b/components/range_cache_memory_engine/src/range_stats.rs
@@ -56,7 +56,7 @@ impl RangeStatsManager {
     }
 
     /// Prevents two instances of this from running concurrently.
-    /// Return `bool`
+    /// Return the previous checking status.
     pub fn set_checking_top_regions(&self, v: bool) -> bool {
         self.checking_top_regions.swap(v, Ordering::Relaxed)
     }

--- a/components/range_cache_memory_engine/src/range_stats.rs
+++ b/components/range_cache_memory_engine/src/range_stats.rs
@@ -388,11 +388,7 @@ pub mod tests {
         );
         let r_i_p: Arc<dyn RegionInfoProvider> = sim.clone();
         let check_is_cached = move |r: &Region| -> bool {
-            r_i_p
-                .find_region_by_key(&r.start_key[1..])
-                .unwrap()
-                .get_id()
-                <= 5
+            r_i_p.find_region_by_key(&r.start_key).unwrap().get_id() <= 5
         };
         let mut _added = Vec::new();
         let mut _removed = Vec::new();

--- a/components/range_cache_memory_engine/src/read.rs
+++ b/components/range_cache_memory_engine/src/read.rs
@@ -696,7 +696,7 @@ mod tests {
     use crate::{
         engine::{cf_to_id, tests::new_region, SkiplistEngine},
         keys::{
-            construct_key, construct_user_key, construct_value, decode_key, encode_key,
+            construct_key, construct_region_key, construct_user_key, construct_value, decode_key, encode_key,
             encode_seek_key, InternalBytes, ValueType,
         },
         perf_context::PERF_CONTEXT,
@@ -1796,7 +1796,7 @@ mod tests {
         let engine = RangeCacheMemoryEngine::new(RangeCacheEngineContext::new_for_tests(Arc::new(
             VersionTrack::new(RangeCacheEngineConfig::config_for_test()),
         )));
-        let region = new_region(1, construct_user_key(0), construct_user_key(30));
+        let region = new_region(1, construct_region_key(0), construct_region_key(30));
         let range = CacheRange::from_region(&region);
         engine.new_region(region.clone());
 
@@ -1815,9 +1815,9 @@ mod tests {
         }
 
         let mut new_regions = vec![
-            new_region(1, construct_user_key(0), construct_user_key(10)),
-            new_region(2, construct_user_key(10), construct_user_key(20)),
-            new_region(3, construct_user_key(10), construct_user_key(20)),
+            new_region(1, construct_region_key(0), construct_region_key(10)),
+            new_region(2, construct_region_key(10), construct_region_key(20)),
+            new_region(3, construct_region_key(20), construct_region_key(30)),
         ];
         new_regions.iter_mut().for_each(|r| {
             r.mut_region_epoch().version = 1;
@@ -1876,7 +1876,7 @@ mod tests {
         let engine = RangeCacheMemoryEngine::new(RangeCacheEngineContext::new_for_tests(Arc::new(
             VersionTrack::new(RangeCacheEngineConfig::config_for_test()),
         )));
-        let region = new_region(1, construct_user_key(0), construct_user_key(30));
+        let region = new_region(1, construct_region_key(0), construct_region_key(30));
         engine.new_region(region.clone());
 
         let guard = &epoch::pin();
@@ -1902,9 +1902,9 @@ mod tests {
         let s2 = engine.snapshot(1, 0, range, 20, 20);
 
         let mut new_regions = vec![
-            new_region(1, construct_user_key(0), construct_user_key(10)),
-            new_region(2, construct_user_key(10), construct_user_key(20)),
-            new_region(3, construct_user_key(10), construct_user_key(20)),
+            new_region(1, construct_region_key(0), construct_region_key(10)),
+            new_region(2, construct_region_key(10), construct_region_key(20)),
+            new_region(3, construct_region_key(10), construct_region_key(20)),
         ];
         new_regions.iter_mut().for_each(|r| {
             r.mut_region_epoch().version = 1;

--- a/components/range_cache_memory_engine/src/read.rs
+++ b/components/range_cache_memory_engine/src/read.rs
@@ -1775,15 +1775,13 @@ mod tests {
             Duration::from_millis(100),
             Duration::from_millis(2000),
             || {
-                let count = engine
+                !engine
                     .core
                     .read()
                     .range_manager()
                     .regions()
                     .values()
-                    .filter(|m| m.get_state() >= RegionState::LoadingCanceled)
-                    .count();
-                count == 0
+                    .any(|m| m.get_state() >= RegionState::LoadingCanceled)
             },
         );
         let write_handle = engine.core.read().engine.cf_handle("write");

--- a/components/range_cache_memory_engine/src/read.rs
+++ b/components/range_cache_memory_engine/src/read.rs
@@ -686,9 +686,9 @@ mod tests {
         raw::DBStatisticsTickerType, util::new_engine_opt, RocksDbOptions, RocksStatistics,
     };
     use engine_traits::{
-        CacheRange, EvictReason, FailedReason, IterMetricsCollector, IterOptions, Iterable, Iterator,
-        MetricsExt, Mutable, Peekable, RangeCacheEngine, ReadOptions, RegionEvent, WriteBatch,
-        WriteBatchExt, CF_DEFAULT, CF_LOCK, CF_WRITE,
+        CacheRange, EvictReason, FailedReason, IterMetricsCollector, IterOptions, Iterable,
+        Iterator, MetricsExt, Mutable, Peekable, RangeCacheEngine, ReadOptions, RegionEvent,
+        WriteBatch, WriteBatchExt, CF_DEFAULT, CF_LOCK, CF_WRITE,
     };
     use keys::DATA_PREFIX_KEY;
     use kvproto::metapb::Region;
@@ -697,7 +697,7 @@ mod tests {
 
     use super::{RangeCacheIterator, RangeCacheSnapshot};
     use crate::{
-        engine::{cf_to_id, tests::new_region, SkiplistEngine},
+        engine::{cf_to_id, SkiplistEngine},
         keys::{
             construct_key, construct_region_key, construct_user_key, construct_value, decode_key,
             encode_key, encode_seek_key, InternalBytes, ValueType,
@@ -705,6 +705,7 @@ mod tests {
         perf_context::PERF_CONTEXT,
         range_manager::RegionState,
         statistics::Tickers,
+        test_util::new_region,
         RangeCacheEngineConfig, RangeCacheEngineContext, RangeCacheMemoryEngine,
         RangeCacheWriteBatch,
     };

--- a/components/range_cache_memory_engine/src/read.rs
+++ b/components/range_cache_memory_engine/src/read.rs
@@ -1781,7 +1781,7 @@ mod tests {
                     .range_manager()
                     .regions()
                     .values()
-                    .any(|m| m.get_state() >= RegionState::LoadingCanceled)
+                    .any(|m| m.get_state().is_evict())
             },
         );
         let write_handle = engine.core.read().engine.cf_handle("write");

--- a/components/range_cache_memory_engine/src/read.rs
+++ b/components/range_cache_memory_engine/src/read.rs
@@ -684,15 +684,15 @@ mod tests {
     };
     use engine_traits::{
         CacheRange, FailedReason, IterMetricsCollector, IterOptions, Iterable, Iterator,
-        MetricsExt, Mutable, Peekable, RangeCacheEngine, ReadOptions, WriteBatch, WriteBatchExt,
-        CF_DEFAULT, CF_LOCK, CF_WRITE,
+        MetricsExt, Mutable, Peekable, RangeCacheEngine, ReadOptions, RegionEvent, WriteBatch,
+        WriteBatchExt, CF_DEFAULT, CF_LOCK, CF_WRITE,
     };
     use tempfile::Builder;
     use tikv_util::config::VersionTrack;
 
     use super::{RangeCacheIterator, RangeCacheSnapshot};
     use crate::{
-        engine::{cf_to_id, SkiplistEngine},
+        engine::{cf_to_id, tests::new_region, SkiplistEngine},
         keys::{
             construct_key, construct_user_key, construct_value, decode_key, encode_key,
             encode_seek_key, InternalBytes, ValueType,
@@ -708,19 +708,15 @@ mod tests {
         let engine = RangeCacheMemoryEngine::new(RangeCacheEngineContext::new_for_tests(Arc::new(
             VersionTrack::new(RangeCacheEngineConfig::config_for_test()),
         )));
-        let range = CacheRange::new(b"k00".to_vec(), b"k10".to_vec());
-        engine.new_range(range.clone());
+        let region = new_region(1, b"k00", b"k10");
+        engine.new_region(region.clone());
 
         let verify_snapshot_count = |snapshot_ts, count| {
             let core = engine.core.read();
             if count > 0 {
                 assert_eq!(
-                    *core
-                        .range_manager
-                        .ranges()
-                        .get(&range)
-                        .unwrap()
-                        .range_snapshot_list()
+                    *core.range_manager.regions()[&region.id]
+                        .region_snapshot_list()
                         .0
                         .get(&snapshot_ts)
                         .unwrap(),
@@ -728,11 +724,8 @@ mod tests {
                 );
             } else {
                 assert!(
-                    core.range_manager
-                        .ranges()
-                        .get(&range)
-                        .unwrap()
-                        .range_snapshot_list()
+                    core.range_manager.regions().regions()[&region.id]
+                        .region_snapshot_list()
                         .0
                         .get(&snapshot_ts)
                         .is_none()
@@ -740,30 +733,31 @@ mod tests {
             }
         };
 
-        let s1 = engine.snapshot(range.clone(), 5, u64::MAX).unwrap();
+        let range = CacheRange::from_region(&region);
+        let s1 = engine.snapshot(1, 0, range.clone(), 5, u64::MAX).unwrap();
 
         {
             let mut core = engine.core.write();
-            let t_range = CacheRange::new(b"k00".to_vec(), b"k02".to_vec());
-            assert!(!core.range_manager.set_safe_point(&t_range, 5));
-            assert!(core.range_manager.set_safe_point(&range, 5));
+            assert!(core.range_manager.set_safe_point(region.id, 5));
         }
         assert_eq!(
-            engine.snapshot(range.clone(), 5, u64::MAX).unwrap_err(),
+            engine
+                .snapshot(region.id, 0, CacheRange::from_region(&region), 5, u64::MAX)
+                .unwrap_err(),
             FailedReason::TooOldRead
         );
-        let s2 = engine.snapshot(range.clone(), 10, u64::MAX).unwrap();
+        let s2 = engine.snapshot(1, 0, range.clone(), 10, u64::MAX).unwrap();
 
         verify_snapshot_count(5, 1);
         verify_snapshot_count(10, 1);
-        let s3 = engine.snapshot(range.clone(), 10, u64::MAX).unwrap();
+        let s3 = engine.snapshot(1, 0, range.clone(), 10, u64::MAX).unwrap();
         verify_snapshot_count(10, 2);
 
         drop(s1);
         verify_snapshot_count(5, 0);
         drop(s2);
         verify_snapshot_count(10, 1);
-        let s4 = engine.snapshot(range.clone(), 10, u64::MAX).unwrap();
+        let s4 = engine.snapshot(1, 0, range.clone(), 10, u64::MAX).unwrap();
         verify_snapshot_count(10, 2);
         drop(s4);
         verify_snapshot_count(10, 1);
@@ -771,11 +765,8 @@ mod tests {
         {
             let core = engine.core.write();
             assert!(
-                core.range_manager
-                    .ranges()
-                    .get(&range)
-                    .unwrap()
-                    .range_snapshot_list()
+                core.range_manager.regions()[&region.id]
+                    .region_snapshot_list()
                     .is_empty()
             );
         }
@@ -898,8 +889,9 @@ mod tests {
         let engine = RangeCacheMemoryEngine::new(RangeCacheEngineContext::new_for_tests(Arc::new(
             VersionTrack::new(RangeCacheEngineConfig::config_for_test()),
         )));
-        let range = CacheRange::new(b"".to_vec(), b"z".to_vec());
-        engine.new_range(range.clone());
+        let region = new_region(1, b"", b"z");
+        let range = CacheRange::from_region(&region);
+        engine.new_region(region.clone());
 
         {
             let mut core = engine.core.write();
@@ -910,7 +902,7 @@ mod tests {
             put_key_val(&sl, "c", "vall", 10, 5);
         }
 
-        let snapshot = engine.snapshot(range.clone(), u64::MAX, 100).unwrap();
+        let snapshot = engine.snapshot(1, 0, range.clone(), u64::MAX, 100).unwrap();
         let mut iter_opt = IterOptions::default();
         iter_opt.set_upper_bound(&range.end, 0);
         iter_opt.set_lower_bound(&range.start, 0);
@@ -936,12 +928,13 @@ mod tests {
         let engine = RangeCacheMemoryEngine::new(RangeCacheEngineContext::new_for_tests(Arc::new(
             VersionTrack::new(RangeCacheEngineConfig::config_for_test()),
         )));
-        let range = CacheRange::new(b"".to_vec(), b"z".to_vec());
-        engine.new_range(range.clone());
+        let region = new_region(1, b"", b"z");
+        let range = CacheRange::from_region(&region);
+        engine.new_region(region.clone());
 
         {
             let mut core = engine.core.write();
-            core.range_manager.set_safe_point(&range, 5);
+            core.range_manager.set_safe_point(region.id, 5);
             let sl = core.engine.data[cf_to_id("write")].clone();
             fill_data_in_skiplist(sl.clone(), (1..10).step_by(1), 1..50, 1);
             // k1 is deleted at seq_num 150 while k49 is deleted at seq num 101
@@ -950,7 +943,7 @@ mod tests {
 
         let opts = ReadOptions::default();
         {
-            let snapshot = engine.snapshot(range.clone(), 10, 60).unwrap();
+            let snapshot = engine.snapshot(1, 0, range.clone(), 10, 60).unwrap();
             for i in 1..10 {
                 for mvcc in 1..50 {
                     let k = construct_key(i, mvcc);
@@ -972,7 +965,7 @@ mod tests {
 
         // all deletions
         {
-            let snapshot = engine.snapshot(range.clone(), 10, u64::MAX).unwrap();
+            let snapshot = engine.snapshot(1, 0, range.clone(), 10, u64::MAX).unwrap();
             for i in 1..10 {
                 for mvcc in 1..50 {
                     let k = construct_key(i, mvcc);
@@ -988,7 +981,7 @@ mod tests {
 
         // some deletions
         {
-            let snapshot = engine.snapshot(range.clone(), 10, 105).unwrap();
+            let snapshot = engine.snapshot(1, 0, range.clone(), 10, 105).unwrap();
             for mvcc in 1..50 {
                 for i in 1..7 {
                     let k = construct_key(i, mvcc);
@@ -1016,20 +1009,21 @@ mod tests {
         let engine = RangeCacheMemoryEngine::new(RangeCacheEngineContext::new_for_tests(Arc::new(
             VersionTrack::new(RangeCacheEngineConfig::config_for_test()),
         )));
-        let range = CacheRange::new(b"".to_vec(), b"z".to_vec());
-        engine.new_range(range.clone());
-        let step: i32 = 2;
+        let region = new_region(1, b"", b"z");
+        let range = CacheRange::from_region(&region);
+        engine.new_region(region.clone());
 
+        let step: i32 = 2;
         {
             let mut core = engine.core.write();
-            core.range_manager.set_safe_point(&range, 5);
+            core.range_manager.set_safe_point(region.id, 5);
             let sl = core.engine.data[cf_to_id("write")].clone();
             fill_data_in_skiplist(sl.clone(), (1..100).step_by(step as usize), 1..10, 1);
             delete_data_in_skiplist(sl, (1..100).step_by(step as usize), 1..10, 200);
         }
 
         let mut iter_opt = IterOptions::default();
-        let snapshot = engine.snapshot(range.clone(), 10, u64::MAX).unwrap();
+        let snapshot = engine.snapshot(1, 0, range.clone(), 10, u64::MAX).unwrap();
         // boundaries are not set
         assert!(snapshot.iterator_opt("lock", iter_opt.clone()).is_err());
 
@@ -1046,7 +1040,7 @@ mod tests {
 
         // Not restricted by bounds, no deletion (seq_num 150)
         {
-            let snapshot = engine.snapshot(range.clone(), 100, 150).unwrap();
+            let snapshot = engine.snapshot(1, 0, range.clone(), 100, 150).unwrap();
             let mut iter = snapshot.iterator_opt("write", iter_opt.clone()).unwrap();
             iter.seek_to_first().unwrap();
             verify_key_values(
@@ -1082,7 +1076,7 @@ mod tests {
 
         // Not restricted by bounds, some deletions (seq_num 230)
         {
-            let snapshot = engine.snapshot(range.clone(), 10, 230).unwrap();
+            let snapshot = engine.snapshot(1, 0, range.clone(), 10, 230).unwrap();
             let mut iter = snapshot.iterator_opt("write", iter_opt.clone()).unwrap();
             iter.seek_to_first().unwrap();
             verify_key_values(
@@ -1126,7 +1120,7 @@ mod tests {
         iter_opt.set_upper_bound(&upper_bound, 0);
         iter_opt.set_lower_bound(&lower_bound, 0);
         {
-            let snapshot = engine.snapshot(range.clone(), 10, 150).unwrap();
+            let snapshot = engine.snapshot(1, 0, range.clone(), 10, 150).unwrap();
             let mut iter = snapshot.iterator_opt("write", iter_opt.clone()).unwrap();
 
             assert!(iter.seek_to_first().unwrap());
@@ -1167,7 +1161,7 @@ mod tests {
 
         // with bounds, some deletions (seq_num 215)
         {
-            let snapshot = engine.snapshot(range.clone(), 10, 215).unwrap();
+            let snapshot = engine.snapshot(1, 0, range.clone(), 10, 215).unwrap();
             let mut iter = snapshot.iterator_opt("write", iter_opt).unwrap();
 
             // sequence can see the deletion
@@ -1203,8 +1197,9 @@ mod tests {
         let engine = RangeCacheMemoryEngine::new(RangeCacheEngineContext::new_for_tests(Arc::new(
             VersionTrack::new(RangeCacheEngineConfig::config_for_test()),
         )));
-        let range = CacheRange::new(b"".to_vec(), b"z".to_vec());
-        engine.new_range(range.clone());
+        let region = new_region(1, b"", b"z");
+        let range = CacheRange::from_region(&region);
+        engine.new_region(region.clone());
         let step: i32 = 2;
 
         {
@@ -1223,7 +1218,7 @@ mod tests {
 
         // Not restricted by bounds, no deletion (seq_num 150)
         {
-            let snapshot = engine.snapshot(range.clone(), 10, 150).unwrap();
+            let snapshot = engine.snapshot(1, 0, range.clone(), 10, 150).unwrap();
             let mut iter = snapshot.iterator_opt("write", iter_opt.clone()).unwrap();
             assert!(iter.seek_to_last().unwrap());
             verify_key_values(
@@ -1262,7 +1257,7 @@ mod tests {
         iter_opt.set_upper_bound(&upper_bound, 0);
         iter_opt.set_lower_bound(&lower_bound, 0);
         {
-            let snapshot = engine.snapshot(range.clone(), 10, 150).unwrap();
+            let snapshot = engine.snapshot(1, 0, range.clone(), 10, 150).unwrap();
             let mut iter = snapshot.iterator_opt("write", iter_opt).unwrap();
 
             assert!(iter.seek_to_last().unwrap());
@@ -1307,8 +1302,9 @@ mod tests {
         let engine = RangeCacheMemoryEngine::new(RangeCacheEngineContext::new_for_tests(Arc::new(
             VersionTrack::new(RangeCacheEngineConfig::config_for_test()),
         )));
-        let range = CacheRange::new(b"".to_vec(), b"z".to_vec());
-        engine.new_range(range.clone());
+        let region = new_region(1, b"", b"z");
+        let range = CacheRange::from_region(&region);
+        engine.new_region(region.clone());
 
         {
             let mut core = engine.core.write();
@@ -1335,7 +1331,7 @@ mod tests {
 
         // seq num 1
         {
-            let snapshot = engine.snapshot(range.clone(), u64::MAX, 1).unwrap();
+            let snapshot = engine.snapshot(1, 0, range.clone(), u64::MAX, 1).unwrap();
             let mut iter = snapshot.iterator_opt("write", iter_opt.clone()).unwrap();
             iter.seek_to_first().unwrap();
             assert_eq!(iter.value(), b"va1");
@@ -1363,7 +1359,7 @@ mod tests {
 
         // seq num 2
         {
-            let snapshot = engine.snapshot(range.clone(), u64::MAX, 2).unwrap();
+            let snapshot = engine.snapshot(1, 0, range.clone(), u64::MAX, 2).unwrap();
             let mut iter = snapshot.iterator_opt("write", iter_opt.clone()).unwrap();
             iter.seek_to_first().unwrap();
             assert_eq!(iter.value(), b"va1");
@@ -1376,7 +1372,7 @@ mod tests {
 
         // seq num 5
         {
-            let snapshot = engine.snapshot(range.clone(), u64::MAX, 5).unwrap();
+            let snapshot = engine.snapshot(1, 0, range.clone(), u64::MAX, 5).unwrap();
             let mut iter = snapshot.iterator_opt("write", iter_opt.clone()).unwrap();
             iter.seek_to_first().unwrap();
             assert_eq!(iter.value(), b"vb2");
@@ -1387,7 +1383,7 @@ mod tests {
 
         // seq num 6
         {
-            let snapshot = engine.snapshot(range.clone(), u64::MAX, 6).unwrap();
+            let snapshot = engine.snapshot(1, 0, range.clone(), u64::MAX, 6).unwrap();
             let mut iter = snapshot.iterator_opt("write", iter_opt.clone()).unwrap();
             iter.seek_to_first().unwrap();
             assert_eq!(iter.value(), b"va4");
@@ -1430,8 +1426,9 @@ mod tests {
         let engine = RangeCacheMemoryEngine::new(RangeCacheEngineContext::new_for_tests(Arc::new(
             VersionTrack::new(RangeCacheEngineConfig::config_for_test()),
         )));
-        let range = CacheRange::new(b"".to_vec(), b"z".to_vec());
-        engine.new_range(range.clone());
+        let region = new_region(1, b"", b"z");
+        let range = CacheRange::from_region(&region);
+        engine.new_region(region.clone());
 
         {
             let mut core = engine.core.write();
@@ -1458,7 +1455,7 @@ mod tests {
 
         // seq num 1
         {
-            let snapshot = engine.snapshot(range.clone(), u64::MAX, 1).unwrap();
+            let snapshot = engine.snapshot(1, 0, range.clone(), u64::MAX, 1).unwrap();
             let mut iter = snapshot.iterator_opt("write", iter_opt.clone()).unwrap();
             iter.seek_to_last().unwrap();
             assert_eq!(iter.value(), b"vc1");
@@ -1476,7 +1473,7 @@ mod tests {
 
         // seq num 2
         {
-            let snapshot = engine.snapshot(range.clone(), u64::MAX, 2).unwrap();
+            let snapshot = engine.snapshot(1, 0, range.clone(), u64::MAX, 2).unwrap();
             let mut iter = snapshot.iterator_opt("write", iter_opt.clone()).unwrap();
             iter.seek_to_last().unwrap();
             assert_eq!(iter.value(), b"vc1");
@@ -1489,7 +1486,7 @@ mod tests {
 
         // seq num 5
         {
-            let snapshot = engine.snapshot(range.clone(), u64::MAX, 5).unwrap();
+            let snapshot = engine.snapshot(1, 0, range.clone(), u64::MAX, 5).unwrap();
             let mut iter = snapshot.iterator_opt("write", iter_opt.clone()).unwrap();
             iter.seek_to_last().unwrap();
             assert_eq!(iter.value(), b"vb2");
@@ -1500,7 +1497,7 @@ mod tests {
 
         // seq num 6
         {
-            let snapshot = engine.snapshot(range.clone(), u64::MAX, 6).unwrap();
+            let snapshot = engine.snapshot(1, 0, range.clone(), u64::MAX, 6).unwrap();
             let mut iter = snapshot.iterator_opt("write", iter_opt.clone()).unwrap();
             iter.seek_to_last().unwrap();
             assert_eq!(iter.value(), b"vc4");
@@ -1524,7 +1521,8 @@ mod tests {
     #[test]
     fn test_iter_user_skip() {
         let mut iter_opt = IterOptions::default();
-        let range = CacheRange::new(b"".to_vec(), b"z".to_vec());
+        let region = new_region(1, b"", b"z");
+        let range = CacheRange::from_region(&region);
         iter_opt.set_upper_bound(&range.end, 0);
         iter_opt.set_lower_bound(&range.start, 0);
 
@@ -1533,7 +1531,7 @@ mod tests {
             let engine = RangeCacheMemoryEngine::new(RangeCacheEngineContext::new_for_tests(
                 Arc::new(VersionTrack::new(RangeCacheEngineConfig::config_for_test())),
             ));
-            engine.new_range(range.clone());
+            engine.new_region(region.clone());
             let sl = {
                 let mut core = engine.core.write();
                 core.range_manager.set_safe_point(&range, 5);
@@ -1548,7 +1546,7 @@ mod tests {
                     put_key_val(&sl, "b", v.as_str(), 10, s + i);
                 }
 
-                let snapshot = engine.snapshot(range.clone(), 10, s + seq).unwrap();
+                let snapshot = engine.snapshot(1, 0, range.clone(), 10, s + seq).unwrap();
                 let mut iter = snapshot.iterator_opt("write", iter_opt.clone()).unwrap();
                 assert!(iter.seek_to_last().unwrap());
                 let k = construct_mvcc_key("b", 10);
@@ -1571,7 +1569,7 @@ mod tests {
             let engine = RangeCacheMemoryEngine::new(RangeCacheEngineContext::new_for_tests(
                 Arc::new(VersionTrack::new(RangeCacheEngineConfig::config_for_test())),
             ));
-            engine.new_range(range.clone());
+            engine.new_region(region.clone());
             let sl = {
                 let mut core = engine.core.write();
                 core.range_manager.set_safe_point(&range, 5);
@@ -1585,7 +1583,7 @@ mod tests {
                     delete_key(&sl, "b", 10, s + i);
                 }
 
-                let snapshot = engine.snapshot(range.clone(), 10, s + seq).unwrap();
+                let snapshot = engine.snapshot(1, 0, range.clone(), 10, s + seq).unwrap();
                 let mut iter = snapshot.iterator_opt("write", iter_opt.clone()).unwrap();
                 assert!(iter.seek_to_last().unwrap());
                 let k = construct_mvcc_key("a", 10);
@@ -1602,7 +1600,7 @@ mod tests {
             let engine = RangeCacheMemoryEngine::new(RangeCacheEngineContext::new_for_tests(
                 Arc::new(VersionTrack::new(RangeCacheEngineConfig::config_for_test())),
             ));
-            engine.new_range(range.clone());
+            engine.new_region(region.clone());
             let sl = {
                 let mut core = engine.core.write();
                 core.range_manager.set_safe_point(&range, 5);
@@ -1614,7 +1612,7 @@ mod tests {
             }
             let v = construct_value(50, 50);
             put_key_val(&sl, "b", v.as_str(), 10, 50);
-            let snapshot = engine.snapshot(range.clone(), 10, 50).unwrap();
+            let snapshot = engine.snapshot(1, 0, range.clone(), 10, 50).unwrap();
             let mut iter = snapshot.iterator_opt("write", iter_opt.clone()).unwrap();
             assert!(iter.seek_to_last().unwrap());
             let k = construct_mvcc_key("b", 10);
@@ -1635,7 +1633,7 @@ mod tests {
             let engine = RangeCacheMemoryEngine::new(RangeCacheEngineContext::new_for_tests(
                 Arc::new(VersionTrack::new(RangeCacheEngineConfig::config_for_test())),
             ));
-            engine.new_range(range.clone());
+            engine.new_region(region.clone());
             let sl = {
                 let mut core = engine.core.write();
                 core.range_manager.set_safe_point(&range, 5);
@@ -1649,7 +1647,7 @@ mod tests {
                 let v = construct_value(50, 50);
                 put_key_val(&sl, "b", v.as_str(), 10, s + 50);
 
-                let snapshot = engine.snapshot(range.clone(), 10, s + seq).unwrap();
+                let snapshot = engine.snapshot(1, 0, range.clone(), 10, s + seq).unwrap();
                 let mut iter = snapshot.iterator_opt("write", iter_opt.clone()).unwrap();
                 assert!(!iter.seek_to_first().unwrap());
                 assert!(!iter.valid().unwrap());
@@ -1667,12 +1665,13 @@ mod tests {
         let engine = RangeCacheMemoryEngine::new(RangeCacheEngineContext::new_for_tests(Arc::new(
             VersionTrack::new(RangeCacheEngineConfig::config_for_test()),
         )));
-        let range = CacheRange::new(b"k000".to_vec(), b"k100".to_vec());
-        engine.new_range(range.clone());
+        let region = new_region(1, b"k000", b"k100");
+        let range = CacheRange::from_region(&region);
+        engine.new_region(region.clone());
 
         {
             let mut core = engine.core.write();
-            core.range_manager.set_safe_point(&range, 5);
+            core.range_manager.set_safe_point(region.id, 5);
             let sl = core.engine.data[cf_to_id("write")].clone();
 
             let guard = &epoch::pin();
@@ -1693,7 +1692,9 @@ mod tests {
         iter_opt.set_upper_bound(&upper_bound, 0);
         iter_opt.set_lower_bound(&lower_bound, 0);
         iter_opt.set_prefix_same_as_start(true);
-        let snapshot = engine.snapshot(range.clone(), u64::MAX, u64::MAX).unwrap();
+        let snapshot = engine
+            .snapshot(1, 0, range.clone(), u64::MAX, u64::MAX)
+            .unwrap();
         let mut iter = snapshot.iterator_opt("write", iter_opt.clone()).unwrap();
 
         // prefix seek, forward
@@ -1761,7 +1762,7 @@ mod tests {
         });
     }
 
-    fn verify_evict_range_deleted(engine: &RangeCacheMemoryEngine, range: &CacheRange) {
+    fn verify_evict_region_deleted(engine: &RangeCacheMemoryEngine, region: &Region) {
         let mut wait = 0;
         while wait < 10 {
             wait += 1;
@@ -1769,7 +1770,7 @@ mod tests {
                 .core
                 .read()
                 .range_manager()
-                .ranges_being_deleted
+                .regions_being_deleted
                 .is_empty()
             {
                 std::thread::sleep(Duration::from_millis(200));
@@ -1778,28 +1779,28 @@ mod tests {
             }
         }
         let write_handle = engine.core.read().engine.cf_handle("write");
-        let start_key = encode_seek_key(&range.start, u64::MAX);
+        let start_key = encode_seek_key(&region.start_key, u64::MAX);
         let mut iter = write_handle.iterator();
 
         let guard = &epoch::pin();
         iter.seek(&start_key, guard);
-        let end = encode_seek_key(&range.end, u64::MAX);
+        let end = encode_seek_key(&region.end_key, u64::MAX);
         assert!(iter.key() > &end || !iter.valid());
     }
 
     #[test]
-    fn test_evict_range_without_snapshot() {
+    fn test_evict_region_without_snapshot() {
         let engine = RangeCacheMemoryEngine::new(RangeCacheEngineContext::new_for_tests(Arc::new(
             VersionTrack::new(RangeCacheEngineConfig::config_for_test()),
         )));
-        let range = CacheRange::new(construct_user_key(0), construct_user_key(30));
-        let evict_range = CacheRange::new(construct_user_key(10), construct_user_key(20));
-        engine.new_range(range.clone());
+        let region = new_region(1, construct_user_key(0), construct_user_key(30));
+        let range = CacheRange::from_region(&region);
+        engine.new_region(region.clone());
 
         let guard = &epoch::pin();
         {
             let mut core = engine.core.write();
-            core.range_manager.set_safe_point(&range, 5);
+            core.range_manager.set_safe_point(region.id, 5);
             let sl = core.engine.data[cf_to_id("write")].clone();
             for i in 0..30 {
                 let user_key = construct_key(i, 10);
@@ -1810,19 +1811,38 @@ mod tests {
             }
         }
 
-        engine.evict_range(&evict_range);
+        let mut new_regions = vec![
+            new_region(1, construct_user_key(0), construct_user_key(10)),
+            new_region(2, construct_user_key(10), construct_user_key(20)),
+            new_region(3, construct_user_key(10), construct_user_key(20)),
+        ];
+        new_regions.iter_mut().for_each(|r| {
+            r.mut_region_epoch().version = 1;
+        });
+
+        engine.on_region_event(RegionEvent::Split {
+            source: region.clone(),
+            new_regions: new_regions.clone(),
+        });
+
+        let evict_region = new_regions[1].clone();
+        engine.evict_region(evict_region.clone());
         assert_eq!(
-            engine.snapshot(range.clone(), 10, 200).unwrap_err(),
-            FailedReason::NotCached
+            engine.snapshot(1, 0, range.clone(), 10, 200).unwrap_err(),
+            FailedReason::EpochNotMatch
         );
         assert_eq!(
-            engine.snapshot(evict_range.clone(), 10, 200).unwrap_err(),
+            engine
+                .snapshot(2, 1, CacheRange::from_region(&evict_region), 10, 200)
+                .unwrap_err(),
             FailedReason::NotCached
         );
 
-        let r_left = CacheRange::new(construct_user_key(0), construct_user_key(10));
-        let r_right = CacheRange::new(construct_user_key(20), construct_user_key(30));
-        let snap_left = engine.snapshot(r_left, 10, 200).unwrap();
+        let r_left = new_regions[0].clone();
+        let r_right = new_regions[2].clone();
+        let snap_left = engine
+            .snapshot(r_left.id, 1, CacheRange::from_region(&r_left), 10, 200)
+            .unwrap();
 
         let mut iter_opt = IterOptions::default();
         let lower_bound = construct_user_key(0);
@@ -1833,7 +1853,9 @@ mod tests {
         iter.seek_to_first().unwrap();
         verify_key_values(&mut iter, (0..10).step_by(1), 10..11, true, true);
 
-        let snap_right = engine.snapshot(r_right, 10, 200).unwrap();
+        let snap_right = engine
+            .snapshot(r_right.id, 1, CacheRange::from_region(&r_right), 10, 200)
+            .unwrap();
         let lower_bound = construct_user_key(20);
         let upper_bound = construct_user_key(30);
         iter_opt.set_upper_bound(&upper_bound, 0);
@@ -1843,7 +1865,7 @@ mod tests {
         verify_key_values(&mut iter, (20..30).step_by(1), 10..11, true, true);
 
         // verify the key, values are delete
-        verify_evict_range_deleted(&engine, &evict_range);
+        verify_evict_region_deleted(&engine, &evict_region);
     }
 
     #[test]
@@ -1851,9 +1873,8 @@ mod tests {
         let engine = RangeCacheMemoryEngine::new(RangeCacheEngineContext::new_for_tests(Arc::new(
             VersionTrack::new(RangeCacheEngineConfig::config_for_test()),
         )));
-        let range = CacheRange::new(construct_user_key(0), construct_user_key(30));
-        let evict_range = CacheRange::new(construct_user_key(10), construct_user_key(20));
-        engine.new_range(range.clone());
+        let region = new_region(1, construct_user_key(0), construct_user_key(30));
+        engine.new_region(region.clone());
 
         let guard = &epoch::pin();
         {
@@ -1873,17 +1894,51 @@ mod tests {
             }
         }
 
-        let s1 = engine.snapshot(range.clone(), 10, 10);
-        let s2 = engine.snapshot(range, 20, 20);
-        engine.evict_range(&evict_range);
-        let range_left = CacheRange::new(construct_user_key(0), construct_user_key(10));
-        let s3 = engine.snapshot(range_left, 20, 20).unwrap();
-        let range_right = CacheRange::new(construct_user_key(20), construct_user_key(30));
-        let s4 = engine.snapshot(range_right, 20, 20).unwrap();
+        let range = CacheRange::from(&region);
+        let s1 = engine.snapshot(1, 0, range.clone(), 10, 10);
+        let s2 = engine.snapshot(1, 0, range, 20, 20);
+
+        let mut new_regions = vec![
+            new_region(1, construct_user_key(0), construct_user_key(10)),
+            new_region(2, construct_user_key(10), construct_user_key(20)),
+            new_region(3, construct_user_key(10), construct_user_key(20)),
+        ];
+        new_regions.iter_mut().for_each(|r| {
+            r.mut_region_epoch().version = 1;
+        });
+
+        engine.on_region_event(RegionEvent::Split {
+            source: region.clone(),
+            new_regions: new_regions.clone(),
+        });
+
+        let evict_region = new_regions[1].clone();
+        engine.evict_region(evict_region.clone());
+
+        let r_left = new_regions[0].clone();
+        let s3 = engine
+            .snapshot(
+                r_left.id,
+                r_left.get_region_epoch().version,
+                CacheRange::from(&r_left),
+                20,
+                20,
+            )
+            .unwrap();
+        let r_right = new_regions[2].clone();
+        let s4 = engine
+            .snapshot(
+                r_right.id,
+                r_right.get_region_epoch().version,
+                CacheRange::from(&r_left),
+                20,
+                20,
+            )
+            .unwrap();
 
         drop(s3);
-        let range_left_eviction = CacheRange::new(construct_user_key(0), construct_user_key(5));
-        engine.evict_range(&range_left_eviction);
+        engine.evict_region(r_left.clone());
+        let evict_range = CacheRange::from_region(&evict_region);
 
         // todo(SpadeA): memory limiter
         {
@@ -1893,7 +1948,7 @@ mod tests {
                     .core
                     .read()
                     .range_manager()
-                    .ranges_being_deleted
+                    .regions_being_deleted
                     .get(&evict_range)
                     .is_some()
             );
@@ -1907,17 +1962,17 @@ mod tests {
                     .core
                     .read()
                     .range_manager()
-                    .ranges_being_deleted
+                    .regions_being_deleted
                     .get(&evict_range)
                     .is_some()
             );
         }
         drop(s2);
         // Now, all snapshots before evicting `evict_range` are released
-        verify_evict_range_deleted(&engine, &evict_range);
+        verify_evict_region_deleted(&engine, &evict_range);
 
         drop(s4);
-        verify_evict_range_deleted(&engine, &range_left_eviction);
+        verify_evict_region_deleted(&engine, &CacheRange::from_region(&r_left));
     }
 
     #[test]
@@ -1925,8 +1980,9 @@ mod tests {
         let engine = RangeCacheMemoryEngine::new(RangeCacheEngineContext::new_for_tests(Arc::new(
             VersionTrack::new(RangeCacheEngineConfig::config_for_test()),
         )));
-        let range = CacheRange::new(b"".to_vec(), b"z".to_vec());
-        engine.new_range(range.clone());
+        let mut iter_opt = IterOptions::default();
+        let region = new_region(1, b"", b"z");
+        let range = CacheRange::from_region(&region);
 
         {
             let mut core = engine.core.write();
@@ -1945,7 +2001,7 @@ mod tests {
         let mut iter_opt = IterOptions::default();
         iter_opt.set_upper_bound(&range.end, 0);
         iter_opt.set_lower_bound(&range.start, 0);
-        let snapshot = engine.snapshot(range.clone(), u64::MAX, 100).unwrap();
+        let snapshot = engine.snapshot(1, 0, range.clone(), u64::MAX, 100).unwrap();
         let mut iter = snapshot.iterator_opt("write", iter_opt.clone()).unwrap();
         iter.seek_to_first().unwrap();
         while iter.valid().unwrap() {
@@ -1969,8 +2025,9 @@ mod tests {
         let engine = RangeCacheMemoryEngine::new(RangeCacheEngineContext::new_for_tests(Arc::new(
             VersionTrack::new(RangeCacheEngineConfig::config_for_test()),
         )));
-        let range = CacheRange::new(b"".to_vec(), b"z".to_vec());
-        engine.new_range(range.clone());
+        let mut iter_opt = IterOptions::default();
+        let region = new_region(1, b"", b"z");
+        let range = CacheRange::from_region(&region);
 
         {
             let mut core = engine.core.write();
@@ -2007,7 +2064,7 @@ mod tests {
         }
 
         let statistics = engine.statistics();
-        let snapshot = engine.snapshot(range.clone(), u64::MAX, 100).unwrap();
+        let snapshot = engine.snapshot(1, 0, range.clone(), u64::MAX, 100).unwrap();
         assert_eq!(PERF_CONTEXT.with(|c| c.borrow().get_read_bytes), 0);
         let key = construct_mvcc_key("a", 10);
         snapshot.get_value_cf("write", &key).unwrap();
@@ -2093,16 +2150,19 @@ mod tests {
         let engine = RangeCacheMemoryEngine::new(RangeCacheEngineContext::new_for_tests(Arc::new(
             VersionTrack::new(RangeCacheEngineConfig::config_for_test()),
         )));
-        let range = CacheRange::new(b"".to_vec(), b"z".to_vec());
-        engine.new_range(range.clone());
+        let mut iter_opt = IterOptions::default();
+        let region = new_region(1, b"", b"z");
+        let range = CacheRange::from_region(&region);
 
         let mut wb = engine.write_batch();
-        wb.prepare_for_region(range.clone());
+        wb.prepare_for_region(&region);
         put_entries(&mut wb);
         wb.set_sequence_number(wb_sequence).unwrap();
         wb.write().unwrap();
 
-        let snap = engine.snapshot(range.clone(), 100, snap_sequence).unwrap();
+        let snap = engine
+            .snapshot(1, 0, range.clone(), 100, snap_sequence)
+            .unwrap();
         let mut iter_opt = IterOptions::default();
         iter_opt.set_upper_bound(&range.end, 0);
         iter_opt.set_lower_bound(&range.start, 0);
@@ -2158,7 +2218,8 @@ mod tests {
         });
 
         let mut wb = engine.write_batch();
-        wb.prepare_for_region(CacheRange::new(b"".to_vec(), b"z".to_vec()));
+        let region = new_region(1, b"", b"z");
+        wb.prepare_for_region(&region);
         wb.put(b"b", b"f").unwrap();
         wb.set_sequence_number(200).unwrap();
 
@@ -2222,7 +2283,7 @@ mod tests {
 
         // For sequence number 102
         let range = CacheRange::new(b"".to_vec(), b"z".to_vec());
-        let snap = engine.snapshot(range.clone(), 100, 102).unwrap();
+        let snap = engine.snapshot(1, 0, range.clone(), 100, 102).unwrap();
         let mut iter_opt = IterOptions::default();
         iter_opt.set_upper_bound(&range.end, 0);
         iter_opt.set_lower_bound(&range.start, 0);
@@ -2264,7 +2325,7 @@ mod tests {
         assert!(!iter.valid().unwrap());
 
         // For sequence number 104
-        let snap = engine.snapshot(range.clone(), 100, 104).unwrap();
+        let snap = engine.snapshot(1, 0, range.clone(), 100, 104).unwrap();
         let mut iter = snap.iterator_opt("default", iter_opt.clone()).unwrap();
         iter.seek(b"c").unwrap();
         assert_eq!(iter.key(), b"c");
@@ -2302,7 +2363,7 @@ mod tests {
         assert!(!iter.valid().unwrap());
 
         // For sequence number 108
-        let snap = engine.snapshot(range.clone(), 100, 108).unwrap();
+        let snap = engine.snapshot(1, 0, range.clone(), 100, 108).unwrap();
         let mut iter = snap.iterator_opt("default", iter_opt.clone()).unwrap();
         iter.seek(b"c").unwrap();
         assert_eq!(iter.key(), b"c");

--- a/components/range_cache_memory_engine/src/test_util.rs
+++ b/components/range_cache_memory_engine/src/test_util.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 
 use crossbeam::epoch;
+use keys::data_key;
 use txn_types::{Key, TimeStamp, Write, WriteType};
 
 use crate::{
@@ -78,7 +79,8 @@ fn put_data_impl(
     write_cf: &SkiplistHandle,
     mem_controller: Arc<MemoryController>,
 ) {
-    let raw_write_k = Key::from_raw(key)
+    let data_key = data_key(key);
+    let raw_write_k = Key::from_raw(&data_key)
         .append_ts(TimeStamp::new(commit_ts))
         .into_encoded();
     let mut write_k = encode_key(&raw_write_k, seq_num, ValueType::Value);
@@ -110,7 +112,7 @@ fn put_data_impl(
     }
 
     if !short_value {
-        let raw_default_k = Key::from_raw(key)
+        let raw_default_k = Key::from_raw(&data_key)
             .append_ts(TimeStamp::new(start_ts))
             .into_encoded();
         let mut default_k = encode_key(&raw_default_k, seq_num + 1, ValueType::Value);

--- a/components/range_cache_memory_engine/src/test_util.rs
+++ b/components/range_cache_memory_engine/src/test_util.rs
@@ -6,6 +6,7 @@ use crossbeam::epoch;
 use engine_rocks::RocksEngine;
 use engine_traits::{SyncMutable, CF_WRITE};
 use keys::data_key;
+use kvproto::metapb::{Peer, Region};
 use txn_types::{Key, TimeStamp, Write, WriteType};
 
 use crate::{
@@ -138,7 +139,8 @@ pub fn put_data_in_rocks(
     rocks_engine: &RocksEngine,
     write_type: WriteType,
 ) {
-    let raw_write_k = Key::from_raw(key)
+    let data_key = data_key(key);
+    let raw_write_k = Key::from_raw(&data_key)
         .append_ts(TimeStamp::new(commit_ts))
         .into_encoded();
     let write_v = Write::new(
@@ -165,4 +167,14 @@ pub fn put_data_in_rocks(
             .into_encoded();
         rocks_engine.put(&raw_default_k, value).unwrap();
     }
+}
+
+pub fn new_region<T1: Into<Vec<u8>>, T2: Into<Vec<u8>>>(id: u64, start: T1, end: T2) -> Region {
+    let mut region = Region::new();
+    region.id = id;
+    region.start_key = start.into();
+    region.end_key = end.into();
+    // push a dummy peer to avoid CacheRange::from_region panic.
+    region.mut_peers().push(Peer::default());
+    region
 }

--- a/components/range_cache_memory_engine/src/write_batch.rs
+++ b/components/range_cache_memory_engine/src/write_batch.rs
@@ -465,7 +465,11 @@ impl WriteBatch for RangeCacheWriteBatch {
     fn clear(&mut self) {
         self.buffer.clear();
         self.save_points.clear();
-        _ = self.sequence_number.take();
+        self.sequence_number = None;
+        self.prepare_for_write_duration = Duration::ZERO;
+        self.current_region = None;
+        self.currnet_region_evicted = false;
+        self.region_save_point = 0;
     }
 
     fn set_save_point(&mut self) {

--- a/components/range_cache_memory_engine/src/write_batch.rs
+++ b/components/range_cache_memory_engine/src/write_batch.rs
@@ -700,7 +700,7 @@ mod tests {
         assert_eq!(skip_engine.node_count(), 0);
 
         // epoch changes but new range is contained by the pending region, will update
-        // the reigon.
+        // the region.
         engine.load_region(r1.clone()).unwrap();
         let mut r1_new = new_region(1, b"k01".to_vec(), b"k05".to_vec());
         r1_new.mut_region_epoch().version = 2;

--- a/components/range_cache_memory_engine/src/write_batch.rs
+++ b/components/range_cache_memory_engine/src/write_batch.rs
@@ -1,4 +1,5 @@
-use core::slice::SlicePattern;
+// Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
+
 use std::{
     sync::{atomic::Ordering, Arc},
     time::Duration,
@@ -253,7 +254,7 @@ impl RangeCacheWriteBatch {
                 "range_start" => log_wrappers::Value(&region.start_key),
                 "range_end" => log_wrappers::Value(&region.end_key),
             );
-            self.evict_current_region(EvictReason::InMemoryEngineDisabled);
+            self.evict_current_region(EvictReason::Disabled);
             return;
         }
         let memory_expect = entry_size();
@@ -335,7 +336,7 @@ impl WriteBatchEntryInternal {
 
     fn value(&self) -> &[u8] {
         match self {
-            WriteBatchEntryInternal::PutValue(value) => value.as_slice(),
+            WriteBatchEntryInternal::PutValue(value) => value,
             WriteBatchEntryInternal::Deletion => &[],
         }
     }
@@ -398,7 +399,7 @@ impl RangeCacheWriteBatchEntry {
     }
 
     fn memory_size_required(&self) -> usize {
-        Self::memory_size_required_for_key_value(self.key.as_slice(), self.inner.value())
+        Self::memory_size_required_for_key_value(&self.key, self.inner.value())
     }
 
     #[inline]

--- a/components/range_cache_memory_engine/src/write_batch.rs
+++ b/components/range_cache_memory_engine/src/write_batch.rs
@@ -776,7 +776,7 @@ mod tests {
                     .range_manager()
                     .regions()
                     .values()
-                    .any(|meta| meta.get_state() >= RegionState::LoadingCanceled)
+                    .any(|meta| meta.get_state().is_evict())
             },
         );
     }

--- a/components/range_cache_memory_engine/src/write_batch.rs
+++ b/components/range_cache_memory_engine/src/write_batch.rs
@@ -271,11 +271,7 @@ impl RangeCacheWriteBatch {
         F1: FnOnce() -> usize,
         F2: FnOnce() -> RangeCacheWriteBatchEntry,
     {
-        if !matches!(
-            self.range_cache_status,
-            RangeCacheStatus::Cached | RangeCacheStatus::Loading
-        ) || self.currnet_region_evicted
-        {
+        if self.range_cache_status == RangeCacheStatus::NotInCache || self.currnet_region_evicted {
             return;
         }
 
@@ -301,12 +297,7 @@ impl RangeCacheWriteBatch {
             return;
         }
 
-        match self.range_cache_status {
-            RangeCacheStatus::Cached | RangeCacheStatus::Loading => {
-                self.buffer.push(entry());
-            }
-            RangeCacheStatus::NotInCache => {}
-        }
+        self.buffer.push(entry());
     }
 
     fn schedule_memory_check(&self) {

--- a/components/range_cache_memory_engine/tests/failpoints/test_memory_engine.rs
+++ b/components/range_cache_memory_engine/tests/failpoints/test_memory_engine.rs
@@ -167,7 +167,7 @@ fn test_clean_up_tombstone() {
 
     engine.new_range(range.clone());
     let mut wb = engine.write_batch();
-    wb.prepare_for_range(range.clone());
+    wb.prepare_for_region(range.clone());
     wb.put_cf("lock", b"k", b"val").unwrap();
     wb.put_cf("lock", b"k1", b"val").unwrap();
     wb.put_cf("lock", b"k2", b"val").unwrap();
@@ -179,7 +179,7 @@ fn test_clean_up_tombstone() {
     wb.write().unwrap();
 
     let mut wb = engine.write_batch();
-    wb.prepare_for_range(range.clone());
+    wb.prepare_for_region(range.clone());
     wb.put_cf("lock", b"k", b"val").unwrap(); // seq 120
     wb.put_cf("lock", b"k1", b"val").unwrap(); // seq 121
     wb.put_cf("lock", b"k2", b"val").unwrap(); // seq 122
@@ -269,9 +269,9 @@ fn test_evict_with_loading_range() {
 
     let mut wb = engine.write_batch();
     // prepare range to trigger loading
-    wb.prepare_for_range(range1.clone());
-    wb.prepare_for_range(range2.clone());
-    wb.prepare_for_range(range3.clone());
+    wb.prepare_for_region(range1.clone());
+    wb.prepare_for_region(range2.clone());
+    wb.prepare_for_region(range3.clone());
     wb.set_sequence_number(10).unwrap();
     wb.write().unwrap();
 
@@ -322,12 +322,12 @@ fn test_cached_write_batch_cleared_when_load_failed() {
 
     let mut wb = engine.write_batch();
     // range1 starts to load
-    wb.prepare_for_range(range1.clone());
+    wb.prepare_for_region(range1.clone());
     rx.recv_timeout(Duration::from_secs(5)).unwrap();
 
     wb.put(b"k05", b"val").unwrap();
     wb.put(b"k06", b"val").unwrap();
-    wb.prepare_for_range(range2.clone());
+    wb.prepare_for_region(range2.clone());
     wb.put(b"k25", b"val").unwrap();
     wb.set_sequence_number(100).unwrap();
     wb.write().unwrap();
@@ -402,20 +402,20 @@ fn test_concurrency_between_delete_range_and_write_to_memory() {
     let range3_clone = range3.clone();
     let handle = std::thread::spawn(move || {
         let mut wb = engine_clone.write_batch();
-        wb.prepare_for_range(range1_clone);
+        wb.prepare_for_region(range1_clone);
         wb.put_cf(CF_LOCK, b"k02", b"val").unwrap();
         wb.put_cf(CF_LOCK, b"k03", b"val").unwrap();
         wb.put_cf(CF_LOCK, b"k04", b"val").unwrap();
         wb.set_sequence_number(100).unwrap();
 
         let mut wb2 = engine_clone.write_batch();
-        wb2.prepare_for_range(range2_clone);
+        wb2.prepare_for_region(range2_clone);
         wb.put_cf(CF_LOCK, b"k22", b"val").unwrap();
         wb.put_cf(CF_LOCK, b"k23", b"val").unwrap();
         wb2.set_sequence_number(200).unwrap();
 
         let mut wb3 = engine_clone.write_batch();
-        wb3.prepare_for_range(range3_clone);
+        wb3.prepare_for_region(range3_clone);
         wb3.set_sequence_number(300).unwrap();
 
         range_prepared_tx.send(true).unwrap();
@@ -539,7 +539,7 @@ fn test_double_delete_range_schedule() {
 
     let mut wb = engine.write_batch();
     // prepare range to trigger loading
-    wb.prepare_for_range(range3.clone());
+    wb.prepare_for_region(range3.clone());
     wb.set_sequence_number(10).unwrap();
     wb.write().unwrap();
 

--- a/components/range_cache_memory_engine/tests/failpoints/test_memory_engine.rs
+++ b/components/range_cache_memory_engine/tests/failpoints/test_memory_engine.rs
@@ -253,7 +253,7 @@ fn test_evict_with_loading_range() {
     let engine_clone = engine.clone();
     fail::cfg_callback("on_snapshot_load_finished", move || {
         let _ = snapshot_load_tx.send(true);
-        engine_clone.evict_region(r);
+        engine_clone.evict_region(&r);
     })
     .unwrap();
 
@@ -287,13 +287,13 @@ fn test_evict_with_loading_range() {
         .unwrap();
 
     engine
-        .snapshot(r1.id, 0, CacheRange::from(&r1), 100, 100)
+        .snapshot(r1.id, 0, CacheRange::from_region(&r1), 100, 100)
         .unwrap_err();
     engine
-        .snapshot(r2.id, 0, CacheRange::from(&r2), 100, 100)
+        .snapshot(r2.id, 0, CacheRange::from_region(&r2), 100, 100)
         .unwrap_err();
     engine
-        .snapshot(r3.id, 0, CacheRange::from(&r3), 100, 100)
+        .snapshot(r3.id, 0, CacheRange::from_region(&r3), 100, 100)
         .unwrap();
 }
 
@@ -437,8 +437,8 @@ fn test_concurrency_between_delete_range_and_write_to_memory() {
     // Now, three ranges are in write status, delete range will not be performed
     // until they leave the write status
 
-    engine.evict_region(r1.clone());
-    engine.evict_region(r2.clone());
+    engine.evict_region(&r1);
+    engine.evict_region(&r2);
 
     let verify_data = |r, expected_num: u64| {
         let handle = engine.core().write().engine().cf_handle(CF_LOCK);
@@ -526,7 +526,7 @@ fn test_double_delete_range_schedule() {
         let _ = snapshot_load_tx.send(true);
         // evict all ranges. So the loading ranges will also be evicted and a delete
         // range task will be scheduled.
-        engine_clone.evict_region(r);
+        engine_clone.evict_region(&r);
     })
     .unwrap();
 

--- a/components/range_cache_memory_engine/tests/failpoints/test_memory_engine.rs
+++ b/components/range_cache_memory_engine/tests/failpoints/test_memory_engine.rs
@@ -65,7 +65,7 @@ fn test_gc_worker() {
     let (write, default) = {
         let mut core = engine.core().write();
         core.mut_range_manager()
-            .new_region(new_region(1, b"".to_vec(), b"z".to_vec()));
+            .new_region(new_region(1, b"", b"z"));
         let engine = core.engine();
         (engine.cf_handle(CF_WRITE), engine.cf_handle(CF_DEFAULT))
     };
@@ -136,7 +136,7 @@ fn test_gc_worker() {
 
     let guard = &epoch::pin();
     for &ts in &[commit_ts1, commit_ts2, commit_ts3] {
-        let key = Key::from_raw(b"k");
+        let key = Key::from_raw(b"zk");
         let key = encoding_for_filter(key.as_encoded(), TimeStamp::new(ts));
 
         assert!(key_exist(&write, &key, guard));
@@ -144,7 +144,7 @@ fn test_gc_worker() {
 
     let _ = rx.recv_timeout(Duration::from_secs(5)).unwrap();
 
-    let key = Key::from_raw(b"k");
+    let key = Key::from_raw(b"zk");
     // now, the outdated mvcc versions should be gone
     for &ts in &[commit_ts1, commit_ts2, commit_ts3] {
         let key = encoding_for_filter(key.as_encoded(), TimeStamp::new(ts));

--- a/components/test_pd_client/src/pd.rs
+++ b/components/test_pd_client/src/pd.rs
@@ -582,17 +582,17 @@ impl PdCluster {
     }
 
     fn scan_regions(&self, start: &[u8], end: &[u8], limit: i32) -> Vec<metapb::Region> {
-        let mut result = vec![];
+        let mut regions = vec![];
         for (_, region) in self.regions.range((Excluded(start.to_vec()), Unbounded)) {
             if !end.is_empty() && region.start_key.as_slice() >= end {
                 break;
             }
-            result.push(region.clone());
-            if result.len() as i32 >= limit {
+            regions.push(region.clone());
+            if regions.len() as i32 >= limit {
                 break;
             }
         }
-        return result;
+        regions
     }
 
     fn get_region_approximate_size(&self, region_id: u64) -> Option<u64> {

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -369,9 +369,15 @@ where
         self.bootstrap_region().unwrap();
         self.start().unwrap();
         if self.range_cache_engine_enabled_with_whole_range {
+            let pd_regions = self.pd_client.scan_regions(&[], &[], i32::MAX).unwrap();
+            let regions: Vec<_> = pd_regions
+                .into_iter()
+                .map(|mut r| r.take_region())
+                .collect();
+
             self.engines
                 .iter()
-                .for_each(|(_, engines)| engines.kv.cache_all());
+                .for_each(|(_, engines)| engines.kv.cache_regions(&regions));
         }
     }
 

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -1023,6 +1023,8 @@ where
                     DATA_MIN_KEY.to_vec(),
                     DATA_MAX_KEY.to_vec(),
                 )),
+                region_id: 0,
+                epoch_version: 0,
             };
             self.get_cf_with_snap_ctx(CF_DEFAULT, key, true, ctx)
         }
@@ -1038,6 +1040,8 @@ where
                     DATA_MIN_KEY.to_vec(),
                     DATA_MAX_KEY.to_vec(),
                 )),
+                region_id: 0,
+                epoch_version: 0,
             };
             self.get_cf_with_snap_ctx(cf, key, true, ctx)
         }
@@ -1053,6 +1057,8 @@ where
                     DATA_MIN_KEY.to_vec(),
                     DATA_MAX_KEY.to_vec(),
                 )),
+                region_id: 0,
+                epoch_version: 0,
             };
             self.get_cf_with_snap_ctx(CF_DEFAULT, key, true, ctx)
         }

--- a/components/test_raftstore/src/range_cache_engine.rs
+++ b/components/test_raftstore/src/range_cache_engine.rs
@@ -1,27 +1,22 @@
 // Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
 
 use engine_rocks::RocksEngine;
-use keys::{DATA_MAX_KEY, DATA_MIN_KEY};
-use kvproto::metapb::{Peer, Region};
+use kvproto::metapb::Region;
 
 use crate::HybridEngineImpl;
 
 pub trait RangCacheEngineExt {
-    fn cache_all(&self);
+    fn cache_regions(&self, _regions: &[Region]);
 }
 
 impl RangCacheEngineExt for HybridEngineImpl {
-    fn cache_all(&self) {
-        let mut region = Region::default();
-        region.id = 1;
-        region.start_key = DATA_MIN_KEY.to_vec();
-        region.end_key = DATA_MAX_KEY.to_vec();
-        region.mut_peers().push(Peer::default());
-
-        self.range_cache_engine().new_region(region);
+    fn cache_regions(&self, regions: &[Region]) {
+        for r in regions {
+            self.range_cache_engine().new_region(r.clone());
+        }
     }
 }
 
 impl RangCacheEngineExt for RocksEngine {
-    fn cache_all(&self) {}
+    fn cache_regions(&self, _regions: &[Region]) {}
 }

--- a/components/test_raftstore/src/range_cache_engine.rs
+++ b/components/test_raftstore/src/range_cache_engine.rs
@@ -1,8 +1,8 @@
 // Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
 
 use engine_rocks::RocksEngine;
-use engine_traits::CacheRange;
 use keys::{DATA_MAX_KEY, DATA_MIN_KEY};
+use kvproto::metapb::{Peer, Region};
 
 use crate::HybridEngineImpl;
 
@@ -12,10 +12,13 @@ pub trait RangCacheEngineExt {
 
 impl RangCacheEngineExt for HybridEngineImpl {
     fn cache_all(&self) {
-        self.range_cache_engine().new_range(CacheRange::new(
-            DATA_MIN_KEY.to_vec(),
-            DATA_MAX_KEY.to_vec(),
-        ));
+        let mut region = Region::default();
+        region.id = 1;
+        region.start_key = DATA_MIN_KEY.to_vec();
+        region.end_key = DATA_MAX_KEY.to_vec();
+        region.mut_peers().push(Peer::default());
+
+        self.range_cache_engine().new_region(region);
     }
 }
 

--- a/metrics/grafana/tikv_details.dashboard.py
+++ b/metrics/grafana/tikv_details.dashboard.py
@@ -2195,7 +2195,7 @@ def RaftProcess() -> RowPanel:
     layout.row(
         [
             graph_panel(
-                title="Enable apply unpersisted log regoin count",
+                title="Enable apply unpersisted log region count",
                 description="The number of regions that enable apply unpersisted raft log",
                 yaxes=yaxes(left_format=UNITS.SHORT),
                 targets=[

--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -21353,7 +21353,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Enable apply unpersisted log regoin count",
+          "title": "Enable apply unpersisted log region count",
           "tooltip": {
             "msResolution": true,
             "shared": true,

--- a/metrics/grafana/tikv_details.json.sha256
+++ b/metrics/grafana/tikv_details.json.sha256
@@ -1,1 +1,1 @@
-623607982360b0eb9e6df493d0fb821428fa97c08280fe558e004256114c7752  ./metrics/grafana/tikv_details.json
+56699194c49baa1d686f33f734a553fbfe50c76b1bf8bfe0b61ce64a242dba65  ./metrics/grafana/tikv_details.json

--- a/src/server/raftkv/mod.rs
+++ b/src/server/raftkv/mod.rs
@@ -650,6 +650,8 @@ where
             // When range cache engine is enabled, we need snapshot context to determine
             // whether we should use range cache engine snapshot for this request.
             ctx.start_ts.map(|ts| SnapshotContext {
+                region_id: 0,
+                epoch_version: 0,
                 read_ts: ts.into_inner(),
                 range: None,
             })

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -100,6 +100,7 @@ raft_log_engine = { workspace = true }
 raftstore = { workspace = true }
 raftstore-v2 = { workspace = true }
 rand = "0.8.3"
+range_cache_memory_engine = { workspace = true }
 resource_control = { workspace = true }
 server = { workspace = true }
 service = { workspace = true }

--- a/tests/failpoints/cases/test_early_apply.rs
+++ b/tests/failpoints/cases/test_early_apply.rs
@@ -148,7 +148,7 @@ fn test_early_apply_yield_followed_with_many_entries() {
 
     fail::remove(before_handle_normal_3_fp);
 
-    // Wait for apply state writting to kv db
+    // Wait for apply state writing to kv db
     sleep_ms(200);
 
     cluster.shutdown();

--- a/tests/failpoints/cases/test_range_cache_engine.rs
+++ b/tests/failpoints/cases/test_range_cache_engine.rs
@@ -631,8 +631,12 @@ fn test_eviction_after_merge() {
     let pd_client = Arc::clone(&cluster.pd_client);
     pd_client.must_merge(r.get_id(), r2.get_id());
 
-    range_cache_engine.snapshot(r.id, r.get_region_epoch().version, range1, 100, 100).unwrap_err();
-    range_cache_engine.snapshot(r2.id, r2.get_region_epoch().version, range2, 100, 100).unwrap_err();
+    range_cache_engine
+        .snapshot(r.id, r.get_region_epoch().version, range1, 100, 100)
+        .unwrap_err();
+    range_cache_engine
+        .snapshot(r2.id, r2.get_region_epoch().version, range2, 100, 100)
+        .unwrap_err();
 }
 
 #[test]
@@ -707,5 +711,13 @@ fn test_eviction_after_ingest_sst() {
         .unwrap();
     assert!(!resp.get_header().has_error(), "{:?}", resp);
 
-    range_cache_engine.snapshot(region.id, region.get_region_epoch().version, range, 100, 100).unwrap_err();
+    range_cache_engine
+        .snapshot(
+            region.id,
+            region.get_region_epoch().version,
+            range,
+            100,
+            100,
+        )
+        .unwrap_err();
 }

--- a/tests/failpoints/cases/test_stale_read.rs
+++ b/tests/failpoints/cases/test_stale_read.rs
@@ -286,7 +286,7 @@ fn test_stale_read_during_merging() {
     // Note: L: leader, F: follower, X: peer is not exist.
     // TODO: what if cluster runs slow and lease is expired.
     // Epoch changed by prepare merge.
-    // We can not use `get_region_with` to get the latest info of reigon 1000,
+    // We can not use `get_region_with` to get the latest info of region 1000,
     // because leader1 is not paused, it executes commit merge very fast
     // and reports pd, its range covers region1000.
     //


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #16141  close #17147

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Move range cache engine's range manager for range-base to region-base
```

This PR refactor the RangeCacheEngine's RangeManager for range-base to region-base.

State Management. The life time of each cached region can be one of following state:
- Pending. Region is triggered to load but not started. 
- Loading. Region is performing loading kvs from rocksdb. under this state, raft apply worker will also write new kvs into skiplist directly.
- Active. Region is cached, ready for read.
- LoadingCanceled. Region is evicted while it's still handling batch loading. 
- PendingEvict. Region should be evicted, but evict is block by on-going apply writ or gc or active snapshot.
- Evicting. Evicted region is still handling delete KVs from skiplist, after the delete finished, this region will be removed from RangeManager.

Region Metadata Management
Each region's metadata is maintained in a single struct called RegionMeta. It manages the region's current epoch version, active snapshot list, gc safe_point, in_gc flag and state.

Batch-Loading behavior changes
This PR simplifies Batch-loading phase by removing the cached entries in memory and directly write new entires to the skiplist. Note that, due to this change, if a batch-loading task is canceled before started, it still need to use region eviction because the raft apply worker may already write new KVs into the skiplist.

 Region Epoch Management
As the new design is region-based, it need to keep up it's local state with raftstore. We use a ApplyObserve to observe raft event and update region meta on some specific events. Note that as region's conf version change does not impact the data layout, so we only track region's epoch version changes but ignore conf-version change.
- LeaderResign. Evict the region as we only cache data for region leader.
- SST Ingestion, DeleteRange. Evict the region because the in-memory kvs are not keep up with rocksdb anymore.
- PrepareMerge, CommitMerge. Evict the region for simplicity because we only merge region when it is not hot.
- Split/BatchSplit. We replace current with new split regions. The new regions should inherit the old region's  state, gc safe_point and in_gc flag. If the old region's snapshot_list is not empty, it is put into the `historical_regions` to track these snapshots.

In addition, as we use a snapshot to handle some time-cost event, e.g. batch loading, it is possible that after handling finished, the region's epoch may already changed, so after some operation, we will check to the region epoch version, if it changes, we will use scan to handle all new regions that overlaps with the original region:
- Pending. We apply worker handle pending region in `prepare_for_region`, if the pending region's version changes, if pending region's range contains the new region's, we replace the pending region with the new region; else, we just discard the pending region.
- Batch Loading. If region epoch version changes, it scans all regions fall in this range and update their state to either "active" or "pending_evict" based on their current state.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
