### PR TITLE
In-memory engine: show eviction reasons in metrics

### DIFF
--- a/components/engine_panic/src/range_cache_engine.rs
+++ b/components/engine_panic/src/range_cache_engine.rs
@@ -1,6 +1,6 @@
 // Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_traits::RangeCacheEngineExt;
+use engine_traits::{EvictReason, RangeCacheEngineExt};
 
 use crate::PanicEngine;
 
@@ -9,7 +9,7 @@ impl RangeCacheEngineExt for PanicEngine {
         panic!()
     }
 
-    fn evict_range(&self, range: &engine_traits::CacheRange) {
+    fn evict_range(&self, range: &engine_traits::CacheRange, evict_range: EvictReason) {
         panic!()
     }
 }

--- a/components/engine_rocks/src/range_cache_engine.rs
+++ b/components/engine_rocks/src/range_cache_engine.rs
@@ -1,6 +1,6 @@
 // Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_traits::RangeCacheEngineExt;
+use engine_traits::{EvictReason, RangeCacheEngineExt};
 
 use crate::RocksEngine;
 
@@ -10,5 +10,5 @@ impl RangeCacheEngineExt for RocksEngine {
     }
 
     #[inline]
-    fn evict_range(&self, _: &engine_traits::CacheRange) {}
+    fn evict_range(&self, _: &engine_traits::CacheRange, _: EvictReason) {}
 }

--- a/components/engine_traits/src/range_cache_engine.rs
+++ b/components/engine_traits/src/range_cache_engine.rs
@@ -20,6 +20,7 @@ pub enum FailedReason {
 #[derive(Debug, Clone, Copy)]
 pub enum EvictReason {
     LoadFailed,
+    LoadFailedWithoutStart,
     MemoryLimitReached,
     BecomeFollower,
     AutoEvict,

--- a/components/engine_traits/src/range_cache_engine.rs
+++ b/components/engine_traits/src/range_cache_engine.rs
@@ -17,6 +17,16 @@ pub enum FailedReason {
     TooOldRead,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub enum EvictReason {
+    LoadFailed,
+    MemoryLimitReached,
+    BecomeFollower,
+    AutoEvict,
+    DeleteRange,
+    Merge,
+}
+
 /// RangeCacheEngine works as a range cache caching some ranges (in Memory or
 /// NVME for instance) to improve the read performance.
 pub trait RangeCacheEngine:
@@ -48,7 +58,7 @@ pub trait RangeCacheEngine:
         false
     }
 
-    fn evict_range(&self, range: &CacheRange);
+    fn evict_range(&self, range: &CacheRange, evict_reason: EvictReason);
 }
 
 pub trait RangeCacheEngineExt {
@@ -56,7 +66,7 @@ pub trait RangeCacheEngineExt {
 
     // TODO(SpadeA): try to find a better way to reduce coupling degree of range
     // cache engine and kv engine
-    fn evict_range(&self, range: &CacheRange);
+    fn evict_range(&self, range: &CacheRange, evict_range: EvictReason);
 }
 
 /// A service that should run in the background to retrieve and apply cache

--- a/components/hybrid_engine/src/misc.rs
+++ b/components/hybrid_engine/src/misc.rs
@@ -1,6 +1,8 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_traits::{CacheRange, KvEngine, MiscExt, RangeCacheEngine, Result, WriteBatchExt};
+use engine_traits::{
+    CacheRange, EvictReason, KvEngine, MiscExt, RangeCacheEngine, Result, WriteBatchExt,
+};
 
 use crate::{engine::HybridEngine, hybrid_metrics::HybridEngineStatisticsReporter};
 
@@ -36,8 +38,10 @@ where
         ranges: &[engine_traits::Range<'_>],
     ) -> Result<bool> {
         for r in ranges {
-            self.range_cache_engine()
-                .evict_range(&CacheRange::new(r.start_key.to_vec(), r.end_key.to_vec()));
+            self.range_cache_engine().evict_range(
+                &CacheRange::new(r.start_key.to_vec(), r.end_key.to_vec()),
+                EvictReason::DeleteRange,
+            );
         }
         self.disk_engine()
             .delete_ranges_cf(wopts, cf, strategy, ranges)

--- a/components/hybrid_engine/src/observer.rs
+++ b/components/hybrid_engine/src/observer.rs
@@ -203,7 +203,7 @@ mod tests {
         fn range_cache_engine_enabled(&self) -> bool {
             self.enabled.load(Ordering::Relaxed)
         }
-        fn evict_range(&self, range: &CacheRange) {
+        fn evict_range(&self, range: &CacheRange, _: EvictReason) {
             self.evicted_ranges.lock().unwrap().push(range.clone());
         }
     }

--- a/components/hybrid_engine/src/observer.rs
+++ b/components/hybrid_engine/src/observer.rs
@@ -2,7 +2,7 @@
 
 use std::sync::{Arc, Mutex};
 
-use engine_traits::{CacheRange, KvEngine, RangeCacheEngineExt};
+use engine_traits::{CacheRange, EvictReason, KvEngine, RangeCacheEngineExt};
 use kvproto::{metapb::Region, raft_cmdpb::AdminCmdType, raft_serverpb::RaftApplyState};
 use raft::StateRole;
 use raftstore::coprocessor::{
@@ -13,7 +13,7 @@ use raftstore::coprocessor::{
 
 #[derive(Clone)]
 pub struct Observer {
-    pending_evict: Arc<Mutex<Vec<CacheRange>>>,
+    pending_evict: Arc<Mutex<Vec<(CacheRange, EvictReason)>>>,
     cache_engine: Arc<dyn RangeCacheEngineExt + Send + Sync>,
 }
 
@@ -82,7 +82,10 @@ impl Observer {
                 "admin_command" => ?cmd.request.get_admin_request().get_cmd_type(),
                 "range" => ?range,
             );
-            self.pending_evict.lock().unwrap().push(range);
+            self.pending_evict
+                .lock()
+                .unwrap()
+                .push((range, EvictReason::Merge));
         }
     }
 
@@ -95,8 +98,8 @@ impl Observer {
             let mut ranges = self.pending_evict.lock().unwrap();
             std::mem::take(&mut *ranges)
         };
-        for range in ranges {
-            self.cache_engine.evict_range(&range);
+        for (range, evict_reason) in ranges {
+            self.cache_engine.evict_range(&range, evict_reason);
         }
     }
 
@@ -111,7 +114,10 @@ impl Observer {
             "region_id" => region.get_id(),
             "range" => ?range,
         );
-        self.pending_evict.lock().unwrap().push(range);
+        self.pending_evict
+            .lock()
+            .unwrap()
+            .push((range, EvictReason::BecomeFollower));
     }
 }
 

--- a/components/hybrid_engine/src/range_cache_engine.rs
+++ b/components/hybrid_engine/src/range_cache_engine.rs
@@ -1,6 +1,6 @@
 // Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_traits::{CacheRange, KvEngine, RangeCacheEngine, RangeCacheEngineExt};
+use engine_traits::{CacheRange, EvictReason, KvEngine, RangeCacheEngine, RangeCacheEngineExt};
 
 use crate::HybridEngine;
 
@@ -14,7 +14,7 @@ where
     }
 
     #[inline]
-    fn evict_range(&self, range: &CacheRange) {
-        self.range_cache_engine().evict_range(range);
+    fn evict_range(&self, range: &CacheRange, evict_range: EvictReason) {
+        self.range_cache_engine().evict_range(range, evict_range);
     }
 }

--- a/components/raftstore/src/coprocessor/region_info_accessor.rs
+++ b/components/raftstore/src/coprocessor/region_info_accessor.rs
@@ -602,6 +602,8 @@ impl RegionCollector {
                         r,
                         ra.map(|ra| ra.region_stat.approximate_size)
                             .unwrap_or_default(),
+                        ra.map(|ra| ra.region_stat.read_keys).unwrap_or_default(),
+                        ra.map(|ra| ra.region_stat.written_keys).unwrap_or_default(),
                     )
                 })
                 .collect::<Vec<_>>()

--- a/components/raftstore/src/coprocessor/region_info_accessor.rs
+++ b/components/raftstore/src/coprocessor/region_info_accessor.rs
@@ -602,8 +602,6 @@ impl RegionCollector {
                         r,
                         ra.map(|ra| ra.region_stat.approximate_size)
                             .unwrap_or_default(),
-                        ra.map(|ra| ra.region_stat.read_keys).unwrap_or_default(),
-                        ra.map(|ra| ra.region_stat.written_keys).unwrap_or_default(),
                     )
                 })
                 .collect::<Vec<_>>()

--- a/components/range_cache_memory_engine/src/background.rs
+++ b/components/range_cache_memory_engine/src/background.rs
@@ -2314,7 +2314,7 @@ pub mod tests {
         let _snap3 = engine.snapshot(range.clone(), 60, 1000).unwrap();
 
         let range2 = CacheRange::new(b"key5".to_vec(), b"key8".to_vec());
-        engine.evict_range(&range2);
+        engine.evict_range(&range2, EvictReason::AutoEvict);
 
         assert_eq!(6, element_count(&default));
         assert_eq!(6, element_count(&write));

--- a/components/range_cache_memory_engine/src/metrics.rs
+++ b/components/range_cache_memory_engine/src/metrics.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 
+use engine_traits::EvictReason;
 use lazy_static::lazy_static;
 use prometheus::*;
 use prometheus_static_metric::*;
@@ -30,12 +31,25 @@ make_auto_flush_static_metric! {
         number_db_prev_found,
     }
 
+    pub label_enum EvictReasonType {
+        merge,
+        auto_evict,
+        load_failed,
+        delete_range,
+        become_follower,
+        memory_limit_reached,
+    }
+
     pub struct GcFilteredCountVec: LocalIntCounter {
         "type" => KeyCountType,
     }
 
     pub struct InMemoryEngineTickerMetrics: LocalIntCounter {
         "type" => TickerEnum,
+    }
+
+    pub struct EvictionDurationVec: LocalHistogram {
+        "type" => EvictReasonType,
     }
 }
 
@@ -63,9 +77,10 @@ lazy_static! {
         exponential_buckets(0.001, 2.0, 20).unwrap()
     )
     .unwrap();
-    pub static ref RANGE_EVICTION_DURATION_HISTOGRAM: Histogram = register_histogram!(
+    pub static ref RANGE_EVICTION_DURATION_HISTOGRAM: HistogramVec = register_histogram_vec!(
         "tikv_range_eviction_duration_secs",
         "Bucketed histogram of range eviction time duration.",
+        &["type"],
         exponential_buckets(0.001, 2.0, 20).unwrap()
     )
     .unwrap();
@@ -114,6 +129,8 @@ lazy_static! {
         auto_flush_from!(IN_MEMORY_ENGINE_FLOW, InMemoryEngineTickerMetrics);
     pub static ref IN_MEMORY_ENGINE_LOCATE_STATIC: InMemoryEngineTickerMetrics =
         auto_flush_from!(IN_MEMORY_ENGINE_LOCATE, InMemoryEngineTickerMetrics);
+    pub static ref RANGE_EVICTION_DURATION_HISTOGRAM_STATIC: EvictionDurationVec =
+        auto_flush_from!(RANGE_EVICTION_DURATION_HISTOGRAM, EvictionDurationVec);
 }
 
 pub fn flush_range_cache_engine_statistics(statistics: &Arc<RangeCacheMemoryEngineStatistics>) {
@@ -158,5 +175,26 @@ fn flush_engine_ticker_metrics(t: Tickers, value: u64) {
         _ => {
             unreachable!()
         }
+    }
+}
+
+pub(crate) fn observe_eviction_duration(secs: f64, evict_reason: EvictReason) {
+    match evict_reason {
+        EvictReason::AutoEvict => RANGE_EVICTION_DURATION_HISTOGRAM_STATIC
+            .auto_evict
+            .observe(secs),
+        EvictReason::BecomeFollower => RANGE_EVICTION_DURATION_HISTOGRAM_STATIC
+            .become_follower
+            .observe(secs),
+        EvictReason::DeleteRange => RANGE_EVICTION_DURATION_HISTOGRAM_STATIC
+            .delete_range
+            .observe(secs),
+        EvictReason::LoadFailed => RANGE_EVICTION_DURATION_HISTOGRAM_STATIC
+            .load_failed
+            .observe(secs),
+        EvictReason::MemoryLimitReached => RANGE_EVICTION_DURATION_HISTOGRAM_STATIC
+            .memory_limit_reached
+            .observe(secs),
+        EvictReason::Merge => RANGE_EVICTION_DURATION_HISTOGRAM_STATIC.merge.observe(secs),
     }
 }

--- a/components/range_cache_memory_engine/src/metrics.rs
+++ b/components/range_cache_memory_engine/src/metrics.rs
@@ -35,6 +35,7 @@ make_auto_flush_static_metric! {
         merge,
         auto_evict,
         load_failed,
+        load_failed_without_start,
         delete_range,
         become_follower,
         memory_limit_reached,
@@ -191,6 +192,9 @@ pub(crate) fn observe_eviction_duration(secs: f64, evict_reason: EvictReason) {
             .observe(secs),
         EvictReason::LoadFailed => RANGE_EVICTION_DURATION_HISTOGRAM_STATIC
             .load_failed
+            .observe(secs),
+        EvictReason::LoadFailedWithoutStart => RANGE_EVICTION_DURATION_HISTOGRAM_STATIC
+            .load_failed_without_start
             .observe(secs),
         EvictReason::MemoryLimitReached => RANGE_EVICTION_DURATION_HISTOGRAM_STATIC
             .memory_limit_reached

--- a/components/range_cache_memory_engine/src/read.rs
+++ b/components/range_cache_memory_engine/src/read.rs
@@ -671,9 +671,9 @@ mod tests {
         raw::DBStatisticsTickerType, util::new_engine_opt, RocksDbOptions, RocksStatistics,
     };
     use engine_traits::{
-        CacheRange, FailedReason, IterMetricsCollector, IterOptions, Iterable, Iterator,
-        MetricsExt, Mutable, Peekable, RangeCacheEngine, ReadOptions, WriteBatch, WriteBatchExt,
-        CF_DEFAULT, CF_LOCK, CF_WRITE,
+        CacheRange, EvictReason, FailedReason, IterMetricsCollector, IterOptions, Iterable,
+        Iterator, MetricsExt, Mutable, Peekable, RangeCacheEngine, ReadOptions, WriteBatch,
+        WriteBatchExt, CF_DEFAULT, CF_LOCK, CF_WRITE,
     };
     use tempfile::Builder;
     use tikv_util::config::VersionTrack;
@@ -1798,7 +1798,7 @@ mod tests {
             }
         }
 
-        engine.evict_range(&evict_range);
+        engine.evict_range(&evict_range, EvictReason::AutoEvict);
         assert_eq!(
             engine.snapshot(range.clone(), 10, 200).unwrap_err(),
             FailedReason::NotCached
@@ -1863,7 +1863,7 @@ mod tests {
 
         let s1 = engine.snapshot(range.clone(), 10, 10);
         let s2 = engine.snapshot(range, 20, 20);
-        engine.evict_range(&evict_range);
+        engine.evict_range(&evict_range, EvictReason::AutoEvict);
         let range_left = CacheRange::new(construct_user_key(0), construct_user_key(10));
         let s3 = engine.snapshot(range_left, 20, 20).unwrap();
         let range_right = CacheRange::new(construct_user_key(20), construct_user_key(30));
@@ -1871,7 +1871,7 @@ mod tests {
 
         drop(s3);
         let range_left_eviction = CacheRange::new(construct_user_key(0), construct_user_key(5));
-        engine.evict_range(&range_left_eviction);
+        engine.evict_range(&range_left_eviction, EvictReason::AutoEvict);
 
         // todo(SpadeA): memory limiter
         {

--- a/components/range_cache_memory_engine/src/write_batch.rs
+++ b/components/range_cache_memory_engine/src/write_batch.rs
@@ -7,7 +7,7 @@ use std::{
 use bytes::Bytes;
 use crossbeam::epoch;
 use engine_traits::{
-    CacheRange, MiscExt, Mutable, RangeCacheEngine, Result, WriteBatch, WriteBatchExt,
+    CacheRange, EvictReason, MiscExt, Mutable, RangeCacheEngine, Result, WriteBatch, WriteBatchExt,
     WriteOptions, CF_DEFAULT,
 };
 use tikv_util::{box_err, config::ReadableSize, error, info, time::Instant, warn};
@@ -243,7 +243,8 @@ impl RangeCacheWriteBatch {
         let mut ranges = vec![];
         let range_manager = core.mut_range_manager();
         for r in std::mem::take(&mut self.ranges_to_evict) {
-            let mut ranges_to_delete = range_manager.evict_range(&r);
+            let mut ranges_to_delete =
+                range_manager.evict_range(&r, EvictReason::MemoryLimitReached);
             if !ranges_to_delete.is_empty() {
                 ranges.append(&mut ranges_to_delete);
                 continue;
@@ -613,13 +614,13 @@ impl Mutable for RangeCacheWriteBatch {
     // them directly
     fn delete_range(&mut self, begin_key: &[u8], end_key: &[u8]) -> Result<()> {
         let range = CacheRange::new(begin_key.to_vec(), end_key.to_vec());
-        self.engine.evict_range(&range);
+        self.engine.evict_range(&range, EvictReason::DeleteRange);
         Ok(())
     }
 
     fn delete_range_cf(&mut self, _: &str, begin_key: &[u8], end_key: &[u8]) -> Result<()> {
         let range = CacheRange::new(begin_key.to_vec(), end_key.to_vec());
-        self.engine.evict_range(&range);
+        self.engine.evict_range(&range, EvictReason::DeleteRange);
         Ok(())
     }
 }

--- a/components/range_cache_memory_engine/src/write_batch.rs
+++ b/components/range_cache_memory_engine/src/write_batch.rs
@@ -959,7 +959,7 @@ mod tests {
         assert_eq!(822, memory_controller.mem_usage());
 
         drop(snap1);
-        engine.evict_range(&range1);
+        engine.evict_range(&range1, EvictReason::AutoEvict);
         flush_epoch();
         wait_evict_done(&engine);
         assert_eq!(548, memory_controller.mem_usage());

--- a/components/range_cache_memory_engine/tests/failpoints/test_memory_engine.rs
+++ b/components/range_cache_memory_engine/tests/failpoints/test_memory_engine.rs
@@ -8,8 +8,8 @@ use std::{
 use crossbeam::epoch;
 use engine_rocks::util::new_engine;
 use engine_traits::{
-    CacheRange, Mutable, RangeCacheEngine, WriteBatch, WriteBatchExt, CF_DEFAULT, CF_LOCK,
-    CF_WRITE, DATA_CFS,
+    CacheRange, EvictReason, Mutable, RangeCacheEngine, WriteBatch, WriteBatchExt, CF_DEFAULT,
+    CF_LOCK, CF_WRITE, DATA_CFS,
 };
 use range_cache_memory_engine::{
     decode_key, encode_key_for_boundary_without_mvcc, encoding_for_filter, test_util::put_data,
@@ -253,7 +253,7 @@ fn test_evict_with_loading_range() {
     let engine_clone = engine.clone();
     fail::cfg_callback("on_snapshot_load_finished", move || {
         let _ = snapshot_load_tx.send(true);
-        engine_clone.evict_range(&r);
+        engine_clone.evict_range(&r, EvictReason::AutoEvict);
     })
     .unwrap();
 
@@ -431,8 +431,8 @@ fn test_concurrency_between_delete_range_and_write_to_memory() {
     // Now, three ranges are in write status, delete range will not be performed
     // until they leave the write status
 
-    engine.evict_range(&range1);
-    engine.evict_range(&range2);
+    engine.evict_range(&range1, EvictReason::AutoEvict);
+    engine.evict_range(&range2, EvictReason::AutoEvict);
 
     let verify_data = |range, expected_num: u64| {
         let handle = engine.core().write().engine().cf_handle(CF_LOCK);
@@ -479,7 +479,7 @@ fn test_concurrency_between_delete_range_and_write_to_memory() {
     snapshot_load_rx
         .recv_timeout(Duration::from_secs(5))
         .unwrap();
-    engine.evict_range(&range3);
+    engine.evict_range(&range3, EvictReason::AutoEvict);
 
     fail::cfg("before_clear_ranges_in_being_written", "pause").unwrap();
     write_batch_consume_rx
@@ -520,7 +520,7 @@ fn test_double_delete_range_schedule() {
         let _ = snapshot_load_tx.send(true);
         // evict all ranges. So the loading ranges will also be evicted and a delete
         // range task will be scheduled.
-        engine_clone.evict_range(&r);
+        engine_clone.evict_range(&r, EvictReason::AutoEvict);
     })
     .unwrap();
 

--- a/metrics/grafana/tikv_details.dashboard.py
+++ b/metrics/grafana/tikv_details.dashboard.py
@@ -4268,10 +4268,10 @@ def RangeCacheMemoryEngine() -> RowPanel:
                 targets=[
                     target(
                         expr=expr_sum_rate(
-                            "tikv_range_load_duration_secs_count",
-                            by_labels=["instance"],
+                            "tikv_range_eviction_duration_secs_count",
+                            by_labels=["instance, type"],
                         ),
-                        legend_format="{{instance}}--loading2",
+                        legend_format="{{instance}}-{{type}}",
                     ),
                 ],
             ),

--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -38199,15 +38199,15 @@
           "targets": [
             {
               "datasource": "${DS_TEST-CLUSTER}",
-              "expr": "sum(rate(\n    tikv_range_load_duration_secs_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (instance) ",
+              "expr": "sum(rate(\n    tikv_range_eviction_duration_secs_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (instance, type) ",
               "format": "time_series",
               "hide": false,
               "instant": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{instance}}--loading2",
+              "legendFormat": "{{instance}}-{{type}}",
               "metric": "",
-              "query": "sum(rate(\n    tikv_range_load_duration_secs_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (instance) ",
+              "query": "sum(rate(\n    tikv_range_eviction_duration_secs_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (instance, type) ",
               "refId": "",
               "step": 10,
               "target": ""

--- a/metrics/grafana/tikv_details.json.sha256
+++ b/metrics/grafana/tikv_details.json.sha256
@@ -1,1 +1,1 @@
-1c5a149c9ff8753b505e48e5ad0d1a6008eb36820b0a512ef8c8a550a08106cf  ./metrics/grafana/tikv_details.json
+5e9ddf182bd05a26f0e04bba1f326f5a57432374ee688d6bedf39c77a09cd820  ./metrics/grafana/tikv_details.json

--- a/tests/failpoints/cases/test_range_cache_engine.rs
+++ b/tests/failpoints/cases/test_range_cache_engine.rs
@@ -7,8 +7,8 @@ use std::{
 
 use engine_rocks::RocksSstWriterBuilder;
 use engine_traits::{
-    CacheRange, RangeCacheEngine, SnapshotContext, SstWriter, SstWriterBuilder, CF_DEFAULT,
-    CF_WRITE, EvictReason,
+    CacheRange, EvictReason, RangeCacheEngine, SnapshotContext, SstWriter, SstWriterBuilder,
+    CF_DEFAULT, CF_WRITE,
 };
 use file_system::calc_crc32_bytes;
 use keys::{data_key, DATA_MAX_KEY, DATA_MIN_KEY};

--- a/tests/failpoints/cases/test_range_cache_engine.rs
+++ b/tests/failpoints/cases/test_range_cache_engine.rs
@@ -8,7 +8,7 @@ use std::{
 use engine_rocks::RocksSstWriterBuilder;
 use engine_traits::{
     CacheRange, RangeCacheEngine, SnapshotContext, SstWriter, SstWriterBuilder, CF_DEFAULT,
-    CF_WRITE,
+    CF_WRITE, EvictReason,
 };
 use file_system::calc_crc32_bytes;
 use keys::{data_key, DATA_MAX_KEY, DATA_MIN_KEY};
@@ -518,7 +518,7 @@ fn test_load_with_eviction() {
         }
         // Now, the range (DATA_MIN_KEY, DATA_MAX_KEY) should be cached
         let range = CacheRange::new(data_key(b"k10"), DATA_MAX_KEY.to_vec());
-        range_cache_engine.evict_range(&range);
+        range_cache_engine.evict_range(&range, EvictReason::AutoEvict);
     }
 
     fail::remove("on_write_impl");


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref #16141

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
show eviction reasons in metrics
```
![image](https://github.com/user-attachments/assets/2f1e642b-8b69-4f3f-8eda-6362230deeb7)

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
