### PR TITLE
cdc: print log to indicate memory free, and adjust finish_scan_lock method

### DIFF
--- a/components/cdc/src/channel.rs
+++ b/components/cdc/src/channel.rs
@@ -513,11 +513,11 @@ mod tests {
 
             let memory_quota = rx.memory_quota.clone();
             let mut drain = rx.drain();
-            block_on_timeout(drain.next(), Duration::from_millis(100)).unwrap_err();
+            recv_timeout(&mut drain, Duration::from_millis(100)).unwrap_err();
             assert_eq!(memory_quota.in_use(), 0);
         }
     }
-    
+
     #[test]
     fn test_barrier() {
         let force_send = false;

--- a/components/cdc/src/channel.rs
+++ b/components/cdc/src/channel.rs
@@ -431,7 +431,8 @@ impl Drop for Drain {
         });
         block_on(&mut drain);
         let takes = start.saturating_elapsed();
-        info!("drop Drain finished, free memory"; "takes" => ?takes, "bytes" => total_bytes);
+        info!("drop Drain finished, free memory";"takes" => ?takes,
+            "freed_bytes" => total_bytes, "inuse_bytes" => self.memory_quota.in_use());
     }
 }
 

--- a/components/cdc/src/channel.rs
+++ b/components/cdc/src/channel.rs
@@ -194,7 +194,7 @@ impl EventBatcher {
     }
 }
 
-pub fn channel(buffer: usize, memory_quota: Arc<MemoryQuota>) -> (Sink, Drain) {
+pub fn channel(conn_id: ConnId, buffer: usize, memory_quota: Arc<MemoryQuota>) -> (Sink, Drain) {
     let (unbounded_sender, unbounded_receiver) = unbounded();
     let (bounded_sender, bounded_receiver) = bounded(buffer);
     (
@@ -207,7 +207,7 @@ pub fn channel(buffer: usize, memory_quota: Arc<MemoryQuota>) -> (Sink, Drain) {
             unbounded_receiver,
             bounded_receiver,
             memory_quota,
-            conn_id: Default::default(),
+            conn_id,
         },
     )
 }

--- a/components/cdc/src/channel.rs
+++ b/components/cdc/src/channel.rs
@@ -6,7 +6,6 @@ use std::{
         atomic::{AtomicBool, Ordering},
         Arc,
     },
-    time::Duration,
 };
 
 use futures::{
@@ -426,7 +425,7 @@ impl Drop for Drain {
         });
         block_on(&mut drain);
         let takes = start.saturating_elapsed();
-        info!("drop Drain finished, free memory", "takes" => ?takes, "bytes" => total_bytes);
+        info!("drop Drain finished, free memory"; "takes" => ?takes, "bytes" => total_bytes);
     }
 }
 

--- a/components/cdc/src/channel.rs
+++ b/components/cdc/src/channel.rs
@@ -473,7 +473,7 @@ mod tests {
     type Send = Box<dyn FnMut(CdcEvent) -> Result<(), SendError>>;
     fn new_test_channel(buffer: usize, capacity: usize, force_send: bool) -> (Send, Drain) {
         let memory_quota = Arc::new(MemoryQuota::new(capacity));
-        let (mut tx, rx) = channel(buffer, memory_quota);
+        let (mut tx, rx) = channel(ConnId::default(), buffer, memory_quota);
         let mut flag = true;
         let send = move |event| {
             flag = !flag;
@@ -492,7 +492,7 @@ mod tests {
         e.region_id = 233;
         {
             let memory_quota = Arc::new(MemoryQuota::new(1024));
-            let (mut tx, mut rx) = channel(10, memory_quota);
+            let (mut tx, mut rx) = channel(ConnId::default(), 10, memory_quota);
 
             let truncated = Arc::new(AtomicBool::new(false));
             let event = CdcEvent::Event(e.clone());
@@ -506,7 +506,7 @@ mod tests {
         }
         {
             let memory_quota = Arc::new(MemoryQuota::new(1024));
-            let (mut tx, mut rx) = channel(10, memory_quota);
+            let (mut tx, mut rx) = channel(ConnId::default(), 10, memory_quota);
 
             let truncated = Arc::new(AtomicBool::new(true));
             let _ = block_on(tx.send_all(vec![CdcEvent::Event(e)], truncated));
@@ -653,7 +653,7 @@ mod tests {
         let max_pending_bytes = 1024;
         let buffer = max_pending_bytes / event.size();
         let memory_quota = Arc::new(MemoryQuota::new(max_pending_bytes as _));
-        let (tx, _rx) = channel(buffer as _, memory_quota);
+        let (tx, _rx) = channel(ConnId::default(), buffer as _, memory_quota);
         for _ in 0..buffer {
             tx.unbounded_send(CdcEvent::Event(e.clone()), false)
                 .unwrap();

--- a/components/cdc/src/channel.rs
+++ b/components/cdc/src/channel.rs
@@ -19,7 +19,13 @@ use futures::{
 use grpcio::WriteFlags;
 use kvproto::cdcpb::{ChangeDataEvent, Event, ResolvedTs};
 use protobuf::Message;
-use tikv_util::{future::block_on_timeout, impl_display_as_debug, info, memory::{MemoryQuota, MemoryQuotaExceeded}, time::Instant, warn};
+use tikv_util::{
+    future::block_on_timeout,
+    impl_display_as_debug, info,
+    memory::{MemoryQuota, MemoryQuotaExceeded},
+    time::Instant,
+    warn,
+};
 
 use crate::metrics::*;
 

--- a/components/cdc/src/channel.rs
+++ b/components/cdc/src/channel.rs
@@ -360,10 +360,6 @@ pub struct Drain {
 }
 
 impl<'a> Drain {
-    pub fn set_conn_id(&'a mut self, conn_id: ConnId) {
-        self.conn_id = conn_id;
-    }
-
     pub fn drain(&'a mut self) -> impl Stream<Item = (CdcEvent, usize)> + 'a {
         let observed = (&mut self.unbounded_receiver).map(|x| (x.created, x.event, x.size));
         let scaned = (&mut self.bounded_receiver).filter_map(|x| {

--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -769,7 +769,7 @@ impl Delegate {
                     }
                     decode_default(default.1, &mut row, &mut _has_value);
                     row.old_value = old_value.finalized().unwrap_or_default();
-                    row_size = row.key.len() + row.value.len();
+                    row_size = row.key.len() + row.value.len() + row.old_value.len();
                 }
                 Some(KvEntry::TxnEntry(TxnEntry::Commit {
                     default,
@@ -797,7 +797,7 @@ impl Delegate {
                     }
                     set_event_row_type(&mut row, EventLogType::Committed);
                     row.old_value = old_value.finalized().unwrap_or_default();
-                    row_size = row.key.len() + row.value.len();
+                    row_size = row.key.len() + row.value.len() + row.old_value.len();
                 }
                 None => {
                     // This type means scan has finished.

--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -1433,7 +1433,7 @@ mod tests {
         let region_epoch = region.get_region_epoch().clone();
 
         let quota = Arc::new(MemoryQuota::new(usize::MAX));
-        let (sink, mut drain) = crate::channel::channel(1, quota.clone());
+        let (sink, mut drain) = channel(ConnId::default(), 1, quota.clone());
         let rx = drain.drain();
         let request_id = RequestId(123);
         let mut downstream = Downstream::new(
@@ -1725,7 +1725,7 @@ mod tests {
         }
         assert_eq!(rows_builder.txns_by_key.len(), 5);
 
-        let (sink, mut drain) = channel(1, Arc::new(MemoryQuota::new(1024)));
+        let (sink, mut drain) = channel(ConnId::default(), 1, Arc::new(MemoryQuota::new(1024)));
         let mut downstream = Downstream::new(
             "peer".to_owned(),
             RegionEpoch::default(),
@@ -1792,7 +1792,7 @@ mod tests {
         }
         assert_eq!(rows_builder.txns_by_key.len(), 5);
 
-        let (sink, mut drain) = channel(1, Arc::new(MemoryQuota::new(1024)));
+        let (sink, mut drain) = channel(ConnId::default(), 1, Arc::new(MemoryQuota::new(1024)));
         let mut downstream = Downstream::new(
             "peer".to_owned(),
             RegionEpoch::default(),

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -1520,10 +1520,10 @@ mod tests {
         let mut suite = mock_endpoint(&cfg, None, ApiVersion::V1);
         suite.add_region(1, 100);
         let quota = Arc::new(MemoryQuota::new(usize::MAX));
-        let (tx, mut rx) = channel::channel(1, quota);
+        let (tx, mut rx) = channel::channel(ConnId::default(), 1, quota);
         let mut rx = rx.drain();
 
-        let conn = Conn::new(tx, String::new());
+        let conn = Conn::new(ConnId::default(), tx, String::new());
         let conn_id = conn.get_id();
         suite.run(Task::OpenConn { conn });
         suite.run(set_conn_version_task(
@@ -1800,14 +1800,14 @@ mod tests {
     #[test]
     fn test_raftstore_is_busy() {
         let quota = Arc::new(MemoryQuota::new(usize::MAX));
-        let (tx, _rx) = channel::channel(1, quota);
+        let (tx, _rx) = channel::channel(ConnId::default(), 1, quota);
         let mut suite = mock_endpoint(&CdcConfig::default(), None, ApiVersion::V1);
 
         // Fill the channel.
         suite.add_region(1 /* region id */, 1 /* cap */);
         suite.fill_raft_rx(1);
 
-        let conn = Conn::new(tx, String::new());
+        let conn = Conn::new(ConnId::default(), tx, String::new());
         let conn_id = conn.get_id();
         suite.run(Task::OpenConn { conn });
         suite.run(set_conn_version_task(
@@ -1855,10 +1855,10 @@ mod tests {
         let mut suite = mock_endpoint(&cfg, None, ApiVersion::V1);
         suite.add_region(1, 100);
         let quota = Arc::new(MemoryQuota::new(usize::MAX));
-        let (tx, mut rx) = channel::channel(1, quota);
+        let (tx, mut rx) = channel::channel(ConnId::default(), 1, quota);
         let mut rx = rx.drain();
 
-        let conn = Conn::new(tx, String::new());
+        let conn = Conn::new(ConnId::default(), tx, String::new());
         let conn_id = conn.get_id();
         suite.run(Task::OpenConn { conn });
 
@@ -2018,10 +2018,10 @@ mod tests {
 
         suite.add_region(1, 100);
         let quota = Arc::new(MemoryQuota::new(usize::MAX));
-        let (tx, mut rx) = channel::channel(1, quota);
+        let (tx, mut rx) = channel::channel(ConnId::default(), 1, quota);
         let mut rx = rx.drain();
 
-        let conn = Conn::new(tx, String::new());
+        let conn = Conn::new(ConnId::default(), tx, String::new());
         let conn_id = conn.get_id();
         suite.run(Task::OpenConn { conn });
 
@@ -2121,11 +2121,11 @@ mod tests {
         suite.add_region(1, 100);
 
         let quota = Arc::new(MemoryQuota::new(usize::MAX));
-        let (tx, mut rx) = channel::channel(1, quota);
+        let (tx, mut rx) = channel::channel(ConnId::default(), 1, quota);
         let mut rx = rx.drain();
         let mut region = Region::default();
         region.set_id(1);
-        let conn = Conn::new(tx, String::new());
+        let conn = Conn::new(ConnId::default(), tx, String::new());
         let conn_id = conn.get_id();
         suite.run(Task::OpenConn { conn });
 
@@ -2217,11 +2217,11 @@ mod tests {
 
         // Register region 3 to another conn which is not support batch resolved ts.
         let quota = Arc::new(MemoryQuota::new(usize::MAX));
-        let (tx, mut rx2) = channel::channel(1, quota);
+        let (tx, mut rx2) = channel::channel(ConnId::default(), 1, quota);
         let mut rx2 = rx2.drain();
         let mut region = Region::default();
         region.set_id(3);
-        let conn = Conn::new(tx, String::new());
+        let conn = Conn::new(ConnId::default(), tx, String::new());
         let conn_id = conn.get_id();
         suite.run(Task::OpenConn { conn });
         suite.run(set_conn_version_task(
@@ -2294,10 +2294,10 @@ mod tests {
         let mut suite = mock_endpoint(&CdcConfig::default(), None, ApiVersion::V1);
         suite.add_region(1, 100);
         let quota = Arc::new(MemoryQuota::new(usize::MAX));
-        let (tx, mut rx) = channel::channel(1, quota);
+        let (tx, mut rx) = channel::channel(ConnId::default(), 1, quota);
         let mut rx = rx.drain();
 
-        let conn = Conn::new(tx, String::new());
+        let conn = Conn::new(ConnId::default(), tx, String::new());
         let conn_id = conn.get_id();
         suite.run(Task::OpenConn { conn });
         suite.run(set_conn_version_task(
@@ -2447,9 +2447,9 @@ mod tests {
         let mut conn_rxs = vec![];
         let quota = Arc::new(MemoryQuota::new(usize::MAX));
         for region_ids in [vec![1, 2], vec![3]] {
-            let (tx, rx) = channel::channel(1, quota.clone());
+            let (tx, rx) = channel::channel(ConnId::default(), 1, quota.clone());
             conn_rxs.push(rx);
-            let conn = Conn::new(tx, String::new());
+            let conn = Conn::new(ConnId::default(), tx, String::new());
             let conn_id = conn.get_id();
             suite.run(Task::OpenConn { conn });
             let version = FeatureGate::batch_resolved_ts();
@@ -2564,8 +2564,8 @@ mod tests {
         let quota = Arc::new(MemoryQuota::new(usize::MAX));
 
         // Open conn a
-        let (tx1, _rx1) = channel::channel(1, quota.clone());
-        let conn_a = Conn::new(tx1, String::new());
+        let (tx1, _rx1) = channel::channel(ConnId::default(), 1, quota.clone());
+        let conn_a = Conn::new(ConnId::default(), tx1, String::new());
         let conn_id_a = conn_a.get_id();
         suite.run(Task::OpenConn { conn: conn_a });
         suite.run(set_conn_version_task(
@@ -2574,9 +2574,9 @@ mod tests {
         ));
 
         // Open conn b
-        let (tx2, mut rx2) = channel::channel(1, quota);
+        let (tx2, mut rx2) = channel::channel(ConnId::default(), 1, quota);
         let mut rx2 = rx2.drain();
-        let conn_b = Conn::new(tx2, String::new());
+        let conn_b = Conn::new(ConnId::default(), tx2, String::new());
         let conn_id_b = conn_b.get_id();
         suite.run(Task::OpenConn { conn: conn_b });
         suite.run(set_conn_version_task(
@@ -2722,10 +2722,10 @@ mod tests {
         };
         let mut suite = mock_endpoint(&cfg, None, ApiVersion::V1);
         let quota = Arc::new(MemoryQuota::new(usize::MAX));
-        let (tx, mut rx) = channel::channel(1, quota);
+        let (tx, mut rx) = channel::channel(ConnId::default(), 1, quota);
         let mut rx = rx.drain();
 
-        let conn = Conn::new(tx, String::new());
+        let conn = Conn::new(ConnId::default(), tx, String::new());
         let conn_id = conn.get_id();
         suite.run(Task::OpenConn { conn });
         // Enable batch resolved ts in the test.
@@ -2819,10 +2819,10 @@ mod tests {
         let mut suite = mock_endpoint(&cfg, None, ApiVersion::V1);
         suite.add_region(1, 100);
         let quota = Arc::new(MemoryQuota::new(usize::MAX));
-        let (tx, mut rx) = channel::channel(1, quota);
+        let (tx, mut rx) = channel::channel(ConnId::default(), 1, quota);
         let mut rx = rx.drain();
 
-        let conn = Conn::new(tx, String::new());
+        let conn = Conn::new(ConnId::default(), tx, String::new());
         let conn_id = conn.get_id();
         suite.run(Task::OpenConn { conn });
 
@@ -3073,9 +3073,9 @@ mod tests {
         let mut suite = mock_endpoint(&cfg, None, ApiVersion::V1);
         suite.add_region(1, 100);
         let quota = Arc::new(MemoryQuota::new(usize::MAX));
-        let (tx, _rx) = channel::channel(1, quota);
+        let (tx, _rx) = channel::channel(ConnId::default(), 1, quota);
 
-        let conn = Conn::new(tx, String::new());
+        let conn = Conn::new(ConnId::default(), tx, String::new());
         let conn_id = conn.get_id();
         suite.run(Task::OpenConn { conn });
 

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -1025,7 +1025,8 @@ impl<T: 'static + CdcHandle<E>, E: KvEngine, S: StoreRegionMeta> Endpoint<T, E, 
         let region_id = region.get_id();
         match self.capture_regions.get_mut(&region_id) {
             None => {
-                debug!("cdc region not found on region ready (finish scan locks)"; "region_id" => region.get_id());
+                debug!("cdc region not found on region ready (finish scan locks)";
+                    "region_id" => region.get_id());
             }
             Some(delegate) => {
                 if delegate.handle.id != observe_id {

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -1026,7 +1026,6 @@ impl<T: 'static + CdcHandle<E>, E: KvEngine, S: StoreRegionMeta> Endpoint<T, E, 
         match self.capture_regions.get_mut(&region_id) {
             None => {
                 debug!("cdc region not found on region ready (finish scan locks)"; "region_id" => region.get_id());
-                return;
             }
             Some(delegate) => {
                 if delegate.handle.id != observe_id {

--- a/components/cdc/src/initializer.rs
+++ b/components/cdc/src/initializer.rs
@@ -707,7 +707,7 @@ mod tests {
     ) {
         let (receiver_worker, rx) = new_receiver_worker();
         let quota = Arc::new(MemoryQuota::new(usize::MAX));
-        let (sink, drain) = crate::channel::channel(buffer, quota);
+        let (sink, drain) = crate::channel::channel(ConnId::default(), buffer, quota);
 
         let pool = Builder::new_multi_thread()
             .thread_name("test-initializer-worker")

--- a/components/cdc/src/observer.rs
+++ b/components/cdc/src/observer.rs
@@ -119,8 +119,6 @@ impl<E: KvEngine> CmdObserver<E> for CdcObserver {
         let mut region = Region::default();
         region.mut_peers().push(Peer::default());
         // Create a snapshot here for preventing the old value was GC-ed.
-        // TODO: only need it after enabling old value, may add a flag to indicate
-        // whether to get it.
         let snapshot =
             RegionSnapshot::from_snapshot(Arc::new(engine.snapshot(None)), Arc::new(region));
         let get_old_value = move |key,

--- a/components/cdc/src/service.rs
+++ b/components/cdc/src/service.rs
@@ -409,7 +409,6 @@ impl Service {
         let (event_sink, mut event_drain) =
             channel(conn_id, CDC_CHANNLE_CAPACITY, self.memory_quota.clone());
         let conn = Conn::new(conn_id, event_sink, ctx.peer());
-        event_drain.set_conn_id(conn_id);
         let mut explicit_features = vec![];
 
         if event_feed_v2 {

--- a/components/cdc/src/service.rs
+++ b/components/cdc/src/service.rs
@@ -339,7 +339,7 @@ impl Service {
                 warn!(
                     "cdc invalid observed start key or end key version";
                     "downstream" => ?peer, "region_id" => request.region_id,
-                    "error" => ?e,
+                    "error" => ?e, "start_key" => ?request.start_key, "end_key" => ?request.end_key,
                 );
                 ObservedRange::default()
             });

--- a/components/cdc/src/service.rs
+++ b/components/cdc/src/service.rs
@@ -103,9 +103,9 @@ struct DownstreamValue {
 }
 
 impl Conn {
-    pub fn new(sink: Sink, peer: String) -> Conn {
+    pub fn new(conn_id: ConnId, sink: Sink, peer: String) -> Conn {
         Conn {
-            id: ConnId::new(),
+            id: conn_id,
             sink,
             downstreams: HashMap::default(),
             peer,
@@ -342,8 +342,8 @@ impl Service {
                     "region_id" => request.region_id,
                     "request_id" => request.region_id,
                     "error" => ?e,
-                    "start_key" => ?request.start_key,
-                    "end_key" => ?request.end_key,
+                    "start_key" => log_wrappers::Value::key(&request.start_key),
+                    "end_key" => log_wrappers::Value::key(&request.end_key),
                 );
                 ObservedRange::default()
             });
@@ -405,10 +405,10 @@ impl Service {
         event_feed_v2: bool,
     ) {
         sink.enhance_batch(true);
+        let conn_id = ConnId::new();
         let (event_sink, mut event_drain) =
-            channel(CDC_CHANNLE_CAPACITY, self.memory_quota.clone());
-        let conn = Conn::new(event_sink, ctx.peer());
-        let conn_id = conn.get_id();
+            channel(conn_id, CDC_CHANNLE_CAPACITY, self.memory_quota.clone());
+        let conn = Conn::new(conn_id, event_sink, ctx.peer());
         event_drain.set_conn_id(conn_id);
         let mut explicit_features = vec![];
 

--- a/components/cdc/src/service.rs
+++ b/components/cdc/src/service.rs
@@ -405,6 +405,7 @@ impl Service {
             channel(CDC_CHANNLE_CAPACITY, self.memory_quota.clone());
         let conn = Conn::new(event_sink, ctx.peer());
         let conn_id = conn.get_id();
+        event_drain.set_conn_id(conn_id);
         let mut explicit_features = vec![];
 
         if event_feed_v2 {

--- a/components/cdc/src/service.rs
+++ b/components/cdc/src/service.rs
@@ -338,8 +338,12 @@ impl Service {
             .unwrap_or_else(|e| {
                 warn!(
                     "cdc invalid observed start key or end key version";
-                    "downstream" => ?peer, "region_id" => request.region_id, "request_id" => request.region_id,
-                    "error" => ?e, "start_key" => ?request.start_key, "end_key" => ?request.end_key,
+                    "downstream" => ?peer,
+                    "region_id" => request.region_id,
+                    "request_id" => request.region_id,
+                    "error" => ?e,
+                    "start_key" => ?request.start_key,
+                    "end_key" => ?request.end_key,
                 );
                 ObservedRange::default()
             });

--- a/components/cdc/src/service.rs
+++ b/components/cdc/src/service.rs
@@ -338,7 +338,7 @@ impl Service {
             .unwrap_or_else(|e| {
                 warn!(
                     "cdc invalid observed start key or end key version";
-                    "downstream" => ?peer, "region_id" => request.region_id,
+                    "downstream" => ?peer, "region_id" => request.region_id, "request_id" => request.region_id,
                     "error" => ?e, "start_key" => ?request.start_key, "end_key" => ?request.end_key,
                 );
                 ObservedRange::default()


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #17368 

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
* add one log to indicate the memory quota is freed when drop the `Drain`
* free the truncated scanned event memory quota.
* refactor `finish_scan_lock` method, to remove the else branch.
* row size calculation should also consider old value
* remove some outdate todo
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
