### PR TITLE
Revert "*: enlarge the default region-size. (#17311)"

### DIFF
--- a/components/raftstore/src/coprocessor/config.rs
+++ b/components/raftstore/src/coprocessor/config.rs
@@ -69,10 +69,8 @@ pub enum ConsistencyCheckMethod {
     Mvcc = 1,
 }
 
-/// Default region split size. In version < 8.3.0, the default split size is
-/// 96MB. In version >= 8.3.0, the default split size is increased to 256MB to
-/// allow for larger region size in TiKV.
-pub const SPLIT_SIZE: ReadableSize = ReadableSize::mb(256);
+/// Default region split size.
+pub const SPLIT_SIZE: ReadableSize = ReadableSize::mb(96);
 pub const RAFTSTORE_V2_SPLIT_SIZE: ReadableSize = ReadableSize::gb(10);
 
 /// Default batch split limit.

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -405,8 +405,7 @@
 ## When Region size change exceeds this config, TiKV will check whether the Region should be split
 ## or not. To reduce the cost of scanning data in the checking process, you can set the value to
 ## 32MB during checking and set it back to the default value in normal operations.
-## It's recommanded to set it to 1/16 of `region-split-size`.
-# region-split-check-diff = "16MB"
+# region-split-check-diff = "6MB"
 
 ## The interval of triggering Region split check.
 # split-region-check-tick-interval = "10s"
@@ -424,11 +423,11 @@
 # raft-log-gc-threshold = 50
 
 ## When the entry count exceeds this value, GC will be forced to trigger.
-# raft-log-gc-count-limit = 196608
+# raft-log-gc-count-limit = 73728
 
 ## When the approximate size of Raft log entries exceeds this value, GC will be forced trigger.
 ## It's recommanded to set it to 3/4 of `region-split-size`.
-# raft-log-gc-size-limit = "192MB"
+# raft-log-gc-size-limit = "72MB"
 
 ## Old Raft logs could be reserved if `raft_log_gc_threshold` is not reached.
 ## GC them after ticks `raft_log_reserve_max_ticks` times.
@@ -507,14 +506,14 @@
 ## When Region [a,e) size exceeds `region_max_size`, it will be split into several Regions [a,b),
 ## [b,c), [c,d), [d,e) and the size of [a,b), [b,c), [c,d) will be `region_split_size` (or a
 ## little larger).
-# region-max-size = "384MB"
-# region-split-size = "256MB"
+# region-max-size = "144MB"
+# region-split-size = "96MB"
 
 ## When the number of keys in Region [a,e) exceeds the `region_max_keys`, it will be split into
 ## several Regions [a,b), [b,c), [c,d), [d,e) and the number of keys in [a,b), [b,c), [c,d) will be
 ## `region_split_keys`.
-# region-max-keys = 3840000
-# region-split-keys = 2560000
+# region-max-keys = 1440000
+# region-split-keys = 960000
 
 ## Set to "mvcc" to do consistency check for MVCC data, or "raw" for raw data.
 # consistency-check-method = "mvcc"
@@ -1296,7 +1295,7 @@
 ## When Backup region [a,e) size exceeds `sst-max-size`, it will be backuped into several Files [a,b),
 ## [b,c), [c,d), [d,e) and the size of [a,b), [b,c), [c,d) will be `sst-max-size` (or a
 ## little larger).
-# sst-max-size = "384MB"
+# sst-max-size = "144MB"
 
 ## Automatically reduce the number of backup threads when the current workload is high,
 ## in order to reduce impact on the cluster's performance during back up.


### PR DESCRIPTION
This reverts commit 74a760fd7e15eb5a40ebcfdb5c663e5afaa36c8f.

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref https://github.com/pingcap/tidb/issues/55374

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Revert the changes on the configuration of region-size. These changes will be delayed until v8.4
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None.
```
