### PR TITLE
Revert "In-memory Engine: do not evict range on applying snapshot

### DIFF
--- a/components/engine_traits/src/range_cache_engine.rs
+++ b/components/engine_traits/src/range_cache_engine.rs
@@ -50,6 +50,7 @@ pub enum EvictReason {
     DeleteRange,
     Merge,
     Disabled,
+    ApplySnapshot,
 }
 
 /// RangeCacheEngine works as a range cache caching some ranges (in Memory or

--- a/components/hybrid_engine/src/observer.rs
+++ b/components/hybrid_engine/src/observer.rs
@@ -6,9 +6,9 @@ use engine_traits::{CacheRange, EvictReason, KvEngine, RangeCacheEngineExt, Regi
 use kvproto::{metapb::Region, raft_cmdpb::AdminCmdType, raft_serverpb::RaftApplyState};
 use raft::StateRole;
 use raftstore::coprocessor::{
-    AdminObserver, ApplyCtxInfo, BoxAdminObserver, BoxCmdObserver, BoxQueryObserver,
-    BoxRoleObserver, Cmd, CmdBatch, CmdObserver, Coprocessor, CoprocessorHost, ObserveLevel,
-    ObserverContext, QueryObserver, RegionState, RoleObserver,
+    AdminObserver, ApplyCtxInfo, ApplySnapshotObserver, BoxAdminObserver, BoxApplySnapshotObserver,
+    BoxCmdObserver, BoxQueryObserver, BoxRoleObserver, Cmd, CmdBatch, CmdObserver, Coprocessor,
+    CoprocessorHost, ObserveLevel, ObserverContext, QueryObserver, RegionState, RoleObserver,
 };
 use tikv_util::info;
 
@@ -44,14 +44,15 @@ impl Observer {
         coprocessor_host
             .registry
             .register_admin_observer(priority, BoxAdminObserver::new(self.clone()));
+        // Evict cache when a peer applies snapshot.
+        coprocessor_host.registry.register_apply_snapshot_observer(
+            priority,
+            BoxApplySnapshotObserver::new(self.clone()),
+        );
         // Evict cache when a leader steps down.
         coprocessor_host
             .registry
             .register_role_observer(priority, BoxRoleObserver::new(self.clone()));
-
-        // NB: We do not evict the cache when applying a snapshot because
-        // the peer must be in the follower role during this process.
-        // The cache is already evicted when the leader steps down.
     }
 
     fn post_exec_cmd(
@@ -129,15 +130,16 @@ impl Observer {
         }
     }
 
-    fn evict_range_on_leader_steps_down(&self, region: &Region) {
+    fn evict_region_range(&self, region: &Region, reason: EvictReason) {
         if !self.cache_engine.range_cache_engine_enabled() {
             return;
         }
 
         let range = CacheRange::from_region(region);
         info!(
-           "ime evict region due to leader step down";
+           "ime evict region";
            "region_id" => region.get_id(),
+           "reason" => ?reason,
            "epoch" => ?region.get_region_epoch(),
            "start_key" => ?log_wrappers::Value(&region.start_key),
            "end_key" => ?log_wrappers::Value(&region.end_key),
@@ -147,7 +149,7 @@ impl Observer {
             .unwrap()
             .push(RegionEvent::Eviction {
                 region: region.clone(),
-                reason: EvictReason::BecomeFollower,
+                reason: reason,
             });
     }
 }
@@ -186,6 +188,21 @@ impl AdminObserver for Observer {
     }
 }
 
+impl ApplySnapshotObserver for Observer {
+    fn post_apply_snapshot(
+        &self,
+        ctx: &mut ObserverContext<'_>,
+        _: u64,
+        _: &raftstore::store::SnapKey,
+        _: Option<&raftstore::store::Snapshot>,
+    ) {
+        // While currently, we evict cached region after leader step down.
+        // A region can may still be loaded when it's leader. E.g, to pre-load
+        // some hot regions before transfering leader.
+        self.evict_region_range(ctx.region(), EvictReason::ApplySnapshot)
+    }
+}
+
 impl RoleObserver for Observer {
     fn on_role_change(
         &self,
@@ -195,7 +212,7 @@ impl RoleObserver for Observer {
         if let StateRole::Follower = change.state
             && change.initialized
         {
-            self.evict_range_on_leader_steps_down(ctx.region())
+            self.evict_region_range(ctx.region(), EvictReason::BecomeFollower)
         }
     }
 }

--- a/components/hybrid_engine/src/observer.rs
+++ b/components/hybrid_engine/src/observer.rs
@@ -45,6 +45,8 @@ impl Observer {
             .registry
             .register_admin_observer(priority, BoxAdminObserver::new(self.clone()));
         // Evict cache when a peer applies snapshot.
+        // Applying snapshot changes the data in rocksdb but not IME,
+        // so we trigger region eviction to keep compatibility.
         coprocessor_host.registry.register_apply_snapshot_observer(
             priority,
             BoxApplySnapshotObserver::new(self.clone()),
@@ -149,7 +151,7 @@ impl Observer {
             .unwrap()
             .push(RegionEvent::Eviction {
                 region: region.clone(),
-                reason: reason,
+                reason,
             });
     }
 }

--- a/components/range_cache_memory_engine/src/metrics.rs
+++ b/components/range_cache_memory_engine/src/metrics.rs
@@ -40,6 +40,7 @@ make_auto_flush_static_metric! {
         become_follower,
         memory_limit_reached,
         disabled,
+        apply_snapshot,
     }
 
     pub struct GcFilteredCountVec: LocalIntCounter {
@@ -203,6 +204,9 @@ pub(crate) fn observe_eviction_duration(secs: f64, evict_reason: EvictReason) {
         EvictReason::Merge => RANGE_EVICTION_DURATION_HISTOGRAM_STATIC.merge.observe(secs),
         EvictReason::Disabled => RANGE_EVICTION_DURATION_HISTOGRAM_STATIC
             .disabled
+            .observe(secs),
+        EvictReason::ApplySnapshot => RANGE_EVICTION_DURATION_HISTOGRAM_STATIC
+            .apply_snapshot
             .observe(secs),
     }
 }


### PR DESCRIPTION
…7237)"

This reverts commit fe7d5232447c5ab8958cccbc666878994230ac3f.

<!-- 
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #17405

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Revert #17237 because cache region can be loaded even when current peer is not leader so we should handle apply snapshot event.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
