### PR TITLE
compaction-filter: consider  mvcc-delete as redundant key to trigger rocksdb compaction

### DIFF
--- a/components/engine_rocks/src/properties.rs
+++ b/components/engine_rocks/src/properties.rs
@@ -567,6 +567,7 @@ pub fn get_range_stats(
         num_entries,
         num_versions: props.num_versions,
         num_rows: props.num_rows,
+        num_deletes: props.num_deletes,
     })
 }
 

--- a/components/engine_traits/src/misc.rs
+++ b/components/engine_traits/src/misc.rs
@@ -57,12 +57,25 @@ pub trait StatisticsReporter<T: ?Sized> {
 
 #[derive(Default)]
 pub struct RangeStats {
-    // The number of entries
+    // The number of entries in write cf.
     pub num_entries: u64,
     // The number of MVCC versions of all rows (num_entries - tombstones).
     pub num_versions: u64,
     // The number of rows.
     pub num_rows: u64,
+    // The number of MVCC deletes of all rows.
+    pub num_deletes: u64,
+}
+
+impl RangeStats {
+    /// The number of redundant keys in the range.
+    /// It's calculated by `num_entries - num_versions + num_deleted`.
+    pub fn redundant_keys(&self) -> u64 {
+        // Consider the number of `mvcc_deletes` as the number of redundant keys.
+        self.num_entries
+            .saturating_sub(self.num_rows)
+            .saturating_add(self.num_deletes)
+    }
 }
 
 pub trait MiscExt: CfNamesExt + FlowControlFactorsExt + WriteBatchExt {

--- a/components/raftstore/src/store/worker/compact.rs
+++ b/components/raftstore/src/store/worker/compact.rs
@@ -445,7 +445,7 @@ pub fn need_compact(range_stats: &RangeStats, compact_threshold: &CompactThresho
     // We trigger region compaction when their are to many tombstones as well as
     // redundant keys, both of which can severly impact scan operation:
     let estimate_num_del = range_stats.num_entries - range_stats.num_versions;
-    let redundant_keys = range_stats.num_entries - range_stats.num_rows;
+    let redundant_keys = range_stats.redundant_keys();
     (redundant_keys >= compact_threshold.redundant_rows_threshold
         && redundant_keys * 100
             >= compact_threshold.redundant_rows_percent_threshold * range_stats.num_entries)


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #17269 

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
compaction-filter: consider mvcc.delete as redundant key to trigger Rocksdb compaction
```



### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
compaction-filter: consider mvcc.delete as redundant key to trigger Rocksdb compaction
```
