### PR TITLE
encryption: add test for temporary KMS service unavailable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6468,6 +6468,7 @@ dependencies = [
  "crossbeam",
  "crypto",
  "dashmap",
+ "encryption",
  "encryption_export",
  "engine_panic",
  "engine_rocks",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ testexport = [
   "engine_rocks/testexport",
   "engine_panic/testexport",
   "hybrid_engine/testexport",
+  "encryption/testexport",
 ]
 test-engine-kv-rocksdb = ["engine_test/test-engine-kv-rocksdb"]
 test-engine-raft-raft-engine = ["engine_test/test-engine-raft-raft-engine"]
@@ -80,6 +81,7 @@ crc64fast = "0.1"
 crossbeam = { workspace = true }
 crypto = { workspace = true }
 dashmap = "5"
+encryption = { workspace = true }
 encryption_export = { workspace = true }
 engine_panic = { workspace = true }
 engine_rocks = { workspace = true }

--- a/components/encryption/Cargo.toml
+++ b/components/encryption/Cargo.toml
@@ -10,6 +10,7 @@ failpoints = ["fail/failpoints"]
 # openssl/vendored is necssary in order to conditionally building SM4 encryption
 # support, as SM4 is disabled on various openssl distributions, such as Rocky Linux 9.
 sm4 = ["openssl/vendored"]
+testexport = []
 
 [dependencies]
 async-trait = "0.1"

--- a/components/encryption/src/lib.rs
+++ b/components/encryption/src/lib.rs
@@ -11,6 +11,8 @@ mod file_dict_file;
 mod io;
 mod manager;
 mod master_key;
+#[cfg(any(test, feature = "testexport"))]
+pub use master_key::fake;
 mod metrics;
 
 use std::{io::ErrorKind, path::Path};

--- a/components/encryption/src/master_key/kms.rs
+++ b/components/encryption/src/master_key/kms.rs
@@ -63,7 +63,7 @@ impl KmsBackend {
         })
     }
 
-    fn encrypt_content(&self, plaintext: &[u8], iv: Iv) -> Result<EncryptedContent> {
+    pub fn encrypt_content(&self, plaintext: &[u8], iv: Iv) -> Result<EncryptedContent> {
         let mut opt_state = self.state.lock().unwrap();
         if opt_state.is_none() {
             let runtime = self.runtime.lock().unwrap();
@@ -98,7 +98,7 @@ impl KmsBackend {
 
     // On decrypt failure, the rule is to return WrongMasterKey error in case it is
     // possible that a wrong master key has been used, or other error otherwise.
-    fn decrypt_content(&self, content: &EncryptedContent) -> Result<Vec<u8>> {
+    pub fn decrypt_content(&self, content: &EncryptedContent) -> Result<Vec<u8>> {
         let vendor_name = self.kms_provider.name();
         match content.metadata.get(MetadataKey::KmsVendor.as_str()) {
             Some(val) if val.as_slice() == vendor_name.as_bytes() => (),
@@ -159,8 +159,8 @@ impl KmsBackend {
         }
     }
 
-    #[cfg(test)]
-    fn clear_state(&mut self) {
+    #[cfg(any(test, feature = "testexport"))]
+    pub fn clear_state(&mut self) {
         let mut opt_state = self.state.lock().unwrap();
         *opt_state = None;
     }
@@ -180,13 +180,15 @@ impl Backend for KmsBackend {
     }
 }
 
-#[cfg(test)]
-mod fake {
+#[cfg(any(test, feature = "testexport"))]
+pub mod fake {
     use async_trait::async_trait;
     use cloud::{
         error::{Error as CloudError, KmsError, Result},
         kms::KmsProvider,
     };
+    use fail::fail_point;
+    use hex::FromHex;
 
     use super::*;
 
@@ -208,9 +210,21 @@ mod fake {
         }
     }
 
+    fn check_fail_point(fail_point_name: &str) -> Result<()> {
+        fail_point!(fail_point_name, |val| {
+            val.and_then(|x| x.parse::<bool>().ok())
+                .filter(|&fail| fail)
+                .map(|_| Err(CloudError::ApiTimeout(box_err!("api timeout"))))
+                .unwrap_or(Ok(()))
+        });
+        Ok(())
+    }
+
     #[async_trait]
     impl KmsProvider for FakeKms {
         async fn generate_data_key(&self) -> Result<DataKeyPair> {
+            check_fail_point("kms_api_timeout_encrypt")?;
+
             Ok(DataKeyPair {
                 encrypted: EncryptedKey::new(FAKE_DATA_KEY_ENCRYPTED.to_vec())?,
                 plaintext: PlainKey::new(self.plaintext_key.clone(), CryptographyType::AesGcm256)
@@ -219,12 +233,14 @@ mod fake {
         }
 
         async fn decrypt_data_key(&self, _ciphertext: &EncryptedKey) -> Result<Vec<u8>> {
+            check_fail_point("kms_api_timeout_decrypt")?;
+
             if self.should_decrypt_data_key_fail {
                 Err(CloudError::KmsError(KmsError::WrongMasterKey(box_err!(
                     "wrong master key"
                 ))))
             } else {
-                Ok(vec![1u8, 32])
+                Ok(hex::decode(PLAINKEY_HEX).unwrap())
             }
         }
 
@@ -232,14 +248,40 @@ mod fake {
             FAKE_VENDOR_NAME
         }
     }
+
+    // See more http://csrc.nist.gov/groups/STM/cavp/documents/mac/gcmtestvectors.zip
+    const PLAIN_TEXT_HEX: &str = "25431587e9ecffc7c37f8d6d52a9bc3310651d46fb0e3bad2726c8f2db653749";
+    const CIPHER_TEXT_HEX: &str =
+        "84e5f23f95648fa247cb28eef53abec947dbf05ac953734618111583840bd980";
+    const PLAINKEY_HEX: &str = "c3d99825f2181f4808acd2068eac7441a65bd428f14d2aab43fefc0129091139";
+    const IV_HEX: &str = "cafabd9672ca6c79a2fbdc22";
+
+    pub fn prepare_data_for_encrypt() -> (Iv, Vec<u8>, Vec<u8>, Vec<u8>) {
+        let iv = Vec::from_hex(IV_HEX).unwrap();
+        let iv = Iv::from_slice(iv.as_slice()).unwrap();
+        let pt = Vec::from_hex(PLAIN_TEXT_HEX).unwrap();
+        let plainkey = Vec::from_hex(PLAINKEY_HEX).unwrap();
+        let ct = Vec::from_hex(CIPHER_TEXT_HEX).unwrap();
+        (iv, pt, plainkey, ct)
+    }
+
+    pub fn prepare_kms_backend(
+        plainkey: Vec<u8>,
+        should_decrypt_data_key_fail: bool,
+    ) -> KmsBackend {
+        KmsBackend::new(Box::new(FakeKms::new(
+            plainkey,
+            should_decrypt_data_key_fail,
+        )))
+        .unwrap()
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use hex::FromHex;
     use matches::assert_matches;
 
-    use super::{fake::FakeKms, *};
+    use super::{fake::*, *};
 
     #[test]
     fn test_state() {
@@ -260,31 +302,6 @@ mod tests {
         .unwrap();
         // updated to the new data key
         assert_eq!(state2.cached(&encrypted2), true);
-    }
-
-    const PLAIN_TEXT_HEX: &str = "25431587e9ecffc7c37f8d6d52a9bc3310651d46fb0e3bad2726c8f2db653749";
-    const CIPHER_TEXT_HEX: &str =
-        "84e5f23f95648fa247cb28eef53abec947dbf05ac953734618111583840bd980";
-    const PLAINKEY_HEX: &str = "c3d99825f2181f4808acd2068eac7441a65bd428f14d2aab43fefc0129091139";
-    const IV_HEX: &str = "cafabd9672ca6c79a2fbdc22";
-
-    #[cfg(test)]
-    fn prepare_data_for_encrypt() -> (Iv, Vec<u8>, Vec<u8>, Vec<u8>) {
-        let iv = Vec::from_hex(IV_HEX).unwrap();
-        let iv = Iv::from_slice(iv.as_slice()).unwrap();
-        let pt = Vec::from_hex(PLAIN_TEXT_HEX).unwrap();
-        let plainkey = Vec::from_hex(PLAINKEY_HEX).unwrap();
-        let ct = Vec::from_hex(CIPHER_TEXT_HEX).unwrap();
-        (iv, pt, plainkey, ct)
-    }
-
-    #[cfg(test)]
-    fn prepare_kms_backend(plainkey: Vec<u8>, should_decrypt_data_key_fail: bool) -> KmsBackend {
-        KmsBackend::new(Box::new(FakeKms::new(
-            plainkey,
-            should_decrypt_data_key_fail,
-        )))
-        .unwrap()
     }
 
     #[test]

--- a/components/encryption/src/master_key/mod.rs
+++ b/components/encryption/src/master_key/mod.rs
@@ -28,6 +28,8 @@ mod metadata;
 use self::metadata::*;
 
 mod kms;
+#[cfg(any(test, feature = "testexport"))]
+pub use self::kms::fake;
 pub use self::kms::KmsBackend;
 
 #[derive(Default, Debug, Clone)]

--- a/tests/failpoints/cases/test_encryption.rs
+++ b/tests/failpoints/cases/test_encryption.rs
@@ -51,3 +51,26 @@ fn create_file_info(id: u64, method: EncryptionMethod) -> FileInfo {
         ..Default::default()
     }
 }
+
+#[test]
+fn test_kms_provider_temporary_unavailable() {
+    #[cfg(any(test, feature = "testexport"))]
+    use encryption::fake::*;
+
+    // Simulate temporary unavailable with a timeout error during encryption.
+    // Expect the backend to handle the timeout gracefully and succeed on the
+    // subsequent retry.
+    fail::cfg("kms_api_timeout_encrypt", "1*return(true)").unwrap();
+    let (iv, pt, plainkey, ..) = prepare_data_for_encrypt();
+    let mut backend = prepare_kms_backend(plainkey, false);
+    let encrypted_content = backend.encrypt_content(&pt, iv).unwrap();
+    // Clear the cached state to ensure that the subsequent
+    // backend.decrypt_content() invocation bypasses the cache and triggers the
+    // mocked FakeKMS::decrypt_data_key() function.
+    backend.clear_state();
+
+    // Same as above.
+    fail::cfg("kms_api_timeout_decrypt", "1*return(true)").unwrap();
+    let pt_decrypt = backend.decrypt_content(&encrypted_content).unwrap();
+    assert_eq!(pt_decrypt, pt);
+}


### PR DESCRIPTION
ref tikv#17410

This commit adds a new test to verify TiKV's recovery after temporary unavailability of the KMS service.

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref #17410

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
This commit adds a new test to verify TiKV's recovery after temporary unavailability of the KMS service.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
no.
```
