### PR TITLE
in-memory-region: fix the inconsistency caused by updating region range

### DIFF
--- a/components/range_cache_memory_engine/src/range_manager.rs
+++ b/components/range_cache_memory_engine/src/range_manager.rs
@@ -125,7 +125,12 @@ impl CacheRegionMeta {
     // check whether we can replace the current outdated pending region with the new
     // one.
     fn can_be_updated_to(&self, region: &CacheRegion) -> bool {
-        assert!(self.region.id == region.id && self.region.epoch_version < region.epoch_version);
+        assert!(
+            self.region.id == region.id && self.region.epoch_version < region.epoch_version,
+            "current: {:?}, new: {:?}",
+            &self.region,
+            region
+        );
         // if the new region's range is contained by the current region, we can directly
         // update to the new one.
         self.region.contains_range(region)
@@ -273,6 +278,13 @@ pub struct RegionManager {
 impl RegionManager {
     pub(crate) fn regions(&self) -> &HashMap<u64, CacheRegionMeta> {
         &self.regions
+    }
+
+    #[cfg(test)]
+    pub(crate) fn region_meta_by_end_key(&self, key: &[u8]) -> Option<&CacheRegionMeta> {
+        self.regions_by_range
+            .get(key)
+            .and_then(|id| self.regions.get(id))
     }
 
     // load a new region directly in the active state.

--- a/components/range_cache_memory_engine/src/range_manager.rs
+++ b/components/range_cache_memory_engine/src/range_manager.rs
@@ -122,18 +122,13 @@ impl CacheRegionMeta {
         &self.region
     }
 
-    // update region info due to epoch version changes. This can only
-    // happen for pending region because otherwise we will always update
-    // the region epoch with ApplyObserver(for loading/active regions) or
-    // no need to update the epoch for evicting regions.
-    fn amend_pending_region(&mut self, region: &CacheRegion) -> bool {
+    // check whether we can replace the current outdated pending region with the new
+    // one.
+    fn can_be_updated_to(&self, region: &CacheRegion) -> bool {
         assert!(self.region.id == region.id && self.region.epoch_version < region.epoch_version);
-        if !self.region.contains_range(region) {
-            return false;
-        }
-
-        self.region = region.clone();
-        true
+        // if the new region's range is contained by the current region, we can directly
+        // update to the new one.
+        self.region.contains_range(region)
     }
 
     pub(crate) fn safe_point(&self) -> u64 {
@@ -375,14 +370,23 @@ impl RegionManager {
         let Some(cached_meta) = self.regions.get_mut(&region.id) else {
             return None;
         };
-        if cached_meta.state == Pending
-            && cached_meta.region.epoch_version != region.epoch_version
-            && !cached_meta.amend_pending_region(region)
+        if cached_meta.state == Pending && cached_meta.region.epoch_version != region.epoch_version
         {
+            let meta = self.remove_region(region.id);
+            if meta.can_be_updated_to(region) {
+                info!("ime update outdated pending region";
+                    "current_meta" => ?meta,
+                    "new_region" => ?region);
+                // the new region's range is smaller than removed region, so it is impossible to
+                // be overlapped with other existing regions.
+                self.load_region(region.clone()).unwrap();
+
+                return Some(RegionState::Pending);
+            }
+
             info!("ime remove outdated pending region";
                 "pending_region" => ?cached_meta.region,
                 "new_region" => ?region);
-            self.remove_region(region.id);
             return None;
         }
         Some(cached_meta.state)
@@ -697,7 +701,7 @@ impl RegionManager {
 
     fn remove_region(&mut self, id: u64) -> CacheRegionMeta {
         let meta = self.regions.remove(&id).unwrap();
-        self.regions_by_range.remove(&meta.region.end);
+        self.regions_by_range.remove(&meta.region.end).unwrap();
         meta
     }
 
@@ -822,6 +826,17 @@ impl RegionManager {
                 ),
                 region_meta,
             );
+        }
+    }
+}
+
+#[cfg(test)]
+impl Drop for RegionManager {
+    fn drop(&mut self) {
+        // check regions and regions by range matches with each other.
+        for (key, id) in &self.regions_by_range {
+            let meta = self.regions.get(id).unwrap();
+            assert_eq!(key, &meta.region.end);
         }
     }
 }

--- a/components/range_cache_memory_engine/src/range_manager.rs
+++ b/components/range_cache_memory_engine/src/range_manager.rs
@@ -385,7 +385,7 @@ impl RegionManager {
             }
 
             info!("ime remove outdated pending region";
-                "pending_region" => ?cached_meta.region,
+                "pending_region" => ?meta.region,
                 "new_region" => ?region);
             return None;
         }

--- a/components/range_cache_memory_engine/src/write_batch.rs
+++ b/components/range_cache_memory_engine/src/write_batch.rs
@@ -979,7 +979,7 @@ mod tests {
             .unwrap();
 
         // load a region with a newer epoch and small range, should trigger replace.
-        let r_new = CacheRegion::new(1, 0, b"k00", b"k05");
+        let r_new = CacheRegion::new(1, 1, b"k00", b"k05");
         let mut wb = RangeCacheWriteBatch::from(&engine);
         wb.prepare_for_region(r_new.clone());
 

--- a/components/range_cache_memory_engine/src/write_batch.rs
+++ b/components/range_cache_memory_engine/src/write_batch.rs
@@ -983,14 +983,15 @@ mod tests {
         let mut wb = RangeCacheWriteBatch::from(&engine);
         wb.prepare_for_region(r_new.clone());
 
-        let cache_region = engine
-            .core()
-            .read()
-            .range_manager()
-            .region_meta(r_new.id)
-            .unwrap()
-            .get_region()
-            .clone();
-        assert_eq!(&cache_region, &r_new);
+        {
+            let core = engine.core().read();
+            let cache_meta = core.range_manager.region_meta(1).unwrap();
+            assert_eq!(cache_meta.get_region(), &r_new);
+            let meta_by_range = core
+                .range_manager
+                .region_meta_by_end_key(&r_new.end)
+                .unwrap();
+            assert_eq!(meta_by_range.get_region(), &r_new);
+        }
     }
 }

--- a/components/range_cache_memory_engine/src/write_batch.rs
+++ b/components/range_cache_memory_engine/src/write_batch.rs
@@ -954,4 +954,43 @@ mod tests {
             .unwrap();
         assert_eq!(snap2.get_value(b"zkk11").unwrap().unwrap(), &val1);
     }
+
+    #[test]
+    fn test_write_batch_update_outdated_pending_region() {
+        let path = Builder::new()
+            .prefix("test_write_batch_update_outdated_pending_region")
+            .tempdir()
+            .unwrap();
+        let path_str = path.path().to_str().unwrap();
+        let rocks_engine = new_engine(path_str, DATA_CFS).unwrap();
+
+        let mut engine = RangeCacheMemoryEngine::new(RangeCacheEngineContext::new_for_tests(
+            Arc::new(VersionTrack::new(RangeCacheEngineConfig::config_for_test())),
+        ));
+        engine.set_disk_engine(rocks_engine.clone());
+
+        let r1 = CacheRegion::new(1, 0, b"k00", b"k10");
+
+        engine
+            .core()
+            .write()
+            .mut_range_manager()
+            .load_region(r1)
+            .unwrap();
+
+        // load a region with a newer epoch and small range, should trigger replace.
+        let r_new = CacheRegion::new(1, 0, b"k00", b"k05");
+        let mut wb = RangeCacheWriteBatch::from(&engine);
+        wb.prepare_for_region(r_new.clone());
+
+        let cache_region = engine
+            .core()
+            .read()
+            .range_manager()
+            .region_meta(r_new.id)
+            .unwrap()
+            .get_region()
+            .clone();
+        assert_eq!(&cache_region, &r_new);
+    }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #17483, close #17484

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
The PR fix the bug by `amend_pending_region` that causes inconsistency
between regions and regions_by_range because it may change the region
range in metadata but not update the key of regions_by_range. This PR
change the original `amend_pending_region` by first remove the old
region and add a new one.
BTW, this PR also add a `Drop` implementation for `RegionManager` in
test environment to check the consistency between regions and
regions_by_range to find this kind of bug easier.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
