### PR TITLE
In-memory engine: provide a callback API for eviction

### DIFF
--- a/components/range_cache_memory_engine/src/background.rs
+++ b/components/range_cache_memory_engine/src/background.rs
@@ -516,7 +516,7 @@ impl BackgroundRunnerCore {
                 meta.set_safe_point(safe_point);
             } else {
                 assert_eq!(meta.get_state(), RegionState::LoadingCanceled);
-                meta.mark_evict(RegionState::Evicting, EvictReason::LoadFailed);
+                meta.mark_evict(RegionState::Evicting, EvictReason::LoadFailed, None);
                 remove_regions.push(meta.get_region().clone());
             }
         };
@@ -573,7 +573,7 @@ impl BackgroundRunnerCore {
             } else {
                 EvictReason::LoadFailedWithoutStart
             };
-            meta.mark_evict(RegionState::Evicting, reason);
+            meta.mark_evict(RegionState::Evicting, reason, None);
             remove_regions.push(meta.get_region().clone());
         };
 
@@ -639,9 +639,11 @@ impl BackgroundRunnerCore {
             }
             let cache_region = CacheRegion::from_region(&region);
             let mut engine_wr = self.engine.write();
-            let deleteable_regions = engine_wr
-                .mut_range_manager()
-                .evict_region(&cache_region, EvictReason::MemoryLimitReached);
+            let deleteable_regions = engine_wr.mut_range_manager().evict_region(
+                &cache_region,
+                EvictReason::MemoryLimitReached,
+                None,
+            );
             if !deleteable_regions.is_empty() {
                 info!(
                     "ime evict on soft limit reached";
@@ -700,9 +702,11 @@ impl BackgroundRunnerCore {
             if self.memory_controller.reached_soft_limit() {
                 let cache_region = CacheRegion::from_region(&evict_region);
                 let mut core = self.engine.write();
-                let deleteable_regions = core
-                    .mut_range_manager()
-                    .evict_region(&cache_region, EvictReason::AutoEvict);
+                let deleteable_regions = core.mut_range_manager().evict_region(
+                    &cache_region,
+                    EvictReason::AutoEvict,
+                    None,
+                );
                 info!(
                     "ime load_evict: soft limit reached";
                     "region_to_evict" => ?&cache_region,
@@ -2440,7 +2444,7 @@ pub mod tests {
         });
         assert_eq!(engine.core.read().range_manager().regions().len(), 3);
 
-        engine.evict_region(&region2, EvictReason::AutoEvict);
+        engine.evict_region(&region2, EvictReason::AutoEvict, None);
         assert_eq!(6, element_count(&default));
         assert_eq!(6, element_count(&write));
 

--- a/components/range_cache_memory_engine/src/engine.rs
+++ b/components/range_cache_memory_engine/src/engine.rs
@@ -313,12 +313,17 @@ impl RangeCacheMemoryEngine {
     /// Evict a region from the in-memory engine. After this call, the region
     /// will not be readable, but the data of the region may not be deleted
     /// immediately due to some ongoing snapshots.
-    pub fn evict_region(&self, region: &CacheRegion, evict_reason: EvictReason) {
-        let deleteable_regions = self
-            .core
-            .write()
-            .range_manager
-            .evict_region(region, evict_reason);
+    pub fn evict_region(
+        &self,
+        region: &CacheRegion,
+        evict_reason: EvictReason,
+        cb: Option<Box<dyn FnOnce() + Send + Sync>>,
+    ) {
+        let deleteable_regions =
+            self.core
+                .write()
+                .range_manager
+                .evict_region(region, evict_reason, cb);
         if !deleteable_regions.is_empty() {
             // The range can be deleted directly.
             if let Err(e) = self
@@ -463,7 +468,7 @@ impl RangeCacheEngine for RangeCacheMemoryEngine {
     fn on_region_event(&self, event: RegionEvent) {
         match event {
             RegionEvent::Eviction { region, reason } => {
-                self.evict_region(&region, reason);
+                self.evict_region(&region, reason, None);
             }
             RegionEvent::Split {
                 source,
@@ -485,7 +490,7 @@ impl RangeCacheEngine for RangeCacheMemoryEngine {
                         true
                     });
                 for r in regions {
-                    self.evict_region(&r, reason);
+                    self.evict_region(&r, reason, None);
                 }
             }
         }
@@ -503,11 +508,17 @@ impl Iterable for RangeCacheMemoryEngine {
 
 #[cfg(test)]
 pub mod tests {
-    use std::sync::Arc;
+    use std::{
+        sync::{mpsc::sync_channel, Arc},
+        time::Duration,
+    };
 
     use crossbeam::epoch;
-    use engine_traits::{CacheRegion, CF_DEFAULT, CF_LOCK, CF_WRITE};
-    use tikv_util::config::{ReadableSize, VersionTrack};
+    use engine_traits::{
+        CacheRegion, EvictReason, Mutable, RangeCacheEngine, WriteBatch, WriteBatchExt, CF_DEFAULT,
+        CF_LOCK, CF_WRITE,
+    };
+    use tikv_util::config::{ReadableDuration, ReadableSize, VersionTrack};
 
     use super::SkiplistEngine;
     use crate::{
@@ -659,5 +670,46 @@ pub mod tests {
 
         iter.next(guard);
         assert!(!iter.valid());
+    }
+
+    #[test]
+    fn test_cb_on_eviction_with_on_going_snapshot() {
+        let mut config = RangeCacheEngineConfig::config_for_test();
+        config.gc_interval = ReadableDuration(Duration::from_secs(1));
+        let engine = RangeCacheMemoryEngine::new(RangeCacheEngineContext::new_for_tests(Arc::new(
+            VersionTrack::new(config),
+        )));
+
+        let region = new_region(1, b"", b"z");
+        let cache_region = CacheRegion::from_region(&region);
+        engine.new_region(region.clone());
+
+        let mut wb = engine.write_batch();
+        wb.prepare_for_region(cache_region.clone());
+        wb.set_sequence_number(10).unwrap();
+        wb.put(b"a", b"val1").unwrap();
+        wb.put(b"b", b"val2").unwrap();
+        wb.put(b"c", b"val3").unwrap();
+        wb.write().unwrap();
+
+        let snap = engine.snapshot(cache_region.clone(), 100, 100).unwrap();
+
+        let (tx, rx) = sync_channel(0);
+        engine.evict_region(
+            &cache_region,
+            EvictReason::BecomeFollower,
+            Some(Box::new(move || {
+                let _ = tx.send(true);
+            })),
+        );
+
+        rx.recv_timeout(Duration::from_secs(1)).unwrap_err();
+        drop(snap);
+        let _ = rx.recv();
+
+        {
+            let core = engine.core().read();
+            assert!(core.range_manager().region_meta(1).is_none());
+        }
     }
 }

--- a/components/range_cache_memory_engine/src/range_manager.rs
+++ b/components/range_cache_memory_engine/src/range_manager.rs
@@ -6,6 +6,7 @@ use std::{
         BTreeMap,
         Bound::{self, Excluded, Unbounded},
     },
+    fmt::Debug,
     result,
     sync::atomic::{AtomicBool, Ordering},
 };
@@ -95,14 +96,24 @@ pub struct CacheRegionMeta {
     state: RegionState,
     // whether a gc task is running with this region.
     in_gc: bool,
-    // region eviction triggers info, used for logging.
+    // region eviction triggers info and callback when eviction finishes.
     evict_info: Option<EvictInfo>,
 }
 
-#[derive(Debug, Clone, Copy)]
 struct EvictInfo {
     start: Instant,
     reason: EvictReason,
+    // called when eviction finishes
+    cb: Option<Box<dyn FnOnce() + Send + Sync>>,
+}
+
+impl Debug for EvictInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EvictInfo")
+            .field("start", &self.start)
+            .field("reason", &self.reason)
+            .finish()
+    }
 }
 
 impl CacheRegionMeta {
@@ -174,7 +185,12 @@ impl CacheRegionMeta {
         self.state = new_state;
     }
 
-    pub(crate) fn mark_evict(&mut self, state: RegionState, reason: EvictReason) {
+    pub(crate) fn mark_evict(
+        &mut self,
+        state: RegionState,
+        reason: EvictReason,
+        cb: Option<Box<dyn FnOnce() + Send + Sync>>,
+    ) {
         use RegionState::*;
         assert_matches!(self.state, Loading | Active | LoadingCanceled);
         assert_matches!(state, PendingEvict | Evicting);
@@ -182,6 +198,7 @@ impl CacheRegionMeta {
         self.evict_info = Some(EvictInfo {
             start: Instant::now_coarse(),
             reason,
+            cb,
         });
     }
 
@@ -205,7 +222,7 @@ impl CacheRegionMeta {
             safe_point: source_meta.safe_point,
             state: source_meta.state,
             in_gc: source_meta.in_gc,
-            evict_info: source_meta.evict_info,
+            evict_info: None,
         }
     }
 
@@ -599,23 +616,16 @@ impl RegionManager {
     }
 
     /// Return ranges that can be deleted now (no ongoing snapshot).
-    // There are two cases based on the relationship between `evict_range` and
-    // cached ranges:
-    // 1. `evict_range` is contained(including equals) by a cached range (at most
-    //    one due to non-overlapping in cached ranges)
-    // 2. `evict_range` is overlapped with (including contains but not be contained)
-    //    one or more cached ranges
-    //
-    // For 1, if the `evict_range` is a proper subset of the cached_range, we will
-    // split the cached_range so that only the `evict_range` part will be evicted
-    // and deleted.
-    //
-    // For 2, this is caused by some special operations such as merge and delete
-    // range. So, conservatively, we evict all ranges overlap with it.
+    // If the region epoch has changed which means the region range may have
+    // changed, evict the regions overlapped with the range of `evict_region`.
+    // `cb` is called when the eviction of the region with id equaling to the id of
+    // `evict_region` has done.
+    // Note: `cb` should not do something heavy.
     pub(crate) fn evict_region(
         &mut self,
         evict_region: &CacheRegion,
         evict_reason: EvictReason,
+        mut cb: Option<Box<dyn FnOnce() + Send + Sync>>,
     ) -> Vec<CacheRegion> {
         info!(
             "ime try to evict region";
@@ -627,9 +637,11 @@ impl RegionManager {
             // if epoch not changed, no need to do range scan.
             if meta.region.epoch_version == evict_region.epoch_version {
                 if let Some(region) =
-                    self.do_evict_region(evict_region.id, evict_region, evict_reason)
+                    self.do_evict_region(evict_region.id, evict_region, evict_reason, cb)
                 {
                     return vec![region];
+                } else {
+                    return vec![];
                 }
             }
         }
@@ -649,7 +661,16 @@ impl RegionManager {
                 "region" => ?evict_region);
         }
         for rid in evict_ids {
-            if let Some(region) = self.do_evict_region(rid, evict_region, evict_reason) {
+            if let Some(region) = self.do_evict_region(
+                rid,
+                evict_region,
+                evict_reason,
+                if rid == evict_region.id {
+                    cb.take()
+                } else {
+                    None
+                },
+            ) {
                 deleteable_regions.push(region);
             }
         }
@@ -662,6 +683,7 @@ impl RegionManager {
         id: u64,
         evict_region: &CacheRegion,
         evict_reason: EvictReason,
+        cb: Option<Box<dyn FnOnce() + Send + Sync>>,
     ) -> Option<CacheRegion> {
         let meta = self.regions.get_mut(&id).unwrap();
         let prev_state = meta.state;
@@ -688,7 +710,7 @@ impl RegionManager {
         }
 
         if prev_state == RegionState::Active {
-            meta.mark_evict(RegionState::PendingEvict, evict_reason);
+            meta.mark_evict(RegionState::PendingEvict, evict_reason, cb);
         } else {
             meta.set_state(RegionState::LoadingCanceled)
         };
@@ -718,6 +740,7 @@ impl RegionManager {
     }
 
     pub fn on_delete_regions(&mut self, regions: &[CacheRegion]) {
+        fail::fail_point!("in_memory_engine_on_delete_regions");
         for r in regions {
             let meta = self.remove_region(r.id);
             assert_eq!(meta.region.epoch_version, r.epoch_version);
@@ -727,6 +750,10 @@ impl RegionManager {
                 evict_info.start.saturating_elapsed_secs(),
                 evict_info.reason,
             );
+            if let Some(cb) = evict_info.cb {
+                cb();
+            }
+
             info!(
                 "ime range eviction done";
                 "region" => ?r,
@@ -898,7 +925,7 @@ mod tests {
         let r_left = CacheRegion::new(1, 2, b"k00", b"k03");
         let r_right = CacheRegion::new(3, 2, b"k06", b"k10");
         range_mgr.split_region(&r1, vec![r_left.clone(), r_evict.clone(), r_right.clone()]);
-        range_mgr.evict_region(&r_evict, EvictReason::AutoEvict);
+        range_mgr.evict_region(&r_evict, EvictReason::AutoEvict, None);
         let meta1 = range_mgr
             .historical_regions
             .get(&KeyAndVersion(r1.end.clone(), 0))
@@ -918,7 +945,7 @@ mod tests {
         // evict a range with accurate match
         range_mgr.region_snapshot(r_left.id, 2, 10).unwrap();
         let snapshot3 = RangeCacheSnapshotMeta::new(r_left.clone(), 10, 3);
-        range_mgr.evict_region(&r_left, EvictReason::AutoEvict);
+        range_mgr.evict_region(&r_left, EvictReason::AutoEvict, None);
         assert_eq!(
             range_mgr.regions.get(&r_left.id).unwrap().state,
             RegionState::PendingEvict,
@@ -951,7 +978,7 @@ mod tests {
         range_mgr.new_region(r1.clone());
         range_mgr.load_region(r2.clone()).unwrap();
         range_mgr.new_region(r3.clone());
-        range_mgr.evict_region(&r1, EvictReason::AutoEvict);
+        range_mgr.evict_region(&r1, EvictReason::AutoEvict, None);
 
         assert_eq!(
             range_mgr.load_region(r1).unwrap_err(),
@@ -977,7 +1004,7 @@ mod tests {
         let r1 = CacheRegion::new(1, 0, b"k00", b"k10");
         let r3 = CacheRegion::new(3, 0, b"k40", b"k50");
         range_mgr.new_region(r1.clone());
-        range_mgr.evict_region(&r1, EvictReason::AutoEvict);
+        range_mgr.evict_region(&r1, EvictReason::AutoEvict, None);
 
         range_mgr.load_region(r3).unwrap();
 
@@ -1020,7 +1047,7 @@ mod tests {
 
             let r4 = CacheRegion::new(4, 2, b"k00", b"k05");
             assert_eq!(
-                range_mgr.evict_region(&r4, EvictReason::AutoEvict),
+                range_mgr.evict_region(&r4, EvictReason::AutoEvict, None),
                 vec![r1]
             );
         }
@@ -1039,7 +1066,7 @@ mod tests {
 
             let r4 = CacheRegion::new(4, 0, b"k", b"k51");
             assert_eq!(
-                range_mgr.evict_region(&r4, EvictReason::AutoEvict),
+                range_mgr.evict_region(&r4, EvictReason::AutoEvict, None),
                 vec![r1, r2, r3]
             );
             assert!(
@@ -1061,7 +1088,7 @@ mod tests {
 
             let r4 = CacheRegion::new(4, 0, b"k25", b"k55");
             assert_eq!(
-                range_mgr.evict_region(&r4, EvictReason::AutoEvict),
+                range_mgr.evict_region(&r4, EvictReason::AutoEvict, None),
                 vec![r2, r3]
             );
             assert_eq!(
@@ -1085,7 +1112,7 @@ mod tests {
 
             let r4 = CacheRegion::new(4, 0, b"k25", b"k75");
             assert_eq!(
-                range_mgr.evict_region(&r4, EvictReason::AutoEvict),
+                range_mgr.evict_region(&r4, EvictReason::AutoEvict, None),
                 vec![r2, r3]
             );
             assert_eq!(

--- a/components/range_cache_memory_engine/src/range_manager.rs
+++ b/components/range_cache_memory_engine/src/range_manager.rs
@@ -110,7 +110,6 @@ struct EvictInfo {
 impl Debug for EvictInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("EvictInfo")
-            .field("start", &self.start)
             .field("reason", &self.reason)
             .finish()
     }
@@ -620,7 +619,7 @@ impl RegionManager {
     // changed, evict the regions overlapped with the range of `evict_region`.
     // `cb` is called when the eviction of the region with id equaling to the id of
     // `evict_region` has done.
-    // Note: `cb` should not do something heavy.
+    // Note: `cb` should not do anything heavy.
     pub(crate) fn evict_region(
         &mut self,
         evict_region: &CacheRegion,

--- a/components/range_cache_memory_engine/src/read.rs
+++ b/components/range_cache_memory_engine/src/read.rs
@@ -1809,7 +1809,7 @@ mod tests {
         });
 
         let evict_region = new_regions[1].clone();
-        engine.evict_region(&evict_region, EvictReason::AutoEvict);
+        engine.evict_region(&evict_region, EvictReason::AutoEvict, None);
         assert_eq!(
             engine.snapshot(range.clone(), 10, 200).unwrap_err(),
             FailedReason::EpochNotMatch
@@ -1886,7 +1886,7 @@ mod tests {
         });
 
         let evict_region = new_regions[1].clone();
-        engine.evict_region(&evict_region, EvictReason::AutoEvict);
+        engine.evict_region(&evict_region, EvictReason::AutoEvict, None);
 
         let r_left = new_regions[0].clone();
         let s3 = engine.snapshot(r_left.clone(), 20, 20).unwrap();
@@ -1894,7 +1894,7 @@ mod tests {
         let s4 = engine.snapshot(r_right, 20, 20).unwrap();
 
         drop(s3);
-        engine.evict_region(&r_left, EvictReason::AutoEvict);
+        engine.evict_region(&r_left, EvictReason::AutoEvict, None);
 
         // todo(SpadeA): memory limiter
         {

--- a/components/range_cache_memory_engine/src/write_batch.rs
+++ b/components/range_cache_memory_engine/src/write_batch.rs
@@ -222,7 +222,7 @@ impl RangeCacheWriteBatch {
             return;
         }
         self.engine
-            .evict_region(self.current_region.as_ref().unwrap(), reason);
+            .evict_region(self.current_region.as_ref().unwrap(), reason, None);
         // cleanup cached entries belong to this region as there is no need
         // to write them.
         assert!(self.save_points.is_empty());
@@ -879,6 +879,7 @@ mod tests {
         engine.evict_region(
             &CacheRegion::from_region(&regions[0]),
             EvictReason::AutoEvict,
+            None,
         );
         wait_evict_done(&engine);
         flush_epoch();

--- a/tests/failpoints/cases/test_range_cache_engine.rs
+++ b/tests/failpoints/cases/test_range_cache_engine.rs
@@ -411,7 +411,11 @@ fn test_load_with_eviction() {
         }
         // Now, the range ["", "") should be cached
         let region = new_region(1, split_key, "");
-        range_cache_engine.evict_region(&CacheRegion::from_region(&region), EvictReason::AutoEvict);
+        range_cache_engine.evict_region(
+            &CacheRegion::from_region(&region),
+            EvictReason::AutoEvict,
+            None,
+        );
     }
 
     fail::remove("on_range_cache_write_batch_write_impl");


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #17498 Ref #16141

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
provide a callback API for eviction
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
