### PR TITLE
In-memory Engine: Adjust memory settings based on available memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2863,9 +2863,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -3609,7 +3609,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.0",
+ "hashbrown 0.15.1",
 ]
 
 [[package]]

--- a/components/in_memory_engine/src/config.rs
+++ b/components/in_memory_engine/src/config.rs
@@ -368,19 +368,16 @@ mod tests {
         // Capacity has a maximum limit.
         let mut cfg = InMemoryEngineConfig::default();
         cfg.enable = true;
-        let mut block_cache_capacity = ReadableSize::gb(100).0 as u64;
+        let mut block_cache_capacity = ReadableSize::gb(100).0;
         cfg.validate(&mut block_cache_capacity, DEFAULT_REGION_SPLIT_SIZE)
             .unwrap();
         assert_eq!(cfg.capacity.unwrap().0, MAX_CAPACITY);
-        assert_eq!(
-            block_cache_capacity,
-            ReadableSize::gb(100).0 as u64 - MAX_CAPACITY
-        );
+        assert_eq!(block_cache_capacity, ReadableSize::gb(100).0 - MAX_CAPACITY);
         // ... unless capacity is set manually.
         let mut cfg = InMemoryEngineConfig::default();
         cfg.enable = true;
         cfg.capacity = Some(ReadableSize(2 * MAX_CAPACITY));
-        let mut block_cache_capacity = ReadableSize::gb(100).0 as u64;
+        let mut block_cache_capacity = ReadableSize::gb(100).0;
         cfg.validate(&mut block_cache_capacity, DEFAULT_REGION_SPLIT_SIZE)
             .unwrap();
         assert_eq!(cfg.capacity.unwrap().0, 2 * MAX_CAPACITY);

--- a/components/in_memory_engine/src/config.rs
+++ b/components/in_memory_engine/src/config.rs
@@ -23,8 +23,12 @@ const MAX_WRITE_KV_SPEED: u64 = 20 * 1024 * 1024;
 // on `capacity`.
 const MAX_RESERVED_DURATION_FOR_WRITE: u64 = 10;
 // Regions' mvcc read amplification statistics is updated every 1min, so we set
-// the minimal load&evcit check duration to 2min.
+// the minimal load&evict check duration to 2min.
 const MIN_LOAD_EVICT_INTERVAL: Duration = Duration::from_secs(120);
+// The default threshold for mvcc amplification. Test shows setting it to 10
+// can benefit common workloads, eg, TPCc (50 warehouse), saving about 20% of
+// unified read pool CPU usage.
+const DEFAULT_MVCC_AMPLIFICATION_THRESHOLD: usize = 10;
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, OnlineConfig)]
 #[serde(default, rename_all = "kebab-case")]
@@ -76,7 +80,7 @@ impl Default for InMemoryEngineConfig {
             load_evict_interval: ReadableDuration(Duration::from_secs(300)),
             evict_threshold: None,
             capacity: None,
-            mvcc_amplification_threshold: 100,
+            mvcc_amplification_threshold: DEFAULT_MVCC_AMPLIFICATION_THRESHOLD,
             cross_check_interval: ReadableDuration(Duration::from_secs(0)),
             expected_region_size: raftstore::coprocessor::config::SPLIT_SIZE,
         }
@@ -168,7 +172,7 @@ impl InMemoryEngineConfig {
             evict_threshold: Some(ReadableSize::gb(1)),
             capacity: Some(ReadableSize::gb(2)),
             expected_region_size: ReadableSize::mb(20),
-            mvcc_amplification_threshold: 10,
+            mvcc_amplification_threshold: DEFAULT_MVCC_AMPLIFICATION_THRESHOLD,
             cross_check_interval: ReadableDuration(Duration::from_secs(0)),
         }
     }

--- a/components/in_memory_engine/src/region_stats.rs
+++ b/components/in_memory_engine/src/region_stats.rs
@@ -265,7 +265,7 @@ impl RegionStatsManager {
                             r.cop_detail.mvcc_amplification()
                                 < mvcc_amplification_to_filter
                         } else {
-                            // In this case, memory usage is relarively low, we only evict those that should not be cached apparently.
+                            // In this case, memory usage is relatively low, we only evict those that should not be cached apparently.
                             r.cop_detail.mvcc_amplification()
                                 <= self.config.value().mvcc_amplification_threshold as f64 / MVCC_AMPLIFICATION_FILTER_FACTOR
                                 || r.cop_detail.iterated_count()  < avg_top_next_prev / ITERATED_COUNT_FILTER_FACTOR

--- a/deny.toml
+++ b/deny.toml
@@ -73,10 +73,6 @@ ignore = [
     #
     # TODO: Upgrade clap to v4.x.
     "RUSTSEC-2021-0145",
-    # Ignore RUSTSEC-2024-0006 as it only included by "rusoto_credential" crate.
-    #
-    # TODO: Upgrade shlex@0.1.1 to v1.3.x.
-    "RUSTSEC-2024-0006",
 ]
 
 # TiKV is licensed under Apache 2.0, according to ASF 3RD PARTY LICENSE POLICY,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3961,8 +3961,10 @@ impl TikvConfig {
             return Err("in-memory-engine is unavailable for feature TTL or API v2".into());
         }
         self.in_memory_engine.expected_region_size = self.coprocessor.region_split_size();
-        self.in_memory_engine
-            .validate(self.coprocessor.region_split_size())?;
+        self.in_memory_engine.validate(
+            &mut self.storage.block_cache.capacity.as_mut().unwrap().0,
+            self.coprocessor.region_split_size(),
+        )?;
 
         // Now, only support cross check in in-memory engine when compaction filter is
         // enabled.


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #16141 

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
This commit adjusts the following in-memory-engine defaults:

* `capacity`: Now IME uses 10% of the block cache and takes an equal
  amount of memory from the system. This is based on tests showing that
  the IME rarely fills its full capacity.
* `mvcc_amplification_threshold`: Change from 100 to 10 which benefit
  common workloads like TPCc (50 warehouse), saving approximately 20%
  of unified read pool CPU usage.

Also, it addresses two security issues:

* Remove ignore of RUSTSEC-2024-0006, as vulnerable shlex 0.1.1 is
  removed by #13814
* Upgrade hashbrown from yanked 0.15.0 to 0.15.1

```

### Check List

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
