### PR TITLE
Extend mem limit for in-mem pessimistic lock 

### DIFF
--- a/components/raftstore/src/store/txn_ext.rs
+++ b/components/raftstore/src/store/txn_ext.rs
@@ -56,11 +56,11 @@ lazy_static! {
     .unwrap();
 }
 
-const GLOBAL_MEM_SIZE_LIMIT: usize = 10 << 30; // 10 GiB
+const GLOBAL_MEM_SIZE_LIMIT: usize = 2 << 30; // 10 GiB
 
 // 128 MiB, so pessimistic locks in one region can be proposed in a single
 // command.
-const PEER_MEM_SIZE_LIMIT: usize = 128 << 20;
+const PEER_MEM_SIZE_LIMIT: usize = 16 << 20;
 
 /// Pessimistic locks of a region peer.
 #[derive(PartialEq)]

--- a/components/raftstore/src/store/txn_ext.rs
+++ b/components/raftstore/src/store/txn_ext.rs
@@ -56,11 +56,11 @@ lazy_static! {
     .unwrap();
 }
 
-const GLOBAL_MEM_SIZE_LIMIT: usize = 100 << 20; // 100 MiB
+const GLOBAL_MEM_SIZE_LIMIT: usize = 10 << 30; // 10 GiB
 
 // 512 KiB, so pessimistic locks in one region can be proposed in a single
 // command.
-const PEER_MEM_SIZE_LIMIT: usize = 512 << 10;
+const PEER_MEM_SIZE_LIMIT: usize = 32 << 20;
 
 /// Pessimistic locks of a region peer.
 #[derive(PartialEq)]

--- a/components/raftstore/src/store/txn_ext.rs
+++ b/components/raftstore/src/store/txn_ext.rs
@@ -58,9 +58,9 @@ lazy_static! {
 
 const GLOBAL_MEM_SIZE_LIMIT: usize = 10 << 30; // 10 GiB
 
-// 512 KiB, so pessimistic locks in one region can be proposed in a single
+// 128 MiB, so pessimistic locks in one region can be proposed in a single
 // command.
-const PEER_MEM_SIZE_LIMIT: usize = 32 << 20;
+const PEER_MEM_SIZE_LIMIT: usize = 128 << 20;
 
 /// Pessimistic locks of a region peer.
 #[derive(PartialEq)]


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #17518

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note

```
