### PR TITLE
*: implement broadcast_txn_status for tikv service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/ekexium/kvproto?branch=feat-resolved-ts-for-large-txn#683006c3a99b4b7555d1242f5a722a40a9ccac14"
+source = "git+https://github.com/ekexium/kvproto?branch=feat-resolved-ts-for-large-txn#cc0810e58b37b947f3f3dc201fc223a46e01dc44"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/ekexium/kvproto?branch=feat-resolved-ts-for-large-txn#b4bbca7aeec20dd0dc3607e95c4cca2dfca65606"
+source = "git+https://github.com/ekexium/kvproto?branch=feat-resolved-ts-for-large-txn#683006c3a99b4b7555d1242f5a722a40a9ccac14"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#0ad602a429126e39bd4a87c687be64f9ae173c02"
+source = "git+https://github.com/ekexium/kvproto?branch=feat-resolved-ts-for-large-txn#b4bbca7aeec20dd0dc3607e95c4cca2dfca65606"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -241,6 +241,8 @@ procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "7693954bd1dd86e
 # After the PR to kvproto is merged, remember to comment this out and run `cargo update -p kvproto`.
 # [patch.'https://github.com/pingcap/kvproto']
 # kvproto = { git = "https://github.com/your_github_id/kvproto", branch = "your_branch" }
+[patch.'https://github.com/pingcap/kvproto']
+kvproto = { git = "https://github.com/ekexium/kvproto", branch = "feat-resolved-ts-for-large-txn" }
 #
 # After the PR to rust-rocksdb is merged, remember to comment this out and run `cargo update -p rocksdb`.
 # [patch.'https://github.com/tikv/rust-rocksdb']

--- a/components/pd_client/src/util.rs
+++ b/components/pd_client/src/util.rs
@@ -952,6 +952,7 @@ pub fn check_resp_header(header: &ResponseHeader) -> Result<()> {
         ErrorType::Unknown => Err(box_err!(err.get_message())),
         ErrorType::InvalidValue => Err(box_err!(err.get_message())),
         ErrorType::GlobalConfigNotFound => panic!("unexpected error {:?}", err),
+        ErrorType::RegionsNotContainAllKeyRange => unimplemented!(),
     }
 }
 

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -111,7 +111,10 @@ use tikv::{
         config_manager::StorageConfigManger,
         kv::LocalTablets,
         mvcc::MvccConsistencyCheckObserver,
-        txn::flow_controller::{EngineFlowController, FlowController},
+        txn::{
+            flow_controller::{EngineFlowController, FlowController},
+            txn_status_cache::TxnStatusCache,
+        },
         Engine, Storage,
     },
 };
@@ -693,6 +696,9 @@ where
             ));
             storage_read_pools.handle()
         };
+        let txn_status_cache = Arc::new(TxnStatusCache::new(
+            self.core.config.storage.txn_status_cache_capacity,
+        ));
 
         let storage = Storage::<_, _, F>::from_engine(
             engines.engine.clone(),
@@ -711,6 +717,7 @@ where
                 .as_ref()
                 .map(|m| m.derive_controller("scheduler-worker-pool".to_owned(), true)),
             self.resource_manager.clone(),
+            txn_status_cache,
         )
         .unwrap_or_else(|e| fatal!("failed to create raft storage: {}", e));
         cfg_controller.register(

--- a/components/test_raftstore-v2/src/server.rs
+++ b/components/test_raftstore-v2/src/server.rs
@@ -68,7 +68,10 @@ use tikv::{
     storage::{
         self,
         kv::{FakeExtension, LocalTablets, RaftExtension, SnapContext},
-        txn::flow_controller::{EngineFlowController, FlowController},
+        txn::{
+            flow_controller::{EngineFlowController, FlowController},
+            txn_status_cache::TxnStatusCache,
+        },
         Engine, Storage,
     },
 };
@@ -539,6 +542,7 @@ impl<EK: KvEngine> ServerCluster<EK> {
                 .as_ref()
                 .map(|m| m.derive_controller("scheduler-worker-pool".to_owned(), true)),
             resource_manager.clone(),
+            Arc::new(TxnStatusCache::new(1 << 2)),
         )?;
         self.storages.insert(node_id, raft_kv_v2.clone());
 

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -70,7 +70,10 @@ use tikv::{
     storage::{
         self,
         kv::{FakeExtension, LocalTablets, SnapContext},
-        txn::flow_controller::{EngineFlowController, FlowController},
+        txn::{
+            flow_controller::{EngineFlowController, FlowController},
+            txn_status_cache::TxnStatusCache,
+        },
         Engine, Storage,
     },
 };
@@ -443,6 +446,7 @@ impl<EK: KvEngineWithRocks> ServerCluster<EK> {
                 .as_ref()
                 .map(|m| m.derive_controller("scheduler-worker-pool".to_owned(), true)),
             resource_manager.clone(),
+            Arc::new(TxnStatusCache::new(1 << 20)),
         )?;
         self.storages.insert(node_id, raft_engine);
 

--- a/components/tikv_util/src/lru.rs
+++ b/components/tikv_util/src/lru.rs
@@ -406,6 +406,11 @@ where
     }
 
     #[inline]
+    pub fn contains_key(&self, key: &K) -> bool {
+        self.get_no_promote(key).is_some()
+    }
+
+    #[inline]
     pub fn get_mut(&mut self, key: &K) -> Option<&mut V> {
         match self.map.get_mut(key) {
             Some(v) => {

--- a/src/server/metrics.rs
+++ b/src/server/metrics.rs
@@ -66,6 +66,7 @@ make_auto_flush_static_metric! {
         kv_flush,
         kv_buffer_batch_get,
         get_health_feedback,
+        broadcast_txn_status,
     }
 
     pub label_enum GcCommandKind {

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -1395,6 +1395,13 @@ fn handle_batch_commands_request<E: Engine, L: LockManager, F: KvFormat>(
                     let resp = std::future::ready(Ok(GetHealthFeedbackResponse::default()).map(oneof!(batch_commands_response::response::Cmd::GetHealthFeedback)));
                     response_batch_commands_request(id, resp, tx.clone(), begin_instant, GrpcTypeKind::get_health_feedback, source, ResourcePriority::unknown);
                 },
+                Some(batch_commands_request::request::Cmd::BroadcastTxnStatus(req)) => {
+                    handle_cluster_id_mismatch!(cluster_id, req);
+                    let begin_instant = Instant::now();
+                    let source = req.get_context().get_request_source().to_owned();
+
+                    todo!("update cache and respond")
+                }
                 Some(batch_commands_request::request::Cmd::Empty(req)) => {
                     let begin_instant = Instant::now();
                     let resp = future_handle_empty(req)

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -11409,7 +11409,7 @@ mod tests {
             storage
                 .sched
                 .get_txn_status_cache()
-                .get_no_promote(10.into())
+                .get_committed_no_promote(10.into())
                 .unwrap(),
             21.into()
         );
@@ -11497,7 +11497,7 @@ mod tests {
             storage
                 .sched
                 .get_txn_status_cache()
-                .get_no_promote(10.into())
+                .get_committed_no_promote(10.into())
                 .is_none()
         );
 
@@ -11517,7 +11517,7 @@ mod tests {
             storage
                 .sched
                 .get_txn_status_cache()
-                .get_no_promote(10.into())
+                .get_committed_no_promote(10.into())
                 .unwrap(),
             20.into()
         );
@@ -11539,7 +11539,7 @@ mod tests {
             storage
                 .sched
                 .get_txn_status_cache()
-                .get_no_promote(30.into())
+                .get_committed_no_promote(30.into())
                 .is_none()
         );
 
@@ -11573,7 +11573,7 @@ mod tests {
             storage
                 .sched
                 .get_txn_status_cache()
-                .get_no_promote(50.into())
+                .get_committed_no_promote(50.into())
                 .unwrap(),
             60.into()
         );
@@ -11618,7 +11618,7 @@ mod tests {
             storage
                 .sched
                 .get_txn_status_cache()
-                .get_no_promote(70.into())
+                .get_committed_no_promote(70.into())
                 .unwrap(),
             80.into()
         );
@@ -11661,7 +11661,7 @@ mod tests {
             storage
                 .sched
                 .get_txn_status_cache()
-                .get_no_promote(90.into())
+                .get_committed_no_promote(90.into())
                 .unwrap(),
             100.into()
         );
@@ -11688,12 +11688,15 @@ mod tests {
             storage
                 .sched
                 .get_txn_status_cache()
-                .get_no_promote(9.into())
+                .get_committed_no_promote(9.into())
                 .is_none()
         );
 
         // CheckTxnStatus: committed transaction
-        storage.sched.get_txn_status_cache().remove(10.into());
+        storage
+            .sched
+            .get_txn_status_cache()
+            .remove_normal(10.into());
         storage
             .sched_txn_command(
                 commands::CheckTxnStatus::new(
@@ -11715,7 +11718,7 @@ mod tests {
             storage
                 .sched
                 .get_txn_status_cache()
-                .get_no_promote(10.into())
+                .get_committed_no_promote(10.into())
                 .unwrap(),
             20.into()
         );
@@ -11758,7 +11761,7 @@ mod tests {
             storage
                 .sched
                 .get_txn_status_cache()
-                .get_no_promote(120.into())
+                .get_committed_no_promote(120.into())
                 .is_none()
         );
 
@@ -11778,7 +11781,7 @@ mod tests {
             storage
                 .sched
                 .get_txn_status_cache()
-                .get_no_promote(120.into())
+                .get_committed_no_promote(120.into())
                 .is_none()
         );
 
@@ -11823,7 +11826,7 @@ mod tests {
             storage
                 .sched
                 .get_txn_status_cache()
-                .remove(130.into())
+                .remove_normal(130.into())
                 .unwrap(),
             140.into()
         );
@@ -11843,7 +11846,7 @@ mod tests {
             storage
                 .sched
                 .get_txn_status_cache()
-                .get_no_promote(130.into())
+                .get_committed_no_promote(130.into())
                 .unwrap(),
             140.into()
         );

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -104,6 +104,7 @@ use tracker::{
 };
 use txn_types::{Key, KvPair, Lock, LockType, TimeStamp, TsSet, Value};
 
+use self::kv::SnapContext;
 pub use self::{
     errors::{get_error_kind_from_header, get_tag_from_header, Error, ErrorHeaderKind, ErrorInner},
     kv::{
@@ -118,7 +119,6 @@ pub use self::{
         StorageCallback, TxnStatus,
     },
 };
-use self::{kv::SnapContext, test_util::latest_feature_gate};
 use crate::{
     read_pool::{ReadPool, ReadPoolHandle},
     server::{lock_manager::waiter_manager, metrics::ResourcePriority},
@@ -128,10 +128,12 @@ use crate::{
         lock_manager::{LockManager, MockLockManager},
         metrics::{CommandKind, *},
         mvcc::{metrics::ScanLockReadTimeSource::resolve_lock, MvccReader, PointGetterBuilder},
+        test_util::latest_feature_gate,
         txn::{
             commands::{RawAtomicStore, RawCompareAndSwap, TypedCommand},
             flow_controller::{EngineFlowController, FlowController},
             scheduler::TxnScheduler,
+            txn_status_cache::TxnStatusCache,
             Command, Error as TxnError, ErrorInner as TxnErrorInner,
         },
         types::StorageCallbackType,
@@ -219,7 +221,7 @@ pub struct Storage<E: Engine, L: LockManager, F: KvFormat> {
 impl<E: Engine, L: LockManager, F: KvFormat> Clone for Storage<E, L, F> {
     #[inline]
     fn clone(&self) -> Self {
-        let refs = self.refs.fetch_add(1, atomic::Ordering::SeqCst);
+        let refs = self.refs.fetch_add(1, Ordering::SeqCst);
 
         trace!(
             "Storage referenced"; "original_ref" => refs
@@ -245,7 +247,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Clone for Storage<E, L, F> {
 impl<E: Engine, L: LockManager, F: KvFormat> Drop for Storage<E, L, F> {
     #[inline]
     fn drop(&mut self) {
-        let refs = self.refs.fetch_sub(1, atomic::Ordering::SeqCst);
+        let refs = self.refs.fetch_sub(1, Ordering::SeqCst);
 
         trace!(
             "Storage de-referenced"; "original_ref" => refs
@@ -276,6 +278,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         causal_ts_provider: Option<Arc<CausalTsProviderImpl>>,
         resource_ctl: Option<Arc<ResourceController>>,
         resource_manager: Option<Arc<ResourceGroupManager>>,
+        txn_status_cache: Arc<TxnStatusCache>,
     ) -> Result<Self> {
         assert_eq!(config.api_version(), F::TAG, "Api version not match");
 
@@ -293,6 +296,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
             feature_gate,
             resource_ctl,
             resource_manager.clone(),
+            txn_status_cache,
         );
 
         info!("Storage started.");
@@ -3534,7 +3538,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> TestStorageBuilder<E, L, F> {
 
     pub fn pipelined_pessimistic_lock(self, enabled: bool) -> Self {
         self.pipelined_pessimistic_lock
-            .store(enabled, atomic::Ordering::Relaxed);
+            .store(enabled, Ordering::Relaxed);
         self
     }
 
@@ -3545,7 +3549,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> TestStorageBuilder<E, L, F> {
 
     pub fn in_memory_pessimistic_lock(self, enabled: bool) -> Self {
         self.in_memory_pessimistic_lock
-            .store(enabled, atomic::Ordering::Relaxed);
+            .store(enabled, Ordering::Relaxed);
         self
     }
 
@@ -3599,6 +3603,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> TestStorageBuilder<E, L, F> {
             ts_provider,
             Some(resource_ctl),
             Some(manager),
+            Arc::new(TxnStatusCache::new_for_test()),
         )
     }
 
@@ -3632,6 +3637,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> TestStorageBuilder<E, L, F> {
             None,
             Some(resource_ctl),
             Some(manager),
+            Arc::new(TxnStatusCache::new_for_test()),
         )
     }
 
@@ -3668,6 +3674,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> TestStorageBuilder<E, L, F> {
             None,
             Some(resource_controller),
             Some(resource_manager),
+            Arc::new(TxnStatusCache::new_for_test()),
         )
     }
 }
@@ -4237,7 +4244,7 @@ mod tests {
                     statistics: &mut Statistics::default(),
                     async_apply_prewrite: false,
                     raw_ext: None,
-                    txn_status_cache: &TxnStatusCache::new_for_test(),
+                    txn_status_cache: Arc::new(TxnStatusCache::new_for_test()),
                 },
             )
             .unwrap();

--- a/src/storage/txn/commands/acquire_pessimistic_lock_resumed.rs
+++ b/src/storage/txn/commands/acquire_pessimistic_lock_resumed.rs
@@ -286,7 +286,7 @@ mod tests {
                     statistics: &mut Default::default(),
                     async_apply_prewrite: false,
                     raw_ext: None,
-                    txn_status_cache: &TxnStatusCache::new_for_test(),
+                    txn_status_cache: Arc::new(TxnStatusCache::new_for_test()),
                 },
             )
             .unwrap();

--- a/src/storage/txn/commands/atomic_store.rs
+++ b/src/storage/txn/commands/atomic_store.rs
@@ -71,6 +71,8 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for RawAtomicStore {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use api_version::{test_kv_format_impl, ApiV2, KvFormat, RawValue};
     use engine_traits::CF_DEFAULT;
     use futures::executor::block_on;
@@ -120,7 +122,7 @@ mod tests {
             statistics: &mut statistic,
             async_apply_prewrite: false,
             raw_ext,
-            txn_status_cache: &TxnStatusCache::new_for_test(),
+            txn_status_cache: Arc::new(TxnStatusCache::new_for_test()),
         };
         let cmd: Command = cmd.into();
         let write_result = cmd.process_write(snap, context).unwrap();

--- a/src/storage/txn/commands/check_secondary_locks.rs
+++ b/src/storage/txn/commands/check_secondary_locks.rs
@@ -236,6 +236,8 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for CheckSecondaryLocks {
 
 #[cfg(test)]
 pub mod tests {
+    use std::sync::Arc;
+
     use concurrency_manager::ConcurrencyManager;
     use kvproto::kvrpcpb::Context;
     use tikv_util::deadline::Deadline;
@@ -278,7 +280,7 @@ pub mod tests {
                     statistics: &mut Default::default(),
                     async_apply_prewrite: false,
                     raw_ext: None,
-                    txn_status_cache: &TxnStatusCache::new_for_test(),
+                    txn_status_cache: Arc::new(TxnStatusCache::new_for_test()),
                 },
             )
             .unwrap();
@@ -317,7 +319,7 @@ pub mod tests {
                         statistics: &mut Default::default(),
                         async_apply_prewrite: false,
                         raw_ext: None,
-                        txn_status_cache: &TxnStatusCache::new_for_test(),
+                        txn_status_cache: Arc::new(TxnStatusCache::new_for_test()),
                     },
                 )
                 .unwrap();

--- a/src/storage/txn/commands/check_txn_status.rs
+++ b/src/storage/txn/commands/check_txn_status.rs
@@ -163,6 +163,8 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for CheckTxnStatus {
 
 #[cfg(test)]
 pub mod tests {
+    use std::sync::Arc;
+
     use concurrency_manager::ConcurrencyManager;
     use kvproto::kvrpcpb::{
         self, Context, LockInfo, PrewriteRequestPessimisticAction::*, WriteConflictReason,
@@ -226,7 +228,7 @@ pub mod tests {
                     statistics: &mut Default::default(),
                     async_apply_prewrite: false,
                     raw_ext: None,
-                    txn_status_cache: &TxnStatusCache::new_for_test(),
+                    txn_status_cache: Arc::new(TxnStatusCache::new_for_test()),
                 },
             )
             .unwrap();
@@ -280,7 +282,7 @@ pub mod tests {
                     statistics: &mut Default::default(),
                     async_apply_prewrite: false,
                     raw_ext: None,
-                    txn_status_cache: &TxnStatusCache::new_for_test(),
+                    txn_status_cache: Arc::new(TxnStatusCache::new_for_test()),
                 },
             )
             .map(|r| {

--- a/src/storage/txn/commands/compare_and_swap.rs
+++ b/src/storage/txn/commands/compare_and_swap.rs
@@ -222,7 +222,7 @@ mod tests {
             statistics: &mut statistic,
             async_apply_prewrite: false,
             raw_ext,
-            txn_status_cache: &TxnStatusCache::new_for_test(),
+            txn_status_cache: Arc::new(TxnStatusCache::new_for_test()),
         };
         let ret = cmd.cmd.process_write(snap, context)?;
         match ret.pr {
@@ -277,7 +277,7 @@ mod tests {
             statistics: &mut statistic,
             async_apply_prewrite: false,
             raw_ext,
-            txn_status_cache: &TxnStatusCache::new_for_test(),
+            txn_status_cache: Arc::new(TxnStatusCache::new_for_test()),
         };
         let cmd: Command = cmd.into();
         let write_result = cmd.process_write(snap, context).unwrap();

--- a/src/storage/txn/commands/flush.rs
+++ b/src/storage/txn/commands/flush.rs
@@ -217,7 +217,7 @@ impl Flush {
 
 #[cfg(test)]
 mod tests {
-    use std::assert_matches::assert_matches;
+    use std::{assert_matches::assert_matches, sync::Arc};
 
     use concurrency_manager::ConcurrencyManager;
     use kvproto::kvrpcpb::{Assertion, AssertionLevel, Context, ExtraOp};
@@ -300,7 +300,7 @@ mod tests {
             statistics: &mut statistics,
             async_apply_prewrite: false,
             raw_ext: None,
-            txn_status_cache: &TxnStatusCache::new_for_test(),
+            txn_status_cache: Arc::new(TxnStatusCache::new_for_test()),
         };
         let snapshot = engine.snapshot(Default::default()).unwrap();
         cmd.cmd.process_write(snapshot.clone(), context)

--- a/src/storage/txn/commands/mod.rs
+++ b/src/storage/txn/commands/mod.rs
@@ -642,7 +642,7 @@ pub struct WriteContext<'a, L: LockManager> {
     pub async_apply_prewrite: bool,
     pub raw_ext: Option<RawExt>,
     // use for apiv2
-    pub txn_status_cache: &'a TxnStatusCache,
+    pub txn_status_cache: Arc<TxnStatusCache>,
 }
 
 pub struct ReaderWithStats<'a, S: Snapshot> {
@@ -930,7 +930,7 @@ pub mod test_util {
             statistics,
             async_apply_prewrite: false,
             raw_ext: None,
-            txn_status_cache: &TxnStatusCache::new_for_test(),
+            txn_status_cache: Arc::new(TxnStatusCache::new_for_test()),
         };
         let ret = cmd.cmd.process_write(snap, context)?;
         let res = match ret.pr {
@@ -1091,7 +1091,7 @@ pub mod test_util {
             statistics,
             async_apply_prewrite: false,
             raw_ext: None,
-            txn_status_cache: &TxnStatusCache::new_for_test(),
+            txn_status_cache: Arc::new(TxnStatusCache::new_for_test()),
         };
 
         let ret = cmd.cmd.process_write(snap, context)?;
@@ -1117,7 +1117,7 @@ pub mod test_util {
             statistics,
             async_apply_prewrite: false,
             raw_ext: None,
-            txn_status_cache: &TxnStatusCache::new_for_test(),
+            txn_status_cache: Arc::new(TxnStatusCache::new_for_test()),
         };
 
         let ret = cmd.cmd.process_write(snap, context)?;

--- a/src/storage/txn/commands/pessimistic_rollback.rs
+++ b/src/storage/txn/commands/pessimistic_rollback.rs
@@ -127,6 +127,8 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for PessimisticRollback {
 
 #[cfg(test)]
 pub mod tests {
+    use std::sync::Arc;
+
     use concurrency_manager::ConcurrencyManager;
     use kvproto::kvrpcpb::Context;
     use tikv_util::deadline::Deadline;
@@ -173,7 +175,7 @@ pub mod tests {
             statistics: &mut Default::default(),
             async_apply_prewrite: false,
             raw_ext: None,
-            txn_status_cache: &TxnStatusCache::new_for_test(),
+            txn_status_cache: Arc::new(TxnStatusCache::new_for_test()),
         };
         let result = command.process_write(snapshot, write_context).unwrap();
         write(engine, &ctx, result.to_be_write.modifies);

--- a/src/storage/txn/commands/prewrite.rs
+++ b/src/storage/txn/commands/prewrite.rs
@@ -996,6 +996,8 @@ pub(in crate::storage::txn) fn fallback_1pc_locks(txn: &mut MvccTxn) {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use concurrency_manager::ConcurrencyManager;
     use engine_rocks::ReadPerfInstant;
     use engine_traits::CF_WRITE;
@@ -1670,7 +1672,7 @@ mod tests {
                     statistics: &mut Statistics::default(),
                     async_apply_prewrite: false,
                     raw_ext: None,
-                    txn_status_cache: &TxnStatusCache::new_for_test(),
+                    txn_status_cache: Arc::new(TxnStatusCache::new_for_test()),
                 }
             };
         }
@@ -1842,7 +1844,7 @@ mod tests {
                 statistics: &mut statistics,
                 async_apply_prewrite: case.async_apply_prewrite,
                 raw_ext: None,
-                txn_status_cache: &TxnStatusCache::new_for_test(),
+                txn_status_cache: Arc::new(TxnStatusCache::new_for_test()),
             };
             let mut engine = TestEngineBuilder::new().build().unwrap();
             let snap = engine.snapshot(Default::default()).unwrap();
@@ -1953,7 +1955,7 @@ mod tests {
             statistics: &mut statistics,
             async_apply_prewrite: false,
             raw_ext: None,
-            txn_status_cache: &TxnStatusCache::new_for_test(),
+            txn_status_cache: Arc::new(TxnStatusCache::new_for_test()),
         };
         let snap = engine.snapshot(Default::default()).unwrap();
         let result = cmd.cmd.process_write(snap, context).unwrap();
@@ -1982,7 +1984,7 @@ mod tests {
             statistics: &mut statistics,
             async_apply_prewrite: false,
             raw_ext: None,
-            txn_status_cache: &TxnStatusCache::new_for_test(),
+            txn_status_cache: Arc::new(TxnStatusCache::new_for_test()),
         };
         let snap = engine.snapshot(Default::default()).unwrap();
         let result = cmd.cmd.process_write(snap, context).unwrap();
@@ -2066,7 +2068,7 @@ mod tests {
             statistics: &mut statistics,
             async_apply_prewrite: false,
             raw_ext: None,
-            txn_status_cache: &TxnStatusCache::new_for_test(),
+            txn_status_cache: Arc::new(TxnStatusCache::new_for_test()),
         };
         let snap = engine.snapshot(Default::default()).unwrap();
         let result = cmd.cmd.process_write(snap, context).unwrap();
@@ -2099,7 +2101,7 @@ mod tests {
             statistics: &mut statistics,
             async_apply_prewrite: false,
             raw_ext: None,
-            txn_status_cache: &TxnStatusCache::new_for_test(),
+            txn_status_cache: Arc::new(TxnStatusCache::new_for_test()),
         };
         let snap = engine.snapshot(Default::default()).unwrap();
         let result = cmd.cmd.process_write(snap, context).unwrap();
@@ -2370,7 +2372,7 @@ mod tests {
             statistics: &mut statistics,
             async_apply_prewrite: false,
             raw_ext: None,
-            txn_status_cache: &TxnStatusCache::new_for_test(),
+            txn_status_cache: Arc::new(TxnStatusCache::new_for_test()),
         };
         let snap = engine.snapshot(Default::default()).unwrap();
         assert!(prewrite_cmd.cmd.process_write(snap, context).is_err());
@@ -2395,7 +2397,7 @@ mod tests {
             statistics: &mut statistics,
             async_apply_prewrite: false,
             raw_ext: None,
-            txn_status_cache: &TxnStatusCache::new_for_test(),
+            txn_status_cache: Arc::new(TxnStatusCache::new_for_test()),
         };
         let snap = engine.snapshot(Default::default()).unwrap();
         assert!(prewrite_cmd.cmd.process_write(snap, context).is_err());
@@ -2602,7 +2604,7 @@ mod tests {
             statistics: &mut statistics,
             async_apply_prewrite: false,
             raw_ext: None,
-            txn_status_cache: &TxnStatusCache::new_for_test(),
+            txn_status_cache: Arc::new(TxnStatusCache::new_for_test()),
         };
         let snap = engine.snapshot(Default::default()).unwrap();
         let res = prewrite_cmd.cmd.process_write(snap, context).unwrap();

--- a/src/storage/txn/commands/prewrite.rs
+++ b/src/storage/txn/commands/prewrite.rs
@@ -502,7 +502,10 @@ impl<K: PrewriteKind> Prewriter<K> {
         // Handle special cases about retried prewrite requests for pessimistic
         // transactions.
         if let TransactionKind::Pessimistic(_) = self.kind.txn_kind() {
-            if let Some(commit_ts) = context.txn_status_cache.get_no_promote(self.start_ts) {
+            if let Some(commit_ts) = context
+                .txn_status_cache
+                .get_committed_no_promote(self.start_ts)
+            {
                 fail_point!("before_prewrite_txn_status_cache_hit");
                 if self.ctx.is_retry_request {
                     MVCC_PREWRITE_REQUEST_AFTER_COMMIT_COUNTER_VEC

--- a/src/storage/txn/commands/txn_heart_beat.rs
+++ b/src/storage/txn/commands/txn_heart_beat.rs
@@ -109,6 +109,8 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for TxnHeartBeat {
 
 #[cfg(test)]
 pub mod tests {
+    use std::sync::Arc;
+
     use concurrency_manager::ConcurrencyManager;
     use kvproto::kvrpcpb::Context;
     use tikv_util::deadline::Deadline;
@@ -153,7 +155,7 @@ pub mod tests {
                     statistics: &mut Default::default(),
                     async_apply_prewrite: false,
                     raw_ext: None,
-                    txn_status_cache: &TxnStatusCache::new_for_test(),
+                    txn_status_cache: Arc::new(TxnStatusCache::new_for_test()),
                 },
             )
             .unwrap();
@@ -196,7 +198,7 @@ pub mod tests {
                         statistics: &mut Default::default(),
                         async_apply_prewrite: false,
                         raw_ext: None,
-                        txn_status_cache: &TxnStatusCache::new_for_test(),
+                        txn_status_cache: Arc::new(TxnStatusCache::new_for_test()),
                     },
                 )
                 .is_err()

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -2084,9 +2084,8 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         }
     }
 
-    #[cfg(test)]
-    pub fn get_txn_status_cache(&self) -> &TxnStatusCache {
-        &self.inner.txn_status_cache
+    pub fn get_txn_status_cache(&self) -> Arc<TxnStatusCache> {
+        self.inner.txn_status_cache.clone()
     }
 }
 

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -284,7 +284,7 @@ struct TxnSchedulerInner<L: LockManager> {
     resource_manager: Option<Arc<ResourceGroupManager>>,
     feature_gate: FeatureGate,
 
-    txn_status_cache: TxnStatusCache,
+    txn_status_cache: Arc<TxnStatusCache>,
 
     memory_quota: Arc<MemoryQuota>,
 }
@@ -442,6 +442,7 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         feature_gate: FeatureGate,
         resource_ctl: Option<Arc<ResourceController>>,
         resource_manager: Option<Arc<ResourceGroupManager>>,
+        txn_status_cache: Arc<TxnStatusCache>,
     ) -> Self {
         let t = Instant::now_coarse();
         let mut task_slots = Vec::with_capacity(TASKS_SLOTS_NUM);
@@ -479,7 +480,7 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
             quota_limiter,
             resource_manager,
             feature_gate,
-            txn_status_cache: TxnStatusCache::new(config.txn_status_cache_capacity),
+            txn_status_cache,
             memory_quota: Arc::new(MemoryQuota::new(config.memory_quota.0 as _)),
         });
 
@@ -1302,7 +1303,7 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
                 statistics: &mut sched_details.stat,
                 async_apply_prewrite: txn_scheduler.inner.enable_async_apply_prewrite,
                 raw_ext,
-                txn_status_cache: &txn_scheduler.inner.txn_status_cache,
+                txn_status_cache: txn_scheduler.inner.txn_status_cache.clone(),
             };
             let begin_instant = Instant::now();
             let res = unsafe {
@@ -2242,6 +2243,7 @@ mod tests {
                 latest_feature_gate(),
                 Some(controller),
                 Some(resource_manager),
+                Arc::new(TxnStatusCache::new_for_test()),
             ),
             engine,
         )
@@ -2592,6 +2594,7 @@ mod tests {
             feature_gate.clone(),
             Some(controller),
             Some(resource_manager),
+            Arc::new(TxnStatusCache::new_for_test()),
         );
         // Use sync mode if pipelined_pessimistic_lock is false.
         assert_eq!(scheduler.pessimistic_lock_mode(), PessimisticLockMode::Sync);

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -894,7 +894,9 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
             // remain not updated after receiving signal from the callback.
             let now = std::time::SystemTime::now();
             for (start_ts, commit_ts) in known_txn_status {
-                self.inner.txn_status_cache.insert(start_ts, commit_ts, now);
+                self.inner
+                    .txn_status_cache
+                    .insert_committed(start_ts, commit_ts, now);
             }
         }
 

--- a/src/storage/txn/txn_status_cache.rs
+++ b/src/storage/txn/txn_status_cache.rs
@@ -346,7 +346,7 @@ impl TxnStatusCache {
         )
     }
 
-    #[cfg(test)]
+    // Not #[cfg(test)]: needed for integration tests in separate files
     pub fn new_for_test() -> Self {
         // 1M capacity should be enough for tests.
         Self::with_slots_and_time_limit(

--- a/src/storage/txn/txn_status_cache.rs
+++ b/src/storage/txn/txn_status_cache.rs
@@ -455,7 +455,7 @@ impl TxnStatusCache {
                 let mut normal_cache = self.normal_cache[slot_index].lock();
                 previous_size = normal_cache.size();
                 previous_allocated = normal_cache.internal_allocated_capacity();
-                normal_cache.insert_if_not_exist(start_ts, entry);
+                normal_cache.insert(start_ts, entry);
                 after_size = normal_cache.size();
                 after_allocated = normal_cache.internal_allocated_capacity();
 

--- a/src/storage/txn/txn_status_cache.rs
+++ b/src/storage/txn/txn_status_cache.rs
@@ -189,9 +189,11 @@ impl TxnState {
         if rolled_back {
             TxnState::RolledBack
         } else if commit_ts.is_zero() {
-            TxnState::Ongoing(max(start_ts, min_commit_ts))
+            TxnState::Ongoing {
+                min_commit_ts: max(start_ts, min_commit_ts),
+            }
         } else {
-            TxnState::Committed(commit_ts)
+            TxnState::Committed { commit_ts }
         }
     }
 }

--- a/src/storage/txn/txn_status_cache.rs
+++ b/src/storage/txn/txn_status_cache.rs
@@ -104,7 +104,32 @@
 //! lock; and for write requests, if it finds the transaction of that lock is
 //! already committed, it can merge together the resolve-lock-committing and the
 //! write operation that the request needs to perform.
-
+//!
+//! ## Design Update-1: Dual-Cache System
+//!
+//! Goal: maximize all TiKV nodes' awareness of large pipelined transactions
+//! during their lifetime, i.e. from their first writes to all locks being
+//! committed. This is crucial to resolved-ts resolver to handle locks belonging
+//! to large transactions.
+//!
+//! The txn_status_cache is then split into two independent parts.
+//! 1. `normal_cache`: For most transactions, including committed and rolled
+//!    back transactions.
+//! 2. `large_txn_cache`: Specifically for ongoing large transactions.
+//!
+//! ### Key characteristics:
+//!
+//! - Large Transaction Identification: Large transactions are identified if
+//!   their `start_ts` and `min_commit_ts` differ. Non-large transactions which
+//!   request to be cached in the cache can also be treated as large
+//!   transactions, as they imply their min_commit_ts are useful.
+//!
+//! - Prioritized Caching: The `large_txn_cache` has a higher priority when
+//!   upserting and retrieving transaction status.
+//!
+//! This dual-cache design allows for more efficient handling of both normal and
+//! large transactions, preventing either type from dominating the cache and
+//! evicting information about transactions of the other type.
 use std::{
     sync::{atomic::AtomicU64, Arc},
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -122,18 +147,35 @@ use crate::storage::metrics::*;
 
 const TXN_STATUS_CACHE_SLOTS: usize = 128;
 
-/// An cache item should be kept for at least this time.
+/// A cache item should be kept for at least this time.
 /// Actually this should be guaranteed only for committed transactions. See
 /// [this section](#
 /// for-filtering-out-unwanted-late-arrived-stale-prewrite-requests) for details
 /// about why this is needed.
 const CACHE_ITEMS_REQUIRED_KEEP_TIME: Duration = Duration::from_secs(30);
+const CACHE_ITEMS_REQUIRED_KEEP_TIME_FOR_LARGE_TXNS: Duration = Duration::from_secs(30);
 
-struct CacheEntry {
-    commit_ts: TimeStamp,
+pub struct CacheEntry {
+    state: TxnState,
     /// The system timestamp in milliseconds when the entry is inserted to the
     /// cache.
-    insert_time: u64,
+    update_time: u64,
+}
+
+impl CacheEntry {
+    pub(crate) fn commit_ts(&self) -> Option<TimeStamp> {
+        match self.state {
+            TxnState::Committed(ts) => Some(ts),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TxnState {
+    Ongoing(TimeStamp),   // min_commit_ts
+    Committed(TimeStamp), // commit_ts
+    RolledBack,
 }
 
 /// Defines the policy to evict expired entries from the cache.
@@ -192,7 +234,7 @@ impl lru::EvictPolicy<TimeStamp, CacheEntry> for TxnStatusCacheEvictPolicy {
         // If it's long enough, remove it.
         if let Some((_, v)) = get_tail_entry.get_tail_entry() {
             if self.now().duration_since(UNIX_EPOCH).unwrap().as_millis() as u64
-                > self.required_keep_time_millis + v.insert_time
+                > self.required_keep_time_millis + v.update_time
             {
                 return true;
             }
@@ -219,7 +261,10 @@ type TxnStatusCacheSlot =
 /// Note that the `TxnStatusCache` updates metrics in some operations assuming
 /// there's at most one instance of `TxnStatusCache` in a process.
 pub struct TxnStatusCache {
-    slots: Vec<CachePadded<Mutex<TxnStatusCacheSlot>>>,
+    // default cache for committed txns
+    normal_cache: Vec<CachePadded<Mutex<TxnStatusCacheSlot>>>,
+    // for large txns, or any txn whose min_commit_ts needs to be cached
+    large_txn_cache: Vec<CachePadded<Mutex<TxnStatusCacheSlot>>>,
     is_enabled: bool,
 }
 
@@ -229,24 +274,28 @@ impl TxnStatusCache {
     fn new_impl(
         slots: usize,
         required_keep_time: Duration,
+        large_txn_required_keep_time: Duration,
         capacity: usize,
+        large_txn_capacity: usize,
         simulated_system_time: Option<Arc<AtomicU64>>,
     ) -> Self {
         if capacity == 0 {
             return Self {
-                slots: vec![],
+                normal_cache: vec![],
+                large_txn_cache: vec![],
                 is_enabled: false,
             };
         }
 
         // The limit of the LruCache of each slot.
         let allowed_capacity_per_slot = capacity / slots;
+        let capacity_per_slot_for_large_txns = large_txn_capacity / slots;
         // The total memory allocated initially by the LruCache's internal data
         // structure for all slots.
 
         let mut initial_allocated_capacity_total = 0;
         let res = Self {
-            slots: (0..slots)
+            normal_cache: (0..slots)
                 .map(|_| {
                     let cache = LruCache::new(
                         allowed_capacity_per_slot,
@@ -254,6 +303,22 @@ impl TxnStatusCache {
                         lru::CountTracker::default(),
                         TxnStatusCacheEvictPolicy::new(
                             required_keep_time,
+                            simulated_system_time.clone(),
+                        ),
+                    );
+                    let allocated_capacity = cache.internal_allocated_capacity();
+                    initial_allocated_capacity_total += allocated_capacity;
+                    Mutex::new(cache).into()
+                })
+                .collect(),
+            large_txn_cache: (0..slots)
+                .map(|_| {
+                    let cache = LruCache::new(
+                        capacity_per_slot_for_large_txns,
+                        0,
+                        lru::CountTracker::default(),
+                        TxnStatusCacheEvictPolicy::new(
+                            large_txn_required_keep_time,
                             simulated_system_time.clone(),
                         ),
                     );
@@ -274,6 +339,7 @@ impl TxnStatusCache {
         Self::with_slots_and_time_limit(
             TXN_STATUS_CACHE_SLOTS,
             CACHE_ITEMS_REQUIRED_KEEP_TIME,
+            CACHE_ITEMS_REQUIRED_KEEP_TIME_FOR_LARGE_TXNS,
             capacity,
         )
     }
@@ -281,15 +347,28 @@ impl TxnStatusCache {
     #[cfg(test)]
     pub fn new_for_test() -> Self {
         // 1M capacity should be enough for tests.
-        Self::with_slots_and_time_limit(16, CACHE_ITEMS_REQUIRED_KEEP_TIME, 1 << 20)
+        Self::with_slots_and_time_limit(
+            16,
+            CACHE_ITEMS_REQUIRED_KEEP_TIME,
+            CACHE_ITEMS_REQUIRED_KEEP_TIME_FOR_LARGE_TXNS,
+            1 << 20,
+        )
     }
 
     pub fn with_slots_and_time_limit(
         slots: usize,
         required_keep_time: Duration,
+        large_txn_required_keep_time: Duration,
         capacity: usize,
     ) -> Self {
-        Self::new_impl(slots, required_keep_time, capacity, None)
+        Self::new_impl(
+            slots,
+            required_keep_time,
+            large_txn_required_keep_time,
+            capacity,
+            capacity,
+            None,
+        )
     }
 
     /// Create a `TxnStatusCache` instance for test purpose, with simulating
@@ -301,13 +380,15 @@ impl TxnStatusCache {
     #[cfg(test)]
     fn with_simulated_system_time(
         slots: usize,
-        requried_keep_time: Duration,
+        required_keep_time: Duration,
         capacity: usize,
     ) -> (Self, Arc<AtomicU64>) {
         let system_time = Arc::new(AtomicU64::new(0));
         let res = Self::new_impl(
             slots,
-            requried_keep_time,
+            required_keep_time,
+            CACHE_ITEMS_REQUIRED_KEEP_TIME_FOR_LARGE_TXNS,
+            capacity,
             capacity,
             Some(system_time.clone()),
         );
@@ -315,78 +396,168 @@ impl TxnStatusCache {
     }
 
     fn slot_index(&self, start_ts: TimeStamp) -> usize {
-        fxhash::hash(&start_ts) % self.slots.len()
+        fxhash::hash(&start_ts) % self.normal_cache.len()
     }
 
-    /// Insert a transaction status into the cache. The current system time
-    /// should be passed from outside to avoid getting system time repeatedly
-    /// when multiple items is being inserted.
+    /// Insert a transaction status into the cache, or update it. The current
+    /// system time should be passed from outside to avoid getting system time
+    /// repeatedly when multiple items are being inserted.
     ///
     /// If the transaction's information is already in the cache, it will
     /// **NOT** be promoted to the most-recent place of the internal LRU.
-    pub fn insert(&self, start_ts: TimeStamp, commit_ts: TimeStamp, now: SystemTime) {
+    pub fn upsert(&self, start_ts: TimeStamp, state: TxnState, now: SystemTime) {
         if !self.is_enabled {
             return;
         }
 
-        let insert_time = now.duration_since(UNIX_EPOCH).unwrap().as_millis() as u64;
-        let mut slot = self.slots[self.slot_index(start_ts)].lock();
-        let previous_size = slot.size();
-        let previous_allocated = slot.internal_allocated_capacity();
-        slot.insert_if_not_exist(
-            start_ts,
-            CacheEntry {
-                commit_ts,
-                insert_time,
-            },
-        );
-        let size = slot.size();
-        let allocated = slot.internal_allocated_capacity();
-        // Update statistics.
-        // CAUTION: Assuming that only one TxnStatusCache instance is in a TiKV process.
+        let update_time = now.duration_since(UNIX_EPOCH).unwrap().as_millis() as u64;
+        let entry = CacheEntry {
+            state: state.clone(),
+            update_time,
+        };
+        let slot_index = self.slot_index(start_ts);
+
+        let mut previous_size = 0;
+        let mut after_size = 0;
+        let mut previous_allocated = 0;
+        let mut after_allocated = 0;
+        match &state {
+            TxnState::Ongoing(min_commit_ts) => {
+                // The large_txn_cache takes precedence over the normal_cache in the retrieval
+                // process.
+                if *min_commit_ts > start_ts {
+                    // This case implies that min_commit_ts would be useful, thus the entry is put
+                    // in the large cache.
+                    let mut large_txn_cache = self.large_txn_cache[slot_index].lock();
+                    previous_size = large_txn_cache.size();
+                    previous_allocated = large_txn_cache.internal_allocated_capacity();
+                    if let Some(existing_entry) = large_txn_cache.get_mut(&start_ts) {
+                        // don't update committed or rolled back txns.
+                        if let TxnState::Ongoing(_) = existing_entry.state {
+                            existing_entry.state = state;
+                            existing_entry.update_time = update_time;
+                        }
+                    } else {
+                        large_txn_cache.insert(start_ts, entry);
+                    }
+                    after_size = large_txn_cache.size();
+                    after_allocated = large_txn_cache.internal_allocated_capacity();
+                } else {
+                    let mut normal_cache = self.normal_cache[slot_index].lock();
+                    previous_size = normal_cache.size();
+                    previous_allocated = normal_cache.internal_allocated_capacity();
+                    normal_cache.insert(start_ts, entry);
+                    after_size = normal_cache.size();
+                    after_allocated = normal_cache.internal_allocated_capacity();
+                }
+            }
+            TxnState::Committed(_) | TxnState::RolledBack => {
+                let mut normal_cache = self.normal_cache[slot_index].lock();
+                previous_size = normal_cache.size();
+                previous_allocated = normal_cache.internal_allocated_capacity();
+                normal_cache.insert_if_not_exist(start_ts, entry);
+                after_size = normal_cache.size();
+                after_allocated = normal_cache.internal_allocated_capacity();
+
+                let mut large_cache = self.large_txn_cache[slot_index].lock();
+                if let Some(existing_entry) = large_cache.get_mut(&start_ts) {
+                    // don't update committed or rolled back txns.
+                    if let TxnState::Ongoing(_) = existing_entry.state {
+                        existing_entry.state = state;
+                        existing_entry.update_time = update_time;
+                    }
+                }
+            }
+        }
         SCHED_TXN_STATUS_CACHE_SIZE
             .used
-            .add(size as i64 - previous_size as i64);
+            .add(after_size as i64 - previous_size as i64);
         SCHED_TXN_STATUS_CACHE_SIZE
             .allocated
-            .add(allocated as i64 - previous_allocated as i64);
+            .add(after_allocated as i64 - previous_allocated as i64);
     }
 
-    /// Try to get an item from the cache, without promoting the item (if
-    /// exists) to the most recent place.
-    pub fn get_no_promote(&self, start_ts: TimeStamp) -> Option<TimeStamp> {
+    /// Insert a committed txn into the normal cache.
+    pub fn insert_committed(&self, start_ts: TimeStamp, commit_ts: TimeStamp, now: SystemTime) {
+        let state = TxnState::Committed(commit_ts);
+        self.upsert(start_ts, state, now);
+    }
+
+    pub fn get(&self, start_ts: TimeStamp) -> Option<TxnState> {
         if !self.is_enabled {
             return None;
         }
 
-        let slot = self.slots[self.slot_index(start_ts)].lock();
-        slot.get_no_promote(&start_ts).map(|entry| entry.commit_ts)
+        let slot_index = self.slot_index(start_ts);
+
+        // large txn cache should be queried first, because it has a higher priority
+        // when upserting. It's possible for a start_ts to exist in both caches.
+        // The one in large_txn_cache is more up-to-date.
+        let mut large_txn_cache = self.large_txn_cache[slot_index].lock();
+        if let Some(entry) = large_txn_cache.get(&start_ts) {
+            return Some(entry.state.clone());
+        }
+
+        let mut normal_cache = self.normal_cache[slot_index].lock();
+        if let Some(entry) = normal_cache.get(&start_ts) {
+            return Some(entry.state.clone());
+        }
+
+        None
     }
 
-    pub fn get(&self, start_ts: TimeStamp) -> Option<TimeStamp> {
+    /// Try to get the committed txn from the normal cache, without promoting
+    /// the item (if exists) to the most recent place.
+    /// If the txn is ongoing or rolled back, returns None.
+    pub fn get_committed_no_promote(&self, start_ts: TimeStamp) -> Option<TimeStamp> {
         if !self.is_enabled {
             return None;
         }
 
-        let mut slot = self.slots[self.slot_index(start_ts)].lock();
-        slot.get(&start_ts).map(|entry| entry.commit_ts)
+        let slot = self.normal_cache[self.slot_index(start_ts)].lock();
+        slot.get_no_promote(&start_ts)
+            .and_then(|entry| entry.commit_ts())
     }
 
-    /// Remove an entry from the cache. We usually don't need to remove anything
-    /// from the `TxnStatusCache`, but it's useful in tests to construct cache-
-    /// miss cases.
+    /// Try to get the committed txn from the normal cache.
+    /// If the txn is ongoing or rolled back, returns None.
+    pub fn get_committed(&self, start_ts: TimeStamp) -> Option<TimeStamp> {
+        if !self.is_enabled {
+            return None;
+        }
+
+        let mut slot = self.normal_cache[self.slot_index(start_ts)].lock();
+        slot.get(&start_ts).and_then(|entry| entry.commit_ts())
+    }
+
+    /// Removes a txn from the normal cache. We usually don't need to
+    /// remove anything from the normal cache, but it's useful in tests
+    /// to construct cache-miss cases.
+    /// Return its commit_ts if it's committed; return None otherwise.
     #[cfg(test)]
-    pub fn remove(&self, start_ts: TimeStamp) -> Option<TimeStamp> {
+    pub fn remove_normal(&self, start_ts: TimeStamp) -> Option<TimeStamp> {
         if !self.is_enabled {
             return None;
         }
 
         let res = {
-            let mut slot = self.slots[self.slot_index(start_ts)].lock();
-            slot.remove(&start_ts).map(|e| e.commit_ts)
+            let mut slot = self.normal_cache[self.slot_index(start_ts)].lock();
+            slot.remove(&start_ts).and_then(|e| e.commit_ts())
         };
-        debug_assert!(self.get_no_promote(start_ts).is_none());
+        debug_assert!(self.get_committed_no_promote(start_ts).is_none());
         res
+    }
+
+    /// Remove a txn from the large-txn cache.
+    /// This could happen when the large txn finishes its
+    /// secondary commit phase, i.e. all locks have been cleared. There is no
+    /// need to keep this txn in cache any longer.
+    pub fn remove_large_txn(&self, start_ts: TimeStamp) -> Option<CacheEntry> {
+        if !self.is_enabled {
+            return None;
+        }
+        let mut slot = self.large_txn_cache[self.slot_index(start_ts)].lock();
+        slot.remove(&start_ts)
     }
 }
 
@@ -414,7 +585,7 @@ mod tests {
         // Spread these items evenly in a specific time limit, so that every time
         // a new item is inserted, an item will be popped out.
         for i in 1..=init_size {
-            c.insert(
+            c.insert_committed(
                 (i as u64).into(),
                 (i as u64 + 1).into(),
                 start_time + Duration::from_millis(i as u64),
@@ -431,7 +602,7 @@ mod tests {
                     .as_millis() as u64,
                 Ordering::Release,
             );
-            c.insert(
+            c.insert_committed(
                 current_time_shift.into(),
                 (current_time_shift + 1).into(),
                 simulated_now,
@@ -445,11 +616,12 @@ mod tests {
         let c = TxnStatusCache::with_slots_and_time_limit(
             TXN_STATUS_CACHE_SLOTS,
             CACHE_ITEMS_REQUIRED_KEEP_TIME,
+            CACHE_ITEMS_REQUIRED_KEEP_TIME_FOR_LARGE_TXNS,
             1 << 20,
         );
         let now = SystemTime::now();
         for i in 1..=init_size {
-            c.insert(
+            c.insert_committed(
                 (i as u64).into(),
                 (i as u64 + 1).into(),
                 now + Duration::from_millis(i as u64),
@@ -458,7 +630,7 @@ mod tests {
         let rand_range = if init_size == 0 { 10000 } else { init_size } as u64;
         b.iter(|| {
             let ts = rand::thread_rng().gen_range(0u64, rand_range);
-            let res = c.get_no_promote(ts.into());
+            let res = c.get_committed_no_promote(ts.into());
             test::black_box(&res);
         })
     }
@@ -633,7 +805,7 @@ mod tests {
         );
         let start_time = SystemTime::now();
         for i in 1..=init_size {
-            c.insert(
+            c.insert_committed(
                 (i as u64).into(),
                 (i as u64 + 1).into(),
                 start_time + Duration::from_millis(i as u64),
@@ -665,9 +837,9 @@ mod tests {
             );
 
             if get_before_insert {
-                test::black_box(c.get_no_promote(time_shift.into()));
+                test::black_box(c.get_committed_no_promote(time_shift.into()));
             }
-            c.insert(time_shift.into(), (time_shift + 1).into(), now);
+            c.insert_committed(time_shift.into(), (time_shift + 1).into(), now);
             test::black_box(&c);
         });
     }
@@ -696,31 +868,31 @@ mod tests {
     #[test]
     fn test_insert_and_get() {
         let c = TxnStatusCache::new_for_test();
-        assert!(c.get_no_promote(1.into()).is_none());
+        assert!(c.get_committed_no_promote(1.into()).is_none());
 
         let now = SystemTime::now();
 
-        c.insert(1.into(), 2.into(), now);
-        assert_eq!(c.get_no_promote(1.into()).unwrap(), 2.into());
-        c.insert(3.into(), 4.into(), now);
-        assert_eq!(c.get_no_promote(3.into()).unwrap(), 4.into());
+        c.insert_committed(1.into(), 2.into(), now);
+        assert_eq!(c.get_committed_no_promote(1.into()).unwrap(), 2.into());
+        c.insert_committed(3.into(), 4.into(), now);
+        assert_eq!(c.get_committed_no_promote(3.into()).unwrap(), 4.into());
 
         // This won't actually happen, since a transaction will never have commit info
         // with two different commit_ts. We just use this to check replacing
         // won't happen.
-        c.insert(1.into(), 4.into(), now);
-        assert_eq!(c.get_no_promote(1.into()).unwrap(), 2.into());
+        c.insert_committed(1.into(), 4.into(), now);
+        assert_eq!(c.get_committed_no_promote(1.into()).unwrap(), 2.into());
 
         let mut start_ts_list: Vec<_> = (1..100).step_by(2).map(TimeStamp::from).collect();
         start_ts_list.shuffle(&mut rand::thread_rng());
         for &start_ts in &start_ts_list {
             let commit_ts = start_ts.next();
-            c.insert(start_ts, commit_ts, now);
+            c.insert_committed(start_ts, commit_ts, now);
         }
         start_ts_list.shuffle(&mut rand::thread_rng());
         for &start_ts in &start_ts_list {
             let commit_ts = start_ts.next();
-            assert_eq!(c.get_no_promote(start_ts).unwrap(), commit_ts);
+            assert_eq!(c.get_committed_no_promote(start_ts).unwrap(), commit_ts);
         }
     }
 
@@ -743,54 +915,54 @@ mod tests {
             Duration::from_millis(1)
         );
 
-        c.insert(1.into(), 2.into(), now());
+        c.insert_committed(1.into(), 2.into(), now());
         set_time(1);
-        c.insert(3.into(), 4.into(), now());
+        c.insert_committed(3.into(), 4.into(), now());
         set_time(2);
-        c.insert(5.into(), 6.into(), now());
+        c.insert_committed(5.into(), 6.into(), now());
         // Size should be calculated by count.
-        assert_eq!(c.slots[0].lock().size(), 3);
+        assert_eq!(c.normal_cache[0].lock().size(), 3);
 
         // Insert entry 1 again. So if entry 1 is the first one to be popped out, it
         // verifies that inserting an existing key won't promote it.
-        c.insert(1.into(), 2.into(), now());
+        c.insert_committed(1.into(), 2.into(), now());
 
         // All the 3 entries are kept
-        assert_eq!(c.get_no_promote(1.into()).unwrap(), 2.into());
-        assert_eq!(c.get_no_promote(3.into()).unwrap(), 4.into());
-        assert_eq!(c.get_no_promote(5.into()).unwrap(), 6.into());
+        assert_eq!(c.get_committed_no_promote(1.into()).unwrap(), 2.into());
+        assert_eq!(c.get_committed_no_promote(3.into()).unwrap(), 4.into());
+        assert_eq!(c.get_committed_no_promote(5.into()).unwrap(), 6.into());
 
         set_time(1001);
-        c.insert(7.into(), 8.into(), now());
+        c.insert_committed(7.into(), 8.into(), now());
         // Entry 1 will be popped out.
-        assert!(c.get_no_promote(1.into()).is_none());
-        assert_eq!(c.get_no_promote(3.into()).unwrap(), 4.into());
-        assert_eq!(c.get_no_promote(5.into()).unwrap(), 6.into());
+        assert!(c.get_committed_no_promote(1.into()).is_none());
+        assert_eq!(c.get_committed_no_promote(3.into()).unwrap(), 4.into());
+        assert_eq!(c.get_committed_no_promote(5.into()).unwrap(), 6.into());
         set_time(1004);
-        c.insert(9.into(), 10.into(), now());
-        // It pops more than 1 entries if there are many expired items at the tail.
+        c.insert_committed(9.into(), 10.into(), now());
+        // It pops more than 1 entry if there are many expired items at the tail.
         // Entry 3 and 5 will be popped out.
-        assert!(c.get_no_promote(1.into()).is_none());
-        assert!(c.get_no_promote(3.into()).is_none());
-        assert!(c.get_no_promote(5.into()).is_none());
-        assert_eq!(c.get_no_promote(7.into()).unwrap(), 8.into());
-        assert_eq!(c.get_no_promote(9.into()).unwrap(), 10.into());
+        assert!(c.get_committed_no_promote(1.into()).is_none());
+        assert!(c.get_committed_no_promote(3.into()).is_none());
+        assert!(c.get_committed_no_promote(5.into()).is_none());
+        assert_eq!(c.get_committed_no_promote(7.into()).unwrap(), 8.into());
+        assert_eq!(c.get_committed_no_promote(9.into()).unwrap(), 10.into());
 
         // Now the cache's contents are:
         // 7@1001, 9@1004
         // Test `get` promotes an entry and entries are not in order on insert time.
-        assert_eq!(c.get(7.into()).unwrap(), 8.into());
+        assert_eq!(c.get_committed(7.into()).unwrap(), 8.into());
         set_time(2003);
-        c.insert(11.into(), 12.into(), now());
-        assert_eq!(c.get_no_promote(7.into()).unwrap(), 8.into());
-        assert_eq!(c.get_no_promote(9.into()).unwrap(), 10.into());
-        assert_eq!(c.get_no_promote(11.into()).unwrap(), 12.into());
+        c.insert_committed(11.into(), 12.into(), now());
+        assert_eq!(c.get_committed_no_promote(7.into()).unwrap(), 8.into());
+        assert_eq!(c.get_committed_no_promote(9.into()).unwrap(), 10.into());
+        assert_eq!(c.get_committed_no_promote(11.into()).unwrap(), 12.into());
 
         set_time(2005);
-        c.insert(13.into(), 14.into(), now());
-        assert!(c.get_no_promote(7.into()).is_none());
-        assert!(c.get_no_promote(9.into()).is_none());
-        assert_eq!(c.get_no_promote(11.into()).unwrap(), 12.into());
+        c.insert_committed(13.into(), 14.into(), now());
+        assert!(c.get_committed_no_promote(7.into()).is_none());
+        assert!(c.get_committed_no_promote(9.into()).is_none());
+        assert_eq!(c.get_committed_no_promote(11.into()).unwrap(), 12.into());
 
         // Now the cache's contents are:
         // 11@2003, 13@2005
@@ -799,50 +971,50 @@ mod tests {
         // the content, it still check the tail to see if anything can be
         // evicted.
         set_time(3004);
-        c.insert(13.into(), 14.into(), now());
-        assert!(c.get_no_promote(11.into()).is_none());
-        assert_eq!(c.get_no_promote(13.into()).unwrap(), 14.into());
+        c.insert_committed(13.into(), 14.into(), now());
+        assert!(c.get_committed_no_promote(11.into()).is_none());
+        assert_eq!(c.get_committed_no_promote(13.into()).unwrap(), 14.into());
 
         set_time(3006);
-        c.insert(13.into(), 14.into(), now());
-        assert!(c.get_no_promote(13.into()).is_none());
+        c.insert_committed(13.into(), 14.into(), now());
+        assert!(c.get_committed_no_promote(13.into()).is_none());
 
         // Now the cache is empty.
-        c.insert(15.into(), 16.into(), now());
+        c.insert_committed(15.into(), 16.into(), now());
         set_time(3008);
-        c.insert(17.into(), 18.into(), now());
+        c.insert_committed(17.into(), 18.into(), now());
         // Test inserting existed entry doesn't promote it.
         // Re-insert 15.
         set_time(3009);
-        c.insert(15.into(), 16.into(), now());
+        c.insert_committed(15.into(), 16.into(), now());
         set_time(4007);
-        c.insert(19.into(), 20.into(), now());
+        c.insert_committed(19.into(), 20.into(), now());
         // 15's insert time is not updated, and is at the tail of the LRU, so it should
         // be popped.
-        assert!(c.get_no_promote(15.into()).is_none());
-        assert_eq!(c.get_no_promote(17.into()).unwrap(), 18.into());
+        assert!(c.get_committed_no_promote(15.into()).is_none());
+        assert_eq!(c.get_committed_no_promote(17.into()).unwrap(), 18.into());
 
         // Now the cache's contents are:
         // 17@3008, 19@4007
         // Test system time being changed, which can lead to current time being less
         // than entries' insert time.
         set_time(2000);
-        c.insert(21.into(), 22.into(), now());
-        assert_eq!(c.get_no_promote(17.into()).unwrap(), 18.into());
-        assert_eq!(c.get_no_promote(19.into()).unwrap(), 20.into());
-        assert_eq!(c.get_no_promote(21.into()).unwrap(), 22.into());
+        c.insert_committed(21.into(), 22.into(), now());
+        assert_eq!(c.get_committed_no_promote(17.into()).unwrap(), 18.into());
+        assert_eq!(c.get_committed_no_promote(19.into()).unwrap(), 20.into());
+        assert_eq!(c.get_committed_no_promote(21.into()).unwrap(), 22.into());
         set_time(3500);
-        c.insert(23.into(), 24.into(), now());
-        assert_eq!(c.get_no_promote(21.into()).unwrap(), 22.into());
-        assert_eq!(c.get(17.into()).unwrap(), 18.into());
-        assert_eq!(c.get(19.into()).unwrap(), 20.into());
-        assert_eq!(c.get(23.into()).unwrap(), 24.into());
+        c.insert_committed(23.into(), 24.into(), now());
+        assert_eq!(c.get_committed_no_promote(21.into()).unwrap(), 22.into());
+        assert_eq!(c.get_committed(17.into()).unwrap(), 18.into());
+        assert_eq!(c.get_committed(19.into()).unwrap(), 20.into());
+        assert_eq!(c.get_committed(23.into()).unwrap(), 24.into());
         // `get` promotes the entries, and entry 21 is put to the tail.
-        c.insert(23.into(), 24.into(), now());
-        assert_eq!(c.get_no_promote(17.into()).unwrap(), 18.into());
-        assert_eq!(c.get_no_promote(19.into()).unwrap(), 20.into());
-        assert!(c.get_no_promote(21.into()).is_none());
-        assert_eq!(c.get_no_promote(23.into()).unwrap(), 24.into());
+        c.insert_committed(23.into(), 24.into(), now());
+        assert_eq!(c.get_committed_no_promote(17.into()).unwrap(), 18.into());
+        assert_eq!(c.get_committed_no_promote(19.into()).unwrap(), 20.into());
+        assert!(c.get_committed_no_promote(21.into()).is_none());
+        assert_eq!(c.get_committed_no_promote(23.into()).unwrap(), 24.into());
 
         // Now the cache's contents are:
         // 17@3008, 19@4007, 23@3500
@@ -850,28 +1022,28 @@ mod tests {
         // the `TxnStatusCacheEvictPolicy` as they are fetched at different time.
         set_time(4009);
         // Insert with time 4007, but check with time 4009
-        c.insert(25.into(), 26.into(), now() - Duration::from_millis(2));
-        assert!(c.get_no_promote(17.into()).is_none());
-        assert_eq!(c.get_no_promote(19.into()).unwrap(), 20.into());
+        c.insert_committed(25.into(), 26.into(), now() - Duration::from_millis(2));
+        assert!(c.get_committed_no_promote(17.into()).is_none());
+        assert_eq!(c.get_committed_no_promote(19.into()).unwrap(), 20.into());
 
         // The cache's contents:
         // 19@4007, 23@3500, 25@4007
         set_time(4010);
-        c.insert(27.into(), 28.into(), now());
+        c.insert_committed(27.into(), 28.into(), now());
         // The cache's contents:
         // 19@4007, 23@3500, 25@4007, 27@4010
 
         // It's also possible to check with a lower time considering that system time
         // may be changed. Insert with time 5018, but check with time 5008
         set_time(5008);
-        c.insert(29.into(), 30.into(), now() + Duration::from_millis(10));
-        assert!(c.get_no_promote(19.into()).is_none());
-        assert!(c.get_no_promote(23.into()).is_none());
-        assert!(c.get_no_promote(25.into()).is_none());
-        assert_eq!(c.get_no_promote(27.into()).unwrap(), 28.into());
-        assert_eq!(c.get_no_promote(29.into()).unwrap(), 30.into());
+        c.insert_committed(29.into(), 30.into(), now() + Duration::from_millis(10));
+        assert!(c.get_committed_no_promote(19.into()).is_none());
+        assert!(c.get_committed_no_promote(23.into()).is_none());
+        assert!(c.get_committed_no_promote(25.into()).is_none());
+        assert_eq!(c.get_committed_no_promote(27.into()).unwrap(), 28.into());
+        assert_eq!(c.get_committed_no_promote(29.into()).unwrap(), 30.into());
 
-        // Now the the cache's contents are:
+        // Now the cache's contents are:
         // 27@4010, 29@5018
         // Considering the case that system time is being changed, it's even
         // possible that the entry being inserted is already expired
@@ -879,29 +1051,43 @@ mod tests {
         // entry will be dropped immediately or not. We just ensure it won't
         // trigger more troubles.
         set_time(7000);
-        c.insert(31.into(), 32.into(), now() - Duration::from_millis(1001));
-        assert!(c.get_no_promote(27.into()).is_none());
-        assert!(c.get_no_promote(29.into()).is_none());
-        assert!(c.get_no_promote(31.into()).is_none());
-        assert_eq!(c.slots[0].lock().size(), 0);
+        c.insert_committed(31.into(), 32.into(), now() - Duration::from_millis(1001));
+        assert!(c.get_committed_no_promote(27.into()).is_none());
+        assert!(c.get_committed_no_promote(29.into()).is_none());
+        assert!(c.get_committed_no_promote(31.into()).is_none());
+        assert_eq!(c.normal_cache[0].lock().size(), 0);
     }
 
     #[test]
     fn test_setting_capacity() {
-        let c = TxnStatusCache::new_impl(2, Duration::from_millis(1000), 10, None);
+        let c = TxnStatusCache::new_impl(
+            2,
+            Duration::from_millis(1000),
+            Duration::from_millis(1000),
+            10,
+            10,
+            None,
+        );
         assert!(c.is_enabled);
-        assert_eq!(c.slots.len(), 2);
-        assert_eq!(c.slots[0].lock().capacity(), 5);
-        assert_eq!(c.slots[1].lock().capacity(), 5);
+        assert_eq!(c.normal_cache.len(), 2);
+        assert_eq!(c.normal_cache[0].lock().capacity(), 5);
+        assert_eq!(c.normal_cache[1].lock().capacity(), 5);
 
-        let c = TxnStatusCache::new_impl(2, Duration::from_millis(1000), 0, None);
+        let c = TxnStatusCache::new_impl(
+            2,
+            Duration::from_millis(1000),
+            Duration::from_millis(1000),
+            0,
+            0,
+            None,
+        );
         assert!(!c.is_enabled);
-        assert_eq!(c.slots.len(), 0);
+        assert_eq!(c.normal_cache.len(), 0);
         // All operations are noops and won't cause panic or return any incorrect
         // result.
-        c.insert(1.into(), 2.into(), SystemTime::now());
-        assert!(c.get_no_promote(1.into()).is_none());
-        assert!(c.get(1.into()).is_none());
+        c.insert_committed(1.into(), 2.into(), SystemTime::now());
+        assert!(c.get_committed_no_promote(1.into()).is_none());
+        assert!(c.get_committed(1.into()).is_none());
     }
 
     #[test]
@@ -918,61 +1104,211 @@ mod tests {
         let now = || UNIX_EPOCH + Duration::from_millis(time.load(Ordering::Acquire));
 
         set_time(0);
-        c.insert(1.into(), 2.into(), now());
+        c.insert_committed(1.into(), 2.into(), now());
         set_time(2);
-        c.insert(3.into(), 4.into(), now());
+        c.insert_committed(3.into(), 4.into(), now());
         set_time(4);
-        c.insert(5.into(), 6.into(), now());
+        c.insert_committed(5.into(), 6.into(), now());
         set_time(6);
-        c.insert(7.into(), 8.into(), now());
+        c.insert_committed(7.into(), 8.into(), now());
 
         // The cache can keep at most 5 entries.
         set_time(8);
-        c.insert(9.into(), 10.into(), now());
+        c.insert_committed(9.into(), 10.into(), now());
         // Entry 1 not evicted. 5 entries in the cache currently
-        assert_eq!(c.slots[0].lock().len(), 5);
-        assert_eq!(c.get_no_promote(1.into()).unwrap(), 2.into());
+        assert_eq!(c.normal_cache[0].lock().len(), 5);
+        assert_eq!(c.get_committed_no_promote(1.into()).unwrap(), 2.into());
         set_time(10);
-        c.insert(11.into(), 12.into(), now());
+        c.insert_committed(11.into(), 12.into(), now());
         // Entry 1 evicted. Still 5 entries in the cache.
-        assert_eq!(c.slots[0].lock().len(), 5);
-        assert!(c.get_no_promote(1.into()).is_none());
-        assert_eq!(c.get_no_promote(3.into()).unwrap(), 4.into());
+        assert_eq!(c.normal_cache[0].lock().len(), 5);
+        assert!(c.get_committed_no_promote(1.into()).is_none());
+        assert_eq!(c.get_committed_no_promote(3.into()).unwrap(), 4.into());
 
         // Nothing will be evicted after trying to insert an existing key.
-        c.insert(11.into(), 12.into(), now());
-        assert_eq!(c.slots[0].lock().len(), 5);
-        assert_eq!(c.get_no_promote(3.into()).unwrap(), 4.into());
+        c.insert_committed(11.into(), 12.into(), now());
+        assert_eq!(c.normal_cache[0].lock().len(), 5);
+        assert_eq!(c.get_committed_no_promote(3.into()).unwrap(), 4.into());
 
         // Current contents (key@time):
         // 3@2, 5@4, 7@6. 9@8, 11@10
         // Evicting by time works as well.
         set_time(1005);
-        c.insert(13.into(), 14.into(), now());
-        assert_eq!(c.slots[0].lock().len(), 4);
-        assert!(c.get_no_promote(3.into()).is_none());
-        assert!(c.get_no_promote(5.into()).is_none());
-        assert_eq!(c.get_no_promote(7.into()).unwrap(), 8.into());
+        c.insert_committed(13.into(), 14.into(), now());
+        assert_eq!(c.normal_cache[0].lock().len(), 4);
+        assert!(c.get_committed_no_promote(3.into()).is_none());
+        assert!(c.get_committed_no_promote(5.into()).is_none());
+        assert_eq!(c.get_committed_no_promote(7.into()).unwrap(), 8.into());
 
         // Reorder the entries by `get` to prepare for testing the next case.
-        assert_eq!(c.get(7.into()).unwrap(), 8.into());
-        assert_eq!(c.get(9.into()).unwrap(), 10.into());
-        assert_eq!(c.get(11.into()).unwrap(), 12.into());
+        assert_eq!(c.get_committed(7.into()).unwrap(), 8.into());
+        assert_eq!(c.get_committed(9.into()).unwrap(), 10.into());
+        assert_eq!(c.get_committed(11.into()).unwrap(), 12.into());
 
-        c.insert(15.into(), 16.into(), now());
+        c.insert_committed(15.into(), 16.into(), now());
         // Current contents:
         // 13@1005, 7@6. 9@8, 11@10, 15@1005
-        assert_eq!(c.slots[0].lock().len(), 5);
+        assert_eq!(c.normal_cache[0].lock().len(), 5);
         // Expired entries that are not the tail can be evicted after the tail
         // is evicted due to capacity exceeded.
         set_time(1011);
-        c.insert(17.into(), 18.into(), now());
-        assert_eq!(c.slots[0].lock().len(), 2);
-        assert!(c.get_no_promote(13.into()).is_none());
-        assert!(c.get_no_promote(7.into()).is_none());
-        assert!(c.get_no_promote(9.into()).is_none());
-        assert!(c.get_no_promote(11.into()).is_none());
-        assert_eq!(c.get(15.into()).unwrap(), 16.into());
-        assert_eq!(c.get(17.into()).unwrap(), 18.into());
+        c.insert_committed(17.into(), 18.into(), now());
+        assert_eq!(c.normal_cache[0].lock().len(), 2);
+        assert!(c.get_committed_no_promote(13.into()).is_none());
+        assert!(c.get_committed_no_promote(7.into()).is_none());
+        assert!(c.get_committed_no_promote(9.into()).is_none());
+        assert!(c.get_committed_no_promote(11.into()).is_none());
+        assert_eq!(c.get_committed(15.into()).unwrap(), 16.into());
+        assert_eq!(c.get_committed(17.into()).unwrap(), 18.into());
+    }
+
+    fn setup_cache() -> TxnStatusCache {
+        TxnStatusCache::with_slots_and_time_limit(
+            16,
+            Duration::from_secs(30),
+            Duration::from_secs(60),
+            1000,
+        )
+    }
+
+    #[test]
+    fn test_upsert_and_get_normal_txn() {
+        let cache = setup_cache();
+        let now = SystemTime::now();
+
+        cache.upsert(1.into(), TxnState::Ongoing(2.into()), now);
+        assert_eq!(cache.get(1.into()), Some(TxnState::Ongoing(2.into())));
+
+        cache.upsert(1.into(), TxnState::Committed(3.into()), now);
+        assert_eq!(cache.get(1.into()), Some(TxnState::Committed(3.into())));
+    }
+
+    #[test]
+    fn test_upsert_and_get_large_txn() {
+        let cache = setup_cache();
+        let now = SystemTime::now();
+        let large_ts = 10000.into();
+
+        cache.upsert(1.into(), TxnState::Ongoing(large_ts), now);
+        assert_eq!(cache.get(1.into()), Some(TxnState::Ongoing(large_ts)));
+
+        cache.upsert(1.into(), TxnState::Committed(large_ts), now);
+        assert_eq!(cache.get(1.into()), Some(TxnState::Committed(large_ts)));
+    }
+
+    #[test]
+    fn test_update_ongoing_txn() {
+        let cache = setup_cache();
+        let now = SystemTime::now();
+
+        cache.upsert(1.into(), TxnState::Ongoing(2.into()), now);
+        cache.upsert(1.into(), TxnState::Ongoing(3.into()), now);
+        assert_eq!(cache.get(1.into()), Some(TxnState::Ongoing(3.into())));
+    }
+
+    #[test]
+    fn test_update_committed_txn() {
+        let cache = setup_cache();
+        let now = SystemTime::now();
+
+        cache.upsert(1.into(), TxnState::Committed(2.into()), now);
+        cache.upsert(1.into(), TxnState::RolledBack, now);
+        assert_eq!(cache.get(1.into()), Some(TxnState::Committed(2.into())));
+    }
+
+    #[test]
+    fn test_normal_to_large_txn_transition() {
+        let cache = setup_cache();
+        let now = SystemTime::now();
+
+        cache.upsert(1.into(), TxnState::Ongoing(1.into()), now);
+        assert_eq!(cache.get(1.into()), Some(TxnState::Ongoing(1.into())));
+
+        cache.upsert(1.into(), TxnState::Ongoing(2.into()), now);
+        assert_eq!(cache.get(1.into()), Some(TxnState::Ongoing(2.into())));
+    }
+
+    #[test]
+    fn test_large_to_normal_txn_transition() {
+        let cache = setup_cache();
+        let now = SystemTime::now();
+
+        cache.upsert(1.into(), TxnState::Ongoing(10000.into()), now);
+        assert_eq!(cache.get(1.into()), Some(TxnState::Ongoing(10000.into())));
+
+        cache.upsert(1.into(), TxnState::Committed(10001.into()), now);
+        assert_eq!(cache.get(1.into()), Some(TxnState::Committed(10001.into())));
+    }
+
+    #[test]
+    fn test_eviction_normal_txn() {
+        let (cache, time) =
+            TxnStatusCache::with_simulated_system_time(1, Duration::from_secs(30), 1);
+
+        time.store(0, Ordering::SeqCst);
+        cache.upsert(1.into(), TxnState::Ongoing(2.into()), SystemTime::now());
+
+        time.store(31 * 1000, Ordering::SeqCst); // 31 seconds later
+        cache.upsert(3.into(), TxnState::Ongoing(4.into()), SystemTime::now());
+        assert_eq!(cache.get(1.into()), None);
+        assert_eq!(cache.get(3.into()), Some(TxnState::Ongoing(4.into())));
+    }
+
+    #[test]
+    fn test_eviction_large_txn() {
+        let (cache, time) =
+            TxnStatusCache::with_simulated_system_time(1, Duration::from_secs(60), 1);
+
+        time.store(0, Ordering::SeqCst);
+        cache.upsert(1.into(), TxnState::Ongoing(10000.into()), SystemTime::now());
+
+        time.store(61 * 1000, Ordering::SeqCst); // 61 seconds later
+        cache.upsert(2.into(), TxnState::Ongoing(20000.into()), SystemTime::now());
+        assert_eq!(cache.get(1.into()), None);
+        assert_eq!(cache.get(2.into()), Some(TxnState::Ongoing(20000.into())));
+    }
+
+    #[test]
+    fn test_capacity_limit() {
+        let cache = TxnStatusCache::with_slots_and_time_limit(
+            1,
+            Duration::from_secs(30),
+            Duration::from_secs(60),
+            5,
+        );
+        let now = SystemTime::now();
+
+        for i in 1..=5 {
+            cache.upsert(i.into(), TxnState::Ongoing((i + 1).into()), now);
+        }
+
+        cache.upsert(6.into(), TxnState::Ongoing(7.into()), now);
+        assert_eq!(cache.get(1.into()), None);
+        assert_eq!(cache.get(6.into()), Some(TxnState::Ongoing(7.into())));
+    }
+
+    #[test]
+    fn test_get_committed() {
+        let cache = setup_cache();
+        let now = SystemTime::now();
+
+        cache.upsert(1.into(), TxnState::Committed(2.into()), now);
+        cache.upsert(3.into(), TxnState::Ongoing(4.into()), now);
+
+        assert_eq!(cache.get_committed(1.into()), Some(2.into()));
+        assert_eq!(cache.get_committed(3.into()), None);
+    }
+
+    #[test]
+    fn test_remove_large_txn() {
+        let cache = setup_cache();
+        let now = SystemTime::now();
+
+        cache.upsert(1.into(), TxnState::Ongoing(10000.into()), now);
+        assert_eq!(cache.get(1.into()), Some(TxnState::Ongoing(10000.into())));
+
+        let removed = cache.remove_large_txn(1.into());
+        assert!(removed.is_some());
+        assert_eq!(cache.get(1.into()), None);
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

This PR is based on and must be merged after https://github.com/tikv/tikv/pull/17460

Issue Number: ref #17459 

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Implement broadcast_txn_status for tikv service
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note

```
