### PR TITLE
cdc: fix unstable test_cdc_pipeline_dml

### DIFF
--- a/components/cdc/src/errors.rs
+++ b/components/cdc/src/errors.rs
@@ -99,9 +99,10 @@ impl Error {
 
     pub fn into_error_event(self, region_id: u64) -> ErrorEvent {
         let mut err_event = ErrorEvent::default();
-        if matches!(self,
-            Error::Sink(SendError::Congested)
-            |Error::MemoryQuotaExceeded(MemoryQuotaExceeded)) {
+        if matches!(
+            self,
+            Error::Sink(SendError::Congested) | Error::MemoryQuotaExceeded(MemoryQuotaExceeded)
+        ) {
             let mut congested = cdcpb::Congested::default();
             congested.set_region_id(region_id);
             err_event.set_congested(congested);

--- a/components/cdc/src/errors.rs
+++ b/components/cdc/src/errors.rs
@@ -99,7 +99,9 @@ impl Error {
 
     pub fn into_error_event(self, region_id: u64) -> ErrorEvent {
         let mut err_event = ErrorEvent::default();
-        if matches!(self, Error::Sink(SendError::Congested)) {
+        if matches!(self,
+            Error::Sink(SendError::Congested)
+            |Error::MemoryQuotaExceeded(MemoryQuotaExceeded)) {
             let mut congested = cdcpb::Congested::default();
             congested.set_region_id(region_id);
             err_event.set_congested(congested);

--- a/components/cdc/tests/failpoints/test_endpoint.rs
+++ b/components/cdc/tests/failpoints/test_endpoint.rs
@@ -688,6 +688,7 @@ fn test_cdc_pipeline_dml() {
     req.request_id = 1;
     req.checkpoint_ts = cf_tso.into_inner();
     block_on(req_tx.send((req, WriteFlags::default()))).unwrap();
+    sleep_ms(100);
 
     let (k, v) = (b"key".to_vec(), vec![b'y'; 16]);
     let mut mutation = Mutation::default();

--- a/components/cdc/tests/failpoints/test_memory_quota.rs
+++ b/components/cdc/tests/failpoints/test_memory_quota.rs
@@ -78,7 +78,7 @@ fn test_resolver_track_lock_memory_quota_exceeded() {
     match events.pop().unwrap().event.unwrap() {
         Event_oneof_event::Error(e) => {
             // Unknown errors are translated into region_not_found.
-            assert!(e.has_region_not_found(), "{:?}", e);
+            assert!(e.has_congested(), "{:?}", e);
         }
         other => panic!("unknown event {:?}", other),
     }
@@ -130,7 +130,7 @@ fn test_pending_on_region_ready_memory_quota_exceeded() {
     match events.pop().unwrap().event.unwrap() {
         Event_oneof_event::Error(e) => {
             // Unknown errors are translated into region_not_found.
-            assert!(e.has_region_not_found(), "{:?}", e);
+            assert!(e.has_congested(), "{:?}", e);
         }
         other => panic!("unknown event {:?}", other),
     }
@@ -194,7 +194,7 @@ fn test_pending_push_lock_memory_quota_exceeded() {
     match events.pop().unwrap().event.unwrap() {
         Event_oneof_event::Error(e) => {
             // Unknown errors are translated into region_not_found.
-            assert!(e.has_region_not_found(), "{:?}", e);
+            assert!(e.has_congested(), "{:?}", e);
         }
         other => panic!("unknown event {:?}", other),
     }
@@ -255,7 +255,7 @@ fn test_scan_lock_memory_quota_exceeded() {
     match events.pop().unwrap().event.unwrap() {
         Event_oneof_event::Error(e) => {
             // Unknown errors are translated into region_not_found.
-            assert!(e.has_region_not_found(), "{:?}", e);
+            assert!(e.has_congested(), "{:?}", e);
         }
         other => panic!("unknown event {:?}", other),
     }

--- a/components/cdc/tests/mod.rs
+++ b/components/cdc/tests/mod.rs
@@ -108,7 +108,7 @@ fn create_event_feed(
             return ChangeDataEvent::default();
         };
         let change_data =
-            if let Some(event) = recv_timeout(&mut events_rx, Duration::from_secs(20)).unwrap() {
+            if let Some(event) = recv_timeout(&mut events_rx, Duration::from_secs(5)).unwrap() {
                 event
             } else {
                 return ChangeDataEvent::default();


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #17534

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
* fix the unstable unit test test_cdc_pipeline_dml
* return `congested` when meet MemoryQuotaExceed error, this happens when push pending locks
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
