### PR TITLE
raftstore: fix panic due to stale peer handling snapshot

### DIFF
--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -3438,9 +3438,16 @@ where
         let mut meta = self.ctx.store_meta.lock().unwrap();
         let region_mismatch = match meta.regions.get(&self.region_id()) {
             Some(region) => *region != *self.region(),
-            // If the region doesn't exist, treat it as a mismatch. This can
-            // happen in rare situations (#17469).
-            None => true,
+            None => {
+                // If the region doesn't exist, treat it as a mismatch. This can
+                // happen in rare situations (e.g. #17469).
+                warn!(
+                    "region not found in meta";
+                    "region_id" => self.fsm.region_id(),
+                    "peer_id" => self.fsm.peer_id(),
+                );
+                true
+            }
         };
         if region_mismatch {
             if !self.fsm.peer.is_initialized() {

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -2645,13 +2645,40 @@ where
             "is_initialized_peer" => is_initialized_peer,
         );
 
+        let msg_type = msg.get_message().get_msg_type();
+        let fp_enable = |target_msg_type: MessageType| -> bool {
+            self.fsm.region_id() == 1000
+                && self.store_id() == 2
+                && !is_initialized_peer
+                && msg_type == target_msg_type
+        };
+        fail_point!(
+            "on_snap_msg_1000_2",
+            fp_enable(MessageType::MsgSnapshot),
+            |_| Ok(())
+        );
+        fail_point!(
+            "on_vote_msg_1000_2",
+            fp_enable(MessageType::MsgRequestVote),
+            |_| Ok(())
+        );
+        fail_point!(
+            "on_append_msg_1000_2",
+            fp_enable(MessageType::MsgAppend),
+            |_| Ok(())
+        );
+        fail_point!(
+            "on_heartbeat_msg_1000_2",
+            fp_enable(MessageType::MsgHeartbeat),
+            |_| Ok(())
+        );
+
         if self.fsm.peer.pending_remove || self.fsm.stopped {
             return Ok(());
         }
 
         self.handle_reported_disk_usage(&msg);
 
-        let msg_type = msg.get_message().get_msg_type();
         if matches!(self.ctx.self_disk_usage, DiskUsage::AlreadyFull)
             && MessageType::MsgTimeoutNow == msg_type
         {

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -3436,6 +3436,10 @@ where
         }
 
         let mut meta = self.ctx.store_meta.lock().unwrap();
+        // Check if the region matches the metadata. A mismatch means another
+        // peer has replaced the current peer, which can happen during a split: a
+        // peer is first created via raft message, then replaced by another peer
+        // (of the same region) when the split is applied.
         let region_mismatch = match meta.regions.get(&self.region_id()) {
             Some(region) => *region != *self.region(),
             None => {

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -3436,7 +3436,13 @@ where
         }
 
         let mut meta = self.ctx.store_meta.lock().unwrap();
-        if meta.regions[&self.region_id()] != *self.region() {
+        let region_mismatch = match meta.regions.get(&self.region_id()) {
+            Some(region) => *region != *self.region(),
+            // If the region doesn't exist, treat it as a mismatch. This can
+            // happen in rare situations (#17469).
+            None => true,
+        };
+        if region_mismatch {
             if !self.fsm.peer.is_initialized() {
                 info!(
                     "stale delegate detected, skip";

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -3463,7 +3463,7 @@ where
                 panic!(
                     "{} meta corrupted: {:?} != {:?}",
                     self.fsm.peer.tag,
-                    meta.regions[&self.region_id()],
+                    meta.regions.get(&self.region_id()),
                     self.region()
                 );
             }

--- a/tests/failpoints/cases/test_split_region.rs
+++ b/tests/failpoints/cases/test_split_region.rs
@@ -559,14 +559,13 @@ fn test_snap_handling_after_peer_is_replaced_by_split_and_removed() {
     //                    ┌───────────┐  ┌───────────┐  ┌───────────┐
     //                    │           │  │           │  │           │
     //      Region 1      │ Peer 1    │  │ Peer 2    │  │ Peer 3    │
-    //      (-∞, k2)      │           │  │           │  │           │
+    //      [k2, +∞)      │           │  │           │  │           │
     // ───────────────────┼───────────┼──┼───────────┼──┼───────────┼──
     //                    │           │  │           │  │           │
     //      Region 1000   │ Peer 1001 │  │ Peer 1003 │  │ Peer 1002 │
-    //      [k2, +∞)      │           │  │           │  │           │
+    //      (-∞, k2)      │           │  │           │  │           │
     //                    └───────────┘  └───────────┘  └───────────┘
     //                       Store 1        Store 2        Store 3
-    //
     //
     // In this test, there is a split operation and Peer 1003 will be created
     // twice (by raft message and by split). The new Peer 1003 will replace the
@@ -593,11 +592,11 @@ fn test_snap_handling_after_peer_is_replaced_by_split_and_removed() {
     // Pause the snapshot apply of Peer 2.
     let before_check_snapshot_1_2_fp = "before_check_snapshot_1_2";
     fail::cfg(before_check_snapshot_1_2_fp, "pause").unwrap();
-    // Add Peer 2
-    pd_client.must_add_peer(r1, new_peer(2, 2));
 
+    // Add Peer 2. The peer will be created but stuck at applying snapshot due
+    // to the failpoint above.
+    pd_client.must_add_peer(r1, new_peer(2, 2));
     cluster.must_put(b"k1", b"v1");
-    cluster.must_put(b"k2", b"v2");
 
     // Before the split, pause the snapshot apply of Peer 1003.
     let before_check_snapshot_1000_2_fp = "before_check_snapshot_1000_2";
@@ -605,33 +604,36 @@ fn test_snap_handling_after_peer_is_replaced_by_split_and_removed() {
 
     // Split the region into Region 1 and Region 1000. Peer 1003 will be created
     // for the first time when it receives a raft message from Peer 1001, but it
-    // will remain uninitialized, waiting for the snapshot.
+    // will remain uninitialized, waiting for a raft snapshot.
     let region = pd_client.get_region(b"k1").unwrap();
     cluster.must_split(&region, b"k2");
-
     cluster.must_put(b"k22", b"v22");
 
     // Check that Store 2 doesn't have any data yet.
     must_get_none(&cluster.get_engine(2), b"k1");
+    must_get_none(&cluster.get_engine(2), b"k22");
 
     // Unblock Peer 2. It will proceed to apply the split operation, which
     // creates Peer 1003 for the second time and replaces the old Peer 1003.
     fail::remove(before_check_snapshot_1_2_fp);
 
-    // Verify that data can be accessed from the new Peer 1003.
+    // Verify that data can be accessed from Peer 2 and the new Peer 1003.
     must_get_equal(&cluster.get_engine(2), b"k1", b"v1");
+    must_get_equal(&cluster.get_engine(2), b"k22", b"v22");
 
     // Immediately remove the new Peer 1003. This removes the region metadata.
     let left = pd_client.get_region(b"k1").unwrap();
     let left_peer_2 = find_peer(&left, 2).cloned().unwrap();
     pd_client.must_remove_peer(left.get_id(), left_peer_2);
     must_get_none(&cluster.get_engine(2), b"k1");
+    must_get_equal(&cluster.get_engine(2), b"k22", b"v22");
 
     // Unblock the old Peer 1003. When it continues to process the snapshot
     // message, it would expect the region metadata to exist, causing a panic if
     // #17469 is not fixed.
     fail::remove(before_check_snapshot_1000_2_fp);
     must_get_none(&cluster.get_engine(2), b"k1");
+    must_get_equal(&cluster.get_engine(2), b"k22", b"v22");
 }
 
 // TiKV uses memory lock to control the order between spliting and creating

--- a/tests/failpoints/cases/test_split_region.rs
+++ b/tests/failpoints/cases/test_split_region.rs
@@ -553,7 +553,26 @@ fn test_split_not_to_split_existing_tombstone_region() {
 }
 
 #[test]
-fn test_snap_handling_after_peer_is_replaced_by_split_and_removed() {
+fn test_stale_peer_handle_snap() {
+    test_stale_peer_handle_raft_msg("on_snap_msg_1000_2");
+}
+
+#[test]
+fn test_stale_peer_handle_vote() {
+    test_stale_peer_handle_raft_msg("on_vote_msg_1000_2");
+}
+
+#[test]
+fn test_stale_peer_handle_append() {
+    test_stale_peer_handle_raft_msg("on_append_msg_1000_2");
+}
+
+#[test]
+fn test_stale_peer_handle_heartbeat() {
+    test_stale_peer_handle_raft_msg("on_heartbeat_msg_1000_2");
+}
+
+fn test_stale_peer_handle_raft_msg(on_handle_raft_msg_1000_2_fp: &str) {
     // The following diagram represents the final state of the test:
     //
     //                    ┌───────────┐  ┌───────────┐  ┌───────────┐
@@ -571,7 +590,8 @@ fn test_snap_handling_after_peer_is_replaced_by_split_and_removed() {
     // twice (by raft message and by split). The new Peer 1003 will replace the
     // old Peer 1003 and but it will be immediately removed. This test verifies
     // that TiKV would not panic if the old Peer 1003 continues to process a
-    // snapshot message.
+    // remaining raft message (which may be a snapshot/vote/heartbeat/append
+    // message).
 
     let mut cluster = new_node_cluster(0, 3);
     configure_for_merge(&mut cluster.cfg);
@@ -598,14 +618,15 @@ fn test_snap_handling_after_peer_is_replaced_by_split_and_removed() {
     pd_client.must_add_peer(r1, new_peer(2, 2));
     cluster.must_put(b"k1", b"v1");
 
-    // Before the split, pause the snapshot apply of Peer 1003.
-    let before_check_snapshot_1000_2_fp = "before_check_snapshot_1000_2";
-    fail::cfg(before_check_snapshot_1000_2_fp, "pause").unwrap();
+    // Before the split, pause Peer 1003 when processing a certain raft message.
+    // The message type depends on the failpoint name input.
+    fail::cfg(on_handle_raft_msg_1000_2_fp, "pause").unwrap();
 
     // Split the region into Region 1 and Region 1000. Peer 1003 will be created
     // for the first time when it receives a raft message from Peer 1001, but it
-    // will remain uninitialized, waiting for a raft snapshot.
+    // will remain uninitialized because it's paused due to the failpoint above.
     let region = pd_client.get_region(b"k1").unwrap();
+
     cluster.must_split(&region, b"k2");
     cluster.must_put(b"k22", b"v22");
 
@@ -628,10 +649,14 @@ fn test_snap_handling_after_peer_is_replaced_by_split_and_removed() {
     must_get_none(&cluster.get_engine(2), b"k1");
     must_get_equal(&cluster.get_engine(2), b"k22", b"v22");
 
-    // Unblock the old Peer 1003. When it continues to process the snapshot
-    // message, it would expect the region metadata to exist, causing a panic if
+    // Unblock the old Peer 1003 so that it can continue to process its raft
+    // message. It would lead to a panic when it processes a snapshot message if
     // #17469 is not fixed.
-    fail::remove(before_check_snapshot_1000_2_fp);
+    fail::remove(on_handle_raft_msg_1000_2_fp);
+
+    // Waiting for the stale peer to handle its raft message.
+    sleep_ms(300);
+
     must_get_none(&cluster.get_engine(2), b"k1");
     must_get_equal(&cluster.get_engine(2), b"k22", b"v22");
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #17469

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
The commit fixes a panic in TiKV that occurs in a rare scenario that
involves region splits and immediate removal of the new peer.

When a region splits, the new peer on a follower can be created in two 
ways: (1) By receiving a Raft message from the new region 
(`fn maybe_create_peer`) (2) By applying the split operation locally 
(`fn on_ready_split_region`). 

Depending on timing, a new peer might first be created by a Raft 
message and then again when the split is applied. This is a known 
situation. When it happens, the second peer replaces the first, and the 
first peer is dicarded. However, the discarded peer may continue 
processing existing messages, leading to unexpected states.

The panic can be reproduced with the following sequence of events:
1. The first peer is created by a Raft message and is waiting for a 
   Raft snapshot.
2. The second peer (of the same reason) is created by 
   `on_ready_split_region` when the split operation is applied, 
   replacing the first peer and closing its mailbox (as expected).
3. The second peer is immediately removed (a rare situation). This 
   removes the region metadata.
4. The first peer continues processing the Raft snapshot message, 
   expecting the metadata of the region to exist, causing the panic.
```

In addition, [this comment](https://github.com/tikv/tikv/issues/17469#issuecomment-2348345113) gives an analysis of the logs when the panic occurred. 

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fixed a TiKV panic due to a stale peer handling snapshot when there is a split and an immediate removal of the new peer. 
```
