### PR TITLE
support change in memory pessimistic lock memory size dynamically

### DIFF
--- a/src/server/lock_manager/config.rs
+++ b/src/server/lock_manager/config.rs
@@ -32,7 +32,7 @@ pub struct Config {
     /// to people who disable the pipelined pessimistic lock feature.
     pub in_memory: bool,
     pub in_memory_peer_size_limit: ReadableSize,
-    pub in_memory_global_size_limit: ReadableSize,
+    pub in_memory_instance_size_limit: ReadableSize,
 }
 
 // u64 is for backward compatibility since v3.x uses it.
@@ -65,7 +65,7 @@ impl Default for Config {
             pipelined: true,
             in_memory: true,
             in_memory_peer_size_limit: ReadableSize::kb(512),
-            in_memory_global_size_limit: ReadableSize::mb(100),
+            in_memory_instance_size_limit: ReadableSize::mb(100),
         }
     }
 }
@@ -86,7 +86,7 @@ pub struct LockManagerConfigManager {
     pub in_memory: Arc<AtomicBool>,
     pub wake_up_delay_duration_ms: Arc<AtomicU64>,
     pub in_memory_peer_size_limit: Arc<AtomicU64>,
-    pub in_memory_global_size_limit: Arc<AtomicU64>,
+    pub in_memory_instance_size_limit: Arc<AtomicU64>,
 }
 
 impl LockManagerConfigManager {
@@ -97,7 +97,7 @@ impl LockManagerConfigManager {
         in_memory: Arc<AtomicBool>,
         wake_up_delay_duration_ms: Arc<AtomicU64>,
         in_memory_peer_size_limit: Arc<AtomicU64>,
-        in_memory_global_size_limit: Arc<AtomicU64>,
+        in_memory_instance_size_limit: Arc<AtomicU64>,
     ) -> Self {
         LockManagerConfigManager {
             waiter_mgr_scheduler,
@@ -106,7 +106,7 @@ impl LockManagerConfigManager {
             in_memory,
             wake_up_delay_duration_ms,
             in_memory_peer_size_limit,
-            in_memory_global_size_limit,
+            in_memory_instance_size_limit,
         }
     }
 }
@@ -141,10 +141,10 @@ impl ConfigManager for LockManagerConfigManager {
             self.in_memory_peer_size_limit.store(p.0, Ordering::Relaxed);
         }
         if let Some(p) = change
-            .remove("in_memory_global_size_limit")
+            .remove("in_memory_instance_size_limit")
             .map(ReadableSize::from)
         {
-            self.in_memory_global_size_limit
+            self.in_memory_instance_size_limit
                 .store(p.0, Ordering::Relaxed);
         }
         Ok(())
@@ -164,7 +164,7 @@ mod tests {
         pipelined = false
         in-memory = false
         in-memory-peer-size-limit = "512KiB"
-        in-memory-global-size-limit = "100MiB"
+        in-memory-instance-size-limit = "100MiB"
         "#;
 
         let config: Config = toml::from_str(conf).unwrap();
@@ -173,6 +173,6 @@ mod tests {
         assert_eq!(config.pipelined, false);
         assert_eq!(config.in_memory, false);
         assert_eq!(config.in_memory_peer_size_limit.0, 512 << 10);
-        assert_eq!(config.in_memory_global_size_limit.0, 100 << 20);
+        assert_eq!(config.in_memory_instance_size_limit.0, 100 << 20);
     }
 }

--- a/src/server/lock_manager/config.rs
+++ b/src/server/lock_manager/config.rs
@@ -31,7 +31,9 @@ pub struct Config {
     /// assume that the success rate of pessimistic transactions is important
     /// to people who disable the pipelined pessimistic lock feature.
     pub in_memory: bool,
+    /// The maximum size of the in-memory pessimistic locks for each region.
     pub in_memory_peer_size_limit: ReadableSize,
+    /// The maximum size of the in-memory pessimistic locks in the TiKV instance.
     pub in_memory_instance_size_limit: ReadableSize,
 }
 

--- a/src/server/lock_manager/config.rs
+++ b/src/server/lock_manager/config.rs
@@ -10,7 +10,7 @@ use std::{
 
 use online_config::{ConfigChange, ConfigManager, OnlineConfig};
 use serde::de::{Deserialize, Deserializer, IntoDeserializer};
-use tikv_util::config::ReadableDuration;
+use tikv_util::config::{ReadableDuration, ReadableSize};
 
 use super::{
     deadlock::Scheduler as DeadlockScheduler, waiter_manager::Scheduler as WaiterMgrScheduler,
@@ -31,6 +31,8 @@ pub struct Config {
     /// assume that the success rate of pessimistic transactions is important
     /// to people who disable the pipelined pessimistic lock feature.
     pub in_memory: bool,
+    pub in_memory_peer_size_limit: ReadableSize,
+    pub in_memory_global_size_limit: ReadableSize,
 }
 
 // u64 is for backward compatibility since v3.x uses it.
@@ -62,6 +64,8 @@ impl Default for Config {
             wake_up_delay_duration: ReadableDuration::millis(20),
             pipelined: true,
             in_memory: true,
+            in_memory_peer_size_limit: ReadableSize::kb(512),
+            in_memory_global_size_limit: ReadableSize::mb(100),
         }
     }
 }
@@ -81,6 +85,8 @@ pub struct LockManagerConfigManager {
     pub pipelined: Arc<AtomicBool>,
     pub in_memory: Arc<AtomicBool>,
     pub wake_up_delay_duration_ms: Arc<AtomicU64>,
+    pub in_memory_peer_size_limit: Arc<AtomicU64>,
+    pub in_memory_global_size_limit: Arc<AtomicU64>,
 }
 
 impl LockManagerConfigManager {
@@ -90,6 +96,8 @@ impl LockManagerConfigManager {
         pipelined: Arc<AtomicBool>,
         in_memory: Arc<AtomicBool>,
         wake_up_delay_duration_ms: Arc<AtomicU64>,
+        in_memory_peer_size_limit: Arc<AtomicU64>,
+        in_memory_global_size_limit: Arc<AtomicU64>,
     ) -> Self {
         LockManagerConfigManager {
             waiter_mgr_scheduler,
@@ -97,6 +105,8 @@ impl LockManagerConfigManager {
             pipelined,
             in_memory,
             wake_up_delay_duration_ms,
+            in_memory_peer_size_limit,
+            in_memory_global_size_limit,
         }
     }
 }
@@ -124,6 +134,19 @@ impl ConfigManager for LockManagerConfigManager {
         if let Some(p) = change.remove("in_memory").map(Into::into) {
             self.in_memory.store(p, Ordering::Relaxed);
         }
+        if let Some(p) = change
+            .remove("in_memory_peer_size_limit")
+            .map(ReadableSize::from)
+        {
+            self.in_memory_peer_size_limit.store(p.0, Ordering::Relaxed);
+        }
+        if let Some(p) = change
+            .remove("in_memory_global_size_limit")
+            .map(ReadableSize::from)
+        {
+            self.in_memory_global_size_limit
+                .store(p.0, Ordering::Relaxed);
+        }
         Ok(())
     }
 }
@@ -140,6 +163,8 @@ mod tests {
         wake-up-delay-duration = 100
         pipelined = false
         in-memory = false
+        in-memory-peer-size-limit = "512KiB"
+        in-memory-global-size-limit = "100MiB"
         "#;
 
         let config: Config = toml::from_str(conf).unwrap();
@@ -147,5 +172,7 @@ mod tests {
         assert_eq!(config.wake_up_delay_duration.as_millis(), 100);
         assert_eq!(config.pipelined, false);
         assert_eq!(config.in_memory, false);
+        assert_eq!(config.in_memory_peer_size_limit.0, 512 << 10);
+        assert_eq!(config.in_memory_global_size_limit.0, 100 << 20);
     }
 }

--- a/src/server/lock_manager/config.rs
+++ b/src/server/lock_manager/config.rs
@@ -31,9 +31,11 @@ pub struct Config {
     /// assume that the success rate of pessimistic transactions is important
     /// to people who disable the pipelined pessimistic lock feature.
     pub in_memory: bool,
-    /// The maximum size of the in-memory pessimistic locks for each region.
+    /// The maximum size of the in-memory pessimistic locks in the TiKV
+    /// instance.
     pub in_memory_peer_size_limit: ReadableSize,
-    /// The maximum size of the in-memory pessimistic locks in the TiKV instance.
+    /// The maximum size of the in-memory pessimistic locks in the TiKV
+    /// instance.
     pub in_memory_instance_size_limit: ReadableSize,
 }
 

--- a/src/server/lock_manager/mod.rs
+++ b/src/server/lock_manager/mod.rs
@@ -64,6 +64,9 @@ pub struct LockManager {
     in_memory: Arc<AtomicBool>,
 
     wake_up_delay_duration_ms: Arc<AtomicU64>,
+
+    in_memory_peer_size_limit: Arc<AtomicU64>,
+    in_memory_global_size_limit: Arc<AtomicU64>,
 }
 
 impl Clone for LockManager {
@@ -78,6 +81,8 @@ impl Clone for LockManager {
             pipelined: self.pipelined.clone(),
             in_memory: self.in_memory.clone(),
             wake_up_delay_duration_ms: self.wake_up_delay_duration_ms.clone(),
+            in_memory_peer_size_limit: self.in_memory_peer_size_limit.clone(),
+            in_memory_global_size_limit: self.in_memory_global_size_limit.clone(),
         }
     }
 }
@@ -98,6 +103,10 @@ impl LockManager {
             in_memory: Arc::new(AtomicBool::new(cfg.in_memory)),
             wake_up_delay_duration_ms: Arc::new(AtomicU64::new(
                 cfg.wake_up_delay_duration.as_millis(),
+            )),
+            in_memory_peer_size_limit: Arc::new(AtomicU64::new(cfg.in_memory_peer_size_limit.0)),
+            in_memory_global_size_limit: Arc::new(AtomicU64::new(
+                cfg.in_memory_global_size_limit.0,
             )),
         }
     }
@@ -221,6 +230,8 @@ impl LockManager {
             self.pipelined.clone(),
             self.in_memory.clone(),
             self.wake_up_delay_duration_ms.clone(),
+            self.in_memory_peer_size_limit.clone(),
+            self.in_memory_global_size_limit.clone(),
         )
     }
 
@@ -229,6 +240,8 @@ impl LockManager {
             pipelined_pessimistic_lock: self.pipelined.clone(),
             in_memory_pessimistic_lock: self.in_memory.clone(),
             wake_up_delay_duration_ms: self.wake_up_delay_duration_ms.clone(),
+            in_memory_peer_size_limit: self.in_memory_peer_size_limit.clone(),
+            in_memory_global_size_limit: self.in_memory_global_size_limit.clone(),
         }
     }
 }
@@ -312,7 +325,7 @@ mod tests {
     use raft::StateRole;
     use raftstore::coprocessor::RegionChangeEvent;
     use security::SecurityConfig;
-    use tikv_util::config::ReadableDuration;
+    use tikv_util::config::{ReadableDuration, ReadableSize};
     use tracker::{TrackerToken, INVALID_TRACKER_TOKEN};
     use txn_types::Key;
 
@@ -328,6 +341,8 @@ mod tests {
             wake_up_delay_duration: ReadableDuration::millis(100),
             pipelined: false,
             in_memory: false,
+            in_memory_peer_size_limit: ReadableSize::kb(512),
+            in_memory_global_size_limit: ReadableSize::mb(100),
         };
         let mut lock_mgr = LockManager::new(&cfg);
 

--- a/src/server/lock_manager/mod.rs
+++ b/src/server/lock_manager/mod.rs
@@ -66,7 +66,7 @@ pub struct LockManager {
     wake_up_delay_duration_ms: Arc<AtomicU64>,
 
     in_memory_peer_size_limit: Arc<AtomicU64>,
-    in_memory_global_size_limit: Arc<AtomicU64>,
+    in_memory_instance_size_limit: Arc<AtomicU64>,
 }
 
 impl Clone for LockManager {
@@ -82,7 +82,7 @@ impl Clone for LockManager {
             in_memory: self.in_memory.clone(),
             wake_up_delay_duration_ms: self.wake_up_delay_duration_ms.clone(),
             in_memory_peer_size_limit: self.in_memory_peer_size_limit.clone(),
-            in_memory_global_size_limit: self.in_memory_global_size_limit.clone(),
+            in_memory_instance_size_limit: self.in_memory_instance_size_limit.clone(),
         }
     }
 }
@@ -105,8 +105,8 @@ impl LockManager {
                 cfg.wake_up_delay_duration.as_millis(),
             )),
             in_memory_peer_size_limit: Arc::new(AtomicU64::new(cfg.in_memory_peer_size_limit.0)),
-            in_memory_global_size_limit: Arc::new(AtomicU64::new(
-                cfg.in_memory_global_size_limit.0,
+            in_memory_instance_size_limit: Arc::new(AtomicU64::new(
+                cfg.in_memory_instance_size_limit.0,
             )),
         }
     }
@@ -231,7 +231,7 @@ impl LockManager {
             self.in_memory.clone(),
             self.wake_up_delay_duration_ms.clone(),
             self.in_memory_peer_size_limit.clone(),
-            self.in_memory_global_size_limit.clone(),
+            self.in_memory_instance_size_limit.clone(),
         )
     }
 
@@ -241,7 +241,7 @@ impl LockManager {
             in_memory_pessimistic_lock: self.in_memory.clone(),
             wake_up_delay_duration_ms: self.wake_up_delay_duration_ms.clone(),
             in_memory_peer_size_limit: self.in_memory_peer_size_limit.clone(),
-            in_memory_global_size_limit: self.in_memory_global_size_limit.clone(),
+            in_memory_instance_size_limit: self.in_memory_instance_size_limit.clone(),
         }
     }
 }
@@ -342,7 +342,7 @@ mod tests {
             pipelined: false,
             in_memory: false,
             in_memory_peer_size_limit: ReadableSize::kb(512),
-            in_memory_global_size_limit: ReadableSize::mb(100),
+            in_memory_instance_size_limit: ReadableSize::mb(100),
         };
         let mut lock_mgr = LockManager::new(&cfg);
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -3290,6 +3290,8 @@ pub struct DynamicConfigs {
     pub pipelined_pessimistic_lock: Arc<AtomicBool>,
     pub in_memory_pessimistic_lock: Arc<AtomicBool>,
     pub wake_up_delay_duration_ms: Arc<AtomicU64>,
+    pub in_memory_peer_size_limit: Arc<AtomicU64>,
+    pub in_memory_global_size_limit: Arc<AtomicU64>,
 }
 
 fn get_priority_tag(priority: CommandPri) -> CommandPriority {
@@ -3389,6 +3391,8 @@ pub struct TestStorageBuilder<E: Engine, L: LockManager, F: KvFormat> {
     lock_mgr: L,
     resource_tag_factory: ResourceTagFactory,
     _phantom: PhantomData<F>,
+    in_memory_peer_size_limit: Arc<AtomicU64>,
+    in_memory_global_size_limit: Arc<AtomicU64>,
 }
 
 /// TestStorageBuilder for Api V1
@@ -3527,6 +3531,8 @@ impl<E: Engine, L: LockManager, F: KvFormat> TestStorageBuilder<E, L, F> {
             lock_mgr,
             resource_tag_factory: ResourceTagFactory::new_for_test(),
             _phantom: PhantomData,
+            in_memory_peer_size_limit: Arc::new(AtomicU64::new(512 << 10)),
+            in_memory_global_size_limit: Arc::new(AtomicU64::new(100 << 20)),
         }
     }
 
@@ -3596,6 +3602,8 @@ impl<E: Engine, L: LockManager, F: KvFormat> TestStorageBuilder<E, L, F> {
                 pipelined_pessimistic_lock: self.pipelined_pessimistic_lock,
                 in_memory_pessimistic_lock: self.in_memory_pessimistic_lock,
                 wake_up_delay_duration_ms: self.wake_up_delay_duration_ms,
+                in_memory_peer_size_limit: self.in_memory_peer_size_limit,
+                in_memory_global_size_limit: self.in_memory_global_size_limit,
             },
             Arc::new(FlowController::Singleton(EngineFlowController::empty())),
             DummyReporter,
@@ -3629,6 +3637,8 @@ impl<E: Engine, L: LockManager, F: KvFormat> TestStorageBuilder<E, L, F> {
                 pipelined_pessimistic_lock: self.pipelined_pessimistic_lock,
                 in_memory_pessimistic_lock: self.in_memory_pessimistic_lock,
                 wake_up_delay_duration_ms: self.wake_up_delay_duration_ms,
+                in_memory_peer_size_limit: self.in_memory_peer_size_limit,
+                in_memory_global_size_limit: self.in_memory_global_size_limit,
             },
             Arc::new(FlowController::Singleton(EngineFlowController::empty())),
             DummyReporter,
@@ -3665,6 +3675,8 @@ impl<E: Engine, L: LockManager, F: KvFormat> TestStorageBuilder<E, L, F> {
                 pipelined_pessimistic_lock: self.pipelined_pessimistic_lock,
                 in_memory_pessimistic_lock: self.in_memory_pessimistic_lock,
                 wake_up_delay_duration_ms: self.wake_up_delay_duration_ms,
+                in_memory_peer_size_limit: self.in_memory_peer_size_limit,
+                in_memory_global_size_limit: self.in_memory_global_size_limit,
             },
             Arc::new(FlowController::Singleton(EngineFlowController::empty())),
             DummyReporter,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -3291,7 +3291,7 @@ pub struct DynamicConfigs {
     pub in_memory_pessimistic_lock: Arc<AtomicBool>,
     pub wake_up_delay_duration_ms: Arc<AtomicU64>,
     pub in_memory_peer_size_limit: Arc<AtomicU64>,
-    pub in_memory_global_size_limit: Arc<AtomicU64>,
+    pub in_memory_instance_size_limit: Arc<AtomicU64>,
 }
 
 fn get_priority_tag(priority: CommandPri) -> CommandPriority {
@@ -3392,7 +3392,7 @@ pub struct TestStorageBuilder<E: Engine, L: LockManager, F: KvFormat> {
     resource_tag_factory: ResourceTagFactory,
     _phantom: PhantomData<F>,
     in_memory_peer_size_limit: Arc<AtomicU64>,
-    in_memory_global_size_limit: Arc<AtomicU64>,
+    in_memory_instance_size_limit: Arc<AtomicU64>,
 }
 
 /// TestStorageBuilder for Api V1
@@ -3532,7 +3532,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> TestStorageBuilder<E, L, F> {
             resource_tag_factory: ResourceTagFactory::new_for_test(),
             _phantom: PhantomData,
             in_memory_peer_size_limit: Arc::new(AtomicU64::new(512 << 10)),
-            in_memory_global_size_limit: Arc::new(AtomicU64::new(100 << 20)),
+            in_memory_instance_size_limit: Arc::new(AtomicU64::new(100 << 20)),
         }
     }
 
@@ -3603,7 +3603,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> TestStorageBuilder<E, L, F> {
                 in_memory_pessimistic_lock: self.in_memory_pessimistic_lock,
                 wake_up_delay_duration_ms: self.wake_up_delay_duration_ms,
                 in_memory_peer_size_limit: self.in_memory_peer_size_limit,
-                in_memory_global_size_limit: self.in_memory_global_size_limit,
+                in_memory_instance_size_limit: self.in_memory_instance_size_limit,
             },
             Arc::new(FlowController::Singleton(EngineFlowController::empty())),
             DummyReporter,
@@ -3638,7 +3638,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> TestStorageBuilder<E, L, F> {
                 in_memory_pessimistic_lock: self.in_memory_pessimistic_lock,
                 wake_up_delay_duration_ms: self.wake_up_delay_duration_ms,
                 in_memory_peer_size_limit: self.in_memory_peer_size_limit,
-                in_memory_global_size_limit: self.in_memory_global_size_limit,
+                in_memory_instance_size_limit: self.in_memory_instance_size_limit,
             },
             Arc::new(FlowController::Singleton(EngineFlowController::empty())),
             DummyReporter,
@@ -3676,7 +3676,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> TestStorageBuilder<E, L, F> {
                 in_memory_pessimistic_lock: self.in_memory_pessimistic_lock,
                 wake_up_delay_duration_ms: self.wake_up_delay_duration_ms,
                 in_memory_peer_size_limit: self.in_memory_peer_size_limit,
-                in_memory_global_size_limit: self.in_memory_global_size_limit,
+                in_memory_instance_size_limit: self.in_memory_instance_size_limit,
             },
             Arc::new(FlowController::Singleton(EngineFlowController::empty())),
             DummyReporter,

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -287,6 +287,9 @@ struct TxnSchedulerInner<L: LockManager> {
     txn_status_cache: TxnStatusCache,
 
     memory_quota: Arc<MemoryQuota>,
+
+    in_memory_peer_size_limit: Arc<AtomicU64>,
+    in_memory_global_size_limit: Arc<AtomicU64>,
 }
 
 #[inline]
@@ -481,6 +484,8 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
             feature_gate,
             txn_status_cache: TxnStatusCache::new(config.txn_status_cache_capacity),
             memory_quota: Arc::new(MemoryQuota::new(config.memory_quota.0 as _)),
+            in_memory_peer_size_limit: dynamic_configs.in_memory_peer_size_limit,
+            in_memory_global_size_limit: dynamic_configs.in_memory_global_size_limit,
         });
 
         SCHED_TXN_MEMORY_QUOTA
@@ -1901,7 +1906,13 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         {
             return false;
         }
-        match pessimistic_locks.insert(mem::take(&mut to_be_write.modifies)) {
+        match pessimistic_locks.insert(
+            mem::take(&mut to_be_write.modifies),
+            self.inner.in_memory_peer_size_limit.load(Ordering::Relaxed) as usize,
+            self.inner
+                .in_memory_global_size_limit
+                .load(Ordering::Relaxed) as usize,
+        ) {
             Ok(()) => {
                 IN_MEMORY_PESSIMISTIC_LOCKING_COUNTER_STATIC.success.inc();
                 true
@@ -2231,6 +2242,8 @@ mod tests {
                     pipelined_pessimistic_lock: Arc::new(AtomicBool::new(true)),
                     in_memory_pessimistic_lock: Arc::new(AtomicBool::new(false)),
                     wake_up_delay_duration_ms: Arc::new(AtomicU64::new(0)),
+                    in_memory_peer_size_limit: Arc::new(AtomicU64::new(512 << 10)),
+                    in_memory_global_size_limit: Arc::new(AtomicU64::new(100 << 20)),
                 },
                 Arc::new(FlowController::Singleton(EngineFlowController::empty())),
                 None,
@@ -2581,6 +2594,8 @@ mod tests {
                 pipelined_pessimistic_lock: Arc::new(AtomicBool::new(false)),
                 in_memory_pessimistic_lock: Arc::new(AtomicBool::new(false)),
                 wake_up_delay_duration_ms: Arc::new(AtomicU64::new(0)),
+                in_memory_peer_size_limit: Arc::new(AtomicU64::new(512 << 10)),
+                in_memory_global_size_limit: Arc::new(AtomicU64::new(100 << 20)),
             },
             Arc::new(FlowController::Singleton(EngineFlowController::empty())),
             None,

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -289,7 +289,7 @@ struct TxnSchedulerInner<L: LockManager> {
     memory_quota: Arc<MemoryQuota>,
 
     in_memory_peer_size_limit: Arc<AtomicU64>,
-    in_memory_global_size_limit: Arc<AtomicU64>,
+    in_memory_instance_size_limit: Arc<AtomicU64>,
 }
 
 #[inline]
@@ -485,7 +485,7 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
             txn_status_cache: TxnStatusCache::new(config.txn_status_cache_capacity),
             memory_quota: Arc::new(MemoryQuota::new(config.memory_quota.0 as _)),
             in_memory_peer_size_limit: dynamic_configs.in_memory_peer_size_limit,
-            in_memory_global_size_limit: dynamic_configs.in_memory_global_size_limit,
+            in_memory_instance_size_limit: dynamic_configs.in_memory_instance_size_limit,
         });
 
         SCHED_TXN_MEMORY_QUOTA
@@ -1910,7 +1910,7 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
             mem::take(&mut to_be_write.modifies),
             self.inner.in_memory_peer_size_limit.load(Ordering::Relaxed) as usize,
             self.inner
-                .in_memory_global_size_limit
+                .in_memory_instance_size_limit
                 .load(Ordering::Relaxed) as usize,
         ) {
             Ok(()) => {
@@ -2243,7 +2243,7 @@ mod tests {
                     in_memory_pessimistic_lock: Arc::new(AtomicBool::new(false)),
                     wake_up_delay_duration_ms: Arc::new(AtomicU64::new(0)),
                     in_memory_peer_size_limit: Arc::new(AtomicU64::new(512 << 10)),
-                    in_memory_global_size_limit: Arc::new(AtomicU64::new(100 << 20)),
+                    in_memory_instance_size_limit: Arc::new(AtomicU64::new(100 << 20)),
                 },
                 Arc::new(FlowController::Singleton(EngineFlowController::empty())),
                 None,
@@ -2595,7 +2595,7 @@ mod tests {
                 in_memory_pessimistic_lock: Arc::new(AtomicBool::new(false)),
                 wake_up_delay_duration_ms: Arc::new(AtomicU64::new(0)),
                 in_memory_peer_size_limit: Arc::new(AtomicU64::new(512 << 10)),
-                in_memory_global_size_limit: Arc::new(AtomicU64::new(100 << 20)),
+                in_memory_instance_size_limit: Arc::new(AtomicU64::new(100 << 20)),
             },
             Arc::new(FlowController::Singleton(EngineFlowController::empty())),
             None,

--- a/tests/failpoints/cases/test_merge.rs
+++ b/tests/failpoints/cases/test_merge.rs
@@ -1393,7 +1393,7 @@ fn test_source_peer_read_delegate_after_apply() {
 #[test]
 fn test_merge_with_concurrent_pessimistic_locking() {
     let peer_size_limit = 512 << 10;
-    let global_size_limit = 100 << 20;
+    let instance_size_limit = 100 << 20;
     let mut cluster = new_server_cluster(0, 2);
     configure_for_merge(&mut cluster.cfg);
     cluster.cfg.pessimistic_txn.pipelined = true;
@@ -1433,7 +1433,7 @@ fn test_merge_with_concurrent_pessimistic_locking() {
                 },
             )],
             peer_size_limit,
-            global_size_limit,
+            instance_size_limit,
         )
         .unwrap();
 
@@ -1487,7 +1487,7 @@ fn test_merge_with_concurrent_pessimistic_locking() {
 #[test]
 fn test_merge_pessimistic_locks_with_concurrent_prewrite() {
     let peer_size_limit = 512 << 10;
-    let global_size_limit = 100 << 20;
+    let instance_size_limit = 100 << 20;
     let mut cluster = new_server_cluster(0, 2);
     configure_for_merge(&mut cluster.cfg);
     cluster.cfg.pessimistic_txn.pipelined = true;
@@ -1534,7 +1534,7 @@ fn test_merge_pessimistic_locks_with_concurrent_prewrite() {
                 (Key::from_raw(b"k1"), lock),
             ],
             peer_size_limit,
-            global_size_limit,
+            instance_size_limit,
         )
         .unwrap();
 
@@ -1578,7 +1578,7 @@ fn test_merge_pessimistic_locks_with_concurrent_prewrite() {
 #[test]
 fn test_retry_pending_prepare_merge_fail() {
     let peer_size_limit = 512 << 10;
-    let global_size_limit = 100 << 20;
+    let instance_size_limit = 100 << 20;
     let mut cluster = new_server_cluster(0, 2);
     configure_for_merge(&mut cluster.cfg);
     cluster.cfg.pessimistic_txn.pipelined = true;
@@ -1618,7 +1618,7 @@ fn test_retry_pending_prepare_merge_fail() {
         .insert(
             vec![(Key::from_raw(b"k1"), l1)],
             peer_size_limit,
-            global_size_limit,
+            instance_size_limit,
         )
         .unwrap();
 
@@ -1661,7 +1661,7 @@ fn test_retry_pending_prepare_merge_fail() {
 #[test]
 fn test_merge_pessimistic_locks_propose_fail() {
     let peer_size_limit = 512 << 10;
-    let global_size_limit = 100 << 20;
+    let instance_size_limit = 100 << 20;
     let mut cluster = new_server_cluster(0, 2);
     configure_for_merge(&mut cluster.cfg);
     cluster.cfg.pessimistic_txn.pipelined = true;
@@ -1700,7 +1700,7 @@ fn test_merge_pessimistic_locks_propose_fail() {
         .insert(
             vec![(Key::from_raw(b"k1"), lock)],
             peer_size_limit,
-            global_size_limit,
+            instance_size_limit,
         )
         .unwrap();
 

--- a/tests/failpoints/cases/test_merge.rs
+++ b/tests/failpoints/cases/test_merge.rs
@@ -1392,6 +1392,8 @@ fn test_source_peer_read_delegate_after_apply() {
 
 #[test]
 fn test_merge_with_concurrent_pessimistic_locking() {
+    let peer_size_limit = 512 << 10;
+    let global_size_limit = 100 << 20;
     let mut cluster = new_server_cluster(0, 2);
     configure_for_merge(&mut cluster.cfg);
     cluster.cfg.pessimistic_txn.pipelined = true;
@@ -1417,18 +1419,22 @@ fn test_merge_with_concurrent_pessimistic_locking() {
     txn_ext
         .pessimistic_locks
         .write()
-        .insert(vec![(
-            Key::from_raw(b"k0"),
-            PessimisticLock {
-                primary: b"k0".to_vec().into_boxed_slice(),
-                start_ts: 10.into(),
-                ttl: 3000,
-                for_update_ts: 20.into(),
-                min_commit_ts: 30.into(),
-                last_change: LastChange::make_exist(15.into(), 3),
-                is_locked_with_conflict: false,
-            },
-        )])
+        .insert(
+            vec![(
+                Key::from_raw(b"k0"),
+                PessimisticLock {
+                    primary: b"k0".to_vec().into_boxed_slice(),
+                    start_ts: 10.into(),
+                    ttl: 3000,
+                    for_update_ts: 20.into(),
+                    min_commit_ts: 30.into(),
+                    last_change: LastChange::make_exist(15.into(), 3),
+                    is_locked_with_conflict: false,
+                },
+            )],
+            peer_size_limit,
+            global_size_limit,
+        )
         .unwrap();
 
     let addr = cluster.sim.rl().get_addr(1);
@@ -1480,6 +1486,8 @@ fn test_merge_with_concurrent_pessimistic_locking() {
 
 #[test]
 fn test_merge_pessimistic_locks_with_concurrent_prewrite() {
+    let peer_size_limit = 512 << 10;
+    let global_size_limit = 100 << 20;
     let mut cluster = new_server_cluster(0, 2);
     configure_for_merge(&mut cluster.cfg);
     cluster.cfg.pessimistic_txn.pipelined = true;
@@ -1520,10 +1528,14 @@ fn test_merge_pessimistic_locks_with_concurrent_prewrite() {
     txn_ext
         .pessimistic_locks
         .write()
-        .insert(vec![
-            (Key::from_raw(b"k0"), lock.clone()),
-            (Key::from_raw(b"k1"), lock),
-        ])
+        .insert(
+            vec![
+                (Key::from_raw(b"k0"), lock.clone()),
+                (Key::from_raw(b"k1"), lock),
+            ],
+            peer_size_limit,
+            global_size_limit,
+        )
         .unwrap();
 
     let mut mutation = Mutation::default();
@@ -1565,6 +1577,8 @@ fn test_merge_pessimistic_locks_with_concurrent_prewrite() {
 
 #[test]
 fn test_retry_pending_prepare_merge_fail() {
+    let peer_size_limit = 512 << 10;
+    let global_size_limit = 100 << 20;
     let mut cluster = new_server_cluster(0, 2);
     configure_for_merge(&mut cluster.cfg);
     cluster.cfg.pessimistic_txn.pipelined = true;
@@ -1601,7 +1615,11 @@ fn test_retry_pending_prepare_merge_fail() {
     txn_ext
         .pessimistic_locks
         .write()
-        .insert(vec![(Key::from_raw(b"k1"), l1)])
+        .insert(
+            vec![(Key::from_raw(b"k1"), l1)],
+            peer_size_limit,
+            global_size_limit,
+        )
         .unwrap();
 
     // Pause apply and write some data to the left region
@@ -1642,6 +1660,8 @@ fn test_retry_pending_prepare_merge_fail() {
 
 #[test]
 fn test_merge_pessimistic_locks_propose_fail() {
+    let peer_size_limit = 512 << 10;
+    let global_size_limit = 100 << 20;
     let mut cluster = new_server_cluster(0, 2);
     configure_for_merge(&mut cluster.cfg);
     cluster.cfg.pessimistic_txn.pipelined = true;
@@ -1677,7 +1697,11 @@ fn test_merge_pessimistic_locks_propose_fail() {
     txn_ext
         .pessimistic_locks
         .write()
-        .insert(vec![(Key::from_raw(b"k1"), lock)])
+        .insert(
+            vec![(Key::from_raw(b"k1"), lock)],
+            peer_size_limit,
+            global_size_limit,
+        )
         .unwrap();
 
     fail::cfg("raft_propose", "pause").unwrap();

--- a/tests/failpoints/cases/test_split_region.rs
+++ b/tests/failpoints/cases/test_split_region.rs
@@ -1161,6 +1161,8 @@ fn test_split_with_concurrent_pessimistic_locking() {
 
 #[test]
 fn test_split_pessimistic_locks_with_concurrent_prewrite() {
+    let peer_size_limit = 512 << 10;
+    let global_size_limit = 100 << 20;
     let mut cluster = new_server_cluster(0, 2);
     cluster.cfg.pessimistic_txn.pipelined = true;
     cluster.cfg.pessimistic_txn.in_memory = true;
@@ -1216,10 +1218,11 @@ fn test_split_pessimistic_locks_with_concurrent_prewrite() {
     {
         let mut locks = txn_ext.pessimistic_locks.write();
         locks
-            .insert(vec![
-                (Key::from_raw(b"a"), lock_a),
-                (Key::from_raw(b"c"), lock_c),
-            ])
+            .insert(
+                vec![(Key::from_raw(b"a"), lock_a), (Key::from_raw(b"c"), lock_c)],
+                peer_size_limit,
+                global_size_limit,
+            )
             .unwrap();
     }
 

--- a/tests/failpoints/cases/test_split_region.rs
+++ b/tests/failpoints/cases/test_split_region.rs
@@ -1162,7 +1162,7 @@ fn test_split_with_concurrent_pessimistic_locking() {
 #[test]
 fn test_split_pessimistic_locks_with_concurrent_prewrite() {
     let peer_size_limit = 512 << 10;
-    let global_size_limit = 100 << 20;
+    let instance_size_limit = 100 << 20;
     let mut cluster = new_server_cluster(0, 2);
     cluster.cfg.pessimistic_txn.pipelined = true;
     cluster.cfg.pessimistic_txn.in_memory = true;
@@ -1221,7 +1221,7 @@ fn test_split_pessimistic_locks_with_concurrent_prewrite() {
             .insert(
                 vec![(Key::from_raw(b"a"), lock_a), (Key::from_raw(b"c"), lock_c)],
                 peer_size_limit,
-                global_size_limit,
+                instance_size_limit,
             )
             .unwrap();
     }

--- a/tests/failpoints/cases/test_transaction.rs
+++ b/tests/failpoints/cases/test_transaction.rs
@@ -563,6 +563,8 @@ fn test_pessimistic_lock_check_valid() {
 
 #[test]
 fn test_concurrent_write_after_transfer_leader_invalidates_locks() {
+    let peer_size_limit = 512 << 10;
+    let global_size_limit = 100 << 20;
     let mut cluster = new_server_cluster(0, 1);
     cluster.cfg.pessimistic_txn.pipelined = true;
     cluster.cfg.pessimistic_txn.in_memory = true;
@@ -588,7 +590,11 @@ fn test_concurrent_write_after_transfer_leader_invalidates_locks() {
     txn_ext
         .pessimistic_locks
         .write()
-        .insert(vec![(Key::from_raw(b"key"), lock.clone())])
+        .insert(
+            vec![(Key::from_raw(b"key"), lock.clone())],
+            peer_size_limit,
+            global_size_limit,
+        )
         .unwrap();
 
     let region = cluster.get_region(b"");

--- a/tests/failpoints/cases/test_transaction.rs
+++ b/tests/failpoints/cases/test_transaction.rs
@@ -564,7 +564,7 @@ fn test_pessimistic_lock_check_valid() {
 #[test]
 fn test_concurrent_write_after_transfer_leader_invalidates_locks() {
     let peer_size_limit = 512 << 10;
-    let global_size_limit = 100 << 20;
+    let instance_size_limit = 100 << 20;
     let mut cluster = new_server_cluster(0, 1);
     cluster.cfg.pessimistic_txn.pipelined = true;
     cluster.cfg.pessimistic_txn.in_memory = true;
@@ -593,7 +593,7 @@ fn test_concurrent_write_after_transfer_leader_invalidates_locks() {
         .insert(
             vec![(Key::from_raw(b"key"), lock.clone())],
             peer_size_limit,
-            global_size_limit,
+            instance_size_limit,
         )
         .unwrap();
 

--- a/tests/failpoints/cases/test_transfer_leader.rs
+++ b/tests/failpoints/cases/test_transfer_leader.rs
@@ -207,7 +207,7 @@ fn test_delete_lock_proposed_after_proposing_locks_2() {
 #[test_case(test_raftstore_v2::new_server_cluster)]
 fn test_delete_lock_proposed_before_proposing_locks() {
     let peer_size_limit = 512 << 10;
-    let global_size_limit = 100 << 20;
+    let instance_size_limit = 100 << 20;
     let mut cluster = new_cluster(0, 3);
     cluster.cfg.raft_store.raft_heartbeat_ticks = 20;
     cluster.run();
@@ -235,7 +235,7 @@ fn test_delete_lock_proposed_before_proposing_locks() {
                 },
             )],
             peer_size_limit,
-            global_size_limit,
+            instance_size_limit,
         )
         .unwrap();
 
@@ -291,7 +291,7 @@ fn test_delete_lock_proposed_before_proposing_locks() {
 #[test_case(test_raftstore_v2::new_server_cluster)]
 fn test_read_lock_after_become_follower() {
     let peer_size_limit = 512 << 10;
-    let global_size_limit = 100 << 20;
+    let instance_size_limit = 100 << 20;
     let mut cluster = new_cluster(0, 3);
     cluster.cfg.raft_store.raft_heartbeat_ticks = 20;
     cluster.run();
@@ -326,7 +326,7 @@ fn test_read_lock_after_become_follower() {
                 },
             )],
             peer_size_limit,
-            global_size_limit,
+            instance_size_limit,
         )
         .unwrap();
 

--- a/tests/integrations/config/dynamic/pessimistic_txn.rs
+++ b/tests/integrations/config/dynamic/pessimistic_txn.rs
@@ -84,7 +84,7 @@ fn test_lock_manager_cfg_update() {
     const DEFAULT_TIMEOUT: u64 = 3000;
     const DEFAULT_DELAY: u64 = 100;
     const DEFAULT_IN_MEMORY_PEER_SIZE_LIMIT: u64 = 512 << 10;
-    const DEFAULT_IN_MEMORY_GLOBAL_SIZE_LIMIT: u64 = 100 << 20;
+    const DEFAULT_IN_MEMORY_INSTANCE_SIZE_LIMIT: u64 = 100 << 20;
     let (mut cfg, _dir) = TikvConfig::with_tmp().unwrap();
     cfg.pessimistic_txn.wait_for_lock_timeout = ReadableDuration::millis(DEFAULT_TIMEOUT);
     cfg.pessimistic_txn.wake_up_delay_duration = ReadableDuration::millis(DEFAULT_DELAY);
@@ -191,17 +191,17 @@ fn test_lock_manager_cfg_update() {
     assert_eq!(
         lock_mgr
             .get_storage_dynamic_configs()
-            .in_memory_global_size_limit
+            .in_memory_instance_size_limit
             .load(Ordering::SeqCst),
-        DEFAULT_IN_MEMORY_GLOBAL_SIZE_LIMIT
+        DEFAULT_IN_MEMORY_INSTANCE_SIZE_LIMIT
     );
     cfg_controller
-        .update_config("pessimistic-txn.in-memory-global-size-limit", "1GiB")
+        .update_config("pessimistic-txn.in-memory-instance-size-limit", "1GiB")
         .unwrap();
     assert_eq!(
         lock_mgr
             .get_storage_dynamic_configs()
-            .in_memory_global_size_limit
+            .in_memory_instance_size_limit
             .load(Ordering::SeqCst),
         1 << 30
     );

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -860,6 +860,8 @@ fn test_serde_custom_tikv_config() {
         wake_up_delay_duration: ReadableDuration::millis(100),
         pipelined: false,
         in_memory: false,
+        in_memory_peer_size_limit: ReadableSize::kb(512),
+        in_memory_global_size_limit: ReadableSize::mb(100),
     };
     value.cdc = CdcConfig {
         min_ts_interval: ReadableDuration::secs(4),

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -861,7 +861,7 @@ fn test_serde_custom_tikv_config() {
         pipelined: false,
         in_memory: false,
         in_memory_peer_size_limit: ReadableSize::kb(512),
-        in_memory_global_size_limit: ReadableSize::mb(100),
+        in_memory_instance_size_limit: ReadableSize::mb(100),
     };
     value.cdc = CdcConfig {
         min_ts_interval: ReadableDuration::secs(4),

--- a/tests/integrations/raftstore/test_flashback.rs
+++ b/tests/integrations/raftstore/test_flashback.rs
@@ -27,7 +27,7 @@ const TEST_VALUE: &[u8] = b"v1";
 fn test_flashback_with_in_memory_pessimistic_locks() {
     let mut cluster = new_cluster(0, 3);
     let peer_size_limit = 512 << 10;
-    let global_size_limit = 100 << 20;
+    let instance_size_limit = 100 << 20;
     cluster.cfg.raft_store.raft_heartbeat_ticks = 20;
     cluster.run();
     cluster.must_transfer_leader(1, new_peer(1, 1));
@@ -54,7 +54,7 @@ fn test_flashback_with_in_memory_pessimistic_locks() {
                     },
                 )],
                 peer_size_limit,
-                global_size_limit,
+                instance_size_limit,
             )
             .unwrap();
         assert_eq!(pessimistic_locks.len(), 1);

--- a/tests/integrations/raftstore/test_merge.rs
+++ b/tests/integrations/raftstore/test_merge.rs
@@ -1451,6 +1451,8 @@ fn test_merge_snapshot_demote() {
 #[test_case(test_raftstore::new_server_cluster)]
 #[test_case(test_raftstore_v2::new_server_cluster)]
 fn test_propose_in_memory_pessimistic_locks() {
+    let peer_size_limit = 512 << 10;
+    let global_size_limit = 100 << 20;
     let mut cluster = new_cluster(0, 2);
     configure_for_merge(&mut cluster.cfg);
     cluster.run();
@@ -1486,7 +1488,11 @@ fn test_propose_in_memory_pessimistic_locks() {
     txn_ext
         .pessimistic_locks
         .write()
-        .insert(vec![(Key::from_raw(b"k1"), l1.clone())])
+        .insert(
+            vec![(Key::from_raw(b"k1"), l1.clone())],
+            peer_size_limit,
+            global_size_limit,
+        )
         .unwrap();
 
     // Insert lock l2 into the right region
@@ -1504,7 +1510,11 @@ fn test_propose_in_memory_pessimistic_locks() {
     txn_ext
         .pessimistic_locks
         .write()
-        .insert(vec![(Key::from_raw(b"k3"), l2.clone())])
+        .insert(
+            vec![(Key::from_raw(b"k3"), l2.clone())],
+            peer_size_limit,
+            global_size_limit,
+        )
         .unwrap();
 
     // Merge left region into the right region
@@ -1582,6 +1592,8 @@ fn test_merge_pessimistic_locks_when_gap_is_too_large() {
 #[test_case(test_raftstore::new_server_cluster)]
 #[test_case(test_raftstore_v2::new_server_cluster)]
 fn test_merge_pessimistic_locks_repeated_merge() {
+    let peer_size_limit = 512 << 10;
+    let global_size_limit = 100 << 20;
     let mut cluster = new_cluster(0, 2);
     configure_for_merge(&mut cluster.cfg);
     cluster.cfg.pessimistic_txn.pipelined = true;
@@ -1615,7 +1627,11 @@ fn test_merge_pessimistic_locks_repeated_merge() {
     txn_ext
         .pessimistic_locks
         .write()
-        .insert(vec![(Key::from_raw(b"k1"), lock.clone())])
+        .insert(
+            vec![(Key::from_raw(b"k1"), lock.clone())],
+            peer_size_limit,
+            global_size_limit,
+        )
         .unwrap();
 
     // Filter MsgAppend, so the proposed PrepareMerge will not succeed

--- a/tests/integrations/raftstore/test_merge.rs
+++ b/tests/integrations/raftstore/test_merge.rs
@@ -1452,7 +1452,7 @@ fn test_merge_snapshot_demote() {
 #[test_case(test_raftstore_v2::new_server_cluster)]
 fn test_propose_in_memory_pessimistic_locks() {
     let peer_size_limit = 512 << 10;
-    let global_size_limit = 100 << 20;
+    let instance_size_limit = 100 << 20;
     let mut cluster = new_cluster(0, 2);
     configure_for_merge(&mut cluster.cfg);
     cluster.run();
@@ -1491,7 +1491,7 @@ fn test_propose_in_memory_pessimistic_locks() {
         .insert(
             vec![(Key::from_raw(b"k1"), l1.clone())],
             peer_size_limit,
-            global_size_limit,
+            instance_size_limit,
         )
         .unwrap();
 
@@ -1513,7 +1513,7 @@ fn test_propose_in_memory_pessimistic_locks() {
         .insert(
             vec![(Key::from_raw(b"k3"), l2.clone())],
             peer_size_limit,
-            global_size_limit,
+            instance_size_limit,
         )
         .unwrap();
 
@@ -1593,7 +1593,7 @@ fn test_merge_pessimistic_locks_when_gap_is_too_large() {
 #[test_case(test_raftstore_v2::new_server_cluster)]
 fn test_merge_pessimistic_locks_repeated_merge() {
     let peer_size_limit = 512 << 10;
-    let global_size_limit = 100 << 20;
+    let instance_size_limit = 100 << 20;
     let mut cluster = new_cluster(0, 2);
     configure_for_merge(&mut cluster.cfg);
     cluster.cfg.pessimistic_txn.pipelined = true;
@@ -1630,7 +1630,7 @@ fn test_merge_pessimistic_locks_repeated_merge() {
         .insert(
             vec![(Key::from_raw(b"k1"), lock.clone())],
             peer_size_limit,
-            global_size_limit,
+            instance_size_limit,
         )
         .unwrap();
 

--- a/tests/integrations/raftstore/test_multi.rs
+++ b/tests/integrations/raftstore/test_multi.rs
@@ -813,7 +813,7 @@ fn test_node_catch_up_logs() {
 #[test]
 fn test_leader_drop_with_pessimistic_lock() {
     let peer_size_limit = 512 << 10;
-    let global_size_limit = 100 << 20;
+    let instance_size_limit = 100 << 20;
     let mut cluster = new_server_cluster(0, 3);
     cluster.run();
     cluster.must_transfer_leader(1, new_peer(1, 1));
@@ -841,7 +841,7 @@ fn test_leader_drop_with_pessimistic_lock() {
                 },
             )],
             peer_size_limit,
-            global_size_limit,
+            instance_size_limit,
         )
         .unwrap();
 

--- a/tests/integrations/raftstore/test_split_region.rs
+++ b/tests/integrations/raftstore/test_split_region.rs
@@ -897,7 +897,7 @@ fn test_split_with_epoch_not_match() {
 #[test_case(test_raftstore_v2::new_server_cluster)]
 fn test_split_with_in_memory_pessimistic_locks() {
     let peer_size_limit = 512 << 10;
-    let global_size_limit = 100 << 20;
+    let instance_size_limit = 100 << 20;
     let mut cluster = new_cluster(0, 3);
     let pd_client = Arc::clone(&cluster.pd_client);
     pd_client.disable_default_operator();
@@ -940,7 +940,7 @@ fn test_split_with_in_memory_pessimistic_locks() {
                     (Key::from_raw(b"c"), lock_c.clone()),
                 ],
                 peer_size_limit,
-                global_size_limit,
+                instance_size_limit,
             )
             .unwrap();
     }

--- a/tests/integrations/raftstore/test_split_region.rs
+++ b/tests/integrations/raftstore/test_split_region.rs
@@ -896,6 +896,8 @@ fn test_split_with_epoch_not_match() {
 #[test_case(test_raftstore::new_server_cluster)]
 #[test_case(test_raftstore_v2::new_server_cluster)]
 fn test_split_with_in_memory_pessimistic_locks() {
+    let peer_size_limit = 512 << 10;
+    let global_size_limit = 100 << 20;
     let mut cluster = new_cluster(0, 3);
     let pd_client = Arc::clone(&cluster.pd_client);
     pd_client.disable_default_operator();
@@ -932,10 +934,14 @@ fn test_split_with_in_memory_pessimistic_locks() {
     {
         let mut locks = txn_ext.pessimistic_locks.write();
         locks
-            .insert(vec![
-                (Key::from_raw(b"a"), lock_a.clone()),
-                (Key::from_raw(b"c"), lock_c.clone()),
-            ])
+            .insert(
+                vec![
+                    (Key::from_raw(b"a"), lock_a.clone()),
+                    (Key::from_raw(b"c"), lock_c.clone()),
+                ],
+                peer_size_limit,
+                global_size_limit,
+            )
             .unwrap();
     }
 

--- a/tests/integrations/raftstore/test_transfer_leader.rs
+++ b/tests/integrations/raftstore/test_transfer_leader.rs
@@ -257,7 +257,7 @@ fn test_sync_max_ts_after_leader_transfer() {
 #[test_case(test_raftstore_v2::new_server_cluster)]
 fn test_propose_in_memory_pessimistic_locks() {
     let peer_size_limit = 512 << 10;
-    let global_size_limit = 100 << 20;
+    let instance_size_limit = 100 << 20;
     let mut cluster = new_cluster(0, 3);
     cluster.cfg.raft_store.raft_heartbeat_ticks = 20;
     cluster.run();
@@ -284,7 +284,7 @@ fn test_propose_in_memory_pessimistic_locks() {
             .insert(
                 vec![(Key::from_raw(b"key"), lock.clone())],
                 peer_size_limit,
-                global_size_limit,
+                instance_size_limit,
             )
             .unwrap();
     }
@@ -305,7 +305,7 @@ fn test_propose_in_memory_pessimistic_locks() {
 #[test_case(test_raftstore_v2::new_server_cluster)]
 fn test_memory_pessimistic_locks_status_after_transfer_leader_failure() {
     let peer_size_limit = 512 << 10;
-    let global_size_limit = 100 << 20;
+    let instance_size_limit = 100 << 20;
     let mut cluster = new_cluster(0, 3);
     cluster.cfg.raft_store.raft_heartbeat_ticks = 20;
     cluster.cfg.raft_store.reactive_memory_lock_tick_interval = ReadableDuration::millis(200);
@@ -332,7 +332,7 @@ fn test_memory_pessimistic_locks_status_after_transfer_leader_failure() {
         .insert(
             vec![(Key::from_raw(b"key"), lock)],
             peer_size_limit,
-            global_size_limit,
+            instance_size_limit,
         )
         .unwrap();
 

--- a/tests/integrations/raftstore/test_transfer_leader.rs
+++ b/tests/integrations/raftstore/test_transfer_leader.rs
@@ -256,6 +256,8 @@ fn test_sync_max_ts_after_leader_transfer() {
 #[test_case(test_raftstore::new_server_cluster)]
 #[test_case(test_raftstore_v2::new_server_cluster)]
 fn test_propose_in_memory_pessimistic_locks() {
+    let peer_size_limit = 512 << 10;
+    let global_size_limit = 100 << 20;
     let mut cluster = new_cluster(0, 3);
     cluster.cfg.raft_store.raft_heartbeat_ticks = 20;
     cluster.run();
@@ -279,7 +281,11 @@ fn test_propose_in_memory_pessimistic_locks() {
         let mut pessimistic_locks = txn_ext.pessimistic_locks.write();
         assert!(pessimistic_locks.is_writable());
         pessimistic_locks
-            .insert(vec![(Key::from_raw(b"key"), lock.clone())])
+            .insert(
+                vec![(Key::from_raw(b"key"), lock.clone())],
+                peer_size_limit,
+                global_size_limit,
+            )
             .unwrap();
     }
 
@@ -298,6 +304,8 @@ fn test_propose_in_memory_pessimistic_locks() {
 #[test_case(test_raftstore::new_server_cluster)]
 #[test_case(test_raftstore_v2::new_server_cluster)]
 fn test_memory_pessimistic_locks_status_after_transfer_leader_failure() {
+    let peer_size_limit = 512 << 10;
+    let global_size_limit = 100 << 20;
     let mut cluster = new_cluster(0, 3);
     cluster.cfg.raft_store.raft_heartbeat_ticks = 20;
     cluster.cfg.raft_store.reactive_memory_lock_tick_interval = ReadableDuration::millis(200);
@@ -321,7 +329,11 @@ fn test_memory_pessimistic_locks_status_after_transfer_leader_failure() {
     txn_ext
         .pessimistic_locks
         .write()
-        .insert(vec![(Key::from_raw(b"key"), lock)])
+        .insert(
+            vec![(Key::from_raw(b"key"), lock)],
+            peer_size_limit,
+            global_size_limit,
+        )
         .unwrap();
 
     // Make it fail to transfer leader


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #17542 

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Support changing the in-memory pessimistic lock memory size limit dynamically.
```

### Related changes

- [x] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Add in-memory pessimistic lock memory size limit configurations and support changing them dynamically.
```
