### PR TITLE
In-memory Engine: fix panic that new region has the same id with evicting region

### DIFF
--- a/components/engine_traits/src/range_cache_engine.rs
+++ b/components/engine_traits/src/range_cache_engine.rs
@@ -114,7 +114,7 @@ pub struct CacheRegion {
     pub epoch_version: u64,
     // data start key of the region range,  equals to data_key(region.start_key).
     pub start: Vec<u8>,
-    // data start key of the region range, equals to data_end_key(region.start_key).
+    // data end key of the region range, equals to data_end_key(region.end_key).
     pub end: Vec<u8>,
 }
 

--- a/components/range_cache_memory_engine/src/range_manager.rs
+++ b/components/range_cache_memory_engine/src/range_manager.rs
@@ -383,9 +383,11 @@ impl RegionMetaMap {
             return overlapped_region_state;
         }
 
-        // check region with same id, it is possible that there is a cache region with
-        // outdated epoch that is in the (pending_)evicting state, and a load is
-        // triggered with newer version and the range is not overlapped.
+        // check region with same id. It is possible that there is a cached region with
+        // outdated epoch that is still in the (pending_)evicting state, and a new load is
+        // triggered after the region is merged and split for multiple times. Thus, the new 
+        // pending region's range may not overlap with the old cached region but their region
+        // ids are the same.
         if let Some(region) = self.regions.get(&region.id) {
             return Some(region.state);
         }

--- a/components/range_cache_memory_engine/src/range_manager.rs
+++ b/components/range_cache_memory_engine/src/range_manager.rs
@@ -291,8 +291,10 @@ impl RegionMetaMap {
         assert!(!self.overlaps_with(&meta.region));
         let id = meta.region.id;
         let data_end_key = meta.region.end.clone();
-        self.regions.insert(id, meta);
-        self.regions_by_range.insert(data_end_key, id);
+        let old_meta = self.regions.insert(id, meta);
+        assert!(old_meta.is_none(), "old_meta: {:?}", old_meta.unwrap());
+        let old_id = self.regions_by_range.insert(data_end_key, id);
+        assert!(old_id.is_none(), "old_region_id: {}", old_id.unwrap());
         if self.regions.len() == 1 {
             assert!(!self.is_active.load(Ordering::Relaxed));
             self.is_active.store(true, Ordering::Relaxed);
@@ -312,6 +314,7 @@ impl RegionMetaMap {
             };
             return Err(reason);
         }
+        info!("ime load new region"; "region" => ?cache_region);
         let meta = CacheRegionMeta::new(cache_region);
         self.new_region_meta(meta);
         Ok(())
@@ -376,7 +379,18 @@ impl RegionMetaMap {
         for id in removed_regions {
             self.remove_region(id);
         }
-        overlapped_region_state
+        if overlapped_region_state.is_some() {
+            return overlapped_region_state;
+        }
+
+        // check region with same id, it is possible that there is a cache region with
+        // outdated epoch that is in the (pending_)evicting state, and a load is
+        // triggered with newer version and the range is not overlapped.
+        if let Some(region) = self.regions.get(&region.id) {
+            return Some(region.state);
+        }
+
+        None
     }
 
     fn on_all_overlapped_regions(&self, region: &CacheRegion, mut f: impl FnMut(&CacheRegionMeta)) {
@@ -913,6 +927,7 @@ impl RegionManager {
             for r in regions {
                 let meta = regions_map.remove_region(r.id);
                 assert_eq!(meta.region.epoch_version, r.epoch_version);
+                info!("ime remove evicted region"; "meta" => ?meta);
 
                 let evict_info = meta.evict_info.unwrap();
                 observe_eviction_duration(
@@ -1186,6 +1201,13 @@ mod tests {
         assert_eq!(
             range_mgr.load_region(r).unwrap_err(),
             LoadFailedReason::PendingRange
+        );
+
+        // test range overlap but id overlap
+        let r = CacheRegion::new(1, 2, b"k20", b"k30");
+        assert_eq!(
+            range_mgr.load_region(r).unwrap_err(),
+            LoadFailedReason::Evicting
         );
     }
 

--- a/components/range_cache_memory_engine/src/range_manager.rs
+++ b/components/range_cache_memory_engine/src/range_manager.rs
@@ -384,10 +384,14 @@ impl RegionMetaMap {
         }
 
         // check region with same id. It is possible that there is a cached region with
-        // outdated epoch that is still in the (pending_)evicting state, and a new load is
-        // triggered after the region is merged and split for multiple times. Thus, the new 
-        // pending region's range may not overlap with the old cached region but their region
-        // ids are the same.
+        // outdated epoch that is still in the (pending_)evicting state, and a new load
+        // is triggered after the region is merged and split for multiple times.
+        // Thus, the new pending region's range may not overlap with the old
+        // cached region but their region ids are the same.
+        // While in theory we should keep the new region as it doesn't overlap with any
+        // other region, but because we use region_id as the unique identifier, we do
+        // not load it for implementation simplicity as this kind of scenario
+        // should be very rare.
         if let Some(region) = self.regions.get(&region.id) {
             return Some(region.state);
         }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #17487, Close #17493, Close #17548

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Fix the bug that in-memory-engine may panic when load new region whose id is the same with a cached region that is being evicted. This can happen when a region is evicted by region merge, and the merged region is split and then load again while the cached region is still in evicting state.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
