### PR TITLE
In-memory engine: fix flaky test `test_load_with_split`

### DIFF
--- a/tests/failpoints/cases/test_range_cache_engine.rs
+++ b/tests/failpoints/cases/test_range_cache_engine.rs
@@ -179,13 +179,6 @@ fn test_load_with_split() {
     cluster.cfg.raft_store.apply_batch_system.pool_size = 2;
     cluster.run();
 
-    let mut tables = vec![];
-    for _ in 0..3 {
-        let product = ProductTable::new();
-        tables.push(product.clone());
-        must_copr_load_data(&mut cluster, &product, 1);
-    }
-
     let (tx, rx) = sync_channel(0);
     // let channel to make load process block at finishing loading snapshot
     let (tx2, rx2) = sync_channel(0);
@@ -207,6 +200,13 @@ fn test_load_with_split() {
             .region_manager()
             .load_region(CacheRegion::from_region(&cache_range))
             .unwrap();
+    }
+
+    let mut tables = vec![];
+    for _ in 0..3 {
+        let product = ProductTable::new();
+        tables.push(product.clone());
+        must_copr_load_data(&mut cluster, &product, 1);
     }
 
     rx.recv_timeout(Duration::from_secs(5)).unwrap();


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #17556

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
fix flaky test `test_load_with_split`
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
