### PR TITLE
In-memory engine: update the calculation of mvcc_amplification

### DIFF
--- a/components/pd_client/src/lib.rs
+++ b/components/pd_client/src/lib.rs
@@ -607,10 +607,7 @@ impl RegionWriteCfCopDetail {
     }
 
     pub fn mvcc_amplification(&self) -> f64 {
-        if self.processed_keys == 0 {
-            0f64
-        } else {
-            (self.next + self.prev) as f64 / self.processed_keys as f64
-        }
+        // Sometimes, processed_keys is 0 even (next + prev) is pretty high
+        (self.next + self.prev) as f64 / (self.processed_keys as f64 + 1)
     }
 }

--- a/components/pd_client/src/lib.rs
+++ b/components/pd_client/src/lib.rs
@@ -602,12 +602,27 @@ impl RegionWriteCfCopDetail {
         )
     }
 
+    #[inline]
     pub fn iterated_count(&self) -> usize {
         self.next + self.prev
     }
 
+    #[inline]
     pub fn mvcc_amplification(&self) -> f64 {
         // Sometimes, processed_keys is 0 even (next + prev) is pretty high
-        (self.next + self.prev) as f64 / (self.processed_keys as f64 + 1)
+        self.iterated_count() as f64 / (self.processed_keys as f64 + 1.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::RegionWriteCfCopDetail;
+
+    #[test]
+    fn test_procssed_key_0() {
+        let mut cop_detail = RegionWriteCfCopDetail::default();
+        cop_detail.next = 11;
+
+        assert_eq!(cop_detail.mvcc_amplification(), 11.0);
     }
 }

--- a/components/raftstore/src/coprocessor/region_info_accessor.rs
+++ b/components/raftstore/src/coprocessor/region_info_accessor.rs
@@ -690,7 +690,7 @@ impl RegionCollector {
             s.cop_detail.iterated_count() >= iterated_count_to_filter
                 // plus processed_keys by 1 to make it not 0
                 && s.cop_detail.mvcc_amplification()
-                    >= self.mvcc_amplification_threshold
+                    >= self.mvcc_amplification_threshold as f64
         });
 
         // TODO(SpadeA): remove it when auto load/evict is stable

--- a/components/raftstore/src/coprocessor/region_info_accessor.rs
+++ b/components/raftstore/src/coprocessor/region_info_accessor.rs
@@ -689,7 +689,7 @@ impl RegionCollector {
         top_regions.retain(|(_, s)| {
             s.cop_detail.iterated_count() >= iterated_count_to_filter
                 // plus processed_keys by 1 to make it not 0
-                && (s.cop_detail.iterated_count()) / (s.cop_detail.processed_keys + 1)
+                && s.cop_detail.mvcc_amplification()
                     >= self.mvcc_amplification_threshold
         });
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref #16141

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
update the calculation of mvcc_amplification
```

Avoid return 0 when processed_ke is 0,  as (next+prev) can be high even processed_key is 0.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
