### PR TITLE
raftstore: skip create logger in `get_entry_header`

### DIFF
--- a/components/raftstore-v2/src/operation/command/admin/merge/prepare.rs
+++ b/components/raftstore-v2/src/operation/command/admin/merge/prepare.rs
@@ -324,7 +324,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             }
             let Err(cmd) = SimpleWriteReqDecoder::new(
                 |buf, index, term| parse_at(&self.logger, buf, index, term),
-                &self.logger,
+                Some(&self.logger),
                 entry.get_data(),
                 entry.get_index(),
                 entry.get_term(),

--- a/components/raftstore-v2/src/operation/command/mod.rs
+++ b/components/raftstore-v2/src/operation/command/mod.rs
@@ -538,7 +538,7 @@ impl<EK: KvEngine, R: ApplyResReporter> Apply<EK, R> {
     pub async fn apply_unsafe_write(&mut self, data: Box<[u8]>) {
         let decoder = match SimpleWriteReqDecoder::new(
             |buf, index, term| parse_at(&self.logger, buf, index, term),
-            &self.logger,
+            Some(&self.logger),
             &data,
             u64::MAX,
             u64::MAX,
@@ -646,7 +646,7 @@ impl<EK: KvEngine, R: ApplyResReporter> Apply<EK, R> {
         let req = match entry.get_entry_type() {
             EntryType::EntryNormal => match SimpleWriteReqDecoder::new(
                 |buf, index, term| parse_at(&self.logger, buf, index, term),
-                &self.logger,
+                Some(&self.logger),
                 entry.get_data(),
                 log_index,
                 entry.get_term(),

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -765,10 +765,9 @@ pub fn get_entry_header(entry: &Entry) -> RaftRequestHeader {
     if entry.get_entry_type() != EntryType::EntryNormal {
         return RaftRequestHeader::default();
     }
-    let logger = slog_global::get_global().new(slog::o!());
     match SimpleWriteReqDecoder::new(
         |_, _, _| RaftCmdRequest::default(),
-        &logger,
+        None,
         entry.get_data(),
         entry.get_index(),
         entry.get_term(),
@@ -818,10 +817,9 @@ pub enum RaftCmd<'a> {
 }
 
 pub fn parse_raft_cmd_request<'a>(data: &'a [u8], index: u64, term: u64, tag: &str) -> RaftCmd<'a> {
-    let logger = slog_global::get_global().new(slog::o!());
     match SimpleWriteReqDecoder::new(
         |_, _, _| parse_data_at(data, index, tag),
-        &logger,
+        None,
         data,
         index,
         term,


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #17563

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
According to the flamegraph, creating a logger takes as much time as
parsing a protobuf message in `get_entry_header`.

As an optimization, skip logger creation since it's only used for panic
logging in `SimpleWriteReqDecoder::new`.
```

### Check List

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
