### PR TITLE
metrics: add busy threads CPU panel

### DIFF
--- a/metrics/grafana/tikv_details.dashboard.py
+++ b/metrics/grafana/tikv_details.dashboard.py
@@ -1472,6 +1472,28 @@ def ThreadCPU() -> RowPanel:
             ),
         ]
     )
+    layout.row(
+        [
+            graph_panel(
+                title="Busy Threads (>80%)",
+                yaxes=yaxes(left_format=UNITS.PERCENT_UNIT),
+                targets=[
+                    target(
+                        expr=expr_topk(
+                            20,
+                            "%s"
+                            % expr_sum_rate(
+                                "tikv_thread_cpu_seconds_total",
+                                label_selectors=['name!~"rocksdb.*"'],
+                                by_labels=["instance", "name"],
+                            ).extra(extra_expr="> 0.8"),
+                        ),
+                        legend_format="{{name}}-{{instance}}",
+                    ),
+                ],
+            ),
+        ]
+    )
     return layout.row_panel
 
 

--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -13457,6 +13457,139 @@
             "align": false,
             "alignLevel": 0
           }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": null,
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 70
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 99,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "topk(20,(\n    sum(rate(\n    tikv_thread_cpu_seconds_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",name!~\"rocksdb.*\"}\n    [$__rate_interval]\n)) by (instance, name) > 0.8\n    \n    \n))  ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{name}}-{{instance}}",
+              "metric": "",
+              "query": "topk(20,(\n    sum(rate(\n    tikv_thread_cpu_seconds_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",name!~\"rocksdb.*\"}\n    [$__rate_interval]\n)) by (instance, name) > 0.8\n    \n    \n))  ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Busy Threads (>80%)",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "percentunit",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
         }
       ],
       "repeat": null,
@@ -13493,7 +13626,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 99,
+      "id": 100,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -13532,7 +13665,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 100,
+          "id": 101,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -13680,7 +13813,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 101,
+          "id": 102,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -13828,7 +13961,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 102,
+          "id": 103,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -13961,7 +14094,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 103,
+          "id": 104,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -14112,7 +14245,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 104,
+      "id": 105,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -14151,7 +14284,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 105,
+          "id": 106,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -14352,7 +14485,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 106,
+          "id": 107,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -14553,7 +14686,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 107,
+          "id": 108,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -14754,7 +14887,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 108,
+          "id": 109,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -14955,7 +15088,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 109,
+          "id": 110,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -15156,7 +15289,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 110,
+          "id": 111,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -15357,7 +15490,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 111,
+          "id": 112,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -15558,7 +15691,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 112,
+          "id": 113,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -15759,7 +15892,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 113,
+          "id": 114,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -15960,7 +16093,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 114,
+          "id": 115,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -16161,7 +16294,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 115,
+          "id": 116,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -16362,7 +16495,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 116,
+          "id": 117,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -16563,7 +16696,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 117,
+          "id": 118,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -16767,7 +16900,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 118,
+      "id": 119,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -16813,7 +16946,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 119,
+          "id": 120,
           "interval": null,
           "legend": {
             "show": false
@@ -16910,7 +17043,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 120,
+          "id": 121,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -17118,7 +17251,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 121,
+          "id": 122,
           "interval": null,
           "legend": {
             "show": false
@@ -17215,7 +17348,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 122,
+          "id": 123,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -17423,7 +17556,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 123,
+          "id": 124,
           "interval": null,
           "legend": {
             "show": false
@@ -17520,7 +17653,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 124,
+          "id": 125,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -17728,7 +17861,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 125,
+          "id": 126,
           "interval": null,
           "legend": {
             "show": false
@@ -17825,7 +17958,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 126,
+          "id": 127,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -18033,7 +18166,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 127,
+          "id": 128,
           "interval": null,
           "legend": {
             "show": false
@@ -18130,7 +18263,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 128,
+          "id": 129,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -18338,7 +18471,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 129,
+          "id": 130,
           "interval": null,
           "legend": {
             "show": false
@@ -18435,7 +18568,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 130,
+          "id": 131,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -18636,7 +18769,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 131,
+          "id": 132,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -18784,7 +18917,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 132,
+          "id": 133,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -18920,7 +19053,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 133,
+      "id": 134,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -18959,7 +19092,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 134,
+          "id": 135,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -19092,7 +19225,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 135,
+          "id": 136,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -19225,7 +19358,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 136,
+          "id": 137,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -19358,7 +19491,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 137,
+          "id": 138,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -19498,7 +19631,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 138,
+          "id": 139,
           "interval": null,
           "legend": {
             "show": false
@@ -19595,7 +19728,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 139,
+          "id": 140,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -19803,7 +19936,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 140,
+          "id": 141,
           "interval": null,
           "legend": {
             "show": false
@@ -19900,7 +20033,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 141,
+          "id": 142,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -20108,7 +20241,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 142,
+          "id": 143,
           "interval": null,
           "legend": {
             "show": false
@@ -20205,7 +20338,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 143,
+          "id": 144,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -20413,7 +20546,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 144,
+          "id": 145,
           "interval": null,
           "legend": {
             "show": false
@@ -20517,7 +20650,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 145,
+          "id": 146,
           "interval": null,
           "legend": {
             "show": false
@@ -20614,7 +20747,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 146,
+          "id": 147,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -20747,7 +20880,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 147,
+          "id": 148,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -20898,7 +21031,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 148,
+      "id": 149,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -20937,7 +21070,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 149,
+          "id": 150,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -21085,7 +21218,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 150,
+          "id": 151,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -21240,7 +21373,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 151,
+          "id": 152,
           "interval": null,
           "legend": {
             "show": false
@@ -21344,7 +21477,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 152,
+          "id": 153,
           "interval": null,
           "legend": {
             "show": false
@@ -21441,7 +21574,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 153,
+          "id": 154,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -21574,7 +21707,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 154,
+          "id": 155,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -21725,7 +21858,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 155,
+      "id": 156,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -21764,7 +21897,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 156,
+          "id": 157,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -21897,7 +22030,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 157,
+          "id": 158,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -22030,7 +22163,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 158,
+          "id": 159,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -22163,7 +22296,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 159,
+          "id": 160,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -22296,7 +22429,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 160,
+          "id": 161,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -22429,7 +22562,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 161,
+          "id": 162,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -22580,7 +22713,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 162,
+      "id": 163,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -22619,7 +22752,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 163,
+          "id": 164,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -22752,7 +22885,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 164,
+          "id": 165,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -22885,7 +23018,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 165,
+          "id": 166,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -23018,7 +23151,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 166,
+          "id": 167,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -23151,7 +23284,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 167,
+          "id": 168,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -23284,7 +23417,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 168,
+          "id": 169,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -23447,7 +23580,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 169,
+          "id": 170,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -23583,7 +23716,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 170,
+      "id": 171,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -23622,7 +23755,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 171,
+          "id": 172,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -23770,7 +23903,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 172,
+          "id": 173,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -23918,7 +24051,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 173,
+          "id": 174,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -24051,7 +24184,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 174,
+          "id": 175,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -24184,7 +24317,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 175,
+          "id": 176,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -24317,7 +24450,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 176,
+          "id": 177,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -24450,7 +24583,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 177,
+          "id": 178,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -24583,7 +24716,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 178,
+          "id": 179,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -24716,7 +24849,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 179,
+          "id": 180,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -24893,7 +25026,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 180,
+      "id": 181,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -24932,7 +25065,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 181,
+          "id": 182,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -25095,7 +25228,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 182,
+          "id": 183,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -25296,7 +25429,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 183,
+          "id": 184,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -25444,7 +25577,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 184,
+          "id": 185,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -25607,7 +25740,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 185,
+          "id": 186,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -25808,7 +25941,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 186,
+          "id": 187,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -25986,7 +26119,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 187,
+          "id": 188,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -26149,7 +26282,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 188,
+          "id": 189,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -26312,7 +26445,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 189,
+          "id": 190,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -26445,7 +26578,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 190,
+          "id": 191,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -26649,7 +26782,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 191,
+      "id": 192,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -26688,7 +26821,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 192,
+          "id": 193,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -26881,7 +27014,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 193,
+          "id": 194,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -27059,7 +27192,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 194,
+          "id": 195,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -27267,7 +27400,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 195,
+          "id": 196,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -27445,7 +27578,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 196,
+          "id": 197,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -27608,7 +27741,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 197,
+          "id": 198,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -27786,7 +27919,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 198,
+          "id": 199,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -27919,7 +28052,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 199,
+          "id": 200,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -28097,7 +28230,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 200,
+          "id": 201,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -28230,7 +28363,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 201,
+          "id": 202,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -28408,7 +28541,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 202,
+          "id": 203,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -28541,7 +28674,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 203,
+          "id": 204,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -28719,7 +28852,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 204,
+          "id": 205,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -28897,7 +29030,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 205,
+          "id": 206,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -29075,7 +29208,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 206,
+          "id": 207,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -29208,7 +29341,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 207,
+          "id": 208,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -29341,7 +29474,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 208,
+          "id": 209,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -29474,7 +29607,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 209,
+          "id": 210,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -29697,7 +29830,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 210,
+          "id": 211,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -29890,7 +30023,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 211,
+          "id": 212,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -30053,7 +30186,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 212,
+          "id": 213,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -30246,7 +30379,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 213,
+          "id": 214,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -30394,7 +30527,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 214,
+          "id": 215,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -30527,7 +30660,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 215,
+          "id": 216,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -30675,7 +30808,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 216,
+          "id": 217,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -30853,7 +30986,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 217,
+          "id": 218,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -31016,7 +31149,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 218,
+          "id": 219,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -31194,7 +31327,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 219,
+          "id": 220,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -31327,7 +31460,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 220,
+          "id": 221,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -31460,7 +31593,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 221,
+          "id": 222,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -31593,7 +31726,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 222,
+          "id": 223,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -31726,7 +31859,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 223,
+          "id": 224,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -31859,7 +31992,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 224,
+          "id": 225,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -31999,7 +32132,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 225,
+          "id": 226,
           "interval": null,
           "legend": {
             "show": false
@@ -32096,7 +32229,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 226,
+          "id": 227,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -32297,7 +32430,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 227,
+          "id": 228,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -32430,7 +32563,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 228,
+          "id": 229,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -32608,7 +32741,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 229,
+          "id": 230,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -32741,7 +32874,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 230,
+          "id": 231,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -32877,7 +33010,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 231,
+      "id": 232,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -32916,7 +33049,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 232,
+          "id": 233,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -33064,7 +33197,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 233,
+          "id": 234,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -33212,7 +33345,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 234,
+          "id": 235,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -33345,7 +33478,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 235,
+          "id": 236,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -33478,7 +33611,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 236,
+          "id": 237,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -33656,7 +33789,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 237,
+          "id": 238,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -33834,7 +33967,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 238,
+          "id": 239,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -34012,7 +34145,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 239,
+          "id": 240,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -34145,7 +34278,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 240,
+          "id": 241,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -34323,7 +34456,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 241,
+          "id": 242,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -34456,7 +34589,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 242,
+          "id": 243,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -34619,7 +34752,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 243,
+          "id": 244,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -34797,7 +34930,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 244,
+          "id": 245,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -34975,7 +35108,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 245,
+          "id": 246,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -35153,7 +35286,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 246,
+          "id": 247,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -35286,7 +35419,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 247,
+          "id": 248,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -35464,7 +35597,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 248,
+          "id": 249,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -35597,7 +35730,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 249,
+          "id": 250,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -35775,7 +35908,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 250,
+          "id": 251,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -35908,7 +36041,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 251,
+          "id": 252,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -36041,7 +36174,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 252,
+          "id": 253,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -36219,7 +36352,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 253,
+          "id": 254,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -36397,7 +36530,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 254,
+          "id": 255,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -36530,7 +36663,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 255,
+          "id": 256,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -36708,7 +36841,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 256,
+          "id": 257,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -36841,7 +36974,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 257,
+          "id": 258,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -37019,7 +37152,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 258,
+          "id": 259,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -37155,7 +37288,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 259,
+      "id": 260,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -37194,7 +37327,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 260,
+          "id": 261,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -37327,7 +37460,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 261,
+          "id": 262,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -37460,7 +37593,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 262,
+          "id": 263,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -37593,7 +37726,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 263,
+          "id": 264,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -37726,7 +37859,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 264,
+          "id": 265,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -37866,7 +37999,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 265,
+          "id": 266,
           "interval": null,
           "legend": {
             "show": false
@@ -37970,7 +38103,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 266,
+          "id": 267,
           "interval": null,
           "legend": {
             "show": false
@@ -38067,7 +38200,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 267,
+          "id": 268,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -38207,7 +38340,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 268,
+          "id": 269,
           "interval": null,
           "legend": {
             "show": false
@@ -38304,7 +38437,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 269,
+          "id": 270,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -38444,7 +38577,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 270,
+          "id": 271,
           "interval": null,
           "legend": {
             "show": false
@@ -38541,7 +38674,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 271,
+          "id": 272,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -38749,7 +38882,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 272,
+          "id": 273,
           "interval": null,
           "legend": {
             "show": false
@@ -38846,7 +38979,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 273,
+          "id": 274,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -39047,7 +39180,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 274,
+          "id": 275,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -39255,7 +39388,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 275,
+          "id": 276,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -39436,7 +39569,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 276,
+      "id": 277,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -39475,7 +39608,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 277,
+          "id": 278,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -39623,7 +39756,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 278,
+          "id": 279,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -39763,7 +39896,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 279,
+          "id": 280,
           "interval": null,
           "legend": {
             "show": false
@@ -39860,7 +39993,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 280,
+          "id": 281,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -39993,7 +40126,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 281,
+          "id": 282,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -40126,7 +40259,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 282,
+          "id": 283,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -40304,7 +40437,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 283,
+          "id": 284,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -40467,7 +40600,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 284,
+          "id": 285,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -40615,7 +40748,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 285,
+          "id": 286,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -40748,7 +40881,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 286,
+          "id": 287,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -40884,7 +41017,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 287,
+      "id": 288,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -40923,7 +41056,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 288,
+          "id": 289,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -41071,7 +41204,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 289,
+          "id": 290,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -41204,7 +41337,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 290,
+          "id": 291,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -41337,7 +41470,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 291,
+          "id": 292,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -41470,7 +41603,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 292,
+          "id": 293,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -41603,7 +41736,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 293,
+          "id": 294,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -41758,7 +41891,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 294,
+          "id": 295,
           "interval": null,
           "legend": {
             "show": false
@@ -41858,7 +41991,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 295,
+      "id": 296,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -41897,7 +42030,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 296,
+          "id": 297,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -42045,7 +42178,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 297,
+          "id": 298,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -42246,7 +42379,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 298,
+          "id": 299,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -42447,7 +42580,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 299,
+          "id": 300,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -42648,7 +42781,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 300,
+          "id": 301,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -42849,7 +42982,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 301,
+          "id": 302,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -42982,7 +43115,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 302,
+          "id": 303,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -43115,7 +43248,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 303,
+          "id": 304,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -43248,7 +43381,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 304,
+          "id": 305,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -43381,7 +43514,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 305,
+          "id": 306,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -43589,7 +43722,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 306,
+          "id": 307,
           "interval": null,
           "legend": {
             "show": false
@@ -43689,7 +43822,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 307,
+      "id": 308,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -43735,7 +43868,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 308,
+          "id": 309,
           "interval": null,
           "legend": {
             "show": false
@@ -43832,7 +43965,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 309,
+          "id": 310,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -44033,7 +44166,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 310,
+          "id": 311,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -44166,7 +44299,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 311,
+          "id": 312,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -44299,7 +44432,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 312,
+          "id": 313,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -44432,7 +44565,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 313,
+          "id": 314,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -44633,7 +44766,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 314,
+          "id": 315,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -44766,7 +44899,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 315,
+          "id": 316,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -44899,7 +45032,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 316,
+          "id": 317,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -45035,7 +45168,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 317,
+      "id": 318,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -45074,7 +45207,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 318,
+          "id": 319,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -45275,7 +45408,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 319,
+          "id": 320,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -45476,7 +45609,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 320,
+          "id": 321,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -45677,7 +45810,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 321,
+          "id": 322,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -45878,7 +46011,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 322,
+          "id": 323,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -46011,7 +46144,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 323,
+          "id": 324,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -46144,7 +46277,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 324,
+          "id": 325,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -46277,7 +46410,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 325,
+          "id": 326,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -46410,7 +46543,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 326,
+          "id": 327,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -46543,7 +46676,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 327,
+          "id": 328,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -46683,7 +46816,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 328,
+          "id": 329,
           "interval": null,
           "legend": {
             "show": false
@@ -46780,7 +46913,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 329,
+          "id": 330,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -46984,7 +47117,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 330,
+      "id": 331,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -47023,7 +47156,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 331,
+          "id": 332,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -47156,7 +47289,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 332,
+          "id": 333,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -47289,7 +47422,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 333,
+          "id": 334,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -47429,7 +47562,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 334,
+          "id": 335,
           "interval": null,
           "legend": {
             "show": false
@@ -47526,7 +47659,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 335,
+          "id": 336,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -47727,7 +47860,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 336,
+          "id": 337,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -47928,7 +48061,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 337,
+          "id": 338,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -48132,7 +48265,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 338,
+      "id": 339,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -48171,7 +48304,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 339,
+          "id": 340,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -48349,7 +48482,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 340,
+          "id": 341,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -48550,7 +48683,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 341,
+          "id": 342,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -48683,7 +48816,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 342,
+          "id": 343,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -48816,7 +48949,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 343,
+          "id": 344,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -48949,7 +49082,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 344,
+          "id": 345,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -49082,7 +49215,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 345,
+          "id": 346,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -49215,7 +49348,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 346,
+          "id": 347,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -49344,7 +49477,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 347,
+          "id": 348,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -49419,7 +49552,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 348,
+          "id": 349,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -49498,7 +49631,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 349,
+          "id": 350,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -49751,7 +49884,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 350,
+          "id": 351,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -49884,7 +50017,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 351,
+          "id": 352,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -50020,7 +50153,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 352,
+      "id": 353,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -50059,7 +50192,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 353,
+          "id": 354,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -50207,7 +50340,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 354,
+          "id": 355,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -50340,7 +50473,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 355,
+          "id": 356,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -50541,7 +50674,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 356,
+          "id": 357,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -50689,7 +50822,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 357,
+          "id": 358,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -50890,7 +51023,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 358,
+          "id": 359,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -51023,7 +51156,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 359,
+          "id": 360,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -51156,7 +51289,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 360,
+          "id": 361,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -51289,7 +51422,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 361,
+          "id": 362,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -51422,7 +51555,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 362,
+          "id": 363,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -51562,7 +51695,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 363,
+          "id": 364,
           "interval": null,
           "legend": {
             "show": false
@@ -51659,7 +51792,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 364,
+          "id": 365,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -51863,7 +51996,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 365,
+      "id": 366,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -51902,7 +52035,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 366,
+          "id": 367,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -52035,7 +52168,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 367,
+          "id": 368,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -52168,7 +52301,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 368,
+          "id": 369,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -52301,7 +52434,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 369,
+          "id": 370,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -52437,7 +52570,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 370,
+      "id": 371,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -52476,7 +52609,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 371,
+          "id": 372,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -52609,7 +52742,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 372,
+          "id": 373,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -52742,7 +52875,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 373,
+          "id": 374,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -52890,7 +53023,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 374,
+          "id": 375,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -53023,7 +53156,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 375,
+          "id": 376,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -53156,7 +53289,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 376,
+          "id": 377,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -53289,7 +53422,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 377,
+          "id": 378,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -53425,7 +53558,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 378,
+      "id": 379,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -53464,7 +53597,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 379,
+          "id": 380,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -53597,7 +53730,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 380,
+          "id": 381,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -53730,7 +53863,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 381,
+          "id": 382,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -53863,7 +53996,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 382,
+          "id": 383,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -53996,7 +54129,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 383,
+          "id": 384,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -54129,7 +54262,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 384,
+          "id": 385,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -54265,7 +54398,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 385,
+      "id": 386,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -54304,7 +54437,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 386,
+          "id": 387,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -54437,7 +54570,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 387,
+          "id": 388,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -54570,7 +54703,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 388,
+          "id": 389,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -54718,7 +54851,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 389,
+          "id": 390,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -54881,7 +55014,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 390,
+          "id": 391,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -55014,7 +55147,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 391,
+          "id": 392,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -55147,7 +55280,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 392,
+          "id": 393,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -55295,7 +55428,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 393,
+          "id": 394,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -55443,7 +55576,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 394,
+          "id": 395,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -55579,7 +55712,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 395,
+      "id": 396,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -55618,7 +55751,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 396,
+          "id": 397,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -55751,7 +55884,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 397,
+          "id": 398,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -55884,7 +56017,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 398,
+          "id": 399,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -56017,7 +56150,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 399,
+          "id": 400,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -56150,7 +56283,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 400,
+          "id": 401,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -56283,7 +56416,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 401,
+          "id": 402,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -56416,7 +56549,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 402,
+          "id": 403,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -56549,7 +56682,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 403,
+          "id": 404,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -56682,7 +56815,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 404,
+          "id": 405,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -56822,7 +56955,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 405,
+          "id": 406,
           "interval": null,
           "legend": {
             "show": false
@@ -56919,7 +57052,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 406,
+          "id": 407,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -57052,7 +57185,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 407,
+          "id": 408,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -57200,7 +57333,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 408,
+          "id": 409,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -57348,7 +57481,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 409,
+          "id": 410,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -57488,7 +57621,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 410,
+          "id": 411,
           "interval": null,
           "legend": {
             "show": false
@@ -57585,7 +57718,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 411,
+          "id": 412,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -57718,7 +57851,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 412,
+          "id": 413,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -57854,7 +57987,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 413,
+      "id": 414,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -57893,7 +58026,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 414,
+          "id": 415,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -58026,7 +58159,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 415,
+          "id": 416,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -58189,7 +58322,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 416,
+          "id": 417,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -58337,7 +58470,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 417,
+          "id": 418,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -58470,7 +58603,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 418,
+          "id": 419,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -58610,7 +58743,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 419,
+          "id": 420,
           "interval": null,
           "legend": {
             "show": false
@@ -58714,7 +58847,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 420,
+          "id": 421,
           "interval": null,
           "legend": {
             "show": false
@@ -58818,7 +58951,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 421,
+          "id": 422,
           "interval": null,
           "legend": {
             "show": false
@@ -58915,7 +59048,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 422,
+          "id": 423,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -59055,7 +59188,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 423,
+          "id": 424,
           "interval": null,
           "legend": {
             "show": false
@@ -59159,7 +59292,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 424,
+          "id": 425,
           "interval": null,
           "legend": {
             "show": false
@@ -59263,7 +59396,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 425,
+          "id": 426,
           "interval": null,
           "legend": {
             "show": false
@@ -59360,7 +59493,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 426,
+          "id": 427,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -59493,7 +59626,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 427,
+          "id": 428,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -59626,7 +59759,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 428,
+          "id": 429,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -59766,7 +59899,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 429,
+          "id": 430,
           "interval": null,
           "legend": {
             "show": false
@@ -59863,7 +59996,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 430,
+          "id": 431,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -59999,7 +60132,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 431,
+      "id": 432,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -60038,7 +60171,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 432,
+          "id": 433,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -60201,7 +60334,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 433,
+          "id": 434,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -60334,7 +60467,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 434,
+          "id": 435,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -60474,7 +60607,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 435,
+          "id": 436,
           "interval": null,
           "legend": {
             "show": false
@@ -60578,7 +60711,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 436,
+          "id": 437,
           "interval": null,
           "legend": {
             "show": false
@@ -60675,7 +60808,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 437,
+          "id": 438,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -60830,7 +60963,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 438,
+          "id": 439,
           "interval": null,
           "legend": {
             "show": false
@@ -60934,7 +61067,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 439,
+          "id": 440,
           "interval": null,
           "legend": {
             "show": false
@@ -61038,7 +61171,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 440,
+          "id": 441,
           "interval": null,
           "legend": {
             "show": false
@@ -61135,7 +61268,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 441,
+          "id": 442,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -61305,7 +61438,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 442,
+          "id": 443,
           "interval": null,
           "legend": {
             "show": false
@@ -61402,7 +61535,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 443,
+          "id": 444,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -61603,7 +61736,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 444,
+          "id": 445,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -61804,7 +61937,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 445,
+          "id": 446,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -61937,7 +62070,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 446,
+          "id": 447,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -62100,7 +62233,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 447,
+          "id": 448,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -62233,7 +62366,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 448,
+          "id": 449,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -62366,7 +62499,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 449,
+          "id": 450,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -62567,7 +62700,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 450,
+          "id": 451,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -62700,7 +62833,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 451,
+          "id": 452,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -62840,7 +62973,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 452,
+          "id": 453,
           "interval": null,
           "legend": {
             "show": false
@@ -62944,7 +63077,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 453,
+          "id": 454,
           "interval": null,
           "legend": {
             "show": false
@@ -63048,7 +63181,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 454,
+          "id": 455,
           "interval": null,
           "legend": {
             "show": false
@@ -63152,7 +63285,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 455,
+          "id": 456,
           "interval": null,
           "legend": {
             "show": false
@@ -63256,7 +63389,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 456,
+          "id": 457,
           "interval": null,
           "legend": {
             "show": false
@@ -63360,7 +63493,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 457,
+          "id": 458,
           "interval": null,
           "legend": {
             "show": false
@@ -63464,7 +63597,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 458,
+          "id": 459,
           "interval": null,
           "legend": {
             "show": false
@@ -63561,7 +63694,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 459,
+          "id": 460,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -63709,7 +63842,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 460,
+          "id": 461,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -63842,7 +63975,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 461,
+          "id": 462,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -63975,7 +64108,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 462,
+          "id": 463,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -64123,7 +64256,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 463,
+          "id": 464,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -64259,7 +64392,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 464,
+      "id": 465,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -64310,7 +64443,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 465,
+          "id": 466,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -64406,7 +64539,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 466,
+          "id": 467,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -64481,7 +64614,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 467,
+          "id": 468,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -64556,7 +64689,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 468,
+          "id": 469,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -64631,7 +64764,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 469,
+          "id": 470,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -64706,7 +64839,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 470,
+          "id": 471,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -64781,7 +64914,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 471,
+          "id": 472,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -64856,7 +64989,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 472,
+          "id": 473,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -64935,7 +65068,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 473,
+          "id": 474,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -65068,7 +65201,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 474,
+          "id": 475,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -65201,7 +65334,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 475,
+          "id": 476,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -65334,7 +65467,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 476,
+          "id": 477,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -65467,7 +65600,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 477,
+          "id": 478,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -65600,7 +65733,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 478,
+          "id": 479,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -65748,7 +65881,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 479,
+          "id": 480,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -65881,7 +66014,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 480,
+          "id": 481,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -66014,7 +66147,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 481,
+          "id": 482,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -66180,7 +66313,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 482,
+          "id": 483,
           "interval": null,
           "legend": {
             "show": false
@@ -66284,7 +66417,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 483,
+          "id": 484,
           "interval": null,
           "legend": {
             "show": false
@@ -66388,7 +66521,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 484,
+          "id": 485,
           "interval": null,
           "legend": {
             "show": false
@@ -66492,7 +66625,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 485,
+          "id": 486,
           "interval": null,
           "legend": {
             "show": false
@@ -66596,7 +66729,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 486,
+          "id": 487,
           "interval": null,
           "legend": {
             "show": false
@@ -66700,7 +66833,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 487,
+          "id": 488,
           "interval": null,
           "legend": {
             "show": false
@@ -66804,7 +66937,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 488,
+          "id": 489,
           "interval": null,
           "legend": {
             "show": false
@@ -66908,7 +67041,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 489,
+          "id": 490,
           "interval": null,
           "legend": {
             "show": false
@@ -67005,7 +67138,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 490,
+          "id": 491,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -67138,7 +67271,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 491,
+          "id": 492,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -67271,7 +67404,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 492,
+          "id": 493,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -67404,7 +67537,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 493,
+          "id": 494,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -67537,7 +67670,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 494,
+          "id": 495,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -67670,7 +67803,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 495,
+          "id": 496,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -67803,7 +67936,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 496,
+          "id": 497,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -67936,7 +68069,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 497,
+          "id": 498,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -68076,7 +68209,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 498,
+          "id": 499,
           "interval": null,
           "legend": {
             "show": false
@@ -68180,7 +68313,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 499,
+          "id": 500,
           "interval": null,
           "legend": {
             "show": false
@@ -68277,7 +68410,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 500,
+          "id": 501,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -68410,7 +68543,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 501,
+          "id": 502,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -68543,7 +68676,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 502,
+          "id": 503,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -68676,7 +68809,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 503,
+          "id": 504,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -68809,7 +68942,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 504,
+          "id": 505,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -68942,7 +69075,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 505,
+          "id": 506,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -69078,7 +69211,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 506,
+      "id": 507,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -69117,7 +69250,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 507,
+          "id": 508,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -69265,7 +69398,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 508,
+          "id": 509,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -69398,7 +69531,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 509,
+          "id": 510,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -69531,7 +69664,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 510,
+          "id": 511,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -69667,7 +69800,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 511,
+      "id": 512,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -69706,7 +69839,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 512,
+          "id": 513,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -69839,7 +69972,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 513,
+          "id": 514,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -69972,7 +70105,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 514,
+          "id": 515,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -70105,7 +70238,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 515,
+          "id": 516,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -70238,7 +70371,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 516,
+          "id": 517,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -70371,7 +70504,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 517,
+          "id": 518,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -70507,7 +70640,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 518,
+      "id": 519,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -70546,7 +70679,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 519,
+          "id": 520,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -70747,7 +70880,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 520,
+          "id": 521,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -70883,7 +71016,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 521,
+      "id": 522,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -70922,7 +71055,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 522,
+          "id": 523,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -71055,7 +71188,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 523,
+          "id": 524,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -71188,7 +71321,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 524,
+          "id": 525,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -71321,7 +71454,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 525,
+          "id": 526,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -71454,7 +71587,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 526,
+          "id": 527,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -71602,7 +71735,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 527,
+          "id": 528,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -71806,7 +71939,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 528,
+      "id": 529,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -71845,7 +71978,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 529,
+          "id": 530,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -71978,7 +72111,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 530,
+          "id": 531,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -72111,7 +72244,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 531,
+          "id": 532,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -72244,7 +72377,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 532,
+          "id": 533,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -72377,7 +72510,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 533,
+          "id": 534,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -72574,7 +72707,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 534,
+          "id": 535,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,

--- a/metrics/grafana/tikv_details.json.sha256
+++ b/metrics/grafana/tikv_details.json.sha256
@@ -1,1 +1,1 @@
-1e46671f95cc621b79bc09f72f97afaa6c569a924265a85861b034f203cf742f  ./metrics/grafana/tikv_details.json
+6cb917e796dceb3c98fd877869ae5c6cdaa6243dd7003184f741ecc6f465a872  ./metrics/grafana/tikv_details.json


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #17583

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Add a new panel that displays threads with CPU usage exceeding 80%.
This panel will enhance troubleshooting efforts by identifying busy
threads that often cause performance issues, which may not be visible
in other existing panels.
```

### Check List

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

![img_v3_02f2_21776c13-b736-4a04-9f8f-4e859775349g](https://github.com/user-attachments/assets/4d0101fe-1248-41ba-9261-e98b9e6534ec)


### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
