### PR TITLE
snap: ensure the state of snapshot flushed after applying snapshots.

### DIFF
--- a/components/raftstore/src/store/snap/io.rs
+++ b/components/raftstore/src/store/snap/io.rs
@@ -370,8 +370,8 @@ where
 /// pairs to db, without ingesting them. `callback` will be invoked after each
 /// batch of key value pairs written to db.
 ///
-/// Attention, callers should manually flush the column family after applying
-/// all sst files to make sure the data is visible to the following operations.
+/// Attention, callers should manually flush and sync the column family after
+/// applying all sst files to make sure the data durability.
 pub fn apply_sst_cf_files_without_ingest<E, F>(
     files: &[&str],
     db: &E,

--- a/components/raftstore/src/store/snap/io.rs
+++ b/components/raftstore/src/store/snap/io.rs
@@ -238,6 +238,9 @@ where
 
 /// Apply the given snapshot file into a column family. `callback` will be
 /// invoked after each batch of key value pairs written to db.
+///
+/// Attention, callers should manually flush the column family after applying
+/// all sst files to make sure the data is visible to the following operations.
 pub fn apply_plain_cf_file<E, F>(
     path: &str,
     key_mgr: Option<&Arc<DataKeyManager>>,
@@ -363,6 +366,12 @@ where
     Ok(())
 }
 
+/// Apply the given snapshot file into a column family by directly writing kv
+/// pairs to db, without ingesting them. `callback` will be invoked after each
+/// batch of key value pairs written to db.
+///
+/// Attention, callers should manually flush the column family after applying
+/// all sst files to make sure the data is visible to the following operations.
 pub fn apply_sst_cf_files_without_ingest<E, F>(
     files: &[&str],
     db: &E,

--- a/components/raftstore/src/store/snap/io.rs
+++ b/components/raftstore/src/store/snap/io.rs
@@ -239,8 +239,8 @@ where
 /// Apply the given snapshot file into a column family. `callback` will be
 /// invoked after each batch of key value pairs written to db.
 ///
-/// Attention, callers should manually flush the column family after applying
-/// all sst files to make sure the data is visible to the following operations.
+/// Attention, callers should manually flush and sync the column family after
+/// applying all sst files to make sure the data durability.
 pub fn apply_plain_cf_file<E, F>(
     path: &str,
     key_mgr: Option<&Arc<DataKeyManager>>,


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref https://github.com/tikv/tikv/issues/17376

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

This pr is an enhancement for the previous work https://github.com/tikv/tikv/pull/17408.

This pr is introduced to ensure that the state of region and snapshot will be flushed after applying
snapshot.

```commit-message
Ensure that the state of snapshot and region will be flushed into kvdb.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None.
```
