### PR TITLE
test: fix flaky test test_limited_future

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,8 +169,9 @@ dependencies = [
 
 [[package]]
 name = "async-speed-limit"
-version = "0.4.1"
-source = "git+https://github.com/tikv/async-speed-limit?branch=master#a113aef3cc24bf7fa5faf2b7025abaf02fc53fe3"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97c1688bb8e4eb3dcd68a8b0e5a81deae887c67362bb482a902b785e83ac2edc"
 dependencies = [
  "futures-core",
  "futures-io",

--- a/components/resource_control/src/future.rs
+++ b/components/resource_control/src/future.rs
@@ -324,7 +324,7 @@ mod tests {
         let dur = start.saturating_elapsed();
         assert_eq!(delta.total_consumed, 150);
         assert!(delta.total_wait_dur_us >= 140_000 && delta.total_wait_dur_us <= 160_000);
-        assert!(dur >= Duration::from_millis(150) && dur <= Duration::from_millis(160));
+        assert!(dur >= Duration::from_millis(140) && dur <= Duration::from_millis(160));
 
         // fetch io bytes failed, consumed value is 0.
         #[cfg(feature = "failpoints")]

--- a/components/resource_control/src/future.rs
+++ b/components/resource_control/src/future.rs
@@ -324,7 +324,11 @@ mod tests {
         let dur = start.saturating_elapsed();
         assert_eq!(delta.total_consumed, 150);
         assert!(delta.total_wait_dur_us >= 140_000 && delta.total_wait_dur_us <= 160_000);
-        assert!(dur >= Duration::from_millis(140) && dur <= Duration::from_millis(160));
+        assert!(
+            dur >= Duration::from_millis(140) && dur <= Duration::from_millis(160),
+            "dur: {:?}",
+            dur
+        );
 
         // fetch io bytes failed, consumed value is 0.
         #[cfg(feature = "failpoints")]

--- a/components/tikv_util/Cargo.toml
+++ b/components/tikv_util/Cargo.toml
@@ -11,7 +11,7 @@ test-cgroup = []
 
 [dependencies]
 # TODO: use `async-speed-limit` in crates.io after new version(v0.4.2) is released.
-async-speed-limit = { git = "https://github.com/tikv/async-speed-limit", branch = "master" }
+async-speed-limit = "0.4.2"
 backtrace = "0.3.9"
 byteorder = "1.2"
 bytes = "1.0"


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #17612

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Fix unstable test test_limited_future due to the configuration change of async-speed-limiter. This PR also update async-speed-limiter to v0.4.2.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
