### PR TITLE
Fix SSE42 error

### DIFF
--- a/scripts/check-bins.py
+++ b/scripts/check-bins.py
@@ -69,15 +69,16 @@ def is_jemalloc_enabled(features):
 def check_sse(executable):
     p = os.popen("nm -n " + executable)
     lines = p.readlines()
-    segments = [(pos, pos + 1) for (pos, l) in enumerate(lines) if "Fast_CRC32" in l]
+    segments = [(pos, pos + 1) for (pos, l) in enumerate(lines) if "crc32c_3way" in l]
     if len(segments) == 0:
         pr("error: %s does not contain sse4.2\n" % executable)
         print("fix this by building tikv with ROCKSDB_SYS_SSE=1")
         sys.exit(1)
 
-    # Make sure the `Fast_CRC32` uses the sse4.2 instruction `crc32`
+    # Make sure the `crc32c_3way` uses the sse4.2 instruction `crc32`
     # f2.*0f 38 is the opcode of `crc32`, see SSE4 Programming Reference.
     opcode_pattern = re.compile(".*f2.*0f 38.*crc32")
+    matched = False
     for start, end in segments:
         s_addr = lines[start].split()[0]
         e_addr = lines[end].split()[0]
@@ -86,10 +87,10 @@ def check_sse(executable):
             if opcode_pattern.search(l):
                 matched = True
                 break
-        else:
-            pr("error %s does not contain sse4.2\n" % executable)
-            print("fix this by building tikv with ROCKSDB_SYS_SSE=1")
-            sys.exit(1)
+    if not matched:
+        pr("error %s does not contain sse4.2\n" % executable)
+        print("fix this by building tikv with ROCKSDB_SYS_SSE=1")
+        sys.exit(1)
 
 def is_openssl_vendored_enabled(features):
     return "openssl-vendored" in features

--- a/scripts/check-bins.py
+++ b/scripts/check-bins.py
@@ -157,8 +157,8 @@ def check_release(enabled_features, args):
         pr("checking binary %s" % arg)
         if is_jemalloc_enabled(enabled_features):
             check_jemalloc(arg)
-        # if is_sse_enabled(enabled_features):
-        #     check_sse(arg)
+        if is_sse_enabled(enabled_features):
+            check_sse(arg)
         check_openssl(arg, is_openssl_vendored_enabled(enabled_features))
         pr("%s [%s] \033[32menabled\033[0m\n" % (arg, " ".join(checked_features)))
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #17617

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Update SSE42 check since RocksDB changed its function name.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
