### PR TITLE
In-memory engine: fix save point empty assertion fail

### DIFF
--- a/components/in_memory_engine/src/write_batch.rs
+++ b/components/in_memory_engine/src/write_batch.rs
@@ -319,13 +319,6 @@ impl WriteBatchEntryInternal {
         }
     }
 
-    fn value(&self) -> &[u8] {
-        match self {
-            WriteBatchEntryInternal::PutValue(value) => value,
-            WriteBatchEntryInternal::Deletion => &[],
-        }
-    }
-
     fn data_size(&self) -> usize {
         match self {
             WriteBatchEntryInternal::PutValue(value) => value.len(),
@@ -381,10 +374,6 @@ impl RegionCacheWriteBatchEntry {
 
     pub fn data_size(&self) -> usize {
         self.key.len() + ENC_KEY_SEQ_LENGTH + self.inner.data_size()
-    }
-
-    fn memory_size_required(&self) -> usize {
-        Self::memory_size_required_for_key_value(&self.key, self.inner.value())
     }
 
     #[inline]


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #17630 Ref #16141 

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
fix save point empty assertion fail
```
Save point empty assertion can fail. For simplifity, does not release evicted region's buffer (it is intended to release memory quickly so that the next region have chances not to be evicted due to memory limit) as eviction during write is rare.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
