### PR TITLE
test: fix flaky test test_query_stats and test_store_disconnect_with_hibernate

### DIFF
--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -2847,6 +2847,11 @@ where
     }
 
     fn reset_raft_tick(&mut self, state: GroupState) {
+        debug!(
+            "reset raft tick to {:?}", state;
+            "region_id"=> self.fsm.region_id(),
+            "peer_id" => self.fsm.peer_id(),
+        );
         self.fsm.reset_hibernate_state(state);
         self.fsm.missing_ticks = 0;
         self.fsm.peer.should_wake_up = false;

--- a/tests/failpoints/cases/test_hibernate.rs
+++ b/tests/failpoints/cases/test_hibernate.rs
@@ -101,10 +101,10 @@ fn test_store_disconnect_with_hibernate() {
     cluster.cfg.raft_store.raft_election_timeout_ticks = 10;
     cluster.cfg.raft_store.unreachable_backoff = ReadableDuration::millis(500);
     cluster.cfg.server.raft_client_max_backoff = ReadableDuration::millis(200);
-    // So the random election timeout will always be 10, which makes the case more
-    // stable.
+    // Use a small range but still random election timeouts, which makes the case
+    // more stable.
     cluster.cfg.raft_store.raft_min_election_timeout_ticks = 10;
-    cluster.cfg.raft_store.raft_max_election_timeout_ticks = 11;
+    cluster.cfg.raft_store.raft_max_election_timeout_ticks = 13;
     configure_for_hibernate(&mut cluster);
     cluster.pd_client.disable_default_operator();
     let r = cluster.run_conf_change();
@@ -116,7 +116,7 @@ fn test_store_disconnect_with_hibernate() {
     must_get_equal(&cluster.get_engine(3), b"k1", b"v1");
 
     // Wait until all peers of region 1 hibernate.
-    thread::sleep(Duration::from_millis(base_tick_ms * 30));
+    thread::sleep(Duration::from_millis(base_tick_ms * 40));
 
     // Stop the region leader.
     fail::cfg("receive_raft_message_from_outside", "pause").unwrap();
@@ -128,7 +128,7 @@ fn test_store_disconnect_with_hibernate() {
     fail::remove("receive_raft_message_from_outside");
 
     // Wait for a while. Peers of region 1 shouldn't hibernate.
-    thread::sleep(Duration::from_millis(base_tick_ms * 30));
+    thread::sleep(Duration::from_millis(base_tick_ms * 40));
     must_get_equal(&cluster.get_engine(2), b"k2", b"v2");
     must_get_equal(&cluster.get_engine(3), b"k2", b"v2");
 }

--- a/tests/integrations/raftstore/test_stats.rs
+++ b/tests/integrations/raftstore/test_stats.rs
@@ -262,19 +262,10 @@ fn test_raw_query_stats_tmpl<F: KvFormat>() {
                     req.set_raw_get(get_req);
                     req
                 });
-                batch_commands(&ctx, &client, get_command, &start_key);
-                assert!(check_split_key(
-                    cluster,
-                    F::encode_raw_key_owned(start_key.clone(), None).into_encoded(),
-                    None
-                ));
-                if check_query_num_read(
-                    cluster,
-                    store_id,
-                    region_id,
-                    QueryKind::Get,
-                    (i + 1) * 1000,
-                ) {
+                if i == 0 {
+                    batch_commands(&ctx, &client, get_command, &start_key);
+                }
+                if check_query_num_read(cluster, store_id, region_id, QueryKind::Get, 1000) {
                     flag = true;
                     break;
                 }
@@ -284,14 +275,16 @@ fn test_raw_query_stats_tmpl<F: KvFormat>() {
     fail::cfg("mock_hotspot_threshold", "return(0)").unwrap();
     fail::cfg("mock_tick_interval", "return(0)").unwrap();
     fail::cfg("mock_collect_tick_interval", "return(0)").unwrap();
-    test_query_num::<F>(raw_get, true);
-    test_query_num::<F>(raw_batch_get, true);
-    test_query_num::<F>(raw_scan, true);
-    test_query_num::<F>(raw_batch_scan, true);
+    test_query_num::<F>(raw_get, true, true);
+    test_query_num::<F>(raw_batch_get, true, true);
+    test_query_num::<F>(raw_scan, true, true);
+    test_query_num::<F>(raw_batch_scan, true, true);
     if F::IS_TTL_ENABLED {
-        test_query_num::<F>(raw_get_key_ttl, true);
+        test_query_num::<F>(raw_get_key_ttl, true, true);
     }
-    test_query_num::<F>(raw_batch_get_command, true);
+    // requests may failed caused by `EpochNotMatch` after split when auto split is
+    // enabled, disable it.
+    test_query_num::<F>(raw_batch_get_command, true, false);
     test_raw_delete_query::<F>();
     fail::remove("mock_tick_interval");
     fail::remove("mock_hotspot_threshold");
@@ -385,19 +378,10 @@ fn test_txn_query_stats_tmpl<F: KvFormat>() {
                     req.set_get(get_req);
                     req
                 });
-                batch_commands(&ctx, &client, get_command, &start_key);
-                assert!(check_split_key(
-                    cluster,
-                    Key::from_raw(&start_key).as_encoded().to_vec(),
-                    None
-                ));
-                if check_query_num_read(
-                    cluster,
-                    store_id,
-                    region_id,
-                    QueryKind::Get,
-                    (i + 1) * 1000,
-                ) {
+                if i == 0 {
+                    batch_commands(&ctx, &client, get_command, &start_key);
+                }
+                if check_query_num_read(cluster, store_id, region_id, QueryKind::Get, 1000) {
                     flag = true;
                     break;
                 }
@@ -407,11 +391,13 @@ fn test_txn_query_stats_tmpl<F: KvFormat>() {
     fail::cfg("mock_hotspot_threshold", "return(0)").unwrap();
     fail::cfg("mock_tick_interval", "return(0)").unwrap();
     fail::cfg("mock_collect_tick_interval", "return(0)").unwrap();
-    test_query_num::<F>(get, false);
-    test_query_num::<F>(batch_get, false);
-    test_query_num::<F>(scan, false);
-    test_query_num::<F>(scan_lock, false);
-    test_query_num::<F>(batch_get_command, false);
+    test_query_num::<F>(get, false, true);
+    test_query_num::<F>(batch_get, false, true);
+    test_query_num::<F>(scan, false, true);
+    test_query_num::<F>(scan_lock, false, true);
+    // requests may failed caused by `EpochNotMatch` after split when auto split is
+    // enabled, disable it.
+    test_query_num::<F>(batch_get_command, false, false);
     test_txn_delete_query::<F>();
     test_pessimistic_lock();
     test_rollback();
@@ -572,15 +558,20 @@ pub fn test_rollback() {
     ));
 }
 
-fn test_query_num<F: KvFormat>(query: Box<Query>, is_raw_kv: bool) {
+fn test_query_num<F: KvFormat>(query: Box<Query>, is_raw_kv: bool, auto_split: bool) {
     let (mut cluster, client, mut ctx) = must_new_and_configure_cluster_and_kv_client(|cluster| {
         cluster.cfg.raft_store.pd_store_heartbeat_tick_interval = ReadableDuration::millis(50);
-        cluster.cfg.split.qps_threshold = 0;
+        if auto_split {
+            cluster.cfg.split.qps_threshold = 0;
+        } else {
+            cluster.cfg.split.qps_threshold = 1000000;
+        }
         cluster.cfg.split.split_balance_score = 2.0;
         cluster.cfg.split.split_contained_score = 2.0;
         cluster.cfg.split.detect_times = 1;
         cluster.cfg.split.sample_threshold = 0;
         cluster.cfg.storage.set_api_version(F::TAG);
+        cluster.cfg.server.enable_request_batch = false;
     });
     ctx.set_api_version(F::CLIENT_TAG);
 
@@ -762,4 +753,13 @@ fn batch_commands(
         }
     });
     rx.recv_timeout(Duration::from_secs(10)).unwrap();
+    sleep_ms(100);
+    // triage metrics flush
+    for _ in 0..10 {
+        let mut req = ScanRequest::default();
+        req.set_context(ctx.to_owned());
+        req.start_key = start_key.to_owned();
+        req.end_key = vec![];
+        client.kv_scan(&req).unwrap();
+    }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #15607

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
