### PR TITLE
[DNM]cdc: cancel the incremental scan task before start to reduce the time cost on the stop the replication

### DIFF
--- a/components/cdc/src/initializer.rs
+++ b/components/cdc/src/initializer.rs
@@ -122,7 +122,7 @@ impl<E: KvEngine> Initializer<E> {
                 "downstream_id" => ?downstream_id,
                 "observe_id" => ?self.observe_id,
                 "conn_id" => ?self.conn_id);
-            return Err(box_err!("scan canceled"))
+            return Err(Error::Other(box_err!("scan canceled")))
         }
 
         // To avoid holding too many snapshots and holding them too long,

--- a/components/cdc/src/initializer.rs
+++ b/components/cdc/src/initializer.rs
@@ -114,12 +114,21 @@ impl<E: KvEngine> Initializer<E> {
         fail_point!("cdc_before_initialize");
         let _permit = concurrency_semaphore.acquire().await;
 
+        let region_id = self.region_id;
+        let downstream_id = self.downstream_id;
+        if self.downstream_state.load() == DownstreamState::Stopped {
+            info!("cdc async incremental scan canceled before start";
+                "region_id" => region_id,
+                "downstream_id" => ?downstream_id,
+                "observe_id" => ?self.observe_id,
+                "conn_id" => ?self.conn_id);
+            return Err(box_err!("scan canceled"))
+        }
+
         // To avoid holding too many snapshots and holding them too long,
         // we need to acquire scan concurrency permit before taking snapshot.
         let sched = self.sched.clone();
-        let region_id = self.region_id;
         let region_epoch = self.region_epoch.clone();
-        let downstream_id = self.downstream_id;
         let downstream_state = self.downstream_state.clone();
         let (cb, fut) = tikv_util::future::paired_future_callback();
         let sink = self.sink.clone();


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #xxx

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note

```
