### PR TITLE
In-memory engine: calculating top stats should not consider reach_stop_load

### DIFF
--- a/components/raftstore/src/coprocessor/region_info_accessor.rs
+++ b/components/raftstore/src/coprocessor/region_info_accessor.rs
@@ -600,7 +600,6 @@ impl RegionCollector {
 
         // Only used to log.
         let mut max_qps = 0;
-        let count = usize::max(count, self.region_activity.len());
         let mut top_regions = self
             .region_activity
             .iter()

--- a/components/raftstore/src/coprocessor/region_info_accessor.rs
+++ b/components/raftstore/src/coprocessor/region_info_accessor.rs
@@ -1,7 +1,6 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::{
-    cmp::Ordering,
     collections::{
         BTreeMap,
         Bound::{Excluded, Unbounded},
@@ -601,51 +600,24 @@ impl RegionCollector {
 
         // Only used to log.
         let mut max_qps = 0;
-        let mut top_regions = if count == 0 {
-            self.regions
-                .values()
-                .map(|ri| {
-                    (
-                        ri.region.clone(),
-                        self.region_activity.get(&ri.region.get_id()),
-                    )
-                })
-                .sorted_by(|(_, a), (_, b)| match (a, b) {
-                    (None, None) => Ordering::Equal,
-                    (None, Some(_)) => Ordering::Greater,
-                    (Some(_), None) => Ordering::Less,
-                    (Some(a), Some(b)) => compare_fn(a, b),
-                })
-                .map(|(r, ra)| {
-                    (
-                        r,
-                        ra.map(|ra| {
-                            max_qps = u64::max(ra.region_stat.query_stats.coprocessor, max_qps);
-                            ra.region_stat.clone()
-                        })
-                        .unwrap_or_default(),
-                    )
-                })
-                .collect::<Vec<_>>()
-        } else {
-            let count = usize::max(count, self.region_activity.len());
-            self.region_activity
-                .iter()
-                .filter_map(|(id, ac)| {
-                    max_qps = u64::max(ac.region_stat.query_stats.coprocessor, max_qps);
-                    self.regions
-                        .get(id)
-                        .filter(|ri| {
-                            ri.role == StateRole::Leader
-                                && ac.region_stat.cop_detail.iterated_count() != 0
-                        })
-                        .map(|ri| (ri, ac))
-                })
-                .sorted_by(|(_, activity_0), (_, activity_1)| compare_fn(activity_0, activity_1))
-                .take(count)
-                .map(|(ri, ac)| (ri.region.clone(), ac.region_stat.clone()))
-                .collect::<Vec<_>>()
-        };
+        let count = usize::max(count, self.region_activity.len());
+        let mut top_regions = self
+            .region_activity
+            .iter()
+            .filter_map(|(id, ac)| {
+                max_qps = u64::max(ac.region_stat.query_stats.coprocessor, max_qps);
+                self.regions
+                    .get(id)
+                    .filter(|ri| {
+                        ri.role == StateRole::Leader
+                            && ac.region_stat.cop_detail.iterated_count() != 0
+                    })
+                    .map(|ri| (ri, ac))
+            })
+            .sorted_by(|(_, activity_0), (_, activity_1)| compare_fn(activity_0, activity_1))
+            .take(count)
+            .map(|(ri, ac)| (ri.region.clone(), ac.region_stat.clone()))
+            .collect::<Vec<_>>();
 
         // TODO(SpadeA): remove it when auto load/evict is stable
         {
@@ -966,7 +938,7 @@ pub trait RegionInfoProvider: Send + Sync {
         unimplemented!()
     }
 
-    fn get_top_regions(&self, _count: Option<NonZeroUsize>) -> Result<TopRegions> {
+    fn get_top_regions(&self, _count: NonZeroUsize) -> Result<TopRegions> {
         unimplemented!()
     }
 
@@ -1045,10 +1017,10 @@ impl RegionInfoProvider for RegionInfoAccessor {
                 })
             })
     }
-    fn get_top_regions(&self, count: Option<NonZeroUsize>) -> Result<TopRegions> {
+    fn get_top_regions(&self, count: NonZeroUsize) -> Result<TopRegions> {
         let (tx, rx) = mpsc::channel();
         let msg = RegionInfoQuery::GetTopRegions {
-            count: count.map_or_else(|| 0, usize::from),
+            count: usize::from(count),
             callback: Box::new(move |regions| {
                 if let Err(e) = tx.send(regions) {
                     warn!("failed to send get_top_regions result: {:?}", e);
@@ -1169,7 +1141,7 @@ impl RegionInfoProvider for MockRegionInfoProvider {
             .ok_or(box_err!("Not found region containing {:?}", key))
     }
 
-    fn get_top_regions(&self, _count: Option<NonZeroUsize>) -> Result<TopRegions> {
+    fn get_top_regions(&self, _count: NonZeroUsize) -> Result<TopRegions> {
         let mut regions = Vec::new();
         let (tx, rx) = mpsc::channel();
 

--- a/tests/integrations/storage/test_region_info_accessor.rs
+++ b/tests/integrations/storage/test_region_info_accessor.rs
@@ -1,7 +1,6 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::{
-    collections::BTreeSet,
     num::NonZeroUsize,
     sync::{mpsc::channel, Arc},
     thread,

--- a/tests/integrations/storage/test_region_info_accessor.rs
+++ b/tests/integrations/storage/test_region_info_accessor.rs
@@ -206,7 +206,6 @@ fn test_region_collection_get_top_regions() {
     let regions = prepare_cluster(&mut cluster);
     let mut region_ids = regions.iter().map(|r| r.get_id()).collect::<Vec<_>>();
     region_ids.sort();
-    let mut all_results = BTreeSet::<u64>::new();
     for node_id in cluster.get_node_ids() {
         let engine = &region_info_providers[&node_id];
         for r in &regions {
@@ -221,7 +220,7 @@ fn test_region_collection_get_top_regions() {
         }
 
         let result = engine
-            .get_top_regions(NonZeroUsize::new(10))
+            .get_top_regions(NonZeroUsize::new(10).unwrap())
             .unwrap()
             .into_iter()
             .map(|(r, _)| r.get_id())
@@ -236,16 +235,7 @@ fn test_region_collection_get_top_regions() {
             assert_gt!(len, 0);
             assert_le!(len, 10);
         }
-        // All the regions for which this node is the leader.
-        let result = engine
-            .get_top_regions(None)
-            .unwrap()
-            .into_iter()
-            .map(|(r, _)| r.get_id())
-            .collect::<Vec<_>>();
-        all_results.extend(result.iter());
     }
-    assert_eq!(all_results.into_iter().collect::<Vec<_>>(), region_ids);
 
     for (_, p) in region_info_providers {
         p.stop();


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref #16141

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
calculating top stats should not consider reach_stop_load
```

This PR also removes get_top_regions with count 0 which is never used now.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
