### PR TITLE
cdc: filter events with the observed range before load old values

### DIFF
--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -578,7 +578,6 @@ impl Delegate {
         request_id: u64,
         entries: Vec<Option<KvEntry>>,
         filter_loop: bool,
-        observed_range: &ObservedRange,
     ) -> Result<Vec<CdcEvent>> {
         let entries_len = entries.len();
         let mut rows = vec![Vec::with_capacity(entries_len)];
@@ -596,9 +595,6 @@ impl Delegate {
                     lock,
                     old_value,
                 })) => {
-                    if !observed_range.contains_encoded_key(&lock.0) {
-                        continue;
-                    }
                     let l = Lock::parse(&lock.1).unwrap();
                     if decode_lock(lock.0, l, &mut row, &mut _has_value) {
                         continue;
@@ -612,9 +608,6 @@ impl Delegate {
                     write,
                     old_value,
                 })) => {
-                    if !observed_range.contains_encoded_key(&write.0) {
-                        continue;
-                    }
                     if decode_write(write.0, &write.1, &mut row, &mut _has_value, false) {
                         continue;
                     }

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -59,7 +59,7 @@ use txn_types::{TimeStamp, TxnExtra, TxnExtraScheduler};
 use crate::{
     channel::{CdcEvent, SendError},
     delegate::{on_init_downstream, Delegate, Downstream, DownstreamId, DownstreamState},
-    initializer::Initializer,
+    initializer::{InitializeStats, Initializer},
     metrics::*,
     old_value::{OldValueCache, OldValueCallback},
     service::{validate_kv_api, Conn, ConnId, FeatureGate},
@@ -160,6 +160,7 @@ type InitCallback = Box<dyn FnOnce() + Send>;
 pub enum Validate {
     Region(u64, Box<dyn FnOnce(Option<&Delegate>) + Send>),
     OldValueCache(Box<dyn FnOnce(&OldValueCache) + Send>),
+    InitializeStats(Box<dyn FnOnce(InitializeStats) + Send>),
 }
 
 pub enum Task {
@@ -287,6 +288,7 @@ impl fmt::Debug for Task {
             Task::Validate(validate) => match validate {
                 Validate::Region(region_id, _) => de.field("region_id", &region_id).finish(),
                 Validate::OldValueCache(_) => de.finish(),
+                Validate::InitializeStats(_) => de.finish(),
             },
             Task::ChangeConfig(change) => de
                 .field("type", &"change_config")
@@ -402,6 +404,9 @@ pub struct Endpoint<T, E, S> {
     resolved_region_count: usize,
     unresolved_region_count: usize,
     warn_resolved_ts_repeat_count: usize,
+
+    // Validate statistics of the next incremental scan. Only for tests.
+    validate_next_initialize_stats: Option<Box<dyn FnOnce(InitializeStats) + Send>>,
 }
 
 impl<T: 'static + CdcHandle<E>, E: KvEngine, S: StoreRegionMeta> Endpoint<T, E, S> {
@@ -505,6 +510,8 @@ impl<T: 'static + CdcHandle<E>, E: KvEngine, S: StoreRegionMeta> Endpoint<T, E, 
             warn_resolved_ts_repeat_count: WARN_RESOLVED_TS_COUNT_THRESHOLD,
             current_ts: TimeStamp::zero(),
             causal_ts_provider,
+
+            validate_next_initialize_stats: None,
         };
         ep.register_min_ts_event(leader_resolver, Instant::now());
         ep
@@ -843,14 +850,18 @@ impl<T: 'static + CdcHandle<E>, E: KvEngine, S: StoreRegionMeta> Endpoint<T, E, 
         let cdc_handle = self.cdc_handle.clone();
         let concurrency_semaphore = self.scan_concurrency_semaphore.clone();
         let memory_quota = self.sink_memory_quota.clone();
+        let validate_initialize_stats = self.validate_next_initialize_stats.take();
         self.workers.spawn(async move {
             CDC_SCAN_TASKS.with_label_values(&["total"]).inc();
             match init
                 .initialize(change_cmd, cdc_handle, concurrency_semaphore, memory_quota)
                 .await
             {
-                Ok(()) => {
+                Ok(stats) => {
                     CDC_SCAN_TASKS.with_label_values(&["finish"]).inc();
+                    if let Some(validate) = validate_initialize_stats {
+                        validate(stats);
+                    }
                 }
                 Err(e) => {
                     CDC_SCAN_TASKS.with_label_values(&["abort"]).inc();
@@ -1318,6 +1329,9 @@ impl<T: 'static + CdcHandle<E>, E: KvEngine, S: StoreRegionMeta + Send> Runnable
                 }
                 Validate::OldValueCache(validate) => {
                     validate(&self.old_value_cache);
+                }
+                Validate::InitializeStats(validate) => {
+                    self.validate_next_initialize_stats = Some(validate);
                 }
             },
             Task::ChangeConfig(change) => self.on_change_cfg(change),

--- a/components/cdc/src/initializer.rs
+++ b/components/cdc/src/initializer.rs
@@ -513,7 +513,7 @@ impl<E: KvEngine> Initializer<E> {
     }
 
     fn ts_filter_is_helpful<S: Snapshot>(&self, snap: &S) -> bool {
-        fail_point!("ts_filter_is_helpful_always_true", |_| return true);
+        fail_point!("ts_filter_is_helpful_always_true", |_| true);
 
         if self.ts_filter_ratio < f64::EPSILON {
             return false;
@@ -586,10 +586,9 @@ impl InitializeStats {
     fn add(&mut self, other: &InitializeStats) {
         self.old_value.add(&other.old_value);
         self.scan.emit += other.scan.emit;
-        self.scan
-            .disk_read
-            .as_mut()
-            .map(|x| *x += other.scan.disk_read.unwrap_or_default());
+        if let Some(x) = self.scan.disk_read.as_mut() {
+            *x += other.scan.disk_read.unwrap_or_default();
+        }
         self.scan.perf_delta += other.scan.perf_delta;
     }
 }

--- a/components/cdc/src/initializer.rs
+++ b/components/cdc/src/initializer.rs
@@ -741,12 +741,14 @@ mod tests {
             total_bytes += v.len();
             let ts = TimeStamp::new(i as _);
             must_prewrite_put(&mut engine, k, v, k, ts);
-            let txn_locks = expected_locks.entry(ts).or_insert_with(|| {
-                let mut txn_locks = TxnLocks::default();
-                txn_locks.sample_lock = Some(k.to_vec().into());
-                txn_locks
-            });
-            txn_locks.lock_count += 1;
+            if i < 90 {
+                let txn_locks = expected_locks.entry(ts).or_insert_with(|| {
+                    let mut txn_locks = TxnLocks::default();
+                    txn_locks.sample_lock = Some(k.to_vec().into());
+                    txn_locks
+                });
+                txn_locks.lock_count += 1;
+            }
         }
 
         let region = Region::default();

--- a/components/cdc/src/old_value.rs
+++ b/components/cdc/src/old_value.rs
@@ -183,7 +183,6 @@ pub fn near_seek_old_value<S: EngineSnapshot>(
     load_from_cf_data: Either<&S, &mut Cursor<S::Iter>>,
     statistics: &mut Statistics,
 ) -> Result<Option<Value>> {
-    println!("near_seek_old_value is called");
     let start = Instant::now();
     tikv_util::defer!(
         CDC_OLD_VALUE_DURATION_HISTOGRAM

--- a/components/cdc/src/old_value.rs
+++ b/components/cdc/src/old_value.rs
@@ -183,6 +183,7 @@ pub fn near_seek_old_value<S: EngineSnapshot>(
     load_from_cf_data: Either<&S, &mut Cursor<S::Iter>>,
     statistics: &mut Statistics,
 ) -> Result<Option<Value>> {
+    println!("near_seek_old_value is called");
     let start = Instant::now();
     tikv_util::defer!(
         CDC_OLD_VALUE_DURATION_HISTOGRAM

--- a/components/cdc/tests/failpoints/test_endpoint.rs
+++ b/components/cdc/tests/failpoints/test_endpoint.rs
@@ -9,12 +9,16 @@ use std::{
 use api_version::{test_kv_format_impl, KvFormat};
 use causal_ts::CausalTsProvider;
 use cdc::{recv_timeout, Delegate, OldValueCache, Task, Validate};
+use engine_traits::{
+    IterOptions, Iterable, Iterator, MiscExt, Mutable, WriteBatch, WriteBatchExt, WriteOptions,
+    CF_DEFAULT, CF_WRITE,
+};
 use futures::{executor::block_on, sink::SinkExt};
 use grpcio::{ChannelBuilder, Environment, WriteFlags};
 use kvproto::{cdcpb::*, kvrpcpb::*, tikvpb_grpc::TikvClient};
 use pd_client::PdClient;
 use test_raftstore::*;
-use tikv_util::{debug, worker::Scheduler, HandyRwLock};
+use tikv_util::{debug, worker::Scheduler, HandyRwLock, keybuilder::KeyBuilder};
 use txn_types::{Key, TimeStamp};
 
 use crate::{new_event_feed, new_event_feed_v2, ClientReceiver, TestSuite, TestSuiteBuilder};
@@ -655,4 +659,81 @@ fn test_delegate_fail_during_incremental_scan() {
     let mut recver = recv.replace(None).unwrap();
     recv_timeout(&mut recver, Duration::from_secs(1)).unwrap_err();
     recv.replace(Some(recver));
+}
+
+#[test]
+fn test_cdc_load_unnecessary_old_value() {
+    let mut suite = TestSuite::new(1, ApiVersion::V1);
+    let region = suite.cluster.get_region(&[]);
+    let rid = region.id;
+    let engine = suite.cluster.get_engine(1);
+
+    let start_tso = block_on(suite.cluster.pd_client.get_tso()).unwrap();
+    let pk = format!("key_{:05}", 0).into_bytes();
+    let mut mutations = Vec::with_capacity(1000);
+    let mut keys = Vec::with_capacity(1000);
+    for i in 0..1000 {
+        let key = format!("key_{:05}", i).into_bytes();
+        keys.push(key.clone());
+
+        let mut mutation = Mutation::default();
+        mutation.set_op(Op::Put);
+        mutation.key = key;
+        mutation.value = vec![b'x'; 16];
+        mutations.push(mutation);
+    }
+    suite.must_kv_prewrite(rid, mutations, pk, start_tso);
+
+    let commit_tso = block_on(suite.cluster.pd_client.get_tso()).unwrap();
+    suite.must_kv_commit(rid, keys, start_tso, commit_tso);
+    engine.flush_cf(CF_WRITE, true).unwrap();
+
+    for cf in &[CF_WRITE, CF_DEFAULT] {
+        let mut wb = suite.cluster.get_engine(1).write_batch();
+        let mut count = 0;
+
+        let start = KeyBuilder::from_vec(vec![b'z'], 0, 0);
+        let end = KeyBuilder::from_vec(vec![b'z'+ 1], 0, 0);
+        let iter_opts = IterOptions::new(Some(start), Some(end), false);
+        let mut iter = engine.iterator_opt(cf, iter_opts).unwrap();
+        let mut valid = iter.seek_to_first().unwrap();
+
+        while valid && count < 900 {
+            count += 1;
+            let key = iter.key();
+            wb.delete_cf(cf, key).unwrap();
+            valid = iter.next().unwrap();
+        }
+        // skip 100 keys.
+        while valid {
+            count += 1;
+            valid = iter.next().unwrap();
+        }
+        println!("count: {}", count);
+        assert!(count == 0 || count == 1000);
+        wb.write_opt(&WriteOptions::default()).unwrap();
+        engine.flush_cf(cf, true).unwrap();
+    }
+
+    fail::cfg("ts_filter_is_helpful_always_true", "return(0)").unwrap();
+    let (mut req_tx, _, receive_event) = new_event_feed_v2(suite.get_region_cdc_client(rid));
+    let mut req = suite.new_changedata_request(rid);
+    req.request_id = 100;
+    req.checkpoint_ts = commit_tso.into_inner() - 1;
+    req.set_start_key(Key::from_raw(b"aa").into_encoded());
+    req.set_end_key(Key::from_raw(b"ab").into_encoded());
+    block_on(req_tx.send((req.clone(), WriteFlags::default()))).unwrap();
+
+    let events = receive_event(false).events.to_vec();
+    assert_eq!(events.len(), 1, "{:?}", events);
+    match events[0].event.as_ref().unwrap() {
+        Event_oneof_event::Entries(es) => {
+            assert!(es.entries.len() == 1);
+            assert_eq!(es.entries[0].get_type(), EventLogType::Initialized);
+        }
+        _ => unreachable!(),
+    }
+
+    fail::remove("ts_filter_is_helpful_always_true");
+    suite.stop();
 }


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Close #16601
Issue Number: Close #17620 

What's Changed:

Filter CDC events with the observed range before load old values. This can reduce CPU usage, especially for the situation with lots of continuous RocksDB Tombstones, which are generated from `drop/truncate table/partition` DDLs.

```commit-message
cdc: filter events with the observed range before load old values
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
None
```
