### PR TITLE
in_memory_engine: fix the assert panic caused by gc

### DIFF
--- a/components/in_memory_engine/src/background.rs
+++ b/components/in_memory_engine/src/background.rs
@@ -2318,12 +2318,12 @@ pub mod tests {
         };
 
         let test_data = [
-            (b"k05".as_slice(), b"val1".as_slice(), 10, 11, 10, false),
-            (b"k05", b"val2", 12, 13, 14, false),
-            (b"k05".as_slice(), b"val1".as_slice(), 14, 15, 18, false),
-            (b"k15".as_slice(), b"val1".as_slice(), 10, 11, 10, false),
-            (b"k15", b"val2", 12, 13, 14, false),
-            (b"k15".as_slice(), b"val1".as_slice(), 14, 15, 18, false),
+            (b"k05".as_slice(), b"val1".as_slice(), 10, 11, 10),
+            (b"k05", b"val2", 12, 13, 14),
+            (b"k05", b"val1", 14, 15, 18),
+            (b"k15", b"val1", 10, 11, 10),
+            (b"k15", b"val2", 12, 13, 14),
+            (b"k15", b"val1", 14, 15, 18),
         ];
 
         for d in test_data {
@@ -2333,7 +2333,7 @@ pub mod tests {
                 d.2,
                 d.3,
                 d.4,
-                d.5,
+                false,
                 &default,
                 &write,
                 memory_controller.clone(),

--- a/components/in_memory_engine/src/background.rs
+++ b/components/in_memory_engine/src/background.rs
@@ -1,6 +1,6 @@
 // Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{fmt, sync::Arc, time::Duration};
+use std::{borrow::Cow, fmt, sync::Arc, time::Duration};
 
 use bytes::Bytes;
 use crossbeam::{
@@ -486,6 +486,7 @@ impl BackgroundRunnerCore {
         safe_point: u64,
         oldest_seqno: u64,
     ) -> FilterMetrics {
+        let mut gc_region = Cow::Borrowed(region);
         let safe_point = {
             let region_manager = self.engine.region_manager();
             // We should also consider the ongoing snapshot of the historical regions
@@ -503,6 +504,11 @@ impl BackgroundRunnerCore {
                 || !region.contains_range(region_meta.get_region())
             {
                 return FilterMetrics::default();
+            }
+
+            // check if region epoch vesion changes.
+            if region.epoch_version != region_meta.get_region().epoch_version {
+                gc_region = Cow::Owned(region_meta.get_region().clone());
             }
 
             let min_snapshot = region_meta
@@ -541,14 +547,16 @@ impl BackgroundRunnerCore {
             skiplist_engine.cf_handle(CF_DEFAULT),
             skiplist_engine.cf_handle(CF_WRITE),
         );
-        filter.filter_keys_in_region(region);
-        self.engine.region_manager().on_gc_region_finished(region);
+        filter.filter_keys_in_region(&gc_region);
+        self.engine
+            .region_manager()
+            .on_gc_region_finished(&gc_region);
 
         let duration = start.saturating_elapsed();
         IN_MEMORY_ENGINE_GC_TIME_HISTOGRAM.observe(duration.as_secs_f64());
         info!(
             "ime region gc complete";
-            "region" => ?region,
+            "region" => ?gc_region.as_ref(),
             "gc_duration" => ?duration,
             "total_version" => filter.metrics.total,
             "filtered_version" => filter.metrics.filtered,
@@ -2286,6 +2294,79 @@ pub mod tests {
 
         assert_eq!(2, element_count(&default));
         assert_eq!(2, element_count(&write));
+    }
+
+    // test the condition that target region is split after scan need gc region and
+    // before the gc task actual start.
+    #[test]
+    fn test_gc_after_region_split() {
+        let config = InMemoryEngineConfig::config_for_test();
+        let engine = RegionCacheMemoryEngine::new(InMemoryEngineContext::new_for_tests(Arc::new(
+            VersionTrack::new(config),
+        )));
+        let memory_controller = engine.memory_controller();
+        let (write, default, region) = {
+            let region = CacheRegion::new(1, 0, b"zk00", b"zk20");
+            engine.core.region_manager().new_region(region.clone());
+
+            let engine = engine.core.engine();
+            (
+                engine.cf_handle(CF_WRITE),
+                engine.cf_handle(CF_DEFAULT),
+                region,
+            )
+        };
+
+        let test_data = [
+            (b"k05".as_slice(), b"val1".as_slice(), 10, 11, 10, false),
+            (b"k05", b"val2", 12, 13, 14, false),
+            (b"k05".as_slice(), b"val1".as_slice(), 14, 15, 18, false),
+            (b"k15".as_slice(), b"val1".as_slice(), 10, 11, 10, false),
+            (b"k15", b"val2", 12, 13, 14, false),
+            (b"k15".as_slice(), b"val1".as_slice(), 14, 15, 18, false),
+        ];
+
+        for d in test_data {
+            put_data(
+                d.0,
+                d.1,
+                d.2,
+                d.3,
+                d.4,
+                d.5,
+                &default,
+                &write,
+                memory_controller.clone(),
+            );
+        }
+
+        assert_eq!(6, element_count(&default));
+        assert_eq!(6, element_count(&write));
+
+        let config = Arc::new(VersionTrack::new(InMemoryEngineConfig::config_for_test()));
+        let (worker, _) = BackgroundRunner::new(
+            engine.core.clone(),
+            memory_controller.clone(),
+            None,
+            config,
+            Arc::new(MockPdClient {}),
+            None,
+        );
+
+        // triggers region split.
+        let new_regions = vec![
+            CacheRegion::new(1, 2, "zk00", "zk10"),
+            CacheRegion::new(2, 2, "zk10", "zk20"),
+        ];
+        engine.on_region_event(RegionEvent::Split {
+            source: region.clone(),
+            new_regions,
+        });
+
+        // still use the original region to do gc, should only gc the region with the
+        // same id.
+        let filter = worker.core.gc_region(&region, 100, 100);
+        assert_eq!(2, filter.filtered);
     }
 
     #[test]


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #17667

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Fix the bug that when region is split before gc task start, the gc task
only mark in_gc state for the region with the same id, but will unset
it for all the regions within the given range.

NOTE: for implementation simplicity, after this change, in the condition,
the gc will only run on the region with the same id, other regions in
the same range will skip this GC round.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
