### PR TITLE
RocksDB: Expose bottommost_file_compaction_delay option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2881,7 +2881,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#78b26b39bc179a0358ad0e5611b9d9934edabefd"
+source = "git+https://github.com/tikv/rust-rocksdb.git#50354af084e72d3a00f2704ce28671e2cb1b03cc"
 dependencies = [
  "bindgen 0.65.1",
  "bzip2-sys",
@@ -2900,7 +2900,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tikv/rust-rocksdb.git#78b26b39bc179a0358ad0e5611b9d9934edabefd"
+source = "git+https://github.com/tikv/rust-rocksdb.git#50354af084e72d3a00f2704ce28671e2cb1b03cc"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -4702,7 +4702,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#78b26b39bc179a0358ad0e5611b9d9934edabefd"
+source = "git+https://github.com/tikv/rust-rocksdb.git#50354af084e72d3a00f2704ce28671e2cb1b03cc"
 dependencies = [
  "libc 0.2.151",
  "librocksdb_sys",

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -421,6 +421,7 @@ macro_rules! cf_config {
             // `periodic_compaction_seconds` in Rocksdb is 30 days as default.
             #[online_config(skip)]
             pub periodic_compaction_seconds: Option<ReadableDuration>,
+            pub bottommost_file_compaction_delay: u32,
             #[online_config(submodule)]
             pub titan: TitanCfConfig,
         }
@@ -706,6 +707,7 @@ macro_rules! build_cf_opt {
                 .0
                 .as_secs(),
         );
+        cf_opts.set_bottommost_file_compaction_delay($opt.bottommost_file_compaction_delay);
         cf_opts
     }};
 }
@@ -779,6 +781,7 @@ impl Default for DefaultCfConfig {
             max_compactions: None,
             ttl: None,
             periodic_compaction_seconds: None,
+            bottommost_file_compaction_delay: 3600,
             titan: TitanCfConfig::default(),
             write_buffer_limit: None,
         }
@@ -949,6 +952,7 @@ impl Default for WriteCfConfig {
             max_compactions: None,
             ttl: None,
             periodic_compaction_seconds: None,
+            bottommost_file_compaction_delay: 3600,
             titan: TitanCfConfig::default_for_disabled(),
             write_buffer_limit: None,
         }
@@ -1069,6 +1073,7 @@ impl Default for LockCfConfig {
             max_compactions: None,
             ttl: None,
             periodic_compaction_seconds: None,
+            bottommost_file_compaction_delay: 0,
             titan: TitanCfConfig::default_for_disabled(),
             write_buffer_limit: None,
         }
@@ -1167,6 +1172,7 @@ impl Default for RaftCfConfig {
             max_compactions: None,
             ttl: None,
             periodic_compaction_seconds: None,
+            bottommost_file_compaction_delay: 0,
             titan: TitanCfConfig::default_for_disabled(),
             write_buffer_limit: None,
         }
@@ -1761,6 +1767,7 @@ impl Default for RaftDefaultCfConfig {
             max_compactions: None,
             ttl: None,
             periodic_compaction_seconds: None,
+            bottommost_file_compaction_delay: 0,
             titan: TitanCfConfig::default(),
             write_buffer_limit: None,
         }

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -397,6 +397,7 @@ fn test_serde_custom_tikv_config() {
                 max_compactions: Some(3),
                 ttl: Some(ReadableDuration::days(10)),
                 periodic_compaction_seconds: Some(ReadableDuration::days(10)),
+                bottommost_file_compaction_delay: 3600,
                 write_buffer_limit: None,
             },
             writecf: WriteCfConfig {
@@ -472,6 +473,7 @@ fn test_serde_custom_tikv_config() {
                 max_compactions: Some(3),
                 ttl: Some(ReadableDuration::days(10)),
                 periodic_compaction_seconds: Some(ReadableDuration::days(10)),
+                bottommost_file_compaction_delay: 3600,
                 write_buffer_limit: None,
             },
             lockcf: LockCfConfig {
@@ -547,6 +549,7 @@ fn test_serde_custom_tikv_config() {
                 max_compactions: Some(3),
                 ttl: Some(ReadableDuration::days(10)),
                 periodic_compaction_seconds: Some(ReadableDuration::days(10)),
+                bottommost_file_compaction_delay: 0,
                 write_buffer_limit: Some(ReadableSize::mb(16)),
             },
             raftcf: RaftCfConfig {
@@ -622,6 +625,7 @@ fn test_serde_custom_tikv_config() {
                 max_compactions: Some(3),
                 ttl: Some(ReadableDuration::days(10)),
                 periodic_compaction_seconds: Some(ReadableDuration::days(10)),
+                bottommost_file_compaction_delay: 0,
                 write_buffer_limit: None,
             },
             titan: titan_db_config.clone(),
@@ -715,6 +719,7 @@ fn test_serde_custom_tikv_config() {
                 max_compactions: Some(3),
                 ttl: None,
                 periodic_compaction_seconds: None,
+                bottommost_file_compaction_delay: 0,
                 write_buffer_limit: None,
             },
             titan: titan_db_config,


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref #17691

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Expose bottommost_file_compaction_delay option
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Expose RocksDB's bottommost_file_compaction_delay option
```
