### PR TITLE
in_memory_engine: add a benchmark for region load

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2563,6 +2563,7 @@ version = "0.0.1"
 dependencies = [
  "bytes",
  "collections",
+ "criterion",
  "crossbeam",
  "crossbeam-skiplist 0.1.3",
  "dashmap",

--- a/components/in_memory_engine/Cargo.toml
+++ b/components/in_memory_engine/Cargo.toml
@@ -14,6 +14,11 @@ name = "failpoints"
 path = "tests/failpoints/mod.rs"
 required-features = ["failpoints"]
 
+[[bench]]
+name = "load_region"
+path = "benches/load_region.rs"
+harness = false
+
 [dependencies]
 engine_traits = { workspace = true }
 collections = { workspace = true }
@@ -51,6 +56,7 @@ tokio = { version = "1.5", features = ["rt-multi-thread"] }
 smallvec = "1.4"
 
 [dev-dependencies]
+criterion = "0.3"
 tempfile = "3.0"
 test_pd = { workspace = true }
 test_util = { workspace = true }

--- a/components/in_memory_engine/benches/load_region.rs
+++ b/components/in_memory_engine/benches/load_region.rs
@@ -1,0 +1,149 @@
+// Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
+
+#![feature(test)]
+
+use std::sync::Arc;
+
+use criterion::*;
+use engine_rocks::{util::new_engine, RocksEngine};
+use engine_traits::{
+    CacheRegion, KvEngine, Mutable, RegionCacheEngine, WriteBatch, WriteBatchExt, CF_DEFAULT,
+    CF_WRITE, DATA_CFS,
+};
+use futures::future::ready;
+use in_memory_engine::{BackgroundRunner, *};
+use keys::{DATA_MAX_KEY, DATA_MIN_KEY};
+use pd_client::PdClient;
+use raftstore::coprocessor::config::SPLIT_SIZE;
+use rand::{thread_rng, RngCore};
+use tikv_util::config::VersionTrack;
+use txn_types::{Key, TimeStamp, Write, WriteType};
+
+/// Benches the performace of background load region
+fn bench_load_region(c: &mut Criterion) {
+    for value_size in [32, 128, 512, 4096] {
+        bench_with_args(c, 128, value_size, SPLIT_SIZE.0 as usize, 100);
+    }
+}
+
+fn bench_with_args(
+    c: &mut Criterion,
+    key_size: usize,
+    value_size: usize,
+    region_size: usize,
+    mvcc_amp_thres: usize,
+) {
+    use std::time::Duration;
+
+    let rocks_engine = prepare_data(key_size, value_size, region_size, mvcc_amp_thres);
+    let mut group = c.benchmark_group("load_region");
+    // the bench is slow and workload is not useful.
+    group.warm_up_time(Duration::from_millis(1)).sample_size(10);
+    group.bench_function(format!("value size {}", value_size), |b| {
+        b.iter_with_large_drop(|| {
+            load_region(&rocks_engine);
+        })
+    });
+}
+
+fn prepare_data(
+    key_size: usize,
+    value_size: usize,
+    region_size: usize,
+    mvcc_amp_thres: usize,
+) -> RocksEngine {
+    let path = tempfile::Builder::new()
+        .prefix("bench_load")
+        .tempdir()
+        .unwrap();
+    let path_str = path.path().to_str().unwrap();
+    let rocks_engine = new_engine(path_str, DATA_CFS).unwrap();
+
+    // prepare for test data
+    let mut r = thread_rng();
+    let mut wb = rocks_engine.write_batch();
+    let mut ts_count = 1;
+    let count = (region_size + key_size + value_size - 1) / (key_size + value_size);
+    let mut key = vec![0u8; key_size];
+    r.fill_bytes(&mut key[..key_size - 8]);
+    let mut key_version_count = 0;
+    let mut mvcc_version = r.next_u32() as usize % (mvcc_amp_thres * 2) + 1;
+    for _i in 0..count {
+        if key_version_count >= mvcc_version {
+            r.fill_bytes(&mut key[..key_size - 8]);
+            mvcc_version = r.next_u32() as usize % (mvcc_amp_thres * 2) + 1;
+            key_version_count = 0;
+        }
+
+        let ts = TimeStamp::new(ts_count);
+        let k = keys::data_key(Key::from_raw(&key).append_ts(ts).as_encoded());
+        let mut value = vec![0u8; value_size];
+        r.fill_bytes(&mut value);
+
+        let v = if value_size <= 256 {
+            Some(value)
+        } else {
+            wb.put_cf(CF_DEFAULT, &k, &value).unwrap();
+            None
+        };
+        let w = Write::new(WriteType::Put, ts, v);
+        wb.put_cf(CF_WRITE, &k, &w.as_ref().to_bytes()).unwrap();
+
+        key_version_count += 1;
+        ts_count += 1;
+    }
+
+    wb.write().unwrap();
+
+    rocks_engine
+}
+
+fn load_region(rocks_engine: &RocksEngine) {
+    let mut engine = RegionCacheMemoryEngine::new(InMemoryEngineContext::new_for_tests(Arc::new(
+        VersionTrack::new(InMemoryEngineConfig::config_for_test()),
+    )));
+    engine.set_disk_engine(rocks_engine.clone());
+    let memory_controller = engine.memory_controller();
+
+    // do load
+    let config = Arc::new(VersionTrack::new(InMemoryEngineConfig::config_for_test()));
+    let (worker, _) = BackgroundRunner::new(
+        engine.core().clone(),
+        memory_controller.clone(),
+        None,
+        config,
+        Arc::new(MockTsPdClient::new()),
+        None,
+    );
+
+    let region = CacheRegion::new(1, 1, DATA_MIN_KEY, DATA_MAX_KEY);
+    engine.load_region(region.clone()).unwrap();
+    // update region state to loading to avoid background load.
+    engine.must_set_region_state(1, RegionState::Loading);
+
+    let snapshot = Arc::new(rocks_engine.snapshot());
+    worker.run_load_region(region, snapshot);
+}
+
+struct MockTsPdClient {
+    ts: TimeStamp,
+}
+
+impl MockTsPdClient {
+    fn new() -> Self {
+        // use now to build a big enough timestamp to ensure gc can run.
+        let now = TimeStamp::physical_now();
+        Self {
+            ts: TimeStamp::compose(now, 0),
+        }
+    }
+}
+
+impl PdClient for MockTsPdClient {
+    fn get_tso(&self) -> pd_client::PdFuture<txn_types::TimeStamp> {
+        Box::pin(ready(Ok(self.ts)))
+    }
+}
+
+criterion_group!(benches, bench_load_region);
+criterion_main!(benches);

--- a/components/in_memory_engine/src/background.rs
+++ b/components/in_memory_engine/src/background.rs
@@ -1739,9 +1739,8 @@ pub mod tests {
     use crossbeam::epoch;
     use engine_rocks::util::new_engine;
     use engine_traits::{
-        CacheRegion, IterOptions, Iterable, Iterator, KvEngine, Mutable, RegionCacheEngine,
-        RegionCacheEngineExt, RegionEvent, SyncMutable, WriteBatch, WriteBatchExt, CF_DEFAULT,
-        CF_LOCK, CF_WRITE, DATA_CFS,
+        CacheRegion, IterOptions, Iterable, Iterator, RegionCacheEngine, RegionCacheEngineExt,
+        RegionEvent, SyncMutable, CF_DEFAULT, CF_LOCK, CF_WRITE, DATA_CFS,
     };
     use futures::future::ready;
     use keys::{data_key, DATA_MAX_KEY, DATA_MIN_KEY};

--- a/components/in_memory_engine/src/background.rs
+++ b/components/in_memory_engine/src/background.rs
@@ -906,6 +906,167 @@ impl BackgroundRunner {
             delete_range_scheduler,
         )
     }
+
+    // used for benchmark.
+    pub fn run_load_region(&self, region: CacheRegion, snapshot: Arc<RocksSnapshot>) {
+        Self::do_load_region(
+            region,
+            snapshot,
+            self.core.clone(),
+            self.delete_range_scheduler.clone(),
+            self.pd_client.clone(),
+            self.config.value().gc_run_interval.0,
+        )
+    }
+
+    fn do_load_region(
+        region: CacheRegion,
+        snapshot: Arc<RocksSnapshot>,
+        core: BackgroundRunnerCore,
+        delete_range_scheduler: Scheduler<BackgroundTask>,
+        pd_client: Arc<dyn PdClient>,
+        gc_run_interval: Duration,
+    ) {
+        fail::fail_point!("ime_before_start_loading_region");
+        fail::fail_point!("ime_on_start_loading_region");
+        let mut is_canceled = false;
+        {
+            let regions_map = core.engine.region_manager().regions_map.read();
+            let region_meta = regions_map.region_meta(region.id).unwrap();
+            // if loading is canceled, we skip the batch load.
+            // NOTE: here we don't check the region epoch version change,
+            // We will handle possible region split and partial cancelation
+            // in `on_snapshot_load_canceled` and `on_snapshot_load_finished`.
+            if region_meta.get_state() != RegionState::Loading {
+                assert_eq!(region_meta.get_state(), RegionState::LoadingCanceled);
+                is_canceled = true;
+            }
+        }
+        let skiplist_engine = core.engine.engine.clone();
+
+        if core.memory_controller.reached_stop_load_threshold() {
+            // We are running out of memory, so cancel the load.
+            is_canceled = true;
+        }
+
+        if is_canceled {
+            info!(
+                "ime snapshot load canceled";
+                "region" => ?region,
+            );
+            core.on_snapshot_load_failed(&region, &delete_range_scheduler, false);
+            return;
+        }
+
+        info!("ime loading region"; "region" => ?&region);
+        let start = Instant::now();
+        let iter_opt = IterOptions::new(
+            Some(KeyBuilder::from_slice(&region.start, 0, 0)),
+            Some(KeyBuilder::from_slice(&region.end, 0, 0)),
+            false,
+        );
+
+        let safe_point = 'load_snapshot: {
+            for &cf in DATA_CFS {
+                let handle = skiplist_engine.cf_handle(cf);
+                let seq = snapshot.sequence_number();
+                let guard = &epoch::pin();
+                match snapshot.iterator_opt(cf, iter_opt.clone()) {
+                    Ok(mut iter) => {
+                        iter.seek_to_first().unwrap();
+                        while iter.valid().unwrap() {
+                            // use the sequence number from RocksDB snapshot here as
+                            // the kv is clearly visible
+                            let mut encoded_key = encode_key(iter.key(), seq, ValueType::Value);
+                            let mut val = InternalBytes::from_vec(iter.value().to_vec());
+
+                            let mem_size = RegionCacheWriteBatchEntry::calc_put_entry_size(
+                                iter.key(),
+                                val.as_bytes(),
+                            );
+
+                            // todo(SpadeA): we can batch acquire the memory size
+                            // here.
+                            if let MemoryUsage::CapacityReached(n) =
+                                core.memory_controller.acquire(mem_size)
+                            {
+                                warn!(
+                                    "ime stop loading snapshot due to memory reaching capacity";
+                                    "region" => ?region,
+                                    "memory_usage(MB)" => ReadableSize(n as u64).as_mb_f64(),
+                                );
+                                break 'load_snapshot None;
+                            }
+
+                            encoded_key.set_memory_controller(core.memory_controller.clone());
+                            val.set_memory_controller(core.memory_controller.clone());
+                            handle.insert(encoded_key, val, guard);
+                            iter.next().unwrap();
+                        }
+                    }
+                    Err(e) => {
+                        error!("ime creating rocksdb iterator failed"; "cf" => cf, "err" => %e);
+                        break 'load_snapshot None;
+                    }
+                }
+            }
+            // gc the range
+            let tso_timeout = std::cmp::min(gc_run_interval, TIMTOUT_FOR_TSO);
+            let now = match block_on_timeout(pd_client.get_tso(), tso_timeout) {
+                Ok(Ok(ts)) => ts,
+                err => {
+                    error!(
+                        "ime get timestamp failed, skip gc loaded region";
+                        "timeout_duration" => ?tso_timeout,
+                        "error" => ?err,
+                    );
+                    // Get timestamp fail so don't do gc.
+                    break 'load_snapshot Some(0);
+                }
+            };
+
+            let safe_point = (|| {
+                fail::fail_point!("ime_safe_point_in_loading", |t| {
+                    t.unwrap().parse::<u64>().unwrap()
+                });
+
+                let safe_point = now
+                    .physical()
+                    .saturating_sub(gc_run_interval.as_millis() as u64);
+                TimeStamp::compose(safe_point, 0).into_inner()
+            })();
+
+            let mut filter = Filter::new(
+                safe_point,
+                u64::MAX,
+                skiplist_engine.cf_handle(CF_DEFAULT),
+                skiplist_engine.cf_handle(CF_WRITE),
+            );
+            filter.filter_keys_in_region(&region);
+
+            Some(safe_point)
+        };
+
+        if let Some(safe_point) = safe_point {
+            if core.on_snapshot_load_finished(&region, &delete_range_scheduler, safe_point) {
+                let duration = start.saturating_elapsed();
+                IN_MEMORY_ENGINE_LOAD_TIME_HISTOGRAM.observe(duration.as_secs_f64());
+                info!(
+                    "ime loading region finished";
+                    "region" => ?region,
+                    "duration(sec)" => ?duration,
+                );
+            } else {
+                info!("ime loading region canceled";"region" => ?region);
+            }
+        } else {
+            info!(
+                "ime snapshot load failed";
+                "region" => ?region,
+            );
+            core.on_snapshot_load_failed(&region, &delete_range_scheduler, true);
+        }
+    }
 }
 
 impl Runnable for BackgroundRunner {
@@ -967,153 +1128,14 @@ impl Runnable for BackgroundRunner {
                 let pd_client = self.pd_client.clone();
                 let gc_run_interval = self.config.value().gc_run_interval.0;
                 let f = async move {
-                    fail::fail_point!("ime_before_start_loading_region");
-                    fail::fail_point!("ime_on_start_loading_region");
-                    let mut is_canceled = false;
-                    {
-                        let regions_map = core.engine.region_manager().regions_map.read();
-                        let region_meta = regions_map.region_meta(region.id).unwrap();
-                        // if loading is canceled, we skip the batch load.
-                        // NOTE: here we don't check the region epoch version change,
-                        // We will handle possible region split and partial cancelation
-                        // in `on_snapshot_load_canceled` and `on_snapshot_load_finished`.
-                        if region_meta.get_state() != RegionState::Loading {
-                            assert_eq!(region_meta.get_state(), RegionState::LoadingCanceled);
-                            is_canceled = true;
-                        }
-                    }
-                    let skiplist_engine = core.engine.engine.clone();
-
-                    if core.memory_controller.reached_stop_load_threshold() {
-                        // We are running out of memory, so cancel the load.
-                        is_canceled = true;
-                    }
-
-                    if is_canceled {
-                        info!(
-                            "ime snapshot load canceled";
-                            "region" => ?region,
-                        );
-                        core.on_snapshot_load_failed(&region, &delete_range_scheduler, false);
-                        return;
-                    }
-
-                    info!("ime loading region"; "region" => ?&region);
-                    let start = Instant::now();
-                    let iter_opt = IterOptions::new(
-                        Some(KeyBuilder::from_slice(&region.start, 0, 0)),
-                        Some(KeyBuilder::from_slice(&region.end, 0, 0)),
-                        false,
+                    Self::do_load_region(
+                        region,
+                        snapshot,
+                        core,
+                        delete_range_scheduler,
+                        pd_client,
+                        gc_run_interval,
                     );
-
-                    let safe_point = 'load_snapshot: {
-                        for &cf in DATA_CFS {
-                            let handle = skiplist_engine.cf_handle(cf);
-                            let seq = snapshot.sequence_number();
-                            let guard = &epoch::pin();
-                            match snapshot.iterator_opt(cf, iter_opt.clone()) {
-                                Ok(mut iter) => {
-                                    iter.seek_to_first().unwrap();
-                                    while iter.valid().unwrap() {
-                                        // use the sequence number from RocksDB snapshot here as
-                                        // the kv is clearly visible
-                                        let mut encoded_key =
-                                            encode_key(iter.key(), seq, ValueType::Value);
-                                        let mut val =
-                                            InternalBytes::from_vec(iter.value().to_vec());
-
-                                        let mem_size =
-                                            RegionCacheWriteBatchEntry::calc_put_entry_size(
-                                                iter.key(),
-                                                val.as_bytes(),
-                                            );
-
-                                        // todo(SpadeA): we can batch acquire the memory size
-                                        // here.
-                                        if let MemoryUsage::CapacityReached(n) =
-                                            core.memory_controller.acquire(mem_size)
-                                        {
-                                            warn!(
-                                                "ime stop loading snapshot due to memory reaching capacity";
-                                                "region" => ?region,
-                                                "memory_usage(MB)" => ReadableSize(n as u64).as_mb_f64(),
-                                            );
-                                            break 'load_snapshot None;
-                                        }
-
-                                        encoded_key
-                                            .set_memory_controller(core.memory_controller.clone());
-                                        val.set_memory_controller(core.memory_controller.clone());
-                                        handle.insert(encoded_key, val, guard);
-                                        iter.next().unwrap();
-                                    }
-                                }
-                                Err(e) => {
-                                    error!("ime creating rocksdb iterator failed"; "cf" => cf, "err" => %e);
-                                    break 'load_snapshot None;
-                                }
-                            }
-                        }
-                        // gc the range
-                        let tso_timeout = std::cmp::min(gc_run_interval, TIMTOUT_FOR_TSO);
-                        let now = match block_on_timeout(pd_client.get_tso(), tso_timeout) {
-                            Ok(Ok(ts)) => ts,
-                            err => {
-                                error!(
-                                    "ime get timestamp failed, skip gc loaded region";
-                                    "timeout_duration" => ?tso_timeout,
-                                    "error" => ?err,
-                                );
-                                // Get timestamp fail so don't do gc.
-                                break 'load_snapshot Some(0);
-                            }
-                        };
-
-                        let safe_point = (|| {
-                            fail::fail_point!("ime_safe_point_in_loading", |t| {
-                                t.unwrap().parse::<u64>().unwrap()
-                            });
-
-                            let safe_point = now
-                                .physical()
-                                .saturating_sub(gc_run_interval.as_millis() as u64);
-                            TimeStamp::compose(safe_point, 0).into_inner()
-                        })();
-
-                        let mut filter = Filter::new(
-                            safe_point,
-                            u64::MAX,
-                            skiplist_engine.cf_handle(CF_DEFAULT),
-                            skiplist_engine.cf_handle(CF_WRITE),
-                        );
-                        filter.filter_keys_in_region(&region);
-
-                        Some(safe_point)
-                    };
-
-                    if let Some(safe_point) = safe_point {
-                        if core.on_snapshot_load_finished(
-                            &region,
-                            &delete_range_scheduler,
-                            safe_point,
-                        ) {
-                            let duration = start.saturating_elapsed();
-                            IN_MEMORY_ENGINE_LOAD_TIME_HISTOGRAM.observe(duration.as_secs_f64());
-                            info!(
-                                "ime loading region finished";
-                                "region" => ?region,
-                                "duration(sec)" => ?duration,
-                            );
-                        } else {
-                            info!("ime loading region canceled";"region" => ?region);
-                        }
-                    } else {
-                        info!(
-                            "ime snapshot load failed";
-                            "region" => ?region,
-                        );
-                        core.on_snapshot_load_failed(&region, &delete_range_scheduler, true);
-                    }
                 };
                 self.region_load_remote.spawn(f);
             }
@@ -1717,8 +1739,9 @@ pub mod tests {
     use crossbeam::epoch;
     use engine_rocks::util::new_engine;
     use engine_traits::{
-        CacheRegion, IterOptions, Iterable, Iterator, RegionCacheEngine, RegionCacheEngineExt,
-        RegionEvent, SyncMutable, CF_DEFAULT, CF_LOCK, CF_WRITE, DATA_CFS,
+        CacheRegion, IterOptions, Iterable, Iterator, KvEngine, Mutable, RegionCacheEngine,
+        RegionCacheEngineExt, RegionEvent, SyncMutable, WriteBatch, WriteBatchExt, CF_DEFAULT,
+        CF_LOCK, CF_WRITE, DATA_CFS,
     };
     use futures::future::ready;
     use keys::{data_key, DATA_MAX_KEY, DATA_MIN_KEY};

--- a/components/in_memory_engine/src/engine.rs
+++ b/components/in_memory_engine/src/engine.rs
@@ -401,6 +401,13 @@ impl RegionCacheMemoryEngine {
         self.core.region_manager().load_region(cache_region)
     }
 
+    // Used for benchmark.
+    pub fn must_set_region_state(&self, id: u64, state: RegionState) {
+        let mut regions_map = self.core.region_manager().regions_map().write();
+        let meta = regions_map.mut_region_meta(id).unwrap();
+        meta.set_state(state);
+    }
+
     /// Evict a region from the in-memory engine. After this call, the region
     /// will not be readable, but the data of the region may not be deleted
     /// immediately due to some ongoing snapshots.

--- a/components/in_memory_engine/src/region_manager.rs
+++ b/components/in_memory_engine/src/region_manager.rs
@@ -200,7 +200,7 @@ impl CacheRegionMeta {
         valid_new_states.contains(&new_state)
     }
 
-    pub(crate) fn set_state(&mut self, new_state: RegionState) {
+    pub fn set_state(&mut self, new_state: RegionState) {
         assert!(self.validate_update_region_state(new_state));
         info!(
             "ime update region meta state";

--- a/components/in_memory_engine/src/region_manager.rs
+++ b/components/in_memory_engine/src/region_manager.rs
@@ -200,7 +200,7 @@ impl CacheRegionMeta {
         valid_new_states.contains(&new_state)
     }
 
-    pub fn set_state(&mut self, new_state: RegionState) {
+    pub(crate) fn set_state(&mut self, new_state: RegionState) {
         assert!(self.validate_update_region_state(new_state));
         info!(
             "ime update region meta state";


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #16141

```
$ cd components/in_memory_engine && cargo bench --bench load_region

Benchmarking load_region/value size 32: Warming up for 1.0000 ms
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 39.3s.
Benchmarking load_region/value size 32: Collecting 10 samples in estimated 39.30                                                                                load_region/value size 32
                        time:   [3.6624 s 3.6983 s 3.7351 s]
                        change: [-0.4625% +0.9910% +2.5652%] (p = 0.24 > 0.05)
                        No change in performance detected.

Benchmarking load_region/value size 128: Warming up for 1.0000 ms
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 25.0s.
Benchmarking load_region/value size 128: Collecting 10 samples in estimated 24.9                                                                                load_region/value size 128
                        time:   [2.4361 s 2.4949 s 2.5594 s]
                        change: [+1.0045% +3.8729% +7.0490%] (p = 0.02 < 0.05)
                        Performance has regressed.

Benchmarking load_region/value size 512: Warming up for 1.0000 ms
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 20.1s.
Benchmarking load_region/value size 512: Collecting 10 samples in estimated 20.1                                                                                load_region/value size 512
                        time:   [1.9580 s 2.0168 s 2.0658 s]
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) low mild

Benchmarking load_region/value size 4096: Collecting 10 samples in estimated 7.1                                                                                load_region/value size 4096
                        time:   [421.39 ms 446.77 ms 466.65 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) low severe
```

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Add a benchmark to test in-memory-engine load region performance.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
