### PR TITLE
In-memory engine: evict region when destroy peer

### DIFF
--- a/components/engine_traits/src/region_cache_engine.rs
+++ b/components/engine_traits/src/region_cache_engine.rs
@@ -57,6 +57,7 @@ pub enum EvictReason {
     ApplySnapshot,
     Flashback,
     Manual,
+    PeerDestroy,
 }
 
 /// RegionCacheEngine works as a region cache caching some regions (in Memory or

--- a/components/in_memory_engine/src/metrics.rs
+++ b/components/in_memory_engine/src/metrics.rs
@@ -43,6 +43,7 @@ make_auto_flush_static_metric! {
         apply_snapshot,
         flashback,
         manual,
+        destroy_peer,
     }
 
     pub struct GcFilteredCountVec: LocalIntCounter {
@@ -236,6 +237,9 @@ pub(crate) fn observe_eviction_duration(secs: f64, evict_reason: EvictReason) {
             .observe(secs),
         EvictReason::Manual => IN_MEMORY_ENGINE_EVICTION_DURATION_HISTOGRAM_STATIC
             .manual
+            .observe(secs),
+        EvictReason::PeerDestroy => IN_MEMORY_ENGINE_EVICTION_DURATION_HISTOGRAM_STATIC
+            .destroy_peer
             .observe(secs),
     }
 }

--- a/components/raftstore/src/coprocessor/dispatcher.rs
+++ b/components/raftstore/src/coprocessor/dispatcher.rs
@@ -315,6 +315,11 @@ impl_box_observer!(
     SnapshotObserver,
     WrappedBoxSnapshotObserver
 );
+impl_box_observer!(
+    BoxDestroyPeerObserver,
+    DestroyPeerObserver,
+    WrappedBoxDestroyPeerObserver
+);
 
 /// Registry contains all registered coprocessors.
 #[derive(Clone)]
@@ -336,6 +341,7 @@ where
     raft_message_observers: Vec<Entry<BoxRaftMessageObserver>>,
     extra_message_observers: Vec<Entry<BoxExtraMessageObserver>>,
     region_heartbeat_observers: Vec<Entry<BoxRegionHeartbeatObserver>>,
+    destroy_peer_observers: Vec<Entry<BoxDestroyPeerObserver>>,
     // For now, `write_batch_observer` and `snapshot_observer` can only have one
     // observer solely because of simplicity. However, it is possible to have
     // multiple observers in the future if needed.
@@ -361,6 +367,7 @@ impl<E: KvEngine> Default for Registry<E> {
             raft_message_observers: Default::default(),
             extra_message_observers: Default::default(),
             region_heartbeat_observers: Default::default(),
+            destroy_peer_observers: Default::default(),
             write_batch_observer: None,
             snapshot_observer: None,
         }
@@ -446,6 +453,14 @@ impl<E: KvEngine> Registry<E> {
         qo: BoxRegionHeartbeatObserver,
     ) {
         push!(priority, qo, self.region_heartbeat_observers);
+    }
+
+    pub fn register_destroy_peer_observer(
+        &mut self,
+        priority: u32,
+        destroy_peer_observer: BoxDestroyPeerObserver,
+    ) {
+        push!(priority, destroy_peer_observer, self.destroy_peer_observers);
     }
 
     pub fn register_write_batch_observer(&mut self, write_batch_observer: BoxWriteBatchObserver) {
@@ -971,6 +986,17 @@ impl<E: KvEngine> CoprocessorHost<E> {
             .as_ref()
             .map(|observer| observer.inner().create_observable_write_batch());
         WriteBatchWrapper::new(wb, observable_wb)
+    }
+
+    pub fn on_destroy_peer(&self, region: &Region) {
+        if self.registry.destroy_peer_observers.is_empty() {
+            return;
+        }
+
+        for observer in &self.registry.destroy_peer_observers {
+            let observer = observer.observer.inner();
+            observer.on_destroy_peer(region);
+        }
     }
 
     pub fn on_snapshot(

--- a/components/raftstore/src/coprocessor/mod.rs
+++ b/components/raftstore/src/coprocessor/mod.rs
@@ -611,6 +611,11 @@ pub trait UpdateSafeTsObserver: Coprocessor {
     fn on_update_safe_ts(&self, _: u64, _: u64, _: u64) {}
 }
 
+pub trait DestroyPeerObserver: Coprocessor {
+    /// Hook to call when destroying a peer.
+    fn on_destroy_peer(&self, _: &Region) {}
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -2663,21 +2663,25 @@ where
                 && !is_initialized_peer
                 && msg_type == target_msg_type
         };
+        #[cfg(feature = "failpoints")]
         fail_point!(
             "on_snap_msg_1000_2",
             fp_enable(MessageType::MsgSnapshot),
             |_| Ok(())
         );
+        #[cfg(feature = "failpoints")]
         fail_point!(
             "on_vote_msg_1000_2",
             fp_enable(MessageType::MsgRequestVote),
             |_| Ok(())
         );
+        #[cfg(feature = "failpoints")]
         fail_point!(
             "on_append_msg_1000_2",
             fp_enable(MessageType::MsgAppend),
             |_| Ok(())
         );
+        #[cfg(feature = "failpoints")]
         fail_point!(
             "on_heartbeat_msg_1000_2",
             fp_enable(MessageType::MsgHeartbeat),

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -2663,25 +2663,21 @@ where
                 && !is_initialized_peer
                 && msg_type == target_msg_type
         };
-        #[cfg(feature = "failpoints")]
         fail_point!(
             "on_snap_msg_1000_2",
             fp_enable(MessageType::MsgSnapshot),
             |_| Ok(())
         );
-        #[cfg(feature = "failpoints")]
         fail_point!(
             "on_vote_msg_1000_2",
             fp_enable(MessageType::MsgRequestVote),
             |_| Ok(())
         );
-        #[cfg(feature = "failpoints")]
         fail_point!(
             "on_append_msg_1000_2",
             fp_enable(MessageType::MsgAppend),
             |_| Ok(())
         );
-        #[cfg(feature = "failpoints")]
         fail_point!(
             "on_heartbeat_msg_1000_2",
             fp_enable(MessageType::MsgHeartbeat),

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -3956,6 +3956,7 @@ where
 
     // [PerformanceCriticalPath] TODO: spin off the I/O code (self.fsm.peer.destroy)
     fn destroy_peer(&mut self, merged_by_target: bool) -> bool {
+        self.ctx.coprocessor_host.on_destroy_peer(self.region());
         fail_point!("destroy_peer");
         // Mark itself as pending_remove
         self.fsm.peer.pending_remove = true;

--- a/tests/failpoints/cases/test_in_memory_engine.rs
+++ b/tests/failpoints/cases/test_in_memory_engine.rs
@@ -858,3 +858,23 @@ fn test_load_during_flashback() {
         );
     }
 }
+
+#[test]
+fn test_eviction_when_destroy_peer() {
+    let mut cluster = new_server_cluster_with_hybrid_engine_with_no_region_cache(0, 1);
+    cluster.run();
+
+    let t1 = ProductTable::new();
+    must_copr_load_data(&mut cluster, &t1, 1);
+    let t2 = ProductTable::new();
+    must_copr_load_data(&mut cluster, &t2, 1);
+
+    let key = t2.get_table_prefix();
+    let split_key = Key::from_raw(&key).into_encoded();
+    let r = cluster.get_region(&split_key);
+    cluster.must_split(&r, &split_key);
+
+    // let router = cluster.get_router(1).unwrap();
+    // let msg = Box::<RaftMessage>::default();
+    // router.send_raft_message(msg)
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #17644 Ref #16141

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Evict region when destroy peer
```
Evict region when destroy peer. Otherwise, the data may be inconsistent "physically" (logically, the data should be consistent due to unreadable for the destroyed range.).

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
