### PR TITLE
compaction-filter: add test for triggering compaction in CheckAndCompact

### DIFF
--- a/components/raftstore/src/store/worker/compact.rs
+++ b/components/raftstore/src/store/worker/compact.rs
@@ -870,4 +870,43 @@ mod tests {
             .unwrap();
         assert_eq!(stats.num_entries - stats.num_versions, 0);
     }
+
+    #[test]
+    fn test_need_compact() {
+        // many tombstone case
+        let range_stats = RangeStats {
+            num_entries: 1000,
+            num_versions: 200,
+            num_deletes: 0,
+            num_rows: 200,
+        };
+        assert!(need_compact(
+            &range_stats,
+            &CompactThreshold::new(10, 30, 100, 100)
+        ));
+
+        // many mvcc put case
+        let range_stats = RangeStats {
+            num_entries: 1000,
+            num_versions: 1000,
+            num_deletes: 0,
+            num_rows: 200,
+        };
+        assert!(need_compact(
+            &range_stats,
+            &CompactThreshold::new(100, 100, 100, 30)
+        ));
+
+        // many mvcc delete case
+        let range_stats = RangeStats {
+            num_entries: 1000,
+            num_versions: 1000,
+            num_deletes: 800,
+            num_rows: 1000,
+        };
+        assert!(need_compact(
+            &range_stats,
+            &CompactThreshold::new(100, 100, 100, 30)
+        ));
+    }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #17269

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
add test for triggering compaction in CheckAndCompact
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
