### PR TITLE
resolved-ts: use min_lock_ts-1 as the candidate of resolved-ts

### DIFF
--- a/components/resolved_ts/src/resolver.rs
+++ b/components/resolved_ts/src/resolver.rs
@@ -571,7 +571,7 @@ impl Resolver {
     // Returns the minimum possible (commit_ts - 1), based on the knowledge we have,
     // i.e. from all locks currently being tracked.
     // The function is to provide an upper bound of resolved-ts. By definition
-    // resolved-ts must be strictly larger than a future commit_ts.
+    // resolved-ts must be strictly smaller than a future commit_ts.
     //
     // "Oldest" doesn't mean it started first, but means it may have the smallest
     // commit_ts, which is the returned ts + 1.


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #17728

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

#### The problem
By the definition of resolved-ts, we require:
 `commit_ts > resolved_ts`, if the commit happens after the calculation of the resolved-ts.

Our implementation uses min_commit_ts to calculate resolved-ts, so that what we have is: 
`commit_ts >= min_commit_ts >= resolved_ts`

`resolved_ts` may be equal to `commit_ts`, which breaks the definition of resolved-ts.

#### The fix
This PR ensures `min_commit_ts > resolved_ts` to fix the problem

```commit-message
Use min_lock_ts-1 as the candidate of resolved-ts, to ensure resolved_ts < lock.min_commit_ts( <= commit_ts).
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
