### PR TITLE
storage: Fix unexpected flow control after unsafe destroy range -- cp to 7.1

### DIFF
--- a/src/storage/txn/flow_controller/singleton_flow_controller.rs
+++ b/src/storage/txn/flow_controller/singleton_flow_controller.rs
@@ -768,9 +768,9 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
         let pending_compaction_bytes = checker.long_term_pending_bytes.get_avg();
         let ignore = if let Some(before) = checker.pending_bytes_before_unsafe_destroy_range {
             // It assumes that the long term average will eventually come down below the
-                // soft limit. If the general traffic flow increases during destroy, the long
-                // term average may never come down and the flow control will be turned off for
-                // a long time, which would be a rather rare case, so just ignore it.
+            // soft limit. If the general traffic flow increases during destroy, the long
+            // term average may never come down and the flow control will be turned off for
+            // a long time, which would be a rather rare case, so just ignore it.
             if pending_compaction_bytes <= before && !self.wait_for_destroy_range_finish {
                 info!(
                     "pending compaction bytes is back to normal";

--- a/src/storage/txn/flow_controller/singleton_flow_controller.rs
+++ b/src/storage/txn/flow_controller/singleton_flow_controller.rs
@@ -587,11 +587,21 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
                 if !enabled {
                     return;
                 }
+                if self.wait_for_destroy_range_finish {
+                    // Concurrent unsafe destroy range, ignore the second one
+                    info!("concurrent unsafe destroy range, ignore");
+                    return;
+                }
                 self.wait_for_destroy_range_finish = true;
                 let soft = (self.soft_pending_compaction_bytes_limit as f64).log2();
-                for cf_checker in self.cf_checkers.values_mut() {
+                for (cf, cf_checker) in &mut self.cf_checkers {
                     let v = cf_checker.long_term_pending_bytes.get_avg();
                     if v <= soft {
+                        info!(
+                            "before unsafe destroy range";
+                            "cf" => cf,
+                            "pending_bytes" => v
+                        );
                         cf_checker.pending_bytes_before_unsafe_destroy_range = Some(v);
                     }
                 }
@@ -614,9 +624,13 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
                             SCHED_THROTTLE_ACTION_COUNTER
                                 .with_label_values(&[cf, "pending_bytes_jump"])
                                 .inc();
-                        } else {
-                            cf_checker.pending_bytes_before_unsafe_destroy_range = None;
                         }
+                        info!(
+                            "after unsafe destroy range";
+                            "cf" => cf,
+                            "before" => before,
+                            "after" => after
+                        );
                     }
                 }
             }
@@ -753,7 +767,17 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
 
         let pending_compaction_bytes = checker.long_term_pending_bytes.get_avg();
         let ignore = if let Some(before) = checker.pending_bytes_before_unsafe_destroy_range {
+            // It assumes that the long term average will eventually come down below the
+                // soft limit. If the general traffic flow increases during destroy, the long
+                // term average may never come down and the flow control will be turned off for
+                // a long time, which would be a rather rare case, so just ignore it.
             if pending_compaction_bytes <= before && !self.wait_for_destroy_range_finish {
+                info!(
+                    "pending compaction bytes is back to normal";
+                    "cf" => &cf,
+                    "pending_compaction_bytes" => pending_compaction_bytes,
+                    "before" => before
+                );
                 checker.pending_bytes_before_unsafe_destroy_range = None;
             }
             true
@@ -1271,6 +1295,14 @@ pub(super) mod tests {
         stub.0
             .pending_compaction_bytes
             .store(10000000 * 1024 * 1024 * 1024, Ordering::Relaxed);
+        send_flow_info(tx, region_id);
+        assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
+
+        // after unsafe destroy range, pending compaction bytes may jump back to a lower
+        // value
+        stub.0
+            .pending_compaction_bytes
+            .store(100 * 1024 * 1024 * 1024, Ordering::Relaxed);
         tx.send(FlowInfo::Compaction("default".to_string(), region_id))
             .unwrap();
         tx.send(FlowInfo::AfterUnsafeDestroyRange(region_id))
@@ -1283,13 +1315,23 @@ pub(super) mod tests {
             flow_controller.discard_ratio(region_id)
         );
 
-        // unfreeze the control
+        // the long term average pending compaction bytes is still high, shouldn't
+        // unfreeze the jump control
+        stub.0
+            .pending_compaction_bytes
+            .store(100 * 1024 * 1024 * 1024, Ordering::Relaxed);
+        send_flow_info(tx, region_id);
+        assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
+
+        // the long term average pending compaction bytes falls below the threshold,
+        // should unfreeze the jump control
         stub.0
             .pending_compaction_bytes
             .store(1024 * 1024, Ordering::Relaxed);
         send_flow_info(tx, region_id);
         assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
 
+        // exceeds the threshold, should perform throttle
         stub.0
             .pending_compaction_bytes
             .store(1000000000 * 1024 * 1024 * 1024, Ordering::Relaxed);


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #17304

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Fix unexpected flow control after unsafe destroy range

Flow controller detects pending compaction bytes jump before and after unsafe destroy range. If there is a jump, the controller enters a state that would ignore the high pending compaction bytes until it falls back to normal. Previously, the controller may not enter the state if the pending compaction bytes is lower than the threshold while long term average pending bytes is still high. Then it would trigger flow control mistakenly.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fix the possible flow control after dropping a large table or partition
```
