### PR TITLE
engine_rocks: ignore rocksdb range deletions

### DIFF
--- a/components/engine_rocks/src/options.rs
+++ b/components/engine_rocks/src/options.rs
@@ -17,6 +17,7 @@ impl From<engine_traits::ReadOptions> for RocksReadOptions {
     fn from(opts: engine_traits::ReadOptions) -> Self {
         let mut r = RawReadOptions::default();
         r.set_fill_cache(opts.fill_cache());
+        r.set_ignore_range_deletions(opts.ignore_range_deletions());
         RocksReadOptions(r)
     }
 }
@@ -63,6 +64,7 @@ impl From<engine_traits::IterOptions> for RocksReadOptions {
 fn build_read_opts(iter_opts: engine_traits::IterOptions) -> RawReadOptions {
     let mut opts = RawReadOptions::new();
     opts.set_fill_cache(iter_opts.fill_cache());
+    opts.set_ignore_range_deletions(iter_opts.ignore_range_deletions());
     opts.set_max_skippable_internal_keys(iter_opts.max_skippable_internal_keys());
     if iter_opts.key_only() {
         opts.set_titan_key_only(true);

--- a/components/engine_traits/src/options.rs
+++ b/components/engine_traits/src/options.rs
@@ -6,6 +6,7 @@ use tikv_util::keybuilder::KeyBuilder;
 #[derive(Clone)]
 pub struct ReadOptions {
     fill_cache: bool,
+    ignore_range_deletions: bool,
 }
 
 impl ReadOptions {
@@ -22,11 +23,19 @@ impl ReadOptions {
     pub fn set_fill_cache(&mut self, v: bool) {
         self.fill_cache = v;
     }
+
+    #[inline]
+    pub fn ignore_range_deletions(&self) -> bool {
+        self.ignore_range_deletions
+    }
 }
 
 impl Default for ReadOptions {
     fn default() -> ReadOptions {
-        ReadOptions { fill_cache: true }
+        ReadOptions {
+            fill_cache: true,
+            ignore_range_deletions: true,
+        }
     }
 }
 
@@ -95,6 +104,7 @@ pub struct IterOptions {
     // never fail a request as incomplete, even on skipping too many keys.
     // It's used to avoid encountering too many tombstones when seeking.
     max_skippable_internal_keys: u64,
+    ignore_range_deletions: bool,
 }
 
 impl IterOptions {
@@ -113,6 +123,7 @@ impl IterOptions {
             key_only: false,
             seek_mode: SeekMode::TotalOrder,
             max_skippable_internal_keys: 0,
+            ignore_range_deletions: true,
         }
     }
 
@@ -247,6 +258,10 @@ impl IterOptions {
     pub fn set_max_skippable_internal_keys(&mut self, threshold: u64) {
         self.max_skippable_internal_keys = threshold;
     }
+
+    pub fn ignore_range_deletions(&self) -> bool {
+        self.ignore_range_deletions
+    }
 }
 
 impl Default for IterOptions {
@@ -261,6 +276,7 @@ impl Default for IterOptions {
             key_only: false,
             seek_mode: SeekMode::TotalOrder,
             max_skippable_internal_keys: 0,
+            ignore_range_deletions: true,
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #xxx

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note

```
