### PR TITLE
in_memory_engine: adjust the default config

### DIFF
--- a/components/hybrid_engine/src/observer/load_eviction.rs
+++ b/components/hybrid_engine/src/observer/load_eviction.rs
@@ -15,7 +15,7 @@ use raftstore::coprocessor::{
     BoxQueryObserver, BoxRoleObserver, Cmd, Coprocessor, CoprocessorHost, DestroyPeerObserver,
     ExtraMessageObserver, ObserverContext, QueryObserver, RegionState, RoleObserver,
 };
-use tikv_util::info;
+use tikv_util::debug;
 
 #[derive(Clone)]
 pub struct LoadEvictionObserver {
@@ -82,7 +82,7 @@ impl LoadEvictionObserver {
                 ))
         {
             let cache_region = CacheRegion::from_region(ctx.region());
-            info!(
+            debug!(
                 "ime evict range due to apply commands";
                 "region" => ?cache_region,
                 "is_ingest_sst" => apply.pending_handle_ssts.is_some(),
@@ -94,7 +94,7 @@ impl LoadEvictionObserver {
         if !state.new_regions.is_empty() {
             let cmd_type = cmd.request.get_admin_request().get_cmd_type();
             assert!(cmd_type == AdminCmdType::BatchSplit || cmd_type == AdminCmdType::Split);
-            info!(
+            debug!(
                 "ime handle region split";
                 "region_id" => ctx.region().get_id(),
                 "admin_command" => ?cmd.request.get_admin_request().get_cmd_type(),
@@ -246,7 +246,7 @@ impl RoleObserver for LoadEvictionObserver {
         if let StateRole::Leader = change.state {
             // Currently, it is only used by the manual load.
             let cache_region = CacheRegion::from_region(ctx.region());
-            info!(
+            debug!(
                 "ime try to load region due to became leader";
                 "region" => ?cache_region,
             );
@@ -255,7 +255,7 @@ impl RoleObserver for LoadEvictionObserver {
             && change.initialized
         {
             let cache_region = CacheRegion::from_region(ctx.region());
-            info!(
+            debug!(
                 "ime try to evict region due to became follower";
                 "region" => ?cache_region,
             );

--- a/components/in_memory_engine/src/background.rs
+++ b/components/in_memory_engine/src/background.rs
@@ -698,6 +698,9 @@ impl BackgroundRunnerCore {
             }
         };
         if !region_stats_manager.ready_for_auto_load_and_evict() {
+            info!(
+                "ime skip check load&evict because the duration from last load&evict check is too short."
+            );
             return;
         }
 
@@ -760,7 +763,7 @@ impl BackgroundRunnerCore {
         if !self.memory_controller.reached_stop_load_threshold() {
             let expected_new_count = self
                 .memory_controller
-                .evict_threshold()
+                .stop_load_threshold()
                 .saturating_sub(self.memory_controller.mem_usage())
                 / region_stats_manager.expected_region_size();
             let expected_new_count = usize::max(expected_new_count, 1);

--- a/components/in_memory_engine/src/config.rs
+++ b/components/in_memory_engine/src/config.rs
@@ -15,6 +15,16 @@ const MIN_GC_RUN_INTERVAL: Duration = Duration::from_secs(10);
 // The maximum interval for GC run is 10 minutes which equals to the minimum
 // value of TiDB GC lifetime.
 const MAX_GC_RUN_INTERVAL: Duration = Duration::from_secs(600);
+// the maximum write kv throughput(20MiB), this is an empiracal value.
+const MAX_WRITE_KV_SPEED: u64 = 20 * 1024 * 1024;
+// The maximun duration in seconds we expect IME to release enough memory after
+// memory usage reaches `evict_threshold`. This is an empiracal value.
+// We use this value to determine the default value of `evict_threshold` based
+// on `capacity`.
+const MAX_RESERVED_DURATION_FOR_WRITE: u64 = 10;
+// Regions' mvcc read amplificatoin statistics is updated every 1min, so we set
+// the minimal load&evcit check duration to 2min.
+const MIN_LOAD_EVICT_INTERVAL: Duration = Duration::from_secs(120);
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, OnlineConfig)]
 #[serde(default, rename_all = "kebab-case")]
@@ -25,11 +35,15 @@ pub struct InMemoryEngineConfig {
     pub capacity: Option<ReadableSize>,
     /// When memory usage reaches this amount, we start to pick some regions to
     /// evict.
+    /// Default value: `capacity` - min(10 * MAX_WRITE_BYTES_SEC, capacity *
+    /// 0.1).
     pub evict_threshold: Option<ReadableSize>,
     /// When memory usage reaches this amount, we stop loading regions.
     // TODO(SpadeA): ultimately we only expose one memory limit to user.
     // When memory usage reaches this amount, no further load will be
     // performed.
+    // Default value: `evict_threshold` - min(RegionSplitSize(256MB) * 2 + MAX_WRITE_BYTES_SEC *
+    // MAX_EVICT_REGION_DUR_SECS，`evict_threshold` * 0.15)
     pub stop_load_threshold: Option<ReadableSize>,
     /// Determines the oldest timestamp (approximately, now - gc_run_interval)
     /// of the read request the in memory engine can serve.
@@ -70,33 +84,42 @@ impl Default for InMemoryEngineConfig {
 }
 
 impl InMemoryEngineConfig {
-    pub fn validate(&mut self) -> Result<(), Box<dyn Error>> {
+    pub fn validate(&mut self, region_split_size: ReadableSize) -> Result<(), Box<dyn Error>> {
         if !self.enable {
             return Ok(());
         }
 
-        if self.evict_threshold.is_none() || self.capacity.is_none() {
+        if self.capacity.is_none() {
             return Err("evict-threshold or capacity not set".into());
         }
 
-        if self.stop_load_threshold.is_none() {
-            self.stop_load_threshold = self.evict_threshold;
-        }
-
-        if self.stop_load_threshold.as_ref().unwrap() > self.evict_threshold.as_ref().unwrap() {
-            return Err(format!(
-                "stop-load-threshold {:?} is larger to evict-threshold {:?}",
-                self.stop_load_threshold.as_ref().unwrap(),
-                self.evict_threshold.as_ref().unwrap()
-            )
-            .into());
-        }
-
-        if self.evict_threshold.as_ref().unwrap() >= self.capacity.as_ref().unwrap() {
+        if self.evict_threshold.is_none() {
+            let capacity = self.capacity.unwrap().0;
+            let delta = std::cmp::min(
+                capacity / 10,
+                MAX_RESERVED_DURATION_FOR_WRITE * MAX_WRITE_KV_SPEED,
+            );
+            self.evict_threshold = Some(ReadableSize(capacity - delta));
+        } else if self.evict_threshold.as_ref().unwrap() >= self.capacity.as_ref().unwrap() {
             return Err(format!(
                 "evict-threshold {:?} is larger or equal to capacity {:?}",
                 self.evict_threshold.as_ref().unwrap(),
                 self.capacity.as_ref().unwrap()
+            )
+            .into());
+        }
+
+        if self.stop_load_threshold.is_none() {
+            let delta = std::cmp::min(
+                self.capacity.unwrap().0 * 15 / 100,
+                region_split_size.0 * 2 + MAX_RESERVED_DURATION_FOR_WRITE * MAX_WRITE_KV_SPEED,
+            );
+            self.stop_load_threshold = Some(ReadableSize(self.evict_threshold.unwrap().0 - delta));
+        } else if self.stop_load_threshold.unwrap() > self.evict_threshold.unwrap() {
+            return Err(format!(
+                "stop-load-threshold {:?} is larger to evict-threshold {:?}",
+                self.stop_load_threshold.as_ref().unwrap(),
+                self.evict_threshold.as_ref().unwrap()
             )
             .into());
         }
@@ -109,6 +132,14 @@ impl InMemoryEngineConfig {
             return Err(format!(
                 "gc-run-interval {:?} should be in the range [{:?}, {:?}]",
                 self.gc_run_interval, MIN_GC_RUN_INTERVAL, MAX_GC_RUN_INTERVAL
+            )
+            .into());
+        }
+
+        if self.load_evict_interval.0 < MIN_LOAD_EVICT_INTERVAL {
+            return Err(format!(
+                "load-evict-interval {:?} should be greater or equal to {:?}",
+                self.load_evict_interval, MIN_LOAD_EVICT_INTERVAL
             )
             .into());
         }
@@ -179,32 +210,68 @@ impl std::ops::Deref for InMemoryEngineConfigManager {
 mod tests {
     use super::*;
 
+    const DEFAULT_REGION_SPLIT_SIZE: ReadableSize = ReadableSize::mb(256);
+
     #[test]
     fn test_validate() {
         let mut cfg = InMemoryEngineConfig::default();
-        cfg.validate().unwrap();
+        cfg.validate(DEFAULT_REGION_SPLIT_SIZE).unwrap();
 
         cfg.enable = true;
-        assert!(cfg.validate().is_err());
+        assert!(cfg.validate(DEFAULT_REGION_SPLIT_SIZE).is_err());
 
         cfg.capacity = Some(ReadableSize::gb(2));
         cfg.evict_threshold = Some(ReadableSize::gb(1));
         cfg.stop_load_threshold = Some(ReadableSize::gb(1));
-        cfg.validate().unwrap();
+        cfg.validate(DEFAULT_REGION_SPLIT_SIZE).unwrap();
 
         // Error if less than MIN_GC_RUN_INTERVAL.
         cfg.gc_run_interval = ReadableDuration(Duration::ZERO);
-        assert!(cfg.validate().is_err());
+        assert!(cfg.validate(DEFAULT_REGION_SPLIT_SIZE).is_err());
         cfg.gc_run_interval = ReadableDuration(Duration::from_secs(9));
-        assert!(cfg.validate().is_err());
+        assert!(cfg.validate(DEFAULT_REGION_SPLIT_SIZE).is_err());
 
         // Error if larger than MIN_GC_RUN_INTERVAL.
         cfg.gc_run_interval = ReadableDuration(Duration::from_secs(601));
-        assert!(cfg.validate().is_err());
+        assert!(cfg.validate(DEFAULT_REGION_SPLIT_SIZE).is_err());
         cfg.gc_run_interval = ReadableDuration(Duration::MAX);
-        assert!(cfg.validate().is_err());
+        assert!(cfg.validate(DEFAULT_REGION_SPLIT_SIZE).is_err());
 
         cfg.gc_run_interval = ReadableDuration(Duration::from_secs(180));
-        cfg.validate().unwrap();
+        cfg.validate(DEFAULT_REGION_SPLIT_SIZE).unwrap();
+
+        #[track_caller]
+        fn check_delta(
+            cfg: &InMemoryEngineConfig,
+            evict_delta: ReadableSize,
+            load_delta: ReadableSize,
+        ) {
+            let real_evict_delta = cfg.capacity.unwrap() - cfg.evict_threshold.unwrap();
+            assert_eq!(real_evict_delta, evict_delta);
+            let real_load_delta = cfg.evict_threshold.unwrap() - cfg.stop_load_threshold.unwrap();
+            assert_eq!(real_load_delta, load_delta);
+        }
+
+        let mut cfg = InMemoryEngineConfig::default();
+        cfg.enable = true;
+        cfg.capacity = Some(ReadableSize::gb(1));
+        cfg.validate(DEFAULT_REGION_SPLIT_SIZE).unwrap();
+        check_delta(
+            &cfg,
+            ReadableSize::gb(1) / 10,
+            ReadableSize::gb(1) * 15 / 100,
+        );
+
+        let mut cfg = InMemoryEngineConfig::default();
+        cfg.enable = true;
+        cfg.capacity = Some(ReadableSize::gb(5));
+        cfg.validate(DEFAULT_REGION_SPLIT_SIZE).unwrap();
+        check_delta(&cfg, ReadableSize::mb(200), ReadableSize::mb(712));
+
+        let mut cfg = InMemoryEngineConfig::default();
+        cfg.enable = true;
+        cfg.capacity = Some(ReadableSize::gb(5));
+        cfg.validate(ReadableSize::mb(96)).unwrap();
+        check_delta(&cfg, ReadableSize::mb(200), ReadableSize::mb(392));
     }
 }

--- a/components/in_memory_engine/src/config.rs
+++ b/components/in_memory_engine/src/config.rs
@@ -18,7 +18,7 @@ const MAX_GC_RUN_INTERVAL: Duration = Duration::from_secs(600);
 // the maximum write kv throughput(20MiB), this is an empirical value.
 const MAX_WRITE_KV_SPEED: u64 = 20 * 1024 * 1024;
 // The maximum duration in seconds we expect IME to release enough memory after
-// memory usage reaches `evict_threshold`. This is an empiracal value.
+// memory usage reaches `evict_threshold`. This is an empirical value.
 // We use this value to determine the default value of `evict_threshold` based
 // on `capacity`.
 const MAX_RESERVED_DURATION_FOR_WRITE: u64 = 10;

--- a/components/in_memory_engine/src/config.rs
+++ b/components/in_memory_engine/src/config.rs
@@ -15,14 +15,14 @@ const MIN_GC_RUN_INTERVAL: Duration = Duration::from_secs(10);
 // The maximum interval for GC run is 10 minutes which equals to the minimum
 // value of TiDB GC lifetime.
 const MAX_GC_RUN_INTERVAL: Duration = Duration::from_secs(600);
-// the maximum write kv throughput(20MiB), this is an empiracal value.
+// the maximum write kv throughput(20MiB), this is an empirical value.
 const MAX_WRITE_KV_SPEED: u64 = 20 * 1024 * 1024;
-// The maximun duration in seconds we expect IME to release enough memory after
+// The maximum duration in seconds we expect IME to release enough memory after
 // memory usage reaches `evict_threshold`. This is an empiracal value.
 // We use this value to determine the default value of `evict_threshold` based
 // on `capacity`.
 const MAX_RESERVED_DURATION_FOR_WRITE: u64 = 10;
-// Regions' mvcc read amplificatoin statistics is updated every 1min, so we set
+// Regions' mvcc read amplification statistics is updated every 1min, so we set
 // the minimal load&evcit check duration to 2min.
 const MIN_LOAD_EVICT_INTERVAL: Duration = Duration::from_secs(120);
 

--- a/components/in_memory_engine/src/memory_controller.rs
+++ b/components/in_memory_engine/src/memory_controller.rs
@@ -86,13 +86,13 @@ impl MemoryController {
     }
 
     #[inline]
-    pub(crate) fn stop_load_threshold(&self) -> usize {
-        self.config.value().stop_load_threshold()
+    pub(crate) fn reached_stop_load_threshold(&self) -> bool {
+        self.mem_usage() >= self.config.value().stop_load_threshold()
     }
 
     #[inline]
-    pub(crate) fn reached_stop_load_threshold(&self) -> bool {
-        self.mem_usage() >= self.config.value().stop_load_threshold()
+    pub(crate) fn stop_load_threshold(&self) -> usize {
+        self.config.value().stop_load_threshold()
     }
 
     #[inline]

--- a/components/in_memory_engine/src/memory_controller.rs
+++ b/components/in_memory_engine/src/memory_controller.rs
@@ -86,6 +86,11 @@ impl MemoryController {
     }
 
     #[inline]
+    pub(crate) fn stop_load_threshold(&self) -> usize {
+        self.config.value().stop_load_threshold()
+    }
+
+    #[inline]
     pub(crate) fn reached_stop_load_threshold(&self) -> bool {
         self.mem_usage() >= self.config.value().stop_load_threshold()
     }

--- a/components/in_memory_engine/src/write_batch.rs
+++ b/components/in_memory_engine/src/write_batch.rs
@@ -146,7 +146,6 @@ impl RegionCacheWriteBatch {
         self.record_last_written_region();
 
         let cached_region = CacheRegion::from_region(region);
-        // TODO: remote range.
         self.set_region_cache_status(
             self.engine
                 .prepare_for_apply(&cached_region, region.is_in_flashback),

--- a/components/tikv_util/src/config.rs
+++ b/components/tikv_util/src/config.rs
@@ -129,6 +129,13 @@ impl Div<ReadableSize> for ReadableSize {
     }
 }
 
+impl Sub<ReadableSize> for ReadableSize {
+    type Output = ReadableSize;
+    fn sub(self, rhs: ReadableSize) -> Self::Output {
+        ReadableSize(self.0 - rhs.0)
+    }
+}
+
 impl Mul<u64> for ReadableSize {
     type Output = ReadableSize;
 

--- a/metrics/grafana/tikv_details.dashboard.py
+++ b/metrics/grafana/tikv_details.dashboard.py
@@ -4543,7 +4543,7 @@ def InMemoryEngine() -> RowPanel:
                 yaxes=yaxes(left_format=UNITS.OPS_PER_SEC),
                 targets=[
                     target(
-                        expr=expr_sum_rate(
+                        expr=expr_sum_delta(
                             "tikv_in_memory_engine_load_duration_secs_count",
                             by_labels=["instance"],
                         ),
@@ -4567,7 +4567,7 @@ def InMemoryEngine() -> RowPanel:
                 yaxes=yaxes(left_format=UNITS.OPS_PER_SEC),
                 targets=[
                     target(
-                        expr=expr_sum_rate(
+                        expr=expr_sum_delta(
                             "tikv_in_memory_engine_eviction_duration_secs_count",
                             by_labels=["type"],
                         ),

--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -38884,7 +38884,7 @@
           "targets": [
             {
               "datasource": "${DS_TEST-CLUSTER}",
-              "expr": "sum(rate(\n    tikv_in_memory_engine_load_duration_secs_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (instance) ",
+              "expr": "sum(delta(\n    tikv_in_memory_engine_load_duration_secs_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (instance) ",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -38892,7 +38892,7 @@
               "intervalFactor": 1,
               "legendFormat": "{{instance}}",
               "metric": "",
-              "query": "sum(rate(\n    tikv_in_memory_engine_load_duration_secs_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (instance) ",
+              "query": "sum(delta(\n    tikv_in_memory_engine_load_duration_secs_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (instance) ",
               "refId": "",
               "step": 10,
               "target": ""
@@ -39122,7 +39122,7 @@
           "targets": [
             {
               "datasource": "${DS_TEST-CLUSTER}",
-              "expr": "sum(rate(\n    tikv_in_memory_engine_eviction_duration_secs_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (type, $additional_groupby) ",
+              "expr": "sum(delta(\n    tikv_in_memory_engine_eviction_duration_secs_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (type, $additional_groupby) ",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -39130,7 +39130,7 @@
               "intervalFactor": 1,
               "legendFormat": "{{type}} {{$additional_groupby}}",
               "metric": "",
-              "query": "sum(rate(\n    tikv_in_memory_engine_eviction_duration_secs_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (type, $additional_groupby) ",
+              "query": "sum(delta(\n    tikv_in_memory_engine_eviction_duration_secs_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (type, $additional_groupby) ",
               "refId": "",
               "step": 10,
               "target": ""

--- a/metrics/grafana/tikv_details.json.sha256
+++ b/metrics/grafana/tikv_details.json.sha256
@@ -1,1 +1,1 @@
-489eb016896d5f733f2db9787b85de0c51a1cf8373affebe85045b779a560cd0  ./metrics/grafana/tikv_details.json
+59ad36b6e5205d53a8bb1fbad4590bb2e48353e5de4aaf907a587cfdcbe58b2e  ./metrics/grafana/tikv_details.json

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3961,7 +3961,8 @@ impl TikvConfig {
             return Err("in-memory-engine is unavailable for feature TTL or API v2".into());
         }
         self.in_memory_engine.expected_region_size = self.coprocessor.region_split_size();
-        self.in_memory_engine.validate()?;
+        self.in_memory_engine
+            .validate(self.coprocessor.region_split_size())?;
 
         // Now, only support cross check in in-memory engine when compaction filter is
         // enabled.


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #16141, close #17762

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Let in_memory_engine's config`evict-threshold` and `stop-load-threshold`
default value generated from `capacity`.
```

- in_memory_engine config default value:
  - `evict-threshold`: default value set to capacity - min(capacity * 0.1, 200MiB)
  - `stop-load-threshold`: default value set to: evict_threshold - min(capacity * 0.15, region_split_size * 2 + 200MiB)
  - set the minimal value of `load-evict-interval` to 120s as the background task will skip the check if the interval is small than 90s.
- Demote some logs in `LoadEvictObserver` from info to debug as RegionManager will also output these logs.
- Change 2 IME load/evcit metrics expression from `rate` to `delta` as the rate is too small and we care the actual event number than its rate.  

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
