### PR TITLE
RocksDB: Deprecate write_global_seq

### DIFF
--- a/components/engine_panic/src/import.rs
+++ b/components/engine_panic/src/import.rs
@@ -24,12 +24,4 @@ impl IngestExternalFileOptions for PanicIngestExternalFileOptions {
     fn move_files(&mut self, f: bool) {
         panic!()
     }
-
-    fn get_write_global_seqno(&self) -> bool {
-        panic!()
-    }
-
-    fn set_write_global_seqno(&mut self, f: bool) {
-        panic!()
-    }
 }

--- a/components/engine_rocks/src/import.rs
+++ b/components/engine_rocks/src/import.rs
@@ -15,7 +15,6 @@ impl ImportExt for RocksEngine {
         let cf = util::get_cf_handle(self.as_inner(), cf_name)?;
         let mut opts = RocksIngestExternalFileOptions::new();
         opts.move_files(true);
-        opts.set_write_global_seqno(false);
         // Note: no need reset the global seqno to 0 for compatibility as #16992
         // enable the TiKV to handle the case on applying abnormal snapshot.
         let now = Instant::now_coarse();
@@ -53,14 +52,6 @@ impl IngestExternalFileOptions for RocksIngestExternalFileOptions {
 
     fn move_files(&mut self, f: bool) {
         self.0.move_files(f);
-    }
-
-    fn get_write_global_seqno(&self) -> bool {
-        self.0.get_write_global_seqno()
-    }
-
-    fn set_write_global_seqno(&mut self, f: bool) {
-        self.0.set_write_global_seqno(f);
     }
 }
 

--- a/components/engine_traits/src/import.rs
+++ b/components/engine_traits/src/import.rs
@@ -12,8 +12,4 @@ pub trait IngestExternalFileOptions {
     fn new() -> Self;
 
     fn move_files(&mut self, f: bool);
-
-    fn get_write_global_seqno(&self) -> bool;
-
-    fn set_write_global_seqno(&mut self, f: bool);
 }

--- a/tests/failpoints/cases/test_import_service.rs
+++ b/tests/failpoints/cases/test_import_service.rs
@@ -469,6 +469,7 @@ fn test_flushed_applied_index_after_ingset() {
 
     // file a write to trigger ready flush, even if the write is not flushed.
     must_raw_put(&client, ctx, b"key1".to_vec(), b"value1".to_vec());
+    std::thread::sleep(std::time::Duration::from_millis(50));
     let count = sst_file_count(&cluster.paths);
     assert_eq!(0, count);
 

--- a/tests/failpoints/cases/test_import_service.rs
+++ b/tests/failpoints/cases/test_import_service.rs
@@ -123,16 +123,6 @@ fn test_ingest_reentrant() {
     // Don't delete ingested sst file or we cannot find sst file in next ingest.
     fail::cfg("dont_delete_ingested_sst", "1*return").unwrap();
 
-    let node_id = *cluster.sim.rl().get_node_ids().iter().next().unwrap();
-    // Use sst save path to track the sst file checksum.
-    let save_path = cluster
-        .sim
-        .rl()
-        .importers
-        .get(&node_id)
-        .unwrap()
-        .get_path(&meta);
-
     // Do ingest and it will ingest success.
     must_ingest_sst(&import, ctx.clone(), meta.clone());
 

--- a/tests/failpoints/cases/test_import_service.rs
+++ b/tests/failpoints/cases/test_import_service.rs
@@ -5,7 +5,6 @@ use std::{
     time::Duration,
 };
 
-use file_system::calc_crc32;
 use futures::executor::block_on;
 use grpcio::{ChannelBuilder, Environment};
 use kvproto::{disk_usage::DiskUsage, import_sstpb::*, tikvpb_grpc::TikvClient};
@@ -134,15 +133,9 @@ fn test_ingest_reentrant() {
         .unwrap()
         .get_path(&meta);
 
-    let checksum1 = calc_crc32(save_path.clone()).unwrap();
     // Do ingest and it will ingest success.
     must_ingest_sst(&import, ctx.clone(), meta.clone());
 
-    let checksum2 = calc_crc32(save_path).unwrap();
-    // TODO: Remove this once write_global_seqno is deprecated.
-    // Checksums are the same since the global seqno in the SST file no longer gets
-    // updated with the default setting, which is write_global_seqno=false.
-    assert_eq!(checksum1, checksum2);
     // Do ingest again and it can be reentrant
     must_ingest_sst(&import, ctx.clone(), meta);
 }

--- a/tests/failpoints/cases/test_import_service.rs
+++ b/tests/failpoints/cases/test_import_service.rs
@@ -106,7 +106,7 @@ fn test_download_to_full_disk() {
 
 #[test]
 fn test_ingest_reentrant() {
-    let (cluster, ctx, _tikv, import) = new_cluster_and_tikv_import_client();
+    let (_cluster, ctx, _tikv, import) = new_cluster_and_tikv_import_client();
 
     let temp_dir = Builder::new()
         .prefix("test_ingest_reentrant")


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #17711

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Deprecate write_global_seq, since it is by default false.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
