### PR TITLE
In-memory Engine: fix panic when destroy an uninitialized region

### DIFF
--- a/components/raftstore/src/coprocessor/dispatcher.rs
+++ b/components/raftstore/src/coprocessor/dispatcher.rs
@@ -954,9 +954,6 @@ impl<E: KvEngine> CoprocessorHost<E> {
     }
 
     pub fn on_applied_current_term(&self, role: StateRole, region: &Region) {
-        if self.registry.cmd_observers.is_empty() {
-            return;
-        }
         for observer in &self.registry.cmd_observers {
             let observer = observer.observer.inner();
             observer.on_applied_current_term(role, region);
@@ -989,10 +986,6 @@ impl<E: KvEngine> CoprocessorHost<E> {
     }
 
     pub fn on_destroy_peer(&self, region: &Region) {
-        if self.registry.destroy_peer_observers.is_empty() {
-            return;
-        }
-
         for observer in &self.registry.destroy_peer_observers {
             let observer = observer.observer.inner();
             observer.on_destroy_peer(region);

--- a/tests/failpoints/cases/test_stale_peer.rs
+++ b/tests/failpoints/cases/test_stale_peer.rs
@@ -136,7 +136,6 @@ fn test_stale_learner_restart() {
     must_get_equal(&cluster.get_engine(2), b"k2", b"v2");
 }
 
-/// pass
 /// Test if a peer can be destroyed through tombstone msg when applying
 /// snapshot.
 //#[test_case(test_raftstore_v2::new_node_cluster)] // unstable test case
@@ -216,7 +215,6 @@ fn test_stale_peer_destroy_when_apply_snapshot() {
     must_get_none(&cluster.get_engine(3), b"k1");
 }
 
-/// pass
 /// Test if destroy a uninitialized peer through tombstone msg would allow a
 /// staled peer be created again.
 #[test_case(test_raftstore::new_node_cluster)]


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!
 
If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #17767

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
IME observes all peer destroy events to timely evict regions. By adding
a new peer, the old and uninitialized peer will be destroyed and IME
must not panic in this situation.
```

### Related changes

- Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- Integration test

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
