### PR TITLE
Rollup of In-memory Engine commits #17805, #17515, #17771, #17763 and #17747

### DIFF
--- a/components/engine_traits/src/region_cache_engine.rs
+++ b/components/engine_traits/src/region_cache_engine.rs
@@ -8,7 +8,7 @@ use std::{
 use keys::{enc_end_key, enc_start_key};
 use kvproto::metapb::Region;
 
-use crate::{Iterable, KvEngine, Snapshot, WriteBatchExt};
+use crate::{KvEngine, Snapshot, WriteBatchExt};
 
 #[derive(Debug, PartialEq)]
 pub enum FailedReason {
@@ -63,7 +63,7 @@ pub enum EvictReason {
 /// RegionCacheEngine works as a region cache caching some regions (in Memory or
 /// NVME for instance) to improve the read performance.
 pub trait RegionCacheEngine:
-    RegionCacheEngineExt + WriteBatchExt + Iterable + Debug + Clone + Unpin + Send + Sync + 'static
+    RegionCacheEngineExt + WriteBatchExt + Debug + Clone + Unpin + Send + Sync + 'static
 {
     type Snapshot: Snapshot;
 
@@ -80,9 +80,6 @@ pub trait RegionCacheEngine:
 
     type DiskEngine: KvEngine;
     fn set_disk_engine(&mut self, disk_engine: Self::DiskEngine);
-
-    // return the region containing the key
-    fn get_region_for_key(&self, key: &[u8]) -> Option<CacheRegion>;
 
     type RangeHintService: RangeHintService;
     fn start_hint_service(&self, range_hint_service: Self::RangeHintService);

--- a/components/in_memory_engine/src/background.rs
+++ b/components/in_memory_engine/src/background.rs
@@ -778,16 +778,8 @@ impl BackgroundRunnerCore {
 // Flush epoch and pin enough times to make the delayed operations be executed
 #[cfg(test)]
 pub(crate) fn flush_epoch() {
-    {
-        let guard = &epoch::pin();
-        guard.flush();
-    }
-    // Local epoch tries to advance the global epoch every 128 pins. When global
-    // epoch advances, the operations(here, means delete) in the older epoch can be
-    // executed.
-    for _ in 0..128 {
-        let _ = &epoch::pin();
-    }
+    let guard = &epoch::pin();
+    guard.flush();
 }
 
 pub struct BackgroundRunner {

--- a/components/in_memory_engine/src/background.rs
+++ b/components/in_memory_engine/src/background.rs
@@ -758,7 +758,7 @@ impl BackgroundRunnerCore {
         if !self.memory_controller.reached_stop_load_threshold() {
             let expected_new_count = self
                 .memory_controller
-                .evict_threshold()
+                .stop_load_threshold()
                 .saturating_sub(self.memory_controller.mem_usage())
                 / region_stats_manager.expected_region_size();
             let expected_new_count = usize::max(expected_new_count, 1);

--- a/components/in_memory_engine/src/engine.rs
+++ b/components/in_memory_engine/src/engine.rs
@@ -14,8 +14,8 @@ use crossbeam_skiplist::{
 };
 use engine_rocks::RocksEngine;
 use engine_traits::{
-    CacheRegion, EvictReason, FailedReason, IterOptions, Iterable, KvEngine, RegionCacheEngine,
-    RegionCacheEngineExt, RegionEvent, Result, CF_DEFAULT, CF_LOCK, CF_WRITE, DATA_CFS,
+    CacheRegion, EvictReason, FailedReason, KvEngine, RegionCacheEngine, RegionCacheEngineExt,
+    RegionEvent, CF_DEFAULT, CF_LOCK, CF_WRITE, DATA_CFS,
 };
 use fail::fail_point;
 use kvproto::metapb::Region;
@@ -30,7 +30,7 @@ use crate::{
         encode_key_for_boundary_with_mvcc, encode_key_for_boundary_without_mvcc, InternalBytes,
     },
     memory_controller::MemoryController,
-    read::{RegionCacheIterator, RegionCacheSnapshot},
+    read::RegionCacheSnapshot,
     region_manager::{
         AsyncFnOnce, LoadFailedReason, RegionCacheStatus, RegionManager, RegionState,
     },
@@ -537,10 +537,6 @@ impl RegionCacheEngine for RegionCacheMemoryEngine {
             .start_bg_hint_service(range_hint_service)
     }
 
-    fn get_region_for_key(&self, key: &[u8]) -> Option<CacheRegion> {
-        self.core.region_manager().get_region_for_key(key)
-    }
-
     fn enabled(&self) -> bool {
         self.config.value().enable
     }
@@ -622,15 +618,6 @@ impl RegionCacheEngineExt for RegionCacheMemoryEngine {
             region: CacheRegion::from_region(region),
             for_manual_range: false,
         });
-    }
-}
-
-impl Iterable for RegionCacheMemoryEngine {
-    type Iterator = RegionCacheIterator;
-
-    fn iterator_opt(&self, _: &str, _: IterOptions) -> Result<Self::Iterator> {
-        // This engine does not support creating iterators directly by the engine.
-        panic!("iterator_opt is not supported on creating by RegionCacheMemoryEngine directly")
     }
 }
 

--- a/components/in_memory_engine/src/memory_controller.rs
+++ b/components/in_memory_engine/src/memory_controller.rs
@@ -91,6 +91,11 @@ impl MemoryController {
     }
 
     #[inline]
+    pub(crate) fn stop_load_threshold(&self) -> usize {
+        self.config.value().stop_load_threshold()
+    }
+
+    #[inline]
     pub(crate) fn evict_threshold(&self) -> usize {
         self.config.value().evict_threshold()
     }

--- a/components/in_memory_engine/src/region_stats.rs
+++ b/components/in_memory_engine/src/region_stats.rs
@@ -265,7 +265,7 @@ impl RegionStatsManager {
                             r.cop_detail.mvcc_amplification()
                                 < mvcc_amplification_to_filter
                         } else {
-                            // In this case, memory usage is relarively low, we only evict those that should not be cached apparently.
+                            // In this case, memory usage is relatively low, we only evict those that should not be cached apparently.
                             r.cop_detail.mvcc_amplification()
                                 <= self.config.value().mvcc_amplification_threshold as f64 / MVCC_AMPLIFICATION_FILTER_FACTOR
                                 || r.cop_detail.iterated_count()  < avg_top_next_prev / ITERATED_COUNT_FILTER_FACTOR

--- a/components/in_memory_engine/src/write_batch.rs
+++ b/components/in_memory_engine/src/write_batch.rs
@@ -42,7 +42,7 @@ pub(crate) const MEM_CONTROLLER_OVERHEAD: usize = 8;
 // default, the memtable size for lock cf is 32MB. As not all ranges will be
 // cached in the memory, just use half of it here.
 const AMOUNT_TO_CLEAN_TOMBSTONE: u64 = ReadableSize::mb(16).0;
-// The value of the delete entry in the in-memory engine. It's just a emptry
+// The value of the delete entry in the in-memory engine. It's just a empty
 // slice.
 const DELETE_ENTRY_VAL: &[u8] = b"";
 
@@ -73,8 +73,8 @@ pub struct RegionCacheWriteBatch {
     // ... -> PollHandler::end), although the same region can call `prepare_for_region`
     // multiple times, it can only call sequentially. This is say, we will not have this:
     // prepare_for_region(region1), prepare_for_region(region2), prepare_for_region(region1).
-    // In case to avoid this asssumption being broken, we record the regions that have called
-    // prepare_for_region and ensure that if the region is not the `currnet_region`, it is not
+    // In case to avoid this assumption being broken, we record the regions that have called
+    // prepare_for_region and ensure that if the region is not the `current_region`, it is not
     // recorded in this vec.
     prepared_regions: SmallVec<[u64; 10]>,
 }

--- a/components/raftstore/src/coprocessor/dispatcher.rs
+++ b/components/raftstore/src/coprocessor/dispatcher.rs
@@ -954,9 +954,6 @@ impl<E: KvEngine> CoprocessorHost<E> {
     }
 
     pub fn on_applied_current_term(&self, role: StateRole, region: &Region) {
-        if self.registry.cmd_observers.is_empty() {
-            return;
-        }
         for observer in &self.registry.cmd_observers {
             let observer = observer.observer.inner();
             observer.on_applied_current_term(role, region);
@@ -989,10 +986,6 @@ impl<E: KvEngine> CoprocessorHost<E> {
     }
 
     pub fn on_destroy_peer(&self, region: &Region) {
-        if self.registry.destroy_peer_observers.is_empty() {
-            return;
-        }
-
         for observer in &self.registry.destroy_peer_observers {
             let observer = observer.observer.inner();
             observer.on_destroy_peer(region);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3961,8 +3961,10 @@ impl TikvConfig {
             return Err("in-memory-engine is unavailable for feature TTL or API v2".into());
         }
         self.in_memory_engine.expected_region_size = self.coprocessor.region_split_size();
-        self.in_memory_engine
-            .validate(self.coprocessor.region_split_size())?;
+        self.in_memory_engine.validate(
+            &mut self.storage.block_cache.capacity.as_mut().unwrap().0,
+            self.coprocessor.region_split_size(),
+        )?;
 
         // Now, only support cross check in in-memory engine when compaction filter is
         // enabled.

--- a/tests/failpoints/cases/test_stale_peer.rs
+++ b/tests/failpoints/cases/test_stale_peer.rs
@@ -136,7 +136,6 @@ fn test_stale_learner_restart() {
     must_get_equal(&cluster.get_engine(2), b"k2", b"v2");
 }
 
-/// pass
 /// Test if a peer can be destroyed through tombstone msg when applying
 /// snapshot.
 //#[test_case(test_raftstore_v2::new_node_cluster)] // unstable test case
@@ -216,7 +215,6 @@ fn test_stale_peer_destroy_when_apply_snapshot() {
     must_get_none(&cluster.get_engine(3), b"k1");
 }
 
-/// pass
 /// Test if destroy a uninitialized peer through tombstone msg would allow a
 /// staled peer be created again.
 #[test_case(test_raftstore::new_node_cluster)]


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number:

ref #17767 
ref #16141

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
In-memory engine: handle error when getting regions info (#17805)

ref tikv/tikv#16141

handle error when getting regions info

Signed-off-by: SpadeA-Tang <u6748471@anu.edu.au>

---

In-memory Engine: Adjust memory settings based on available memory (#17515)

ref tikv/tikv#16141

This commit adjusts the following in-memory-engine defaults:

* `capacity`: Now IME uses 10% of the block cache and takes an equal
  amount of memory from the system. This is based on tests showing that
  the IME rarely fills its full capacity.
* `mvcc_amplification_threshold`: Change from 100 to 10 which benefit
  common workloads like TPCc (50 warehouse), saving approximately 20%
  of unified read pool CPU usage.

Also, it addresses two security issues:

* Upgrade hashbrown from yanked 0.15.0 to 0.15.1

Signed-off-by: Neil Shen <overvenus@gmail.com>

---

In-memory Engine: fix panic when destroy an uninitialized region (#17771)

close tikv/tikv#17767

IME observes all peer destroy events to timely evict regions. By adding
a new peer, the old and uninitialized peer will be destroyed and IME
must not panic in this situation.

Signed-off-by: Neil Shen <overvenus@gmail.com>

---

In-memory Engine: remove dead code and fix typos (#17763)

ref tikv/tikv#16141

Signed-off-by: Neil Shen <overvenus@gmail.com>

---

In-memory engine: use stop-load-threshold for loading new regions (#17747)

ref tikv/tikv#16141

use stop-load-threshold for loading new regions

Signed-off-by: SpadeA-Tang <tangchenjie1210@gmail.com>
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
