### PR TITLE
expr: fix panic when using radians and degree

### DIFF
--- a/components/tidb_query_expr/src/impl_math.rs
+++ b/components/tidb_query_expr/src/impl_math.rs
@@ -1187,7 +1187,10 @@ mod tests {
             ),
             (Some(f64::NAN), None),
             (Some(f64::INFINITY), Some(Real::new(f64::INFINITY).unwrap())),
-            (Some(1.0E308), Some(Real::new(1.0E308 * (std::f64::consts::PI / 180_f64)).unwrap()))
+            (
+                Some(1.0E308),
+                Some(Real::new(1.0E308 * (std::f64::consts::PI / 180_f64)).unwrap()),
+            ),
         ];
         for (input, expect) in test_cases {
             let output = RpnFnScalarEvaluator::new()
@@ -1230,7 +1233,11 @@ mod tests {
             (None, None, false),
             (Some(f64::NAN), None, false),
             (Some(0f64), Some(Real::new(0f64).unwrap()), false),
-            (Some(1f64), Some(Real::new(57.29577951308232_f64).unwrap()), false),
+            (
+                Some(1f64),
+                Some(Real::new(57.29577951308232_f64).unwrap()),
+                false,
+            ),
             (
                 Some(std::f64::consts::PI),
                 Some(Real::new(180.0_f64).unwrap()),


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close https://github.com/tikv/tikv/issues/17852

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:
1. `radians` changes from `arg * PI / 180` to `arg * (PI / 180)` to avoid infinite float issues. FYI: https://github.com/mysql/mysql-server/blob/ee079e5ca930ce5ed0643326abadeed8cd41fffc/sql/item_func.h#L1556 MySQL also calculate `PI / 180` firstly.
2. The result of `degrees` can be infinite so adding a check for it.

```commit-message
expr: fix panic when using radians and degree
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
