### PR TITLE
lock_manager: Skip updating lock wait info for non-fair-locking requests (#17500)

### DIFF
--- a/src/server/lock_manager/waiter_manager.rs
+++ b/src/server/lock_manager/waiter_manager.rs
@@ -554,7 +554,9 @@ impl WaiterManager {
                 continue;
             }
 
-            if let Some((previous_wait_info, diag_ctx)) = previous_wait_info {
+            if let Some((previous_wait_info, diag_ctx)) = previous_wait_info
+                && previous_wait_info.allow_lock_with_conflict
+            {
                 self.detector_scheduler
                     .clean_up_wait_for(event.start_ts, previous_wait_info);
                 self.detector_scheduler
@@ -678,6 +680,7 @@ pub mod tests {
                 key: Key::from_raw(b""),
                 lock_digest: LockDigest { ts: lock_ts, hash },
                 lock_info: Default::default(),
+                allow_lock_with_conflict: false,
             },
             cancel_callback: Box::new(|_| ()),
             diag_ctx: DiagnosticContext::default(),
@@ -798,6 +801,7 @@ pub mod tests {
                 key: Key::from_raw(&raw_key),
                 lock_digest: lock,
                 lock_info: info.clone(),
+                allow_lock_with_conflict: false,
             },
             cb,
             Instant::now() + Duration::from_millis(3000),
@@ -1202,6 +1206,7 @@ pub mod tests {
                     key: key.to_raw().unwrap(),
                     ..Default::default()
                 },
+                allow_lock_with_conflict: false,
             },
         };
         scheduler.update_wait_for(vec![event]);

--- a/src/storage/lock_manager/lock_waiting_queue.rs
+++ b/src/storage/lock_manager/lock_waiting_queue.rs
@@ -618,6 +618,7 @@ impl<L: LockManager> LockWaitQueues<L> {
                                 hash: entry.lock_hash,
                             },
                             lock_info: key_state.current_lock.clone(),
+                            allow_lock_with_conflict: entry.parameters.allow_lock_with_conflict,
                         },
                     };
                     update_wait_for_events.push(event);

--- a/src/storage/lock_manager/mod.rs
+++ b/src/storage/lock_manager/mod.rs
@@ -97,6 +97,7 @@ pub struct KeyLockWaitInfo {
     pub key: Key,
     pub lock_digest: LockDigest,
     pub lock_info: LockInfo,
+    pub allow_lock_with_conflict: bool,
 }
 
 /// Uniquely identifies a lock-waiting request in a `LockManager`.

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -989,6 +989,7 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         let start_ts = lock_info.parameters.start_ts;
         let is_first_lock = lock_info.parameters.is_first_lock;
         let wait_timeout = lock_info.parameters.wait_timeout;
+        let allow_lock_with_conflict = lock_info.parameters.allow_lock_with_conflict;
 
         let diag_ctx = DiagnosticContext {
             key: lock_info.key.to_raw().unwrap(),
@@ -1016,6 +1017,7 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
             key,
             lock_digest,
             lock_info: lock_info_pb,
+            allow_lock_with_conflict,
         };
         self.inner.lock_mgr.wait_for(
             wait_token,


### PR DESCRIPTION
This PR ports https://github.com/tikv/tikv/pull/17500 to master.
https://github.com/tikv/tikv/pull/17500 was first planned to be used as the fix for versions <= 8.1, however, the complete fix (https://github.com/tikv/tikv/pull/17451) was then still considered too risky. So we decided to also use https://github.com/tikv/tikv/pull/17500 as the fix for master as well as 8.5 branch, and the complete fix will be left and may be considered in the future.

After this fix, there may be a little more false posotive / false negative cases in the deadlock detection under lock contention scenarios.

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #17394

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
lock_manager: Skip updating lock wait info for non-fair-locking requests

This is a simpler and lower-risky fix of the OOM issue #17394 for released branches, as an alternative solution to #17451 .
In this way, for acquire_pessimistic_lock requests without enabling fair locking, the behavior of update_wait_for will be a noop. So that if fair locking is globally disabled, the behavior will be equivalent to versions before 7.0.
```

This is a simple alternative solution to #17451 .
For non-fair locking scenario, it's confirmed that the problem can be avoided.

Before:
![image](https://github.com/user-attachments/assets/5d8d0adc-8aa5-488d-b5c0-6e41421bed5e)

After: 
![image](https://github.com/user-attachments/assets/bdcb150d-f174-4c85-be35-abb46a04a7cc)


### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fix an issue that when frequently updating a row while many transaction is waiting on the lock, it might sometimes cause TiKV OOM
```
