### PR TITLE
fix dead lock when create external storage in less threads

### DIFF
--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -508,6 +508,9 @@ impl<E: KvEngine> SstImporter<E> {
             })?;
         }
 
+        // The `DashMap` locks the entry to ensure that only one thread loads the credentials at a time.
+        // However, if the thread gets blocked during the loading process, it can lead to a deadlock.
+        // To avoid this, blocking operations must be performed outside of the `DashMap`.
         let ext_storage = tokio::task::block_in_place(move || {
             self.external_storage_or_cache(backend, cache_key)
         })?;

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -2183,13 +2183,15 @@ mod tests {
 
         // test do_download_kv_file().
         assert!(importer.import_support_download());
-        let output = block_on_external_io(importer.read_from_kv_file(
-            &kv_meta,
-            ext_storage,
-            &backend,
-            &Limiter::new(f64::INFINITY),
-        ))
-        .unwrap();
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let output = runtime
+            .block_on(importer.read_from_kv_file(
+                &kv_meta,
+                ext_storage,
+                &backend,
+                &Limiter::new(f64::INFINITY),
+            ))
+            .unwrap();
         assert_eq!(*output, buff);
         check_file_exists(&path.save, None);
 

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -508,9 +508,10 @@ impl<E: KvEngine> SstImporter<E> {
             })?;
         }
 
-        // The `DashMap` locks the entry to ensure that only one thread loads the credentials at a time.
-        // However, if the thread gets blocked during the loading process, it can lead to a deadlock.
-        // To avoid this, blocking operations must be performed outside of the `DashMap`.
+        // The `DashMap` locks the entry to ensure that only one thread loads the
+        // credentials at a time. However, if the thread gets blocked during the
+        // loading process, it can lead to a deadlock. To avoid this, blocking
+        // operations must be performed outside of the `DashMap`.
         let ext_storage = tokio::task::block_in_place(move || {
             self.external_storage_or_cache(backend, cache_key)
         })?;

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -508,9 +508,9 @@ impl<E: KvEngine> SstImporter<E> {
             })?;
         }
 
-        let ext_storage = tokio::task::block_in_place(move ||
+        let ext_storage = tokio::task::block_in_place(move || {
             self.external_storage_or_cache(backend, cache_key)
-        )?;
+        })?;
         let ext_storage = self.wrap_kms(ext_storage, support_kms);
 
         let result = ext_storage

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -508,7 +508,9 @@ impl<E: KvEngine> SstImporter<E> {
             })?;
         }
 
-        let ext_storage = self.external_storage_or_cache(backend, cache_key)?;
+        let ext_storage = tokio::task::block_in_place(move ||
+            self.external_storage_or_cache(backend, cache_key)
+        )?;
         let ext_storage = self.wrap_kms(ext_storage, support_kms);
 
         let result = ext_storage


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
Problem:

Previously, Rusoto’s behavior involved lazy loading of credentials, so this issue never surfaced. However, the new SDK may block during credential loading.

We implemented a DashMap that locks the entry to ensure only one thread can load the credentials at a time. However, if this thread gets blocked during the runtime, it can lead to a deadlock.

What's Changed:
block outside of dashmap.
### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
