### PR TITLE
raftstore: add more duplicate entry check before proposing write command and batching commands

### DIFF
--- a/src/server/raftkv/mod.rs
+++ b/src/server/raftkv/mod.rs
@@ -22,7 +22,7 @@ use std::{
 
 use collections::{HashMap, HashSet};
 use concurrency_manager::ConcurrencyManager;
-use engine_traits::{CfName, KvEngine, MvccProperties, Snapshot};
+use engine_traits::{CfName, KvEngine, MvccProperties, Snapshot, CF_LOCK};
 use futures::{future::BoxFuture, task::AtomicWaker, Future, Stream, StreamExt, TryFutureExt};
 use hybrid_engine::HybridEngineSnapshot;
 use in_memory_engine::RegionCacheMemoryEngine;
@@ -506,6 +506,21 @@ where
         }
 
         let reqs: Vec<Request> = batch.modifies.into_iter().map(Into::into).collect();
+        // Ref: https://github.com/tikv/tikv/issues/16818.
+        // Check for duplicate key entries before proposing commands.
+        // TODO: remove this check when the cause of issue 16818 is located.
+        let mut keys_set = std::collections::HashSet::new();
+        for req in &reqs {
+            if req.has_put() && req.get_put().get_cf() == CF_LOCK {
+                let key = req.get_put().get_key();
+                if !keys_set.insert(key.to_vec()) {
+                    panic!(
+                        "found duplicate key in Lock CF PUT request, key: {:?}, extra: {:?}, ctx: {:?}, reqs: {:?}, avoid_batch:{:?}",
+                        key, batch.extra, ctx, reqs, batch.avoid_batch
+                    );
+                }
+            }
+        }
         let txn_extra = batch.extra;
         let mut header = new_request_header(ctx);
         if batch.avoid_batch {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref #16818 

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

For the issue https://github.com/tikv/tikv/issues/16818.

Possible reasons for the occurrence of duplicate `PUT` requests to the lock CF for the same key in a single `RaftCmdRequest` are as follows:

1. **Duplicate Entries in the Proposed `RaftCmdRequest`**:  
   The `RaftCmdRequest` being proposed contains duplicate entries. For example, the transaction write command initiated during async write may have duplicate key entries. This is typically unexpected. In TiKV's transaction model, every key being written must acquire a latch before writing. Concurrent writes to the same key are sequenced through the latch and should not end up in the same `RaftCmdRequest`.

2. **Batch Builder Aggregating Writes to the Same Key**:  
   During the batch building process for proposing raft commands, writes to the same key are grouped into a single batch. However, this possibility is quite low because, as mentioned above, writes to the same key should only proceed after the latch is released during the `apply` phase. For writes to occur, `apply` must have already completed, making it unlikely that these commands are processed together in a single raft store loop.

3. **Issues with Latch Release Timing**:  
   The latch is expected to be released only after the `apply` phase is completed. If there's a problem with the latch release mechanism, it could allow duplicate writes to proceed. There is no any recent modification to this part of the code from my observation.

4. **Batch Processing In The Apply Worker**
It seems nearly impossible based on the code. While there is batch processing during the Apply phase, the panic check for duplicate entries in the change logs observed by CDC is still performed at the `RaftCmdRequest` level. In other words, batching during the Apply phase does not modify the contents of the original `RaftCmdRequest`. Therefore, it is unlikely that the problem originates from this step.

This PR attempts to add checks in the aforementioned areas. If a duplicate entry is detected, TiKV will panic, helping to narrow down the scope of the investigation. Once the issue is identified and resolved, the related checking code can be removed.

From the benchbot regression, there is no significant differences

Patched version:
<img width="1051" alt="image" src="https://github.com/user-attachments/assets/198006cc-ed69-4942-ae5b-207e99a9dc88">


Nightly version:
<img width="1255" alt="image" src="https://github.com/user-attachments/assets/2ca63f7e-b82f-44d6-9cb6-595d4dfd0c9d">




### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [x] Performance regression: Consumes more CPU
- [x] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
