### PR TITLE
use raft casual message to ensure only load region if it is load when…

### DIFF
--- a/components/in_memory_engine/src/engine.rs
+++ b/components/in_memory_engine/src/engine.rs
@@ -20,7 +20,7 @@ use engine_traits::{
 use fail::fail_point;
 use kvproto::metapb::Region;
 use pd_client::PdClient;
-use raftstore::{coprocessor::RegionInfoProvider, store::CasualRouter};
+use raftstore::{coprocessor::RegionInfoProvider, store::ClonableCasualRouter};
 use slog_global::error;
 use tikv_util::{config::VersionTrack, info, warn, worker::Scheduler};
 
@@ -359,7 +359,7 @@ impl RegionCacheMemoryEngine {
     pub fn with_region_info_provider(
         in_memory_engine_context: InMemoryEngineContext,
         region_info_provider: Option<Arc<dyn RegionInfoProvider>>,
-        raft_casual_router: Option<Box<dyn CasualRouter<RocksEngine>>>,
+        raft_casual_router: Option<Box<dyn ClonableCasualRouter<RocksEngine>>>,
     ) -> Self {
         let core = Arc::new(RegionCacheMemoryEngineCore::new());
         let skiplist_engine = core.engine().clone();

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -1321,6 +1321,9 @@ where
                 }
                 self.fsm.has_ready = true;
             }
+            CasualMessage::InMemoryEnginePendingRegion { add_pending_cb, .. } => {
+                add_pending_cb(&self.fsm.peer.region(), self.fsm.peer.is_leader());
+            }
             CasualMessage::InMemoryEngineLoadRegion {
                 region_id,
                 trigger_load_cb,

--- a/components/raftstore/src/store/mod.rs
+++ b/components/raftstore/src/store/mod.rs
@@ -76,7 +76,10 @@ pub use self::{
         SnapManagerBuilder, Snapshot, SnapshotStatistics, TabletSnapKey, TabletSnapManager,
     },
     snapshot_backup::SnapshotBrWaitApplySyncer,
-    transport::{CasualRouter, ProposalRouter, SignificantRouter, StoreRouter, Transport},
+    transport::{
+        CasualRouter, ClonableCasualRouter, ProposalRouter, SignificantRouter, StoreRouter,
+        Transport,
+    },
     txn_ext::{LocksStatus, PeerPessimisticLocks, PessimisticLockPair, TxnExt},
     unsafe_recovery::{
         demote_failed_voters_request, exit_joint_request, ForceLeaderState,

--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -661,6 +661,14 @@ pub enum CasualMessage<EK: KvEngine> {
     // Trigger raft to campaign which is used after exiting force leader
     // or make new splitted peers campaign to get votes.
     Campaign(CampaignType),
+
+    // Check and add pending region for in_memory_engine,
+    // skip add this region if it is not leader or the epoch is not match
+    InMemoryEnginePendingRegion {
+        region_id: u64,
+        add_pending_cb: Box<dyn FnOnce(&Region, bool) + Send + 'static>,
+    },
+
     // Trigger loading pending region for in_memory_engine,
     InMemoryEngineLoadRegion {
         region_id: u64,
@@ -739,9 +747,14 @@ impl<EK: KvEngine> fmt::Debug for CasualMessage<EK> {
             CasualMessage::Campaign(_) => {
                 write!(fmt, "Campaign")
             }
+            CasualMessage::InMemoryEnginePendingRegion { region_id, .. } => write!(
+                fmt,
+                "[region={}] try to add pending region to in memory cache",
+                region_id,
+            ),
             CasualMessage::InMemoryEngineLoadRegion { region_id, .. } => write!(
                 fmt,
-                "[region={}] try load in memory region cache",
+                "[region={}] try to load in memory region cache",
                 region_id
             ),
         }

--- a/components/server/src/common.rs
+++ b/components/server/src/common.rs
@@ -35,7 +35,7 @@ use in_memory_engine::{
 };
 use pd_client::{PdClient, RpcClient};
 use raft_log_engine::RaftLogEngine;
-use raftstore::{coprocessor::RegionInfoProvider, store::CasualRouter};
+use raftstore::{coprocessor::RegionInfoProvider, store::ClonableCasualRouter};
 use security::SecurityManager;
 use tikv::{
     config::{ConfigController, DbConfigManger, DbType, TikvConfig},
@@ -702,7 +702,7 @@ pub fn build_hybrid_engine(
     disk_engine: RocksEngine,
     pd_client: Option<Arc<RpcClient>>,
     region_info_provider: Option<Arc<dyn RegionInfoProvider>>,
-    casual_router: Box<dyn CasualRouter<RocksEngine>>,
+    casual_router: Box<dyn ClonableCasualRouter<RocksEngine>>,
 ) -> HybridEngine<RocksEngine, RegionCacheMemoryEngine> {
     // todo(SpadeA): add config for it
     let mut memory_engine = RegionCacheMemoryEngine::with_region_info_provider(


### PR DESCRIPTION
… load top regions

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #16141

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
In order to workaround the data inconsistency found in jepsen test, currently, we will only cache region leader. So This PR use a raft CasualMessage in top regions load to ensure only region leader can be cached.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
