### PR TITLE
raftstore: do not try to fold replica reads' read index

### DIFF
--- a/components/raftstore/src/store/read_queue.rs
+++ b/components/raftstore/src/store/read_queue.rs
@@ -289,28 +289,9 @@ impl<C: ErrorCallback> ReadIndexQueue<C> {
         if min_changed_offset != usize::MAX {
             self.ready_cnt = cmp::max(self.ready_cnt, max_changed_offset + 1);
         }
-        if max_changed_offset > 0 {
-            self.fold(min_changed_offset, max_changed_offset);
-        }
-    }
-
-    fn fold(&mut self, min_changed_offset: usize, max_changed_offset: usize) {
-        let mut r_idx = self.reads[max_changed_offset].read_index.unwrap();
-        let mut check_offset = max_changed_offset - 1;
-        loop {
-            let l_idx = self.reads[check_offset].read_index.unwrap_or(u64::MAX);
-            if l_idx > r_idx {
-                self.reads[check_offset].read_index = Some(r_idx);
-            } else if check_offset < min_changed_offset {
-                break;
-            } else {
-                r_idx = l_idx;
-            }
-            if check_offset == 0 {
-                break;
-            }
-            check_offset -= 1;
-        }
+        // NOTE: We should not try to fold these read index requests anymore,
+        // any earlier request can relay a higher committed index due to txn lock
+        // when 1pc/async-commit is used.
     }
 
     pub fn gc(&mut self) {
@@ -506,65 +487,6 @@ mod tests {
 
     use super::*;
     use crate::store::Callback;
-
-    #[test]
-    fn test_read_queue_fold() {
-        let mut queue = ReadIndexQueue::<Callback<KvTestSnapshot>> {
-            handled_cnt: 125,
-            ..Default::default()
-        };
-        for _ in 0..100 {
-            let id = Uuid::new_v4();
-            queue.reads.push_back(ReadIndexRequest::with_command(
-                id,
-                RaftCmdRequest::default(),
-                Callback::None,
-                Timespec::new(0, 0),
-            ));
-
-            let offset = queue.handled_cnt + queue.reads.len() - 1;
-            queue.contexts.insert(id, offset);
-        }
-
-        queue.advance_replica_reads(Vec::new());
-        assert_eq!(queue.ready_cnt, 0);
-
-        queue.advance_replica_reads(vec![(queue.reads[0].id, None, 100)]);
-        assert_eq!(queue.ready_cnt, 1);
-
-        queue.advance_replica_reads(vec![(queue.reads[1].id, None, 100)]);
-        assert_eq!(queue.ready_cnt, 2);
-
-        queue.advance_replica_reads(vec![
-            (queue.reads[80].id, None, 80),
-            (queue.reads[84].id, None, 100),
-            (queue.reads[82].id, None, 70),
-            (queue.reads[78].id, None, 120),
-            (queue.reads[77].id, None, 40),
-        ]);
-        assert_eq!(queue.ready_cnt, 85);
-
-        queue.advance_replica_reads(vec![
-            (queue.reads[20].id, None, 80),
-            (queue.reads[24].id, None, 100),
-            (queue.reads[22].id, None, 70),
-            (queue.reads[18].id, None, 120),
-            (queue.reads[17].id, None, 40),
-        ]);
-        assert_eq!(queue.ready_cnt, 85);
-
-        for i in 0..78 {
-            assert_eq!(queue.reads[i].read_index.unwrap(), 40, "#{} failed", i);
-        }
-        for i in 78..83 {
-            assert_eq!(queue.reads[i].read_index.unwrap(), 70, "#{} failed", i);
-        }
-        for i in 84..85 {
-            assert_eq!(queue.reads[i].read_index.unwrap(), 100, "#{} failed", i);
-        }
-
-        queue.clear_all(None);
-    }
 
     #[test]
     fn test_become_leader_then_become_follower() {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #17018

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Remove the logic that tries to adjust replica reads' read index in `advance_replica_reads`. This optimization is no correct anymore after 1pc/async-commit is introduced because an earlier readIndex request can rely on a higher committed index due to async-commit lock, thus decrease the read index can cause follower read request reading out-dated data. 

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
