### PR TITLE
storage: fix the check if reserve-space == 0. (#17964)

### DIFF
--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -1380,10 +1380,6 @@ where
         let snap_mgr = self.snap_mgr.clone().unwrap();
         let reserve_space = disk::get_disk_reserved_space();
         let reserve_raft_space = disk::get_raft_disk_reserved_space();
-        if reserve_space == 0 && reserve_raft_space == 0 {
-            info!("disk space checker not enabled");
-            return;
-        }
         let raft_path = engines.raft.get_engine_path().to_string();
         let separated_raft_mount_path =
             path_in_diff_mount_point(raft_path.as_str(), engines.kv.path());
@@ -1460,8 +1456,13 @@ where
                         capacity
                     );
                 }
-                // Update disk status.
-                disk::set_disk_status(cur_disk_status);
+                // Update disk status if disk space checker is enabled.
+                if reserve_space == 0 && reserve_raft_space == 0 {
+                    info!("ignore updating disk status as no reserve space is set");
+                } else {
+                    disk::set_disk_status(cur_disk_status);
+                }
+                // Update disk capacity, used size and available size.
                 disk::set_disk_capacity(capacity);
                 disk::set_disk_used_size(used_size);
                 disk::set_disk_available_size(available);

--- a/components/server/src/server2.rs
+++ b/components/server/src/server2.rs
@@ -1143,10 +1143,6 @@ where
         let snap_mgr = self.snap_mgr.clone().unwrap();
         let reserve_space = disk::get_disk_reserved_space();
         let reserve_raft_space = disk::get_raft_disk_reserved_space();
-        if reserve_space == 0 && reserve_raft_space == 0 {
-            info!("disk space checker not enabled");
-            return;
-        }
         let raft_engine = self.engines.as_ref().unwrap().raft_engine.clone();
         let tablet_registry = self.tablet_registry.clone().unwrap();
         let raft_path = raft_engine.get_engine_path().to_string();
@@ -1227,8 +1223,13 @@ where
                         capacity
                     );
                 }
-                // Update disk status.
-                disk::set_disk_status(cur_disk_status);
+                // Update disk status if disk space checker is enabled.
+                if reserve_space == 0 && reserve_raft_space == 0 {
+                    info!("ignore updating disk status as no reserve space is set");
+                } else {
+                    disk::set_disk_status(cur_disk_status);
+                }
+                // Update disk capacity, used size and available size.
                 disk::set_disk_capacity(capacity);
                 disk::set_disk_used_size(used_size);
                 disk::set_disk_available_size(available);

--- a/tests/integrations/raftstore/test_stats.rs
+++ b/tests/integrations/raftstore/test_stats.rs
@@ -48,6 +48,7 @@ fn test_simple_store_stats<T: Simulator<RocksEngine>>(cluster: &mut Cluster<Rock
     let pd_client = Arc::clone(&cluster.pd_client);
 
     cluster.cfg.raft_store.pd_store_heartbeat_tick_interval = ReadableDuration::millis(20);
+    cluster.cfg.storage.reserve_space = ReadableSize(0);
     cluster.run();
 
     // wait store reports stats.


### PR DESCRIPTION
This is an manual cherry-pick of #17964

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref https://github.com/tikv/tikv/issues/17939

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

With https://github.com/tikv/tikv/pull/17947, the checking and updating of the disk_stat has been
unified into the disk-checker by triggering a periodical task.

However, this approach is incompatible with the scenario where `reserve-space` is set
to 0, which prevents the checker from functioning as intended and leads to disk stats not
being updated periodically. This PR addresses and resolves this issue.

```commit-message
This PR addresses and resolves the issue that if `reserver-space` is set to 0, 
the disk stats could not be updated as expected.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None.
```
