### PR TITLE
*: update rust-rocksdb to fix crash bugs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3702,7 +3702,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-7.5#268d20d61b8bf097f064a87a9af3cb91725ff179"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-7.5#12bf60e27a527e7042dc3bc1e2f39342dfcb2cb4"
 dependencies = [
  "bindgen 0.65.1",
  "bzip2-sys",
@@ -3721,7 +3721,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-7.5#268d20d61b8bf097f064a87a9af3cb91725ff179"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-7.5#12bf60e27a527e7042dc3bc1e2f39342dfcb2cb4"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -5685,7 +5685,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-7.5#268d20d61b8bf097f064a87a9af3cb91725ff179"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-7.5#12bf60e27a527e7042dc3bc1e2f39342dfcb2cb4"
 dependencies = [
  "libc 0.2.151",
  "librocksdb_sys",


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18003

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
This pr revert the relevant updates to `titan` and calibrate
the commit-id to a valid version, used to fix the crash bug
when rolling back tikv from v8.1.2-pre to v8.1.0.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None.
```
