### PR TITLE
in_memory_engine: do not force disable in memory engine for replica read

### DIFF
--- a/src/server/raftkv/mod.rs
+++ b/src/server/raftkv/mod.rs
@@ -621,19 +621,13 @@ where
     type IMSnap = RegionSnapshot<HybridEngineSnapshot<E, RegionCacheMemoryEngine>>;
     type IMSnapshotRes = impl Future<Output = kv::Result<Self::IMSnap>> + Send;
     fn async_in_memory_snapshot(&mut self, ctx: SnapContext<'_>) -> Self::IMSnapshotRes {
-        let replica_read = ctx.pb_ctx.get_replica_read();
-        async_snapshot(&mut self.router, ctx).map_ok(move |region_snap| {
+        async_snapshot(&mut self.router, ctx).map_ok(|region_snap| {
             // TODO: Remove replace_snapshot. Taking a snapshot and replacing it
             // with a new one is a bit confusing.
             // A better way to build an in-memory snapshot is to return
             // `HybridEngineSnapshot<RegionSnapshot<E>, RegionCacheMemoryEngine>>;`
             // so the `replace_snapshot` can be removed.
-            region_snap.replace_snapshot(move |disk_snap, mut pinned| {
-                // Disable in-memory-engine snapshot for now as there may be some bugs.
-                // TODO: we may remove this restriction once we fix the related bug.
-                if replica_read {
-                    pinned = None;
-                }
+            region_snap.replace_snapshot(move |disk_snap, pinned| {
                 HybridEngineSnapshot::from_observed_snapshot(disk_snap, pinned)
             })
         })


### PR DESCRIPTION

This reverts commit e7a810b8947ba95117d42f45bf14248eea06a5b5.

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #16141

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
This commit rollback PR #17927 as it is not the root cause. This rollback can all use IME for following read scenario. 
NOTE: We decide not cherry-pick it back to v8.5 as there may be other potential issue.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
