### PR TITLE
resolve: returns StoreTombstone directly if PD returns `store not found`.

### DIFF
--- a/src/server/resolve.rs
+++ b/src/server/resolve.rs
@@ -116,6 +116,8 @@ where
                 // after 30 days of deletion. PD returns
                 // "invalid store ID %d, not found" for such store id.
                 // See https://github.com/tikv/pd/blob/v7.3.0/server/grpc_service.go#L777-L780
+                // And to avoid repeatedly logging the same errors, it
+                // can directly return the `StoreTombstone` err.
                 if format!("{:?}", e).contains("not found") {
                     RESOLVE_STORE_COUNTER_STATIC.not_found.inc();
                     info!("resolve store not found"; "store_id" => store_id);


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close https://github.com/tikv/tikv/issues/17875

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
This PR optimizes the error handling progress when resolving address returns
by the response from PD. 

If the response contains `store xxx not found`, the resolver could directly returns
the `StoreTombstone` Error to make the raft-client end the retrying loop quickly.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
This PR optimizes the error handling progress when resolving address returns
by the response from PD. 
```
