### PR TITLE
server: polish the logging when updating disk status.

### DIFF
--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -1385,7 +1385,8 @@ where
         let snap_mgr = self.snap_mgr.clone().unwrap();
         let reserve_space = disk::get_disk_reserved_space();
         let reserve_raft_space = disk::get_raft_disk_reserved_space();
-        if reserve_space == 0 && reserve_raft_space == 0 {
+        let should_update_disk_status = reserve_space != 0 || reserve_raft_space != 0;
+        if !should_update_disk_status {
             info!("ignore updating disk status as no reserve space is set");
         }
         let raft_path = engines.raft.get_engine_path().to_string();
@@ -1465,7 +1466,7 @@ where
                     );
                 }
                 // Update disk status if disk space checker is enabled.
-                if reserve_space != 0 || reserve_raft_space != 0 {
+                if should_update_disk_status {
                     disk::set_disk_status(cur_disk_status);
                 }
                 // Update disk capacity, used size and available size.

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -1385,6 +1385,9 @@ where
         let snap_mgr = self.snap_mgr.clone().unwrap();
         let reserve_space = disk::get_disk_reserved_space();
         let reserve_raft_space = disk::get_raft_disk_reserved_space();
+        if reserve_space == 0 && reserve_raft_space == 0 {
+            info!("ignore updating disk status as no reserve space is set");
+        }
         let raft_path = engines.raft.get_engine_path().to_string();
         let separated_raft_mount_path =
             path_in_diff_mount_point(raft_path.as_str(), engines.kv.path());
@@ -1462,9 +1465,7 @@ where
                     );
                 }
                 // Update disk status if disk space checker is enabled.
-                if reserve_space == 0 && reserve_raft_space == 0 {
-                    info!("ignore updating disk status as no reserve space is set");
-                } else {
+                if reserve_space != 0 || reserve_raft_space != 0 {
                     disk::set_disk_status(cur_disk_status);
                 }
                 // Update disk capacity, used size and available size.

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -1385,8 +1385,8 @@ where
         let snap_mgr = self.snap_mgr.clone().unwrap();
         let reserve_space = disk::get_disk_reserved_space();
         let reserve_raft_space = disk::get_raft_disk_reserved_space();
-        let should_update_disk_status = reserve_space != 0 || reserve_raft_space != 0;
-        if !should_update_disk_status {
+        let need_update_disk_status = reserve_space != 0 || reserve_raft_space != 0;
+        if !need_update_disk_status {
             info!("ignore updating disk status as no reserve space is set");
         }
         let raft_path = engines.raft.get_engine_path().to_string();
@@ -1466,7 +1466,7 @@ where
                     );
                 }
                 // Update disk status if disk space checker is enabled.
-                if should_update_disk_status {
+                if need_update_disk_status {
                     disk::set_disk_status(cur_disk_status);
                 }
                 // Update disk capacity, used size and available size.

--- a/components/server/src/server2.rs
+++ b/components/server/src/server2.rs
@@ -1171,6 +1171,9 @@ where
         let snap_mgr = self.snap_mgr.clone().unwrap();
         let reserve_space = disk::get_disk_reserved_space();
         let reserve_raft_space = disk::get_raft_disk_reserved_space();
+        if reserve_space == 0 && reserve_raft_space == 0 {
+            info!("ignore updating disk status as no reserve space is set");
+        }
         let raft_engine = self.engines.as_ref().unwrap().raft_engine.clone();
         let tablet_registry = self.tablet_registry.clone().unwrap();
         let raft_path = raft_engine.get_engine_path().to_string();
@@ -1252,9 +1255,7 @@ where
                     );
                 }
                 // Update disk status if disk space checker is enabled.
-                if reserve_space == 0 && reserve_raft_space == 0 {
-                    info!("ignore updating disk status as no reserve space is set");
-                } else {
+                if reserve_space != 0 || reserve_raft_space != 0 {
                     disk::set_disk_status(cur_disk_status);
                 }
                 // Update disk capacity, used size and available size.

--- a/components/server/src/server2.rs
+++ b/components/server/src/server2.rs
@@ -1171,7 +1171,8 @@ where
         let snap_mgr = self.snap_mgr.clone().unwrap();
         let reserve_space = disk::get_disk_reserved_space();
         let reserve_raft_space = disk::get_raft_disk_reserved_space();
-        if reserve_space == 0 && reserve_raft_space == 0 {
+        let should_update_disk_status = reserve_space != 0 || reserve_raft_space != 0;
+        if !should_update_disk_status {
             info!("ignore updating disk status as no reserve space is set");
         }
         let raft_engine = self.engines.as_ref().unwrap().raft_engine.clone();
@@ -1255,7 +1256,7 @@ where
                     );
                 }
                 // Update disk status if disk space checker is enabled.
-                if reserve_space != 0 || reserve_raft_space != 0 {
+                if should_update_disk_status {
                     disk::set_disk_status(cur_disk_status);
                 }
                 // Update disk capacity, used size and available size.

--- a/components/server/src/server2.rs
+++ b/components/server/src/server2.rs
@@ -1171,8 +1171,8 @@ where
         let snap_mgr = self.snap_mgr.clone().unwrap();
         let reserve_space = disk::get_disk_reserved_space();
         let reserve_raft_space = disk::get_raft_disk_reserved_space();
-        let should_update_disk_status = reserve_space != 0 || reserve_raft_space != 0;
-        if !should_update_disk_status {
+        let need_update_disk_status = reserve_space != 0 || reserve_raft_space != 0;
+        if !need_update_disk_status {
             info!("ignore updating disk status as no reserve space is set");
         }
         let raft_engine = self.engines.as_ref().unwrap().raft_engine.clone();
@@ -1256,7 +1256,7 @@ where
                     );
                 }
                 // Update disk status if disk space checker is enabled.
-                if should_update_disk_status {
+                if need_update_disk_status {
                     disk::set_disk_status(cur_disk_status);
                 }
                 // Update disk capacity, used size and available size.


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref https://github.com/tikv/tikv/issues/17939

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

As the updating interval is `1s`, the logging introduced by https://github.com/tikv/tikv/pull/17964 is too frequent. This PR polishes the logging when periodically updating the disk status.

```commit-message
Polish the logging when periodically updating the disk status.

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None.
```
