### PR TITLE
raftstore: support listing region overlap files for tikv-ctl

### DIFF
--- a/cmd/tikv-ctl/src/cmd.rs
+++ b/cmd/tikv-ctl/src/cmd.rs
@@ -551,6 +551,20 @@ pub enum Cmd {
         /// PD endpoints
         pd: String,
     },
+    ListRegionFiles {
+        #[structopt(long)]
+        /// specify manifest, if not set, it will look up manifest file in db
+        /// path
+        manifest: Option<String>,
+
+        #[structopt(long)]
+        // RocksDB level
+        level: Option<u32>,
+
+        #[structopt(long, value_delimiter = ",")]
+        /// PD endpoints
+        pd: String,
+    },
     /// Reset data in a TiKV to a certain version
     ResetToVersion {
         #[structopt(short = "v")]

--- a/cmd/tikv-ctl/src/cmd.rs
+++ b/cmd/tikv-ctl/src/cmd.rs
@@ -551,7 +551,7 @@ pub enum Cmd {
         /// PD endpoints
         pd: String,
     },
-    /// List all regions and their overlapping files
+    /// List regions and their overlapping files
     RegionOverlapFiles {
         #[structopt(long)]
         /// specify manifest, if not set, it will look up manifest file in db

--- a/cmd/tikv-ctl/src/cmd.rs
+++ b/cmd/tikv-ctl/src/cmd.rs
@@ -551,7 +551,7 @@ pub enum Cmd {
         /// PD endpoints
         pd: String,
     },
-    /// List region overlap files
+    /// List all regions and their overlapping files
     RegionOverlapFiles {
         #[structopt(long)]
         /// specify manifest, if not set, it will look up manifest file in db

--- a/cmd/tikv-ctl/src/cmd.rs
+++ b/cmd/tikv-ctl/src/cmd.rs
@@ -487,6 +487,26 @@ pub enum Cmd {
         /// How to compact the bottommost level
         bottommost: String,
     },
+    /// List regions and their overlapping files
+    RegionOverlapFiles {
+        #[structopt(long)]
+        /// specify manifest, if not set, it will look up manifest file in db
+        /// path
+        manifest: Option<String>,
+
+        #[structopt(long)]
+        /// specify manifest, if not set, it will look up manifest file in db
+        /// path
+        cf: Option<String>,
+
+        #[structopt(long)]
+        // RocksDB level
+        level: Option<u32>,
+
+        #[structopt(long, value_delimiter = ",")]
+        /// PD endpoints
+        pd: String,
+    },
     /// Show region properties
     RegionProperties {
         #[structopt(short = "r")]
@@ -546,26 +566,6 @@ pub enum Cmd {
         /// specify manifest, if not set, it will look up manifest file in db
         /// path
         manifest: Option<String>,
-
-        #[structopt(long, value_delimiter = ",")]
-        /// PD endpoints
-        pd: String,
-    },
-    /// List regions and their overlapping files
-    RegionOverlapFiles {
-        #[structopt(long)]
-        /// specify manifest, if not set, it will look up manifest file in db
-        /// path
-        manifest: Option<String>,
-
-        #[structopt(long)]
-        /// specify manifest, if not set, it will look up manifest file in db
-        /// path
-        cf: Option<String>,
-
-        #[structopt(long)]
-        // RocksDB level
-        level: Option<u32>,
 
         #[structopt(long, value_delimiter = ",")]
         /// PD endpoints

--- a/cmd/tikv-ctl/src/cmd.rs
+++ b/cmd/tikv-ctl/src/cmd.rs
@@ -551,6 +551,7 @@ pub enum Cmd {
         /// PD endpoints
         pd: String,
     },
+    /// List region overlap files
     RegionOverlapFiles {
         #[structopt(long)]
         /// specify manifest, if not set, it will look up manifest file in db

--- a/cmd/tikv-ctl/src/cmd.rs
+++ b/cmd/tikv-ctl/src/cmd.rs
@@ -551,11 +551,16 @@ pub enum Cmd {
         /// PD endpoints
         pd: String,
     },
-    ListRegionFiles {
+    RegionOverlapFiles {
         #[structopt(long)]
         /// specify manifest, if not set, it will look up manifest file in db
         /// path
         manifest: Option<String>,
+
+        #[structopt(long)]
+        /// specify manifest, if not set, it will look up manifest file in db
+        /// path
+        cf: Option<String>,
 
         #[structopt(long)]
         // RocksDB level

--- a/cmd/tikv-ctl/src/main.rs
+++ b/cmd/tikv-ctl/src/main.rs
@@ -1481,9 +1481,9 @@ fn print_region_sst_mapping(
                     "region_id: {}, region.start_key: {:?}, region.end_Key{:?}, sst start: {:?} sst end: {:?}",
                     region_id,
                     hex::encode(&region.start_key).to_uppercase(),
-                    *hex::encode(&region.end_key).to_uppercase(),
-                    *hex::encode(&sst_start_key).to_uppercase(),
-                    *hex::encode(&sst_end_key).to_uppercase(),
+                    hex::encode(&region.end_key).to_uppercase(),
+                    hex::encode(&sst_start_key).to_uppercase(),
+                    hex::encode(&sst_end_key).to_uppercase(),
                 );
                 region_sst_map
                     .entry((region_start_key_hex, region_end_key_hex, region_id))

--- a/cmd/tikv-ctl/src/main.rs
+++ b/cmd/tikv-ctl/src/main.rs
@@ -1383,8 +1383,6 @@ fn print_region_sst_mapping(
         .split("--------------- Column family")
         .collect();
 
-    println!("ffffffffffffffffffffffffff");
-
     // Locate the "default" column family section
     let default_cf_section = cf_sections
     .iter()
@@ -1392,7 +1390,6 @@ fn print_region_sst_mapping(
     .map(|&section| section) // 解引用，获取 &str
     .expect("default column family not found");
 
-    println!("ggggggggggggggggggggggg");
     // If level is specified, split the default CF section by levels and locate the
     // desired level
     let level_section = if let Some(level) = level {
@@ -1483,13 +1480,10 @@ fn print_region_sst_mapping(
                 println!(
                     "region_id: {}, region.start_key: {:?}, region.end_Key{:?}, sst start: {:?} sst end: {:?}",
                     region_id,
-                    region.start_key,
-                    region.end_key,
-                    sst_start_key,
-                    sst_end_key /* hex::encode(&region.start_key).to_uppercase(),
-                                 * hex::encode(&region.end_key).to_uppercase(),
-                                 * hex::encode(&sst_start_key).to_uppercase(),
-                                 * hex::encode(&sst_end_key).to_uppercase() */
+                    hex::encode(&region.start_key).to_uppercase(),
+                    *hex::encode(&region.end_key).to_uppercase(),
+                    *hex::encode(&sst_start_key).to_uppercase(),
+                    *hex::encode(&sst_end_key).to_uppercase(),
                 );
                 region_sst_map
                     .entry((region_start_key_hex, region_end_key_hex, region_id))


### PR DESCRIPTION
<img width="1307" alt="image" src="https://github.com/user-attachments/assets/0905577f-2e2a-443f-af5c-02fe05a6ef66">
<img width="1919" alt="image" src="https://github.com/user-attachments/assets/30a9d676-074d-4fc6-939a-c417ef5a9ea4">

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->


### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #xxx

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
TODO
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note

```
