### PR TITLE
In-memory Engine: fix pre-load uninitialized peer panic

### DIFF
--- a/components/hybrid_engine/src/observer/load_eviction.rs
+++ b/components/hybrid_engine/src/observer/load_eviction.rs
@@ -267,9 +267,16 @@ impl RoleObserver for LoadEvictionObserver {
 }
 
 impl ExtraMessageObserver for LoadEvictionObserver {
-    fn on_extra_message(&self, r: &Region, extra_msg: &ExtraMessage) {
+    fn on_extra_message(&self, region: &Region, extra_msg: &ExtraMessage) {
         if extra_msg.get_type() == ExtraMessageType::MsgPreLoadRegionRequest {
-            self.cache_engine.load_region(r);
+            if region.get_peers().is_empty() {
+                // MsgPreLoadRegionRequest is sent before leader issue a
+                // transfer leader request. It is possible that the peer
+                // is not initialized yet.
+                warn!("ime skip pre-load an uninitialized region"; "region" => ?region);
+                return;
+            }
+            self.cache_engine.load_region(region);
         }
     }
 }

--- a/components/raftstore/src/store/worker/disk_check.rs
+++ b/components/raftstore/src/store/worker/disk_check.rs
@@ -72,7 +72,8 @@ impl Runner {
     /// Only for test.
     /// Generate a dummy Runner.
     pub fn dummy() -> Self {
-        Self::build(PathBuf::from("./").join(Self::DISK_IO_LATENCY_INSPECT_FILENAME))
+        let tmp = std::env::temp_dir();
+        Self::build(tmp.join(Self::DISK_IO_LATENCY_INSPECT_FILENAME))
     }
 
     #[inline]

--- a/components/raftstore/src/store/worker/disk_check.rs
+++ b/components/raftstore/src/store/worker/disk_check.rs
@@ -72,8 +72,7 @@ impl Runner {
     /// Only for test.
     /// Generate a dummy Runner.
     pub fn dummy() -> Self {
-        let tmp = std::env::temp_dir();
-        Self::build(tmp.join(Self::DISK_IO_LATENCY_INSPECT_FILENAME))
+        Self::build(PathBuf::from("./").join(Self::DISK_IO_LATENCY_INSPECT_FILENAME))
     }
 
     #[inline]


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! 

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18046 

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Avoid loading region into IME when it is uninitialized to prevent panic
on encoding region end key. This is because `MsgPreLoadRegionRequest`
is sent before leader issue a transfer leader request.
```

### Related changes

- [x] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fix the issue of unexpected assert failure when TiKV enables In-memory Engine
```
