### PR TITLE
metrics: let panel series overrides compatible with additional group_by

### DIFF
--- a/metrics/grafana/common.py
+++ b/metrics/grafana/common.py
@@ -1117,7 +1117,8 @@ def graph_panel_histogram_quantiles(
         ],
         series_overrides=[
             series_override(
-                alias="count",
+                # use regex because the real alias is "count ${additional_groupby}"
+                alias="/^count/",
                 fill=2,
                 yaxis=2,
                 zindex=-3,
@@ -1127,7 +1128,8 @@ def graph_panel_histogram_quantiles(
                 transform_negative_y=True,
             ),
             series_override(
-                alias="avg",
+                # use regex because the real alias is "avg ${additional_groupby}"
+                alias="/^avg/",
                 fill=7,
             ),
         ],

--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -4378,7 +4378,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -4391,7 +4391,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -5055,7 +5055,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -5068,7 +5068,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -8398,7 +8398,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -8411,7 +8411,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -8704,7 +8704,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -8717,7 +8717,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -9010,7 +9010,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -9023,7 +9023,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -9316,7 +9316,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -9329,7 +9329,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -9622,7 +9622,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -9635,7 +9635,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -9956,7 +9956,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -9969,7 +9969,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -10157,7 +10157,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -10170,7 +10170,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -10358,7 +10358,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -10371,7 +10371,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -14480,7 +14480,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -14493,7 +14493,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -14681,7 +14681,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -14694,7 +14694,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -14882,7 +14882,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -14895,7 +14895,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -15083,7 +15083,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -15096,7 +15096,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -15284,7 +15284,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -15297,7 +15297,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -15485,7 +15485,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -15498,7 +15498,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -15686,7 +15686,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -15699,7 +15699,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -15887,7 +15887,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -15900,7 +15900,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -16088,7 +16088,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -16101,7 +16101,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -16289,7 +16289,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -16302,7 +16302,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -16490,7 +16490,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -16503,7 +16503,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -16691,7 +16691,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -16704,7 +16704,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -16892,7 +16892,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -16905,7 +16905,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -17240,7 +17240,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -17253,7 +17253,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -17546,7 +17546,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -17559,7 +17559,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -17852,7 +17852,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -17865,7 +17865,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -18158,7 +18158,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -18171,7 +18171,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -18464,7 +18464,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -18477,7 +18477,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -18770,7 +18770,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -18783,7 +18783,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -19931,7 +19931,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -19944,7 +19944,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -20237,7 +20237,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -20250,7 +20250,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -20543,7 +20543,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -20556,7 +20556,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -24102,7 +24102,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -24115,7 +24115,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -24408,7 +24408,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -24421,7 +24421,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -27127,7 +27127,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -27140,7 +27140,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -27639,7 +27639,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -27652,7 +27652,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -28477,7 +28477,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -28490,7 +28490,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -34129,7 +34129,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -34142,7 +34142,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -39508,7 +39508,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -39521,7 +39521,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -41193,7 +41193,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -41206,7 +41206,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -41499,7 +41499,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -41512,7 +41512,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -45588,7 +45588,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -45601,7 +45601,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -45789,7 +45789,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -45802,7 +45802,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -45990,7 +45990,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -46003,7 +46003,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -46381,7 +46381,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -46394,7 +46394,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -46582,7 +46582,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -46595,7 +46595,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -46783,7 +46783,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -46796,7 +46796,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -46984,7 +46984,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -46997,7 +46997,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -47717,7 +47717,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -47730,7 +47730,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -48170,7 +48170,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -48183,7 +48183,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -48770,7 +48770,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -48783,7 +48783,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -49412,7 +49412,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -49425,7 +49425,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -49613,7 +49613,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -49626,7 +49626,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -49814,7 +49814,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -49827,7 +49827,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -50015,7 +50015,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -50028,7 +50028,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -51119,7 +51119,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -51132,7 +51132,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -51866,7 +51866,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -51879,7 +51879,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -52067,7 +52067,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -52080,7 +52080,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -52268,7 +52268,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -52281,7 +52281,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -52689,7 +52689,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -52702,7 +52702,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -54680,7 +54680,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -54693,7 +54693,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -55029,7 +55029,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -55042,7 +55042,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -56000,7 +56000,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -56013,7 +56013,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -65773,7 +65773,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -65786,7 +65786,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -65974,7 +65974,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -65987,7 +65987,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -66737,7 +66737,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -66750,7 +66750,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -75242,7 +75242,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -75255,7 +75255,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -76298,7 +76298,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -76311,7 +76311,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,
@@ -77073,7 +77073,7 @@
           "repeatDirection": null,
           "seriesOverrides": [
             {
-              "alias": "count",
+              "alias": "/^count/",
               "bars": false,
               "dashLength": 1,
               "dashes": true,
@@ -77086,7 +77086,7 @@
               "zindex": -3
             },
             {
-              "alias": "avg",
+              "alias": "/^avg/",
               "bars": false,
               "fill": 7,
               "fillBelowTo": null,

--- a/metrics/grafana/tikv_details.json.sha256
+++ b/metrics/grafana/tikv_details.json.sha256
@@ -1,1 +1,1 @@
-fb206d6a1e887c038e752582478ff75d8b508d40f402392f7d152126891272a9  ./metrics/grafana/tikv_details.json
+6f498305f4f2832c024c725cae0fc7c90236091f3dafbcf3d1eee2b0e16e7b45  ./metrics/grafana/tikv_details.json


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18060

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Use regex expression in panel seriesOverrides to let it compatible with the optional "additional_groupby" alias.
```

Current:

<img width="1428" alt="image" src="https://github.com/user-attachments/assets/aeba6a5f-fb35-46f5-924f-cd2bca5df684" />

After this change:

<img width="1437" alt="image" src="https://github.com/user-attachments/assets/cd70fc36-347f-40dc-8633-217b7d7dafe7" />


### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
