### PR TITLE
server: print more information when default not found error is encountered

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7915,6 +7915,7 @@ dependencies = [
  "codec",
  "collections",
  "error_code",
+ "fail",
  "farmhash",
  "kvproto",
  "log_wrappers",

--- a/components/error_code/src/coprocessor.rs
+++ b/components/error_code/src/coprocessor.rs
@@ -18,5 +18,6 @@ define_error_codes!(
     STORAGE_ERROR => ("StorageError", "", ""),
     INVALID_CHARACTER_STRING => ("InvalidCharacterString", "", ""),
 
-    INVALID_MAX_TS_UPDATE => ("InvalidMaxTsUpdate", "", "")
+    INVALID_MAX_TS_UPDATE => ("InvalidMaxTsUpdate", "", ""),
+    DEFAULT_NOT_FOUND => ("DefaultNotFound", "", "")
 );

--- a/components/txn_types/Cargo.toml
+++ b/components/txn_types/Cargo.toml
@@ -11,6 +11,7 @@ byteorder = "1.2"
 codec = { workspace = true }
 collections = { workspace = true }
 error_code = { workspace = true }
+fail = "0.5"
 farmhash = "1.1.5"
 kvproto = { workspace = true }
 log_wrappers = { workspace = true }

--- a/components/txn_types/src/types.rs
+++ b/components/txn_types/src/types.rs
@@ -5,6 +5,7 @@ use std::fmt::{self, Debug, Display, Formatter};
 use bitflags::bitflags;
 use byteorder::{ByteOrder, NativeEndian};
 use collections::HashMap;
+use fail::fail_point;
 use kvproto::kvrpcpb::{self, Assertion};
 use tikv_util::{
     codec,
@@ -23,6 +24,7 @@ pub const SHORT_VALUE_MAX_LEN: usize = 255;
 pub const SHORT_VALUE_PREFIX: u8 = b'v';
 
 pub fn is_short_value(value: &[u8]) -> bool {
+    fail_point!("is_short_value_always_false", |_| { false });
     value.len() <= SHORT_VALUE_MAX_LEN
 }
 

--- a/src/coprocessor/error.rs
+++ b/src/coprocessor/error.rs
@@ -34,6 +34,9 @@ pub enum Error {
     InvalidMaxTsUpdate(#[from] concurrency_manager::InvalidMaxTsUpdate),
 
     #[error("{0}")]
+    DefaultNotFound(String),
+
+    #[error("{0}")]
     Other(String),
 }
 
@@ -91,6 +94,9 @@ impl From<MvccError> for Error {
         match err {
             MvccError(box MvccErrorInner::KeyIsLocked(info)) => Error::Locked(info),
             MvccError(box MvccErrorInner::Kv(kv_error)) => Error::from(kv_error),
+            e @ MvccError(box MvccErrorInner::DefaultNotFound { .. }) => {
+                Error::DefaultNotFound(e.to_string())
+            }
             e => Error::Other(e.to_string()),
         }
     }
@@ -141,6 +147,7 @@ impl ErrorCodeExt for Error {
             Error::MaxPendingTasksExceeded => error_code::coprocessor::MAX_PENDING_TASKS_EXCEEDED,
             Error::MemoryQuotaExceeded => error_code::coprocessor::MEMORY_QUOTA_EXCEEDED,
             Error::InvalidMaxTsUpdate(_) => error_code::coprocessor::INVALID_MAX_TS_UPDATE,
+            Error::DefaultNotFound { .. } => error_code::coprocessor::DEFAULT_NOT_FOUND,
             Error::Other(_) => error_code::UNKNOWN,
         }
     }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -707,7 +707,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                     ) = &result
                     {
                         error!("default not found in storage get";
-                            "err" => e.to_string(),
+                            "err" => ?e,
                             "RpcContext" => ?&ctx,
                         );
                     }
@@ -1330,7 +1330,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                     ) = &result
                     {
                         error!("default not found in storage batch_get";
-                            "err" => e.to_string(),
+                            "err" => ?e,
                             "RpcContext" => ?&ctx,
                         );
                     }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -700,6 +700,17 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                                 r
                             })
                     });
+                    if let Err(
+                        e @ Error(box ErrorInner::Txn(TxnError(box TxnErrorInner::Mvcc(
+                            mvcc::Error(box mvcc::ErrorInner::DefaultNotFound { .. }),
+                        )))),
+                    ) = &result
+                    {
+                        error!("default not found in storage get";
+                            "err" => e.to_string(),
+                            "RpcContext" => ?&ctx,
+                        );
+                    }
                     metrics::tls_collect_scan_details(CMD, &statistics);
                     metrics::tls_collect_read_flow(
                         ctx.get_region_id(),
@@ -1312,6 +1323,17 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                             });
                         (result, stats)
                     });
+                    if let Err(
+                        e @ Error(box ErrorInner::Txn(TxnError(box TxnErrorInner::Mvcc(
+                            mvcc::Error(box mvcc::ErrorInner::DefaultNotFound { .. }),
+                        )))),
+                    ) = &result
+                    {
+                        error!("default not found in storage batch_get";
+                            "err" => e.to_string(),
+                            "RpcContext" => ?&ctx,
+                        );
+                    }
                     metrics::tls_collect_scan_details(CMD, &stats);
                     let now = Instant::now();
                     SCHED_PROCESSING_READ_HISTOGRAM_STATIC

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -449,10 +449,12 @@ pub fn default_not_found_error(key: Vec<u8>, hint: &str) -> Error {
             hint,
         );
     } else {
+        let bt = backtrace::Backtrace::new();
         error!(
             "default value not found";
             "key" => &log_wrappers::Value::key(&key),
             "hint" => hint,
+            "bt" => ?bt,
         );
         Error::from(ErrorInner::DefaultNotFound { key })
     }

--- a/src/storage/mvcc/reader/point_getter.rs
+++ b/src/storage/mvcc/reader/point_getter.rs
@@ -365,6 +365,12 @@ impl<S: Snapshot> PointGetter<S> {
         write_start_ts: TimeStamp,
         user_key: &Key,
     ) -> Result<Value> {
+        fail_point!("load_data_from_default_cf_default_not_found", |_| Err(
+            default_not_found_error(
+                user_key.clone().append_ts(write_start_ts).into_encoded(),
+                "load_data_from_default_cf",
+            )
+        ));
         self.statistics.data.get += 1;
         // TODO: We can avoid this clone.
         let value = self

--- a/src/storage/mvcc/reader/scanner/mod.rs
+++ b/src/storage/mvcc/reader/scanner/mod.rs
@@ -365,6 +365,12 @@ pub fn near_load_data_by_write<I>(
 where
     I: Iterator,
 {
+    fail_point!("near_load_data_by_write_default_not_found", |_| Err(
+        default_not_found_error(
+            user_key.clone().append_ts(write_start_ts).into_encoded(),
+            "near_load_data_by_write",
+        )
+    ));
     let seek_key = user_key.clone().append_ts(write_start_ts);
     match statistics.load_data_hint() {
         LoadDataHint::NearSeek => default_cursor.near_seek(&seek_key, &mut statistics.data)?,

--- a/tests/failpoints/cases/test_coprocessor.rs
+++ b/tests/failpoints/cases/test_coprocessor.rs
@@ -5,18 +5,21 @@ use std::{sync::Arc, thread, time::Duration};
 use futures::executor::block_on;
 use grpcio::{ChannelBuilder, Environment};
 use kvproto::{
-    coprocessor::Request,
-    kvrpcpb::{Context, IsolationLevel},
+    coprocessor::{KeyRange, Request},
+    kvrpcpb::{Context, GetRequest, IsolationLevel, Mutation, Op},
     tikvpb::TikvClient,
 };
 use more_asserts::{assert_ge, assert_le};
+use pd_client::PdClient;
 use protobuf::Message;
 use raftstore::store::Bucket;
 use test_coprocessor::*;
+use test_raftstore::{must_kv_commit, must_kv_prewrite, must_new_cluster_and_kv_client};
 use test_raftstore_macro::test_case;
 use test_storage::*;
+use test_util::init_log_for_test;
 use tidb_query_datatype::{
-    codec::{datum, Datum},
+    codec::{datum, table::encode_row_key, Datum},
     expr::EvalContext,
 };
 use tikv_util::HandyRwLock;
@@ -498,4 +501,90 @@ fn test_follower_buckets() {
         wait_refresh_buckets(endpoint, &mut req.clone());
     }
     fail::remove("skip_check_stale_read_safe");
+}
+
+#[test]
+fn test_default_not_found_log_info() {
+    let (mut cluster, _client, _ctx) = must_new_cluster_and_kv_client();
+    let pd_client = Arc::clone(&cluster.pd_client);
+    pd_client.disable_default_operator();
+
+    let product = ProductTable::new();
+    let row_key = encode_row_key(product.table_id(), 2);
+
+    let r1 = cluster.get_region(row_key.as_slice());
+    let region_id = r1.get_id();
+    let leader = cluster.leader_of_region(region_id).unwrap();
+    let epoch = cluster.get_region_epoch(region_id);
+    let mut ctx = Context::default();
+    ctx.set_region_id(region_id);
+    ctx.set_peer(leader.clone());
+    ctx.set_region_epoch(epoch);
+    let env = Arc::new(Environment::new(1));
+    let channel =
+        ChannelBuilder::new(env).connect(&cluster.sim.rl().get_addr(leader.get_store_id()));
+    let client = TikvClient::new(channel);
+
+    // Write record.
+    fail::cfg("is_short_value_always_false", "return()").unwrap();
+    let mut mutation = Mutation::default();
+    let value = b"v2".to_vec();
+    mutation.set_op(Op::Put);
+    mutation.set_key(row_key.clone());
+    mutation.set_value(value.clone());
+    let prewrite_ts = block_on(pd_client.get_tso()).unwrap().into_inner();
+    must_kv_prewrite(
+        &client,
+        ctx.clone(),
+        vec![mutation],
+        row_key.clone(),
+        prewrite_ts,
+    );
+    let commit_ts = block_on(pd_client.get_tso()).unwrap().into_inner();
+    must_kv_commit(
+        &client,
+        ctx.clone(),
+        vec![row_key.clone()],
+        prewrite_ts,
+        commit_ts,
+        commit_ts,
+    );
+
+    let env = Arc::new(Environment::new(1));
+    let channel =
+        ChannelBuilder::new(env).connect(&cluster.sim.rl().get_addr(leader.get_store_id()));
+    let client = TikvClient::new(channel);
+
+    let mut ctx = Context::default();
+    ctx.set_region_id(r1.get_id());
+    ctx.set_region_epoch(r1.get_region_epoch().clone());
+    ctx.set_peer(test_raftstore::new_peer(1, 1));
+
+    // Read with coprocessor request.
+    let read_ts = block_on(pd_client.get_tso()).unwrap().into_inner();
+    let mut cop_req = DagSelect::from(&product).build();
+    cop_req.set_context(ctx.clone());
+    cop_req.set_start_ts(read_ts);
+    let mut key_range = KeyRange::new();
+    let start_key = encode_row_key(product.table_id(), 1);
+    let end_key = encode_row_key(product.table_id(), 3);
+    key_range.set_start(start_key);
+    key_range.set_end(end_key);
+    cop_req.mut_ranges().clear();
+    cop_req.mut_ranges().push(key_range);
+    fail::cfg("near_load_data_by_write_default_not_found", "return()").unwrap();
+    let cop_resp = client.coprocessor(&cop_req).unwrap();
+    assert!(cop_resp.get_other_error().contains("default not found"));
+
+    // Read with get request.
+    let mut get_req = GetRequest::default();
+    get_req.set_context(ctx);
+    get_req.set_key(row_key.clone());
+    get_req.set_version(read_ts);
+    fail::cfg("load_data_from_default_cf_default_not_found", "return()").unwrap();
+    let get_resp = client.kv_get(&get_req).unwrap();
+    assert!(get_resp.get_error().get_abort().contains("DefaultNotFound"));
+    fail::remove("is_short_value_always_false");
+    fail::remove("near_load_data_by_write_default_not_found");
+    fail::remove("load_data_from_default_cf_default_not_found");
 }

--- a/tests/failpoints/cases/test_coprocessor.rs
+++ b/tests/failpoints/cases/test_coprocessor.rs
@@ -17,7 +17,6 @@ use test_coprocessor::*;
 use test_raftstore::{must_kv_commit, must_kv_prewrite, must_new_cluster_and_kv_client};
 use test_raftstore_macro::test_case;
 use test_storage::*;
-use test_util::init_log_for_test;
 use tidb_query_datatype::{
     codec::{datum, table::encode_row_key, Datum},
     expr::EvalContext,


### PR DESCRIPTION


<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18065

The coprocessor path log is like:
```
[ERRO] default not found in coprocessor request processing, reqCtx: ReqContext { tag: select, context: region_id: 1 region_epoch { conf_ver: 1 version: 1 } peer { id: 1 store_id: 1 }, ranges: [start: 7480000000000000055F728000000000000001 end: 7480000000000000055F728000000000000003], deadline: Deadline { deadline: MonotonicCoarse(Timespec { sec: 44231, nsec: 825857275 }) }, peer: Some("ipv4:127.0.0.1:48380"), is_desc_scan: Some(false), txn_start_ts: TimeStamp(6), bypass_locks: Empty, access_locks: Empty, cache_match_version: None, lower_bound: [116, 128, 0, 0, 0, 0, 0, 0, 5, 95, 114, 128, 0, 0, 0, 0, 0, 0, 1], upper_bound: [116, 128, 0, 0, 0, 0, 0, 0, 5, 95, 114, 128, 0, 0, 0, 0, 0, 0, 3], perf_level: Uninitialized, allowed_in_flashback: false }, err: default not found: key:7480000000000000FF055F728000000000FF0000020000000000FAFFFFFFFFFFFFFFFB, maybe read truncated/dropped table data?, thread_id: 132
```
With request context information.

The storage get and batch-get log is like:
```
[ERRO] default not found in storage get, RpcContext: region_id: 1 region_epoch { conf_ver: 1 version: 1 } peer { id: 1 store_id: 1 }, err: default not found: key:7480000000000000FF055F728000000000FF0000020000000000FAFFFFFFFFFFFFFFFB, maybe read truncated/dropped table data?, thread_id: 18
```
With RPC context information.


With call stack information, like
```
 1: tikv::storage::mvcc::reader::point_getter::PointGetter<S>::load_data_from_default_cf::{{closure}}
             at src/storage/mvcc/reader/point_getter.rs:369:13
   2: core::option::Option<T>::map
             at /rustc/89e2160c4ca5808657ed55392620ed1dbbce78d1/library/core/src/option.rs:1072:29
   3: fail::eval
             at src/index.crates.io-6f17d22bba15001f/fail-0.5.1/src/lib.rs:643:5
   4: tikv::storage::mvcc::reader::point_getter::PointGetter<S>::load_data_from_default_cf
             at src/storage/mvcc/reader/point_getter.rs:368:9
   5: tikv::storage::mvcc::reader::point_getter::PointGetter<S>::load_data
             at src/storage/mvcc/reader/point_getter.rs:308:41
   6: tikv::storage::mvcc::reader::point_getter::PointGetter<S>::get
             at src/storage/mvcc/reader/point_getter.rs:181:9
   7: <tikv::storage::txn::store::SnapshotStore<S> as tikv::storage::txn::store::Store>::get
             at src/storage/txn/store.rs:306:17
   8: tikv::storage::Storage<E,L,F>::get::{{closure}}::{{closure}}

```

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Print more information in logs when default not found error is encounterred.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
