### PR TITLE
txn: prevent 1pc locks from being skipped when reading with max-ts

### DIFF
--- a/src/storage/txn/actions/prewrite.rs
+++ b/src/storage/txn/actions/prewrite.rs
@@ -618,9 +618,9 @@ impl<'a> PrewriteMutation<'a> {
         if let Some(secondary_keys) = self.secondary_keys {
             lock.use_async_commit = true;
             lock.secondaries = secondary_keys.to_owned();
-        } else if try_one_pc && lock.primary == self.key.to_raw()? {
-            // Set `use_one_pc` to true when the key is primary. It's used to prevent the
-            // in-memory lock from being skipped when reading with max_ts.
+        } else if try_one_pc {
+            // Set `use_one_pc` to true to prevent the in-memory lock from being skipped
+            // when reading with max-ts.
             lock.use_one_pc = true;
         }
 
@@ -2801,10 +2801,10 @@ pub mod tests {
         )
         .unwrap();
 
-        // lock.use_one_pc should be set to true for primary key when using 1PC.
+        // lock.use_one_pc should be set to true when using 1pc.
         assert_eq!(txn.guards.len(), 2);
         txn.guards[0].with_lock(|l| assert!(l.as_ref().unwrap().use_one_pc));
-        txn.guards[1].with_lock(|l| assert!(!l.as_ref().unwrap().use_one_pc));
+        txn.guards[1].with_lock(|l| assert!(l.as_ref().unwrap().use_one_pc));
 
         // read with max_ts should be blocked by the lock.
         for &key in &[k1, k2] {

--- a/src/storage/txn/actions/prewrite.rs
+++ b/src/storage/txn/actions/prewrite.rs
@@ -930,7 +930,7 @@ pub mod tests {
     use std::sync::Arc;
 
     use concurrency_manager::ConcurrencyManager;
-    use kvproto::kvrpcpb::{Context, IsolationLevel};
+    use kvproto::kvrpcpb::Context;
     #[cfg(test)]
     use rand::{Rng, SeedableRng};
     #[cfg(test)]
@@ -2805,7 +2805,7 @@ pub mod tests {
                 &k,
                 TimeStamp::max(),
                 &TsSet::Empty,
-                IsolationLevel::Si,
+                crate::storage::IsolationLevel::Si,
             )
         });
         assert!(res.is_err());

--- a/src/storage/txn/actions/prewrite.rs
+++ b/src/storage/txn/actions/prewrite.rs
@@ -618,6 +618,12 @@ impl<'a> PrewriteMutation<'a> {
         if let Some(secondary_keys) = self.secondary_keys {
             lock.use_async_commit = true;
             lock.secondaries = secondary_keys.to_owned();
+        } else if try_one_pc && lock.primary == self.key.to_raw()? {
+            // Set use_async_commit to true when try_one_pc and the key is primary. If
+            // use_async_commit is false and async-prewrite-apply is enabled, there is a
+            // chance that reads with max_ts cannot see the previous writes because the mem
+            // lock can be skipped and the data hasn't been applied yet.
+            lock.use_async_commit = true;
         }
 
         let final_min_commit_ts = if lock.use_async_commit || try_one_pc {
@@ -814,14 +820,6 @@ fn async_commit_timestamps(
     max_commit_ts: TimeStamp,
     txn: &mut MvccTxn,
 ) -> Result<TimeStamp> {
-    // When 1pc is enable and async-commit is diabled, a transaction can be commited
-    // by 1pc but lock.use_async_commit might be still false.
-    // And if async-prewrite-apply is also enabled, then there is a chance that
-    // reads with max_ts cannot see the previous writes because the mem lock can
-    // be skipped and the data hasn't been applied yet.
-    // So we always set use_async_commit to true here to avoid the issue.
-    lock.use_async_commit = true;
-
     // This operation should not block because the latch makes sure only one thread
     // is operating on this key.
     let key_guard = ::futures_executor::block_on(txn.concurrency_manager.lock_key(key));
@@ -1283,7 +1281,7 @@ pub mod tests {
         assert_eq!(modifies.len(), 2); // the mutation that meets CommitTsTooLarge still exists
         write(&engine, &Default::default(), modifies);
         // success 1pc prewrite needs to be transformed to locks
-        assert!(!must_locked(&mut engine, b"k1", 10).use_async_commit);
+        assert!(must_locked(&mut engine, b"k1", 10).use_async_commit);
         assert!(!must_locked(&mut engine, b"k2", 10).use_async_commit);
     }
 
@@ -2778,11 +2776,24 @@ pub mod tests {
         let mut txn = MvccTxn::new(10.into(), cm.clone());
         let mut reader = SnapshotReader::new(10.into(), snapshot, false);
 
+        let k1 = b"k1";
+        let k2 = b"k2";
+
         prewrite(
             &mut txn,
             &mut reader,
-            &optimistic_async_props(b"k", 10.into(), 50.into(), 1, true),
-            Mutation::make_put(Key::from_raw(b"k"), b"v".to_vec()),
+            &optimistic_async_props(k1, 10.into(), 50.into(), 2, true),
+            Mutation::make_put(Key::from_raw(k1), b"v1".to_vec()),
+            &None,
+            SkipPessimisticCheck,
+            None,
+        )
+        .unwrap();
+        prewrite(
+            &mut txn,
+            &mut reader,
+            &optimistic_async_props(k1, 10.into(), 50.into(), 1, true),
+            Mutation::make_put(Key::from_raw(k2), b"v2".to_vec()),
             &None,
             SkipPessimisticCheck,
             None,
@@ -2791,23 +2802,23 @@ pub mod tests {
 
         // lock.use_async_commit should be set to true when using 1PC even when
         // secondary_keys is empty.
-        assert_eq!(txn.guards.len(), 1);
-        txn.guards[0].with_lock(|l| {
-            let l = l.as_ref().unwrap();
-            assert_eq!(l.use_async_commit, true);
-        });
+        assert_eq!(txn.guards.len(), 2);
+        txn.guards[0].with_lock(|l| assert!(l.as_ref().unwrap().use_async_commit));
+        txn.guards[1].with_lock(|l| assert!(!l.as_ref().unwrap().use_async_commit));
 
         // read with max_ts should be blocked by the lock.
-        let k = Key::from_raw(b"k");
-        let res = cm.read_key_check(&k, |l| {
-            Lock::check_ts_conflict(
-                Cow::Borrowed(l),
-                &k,
-                TimeStamp::max(),
-                &TsSet::Empty,
-                crate::storage::IsolationLevel::Si,
-            )
-        });
-        assert!(res.is_err());
+        for &key in &[k1, k2] {
+            let k = Key::from_raw(key);
+            let res = cm.read_key_check(&k, |l| {
+                Lock::check_ts_conflict(
+                    Cow::Borrowed(l),
+                    &k,
+                    TimeStamp::max(),
+                    &TsSet::Empty,
+                    crate::storage::IsolationLevel::Si,
+                )
+            });
+            assert!(res.is_err());
+        }
     }
 }

--- a/src/storage/txn/actions/prewrite.rs
+++ b/src/storage/txn/actions/prewrite.rs
@@ -619,11 +619,9 @@ impl<'a> PrewriteMutation<'a> {
             lock.use_async_commit = true;
             lock.secondaries = secondary_keys.to_owned();
         } else if try_one_pc && lock.primary == self.key.to_raw()? {
-            // Set use_async_commit to true when try_one_pc and the key is primary. If
-            // use_async_commit is false and async-prewrite-apply is enabled, there is a
-            // chance that reads with max_ts cannot see the previous writes because the mem
-            // lock can be skipped and the data hasn't been applied yet.
-            lock.use_async_commit = true;
+            // Set `use_one_pc` to true when the key is primary. It's used to prevent the
+            // in-memory lock from being skipped when reading with max_ts.
+            lock.use_one_pc = true;
         }
 
         let final_min_commit_ts = if lock.use_async_commit || try_one_pc {
@@ -1281,7 +1279,7 @@ pub mod tests {
         assert_eq!(modifies.len(), 2); // the mutation that meets CommitTsTooLarge still exists
         write(&engine, &Default::default(), modifies);
         // success 1pc prewrite needs to be transformed to locks
-        assert!(must_locked(&mut engine, b"k1", 10).use_async_commit);
+        assert!(!must_locked(&mut engine, b"k1", 10).use_async_commit);
         assert!(!must_locked(&mut engine, b"k2", 10).use_async_commit);
     }
 
@@ -2767,7 +2765,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_1pc_set_lock_use_async_commit() {
+    fn test_1pc_set_lock_use_one_pc() {
         let mut engine = crate::storage::TestEngineBuilder::new().build().unwrap();
         let cm = ConcurrencyManager::new(42.into());
 
@@ -2800,11 +2798,10 @@ pub mod tests {
         )
         .unwrap();
 
-        // lock.use_async_commit should be set to true when using 1PC even when
-        // secondary_keys is empty.
+        // lock.use_one_pc should be set to true for primary key when using 1PC.
         assert_eq!(txn.guards.len(), 2);
-        txn.guards[0].with_lock(|l| assert!(l.as_ref().unwrap().use_async_commit));
-        txn.guards[1].with_lock(|l| assert!(!l.as_ref().unwrap().use_async_commit));
+        txn.guards[0].with_lock(|l| assert!(l.as_ref().unwrap().use_one_pc));
+        txn.guards[1].with_lock(|l| assert!(!l.as_ref().unwrap().use_one_pc));
 
         // read with max_ts should be blocked by the lock.
         for &key in &[k1, k2] {

--- a/src/storage/txn/actions/prewrite.rs
+++ b/src/storage/txn/actions/prewrite.rs
@@ -636,6 +636,7 @@ impl<'a> PrewriteMutation<'a> {
             fail_point!("after_calculate_min_commit_ts");
             if let Err(Error(box ErrorInner::CommitTsTooLarge { .. })) = &res {
                 try_one_pc = false;
+                lock.use_one_pc = false;
                 lock.use_async_commit = false;
                 lock.secondaries = Vec::new();
             }
@@ -1281,6 +1282,8 @@ pub mod tests {
         // success 1pc prewrite needs to be transformed to locks
         assert!(!must_locked(&mut engine, b"k1", 10).use_async_commit);
         assert!(!must_locked(&mut engine, b"k2", 10).use_async_commit);
+        assert!(!must_locked(&mut engine, b"k1", 10).use_one_pc);
+        assert!(!must_locked(&mut engine, b"k2", 10).use_one_pc);
     }
 
     pub fn try_pessimistic_prewrite_check_not_exists<E: Engine>(

--- a/src/storage/txn/commands/prewrite.rs
+++ b/src/storage/txn/commands/prewrite.rs
@@ -989,6 +989,8 @@ fn handle_1pc_locks(txn: &mut MvccTxn, commit_ts: TimeStamp) -> ReleasedLocks {
 /// Change all 1pc locks in txn to 2pc locks.
 pub(in crate::storage::txn) fn fallback_1pc_locks(txn: &mut MvccTxn) {
     for (key, lock, remove_pessimistic_lock) in std::mem::take(&mut txn.locks_for_1pc) {
+        // Here we do not need to revert `lock.use_one_pc` since it's not persisted,
+        // that is, it just likes `lock.to_bytes()` will set it to false automatically.
         let is_new_lock = !remove_pessimistic_lock;
         txn.put_lock(key, &lock, is_new_lock);
     }

--- a/src/storage/txn/commands/prewrite.rs
+++ b/src/storage/txn/commands/prewrite.rs
@@ -988,9 +988,8 @@ fn handle_1pc_locks(txn: &mut MvccTxn, commit_ts: TimeStamp) -> ReleasedLocks {
 
 /// Change all 1pc locks in txn to 2pc locks.
 pub(in crate::storage::txn) fn fallback_1pc_locks(txn: &mut MvccTxn) {
-    for (key, lock, remove_pessimistic_lock) in std::mem::take(&mut txn.locks_for_1pc) {
-        // Here we do not need to revert `lock.use_one_pc` since it's not persisted,
-        // that is, it just likes `lock.to_bytes()` will set it to false automatically.
+    for (key, mut lock, remove_pessimistic_lock) in std::mem::take(&mut txn.locks_for_1pc) {
+        lock.use_one_pc = false;
         let is_new_lock = !remove_pessimistic_lock;
         txn.put_lock(key, &lock, is_new_lock);
     }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18117 

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Introduce a new field `use_one_pc` to the `Lock` struct to indicate whether the txn uses 1pc, and use it to prevent locks from being skipped when reading with max-ts.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [x] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fix an issue that reads cannot see previous writes when `tidb_enable_async_commit = 0`, `tidb_enable_1pc = 1` and `storage.enable-async-apply-prewrite = true`.
```
