### PR TITLE
rocksdb: resolve flow control issues caused by clock-skew problems.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3814,7 +3814,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#7bdeea1ec51047208cde6e5bb729bcbe3e04afe9"
+source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#4f447e99336728681814d3b9c2f25a5362f96e6c"
 dependencies = [
  "bindgen 0.65.1",
  "bzip2-sys",
@@ -3833,7 +3833,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#7bdeea1ec51047208cde6e5bb729bcbe3e04afe9"
+source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#4f447e99336728681814d3b9c2f25a5362f96e6c"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -5791,7 +5791,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#7bdeea1ec51047208cde6e5bb729bcbe3e04afe9"
+source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#4f447e99336728681814d3b9c2f25a5362f96e6c"
 dependencies = [
  "libc 0.2.151",
  "librocksdb_sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3814,7 +3814,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#6f2b16cfbf8ec633918a392585b6bfa341d30341"
+source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#4a35039ef167dabf5df402734ac60e5ea32109be"
 dependencies = [
  "bindgen 0.65.1",
  "bzip2-sys",
@@ -3833,7 +3833,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#6f2b16cfbf8ec633918a392585b6bfa341d30341"
+source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#4a35039ef167dabf5df402734ac60e5ea32109be"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -5791,7 +5791,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#6f2b16cfbf8ec633918a392585b6bfa341d30341"
+source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#4a35039ef167dabf5df402734ac60e5ea32109be"
 dependencies = [
  "libc 0.2.151",
  "librocksdb_sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3814,7 +3814,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#736390009e6679eb0ce5d99e264898d96b21bd9f"
+source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#0aa21fa38b6bcf949b9b7a1afedb83d73849b341"
 dependencies = [
  "bindgen 0.65.1",
  "bzip2-sys",
@@ -3833,7 +3833,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#736390009e6679eb0ce5d99e264898d96b21bd9f"
+source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#0aa21fa38b6bcf949b9b7a1afedb83d73849b341"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -5791,7 +5791,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#736390009e6679eb0ce5d99e264898d96b21bd9f"
+source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#0aa21fa38b6bcf949b9b7a1afedb83d73849b341"
 dependencies = [
  "libc 0.2.151",
  "librocksdb_sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3814,7 +3814,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#0aa21fa38b6bcf949b9b7a1afedb83d73849b341"
+source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#6f2b16cfbf8ec633918a392585b6bfa341d30341"
 dependencies = [
  "bindgen 0.65.1",
  "bzip2-sys",
@@ -3833,7 +3833,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#0aa21fa38b6bcf949b9b7a1afedb83d73849b341"
+source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#6f2b16cfbf8ec633918a392585b6bfa341d30341"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -5791,7 +5791,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#0aa21fa38b6bcf949b9b7a1afedb83d73849b341"
+source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#6f2b16cfbf8ec633918a392585b6bfa341d30341"
 dependencies = [
  "libc 0.2.151",
  "librocksdb_sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3814,7 +3814,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#a64cc9d6637836456e0ac3f2578f41cc56390bcf"
+source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#7e4f9b29873c5fc8ff985f7ea102b1f6f560e65f"
 dependencies = [
  "bindgen 0.65.1",
  "bzip2-sys",
@@ -3833,7 +3833,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#a64cc9d6637836456e0ac3f2578f41cc56390bcf"
+source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#7e4f9b29873c5fc8ff985f7ea102b1f6f560e65f"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -5791,7 +5791,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#a64cc9d6637836456e0ac3f2578f41cc56390bcf"
+source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#7e4f9b29873c5fc8ff985f7ea102b1f6f560e65f"
 dependencies = [
  "libc 0.2.151",
  "librocksdb_sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3814,7 +3814,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#4f447e99336728681814d3b9c2f25a5362f96e6c"
+source = "git+https://github.com/tikv/rust-rocksdb.git#19eeae6dc7734af12475fbcf9d368168a0314085"
 dependencies = [
  "bindgen 0.65.1",
  "bzip2-sys",
@@ -3833,7 +3833,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#4f447e99336728681814d3b9c2f25a5362f96e6c"
+source = "git+https://github.com/tikv/rust-rocksdb.git#19eeae6dc7734af12475fbcf9d368168a0314085"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -5791,7 +5791,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#4f447e99336728681814d3b9c2f25a5362f96e6c"
+source = "git+https://github.com/tikv/rust-rocksdb.git#19eeae6dc7734af12475fbcf9d368168a0314085"
 dependencies = [
  "libc 0.2.151",
  "librocksdb_sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3814,7 +3814,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#4a35039ef167dabf5df402734ac60e5ea32109be"
+source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#a64cc9d6637836456e0ac3f2578f41cc56390bcf"
 dependencies = [
  "bindgen 0.65.1",
  "bzip2-sys",
@@ -3833,7 +3833,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#4a35039ef167dabf5df402734ac60e5ea32109be"
+source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#a64cc9d6637836456e0ac3f2578f41cc56390bcf"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -5791,7 +5791,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#4a35039ef167dabf5df402734ac60e5ea32109be"
+source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#a64cc9d6637836456e0ac3f2578f41cc56390bcf"
 dependencies = [
  "libc 0.2.151",
  "librocksdb_sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3814,7 +3814,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#7e4f9b29873c5fc8ff985f7ea102b1f6f560e65f"
+source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#8f933ad8fbf6cafa8f756a2b70aa5c92c1cbcc1c"
 dependencies = [
  "bindgen 0.65.1",
  "bzip2-sys",
@@ -3833,7 +3833,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#7e4f9b29873c5fc8ff985f7ea102b1f6f560e65f"
+source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#8f933ad8fbf6cafa8f756a2b70aa5c92c1cbcc1c"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -5791,7 +5791,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#7e4f9b29873c5fc8ff985f7ea102b1f6f560e65f"
+source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#8f933ad8fbf6cafa8f756a2b70aa5c92c1cbcc1c"
 dependencies = [
  "libc 0.2.151",
  "librocksdb_sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3814,7 +3814,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#2bb1e4e32b9e45cf3fd8210766a9db38eacd5e4d"
+source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#736390009e6679eb0ce5d99e264898d96b21bd9f"
 dependencies = [
  "bindgen 0.65.1",
  "bzip2-sys",
@@ -3833,7 +3833,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tikv/rust-rocksdb.git#2bb1e4e32b9e45cf3fd8210766a9db38eacd5e4d"
+source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#736390009e6679eb0ce5d99e264898d96b21bd9f"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -5791,7 +5791,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#2bb1e4e32b9e45cf3fd8210766a9db38eacd5e4d"
+source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#736390009e6679eb0ce5d99e264898d96b21bd9f"
 dependencies = [
  "libc 0.2.151",
  "librocksdb_sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3814,7 +3814,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#8f933ad8fbf6cafa8f756a2b70aa5c92c1cbcc1c"
+source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#7bdeea1ec51047208cde6e5bb729bcbe3e04afe9"
 dependencies = [
  "bindgen 0.65.1",
  "bzip2-sys",
@@ -3833,7 +3833,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#8f933ad8fbf6cafa8f756a2b70aa5c92c1cbcc1c"
+source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#7bdeea1ec51047208cde6e5bb729bcbe3e04afe9"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -5791,7 +5791,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#8f933ad8fbf6cafa8f756a2b70aa5c92c1cbcc1c"
+source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=fix_clock_skew#7bdeea1ec51047208cde6e5bb729bcbe3e04afe9"
 dependencies = [
  "libc 0.2.151",
  "librocksdb_sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ testexport = [
   "engine_rocks/testexport",
   "engine_panic/testexport",
   "encryption/testexport",
-  "file_system/testexport"
+  "file_system/testexport",
 ]
 test-engine-kv-rocksdb = ["engine_test/test-engine-kv-rocksdb"]
 test-engine-raft-raft-engine = ["engine_test/test-engine-raft-raft-engine"]
@@ -225,6 +225,8 @@ sysinfo = { git = "https://github.com/tikv/sysinfo", branch = "0.26-fix-cpu" }
 # After the PR to rust-rocksdb is merged, remember to comment this out and run `cargo update -p rocksdb`.
 # [patch.'https://github.com/tikv/rust-rocksdb']
 # rocksdb = { git = "https://github.com/your_github_id/rust-rocksdb", branch = "your_branch" }
+[patch.'https://github.com/tikv/rust-rocksdb']
+rocksdb = { git = "https://github.com/LykxSassinator/rust-rocksdb", branch = "fix_clock_skew" }
 
 [workspace]
 # See https://github.com/rust-lang/rfcs/blob/master/text/2957-cargo-features2.md

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,8 +225,6 @@ sysinfo = { git = "https://github.com/tikv/sysinfo", branch = "0.26-fix-cpu" }
 # After the PR to rust-rocksdb is merged, remember to comment this out and run `cargo update -p rocksdb`.
 # [patch.'https://github.com/tikv/rust-rocksdb']
 # rocksdb = { git = "https://github.com/your_github_id/rust-rocksdb", branch = "your_branch" }
-[patch.'https://github.com/tikv/rust-rocksdb']
-rocksdb = { git = "https://github.com/LykxSassinator/rust-rocksdb", branch = "fix_clock_skew" }
 
 [workspace]
 # See https://github.com/rust-lang/rfcs/blob/master/text/2957-cargo-features2.md

--- a/deny.toml
+++ b/deny.toml
@@ -99,4 +99,4 @@ exceptions = [
 [sources]
 unknown-git = "deny"
 unknown-registry = "deny"
-allow-org = { github = ["tikv", "pingcap", "rust-lang"] }
+allow-org = { github = ["tikv", "pingcap", "rust-lang", "LykxSassinator"] }

--- a/deny.toml
+++ b/deny.toml
@@ -99,4 +99,4 @@ exceptions = [
 [sources]
 unknown-git = "deny"
 unknown-registry = "deny"
-allow-org = { github = ["tikv", "pingcap", "rust-lang", "LykxSassinator"] }
+allow-org = { github = ["tikv", "pingcap", "rust-lang"] }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close https://github.com/tikv/tikv/issues/17995
Currently, in TIKV, there are two issues encountered when enabling auto-tuning on WriteAmpBasedRateLimiter in the presence of clock-skew problems:
- The `Request()` operation may experience excessive waiting if the time offset is too large, causing pending compactions to hang unexpectedly.
- The `Tune()` process uses an excessively small value for updated bytes to calculate the next `rate_bytes_per_sec_`. This results in the next `Request()` being starved, as `rate_bytes_per_sec_` becomes significantly smaller than the pending requested bytes.

![image](https://github.com/user-attachments/assets/22d20177-4846-4e24-b1fd-88b8957cf362)


To address these two issues in the presence of clock-skew problems, this PR introduces the following changes:
- Clamps the wait-time limit between 0 and `refill_period_us_` to prevent excessively long waits.
- To preserve the current tuning algorithm, the maximum rate limiter is used if it encounters clock-skew issues, ensuring that `Request()` operations do not starve.

After applying this PR, the testing results as followings shows proves that it can solve the clock-skew problem as expected:
![image](https://github.com/user-attachments/assets/40ede9a6-ba94-48dd-9eb7-fa8c9d06a6c9)

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Address clock-skew issues.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Resolve flow control issues caused by clock-skew problems.
```
