### PR TITLE
expr: support scalar function from_unixtime in tikv

### DIFF
--- a/components/tidb_query_datatype/src/codec/mysql/time/mod.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/time/mod.rs
@@ -1484,6 +1484,19 @@ impl Time {
         Time::try_from_chrono_datetime(ctx, timestamp.naive_local(), time_type, fsp as i8)
     }
 
+    pub fn from_unixtime(
+        ctx: &mut EvalContext,
+        seconds: i64,
+        nanos: u32,
+        time_type: TimeType,
+        fsp: i8,
+    ) -> Result<Self> {
+        let timestamp = Utc.timestamp(seconds, nanos);
+        let timestamp = ctx.cfg.tz.from_utc_datetime(&timestamp.naive_utc());
+        let timestamp = timestamp.round_subsecs(fsp as u16);
+        Time::try_from_chrono_datetime(ctx, timestamp.naive_local(), time_type, fsp)
+    }
+
     pub fn from_year(
         ctx: &mut EvalContext,
         year: u32,

--- a/components/tidb_query_expr/src/lib.rs
+++ b/components/tidb_query_expr/src/lib.rs
@@ -931,6 +931,8 @@ fn map_expr_node_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
         ScalarFuncSig::SubDateDurationRealDatetime => sub_date_time_duration_interval_any_as_datetime_fn_meta::<Real>(),
         ScalarFuncSig::AddDateDurationDecimalDatetime => add_date_time_duration_interval_any_as_datetime_fn_meta::<Decimal>(),
         ScalarFuncSig::SubDateDurationDecimalDatetime => sub_date_time_duration_interval_any_as_datetime_fn_meta::<Decimal>(),
+        ScalarFuncSig::FromUnixTime1Arg => from_unixtime_1_arg_fn_meta(),
+        ScalarFuncSig::FromUnixTime2Arg => from_unixtime_2_arg_fn_meta(),
         _ => return Err(other_err!(
             "ScalarFunction {:?} is not supported in batch mode",
             value


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close https://github.com/tikv/tikv/issues/18111

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Support scalar function from_unixtime in tikv
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Support scalar function from_unixtime in tikv.
```
