### PR TITLE
config: rename config items for max-ts checker

### DIFF
--- a/components/concurrency_manager/src/lib.rs
+++ b/components/concurrency_manager/src/lib.rs
@@ -95,7 +95,7 @@ pub struct ConcurrencyManager {
     // approximate limit.
     max_ts_limit: Arc<AtomicCell<MaxTsLimit>>,
     limit_valid_duration: Duration,
-    action_on_invalid_max_ts: Arc<AtomicActionOnInvalidMaxTs>,
+    action_on_invalid_max_ts_update: Arc<AtomicActionOnInvalidMaxTs>,
 
     max_ts_drift_allowance_ms: Arc<AtomicU64>,
 
@@ -118,7 +118,7 @@ impl ConcurrencyManager {
     pub fn new_with_config(
         latest_ts: TimeStamp,
         limit_valid_duration: Duration,
-        action_on_invalid_max_ts: ActionOnInvalidMaxTs,
+        action_on_invalid_max_ts_update: ActionOnInvalidMaxTs,
         tso: Option<Arc<dyn TSOProvider>>,
         max_ts_drift_allowance: Duration,
     ) -> Self {
@@ -129,7 +129,7 @@ impl ConcurrencyManager {
 
         if limit_valid_duration >= max_ts_drift_allowance {
             error!("improper setting: limit_valid_duration >= max_ts_drift_allowance; \
-                consider increasing max-ts-drift-allowance or decreasing max-ts-sync-interval";
+                consider increasing storage.max-ts.max-drift or decreasing storage.max-ts.cache-sync-interval";
                 "limit_valid_duration" => ?limit_valid_duration,
                 "max_ts_drift_allowance" => ?max_ts_drift_allowance,
             );
@@ -139,8 +139,8 @@ impl ConcurrencyManager {
             max_ts: Arc::new(AtomicU64::new(latest_ts.into_inner())),
             max_ts_limit: Arc::new(AtomicCell::new(initial_limit)),
             lock_table: LockTable::default(),
-            action_on_invalid_max_ts: Arc::new(AtomicActionOnInvalidMaxTs::new(
-                action_on_invalid_max_ts,
+            action_on_invalid_max_ts_update: Arc::new(AtomicActionOnInvalidMaxTs::new(
+                action_on_invalid_max_ts_update,
             )),
             limit_valid_duration,
             time_provider: Arc::new(CoarseInstantTimeProvider),
@@ -155,7 +155,7 @@ impl ConcurrencyManager {
     fn new_with_time_provider(
         latest_ts: TimeStamp,
         limit_valid_duration: Duration,
-        action_on_invalid_max_ts: ActionOnInvalidMaxTs,
+        action_on_invalid_max_ts_update: ActionOnInvalidMaxTs,
         time_provider: Arc<dyn TimeProvider>,
         tso: Option<Arc<dyn TSOProvider>>,
         max_ts_drift_allowance: Duration,
@@ -168,8 +168,8 @@ impl ConcurrencyManager {
             max_ts: Arc::new(AtomicU64::new(latest_ts.into_inner())),
             max_ts_limit: Arc::new(AtomicCell::new(initial_limit)),
             lock_table: LockTable::default(),
-            action_on_invalid_max_ts: Arc::new(AtomicActionOnInvalidMaxTs::new(
-                action_on_invalid_max_ts,
+            action_on_invalid_max_ts_update: Arc::new(AtomicActionOnInvalidMaxTs::new(
+                action_on_invalid_max_ts_update,
             )),
             limit_valid_duration,
             time_provider,
@@ -305,7 +305,7 @@ impl ConcurrencyManager {
             );
         }
 
-        match self.action_on_invalid_max_ts.load() {
+        match self.action_on_invalid_max_ts_update.load() {
             ActionOnInvalidMaxTs::Panic if tso_confirmed => {
                 panic!(
                     "invalid max_ts update: {} exceeds the limit {}, source={}",
@@ -322,11 +322,13 @@ impl ConcurrencyManager {
         }
     }
 
-    /// Set the maximum allowed value for max_ts updates, except for the updates
-    /// from PD TSO. The limit must be updated regularly to prevent the
-    /// blocking of max_ts. It prevents max_ts from being updated to an
-    /// unreasonable value, which is usually caused by bugs or unsafe
-    /// usages.
+    /// Set the maximum allowed value for max_ts updates.
+    /// The actual limit is calculated by adding a drift allowance to the
+    /// provided timestamp to accommodate lag in TSO syncing.
+    /// The limit must be updated regularly to prevent failure of updating
+    /// max_ts.
+    /// It prevents max_ts from being updated to an unreasonable
+    /// value, which is usually caused by bugs or unsafe usages.
     ///
     /// # Note
     /// If the new limit is smaller than the current limit, this operation will
@@ -450,8 +452,8 @@ impl ConcurrencyManager {
         min_lock
     }
 
-    pub fn set_action_on_invalid_max_ts(&self, action: ActionOnInvalidMaxTs) {
-        self.action_on_invalid_max_ts.store(action);
+    pub fn set_action_on_invalid_max_ts_update(&self, action: ActionOnInvalidMaxTs) {
+        self.action_on_invalid_max_ts_update.store(action);
     }
 
     pub fn set_max_ts_drift_allowance(&self, allowance: Duration) {

--- a/components/concurrency_manager/src/lib.rs
+++ b/components/concurrency_manager/src/lib.rs
@@ -250,7 +250,7 @@ impl ConcurrencyManager {
         source: impl slog::Value + Display,
         using_approximate: bool,
     ) -> Result<(), crate::InvalidMaxTsUpdate> {
-        warn!("possible invalid max-ts update; double checking";
+        warn!("possible invalid max_ts update; double checking";
             "attempted_ts" => new_ts,
             "limit" => limit.into_inner(),
             "source" => &source,

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -5907,7 +5907,7 @@ where
             txn_ext: self.txn_ext.clone(),
         }) {
             error!(
-                "failed to update max ts";
+                "failed to update max_ts";
                 "err" => ?e,
             );
         }

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -404,15 +404,16 @@ where
         let latest_ts = block_on(pd_client.get_tso()).expect("failed to get timestamp from PD");
         let concurrency_manager = ConcurrencyManager::new_with_config(
             latest_ts,
-            (config.storage.max_ts_sync_interval * LIMIT_VALID_TIME_MULTIPLIER).into(),
+            (config.storage.max_ts.cache_sync_interval * LIMIT_VALID_TIME_MULTIPLIER).into(),
             config
                 .storage
-                .action_on_invalid_max_ts
+                .max_ts
+                .action_on_invalid_update
                 .as_str()
                 .try_into()
                 .unwrap(),
             Some(pd_client.clone()),
-            config.storage.max_ts_drift_allowance.0,
+            config.storage.max_ts.max_drift.0,
         );
 
         // use different quota for front-end and back-end requests
@@ -1171,7 +1172,7 @@ where
         let cm = self.concurrency_manager.clone();
         let pd_client = self.pd_client.clone();
 
-        let max_ts_sync_interval = self.core.config.storage.max_ts_sync_interval.into();
+        let max_ts_sync_interval = self.core.config.storage.max_ts.cache_sync_interval.into();
         self.core
             .background_worker
             .spawn_interval_async_task(max_ts_sync_interval, move || {

--- a/components/server/src/server2.rs
+++ b/components/server/src/server2.rs
@@ -328,15 +328,16 @@ where
         let latest_ts = block_on(pd_client.get_tso()).expect("failed to get timestamp from PD");
         let concurrency_manager = ConcurrencyManager::new_with_config(
             latest_ts,
-            (config.storage.max_ts_sync_interval * LIMIT_VALID_TIME_MULTIPLIER).into(),
+            (config.storage.max_ts.cache_sync_interval * LIMIT_VALID_TIME_MULTIPLIER).into(),
             config
                 .storage
-                .action_on_invalid_max_ts
+                .max_ts
+                .action_on_invalid_update
                 .as_str()
                 .try_into()
                 .unwrap(),
             Some(pd_client.clone()),
-            config.storage.max_ts_drift_allowance.0,
+            config.storage.max_ts.max_drift.0,
         );
 
         // use different quota for front-end and back-end requests
@@ -964,7 +965,7 @@ where
         let cm = self.concurrency_manager.clone();
         let pd_client = self.pd_client.clone();
 
-        let max_ts_sync_interval = self.core.config.storage.max_ts_sync_interval.into();
+        let max_ts_sync_interval = self.core.config.storage.max_ts.cache_sync_interval.into();
         self.core
             .background_worker
             .spawn_interval_async_task(max_ts_sync_interval, move || {

--- a/src/server/raftkv/mod.rs
+++ b/src/server/raftkv/mod.rs
@@ -840,7 +840,7 @@ impl ReadIndexObserver for ReplicaReadLockChecker {
                 .concurrency_manager
                 .update_max_ts(start_ts, || format!("read_index-{}", start_ts))
             {
-                error!("failed to update max ts in concurrency manager"; "err" => ?e);
+                error!("failed to update max_ts in concurrency manager"; "err" => ?e);
             }
             for range in request.mut_key_ranges().iter_mut() {
                 let key_bound = |key: Vec<u8>| {

--- a/src/storage/config_manager.rs
+++ b/src/storage/config_manager.rs
@@ -110,16 +110,19 @@ impl<EK: Engine, K: ConfigurableDb, L: LockManager> ConfigManager
                 }
             }
         }
-        if let Some(v) = change.remove("action_on_invalid_max_ts") {
-            let str_v: String = v.into();
-            let action: concurrency_manager::ActionOnInvalidMaxTs = str_v.try_into()?;
-            self.concurrency_manager
-                .set_action_on_invalid_max_ts(action);
+        if let Some(ConfigValue::Module(mut max_ts)) = change.remove("max_ts") {
+            if let Some(v) = max_ts.remove("action_on_invalid_update") {
+                let str_v: String = v.into();
+                let action: concurrency_manager::ActionOnInvalidMaxTs = str_v.try_into()?;
+                self.concurrency_manager
+                    .set_action_on_invalid_max_ts_update(action);
+            }
+            if let Some(v) = max_ts.remove("max_drift") {
+                let dur_v: ReadableDuration = v.into();
+                self.concurrency_manager.set_max_ts_drift_allowance(dur_v.0);
+            }
         }
-        if let Some(v) = change.remove("max_ts_drift_allowance") {
-            let dur_v: ReadableDuration = v.into();
-            self.concurrency_manager.set_max_ts_drift_allowance(dur_v.0);
-        }
+
         Ok(())
     }
 }

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -36,7 +36,8 @@ use tikv::{
         lock_manager::Config as PessimisticTxnConfig, Config as ServerConfig,
     },
     storage::config::{
-        BlockCacheConfig, Config as StorageConfig, EngineType, FlowControlConfig, IoRateLimitConfig,
+        BlockCacheConfig, Config as StorageConfig, EngineType, FlowControlConfig,
+        IoRateLimitConfig, MaxTsConfig,
     },
 };
 use tikv_util::config::{LogFormat, ReadableDuration, ReadableSchedule, ReadableSize};
@@ -780,9 +781,11 @@ fn test_serde_custom_tikv_config() {
         background_error_recovery_window: ReadableDuration::hours(1),
         txn_status_cache_capacity: 1000,
         memory_quota: ReadableSize::kb(123),
-        max_ts_drift_allowance: ReadableDuration::secs(333),
-        max_ts_sync_interval: ReadableDuration::secs(44),
-        action_on_invalid_max_ts: "error".to_owned(),
+        max_ts: MaxTsConfig {
+            max_drift: ReadableDuration::secs(333),
+            cache_sync_interval: ReadableDuration::secs(44),
+            action_on_invalid_update: "error".to_owned(),
+        },
     };
     value.coprocessor = CopConfig {
         split_region_on_table: false,

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -105,9 +105,11 @@ enable-ttl = true
 ttl-check-poll-interval = "0s"
 txn-status-cache-capacity = 1000
 memory-quota = "123KB"
-max-ts-drift-allowance = "333s"
-max-ts-sync-interval = "44s"
-action-on-invalid-max-ts = "error"
+
+[storage.max-ts]
+max-drift = "333s"
+cache-sync-interval = "44s"
+action-on-invalid-update = "error"
 
 [storage.block-cache]
 capacity = "40GB"

--- a/tests/integrations/config/test_config_client.rs
+++ b/tests/integrations/config/test_config_client.rs
@@ -11,7 +11,7 @@ use std::{
 use online_config::{ConfigChange, OnlineConfig};
 use raftstore::store::Config as RaftstoreConfig;
 use tikv::config::*;
-use tikv_util::config::{ReadableOffsetTime, ReadableSchedule};
+use tikv_util::config::{ReadableDuration, ReadableOffsetTime, ReadableSchedule};
 
 fn change(name: &str, value: &str) -> HashMap<String, String> {
     let mut m = HashMap::new();
@@ -54,10 +54,16 @@ fn test_update_config() {
         .update(change("raftstore.raft-log-gc-threshold", "2000"))
         .unwrap();
     cfg.raft_store.raft_log_gc_threshold = 2000;
+    cfg_controller
+        .update(change("storage.max-ts.max-drift", "365s"))
+        .unwrap();
+    cfg.storage.max_ts.max_drift = ReadableDuration::secs(365);
     assert_eq!(cfg_controller.get_current(), cfg);
 
     // update not support config
     let res = cfg_controller.update(change("server.addr", "localhost:3000"));
+    res.unwrap_err();
+    let res = cfg_controller.update(change("storage.max-ts.cache-sync-interval", "3s"));
     res.unwrap_err();
     assert_eq!(cfg_controller.get_current(), cfg);
 

--- a/tests/integrations/config/test_config_client.rs
+++ b/tests/integrations/config/test_config_client.rs
@@ -60,6 +60,15 @@ fn test_update_config() {
     cfg.storage.max_ts.max_drift = ReadableDuration::secs(365);
     assert_eq!(cfg_controller.get_current(), cfg);
 
+    // update that fails the validation
+    assert!(
+        cfg_controller
+            .update(change("storage.max-ts.max-drift", "3s"))
+            .unwrap_err()
+            .to_string()
+            .contains("smaller than or equal to storage.max-ts.cache-sync-interval")
+    );
+
     // update not support config
     let res = cfg_controller.update(change("server.addr", "localhost:3000"));
     res.unwrap_err();


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #17916
<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
config: rename config items for max-ts checker
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Rename config items for max-ts checker. Introduce the `storage.max-ts` section.
```
