### PR TITLE
[CP-to-8.1] Update rocksdb to fix clock-skew issues.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3778,7 +3778,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-7.5#12bf60e27a527e7042dc3bc1e2f39342dfcb2cb4"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-7.5#fa1a8745a1475010053728922189ad47f25c5122"
 dependencies = [
  "bindgen 0.65.1",
  "bzip2-sys",
@@ -3797,7 +3797,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-7.5#12bf60e27a527e7042dc3bc1e2f39342dfcb2cb4"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-7.5#fa1a8745a1475010053728922189ad47f25c5122"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -5813,7 +5813,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-7.5#12bf60e27a527e7042dc3bc1e2f39342dfcb2cb4"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-7.5#fa1a8745a1475010053728922189ad47f25c5122"
 dependencies = [
  "libc 0.2.151",
  "librocksdb_sys",


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref https://github.com/tikv/tikv/issues/17995
Currently, in TIKV, there are two issues encountered when enabling auto-tuning on WriteAmpBasedRateLimiter in the presence of clock-skew problems:
- The `Request()` operation may experience excessive waiting if the time offset is too large, causing pending compactions to hang unexpectedly.
- The `Tune()` process uses an excessively small value for updated bytes to calculate the next `rate_bytes_per_sec_`. This results in the next `Request()` being starved, as `rate_bytes_per_sec_` becomes significantly smaller than the pending requested bytes.

![image](https://github.com/user-attachments/assets/22d20177-4846-4e24-b1fd-88b8957cf362)


To address these two issues in the presence of clock-skew problems, this PR introduces the following changes:
- Clamps the wait-time limit between 0 and `refill_period_us_` to prevent excessively long waits.
- To preserve the current tuning algorithm, the maximum rate limiter is used if it encounters clock-skew issues, ensuring that `Request()` operations do not starve.

After applying this PR, the testing results as followings shows proves that it can solve the clock-skew problem as expected:
![image](https://github.com/user-attachments/assets/40ede9a6-ba94-48dd-9eb7-fa8c9d06a6c9)

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Address clock-skew issues.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Resolve flow control issues caused by clock-skew problems.
```
