### PR TITLE
aws: remove region check when create s3 storage

### DIFF
--- a/components/cloud/aws/src/kms.rs
+++ b/components/cloud/aws/src/kms.rs
@@ -58,10 +58,7 @@ impl AwsKms {
             .credentials_provider(credentials_provider)
             .http_client(client);
 
-        loader = util::configure_region(
-            loader,
-            &config.location.region,
-        )?;
+        loader = util::configure_region(loader, &config.location.region)?;
 
         loader = util::configure_endpoint(loader, &config.location.endpoint);
 

--- a/components/cloud/aws/src/kms.rs
+++ b/components/cloud/aws/src/kms.rs
@@ -61,7 +61,6 @@ impl AwsKms {
         loader = util::configure_region(
             loader,
             &config.location.region,
-            !config.location.endpoint.is_empty(),
         )?;
 
         loader = util::configure_endpoint(loader, &config.location.endpoint);

--- a/components/cloud/aws/src/s3.rs
+++ b/components/cloud/aws/src/s3.rs
@@ -878,7 +878,8 @@ mod tests {
         assert_eq!(s.config.multi_part_size, 5 * 1024 * 1024);
 
         config.bucket.region = StringNonEmpty::opt("foo".to_string());
-        assert!(S3Storage::new(config).is_ok());
+        // should not panic even if region is invalid
+        S3Storage::new(config).unwrap();
     }
 
     #[tokio::test]

--- a/components/cloud/aws/src/s3.rs
+++ b/components/cloud/aws/src/s3.rs
@@ -258,7 +258,7 @@ impl S3Storage {
         let mut loader =
             aws_config::defaults(BehaviorVersion::latest()).credentials_provider(creds);
 
-        loader = util::configure_region(loader, &bucket_region, !bucket_endpoint.is_empty())?;
+        loader = util::configure_region(loader, &bucket_region)?;
         loader = util::configure_endpoint(loader, &bucket_endpoint);
         loader = loader.http_client(client);
         Ok(loader.load().await)

--- a/components/cloud/aws/src/s3.rs
+++ b/components/cloud/aws/src/s3.rs
@@ -878,7 +878,7 @@ mod tests {
         assert_eq!(s.config.multi_part_size, 5 * 1024 * 1024);
 
         config.bucket.region = StringNonEmpty::opt("foo".to_string());
-        assert!(S3Storage::new(config).is_err());
+        assert!(S3Storage::new(config).is_ok());
     }
 
     #[tokio::test]

--- a/components/cloud/aws/src/util.rs
+++ b/components/cloud/aws/src/util.rs
@@ -92,37 +92,11 @@ pub fn configure_endpoint(loader: ConfigLoader, endpoint: &str) -> ConfigLoader 
 pub fn configure_region(
     loader: ConfigLoader,
     region: &str,
-    custom: bool,
 ) -> io::Result<ConfigLoader> {
     if !region.is_empty() {
-        validate_region(region, custom)?;
         Ok(loader.region(Region::new(region.to_owned())))
     } else {
         Ok(loader.region(DefaultRegionProvider::new()))
-    }
-}
-
-fn validate_region(region: &str, custom: bool) -> io::Result<()> {
-    if custom {
-        return Ok(());
-    }
-    let v: &str = &region.to_lowercase();
-
-    match v {
-        "ap-east-1" | "apeast1" | "ap-northeast-1" | "apnortheast1" | "ap-northeast-2"
-        | "apnortheast2" | "ap-northeast-3" | "apnortheast3" | "ap-south-1" | "apsouth1"
-        | "ap-southeast-1" | "apsoutheast1" | "ap-southeast-2" | "apsoutheast2"
-        | "ca-central-1" | "cacentral1" | "eu-central-1" | "eucentral1" | "eu-west-1"
-        | "euwest1" | "eu-west-2" | "euwest2" | "eu-west-3" | "euwest3" | "eu-north-1"
-        | "eunorth1" | "eu-south-1" | "eusouth1" | "me-south-1" | "mesouth1" | "us-east-1"
-        | "useast1" | "sa-east-1" | "saeast1" | "us-east-2" | "useast2" | "us-west-1"
-        | "uswest1" | "us-west-2" | "uswest2" | "us-gov-east-1" | "usgoveast1"
-        | "us-gov-west-1" | "usgovwest1" | "cn-north-1" | "cnnorth1" | "cn-northwest-1"
-        | "cnnorthwest1" | "af-south-1" | "afsouth1" => Ok(()),
-        _ => Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!("invalid aws region format {}", region),
-        )),
     }
 }
 

--- a/components/cloud/aws/src/util.rs
+++ b/components/cloud/aws/src/util.rs
@@ -89,10 +89,7 @@ pub fn configure_endpoint(loader: ConfigLoader, endpoint: &str) -> ConfigLoader 
     }
 }
 
-pub fn configure_region(
-    loader: ConfigLoader,
-    region: &str,
-) -> io::Result<ConfigLoader> {
+pub fn configure_region(loader: ConfigLoader, region: &str) -> io::Result<ConfigLoader> {
     if !region.is_empty() {
         Ok(loader.region(Region::new(region.to_owned())))
     } else {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close https://github.com/tikv/tikv/issues/18159

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

At an earlier stage, TiKV implemented region name validation to prevent errors caused by users setting random or incorrect region names. While this safeguard was effective in avoiding user mistakes, it also introduced limitations for the system itself.

Specifically, this check can cause backups to fail if new regions are added but the validation logic is not promptly updated to reflect the changes. To ensure greater flexibility and reduce the risk of backup disruptions, it is better to move this check to a more appropriate stage in the process.
```commit-message
s3: remove region check when create storage
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
Normally br will check the region at the client side and report dns error
```
[2025/01/21 12:43:44.930 +00:00] [WARN] [s3.go:1195] ["failed to request s3, retrying"] [error="RequestError: send request failed\ncaused by: dial tcp: lookup s3.random.amazonaws.com on 10.100.0.10:53: no such host"] [backoff=9.816985936s]
```

After hard code to send request to tikv, will report dns error too via new aws sdk.
```
[2025/01/21 13:05:10.248 +00:00] [WARN] [util.rs:110] ["aws request fails"] [uuid=xxx] [context=upload_small_file] [retry?=true] [err="aws-sdk error: DispatchFailure(DispatchFailure { source: ConnectorError { kind: Io, source: hyper::Error(Connect, ConnectError(\"dns error\", Custom { kind: Uncategorized, error: \"failed to lookup address information: Name or service not known\" })), connection: Unknown } })"] [thread_id=116]
```
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fix the issue that backup cannot succeed with new sdk on some regions.
```
