### PR TITLE
log-backup: remove unnecessary safepoint for log backup

### DIFF
--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -56,8 +56,8 @@ use super::metrics::HANDLE_EVENT_DURATION_HISTOGRAM;
 use crate::{
     annotate,
     checkpoint_manager::{
-        BasicFlushObserver, CheckpointManager, CheckpointV3FlushObserver, FlushObserver,
-        GetCheckpointResult, RegionIdWithVersion, Subscription,
+        CheckpointManager, CheckpointV3FlushObserver, FlushObserver, GetCheckpointResult,
+        RegionIdWithVersion, Subscription,
     },
     errors::{Error, ReportableResult, Result},
     event_loader::InitialDataLoader,
@@ -457,8 +457,7 @@ where
     }
 
     fn flush_observer(&self) -> impl FlushObserver {
-        let basic = BasicFlushObserver::new(self.pd_client.clone(), self.store_id);
-        CheckpointV3FlushObserver::new(self.scheduler.clone(), self.meta_client.clone(), basic)
+        CheckpointV3FlushObserver::new(self.scheduler.clone(), self.meta_client.clone())
     }
 
     /// Convert a batch of events to the cmd batch, and update the resolver


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #13889

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
This PR removes the gc-safepoint `backup-stream-{task}-{store-id}`, because the-log-backup-advancer now keeps the gc-safepoint `log-backup-coordinator` instead.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
