### PR TITLE
resource_control: fix unused warnings

### DIFF
--- a/components/resource_control/src/future.rs
+++ b/components/resource_control/src/future.rs
@@ -205,7 +205,7 @@ pub async fn with_resource_limiter<F: Future>(
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "failpoints"))]
 mod tests {
     use std::sync::mpsc::{channel, Sender};
 
@@ -239,10 +239,8 @@ mod tests {
         }
     }
 
-    #[allow(clippy::unused_async)]
     async fn empty() {}
 
-    #[cfg(feature = "failpoints")]
     #[test]
     fn test_limited_future() {
         let pool = YatpPoolBuilder::new(DefaultTicker::default())

--- a/components/resource_control/src/future.rs
+++ b/components/resource_control/src/future.rs
@@ -239,6 +239,7 @@ mod tests {
         }
     }
 
+    #[allow(clippy::unused_async)]
     async fn empty() {}
 
     #[test]


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #15990

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

Fix unused warnings when running the following command

```
cargo check --workspace --all-targets
```

### Check List

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
