### PR TITLE
cargo-deny: ignore RUSTSEC-2025-0004 check.

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -51,6 +51,14 @@ reason = """
 X509StoreRef::objects is unsound, see RUSTSEC-2020-0071
 """
 
+# See more about RUSTSEC-2025-0004 in deny.toml.
+[[disallowed-methods]]
+path = "openssl::ssl::select_next_proto"
+reason = """
+openssl::ssl::select_next_proto may return a buffer use after free, \
+see RUSTSEC-2025-0004
+"""
+
 # See more about RUSTSEC-2024-0357 in deny.toml.
 [[disallowed-types]]
 path = "openssl::bio::MemBio"

--- a/deny.toml
+++ b/deny.toml
@@ -73,6 +73,13 @@ ignore = [
     #
     # TODO: Upgrade clap to v4.x.
     "RUSTSEC-2021-0145",
+    # Ignore RUSTSEC-2025-0004, as it will trigger a recursive upgrade of OpenSSL
+    # to version 3.x.
+    #
+    # NB: Upgrading openssl the version >= 0.10.70 do fix the issue but it
+    # also upgrade the OpenSSL to v3.x which causes performance degradation.
+    # See https://github.com/openssl/openssl/issues/17064
+    "RUSTSEC-2025-0004",
 ]
 
 # TiKV is licensed under Apache 2.0, according to ASF 3RD PARTY LICENSE POLICY,


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close https://github.com/tikv/tikv/issues/18179

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Ignore the deny "RUSTSEC-2025-0004", as it will introduce recursive upgrading to
OpenSSL to v3.x from v1.x, causing performance regressions.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None.
```
