### PR TITLE
Support `timestampdiff` expression function

### DIFF
--- a/components/tidb_query_datatype/src/codec/mysql/time/interval.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/time/interval.rs
@@ -67,6 +67,21 @@ impl IntervalUnit {
         }
     }
 
+    pub fn is_valid_for_timestamp(&self) -> bool {
+        matches!(
+            self,
+            IntervalUnit::Microsecond
+                | IntervalUnit::Second
+                | IntervalUnit::Minute
+                | IntervalUnit::Hour
+                | IntervalUnit::Day
+                | IntervalUnit::Week
+                | IntervalUnit::Month
+                | IntervalUnit::Quarter
+                | IntervalUnit::Year
+        )
+    }
+
     pub fn is_clock_unit(&self) -> bool {
         use IntervalUnit::*;
         matches!(

--- a/components/tidb_query_datatype/src/codec/mysql/time/mod.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/time/mod.rs
@@ -3823,7 +3823,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_daynr() -> Result<()> {
+    fn test_get_daynr() {
         let test_cases = [
             (0, 0, 0, 0),
             (0, 1, 1, 1),
@@ -3839,6 +3839,137 @@ mod tests {
             let result = Time::get_daynr(year, month, day);
             assert_eq!(result, expected);
         }
-        Ok(())
+    }
+
+    #[test]
+    fn test_timestamp_diff() {
+        let test_cases = vec![
+            (
+                "2025-02-05 12:00:00",
+                "2025-02-05 12:00:00",
+                IntervalUnit::Microsecond,
+                0,
+            ),
+            (
+                "2025-02-05 12:00:00",
+                "2025-02-05 12:00:00.000001",
+                IntervalUnit::Microsecond,
+                1,
+            ),
+            (
+                "2025-02-05 12:00:00",
+                "2025-02-05 12:00:10",
+                IntervalUnit::Second,
+                10,
+            ),
+            (
+                "2025-02-05 12:00:00",
+                "2025-02-05 12:10:00",
+                IntervalUnit::Minute,
+                10,
+            ),
+            (
+                "2025-02-05 12:00:00",
+                "2025-02-05 14:00:00",
+                IntervalUnit::Hour,
+                2,
+            ),
+            (
+                "2025-02-05 12:00:00",
+                "2025-02-07 12:00:00",
+                IntervalUnit::Day,
+                2,
+            ),
+            (
+                "2025-02-05 12:00:00",
+                "2025-03-05 12:00:00",
+                IntervalUnit::Month,
+                1,
+            ),
+            (
+                "2025-02-05 12:00:00",
+                "2025-08-05 12:00:00",
+                IntervalUnit::Quarter,
+                2,
+            ),
+            (
+                "2025-02-05 12:00:00",
+                "2027-02-05 12:00:00",
+                IntervalUnit::Year,
+                2,
+            ),
+            (
+                "2024-02-29 12:00:00",
+                "2025-02-28 12:00:00",
+                IntervalUnit::Year,
+                0,
+            ),
+            (
+                "2024-12-31 23:59:59",
+                "2025-01-01 00:00:00",
+                IntervalUnit::Second,
+                1,
+            ),
+            (
+                "2024-03-31 23:59:59",
+                "2024-04-01 00:00:00",
+                IntervalUnit::Second,
+                1,
+            ),
+            (
+                "2024-02-28 12:00:00",
+                "2024-02-29 12:00:00",
+                IntervalUnit::Day,
+                1,
+            ),
+            (
+                "2024-02-28 12:00:00",
+                "2024-03-01 12:00:00",
+                IntervalUnit::Day,
+                2,
+            ),
+            (
+                "2025-02-05 12:00:00",
+                "2028-02-05 12:00:00",
+                IntervalUnit::Year,
+                3,
+            ),
+            (
+                "2025-02-05 12:00:00",
+                "2025-12-05 12:00:00",
+                IntervalUnit::Month,
+                10,
+            ),
+            (
+                "2025-02-05 12:00:00",
+                "2025-02-19 12:00:00",
+                IntervalUnit::Week,
+                2,
+            ),
+            (
+                "2025-02-05 12:00:00",
+                "2025-02-05 16:00:00",
+                IntervalUnit::Hour,
+                4,
+            ),
+            (
+                "2025-02-05 12:00:00",
+                "2025-02-06 00:00:00",
+                IntervalUnit::Hour,
+                12,
+            ),
+        ];
+
+        let mut ctx = EvalContext::default();
+        for (start, end, unit, expected) in test_cases {
+            let start_dt = Time::parse_timestamp(&mut ctx, start, MAX_FSP, false).unwrap();
+            let end_dt = Time::parse_timestamp(&mut ctx, end, MAX_FSP, false).unwrap();
+            let result = start_dt.timestamp_diff(&end_dt, unit).unwrap();
+            assert_eq!(
+                result, expected,
+                "Failed for {} -> {} in {:?}",
+                start, end, unit
+            );
+        }
     }
 }

--- a/components/tidb_query_expr/src/impl_time.rs
+++ b/components/tidb_query_expr/src/impl_time.rs
@@ -1621,6 +1621,7 @@ fn build_timestamp_diff_meta(expr: &mut Expr) -> Result<IntervalUnit> {
     Ok(unit)
 }
 
+/// See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_timestampdiff
 #[rpn_fn(capture = [ctx, metadata], metadata_mapper = build_timestamp_diff_meta)]
 #[inline]
 pub fn timestamp_diff(
@@ -4045,6 +4046,168 @@ mod tests {
 
             let expected = expected.map(|str| str.as_bytes().to_vec());
             assert_eq!(output, expected);
+        }
+    }
+
+    #[test]
+    fn test_timestamp_diff() {
+        let test_cases = vec![
+            (
+                Some("2025-02-05 12:00:00"),
+                Some("2025-02-05 12:00:00"),
+                "MicroseCond",
+                Some(0),
+            ),
+            (
+                Some("2025-02-05 12:00:00"),
+                Some("2025-02-05 12:00:00.000001"),
+                "microsecond",
+                Some(1),
+            ),
+            (
+                Some("2025-02-05 12:00:00"),
+                Some("2025-02-05 12:00:10"),
+                "Second",
+                Some(10),
+            ),
+            (
+                Some("2025-02-05 12:00:00"),
+                Some("2025-02-05 12:10:00"),
+                "Minute",
+                Some(10),
+            ),
+            (
+                Some("2025-02-05 12:00:00"),
+                Some("2025-02-05 14:00:00"),
+                "Hour",
+                Some(2),
+            ),
+            (
+                Some("2025-02-05 12:00:00"),
+                Some("2025-02-07 12:00:00"),
+                "Day",
+                Some(2),
+            ),
+            (
+                Some("2025-02-05 12:00:00"),
+                Some("2025-03-05 12:00:00"),
+                "Month",
+                Some(1),
+            ),
+            (
+                Some("2025-02-05 12:00:00"),
+                Some("2025-08-05 12:00:00"),
+                "Quarter",
+                Some(2),
+            ),
+            (
+                Some("2025-02-05 12:00:00"),
+                Some("2027-02-05 12:00:00"),
+                "Year",
+                Some(2),
+            ),
+            (
+                Some("2024-02-29 12:00:00"),
+                Some("2025-02-28 12:00:00"),
+                "Year",
+                Some(0),
+            ),
+            (
+                Some("2024-12-31 23:59:59"),
+                Some("2025-01-01 00:00:00"),
+                "Second",
+                Some(1),
+            ),
+            (
+                Some("2024-03-31 23:59:59"),
+                Some("2024-04-01 00:00:00"),
+                "Second",
+                Some(1),
+            ),
+            (
+                Some("2024-02-28 12:00:00"),
+                Some("2024-02-29 12:00:00"),
+                "Day",
+                Some(1),
+            ),
+            (
+                Some("2024-02-28 12:00:00"),
+                Some("2024-03-01 12:00:00"),
+                "DAY",
+                Some(2),
+            ),
+            (
+                Some("2025-02-05 12:00:00"),
+                Some("2028-02-05 12:00:00"),
+                "Year",
+                Some(3),
+            ),
+            (
+                Some("2025-02-05 12:00:00"),
+                Some("2025-12-05 12:00:00"),
+                "Month",
+                Some(10),
+            ),
+            (
+                Some("2025-02-05 12:00:00"),
+                Some("2025-02-19 12:00:00"),
+                "Week",
+                Some(2),
+            ),
+            (
+                Some("2025-02-05 12:00:00"),
+                Some("2025-02-05 16:00:00"),
+                "hour",
+                Some(4),
+            ),
+            (
+                Some("2025-02-05 12:00:00"),
+                Some("2025-02-06 00:00:00"),
+                "HOUR",
+                Some(12),
+            ),
+            (None, Some("2025-02-06 00:00:00"), "DAY", None),
+            (Some("2025-02-06 00:00:00"), None, "YEAR", None),
+            (None, None, "MONTH", None),
+        ];
+        let mut ctx = EvalContext::default();
+        for (t1, t2, unit, expected) in test_cases {
+            let mut builder =
+                ExprDefBuilder::scalar_func(ScalarFuncSig::TimestampDiff, FieldTypeTp::LongLong);
+            builder = builder.push_child(ExprDefBuilder::constant_bytes(unit.as_bytes().to_vec()));
+            if let Some(t) = t1 {
+                let time = DateTime::parse_timestamp(&mut ctx, t, MAX_FSP, true).unwrap();
+                builder = builder.push_child(ExprDefBuilder::constant_time(
+                    time.to_packed_u64(&mut ctx).unwrap(),
+                    TimeType::Timestamp,
+                ));
+            } else {
+                builder = builder.push_child(ExprDefBuilder::constant_null(FieldTypeTp::DateTime));
+            }
+            if let Some(t) = t2 {
+                let time = DateTime::parse_timestamp(&mut ctx, t, MAX_FSP, true).unwrap();
+                builder = builder.push_child(ExprDefBuilder::constant_time(
+                    time.to_packed_u64(&mut ctx).unwrap(),
+                    TimeType::Timestamp,
+                ));
+            } else {
+                builder = builder.push_child(ExprDefBuilder::constant_null(FieldTypeTp::DateTime));
+            }
+            let node = builder.build();
+            let exp = RpnExpressionBuilder::build_from_expr_tree(node, &mut ctx, 1).unwrap();
+
+            let schema = &[];
+            let mut columns = LazyBatchColumnVec::empty();
+            let val = exp.eval(&mut ctx, schema, &mut columns, &[0], 1).unwrap();
+
+            assert!(val.is_vector());
+            let value = val.vector_value().unwrap().as_ref().to_int_vec();
+            assert_eq!(value.len(), 1);
+            assert_eq!(
+                value[0], expected,
+                "expected {:?}, got {:?}",
+                expected, value[0]
+            );
         }
     }
 }

--- a/components/tidb_query_expr/src/lib.rs
+++ b/components/tidb_query_expr/src/lib.rs
@@ -933,6 +933,7 @@ fn map_expr_node_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
         ScalarFuncSig::SubDateDurationDecimalDatetime => sub_date_time_duration_interval_any_as_datetime_fn_meta::<Decimal>(),
         ScalarFuncSig::FromUnixTime1Arg => from_unixtime_1_arg_fn_meta(),
         ScalarFuncSig::FromUnixTime2Arg => from_unixtime_2_arg_fn_meta(),
+        ScalarFuncSig::TimestampDiff => timestamp_diff_fn_meta(),
         _ => return Err(other_err!(
             "ScalarFunction {:?} is not supported in batch mode",
             value


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close https://github.com/tikv/tikv/issues/18184

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Support `timestampdiff` expression function
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Support `timestampdiff` expression function
```
