### PR TITLE
importer: add memory limit for importers to avoid OOM

### DIFF
--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -97,7 +97,7 @@ const SUSPEND_REQUEST_MAX_SECS: u64 = // 6h
 fn check_import_resources() -> Result<()> {
     // Check disk space first
     if get_disk_status(0) != DiskUsage::Normal {
-        return Err(Error::ResourceNotEnough("Disk space not enough".to_owned()).into());
+        return Err(Error::DiskSpaceNotEnough.into());
     }
 
     // Check memory usage

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -39,7 +39,10 @@ use tikv_util::{
     config::ReadableSize,
     future::{create_stream_with_buffer, paired_future_callback},
     resizable_threadpool::{DeamonRuntimeHandle, ResizableRuntime},
-    sys::disk::{get_disk_status, DiskUsage},
+    sys::{
+        disk::{get_disk_status, DiskUsage},
+        memory_usage_reaches_high_water,
+    },
     time::{Instant, Limiter},
     HandyRwLock,
 };
@@ -89,6 +92,23 @@ const WRITER_GC_INTERVAL: Duration = Duration::from_secs(300);
 /// This may save us from some client sending insane value to the server.
 const SUSPEND_REQUEST_MAX_SECS: u64 = // 6h
     6 * 60 * 60;
+
+/// Check if the system has enough resources for import tasks
+fn check_import_resources() -> Result<()> {
+    // Check disk space first
+    if get_disk_status(0) != DiskUsage::Normal {
+        return Err(Error::ResourceNotEnough("Disk space not enough".to_owned()).into());
+    }
+
+    // Check memory usage
+    // high water is 90% of the memory limit by default
+    let mut usage = 0;
+    if memory_usage_reaches_high_water(&mut usage) {
+        return Err(Error::ResourceNotEnough("Memory usage too high".to_owned()).into());
+    }
+
+    Ok(())
+}
 
 fn transfer_error(err: storage::Error) -> ImportPbError {
     let mut e = ImportPbError::default();
@@ -621,9 +641,11 @@ macro_rules! impl_write {
                         .try_fold(
                             (writer, resource_limiter),
                             |(mut writer, limiter), req| async move {
-                                if get_disk_status(0) != DiskUsage::Normal {
-                                    warn!("Upload failed due to not enough disk space");
-                                    return Err(Error::DiskSpaceNotEnough);
+                                match check_import_resources() {
+                                    Ok(()) => (),
+                                    Err(e) => {
+                                        return Err(e);
+                                    }
                                 }
 
                                 let batch = match req.chunk {
@@ -772,9 +794,12 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
                 let file = import.create(meta)?;
                 let mut file = rx
                     .try_fold(file, |mut file, chunk| async move {
-                        if get_disk_status(0) != DiskUsage::Normal {
-                            warn!("Upload failed due to not enough disk space");
-                            return Err(Error::DiskSpaceNotEnough);
+                        match check_import_resources() {
+                            Ok(()) => (),
+                            Err(e) => {
+                                warn!("Upload failed due to not enough disk space");
+                                return Err(e);
+                            }
                         }
 
                         let start = Instant::now_coarse();
@@ -850,9 +875,12 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
                 .observe(start.saturating_elapsed().as_secs_f64());
 
             let mut resp = ApplyResponse::default();
-            if get_disk_status(0) != DiskUsage::Normal {
-                resp.set_error(Error::DiskSpaceNotEnough.into());
-                return send_rpc_response!(Ok(resp), sink, label, start);
+            match check_import_resources() {
+                Ok(()) => (),
+                Err(e) => {
+                    resp.set_error(e.into());
+                    return crate::send_rpc_response!(Ok(resp), sink, label, start);
+                }
             }
 
             match Self::do_apply(req, importer, applier, limiter, max_raft_size).await {
@@ -897,10 +925,14 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
             sst_importer::metrics::IMPORTER_DOWNLOAD_DURATION
                 .with_label_values(&["queue"])
                 .observe(start.saturating_elapsed().as_secs_f64());
-            if get_disk_status(0) != DiskUsage::Normal {
-                let mut resp = DownloadResponse::default();
-                resp.set_error(Error::DiskSpaceNotEnough.into());
-                return crate::send_rpc_response!(Ok(resp), sink, label, timer);
+
+            let mut resp = DownloadResponse::default();
+            match check_import_resources() {
+                Ok(()) => (),
+                Err(e) => {
+                    resp.set_error(e.into());
+                    return crate::send_rpc_response!(Ok(resp), sink, label, timer);
+                }
             }
 
             // FIXME: download() should be an async fn, to allow BR to cancel

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -97,14 +97,14 @@ const SUSPEND_REQUEST_MAX_SECS: u64 = // 6h
 fn check_import_resources() -> Result<()> {
     // Check disk space first
     if get_disk_status(0) != DiskUsage::Normal {
-        return Err(Error::DiskSpaceNotEnough.into());
+        return Err(Error::DiskSpaceNotEnough);
     }
 
     // Check memory usage
     // high water is 90% of the memory limit by default
     let mut usage = 0;
     if memory_usage_reaches_high_water(&mut usage) {
-        return Err(Error::ResourceNotEnough("Memory usage too high".to_owned()).into());
+        return Err(Error::ResourceNotEnough("Memory usage too high".to_owned()));
     }
 
     Ok(())

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -104,7 +104,10 @@ fn check_import_resources() -> Result<()> {
     // high water is 90% of the memory limit by default
     let mut usage = 0;
     if memory_usage_reaches_high_water(&mut usage) {
-        return Err(Error::ResourceNotEnough("Memory usage too high".to_owned()));
+        return Err(Error::ResourceNotEnough(format!(
+            "Memory usage too high: {} bytes",
+            usage
+        )));
     }
 
     Ok(())
@@ -791,7 +794,7 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
                         match check_import_resources() {
                             Ok(()) => (),
                             Err(e) => {
-                                warn!("Upload failed due to not enough disk space");
+                                warn!("Upload failed due to not enough resource {:?}", e);
                                 return Err(e);
                             }
                         }

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -641,13 +641,7 @@ macro_rules! impl_write {
                         .try_fold(
                             (writer, resource_limiter),
                             |(mut writer, limiter), req| async move {
-                                match check_import_resources() {
-                                    Ok(()) => (),
-                                    Err(e) => {
-                                        return Err(e);
-                                    }
-                                }
-
+                                check_import_resources()?;
                                 let batch = match req.chunk {
                                     Some($chunk_ty::Batch(b)) => b,
                                     _ => return Err(Error::InvalidChunk),

--- a/tests/failpoints/cases/test_import_service.rs
+++ b/tests/failpoints/cases/test_import_service.rs
@@ -68,7 +68,7 @@ fn test_download_sst_blocking_sst_writer() {
 }
 
 #[test]
-fn test_download_to_full_disk() {
+fn test_download_to_full_resource() {
     let (_cluster, ctx, _tikv, import) = new_cluster_and_tikv_import_client();
     let temp_dir = Builder::new()
         .prefix("test_download_sst_blocking_sst_writer")
@@ -102,6 +102,14 @@ fn test_download_to_full_disk() {
         "TiKV disk space is not enough."
     );
     disk::set_disk_status(DiskUsage::Normal);
+
+    // high memory usage
+    fail::cfg("memory_usage_reaches_high_water", "return").unwrap();
+    let result = import.download(&download).unwrap();
+    assert!(!result.get_is_empty());
+    assert!(result.has_error());
+    assert_eq!(result.get_error().get_message(), "Memory usage too high");
+    fail::remove("memory_usage_reaches_high_water");
 }
 
 #[test]

--- a/tests/failpoints/cases/test_import_service.rs
+++ b/tests/failpoints/cases/test_import_service.rs
@@ -108,9 +108,11 @@ fn test_download_to_full_resource() {
     let result = import.download(&download).unwrap();
     assert!(!result.get_is_empty());
     assert!(result.has_error());
-    assert_eq!(
-        result.get_error().get_message(),
-        "resource is not enough Memory usage too high"
+    assert!(
+        result
+            .get_error()
+            .get_message()
+            .contains("Memory usage too high")
     );
     fail::remove("memory_usage_reaches_high_water");
 }

--- a/tests/failpoints/cases/test_import_service.rs
+++ b/tests/failpoints/cases/test_import_service.rs
@@ -108,7 +108,7 @@ fn test_download_to_full_resource() {
     let result = import.download(&download).unwrap();
     assert!(!result.get_is_empty());
     assert!(result.has_error());
-    assert_eq!(result.get_error().get_message(), "Memory usage too high");
+    assert_eq!(result.get_error().get_message(), "resource is not enough Memory usage too high");
     fail::remove("memory_usage_reaches_high_water");
 }
 

--- a/tests/failpoints/cases/test_import_service.rs
+++ b/tests/failpoints/cases/test_import_service.rs
@@ -108,7 +108,10 @@ fn test_download_to_full_resource() {
     let result = import.download(&download).unwrap();
     assert!(!result.get_is_empty());
     assert!(result.has_error());
-    assert_eq!(result.get_error().get_message(), "resource is not enough Memory usage too high");
+    assert_eq!(
+        result.get_error().get_message(),
+        "resource is not enough Memory usage too high"
+    );
     fail::remove("memory_usage_reaches_high_water");
 }
 

--- a/tests/integrations/import/test_apply_log.rs
+++ b/tests/integrations/import/test_apply_log.rs
@@ -33,7 +33,7 @@ fn test_basic_apply() {
 }
 
 #[test]
-fn test_apply_full_disk() {
+fn test_apply_full_resource() {
     let (_cluster, ctx, _tikv, import) = new_cluster_and_tikv_import_client();
     let tmp = TempDir::new().unwrap();
     let storage = LocalStorage::new(tmp.path()).unwrap();
@@ -58,6 +58,12 @@ fn test_apply_full_disk() {
         "TiKV disk space is not enough."
     );
     disk::set_disk_status(DiskUsage::Normal);
+
+    fail::cfg("memory_usage_reaches_high_water", "return").unwrap();
+    let result = import.apply(&req).unwrap();
+    assert!(result.has_error());
+    assert_eq!(result.get_error().get_message(), "Memory usage too high");
+    fail::remove("memory_usage_reaches_high_water");
 }
 
 #[test]

--- a/tests/integrations/import/test_apply_log.rs
+++ b/tests/integrations/import/test_apply_log.rs
@@ -62,7 +62,7 @@ fn test_apply_full_resource() {
     fail::cfg("memory_usage_reaches_high_water", "return").unwrap();
     let result = import.apply(&req).unwrap();
     assert!(result.has_error());
-    assert_eq!(result.get_error().get_message(), "Memory usage too high");
+    assert_eq!(result.get_error().get_message(), "resource is not enough Memory usage too high");
     fail::remove("memory_usage_reaches_high_water");
 }
 

--- a/tests/integrations/import/test_apply_log.rs
+++ b/tests/integrations/import/test_apply_log.rs
@@ -62,9 +62,11 @@ fn test_apply_full_resource() {
     fail::cfg("memory_usage_reaches_high_water", "return").unwrap();
     let result = import.apply(&req).unwrap();
     assert!(result.has_error());
-    assert_eq!(
-        result.get_error().get_message(),
-        "resource is not enough Memory usage too high"
+    assert!(
+        result
+            .get_error()
+            .get_message()
+            .contains("Memory usage too high")
     );
     fail::remove("memory_usage_reaches_high_water");
 }

--- a/tests/integrations/import/test_apply_log.rs
+++ b/tests/integrations/import/test_apply_log.rs
@@ -62,7 +62,10 @@ fn test_apply_full_resource() {
     fail::cfg("memory_usage_reaches_high_water", "return").unwrap();
     let result = import.apply(&req).unwrap();
     assert!(result.has_error());
-    assert_eq!(result.get_error().get_message(), "resource is not enough Memory usage too high");
+    assert_eq!(
+        result.get_error().get_message(),
+        "resource is not enough Memory usage too high"
+    );
     fail::remove("memory_usage_reaches_high_water");
 }
 

--- a/tests/integrations/import/test_sst_service.rs
+++ b/tests/integrations/import/test_sst_service.rs
@@ -338,9 +338,6 @@ fn test_download_sst() {
         .mut_sst()
         .mut_range()
         .set_end(vec![sst_range.1 + 1]);
-
-    // let result = import.download(&download).unwrap();
-
     let result = import.download(&download).unwrap();
     assert!(result.get_is_empty());
 

--- a/tests/integrations/import/test_sst_service.rs
+++ b/tests/integrations/import/test_sst_service.rs
@@ -47,6 +47,14 @@ fn test_upload_sst() {
     );
     set_disk_status(DiskUsage::Normal);
 
+    // high memory usage
+    fail::cfg("memory_usage_reaches_high_water", "return").unwrap();
+    assert_to_string_contains!(
+        send_upload_sst(&import, &meta, &data).unwrap_err(),
+        "Memory usage too high"
+    );
+    fail::remove("memory_usage_reaches_high_water");
+
     let mut meta = new_sst_meta(crc32, length);
     meta.set_region_id(ctx.get_region_id());
     meta.set_region_epoch(ctx.get_region_epoch().clone());
@@ -97,11 +105,16 @@ fn test_write_sst() {
 }
 
 #[test]
-fn test_write_sst_when_disk_full() {
+fn test_write_sst_when_resource_full() {
     set_disk_status(DiskUsage::AlmostFull);
     let (_cluster, ctx, tikv, import) = new_cluster_and_tikv_import_client();
     run_test_write_sst(ctx, tikv, import, "DiskSpaceNotEnough");
     set_disk_status(DiskUsage::Normal);
+
+    fail::cfg("memory_usage_reaches_high_water", "return").unwrap();
+    let (_cluster, ctx, tikv, import) = new_cluster_and_tikv_import_client();
+    run_test_write_sst(ctx, tikv, import, "Memory usage too high");
+    fail::remove("memory_usage_reaches_high_water");
 }
 
 #[test]
@@ -325,6 +338,9 @@ fn test_download_sst() {
         .mut_sst()
         .mut_range()
         .set_end(vec![sst_range.1 + 1]);
+
+    // let result = import.download(&download).unwrap();
+
     let result = import.download(&download).unwrap();
     assert!(result.get_is_empty());
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref https://github.com/tikv/tikv/issues/18124
<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:
To prevent TiKV OOM during imports, this PR introduces a memory usage detection mechanism with a limiter. If a TiKV node reaches 90% memory usage, it will reject further import requests to ensure stability.

```commit-message
Add memory limit for importers to prevent OOM in TiKV
```

### Related changes

- [x] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [x] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Add memory limit for importers to prevent OOM in TiKV
```
