### PR TITLE
txn: optimize the performance of schedulers by read cursor

### DIFF
--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -58,18 +58,6 @@ impl<S: EngineSnapshot> SnapshotReader<S> {
         }
     }
 
-    pub fn new_scan_mode_with_ctx(
-        start_ts: TimeStamp,
-        snapshot: S,
-        scan_mode: ScanMode,
-        ctx: &Context,
-    ) -> Self {
-        SnapshotReader {
-            reader: MvccReader::new_with_ctx(snapshot, Some(scan_mode), ctx),
-            start_ts,
-        }
-    }
-
     #[inline(always)]
     pub fn get_txn_commit_record(&mut self, key: &Key) -> Result<TxnCommitRecord> {
         self.reader.get_txn_commit_record(key, self.start_ts)
@@ -133,6 +121,16 @@ impl<S: EngineSnapshot> SnapshotReader<S> {
     #[inline(always)]
     pub fn take_statistics(&mut self) -> Statistics {
         std::mem::take(&mut self.reader.statistics)
+    }
+
+    #[inline(always)]
+    pub fn set_scan_mode(&mut self, scan_mode: ScanMode) {
+        self.reader.scan_mode = Some(scan_mode);
+    }
+
+    #[inline(always)]
+    pub fn set_lower_bound(&mut self, lower: Key) {
+        self.reader.set_range(Some(lower), None);
     }
 }
 

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -58,6 +58,18 @@ impl<S: EngineSnapshot> SnapshotReader<S> {
         }
     }
 
+    pub fn new_scan_mode_with_ctx(
+        start_ts: TimeStamp,
+        snapshot: S,
+        scan_mode: ScanMode,
+        ctx: &Context,
+    ) -> Self {
+        SnapshotReader {
+            reader: MvccReader::new_with_ctx(snapshot, Some(scan_mode), ctx),
+            start_ts,
+        }
+    }
+
     #[inline(always)]
     pub fn get_txn_commit_record(&mut self, key: &Key) -> Result<TxnCommitRecord> {
         self.reader.get_txn_commit_record(key, self.start_ts)

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -124,7 +124,7 @@ impl<S: EngineSnapshot> SnapshotReader<S> {
     }
 
     #[inline(always)]
-    pub fn setup_with_hint_items<T>(&mut self, items: &mut Vec<T>, key_of: fn(&T) -> &Key) {
+    pub fn setup_with_hint_items<T>(&mut self, items: &mut [T], key_of: fn(&T) -> &Key) {
         // enable scan mode if there are multiple items, so that we don't need to seek
         // for every key.
         if items.len() > 1 {

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -125,7 +125,8 @@ impl<S: EngineSnapshot> SnapshotReader<S> {
 
     #[inline(always)]
     pub fn setup_with_hint_items<T>(&mut self, items: &mut Vec<T>, key_of: fn(&T) -> &Key) {
-        // enable scan mode if there are multiple items, so that we don't need to seek for every key.
+        // enable scan mode if there are multiple items, so that we don't need to seek
+        // for every key.
         if items.len() > 1 {
             items.sort_by(|a, b| key_of(a).cmp(key_of(b)));
             self.reader.scan_mode = Some(ScanMode::Forward);

--- a/src/storage/txn/commands/acquire_pessimistic_lock.rs
+++ b/src/storage/txn/commands/acquire_pessimistic_lock.rs
@@ -2,7 +2,7 @@
 
 // #[PerformanceCriticalPath]
 use kvproto::kvrpcpb::ExtraOp;
-use tikv_kv::{Modify, ScanMode};
+use tikv_kv::Modify;
 use txn_types::{insert_old_value_if_resolved, Key, OldValues, TimeStamp, TxnExtra};
 
 use crate::storage::{
@@ -90,11 +90,7 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for AcquirePessimisticLock 
         let mut txn = MvccTxn::new(start_ts, context.concurrency_manager);
 
         let mut snapshot_reader = SnapshotReader::new_with_ctx(start_ts, snapshot, &ctx);
-        if keys.len() > 1 {
-            keys.sort();
-            snapshot_reader.set_scan_mode(ScanMode::Forward);
-            snapshot_reader.set_lower_bound(keys.first().unwrap().0.clone());
-        }
+        snapshot_reader.setup_with_hint_items(&mut keys, |k| &k.0);
         let mut reader = ReaderWithStats::new(snapshot_reader, context.statistics);
 
         let total_keys = keys.len();

--- a/src/storage/txn/commands/acquire_pessimistic_lock.rs
+++ b/src/storage/txn/commands/acquire_pessimistic_lock.rs
@@ -2,7 +2,7 @@
 
 // #[PerformanceCriticalPath]
 use kvproto::kvrpcpb::ExtraOp;
-use tikv_kv::Modify;
+use tikv_kv::{Modify, ScanMode};
 use txn_types::{insert_old_value_if_resolved, Key, OldValues, TimeStamp, TxnExtra};
 
 use crate::storage::{
@@ -86,12 +86,16 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for AcquirePessimisticLock 
             ))));
         }
 
-        let (start_ts, ctx, keys) = (self.start_ts, self.ctx, self.keys);
+        let (start_ts, ctx, mut keys) = (self.start_ts, self.ctx, self.keys);
         let mut txn = MvccTxn::new(start_ts, context.concurrency_manager);
-        let mut reader = ReaderWithStats::new(
-            SnapshotReader::new_with_ctx(start_ts, snapshot, &ctx),
-            context.statistics,
-        );
+
+        let mut snapshot_reader = SnapshotReader::new_with_ctx(start_ts, snapshot, &ctx);
+        if keys.len() > 1 {
+            keys.sort();
+            snapshot_reader.set_scan_mode(ScanMode::Forward);
+            snapshot_reader.set_lower_bound(keys.first().unwrap().0.clone());
+        }
+        let mut reader = ReaderWithStats::new(snapshot_reader, context.statistics);
 
         let total_keys = keys.len();
         let mut res = PessimisticLockResults::with_capacity(total_keys);

--- a/src/storage/txn/commands/check_secondary_locks.rs
+++ b/src/storage/txn/commands/check_secondary_locks.rs
@@ -1,5 +1,6 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
+use tikv_kv::ScanMode;
 // #[PerformanceCriticalPath]
 use txn_types::{Key, Lock, WriteType};
 
@@ -141,7 +142,7 @@ fn check_status_from_lock<S: Snapshot>(
 }
 
 impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for CheckSecondaryLocks {
-    fn process_write(self, snapshot: S, context: WriteContext<'_, L>) -> Result<WriteResult> {
+    fn process_write(mut self, snapshot: S, context: WriteContext<'_, L>) -> Result<WriteResult> {
         // It is not allowed for commit to overwrite a protected rollback. So we update
         // max_ts to prevent this case from happening.
         let region_id = self.ctx.get_region_id();
@@ -152,10 +153,14 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for CheckSecondaryLocks {
             })?;
 
         let mut txn = MvccTxn::new(self.start_ts, context.concurrency_manager);
-        let mut reader = ReaderWithStats::new(
-            SnapshotReader::new_with_ctx(self.start_ts, snapshot, &self.ctx),
-            context.statistics,
-        );
+
+        let mut snapshot_reader = SnapshotReader::new_with_ctx(self.start_ts, snapshot, &self.ctx);
+        if self.keys.len() > 1 {
+            self.keys.sort();
+            snapshot_reader.set_scan_mode(ScanMode::Forward);
+            snapshot_reader.set_lower_bound(self.keys.first().unwrap().clone());
+        }
+        let mut reader = ReaderWithStats::new(snapshot_reader, context.statistics);
         let mut released_locks = ReleasedLocks::new();
         let mut result = SecondaryLocksStatus::Locked(Vec::new());
 

--- a/src/storage/txn/commands/check_secondary_locks.rs
+++ b/src/storage/txn/commands/check_secondary_locks.rs
@@ -1,7 +1,6 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
 // #[PerformanceCriticalPath]
-use tikv_kv::ScanMode;
 use txn_types::{Key, Lock, WriteType};
 
 use crate::storage::{
@@ -155,11 +154,7 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for CheckSecondaryLocks {
         let mut txn = MvccTxn::new(self.start_ts, context.concurrency_manager);
 
         let mut snapshot_reader = SnapshotReader::new_with_ctx(self.start_ts, snapshot, &self.ctx);
-        if self.keys.len() > 1 {
-            self.keys.sort();
-            snapshot_reader.set_scan_mode(ScanMode::Forward);
-            snapshot_reader.set_lower_bound(self.keys.first().unwrap().clone());
-        }
+        snapshot_reader.setup_with_hint_items(&mut self.keys, |k| k);
         let mut reader = ReaderWithStats::new(snapshot_reader, context.statistics);
         let mut released_locks = ReleasedLocks::new();
         let mut result = SecondaryLocksStatus::Locked(Vec::new());

--- a/src/storage/txn/commands/check_secondary_locks.rs
+++ b/src/storage/txn/commands/check_secondary_locks.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
-use tikv_kv::ScanMode;
 // #[PerformanceCriticalPath]
+use tikv_kv::ScanMode;
 use txn_types::{Key, Lock, WriteType};
 
 use crate::storage::{

--- a/src/storage/txn/commands/commit.rs
+++ b/src/storage/txn/commands/commit.rs
@@ -55,15 +55,28 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for Commit {
             }));
         }
         let mut txn = MvccTxn::new(self.lock_ts, context.concurrency_manager);
-        let mut reader = ReaderWithStats::new(
-            SnapshotReader::new_with_ctx(self.lock_ts, snapshot, &self.ctx),
-            context.statistics,
-        );
+        let mut keys = self.keys;
+        let snapshot_reader = if keys.len() <= 1 {
+            SnapshotReader::new_with_ctx(self.lock_ts, snapshot, &self.ctx)
+        } else {
+            let mut snapshot_reader = SnapshotReader::new_scan_mode_with_ctx(
+                self.lock_ts,
+                snapshot,
+                tikv_kv::ScanMode::Forward,
+                &self.ctx,
+            );
+            keys.sort();
+            snapshot_reader
+                .reader
+                .set_range(keys.first().cloned(), None);
+            snapshot_reader
+        };
+        let mut reader = ReaderWithStats::new(snapshot_reader, context.statistics);
 
-        let rows = self.keys.len();
+        let rows = keys.len();
         // Pessimistic txn needs key_hashes to wake up waiters
         let mut released_locks = ReleasedLocks::new();
-        for k in self.keys {
+        for k in keys {
             released_locks.push(commit(&mut txn, &mut reader, k, self.commit_ts)?);
         }
 

--- a/src/storage/txn/commands/commit.rs
+++ b/src/storage/txn/commands/commit.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
-use tikv_kv::ScanMode;
 // #[PerformanceCriticalPath]
+use tikv_kv::ScanMode;
 use txn_types::Key;
 
 use crate::storage::{

--- a/src/storage/txn/commands/commit.rs
+++ b/src/storage/txn/commands/commit.rs
@@ -59,13 +59,13 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for Commit {
         let snapshot_reader = if keys.len() <= 1 {
             SnapshotReader::new_with_ctx(self.lock_ts, snapshot, &self.ctx)
         } else {
+            keys.sort();
             let mut snapshot_reader = SnapshotReader::new_scan_mode_with_ctx(
                 self.lock_ts,
                 snapshot,
                 tikv_kv::ScanMode::Forward,
                 &self.ctx,
             );
-            keys.sort();
             snapshot_reader
                 .reader
                 .set_range(keys.first().cloned(), None);

--- a/src/storage/txn/commands/flush.rs
+++ b/src/storage/txn/commands/flush.rs
@@ -2,9 +2,9 @@
 
 use std::mem;
 
+// #[PerformanceCriticalPath]
 use kvproto::kvrpcpb::{AssertionLevel, ExtraOp, PrewriteRequestPessimisticAction};
 use tikv_kv::ScanMode;
-// #[PerformanceCriticalPath]
 use txn_types::{insert_old_value_if_resolved, Mutation, OldValues, TimeStamp, TxnExtra};
 
 use crate::storage::{

--- a/src/storage/txn/commands/prewrite.rs
+++ b/src/storage/txn/commands/prewrite.rs
@@ -1220,7 +1220,7 @@ mod tests {
         .unwrap();
         let d = perf.delta();
         assert_eq!(1, statistic.write.seek);
-        assert_eq!(d.internal_delete_skipped_count, 0);
+        assert_eq!(d.internal_delete_skipped_count, 40);
     }
 
     #[test]

--- a/src/storage/txn/commands/prewrite.rs
+++ b/src/storage/txn/commands/prewrite.rs
@@ -13,7 +13,7 @@ use kvproto::kvrpcpb::{
     AssertionLevel, ExtraOp, PrewriteRequestForUpdateTsConstraint,
     PrewriteRequestPessimisticAction::{self, *},
 };
-use tikv_kv::SnapshotExt;
+use tikv_kv::{ScanMode, SnapshotExt};
 use txn_types::{
     insert_old_value_if_resolved, Key, Mutation, OldValues, TimeStamp, TxnExtra, Write, WriteType,
 };
@@ -537,20 +537,12 @@ impl<K: PrewriteKind> Prewriter<K> {
         self.check_max_ts_synced(&snapshot)?;
 
         let mut txn = MvccTxn::new(self.start_ts, context.concurrency_manager);
-        let snapshot_reader = if self.mutations.len() <= 1 {
-            SnapshotReader::new_with_ctx(self.start_ts, snapshot, &self.ctx)
-        } else {
+        let mut snapshot_reader = SnapshotReader::new_with_ctx(self.start_ts, snapshot, &self.ctx);
+
+        if self.mutations.len() > 1 {
             self.mutations.sort_by(|a, b| a.key().cmp(b.key()));
-            let mut snapshot_reader = SnapshotReader::new_scan_mode_with_ctx(
-                self.start_ts,
-                snapshot,
-                tikv_kv::ScanMode::Forward,
-                &self.ctx,
-            );
-            snapshot_reader
-                .reader
-                .set_range(self.mutations.first().map(|m| m.key().clone()), None);
-            snapshot_reader
+            snapshot_reader.set_scan_mode(ScanMode::Forward);
+            snapshot_reader.set_lower_bound(self.mutations.first().unwrap().key().clone());
         };
         let mut reader = ReaderWithStats::new(snapshot_reader, context.statistics);
         // Set extra op here for getting the write record when check write conflict in

--- a/src/storage/txn/commands/resolve_lock.rs
+++ b/src/storage/txn/commands/resolve_lock.rs
@@ -84,9 +84,18 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for ResolveLock {
 
         let mut txn = MvccTxn::new(TimeStamp::zero(), context.concurrency_manager);
         let mut reader = ReaderWithStats::new(
-            SnapshotReader::new_with_ctx(TimeStamp::zero(), snapshot, &ctx),
+            SnapshotReader::new_scan_mode_with_ctx(
+                TimeStamp::zero(),
+                snapshot,
+                tikv_kv::ScanMode::Forward,
+                &ctx,
+            ),
             context.statistics,
         );
+        reader
+            .reader
+            .reader
+            .set_range(key_locks.first().map(|(k, _)| k.clone()), None);
 
         let mut scan_key = self.scan_key.take();
         let rows = key_locks.len();

--- a/src/storage/txn/commands/rollback.rs
+++ b/src/storage/txn/commands/rollback.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
-use tikv_kv::ScanMode;
 // #[PerformanceCriticalPath]
+use tikv_kv::ScanMode;
 use txn_types::{Key, TimeStamp};
 
 use crate::storage::{


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18208

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
When the write schedulers need to read multiple keys, it can be done using a cursor, which includes near-seek optimizations.
This PR leverages the cursor to minimize costly seek operations.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Pipelined DML which resolve 2e8 locks
- nightly: 43m31s

![image](https://github.com/user-attachments/assets/22edbfa6-9916-4323-95e7-9daf24b6cff7)

- this PR: 36m51s

![image](https://github.com/user-attachments/assets/a677e39e-83ba-46fd-adf5-7cc4452f484e)


Range non-index update on sysbench table (50 continous keys)

- nightly: 4494tps

- this PR: 5624tps

![CPU](https://github.com/user-attachments/assets/ba014cb5-024c-4d2d-8b80-4282446dfff3)

Scheduler prewrite

![Scheduler prewrite](https://github.com/user-attachments/assets/b1fadd7e-2e38-4d10-9b2a-dfb6f0c5e6ef)

Scheduler commit

![Scheduler commit](https://github.com/user-attachments/assets/3f968ed8-25b9-451d-86cd-52533ed52eb0)

Sysbench bulk insert, the bottleneck is not in the scheduler side, so the result is close. However, the CPU usage in scheduler pool is quite different.

- nightly: 279223tps
- this PR: 284872tps

![image](https://github.com/user-attachments/assets/740404ef-2b04-457c-8112-babae0d3bedb)

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Optimize the write performance by using read cursor in transaction scheduler.
```
