### PR TITLE
raftstore: clean up the disk_latency_inspector file at exit

### DIFF
--- a/components/raftstore/src/store/worker/disk_check.rs
+++ b/components/raftstore/src/store/worker/disk_check.rs
@@ -130,6 +130,14 @@ impl Runnable for Runner {
     }
 }
 
+impl Drop for Runner {
+    fn drop(&mut self) {
+        if let Err(e) = std::fs::remove_file(&self.target) {
+            warn!("remove disk latency inspection file failed"; "err" => ?e);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use tikv_util::worker::Builder;

--- a/components/raftstore/src/store/worker/disk_check.rs
+++ b/components/raftstore/src/store/worker/disk_check.rs
@@ -133,7 +133,7 @@ impl Runnable for Runner {
 impl Drop for Runner {
     fn drop(&mut self) {
         if let Err(e) = std::fs::remove_file(&self.target) {
-            warn!("remove disk latency inspection file failed"; "err" => ?e);
+            warn!("remove disk latency inspector file failed"; "err" => ?e);
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #17884

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Cleanup the useless stub file ".disk_latency_inspector.tmp" when the running is dropped.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
 - After this change, there won't be a obsolescent ".disk_latency_inspector.tmp" under tests directory after running integration tests.
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
