### PR TITLE
use default credential loader when there isn't user specified cred

### DIFF
--- a/components/cloud/azure/src/azblob.rs
+++ b/components/cloud/azure/src/azblob.rs
@@ -11,7 +11,10 @@ use azure_core::{
     auth::{TokenCredential, TokenResponse},
     new_http_client,
 };
-use azure_identity::{ClientSecretCredential, DefaultAzureCredential, TokenCredentialOptions};
+use azure_identity::{
+    AutoRefreshingTokenCredential, ClientSecretCredential, DefaultAzureCredential,
+    TokenCredentialOptions,
+};
 use azure_storage::{prelude::*, ConnectionString, ConnectionStringBuilder};
 use azure_storage_blobs::{blob::operations::PutBlockBlobBuilder, prelude::*};
 use cloud::blob::{
@@ -386,6 +389,16 @@ trait ContainerBuilder: 'static + Send + Sync {
 /// Also see [`DefaultAzureCredential`].
 struct DefaultContainerBuilder {
     config: Config,
+    cred: AutoRefreshingTokenCredential,
+}
+
+impl DefaultContainerBuilder {
+    fn new(config: Config) -> Self {
+        Self {
+            config,
+            cred: AutoRefreshingTokenCredential::new(Arc::<DefaultAzureCredential>::default()),
+        }
+    }
 }
 
 #[async_trait]
@@ -394,9 +407,9 @@ impl ContainerBuilder for DefaultContainerBuilder {
         let account_name = self.config.get_account_name()?;
         let bucket = (*self.config.bucket.bucket).to_owned();
 
-        let cred = DefaultAzureCredential::default();
         let token_resource = format!("https://{}.blob.core.windows.net", &account_name);
-        let token = cred
+        let token = self
+            .cred
             .get_token(&token_resource)
             .await
             .map_err(|e| {
@@ -672,7 +685,7 @@ impl AzureStorage {
             // default.
             Ok(AzureStorage {
                 config: config.clone(),
-                client_builder: Arc::new(DefaultContainerBuilder { config }),
+                client_builder: Arc::new(DefaultContainerBuilder::new(config)),
             })
         }
     }

--- a/components/cloud/azure/src/azblob.rs
+++ b/components/cloud/azure/src/azblob.rs
@@ -11,7 +11,7 @@ use azure_core::{
     auth::{TokenCredential, TokenResponse},
     new_http_client,
 };
-use azure_identity::{ClientSecretCredential, TokenCredentialOptions};
+use azure_identity::{ClientSecretCredential, DefaultAzureCredential, TokenCredentialOptions};
 use azure_storage::{prelude::*, ConnectionString, ConnectionStringBuilder};
 use azure_storage_blobs::{blob::operations::PutBlockBlobBuilder, prelude::*};
 use cloud::blob::{
@@ -381,6 +381,41 @@ trait ContainerBuilder: 'static + Send + Sync {
     async fn get_client(&self) -> io::Result<Arc<ContainerClient>>;
 }
 
+/// Load the container client by the default behavior of the Azure SDK.
+///
+/// Also see [`DefaultAzureCredential`].
+struct DefaultContainerBuilder {
+    config: Config,
+}
+
+#[async_trait]
+impl ContainerBuilder for DefaultContainerBuilder {
+    async fn get_client(&self) -> io::Result<Arc<ContainerClient>> {
+        let account_name = self.config.get_account_name()?;
+        let bucket = (*self.config.bucket.bucket).to_owned();
+
+        let cred = DefaultAzureCredential::default();
+        let token_resource = format!("https://{}.blob.core.windows.net", &account_name);
+        let token = cred
+            .get_token(&token_resource)
+            .await
+            .map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("failed to get token from Azure AD, err: {:?}", e),
+                )
+            })?
+            .token;
+
+        let client = BlobServiceClient::new(
+            account_name,
+            StorageCredentials::bearer_token(token.secret()),
+        )
+        .container_client(bucket);
+        Ok(Arc::new(client))
+    }
+}
+
 struct SharedKeyContainerBuilder {
     container_client: Arc<ContainerClient>,
 }
@@ -633,10 +668,12 @@ impl AzureStorage {
                 client_builder,
             })
         } else {
-            Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "credential info not found".to_owned(),
-            ))
+            // When we cannot detect any user-specified configuration, fall back to the SDK
+            // default.
+            Ok(AzureStorage {
+                config: config.clone(),
+                client_builder: Arc::new(DefaultContainerBuilder { config }),
+            })
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18206

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Now, azure blob storage authorizates by the client default when there isn't user provided key.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
I ran a full backup / restore / pitr restore with this patch in an azure virtual machine, with permissions provided by the user provided identity.
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Now, azure blob storage authorizates by the client default when there isn't user provided key.
```
