### PR TITLE
log_backup: always wait force flush RPCs

### DIFF
--- a/components/backup-stream/src/checkpoint_manager.rs
+++ b/components/backup-stream/src/checkpoint_manager.rs
@@ -53,7 +53,6 @@ impl std::fmt::Debug for CheckpointManager {
 enum SubscriptionOp {
     Add(Subscription),
     Emit(Box<[FlushEvent]>),
-    #[cfg(test)]
     Inspect(Box<dyn FnOnce(&SubscriptionManager) + Send>),
 }
 
@@ -76,7 +75,6 @@ impl SubscriptionManager {
                 SubscriptionOp::Emit(events) => {
                     self.emit_events(events).await;
                 }
-                #[cfg(test)]
                 SubscriptionOp::Inspect(f) => {
                     f(&self);
                 }
@@ -392,8 +390,7 @@ impl CheckpointManager {
         self.resolved_ts.values().map(|x| x.checkpoint).min()
     }
 
-    #[cfg(test)]
-    fn sync_with_subs_mgr<T: Send + 'static>(
+    pub fn sync_with_subs_mgr<T: Send + 'static>(
         &mut self,
         f: impl FnOnce(&SubscriptionManager) -> T + Send + 'static,
     ) -> T {

--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -2,7 +2,7 @@
 
 use std::{
     any::Any,
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     fmt,
     marker::PhantomData,
     mem::ManuallyDrop,
@@ -105,6 +105,7 @@ pub struct Endpoint<S, R, E: KvEngine, PDC> {
     /// Each time we spawn a task, once time goes by, we abort that task.
     pub abort_last_storage_save: Option<AbortHandle>,
     pub initial_scan_semaphore: Arc<Semaphore>,
+    flush_done_subscribers: HashMap<String, Sender<FlushResult>>,
 }
 
 impl<S, R, E: KvEngine, PDC> Drop for Endpoint<S, R, E, PDC> {
@@ -210,6 +211,7 @@ where
             config,
             checkpoint_mgr,
             abort_last_storage_save: None,
+            flush_done_subscribers: Default::default(),
         };
         ep.pool.spawn(root!(ep.min_ts_worker()));
         ep
@@ -881,21 +883,35 @@ where
         }
     }
 
-    pub fn on_force_flush(&self, task: TaskSelectorRef<'_>, sender: Sender<FlushResult>) {
-        self.pool.block_on(async move {
+    fn subscribe_flush_done(&mut self, task: &str, mailbox: Sender<FlushResult>) {
+        if let Some(old_one) = self.flush_done_subscribers.insert(task.to_owned(), mailbox) {
+            let res = FlushResult {
+                task: task.to_owned(),
+                error: Some(Box::new(Error::Other(box_err!(
+                    "another waiter enters and this one was aborted: try again later"
+                )))),
+            };
+            let _ = old_one.try_send(res);
+        }
+    }
+
+    pub fn on_force_flush(&mut self, task: TaskSelectorRef<'_>, sender: Sender<FlushResult>) {
+        let hnd = self.pool.handle().clone();
+        hnd.block_on(async {
             info!("Triggering force flush."; "selector" => ?task);
             let handlers = self.range_router.select_task_handler(task);
             for hnd in handlers {
                 let mts = self.prepare_min_ts().await;
                 let sched = self.scheduler.clone();
                 let sender = sender.clone();
+                self.subscribe_flush_done(&hnd.task.info.name, sender);
                 match hnd.set_flushing_status_cas(false, true) {
                     Ok(_) => {
                         self.region_op(ObserveOp::ResolveRegions {
                             callback: Box::new(move |res| {
                                 try_send!(
                                     sched,
-                                    Task::ExecFlush(hnd.task.info.name.to_owned(), res, sender)
+                                    Task::ExecFlush(hnd.task.info.name.to_owned(), res)
                                 );
                             }),
                             min_ts: mts,
@@ -903,11 +919,7 @@ where
                         .await;
                     }
                     Err(_) => {
-                        let res = FlushResult {
-                            task: hnd.task.info.name.to_owned(),
-                            error: Some(Error::Other(box_err!("task is flushing"))),
-                        };
-                        let _ = sender.send(res).await;
+                        info!("")
                     }
                 }
             }
@@ -919,10 +931,9 @@ where
             let mts = self.prepare_min_ts().await;
             let sched = self.scheduler.clone();
             info!("min_ts prepared for flushing"; "min_ts" => %mts);
-            let (tx, _) = tokio::sync::mpsc::channel(1);
             self.region_op(ObserveOp::ResolveRegions {
                 callback: Box::new(move |res| {
-                    try_send!(sched, Task::ExecFlush(task, res, tx));
+                    try_send!(sched, Task::ExecFlush(task, res));
                 }),
                 min_ts: mts,
             })
@@ -930,19 +941,17 @@ where
         })
     }
 
-    fn on_exec_flush(&mut self, task: String, resolved: ResolvedRegions, cb: Sender<FlushResult>) {
+    fn on_exec_flush(&mut self, task: String, resolved: ResolvedRegions) {
         self.checkpoint_mgr.freeze();
         let fut = self.do_flush(task.clone(), resolved);
+        let sched = self.scheduler.clone();
         self.pool.spawn(root!("flush"; async move {
             let res = fut.await;
             if let Err(ref err) = &res {
                 err.report("during updating flush status")
             }
-            // If nobody waits us, it is no need to construct the result.
-            if !cb.is_closed() {
-                let flush_res = FlushResult { task, error: res.err() };
-                let _ = cb.send(flush_res).await;
-            }
+            let flush_res = FlushResult { task, error: res.err().map(Box::new) };
+            try_send!(sched, Task::Flushed(flush_res));
         }));
     }
 
@@ -1088,9 +1097,19 @@ where
                 }
             }
             Task::MarkFailover(t) => self.failover_time = Some(t),
-            Task::ExecFlush(task, min_ts, cb) => self.on_exec_flush(task, min_ts, cb),
+            Task::ExecFlush(task, min_ts) => self.on_exec_flush(task, min_ts),
             Task::RegionCheckpointsOp(s) => self.handle_region_checkpoints_op(s),
             Task::UpdateGlobalCheckpoint(task) => self.on_update_global_checkpoint(task),
+            Task::Flushed(result) => self.on_flushed(result),
+        }
+    }
+
+    fn on_flushed(&mut self, result: FlushResult) {
+        if let Some(sender) = self.flush_done_subscribers.remove(&result.task) {
+            if let Err(err) = sender.try_send(result) {
+                let err_msg = err.to_string();
+                info!("failed to send flush result, waiter is gone or channel blocked"; "err" => %err_msg, "result" => ?err.into_inner());
+            }
         }
     }
 
@@ -1289,7 +1308,7 @@ impl fmt::Debug for RegionCheckpointOperation {
 #[derive(Debug)]
 pub struct FlushResult {
     pub task: String,
-    pub error: Option<Error>,
+    pub error: Option<Box<Error>>,
 }
 
 pub enum Task {
@@ -1319,9 +1338,11 @@ pub enum Task {
     MarkFailover(Instant),
     /// Flush the task with name.
     Flush(String),
+    /// The task was flushed.
+    Flushed(FlushResult),
     /// Execute the flush with the calculated resolved result.
     /// This is an internal command only issued by the `Flush` task.
-    ExecFlush(String, ResolvedRegions, Sender<FlushResult>),
+    ExecFlush(String, ResolvedRegions),
     /// The command for getting region checkpoints.
     RegionCheckpointsOp(RegionCheckpointOperation),
     /// update global-checkpoint-ts to storage.
@@ -1419,6 +1440,7 @@ impl std::fmt::Debug for ObserveOp {
 impl fmt::Debug for Task {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::Flushed(task) => f.debug_tuple("Flushed").field(task).finish(),
             Self::WatchTask(arg0) => f.debug_tuple("WatchTask").field(arg0).finish(),
             Self::BatchEvent(arg0) => f
                 .debug_tuple("BatchEvent")
@@ -1436,7 +1458,7 @@ impl fmt::Debug for Task {
                 .debug_tuple("MarkFailover")
                 .field(&format_args!("{:?} ago", t.saturating_elapsed()))
                 .finish(),
-            Self::ExecFlush(arg0, arg1, _) => f
+            Self::ExecFlush(arg0, arg1) => f
                 .debug_tuple("ExecFlush")
                 .field(arg0)
                 .field(&arg1.global_checkpoint())
@@ -1458,6 +1480,7 @@ impl fmt::Display for Task {
 impl Task {
     fn label(&self) -> &'static str {
         match self {
+            Task::Flushed(_) => "flushed",
             Task::WatchTask(w) => match w {
                 TaskOp::AddTask(_) => "watch_task.add",
                 TaskOp::RemoveTask(_) => "watch_task.remove",

--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -919,7 +919,7 @@ where
                         .await;
                     }
                     Err(_) => {
-                        info!("")
+                        info!("on_force_flush: a flush is on the way, waiting its finish..."; "task" => %hnd.task.info.name);
                     }
                 }
             }
@@ -1109,11 +1109,11 @@ where
             // Send the message after the subscription manager have tried to sent this flush
             // result to subscribers.
             self.checkpoint_mgr.sync_with_subs_mgr(move |_| {
-            if let Err(err) = sender.try_send(result) {
-                let err_msg = err.to_string();
-                info!("failed to send flush result, waiter is gone or channel blocked"; "err" => %err_msg, "result" => ?err.into_inner());
-            }
-        })
+                if let Err(err) = sender.try_send(result) {
+                    let err_msg = err.to_string();
+                    info!("failed to send flush result, waiter is gone or channel blocked"; "err" => %err_msg, "result" => ?err.into_inner());
+                }
+            })
         }
     }
 

--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -1106,10 +1106,14 @@ where
 
     fn on_flushed(&mut self, result: FlushResult) {
         if let Some(sender) = self.flush_done_subscribers.remove(&result.task) {
+            // Send the message after the subscription manager have tried to sent this flush
+            // result to subscribers.
+            self.checkpoint_mgr.sync_with_subs_mgr(move |_| {
             if let Err(err) = sender.try_send(result) {
                 let err_msg = err.to_string();
                 info!("failed to send flush result, waiter is gone or channel blocked"; "err" => %err_msg, "result" => ?err.into_inner());
             }
+        })
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18262

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
This will make `force-flush` wait the last flush if there is a running one instead of just return an error.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
