### PR TITLE
Make unix_timestamp return 0 when datetime is invalid

### DIFF
--- a/components/tidb_query_expr/src/impl_time.rs
+++ b/components/tidb_query_expr/src/impl_time.rs
@@ -1620,7 +1620,7 @@ fn find_zone_transition(
 
     let mut i = 0;
     while t1 + chrono::Duration::seconds(1) < t2 {
-        if i > 1000000 {
+        if i > 1000 {
             // Just avoid infinity loop because of potential bug, maybe we can remove it in
             // the future
             return Err(
@@ -1673,8 +1673,14 @@ fn get_micro_timestamp(time: &DateTime, tz: &Tz) -> Result<i64> {
     let hour = time.hour();
     let minute = time.minute();
     let second = time.second();
-    let naive_date = chrono::NaiveDate::from_ymd(year, month, day);
-    let naive_time = chrono::NaiveTime::from_hms_micro(hour, minute, second, time.micro());
+    let naive_date = match chrono::NaiveDate::from_ymd_opt(year, month, day) {
+        Some(v) => v,
+        None => return Ok(0),
+    };
+    let naive_time = match chrono::NaiveTime::from_hms_micro_opt(hour, minute, second, time.micro()) {
+        Some(v) => v,
+        None => return Ok(0),
+    };
     let naive_datetime = chrono::NaiveDateTime::new(naive_date, naive_time);
 
     // MySQL chooses earliest time when there are multi mapped time
@@ -4267,6 +4273,9 @@ mod tests {
             ("2009-09-20 07:32:39", 0, "US/Eastern", 1253446359),
             ("2020-03-29 03:45:00", 0, "Europe/Vilnius", 1585443600),
             ("2020-10-25 03:45:00", 0, "Europe/Vilnius", 1603586700),
+            ("0-10-25 03:45:00", 0, "", 0),
+            ("2000-0-25 03:45:00", 0, "", 0),
+            ("2000-1-0 03:45:00", 0, "", 0),
         ];
 
         for (datetime, offset, time_zone_name, expected) in cases {

--- a/components/tidb_query_expr/src/impl_time.rs
+++ b/components/tidb_query_expr/src/impl_time.rs
@@ -1620,7 +1620,7 @@ fn find_zone_transition(
 
     let mut i = 0;
     while t1 + chrono::Duration::seconds(1) < t2 {
-        if i > 1000 {
+        if i > 100 {
             // Just avoid infinity loop because of potential bug, maybe we can remove it in
             // the future
             return Err(

--- a/components/tidb_query_expr/src/impl_time.rs
+++ b/components/tidb_query_expr/src/impl_time.rs
@@ -1677,7 +1677,8 @@ fn get_micro_timestamp(time: &DateTime, tz: &Tz) -> Result<i64> {
         Some(v) => v,
         None => return Ok(0),
     };
-    let naive_time = match chrono::NaiveTime::from_hms_micro_opt(hour, minute, second, time.micro()) {
+    let naive_time = match chrono::NaiveTime::from_hms_micro_opt(hour, minute, second, time.micro())
+    {
         Some(v) => v,
         None => return Ok(0),
     };


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18222


<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Make unix_timestamp return 0 when datetime is invalid
```
