### PR TITLE
compact_log_backup: added minimal compactions size

### DIFF
--- a/cmd/tikv-ctl/src/cmd.rs
+++ b/cmd/tikv-ctl/src/cmd.rs
@@ -4,6 +4,7 @@ use std::{borrow::ToOwned, str, string::ToString, sync::LazyLock, u64};
 
 use clap::{crate_authors, AppSettings};
 use engine_traits::{SstCompressionType, CF_DEFAULT};
+use raft_engine::ReadableSize;
 use structopt::StructOpt;
 
 const RAW_KEY_HINT: &str = "Raw key (generally starts with \"z\") in escaped form";
@@ -698,12 +699,12 @@ pub enum Cmd {
 
         #[structopt(
             long,
-            default_value = "16777216", // 16 MiB
+            default_value = "16M",
             help(
                 "specify the minimal compaction size in bytes, if backup data of a region doesn't reach this threshold, it won't be compacted"
             )
         )]
-        minimal_compaction_size: u64,
+        minimal_compaction_size: ReadableSize,
     },
     /// Get the state of a region's RegionReadProgress.
     GetRegionReadProgress {

--- a/cmd/tikv-ctl/src/cmd.rs
+++ b/cmd/tikv-ctl/src/cmd.rs
@@ -688,8 +688,22 @@ pub enum Cmd {
         )]
         compression_level: Option<i32>,
 
-        #[structopt(long, help("Don't try to skip already finished compactions."))]
+        #[structopt(
+            long,
+            help(
+                "if set, all checkpoints will be ignored. i.e. all finished compaction will be regenerated."
+            )
+        )]
         force_regenerate: bool,
+
+        #[structopt(
+            long,
+            default_value = "16777216", // 16 MiB
+            help(
+                "specify the minimal compaction size in bytes, if backup data of a region doesn't reach this threshold, it won't be compacted"
+            )
+        )]
+        minimal_compaction_size: u64,
     },
     /// Get the state of a region's RegionReadProgress.
     GetRegionReadProgress {

--- a/cmd/tikv-ctl/src/main.rs
+++ b/cmd/tikv-ctl/src/main.rs
@@ -471,7 +471,7 @@ fn main() {
             } else {
                 Some(compact_log_hooks::checkpoint::Checkpoint::default())
             };
-            let skip_small_compaction = SkipSmallCompaction::new(minimal_compaction_size);
+            let skip_small_compaction = SkipSmallCompaction::new(minimal_compaction_size.0);
             let hooks = (
                 (
                     (log_to_term, checkpoint),

--- a/cmd/tikv-ctl/src/main.rs
+++ b/cmd/tikv-ctl/src/main.rs
@@ -20,7 +20,10 @@ use std::{
 };
 
 use collections::HashMap;
-use compact_log_backup::{exec_hooks as compact_log_hooks, execute as compact_log, TraceResultExt};
+use compact_log_backup::{
+    exec_hooks::{self as compact_log_hooks, skip_small_compaction::SkipSmallCompaction},
+    execute as compact_log, TraceResultExt,
+};
 use crypto::fips;
 use encryption_export::{
     create_backend, data_key_manager_from_config, DataKeyManager, DecrypterReader, Iv,
@@ -397,6 +400,7 @@ fn main() {
             compression_level,
             name,
             force_regenerate,
+            minimal_compaction_size,
         } => {
             let tmp_engine =
                 TemporaryRocks::new(&cfg).expect("failed to create temp engine for writing SSTs.");
@@ -467,8 +471,12 @@ fn main() {
             } else {
                 Some(compact_log_hooks::checkpoint::Checkpoint::default())
             };
+            let skip_small_compaction = SkipSmallCompaction::new(minimal_compaction_size);
             let hooks = (
-                ((log_to_term, checkpoint), with_status_server),
+                (
+                    (log_to_term, checkpoint),
+                    (with_status_server, skip_small_compaction),
+                ),
                 (save_meta, with_lock),
             );
             match exec.run(hooks) {

--- a/components/compact-log-backup/src/exec_hooks/mod.rs
+++ b/components/compact-log-backup/src/exec_hooks/mod.rs
@@ -13,6 +13,7 @@ pub mod checkpoint;
 pub mod consistency;
 pub mod observability;
 pub mod save_meta;
+pub mod skip_small_compaction;
 
 #[derive(Default)]
 pub struct CollectStatistic {

--- a/components/compact-log-backup/src/exec_hooks/skip_small_compaction.rs
+++ b/components/compact-log-backup/src/exec_hooks/skip_small_compaction.rs
@@ -1,0 +1,30 @@
+// Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
+
+use tikv_util::info;
+
+use crate::execute::hooking::{CId, ExecHooks, SubcompactionStartCtx};
+
+/// A hook that skips small compaction.
+///
+/// The size threshold is compared with "original KV size":
+/// the length of each key value pairs in its original form.
+pub struct SkipSmallCompaction {
+    size_threshold: u64,
+}
+
+impl SkipSmallCompaction {
+    /// Creates a new `SkipSmallCompaction` hook.
+    pub fn new(size_threshold: u64) -> Self {
+        Self { size_threshold }
+    }
+}
+
+impl ExecHooks for SkipSmallCompaction {
+    fn before_a_subcompaction_start(&mut self, _cid: CId, cx: SubcompactionStartCtx<'_>) {
+        if cx.subc.size < self.size_threshold {
+            info!("Skipped a small compaction."; 
+                "size" => cx.subc.size, "threshold" => self.size_threshold);
+            cx.skip();
+        }
+    }
+}

--- a/components/compact-log-backup/src/execute/mod.rs
+++ b/components/compact-log-backup/src/execute/mod.rs
@@ -41,8 +41,8 @@ const COMPACTION_V1_PREFIX: &str = "v1/compactions";
 /// The config for an execution of a compaction.
 ///
 /// This structure itself fully defines what work the compaction need to do.
-/// That is, keeping this structure unchanged, the compaction should always
-/// generate the same artifices.
+/// That is, keeping this structure unchanged, the compaction task generated
+/// should be the same. (But some of them may be filtered out later.)
 #[derive(Debug)]
 pub struct ExecutionConfig {
     /// Filter out files doesn't contain any record with TS great or equal than


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18234

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Added `--minimal-compact-size` to `compact-log-backup`.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
