### PR TITLE
raftstore: avoid early hibernate if pending on applying logs when restart

### DIFF
--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -2352,6 +2352,12 @@ where
             self.fsm.hibernate_state.group_state() == GroupState::Chaos,
             |_| {}
         );
+        fail_point!(
+            "on_raft_base_tick_ordered_1003",
+            self.fsm.peer.peer_id() == 1003
+                && self.fsm.hibernate_state.group_state() == GroupState::Ordered,
+            |_| {}
+        );
 
         if self.fsm.peer.pending_remove {
             self.fsm.peer.mut_store().flush_entry_cache_metrics();

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -2963,6 +2963,7 @@ where
         if !self.ctx.cfg.hibernate_regions
             || self.fsm.peer.has_uncommitted_log()
             || self.fsm.peer.wait_data
+            || self.fsm.peer.busy_on_apply.is_some() /* still under applying raft logs */
             || from.get_id() != self.fsm.peer.leader_id()
         {
             // Ignore the message means rejecting implicitly.

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -2352,12 +2352,6 @@ where
             self.fsm.hibernate_state.group_state() == GroupState::Chaos,
             |_| {}
         );
-        fail_point!(
-            "on_raft_base_tick_ordered_1003",
-            self.fsm.peer.peer_id() == 1003
-                && self.fsm.hibernate_state.group_state() == GroupState::Ordered,
-            |_| {}
-        );
 
         if self.fsm.peer.pending_remove {
             self.fsm.peer.mut_store().flush_entry_cache_metrics();
@@ -2559,6 +2553,9 @@ where
                     .peer
                     .region_buckets_info_mut()
                     .add_bucket_flow(&res.bucket_stat);
+                // Update the state whether the peer is pending on applying raft
+                // logs if necesssary.
+                self.on_check_peer_complete_apply_logs();
 
                 self.fsm.has_ready |= self.fsm.peer.post_apply(
                     self.ctx,
@@ -2969,7 +2966,6 @@ where
         if !self.ctx.cfg.hibernate_regions
             || self.fsm.peer.has_uncommitted_log()
             || self.fsm.peer.wait_data
-            || self.fsm.peer.busy_on_apply.is_some() /* still under applying raft logs */
             || from.get_id() != self.fsm.peer.leader_id()
         {
             // Ignore the message means rejecting implicitly.

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -1609,8 +1609,6 @@ where
                 && !self.is_leader()
                 // Keep ticking if it's waiting for snapshot.
                 && !self.wait_data
-                // Keep ticking if it still has some pending and unapplied raft logs.
-                && self.busy_on_apply.is_none()
         }
     }
 

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -1609,6 +1609,8 @@ where
                 && !self.is_leader()
                 // Keep ticking if it's waiting for snapshot.
                 && !self.wait_data
+                // Keep ticking if it still has some pending and unapplied raft logs.
+                && self.busy_on_apply.is_none()
         }
     }
 

--- a/tests/failpoints/cases/test_hibernate.rs
+++ b/tests/failpoints/cases/test_hibernate.rs
@@ -40,7 +40,8 @@ fn test_break_leadership_on_restart() {
     // Peer 3 will:
     // 1. steps a heartbeat message from its leader and then ticks 1 time.
     // 2. ticks a peer_stale_state_check, which will change state from Idle to
-    // PreChaos. 3. continues to tick until it hibernates totally.
+    //    PreChaos.
+    // 3. continues to tick until it hibernates totally.
     let (tx, rx) = mpsc::sync_channel(128);
     fail::cfg_callback("on_raft_base_tick_idle", move || tx.send(0).unwrap()).unwrap();
     let mut raft_msg = RaftMessage::default();
@@ -80,6 +81,75 @@ fn test_break_leadership_on_restart() {
     // Peer 3 shouldn't start a new election, otherwise the leader may step down
     // incorrectly.
     rx.recv_timeout(Duration::from_secs(2)).unwrap_err();
+}
+
+#[test]
+fn test_restart_peer_busy_on_apply() {
+    let mut cluster = new_node_cluster(0, 3);
+    let base_tick_ms = 50;
+    cluster.cfg.raft_store.raft_base_tick_interval = ReadableDuration::millis(base_tick_ms);
+    cluster.cfg.raft_store.raft_heartbeat_ticks = 2;
+    cluster.cfg.raft_store.raft_election_timeout_ticks = 10;
+    // So the random election timeout will always be 10, which makes the case more
+    // stable.
+    cluster.cfg.raft_store.raft_min_election_timeout_ticks = 10;
+    cluster.cfg.raft_store.raft_max_election_timeout_ticks = 11;
+    // Set a fairy small leader transfer log gap
+    cluster.cfg.raft_store.leader_transfer_max_log_lag = 10;
+    cluster.cfg.raft_store.min_pending_apply_region_count = 1;
+    configure_for_hibernate(&mut cluster.cfg);
+    cluster.pd_client.disable_default_operator();
+    let r = cluster.run_conf_change();
+    cluster.pd_client.must_add_peer(r, new_peer(2, 1002));
+    cluster.pd_client.must_add_peer(r, new_peer(3, 1003));
+
+    cluster.must_put(b"k1", b"v1");
+    must_get_equal(&cluster.get_engine(2), b"k1", b"v1");
+    must_get_equal(&cluster.get_engine(3), b"k1", b"v1");
+
+    // Make a log gap on Peer 1003.
+    cluster.stop_node(3);
+    for _ in 0..=11 {
+        cluster.must_put(b"k2", b"v2");
+    }
+
+    // Pause the applying processing in Peer 3 to make a log gap.
+    fail::cfg("on_handle_apply_1003", "pause").unwrap();
+    // Restart the node 3 and check the Peer 1003 is under applying stage.
+    cluster.run_node(3).unwrap();
+
+    // Wait for a while and check the node is still busy on applying.
+    thread::sleep(Duration::from_millis(base_tick_ms * 30));
+    cluster.must_send_store_heartbeat(3);
+    thread::sleep(Duration::from_millis(base_tick_ms));
+    let stats = cluster.pd_client.get_store_stats(3).unwrap();
+    assert!(stats.is_busy);
+
+    // Recover the applying processing on Peer 1003 and wait for a while, then
+    // the region will be hibernated.
+    fail::remove("on_handle_apply_1003");
+    thread::sleep(Duration::from_millis(base_tick_ms * 10));
+    cluster.must_send_store_heartbeat(3);
+    thread::sleep(Duration::from_millis(base_tick_ms));
+    let stats = cluster.pd_client.get_store_stats(3).unwrap();
+    assert!(!stats.is_busy);
+    // Check hibernated.
+    let (tx, rx) = mpsc::sync_channel(128);
+    fail::cfg_callback("on_raft_base_tick_idle", move || tx.send(0).unwrap()).unwrap();
+    let mut raft_msg = RaftMessage::default();
+    raft_msg.region_id = 1;
+    raft_msg.set_from_peer(new_peer(1, 1));
+    raft_msg.set_to_peer(new_peer(3, 1003));
+    raft_msg.mut_region_epoch().version = 1;
+    raft_msg.mut_region_epoch().conf_ver = 3;
+    raft_msg.mut_message().msg_type = MessageType::MsgHeartbeat;
+    raft_msg.mut_message().from = 1;
+    raft_msg.mut_message().to = 1003;
+    raft_msg.mut_message().term = 6;
+    let router = cluster.sim.rl().get_router(3).unwrap();
+    router.send_raft_message(raft_msg).unwrap();
+    assert_eq!(rx.recv_timeout(Duration::from_secs(1)).unwrap(), 0);
+    fail::remove("on_raft_base_tick_idle");
 }
 
 #[test]

--- a/tests/failpoints/cases/test_hibernate.rs
+++ b/tests/failpoints/cases/test_hibernate.rs
@@ -118,30 +118,11 @@ fn test_restart_peer_busy_on_apply() {
     // Restart the node 3 and check the Peer 1003 is under applying stage.
     cluster.run_node(3).unwrap();
 
-    let (tx, rx) = mpsc::sync_channel(128);
-    // Wait for a while and check the node is still busy on applying.
+    // Wait for a while to make Peer 1003 enter `hibernate` state and
+    // check the node is still busy on applying.
     thread::sleep(Duration::from_millis(base_tick_ms * 30));
-    cluster.must_send_store_heartbeat(3);
-    thread::sleep(Duration::from_millis(base_tick_ms));
-    let stats = cluster.pd_client.get_store_stats(3).unwrap();
-    assert!(stats.is_busy);
-    let ordered_tx = tx.clone();
-    fail::cfg_callback("on_raft_base_tick_ordered_1003", move || {
-        ordered_tx.send(1003).unwrap()
-    })
-    .unwrap();
-    assert_eq!(rx.recv_timeout(Duration::from_secs(1)).unwrap(), 1003);
-    fail::remove("on_raft_base_tick_ordered_1003");
-
-    // Recover the applying processing on Peer 1003 and wait for a while, then
-    // the region will be hibernated.
-    fail::remove("on_handle_apply_1003");
-    thread::sleep(Duration::from_millis(base_tick_ms * 10));
-    cluster.must_send_store_heartbeat(3);
-    thread::sleep(Duration::from_millis(base_tick_ms));
-    let stats = cluster.pd_client.get_store_stats(3).unwrap();
-    assert!(!stats.is_busy);
     // Check hibernated.
+    let (tx, rx) = mpsc::sync_channel(128);
     fail::cfg_callback("on_raft_base_tick_idle", move || tx.send(0).unwrap()).unwrap();
     let mut raft_msg = RaftMessage::default();
     raft_msg.region_id = 1;
@@ -157,6 +138,19 @@ fn test_restart_peer_busy_on_apply() {
     router.send_raft_message(raft_msg).unwrap();
     assert_eq!(rx.recv_timeout(Duration::from_secs(1)).unwrap(), 0);
     fail::remove("on_raft_base_tick_idle");
+    cluster.must_send_store_heartbeat(3);
+    thread::sleep(Duration::from_millis(base_tick_ms));
+    let stats = cluster.pd_client.get_store_stats(3).unwrap();
+    assert!(stats.is_busy);
+
+    // Recover the applying processing on Peer 1003 and wait for a while, then
+    // the region will be hibernated.
+    fail::remove("on_handle_apply_1003");
+    thread::sleep(Duration::from_millis(base_tick_ms * 10));
+    cluster.must_send_store_heartbeat(3);
+    thread::sleep(Duration::from_millis(base_tick_ms));
+    let stats = cluster.pd_client.get_store_stats(3).unwrap();
+    assert!(!stats.is_busy);
 }
 
 #[test]


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18233

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

In previous work #16239, we introduced the `busy_on_apply` state to indicate
whether a `Peer` is pending the application of pending Raft logs upon restart.

However, this approach misses a corner case: if the `Peer` quickly enters the
`hibernate` state after restarting, the `busy_on_apply` state may not be updated
in a timely manner. This results in the Node failed to update the count of pending
applying regions, continuously reporting an incorrect `is_busy == true` state to PD. 
Consequently, this can slow down the rolling-restart progress more than expected.

Therefore, this PR addresses this issue by updating the applied state in `on_apply_res`.

```commit-message
Fix the bug where some hibernated peers, marked with `busy_on_apply == true`, 
cannot be reset with normal even thought the `applied_index == committed_index`.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fix the bug where some hibernated peers, marked with `busy_on_apply == true`, 
cannot be reset with normal even thought the `applied_index == committed_index`.
```
