### PR TITLE
import: relax memory check constraints

### DIFF
--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -952,6 +952,8 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
             match check_import_resources() {
                 Ok(()) => (),
                 Err(e) => {
+                    // in case of immediate retry from client side
+                    tokio::time::sleep(Duration::from_secs(1)).await;
                     resp.set_error(e.into());
                     return crate::send_rpc_response!(Ok(resp), sink, label, timer);
                 }

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -41,7 +41,7 @@ use tikv_util::{
     resizable_threadpool::{DeamonRuntimeHandle, ResizableRuntime},
     sys::{
         disk::{get_disk_status, DiskUsage},
-        get_global_memory_usage, memory_usage_reaches_high_water, SysQuota,
+        get_global_memory_usage, SysQuota,
     },
     time::{Instant, Limiter},
     HandyRwLock,
@@ -110,7 +110,7 @@ fn check_import_resources() -> Result<()> {
             t.unwrap().parse::<u64>().unwrap()
         });
         SysQuota::memory_limit_in_bytes()
-    });
+    })();
 
     if mem_limit == 0 || mem_limit < usage {
         // make it through when cannot get correct memory

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -29,6 +29,7 @@ use raftstore::{
     RegionInfoAccessor,
 };
 use raftstore_v2::StoreMeta;
+use rand::Rng;
 use resource_control::{with_resource_limiter, ResourceGroupManager};
 use sst_importer::{
     error_inc, metrics::*, sst_importer::DownloadExt, Config, ConfigManager, Error, Result,
@@ -98,9 +99,16 @@ const REJECT_SERVE_MEMORY_USAGE: u64 = 1024 * 1024 * 1024; //1G
 const HIGH_IMPORT_MEMORY_WATER_RATIO: f64 = 0.95;
 
 /// Check if the system has enough resources for import tasks
-fn check_import_resources() -> Result<()> {
+async fn check_import_resources() -> Result<()> {
+    // these error(memory or disk) cannot be recover at a short time,
+    // in case client retry immediately, sleep for a while
+    async fn sleep_with_jitter() {
+        let jitter = rand::thread_rng().gen_range(1000, 2000);
+        tokio::time::sleep(Duration::from_millis(jitter)).await;
+    }
     // Check disk space first
     if get_disk_status(0) != DiskUsage::Normal {
+        sleep_with_jitter().await;
         return Err(Error::DiskSpaceNotEnough);
     }
 
@@ -115,24 +123,26 @@ fn check_import_resources() -> Result<()> {
     if mem_limit == 0 || mem_limit < usage {
         // make it through when cannot get correct memory
         warn!(
-            "Memory limit isn't correct. skip next check, limit is {}, usage is {}",
+            "Memory limit isn't correct. skip next check, limit is {} bytes, usage is {} bytes",
             mem_limit, usage
         );
         return Ok(());
     }
 
-    let usage_ratio = usage as f64 / mem_limit as f64;
+    let available_memory = mem_limit - usage;
+    let min_required_memory = std::cmp::min(
+        REJECT_SERVE_MEMORY_USAGE,
+        ((1.0 - HIGH_IMPORT_MEMORY_WATER_RATIO) * mem_limit as f64) as u64,
+    );
 
     // Reject ONLY if BOTH:
     // - Available memory is below REJECT_SERVE_MEMORY_USAGE
-    // - Memory usage ratio is 90%+
-    if mem_limit - usage < REJECT_SERVE_MEMORY_USAGE
-        && usage_ratio >= HIGH_IMPORT_MEMORY_WATER_RATIO
-    {
+    // - Memory usage ratio is 95%+
+    if available_memory < min_required_memory {
+        sleep_with_jitter().await;
         return Err(Error::ResourceNotEnough(format!(
-            "Memory usage too high: {} bytes (≈{:.1}%)",
-            usage,
-            usage_ratio * 100.0
+            "Memory usage too high, usage: {} bytes, mem limit {} bytes",
+            usage, mem_limit
         )));
     }
     Ok(())
@@ -669,7 +679,7 @@ macro_rules! impl_write {
                         .try_fold(
                             (writer, resource_limiter),
                             |(mut writer, limiter), req| async move {
-                                check_import_resources()?;
+                                check_import_resources().await?;
                                 let batch = match req.chunk {
                                     Some($chunk_ty::Batch(b)) => b,
                                     _ => return Err(Error::InvalidChunk),
@@ -816,7 +826,7 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
                 let file = import.create(meta)?;
                 let mut file = rx
                     .try_fold(file, |mut file, chunk| async move {
-                        match check_import_resources() {
+                        match check_import_resources().await {
                             Ok(()) => (),
                             Err(e) => {
                                 warn!("Upload failed due to not enough resource {:?}", e);
@@ -897,7 +907,7 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
                 .observe(start.saturating_elapsed().as_secs_f64());
 
             let mut resp = ApplyResponse::default();
-            match check_import_resources() {
+            match check_import_resources().await {
                 Ok(()) => (),
                 Err(e) => {
                     resp.set_error(e.into());
@@ -949,11 +959,9 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
                 .observe(start.saturating_elapsed().as_secs_f64());
 
             let mut resp = DownloadResponse::default();
-            match check_import_resources() {
+            match check_import_resources().await {
                 Ok(()) => (),
                 Err(e) => {
-                    // in case of immediate retry from client side
-                    tokio::time::sleep(Duration::from_secs(1)).await;
                     resp.set_error(e.into());
                     return crate::send_rpc_response!(Ok(resp), sink, label, timer);
                 }

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -1330,7 +1330,7 @@ mod test {
     use txn_types::{Key, TimeStamp, Write, WriteBatchFlags, WriteType};
 
     use crate::{
-        import::sst_service::{check_import_resources, check_local_region_stale, RequestCollector},
+        import::sst_service::{check_local_region_stale, RequestCollector},
         server::raftkv,
     };
 
@@ -1683,10 +1683,5 @@ mod test {
                 .to_string()
                 .contains("retry write later")
         );
-    }
-
-    fn test_import_memory_check() {
-        let result = check_import_resources();
-        assert!(result.is_ok()); // Skips check when mem_limit < usage
     }
 }

--- a/tests/integrations/import/test_apply_log.rs
+++ b/tests/integrations/import/test_apply_log.rs
@@ -59,7 +59,8 @@ fn test_apply_full_resource() {
     );
     disk::set_disk_status(DiskUsage::Normal);
 
-    fail::cfg("memory_usage_reaches_high_water", "return").unwrap();
+    fail::cfg("mock_memory_usage", "return(10307921510)").unwrap(); // 9.5G
+    fail::cfg("mock_memory_limit", "return(10737418240)").unwrap(); // 10G
     let result = import.apply(&req).unwrap();
     assert!(result.has_error());
     assert!(
@@ -68,7 +69,8 @@ fn test_apply_full_resource() {
             .get_message()
             .contains("Memory usage too high")
     );
-    fail::remove("memory_usage_reaches_high_water");
+    fail::remove("mock_memory_usage");
+    fail::remove("mock_memory_limit");
 }
 
 #[test]

--- a/tests/integrations/import/test_sst_service.rs
+++ b/tests/integrations/import/test_sst_service.rs
@@ -48,12 +48,14 @@ fn test_upload_sst() {
     set_disk_status(DiskUsage::Normal);
 
     // high memory usage
-    fail::cfg("memory_usage_reaches_high_water", "return").unwrap();
+    fail::cfg("mock_memory_usage", "return(10307921510)").unwrap(); // 9.5G
+    fail::cfg("mock_memory_limit", "return(10737418240)").unwrap(); // 10G
     assert_to_string_contains!(
         send_upload_sst(&import, &meta, &data).unwrap_err(),
         "Memory usage too high"
     );
-    fail::remove("memory_usage_reaches_high_water");
+    fail::remove("mock_memory_usage");
+    fail::remove("mock_memory_limit");
 
     let mut meta = new_sst_meta(crc32, length);
     meta.set_region_id(ctx.get_region_id());
@@ -111,10 +113,12 @@ fn test_write_sst_when_resource_full() {
     run_test_write_sst(ctx, tikv, import, "DiskSpaceNotEnough");
     set_disk_status(DiskUsage::Normal);
 
-    fail::cfg("memory_usage_reaches_high_water", "return").unwrap();
+    fail::cfg("mock_memory_usage", "return(10307921510)").unwrap(); // 9.5G
+    fail::cfg("mock_memory_limit", "return(10737418240)").unwrap(); // 10G
     let (_cluster, ctx, tikv, import) = new_cluster_and_tikv_import_client();
     run_test_write_sst(ctx, tikv, import, "Memory usage too high");
-    fail::remove("memory_usage_reaches_high_water");
+    fail::remove("mock_memory_usage");
+    fail::remove("mock_memory_limit");
 }
 
 #[test]


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref https://github.com/tikv/tikv/issues/18124

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:
The previously (https://github.com/tikv/tikv/pull/18192) implemented memory check was too conservative, leading to unnecessary rejections even when there was still available memory.

For example, on an 8GB node, the memory_usage_limit was calculated as 6GB, and applying the 0.9 threshold effectively resulted in a 5.4GB limit, which is only 67.5% of the total memory. This led to premature rejection of import requests, even when the system still had usable memory.
```commit-message
import: make memory check more aggressive.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
