### PR TITLE
revert: "grpc: set compression args for TiKV service (#17180) #17312"

### DIFF
--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -99,8 +99,6 @@ where
             .http2_max_ping_strikes(i32::MAX) // For pings without data from clients.
             .keepalive_time(self.cfg.value().grpc_keepalive_time.into())
             .keepalive_timeout(self.cfg.value().grpc_keepalive_timeout.into())
-            .default_compression_algorithm(self.cfg.value().grpc_compression_algorithm())
-            .default_gzip_compression_level(self.cfg.value().grpc_gzip_compression_level)
             .build_args();
 
         let sb = ServerBuilder::new(Arc::clone(&env))


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

This PR is used to fix relevant upgrading issues of TiKV whose version <= 4.0,
lacking the ability to decompress the compressed grpc packets.

Although the previous work #17312 has fixed the grpc compression issues #17176,
making the grpc packets transferred between TiDB and TiKV nodes with compression
in reality, it blocks the rolling upgrading progress when upgrading one cluster (< 5.0)
to a higher version. 

The root cause is that the TiDB node (< 5.0) lacks the ability of decompression until
the version >= 5.0, fixed by [PR#20438](https://github.com/pingcap/tidb/pull/20438). And when rolling upgrading the cluster, 
the TiDB nodes (version < 5.0) cannot correctly decompress the compressed data
sent by the TiKV node, which has already been upgraded to the version >= 6.5.11. 
And it will make the whole cluster abnormal for the service.

Issue Number: Close https://github.com/tikv/tikv/issues/18079

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Revert PR #17312 to fix relevant issues when one cluster upgrades from the version <= 5.0 to the version > 5.0.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Revert PR #17312 to fix relevant issues when one cluster upgrades from the version <= 5.0 to the version > 5.0.
```
