### PR TITLE
raftstore: skip sync WAL for transfer leader admin commands

### DIFF
--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -5358,7 +5358,7 @@ mod tests {
         // Admin command
         for admin_cmd in AdminCmdType::values() {
             let mut req = RaftCmdRequest::default();
-            req.mut_admin_request().set_cmd_type(admin_cmd.clone());
+            req.mut_admin_request().set_cmd_type(*admin_cmd);
             assert_eq!(
                 should_sync_log(&req),
                 matches!(

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -873,10 +873,18 @@ fn has_high_latency_operation(cmd: &RaftCmdRequest) -> bool {
 /// Checks if a write is needed to be issued after handling the command.
 fn should_sync_log(cmd: &RaftCmdRequest) -> bool {
     if cmd.has_admin_request() {
-        if cmd.get_admin_request().get_cmd_type() == AdminCmdType::CompactLog {
-            // We do not need to sync WAL before compact log, because this request will send
-            // a msg to raft_gc_log thread to delete the entries before this
-            // index instead of deleting them in apply thread directly.
+        if matches!(
+            cmd.get_admin_request().get_cmd_type(),
+            // We do not need to sync WAL before compact log, because this
+            // request will send a msg to raft_gc_log thread to delete the entries
+            // before this index instead of deleting them in apply thread directly.
+            AdminCmdType::CompactLog
+            // ComputeHash, VerifyHash and TransferLeader are read-only commands,
+            // so they do not need to sync WAL.
+            | AdminCmdType::ComputeHash
+                | AdminCmdType::VerifyHash
+                | AdminCmdType::TransferLeader
+        ) {
             return false;
         }
         return true;
@@ -5183,7 +5191,7 @@ mod tests {
         metapb::{self, RegionEpoch},
         raft_cmdpb::*,
     };
-    use protobuf::Message;
+    use protobuf::{Message, ProtobufEnum};
     use raft::eraftpb::{ConfChange, ConfChangeV2};
     use sst_importer::Config as ImportConfig;
     use tempfile::{Builder, TempDir};
@@ -5348,10 +5356,32 @@ mod tests {
     #[test]
     fn test_should_sync_log() {
         // Admin command
-        let mut req = RaftCmdRequest::default();
-        req.mut_admin_request()
-            .set_cmd_type(AdminCmdType::ComputeHash);
-        assert_eq!(should_sync_log(&req), true);
+        for admin_cmd in AdminCmdType::values() {
+            let mut req = RaftCmdRequest::default();
+            req.mut_admin_request().set_cmd_type(admin_cmd.clone());
+            assert_eq!(
+                should_sync_log(&req),
+                matches!(
+                    admin_cmd,
+                    AdminCmdType::InvalidAdmin |
+                    AdminCmdType::ChangePeer |
+                    AdminCmdType::Split |
+                    // AdminCmdType::CompactLog |
+                    // AdminCmdType::TransferLeader |
+                    // AdminCmdType::ComputeHash |
+                    // AdminCmdType::VerifyHash |
+                    AdminCmdType::PrepareMerge |
+                    AdminCmdType::CommitMerge |
+                    AdminCmdType::RollbackMerge |
+                    AdminCmdType::BatchSplit |
+                    AdminCmdType::ChangePeerV2 |
+                    AdminCmdType::PrepareFlashback |
+                    AdminCmdType::FinishFlashback |
+                    AdminCmdType::BatchSwitchWitness |
+                    AdminCmdType::UpdateGcPeer
+                )
+            );
+        }
 
         // IngestSst command
         let mut req = Request::default();


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: close #18275 

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

Excluding TransferLeader from WAL synchronization, TiKV can reduce unnecessary I/O operations, thereby mitigating latency spikes during leader transfers.


```commit-message

```

### Check List

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
