### PR TITLE
concurrency-manager: (release-6.5) do not assert in max ts checker

### DIFF
--- a/components/concurrency_manager/src/lib.rs
+++ b/components/concurrency_manager/src/lib.rs
@@ -210,7 +210,6 @@ impl ConcurrencyManager {
         if !limit.limit.is_zero() && new_ts > limit.limit {
             let last_update = limit.update_time;
             let now = self.time_provider.now();
-            assert!(now >= last_update);
             let duration_to_last_limit_update = now - last_update;
 
             if duration_to_last_limit_update < self.limit_valid_duration {

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -9,12 +9,13 @@ use std::{
         mpsc::Sender,
         Arc, Mutex,
     },
+    time::Duration,
     vec::IntoIter,
 };
 
 use api_version::{ApiV2, KvFormat};
 use collections::HashMap;
-use concurrency_manager::ConcurrencyManager;
+use concurrency_manager::{ActionOnInvalidMaxTs, ConcurrencyManager};
 use engine_rocks::FlowInfo;
 use engine_traits::{
     raw_ttl::ttl_current_ts, DeleteStrategy, Error as EngineError, KvEngine, MiscExt, Range,
@@ -359,7 +360,14 @@ impl<E: Engine> GcRunnerCore<E> {
 
     fn new_txn() -> MvccTxn {
         // TODO txn only used for GC, but this is hacky, maybe need an Option?
-        let concurrency_manager = ConcurrencyManager::new(1.into());
+        // a dummy cm
+        let concurrency_manager = ConcurrencyManager::new_with_config(
+            1.into(),
+            Duration::from_secs(45),
+            ActionOnInvalidMaxTs::Log,
+            None,
+            Duration::from_secs(46),
+        );
         MvccTxn::new(TimeStamp::zero(), concurrency_manager)
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #17916

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Do not assert in max-ts checker.
Fix a fake error log in gc worker.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
