### PR TITLE
cdc: fix unresolved region metrics

### DIFF
--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -621,6 +621,7 @@ impl Delegate {
         let locks = match &self.lock_tracker {
             LockTracker::Prepared { locks, .. } => locks,
             _ => {
+                advance.blocked_on_scan += 1;
                 let now = Instant::now_coarse();
                 let elapsed = now.duration_since(self.created);
                 if elapsed > WARN_LAG_THRESHOLD

--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -621,7 +621,7 @@ impl Delegate {
         let locks = match &self.lock_tracker {
             LockTracker::Prepared { locks, .. } => locks,
             _ => {
-                advance.blocked_on_scan += 1;
+                advance.blocked_on_scan += self.downstreams.len();
                 let now = Instant::now_coarse();
                 let elapsed = now.duration_since(self.created);
                 if elapsed > WARN_LAG_THRESHOLD

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -157,7 +157,7 @@ type InitCallback = Box<dyn FnOnce() + Send>;
 pub enum Validate {
     Region(u64, Box<dyn FnOnce(Option<&Delegate>) + Send>),
     OldValueCache(Box<dyn FnOnce(&OldValueCache) + Send>),
-    UnresolvedRegion(Box<dyn FnOnce(usize) + Send> ),
+    UnresolvedRegion(Box<dyn FnOnce(usize) + Send>),
 }
 
 pub enum Task {

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -157,6 +157,7 @@ type InitCallback = Box<dyn FnOnce() + Send>;
 pub enum Validate {
     Region(u64, Box<dyn FnOnce(Option<&Delegate>) + Send>),
     OldValueCache(Box<dyn FnOnce(&OldValueCache) + Send>),
+    UnresolvedRegion(Box<dyn FnOnce(usize) + Send> ),
 }
 
 pub enum Task {
@@ -286,6 +287,7 @@ impl fmt::Debug for Task {
             Task::Validate(validate) => match validate {
                 Validate::Region(region_id, _) => de.field("region_id", &region_id).finish(),
                 Validate::OldValueCache(_) => de.finish(),
+                Validate::UnresolvedRegion(_) => de.finish(),
             },
             Task::ChangeConfig(change) => de
                 .field("type", &"change_config")
@@ -1287,6 +1289,9 @@ impl<T: 'static + CdcHandle<E>, E: KvEngine, S: StoreRegionMeta + Send> Runnable
                 }
                 Validate::OldValueCache(validate) => {
                     validate(&self.old_value_cache);
+                }
+                Validate::UnresolvedRegion(validate) => {
+                    validate(self.unresolved_region_count);
                 }
             },
             Task::ChangeConfig(change) => self.on_change_cfg(change),

--- a/components/cdc/tests/failpoints/test_endpoint.rs
+++ b/components/cdc/tests/failpoints/test_endpoint.rs
@@ -734,14 +734,19 @@ fn test_cdc_unresolved_region_count_before_finish_scan_lock() {
             let (tx, rx) = mpsc::sync_channel(1);
             let checker = move |c: usize| tx.send(c).unwrap();
             scheduler
-                .schedule(Task::Validate(Validate::UnresolvedRegion(Box::new(checker))))
+                .schedule(Task::Validate(Validate::UnresolvedRegion(Box::new(
+                    checker,
+                ))))
                 .unwrap();
             let actual_count = rx.recv().unwrap();
             if actual_count == target_count {
                 return;
             }
             if start.elapsed() > Duration::from_secs(5) {
-                panic!("check unresolve region failed, actual_count: {}, target_count: {}", actual_count, target_count);
+                panic!(
+                    "check unresolve region failed, actual_count: {}, target_count: {}",
+                    actual_count, target_count
+                );
             }
         }
     }
@@ -778,7 +783,8 @@ fn test_cdc_unresolved_region_count_before_finish_scan_lock() {
     let mut event_feeds = Vec::with_capacity(region_count);
     let mut receive_events = Vec::with_capacity(region_count);
     for region in regions.clone() {
-        let (mut req_tx, event_feed, receive_event) = new_event_feed(suite.get_region_cdc_client(region.id));
+        let (mut req_tx, event_feed, receive_event) =
+            new_event_feed(suite.get_region_cdc_client(region.id));
         let mut req = suite.new_changedata_request(region.id);
         req.mut_header().set_ticdc_version("7.0.0".into());
         req.set_region_epoch(region.get_region_epoch().clone());
@@ -793,7 +799,7 @@ fn test_cdc_unresolved_region_count_before_finish_scan_lock() {
     // Wait until all initialization finishes and check again.
     fail::remove("before_schedule_resolver_ready");
     for receive_event in receive_events {
-        receive_event(false); 
+        receive_event(false);
     }
     check_unresolved_region_count(&suite.endpoints[&1].scheduler(), 0);
 

--- a/components/cdc/tests/failpoints/test_endpoint.rs
+++ b/components/cdc/tests/failpoints/test_endpoint.rs
@@ -3,7 +3,7 @@
 use std::{
     sync::{mpsc, Arc},
     thread,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use api_version::{test_kv_format_impl, KvFormat};
@@ -60,6 +60,7 @@ fn test_cdc_double_scan_deregister_impl<F: KvFormat>() {
 
     // wait for the second connection register to the delegate.
     suite.must_wait_delegate_condition(
+        1,
         1,
         Arc::new(|d: Option<&Delegate>| d.unwrap().downstreams().len() == 2),
     );
@@ -722,4 +723,85 @@ fn test_cdc_pipeline_dml() {
     assert_eq!(entries[0].generation, 1);
     assert_eq!(entries[0].value, vec![b'x'; 16]);
     assert_eq!(entries[1].r_type, EventLogType::Initialized);
+}
+
+#[test]
+fn test_cdc_unresolved_region_count_before_finish_scan_lock() {
+    fn check_unresolved_region_count(scheduler: &Scheduler<Task>, target_count: usize) {
+        let start = Instant::now();
+        loop {
+            sleep_ms(100);
+            let (tx, rx) = mpsc::sync_channel(1);
+            let checker = move |c: usize| tx.send(c).unwrap();
+            scheduler
+                .schedule(Task::Validate(Validate::UnresolvedRegion(Box::new(checker))))
+                .unwrap();
+            let actual_count = rx.recv().unwrap();
+            if actual_count == target_count {
+                return;
+            }
+            if start.elapsed() > Duration::from_secs(5) {
+                panic!("check unresolve region failed, actual_count: {}, target_count: {}", actual_count, target_count);
+            }
+        }
+    }
+
+    let cluster = new_server_cluster(0, 1);
+    let mut suite = TestSuiteBuilder::new().cluster(cluster).build();
+
+    // create regions
+    let region_count = 100;
+    let split_keys: Vec<Vec<u8>> = (1..=region_count * 2 - 1)
+        .step_by(2)
+        .map(|i| format!("key_{:03}", i).into_bytes())
+        .collect();
+    let get_keys: Vec<Vec<u8>> = (0..=region_count * 2)
+        .step_by(2)
+        .map(|i| format!("key_{:03}", i).into_bytes())
+        .collect();
+    for i in 0..region_count - 1 {
+        let split_key = &split_keys[i];
+        let target_region = suite.cluster.get_region(split_key);
+        suite.cluster.must_split(&target_region, split_key);
+    }
+    let mut regions = Vec::with_capacity(region_count);
+    for i in 0..region_count {
+        let get_key = &get_keys[i];
+        let region = suite.cluster.get_region(get_key);
+        regions.push(region.clone());
+    }
+
+    fail::cfg("before_schedule_resolver_ready", "pause").unwrap();
+
+    // create event feed for all regions
+    let mut req_txs = Vec::with_capacity(region_count);
+    let mut event_feeds = Vec::with_capacity(region_count);
+    let mut receive_events = Vec::with_capacity(region_count);
+    for region in regions.clone() {
+        let (mut req_tx, event_feed, receive_event) = new_event_feed(suite.get_region_cdc_client(region.id));
+        let mut req = suite.new_changedata_request(region.id);
+        req.mut_header().set_ticdc_version("7.0.0".into());
+        req.set_region_epoch(region.get_region_epoch().clone());
+        block_on(req_tx.send((req, WriteFlags::default()))).unwrap();
+        req_txs.push(req_tx);
+        event_feeds.push(event_feed);
+        receive_events.push(receive_event);
+    }
+
+    check_unresolved_region_count(&suite.endpoints[&1].scheduler(), region_count);
+
+    // Wait until all initialization finishes and check again.
+    fail::remove("before_schedule_resolver_ready");
+    for receive_event in receive_events {
+        receive_event(false); 
+    }
+    check_unresolved_region_count(&suite.endpoints[&1].scheduler(), 0);
+
+    for req_tx in req_txs {
+        drop(req_tx);
+    }
+    for event_feed in event_feeds {
+        drop(event_feed);
+    }
+    suite.stop();
 }

--- a/components/cdc/tests/mod.rs
+++ b/components/cdc/tests/mod.rs
@@ -699,10 +699,11 @@ impl TestSuite {
 
     pub fn must_wait_delegate_condition(
         &self,
+        node_id: u64,
         region_id: u64,
         cond: Arc<dyn Fn(Option<&Delegate>) -> bool + Sync + Send>,
     ) {
-        let scheduler = self.endpoints[&region_id].scheduler();
+        let scheduler = self.endpoints[&node_id].scheduler();
         let start = Instant::now();
         loop {
             sleep_ms(100);


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18306

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
 Include regions that have not completed scan locking in the unresolved region count.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [x] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None.
```
