### PR TITLE
txn: revert #18200 to fix the data inconsistency

### DIFF
--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -122,18 +122,6 @@ impl<S: EngineSnapshot> SnapshotReader<S> {
     pub fn take_statistics(&mut self) -> Statistics {
         std::mem::take(&mut self.reader.statistics)
     }
-
-    #[inline(always)]
-    pub fn setup_with_hint_items<T>(&mut self, items: &mut [T], key_of: fn(&T) -> &Key) {
-        // enable scan mode if there are multiple items, so that we don't need to seek
-        // for every key.
-        if items.len() > 1 {
-            items.sort_by(|a, b| key_of(a).cmp(key_of(b)));
-            self.reader.scan_mode = Some(ScanMode::Forward);
-            self.reader
-                .set_range(Some(key_of(items.first().unwrap()).clone()), None);
-        }
-    }
 }
 
 pub struct MvccReader<S: EngineSnapshot> {

--- a/src/storage/txn/commands/acquire_pessimistic_lock.rs
+++ b/src/storage/txn/commands/acquire_pessimistic_lock.rs
@@ -86,12 +86,12 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for AcquirePessimisticLock 
             ))));
         }
 
-        let (start_ts, ctx, mut keys) = (self.start_ts, self.ctx, self.keys);
+        let (start_ts, ctx, keys) = (self.start_ts, self.ctx, self.keys);
         let mut txn = MvccTxn::new(start_ts, context.concurrency_manager);
-
-        let mut snapshot_reader = SnapshotReader::new_with_ctx(start_ts, snapshot, &ctx);
-        snapshot_reader.setup_with_hint_items(&mut keys, |k| &k.0);
-        let mut reader = ReaderWithStats::new(snapshot_reader, context.statistics);
+        let mut reader = ReaderWithStats::new(
+            SnapshotReader::new_with_ctx(start_ts, snapshot, &ctx),
+            context.statistics,
+        );
 
         let total_keys = keys.len();
         let mut res = PessimisticLockResults::with_capacity(total_keys);

--- a/src/storage/txn/commands/commit.rs
+++ b/src/storage/txn/commands/commit.rs
@@ -55,15 +55,15 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for Commit {
             }));
         }
         let mut txn = MvccTxn::new(self.lock_ts, context.concurrency_manager);
-        let mut keys = self.keys;
-        let mut snapshot_reader = SnapshotReader::new_with_ctx(self.lock_ts, snapshot, &self.ctx);
-        snapshot_reader.setup_with_hint_items(&mut keys, |k| k);
-        let mut reader = ReaderWithStats::new(snapshot_reader, context.statistics);
+        let mut reader = ReaderWithStats::new(
+            SnapshotReader::new_with_ctx(self.lock_ts, snapshot, &self.ctx),
+            context.statistics,
+        );
 
-        let rows = keys.len();
+        let rows = self.keys.len();
         // Pessimistic txn needs key_hashes to wake up waiters
         let mut released_locks = ReleasedLocks::new();
-        for k in keys {
+        for k in self.keys {
             released_locks.push(commit(&mut txn, &mut reader, k, self.commit_ts)?);
         }
 

--- a/src/storage/txn/commands/flush.rs
+++ b/src/storage/txn/commands/flush.rs
@@ -2,8 +2,8 @@
 
 use std::mem;
 
-// #[PerformanceCriticalPath]
 use kvproto::kvrpcpb::{AssertionLevel, ExtraOp, PrewriteRequestPessimisticAction};
+// #[PerformanceCriticalPath]
 use txn_types::{insert_old_value_if_resolved, Mutation, OldValues, TimeStamp, TxnExtra};
 
 use crate::storage::{
@@ -76,10 +76,10 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for Flush {
         }
         let rows = self.mutations.len();
         let mut txn = MvccTxn::new(self.start_ts, context.concurrency_manager);
-
-        let mut snapshot_reader = SnapshotReader::new_with_ctx(self.start_ts, snapshot, &self.ctx);
-        snapshot_reader.setup_with_hint_items(&mut self.mutations, |m| m.key());
-        let mut reader = ReaderWithStats::new(snapshot_reader, context.statistics);
+        let mut reader = ReaderWithStats::new(
+            SnapshotReader::new_with_ctx(self.start_ts, snapshot, &self.ctx),
+            context.statistics,
+        );
         let mut old_values = Default::default();
 
         let res = self.flush(&mut txn, &mut reader, &mut old_values, context.extra_op);

--- a/src/storage/txn/commands/resolve_lock.rs
+++ b/src/storage/txn/commands/resolve_lock.rs
@@ -80,13 +80,13 @@ impl CommandExt for ResolveLock {
 
 impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for ResolveLock {
     fn process_write(mut self, snapshot: S, context: WriteContext<'_, L>) -> Result<WriteResult> {
-        let (ctx, txn_status, mut key_locks) = (self.ctx, self.txn_status, self.key_locks);
+        let (ctx, txn_status, key_locks) = (self.ctx, self.txn_status, self.key_locks);
 
         let mut txn = MvccTxn::new(TimeStamp::zero(), context.concurrency_manager);
-
-        let mut snapshot_reader = SnapshotReader::new_with_ctx(TimeStamp::zero(), snapshot, &ctx);
-        snapshot_reader.setup_with_hint_items(&mut key_locks, |k| &k.0);
-        let mut reader = ReaderWithStats::new(snapshot_reader, context.statistics);
+        let mut reader = ReaderWithStats::new(
+            SnapshotReader::new_with_ctx(TimeStamp::zero(), snapshot, &ctx),
+            context.statistics,
+        );
 
         let mut scan_key = self.scan_key.take();
         let rows = key_locks.len();

--- a/src/storage/txn/commands/rollback.rs
+++ b/src/storage/txn/commands/rollback.rs
@@ -48,12 +48,12 @@ impl CommandExt for Rollback {
 }
 
 impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for Rollback {
-    fn process_write(mut self, snapshot: S, context: WriteContext<'_, L>) -> Result<WriteResult> {
+    fn process_write(self, snapshot: S, context: WriteContext<'_, L>) -> Result<WriteResult> {
         let mut txn = MvccTxn::new(self.start_ts, context.concurrency_manager);
-
-        let mut snapshot_reader = SnapshotReader::new_with_ctx(self.start_ts, snapshot, &self.ctx);
-        snapshot_reader.setup_with_hint_items(&mut self.keys, |k| k);
-        let mut reader = ReaderWithStats::new(snapshot_reader, context.statistics);
+        let mut reader = ReaderWithStats::new(
+            SnapshotReader::new_with_ctx(self.start_ts, snapshot, &self.ctx),
+            context.statistics,
+        );
 
         let rows = self.keys.len();
         let mut released_locks = ReleasedLocks::new();


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18249

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
This reverts commit 57b0b62c211c3555c16ea9b80babd13676a12e2c because it introduces a consistency issue.
The cursor in the MVCC reader requires stricter usage (the key and timestamp must be monotonic).
However, the complex usage in schedulers does not guarantee this invariant, which leads to the consistency issue.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code


Run the bank workload successed.
```
./main
[2025/03/19 17:10:02.993 +08:00] [INFO] [main.go:118] ["Start bank workload"]
[2025/03/19 17:10:02.993 +08:00] [INFO] [main.go:192] ["Setting up bank tables and accounts..."]
[2025/03/19 17:10:03.332 +08:00] [INFO] [main.go:397] ["Balance verification passed"] [total=2000000]
[2025/03/19 17:10:03.333 +08:00] [INFO] [main.go:281] ["Starting bank transfers..."]
[2025/03/19 17:10:03.337 +08:00] [INFO] [main.go:397] ["Balance verification passed"] [total=2000000]
[2025/03/19 17:10:05.379 +08:00] [INFO] [main.go:397] ["Balance verification passed"] [total=2000000]
...
[2025/03/19 17:19:58.795 +08:00] [INFO] [main.go:397] ["Balance verification passed"] [total=2000000]
[2025/03/19 17:20:02.540 +08:00] [INFO] [main.go:397] ["Balance verification passed"] [total=2000000]
[2025/03/19 17:20:03.333 +08:00] [INFO] [main.go:148] ["Runtime completed, stopping workload"]
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
