### PR TITLE
server: fix grpc_wait_time measurement

### DIFF
--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -1313,8 +1313,12 @@ fn response_batch_commands_request<F, T>(
     T: Default,
 {
     let task = async move {
+        let resp_res = resp.await;
+        // GrpcRequestDuration must be initialized after the response is ready,
+        // because it measures the grpc_wait_time, which is the time from
+        // receiving the response to sending it.
         let measure = GrpcRequestDuration::new(begin, label, source, resource_priority);
-        match resp.await {
+        match resp_res {
             Ok(resp) => {
                 let task = MeasuredSingleResponse::new(id, resp, measure, None);
                 if let Err(e) = tx.send_with(task, WakePolicy::Immediately) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18310

This bug is caused by https://github.com/tikv/tikv/pull/16599

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
The grpc_wait_time should measure the response wait time only.
```

### Check List

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

TiDB slow query:

| Header | TiDB Slowquery |
|--------|--------|
| Before | Slowest_prewrite_rpc_detail: { ... tikv_grpc_process_time: 8.18µs, **tikv_grpc_wait_time: 1.29s**, tikv_wall_time: 1.29s} |
| After | Slowest_prewrite_rpc_detail: { ... tikv_grpc_process_time: 11µs, **tikv_grpc_wait_time: 41.7µs**, tikv_wall_time: 2.32s}  | 

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
