### PR TITLE
tikv_util: fix tokio-timer panic when clock goes backward

### DIFF
--- a/components/tikv_util/src/timer.rs
+++ b/components/tikv_util/src/timer.rs
@@ -3,7 +3,10 @@
 use std::{
     cmp::{Ord, Ordering, Reverse},
     collections::BinaryHeap,
-    sync::{mpsc, Arc},
+    sync::{
+        atomic::{AtomicU64, Ordering as AtomicOrdering},
+        mpsc, Arc,
+    },
     thread::Builder,
     time::Duration,
 };
@@ -92,27 +95,16 @@ impl<T> Ord for TimeoutTask<T> {
     }
 }
 
-lazy_static! {
-    pub static ref GLOBAL_TIMER_HANDLE: Handle = start_global_timer("timer");
+struct SystemClock;
+
+impl Now for SystemClock {
+    fn now(&self) -> std::time::Instant {
+        std::time::Instant::now()
+    }
 }
 
-/// Create a global timer with specific thread name.
-pub fn start_global_timer(name: &str) -> Handle {
-    let (tx, rx) = mpsc::channel();
-    let props = crate::thread_group::current_properties();
-    Builder::new()
-        .name(thd_name!(name))
-        .spawn_wrapper(move || {
-            crate::thread_group::set_properties(props);
-
-            let mut timer = tokio_timer::Timer::default();
-            tx.send(timer.handle()).unwrap();
-            loop {
-                timer.turn(None).unwrap();
-            }
-        })
-        .unwrap();
-    rx.recv().unwrap()
+lazy_static! {
+    pub static ref GLOBAL_TIMER_HANDLE: Handle = start_timer_thread("timer", SystemClock);
 }
 
 /// A struct that marks the *zero* time.
@@ -196,28 +188,91 @@ impl Default for SteadyTimer {
 }
 
 fn start_global_steady_timer() -> SteadyTimer {
-    let (tx, rx) = mpsc::channel();
     let clock = SteadyClock::default();
-    let clock_ = clock.clone();
+    let handle = start_timer_thread("steady-timer", clock.clone());
+    SteadyTimer { clock, handle }
+}
+
+/// A clock that ratchets forward.
+///
+/// It is used to workaround a panic[^1] in tokio-timer when the clock goes
+/// backward, which is possible in some environments, e.g., aliyun ECS g7.
+///
+/// [^1]: https://github.com/tokio-rs/tokio/pull/515
+struct RatchetClock<T: Now> {
+    clock: T,
+    start: std::time::Instant,
+
+    // The last recorded time in milliseconds.
+    //
+    // Using u64 is sufficient here because tokio-timer operates with millisecond
+    // precision, and `u64::MAX` milliseconds represent an extremely large time span
+    // (several million years).
+    last_now_ms: AtomicU64,
+}
+
+impl<T: Now> Now for RatchetClock<T> {
+    fn now(&self) -> std::time::Instant {
+        let now = self.clock.now();
+        let now_ms = now.saturating_duration_since(self.start).as_millis() as u64;
+        let mut last_now_ms = self.last_now_ms.load(AtomicOrdering::Relaxed);
+        loop {
+            if now_ms > last_now_ms {
+                match self.last_now_ms.compare_exchange_weak(
+                    last_now_ms,
+                    now_ms,
+                    AtomicOrdering::SeqCst,
+                    AtomicOrdering::SeqCst,
+                ) {
+                    Ok(_) => {
+                        return now;
+                    }
+                    Err(last_now) => {
+                        last_now_ms = last_now;
+                    }
+                }
+            } else {
+                return self.start + Duration::from_millis(last_now_ms);
+            }
+        }
+    }
+}
+
+impl<T: Now> RatchetClock<T> {
+    fn new(clock: T) -> Self {
+        RatchetClock {
+            clock,
+            start: std::time::Instant::now(),
+            last_now_ms: AtomicU64::new(0),
+        }
+    }
+}
+
+/// Start a timer thread with specific thread name and clock source.
+fn start_timer_thread<T: Now>(name: &str, clock: T) -> Handle {
+    let (tx, rx) = mpsc::channel();
+    let props = crate::thread_group::current_properties();
+    let ratchet_clock = RatchetClock::new(clock);
+    let clock = Clock::new_with_now(ratchet_clock);
     Builder::new()
-        .name(thd_name!("steady-timer"))
+        .name(thd_name!(name))
         .spawn_wrapper(move || {
-            let c = Clock::new_with_now(clock_);
-            let mut timer = tokio_timer::Timer::new_with_now(ParkThread::new(), c);
+            crate::thread_group::set_properties(props);
+
+            let mut timer = tokio_timer::Timer::new_with_now(ParkThread::new(), clock);
             tx.send(timer.handle()).unwrap();
             loop {
                 timer.turn(None).unwrap();
             }
         })
         .unwrap();
-    SteadyTimer {
-        clock,
-        handle: rx.recv().unwrap(),
-    }
+    rx.recv().unwrap()
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::AtomicBool;
+
     use futures::{compat::Future01CompatExt, executor::block_on};
 
     use super::*;
@@ -275,5 +330,38 @@ mod tests {
             end,
             elapsed
         );
+    }
+
+    #[test]
+    fn test_ratchet_clock() {
+        struct BadClock {
+            backward: AtomicBool,
+        }
+        impl Now for BadClock {
+            fn now(&self) -> std::time::Instant {
+                let now = std::time::Instant::now();
+                if self.backward.load(AtomicOrdering::Relaxed) {
+                    self.backward.store(false, AtomicOrdering::Relaxed);
+                    now - Duration::from_millis(10)
+                } else {
+                    self.backward.store(true, AtomicOrdering::Relaxed);
+                    now
+                }
+            }
+        }
+        let clock = BadClock {
+            backward: AtomicBool::new(false),
+        };
+        let handle = start_timer_thread("timer", clock);
+
+        for i in 0..100 {
+            let deadline = if i % 2 == 0 {
+                std::time::Instant::now() + Duration::from_millis(i)
+            } else {
+                std::time::Instant::now() - Duration::from_millis(i)
+            };
+            let delay = handle.delay(deadline);
+            block_on(delay.compat()).unwrap();
+        }
     }
 }

--- a/components/tikv_util/src/timer.rs
+++ b/components/tikv_util/src/timer.rs
@@ -225,7 +225,7 @@ impl<T: Now> Now for RatchetClock<T> {
                     AtomicOrdering::SeqCst,
                 ) {
                     Ok(_) => {
-                        return now;
+                        return self.start + Duration::from_millis(now_ms);
                     }
                     Err(last_now) => {
                         last_now_ms = last_now;


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!
 
If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #16623 Close #14518

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
This commit workarounds a panic[^1] in tokio-timer when the clock goes
backward, which is possible in some environments, e.g., aliyun ECS g7.

[^1]: https://github.com/tokio-rs/tokio/pull/515
```

### Related changes

- Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fix the issue that TiKV panics due to system clock goes backward
```
