### PR TITLE
sst_importer: Get Memory limit at the sst service initialization

### DIFF
--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -99,7 +99,17 @@ const REJECT_SERVE_MEMORY_USAGE: u64 = 1024 * 1024 * 1024; //1G
 const HIGH_IMPORT_MEMORY_WATER_RATIO: f64 = 0.95;
 
 /// Check if the system has enough resources for import tasks
-async fn check_import_resources() -> Result<()> {
+async fn check_import_resources(mem_limit: u64) -> Result<()> {
+    #[cfg(feature = "failpoints")]
+    let mem_limit = (|| {
+        fail_point!("mock_memory_limit", |t| {
+            t.unwrap().parse::<u64>().unwrap()
+        });
+        mem_limit
+    })();
+    #[cfg(not(feature = "failpoints"))]
+    let mem_limit = mem_limit;
+
     // these error(memory or disk) cannot be recover at a short time,
     // in case client retry immediately, sleep for a while
     async fn sleep_with_jitter() {
@@ -113,13 +123,6 @@ async fn check_import_resources() -> Result<()> {
     }
 
     let usage = get_global_memory_usage();
-    let mem_limit = (|| {
-        fail_point!("mock_memory_limit", |t| {
-            t.unwrap().parse::<u64>().unwrap()
-        });
-        SysQuota::memory_limit_in_bytes()
-    })();
-
     if mem_limit == 0 || mem_limit < usage {
         // make it through when cannot get correct memory
         warn!(
@@ -195,6 +198,8 @@ pub struct ImportSstService<E: Engine> {
 
     // When less than now, don't accept any requests.
     suspend: Arc<SuspendDeadline>,
+
+    mem_limit: u64,
 }
 
 struct RequestCollector {
@@ -431,6 +436,7 @@ impl<E: Engine> ImportSstService<E> {
         // Drop the initial pool to accept new tasks
         threads_clone.lock().unwrap().adjust_with(num_threads);
 
+        let mem_limit = SysQuota::memory_limit_in_bytes();
         ImportSstService {
             cfg: cfg_mgr,
             tablets,
@@ -446,6 +452,7 @@ impl<E: Engine> ImportSstService<E> {
             store_meta,
             resource_manager,
             suspend: Arc::default(),
+            mem_limit,
         }
     }
 
@@ -595,6 +602,7 @@ macro_rules! impl_write {
         ) {
             let import = self.importer.clone();
             let tablets = self.tablets.clone();
+            let mem_limit = self.mem_limit;
             let region_info_accessor = self.region_info_accessor.clone();
             let (rx, buf_driver) =
                 create_stream_with_buffer(stream, self.cfg.rl().stream_channel_window);
@@ -667,7 +675,7 @@ macro_rules! impl_write {
                             );
                         }
                     };
-                    if let Err(e) = check_import_resources().await {
+                    if let Err(e) = check_import_resources(mem_limit).await {
                         warn!("Write failed due to not enough resource {:?}", e);
                         return (Err(e), Some(rx));
                     }
@@ -813,6 +821,7 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
         let label = "upload";
         let timer = Instant::now_coarse();
         let import = self.importer.clone();
+        let mem_limit= self.mem_limit;
         let (rx, buf_driver) =
             create_stream_with_buffer(stream, self.cfg.rl().stream_channel_window);
         let mut map_rx = rx.map_err(Error::from);
@@ -827,7 +836,7 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
                     _ => return Err(Error::InvalidChunk),
                 };
                 let file = import.create(meta)?;
-                if let Err(e) = check_import_resources().await {
+                if let Err(e) = check_import_resources(mem_limit).await {
                     warn!("Upload failed due to not enough resource {:?}", e);
                     return Err(e);
                 }
@@ -895,6 +904,7 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
         let start = Instant::now();
         let importer = self.importer.clone();
         let limiter = self.limiter.clone();
+        let mem_limit= self.mem_limit;
         let max_raft_size = self.raft_entry_max_size.0 as usize;
         let applier = self.writer.clone();
 
@@ -906,7 +916,7 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
                 .observe(start.saturating_elapsed().as_secs_f64());
 
             let mut resp = ApplyResponse::default();
-            match check_import_resources().await {
+            match check_import_resources(mem_limit).await {
                 Ok(()) => (),
                 Err(e) => {
                     resp.set_error(e.into());
@@ -939,6 +949,7 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
         let timer = Instant::now_coarse();
         let importer = Arc::clone(&self.importer);
         let limiter = self.limiter.clone();
+        let mem_limit = self.mem_limit;
         let region_id = req.get_sst().get_region_id();
         let tablets = self.tablets.clone();
         let start = Instant::now();
@@ -959,7 +970,7 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
                 .observe(start.saturating_elapsed().as_secs_f64());
 
             let mut resp = DownloadResponse::default();
-            match check_import_resources().await {
+            match check_import_resources(mem_limit).await {
                 Ok(()) => (),
                 Err(e) => {
                     resp.set_error(e.into());
@@ -1007,7 +1018,7 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
                 ),
                 resource_limiter,
             );
-            let mut resp = DownloadResponse::default();
+            let mut resp: DownloadResponse = DownloadResponse::default();
             match res.await {
                 Ok(range) => match range {
                     Some(r) => resp.set_range(r),

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -821,7 +821,7 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
         let label = "upload";
         let timer = Instant::now_coarse();
         let import = self.importer.clone();
-        let mem_limit= self.mem_limit;
+        let mem_limit = self.mem_limit;
         let (rx, buf_driver) =
             create_stream_with_buffer(stream, self.cfg.rl().stream_channel_window);
         let mut map_rx = rx.map_err(Error::from);
@@ -904,7 +904,7 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
         let start = Instant::now();
         let importer = self.importer.clone();
         let limiter = self.limiter.clone();
-        let mem_limit= self.mem_limit;
+        let mem_limit = self.mem_limit;
         let max_raft_size = self.raft_entry_max_size.0 as usize;
         let applier = self.writer.clone();
 
@@ -1018,7 +1018,7 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
                 ),
                 resource_limiter,
             );
-            let mut resp: DownloadResponse = DownloadResponse::default();
+            let mut resp = DownloadResponse::default();
             match res.await {
                 Ok(range) => match range {
                     Some(r) => resp.set_range(r),

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -910,7 +910,8 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
                 Ok(()) => (),
                 Err(e) => {
                     resp.set_error(e.into());
-                    return crate::send_rpc_response!(Ok(resp), sink, label, start);
+                    crate::send_rpc_response!(Ok(resp), sink, label, start);
+                    return;
                 }
             }
 
@@ -962,7 +963,8 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
                 Ok(()) => (),
                 Err(e) => {
                     resp.set_error(e.into());
-                    return crate::send_rpc_response!(Ok(resp), sink, label, timer);
+                    crate::send_rpc_response!(Ok(resp), sink, label, timer);
+                    return;
                 }
             }
 
@@ -985,7 +987,8 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
                     ));
                     let mut resp = DownloadResponse::default();
                     resp.set_error(error.into());
-                    return crate::send_rpc_response!(Ok(resp), sink, label, timer);
+                    crate::send_rpc_response!(Ok(resp), sink, label, timer);
+                    return;
                 }
             };
 

--- a/tests/failpoints/cases/test_import_service.rs
+++ b/tests/failpoints/cases/test_import_service.rs
@@ -20,8 +20,70 @@ mod util;
 
 use self::util::{
     new_cluster_and_tikv_import_client, new_cluster_and_tikv_import_client_tde,
-    open_cluster_and_tikv_import_client_v2,
+    open_cluster_and_tikv_import_client, open_cluster_and_tikv_import_client_v2,
 };
+
+#[test]
+fn test_concurrent_download_sst() {
+    let mut config = TikvConfig::default();
+    // neet set server threads to a large number;
+    config.import.num_threads = 10;
+    let (_cluster, ctx, tikv, import) = open_cluster_and_tikv_import_client(Some(config));
+    let temp_dir = Builder::new()
+        .prefix("test_concurrent_download_sst")
+        .tempdir()
+        .unwrap();
+
+    let metas = Arc::new(Mutex::new(Vec::new()));
+    let threads: Vec<_> = (0..10)
+        .map(|i| {
+            let file_name = format!("test_{}.sst", i);
+            let sst_path = temp_dir.path().join(&file_name);
+            let sst_range = (i, (i + 1) * 2);
+            let (mut meta, _) = gen_sst_file(sst_path, sst_range);
+            meta.set_region_id(ctx.get_region_id());
+            meta.set_region_epoch(ctx.get_region_epoch().clone());
+
+            // Run multiple concurrent downloads
+            let mut download = DownloadRequest::default();
+            download.set_sst(meta.clone());
+            download.set_storage_backend(external_storage::make_local_backend(temp_dir.path()));
+            download.set_name(file_name);
+            download.mut_sst().mut_range().set_start(vec![sst_range.1]);
+            download
+                .mut_sst()
+                .mut_range()
+                .set_end(vec![sst_range.1 + 1]);
+            download.mut_sst().mut_range().set_start(Vec::new());
+            download.mut_sst().mut_range().set_end(Vec::new());
+            let import = import.clone();
+            let download = download.clone();
+            let metas = Arc::clone(&metas);
+
+            std::thread::spawn(move || {
+                let result: DownloadResponse = import.download(&download).unwrap();
+                assert!(!result.get_is_empty());
+                assert_eq!(result.get_range().get_start(), &[sst_range.0]);
+                assert_eq!(result.get_range().get_end(), &[sst_range.1 - 1]);
+                // Only store meta after successful download
+                metas.lock().unwrap().push((meta, sst_range));
+                println!("Thread {} completed download", i);
+            })
+        })
+        .collect();
+
+    // Wait for all downloads to complete
+    for handle in threads {
+        handle.join().unwrap();
+    }
+
+    // Now ingest all SSTs in order
+    let metas = metas.lock().unwrap();
+    for (meta, sst_range) in metas.iter() {
+        must_ingest_sst(&import, ctx.clone(), meta.clone());
+        check_ingested_kvs(&tikv, &ctx, *sst_range);
+    }
+}
 
 // Opening sst writer involves IO operation, it may block threads for a while.
 // Test if download sst works when opening sst writer is blocked.


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18317
and close https://github.com/pingcap/tidb/issues/60140

1. Get memory limit multiple times is unnecessary. 
2. The previous memory checks's granularity was too fine, performing a check on every chunk. Since Lightning writes in 16KB chunks, the frequent checks resulted in noticeable overhead.

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

1. This PR change the behavior to only get memory limit once at beginning. 
2. This PR adjusts the memory check to be performed per request instead of per chunk
```commit-message
sst_importer: Get Memory limit at the sst service initialization #18321
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
