### PR TITLE
[DNM] [FOR TEST] disable lto on dist-release

### DIFF
--- a/etc/cargo.config.dist
+++ b/etc/cargo.config.dist
@@ -6,7 +6,7 @@
 opt-level = 3
 debug = true
 rpath = false
-lto = true
+lto = false
 debug-assertions = false
 codegen-units = 1
 panic = "unwind"


### PR DESCRIPTION
As title, it seems LTO may break the debug info and `gdb` doesn't work. We need a temporary binary to debug some problem.