### PR TITLE
txn: add pessimistic lock command read value test

### DIFF
--- a/src/storage/txn/commands/acquire_pessimistic_lock.rs
+++ b/src/storage/txn/commands/acquire_pessimistic_lock.rs
@@ -208,3 +208,149 @@ pub(super) fn make_write_data(modifies: Vec<Modify>, old_values: OldValues) -> W
         WriteData::default()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::{
+        txn::{
+            actions::{
+                acquire_pessimistic_lock::tests::must_pessimistic_locked,
+                tests::{must_prewrite_delete, must_prewrite_lock, must_prewrite_put},
+            },
+            commands::test_util::pessimistic_lock,
+            tests::{must_commit, must_rollback},
+        },
+        Statistics, TestEngineBuilder,
+    };
+
+    impl PartialEq for PessimisticLockKeyResult {
+        fn eq(&self, other: &Self) -> bool {
+            match (self, other) {
+                (Self::Empty, Self::Empty) => true,
+                (Self::Value(a), Self::Value(b)) => a == b,
+                (Self::Existence(a), Self::Existence(b)) => a == b,
+                (
+                    Self::LockedWithConflict {
+                        value: v1,
+                        conflict_ts: ts1,
+                    },
+                    Self::LockedWithConflict {
+                        value: v2,
+                        conflict_ts: ts2,
+                    },
+                ) => v1 == v2 && ts1 == ts2,
+                (Self::Waiting, Self::Waiting) => true,
+                (Self::Failed(a), Self::Failed(b)) => format!("{:?}", a) == format!("{:?}", b),
+                _ => false,
+            }
+        }
+    }
+
+    #[test]
+    fn test_pessimistic_with_value() {
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+        let mut statistics = Statistics::default();
+
+        let k1 = b"k1";
+        let k2 = b"k2";
+        let k3 = b"k3";
+        let k4 = b"k4";
+        let k5 = b"k5";
+
+        let v1 = b"v1";
+        let v2 = b"v2";
+        let v3 = b"v3";
+
+        // MVCC Versions
+        // commit_ts  writes
+        // 20         k1: put(v1)  k2: put(v1) k3: put(v1)    k4: put(v1)
+        // 40         k1: put(v2)  k2: put(v2) k3: delete     k4: delete
+        // 50         k1: rollback             k3: rollback
+        // 60                      k2: lock                   k4: lock
+        // values:    k1: v2       k2: v2      k3: -          k4: -          k5: -
+
+        // version 20
+        for k in [k1, k2, k3, k4] {
+            must_prewrite_put(&mut engine, k, v1, k1, 10);
+        }
+        for k in [k1, k2, k3, k4] {
+            must_commit(&mut engine, k, 10, 20);
+        }
+        // version 40
+        for k in [k1, k2] {
+            must_prewrite_put(&mut engine, k, v2, k1, 30);
+        }
+        for k in [k3, k4] {
+            must_prewrite_delete(&mut engine, k, k1, 30);
+        }
+        for k in [k1, k2, k3, k4] {
+            must_commit(&mut engine, k, 30, 40);
+        }
+        // version 50
+        for k in [k1, k3] {
+            must_prewrite_put(&mut engine, k, v3, k1, 50);
+        }
+        for k in [k1, k3] {
+            must_rollback(&mut engine, k, 50, false)
+        }
+        // version 60
+        for k in [k2, k4] {
+            must_prewrite_lock(&mut engine, k, v2, 51);
+        }
+        for k in [k2, k4] {
+            must_commit(&mut engine, k, 51, 60);
+        }
+
+        for start_ts in [15, 25, 35, 45, 55, 65] {
+            let for_update_ts = start_ts + 50;
+            let pk = k1.to_vec();
+            let keys = vec![k1, k2, k3, k4, k5];
+            let expects: Vec<PessimisticLockKeyResult> = [Some(v2), Some(v2), None, None, None]
+                .iter()
+                .map(|v| PessimisticLockKeyResult::Value(v.map(|b| b.to_vec())))
+                .collect();
+            let res = pessimistic_lock(
+                &mut engine,
+                &mut statistics,
+                keys.clone()
+                    .into_iter()
+                    .map(|k| (k.as_ref(), false))
+                    .collect(),
+                pk,
+                start_ts,
+                for_update_ts,
+                true,
+            );
+            assert_eq!(res.0, expects);
+            for key in keys.clone() {
+                must_pessimistic_locked(&mut engine, key, start_ts, for_update_ts);
+            }
+            for key in keys.clone() {
+                must_rollback(&mut engine, key, start_ts, false)
+            }
+
+            // single key lock test
+            for (i, key) in keys.into_iter().enumerate() {
+                let start_ts = start_ts + 1;
+                let for_update_ts = start_ts + 50;
+                let pk = key.to_vec();
+                let keys = vec![(key.as_ref(), false)];
+                let expect = &expects[i];
+                let res = pessimistic_lock(
+                    &mut engine,
+                    &mut statistics,
+                    keys,
+                    pk,
+                    start_ts,
+                    for_update_ts,
+                    true,
+                );
+                assert_eq!(res.0.len(), 1);
+                assert_eq!(&res.0[0], expect);
+                must_pessimistic_locked(&mut engine, key, start_ts, for_update_ts);
+                must_rollback(&mut engine, key, start_ts, false);
+            }
+        }
+    }
+}

--- a/src/storage/txn/commands/acquire_pessimistic_lock.rs
+++ b/src/storage/txn/commands/acquire_pessimistic_lock.rs
@@ -248,7 +248,7 @@ mod tests {
     }
 
     #[test]
-    fn test_pessimistic_with_value() {
+    fn test_pessimistic_with_return_values() {
         let mut engine = TestEngineBuilder::new().build().unwrap();
         let mut statistics = Statistics::default();
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #18208

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
#18200 introduced an optimization that could return incorrect results when handling pessimistic lock requests with the `return_values` flag, but this error wasn't covered by tests.
This PR adds tests for the `acquire_pessimistic_lock` command when values are required.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
