### PR TITLE
sst_importer: add lock for ponential duplicate download

### DIFF
--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -1159,6 +1159,19 @@ impl<E: KvEngine> SstImporter<E> {
         ext: DownloadExt<'_>,
     ) -> Result<Option<Range>> {
         let path = self.dir.join_for_write(meta)?;
+        let path_str = path.temp.to_string_lossy().to_string();
+
+        match self.file_locks.entry(path_str) {
+            Entry::Occupied(_guard) => {
+                // Another download is already in progress
+                info!("ignored duplicated download request {:?}", meta);
+                return Ok(None);
+            }
+            Entry::Vacant(entry) => {
+                // We're the first one, insert our marker and proceed with download
+                entry.insert((CacheKvFile::Fs(Arc::new(path.temp.clone())), Instant::now()));
+            }
+        }
 
         let file_crypter = crypter.map(|c| FileEncryptionInfo {
             method: c.cipher_type,


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close https://github.com/tikv/tikv/issues/18335

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:
Even though each download request is assigned a UUID, duplicate requests can still occur, possibly due to network issues or improper retries. If a duplicate request happens, we might (in the best case) report a download failure. However, in the worst case, the simulated download could corrupt the file, causing TiKV to panic due to a broken checksum in the ingested file.
```commit-message
sst_importer: add lock for ponential duplicate download
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fixed a rare issue where duplicate download requests—caused by improper retries due to network issues—could corrupt files and trigger TiKV panic due to checksum mismatch.
```
