### PR TITLE
raftstore/store: compact the write cf before default cf

### DIFF
--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -2787,8 +2787,10 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
             self.fsm.store.last_compact_checked_key = last_key;
         }
 
-        // Schedule the task.
-        let cf_names = vec![CF_DEFAULT.to_owned(), CF_WRITE.to_owned()];
+        // Schedule the task. 
+        // Since compaction-filter only works for the write-cf and during compaction it may perform(write) 
+        // deletion operations in the default-cf, so we compact the write-cf before the default-cf.
+        let cf_names = vec![CF_WRITE.to_owned(),CF_DEFAULT.to_owned()];
         if let Err(e) = self.ctx.cleanup_scheduler.schedule(CleanupTask::Compact(
             CompactTask::CheckAndCompact {
                 cf_names,

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -2787,10 +2787,11 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
             self.fsm.store.last_compact_checked_key = last_key;
         }
 
-        // Schedule the task. 
-        // Since compaction-filter only works for the write-cf and during compaction it may perform(write) 
-        // deletion operations in the default-cf, so we compact the write-cf before the default-cf.
-        let cf_names = vec![CF_WRITE.to_owned(),CF_DEFAULT.to_owned()];
+        // Schedule the task.
+        // Since compaction-filter only works for the write-cf and during compaction it
+        // may perform(write) deletion operations in the default-cf, so we compact the
+        // write-cf before the default-cf.
+        let cf_names = vec![CF_WRITE.to_owned(), CF_DEFAULT.to_owned()];
         if let Err(e) = self.ctx.cleanup_scheduler.schedule(CleanupTask::Compact(
             CompactTask::CheckAndCompact {
                 cf_names,


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #[18349](https://github.com/tikv/tikv/issues/18349)

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
compact the write cf before default cf 
```

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
