### PR TITLE
sst_importer: make duplicated download report error

### DIFF
--- a/components/error_code/src/sst_importer.rs
+++ b/components/error_code/src/sst_importer.rs
@@ -28,5 +28,7 @@ define_error_codes!(
         "Probably there are some export tools don't support exporting data inserted by `ingest`(say, snapshot backup). Check the user manual and stop them."),
     REQUEST_TOO_NEW => ("RequestTooNew", "", ""),
     REQUEST_TOO_OLD => ("RequestTooOld", "", ""),
-    DISK_SPACE_NOT_ENOUGH => ("DiskSpaceNotEnough", "", "")
+    DISK_SPACE_NOT_ENOUGH => ("DiskSpaceNotEnough", "", ""),
+    MISMATCH_REQUEST => ("MisMatchedRequest", "", ""),
+    ERROR_WRAPPER => ("WrappedError", "", "")
 );

--- a/components/sst_importer/src/errors.rs
+++ b/components/sst_importer/src/errors.rs
@@ -139,6 +139,12 @@ pub enum Error {
 
     #[error("TiKV disk space is not enough.")]
     DiskSpaceNotEnough,
+
+    #[error("mismatch request type")]
+    MisMatchRequest,
+
+    #[error("a general error wrapper")]
+    ErrorWrapper(String),
 }
 
 impl Error {
@@ -226,6 +232,8 @@ impl ErrorCodeExt for Error {
             Error::RequestTooNew(_) => error_code::sst_importer::REQUEST_TOO_NEW,
             Error::RequestTooOld(_) => error_code::sst_importer::REQUEST_TOO_OLD,
             Error::DiskSpaceNotEnough => error_code::sst_importer::DISK_SPACE_NOT_ENOUGH,
+            Error::MisMatchRequest => error_code::sst_importer::MISMATCH_REQUEST,
+            Error::ErrorWrapper(_) => error_code::sst_importer::ERROR_WRAPPER,
         }
     }
 }

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -1229,11 +1229,10 @@ impl<E: KvEngine> SstImporter<E> {
                     }
                     Err(e) => {
                         // Since error is not cloneable,
-                        // we send the origin error to other tasks.
-                        // becasue this task has to fail.
+                        // we send the error with wrapper.
                         warn!("origin download failed"; "meta" => ?meta, "name" => name, "error" => %e);
-                        let _ = tx.send(Some(Err(e)));
-                        Err(Error::FileConflict)
+                        let _ = tx.send(Some(Err(Error::ErrorWrapper(e.to_string().clone()))));
+                        Err(e)
                     }
                 }
             }

--- a/tests/failpoints/cases/test_import_service.rs
+++ b/tests/failpoints/cases/test_import_service.rs
@@ -8,7 +8,6 @@ use std::{
 use futures::{executor::block_on, stream::StreamExt};
 use grpcio::{ChannelBuilder, Environment};
 use kvproto::{disk_usage::DiskUsage, import_sstpb::*, tikvpb_grpc::TikvClient};
-use rand;
 use tempfile::{Builder, TempDir};
 use test_raftstore::{must_raw_put, Simulator};
 use test_sst_importer::*;

--- a/tests/failpoints/cases/test_import_service.rs
+++ b/tests/failpoints/cases/test_import_service.rs
@@ -57,7 +57,7 @@ fn test_concurrent_download_sst_with_fail() {
     ));
 
     let threads: Vec<_> = (0..10)
-        .flat_map(|i: u8| vec![i, i, i]) // duplciate sst file
+        .flat_map(|i: u8| vec![i, i, i]) // duplicate sst file
         .map(|i| {
             let import = import.clone();
             let metas = Arc::clone(&metas);

--- a/tests/failpoints/cases/test_import_service.rs
+++ b/tests/failpoints/cases/test_import_service.rs
@@ -80,9 +80,15 @@ fn test_concurrent_download_sst() {
 
                 let result: DownloadResponse = import.download(&download).unwrap();
                 // Some download might fail, when there is duplicated request.
-                if !result.get_is_empty() {
+                if !result.has_error() {
                     assert_eq!(result.get_range().get_start(), &[sst_range.0]);
                     assert_eq!(result.get_range().get_end(), &[sst_range.1 - 1]);
+                } else {
+                    // ensure download do not set is_empty to true.
+                    assert_eq!(result.get_is_empty(), false);
+                    // ensure failed download report error.
+                    let err_msg = result.get_error().get_message();
+                    assert!(err_msg.contains("cannot duplicated download file"), "{:?}", err_msg);
                 }
             })
         })

--- a/tests/failpoints/cases/test_import_service.rs
+++ b/tests/failpoints/cases/test_import_service.rs
@@ -35,7 +35,7 @@ fn test_concurrent_download_sst_with_fail() {
 
     let temp_path = temp_dir.path().to_owned();
     let local_backend = external_storage::make_local_backend(&temp_path);
-    let inject_err_fn= |i| { i % 2 == 0 };
+    let inject_err_fn = |i| i % 2 == 0;
 
     let metas: Arc<Mutex<Vec<_>>> = Arc::new(Mutex::new(
         (0..10)
@@ -47,14 +47,13 @@ fn test_concurrent_download_sst_with_fail() {
                 meta.set_region_id(ctx.get_region_id());
                 meta.set_region_epoch(ctx.get_region_epoch().clone());
                 if inject_err_fn(i) {
-                    //random inject the wrong length to make download fail
+                    // random inject the wrong length to make download fail
                     meta.set_length(1);
                 }
                 (meta, file_name, sst_range)
             })
             .collect(),
     ));
-
 
     let threads: Vec<_> = (0..10)
         .flat_map(|i: u8| vec![i, i, i]) // duplciate sst file
@@ -86,10 +85,10 @@ fn test_concurrent_download_sst_with_fail() {
                     // we only allow two kinds of error
                     // the origin thread reports file conflict.
                     // the other threads report a wrapped error.
-                    if !err_msg.contains("ingest file conflict") {
+                    if !err_msg.contains("Cannot read local") {
                         assert!(err_msg.contains("a general error wrapper"), "{:?}", err_msg);
                     } else {
-                        assert!(err_msg.contains("ingest file conflict"), "{:?}", err_msg);
+                        assert!(err_msg.contains("Cannot read local"), "{:?}", err_msg);
                     }
                 } else {
                     assert_eq!(result.get_range().get_start(), &[sst_range.0]);
@@ -127,7 +126,7 @@ fn test_concurrent_download_sst() {
     let temp_path = temp_dir.path().to_owned();
     let local_backend = external_storage::make_local_backend(&temp_path);
 
-    fail::cfg("create_local_storage_yield", "return(1000)").unwrap();
+    fail::cfg("create_local_storage_yield", "return(100)").unwrap();
     let metas: Arc<Mutex<Vec<_>>> = Arc::new(Mutex::new(
         (0..10)
             .map(|i| {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close https://github.com/tikv/tikv/issues/18335

- In the previous fix, we added a lock to all download requests and returned OK(None) to skip duplicate download attempts. However, in some more extreme scenarios, returning OK(None) is not appropriate, as it can lead to inconsistent outcomes—some peers may successfully complete the download while others fail.

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

- Historically, BR has relied on the assumption that all peers must either succeed or fail together; partial failures are not acceptable. Therefore, the new code will make duplicated threads wait for origin download finish the request.
```commit-message
sst_importer: make duplicated download report error 
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
