### PR TITLE
deps: Revert openssl changes of #18356

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4531,9 +4531,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.72"
+version = "0.10.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
+checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
 dependencies = [
  "bitflags 2.4.1",
  "cfg-if 1.0.0",
@@ -4546,13 +4546,13 @@ dependencies = [
 
 [[package]]
 name = "openssl-macros"
-version = "0.1.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -4563,18 +4563,18 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-src"
-version = "300.4.2+3.4.1"
+version = "111.25.0+1.1.1t"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168ce4e058f975fe43e89d9ccf78ca668601887ae736090aacc23ae353c298e2"
+checksum = "3173cd3626c43e3854b1b727422a276e568d9ec5fe8cec197822cf52cfb743d6"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.107"
+version = "0.9.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
+checksum = "db7e971c2c2bba161b2d2fdf37080177eff520b3bc044787c7f1f5f9e78d869b"
 dependencies = [
  "cc",
  "libc 0.2.151",
@@ -7991,7 +7991,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4101,14 +4101,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.2"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
- "hermit-abi 0.3.9",
  "libc 0.2.151",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7750,20 +7749,21 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.41.1"
+version = "1.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
+checksum = "68722da18b0fc4a05fdc1120b302b82051265792a1e1b399086e9b204b10ad3d"
 dependencies = [
  "backtrace",
  "bytes",
  "libc 0.2.151",
- "mio 1.0.2",
+ "mio 0.8.11",
+ "num_cpus",
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7777,9 +7777,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7991,7 +7991,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "static_assertions",
 ]
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -90,5 +90,19 @@ openssl::asn1::Asn1GeneralizedTimeRef may call openssl::bio::MemBio::get_buf, \
 see RUSTSEC-2024-0357
 """
 
+# See more about RUSTSEC-2025-0022 in deny.toml.
+[[disallowed-types]]
+path = "openssl::cipher::Cipher::fetch"
+reason = """
+When a Some(...) value was passed to the properties argument of openssl::cipher::Cipher::fetch, \
+a use-after-free would result. See RUSTSEC-2025-0022
+"""
+[[disallowed-types]]
+path = "openssl::md::Md::fetch"
+reason = """
+When a Some(...) value was passed to the properties argument of openssl::md::Md::fetch, \
+a use-after-free would result. See RUSTSEC-2025-0022
+"""
+
 avoid-breaking-exported-api = false
 upper-case-acronyms-aggressive = true

--- a/deny.toml
+++ b/deny.toml
@@ -80,6 +80,13 @@ ignore = [
     # also upgrade the OpenSSL to v3.x which causes performance degradation.
     # See https://github.com/openssl/openssl/issues/17064
     "RUSTSEC-2025-0004",
+    # Ignore RUSTSEC-2025-0022, as it will trigger a recursive upgrade of OpenSSL
+    # to version 3.x.
+    #
+    # NB: Upgrading openssl the version >= 0.10.72 do fix the issue but it
+    # also upgrade the OpenSSL to v3.x which causes performance degradation.
+    # See https://github.com/openssl/openssl/issues/17064
+    "RUSTSEC-2025-0022",
 ]
 
 # TiKV is licensed under Apache 2.0, according to ASF 3RD PARTY LICENSE POLICY,


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18363

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
deps: Revert openssl changes of #18356
```

Diff with 3eb3439fd88f0db9de06ef92e845e80b32c9b49a: https://github.com/tikv/tikv/compare/3eb3439fd88f0db9de06ef92e845e80b32c9b49a...pingyu:tikv:revert-openssl

- Ignore [RUSTSEC-2025-0022](https://rustsec.org/advisories/RUSTSEC-2025-0022) to avoid upgrade openssl to 3.x.x
- Fix [RUSTSEC-2025-0023](https://rustsec.org/advisories/RUSTSEC-2025-0023) by downgrade `tokio` to `1.38.2`. Upgrade `tokio` to `1.43.2` will recursively upgrade `libc` from `0.2.151` to `0.2.171` which is risky.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Regression build test On MacOS:

```
❯ uname -a
Darwin x.x.x.x 24.4.0 Darwin Kernel Version 24.4.0: Wed Mar 19 21:18:00 PDT 2025; root:xnu-11417.101.15~1/RELEASE_ARM64_T8122 arm64
❯ make build
    Finished dev [unoptimized] target(s) in 3m 52s
warning: the following packages contain code that will be rejected by a future version of Rust: fs_extra v1.1.0, nom v5.1.0, quick-xml v0.22.0
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
deps: Revert openssl changes of #18356
```
