### PR TITLE
crypto: fix FIPS compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1873,6 +1873,7 @@ name = "crypto"
 version = "0.0.1"
 dependencies = [
  "openssl",
+ "openssl-sys",
  "slog",
  "slog-global",
 ]

--- a/components/crypto/Cargo.toml
+++ b/components/crypto/Cargo.toml
@@ -7,6 +7,9 @@ license = "Apache-2.0"
 
 [dependencies]
 openssl = { workspace = true }
+# Keep openssl-sys in the dependencies, so the build script can detect the
+# openssl version.
+openssl-sys = { workspace = true }
 slog = { workspace = true }
 # better to not use slog-global, but pass in the logger
 slog-global = { workspace = true }

--- a/components/crypto/build.rs
+++ b/components/crypto/build.rs
@@ -24,7 +24,7 @@ fn main() {
             "
 
 The DEP_OPENSSL_VERSION_NUMBER environment variable is not found.
-Please make sure \"openssl-sys\" is in fips's dependencies.
+Please make sure \"openssl-sys\" is in crypto's dependencies.
 
 "
         )

--- a/components/crypto/src/fips.rs
+++ b/components/crypto/src/fips.rs
@@ -2,6 +2,11 @@
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+// Ensure that the openssl_sys crate is a dependency of this crate, so the build
+// script can detect the openssl version, `ossl1` or `ossl3`.
+const _OPENSSL_VERSION: unsafe extern "C" fn(*const openssl_sys::SSL) -> i32 =
+    openssl_sys::SSL_version;
+
 static FIPS_VERSION: AtomicUsize = AtomicUsize::new(0);
 
 /// Enable OpenSSL FIPS mode if `can_enable` returns true.


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #17465

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

#17466 breaks FIPS compilation unexpectedly by removing the openssl-sys dependency of the crypto crate.

```commit-message
Ensure that the openssl_sys crate is a dependency of this crate, 
so the build script can detect the openssl version, `ossl1` or `ossl3`.
```

### Check List

Tests <!-- At least one of them must be included. -->

- Manual test: https://cd.pingcap.net/job/build-common/352568/console

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
