### PR TITLE
chore: Upgrade crossbeam-channel from yanked 0.5.13 to 0.5.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1800,9 +1800,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.13"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
Issue Number: ref #15990
```
error[yanked]: detected yanked crate (try `cargo update -p crossbeam-channel`)
    ┌─ /home/jenkins/tikv-src/Cargo.lock:120:1
    │
120 │ crossbeam-channel 0.5.13 registry+https://github.com/rust-lang/crates.io-index
    │ 
```

What's Changed:
```commit-message
Upgrade crossbeam-channel from yanked 0.5.13 to 0.5.15.
```


### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
