### PR TITLE
Introduce a new observer `on_apply_snapshot_committed` to notice the snapshot data is committed on disk

### DIFF
--- a/components/raftstore/src/coprocessor/dispatcher.rs
+++ b/components/raftstore/src/coprocessor/dispatcher.rs
@@ -819,6 +819,20 @@ impl<E: KvEngine> CoprocessorHost<E> {
         }
     }
 
+    pub fn on_apply_snapshot_committed(
+        &self,
+        region: &Region,
+        peer_id: u64,
+        snap_key: &crate::store::SnapKey,
+        snap: Option<&crate::store::Snapshot>,
+    ) {
+        let mut ctx = ObserverContext::new(region);
+        for observer in &self.registry.apply_snapshot_observers {
+            let observer = observer.observer.inner();
+            observer.on_apply_snapshot_committed(&mut ctx, peer_id, snap_key, snap);
+        }
+    }
+
     pub fn new_split_checker_host<'a>(
         &'a self,
         region: &Region,

--- a/components/raftstore/src/coprocessor/dispatcher.rs
+++ b/components/raftstore/src/coprocessor/dispatcher.rs
@@ -1539,7 +1539,7 @@ mod tests {
             term: 0,
             idx: 0,
         };
-        host.on_apply_snapshot_committed(region, 0, &sk, None);
+        host.on_apply_snapshot_committed(&region, 0, &sk, None);
         index += ObserverIndex::ApplySnapshotCommitted as usize;
         assert_all!([&ob.called], &[index]);
     }

--- a/components/raftstore/src/coprocessor/dispatcher.rs
+++ b/components/raftstore/src/coprocessor/dispatcher.rs
@@ -1539,7 +1539,7 @@ mod tests {
             term: 0,
             idx: 0,
         };
-        host.on_apply_snapshot_committed(region.get_id(), 0, &sk, None);
+        host.on_apply_snapshot_committed(region, 0, &sk, None);
         index += ObserverIndex::ApplySnapshotCommitted as usize;
         assert_all!([&ob.called], &[index]);
     }

--- a/components/raftstore/src/coprocessor/mod.rs
+++ b/components/raftstore/src/coprocessor/mod.rs
@@ -223,7 +223,8 @@ pub trait ApplySnapshotObserver: Coprocessor {
         false
     }
 
-    // Hook when apply snapshot is committed on disk.
+    // Hook when apply snapshot is ingested, and the state has been changed to Normal and persisted.
+    // The snapshot will not be re-iningested after the restart if this hook is called.
     fn on_apply_snapshot_committed(
         &self,
         _: &mut ObserverContext<'_>,

--- a/components/raftstore/src/coprocessor/mod.rs
+++ b/components/raftstore/src/coprocessor/mod.rs
@@ -222,6 +222,16 @@ pub trait ApplySnapshotObserver: Coprocessor {
     fn should_pre_apply_snapshot(&self) -> bool {
         false
     }
+
+    // Hook when apply snapshot is committed on disk.
+    fn on_apply_snapshot_committed(
+        &self,
+        _: &mut ObserverContext<'_>,
+        _: u64,
+        _: &crate::store::SnapKey,
+        _: Option<&crate::store::Snapshot>,
+    ) {
+    }
 }
 
 /// SplitChecker is invoked during a split check scan, and decides to use

--- a/components/raftstore/src/coprocessor/mod.rs
+++ b/components/raftstore/src/coprocessor/mod.rs
@@ -223,8 +223,9 @@ pub trait ApplySnapshotObserver: Coprocessor {
         false
     }
 
-    // Hook when apply snapshot is ingested, and the state has been changed to Normal and persisted.
-    // The snapshot will not be re-iningested after the restart if this hook is called.
+    // Hook when apply snapshot is ingested, and the state has been changed to
+    // Normal and persisted. The snapshot will not be re-iningested after the
+    // restart if this hook is called.
     fn on_apply_snapshot_committed(
         &self,
         _: &mut ObserverContext<'_>,

--- a/components/raftstore/src/store/worker/region.rs
+++ b/components/raftstore/src/store/worker/region.rs
@@ -392,7 +392,7 @@ where
 
         let tombstone = match self.apply_snap(region_id, peer_id, Arc::clone(&status)) {
             Ok(()) => {
-                fail_point!("region_apply_return_not_change_state", |_| { () });
+                fail_point!("region_apply_return_not_change_state");
                 status.swap(JOB_STATUS_FINISHED, Ordering::SeqCst);
                 SNAP_COUNTER.apply.success.inc();
                 false

--- a/components/raftstore/src/store/worker/region.rs
+++ b/components/raftstore/src/store/worker/region.rs
@@ -354,6 +354,7 @@ where
         self.coprocessor_host
             .post_apply_snapshot(&region, peer_id, &snap_key, Some(&s));
 
+        fail_point!("region_apply_snap_before_write", |_| { Ok(()) });
         // Delete snapshot state and assure the relative region state and snapshot state
         // is updated and flushed into kvdb.
         region_state.set_state(PeerState::Normal);
@@ -365,6 +366,8 @@ where
         wb.write_opt(&wopts).unwrap_or_else(|e| {
             panic!("{} failed to save apply_snap result: {:?}", region_id, e);
         });
+        self.coprocessor_host
+            .on_apply_snapshot_committed(&region, peer_id, &snap_key, Some(&s));
         info!(
             "apply new data";
             "region_id" => region_id,
@@ -389,6 +392,7 @@ where
 
         let tombstone = match self.apply_snap(region_id, peer_id, Arc::clone(&status)) {
             Ok(()) => {
+                fail_point!("region_apply_return_not_change_state", |_| { () });
                 status.swap(JOB_STATUS_FINISHED, Ordering::SeqCst);
                 SNAP_COUNTER.apply.success.inc();
                 false


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref #13855

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

The current applying snapshot process is:
- Apply the snapshot in raftstore, and set region's state to Applying
- Schedule the region into region worker for ingesting data
- The region worker ingest the data from the snapshot
- The region's state is updated to Normal and is persisted
- The apply snapshot state is changed to FINISHED, and the region can handle normal raft messages

Before the Normal state is persisted, the ingesting phase could be replayed after a restart. However, if we the snapshot is written into other storages such as TiFlash, it becomes a need to know when the state is persisted as Normal, so the snapshot ingestion won't be replayed anymore.

```commit-message
Introduce a new observer `on_apply_snapshot_committed` so that subscribers can be notified if the snapshot data has been committed in disk
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
