### PR TITLE
server: do not set defualt compression algorithm for grpc channel

### DIFF
--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -10,6 +10,7 @@ use std::{
 
 use api_version::KvFormat;
 use futures::{compat::Stream01CompatExt, stream::StreamExt};
+use grpcio::CompressionLevel::{GRPC_COMPRESS_LEVEL_HIGH, GRPC_COMPRESS_LEVEL_LOW, GRPC_COMPRESS_LEVEL_NONE};
 use grpcio::{ChannelBuilder, Environment, ResourceQuota, Server as GrpcServer, ServerBuilder};
 use grpcio_health::{create_health, HealthService};
 use health_controller::HealthController;
@@ -38,6 +39,7 @@ use super::{
     transport::ServerTransport,
     Config, Error, Result,
 };
+use crate::server::config::GrpcCompressionType;
 use crate::{
     coprocessor::Endpoint,
     coprocessor_v2,
@@ -93,6 +95,20 @@ where
         let ip: String = format!("{}", addr.ip());
         let mem_quota = ResourceQuota::new(Some("ServerMemQuota"))
             .resize_memory(self.cfg.value().grpc_memory_pool_quota.0 as usize);
+
+        // Best-effort algorithm selection: If the client doesn't support the specified algorithm,
+        // the server may fall back to a different one or disable compression entirely.
+        //
+        // This is a bit hacky to map Low and High to gzip and deflate respectively.
+        // See CompressionAlgorithmForLevel in gRPC implementation for details.
+        //
+        // We cannot set default compression algorithm to here, because it won't check whether the
+        // client side supports the algorithm
+        let compression_level = match self.cfg.value().grpc_compression_type {
+            GrpcCompressionType::None => GRPC_COMPRESS_LEVEL_NONE,
+            GrpcCompressionType::Deflate => GRPC_COMPRESS_LEVEL_HIGH,
+            GrpcCompressionType::Gzip => GRPC_COMPRESS_LEVEL_LOW,
+        };
         let channel_args = ChannelBuilder::new(Arc::clone(&env))
             .stream_initial_window_size(self.cfg.value().grpc_stream_initial_window_size.0 as i32)
             .max_concurrent_stream(self.cfg.value().grpc_concurrent_stream)
@@ -102,8 +118,8 @@ where
             .http2_max_ping_strikes(i32::MAX) // For pings without data from clients.
             .keepalive_time(self.cfg.value().grpc_keepalive_time.into())
             .keepalive_timeout(self.cfg.value().grpc_keepalive_timeout.into())
-            .default_compression_algorithm(self.cfg.value().grpc_compression_algorithm())
             .default_gzip_compression_level(self.cfg.value().grpc_gzip_compression_level)
+            .default_compression_level(compression_level)
             .build_args();
 
         let sb = ServerBuilder::new(Arc::clone(&env))


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #17176, #18079

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Fix the issue that TiKV gRPC service responses don't respect the grpc-accept-encoding of clients.
Do not set defualt compression algorithm for grpc channel; set level instead.
The default algorithm won't check whether the algorithm is supported by client.
```

#### Manual tests

I verified the fix with the following test cases:

##### Test Case 1: Nightly TiKV (Before Fix) with GZIP compression

Configured TiKV with compression-type = gzip
Packet capture shows TiDB sends grpc-accept-encoding header that accepts gzip
Communication works as expected

##### Test Case 2: Nightly TiKV (Before Fix) with DEFLATE compression

Changed TiKV config to use compression-type = deflate
TiDB failed to communicate with error: "rpc error: code = Unimplemented desc = grpc: Decompressor is not installed for grpc-encoding \"deflate\""
TiDB Dashboard couldn't search TiKV logs
Packet capture confirmed TiKV was sending responses with deflate encoding that clients couldn't decode

##### Test Case 3: Fixed TiKV with DEFLATE compression

Applied the PR patch to TiKV, kept compression-type = deflate
TiDB could query normally
TiDB Dashboard could search TiKV logs
Packet capture showed TiKV sending responses with gzip encoding (not deflate)
This confirms the fix - TiKV now correctly uses an encoding the client can understand

##### Test Case 4: TiDB without GZIP support + Fixed TiKV

Used a TiDB build without gzip support
With unpatched TiKV set to use gzip, TiDB failed with: "rpc error: code = Unimplemented desc = grpc: Decompressor is not installed for grpc-encoding \"gzip\""
After applying the patch to TiKV, TiDB worked normally
Packet capture showed TiKV responses had no compression encoding

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fix the issue that TiKV may use an compression algorithm that the client side cannot decode.
```
