### PR TITLE
txn_status_cache: avoid deadlock in txn_status_cache with Pipelined DML

### DIFF
--- a/src/storage/txn/txn_status_cache.rs
+++ b/src/storage/txn/txn_status_cache.rs
@@ -1530,7 +1530,7 @@ mod tests {
         use fail::FailScenario;
         use txn_types::TimeStamp;
 
-        let scenario = FailScenario::setup();
+        let _scenario = FailScenario::setup();
         fail::cfg("txn_status_cache_get_after_large_before_normal", "pause").unwrap();
         fail::cfg("txn_status_cache_upsert_after_normal_before_large", "pause").unwrap();
 
@@ -1569,6 +1569,5 @@ mod tests {
         // if deadlock, thread1 will not join, test will hang here
         thread1.join().unwrap();
         thread2.join().unwrap();
-        drop(scenario);
     }
 }

--- a/src/storage/txn/txn_status_cache.rs
+++ b/src/storage/txn/txn_status_cache.rs
@@ -286,6 +286,10 @@ pub struct TxnStatusCache {
     // for large txns, or any txn whose min_commit_ts needs to be cached
     // It is isolated from the normal cache to prevents large transactions from being evicted due
     // to normal transactions. This is how this module "prioritizes" large transactions.
+    // 
+    // Invariant: when a process needs to acquire both locks, 
+    // it must first acquire the large_txn_cache lock, then the normal_cache lock, 
+    // to avoid deadlock.
     large_txn_cache: Vec<CachePadded<Mutex<TxnStatusCacheSlot>>>,
     is_enabled: bool,
 }
@@ -467,6 +471,8 @@ impl TxnStatusCache {
             }
             // normal cache path
             _ => {
+                // Always acquire large_txn_cache lock, then normal_cache lock to avoid deadlock
+                let mut large_cache = self.large_txn_cache[slot_index].lock();
                 let mut normal_cache = self.normal_cache[slot_index].lock();
                 previous_size = normal_cache.size();
                 previous_allocated = normal_cache.internal_allocated_capacity();
@@ -484,8 +490,9 @@ impl TxnStatusCache {
                 }
                 after_size = normal_cache.size();
                 after_allocated = normal_cache.internal_allocated_capacity();
+                
+                fail_point!("txn_status_cache_upsert_after_normal_before_large");
 
-                let mut large_cache = self.large_txn_cache[slot_index].lock();
                 if let Some(existing_entry) = large_cache.get_mut(&start_ts) {
                     // don't update committed or rolled back txns.
                     if let TxnState::Ongoing { min_commit_ts } = existing_entry.state {
@@ -528,6 +535,8 @@ impl TxnStatusCache {
         if let Some(entry) = large_txn_cache.get(&start_ts) {
             return Some(entry.state);
         }
+        
+        fail_point!("txn_status_cache_get_after_large_before_normal");
 
         let mut normal_cache = self.normal_cache[slot_index].lock();
         if let Some(entry) = normal_cache.get(&start_ts) {
@@ -1512,5 +1521,53 @@ mod tests {
         let removed = cache.remove_large_txn(1.into());
         assert!(removed.is_some());
         assert_eq!(cache.get(1.into()), None);
+    }
+
+    #[test]
+    fn test_txn_status_cache_lock_order() {
+        use std::sync::Arc;
+        use std::thread;
+        use std::time::Duration;
+        use fail::FailScenario;
+        use txn_types::TimeStamp;
+
+        let scenario = FailScenario::setup();
+        fail::cfg("txn_status_cache_get_after_large_before_normal", "pause").unwrap();
+        fail::cfg("txn_status_cache_upsert_after_normal_before_large", "pause").unwrap();
+
+        let cache = Arc::new(TxnStatusCache::with_slots_and_time_limit(
+            1, // Use single slot for maximum contention
+            Duration::from_secs(30),
+            Duration::from_secs(60),
+            1000,
+        ));
+        
+        let start_ts = TimeStamp::from(42);
+        let now = SystemTime::now();
+
+        // Start thread 1 (upsert operation)
+        let cache_clone1 = cache.clone();
+        let thread1 = thread::spawn(move || {
+            let state = TxnState::Committed { commit_ts: TimeStamp::from(43) };
+            cache_clone1.upsert(start_ts, state, now);
+        });
+        
+        // Start thread 2 (get operation)
+        let cache_clone2 = cache.clone();
+        let thread2 = thread::spawn(move || {
+            let _ = cache_clone2.get(start_ts);
+        });
+        
+        // Wait a moment to ensure both threads have reached their failpoints
+        thread::sleep(Duration::from_millis(300));
+        
+        // Release the failpoints
+        fail::remove("txn_status_cache_get_after_large_before_normal");
+        fail::remove("txn_status_cache_upsert_after_normal_before_large");
+        
+        // if deadlock, thread1 will not join, test will hang here
+        thread1.join().unwrap();
+        thread2.join().unwrap();
+        drop(scenario);
     }
 }

--- a/src/storage/txn/txn_status_cache.rs
+++ b/src/storage/txn/txn_status_cache.rs
@@ -286,9 +286,9 @@ pub struct TxnStatusCache {
     // for large txns, or any txn whose min_commit_ts needs to be cached
     // It is isolated from the normal cache to prevents large transactions from being evicted due
     // to normal transactions. This is how this module "prioritizes" large transactions.
-    // 
-    // Invariant: when a process needs to acquire both locks, 
-    // it must first acquire the large_txn_cache lock, then the normal_cache lock, 
+    //
+    // Invariant: when a process needs to acquire both locks,
+    // it must first acquire the large_txn_cache lock, then the normal_cache lock,
     // to avoid deadlock.
     large_txn_cache: Vec<CachePadded<Mutex<TxnStatusCacheSlot>>>,
     is_enabled: bool,
@@ -490,7 +490,7 @@ impl TxnStatusCache {
                 }
                 after_size = normal_cache.size();
                 after_allocated = normal_cache.internal_allocated_capacity();
-                
+
                 fail_point!("txn_status_cache_upsert_after_normal_before_large");
 
                 if let Some(existing_entry) = large_cache.get_mut(&start_ts) {
@@ -535,7 +535,7 @@ impl TxnStatusCache {
         if let Some(entry) = large_txn_cache.get(&start_ts) {
             return Some(entry.state);
         }
-        
+
         fail_point!("txn_status_cache_get_after_large_before_normal");
 
         let mut normal_cache = self.normal_cache[slot_index].lock();
@@ -1525,9 +1525,8 @@ mod tests {
 
     #[test]
     fn test_txn_status_cache_lock_order() {
-        use std::sync::Arc;
-        use std::thread;
-        use std::time::Duration;
+        use std::{sync::Arc, thread, time::Duration};
+
         use fail::FailScenario;
         use txn_types::TimeStamp;
 
@@ -1541,30 +1540,32 @@ mod tests {
             Duration::from_secs(60),
             1000,
         ));
-        
+
         let start_ts = TimeStamp::from(42);
         let now = SystemTime::now();
 
         // Start thread 1 (upsert operation)
         let cache_clone1 = cache.clone();
         let thread1 = thread::spawn(move || {
-            let state = TxnState::Committed { commit_ts: TimeStamp::from(43) };
+            let state = TxnState::Committed {
+                commit_ts: TimeStamp::from(43),
+            };
             cache_clone1.upsert(start_ts, state, now);
         });
-        
+
         // Start thread 2 (get operation)
         let cache_clone2 = cache.clone();
         let thread2 = thread::spawn(move || {
             let _ = cache_clone2.get(start_ts);
         });
-        
+
         // Wait a moment to ensure both threads have reached their failpoints
         thread::sleep(Duration::from_millis(300));
-        
+
         // Release the failpoints
         fail::remove("txn_status_cache_get_after_large_before_normal");
         fail::remove("txn_status_cache_upsert_after_normal_before_large");
-        
+
         // if deadlock, thread1 will not join, test will hang here
         thread1.join().unwrap();
         thread2.join().unwrap();


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18384 

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Fix the deadlock issue in txn_status_cache.
When both large_txn_cache and normal_cache needs locking, always acquire large_txn_cache first.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fix the deadlock issue in txn_status_cache.
```
