### PR TITLE
compact_log_backup: correct version assignment in subcompaction metadata

### DIFF
--- a/components/compact-log-backup/src/compaction/exec.rs
+++ b/components/compact-log-backup/src/compaction/exec.rs
@@ -264,7 +264,7 @@ where
         meta.set_end_key(end_key);
         meta.set_cf(cf.to_owned());
         meta.name = name.to_owned();
-        meta.end_version = u64::MAX;
+        meta.start_version = u64::MAX;
 
         let mut data_key = keys::DATA_PREFIX_KEY.to_vec();
         for item in sorted_items {

--- a/components/compact-log-backup/src/test_util.rs
+++ b/components/compact-log-backup/src/test_util.rs
@@ -491,6 +491,19 @@ impl TmpStorage {
             // Verify the actual content
             res.verify_checksum().unwrap();
             verify_the_same::<RocksEngine>(sst_path, cm.must_iter()).unwrap();
+
+            // For now, only one SSTs should be written.
+            assert_eq!(res.meta.sst_outputs.len(), 1);
+            let sst_file = &res.meta.sst_outputs[0];
+            assert_eq!(res.origin.input_min_ts, sst_file.start_version);
+            assert_eq!(res.origin.input_max_ts, sst_file.end_version);
+            assert_eq!(res.origin.cf, sst_file.cf);
+
+            if res.expected_crc64.is_some() {
+                assert_eq!(res.expected_crc64, Some(sst_file.crc64xor));
+            }
+            assert_eq!(res.expected_size, sst_file.total_bytes);
+            assert_eq!(res.expected_keys, sst_file.total_kvs);
         }
     }
 


### PR DESCRIPTION
… SST verification tests

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18390

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Fixed a bug that caused the time range of compaction generated SSTs are too huge.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fixed a bug that caused the time range of compaction generated SSTs are too huge.
```
