### PR TITLE
sst_importer: support ignore keys by ts during download (#17951)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3686,7 +3686,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git?branch=release-8.5-log-compact#aad336da031034d5f16fadb223cea585c9b56bb0"
+source = "git+https://github.com/pingcap/kvproto.git#b6a98c6bf02d1864e74029f31ff99951719d96c1"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3686,7 +3686,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#4a3e17f5e62dc3999e2c0f63293fdeffced80626"
+source = "git+https://github.com/pingcap/kvproto.git?branch=release-8.5-log-compact#aad336da031034d5f16fadb223cea585c9b56bb0"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -430,7 +430,7 @@ grpcio-health = { version = "0.10.4", default-features = false, features = [
   "protobuf-codec",
 ] }
 tipb = { git = "https://github.com/pingcap/tipb.git" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git" }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-8.5-log-compact" }
 yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
 tokio-timer = { git = "https://github.com/tikv/tokio", branch = "tokio-timer-hotfix" }
 tokio-executor = { git = "https://github.com/tikv/tokio", branch = "tokio-timer-hotfix" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -430,7 +430,7 @@ grpcio-health = { version = "0.10.4", default-features = false, features = [
   "protobuf-codec",
 ] }
 tipb = { git = "https://github.com/pingcap/tipb.git" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-8.5-log-compact" }
+kvproto = { git = "https://github.com/pingcap/kvproto.git" }
 yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
 tokio-timer = { git = "https://github.com/tikv/tokio", branch = "tokio-timer-hotfix" }
 tokio-executor = { git = "https://github.com/tikv/tokio", branch = "tokio-timer-hotfix" }

--- a/components/sst_importer/src/metrics.rs
+++ b/components/sst_importer/src/metrics.rs
@@ -104,7 +104,12 @@ lazy_static! {
     .unwrap();
     pub static ref INPORTER_APPLY_COUNT: IntCounterVec = register_int_counter_vec!(
         "tikv_import_apply_count",
-        "Bucketed histogram of importer apply count",
+        "The operations of importer apply keys",
+        &["type"]
+    ).unwrap();
+    pub static ref INPORTER_DOWNLOAD_COMPACT_KEYS_COUNT: IntCounterVec = register_int_counter_vec!(
+        "tikv_import_download_compact_keys_count",
+        "The operations of importer download keys from compacted SST files",
         &["type"]
     ).unwrap();
     pub static ref EXT_STORAGE_CACHE_COUNT: IntCounterVec = register_int_counter_vec!(

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -1237,6 +1237,8 @@ impl<E: KvEngine> SstImporter<E> {
         let direct_retval = (|| -> Result<Option<_>> {
             if rewrite_rule.old_key_prefix != rewrite_rule.new_key_prefix
                 || rewrite_rule.new_timestamp != 0
+                || rewrite_rule.ignore_after_timestamp != 0
+                || rewrite_rule.ignore_before_timestamp != 0
             {
                 // must iterate if we perform key rewrite
                 return Ok(None);
@@ -1363,6 +1365,29 @@ impl<E: KvEngine> SstImporter<E> {
 
             let mut value = Cow::Borrowed(iter.value());
 
+            if rewrite_rule.ignore_after_timestamp != 0 {
+                let ts = Key::decode_ts_from(iter.key())?;
+                if ts > TimeStamp::new(rewrite_rule.ignore_after_timestamp) {
+                    iter.next()?;
+                    INPORTER_DOWNLOAD_COMPACT_KEYS_COUNT
+                        .with_label_values(&["after"])
+                        .inc();
+                    continue;
+                }
+            }
+            if rewrite_rule.ignore_before_timestamp != 0 {
+                // Let the client decide the ts here for default/write CF.
+                // Normally the ts in default CF is less than the ts in write CF.
+                let ts = Key::decode_ts_from(iter.key())?;
+                if ts < TimeStamp::new(rewrite_rule.ignore_before_timestamp) {
+                    iter.next()?;
+                    INPORTER_DOWNLOAD_COMPACT_KEYS_COUNT
+                        .with_label_values(&["before"])
+                        .inc();
+                    continue;
+                }
+            }
+
             if rewrite_rule.new_timestamp != 0 {
                 data_key = Key::from_encoded(data_key)
                     .truncate_ts()
@@ -1375,7 +1400,7 @@ impl<E: KvEngine> SstImporter<E> {
                     })?
                     .append_ts(TimeStamp::new(rewrite_rule.new_timestamp))
                     .into_encoded();
-                if meta.get_cf_name() == CF_WRITE {
+                if cf_name == CF_WRITE {
                     let mut write = WriteRef::parse(iter.value()).map_err(|e| {
                         Error::BadFormat(format!(
                             "write {}: {}",
@@ -2142,6 +2167,19 @@ mod tests {
         Ok((ext_sst_dir, backend, meta))
     }
 
+    fn new_compacted_file_rewrite_rule(
+        old_key_prefix: &[u8],
+        new_key_prefix: &[u8],
+        new_timestamp: u64,
+        ignore_before_timestamp: u64,
+        ignore_after_timestamp: u64,
+    ) -> RewriteRule {
+        let mut rule = new_rewrite_rule(old_key_prefix, new_key_prefix, new_timestamp);
+        rule.ignore_before_timestamp = ignore_before_timestamp;
+        rule.ignore_after_timestamp = ignore_after_timestamp;
+        rule
+    }
+
     fn new_rewrite_rule(
         old_key_prefix: &[u8],
         new_key_prefix: &[u8],
@@ -2855,6 +2893,206 @@ mod tests {
                 (get_encoded_key(b"t123_r07", 16), b"pqrst".to_vec()),
             ]
         );
+    }
+    #[test]
+    fn test_download_compacted_sst_with_key_rewrite_ts_default() {
+        // performs the download.
+        let importer_dir = tempfile::tempdir().unwrap();
+        let cfg = Config::default();
+        let importer =
+            SstImporter::<TestEngine>::new(&cfg, &importer_dir, None, ApiVersion::V1, false)
+                .unwrap();
+
+        // creates a sample SST file.
+        let (_ext_sst_dir, backend, meta) = create_sample_external_sst_file_txn_default().unwrap();
+        let db = create_sst_test_engine().unwrap();
+        let downloads = vec![
+            (
+                // no filter
+                new_compacted_file_rewrite_rule(b"t123", b"t567", 0, 0, 0),
+                vec![
+                    (get_encoded_key(b"t567_r01", 1), b"abc".to_vec()),
+                    (get_encoded_key(b"t567_r04", 3), b"xyz".to_vec()),
+                    (get_encoded_key(b"t567_r07", 7), b"pqrst".to_vec()),
+                ],
+            ),
+            (
+                // filter key between ts range [2, 6],
+                new_compacted_file_rewrite_rule(b"t123", b"t123", 0, 2, 6),
+                vec![(get_encoded_key(b"t123_r04", 3), b"xyz".to_vec())],
+            ),
+            (
+                // filter key between ts range [7, 18]
+                new_compacted_file_rewrite_rule(b"t123", b"t567", 0, 7, 18),
+                vec![(get_encoded_key(b"t567_r07", 7), b"pqrst".to_vec())],
+            ),
+        ];
+        for case in downloads {
+            let _ = importer
+                .download(
+                    &meta,
+                    &backend,
+                    "sample_default.sst",
+                    &case.0,
+                    None,
+                    Limiter::new(f64::INFINITY),
+                    db.clone(),
+                )
+                .unwrap()
+                .unwrap();
+
+            // verifies that the file is saved to the correct place.
+            // (the file size may be changed, so not going to check the file size)
+            let sst_file_path = importer.dir.join_for_read(&meta).unwrap().save;
+            assert!(sst_file_path.is_file());
+
+            // verifies the SST content is correct.
+            let sst_reader = new_sst_reader(sst_file_path.to_str().unwrap(), None);
+            sst_reader.verify_checksum().unwrap();
+            let mut iter = sst_reader.iter(IterOptions::default()).unwrap();
+            iter.seek_to_first().unwrap();
+            assert_eq!(collect(iter), case.1);
+        }
+    }
+
+    #[test]
+    fn test_download_compacted_sst_with_key_rewrite_ts_write() {
+        // performs the download.
+        let importer_dir = tempfile::tempdir().unwrap();
+        let cfg = Config::default();
+        let importer =
+            SstImporter::<TestEngine>::new(&cfg, &importer_dir, None, ApiVersion::V1, false)
+                .unwrap();
+
+        // creates a sample SST file.
+        let (_ext_sst_dir, backend, meta) = create_sample_external_sst_file_txn_write().unwrap();
+        let db = create_sst_test_engine().unwrap();
+        let downloads = vec![
+            (
+                // filter key between ts range [4, 8]
+                new_compacted_file_rewrite_rule(b"t123", b"t567", 0, 4, 8),
+                vec![
+                    (
+                        get_encoded_key(b"t567_r01", 5),
+                        get_write_value(WriteType::Put, 1, None),
+                    ),
+                    (
+                        get_encoded_key(b"t567_r02", 5),
+                        get_write_value(WriteType::Delete, 1, None),
+                    ),
+                    (
+                        get_encoded_key(b"t567_r04", 4),
+                        get_write_value(WriteType::Put, 3, None),
+                    ),
+                    (
+                        get_encoded_key(b"t567_r07", 8),
+                        get_write_value(WriteType::Put, 7, None),
+                    ),
+                    (
+                        get_encoded_key(b"t567_r13", 8),
+                        get_write_value(WriteType::Put, 7, Some(b"www".to_vec())),
+                    ),
+                ],
+            ),
+            (
+                // filter key between ts range [5, 6]
+                new_compacted_file_rewrite_rule(b"t123", b"t567", 0, 5, 6),
+                vec![
+                    (
+                        get_encoded_key(b"t567_r01", 5),
+                        get_write_value(WriteType::Put, 1, None),
+                    ),
+                    (
+                        get_encoded_key(b"t567_r02", 5),
+                        get_write_value(WriteType::Delete, 1, None),
+                    ),
+                ],
+            ),
+            (
+                // filter key between ts range [4, 5]
+                new_compacted_file_rewrite_rule(b"t123", b"t567", 0, 4, 5),
+                vec![
+                    (
+                        get_encoded_key(b"t567_r01", 5),
+                        get_write_value(WriteType::Put, 1, None),
+                    ),
+                    (
+                        get_encoded_key(b"t567_r02", 5),
+                        get_write_value(WriteType::Delete, 1, None),
+                    ),
+                    (
+                        get_encoded_key(b"t567_r04", 4),
+                        get_write_value(WriteType::Put, 3, None),
+                    ),
+                ],
+            ),
+            (
+                // no filter
+                new_compacted_file_rewrite_rule(b"t123", b"t567", 0, 0, 0),
+                vec![
+                    (
+                        get_encoded_key(b"t567_r01", 5),
+                        get_write_value(WriteType::Put, 1, None),
+                    ),
+                    (
+                        get_encoded_key(b"t567_r02", 5),
+                        get_write_value(WriteType::Delete, 1, None),
+                    ),
+                    (
+                        get_encoded_key(b"t567_r04", 4),
+                        get_write_value(WriteType::Put, 3, None),
+                    ),
+                    (
+                        get_encoded_key(b"t567_r07", 8),
+                        get_write_value(WriteType::Put, 7, None),
+                    ),
+                    (
+                        get_encoded_key(b"t567_r13", 8),
+                        get_write_value(WriteType::Put, 7, Some(b"www".to_vec())),
+                    ),
+                ],
+            ),
+            (
+                // no rewrite rule, but has filter ts range [5, 5]
+                new_compacted_file_rewrite_rule(b"t123", b"t123", 0, 5, 5),
+                vec![
+                    (
+                        get_encoded_key(b"t123_r01", 5),
+                        get_write_value(WriteType::Put, 1, None),
+                    ),
+                    (
+                        get_encoded_key(b"t123_r02", 5),
+                        get_write_value(WriteType::Delete, 1, None),
+                    ),
+                ],
+            ),
+        ];
+        for case in downloads {
+            let _ = importer
+                .download(
+                    &meta,
+                    &backend,
+                    "sample_write.sst",
+                    &case.0,
+                    None,
+                    Limiter::new(f64::INFINITY),
+                    db.clone(),
+                )
+                .unwrap()
+                .unwrap();
+
+            // verifies that the file is saved to the correct place.
+            // (the file size may be changed, so not going to check the file size)
+            let sst_file_path = importer.dir.join_for_read(&meta).unwrap().save;
+            assert!(sst_file_path.is_file());
+
+            // verifies the SST content is correct.
+            let sst_reader = new_sst_reader(sst_file_path.to_str().unwrap(), None);
+            sst_reader.verify_checksum().unwrap();
+            let mut iter = sst_reader.iter(IterOptions::default()).unwrap();
+            iter.seek_to_first().unwrap();
+            assert_eq!(collect(iter), case.1);
+        }
     }
 
     #[test]


### PR DESCRIPTION
Adapt ignore rules to make the download can skip some keys larger then specify timestamp

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

Add support for skipping version entries based on boundary timestamps:
- Ignore entries before a specific timestamp — to exclude stale or unfinished versions.
- Ignore entries after a specific timestamp — to avoid restoring data beyond the target restore point.

This filtering should apply independently to each CF (column family) as appropriate.


Issue Number: Close https://github.com/tikv/tikv/issues/18399
<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
sst_importer: support ignore keys by ts during download
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Make restore support skip keys in sst files by timestamp
```
