### PR TITLE
server: remove unused check added for investigations

### DIFF
--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -7689,38 +7689,4 @@ mod tests {
         let req_size = req.compute_size();
         assert!(!builder.can_batch(&cfg, &req, req_size));
     }
-
-    #[test]
-    #[should_panic]
-    fn test_batch_build_with_duplicate_lock_cf_keys() {
-        let mut builder = BatchRaftCmdRequestBuilder::<KvTestEngine>::new();
-
-        // Create first request.
-        let mut req1 = RaftCmdRequest::default();
-        let mut put1 = Request::default();
-        let mut put_req1 = PutRequest::default();
-        put_req1.set_cf(CF_LOCK.to_string());
-        put_req1.set_key(b"key1".to_vec());
-        put_req1.set_value(b"value1".to_vec());
-        put1.set_cmd_type(CmdType::Put);
-        put1.set_put(put_req1);
-        req1.mut_requests().push(put1);
-
-        // Create second request with same key in Lock CF.
-        let mut req2 = RaftCmdRequest::default();
-        let mut put2 = Request::default();
-        let mut put_req2 = PutRequest::default();
-        put_req2.set_cf(CF_LOCK.to_string());
-        put_req2.set_key(b"key1".to_vec());
-        put_req2.set_value(b"value2".to_vec());
-        put2.set_cmd_type(CmdType::Put);
-        put2.set_put(put_req2);
-        req2.mut_requests().push(put2);
-
-        // Add both requests to batch builder, should cause panic.
-        let size = req1.compute_size();
-        builder.add(RaftCommand::new(req1, Callback::None), size);
-        let size = req2.compute_size();
-        builder.add(RaftCommand::new(req2, Callback::None), size);
-    }
 }

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -439,7 +439,6 @@ where
             propose_checked: None,
             request: None,
             callbacks: vec![],
-            lock_cf_keys: HashSet::default(),
         }
     }
 
@@ -522,7 +521,6 @@ where
             self.batch_req_size = 0;
             self.has_proposed_cb = false;
             self.propose_checked = None;
-            self.lock_cf_keys = HashSet::default();
             if self.callbacks.len() == 1 {
                 let cb = self.callbacks.pop().unwrap();
                 return Some((req, cb));

--- a/src/server/raftkv/mod.rs
+++ b/src/server/raftkv/mod.rs
@@ -22,7 +22,7 @@ use std::{
 
 use collections::{HashMap, HashSet};
 use concurrency_manager::ConcurrencyManager;
-use engine_traits::{CfName, KvEngine, MvccProperties, Snapshot, CF_LOCK};
+use engine_traits::{CfName, KvEngine, MvccProperties, Snapshot};
 use futures::{future::BoxFuture, task::AtomicWaker, Future, Stream, StreamExt, TryFutureExt};
 use hybrid_engine::HybridEngineSnapshot;
 use in_memory_engine::RegionCacheMemoryEngine;

--- a/src/server/raftkv/mod.rs
+++ b/src/server/raftkv/mod.rs
@@ -506,21 +506,6 @@ where
         }
 
         let reqs: Vec<Request> = batch.modifies.into_iter().map(Into::into).collect();
-        // Ref: https://github.com/tikv/tikv/issues/16818.
-        // Check for duplicate key entries before proposing commands.
-        // TODO: remove this check when the cause of issue 16818 is located.
-        let mut keys_set = std::collections::HashSet::new();
-        for req in &reqs {
-            if req.has_put() && req.get_put().get_cf() == CF_LOCK {
-                let key = req.get_put().get_key();
-                if !keys_set.insert(key.to_vec()) {
-                    panic!(
-                        "found duplicate key in Lock CF PUT request, key: {:?}, extra: {:?}, ctx: {:?}, reqs: {:?}, avoid_batch:{:?}",
-                        key, batch.extra, ctx, reqs, batch.avoid_batch
-                    );
-                }
-            }
-        }
         let txn_extra = batch.extra;
         let mut header = new_request_header(ctx);
         if batch.avoid_batch {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref #16818

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Remove unused check logic added in previous investigations of #16818.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
