### PR TITLE
txn: collect mvcc for err `TxnLockNotFound` when commit secondary failed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3754,7 +3754,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#258e68e813aa1af3a9817ce87630e2ec638851cd"
+source = "git+https://github.com/pingcap/kvproto.git#e89bec5a53cc25bc13bc3d4b75af97c95cdedb3d"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/components/test_storage/src/sync_storage.rs
+++ b/components/test_storage/src/sync_storage.rs
@@ -260,7 +260,7 @@ impl<E: Engine, F: KvFormat> SyncTestStorage<E, F> {
         commit_ts: impl Into<TimeStamp>,
     ) -> Result<TxnStatus> {
         wait_op!(|cb| self.store.sched_txn_command(
-            commands::Commit::new(keys, start_ts.into(), commit_ts.into(), ctx),
+            commands::Commit::new(keys, start_ts.into(), commit_ts.into(), None, ctx),
             cb,
         ))
         .unwrap()

--- a/components/tikv_util/src/log.rs
+++ b/components/tikv_util/src/log.rs
@@ -83,7 +83,7 @@ macro_rules! trace(($($args:tt)+) => {
     ::slog_global::trace!($($args)+)
 };);
 
-/// Logs a infor or debug level message using the slog global logger.
+/// Logs a info or debug level message using the slog global logger.
 #[macro_export]
 macro_rules! info_or_debug{
   ($cond:expr; $($args:tt)+) => {
@@ -91,6 +91,18 @@ macro_rules! info_or_debug{
             info!($($args)+)
         } else {
             debug!($($args)+)
+        }
+  };
+}
+
+/// Logs a info or error level message using the slog global logger.
+#[macro_export]
+macro_rules! info_or_error{
+  ($cond:expr; $($args:tt)+) => {
+        if $cond {
+            info!($($args)+)
+        } else {
+            error!($($args)+)
         }
   };
 }

--- a/components/txn_types/src/lib.rs
+++ b/components/txn_types/src/lib.rs
@@ -14,8 +14,9 @@ pub use lock::{Lock, LockType, PessimisticLock, TxnLockRef};
 use thiserror::Error;
 pub use timestamp::{TimeStamp, TsSet, TSO_PHYSICAL_SHIFT_BITS};
 pub use types::{
-    insert_old_value_if_resolved, is_short_value, Key, KvPair, LastChange, Mutation, MutationType,
-    OldValue, OldValues, TxnExtra, TxnExtraScheduler, Value, WriteBatchFlags, SHORT_VALUE_MAX_LEN,
+    insert_old_value_if_resolved, is_short_value, CommitRole, Key, KvPair, LastChange, Mutation,
+    MutationType, OldValue, OldValues, TxnExtra, TxnExtraScheduler, Value, WriteBatchFlags,
+    SHORT_VALUE_MAX_LEN,
 };
 pub use write::{Write, WriteRef, WriteType};
 

--- a/components/txn_types/src/types.rs
+++ b/components/txn_types/src/types.rs
@@ -676,6 +676,14 @@ impl LastChange {
     }
 }
 
+#[derive(Debug, Copy, Clone)]
+pub enum CommitRole {
+    /// Indicates it commits the primary key in request.
+    Primary,
+    /// Indicates it commits the secondary key(s) in request.
+    Secondary,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/import/duplicate_detect.rs
+++ b/src/import/duplicate_detect.rs
@@ -316,7 +316,7 @@ mod tests {
         let start_ts = ts - 1;
         let keys: Vec<Key> = data.iter().map(|(key, _)| Key::from_raw(key)).collect();
         prewrite_data(storage, primary, data, start_ts);
-        let cmd = commands::Commit::new(keys, start_ts.into(), ts.into(), Context::default());
+        let cmd = commands::Commit::new(keys, start_ts.into(), ts.into(), None, Context::default());
         let (tx, rx) = channel();
         storage
             .sched_txn_command(

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -1801,7 +1801,7 @@ mod tests {
         // Commit.
         let keys: Vec<_> = init_keys.iter().map(|k| Key::from_raw(k)).collect();
         wait_op!(|cb| storage.sched_txn_command(
-            commands::Commit::new(keys, start_ts, commit_ts.into(), Context::default()),
+            commands::Commit::new(keys, start_ts, commit_ts.into(), None, Context::default()),
             cb
         ))
         .unwrap()

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -4380,6 +4380,7 @@ mod tests {
                     vec![Key::from_raw(b"x")],
                     100.into(),
                     101.into(),
+                    None,
                     Context::default(),
                 ),
                 expect_ok_callback(tx, 3),
@@ -4616,6 +4617,7 @@ mod tests {
                     ],
                     1.into(),
                     2.into(),
+                    None,
                     Context::default(),
                 ),
                 expect_ok_callback(tx, 1),
@@ -4966,6 +4968,7 @@ mod tests {
                     ],
                     1.into(),
                     2.into(),
+                    None,
                     Context::default(),
                 ),
                 expect_ok_callback(tx, 1),
@@ -5114,6 +5117,7 @@ mod tests {
                     ],
                     1.into(),
                     2.into(),
+                    None,
                     Context::default(),
                 ),
                 expect_ok_callback(tx, 1),
@@ -5199,6 +5203,7 @@ mod tests {
                     ],
                     1.into(),
                     2.into(),
+                    None,
                     Context::default(),
                 ),
                 expect_ok_callback(tx, 1),
@@ -5270,6 +5275,7 @@ mod tests {
                     vec![Key::from_raw(b"x")],
                     100.into(),
                     110.into(),
+                    None,
                     Context::default(),
                 ),
                 expect_value_callback(tx.clone(), 2, TxnStatus::committed(110.into())),
@@ -5281,6 +5287,7 @@ mod tests {
                     vec![Key::from_raw(b"y")],
                     101.into(),
                     111.into(),
+                    None,
                     Context::default(),
                 ),
                 expect_value_callback(tx.clone(), 3, TxnStatus::committed(111.into())),
@@ -5532,6 +5539,7 @@ mod tests {
                         vec![key.clone()],
                         start_ts,
                         commit_ts,
+                        None,
                         Context::default(),
                     ),
                     expect_value_callback(tx.clone(), 1, TxnStatus::committed(commit_ts)),
@@ -5647,6 +5655,7 @@ mod tests {
                     vec![Key::from_raw(b"k")],
                     ts,
                     *ts.incr(),
+                    None,
                     Context::default(),
                 ),
                 expect_value_callback(tx.clone(), 1, TxnStatus::committed(ts)),
@@ -5771,6 +5780,7 @@ mod tests {
                         vec![key.clone()],
                         start_ts,
                         commit_ts,
+                        None,
                         Context::default(),
                     ),
                     expect_value_callback(tx.clone(), i as i32, TxnStatus::committed(commit_ts)),
@@ -5830,7 +5840,7 @@ mod tests {
         rx.recv().unwrap();
         storage
             .sched_txn_command(
-                commands::Commit::new(vec![k.clone()], ts, *ts.incr(), Context::default()),
+                commands::Commit::new(vec![k.clone()], ts, *ts.incr(), None, Context::default()),
                 expect_value_callback(tx.clone(), 1, TxnStatus::committed(ts)),
             )
             .unwrap();
@@ -5855,7 +5865,7 @@ mod tests {
         rx.recv().unwrap();
         storage
             .sched_txn_command(
-                commands::Commit::new(vec![k.clone()], ts, *ts.incr(), Context::default()),
+                commands::Commit::new(vec![k.clone()], ts, *ts.incr(), None, Context::default()),
                 expect_value_callback(tx, 3, TxnStatus::committed(ts)),
             )
             .unwrap();
@@ -5907,6 +5917,7 @@ mod tests {
                     vec![Key::from_raw(b"k")],
                     ts,
                     *ts.incr(),
+                    None,
                     Context::default(),
                 ),
                 expect_value_callback(tx.clone(), 1, TxnStatus::committed(ts)),
@@ -5982,7 +5993,7 @@ mod tests {
         ctx.set_priority(CommandPri::High);
         storage
             .sched_txn_command(
-                commands::Commit::new(vec![Key::from_raw(b"x")], 100.into(), 101.into(), ctx),
+                commands::Commit::new(vec![Key::from_raw(b"x")], 100.into(), 101.into(), None, ctx),
                 expect_ok_callback(tx, 2),
             )
             .unwrap();
@@ -6037,6 +6048,7 @@ mod tests {
                     vec![Key::from_raw(b"x")],
                     100.into(),
                     101.into(),
+                    None,
                     Context::default(),
                 ),
                 expect_ok_callback(tx.clone(), 2),
@@ -6094,6 +6106,7 @@ mod tests {
                     ],
                     100.into(),
                     101.into(),
+                    None,
                     Context::default(),
                 ),
                 expect_ok_callback(tx.clone(), 1),
@@ -8664,7 +8677,13 @@ mod tests {
 
         storage
             .sched_txn_command(
-                commands::Commit::new(vec![k.clone()], ts(10, 0), ts(20, 0), Context::default()),
+                commands::Commit::new(
+                    vec![k.clone()],
+                    ts(10, 0),
+                    ts(20, 0),
+                    None,
+                    Context::default(),
+                ),
                 expect_ok_callback(tx.clone(), 0),
             )
             .unwrap();
@@ -8723,7 +8742,7 @@ mod tests {
 
         storage
             .sched_txn_command(
-                commands::Commit::new(vec![k], ts(25, 0), ts(28, 0), Context::default()),
+                commands::Commit::new(vec![k], ts(25, 0), ts(28, 0), None, Context::default()),
                 expect_fail_callback(tx, 0, |e| match e {
                     Error(box ErrorInner::Txn(TxnError(box TxnErrorInner::Mvcc(mvcc::Error(
                         box mvcc::ErrorInner::TxnLockNotFound { .. },
@@ -8801,7 +8820,13 @@ mod tests {
 
         storage
             .sched_txn_command(
-                commands::Commit::new(vec![k1.clone()], 10.into(), 20.into(), Context::default()),
+                commands::Commit::new(
+                    vec![k1.clone()],
+                    10.into(),
+                    20.into(),
+                    None,
+                    Context::default(),
+                ),
                 expect_ok_callback(tx.clone(), 0),
             )
             .unwrap();
@@ -9012,6 +9037,7 @@ mod tests {
                     vec![key.clone(), key2.clone()],
                     10.into(),
                     20.into(),
+                    None,
                     Context::default(),
                 ),
                 expect_ok_callback(tx.clone(), 0),
@@ -9132,6 +9158,7 @@ mod tests {
                         vec![Key::from_raw(&key(1))],
                         10.into(),
                         20.into(),
+                        None,
                         Context::default(),
                     ),
                     expect_ok_callback(tx.clone(), 0),
@@ -9166,6 +9193,7 @@ mod tests {
                         vec![Key::from_raw(&key(2))],
                         30.into(),
                         40.into(),
+                        None,
                         Context::default(),
                     ),
                     expect_ok_callback(tx.clone(), 0),
@@ -9420,6 +9448,7 @@ mod tests {
                         vec![Key::from_raw(&key(4))],
                         30.into(),
                         40.into(),
+                        None,
                         Context::default(),
                     ),
                     expect_ok_callback(tx.clone(), 0),
@@ -9485,6 +9514,7 @@ mod tests {
                         vec![Key::from_raw(&key(6))],
                         10.into(),
                         20.into(),
+                        None,
                         Context::default(),
                     ),
                     expect_ok_callback(tx.clone(), 0),
@@ -9903,7 +9933,7 @@ mod tests {
         let h = lock_blocked(&keys, 15, 10, 20);
         storage
             .sched_txn_command(
-                commands::Commit::new(keys.clone(), 10.into(), 20.into(), Context::default()),
+                commands::Commit::new(keys.clone(), 10.into(), 20.into(), None, Context::default()),
                 expect_ok_callback(tx.clone(), 0),
             )
             .unwrap();
@@ -10788,6 +10818,7 @@ mod tests {
                     vec![Key::from_raw(b"k1")],
                     10.into(),
                     20.into(),
+                    None,
                     Context::default(),
                 ),
                 expect_ok_callback(tx.clone(), 0),
@@ -11489,7 +11520,13 @@ mod tests {
         let (tx, rx) = channel();
         storage
             .sched_txn_command(
-                commands::Commit::new(vec![k1.clone()], 10.into(), 21.into(), Context::default()),
+                commands::Commit::new(
+                    vec![k1.clone()],
+                    10.into(),
+                    21.into(),
+                    None,
+                    Context::default(),
+                ),
                 expect_ok_callback(tx, 0),
             )
             .unwrap();
@@ -11598,6 +11635,7 @@ mod tests {
                     vec![Key::from_raw(b"k1")],
                     10.into(),
                     20.into(),
+                    None,
                     Context::default(),
                 ),
                 expect_ok_callback(tx.clone(), 0),
@@ -11620,6 +11658,7 @@ mod tests {
                     vec![Key::from_raw(b"k2")],
                     30.into(),
                     40.into(),
+                    None,
                     Context::default(),
                 ),
                 expect_fail_callback(tx, 0, |_| ()),
@@ -11907,6 +11946,7 @@ mod tests {
                     vec![Key::from_raw(b"k9")],
                     130.into(),
                     140.into(),
+                    None,
                     Context::default(),
                 ),
                 expect_ok_callback(tx.clone(), 0),

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -27,6 +27,7 @@ pub use self::{
     reader::*,
     txn::{GcInfo, MvccTxn, ReleasedLock, MAX_TXN_WRITE_SIZE},
 };
+pub use crate::storage::types::MvccInfo;
 
 #[derive(Debug, Error)]
 pub enum ErrorInner {
@@ -69,6 +70,7 @@ pub enum ErrorInner {
         start_ts: TimeStamp,
         commit_ts: TimeStamp,
         key: Vec<u8>,
+        mvcc_info: Option<MvccInfo>,
     },
 
     #[error("txn not found {} key: {}", .start_ts, log_wrappers::Value::key(.key))]
@@ -200,10 +202,12 @@ impl ErrorInner {
                 start_ts,
                 commit_ts,
                 key,
+                mvcc_info,
             } => Some(ErrorInner::TxnLockNotFound {
                 start_ts: *start_ts,
                 commit_ts: *commit_ts,
                 key: key.to_owned(),
+                mvcc_info: mvcc_info.clone(),
             }),
             ErrorInner::TxnNotFound { start_ts, key } => Some(ErrorInner::TxnNotFound {
                 start_ts: *start_ts,

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -1151,7 +1151,14 @@ pub mod tests {
             let cm = ConcurrencyManager::new_for_test(start_ts);
             let mut txn = MvccTxn::new(start_ts, cm);
             let mut reader = SnapshotReader::new(start_ts, snap, true);
-            commit(&mut txn, &mut reader, Key::from_raw(pk), commit_ts.into()).unwrap();
+            commit(
+                &mut txn,
+                &mut reader,
+                Key::from_raw(pk),
+                commit_ts.into(),
+                None,
+            )
+            .unwrap();
             self.write(txn.into_modifies());
         }
 

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -269,6 +269,7 @@ pub(crate) fn make_txn_error(
                 start_ts,
                 commit_ts: TimeStamp::zero(),
                 key: key.to_raw().unwrap(),
+                mvcc_info: None,
             },
             "txnnotfound" => ErrorInner::TxnNotFound {
                 start_ts,
@@ -830,7 +831,7 @@ pub(crate) mod tests {
         let snapshot = engine.snapshot(Default::default()).unwrap();
         let mut txn = MvccTxn::new(10.into(), cm);
         let mut reader = SnapshotReader::new(10.into(), snapshot, true);
-        commit(&mut txn, &mut reader, key, 15.into()).unwrap();
+        commit(&mut txn, &mut reader, key, 15.into(), None).unwrap();
         assert!(txn.write_size() > 0);
         engine
             .write(&ctx, WriteData::from_modifies(txn.into_modifies()))
@@ -1243,7 +1244,7 @@ pub(crate) mod tests {
 
         let k = b"k";
         must_acquire_pessimistic_lock(&mut engine, k, k, 10, 10);
-        must_commit_err(&mut engine, k, 20, 30);
+        must_commit_err(&mut engine, k, 20, 30, None);
         must_commit(&mut engine, k, 10, 20);
         must_seek_write_none(&mut engine, k, 30);
     }

--- a/src/storage/txn/actions/flashback_to_version.rs
+++ b/src/storage/txn/actions/flashback_to_version.rs
@@ -223,6 +223,7 @@ pub fn commit_flashback_key(
             start_ts: flashback_start_ts,
             commit_ts: flashback_commit_ts,
             key: key_to_commit.to_raw()?,
+            mvcc_info: None,
         }));
     }
     Ok(())

--- a/src/storage/txn/actions/mod.rs
+++ b/src/storage/txn/actions/mod.rs
@@ -15,5 +15,6 @@ pub mod commit;
 pub mod common;
 pub mod flashback_to_version;
 pub mod gc;
+pub mod mvcc;
 pub mod prewrite;
 pub mod tests;

--- a/src/storage/txn/actions/mvcc.rs
+++ b/src/storage/txn/actions/mvcc.rs
@@ -1,0 +1,215 @@
+// Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+
+use tikv_kv::Snapshot;
+use txn_types::{Key, TimeStamp, Value, Write};
+
+use crate::storage::mvcc::{Lock as MvccLock, MvccReader};
+
+type LockWritesVals = (
+    Option<MvccLock>,
+    Vec<(TimeStamp, Write)>,
+    Vec<(TimeStamp, Value)>,
+);
+
+pub fn find_mvcc_infos_by_key<S: Snapshot>(
+    reader: &mut MvccReader<S>,
+    key: &Key,
+    mut ts: TimeStamp,
+) -> crate::storage::txn::Result<LockWritesVals> {
+    let mut writes = vec![];
+    let mut values = vec![];
+    let lock = reader.load_lock(key)?;
+    loop {
+        let opt = reader.seek_write(key, ts)?;
+        match opt {
+            Some((commit_ts, write)) => {
+                writes.push((commit_ts, write));
+                if commit_ts.is_zero() {
+                    break;
+                }
+                ts = commit_ts.prev();
+            }
+            None => break,
+        };
+    }
+    for (ts, v) in reader.scan_values_in_default(key)? {
+        values.push((ts, v));
+    }
+    Ok((lock, writes, values))
+}
+
+pub fn collect_mvcc_info_for_debug<S: Snapshot>(
+    reader: &mut MvccReader<S>,
+    key: &Key,
+) -> Option<LockWritesVals> {
+    match find_mvcc_infos_by_key(reader, key, TimeStamp::max()) {
+        Ok(mvcc_info) => Some(mvcc_info),
+        Err(e) => {
+            warn!(
+                "failed to collect mvcc as debug info";
+                "key" => %key,
+                "err" => format!("{:?}", e),
+            );
+            None
+        }
+    }
+}
+
+pub mod tests {
+    #[cfg(test)]
+    use std::array;
+
+    use tikv_kv::Engine;
+    #[cfg(test)]
+    use tikv_kv::Snapshot;
+    use txn_types::{Key, TimeStamp};
+    #[cfg(test)]
+    use txn_types::{Lock, Value, Write, SHORT_VALUE_MAX_LEN};
+
+    use crate::storage::txn::actions::mvcc::{find_mvcc_infos_by_key, LockWritesVals, MvccReader};
+    #[cfg(test)]
+    use crate::storage::{
+        mvcc::SnapshotReader,
+        txn::{
+            actions::mvcc::collect_mvcc_info_for_debug,
+            tests::{must_commit, must_prewrite_put},
+        },
+        TestEngineBuilder,
+    };
+
+    #[cfg(test)]
+    const LONG_VALUE_MIN_LEN: usize = SHORT_VALUE_MAX_LEN + 1;
+
+    pub fn must_find_mvcc_infos<E: Engine>(
+        engine: &mut E,
+        key: &[u8],
+        ts: impl Into<TimeStamp>,
+    ) -> LockWritesVals {
+        let snapshot = engine.snapshot(Default::default()).unwrap();
+        let mut reader = MvccReader::new(snapshot, None, true);
+        find_mvcc_infos_by_key(&mut reader, &Key::from_raw(key), ts.into()).unwrap()
+    }
+
+    #[test]
+    fn test_find_mvcc_infos_by_key() {
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+
+        fn check_lock<S: Snapshot>(
+            lock: Lock,
+            key: &[u8],
+            start_ts: impl Into<TimeStamp>,
+            reader: &mut SnapshotReader<S>,
+        ) {
+            let expected_lock = reader.load_lock(&Key::from_raw(key)).unwrap().unwrap();
+            assert_eq!(lock.ts, start_ts.into());
+            assert_eq!(lock, expected_lock);
+        }
+
+        fn check_write<S: Snapshot>(
+            write: (TimeStamp, Write),
+            key: &[u8],
+            start_ts: impl Into<TimeStamp>,
+            commit_ts: impl Into<TimeStamp>,
+            val: &[u8],
+            data: Option<(TimeStamp, Value)>,
+            reader: &mut SnapshotReader<S>,
+        ) {
+            let expected_start_ts = start_ts.into();
+            let expected_commit_ts = commit_ts.into();
+            let expected_value = Value::from(val.to_vec());
+            let (commit_ts, write) = write;
+            let tag = format!(
+                "check_write, start_ts: {:?}, commit_ts: {:?}",
+                expected_start_ts, expected_commit_ts
+            );
+            assert_eq!(commit_ts, expected_commit_ts, "{}", tag);
+            assert_eq!(write.start_ts, expected_start_ts, "{}", tag);
+
+            let expected_write = reader
+                .get_write_with_commit_ts(&Key::from_raw(key), commit_ts)
+                .unwrap()
+                .unwrap();
+            assert_eq!((write.clone(), commit_ts), expected_write, "{}", tag);
+            match data {
+                Some((ts, value)) => {
+                    assert_eq!(ts, expected_start_ts, "{}", tag);
+                    assert_eq!(value, expected_value, "{}", tag);
+                    let data_cf_value = reader
+                        .load_data(&Key::from_raw(key), write.clone())
+                        .unwrap();
+                    assert_eq!(data_cf_value, expected_value, "{}", tag);
+                    assert_eq!(write.short_value, None, "{}", tag);
+                }
+                None => {
+                    assert_eq!(write.short_value.unwrap(), expected_value, "{}", tag);
+                }
+            }
+        }
+
+        // Construct mvcc
+        // LockCF:
+        //   k1 => 21
+        // WriteCF:
+        //   k1@20 => 11
+        //   k1@10 => 1
+        // DataCF:
+        //   k1@11 => v2
+        let k = b"k1";
+        let big_val: &[u8] = &array::from_fn::<_, LONG_VALUE_MIN_LEN, _>(|i| i as u8);
+        must_prewrite_put(&mut engine, k, big_val, k, 1);
+        must_commit(&mut engine, k, 1, 10);
+        must_prewrite_put(&mut engine, k, b"v2", k, 11);
+        must_commit(&mut engine, k, 11, 20);
+        must_prewrite_put(&mut engine, k, b"v3", k, 21);
+        let snapshot = engine.snapshot(Default::default()).unwrap();
+        let mut reader = SnapshotReader::new(TimeStamp::max(), snapshot, true);
+
+        // with ts 12, can only read the write/default CF before 12.
+        // lock is always read.
+        let (lock, writes, values) = must_find_mvcc_infos(&mut engine, k, 12);
+        assert!(lock.is_some());
+        assert_eq!(writes.len(), 1);
+        assert_eq!(values.len(), 1);
+        check_lock(lock.unwrap(), k, 21, &mut reader);
+        check_write(
+            writes[0].clone(),
+            k,
+            1,
+            10,
+            big_val,
+            Some(values[0].clone()),
+            &mut reader,
+        );
+
+        // with ts 22, can read all the writes/default CF before 22.
+        let (lock, writes, values) = must_find_mvcc_infos(&mut engine, k, 22);
+        assert!(lock.is_some());
+        assert_eq!(writes.len(), 2);
+        assert_eq!(values.len(), 1);
+        check_lock(lock.clone().unwrap(), k, 21, &mut reader);
+        for (i, (start_ts, commit_ts, val)) in [(11, 20, b"v2" as &[u8]), (1, 10, big_val)]
+            .iter()
+            .enumerate()
+        {
+            check_write(
+                writes[i].clone(),
+                k,
+                *start_ts,
+                *commit_ts,
+                val,
+                if val.len() > SHORT_VALUE_MAX_LEN {
+                    Some(values[0].clone())
+                } else {
+                    None
+                },
+                &mut reader,
+            );
+        }
+
+        // collect_mvcc_info_for_debug should collect all mvcc info
+        assert_eq!(
+            collect_mvcc_info_for_debug(&mut reader.reader, &Key::from_raw(k)).unwrap(),
+            (lock, writes, values),
+        )
+    }
+}

--- a/src/storage/txn/commands/commit.rs
+++ b/src/storage/txn/commands/commit.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
 // #[PerformanceCriticalPath]
-use txn_types::Key;
+use txn_types::{CommitRole, Key};
 
 use crate::storage::{
     kv::WriteData,
@@ -31,6 +31,8 @@ command! {
             lock_ts: txn_types::TimeStamp,
             /// The commit timestamp.
             commit_ts: txn_types::TimeStamp,
+            /// The commit role of the transaction.
+            commit_role: Option<CommitRole>,
         }
         in_heap => {
             keys,
@@ -64,7 +66,13 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for Commit {
         // Pessimistic txn needs key_hashes to wake up waiters
         let mut released_locks = ReleasedLocks::new();
         for k in self.keys {
-            released_locks.push(commit(&mut txn, &mut reader, k, self.commit_ts)?);
+            released_locks.push(commit(
+                &mut txn,
+                &mut reader,
+                k,
+                self.commit_ts,
+                self.commit_role,
+            )?);
         }
 
         let pr = ProcessResult::TxnStatus {

--- a/src/storage/txn/commands/mvcc_by_key.rs
+++ b/src/storage/txn/commands/mvcc_by_key.rs
@@ -6,7 +6,8 @@ use txn_types::{Key, TimeStamp};
 use crate::storage::{
     mvcc::MvccReader,
     txn::{
-        commands::{find_mvcc_infos_by_key, Command, CommandExt, ReadCommand, TypedCommand},
+        actions::mvcc::find_mvcc_infos_by_key,
+        commands::{Command, CommandExt, ReadCommand, TypedCommand},
         ProcessResult, Result,
     },
     types::MvccInfo,

--- a/src/storage/txn/commands/mvcc_by_key.rs
+++ b/src/storage/txn/commands/mvcc_by_key.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
 // #[PerformanceCriticalPath]
-use txn_types::{Key, TimeStamp};
+use txn_types::Key;
 
 use crate::storage::{
     mvcc::MvccReader,
@@ -42,7 +42,7 @@ impl CommandExt for MvccByKey {
 impl<S: Snapshot> ReadCommand<S> for MvccByKey {
     fn process_read(self, snapshot: S, statistics: &mut Statistics) -> Result<ProcessResult> {
         let mut reader = MvccReader::new_with_ctx(snapshot, None, &self.ctx);
-        let result = find_mvcc_infos_by_key(&mut reader, &self.key, TimeStamp::max());
+        let result = find_mvcc_infos_by_key(&mut reader, &self.key);
         statistics.add(&reader.statistics);
         let (lock, writes, values) = result?;
         Ok(ProcessResult::MvccKey {

--- a/src/storage/txn/commands/mvcc_by_start_ts.rs
+++ b/src/storage/txn/commands/mvcc_by_start_ts.rs
@@ -42,7 +42,7 @@ impl<S: Snapshot> ReadCommand<S> for MvccByStartTs {
         let mut reader = MvccReader::new_with_ctx(snapshot, Some(ScanMode::Forward), &self.ctx);
         match reader.seek_ts(self.start_ts)? {
             Some(key) => {
-                let result = find_mvcc_infos_by_key(&mut reader, &key, TimeStamp::max());
+                let result = find_mvcc_infos_by_key(&mut reader, &key);
                 statistics.add(&reader.statistics);
                 let (lock, writes, values) = result?;
                 Ok(ProcessResult::MvccStartTs {

--- a/src/storage/txn/commands/mvcc_by_start_ts.rs
+++ b/src/storage/txn/commands/mvcc_by_start_ts.rs
@@ -6,7 +6,8 @@ use txn_types::{Key, TimeStamp};
 use crate::storage::{
     mvcc::MvccReader,
     txn::{
-        commands::{find_mvcc_infos_by_key, Command, CommandExt, ReadCommand, TypedCommand},
+        actions::mvcc::find_mvcc_infos_by_key,
+        commands::{Command, CommandExt, ReadCommand, TypedCommand},
         ProcessResult, Result,
     },
     types::MvccInfo,

--- a/src/storage/txn/commands/resolve_lock.rs
+++ b/src/storage/txn/commands/resolve_lock.rs
@@ -111,7 +111,7 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for ResolveLock {
                 // Continue to resolve locks if the not found committed locks are pessimistic
                 // type. They could be left if the transaction is finally committed and
                 // pessimistic conflict retry happens during execution.
-                match commit(&mut txn, &mut reader, current_key.clone(), commit_ts) {
+                match commit(&mut txn, &mut reader, current_key.clone(), commit_ts, None) {
                     Ok(res) => {
                         known_txn_status.push((current_lock.ts, commit_ts));
                         res

--- a/src/storage/txn/commands/resolve_lock_lite.rs
+++ b/src/storage/txn/commands/resolve_lock_lite.rs
@@ -63,7 +63,7 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for ResolveLockLite {
         let mut released_locks = ReleasedLocks::new();
         for key in self.resolve_keys {
             released_locks.push(if !self.commit_ts.is_zero() {
-                commit(&mut txn, &mut reader, key, self.commit_ts)?
+                commit(&mut txn, &mut reader, key, self.commit_ts, None)?
             } else {
                 cleanup(&mut txn, &mut reader, key, TimeStamp::zero(), false)?
             });

--- a/src/storage/txn/mod.rs
+++ b/src/storage/txn/mod.rs
@@ -274,6 +274,7 @@ pub mod tests {
             must_succeed_on_region as must_commit_on_region,
         },
         gc::tests::must_succeed as must_gc,
+        mvcc::tests::must_find_mvcc_infos,
         prewrite::tests::{
             try_pessimistic_prewrite_check_not_exists, try_prewrite_check_not_exists,
             try_prewrite_insert,

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -2300,6 +2300,7 @@ mod tests {
                 vec![Key::from_raw(b"k")],
                 10.into(),
                 20.into(),
+                None,
                 Context::default(),
             )
             .into(),

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -745,7 +745,7 @@ mod tests {
                 let mut reader = SnapshotReader::new(START_TS, self.snapshot.clone(), true);
                 for key in &self.keys {
                     let key = key.as_bytes();
-                    commit(&mut txn, &mut reader, Key::from_raw(key), COMMIT_TS).unwrap();
+                    commit(&mut txn, &mut reader, Key::from_raw(key), COMMIT_TS, None).unwrap();
                 }
                 let write_data = WriteData::from_modifies(txn.into_modifies());
                 self.engine.write(&self.ctx, write_data).unwrap();

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -53,6 +53,11 @@ impl MvccInfo {
                     write_info.set_start_ts(write.start_ts.into_inner());
                     write_info.set_commit_ts(commit_ts.into_inner());
                     write_info.set_short_value(write.short_value.unwrap_or_default());
+                    write_info.set_has_overlapped_rollback(write.has_overlapped_rollback);
+                    if let Some(gc_fence) = write.gc_fence {
+                        write_info.set_has_gc_fence(true);
+                        write_info.set_gc_fence(gc_fence.into_inner());
+                    }
                     if !matches!(
                         write.last_change,
                         LastChange::NotExist | LastChange::Exist { .. }

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -17,7 +17,7 @@ use crate::storage::{
 
 /// `MvccInfo` stores all mvcc information of given key.
 /// Used by `MvccGetByKey` and `MvccGetByStartTs`.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct MvccInfo {
     pub lock: Option<Lock>,
     /// commit_ts and write

--- a/tests/benches/hierarchy/mvcc/mod.rs
+++ b/tests/benches/hierarchy/mvcc/mod.rs
@@ -126,7 +126,7 @@ fn mvcc_commit<E: Engine, F: EngineFactory<E>>(b: &mut Bencher<'_>, config: &Ben
             for key in keys {
                 let mut txn = mvcc::MvccTxn::new(1.into(), cm.clone());
                 let mut reader = SnapshotReader::new(1.into(), snapshot.clone(), true);
-                black_box(commit(&mut txn, &mut reader, key, 1.into())).unwrap();
+                black_box(commit(&mut txn, &mut reader, key, 1.into(), None)).unwrap();
             }
         },
         BatchSize::SmallInput,

--- a/tests/benches/hierarchy/txn/mod.rs
+++ b/tests/benches/hierarchy/txn/mod.rs
@@ -124,7 +124,7 @@ fn txn_commit<E: Engine, F: EngineFactory<E>>(b: &mut Bencher<'_>, config: &Benc
                 let snapshot = engine.snapshot(Default::default()).unwrap();
                 let mut txn = mvcc::MvccTxn::new(1.into(), cm.clone());
                 let mut reader = SnapshotReader::new(1.into(), snapshot, true);
-                commit(&mut txn, &mut reader, key, 2.into()).unwrap();
+                commit(&mut txn, &mut reader, key, 2.into(), None).unwrap();
                 let write_data = WriteData::from_modifies(txn.into_modifies());
                 black_box(engine.write(&ctx, write_data)).unwrap();
             }

--- a/tests/failpoints/cases/test_storage.rs
+++ b/tests/failpoints/cases/test_storage.rs
@@ -533,7 +533,13 @@ fn test_pipelined_pessimistic_lock() {
     rx.recv().unwrap();
     storage
         .sched_txn_command(
-            commands::Commit::new(vec![key.clone()], 10.into(), 20.into(), Context::default()),
+            commands::Commit::new(
+                vec![key.clone()],
+                10.into(),
+                20.into(),
+                None,
+                Context::default(),
+            ),
             expect_ok_callback(tx.clone(), 0),
         )
         .unwrap();
@@ -1051,6 +1057,7 @@ fn test_async_apply_prewrite_impl<E: Engine, F: KvFormat>(
                     vec![Key::from_raw(key)],
                     start_ts,
                     min_commit_ts,
+                    None,
                     ctx.clone(),
                 ),
                 Box::new(move |r| tx.send(r).unwrap()),
@@ -1085,7 +1092,13 @@ fn test_async_apply_prewrite_impl<E: Engine, F: KvFormat>(
         let (tx, rx) = channel();
         storage
             .sched_txn_command(
-                commands::Commit::new(vec![Key::from_raw(key)], start_ts, commit_ts, ctx.clone()),
+                commands::Commit::new(
+                    vec![Key::from_raw(key)],
+                    start_ts,
+                    commit_ts,
+                    None,
+                    ctx.clone(),
+                ),
                 Box::new(move |r| tx.send(r).unwrap()),
             )
             .unwrap();
@@ -1263,7 +1276,13 @@ fn test_async_apply_prewrite_fallback() {
     let (tx, rx) = channel();
     storage
         .sched_txn_command(
-            commands::Commit::new(vec![Key::from_raw(key)], 10.into(), res.min_commit_ts, ctx),
+            commands::Commit::new(
+                vec![Key::from_raw(key)],
+                10.into(),
+                res.min_commit_ts,
+                None,
+                ctx,
+            ),
             Box::new(move |r| tx.send(r).unwrap()),
         )
         .unwrap();


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18425 

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
txn: collect mvcc for err `TxnLockNotFound` when commit secondary failed
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
