### PR TITLE
compacted restore: add region boundaries in log backup and support ts…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -889,6 +889,7 @@ dependencies = [
  "bytes",
  "chrono",
  "concurrency_manager",
+ "crc64fast",
  "crossbeam",
  "crossbeam-channel",
  "dashmap",
@@ -3700,7 +3701,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#4fa2b26b2d8003523908b124ab6e70580023eee6"
+source = "git+https://github.com/pingcap/kvproto.git?branch=release-8.1#eb848b5df53e4cc4a01e7b082c18cb083dfa6f60"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -419,7 +419,7 @@ grpcio-health = { version = "0.10.4", default-features = false, features = [
   "protobuf-codec",
 ] }
 tipb = { git = "https://github.com/pingcap/tipb.git" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git" }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-8.1" }
 yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
 tokio-timer = { git = "https://github.com/tikv/tokio", branch = "tokio-timer-hotfix" }
 tokio-executor = { git = "https://github.com/tikv/tokio", branch = "tokio-timer-hotfix" }

--- a/components/backup-stream/Cargo.toml
+++ b/components/backup-stream/Cargo.toml
@@ -31,6 +31,7 @@ async-trait = { version = "0.1" }
 bytes = "1"
 chrono = { workspace = true }
 concurrency_manager = { workspace = true }
+crc64fast = "0.1"
 crossbeam = "0.8"
 crossbeam-channel = "0.5"
 dashmap = "5"

--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -60,7 +60,7 @@ use crate::{
     metadata::{store::MetaStore, MetadataClient, MetadataEvent, StreamTask},
     metrics::{self, TaskStatus},
     observer::BackupStreamObserver,
-    router::{self, ApplyEvents, Router, TaskSelector},
+    router::{self, ApplyEvents, FlushContext, Router, TaskSelector},
     subscription_manager::{RegionSubscriptionManager, ResolvedRegions},
     subscription_track::{Ref, RefMut, ResolveResult, SubscriptionTracer},
     try_send,
@@ -819,19 +819,25 @@ where
         }
     }
 
-    fn do_flush(&self, task: String, mut resolved: ResolvedRegions) -> future![Result<()>] {
+    fn do_flush(&self, task: String, resolved: ResolvedRegions) -> future![Result<()>] {
         let router = self.range_router.clone();
         let store_id = self.store_id;
         let mut flush_ob = self.flush_observer();
         async move {
             let mut new_rts = resolved.global_checkpoint();
             fail::fail_point!("delay_on_flush");
-            flush_ob.before(resolved.take_resolve_result()).await;
+            flush_ob.before(resolved.resolve_results().to_vec()).await;
             if let Some(rewritten_rts) = flush_ob.rewrite_resolved_ts(&task).await {
                 info!("rewriting resolved ts"; "old" => %new_rts, "new" => %rewritten_rts);
                 new_rts = rewritten_rts.min(new_rts);
             }
-            if let Some(rts) = router.do_flush(&task, store_id, new_rts).await {
+            let cx = FlushContext {
+                task_name: &task,
+                store_id,
+                resolved_regions: &resolved,
+                resolved_ts: new_rts,
+            };
+            if let Some(rts) = router.do_flush(cx).await {
                 info!("flushing and refreshing checkpoint ts.";
                     "checkpoint_ts" => %rts,
                     "task" => %task,

--- a/components/backup-stream/src/lib.rs
+++ b/components/backup-stream/src/lib.rs
@@ -1,5 +1,6 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 #![feature(slice_group_by)]
+#![feature(trait_alias)]
 #![feature(result_flattening)]
 #![feature(assert_matches)]
 #![feature(test)]

--- a/components/backup-stream/src/subscription_manager.rs
+++ b/components/backup-stream/src/subscription_manager.rs
@@ -86,25 +86,21 @@ impl ResolvedRegions {
     /// Note: Maybe we can compute the global checkpoint internal and getting
     /// the interface clear. However we must take the `min_ts` or we cannot
     /// provide valid global checkpoint if there isn't any region checkpoint.
-    pub fn new(checkpoint: TimeStamp, checkpoints: Vec<ResolveResult>) -> Self {
+    pub const fn new(checkpoint: TimeStamp, checkpoints: Vec<ResolveResult>) -> Self {
         Self {
             items: checkpoints,
             checkpoint,
         }
     }
 
-    /// take the region checkpoints from the structure.
-    #[deprecated = "please use `take_resolve_result` instead."]
-    pub fn take_region_checkpoints(&mut self) -> Vec<(Region, TimeStamp)> {
-        std::mem::take(&mut self.items)
-            .into_iter()
-            .map(|x| (x.region, x.checkpoint))
-            .collect()
-    }
-
     /// take the resolve result from this struct.
     pub fn take_resolve_result(&mut self) -> Vec<ResolveResult> {
         std::mem::take(&mut self.items)
+    }
+
+    /// Get the resolve results.
+    pub fn resolve_results(&self) -> &[ResolveResult] {
+        &self.items
     }
 
     /// get the global checkpoint.

--- a/components/backup-stream/src/subscription_track.rs
+++ b/components/backup-stream/src/subscription_track.rs
@@ -100,7 +100,7 @@ impl ActiveSubscription {
     }
 }
 
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Clone)]
 pub enum CheckpointType {
     MinTs,
     StartTsOfInitialScan,
@@ -120,6 +120,7 @@ impl std::fmt::Debug for CheckpointType {
     }
 }
 
+#[derive(Clone)]
 pub struct ResolveResult {
     pub region: Region,
     pub checkpoint: TimeStamp,

--- a/components/backup-stream/tests/integration/mod.rs
+++ b/components/backup-stream/tests/integration/mod.rs
@@ -7,19 +7,24 @@
 mod suite;
 
 mod all {
-    use std::time::{Duration, Instant};
+    use std::{
+        os::unix::ffi::OsStrExt,
+        time::{Duration, Instant},
+    };
 
     use backup_stream::{
         errors::Error, router::TaskSelector, GetCheckpointResult, RegionCheckpointOperation,
         RegionSet, Task,
     };
     use futures::{Stream, StreamExt};
+    use kvproto::metapb::RegionEpoch;
     use pd_client::PdClient;
     use test_raftstore::IsolationFilterFactory;
     use tikv::config::BackupStreamConfig;
     use tikv_util::{box_err, defer, info, HandyRwLock};
     use tokio::time::timeout;
     use txn_types::{Key, TimeStamp};
+    use walkdir::WalkDir;
 
     use super::suite::{
         make_record_key, make_split_key_at_record, mutation, run_async_test, SuiteBuilder,
@@ -41,6 +46,65 @@ mod all {
             suite.flushed_files.path(),
             round1.union(&round2).map(Vec::as_slice),
         );
+        suite.cluster.shutdown();
+    }
+
+    #[test]
+    fn region_boundaries() {
+        let mut suite = SuiteBuilder::new_named("region_boundaries")
+            .nodes(1)
+            .build();
+        let round = run_async_test(async {
+            suite.must_split(&make_split_key_at_record(1, 42));
+            suite.must_split(&make_split_key_at_record(1, 86));
+            let round1 = suite.write_records(0, 128, 1).await;
+            suite.must_register_task(1, "region_boundaries");
+            round1
+        });
+        suite.force_flush_files("region_boundaries");
+        suite.wait_for_flush();
+        suite.check_for_write_records(suite.flushed_files.path(), round.iter().map(Vec::as_slice));
+
+        let a_meta = WalkDir::new(suite.flushed_files.path().join("v1/backupmeta"))
+            .contents_first(true)
+            .into_iter()
+            .find(|v| {
+                v.as_ref()
+                    .map(|v| v.file_name().as_bytes().ends_with(b".meta"))
+                    .map_or(false, |b| b)
+            })
+            .unwrap()
+            .unwrap();
+        let mut a_meta_content = protobuf::parse_from_bytes::<kvproto::brpb::Metadata>(
+            &std::fs::read(a_meta.path()).unwrap(),
+        )
+        .unwrap();
+        let dfs = a_meta_content.mut_file_groups()[0].mut_data_files_info();
+        // Two regions, two CFs.
+        assert_eq!(dfs.len(), 6);
+        dfs.sort_by(|x1, x2| x1.start_key.cmp(&x2.start_key));
+        let hnd_key = |hnd| make_split_key_at_record(1, hnd);
+        let epoch = |ver, conf_ver| {
+            let mut e = RegionEpoch::new();
+            e.set_version(ver);
+            e.set_conf_ver(conf_ver);
+            e
+        };
+        assert_eq!(dfs[0].region_start_key, b"");
+        assert_eq!(dfs[0].region_end_key, hnd_key(42));
+        assert_eq!(dfs[0].region_epoch.len(), 1, "{:?}", dfs[0]);
+        assert_eq!(dfs[0].region_epoch[0], epoch(2, 1), "{:?}", dfs[0]);
+
+        assert_eq!(dfs[2].region_start_key, hnd_key(42));
+        assert_eq!(dfs[2].region_end_key, hnd_key(86));
+        assert_eq!(dfs[2].region_epoch.len(), 1, "{:?}", dfs[2]);
+        assert_eq!(dfs[2].region_epoch[0], epoch(3, 1), "{:?}", dfs[2]);
+
+        assert_eq!(dfs[4].region_start_key, hnd_key(86));
+        assert_eq!(dfs[4].region_end_key, b"");
+        assert_eq!(dfs[4].region_epoch.len(), 1, "{:?}", dfs[4]);
+        assert_eq!(dfs[4].region_epoch[0], epoch(3, 1), "{:?}", dfs[4]);
+
         suite.cluster.shutdown();
     }
 

--- a/components/sst_importer/src/metrics.rs
+++ b/components/sst_importer/src/metrics.rs
@@ -104,7 +104,12 @@ lazy_static! {
     .unwrap();
     pub static ref INPORTER_APPLY_COUNT: IntCounterVec = register_int_counter_vec!(
         "tikv_import_apply_count",
-        "Bucketed histogram of importer apply count",
+        "The operations of importer apply keys",
+        &["type"]
+    ).unwrap();
+    pub static ref INPORTER_DOWNLOAD_COMPACT_KEYS_COUNT: IntCounterVec = register_int_counter_vec!(
+        "tikv_import_download_compact_keys_count",
+        "The operations of importer download keys from compacted SST files",
         &["type"]
     ).unwrap();
     pub static ref EXT_STORAGE_CACHE_COUNT: IntCounterVec = register_int_counter_vec!(

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -1175,6 +1175,8 @@ impl<E: KvEngine> SstImporter<E> {
         let direct_retval = (|| -> Result<Option<_>> {
             if rewrite_rule.old_key_prefix != rewrite_rule.new_key_prefix
                 || rewrite_rule.new_timestamp != 0
+                || rewrite_rule.ignore_after_timestamp != 0
+                || rewrite_rule.ignore_before_timestamp != 0
             {
                 // must iterate if we perform key rewrite
                 return Ok(None);
@@ -1301,6 +1303,29 @@ impl<E: KvEngine> SstImporter<E> {
 
             let mut value = Cow::Borrowed(iter.value());
 
+            if rewrite_rule.ignore_after_timestamp != 0 {
+                let ts = Key::decode_ts_from(iter.key())?;
+                if ts > TimeStamp::new(rewrite_rule.ignore_after_timestamp) {
+                    iter.next()?;
+                    INPORTER_DOWNLOAD_COMPACT_KEYS_COUNT
+                        .with_label_values(&["after"])
+                        .inc();
+                    continue;
+                }
+            }
+            if rewrite_rule.ignore_before_timestamp != 0 {
+                // Let the client decide the ts here for default/write CF.
+                // Normally the ts in default CF is less than the ts in write CF.
+                let ts = Key::decode_ts_from(iter.key())?;
+                if ts < TimeStamp::new(rewrite_rule.ignore_before_timestamp) {
+                    iter.next()?;
+                    INPORTER_DOWNLOAD_COMPACT_KEYS_COUNT
+                        .with_label_values(&["before"])
+                        .inc();
+                    continue;
+                }
+            }
+
             if rewrite_rule.new_timestamp != 0 {
                 data_key = Key::from_encoded(data_key)
                     .truncate_ts()
@@ -1313,7 +1338,7 @@ impl<E: KvEngine> SstImporter<E> {
                     })?
                     .append_ts(TimeStamp::new(rewrite_rule.new_timestamp))
                     .into_encoded();
-                if meta.get_cf_name() == CF_WRITE {
+                if cf_name == CF_WRITE {
                     let mut write = WriteRef::parse(iter.value()).map_err(|e| {
                         Error::BadFormat(format!(
                             "write {}: {}",
@@ -1856,6 +1881,19 @@ mod tests {
 
         let backend = external_storage::make_local_backend(ext_sst_dir.path());
         Ok((ext_sst_dir, backend, meta))
+    }
+
+    fn new_compacted_file_rewrite_rule(
+        old_key_prefix: &[u8],
+        new_key_prefix: &[u8],
+        new_timestamp: u64,
+        ignore_before_timestamp: u64,
+        ignore_after_timestamp: u64,
+    ) -> RewriteRule {
+        let mut rule = new_rewrite_rule(old_key_prefix, new_key_prefix, new_timestamp);
+        rule.ignore_before_timestamp = ignore_before_timestamp;
+        rule.ignore_after_timestamp = ignore_after_timestamp;
+        rule
     }
 
     fn new_rewrite_rule(
@@ -2552,6 +2590,202 @@ mod tests {
                 (get_encoded_key(b"t123_r07", 16), b"pqrst".to_vec()),
             ]
         );
+    }
+    #[test]
+    fn test_download_compacted_sst_with_key_rewrite_ts_default() {
+        // performs the download.
+        let importer_dir = tempfile::tempdir().unwrap();
+        let cfg = Config::default();
+        let importer = SstImporter::new(&cfg, &importer_dir, None, ApiVersion::V1, false).unwrap();
+
+        // creates a sample SST file.
+        let (_ext_sst_dir, backend, meta) = create_sample_external_sst_file_txn_default().unwrap();
+        let db = create_sst_test_engine().unwrap();
+        let downloads = vec![
+            (
+                // no filter
+                new_compacted_file_rewrite_rule(b"t123", b"t567", 0, 0, 0),
+                vec![
+                    (get_encoded_key(b"t567_r01", 1), b"abc".to_vec()),
+                    (get_encoded_key(b"t567_r04", 3), b"xyz".to_vec()),
+                    (get_encoded_key(b"t567_r07", 7), b"pqrst".to_vec()),
+                ],
+            ),
+            (
+                // filter key between ts range [2, 6],
+                new_compacted_file_rewrite_rule(b"t123", b"t123", 0, 2, 6),
+                vec![(get_encoded_key(b"t123_r04", 3), b"xyz".to_vec())],
+            ),
+            (
+                // filter key between ts range [7, 18]
+                new_compacted_file_rewrite_rule(b"t123", b"t567", 0, 7, 18),
+                vec![(get_encoded_key(b"t567_r07", 7), b"pqrst".to_vec())],
+            ),
+        ];
+        for case in downloads {
+            let _ = importer
+                .download(
+                    &meta,
+                    &backend,
+                    "sample_default.sst",
+                    &case.0,
+                    None,
+                    Limiter::new(f64::INFINITY),
+                    db.clone(),
+                )
+                .unwrap()
+                .unwrap();
+
+            // verifies that the file is saved to the correct place.
+            // (the file size may be changed, so not going to check the file size)
+            let sst_file_path = importer.dir.join_for_read(&meta).unwrap().save;
+            assert!(sst_file_path.is_file());
+
+            // verifies the SST content is correct.
+            let sst_reader = new_sst_reader(sst_file_path.to_str().unwrap(), None);
+            sst_reader.verify_checksum().unwrap();
+            let mut iter = sst_reader.iter(IterOptions::default()).unwrap();
+            iter.seek_to_first().unwrap();
+            assert_eq!(collect(iter), case.1);
+        }
+    }
+
+    #[test]
+    fn test_download_compacted_sst_with_key_rewrite_ts_write() {
+        // performs the download.
+        let importer_dir = tempfile::tempdir().unwrap();
+        let cfg = Config::default();
+        let importer = SstImporter::new(&cfg, &importer_dir, None, ApiVersion::V1, false).unwrap();
+
+        // creates a sample SST file.
+        let (_ext_sst_dir, backend, meta) = create_sample_external_sst_file_txn_write().unwrap();
+        let db = create_sst_test_engine().unwrap();
+        let downloads = vec![
+            (
+                // filter key between ts range [4, 8]
+                new_compacted_file_rewrite_rule(b"t123", b"t567", 0, 4, 8),
+                vec![
+                    (
+                        get_encoded_key(b"t567_r01", 5),
+                        get_write_value(WriteType::Put, 1, None),
+                    ),
+                    (
+                        get_encoded_key(b"t567_r02", 5),
+                        get_write_value(WriteType::Delete, 1, None),
+                    ),
+                    (
+                        get_encoded_key(b"t567_r04", 4),
+                        get_write_value(WriteType::Put, 3, None),
+                    ),
+                    (
+                        get_encoded_key(b"t567_r07", 8),
+                        get_write_value(WriteType::Put, 7, None),
+                    ),
+                    (
+                        get_encoded_key(b"t567_r13", 8),
+                        get_write_value(WriteType::Put, 7, Some(b"www".to_vec())),
+                    ),
+                ],
+            ),
+            (
+                // filter key between ts range [5, 6]
+                new_compacted_file_rewrite_rule(b"t123", b"t567", 0, 5, 6),
+                vec![
+                    (
+                        get_encoded_key(b"t567_r01", 5),
+                        get_write_value(WriteType::Put, 1, None),
+                    ),
+                    (
+                        get_encoded_key(b"t567_r02", 5),
+                        get_write_value(WriteType::Delete, 1, None),
+                    ),
+                ],
+            ),
+            (
+                // filter key between ts range [4, 5]
+                new_compacted_file_rewrite_rule(b"t123", b"t567", 0, 4, 5),
+                vec![
+                    (
+                        get_encoded_key(b"t567_r01", 5),
+                        get_write_value(WriteType::Put, 1, None),
+                    ),
+                    (
+                        get_encoded_key(b"t567_r02", 5),
+                        get_write_value(WriteType::Delete, 1, None),
+                    ),
+                    (
+                        get_encoded_key(b"t567_r04", 4),
+                        get_write_value(WriteType::Put, 3, None),
+                    ),
+                ],
+            ),
+            (
+                // no filter
+                new_compacted_file_rewrite_rule(b"t123", b"t567", 0, 0, 0),
+                vec![
+                    (
+                        get_encoded_key(b"t567_r01", 5),
+                        get_write_value(WriteType::Put, 1, None),
+                    ),
+                    (
+                        get_encoded_key(b"t567_r02", 5),
+                        get_write_value(WriteType::Delete, 1, None),
+                    ),
+                    (
+                        get_encoded_key(b"t567_r04", 4),
+                        get_write_value(WriteType::Put, 3, None),
+                    ),
+                    (
+                        get_encoded_key(b"t567_r07", 8),
+                        get_write_value(WriteType::Put, 7, None),
+                    ),
+                    (
+                        get_encoded_key(b"t567_r13", 8),
+                        get_write_value(WriteType::Put, 7, Some(b"www".to_vec())),
+                    ),
+                ],
+            ),
+            (
+                // no rewrite rule, but has filter ts range [5, 5]
+                new_compacted_file_rewrite_rule(b"t123", b"t123", 0, 5, 5),
+                vec![
+                    (
+                        get_encoded_key(b"t123_r01", 5),
+                        get_write_value(WriteType::Put, 1, None),
+                    ),
+                    (
+                        get_encoded_key(b"t123_r02", 5),
+                        get_write_value(WriteType::Delete, 1, None),
+                    ),
+                ],
+            ),
+        ];
+        for case in downloads {
+            let _ = importer
+                .download(
+                    &meta,
+                    &backend,
+                    "sample_write.sst",
+                    &case.0,
+                    None,
+                    Limiter::new(f64::INFINITY),
+                    db.clone(),
+                )
+                .unwrap()
+                .unwrap();
+
+            // verifies that the file is saved to the correct place.
+            // (the file size may be changed, so not going to check the file size)
+            let sst_file_path = importer.dir.join_for_read(&meta).unwrap().save;
+            assert!(sst_file_path.is_file());
+
+            // verifies the SST content is correct.
+            let sst_reader = new_sst_reader(sst_file_path.to_str().unwrap(), None);
+            sst_reader.verify_checksum().unwrap();
+            let mut iter = sst_reader.iter(IterOptions::default()).unwrap();
+            iter.seek_to_first().unwrap();
+            assert_eq!(collect(iter), case.1);
+        }
     }
 
     #[test]


### PR DESCRIPTION
cherry-pick 
https://github.com/tikv/tikv/pull/17407
https://github.com/tikv/tikv/pull/17951
to release-8.1
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
Add more region informations during log backup
- region boundaries


Add support for skipping version entries based on boundary timestamps:
- Ignore entries before a specific timestamp — to exclude stale or unfinished versions.
- Ignore entries after a specific timestamp — to avoid restoring data beyond the target restore point.

This filtering should apply independently to each CF (column family) as appropriate.


Issue Number: Close https://github.com/tikv/tikv/issues/18399
<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
compacted log backup: add region boundaries in log backup &&  support ignore keys by ts during download
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Make restore support compacted sst files.
```
