### PR TITLE
raftstore: enhance the detection to cover I/O jitters on kvdb.

### DIFF
--- a/components/health_controller/src/reporters.rs
+++ b/components/health_controller/src/reporters.rs
@@ -67,10 +67,7 @@ impl UnifiedSlowScore {
         // The second factor is for KvDB Disk I/O.
         unified_slow_score
             .factors
-            .push(SlowScore::new_with_extra_config(
-                cfg.inspect_kvdb_interval,
-                0.6,
-            ));
+            .push(SlowScore::new(cfg.inspect_kvdb_interval));
         unified_slow_score
     }
 

--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -1680,7 +1680,6 @@ mod tests {
 
         cfg = Config::new();
         cfg.inspect_kvdb_interval = ReadableDuration::millis(1);
-        cfg.inspect_interval = ReadableDuration::millis(100);
         cfg.optimize_inspector(true);
         assert_eq!(cfg.inspect_kvdb_interval, ReadableDuration::millis(1));
     }

--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -708,18 +708,6 @@ impl Config {
         // to inspect kvdb.
         if !separated_raft_mount_path {
             self.inspect_kvdb_interval = ReadableDuration::ZERO;
-        } else {
-            // If the inspect_kvdb_interval is less than inspect_interval, it should
-            // use `inspect_interval` * 10 as an empirical inspect interval for KvDB Disk
-            // I/O.
-            let inspect_kvdb_interval = if self.inspect_kvdb_interval < self.inspect_interval
-                && self.inspect_kvdb_interval != ReadableDuration::ZERO
-            {
-                self.inspect_interval * 10
-            } else {
-                self.inspect_kvdb_interval
-            };
-            self.inspect_kvdb_interval = inspect_kvdb_interval;
         }
     }
 
@@ -1694,6 +1682,6 @@ mod tests {
         cfg.inspect_kvdb_interval = ReadableDuration::millis(1);
         cfg.inspect_interval = ReadableDuration::millis(100);
         cfg.optimize_inspector(true);
-        assert_eq!(cfg.inspect_kvdb_interval, ReadableDuration::secs(1));
+        assert_eq!(cfg.inspect_kvdb_interval, ReadableDuration::millis(1));
     }
 }

--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -566,7 +566,7 @@ impl Default for Config {
             region_split_size: ReadableSize(0),
             clean_stale_peer_delay: ReadableDuration::minutes(0),
             inspect_interval: ReadableDuration::millis(100),
-            inspect_kvdb_interval: ReadableDuration::secs(2),
+            inspect_kvdb_interval: ReadableDuration::millis(100),
             // The default value of `inspect_cpu_util_thd` is 0.4, which means
             // when the cpu utilization is greater than 40%, the store might be
             // regarded as a slow node if there exists delayed inspected messages.

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -488,6 +488,14 @@ where
 
 const DEFAULT_LOAD_BASE_SPLIT_CHECK_INTERVAL: Duration = Duration::from_secs(1);
 const DEFAULT_COLLECT_TICK_INTERVAL: Duration = Duration::from_secs(1);
+/// The default interval for inspecting latency ticks.
+///
+/// This constant defines the minimum time interval between inspection
+/// operations. The actual interval should not be less than 100 microsecs
+/// since that is the minimum delay required for a single I/O operation. Setting
+/// an interval smaller than this threshold could lead to inefficient resource
+/// usage and potential performance degradation.
+const DEFAULT_INSPECT_LATENCY_TICK_INTERVAL: Duration = Duration::from_micros(100);
 
 fn default_collect_tick_interval() -> Duration {
     fail_point!("mock_collect_tick_interval", |_| {
@@ -630,7 +638,8 @@ where
             ),
             // Use the smallest inspect latency as the minimal limitation for collecting tick.
             collect_tick_interval: cmp::min(
-                cmp::min(inspect_latency_interval, inspect_kvdb_latency_interval),
+                cmp::min(inspect_latency_interval, inspect_kvdb_latency_interval)
+                    .max(DEFAULT_INSPECT_LATENCY_TICK_INTERVAL),
                 cmp::min(default_collect_tick_interval(), interval),
             ),
             inspect_latency_interval,
@@ -650,7 +659,8 @@ where
                 cmp::min(
                     self.inspect_latency_interval,
                     self.inspect_kvdb_latency_interval,
-                ),
+                )
+                .max(DEFAULT_INSPECT_LATENCY_TICK_INTERVAL),
                 default_collect_tick_interval(),
             )
         {

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -628,9 +628,9 @@ where
                 DEFAULT_LOAD_BASE_SPLIT_CHECK_INTERVAL,
                 interval,
             ),
-            // Use `inspect_latency_interval` as the minimal limitation for collecting tick.
+            // Use the smallest inspect latency as the minimal limitation for collecting tick.
             collect_tick_interval: cmp::min(
-                inspect_latency_interval,
+                cmp::min(inspect_latency_interval, inspect_kvdb_latency_interval),
                 cmp::min(default_collect_tick_interval(), interval),
             ),
             inspect_latency_interval,
@@ -647,7 +647,10 @@ where
     ) -> Result<(), io::Error> {
         if self.collect_tick_interval
             < cmp::min(
-                self.inspect_latency_interval,
+                cmp::min(
+                    self.inspect_latency_interval,
+                    self.inspect_kvdb_latency_interval,
+                ),
                 default_collect_tick_interval(),
             )
         {

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -255,6 +255,7 @@ fn test_serde_custom_tikv_config() {
         io_reschedule_concurrent_max_count: 1234,
         io_reschedule_hotpot_duration: ReadableDuration::secs(4321),
         inspect_interval: ReadableDuration::millis(444),
+        inspect_kvdb_interval: ReadableDuration::millis(333),
         inspect_cpu_util_thd: 0.666,
         check_leader_lease_interval: ReadableDuration::millis(123),
         renew_leader_lease_advance_duration: ReadableDuration::millis(456),

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -231,6 +231,7 @@ waterfall-metrics = true
 io-reschedule-concurrent-max-count = 1234
 io-reschedule-hotpot-duration = "4321s"
 inspect-interval = "444ms"
+inspect-kvdb-interval = "333ms"
 inspect-cpu-util-thd = 0.666
 check-leader-lease-interval = "123ms"
 renew-leader-lease-advance-duration = "456ms"


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close https://github.com/tikv/tikv/issues/18463

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

In previous work https://github.com/tikv/tikv/pull/17801, TiKV has introduced the detection mechanism for kvdb disk to detect I/O hang issues. 

However, recent customer feedback highlighted the need to extend detection coverage to I/O jitters, ensuring TiKV can automatically recover from abnormal states caused by KVDB I/O jitters.

Therefore, this ticket is built to tracks the development efforts to enhance TiKV’s I/O jitter detection and recovery mechanism. And the majority parts of this change are listed as followings show:
- for configurations:
  - `raftstore.inspect_kvdb_interval`: 2s -> 100ms
- for detection mechanism on kvdb:
  - `SlowScore::ratio_thresh`：60% -> 10%

```commit-message
Enhances the detection mechanism to cover the I/O jitters on kvdb disk if deploys with separated mount paths.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

| Workloads| v8.5.1 | With this PR |
| :--- | --- | --- |
| Special workloads | ![image](https://github.com/user-attachments/assets/af0b0cbb-316c-4019-9beb-2c94a79c6d1b) | ![image](https://github.com/user-attachments/assets/4cef442b-a057-400c-9522-109df2cf2deb) |
| tpcc 1k warehouses | ![image](https://github.com/user-attachments/assets/846774ca-d236-4aab-b056-b46251c3609c) | ![image](https://github.com/user-attachments/assets/9212cf2c-6bec-4ed8-a3af-56db8de40a88) |  
| Sysbench - oltp_read_write | ![image](https://github.com/user-attachments/assets/c86af6b2-fc75-430e-a511-7178b8f3326e) | ![image](https://github.com/user-attachments/assets/90e21f2f-2365-44be-9853-336729edd8b2) |

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Enhances the detection mechanism to cover the I/O jitters on kvdb disk if deploys with separated mount paths.
```