### PR TITLE
txn: collect mvcc for error `CommitTsExpired`

### DIFF
--- a/src/storage/errors.rs
+++ b/src/storage/errors.rs
@@ -19,7 +19,7 @@ use crate::storage::{
     kv::{self, Error as KvError, ErrorInner as KvErrorInner},
     mvcc::{Error as MvccError, ErrorInner as MvccErrorInner},
     txn::{self, Error as TxnError, ErrorInner as TxnErrorInner},
-    CommandKind, Result,
+    types, CommandKind, Result,
 };
 
 #[derive(Debug, Error)]
@@ -364,6 +364,30 @@ pub fn extract_committed(err: &Error) -> Option<TimeStamp> {
     }
 }
 
+fn ensure_debug_info_for_key_error(err: &mut kvrpcpb::KeyError) -> &mut kvrpcpb::DebugInfo {
+    if err.debug_info.is_none() {
+        err.set_debug_info(kvrpcpb::DebugInfo::default());
+    }
+    err.debug_info.as_mut().unwrap()
+}
+
+fn add_debug_mvcc_for_key_error(
+    err: &mut kvrpcpb::KeyError,
+    key: &[u8],
+    mvcc_info: Option<types::MvccInfo>,
+) {
+    if let Some(mut mvcc) = mvcc_info {
+        let debug_info = ensure_debug_info_for_key_error(err);
+        // remove the values in default CF to reduce the size of the response.
+        mvcc.values.clear();
+        // set mvcc info to debug_info
+        let mut mvcc_debug_info = kvrpcpb::MvccDebugInfo::default();
+        mvcc_debug_info.set_key(key.to_owned());
+        mvcc_debug_info.set_mvcc(mvcc.into_proto());
+        debug_info.mvcc_info.push(mvcc_debug_info);
+    }
+}
+
 pub fn extract_key_error(err: &Error) -> kvrpcpb::KeyError {
     let mut key_error = kvrpcpb::KeyError::default();
     match err {
@@ -429,20 +453,7 @@ pub fn extract_key_error(err: &Error) -> kvrpcpb::KeyError {
             let mut txn_lock_not_found = kvrpcpb::TxnLockNotFound::default();
             txn_lock_not_found.set_key(key.clone());
             key_error.set_txn_lock_not_found(txn_lock_not_found);
-            // if mvcc_info is present, fill the debug_info for client's further debugging.
-            if let Some(mvcc_info) = mvcc_info {
-                // remove the values in default CF to reduce the size of the response.
-                let mut mvcc_info = mvcc_info.clone();
-                mvcc_info.values.clear();
-
-                let mut mvcc_debug_info = kvrpcpb::MvccDebugInfo::default();
-                mvcc_debug_info.set_key(key.clone());
-                mvcc_debug_info.set_mvcc(mvcc_info.into_proto());
-
-                let mut debug_info = kvrpcpb::DebugInfo::default();
-                debug_info.set_mvcc_info(vec![mvcc_debug_info].into());
-                key_error.set_debug_info(debug_info);
-            }
+            add_debug_mvcc_for_key_error(&mut key_error, key, mvcc_info.clone());
         }
         Error(box ErrorInner::Txn(TxnError(box TxnErrorInner::Mvcc(MvccError(
             box MvccErrorInner::TxnNotFound { start_ts, key },
@@ -475,6 +486,7 @@ pub fn extract_key_error(err: &Error) -> kvrpcpb::KeyError {
                 commit_ts,
                 key,
                 min_commit_ts,
+                mvcc_info,
             },
         ))))) => {
             let mut commit_ts_expired = kvrpcpb::CommitTsExpired::default();
@@ -483,6 +495,7 @@ pub fn extract_key_error(err: &Error) -> kvrpcpb::KeyError {
             commit_ts_expired.set_key(key.to_owned());
             commit_ts_expired.set_min_commit_ts(min_commit_ts.into_inner());
             key_error.set_commit_ts_expired(commit_ts_expired);
+            add_debug_mvcc_for_key_error(&mut key_error, key, mvcc_info.clone());
         }
         Error(box ErrorInner::Txn(TxnError(box TxnErrorInner::Mvcc(MvccError(
             box MvccErrorInner::CommitTsTooLarge { min_commit_ts, .. },
@@ -640,10 +653,8 @@ mod test {
         assert_eq!(got, expect);
     }
 
-    #[test]
-    fn test_extract_key_error_txn_lock_not_found() {
-        let key = b"key".to_vec();
-        let mvcc_info = MvccInfo {
+    fn mock_mvcc_info() -> MvccInfo {
+        MvccInfo {
             lock: Some(Lock::new(
                 LockType::Lock,
                 b"k".to_vec(),
@@ -660,17 +671,38 @@ mod test {
                 Write::new(WriteType::Lock, 7.into(), None),
             )],
             values: vec![(TimeStamp::new(7), b"v".to_vec())],
-        };
+        }
+    }
 
-        let case = Error::from(TxnError::from(MvccError::from(
-            MvccErrorInner::TxnLockNotFound {
-                start_ts: TimeStamp::new(123),
-                commit_ts: TimeStamp::new(456),
-                key: key.clone(),
-                mvcc_info: Some(mvcc_info.clone()),
-            },
-        )));
+    fn expected_debug_info_from_mvcc(key: Vec<u8>, mvcc: MvccInfo) -> kvrpcpb::DebugInfo {
+        let mut expect_pb_mvcc_info = mvcc.clone().into_proto();
+        // should clear the values in default CF to reduce the size of the response.
+        expect_pb_mvcc_info.values.clear();
+        kvrpcpb::DebugInfo {
+            mvcc_info: vec![kvrpcpb::MvccDebugInfo {
+                key,
+                mvcc: Some(expect_pb_mvcc_info).into(),
+                ..Default::default()
+            }]
+            .into(),
+            ..Default::default()
+        }
+    }
 
+    #[test]
+    fn test_extract_key_error_txn_lock_not_found() {
+        fn mock_txn_lock_not_found_err(has_mvcc: bool) -> kvrpcpb::KeyError {
+            extract_key_error(&Error::from(TxnError::from(MvccError::from(
+                MvccErrorInner::TxnLockNotFound {
+                    start_ts: TimeStamp::new(123),
+                    commit_ts: TimeStamp::new(456),
+                    key: b"key".to_vec(),
+                    mvcc_info: has_mvcc.then(|| mock_mvcc_info()),
+                },
+            ))))
+        }
+
+        let key = b"key".to_vec();
         let mut expect = kvrpcpb::KeyError::default();
         let mut txn_lock_not_found = kvrpcpb::TxnLockNotFound::default();
         txn_lock_not_found.set_key(key.clone());
@@ -687,20 +719,53 @@ mod test {
             ))),
         );
         expect.set_retryable(expected_retryable_msg);
-        let mut expect_pb_mvcc_info = mvcc_info.clone().into_proto();
-        // should clear the values in default CF to reduce the size of the response.
-        expect_pb_mvcc_info.values.clear();
-        expect.set_debug_info(kvrpcpb::DebugInfo {
-            mvcc_info: vec![kvrpcpb::MvccDebugInfo {
-                key: key.clone(),
-                mvcc: Some(expect_pb_mvcc_info).into(),
-                ..Default::default()
-            }]
-            .into(),
-            ..Default::default()
-        });
 
-        let got = extract_key_error(&case);
-        assert_eq!(got, expect);
+        // without mvcc
+        expect.clear_debug_info();
+        assert_eq!(mock_txn_lock_not_found_err(false), expect);
+
+        // with mvcc
+        let mvcc_info = Some(mock_mvcc_info());
+        expect.set_debug_info(expected_debug_info_from_mvcc(
+            key.clone(),
+            mvcc_info.clone().unwrap(),
+        ));
+        assert_eq!(mock_txn_lock_not_found_err(true), expect);
+    }
+
+    #[test]
+    fn test_extract_key_error_commit_ts_expired() {
+        fn mock_commit_ts_expired_err(has_mvcc: bool) -> kvrpcpb::KeyError {
+            extract_key_error(&Error::from(TxnError::from(MvccError::from(
+                MvccErrorInner::CommitTsExpired {
+                    start_ts: TimeStamp::new(123),
+                    commit_ts: TimeStamp::new(456),
+                    key: b"key".to_vec(),
+                    min_commit_ts: TimeStamp::new(789),
+                    mvcc_info: has_mvcc.then(|| mock_mvcc_info()),
+                },
+            ))))
+        }
+
+        let key = b"key".to_vec();
+        let mut expect = kvrpcpb::KeyError::default();
+        let mut commit_ts_expired = kvrpcpb::CommitTsExpired::default();
+        commit_ts_expired.set_key(key.clone());
+        commit_ts_expired.set_start_ts(123);
+        commit_ts_expired.set_attempted_commit_ts(456);
+        commit_ts_expired.set_min_commit_ts(789);
+        expect.set_commit_ts_expired(commit_ts_expired);
+
+        // without mvcc
+        expect.clear_debug_info();
+        assert_eq!(mock_commit_ts_expired_err(false), expect);
+
+        // with mvcc
+        let mvcc = Some(mock_mvcc_info());
+        expect.set_debug_info(expected_debug_info_from_mvcc(
+            key.clone(),
+            mvcc.clone().unwrap(),
+        ));
+        assert_eq!(mock_commit_ts_expired_err(true), expect);
     }
 }

--- a/src/storage/errors.rs
+++ b/src/storage/errors.rs
@@ -364,11 +364,15 @@ pub fn extract_committed(err: &Error) -> Option<TimeStamp> {
     }
 }
 
-fn ensure_debug_info_for_key_error(err: &mut kvrpcpb::KeyError) -> &mut kvrpcpb::DebugInfo {
-    if err.debug_info.is_none() {
-        err.set_debug_info(kvrpcpb::DebugInfo::default());
+fn get_or_insert_default_for_key_error_debug_info(
+    err: &mut kvrpcpb::KeyError,
+) -> &mut kvrpcpb::DebugInfo {
+    let debug_info = &mut err.debug_info;
+    if debug_info.is_none() {
+        debug_info.set_default()
+    } else {
+        debug_info.as_mut().unwrap()
     }
-    err.debug_info.as_mut().unwrap()
 }
 
 fn add_debug_mvcc_for_key_error(
@@ -377,7 +381,7 @@ fn add_debug_mvcc_for_key_error(
     mvcc_info: Option<types::MvccInfo>,
 ) {
     if let Some(mut mvcc) = mvcc_info {
-        let debug_info = ensure_debug_info_for_key_error(err);
+        let debug_info = get_or_insert_default_for_key_error_debug_info(err);
         // remove the values in default CF to reduce the size of the response.
         mvcc.values.clear();
         // set mvcc info to debug_info

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -135,6 +135,7 @@ pub enum ErrorInner {
         commit_ts: TimeStamp,
         key: Vec<u8>,
         min_commit_ts: TimeStamp,
+        mvcc_info: Option<MvccInfo>,
     },
 
     #[error("bad format key(version)")]
@@ -265,11 +266,13 @@ impl ErrorInner {
                 commit_ts,
                 key,
                 min_commit_ts,
+                mvcc_info,
             } => Some(ErrorInner::CommitTsExpired {
                 start_ts: *start_ts,
                 commit_ts: *commit_ts,
                 key: key.clone(),
                 min_commit_ts: *min_commit_ts,
+                mvcc_info: mvcc_info.clone(),
             }),
             ErrorInner::KeyVersion => Some(ErrorInner::KeyVersion),
             ErrorInner::Committed {

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -304,6 +304,7 @@ pub(crate) fn make_txn_error(
                 commit_ts: TimeStamp::zero(),
                 key: key.to_raw().unwrap(),
                 min_commit_ts: TimeStamp::zero(),
+                mvcc_info: None,
             },
             "pessimisticlocknotfound" => ErrorInner::PessimisticLockNotFound {
                 start_ts,


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18441

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
When the secondary commit failed with error `CommitTsExpired`, collect the MVCC info for debugging.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
