### PR TITLE
txn: return debug info for some error when `commit_role` is unknown

### DIFF
--- a/src/storage/txn/actions/commit.rs
+++ b/src/storage/txn/actions/commit.rs
@@ -413,8 +413,8 @@ pub mod tests {
             ts(10, 0),
             ts(20, 0),
             ts(20, 1),
-            // The secondary key should not collect mvcc because it may be a bug.
-            // Although the commit role is none, we can get it from the lock.
+            // The mvcc info should be collected committing secondary keys as it could be a bug.
+            // Although the commit role is none, the primary key could be read from the lock.
             true,
         );
         must_succeed(&mut engine, k, ts(10, 0), ts(20, 1));


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18441

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
 In the previous PR, we only collect mvcc info when `commit_role` is `Secondary` when `commit_ts < min_commit_ts`. However, when resolving a lock, the `commit_role` of `commit` is None and we cannot get any mvcc info when this error happens. This PR does an enhancement and checks whether the resolved key is primary in the lock, if not, it still collect mvcc for further debugging.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
