### PR TITLE
Raftstore: Close some background schedulers before shutting down

### DIFF
--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -1641,6 +1641,8 @@ struct Workers<EK: KvEngine> {
     coprocessor_host: CoprocessorHost<EK>,
 
     refresh_config_worker: LazyWorker<RefreshConfigTask>,
+
+    on_stop_hooks: Vec<Box<dyn FnOnce() + Send>>,
 }
 
 pub struct RaftBatchSystem<EK: KvEngine, ER: RaftEngine> {
@@ -1731,7 +1733,7 @@ impl<EK: KvEngine, ER: RaftEngine> RaftBatchSystem<EK, ER> {
             .thread_count(cfg.value().snap_generator_pool_size)
             .thread_count_limits(1, SNAP_GENERATOR_MAX_POOL_SIZE)
             .create();
-        let workers = Workers {
+        let mut workers = Workers {
             pd_worker,
             background_worker,
             cleanup_worker: Worker::new("cleanup-worker"),
@@ -1741,7 +1743,20 @@ impl<EK: KvEngine, ER: RaftEngine> RaftBatchSystem<EK, ER> {
             raftlog_fetch_worker: Worker::new("raftlog-fetch-worker"),
             coprocessor_host: coprocessor_host.clone(),
             refresh_config_worker: LazyWorker::new("refreash-config-worker"),
+            on_stop_hooks: vec![],
         };
+        // Ideally, we should not stop split_check_scheduler when Workers stop, since
+        // Workers do not own it. But, no body owns it, it is shared. And, since the
+        // split check worker internally runs a infinite loop, it will not stop
+        // when shutting down the threadpool, causing the reference to the kv
+        // engine inside the scheduler to be dangle, so that the kv engine never
+        // closes until the process exits. If we want to restart engines in the same
+        // process, e.g. in a test that requires restarting the engines, we need to stop
+        // the scheduler first.
+        let split_check_scheduler_clone = split_check_scheduler.clone();
+        workers.on_stop_hooks.push(Box::new(move || {
+            split_check_scheduler_clone.stop();
+        }));
         mgr.init()?;
 
         let snap_gen_runner = SnapGenRunner::new(
@@ -1766,6 +1781,14 @@ impl<EK: KvEngine, ER: RaftEngine> RaftBatchSystem<EK, ER> {
         let region_scheduler = workers
             .region_worker
             .start_with_timer("region-worker", region_runner);
+        // Same as split_check_scheduler, region worker also runs a infinite
+        // loop, that will not stop when shutting down the threadpool, causing the
+        // reference to the kv engine inside the scheduler to be dangle. So we need
+        // to stop the scheduler before shutting down the threadpool.
+        let region_scheduler_clone = region_scheduler.clone();
+        workers.on_stop_hooks.push(Box::new(move || {
+            region_scheduler_clone.stop();
+        }));
         let raftlog_gc_runner = RaftlogGcRunner::new(
             engines.clone(),
             cfg.value().raft_log_compact_sync_interval.0,
@@ -1773,6 +1796,14 @@ impl<EK: KvEngine, ER: RaftEngine> RaftBatchSystem<EK, ER> {
         let raftlog_gc_scheduler = workers
             .background_worker
             .start_with_timer("raft-gc-worker", raftlog_gc_runner);
+        // Same as split_check_scheduler, raftlog_gc_scheduler also runs a infinite
+        // loop, that will not stop when shutting down the threadpool, causing the
+        // reference to the raft engine inside the scheduler to be dangle. So we need
+        // to stop the scheduler before shutting down the threadpool.
+        let reftlog_gc_scheduler_clone = raftlog_gc_scheduler.clone();
+        workers.on_stop_hooks.push(Box::new(move || {
+            reftlog_gc_scheduler_clone.stop();
+        }));
 
         let raftlog_fetch_scheduler = workers.raftlog_fetch_worker.start(
             "raftlog-fetch-worker",
@@ -1983,6 +2014,9 @@ impl<EK: KvEngine, ER: RaftEngine> RaftBatchSystem<EK, ER> {
             return;
         }
         let mut workers = self.workers.take().unwrap();
+        for hook in workers.on_stop_hooks.drain(..) {
+            hook();
+        }
         // Wait all workers finish.
         workers.pd_worker.stop();
 

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -1800,9 +1800,9 @@ impl<EK: KvEngine, ER: RaftEngine> RaftBatchSystem<EK, ER> {
         // loop, that will not stop when shutting down the threadpool, causing the
         // reference to the raft engine inside the scheduler to be dangle. So we need
         // to stop the scheduler before shutting down the threadpool.
-        let reftlog_gc_scheduler_clone = raftlog_gc_scheduler.clone();
+        let raftlog_gc_scheduler_clone = raftlog_gc_scheduler.clone();
         workers.on_stop_hooks.push(Box::new(move || {
-            reftlog_gc_scheduler_clone.stop();
+            raftlog_gc_scheduler_clone.stop();
         }));
 
         let raftlog_fetch_scheduler = workers.raftlog_fetch_worker.start(


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref #18434

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Close some background schedulers before shutting down.

We need to restart both the KV engine and the Raft engine in a test to set some non-online configs.
e.g. turning off Titan.
These background workers have references to either the KV engine or the Raft engine, and they are also
self-referencing, causing the KV engine and Raft engine never get closed on shutting down. We need this
to interrupt the infinite loop, and release the DBs' references.

The best way to resolve this would be using tokio's unbound channel which allows downgrade to weak ptr.
However, TiKV just has too many Arc circular dependencies, it is nearly impossible to detangle it.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
