### PR TITLE
*: linearizability debug logs as a build feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7628,6 +7628,7 @@ dependencies = [
  "toml",
  "tracker",
  "url",
+ "uuid 0.8.2",
  "yatp",
 ]
 
@@ -7941,6 +7942,7 @@ dependencies = [
 name = "tracker"
 version = "0.0.1"
 dependencies = [
+ "chrono",
  "crossbeam-utils",
  "kvproto",
  "lazy_static",
@@ -7949,6 +7951,7 @@ dependencies = [
  "prometheus",
  "slab",
  "slog",
+ "uuid 0.8.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,11 @@ openssl-vendored = [
   # NB: Enable SM4 support if OpenSSL is built from source and statically linked.
   "encryption_export/sm4",
 ]
+linearizability-track = [
+  "raftstore/linearizability-track",
+  "tikv_util/linearizability-track",
+  "tracker/linearizability-track",
+]
 
 # for testing configure propegate to other crates
 # https://stackoverflow.com/questions/41700543/can-we-share-test-utilites-between-crates

--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,10 @@ ifneq ($(NO_ASYNC_BACKTRACE),1)
 ENABLE_FEATURES += trace-async-tasks
 endif
 
+ifeq ($(LINEARIZABILITY_TRACK),1)
+ENABLE_FEATURES += linearizability-track
+endif
+
 export DOCKER_FILE ?= Dockerfile
 export DOCKER_IMAGE_NAME ?= pingcap/tikv
 export DOCKER_IMAGE_TAG ?= latest

--- a/cmd/tikv-server/Cargo.toml
+++ b/cmd/tikv-server/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [features]
-default = ["test-engine-kv-rocksdb", "test-engine-raft-raft-engine", "linearizability-track"]
+default = ["test-engine-kv-rocksdb", "test-engine-raft-raft-engine"]
 trace-async-tasks = ["dep:tracing-active-tree", "dep:tracing-subscriber"]
 trace-tablet-lifetime = ["tikv/trace-tablet-lifetime"]
 tcmalloc = ["server/tcmalloc"]

--- a/cmd/tikv-server/Cargo.toml
+++ b/cmd/tikv-server/Cargo.toml
@@ -30,6 +30,7 @@ test-engines-panic = ["server/test-engines-panic"]
 nortcheck = ["server/nortcheck"]
 
 pprof-fp = ["tikv/pprof-fp"]
+linearizability-track = ["server/linearizability-track", "tikv/linearizability-track"]
 
 [dependencies]
 clap = { workspace = true }

--- a/cmd/tikv-server/Cargo.toml
+++ b/cmd/tikv-server/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [features]
-default = ["test-engine-kv-rocksdb", "test-engine-raft-raft-engine"]
+default = ["test-engine-kv-rocksdb", "test-engine-raft-raft-engine", "linearizability-track"]
 trace-async-tasks = ["dep:tracing-active-tree", "dep:tracing-subscriber"]
 trace-tablet-lifetime = ["tikv/trace-tablet-lifetime"]
 tcmalloc = ["server/tcmalloc"]

--- a/components/raftstore/Cargo.toml
+++ b/components/raftstore/Cargo.toml
@@ -18,6 +18,7 @@ test-engine-kv-rocksdb = ["engine_test/test-engine-kv-rocksdb"]
 test-engine-raft-raft-engine = ["engine_test/test-engine-raft-raft-engine"]
 test-engines-rocksdb = ["engine_test/test-engines-rocksdb"]
 test-engines-panic = ["engine_test/test-engines-panic"]
+linearizability-track = []
 
 [dependencies]
 batch-system = { workspace = true }

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -4522,19 +4522,17 @@ where
                     #[cfg(feature = "linearizability-track")]
                     let (mut min_index, mut max_index) = (u64::MAX, 0);
                     #[cfg(feature = "linearizability-track")]
-                    {
-                        apply.entries.first().map(|cached_entries| {
-                            cached_entries.iter_entries(|entry| {
-                                let index = entry.get_index();
-                                if index < min_index {
-                                    min_index = index;
-                                }
-                                if index > max_index {
-                                    max_index = index;
-                                }
-                            });
+                    apply.entries.first().map(|cached_entries| {
+                        cached_entries.iter_entries(|entry| {
+                            let index = entry.get_index();
+                            if index < min_index {
+                                min_index = index;
+                            }
+                            if index > max_index {
+                                max_index = index;
+                            }
                         });
-                    }
+                    });
                     #[cfg(feature = "linearizability-track")]
                     let before_seq_no = if min_index <= max_index {
                         Some(apply_ctx.engine.get_latest_sequence_number())
@@ -4771,15 +4769,13 @@ where
 
     fn handle_normal(&mut self, normal: &mut impl DerefMut<Target = ApplyFsm<EK>>) -> HandleResult {
         #[cfg(feature = "linearizability-track")]
-        {
-            set_tls_peer_state(PeerStateTracker::new(
-                normal.delegate.region_id(),
-                normal.delegate.id(),
-                normal.delegate.term,
-                normal.delegate.apply_state.commit_index,
-                normal.delegate.apply_state.applied_index,
-            ));
-        }
+        set_tls_peer_state(PeerStateTracker::new(
+            normal.delegate.region_id(),
+            normal.delegate.id(),
+            normal.delegate.term,
+            normal.delegate.apply_state.commit_index,
+            normal.delegate.apply_state.applied_index,
+        ));
 
         let mut handle_result = HandleResult::KeepProcessing;
         normal.delegate.handle_start = Some(Instant::now_coarse());

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -71,9 +71,9 @@ use tikv_util::{
     worker::Scheduler,
 };
 use time::Timespec;
-#[cfg(feature = "linearizability-track")]
-use tracker::{clear_tls_peer_state, set_tls_peer_state, PeerStateTracker};
 use tracker::{GLOBAL_TRACKERS, TrackerToken, TrackerTokenArray};
+#[cfg(feature = "linearizability-track")]
+use tracker::{PeerStateTracker, clear_tls_peer_state, set_tls_peer_state};
 use uuid::Builder as UuidBuilder;
 
 use self::memtrace::*;

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -75,6 +75,8 @@ use tikv_util::{
     yatp_pool::FuturePool,
 };
 use time::{self, Timespec};
+#[cfg(feature = "linearizability-track")]
+use tracker::{clear_tls_peer_state, set_tls_peer_state, PeerStateDebug};
 
 use crate::{
     Error, Result, bytes_capacity,
@@ -1075,6 +1077,16 @@ impl<EK: KvEngine, ER: RaftEngine, T: Transport> PollHandler<PeerFsm<EK, ER>, St
             "peer_id" => peer.peer_id(),
         };
         let mut handle_result = HandleResult::KeepProcessing;
+        #[cfg(feature = "linearizability-track")]
+        {
+            set_tls_peer_state(PeerStateDebug::new(
+                peer.region_id(),
+                peer.peer_id(),
+                peer.get_peer().term(),
+                peer.get_peer().get_store().commit_index(),
+                peer.get_peer().get_store().applied_index(),
+            ));
+        }
 
         fail_point!(
             "pause_on_peer_collect_message",
@@ -1122,6 +1134,8 @@ impl<EK: KvEngine, ER: RaftEngine, T: Transport> PollHandler<PeerFsm<EK, ER>, St
             }
         }
 
+        #[cfg(feature = "linearizability-track")]
+        clear_tls_peer_state();
         handle_result
     }
 

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -76,7 +76,7 @@ use tikv_util::{
 };
 use time::{self, Timespec};
 #[cfg(feature = "linearizability-track")]
-use tracker::{clear_tls_peer_state, set_tls_peer_state, PeerStateDebug};
+use tracker::{clear_tls_peer_state, set_tls_peer_state, PeerStateTracker};
 
 use crate::{
     Error, Result, bytes_capacity,
@@ -1079,7 +1079,7 @@ impl<EK: KvEngine, ER: RaftEngine, T: Transport> PollHandler<PeerFsm<EK, ER>, St
         let mut handle_result = HandleResult::KeepProcessing;
         #[cfg(feature = "linearizability-track")]
         {
-            set_tls_peer_state(PeerStateDebug::new(
+            set_tls_peer_state(PeerStateTracker::new(
                 peer.region_id(),
                 peer.peer_id(),
                 peer.get_peer().term(),

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -76,7 +76,7 @@ use tikv_util::{
 };
 use time::{self, Timespec};
 #[cfg(feature = "linearizability-track")]
-use tracker::{clear_tls_peer_state, set_tls_peer_state, PeerStateTracker};
+use tracker::{PeerStateTracker, clear_tls_peer_state, set_tls_peer_state};
 
 use crate::{
     Error, Result, bytes_capacity,

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -1078,15 +1078,13 @@ impl<EK: KvEngine, ER: RaftEngine, T: Transport> PollHandler<PeerFsm<EK, ER>, St
         };
         let mut handle_result = HandleResult::KeepProcessing;
         #[cfg(feature = "linearizability-track")]
-        {
-            set_tls_peer_state(PeerStateTracker::new(
-                peer.region_id(),
-                peer.peer_id(),
-                peer.get_peer().term(),
-                peer.get_peer().get_store().commit_index(),
-                peer.get_peer().get_store().applied_index(),
-            ));
-        }
+        set_tls_peer_state(PeerStateTracker::new(
+            peer.region_id(),
+            peer.peer_id(),
+            peer.get_peer().term(),
+            peer.get_peer().get_store().commit_index(),
+            peer.get_peer().get_store().applied_index(),
+        ));
 
         fail_point!(
             "pause_on_peer_collect_message",

--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -223,8 +223,7 @@ where
             Callback::Write { trackers, .. } => trackers
                 .first()
                 .copied()
-                .map(|t| t.as_tracker_token())
-                .flatten(),
+                .and_then(|t| t.as_tracker_token()),
             _ => None,
         }
     }

--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -216,6 +216,18 @@ where
         };
         committed_cb.take()
     }
+
+    pub fn as_tracker_token(&self) -> Option<TrackerToken> {
+        match self {
+            Callback::Read { tracker, .. } => Some(*tracker),
+            Callback::Write { trackers, .. } => trackers
+                .first()
+                .copied()
+                .map(|t| t.as_tracker_token())
+                .flatten(),
+            _ => None,
+        }
+    }
 }
 
 pub trait ReadCallback: ErrorCallback {

--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -220,10 +220,9 @@ where
     pub fn as_tracker_token(&self) -> Option<TrackerToken> {
         match self {
             Callback::Read { tracker, .. } => Some(*tracker),
-            Callback::Write { trackers, .. } => trackers
-                .first()
-                .copied()
-                .and_then(|t| t.as_tracker_token()),
+            Callback::Write { trackers, .. } => {
+                trackers.first().copied().and_then(|t| t.as_tracker_token())
+            }
             _ => None,
         }
     }

--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -1248,7 +1248,7 @@ where
                     GLOBAL_TRACKERS.with_tracker(tracker, |t| {
                         t.metrics.local_read = true;
                         #[cfg(feature = "linearizability-track")]
-                        t.prpose_must_checked();
+                        t.propose_must_checked();
                     })
                 });
 

--- a/components/server/Cargo.toml
+++ b/components/server/Cargo.toml
@@ -21,6 +21,7 @@ test-engines-rocksdb = ["tikv/test-engines-rocksdb"]
 test-engines-panic = ["tikv/test-engines-panic"]
 nortcheck = ["engine_rocks/nortcheck"]
 backup-stream-debug = ["backup-stream/backup-stream-debug"]
+linearizability-track = ["tikv/linearizability-track"]
 
 [dependencies]
 api_version = { workspace = true }

--- a/components/tikv_util/Cargo.toml
+++ b/components/tikv_util/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 [features]
 failpoints = ["fail/failpoints"]
 test-cgroup = []
+linearizability-track = []
 
 [dependencies]
 # TODO: use `async-speed-limit` in crates.io after new version(v0.4.2) is released.
@@ -66,6 +67,7 @@ tokio-timer = { workspace = true }
 tokio-util = { version = "0.7", features = ["rt"] }
 tracker = { workspace = true }
 url = "2"
+uuid = { version = "0.8.1", features = ["serde", "v4"] }
 yatp = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/components/tikv_util/src/lib.rs
+++ b/components/tikv_util/src/lib.rs
@@ -51,6 +51,7 @@ pub mod macros;
 pub mod callback;
 pub mod deadline;
 pub mod keybuilder;
+pub mod linearizability_track;
 pub mod logger;
 pub mod lru;
 pub mod math;

--- a/components/tikv_util/src/linearizability_track.rs
+++ b/components/tikv_util/src/linearizability_track.rs
@@ -1,0 +1,67 @@
+#[cfg(feature = "linearizability-track")]
+pub use linearizability_track::*;
+
+#[cfg(feature = "linearizability-track")]
+mod linearizability_track {
+    use tracker::{get_tls_peer_state, TrackerToken, GLOBAL_TRACKERS};
+    use uuid::Uuid;
+
+    pub fn log(token: TrackerToken) {
+        GLOBAL_TRACKERS.with_tracker(token, |tracker| {
+            if let Some(debug) = tracker.linearizability_track.as_ref() {
+                match debug.scheduler_snapshot_states {
+                    Some(ref states) => {
+                        info!("Linearizability Tracker Write";
+                            "apply_state" => ?debug.apply_state,
+                            "ready_state" => ?debug.ready_state,
+                            "propose_state" => ?debug.propose_state,
+                            "scheduler_snapshot_seq_no" => ?debug.snapshot_seq_no,
+                            "scheduler_snapshot_ready" => ?states.1,
+                            "scheduler_snapshot_propose" => ?states.0,
+                            "success" => debug.success,
+                            "duration" => ?tracker.req_info.begin.elapsed(),
+                            "req_type" => ?tracker.req_info.request_type,
+                            "start_ts" => tracker.req_info.start_ts,
+                        );
+                    }
+                    None => {
+                        info!("Linearizability Tracker Read";
+                            "snapshot_seq_no" => ?debug.snapshot_seq_no,
+                            "ready_state" => ?debug.ready_state,
+                            "propose_state" => ?debug.propose_state,
+                            "success" => debug.success,
+                            "duration" => ?tracker.req_info.begin.elapsed(),
+                            "req_type" => ?tracker.req_info.request_type,
+                            "start_ts" => tracker.req_info.start_ts,
+                        );
+                    }
+                }
+            }
+        });
+    }
+
+    pub fn log_read_index(uuid: Uuid, start_ts: u64) {
+        let peer_state = get_tls_peer_state();
+        info!("Linearizability Tracker leader step read index";
+            "peer_state" => ?peer_state,
+            "uuid" => ?uuid,
+            "start_ts" => start_ts,
+        );
+    }
+
+    pub fn log_apply_entries(
+        min_index: u64,
+        max_index: u64,
+        before_seq_no: u64,
+        after_seq_no: u64,
+    ) {
+        let peer_state = get_tls_peer_state();
+        info!("Linearizability Tracker apply entries";
+            "after_seq_no" => after_seq_no,
+            "before_seq_no" => before_seq_no,
+            "to" => max_index,
+            "from" => min_index,
+            "peer_state" => ?peer_state,
+        );
+    }
+}

--- a/components/tikv_util/src/linearizability_track.rs
+++ b/components/tikv_util/src/linearizability_track.rs
@@ -3,7 +3,7 @@ pub use linearizability_track::*;
 
 #[cfg(feature = "linearizability-track")]
 mod linearizability_track {
-    use tracker::{get_tls_peer_state, TrackerToken, GLOBAL_TRACKERS};
+    use tracker::{GLOBAL_TRACKERS, TrackerToken, get_tls_peer_state};
     use uuid::Uuid;
 
     pub fn log(token: TrackerToken) {

--- a/components/tikv_util/src/linearizability_track.rs
+++ b/components/tikv_util/src/linearizability_track.rs
@@ -11,7 +11,7 @@ mod linearizability_track {
             if let Some(debug) = tracker.linearizability_track.as_ref() {
                 match debug.scheduler_snapshot_states {
                     Some(ref states) => {
-                        info!("Linearizability Tracker Write";
+                        info!("Linearizability Track Write";
                             "apply_state" => ?debug.apply_state,
                             "ready_state" => ?debug.ready_state,
                             "propose_state" => ?debug.propose_state,
@@ -25,7 +25,7 @@ mod linearizability_track {
                         );
                     }
                     None => {
-                        info!("Linearizability Tracker Read";
+                        info!("Linearizability Track Read";
                             "snapshot_seq_no" => ?debug.snapshot_seq_no,
                             "ready_state" => ?debug.ready_state,
                             "propose_state" => ?debug.propose_state,
@@ -42,7 +42,7 @@ mod linearizability_track {
 
     pub fn log_read_index(uuid: Uuid, start_ts: u64) {
         let peer_state = get_tls_peer_state();
-        info!("Linearizability Tracker leader step read index";
+        info!("Linearizability Track leader step read index";
             "peer_state" => ?peer_state,
             "uuid" => ?uuid,
             "start_ts" => start_ts,
@@ -56,7 +56,7 @@ mod linearizability_track {
         after_seq_no: u64,
     ) {
         let peer_state = get_tls_peer_state();
-        info!("Linearizability Tracker apply entries";
+        info!("Linearizability Track apply entries";
             "after_seq_no" => after_seq_no,
             "before_seq_no" => before_seq_no,
             "to" => max_index,

--- a/components/tracker/Cargo.toml
+++ b/components/tracker/Cargo.toml
@@ -5,7 +5,11 @@ edition = "2021"
 publish = false
 license = "Apache-2.0"
 
+[features]
+linearizability-track = []
+
 [dependencies]
+chrono = { workspace = true }
 crossbeam-utils = { workspace = true }
 kvproto = { workspace = true }
 lazy_static = "1"
@@ -14,3 +18,4 @@ pin-project = "1"
 prometheus = "0.13"
 slab = "0.4"
 slog = { workspace = true }
+uuid = { version = "0.8.1", features = ["serde", "v4"] }

--- a/components/tracker/src/lib.rs
+++ b/components/tracker/src/lib.rs
@@ -272,11 +272,12 @@ mod linearizability_track {
             }
         }
 
-        pub fn track_propose_read_index(&mut self, uuid: Uuid) {
+        pub fn track_propose_read_index(&mut self, uuid: Uuid, is_leader: bool) {
             match self.linearizability_track.as_mut() {
                 Some(debug) => {
                     debug.propose_state = ProposeState::ReadIndex(
                         chrono::offset::Local::now(),
+                        is_leader,
                         uuid,
                         get_tls_peer_state(),
                     );
@@ -414,7 +415,7 @@ mod linearizability_track {
         None,
         Skip(DateTime<Local>, String),
         Amend(DateTime<Local>, Uuid, PeerStateTracker),
-        ReadIndex(DateTime<Local>, Uuid, PeerStateTracker),
+        ReadIndex(DateTime<Local>, bool, Uuid, PeerStateTracker),
         Normal(DateTime<Local>, PeerStateTracker),
     }
 
@@ -436,10 +437,10 @@ mod linearizability_track {
                     "amend at {:?}, to {:?}, peer_state {:?}",
                     time, uuid, state
                 ),
-                ProposeState::ReadIndex(time, uuid, state) => write!(
+                ProposeState::ReadIndex(time, is_leader, uuid, state) => write!(
                     f,
-                    "propose read-index at {:?}, uuid: {:?}, peer_state {:?}",
-                    time, uuid, state
+                    "propose read-index at {:?}, is_leader: {}, uuid: {:?}, peer_state {:?}",
+                    time, is_leader, uuid, state
                 ),
                 ProposeState::Normal(time, state) => {
                     write!(f, "propose normal at {:?}, peer_state {:?}", time, state)

--- a/components/tracker/src/lib.rs
+++ b/components/tracker/src/lib.rs
@@ -295,7 +295,7 @@ mod linearizability_track {
             }
         }
 
-        pub fn prpose_must_checked(&self) {
+        pub fn propose_must_checked(&self) {
             match self.linearizability_track.as_ref() {
                 Some(debug) => {
                     assert_ne!(debug.propose_state, ProposeState::None);
@@ -307,7 +307,6 @@ mod linearizability_track {
         pub fn track_ready_committed(&mut self) {
             match self.linearizability_track.as_mut() {
                 Some(debug) => {
-                    assert_eq!(debug.ready_state, ReadyState::None);
                     debug.ready_state =
                         ReadyState::Committed(chrono::offset::Local::now(), get_tls_peer_state());
                 }

--- a/components/tracker/src/lib.rs
+++ b/components/tracker/src/lib.rs
@@ -231,7 +231,7 @@ mod linearizability_track {
     use super::*;
     use crate::tls::get_tls_peer_state;
 
-    pub const INVALID_PEER_STATE: PeerStateDebug = PeerStateDebug {
+    pub const INVALID_PEER_STATE: PeerStateTracker = PeerStateTracker {
         region_id: 0,
         peer_id: 0,
         term: 0,
@@ -240,7 +240,7 @@ mod linearizability_track {
     };
 
     #[derive(Debug, Default, PartialEq, Clone, Copy)]
-    pub struct PeerStateDebug {
+    pub struct PeerStateTracker {
         pub region_id: u64,
         pub peer_id: u64,
         pub term: u64,
@@ -371,7 +371,7 @@ mod linearizability_track {
         }
     }
 
-    impl PeerStateDebug {
+    impl PeerStateTracker {
         pub fn new(
             region_id: u64,
             peer_id: u64,
@@ -414,9 +414,9 @@ mod linearizability_track {
     pub enum ProposeState {
         None,
         Skip(DateTime<Local>, String),
-        Amend(DateTime<Local>, Uuid, PeerStateDebug),
-        ReadIndex(DateTime<Local>, Uuid, PeerStateDebug),
-        Normal(DateTime<Local>, PeerStateDebug),
+        Amend(DateTime<Local>, Uuid, PeerStateTracker),
+        ReadIndex(DateTime<Local>, Uuid, PeerStateTracker),
+        Normal(DateTime<Local>, PeerStateTracker),
     }
 
     impl Default for ProposeState {
@@ -452,8 +452,8 @@ mod linearizability_track {
     #[derive(PartialEq)]
     pub enum ReadyState {
         None,
-        Committed(DateTime<Local>, PeerStateDebug),
-        ReplicaRead(DateTime<Local>, Option<u64>, PeerStateDebug),
+        Committed(DateTime<Local>, PeerStateTracker),
+        ReplicaRead(DateTime<Local>, Option<u64>, PeerStateTracker),
     }
 
     impl Default for ReadyState {
@@ -483,7 +483,7 @@ mod linearizability_track {
     #[derive(PartialEq)]
     pub enum ApplyState {
         None,
-        Applied(DateTime<Local>, PeerStateDebug),
+        Applied(DateTime<Local>, PeerStateTracker),
     }
 
     impl Default for ApplyState {

--- a/components/tracker/src/tls.rs
+++ b/components/tracker/src/tls.rs
@@ -76,13 +76,13 @@ impl<F: Future> Future for TlsTrackedFuture<F> {
 #[cfg(feature = "linearizability-track")]
 mod linearizability_track {
     use super::*;
-    use crate::linearizability_track::{PeerStateDebug, INVALID_PEER_STATE};
+    use crate::linearizability_track::{PeerStateTracker, INVALID_PEER_STATE};
 
     thread_local! {
-        static TLS_PEER_STATE: Cell<PeerStateDebug> = const { Cell::new(INVALID_PEER_STATE) };
+        static TLS_PEER_STATE: Cell<PeerStateTracker> = const { Cell::new(INVALID_PEER_STATE) };
     }
 
-    pub fn set_tls_peer_state(peer: PeerStateDebug) {
+    pub fn set_tls_peer_state(peer: PeerStateTracker) {
         TLS_PEER_STATE.with(|c| {
             c.set(peer);
         })
@@ -92,7 +92,7 @@ mod linearizability_track {
         set_tls_peer_state(INVALID_PEER_STATE);
     }
 
-    pub fn get_tls_peer_state() -> PeerStateDebug {
+    pub fn get_tls_peer_state() -> PeerStateTracker {
         TLS_PEER_STATE.with(|c| c.get())
     }
 }

--- a/components/tracker/src/tls.rs
+++ b/components/tracker/src/tls.rs
@@ -76,7 +76,7 @@ impl<F: Future> Future for TlsTrackedFuture<F> {
 #[cfg(feature = "linearizability-track")]
 mod linearizability_track {
     use super::*;
-    use crate::linearizability_track::{PeerStateTracker, INVALID_PEER_STATE};
+    use crate::linearizability_track::{INVALID_PEER_STATE, PeerStateTracker};
 
     thread_local! {
         static TLS_PEER_STATE: Cell<PeerStateTracker> = const { Cell::new(INVALID_PEER_STATE) };

--- a/src/server/raftkv/mod.rs
+++ b/src/server/raftkv/mod.rs
@@ -781,13 +781,10 @@ where
             }
             Ok(CmdRes::Snap(s)) => {
                 #[cfg(feature = "linearizability-track")]
-                {
+                GLOBAL_TRACKERS.with_tracker(tracker, |tracker| {
                     use engine_traits::SnapshotMiscExt;
-                    let seq_no = s.get_snapshot().sequence_number();
-                    GLOBAL_TRACKERS.with_tracker(tracker, |tracker| {
-                        tracker.track_snapshot_seq_no(seq_no);
-                    });
-                }
+                    tracker.track_snapshot_seq_no(s.get_snapshot().sequence_number());
+                });
                 Ok(s)
             }
             Err(e) => {

--- a/src/server/raftkv/mod.rs
+++ b/src/server/raftkv/mod.rs
@@ -52,6 +52,8 @@ use raftstore::{
 };
 use thiserror::Error;
 use tikv_kv::{OnAppliedCb, WriteEvent, write_modifies};
+#[cfg(feature = "linearizability-track")]
+use tikv_util::linearizability_track::log_read_index;
 use tikv_util::{
     callback::must_call,
     future::{paired_future_callback, paired_must_called_future_callback},
@@ -777,7 +779,17 @@ where
                 };
                 Err(e)
             }
-            Ok(CmdRes::Snap(s)) => Ok(s),
+            Ok(CmdRes::Snap(s)) => {
+                #[cfg(feature = "linearizability-track")]
+                {
+                    use engine_traits::SnapshotMiscExt;
+                    let seq_no = s.get_snapshot().sequence_number();
+                    GLOBAL_TRACKERS.with_tracker(tracker, |tracker| {
+                        tracker.track_snapshot_seq_no(seq_no);
+                    });
+                }
+                Ok(s)
+            }
             Err(e) => {
                 let status_kind = get_status_kind_from_engine_error(&e);
                 ASYNC_REQUESTS_COUNTER_VEC.snapshot.get(status_kind).inc();
@@ -825,6 +837,8 @@ impl ReadIndexObserver for ReplicaReadLockChecker {
         let mut rctx = ReadIndexContext::parse(msg.get_entries()[0].get_data()).unwrap();
         if let Some(mut request) = rctx.request.take() {
             let begin_instant = Instant::now();
+            #[cfg(feature = "linearizability-track")]
+            log_read_index(rctx.id, request.get_start_ts());
 
             let start_ts = request.get_start_ts().into();
             if let Err(e) = self

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -37,6 +37,8 @@ use raftstore::{
 use resource_control::ResourceGroupManager;
 use tikv_alloc::trace::MemoryTraceGuard;
 use tikv_kv::{RaftExtension, StageLatencyStats};
+#[cfg(feature = "linearizability-track")]
+use tikv_util::linearizability_track;
 use tikv_util::{
     future::{paired_future_callback, poll_future_notify},
     mpsc::future::{BatchReceiver, Sender, WakePolicy, unbounded},
@@ -1640,6 +1642,8 @@ fn future_get<E: Engine, L: LockManager, F: KvFormat>(
                     GLOBAL_TRACKERS.with_tracker(tracker, |tracker| {
                         tracker.write_scan_detail(exec_detail_v2.mut_scan_detail_v2());
                         tracker.merge_time_detail(exec_detail_v2.mut_time_detail_v2());
+                        #[cfg(feature = "linearizability-track")]
+                        tracker.track_success();
                     });
                     set_time_detail(exec_detail_v2, duration, &stats.latency_stats);
                     match val {
@@ -1650,6 +1654,8 @@ fn future_get<E: Engine, L: LockManager, F: KvFormat>(
                 Err(e) => resp.set_error(extract_key_error(&e)),
             }
         }
+        #[cfg(feature = "linearizability-track")]
+        linearizability_track::log(tracker);
         GLOBAL_TRACKERS.remove(tracker);
         Ok(resp)
     }
@@ -1710,6 +1716,10 @@ fn future_scan<E: Engine, L: LockManager, F: KvFormat>(
             match v {
                 Ok(kv_res) => {
                     resp.set_pairs(map_kv_pairs(kv_res).into());
+                    #[cfg(feature = "linearizability-track")]
+                    GLOBAL_TRACKERS.with_tracker(tracker, |tracker| {
+                        tracker.track_success();
+                    });
                 }
                 Err(e) => {
                     let key_error = extract_key_error(&e);
@@ -1721,6 +1731,8 @@ fn future_scan<E: Engine, L: LockManager, F: KvFormat>(
                 }
             }
         }
+        #[cfg(feature = "linearizability-track")]
+        linearizability_track::log(tracker);
         GLOBAL_TRACKERS.remove(tracker);
         Ok(resp)
     }
@@ -1757,6 +1769,8 @@ fn future_batch_get<E: Engine, L: LockManager, F: KvFormat>(
                     GLOBAL_TRACKERS.with_tracker(tracker, |tracker| {
                         tracker.write_scan_detail(exec_detail_v2.mut_scan_detail_v2());
                         tracker.merge_time_detail(exec_detail_v2.mut_time_detail_v2());
+                        #[cfg(feature = "linearizability-track")]
+                        tracker.track_success();
                     });
                     set_time_detail(exec_detail_v2, duration, &stats.latency_stats);
                     resp.set_pairs(pairs.into());
@@ -1771,6 +1785,8 @@ fn future_batch_get<E: Engine, L: LockManager, F: KvFormat>(
                 }
             }
         }
+        #[cfg(feature = "linearizability-track")]
+        linearizability_track::log(tracker);
         GLOBAL_TRACKERS.remove(tracker);
         Ok(resp)
     }
@@ -1805,6 +1821,8 @@ fn future_buffer_batch_get<E: Engine, L: LockManager, F: KvFormat>(
                     stats.stats.write_scan_detail(scan_detail_v2);
                     GLOBAL_TRACKERS.with_tracker(tracker, |tracker| {
                         tracker.write_scan_detail(scan_detail_v2);
+                        #[cfg(feature = "linearizability-track")]
+                        tracker.track_success();
                     });
                     set_time_detail(exec_detail_v2, duration, &stats.latency_stats);
                     resp.set_pairs(pairs.into());
@@ -1815,6 +1833,8 @@ fn future_buffer_batch_get<E: Engine, L: LockManager, F: KvFormat>(
                 }
             }
         }
+        #[cfg(feature = "linearizability-track")]
+        linearizability_track::log(tracker);
         GLOBAL_TRACKERS.remove(tracker);
         Ok(resp)
     }
@@ -1848,10 +1868,18 @@ fn future_scan_lock<E: Engine, L: LockManager, F: KvFormat>(
             resp.set_region_error(err);
         } else {
             match v {
-                Ok(locks) => resp.set_locks(locks.into()),
+                Ok(locks) => {
+                    #[cfg(feature = "linearizability-track")]
+                    GLOBAL_TRACKERS.with_tracker(tracker, |tracker| {
+                        tracker.track_success();
+                    });
+                    resp.set_locks(locks.into())
+                }
                 Err(e) => resp.set_error(extract_key_error(&e)),
             }
         }
+        #[cfg(feature = "linearizability-track")]
+        linearizability_track::log(tracker);
         GLOBAL_TRACKERS.remove(tracker);
         Ok(resp)
     }
@@ -2398,6 +2426,7 @@ macro_rules! txn_command_future {
 
             async move {
                 defer!{{
+                    #[cfg(feature="linearizability-track")] linearizability_track::log($tracker);
                     GLOBAL_TRACKERS.remove($tracker);
                 }};
                 let $v = match res {
@@ -2408,6 +2437,12 @@ macro_rules! txn_command_future {
                 if let Some(err) = extract_region_error(&$v) {
                     $resp.set_region_error(err);
                 } else {
+                    #[cfg(feature="linearizability-track")]
+                    if $v.is_ok() {
+                        GLOBAL_TRACKERS.with_tracker($tracker, |tracker| {
+                            tracker.track_success();
+                        });
+                    }
                     $else_branch
                 }
                 Ok($resp)

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -750,6 +750,10 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
                     SCHED_STAGE_COUNTER_VEC.get(tag).snapshot_ok.inc();
                     let term = snapshot.ext().get_term();
                     let extra_op = snapshot.ext().get_txn_extra_op();
+                    #[cfg(feature = "linearizability-track")]
+                    GLOBAL_TRACKERS.with_tracker(task.tracker_token(), |tracker| {
+                        tracker.track_flush_scheduler_snapshot();
+                    });
                     if !sched
                         .inner
                         .get_task_slot(task.cid())


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #18460

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Add a build-time feature that prints logs for linearizability debugging.
```

Examples:

#### Write logs

```
[2025/05/15 12:54:13.486 +09:00] [INFO] [linearizability_track.rs:14] ["Linearizability Tracker Write"] [start_ts=458039296902299683] [req_type=KvPrewrite] [duration=466.162µs] [success=true] [scheduler_snapshot_propose="skip at 2025-05-15T12:54:13.485908499+09:00, reason localrouter-local-read"] [scheduler_snapshot_ready=None] [scheduler_snapshot_seq_no=Some(7944)] [propose_state="propose normal at 2025-05-15T12:54:13.486001063+09:00, peer_state PeerStateDebug { region_id: 18, peer_id: 19, term: 6, committed_index: 87, applied_index: 87 }"] [ready_state="committed at 2025-05-15T12:54:13.486265418+09:00, peer_state PeerStateDebug { region_id: 18, peer_id: 19, term: 6, committed_index: 87, applied_index: 87 }"] [apply_state="applied at 2025-05-15T12:54:13.486294132+09:00, peer_state PeerStateDebug { region_id: 18, peer_id: 19, term: 6, committed_index: 87, applied_index: 87 }"] [thread_id=73]
```
- scheduler
  - scheduler_snapshot_propose: the peer state when prososing of the snapshot
  - scheduler_snapshot_ready: the peer state when handling ready of the snapshot
  - scheduler_snapshot_seq_no: the RocksDB snapshot's sequence number for scheduler processing
- async write
  - propose_state: the peer state when prososing
  - ready_state: the peer state when handling the ready
  - apply_state: the peer state when applying the log

#### Read logs

```
[2025/05/15 11:11:11.637 +09:00] [INFO] [linearizability_track.rs:28] ["Linearizability Tracker Read"] [start_ts=458037676368461825] [req_type=KvBatchGet] [duration=433.111µs] [success=true] [propose_state="propose read-index at 2025-05-15T11:11:11.637066907+09:00, uuid: dde615bd-77ff-47a7-9dab-575bfca72b4b, peer_state PeerStateDebug { region_id: 18, peer_id: 255, term: 6, committed_index: 96, applied_index: 96 }"] [ready_state="replica-read at 2025-05-15T11:11:11.637245953+09:00, read_index: Some(96), peer_state PeerStateDebug { region_id: 18, peer_id: 255, term: 6, committed_index: 96, applied_index: 96 }"] [snapshot_seq_no=Some(3267)] [thread_id=32]
[2025/05/15 14:27:34.352 +09:00] [INFO] [linearizability_track.rs:28] ["Linearizability Tracker Read"] [start_ts=458040765144629249] [req_type=KvBatchGet] [duration=194.133µs] [success=true] [propose_state="skip at 2025-05-15T14:27:34.352739731+09:00, reason localrouter-local-read"] [ready_state=None] [snapshot_seq_no=Some(4506)] [thread_id=51]
```

- propose_state: the peer state when proposing the read-index (if needed)
- ready_state: the peer state when handling the ready
- snapshot_seq_no: the RocksDB snapshot's sequence number for reading

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note

```
