### PR TITLE
raftkv: add InvalidMaxTsUpdate RPC error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3750,7 +3750,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#08fddd37b0f5526219ac9730c51d4689cf3b6d33"
+source = "git+https://github.com/deep-bi/kvproto.git?branch=add-invalid-max-ts-update-error#14d255a4613cffef6da8e707b280a23ccf4682f3"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -220,8 +220,8 @@ sysinfo = { git = "https://github.com/tikv/sysinfo", branch = "0.26-fix-cpu" }
 # When you modify TiKV cooperatively with kvproto, this will be useful to submit the PR to TiKV and the PR to
 # kvproto at the same time.
 # After the PR to kvproto is merged, remember to comment this out and run `cargo update -p kvproto`.
-# [patch.'https://github.com/pingcap/kvproto']
-# kvproto = { git = "https://github.com/your_github_id/kvproto", branch = "your_branch" }
+[patch.'https://github.com/pingcap/kvproto']
+kvproto = { git = "https://github.com/deep-bi/kvproto.git", branch = "add-invalid-max-ts-update-error" }
 #
 # After the PR to rust-rocksdb is merged, remember to comment this out and run `cargo update -p rocksdb`.
 # [patch.'https://github.com/tikv/rust-rocksdb']

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -6979,6 +6979,7 @@ where
             request: None,
             locked: None,
             read_index_safe_ts: None,
+            region_error: None,
         };
         self.fsm.peer.raft_group.read_index(rctx.to_bytes());
         debug!(

--- a/components/raftstore/src/store/read_queue.rs
+++ b/components/raftstore/src/store/read_queue.rs
@@ -4,10 +4,7 @@
 use std::{cmp, collections::VecDeque, mem};
 
 use collections::HashMap;
-use kvproto::{
-    kvrpcpb::LockInfo,
-    raft_cmdpb::{self, RaftCmdRequest},
-};
+use kvproto::{errorpb, kvrpcpb::LockInfo, raft_cmdpb::{self, RaftCmdRequest}};
 use protobuf::Message;
 use tikv_util::{
     MustConsumeVec, box_err,
@@ -341,6 +338,7 @@ pub struct ReadIndexContext {
     pub request: Option<raft_cmdpb::ReadIndexRequest>,
     pub locked: Option<LockInfo>,
     pub read_index_safe_ts: Option<u64>,
+    pub region_error: Option<errorpb::Error>,
 }
 
 impl ReadIndexContext {
@@ -358,6 +356,7 @@ impl ReadIndexContext {
             request: None,
             locked: None,
             read_index_safe_ts: None,
+            region_error: None,
         };
         let mut bytes = &bytes[UUID_LEN..];
         while !bytes.is_empty() {
@@ -480,6 +479,7 @@ mod read_index_ctx_tests {
                 request: None,
                 locked: None,
                 read_index_safe_ts: None,
+                region_error: None,
             }
         );
 
@@ -501,6 +501,7 @@ mod read_index_ctx_tests {
             request: Some(request),
             locked: Some(locked),
             read_index_safe_ts: Some(1),
+            region_error: None,
         };
         let bytes = ctx.to_bytes();
         let parsed_ctx = ReadIndexContext::parse(&bytes).unwrap();

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -939,7 +939,10 @@ macro_rules! make_error_response_common {
             Error::InvalidMaxTsUpdate(e) => {
                 $tag = "invalid_max_ts_update";
                 let mut err = errorpb::Error::default();
-                err.set_message(e.to_string());
+                let mut invalid_max_ts_err = errorpb::InvalidMaxTsUpdate::default();
+                invalid_max_ts_err.set_attempted_ts(e.attempted_ts.into_inner());
+                invalid_max_ts_err.set_limit_ts(e.limit.into_inner());
+                err.set_invalid_max_ts_update(invalid_max_ts_err);
                 $resp.set_region_error(err);
             }
             Error::DefaultNotFound(_) => {

--- a/tests/integrations/raftstore/test_replica_read.rs
+++ b/tests/integrations/raftstore/test_replica_read.rs
@@ -574,6 +574,7 @@ fn test_malformed_read_index() {
         request: None,
         locked: None,
         read_index_safe_ts: None,
+        region_error: None,
     };
     let mut e = raft::eraftpb::Entry::default();
     e.set_data(rctx.to_bytes().into());


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Close #18253

What's Changed:

```commit-message
Add a dedicated InvalidMaxTsUpdate RPC error so update_max_ts failures become real, typed errors instead of silent logs.
```

Related kvproto pr: https://github.com/pingcap/kvproto/pull/1317

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
