### PR TITLE
*: bump version of pprof-rs to 0.15 (#18485)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,7 +247,7 @@ checksum = "7b2d0f03b3640e3a630367e40c468cb7f309529c708ed1d88597047b0e7c6ef7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -311,7 +311,7 @@ dependencies = [
  "prometheus",
  "slog",
  "slog-global",
- "thiserror",
+ "thiserror 1.0.40",
  "tikv_util",
  "tokio",
  "tokio-util",
@@ -574,7 +574,7 @@ dependencies = [
  "regex-lite",
  "roxmltree",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.40",
 ]
 
 [[package]]
@@ -861,7 +861,7 @@ dependencies = [
  "slog",
  "slog-global",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.40",
  "tikv",
  "tikv_alloc",
  "tikv_util",
@@ -902,7 +902,7 @@ dependencies = [
  "pin-project",
  "prometheus",
  "prometheus-static-metric",
- "protobuf",
+ "protobuf 2.8.0",
  "raft",
  "raftstore",
  "rand 0.8.5",
@@ -915,7 +915,7 @@ dependencies = [
  "test_pd_client",
  "test_raftstore",
  "test_util",
- "thiserror",
+ "thiserror 1.0.40",
  "tidb_query_datatype",
  "tikv",
  "tikv_kv",
@@ -987,7 +987,7 @@ dependencies = [
  "byteorder",
  "libc 0.2.151",
  "regex",
- "thiserror",
+ "thiserror 1.0.40",
 ]
 
 [[package]]
@@ -1037,7 +1037,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.79",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1238,7 +1238,7 @@ dependencies = [
  "slog",
  "slog-global",
  "test_pd_client",
- "thiserror",
+ "thiserror 1.0.40",
  "tikv_util",
  "tokio",
  "txn_types",
@@ -1299,7 +1299,7 @@ dependencies = [
  "pd_client",
  "prometheus",
  "prometheus-static-metric",
- "protobuf",
+ "protobuf 2.8.0",
  "raft",
  "raftstore",
  "resolved_ts",
@@ -1310,7 +1310,7 @@ dependencies = [
  "test_pd_client",
  "test_raftstore",
  "test_util",
- "thiserror",
+ "thiserror 1.0.40",
  "tikv",
  "tikv_kv",
  "tikv_util",
@@ -1460,8 +1460,8 @@ dependencies = [
  "kvproto",
  "lazy_static",
  "prometheus",
- "protobuf",
- "thiserror",
+ "protobuf 2.8.0",
+ "thiserror 1.0.40",
  "tikv_util",
  "url",
  "uuid 0.8.2",
@@ -1496,10 +1496,10 @@ dependencies = [
  "error_code",
  "libc 0.2.151",
  "panic_hook",
- "protobuf",
+ "protobuf 2.8.0",
  "rand 0.8.5",
  "static_assertions",
- "thiserror",
+ "thiserror 1.0.40",
  "tikv_alloc",
 ]
 
@@ -1531,7 +1531,7 @@ dependencies = [
  "serde",
  "slog",
  "slog-global",
- "thiserror",
+ "thiserror 1.0.40",
  "tikv_alloc",
  "tikv_util",
  "tokio",
@@ -1996,7 +1996,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2056,7 +2056,7 @@ dependencies = [
  "online_config",
  "openssl",
  "prometheus",
- "protobuf",
+ "protobuf 2.8.0",
  "rand 0.8.5",
  "serde",
  "serde_derive",
@@ -2064,7 +2064,7 @@ dependencies = [
  "slog-global",
  "tempfile",
  "test_util",
- "thiserror",
+ "thiserror 1.0.40",
  "tikv_util",
  "tokio",
  "toml",
@@ -2082,7 +2082,7 @@ dependencies = [
  "file_system",
  "gcp",
  "kvproto",
- "protobuf",
+ "protobuf 2.8.0",
  "rust-ini",
  "slog",
  "slog-global",
@@ -2122,7 +2122,7 @@ dependencies = [
  "prometheus",
  "prometheus-static-metric",
  "proptest",
- "protobuf",
+ "protobuf 2.8.0",
  "raft",
  "rand 0.8.5",
  "regex",
@@ -2183,12 +2183,12 @@ dependencies = [
  "keys",
  "kvproto",
  "log_wrappers",
- "protobuf",
+ "protobuf 2.8.0",
  "raft",
  "serde",
  "slog",
  "slog-global",
- "thiserror",
+ "thiserror 1.0.40",
  "tikv_util",
  "toml",
  "tracker",
@@ -2250,7 +2250,7 @@ checksum = "3bf679796c0322556351f287a51b49e48f7c4986e727b5dd78c972d30e2e16cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2438,7 +2438,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed3d8a5e20435ff00469e51a0d82049bae66504b5c429920dadf9bb54d47b3f"
 dependencies = [
  "libc 0.2.151",
- "thiserror",
+ "thiserror 1.0.40",
  "winapi 0.3.9",
 ]
 
@@ -2674,7 +2674,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2887,7 +2887,7 @@ dependencies = [
  "libc 0.2.151",
  "log",
  "parking_lot 0.11.1",
- "protobuf",
+ "protobuf 2.8.0",
 ]
 
 [[package]]
@@ -2896,7 +2896,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed97a17310fd00ff4109357584a00244e2a785d05b7ee0ef4d1e8fb1d84266df"
 dependencies = [
- "protobuf",
+ "protobuf 2.8.0",
 ]
 
 [[package]]
@@ -2909,7 +2909,7 @@ dependencies = [
  "futures-util",
  "grpcio",
  "log",
- "protobuf",
+ "protobuf 2.8.0",
 ]
 
 [[package]]
@@ -3191,7 +3191,7 @@ dependencies = [
  "online_config",
  "prometheus",
  "prometheus-static-metric",
- "protobuf",
+ "protobuf 2.8.0",
  "raft",
  "raftstore",
  "slog",
@@ -3219,7 +3219,7 @@ dependencies = [
  "httpdate",
  "itoa 1.0.1",
  "pin-project-lite",
- "socket2 0.4.7",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -3395,7 +3395,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3469,7 +3469,7 @@ dependencies = [
  "tempfile",
  "test_pd",
  "test_util",
- "thiserror",
+ "thiserror 1.0.40",
  "tikv_alloc",
  "tikv_util",
  "tokio",
@@ -3678,7 +3678,7 @@ dependencies = [
  "kvproto",
  "log_wrappers",
  "panic_hook",
- "thiserror",
+ "thiserror 1.0.40",
  "tikv_alloc",
  "tikv_util",
 ]
@@ -3690,7 +3690,7 @@ source = "git+https://github.com/pingcap/kvproto.git#b6a98c6bf02d1864e74029f31ff
 dependencies = [
  "futures 0.3.15",
  "grpcio",
- "protobuf",
+ "protobuf 2.8.0",
  "protobuf-build",
  "raft-proto",
 ]
@@ -3854,7 +3854,7 @@ version = "0.0.1"
 dependencies = [
  "atomic",
  "hex 0.4.3",
- "protobuf",
+ "protobuf 2.8.0",
  "serde",
  "slog",
  "slog-term",
@@ -4101,7 +4101,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4311,7 +4311,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4412,7 +4412,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "sha2 0.9.1",
- "thiserror",
+ "thiserror 1.0.40",
  "url",
 ]
 
@@ -4649,7 +4649,7 @@ dependencies = [
  "serde_derive",
  "slog",
  "slog-global",
- "thiserror",
+ "thiserror 1.0.40",
  "tikv_alloc",
  "tikv_util",
  "tokio",
@@ -4836,9 +4836,9 @@ dependencies = [
 
 [[package]]
 name = "pprof"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebbe2f8898beba44815fdc9e5a4ae9c929e21c5dc29b0c774a15555f7f58d6d0"
+checksum = "38a01da47675efa7673b032bf8efd8214f1917d89685e07e395ab125ea42b187"
 dependencies = [
  "aligned-vec",
  "backtrace",
@@ -4849,13 +4849,13 @@ dependencies = [
  "log",
  "nix 0.26.2",
  "once_cell",
- "parking_lot 0.12.1",
- "protobuf",
- "protobuf-codegen-pure",
+ "protobuf 3.7.2",
+ "protobuf-codegen 3.7.2",
  "smallvec",
+ "spin",
  "symbolic-demangle",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -4907,7 +4907,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b69d39aab54d069e7f2fe8cb970493e7834601ca2d8c65fd7bbd183578080d1"
 dependencies = [
  "proc-macro2",
- "syn 2.0.79",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4936,9 +4936,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.87"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -4990,9 +4990,9 @@ dependencies = [
  "libc 0.2.151",
  "memchr",
  "parking_lot 0.11.1",
- "protobuf",
+ "protobuf 2.8.0",
  "reqwest",
- "thiserror",
+ "thiserror 1.0.40",
 ]
 
 [[package]]
@@ -5039,6 +5039,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.40",
+]
+
+[[package]]
 name = "protobuf-build"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5046,8 +5057,8 @@ checksum = "c852d9625b912c3e50480cdc701f60f49890b5d7ad46198dd583600f15e7c6ec"
 dependencies = [
  "bitflags 1.3.2",
  "grpcio-compiler",
- "protobuf",
- "protobuf-codegen",
+ "protobuf 2.8.0",
+ "protobuf-codegen 2.8.0",
  "protobuf-src",
  "regex",
 ]
@@ -5058,17 +5069,38 @@ version = "2.8.0"
 source = "git+https://github.com/pingcap/rust-protobuf?branch=v2.8#6d445fe5ff4e99621a800be0f2c54dc96f056bac"
 dependencies = [
  "heck 0.3.1",
- "protobuf",
+ "protobuf 2.8.0",
 ]
 
 [[package]]
-name = "protobuf-codegen-pure"
-version = "2.8.0"
+name = "protobuf-codegen"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00993dc5fbbfcf9d8a005f6b6c29fd29fd6d86deba3ae3f41fd20c624c414616"
+checksum = "5d3976825c0014bbd2f3b34f0001876604fe87e0c86cd8fa54251530f1544ace"
 dependencies = [
- "protobuf",
- "protobuf-codegen",
+ "anyhow",
+ "once_cell",
+ "protobuf 3.7.2",
+ "protobuf-parse",
+ "regex",
+ "tempfile",
+ "thiserror 1.0.40",
+]
+
+[[package]]
+name = "protobuf-parse"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4aeaa1f2460f1d348eeaeed86aea999ce98c1bded6f089ff8514c9d9dbdc973"
+dependencies = [
+ "anyhow",
+ "indexmap 2.0.1",
+ "log",
+ "protobuf 3.7.2",
+ "protobuf-support",
+ "tempfile",
+ "thiserror 1.0.40",
+ "which",
 ]
 
 [[package]]
@@ -5078,6 +5110,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7ac8852baeb3cc6fb83b93646fb93c0ffe5d14bf138c945ceb4b9948ee0e3c1"
 dependencies = [
  "autotools",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.40",
 ]
 
 [[package]]
@@ -5122,11 +5163,11 @@ dependencies = [
  "bytes",
  "fxhash",
  "getset",
- "protobuf",
+ "protobuf 2.8.0",
  "raft-proto",
  "rand 0.8.5",
  "slog",
- "thiserror",
+ "thiserror 1.0.40",
 ]
 
 [[package]]
@@ -5153,14 +5194,14 @@ dependencies = [
  "parking_lot 0.12.1",
  "prometheus",
  "prometheus-static-metric",
- "protobuf",
+ "protobuf 2.8.0",
  "rayon",
  "rhai",
  "scopeguard",
  "serde",
  "serde_repr",
  "strum 0.26.3",
- "thiserror",
+ "thiserror 1.0.40",
 ]
 
 [[package]]
@@ -5179,7 +5220,7 @@ version = "0.7.0"
 source = "git+https://github.com/tikv/raft-rs?branch=master#0d01b20312f74889a5e44ad4180aade5da2f16fa"
 dependencies = [
  "bytes",
- "protobuf",
+ "protobuf 2.8.0",
  "protobuf-build",
 ]
 
@@ -5244,7 +5285,7 @@ dependencies = [
  "pd_client",
  "prometheus",
  "prometheus-static-metric",
- "protobuf",
+ "protobuf 2.8.0",
  "raft",
  "raft-proto",
  "rand 0.8.5",
@@ -5261,7 +5302,7 @@ dependencies = [
  "strum 0.20.0",
  "tempfile",
  "test_sst_importer",
- "thiserror",
+ "thiserror 1.0.40",
  "tidb_query_datatype",
  "tikv_alloc",
  "tikv_util",
@@ -5298,7 +5339,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "pd_client",
  "prometheus",
- "protobuf",
+ "protobuf 2.8.0",
  "raft",
  "raft-proto",
  "raftstore",
@@ -5312,7 +5353,7 @@ dependencies = [
  "tempfile",
  "test_pd",
  "test_util",
- "thiserror",
+ "thiserror 1.0.40",
  "tikv_util",
  "time 0.1.43",
  "tracker",
@@ -5620,7 +5661,7 @@ dependencies = [
  "online_config",
  "pd_client",
  "prometheus",
- "protobuf",
+ "protobuf 2.8.0",
  "raft",
  "raftstore",
  "security",
@@ -5630,7 +5671,7 @@ dependencies = [
  "test_raftstore",
  "test_sst_importer",
  "test_util",
- "thiserror",
+ "thiserror 1.0.40",
  "tikv",
  "tikv_kv",
  "tikv_util",
@@ -5655,7 +5696,7 @@ dependencies = [
  "pd_client",
  "pin-project",
  "prometheus",
- "protobuf",
+ "protobuf 2.8.0",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -6006,7 +6047,7 @@ checksum = "a3385e45322e8f9931410f01b3031ec534c3947d0e94c18049af4d9f9907d4e0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6047,7 +6088,7 @@ checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
 dependencies = [
  "percent-encoding",
  "serde",
- "thiserror",
+ "thiserror 1.0.40",
 ]
 
 [[package]]
@@ -6127,7 +6168,7 @@ dependencies = [
  "log_wrappers",
  "pd_client",
  "prometheus",
- "protobuf",
+ "protobuf 2.8.0",
  "raft",
  "raft_log_engine",
  "raftstore",
@@ -6343,7 +6384,7 @@ dependencies = [
  "slog",
  "slog-global",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.40",
  "tikv",
  "tikv_util",
  "tokio",
@@ -6380,22 +6421,21 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
-dependencies = [
- "libc 0.2.151",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "socket2"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc 0.2.151",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -6425,7 +6465,7 @@ dependencies = [
  "online_config",
  "openssl",
  "prometheus",
- "protobuf",
+ "protobuf 2.8.0",
  "rand 0.8.5",
  "serde",
  "serde_derive",
@@ -6434,7 +6474,7 @@ dependencies = [
  "tempfile",
  "test_sst_importer",
  "test_util",
- "thiserror",
+ "thiserror 1.0.40",
  "tikv_alloc",
  "tikv_util",
  "tokio",
@@ -6543,7 +6583,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.79",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6587,9 +6627,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6610,7 +6650,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6649,7 +6689,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "thiserror",
+ "thiserror 1.0.40",
  "url",
 ]
 
@@ -6749,7 +6789,7 @@ dependencies = [
  "futures-util",
  "grpcio",
  "kvproto",
- "protobuf",
+ "protobuf 2.8.0",
  "raftstore",
  "rand 0.8.5",
  "test_raftstore",
@@ -6769,7 +6809,7 @@ dependencies = [
  "futures 0.3.15",
  "kvproto",
  "pd_client",
- "protobuf",
+ "protobuf 2.8.0",
  "resource_metering",
  "test_storage",
  "tidb_query_common",
@@ -6845,7 +6885,7 @@ dependencies = [
  "lazy_static",
  "log_wrappers",
  "pd_client",
- "protobuf",
+ "protobuf 2.8.0",
  "raft",
  "raftstore",
  "rand 0.8.5",
@@ -6887,7 +6927,7 @@ dependencies = [
  "kvproto",
  "log_wrappers",
  "pd_client",
- "protobuf",
+ "protobuf 2.8.0",
  "raft",
  "raftstore",
  "raftstore-v2",
@@ -7017,7 +7057,7 @@ dependencies = [
  "pd_client",
  "perfcnt",
  "profiler",
- "protobuf",
+ "protobuf 2.8.0",
  "raft",
  "raft_log_engine",
  "raftstore",
@@ -7080,7 +7120,16 @@ version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.40",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -7091,7 +7140,18 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7145,7 +7205,7 @@ dependencies = [
  "prometheus",
  "prometheus-static-metric",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.40",
  "tikv_util",
  "time 0.1.43",
  "yatp",
@@ -7180,14 +7240,14 @@ dependencies = [
  "num-derive 0.3.0",
  "num-traits",
  "ordered-float",
- "protobuf",
+ "protobuf 2.8.0",
  "regex",
  "serde",
  "serde_json",
  "slog",
  "slog-global",
  "static_assertions",
- "thiserror",
+ "thiserror 1.0.40",
  "tidb_query_common",
  "tikv_alloc",
  "tikv_util",
@@ -7209,7 +7269,7 @@ dependencies = [
  "kvproto",
  "log_wrappers",
  "match-template",
- "protobuf",
+ "protobuf 2.8.0",
  "slog",
  "slog-global",
  "smallvec",
@@ -7243,7 +7303,7 @@ dependencies = [
  "openssl",
  "panic_hook",
  "profiler",
- "protobuf",
+ "protobuf 2.8.0",
  "regex",
  "safemem",
  "serde",
@@ -7334,7 +7394,7 @@ dependencies = [
  "pprof",
  "prometheus",
  "prometheus-static-metric",
- "protobuf",
+ "protobuf 2.8.0",
  "raft",
  "raft_log_engine",
  "raftstore",
@@ -7362,7 +7422,7 @@ dependencies = [
  "sysinfo",
  "tempfile",
  "test_util",
- "thiserror",
+ "thiserror 1.0.40",
  "tidb_query_common",
  "tidb_query_datatype",
  "tidb_query_executors",
@@ -7408,7 +7468,7 @@ dependencies = [
  "log",
  "log_wrappers",
  "pd_client",
- "protobuf",
+ "protobuf 2.8.0",
  "raft",
  "raft-engine",
  "raft-engine-ctl",
@@ -7520,7 +7580,7 @@ dependencies = [
  "slog-global",
  "slog_derive",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.40",
  "tikv_util",
  "tracker",
  "txn_types",
@@ -7567,7 +7627,7 @@ dependencies = [
  "procinfo",
  "prometheus",
  "prometheus-static-metric",
- "protobuf",
+ "protobuf 2.8.0",
  "rand 0.8.5",
  "regex",
  "serde",
@@ -7580,7 +7640,7 @@ dependencies = [
  "strum 0.20.0",
  "sysinfo",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.40",
  "tikv_alloc",
  "time 0.1.43",
  "tokio",
@@ -7674,7 +7734,7 @@ source = "git+https://github.com/pingcap/tipb.git#cf70966bef25e205cb845c19265301
 dependencies = [
  "futures 0.3.15",
  "grpcio",
- "protobuf",
+ "protobuf 2.8.0",
  "protobuf-build",
 ]
 
@@ -7701,7 +7761,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.7",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
@@ -7723,7 +7783,7 @@ checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7840,7 +7900,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7950,7 +8010,7 @@ dependencies = [
  "panic_hook",
  "rand 0.8.5",
  "slog",
- "thiserror",
+ "thiserror 1.0.40",
  "tikv_alloc",
  "tikv_util",
 ]
@@ -8622,7 +8682,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.101",
  "synstructure",
 ]
 
@@ -8643,7 +8703,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -8663,7 +8723,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.101",
  "synstructure",
 ]
 
@@ -8692,7 +8752,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.101",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,7 +132,7 @@ paste = "1.0"
 pd_client = { workspace = true }
 pin-project = "1.0"
 pnet_datalink = "0.23"
-pprof = { version = "0.14", default-features = false, features = [
+pprof = { version = "0.15", default-features = false, features = [
   "flamegraph",
   "protobuf-codec",
 ] }


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Close https://github.com/tikv/tikv/issues/18474

What's Changed:

Bump the version of pprof-rs to 0.15

```commit-message
bump the version of pprof-rs to 0.15
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
None
```
