### PR TITLE
backup: move verbose errors to warn level

### DIFF
--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -970,7 +970,8 @@ impl<E: Engine, R: RegionInfoProvider + Clone + 'static> Endpoint<E, R> {
             loop {
                 // when get the guard, release it until we finish scanning a batch,
                 // because if we were suspended during scanning,
-                // the region info have higher possibility to change (then we must compensate that by the fine-grained backup).
+                // the region info have higher possibility to change (then we must compensate
+                // that by the fine-grained backup).
                 let guard = soft_limit_keeper.guard().await;
                 if let Err(e) = guard {
                     warn!("failed to retrieve limit guard, omitting."; "err" => %e);
@@ -980,14 +981,16 @@ impl<E: Engine, R: RegionInfoProvider + Clone + 'static> Endpoint<E, R> {
                     // It is critical to speed up backup, otherwise workers are
                     // blocked by each other.
                     //
-                    // If we use [tokio::sync::Mutex] here, until we give back the control flow to the scheduler
-                    // or tasks waiting for the lock won't be waked up due to the characteristic of the runtime...
+                    // If we use [tokio::sync::Mutex] here, until we give back the control flow to
+                    // the scheduler or tasks waiting for the lock won't be
+                    // waked up due to the characteristic of the runtime...
                     //
                     // The worst case is when using `noop` backend:
-                    // the task seems never yielding and in fact the backup would executing sequentially.
+                    // the task seems never yielding and in fact the backup would executing
+                    // sequentially.
                     //
-                    // Anyway, even tokio itself doesn't recommend to use it unless the lock guard needs to be `Send`.
-                    // (See https://tokio.rs/tokio/tutorial/shared-state)
+                    // Anyway, even tokio itself doesn't recommend to use it unless the lock guard
+                    // needs to be `Send`. (See https://tokio.rs/tokio/tutorial/shared-state)
                     // Use &mut and mark the type for making rust-analyzer happy.
                     let progress: &mut Progress<_> = &mut prs.lock().unwrap();
                     match progress.forward(batch_size, request.replica_read) {
@@ -997,8 +1000,9 @@ impl<E: Engine, R: RegionInfoProvider + Clone + 'static> Endpoint<E, R> {
                 };
 
                 for brange in batch {
-                    // wake up the scheduler for each loop for awaking tasks waiting for some lock or channels.
-                    // because the softlimit permit is held by current task, there isn't risk of being suspended for long time.
+                    // wake up the scheduler for each loop for awaking tasks waiting for some lock
+                    // or channels. because the softlimit permit is held by
+                    // current task, there isn't risk of being suspended for long time.
                     tokio::task::yield_now().await;
                     let engine = engine.clone();
                     if request.cancel.load(Ordering::SeqCst) {
@@ -1007,7 +1011,8 @@ impl<E: Engine, R: RegionInfoProvider + Clone + 'static> Endpoint<E, R> {
                     }
                     // TODO: make file_name unique and short
                     let key = brange.start_key.clone().and_then(|k| {
-                        // use start_key sha256 instead of start_key to avoid file name too long os error
+                        // use start_key sha256 instead of start_key to avoid file name too long os
+                        // error
                         let input = brange.codec.decode_backup_key(Some(k)).unwrap_or_default();
                         file_system::sha256(&input).ok().map(hex::encode)
                     });
@@ -1046,7 +1051,8 @@ impl<E: Engine, R: RegionInfoProvider + Clone + 'static> Endpoint<E, R> {
                             sst_max_size,
                             request.cipher.clone(),
                         );
-                        with_resource_limiter(brange.backup(
+                        with_resource_limiter(
+                            brange.backup(
                                 writer_builder,
                                 engine,
                                 concurrency_manager.clone(),
@@ -1057,15 +1063,17 @@ impl<E: Engine, R: RegionInfoProvider + Clone + 'static> Endpoint<E, R> {
                                 saver_tx.clone(),
                                 _backend.name(),
                                 resource_limiter.clone(),
-                            ), resource_limiter.clone())
-                            .await
+                            ),
+                            resource_limiter.clone(),
+                        )
+                        .await
                     };
                     match stat {
                         Err(err) => {
                             warn!("error during backup"; "region" => ?brange.region, "err" => %err);
                             let mut resp = BackupResponse::new();
                             resp.set_error(err.into());
-                            if let Err(err) =  resp_tx.unbounded_send(resp) {
+                            if let Err(err) = resp_tx.unbounded_send(resp) {
                                 warn!("failed to send response"; "err" => ?err)
                             }
                         }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18493 

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Some of non-fatal error level logs during backing up are now warn level.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Some of non-fatal error level logs during backing up are now warn level.
```
