### PR TITLE
config: adjust default value of config `rocksdb.max-manifest-file-size`  from 128MiB to 512MiB

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1354,7 +1354,7 @@ impl Default for DbConfig {
             max_total_wal_size: None,
             max_background_jobs: 0,
             max_background_flushes: 0,
-            max_manifest_file_size: ReadableSize::mb(128),
+            max_manifest_file_size: ReadableSize::mb(512),
             create_if_missing: true,
             max_open_files: 40960,
             enable_statistics: true,


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #15990

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
The default value of config `rocksdb.max-manifest-file-size` is too small for large clusters with more than 100k sst files. It can cause long ingest latency when the effective manifest file size exceed the threshold. So this PR adjust the default value to 512MiB which should be a large enough value.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
