### PR TITLE
[hotfix-to-7.5.6] raftstore: directly write kvs rather than ingestion when merging small regions. (#17408)

### DIFF
--- a/components/pd_client/src/util.rs
+++ b/components/pd_client/src/util.rs
@@ -731,10 +731,11 @@ impl PdConnector {
 
     // There are 3 kinds of situations we will return the new client:
     // 1. the force is true which represents the client is newly created or the
-    // original connection has some problem 2. the previous forwarded host is
-    // not empty and it can connect the leader now which represents the network
-    // partition problem to leader may be recovered 3. the member information of
-    // PD has been changed
+    // original connection has some problem.
+    // 2. the previous forwarded host is not empty and it can connect the leader
+    // now which represents the network partition problem to leader may be
+    // recovered.
+    // 3. the member information of PD has been changed.
     pub async fn reconnect_pd(
         &self,
         members_resp: GetMembersResponse,

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -4328,14 +4328,12 @@ where
             share_size = self
                 .fsm
                 .peer
-                .split_check_trigger
-                .approximate_size
+                .approximate_size()
                 .map(|v| v / new_region_count);
             share_keys = self
                 .fsm
                 .peer
-                .split_check_trigger
-                .approximate_keys
+                .approximate_keys()
                 .map(|v| v / new_region_count);
         }
 
@@ -4351,8 +4349,8 @@ where
         let (is_leader, is_follower) = (self.fsm.peer.is_leader(), self.fsm.peer.is_follower());
         if is_leader {
             if share_source_region_size {
-                self.fsm.peer.split_check_trigger.approximate_size = share_size;
-                self.fsm.peer.split_check_trigger.approximate_keys = share_keys;
+                self.fsm.peer.set_approximate_size(share_size);
+                self.fsm.peer.set_approximate_keys(share_keys);
             }
             self.fsm.peer.heartbeat_pd(self.ctx);
             // Notify pd immediately to let it update the region meta.
@@ -4487,8 +4485,8 @@ where
             new_peer.has_ready |= campaigned;
 
             if is_leader {
-                new_peer.peer.split_check_trigger.approximate_size = share_size;
-                new_peer.peer.split_check_trigger.approximate_keys = share_keys;
+                new_peer.peer.set_approximate_size(share_size);
+                new_peer.peer.set_approximate_keys(share_keys);
                 *new_peer.peer.txn_ext.pessimistic_locks.write() = locks;
                 // The new peer is likely to become leader, send a heartbeat immediately to
                 // reduce client query miss.

--- a/components/raftstore/src/store/mod.rs
+++ b/components/raftstore/src/store/mod.rs
@@ -71,7 +71,7 @@ pub use self::{
     replication_mode::{GlobalReplicationState, StoreGroup},
     snap::{
         check_abort, copy_snapshot,
-        snap_io::{apply_sst_cf_file, build_sst_cf_file_list},
+        snap_io::{apply_sst_cf_files_by_ingest, build_sst_cf_file_list},
         ApplyOptions, CfFile, Error as SnapError, SnapEntry, SnapKey, SnapManager,
         SnapManagerBuilder, Snapshot, SnapshotStatistics, TabletSnapKey, TabletSnapManager,
     },

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -1656,6 +1656,26 @@ where
         self.raft_group.mut_store()
     }
 
+    #[inline]
+    pub fn approximate_size(&self) -> Option<u64> {
+        self.split_check_trigger.approximate_size
+    }
+
+    #[inline]
+    pub fn approximate_keys(&self) -> Option<u64> {
+        self.split_check_trigger.approximate_keys
+    }
+
+    #[inline]
+    pub fn set_approximate_size(&mut self, approximate_size: Option<u64>) {
+        self.split_check_trigger.approximate_size = approximate_size;
+    }
+
+    #[inline]
+    pub fn set_approximate_keys(&mut self, approximate_keys: Option<u64>) {
+        self.split_check_trigger.approximate_keys = approximate_keys;
+    }
+
     /// Whether the snapshot is handling.
     /// See the comments of `check_snap_status` for more details.
     #[inline]
@@ -5502,8 +5522,8 @@ where
             pending_peers: self.collect_pending_peers(ctx),
             written_bytes: self.peer_stat.written_bytes,
             written_keys: self.peer_stat.written_keys,
-            approximate_size: self.split_check_trigger.approximate_size,
-            approximate_keys: self.split_check_trigger.approximate_keys,
+            approximate_size: self.approximate_size(),
+            approximate_keys: self.approximate_keys(),
             replication_status: self.region_replication_status(ctx),
             wait_data_peers: self.wait_data_peers.clone(),
         });

--- a/components/raftstore/src/store/snap.rs
+++ b/components/raftstore/src/store/snap.rs
@@ -35,7 +35,9 @@ use protobuf::Message;
 use raft::eraftpb::Snapshot as RaftSnapshot;
 use thiserror::Error;
 use tikv_util::{
-    box_err, box_try, debug, error, info,
+    box_err, box_try,
+    config::ReadableSize,
+    debug, error, info,
     time::{duration_to_sec, Instant, Limiter, UnixSecs},
     warn, HandyRwLock,
 };
@@ -1100,6 +1102,9 @@ impl Snapshot {
     }
 
     pub fn apply<EK: KvEngine>(&mut self, options: ApplyOptions<EK>) -> Result<()> {
+        let apply_without_ingest = self
+            .mgr
+            .can_apply_cf_without_ingest(self.total_size(), self.total_count());
         let post_check = |cf_file: &CfFile, offset: usize| {
             if !plain_file_used(cf_file.cf) {
                 let file_paths = cf_file.file_paths();
@@ -1126,27 +1131,27 @@ impl Snapshot {
         let abort_checker = ApplyAbortChecker(options.abort);
         let coprocessor_host = options.coprocessor_host;
         let region = options.region;
-        let key_mgr = self.mgr.encryption_key_manager.as_ref();
+        let key_mgr = self.mgr.encryption_key_manager.clone();
+        let batch_size = options.write_batch_size;
         for cf_file in &mut self.cf_files {
             if cf_file.size.is_empty() {
                 // Skip empty cf file.
                 continue;
             }
             let cf = cf_file.cf;
+            let mut cb = |kv: &[(Vec<u8>, Vec<u8>)]| {
+                coprocessor_host.post_apply_plain_kvs_from_snapshot(&region, cf, kv)
+            };
             if plain_file_used(cf_file.cf) {
                 let path = &cf_file.file_paths()[0];
-                let batch_size = options.write_batch_size;
-                let cb = |kv: &[(Vec<u8>, Vec<u8>)]| {
-                    coprocessor_host.post_apply_plain_kvs_from_snapshot(&region, cf, kv)
-                };
                 snap_io::apply_plain_cf_file(
                     path,
-                    key_mgr,
+                    key_mgr.as_ref(),
                     &abort_checker,
                     &options.db,
                     cf,
                     batch_size,
-                    cb,
+                    &mut cb,
                 )?;
             } else {
                 let _timer = INGEST_SST_DURATION_SECONDS.start_coarse_timer();
@@ -1156,8 +1161,22 @@ impl Snapshot {
                     .iter()
                     .map(|s| s.as_str())
                     .collect::<Vec<&str>>();
-                snap_io::apply_sst_cf_file(clone_files.as_slice(), &options.db, cf)?;
-                coprocessor_host.post_apply_sst_from_snapshot(&region, cf, path);
+                if apply_without_ingest {
+                    // Apply the snapshot without ingest, to accelerate the applying process.
+                    snap_io::apply_sst_cf_files_without_ingest(
+                        clone_files.as_slice(),
+                        &options.db,
+                        cf,
+                        key_mgr.clone(),
+                        &abort_checker,
+                        batch_size,
+                        &mut cb,
+                    )?;
+                } else {
+                    // Apply the snapshot by ingest.
+                    snap_io::apply_sst_cf_files_by_ingest(clone_files.as_slice(), &options.db, cf)?;
+                    coprocessor_host.post_apply_sst_from_snapshot(&region, cf, path);
+                }
             }
         }
         Ok(())
@@ -1430,6 +1449,9 @@ struct SnapManagerCore {
     max_per_file_size: Arc<AtomicU64>,
     enable_multi_snapshot_files: Arc<AtomicBool>,
     stats: Arc<Mutex<Vec<SnapshotStat>>>,
+    // Minimal column family size & kv counts for applying by ingest.
+    min_ingest_cf_size: u64,
+    min_ingest_cf_kvs: u64,
 }
 
 /// `SnapManagerCore` trace all current processing snapshots.
@@ -1768,6 +1790,11 @@ impl SnapManager {
         self.core.limiter.speed_limit()
     }
 
+    pub fn set_min_ingest_cf_limit(&mut self, bytes: ReadableSize) {
+        self.core.min_ingest_cf_size = bytes.0;
+        self.core.min_ingest_cf_kvs = std::cmp::max(10000, (bytes.as_mb_f64() * 10000.0) as u64);
+    }
+
     pub fn collect_stat(&self, snap: SnapshotStat) {
         debug!(
             "collect snapshot stat";
@@ -1964,6 +1991,16 @@ impl SnapManagerCore {
         }
         u64::MAX
     }
+
+    pub fn can_apply_cf_without_ingest(&self, cf_size: u64, cf_kvs: u64) -> bool {
+        if self.min_ingest_cf_size == 0 {
+            return false;
+        }
+        // If the size and the count of keys of cf are relatively small, it's
+        // recommended to directly write it into kvdb rather than ingest,
+        // for mitigating performance issue when ingesting snapshot.
+        cf_size <= self.min_ingest_cf_size && cf_kvs <= self.min_ingest_cf_kvs
+    }
 }
 
 #[derive(Clone, Default)]
@@ -1974,6 +2011,8 @@ pub struct SnapManagerBuilder {
     enable_multi_snapshot_files: bool,
     enable_receive_tablet_snapshot: bool,
     key_manager: Option<Arc<DataKeyManager>>,
+    min_ingest_snapshot_size: u64,
+    min_ingest_snapshot_kvs: u64,
 }
 
 impl SnapManagerBuilder {
@@ -1997,6 +2036,13 @@ impl SnapManagerBuilder {
     }
     pub fn enable_receive_tablet_snapshot(mut self, enabled: bool) -> SnapManagerBuilder {
         self.enable_receive_tablet_snapshot = enabled;
+        self
+    }
+    pub fn min_ingest_snapshot_limit(mut self, bytes: ReadableSize) -> SnapManagerBuilder {
+        self.min_ingest_snapshot_size = bytes.0;
+        // Keeps the same assumptions in region size, "Assume the average size of KVs is
+        // 100B". So, it calculate the count of kvs with `bytes / `MiB` * 10000`.
+        self.min_ingest_snapshot_kvs = std::cmp::max(10000, (bytes.as_mb_f64() * 10000.0) as u64);
         self
     }
     #[must_use]
@@ -2037,6 +2083,8 @@ impl SnapManagerBuilder {
                     self.enable_multi_snapshot_files,
                 )),
                 stats: Default::default(),
+                min_ingest_cf_size: self.min_ingest_snapshot_size,
+                min_ingest_cf_kvs: self.min_ingest_snapshot_kvs,
             },
             max_total_size: Arc::new(AtomicU64::new(max_total_size)),
             tablet_snap_manager,
@@ -2345,9 +2393,6 @@ pub mod tests {
     use tikv_util::time::Limiter;
 
     use super::*;
-    // ApplyOptions, SnapEntry, SnapKey, SnapManager, SnapManagerBuilder, SnapManagerCore,
-    // Snapshot, SnapshotStatistics, META_FILE_SUFFIX, SNAPSHOT_CFS, SNAP_GEN_PREFIX,
-    // };
     use crate::{
         coprocessor::CoprocessorHost,
         store::{peer_storage::JOB_STATUS_RUNNING, INIT_EPOCH_CONF_VER, INIT_EPOCH_VER},
@@ -2523,6 +2568,8 @@ pub mod tests {
             max_per_file_size: Arc::new(AtomicU64::new(max_per_file_size)),
             enable_multi_snapshot_files: Arc::new(AtomicBool::new(true)),
             stats: Default::default(),
+            min_ingest_cf_size: 0,
+            min_ingest_cf_kvs: 0,
         }
     }
 

--- a/components/raftstore/src/store/snap/io.rs
+++ b/components/raftstore/src/store/snap/io.rs
@@ -12,8 +12,8 @@ use encryption::{
     from_engine_encryption_method, DataKeyManager, DecrypterReader, EncrypterWriter, Iv,
 };
 use engine_traits::{
-    CfName, EncryptionKeyManager, Error as EngineError, Iterable, KvEngine, Mutable,
-    SstCompressionType, SstReader, SstWriter, SstWriterBuilder, WriteBatch,
+    CfName, EncryptionKeyManager, Error as EngineError, IterOptions, Iterable, Iterator, KvEngine,
+    Mutable, RefIterable, SstCompressionType, SstReader, SstWriter, SstWriterBuilder, WriteBatch,
 };
 use fail::fail_point;
 use kvproto::encryptionpb::EncryptionMethod;
@@ -252,7 +252,7 @@ pub fn apply_plain_cf_file<E, F>(
     db: &E,
     cf: &str,
     batch_size: usize,
-    mut callback: F,
+    callback: &mut F,
 ) -> Result<(), Error>
 where
     E: KvEngine,
@@ -302,17 +302,102 @@ where
     }
 }
 
-pub fn apply_sst_cf_file<E>(files: &[&str], db: &E, cf: &str) -> Result<(), Error>
+pub fn apply_sst_cf_files_by_ingest<E>(files: &[&str], db: &E, cf: &str) -> Result<(), Error>
 where
     E: KvEngine,
 {
     if files.len() > 1 {
         info!(
-            "apply_sst_cf_file starts on cf {}. All files {:?}",
+            "apply_sst_cf_files_by_ingest starts on cf {}. All files {:?}",
             cf, files
         );
     }
     box_try!(db.ingest_external_file_cf(cf, files));
+    Ok(())
+}
+
+fn apply_sst_cf_file_without_ingest<E, F>(
+    path: &str,
+    db: &E,
+    cf: &str,
+    key_mgr: Option<Arc<DataKeyManager>>,
+    stale_detector: &impl StaleDetector,
+    batch_size: usize,
+    callback: &mut F,
+) -> Result<(), Error>
+where
+    E: KvEngine,
+    F: for<'r> FnMut(&'r [(Vec<u8>, Vec<u8>)]),
+{
+    let sst_reader = if let Some(mgr) = key_mgr {
+        E::SstReader::open_encrypted(path, mgr)?
+    } else {
+        E::SstReader::open(path)?
+    };
+    let mut iter = sst_reader.iter(IterOptions::default())?;
+    iter.seek_to_first()?;
+
+    let mut wb = db.write_batch();
+    let mut write_to_db = |batch: &mut Vec<(Vec<u8>, Vec<u8>)>| -> Result<(), EngineError> {
+        batch.iter().try_for_each(|(k, v)| wb.put_cf(cf, k, v))?;
+        wb.write()?;
+        wb.clear();
+        callback(batch);
+        batch.clear();
+        Ok(())
+    };
+
+    // Collect keys to a vec rather than wb so that we can invoke the callback less
+    // times.
+    let mut batch = Vec::with_capacity(1024);
+    let mut batch_data_size = 0;
+    loop {
+        if stale_detector.is_stale() {
+            return Err(Error::Abort);
+        }
+        if !iter.valid()? {
+            break;
+        }
+        let key = iter.key().to_vec();
+        let value = iter.value().to_vec();
+        batch_data_size += key.len() + value.len();
+        batch.push((key, value));
+        if batch_data_size >= batch_size {
+            box_try!(write_to_db(&mut batch));
+            batch_data_size = 0;
+        }
+        iter.next()?;
+    }
+    if !batch.is_empty() {
+        box_try!(write_to_db(&mut batch));
+    }
+    Ok(())
+}
+
+pub fn apply_sst_cf_files_without_ingest<E, F>(
+    files: &[&str],
+    db: &E,
+    cf: &str,
+    key_mgr: Option<Arc<DataKeyManager>>,
+    stale_detector: &impl StaleDetector,
+    batch_size: usize,
+    callback: &mut F,
+) -> Result<(), Error>
+where
+    E: KvEngine,
+    F: for<'r> FnMut(&'r [(Vec<u8>, Vec<u8>)]),
+{
+    for path in files {
+        box_try!(apply_sst_cf_file_without_ingest(
+            path,
+            db,
+            cf,
+            key_mgr.clone(),
+            stale_detector,
+            batch_size,
+            callback
+        ));
+    }
     Ok(())
 }
 
@@ -413,11 +498,19 @@ mod tests {
 
                     let detector = TestStaleDetector {};
                     let tmp_file_path = &cf_file.tmp_file_paths()[0];
-                    apply_plain_cf_file(tmp_file_path, None, &detector, &db1, cf, 16, |v| {
-                        v.iter()
-                            .cloned()
-                            .for_each(|pair| applied_keys.entry(cf).or_default().push(pair))
-                    })
+                    apply_plain_cf_file(
+                        tmp_file_path,
+                        None,
+                        &detector,
+                        &db1,
+                        cf,
+                        16,
+                        &mut |v: &[(Vec<u8>, Vec<u8>)]| {
+                            v.iter()
+                                .cloned()
+                                .for_each(|pair| applied_keys.entry(cf).or_default().push(pair))
+                        },
+                    )
                     .unwrap();
                 }
 
@@ -505,7 +598,7 @@ mod tests {
                         .iter()
                         .map(|s| s.as_str())
                         .collect::<Vec<&str>>();
-                    apply_sst_cf_file(&tmp_file_paths, &db1, CF_DEFAULT).unwrap();
+                    apply_sst_cf_files_by_ingest(&tmp_file_paths, &db1, CF_DEFAULT).unwrap();
                     assert_eq_db(&db, &db1);
                 }
             }

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -714,6 +714,7 @@ where
             .enable_receive_tablet_snapshot(
                 self.core.config.raft_store.enable_v2_compatible_learner,
             )
+            .min_ingest_snapshot_limit(self.core.config.server.snap_min_ingest_size)
             .build(snap_path);
 
         // Create coprocessor endpoint.

--- a/components/test_raftstore/src/node.rs
+++ b/components/test_raftstore/src/node.rs
@@ -277,6 +277,7 @@ impl Simulator for NodeCluster {
                 .max_per_file_size(cfg.raft_store.max_snapshot_file_raw_size.0)
                 .enable_multi_snapshot_files(true)
                 .enable_receive_tablet_snapshot(cfg.raft_store.enable_v2_compatible_learner)
+                .min_ingest_snapshot_limit(cfg.server.snap_min_ingest_size)
                 .build(tmp.path().to_str().unwrap());
             (snap_mgr, Some(tmp))
         } else {

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -468,6 +468,7 @@ impl ServerCluster {
             .max_per_file_size(cfg.raft_store.max_snapshot_file_raw_size.0)
             .enable_multi_snapshot_files(true)
             .enable_receive_tablet_snapshot(cfg.raft_store.enable_v2_compatible_learner)
+            .min_ingest_snapshot_limit(cfg.server.snap_min_ingest_size)
             .build(tmp_str);
         self.snap_mgrs.insert(node_id, snap_mgr.clone());
         let server_cfg = Arc::new(VersionTrack::new(cfg.server.clone()));

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -173,6 +173,10 @@ pub struct Config {
     #[serde(alias = "snap-max-write-bytes-per-sec")]
     pub snap_io_max_bytes_per_sec: ReadableSize,
     pub snap_max_total_size: ReadableSize,
+    /// Minimal size of snapshot for applying with ingestion.
+    /// If the size of snapshot is smaller than this value, it will be applied
+    /// without ingestion, just bulk write kvs to kvdb.
+    pub snap_min_ingest_size: ReadableSize,
     #[online_config(skip)]
     pub stats_concurrency: usize,
     #[online_config(skip)]
@@ -281,6 +285,7 @@ impl Default for Config {
             end_point_memory_quota: *DEFAULT_ENDPOINT_MEMORY_QUOTA,
             snap_io_max_bytes_per_sec: ReadableSize(DEFAULT_SNAP_MAX_BYTES_PER_SEC),
             snap_max_total_size: ReadableSize(0),
+            snap_min_ingest_size: ReadableSize::mb(2),
             stats_concurrency: 1,
             // 75 means a gRPC thread is under heavy load if its total CPU usage
             // is greater than 75%.

--- a/src/server/snap.rs
+++ b/src/server/snap.rs
@@ -461,9 +461,13 @@ impl<R: RaftExtension + 'static> Runner<R> {
             };
             self.snap_mgr.set_speed_limit(limit);
             self.snap_mgr.set_max_total_snap_size(max_total_size);
-            info!("refresh snapshot manager config";
-            "speed_limit"=> limit,
-            "max_total_snap_size"=> max_total_size);
+            self.snap_mgr
+                .set_min_ingest_cf_limit(incoming.snap_min_ingest_size);
+            info!(
+                "refresh snapshot manager config";
+                "speed_limit" => limit,
+                "max_total_snap_size" => max_total_size,
+                "min_ingest_cf_size" => ?incoming.snap_min_ingest_size);
             self.cfg = incoming.clone();
         }
     }

--- a/tests/integrations/raftstore/test_snap.rs
+++ b/tests/integrations/raftstore/test_snap.rs
@@ -1037,3 +1037,76 @@ fn test_v2_leaner_snapshot_commit_index() {
 
     cluster.must_put(b"k3", b"v3");
 }
+
+#[test_case(test_raftstore::new_node_cluster)]
+#[test_case(test_raftstore::new_server_cluster)]
+fn test_node_apply_snapshot_by_or_without_ingest() {
+    let validate_sst_files = |dir: &std::path::Path| -> bool {
+        let mut sst_file_count = 0_usize;
+        for entry in fs::read_dir(dir).unwrap() {
+            let path = entry.unwrap().path();
+            if path.is_file() && path.ends_with(".sst") {
+                sst_file_count += 1;
+            }
+        }
+        sst_file_count > 0
+    };
+    let check_snap_count = |snap_dir: &str| -> usize {
+        let mut valid_snap_count = 0_usize;
+        for entry in fs::read_dir(snap_dir).unwrap() {
+            let path = entry.unwrap().path();
+            if path.is_dir() && validate_sst_files(&path) {
+                valid_snap_count += 1;
+            }
+        }
+        valid_snap_count
+    };
+    for snap_min_ingest_size in [ReadableSize::mb(1), ReadableSize::default()] {
+        let mut cluster = new_cluster(0, 4);
+        cluster.cfg.raft_store.raft_log_gc_tick_interval = ReadableDuration::millis(20);
+        cluster.cfg.raft_store.raft_log_gc_count_limit = Some(2);
+        cluster.cfg.raft_store.merge_max_log_gap = 1;
+        cluster.cfg.raft_store.snap_mgr_gc_tick_interval = ReadableDuration::millis(50);
+        cluster.cfg.server.snap_min_ingest_size = snap_min_ingest_size;
+
+        let pd_client = Arc::clone(&cluster.pd_client);
+        // Disable default max peer count check.
+        pd_client.disable_default_operator();
+        cluster.run();
+
+        // In case of removing leader, let's transfer leader to some node first.
+        cluster.must_transfer_leader(1, new_peer(1, 1));
+        cluster.must_put(b"k1", b"v1");
+        cluster.must_put(b"k2", b"v2");
+        pd_client.must_remove_peer(1, new_peer(4, 4));
+        pd_client.add_peer(1, new_peer(4, 5));
+        let snap_dir = cluster.get_snap_dir(4);
+        // Verify that the snap has been received.
+        for _ in 0..10 {
+            if check_snap_count(&snap_dir) > 0 {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        let engine4 = cluster.get_engine(4);
+        must_get_equal(&engine4, b"k1", b"v1");
+        must_get_equal(&engine4, b"k2", b"v2");
+
+        pd_client.must_remove_peer(1, new_peer(3, 3));
+        pd_client.must_remove_peer(1, new_peer(4, 5));
+        cluster.must_put(b"k3", b"v3");
+        cluster.must_put(b"k3", b"v3");
+        pd_client.add_peer(1, new_peer(3, 6));
+        let engine3 = cluster.get_engine(3);
+        must_get_equal(&engine3, b"k3", b"v3");
+        must_get_equal(&engine3, b"k3", b"v3");
+        // Verify that the snap will be gced.
+        let snap_dir = cluster.get_snap_dir(3);
+        for _ in 0..10 {
+            if check_snap_count(&snap_dir) == 0 {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+}

--- a/tests/integrations/storage/test_titan.rs
+++ b/tests/integrations/storage/test_titan.rs
@@ -16,7 +16,9 @@ use engine_traits::{
 };
 use keys::data_key;
 use kvproto::metapb::{Peer, Region};
-use raftstore::store::{apply_sst_cf_file, build_sst_cf_file_list, CfFile, RegionSnapshot};
+use raftstore::store::{
+    apply_sst_cf_files_by_ingest, build_sst_cf_file_list, CfFile, RegionSnapshot,
+};
 use tempfile::Builder;
 use test_raftstore::*;
 use tikv::{
@@ -408,13 +410,13 @@ fn test_delete_files_in_range_for_titan() {
         .iter()
         .map(|s| s.as_str())
         .collect::<Vec<&str>>();
-    apply_sst_cf_file(&tmp_file_paths, &engines1.kv, CF_DEFAULT).unwrap();
+    apply_sst_cf_files_by_ingest(&tmp_file_paths, &engines1.kv, CF_DEFAULT).unwrap();
     let tmp_file_paths = cf_file_write.tmp_file_paths();
     let tmp_file_paths = tmp_file_paths
         .iter()
         .map(|s| s.as_str())
         .collect::<Vec<&str>>();
-    apply_sst_cf_file(&tmp_file_paths, &engines1.kv, CF_WRITE).unwrap();
+    apply_sst_cf_files_by_ingest(&tmp_file_paths, &engines1.kv, CF_WRITE).unwrap();
 
     // Do scan on other DB.
     let mut r = Region::default();


### PR DESCRIPTION
This is a manual cherry-pick of #17408

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #17412, #17376

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Previously, snapshots of regions, with the exception of the `lock_cf` column family,
were flushed to SST files, while `lock_cf` was flushed to plain files. This approach could
lead to a high volume of `ingest` tasks for merging regions, especially when the TiKV
node contained a large number of small-sized regions.  As we all know, an excess of `ingest`
tasks can significantly impair the overall performance of the TiKV node.

To address this issue, this pull request introduces a new configuration option called
`snap_min_ingest_size`. When a region's size is below the threshold set by `snap_min_ingest_size`,
its corresponding snapshot will now be applied without `ingest` SST files. This change
is expected to reduce the frequency of ingest tasks and thereby enhance the TiKV node's processing efficiency.
```
And the following comparison shows that this pr can greatly reduce the duration of merging numerous small regions.
| Nightly(222e0a) | This PR |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/ceb76ac5-f810-4ae7-8ee3-e5f2f61e2559) | ![image](https://github.com/user-attachments/assets/7d0da8ce-86d6-4d20-99c5-203022dd26f8) |

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
To mitigate the high apply wait duration problem, it directly dumps and flushes key-value pairs in sst files of snapshots when merging small regions rather than ingestion.
```
