### PR TITLE
[hotfix-to-7.5.6] raftstore: remove stale ranges by DeleteByKeys rather than ingesting. (#18040)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2936,7 +2936,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git?branch=release-7.5#c4a09794a10c8564d8b4645f45b4092b8ff0b29c"
+source = "git+https://github.com/pingcap/kvproto.git?branch=release-7.5#5030ed622c154001aa3e188dd8e56de8d4965732"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/components/raftstore/src/store/worker/metrics.rs
+++ b/components/raftstore/src/store/worker/metrics.rs
@@ -65,6 +65,16 @@ make_static_metric! {
     pub struct LocalReadRejectCounter : LocalIntCounter {
        "reason" => RejectReason,
     }
+
+    pub label_enum ClearOverlapRegionType {
+        by_key,
+        by_range,
+        by_ingest_files,
+    }
+
+    pub struct ClearOverlapRegionDuration : Histogram {
+        "type" => ClearOverlapRegionType,
+    }
 }
 
 pub struct LocalReadMetrics {
@@ -241,4 +251,11 @@ lazy_static! {
         "Total number of renewing lease in advance from local reader."
     )
     .unwrap();
+    pub static ref CLEAR_OVERLAP_REGION_DURATION: ClearOverlapRegionDuration = register_static_histogram_vec!(
+        ClearOverlapRegionDuration,
+        "tikv_raftstore_clear_overlap_region_duration_seconds",
+        "Bucketed histogram of clear overlap region duration.",
+        &["type"],
+        exponential_buckets(0.005, 2.0, 20).unwrap()
+    ).unwrap();
 }

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -1399,6 +1399,7 @@ where
 
         let scheduler = self.scheduler.clone();
         let router = self.router.clone();
+        let mut snap_mgr = self.snap_mgr.clone();
         let resp = self
             .pd_client
             .store_heartbeat(stats, store_report, dr_autosync_status);
@@ -1469,6 +1470,36 @@ where
                             scheduler.schedule(Task::ControlGrpcServer(op.get_ctrl_event()))
                         {
                             warn!("fail to schedule control grpc task"; "err" => ?e);
+                        }
+                    }
+                    // NodeState for this store.
+                    {
+                        let state = (|| {
+                            #[cfg(feature = "failpoints")]
+                            fail_point!("manually_set_store_offline", |_| {
+                                metapb::NodeState::Removing
+                            });
+                            resp.get_state()
+                        })();
+                        match state {
+                            metapb::NodeState::Removing | metapb::NodeState::Removed => {
+                                let is_offlined = snap_mgr.is_offlined();
+                                if !is_offlined {
+                                    snap_mgr.set_offline(true);
+                                    info!("store is offlined by pd");
+                                }
+                            }
+                            // As for NodeState::Preparing | Serving, if `is_offlined == true`,
+                            // it means the store has been re-added into the cluster and
+                            // the offline operation is terminated. Therefore, the state
+                            // `is_offlined` should be reset with `false`.
+                            _ => {
+                                let is_offlined = snap_mgr.is_offlined();
+                                if is_offlined {
+                                    snap_mgr.set_offline(false);
+                                    info!("store is remarked with serving state by pd");
+                                }
+                            }
                         }
                     }
                 }

--- a/components/raftstore/src/store/worker/region.rs
+++ b/components/raftstore/src/store/worker/region.rs
@@ -625,7 +625,7 @@ where
     /// with it.
     fn clean_overlap_ranges(&mut self, start_key: Vec<u8>, end_key: Vec<u8>) -> Result<()> {
         let (start_key, end_key) = self.clean_overlap_ranges_roughly(start_key, end_key);
-        self.delete_all_in_range(&[Range::new(&start_key, &end_key)])
+        self.delete_all_in_range(&[Range::new(&start_key, &end_key)], false)
     }
 
     /// Inserts a new pending range, and it will be cleaned up with some delay.
@@ -648,6 +648,10 @@ where
 
     /// Cleans up stale ranges.
     fn clean_stale_ranges(&mut self) {
+        if self.mgr.is_offlined() {
+            info!("no need to clear stale range as store is marked offlined");
+            return;
+        }
         STALE_PEER_PENDING_DELETE_RANGE_GAUGE.set(self.pending_delete_ranges.len() as f64);
         if self.ingest_maybe_stall() {
             return;
@@ -676,7 +680,7 @@ where
                 Range::new(start, end)
             })
             .collect();
-
+        // Clear sst files belonging to the given range directly.
         self.engine
             .delete_ranges_cfs(
                 &WriteOptions::default(),
@@ -687,10 +691,13 @@ where
                 error!("failed to delete files in range"; "err" => %e);
             })
             .unwrap();
-        if let Err(e) = self.delete_all_in_range(&ranges) {
+        // Remove all overlapped ranges directly without ingesting.
+        if let Err(e) = self.delete_all_in_range(&ranges, true) {
             error!("failed to cleanup stale range"; "err" => %e);
             return;
         }
+        // Clear related blob files belonging to the given range directly after clearing
+        // all stale keys in sst files.
         self.engine
             .delete_ranges_cfs(
                 &WriteOptions::default(),
@@ -726,20 +733,42 @@ where
         false
     }
 
-    fn delete_all_in_range(&self, ranges: &[Range<'_>]) -> Result<()> {
+    fn delete_all_in_range(&self, ranges: &[Range<'_>], forcely_by_key: bool) -> Result<()> {
         let wopts = WriteOptions::default();
         for cf in self.engine.cf_names() {
             // CF_LOCK usually contains fewer keys than other CFs, so we delete them by key.
-            let strategy = if cf == CF_LOCK {
-                DeleteStrategy::DeleteByKey
+            let (strategy, observer) = if cf == CF_LOCK {
+                (
+                    DeleteStrategy::DeleteByKey,
+                    &CLEAR_OVERLAP_REGION_DURATION.by_key,
+                )
             } else if self.use_delete_range {
-                DeleteStrategy::DeleteByRange
+                (
+                    DeleteStrategy::DeleteByRange,
+                    &CLEAR_OVERLAP_REGION_DURATION.by_range,
+                )
+            // Meanwhile, if `forcely_by_key` is specified and
+            // `cfg.use_delete_range` is not enabled, it should remove the
+            // range by delete keys rather than ingestion.
+            } else if forcely_by_key {
+                (
+                    DeleteStrategy::DeleteByKey,
+                    &CLEAR_OVERLAP_REGION_DURATION.by_key,
+                )
             } else {
-                DeleteStrategy::DeleteByWriter {
-                    sst_path: self.mgr.get_temp_path_for_ingest(),
-                }
+                // Deprecated method for clearing stale ranges due to potential latency
+                // jitters. It's still applicable when clearing overlapped regions
+                // before applying the newly added snapshot.
+                (
+                    DeleteStrategy::DeleteByWriter {
+                        sst_path: self.mgr.get_temp_path_for_ingest(),
+                    },
+                    &CLEAR_OVERLAP_REGION_DURATION.by_ingest_files,
+                )
             };
+            let start = Instant::now();
             box_try!(self.engine.delete_ranges_cf(&wopts, cf, strategy, ranges));
+            observer.observe(start.saturating_elapsed_secs());
         }
 
         Ok(())

--- a/tests/failpoints/cases/test_stale_peer.rs
+++ b/tests/failpoints/cases/test_stale_peer.rs
@@ -1,12 +1,14 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::{
+    fs,
+    path::Path,
     sync::{atomic::AtomicBool, mpsc, Arc},
     thread,
     time::Duration,
 };
 
-use engine_traits::{RaftEngineDebug, RaftEngineReadOnly};
+use engine_traits::{RaftEngine, RaftEngineDebug, RaftEngineReadOnly};
 use futures::executor::block_on;
 use kvproto::raft_serverpb::{PeerState, RaftLocalState, RaftMessage};
 use pd_client::PdClient;
@@ -43,6 +45,65 @@ fn test_one_node_leader_missing() {
     // Check stale state 3 times,
     thread::sleep(cluster.cfg.raft_store.peer_stale_state_check_interval.0 * 3);
     fail::remove(check_stale_state);
+}
+
+#[test]
+fn test_clean_stale_peer() {
+    let validate_data_files = |dir: &std::path::Path| -> bool {
+        let mut data_file = 0_usize;
+        for entry in fs::read_dir(dir).unwrap() {
+            let path = entry.unwrap().path();
+            if path.is_file() && path.to_str().unwrap().ends_with(".log") {
+                data_file += 1;
+            }
+        }
+        data_file > 0
+    };
+    let mut cluster = new_node_cluster(0, 3);
+    cluster.cfg.raft_store.snap_mgr_gc_tick_interval = ReadableDuration::millis(100);
+    cluster.cfg.raft_store.pd_heartbeat_tick_interval = ReadableDuration::millis(100);
+    // Disable raft log gc in this test case.
+    cluster.cfg.raft_store.raft_log_gc_tick_interval = ReadableDuration::secs(60);
+
+    let pd_client = Arc::clone(&cluster.pd_client);
+    // Disable default max peer count check.
+    pd_client.disable_default_operator();
+
+    let region_id = cluster.run_conf_change();
+
+    // Manually set store 3 is offlined.
+    fail::cfg("manually_set_store_offline", "return").unwrap();
+    pd_client.must_add_peer(region_id, new_peer(2, 2));
+    pd_client.must_add_peer(region_id, new_peer(3, 3));
+
+    (0..10).for_each(|_| cluster.must_put(b"k1", b"v1"));
+    // Send heartbeats to pd to ensure that heartbeat responses have been received
+    // by node 3.
+    cluster.must_send_store_heartbeat(3);
+    must_get_equal(&cluster.get_engine(3), b"k1", b"v1");
+    pd_client.must_remove_peer(region_id, new_peer(3, 3));
+    // Since the node 3 is marked with NodeState::Removing, its `offlined == true`
+    // in SnapManager, and no need to clear the corresponding data.
+    sleep_ms(500);
+    let engine = cluster.get_engine(3);
+    let engine_path = Path::new(engine.get_engine_path());
+    assert!(validate_data_files(engine_path));
+    fail::remove("manually_set_store_offline");
+    // After the state is cleared, the store should be marked with
+    // NodeState::Serving. And after adding a new peer to store 3,
+    // all previous data should be synced to it.
+    cluster.must_send_store_heartbeat(3);
+    cluster.must_put(b"k10", b"v10");
+    let engine = cluster.get_engine(3);
+    let (key, value) = (b"k10", b"v10");
+    must_get_none(&engine, key);
+    pd_client.must_add_peer(region_id, new_peer(3, 4));
+    must_get_equal(&engine, key, value);
+    must_get_equal(&cluster.get_engine(3), b"k1", b"v1");
+    // Remove the peer 4.
+    pd_client.must_remove_peer(region_id, new_peer(3, 4));
+    sleep_ms(500);
+    must_get_none(&engine, key);
 }
 
 #[test_case(test_raftstore::new_node_cluster)]


### PR DESCRIPTION
This is a manual cherry-pick of #18040

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18107, Ref https://github.com/tikv/tikv/issues/18042

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
This PR mainly contains the following parts for optimization on scaling, used to mitigate the impacts, introduced by unnecessary ingesting sst files:
- Directly clearing stale ranges by DeleteByKeys during the balancing regions process.
- Do not clear data of offline stores during the scale-in process, as this data will be automatically cleared when the corresponding node goes offline.

What's Changed:

```commit-message
Optimizing the processing of clearing stale-ranges by DeleteByKeys, rather than ingesting.

This optimization is used to mitigate the impacts, introduced by unnecessary ingesting sst
files on latency when scaling.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Taking the `grpc messages duration` in TiKV metrics panel as examples, positive performance feedbacks on reducing the long-tail latency can be reviewed from the following comparison results:
| Commit | Comparisons on `grpc messages duration` |
| --- | --- |
| master | ![image](https://github.com/user-attachments/assets/38b158a1-e0c3-43b5-9c0f-f40517d9db67) |
| This PR | ![image](https://github.com/user-attachments/assets/2e9f45b8-d6ac-4db4-9a1c-abb6463e883c) |

Meanwhile, the following E2E long-tail reduction also proves that this PR makes positive improvements effects:
| Commit | Scale-Out (Before -> Scaling) | Scale-in (Before -> Scaling) |
| --- | --- | --- |
| master | P99: 7.2ms -> ~ 11.3 ms  P999: 62ms -> ~89.2 ms | P99: 7.2ms -> ~ 16.1 ms  P999: 62ms -> ~100 ms |
| This PR | P99: 7.2 ms -> ~10.6 ms   P999: 62 ms -> ~76.9ms | P99: 7.2ms -> ~ 15.3 ms   P999: 62ms -> ~96 ms |

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Optimizing the processing of clearing stale-ranges by DeleteByKeys to mitigate the impacts
on latency.
```
