### PR TITLE
[hotifx-to-7.5] raftstore: support rocksdb writes during ingestion #18096

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3002,7 +3002,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-7.5#45576ddd5e6d0c6f33cf8110f87121eb167bede8"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-7.5#63a07c7ded4e646300788b364d090828de76fe48"
 dependencies = [
  "bindgen 0.65.1",
  "bzip2-sys",
@@ -3021,7 +3021,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-7.5#45576ddd5e6d0c6f33cf8110f87121eb167bede8"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-7.5#63a07c7ded4e646300788b364d090828de76fe48"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -4930,7 +4930,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-7.5#45576ddd5e6d0c6f33cf8110f87121eb167bede8"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-7.5#63a07c7ded4e646300788b364d090828de76fe48"
 dependencies = [
  "libc 0.2.146",
  "librocksdb_sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,9 +770,9 @@ checksum = "12ae9db68ad7fac5fe51304d20f016c911539251075a214f8e663babefa35187"
 
 [[package]]
 name = "bytemuck"
-version = "1.9.1"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdead85bdec19c194affaeeb670c0e41fe23de31459efd1c174d049269cf02cc"
+checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
 
 [[package]]
 name = "byteorder"
@@ -1700,6 +1700,7 @@ dependencies = [
  "log_wrappers",
  "protobuf",
  "raft",
+ "rand 0.8.5",
  "serde",
  "serde_derive",
  "slog",
@@ -4878,9 +4879,9 @@ checksum = "18eb52b6664d331053136fcac7e4883bdc6f5fc04a6aab3b0f75eafb80ab88b3"
 
 [[package]]
 name = "rgb"
-version = "0.8.32"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e74fdc210d8f24a7dbfedc13b04ba5764f5232754ccebfdf5fff1bad791ccbc6"
+checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
 dependencies = [
  "bytemuck",
 ]

--- a/components/engine_panic/src/import.rs
+++ b/components/engine_panic/src/import.rs
@@ -1,15 +1,23 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::path::Path;
-
-use engine_traits::{ImportExt, IngestExternalFileOptions, Result};
+use engine_traits::{ImportExt, IngestExternalFileOptions, Range, Result};
+use tikv_util::range_latch::RangeLatchGuard;
 
 use crate::engine::PanicEngine;
 
 impl ImportExt for PanicEngine {
     type IngestExternalFileOptions = PanicIngestExternalFileOptions;
 
-    fn ingest_external_file_cf(&self, cf: &str, files: &[&str]) -> Result<()> {
+    fn ingest_external_file_cf(
+        &self,
+        cf: &str,
+        files: &[&str],
+        range: Option<Range<'_>>,
+    ) -> Result<()> {
+        panic!()
+    }
+
+    fn acquire_ingest_latch(&self, range: Range<'_>) -> RangeLatchGuard<'_> {
         panic!()
     }
 }
@@ -25,11 +33,7 @@ impl IngestExternalFileOptions for PanicIngestExternalFileOptions {
         panic!()
     }
 
-    fn get_write_global_seqno(&self) -> bool {
-        panic!()
-    }
-
-    fn set_write_global_seqno(&mut self, f: bool) {
+    fn allow_write(&mut self, f: bool) {
         panic!()
     }
 }

--- a/components/engine_rocks/src/engine.rs
+++ b/components/engine_rocks/src/engine.rs
@@ -4,6 +4,7 @@ use std::{any::Any, sync::Arc};
 
 use engine_traits::{IterOptions, Iterable, KvEngine, Peekable, ReadOptions, Result, SyncMutable};
 use rocksdb::{DBIterator, Writable, DB};
+use tikv_util::range_latch::RangeLatch;
 
 use crate::{
     db_vector::RocksDbVector, options::RocksReadOptions, r2e, util::get_cf_handle,
@@ -148,6 +149,9 @@ pub struct RocksEngine {
     support_multi_batch_write: bool,
     #[cfg(feature = "trace-lifetime")]
     _id: trace::TabletTraceId,
+    // Used to ensure mutual exclusivity between compaction filter writes and the SST ingestion
+    // operation.
+    pub ingest_latch: Arc<RangeLatch>,
 }
 
 impl RocksEngine {
@@ -158,6 +162,7 @@ impl RocksEngine {
             #[cfg(feature = "trace-lifetime")]
             _id: trace::TabletTraceId::new(db.path(), &db),
             db,
+            ingest_latch: Arc::new(RangeLatch::new()),
         }
     }
 

--- a/components/engine_rocks/src/import.rs
+++ b/components/engine_rocks/src/import.rs
@@ -3,14 +3,10 @@
 use engine_traits::{ImportExt, IngestExternalFileOptions, Range, Result};
 use fail::fail_point;
 use rocksdb::IngestExternalFileOptions as RawIngestExternalFileOptions;
-use tikv_util::{range_latch::RangeLatchGuard, time::Instant};
+use tikv_util::range_latch::RangeLatchGuard;
 
 use crate::{
-    engine::RocksEngine,
-    perf_context_metrics::{
-        INGEST_EXTERNAL_FILE_ALLOW_WRITE_COUNTER, INGEST_EXTERNAL_FILE_TIME_HISTOGRAM,
-    },
-    r2e, util,
+    engine::RocksEngine, perf_context_metrics::INGEST_EXTERNAL_FILE_ALLOW_WRITE_COUNTER, r2e, util,
 };
 
 impl ImportExt for RocksEngine {

--- a/components/engine_rocks/src/import.rs
+++ b/components/engine_rocks/src/import.rs
@@ -1,18 +1,52 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_traits::{ImportExt, IngestExternalFileOptions, Result};
+use engine_traits::{ImportExt, IngestExternalFileOptions, Range, Result};
+use fail::fail_point;
 use rocksdb::IngestExternalFileOptions as RawIngestExternalFileOptions;
+use tikv_util::{range_latch::RangeLatchGuard, time::Instant};
 
-use crate::{engine::RocksEngine, r2e, util};
+use crate::{
+    engine::RocksEngine,
+    perf_context_metrics::{
+        INGEST_EXTERNAL_FILE_ALLOW_WRITE_COUNTER, INGEST_EXTERNAL_FILE_TIME_HISTOGRAM,
+    },
+    r2e, util,
+};
 
 impl ImportExt for RocksEngine {
     type IngestExternalFileOptions = RocksIngestExternalFileOptions;
 
-    fn ingest_external_file_cf(&self, cf: &str, files: &[&str]) -> Result<()> {
-        let cf = util::get_cf_handle(self.as_inner(), cf)?;
+    fn ingest_external_file_cf(
+        &self,
+        cf_name: &str,
+        files: &[&str],
+        range: Option<Range<'_>>,
+    ) -> Result<()> {
+        // Acquire latch to prevent concurrency with compaction-filter operations
+        // when using RocksDB IngestExternalFileOptions.allow_write = true.
+        let _region_inject_latch_guard = range.as_ref().map(|r| {
+            self.ingest_latch
+                .acquire(r.start_key.to_vec(), r.end_key.to_vec())
+        });
+        fail_point!("after_apply_snapshot_ingest_latch_acquired");
+
+        let cf = util::get_cf_handle(self.as_inner(), cf_name)?;
         let mut opts = RocksIngestExternalFileOptions::new();
         opts.move_files(true);
-        opts.set_write_global_seqno(false);
+        let allow_write = range.is_some();
+        opts.allow_write(allow_write);
+        if allow_write {
+            INGEST_EXTERNAL_FILE_ALLOW_WRITE_COUNTER
+                .with_label_values(&["
+            allow_write"])
+                .inc();
+        } else {
+            INGEST_EXTERNAL_FILE_ALLOW_WRITE_COUNTER
+                .with_label_values(&["
+            not_allow_write"])
+                .inc();
+        }
+
         // Note: no need reset the global seqno to 0 for compatibility as #16992
         // This is calling a specially optimized version of
         // ingest_external_file_cf. In cases where the memtable needs to be
@@ -24,6 +58,11 @@ impl ImportExt for RocksEngine {
             .ingest_external_file_optimized(cf, &opts.0, files)
             .map_err(r2e)?;
         Ok(())
+    }
+
+    fn acquire_ingest_latch(&self, range: Range<'_>) -> RangeLatchGuard<'_> {
+        self.ingest_latch
+            .acquire(range.start_key.to_vec(), range.end_key.to_vec())
     }
 }
 
@@ -38,12 +77,8 @@ impl IngestExternalFileOptions for RocksIngestExternalFileOptions {
         self.0.move_files(f);
     }
 
-    fn get_write_global_seqno(&self) -> bool {
-        self.0.get_write_global_seqno()
-    }
-
-    fn set_write_global_seqno(&mut self, f: bool) {
-        self.0.set_write_global_seqno(f);
+    fn allow_write(&mut self, f: bool) {
+        self.0.set_allow_write(f);
     }
 }
 
@@ -118,7 +153,11 @@ mod tests {
             sst2.put(v.as_bytes(), v.as_bytes()).unwrap();
         }
         sst2.finish().unwrap();
-        db.ingest_external_file_cf(CF_DEFAULT, &[p1.to_str().unwrap(), p2.to_str().unwrap()])
-            .unwrap();
+        db.ingest_external_file_cf(
+            CF_DEFAULT,
+            &[p1.to_str().unwrap(), p2.to_str().unwrap()],
+            None,
+        )
+        .unwrap();
     }
 }

--- a/components/engine_rocks/src/misc.rs
+++ b/components/engine_rocks/src/misc.rs
@@ -5,6 +5,7 @@ use engine_traits::{
     Range, RangeStats, Result, SstWriter, SstWriterBuilder, WriteBatch, WriteBatchExt,
     WriteOptions,
 };
+use fail::fail_point;
 use rocksdb::{FlushOptions, Range as RocksRange};
 use tikv_util::{box_try, keybuilder::KeyBuilder};
 
@@ -32,6 +33,7 @@ impl RocksEngine {
         cf: &str,
         sst_path: String,
         ranges: &[Range<'_>],
+        allow_write_during_ingestion: bool,
     ) -> Result<bool> {
         let mut written = false;
         let mut ranges = ranges.to_owned();
@@ -40,13 +42,13 @@ impl RocksEngine {
         let mut writer_wrapper: Option<RocksSstWriter> = None;
         let mut data: Vec<Vec<u8>> = vec![];
         let mut last_end_key: Option<Vec<u8>> = None;
-        for r in ranges {
+        for r in &ranges {
             // There may be a range overlap with next range
             if last_end_key
                 .as_ref()
                 .map_or(false, |key| key.as_slice() > r.start_key)
             {
-                written |= self.delete_all_in_range_cf_by_key(wopts, cf, &r)?;
+                written |= self.delete_all_in_range_cf_by_key(wopts, cf, r)?;
                 continue;
             }
             last_end_key = Some(r.end_key.to_owned());
@@ -72,7 +74,11 @@ impl RocksEngine {
                 } else {
                     data.push(it.key().to_vec());
                 }
-                if data.len() > MAX_DELETE_COUNT_BY_KEY {
+                let max_delete_count_by_key = (|| {
+                    fail_point!("manually_set_max_delete_count_by_key", |_| { 0 });
+                    MAX_DELETE_COUNT_BY_KEY
+                })();
+                if data.len() > max_delete_count_by_key {
                     let builder = RocksSstWriterBuilder::new().set_db(self).set_cf(cf);
                     let mut writer = builder.build(sst_path.as_str())?;
                     for key in data.iter() {
@@ -87,7 +93,24 @@ impl RocksEngine {
 
         if let Some(writer) = writer_wrapper {
             writer.finish()?;
-            self.ingest_external_file_cf(cf, &[sst_path.as_str()])?;
+            let (min_start_key, max_end_key) = ranges.iter().fold(
+                (ranges[0].start_key, ranges[0].end_key),
+                |(min_start, max_end), range| {
+                    (
+                        std::cmp::min(min_start, range.start_key),
+                        std::cmp::max(max_end, range.end_key),
+                    )
+                },
+            );
+            let range_to_lock = if allow_write_during_ingestion {
+                Some(Range {
+                    start_key: min_start_key,
+                    end_key: max_end_key,
+                })
+            } else {
+                None
+            };
+            self.ingest_external_file_cf(cf, &[sst_path.as_str()], range_to_lock)?;
         } else {
             let mut wb = self.write_batch();
             for key in data.iter() {
@@ -269,8 +292,17 @@ impl MiscExt for RocksEngine {
                     written |= self.delete_all_in_range_cf_by_key(wopts, cf, r)?;
                 }
             }
-            DeleteStrategy::DeleteByWriter { sst_path } => {
-                written |= self.delete_all_in_range_cf_by_ingest(wopts, cf, sst_path, ranges)?;
+            DeleteStrategy::DeleteByWriter {
+                sst_path,
+                allow_write_during_ingestion,
+            } => {
+                written |= self.delete_all_in_range_cf_by_ingest(
+                    wopts,
+                    cf,
+                    sst_path,
+                    ranges,
+                    allow_write_during_ingestion,
+                )?;
             }
         }
         Ok(written)
@@ -613,7 +645,10 @@ mod tests {
             data.push(i.to_string().as_bytes().to_vec());
         }
         test_delete_ranges(
-            DeleteStrategy::DeleteByWriter { sst_path },
+            DeleteStrategy::DeleteByWriter {
+                sst_path,
+                allow_write_during_ingestion: false,
+            },
             &data,
             &[
                 Range::new(&data[2], &data[499]),

--- a/components/engine_rocks/src/perf_context_metrics.rs
+++ b/components/engine_rocks/src/perf_context_metrics.rs
@@ -52,4 +52,20 @@ lazy_static! {
         auto_flush_from!(APPLY_PERF_CONTEXT_TIME_HISTOGRAM, PerfContextTimeDuration);
     pub static ref STORE_PERF_CONTEXT_TIME_HISTOGRAM_STATIC: PerfContextTimeDuration =
         auto_flush_from!(STORE_PERF_CONTEXT_TIME_HISTOGRAM, PerfContextTimeDuration);
+    pub static ref INGEST_EXTERNAL_FILE_TIME_HISTOGRAM: IngestExternalFileTimeDuration =
+        register_static_histogram_vec!(
+            IngestExternalFileTimeDuration,
+            "tikv_storage_ingest_external_file_duration_secs",
+            "Bucketed histogram of ingest external file duration.",
+            &["cf", "type"],
+            exponential_buckets(0.005, 2.0, 20).unwrap()
+        )
+        .unwrap();
+    pub static ref INGEST_EXTERNAL_FILE_ALLOW_WRITE_COUNTER: IntCounterVec =
+        register_int_counter_vec!(
+            "tikv_storage_ingest_external_file_allow_write_counter",
+            "Total number of RocksDB ingest SST operations for both allow_write enabled and disabled",
+            &["type"]
+        )
+        .unwrap();
 }

--- a/components/engine_rocks/src/perf_context_metrics.rs
+++ b/components/engine_rocks/src/perf_context_metrics.rs
@@ -52,15 +52,6 @@ lazy_static! {
         auto_flush_from!(APPLY_PERF_CONTEXT_TIME_HISTOGRAM, PerfContextTimeDuration);
     pub static ref STORE_PERF_CONTEXT_TIME_HISTOGRAM_STATIC: PerfContextTimeDuration =
         auto_flush_from!(STORE_PERF_CONTEXT_TIME_HISTOGRAM, PerfContextTimeDuration);
-    pub static ref INGEST_EXTERNAL_FILE_TIME_HISTOGRAM: IngestExternalFileTimeDuration =
-        register_static_histogram_vec!(
-            IngestExternalFileTimeDuration,
-            "tikv_storage_ingest_external_file_duration_secs",
-            "Bucketed histogram of ingest external file duration.",
-            &["cf", "type"],
-            exponential_buckets(0.005, 2.0, 20).unwrap()
-        )
-        .unwrap();
     pub static ref INGEST_EXTERNAL_FILE_ALLOW_WRITE_COUNTER: IntCounterVec =
         register_int_counter_vec!(
             "tikv_storage_ingest_external_file_allow_write_counter",

--- a/components/engine_traits/Cargo.toml
+++ b/components/engine_traits/Cargo.toml
@@ -31,4 +31,5 @@ txn_types = { workspace = true }
 
 [dev-dependencies]
 serde_derive = "1.0"
+rand = "0.8.5"
 toml = "0.5"

--- a/components/engine_traits/src/import.rs
+++ b/components/engine_traits/src/import.rs
@@ -1,11 +1,25 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use crate::errors::Result;
+use tikv_util::range_latch::RangeLatchGuard;
+
+use crate::{errors::Result, Range};
 
 pub trait ImportExt {
     type IngestExternalFileOptions: IngestExternalFileOptions;
 
-    fn ingest_external_file_cf(&self, cf: &str, files: &[&str]) -> Result<()>;
+    /// Ingests external files into the specified column family.
+    ///
+    /// If the range is specified, it enables `RocksDB
+    /// IngestExternalFileOptions.allow_write` and locks the
+    /// specified range.  
+    fn ingest_external_file_cf(
+        &self,
+        cf: &str,
+        files: &[&str],
+        range: Option<Range<'_>>,
+    ) -> Result<()>;
+
+    fn acquire_ingest_latch(&self, range: Range<'_>) -> RangeLatchGuard<'_>;
 }
 
 pub trait IngestExternalFileOptions {
@@ -13,7 +27,5 @@ pub trait IngestExternalFileOptions {
 
     fn move_files(&mut self, f: bool);
 
-    fn get_write_global_seqno(&self) -> bool;
-
-    fn set_write_global_seqno(&mut self, f: bool);
+    fn allow_write(&mut self, f: bool);
 }

--- a/components/engine_traits/src/misc.rs
+++ b/components/engine_traits/src/misc.rs
@@ -35,7 +35,13 @@ pub enum DeleteStrategy {
     DeleteByRange,
     /// Delete by ingesting a SST file with deletions. Useful when the number of
     /// ranges is too many.
-    DeleteByWriter { sst_path: String },
+    /// Set `allow_write_during_ingestion` to true to minimize the impact on
+    /// foreground performance, but you must ensure that no concurrent
+    /// writes overlap with the data being ingested.
+    DeleteByWriter {
+        sst_path: String,
+        allow_write_during_ingestion: bool,
+    },
 }
 
 /// `StatisticsReporter` can be used to report engine's private statistics to

--- a/components/raftstore/src/store/snap.rs
+++ b/components/raftstore/src/store/snap.rs
@@ -1174,7 +1174,13 @@ impl Snapshot {
                     )?;
                 } else {
                     // Apply the snapshot by ingest.
-                    snap_io::apply_sst_cf_files_by_ingest(clone_files.as_slice(), &options.db, cf)?;
+                    snap_io::apply_sst_cf_files_by_ingest(
+                        clone_files.as_slice(),
+                        &options.db,
+                        cf,
+                        enc_start_key(&region),
+                        enc_end_key(&region),
+                    )?;
                     coprocessor_host.post_apply_sst_from_snapshot(&region, cf, path);
                 }
             }
@@ -2003,6 +2009,7 @@ impl SnapManagerCore {
     }
 
     pub fn can_apply_cf_without_ingest(&self, cf_size: u64, cf_kvs: u64) -> bool {
+        fail_point!("apply_cf_without_ingest_false", |_| { false });
         if self.min_ingest_cf_size == 0 {
             return false;
         }

--- a/components/raftstore/src/store/snap/io.rs
+++ b/components/raftstore/src/store/snap/io.rs
@@ -12,7 +12,7 @@ use encryption::{
     from_engine_encryption_method, DataKeyManager, DecrypterReader, EncrypterWriter, Iv,
 };
 use engine_traits::{
-    CfName, Error as EngineError, ExternalSstFileInfo, IterOptions, Iterable, Iterator, KvEngine,
+    CfName, EncryptionKeyManager, Error as EngineError, IterOptions, Iterable, Iterator, KvEngine,
     Mutable, Range, RefIterable, SstCompressionType, SstReader, SstWriter, SstWriterBuilder,
     WriteBatch,
 };

--- a/components/raftstore/src/store/snap/io.rs
+++ b/components/raftstore/src/store/snap/io.rs
@@ -12,8 +12,9 @@ use encryption::{
     from_engine_encryption_method, DataKeyManager, DecrypterReader, EncrypterWriter, Iv,
 };
 use engine_traits::{
-    CfName, EncryptionKeyManager, Error as EngineError, IterOptions, Iterable, Iterator, KvEngine,
-    Mutable, RefIterable, SstCompressionType, SstReader, SstWriter, SstWriterBuilder, WriteBatch,
+    CfName, Error as EngineError, ExternalSstFileInfo, IterOptions, Iterable, Iterator, KvEngine,
+    Mutable, Range, RefIterable, SstCompressionType, SstReader, SstWriter, SstWriterBuilder,
+    WriteBatch,
 };
 use fail::fail_point;
 use kvproto::encryptionpb::EncryptionMethod;
@@ -302,7 +303,13 @@ where
     }
 }
 
-pub fn apply_sst_cf_files_by_ingest<E>(files: &[&str], db: &E, cf: &str) -> Result<(), Error>
+pub fn apply_sst_cf_files_by_ingest<E>(
+    files: &[&str],
+    db: &E,
+    cf: &str,
+    start_key: Vec<u8>,
+    end_key: Vec<u8>,
+) -> Result<(), Error>
 where
     E: KvEngine,
 {
@@ -312,7 +319,31 @@ where
             cf, files
         );
     }
-    box_try!(db.ingest_external_file_cf(cf, files));
+    // We set start_key and end_key to enable RocksDB
+    // IngestExternalFileOptions.allow_write = true, minimizing the impact on
+    // foreground performance.
+    //
+    // We can safely enable `allow_write` because no concurrent writes overlap with
+    // the data to be ingested, due to:
+    //   1. The region's snapshot is unapplied, ensuring there are no foreground
+    //      write operations.
+    //   2. If a peer is migrated out and then migrated back, and we are in the
+    //      apply snapshot phase, the delete_all_in_range in DestroyTask cannot
+    //      concurrently delete the overlapping key range. This is because the
+    //      single-threaded, queue-based region worker ensures that DestroyTask is
+    //      always completed before ApplyTask is executed.
+    //   3. The compaction filter may write to the default column family
+    //      concurrently, but we use ingest latch to avoid such situations.
+    //
+    // Refer to https://github.com/tikv/tikv/issues/18081.
+    box_try!(db.ingest_external_file_cf(
+        cf,
+        files,
+        Some(Range {
+            start_key: start_key.as_slice(),
+            end_key: end_key.as_slice()
+        })
+    ));
     Ok(())
 }
 
@@ -598,7 +629,8 @@ mod tests {
                         .iter()
                         .map(|s| s.as_str())
                         .collect::<Vec<&str>>();
-                    apply_sst_cf_files_by_ingest(&tmp_file_paths, &db1, CF_DEFAULT).unwrap();
+                    apply_sst_cf_files_by_ingest(&tmp_file_paths, &db1, CF_DEFAULT, vec![], vec![])
+                        .unwrap();
                     assert_eq_db(&db, &db1);
                 }
             }

--- a/components/raftstore/src/store/worker/region.rs
+++ b/components/raftstore/src/store/worker/region.rs
@@ -466,7 +466,7 @@ where
         check_abort(&abort)?;
         self.clean_overlap_ranges(start_key, end_key)?;
         check_abort(&abort)?;
-        fail_point!("apply_snap_cleanup_range");
+        fail_point!("apply_snap_cleanup_range", |_| { Ok(()) });
 
         // apply snapshot
         let apply_state = self.apply_state(region_id)?;
@@ -508,6 +508,7 @@ where
             "region_id" => region_id,
             "time_takes" => ?timer.saturating_elapsed(),
         );
+        fail_point!("apply_snapshot_finished");
         Ok(())
     }
 
@@ -624,8 +625,18 @@ where
     /// Cleans up data in the given range and all pending ranges overlapping
     /// with it.
     fn clean_overlap_ranges(&mut self, start_key: Vec<u8>, end_key: Vec<u8>) -> Result<()> {
+        fail_point!("before_clean_overlap_ranges", |_| { Ok(()) });
         let (start_key, end_key) = self.clean_overlap_ranges_roughly(start_key, end_key);
-        self.delete_all_in_range(&[Range::new(&start_key, &end_key)], false)
+        // We enable the `allow_write_during_ingestion` to enable RocksDB
+        // IngestExternalFileOptions.allow_write = true, minimizing the impact on
+        // foreground performance.
+        // This is safe because no overlapping writes occur during ingestion; for the
+        // reason, refer to the comments in `apply_sst_cf_files_by_ingest`.
+        self.delete_all_in_range(
+            &[Range::new(&start_key, &end_key)],
+            false,
+            true, // allow_write_during_ingestion
+        )
     }
 
     /// Inserts a new pending range, and it will be cleaned up with some delay.
@@ -648,6 +659,7 @@ where
 
     /// Cleans up stale ranges.
     fn clean_stale_ranges(&mut self) {
+        fail_point!("before_clean_stale_ranges", |_| {});
         if self.mgr.is_offlined() {
             info!("no need to clear stale range as store is marked offlined");
             return;
@@ -692,7 +704,7 @@ where
             })
             .unwrap();
         // Remove all overlapped ranges directly without ingesting.
-        if let Err(e) = self.delete_all_in_range(&ranges, true) {
+        if let Err(e) = self.delete_all_in_range(&ranges, true, false) {
             error!("failed to cleanup stale range"; "err" => %e);
             return;
         }
@@ -733,7 +745,12 @@ where
         false
     }
 
-    fn delete_all_in_range(&self, ranges: &[Range<'_>], forcely_by_key: bool) -> Result<()> {
+    fn delete_all_in_range(
+        &self,
+        ranges: &[Range<'_>],
+        forcely_by_key: bool,
+        allow_write_during_ingestion: bool,
+    ) -> Result<()> {
         let wopts = WriteOptions::default();
         for cf in self.engine.cf_names() {
             // CF_LOCK usually contains fewer keys than other CFs, so we delete them by key.
@@ -762,6 +779,7 @@ where
                 (
                     DeleteStrategy::DeleteByWriter {
                         sst_path: self.mgr.get_temp_path_for_ingest(),
+                        allow_write_during_ingestion,
                     },
                     &CLEAR_OVERLAP_REGION_DURATION.by_ingest_files,
                 )

--- a/components/sst_importer/src/import_file.rs
+++ b/components/sst_importer/src/import_file.rs
@@ -409,7 +409,8 @@ impl ImportDir {
 
         for (cf, cf_paths) in paths {
             let files: Vec<&str> = cf_paths.iter().map(|p| p.clone.to_str().unwrap()).collect();
-            engine.ingest_external_file_cf(cf, &files)?;
+            // TODO(hwy): Use RocksDB IngestExternalFileOptions.allow_write = true.
+            engine.ingest_external_file_cf(cf, &files, None)?;
         }
         INPORTER_INGEST_COUNT.observe(metas.len() as _);
         IMPORTER_INGEST_BYTES.observe(ingest_bytes as _);
@@ -603,7 +604,7 @@ mod test {
 
     #[cfg(feature = "test-engines-rocksdb")]
     fn test_path_with_range_and_km(km: Option<DataKeyManager>) {
-        use engine_rocks::{RocksEngine, RocksSstWriterBuilder};
+        use engine_rocks::RocksSstWriterBuilder;
         use engine_test::ctor::{CfOptions, DbOptions};
         use engine_traits::{SstWriter, SstWriterBuilder};
         use tempfile::TempDir;

--- a/components/sst_importer/src/util.rs
+++ b/components/sst_importer/src/util.rs
@@ -210,7 +210,7 @@ mod tests {
         prepare_sst_for_ingestion(&sst_path, &sst_clone, key_manager).unwrap();
         check_hard_link(&sst_path, 2);
         check_hard_link(&sst_clone, 2);
-        db.ingest_external_file_cf(CF_DEFAULT, &[sst_clone.to_str().unwrap()])
+        db.ingest_external_file_cf(CF_DEFAULT, &[sst_clone.to_str().unwrap()], None)
             .unwrap();
         check_db_with_kvs(&db, CF_DEFAULT, &kvs);
         assert!(!sst_clone.exists());
@@ -227,7 +227,7 @@ mod tests {
         prepare_sst_for_ingestion(&sst_path, &sst_clone, key_manager).unwrap();
         check_hard_link(&sst_path, 2);
         check_hard_link(&sst_clone, 1);
-        db.ingest_external_file_cf(CF_DEFAULT, &[sst_clone.to_str().unwrap()])
+        db.ingest_external_file_cf(CF_DEFAULT, &[sst_clone.to_str().unwrap()], None)
             .unwrap();
         check_db_with_kvs(&db, CF_DEFAULT, &kvs);
         assert!(!sst_clone.exists());
@@ -305,7 +305,7 @@ mod tests {
         check_hard_link(&sst_path, 1);
         check_hard_link(&sst_clone, 1);
 
-        db.ingest_external_file_cf(CF_DEFAULT, &[sst_clone.to_str().unwrap()])
+        db.ingest_external_file_cf(CF_DEFAULT, &[sst_clone.to_str().unwrap()], None)
             .unwrap();
         check_db_with_kvs(&db, CF_DEFAULT, &kvs);
         assert!(!sst_clone.exists());

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -897,7 +897,7 @@ pub fn must_new_and_configure_cluster(
     must_new_and_configure_cluster_mul(1, configure)
 }
 
-fn must_new_and_configure_cluster_mul(
+pub fn must_new_and_configure_cluster_mul(
     count: usize,
     mut configure: impl FnMut(&mut Cluster<ServerCluster>),
 ) -> (Cluster<ServerCluster>, metapb::Peer, Context) {

--- a/components/tikv_util/src/lib.rs
+++ b/components/tikv_util/src/lib.rs
@@ -55,6 +55,7 @@ pub mod memory;
 pub mod metrics;
 pub mod mpsc;
 pub mod quota_limiter;
+pub mod range_latch;
 pub mod slow_score;
 pub mod store;
 pub mod stream;

--- a/components/tikv_util/src/range_latch.rs
+++ b/components/tikv_util/src/range_latch.rs
@@ -1,0 +1,281 @@
+use std::{
+    collections::{
+        BTreeMap,
+        Bound::{Excluded, Unbounded},
+    },
+    sync::{Arc, Mutex},
+};
+
+/// A structure used to manage range-based latch with mutual exclusion.
+///
+/// Currently used to ensure mutual exclusion between compaction filter and
+/// ingest SST operations. When using RocksDB
+/// IngestExternalFileOptions.allow_write = true for ingest SST, concurrent
+/// overlapping writes must be avoided during ingestion to ensure
+/// sequence number consistency across LSM-tree levels in RocksDB. However, the
+/// compaction filter might concurrently write overlapping keys to the default
+/// column family. For example, if a region is migrated out and then migrated
+/// back, it might cause concurrent compaction filter overlaps with the
+/// apply-snapshot-ingest process. Therefore, it must be made mutually exclusive
+/// with the ingest latch.
+//
+/// This implementation is designed for scenarios with low concurrency.
+/// In the current scenario, the number of compaction filter threads are limited
+/// by `RocksDB.max_background_jobs`, and the region worker, which handles
+/// apply-snapshot-ingest or destroy-peer-ingest, operates as a single thread.
+/// Due to this low level of concurrency, the overhead of range latch is
+/// minimal, and potential conflicts are rare.
+///
+/// NOTE: Both the compaction filter and ingest SST operations that
+/// use this `RangeLatch` enforce self-mutual exclusion. While this might
+/// appear somewhat overkill, its impact on performance is minimal due to
+/// the system's low concurrency and the brief duration of latch holding.
+///
+/// NOTE: Why do we use a range-latch instead of a region-id latch? This is
+/// because region-id is mutable and there is currently no mechanism to notify
+/// the compaction filter in real time. For example, if a region is migrated
+/// out, split, and then migrated back, the compaction filter might hold the old
+/// region-id while the apply-snapshot-ingest process holds the new region-id.
+#[derive(Debug, Default)]
+pub struct RangeLatch {
+    /// A BTreeMap storing active range latches.
+    /// Key: The start key of the range (sorted order).
+    /// Value: A tuple of:
+    ///   - `Arc<Mutex<()>>`: The latch object for this range.
+    ///   - `(Vec<u8>, Vec<u8>)`: The actual range definition (start_key,
+    ///     end_key).
+    range_latches: Mutex<BTreeMap<Vec<u8>, (Arc<Mutex<()>>, (Vec<u8>, Vec<u8>))>>,
+}
+
+impl RangeLatch {
+    pub fn new() -> Self {
+        Self {
+            range_latches: Mutex::new(BTreeMap::new()),
+        }
+    }
+
+    /// Acquires a range latch for the specified `[start_key, end_key)`.
+    /// This function ensures that a range latch is only granted when there are
+    /// no overlapping ranges already latched. If overlaps exist, the
+    /// function waits until those latches are released before proceeding.
+    ///
+    /// Live-locks can occur in this implementation. For example, a thread
+    /// attempting to acquire a latch for the range `[a, z)` might encounter
+    /// that `[a, b)` and `[b, c)` are already latched by other threads. The
+    /// thread will first wait for [a, b) to be released and successfully
+    /// acquire it. However, while waiting for [b, c) to be released,
+    /// another thread might acquire [a, b) again, forcing the original thread
+    /// to wait for [a, b) once more. This process could repeat
+    /// indefinitely if threads continuously "jump the queue.". Fortunately,
+    /// such live-locks are unlikely to persist for long due to the user's low
+    /// concurrency, as conflicting latches are eventually released, allowing
+    /// threads to make progress naturally.
+    ///
+    /// Deadlocks cannot occur in the current scenario, as each caller thread
+    /// holds at most one lock at a time.
+    pub fn acquire<'a>(
+        self: &'a Arc<Self>,
+        start_key: Vec<u8>,
+        end_key: Vec<u8>,
+    ) -> RangeLatchGuard<'a> {
+        loop {
+            let mut range_latches = self.range_latches.lock().unwrap();
+
+            // Collect all overlapping ranges
+            let overlapping_ranges = range_latches
+                .range((Unbounded::<Vec<u8>>, Excluded(end_key.clone())))
+                .filter(|(_, (_, (existing_start, existing_end)))| {
+                    !(end_key <= *existing_start || start_key >= *existing_end)
+                })
+                .map(|(key, (mutex, range))| (key.clone(), (mutex.clone(), range.clone())))
+                .collect::<Vec<_>>();
+
+            // If no conflicts, insert the new range and return the guard
+            if overlapping_ranges.is_empty() {
+                let mutex = Arc::new(Mutex::new(()));
+                let previous_value = range_latches.insert(
+                    start_key.clone(),
+                    (mutex.clone(), (start_key.clone(), end_key.clone())),
+                );
+                debug_assert!(previous_value.is_none());
+
+                // Now acquire the latch after releasing the write guard
+                let mutex_guard = mutex.lock().unwrap();
+                // Safety: `_mutex_guard` is declared before `handle` in `KeyHandleGuard`.
+                // So the mutex guard will be released earlier than the `Arc<KeyHandle>`.
+                // Then we can make sure the mutex guard doesn't point to released memory.
+                let mutex_guard = unsafe { std::mem::transmute(mutex_guard) };
+
+                return RangeLatchGuard {
+                    start_key,
+                    _mutex_guard: mutex_guard,
+                    handle: self,
+                };
+            }
+            drop(range_latches);
+
+            // Wait for all overlapping ranges to be released
+            for (_, (mutex, (..))) in overlapping_ranges {
+                let _guard = mutex.lock().unwrap();
+            }
+        }
+    }
+}
+
+/// A guard that holds the range latch.
+#[derive(Debug)]
+pub struct RangeLatchGuard<'a> {
+    start_key: Vec<u8>,
+    /// Hold the mutex guard to prevent concurrent access to the same range.
+    ///
+    /// This field must be declared before `handle` so it will be dropped before
+    /// `handle`.
+    _mutex_guard: std::sync::MutexGuard<'a, ()>,
+    /// Holds a reference to RangeLatch to release the latch when the guard is
+    /// dropped.
+    handle: &'a RangeLatch,
+}
+
+impl<'a> Drop for RangeLatchGuard<'a> {
+    fn drop(&mut self) {
+        let mut range_latches = self.handle.range_latches.lock().unwrap();
+        range_latches.remove(&self.start_key);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::HashSet,
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        },
+        thread,
+        time::Duration,
+    };
+
+    use rand::Rng;
+
+    use super::*;
+
+    #[test]
+    fn test_single_thread_non_overlapping_ranges() {
+        let latch = Arc::new(RangeLatch::new());
+
+        // Acquire non-overlapping ranges
+        let guard1 = latch.acquire(vec![0], vec![10]);
+        let guard2 = latch.acquire(vec![20], vec![30]);
+        let guard3 = latch.acquire(vec![30], vec![50]);
+
+        // Drop guards to release latches
+        drop(guard1);
+        drop(guard2);
+        drop(guard3);
+    }
+
+    #[test]
+    fn test_two_threads_overlapping_ranges() {
+        fn do_test(range1: (Vec<u8>, Vec<u8>), range2: (Vec<u8>, Vec<u8>)) {
+            let latch = Arc::new(RangeLatch::new());
+            let latch_clone = Arc::clone(&latch);
+            let is_thread_done = Arc::new(AtomicBool::new(false));
+            let is_thread_done_clone = Arc::clone(&is_thread_done);
+
+            // Main thread acquires the first latch
+            let guard = latch.acquire(range1.0, range1.1);
+
+            let handle = thread::spawn(move || {
+                let _guard = latch_clone.acquire(range2.0, range2.1);
+                is_thread_done_clone.store(true, Ordering::SeqCst);
+            });
+
+            thread::sleep(Duration::from_millis(500));
+            // Verify that the second thread is still waiting
+            assert!(!is_thread_done.load(Ordering::SeqCst));
+
+            // Release the first latch
+            drop(guard);
+
+            // Wait a bit to let the second thread complete
+            thread::sleep(Duration::from_millis(100));
+            assert!(is_thread_done.load(Ordering::SeqCst));
+
+            // Ensure the second thread completes successfully
+            handle.join().unwrap();
+        }
+
+        // Test different overlapping cases
+        do_test((vec![0], vec![10]), (vec![5], vec![15])); // Overlap at the end
+        do_test((vec![5], vec![15]), (vec![0], vec![10])); // Overlap at the begin
+        do_test((vec![0], vec![10]), (vec![4], vec![5])); // Contained within
+        do_test((vec![5], vec![15]), (vec![0], vec![20])); // Fully contained
+    }
+
+    fn concurrent_random_ranges_test(num_threads: usize, num_latches: usize) {
+        // Shared latch and active ranges tracker
+        let latch = Arc::new(RangeLatch::new());
+        let active_ranges = Arc::new(Mutex::new(HashSet::new()));
+
+        let mut handles = Vec::new();
+
+        for _ in 0..num_threads {
+            let latch_clone = Arc::clone(&latch);
+            let active_ranges_clone = Arc::clone(&active_ranges);
+
+            handles.push(thread::spawn(move || {
+                let mut rng = rand::thread_rng();
+
+                for _ in 0..num_latches {
+                    let start: u8 = rng.gen_range(0..200);
+                    let end = rng.gen_range(start + 1..201);
+
+                    // Acquire the range latch
+                    let _guard = latch_clone.acquire(vec![start], vec![end]);
+
+                    // Check for overlap
+                    {
+                        let mut ranges = active_ranges_clone.lock().unwrap();
+                        for (existing_start, existing_end) in ranges.iter() {
+                            assert!(
+                                end <= *existing_start || start >= *existing_end,
+                                "Overlapping range detected: [{}, {}) overlaps with [{}, {})",
+                                start,
+                                end,
+                                existing_start,
+                                existing_end
+                            );
+                        }
+
+                        // Add the current range to the active set
+                        ranges.insert((start, end));
+                    }
+
+                    // Hold the latch for a short period
+                    thread::sleep(Duration::from_millis(10));
+
+                    // Remove the range from the active set
+                    {
+                        let mut ranges = active_ranges_clone.lock().unwrap();
+                        ranges.remove(&(start, end));
+                    }
+                }
+            }));
+        }
+
+        // Wait for all threads to complete
+        for handle in handles {
+            handle.join().unwrap();
+        }
+    }
+
+    #[test]
+    fn test_concurrent_random_ranges_many_latches() {
+        concurrent_random_ranges_test(5, 100);
+    }
+
+    #[test]
+    fn test_concurrent_random_ranges_many_threads() {
+        concurrent_random_ranges_test(100, 5);
+    }
+}

--- a/src/server/gc_worker/compaction_filter.rs
+++ b/src/server/gc_worker/compaction_filter.rs
@@ -282,10 +282,12 @@ impl CompactionFilterFactory for WriteCompactionFilterFactory {
 
 pub struct DeleteBatch<B> {
     pub batch: Either<B, Vec<Key>>,
+    pub smallest_key: Option<Key>,
+    pub largest_key: Option<Key>,
 }
 
 impl<B: WriteBatch> DeleteBatch<B> {
-    fn new<EK>(db: &Option<EK>) -> Self
+    pub fn new<EK>(db: &Option<EK>) -> Self
     where
         EK: KvEngine<WriteBatch = B>,
     {
@@ -294,11 +296,34 @@ impl<B: WriteBatch> DeleteBatch<B> {
                 Some(db) => Either::Left(db.write_batch_with_cap(DEFAULT_DELETE_BATCH_SIZE)),
                 None => Either::Right(Vec::with_capacity(64)),
             },
+            smallest_key: None,
+            largest_key: None,
         }
     }
 
     // `key` has prefix `DATA_KEY`.
-    fn delete(&mut self, key: &[u8], ts: TimeStamp) -> Result<(), String> {
+    pub fn delete(&mut self, key: &[u8], ts: TimeStamp) -> Result<(), String> {
+        match &self.smallest_key {
+            Some(smallest) => {
+                debug_assert!(key >= smallest.as_encoded().as_slice());
+            }
+            None => {
+                // Smallest key is the first key because compaction processes keys in asending
+                // order.
+                self.smallest_key = Some(Key::from_encoded_slice(key));
+            }
+        }
+        match &self.largest_key {
+            Some(largest) => {
+                debug_assert!(key >= largest.as_encoded().as_slice());
+                self.largest_key = Some(Key::from_encoded_slice(key));
+            }
+            None => {
+                self.largest_key = Some(Key::from_encoded_slice(key));
+            }
+        }
+        debug_assert_le!(self.smallest_key, self.largest_key);
+
         match &mut self.batch {
             Either::Left(batch) => {
                 let key = Key::from_encoded_slice(key).append_ts(ts);
@@ -550,6 +575,34 @@ impl WriteCompactionFilter {
         if self.write_batch.count() > DEFAULT_DELETE_BATCH_COUNT || force {
             let err = match &mut self.write_batch.batch {
                 Either::Left(wb) => {
+                    // Acquire latch to prevent concurrency with ingestion operations
+                    // using RocksDB IngestExternalFileOptions.allow_write = true.
+                    let _region_inject_latch_guard = match self.engine.as_ref() {
+                        Some(engine) => {
+                            let smallest_key = self
+                                .write_batch
+                                .smallest_key
+                                .as_ref()
+                                .unwrap()
+                                .as_encoded()
+                                .clone();
+                            let largest_key = self
+                                .write_batch
+                                .largest_key
+                                .as_ref()
+                                .unwrap()
+                                .as_encoded()
+                                .clone();
+                            Some(
+                                engine
+                                    .ingest_latch
+                                    .acquire(smallest_key, keys::next_key(&largest_key)),
+                            )
+                        }
+                        None => None,
+                    };
+                    fail_point!("compaction_filter_ingest_latch_acquired_flush");
+
                     let mut wopts = WriteOptions::default();
                     wopts.set_no_slowdown(true);
                     match do_flush(wb, &wopts) {
@@ -695,6 +748,7 @@ impl CompactionFilter for WriteCompactionFilter {
         value: &[u8],
         value_type: CompactionFilterValueType,
     ) -> CompactionFilterDecision {
+        fail_point!("before_compaction_filter");
         if self.encountered_errors {
             // If there are already some errors, do nothing.
             return CompactionFilterDecision::Keep;
@@ -1237,5 +1291,56 @@ pub mod tests {
         gc_runner.target_level = Some(6);
         gc_runner.safe_point(200).gc(&raw_engine);
         must_get_none(&mut engine, b"zkey", 200);
+    }
+
+    #[test]
+    fn test_delete_batch_smallest_and_largest_key_update() {
+        let mut cfg = DbConfig::default();
+        cfg.writecf.disable_auto_compactions = true;
+        cfg.writecf.dynamic_level_bytes = false;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let builder = TestEngineBuilder::new().path(dir.path());
+        let engine = builder.build_with_cfg(&cfg).unwrap();
+        let raw_engine = engine.get_rocksdb();
+
+        let mut delete_batch = DeleteBatch::new(&Some(raw_engine.clone()));
+
+        let key1 = b"key1";
+        let key2 = b"key2";
+        let key3 = b"key3";
+        let ts1 = TimeStamp::new(100);
+        let ts2 = TimeStamp::new(200);
+        let ts3 = TimeStamp::new(300);
+
+        delete_batch.delete(key1, ts1).unwrap();
+        assert_eq!(
+            delete_batch.smallest_key.as_ref().unwrap().as_encoded(),
+            key1
+        );
+        assert_eq!(
+            delete_batch.largest_key.as_ref().unwrap().as_encoded(),
+            key1
+        );
+
+        delete_batch.delete(key2, ts2).unwrap();
+        assert_eq!(
+            delete_batch.smallest_key.as_ref().unwrap().as_encoded(),
+            key1
+        );
+        assert_eq!(
+            delete_batch.largest_key.as_ref().unwrap().as_encoded(),
+            key2
+        );
+
+        delete_batch.delete(key3, ts3).unwrap();
+        assert_eq!(
+            delete_batch.smallest_key.as_ref().unwrap().as_encoded(),
+            key1
+        );
+        assert_eq!(
+            delete_batch.largest_key.as_ref().unwrap().as_encoded(),
+            key3
+        );
     }
 }

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -18,8 +18,8 @@ use collections::HashMap;
 use concurrency_manager::{ActionOnInvalidMaxTs, ConcurrencyManager};
 use engine_rocks::FlowInfo;
 use engine_traits::{
-    raw_ttl::ttl_current_ts, DeleteStrategy, Error as EngineError, KvEngine, MiscExt, Range,
-    WriteBatch, WriteOptions, CF_DEFAULT, CF_LOCK, CF_WRITE,
+    raw_ttl::ttl_current_ts, DeleteStrategy, Error as EngineError, ImportExt, KvEngine, MiscExt,
+    Range, WriteBatch, WriteOptions, CF_DEFAULT, CF_LOCK, CF_WRITE,
 };
 use file_system::{IoType, WithIoType};
 use futures::executor::block_on;
@@ -1054,6 +1054,19 @@ impl<E: Engine> GcRunnerCore<E> {
                 id,
                 region_info_provider,
             } => {
+                let smallest_key = wb.smallest_key.as_ref().unwrap().as_encoded().as_slice();
+                let largest_key = wb.largest_key.as_ref().unwrap().as_encoded().as_slice();
+                // unwrap() is safe as None only occurs in multi-rocksdb version.
+                let kv_engine = self.engine.kv_engine().unwrap();
+                // Acquire latch to prevent concurrency with ingestion operations
+                // using RocksDB IngestExternalFileOptions.allow_write = true.
+                let _ingest_latch_guard = kv_engine.acquire_ingest_latch(Range {
+                    start_key: smallest_key,
+                    end_key: keys::next_key(largest_key).as_slice(),
+                });
+
+                fail_point!("after_gc_orphan_versions_ingest_latch_acquired");
+
                 let count = wb.count();
                 match wb.batch {
                     Either::Left(mut wb) => {
@@ -1544,11 +1557,10 @@ pub mod test_gc_worker {
 
 #[cfg(test)]
 mod tests {
-
     use std::{
         collections::{BTreeMap, BTreeSet},
         path::Path,
-        sync::mpsc,
+        sync::{atomic::AtomicBool, mpsc},
         thread,
         time::Duration,
     };
@@ -2863,5 +2875,129 @@ mod tests {
         cfg_manager.dispatch(config_change).unwrap();
 
         assert_eq!(gc_worker.get_worker_thread_count(), 2);
+    }
+
+    // This test verifies that the GcOrphanVersions task is blocked by concurrent
+    // ingest operations.
+    #[test]
+    fn test_gc_orphan_version_blocked_by_ingest() {
+        let store_id = 1;
+        let engine = TestEngineBuilder::new().build().unwrap();
+        let prefixed_engine = PrefixedEngine(engine.clone());
+        let (tx, _rx) = mpsc::channel();
+        let cfg = GcConfig::default();
+        let coprocessor_host = CoprocessorHost::default();
+        let mut runner = GcRunnerCore::new(
+            store_id,
+            prefixed_engine.clone(),
+            tx,
+            GcWorkerConfigManager(Arc::new(VersionTrack::new(cfg.clone())), None)
+                .0
+                .tracker("gc-worker".to_owned()),
+            cfg,
+            coprocessor_host,
+        );
+
+        let kv_engine = engine.kv_engine().unwrap();
+        let _ingest_latch_guard = kv_engine.acquire_ingest_latch(Range {
+            start_key: b"a",
+            end_key: b"b",
+        });
+
+        let gc_task_completed = Arc::new(AtomicBool::new(false));
+        let gc_task_completed_clone = gc_task_completed.clone();
+        let gc_handle = thread::spawn(move || {
+            let mut wb = DeleteBatch::new(&Some(engine.kv_engine().unwrap()));
+            wb.delete(b"a", 100_u64.into()).unwrap();
+            wb.delete(b"b", 101_u64.into()).unwrap();
+            let region_info_provider = Arc::new(MockRegionInfoProvider::new(vec![]));
+            let task = GcTask::OrphanVersions {
+                wb,
+                region_info_provider,
+                id: 0,
+            };
+            runner.run(task);
+            gc_task_completed_clone.store(true, Ordering::SeqCst);
+        });
+
+        thread::sleep(Duration::from_millis(500));
+        // The GC task must remain pending as _ingest_latch_guard is holding the latch.
+        assert!(
+            !gc_task_completed.load(Ordering::SeqCst),
+            "GC task completed before dropping the guard"
+        );
+        drop(_ingest_latch_guard);
+        gc_handle.join().expect("Gc thread panicked");
+        // The GC task must have finished as _ingest_latch_guard has released the latch.
+        assert!(
+            gc_task_completed.load(Ordering::SeqCst),
+            "GC task did not complete as expected"
+        );
+    }
+
+    // This test verifies that the GcOrphanVersions task blocks the ingest
+    // operation.
+    #[cfg(feature = "failpoints")]
+    #[test]
+    fn test_gc_orphan_version_blocks_ingest() {
+        let store_id = 1;
+        let engine = TestEngineBuilder::new().build().unwrap();
+        let prefixed_engine = PrefixedEngine(engine.clone());
+        let (tx, _rx) = mpsc::channel();
+        let cfg = GcConfig::default();
+        let coprocessor_host = CoprocessorHost::default();
+        let mut runner = GcRunnerCore::new(
+            store_id,
+            prefixed_engine.clone(),
+            tx,
+            GcWorkerConfigManager(Arc::new(VersionTrack::new(cfg.clone())), None)
+                .0
+                .tracker("gc-worker".to_owned()),
+            cfg,
+            coprocessor_host,
+        );
+
+        let engine_clone = engine.clone();
+        let gc_handle = thread::spawn(move || {
+            fail::cfg("after_gc_orphan_versions_ingest_latch_acquired", "pause").unwrap();
+            let mut wb = DeleteBatch::new(&Some(engine_clone.kv_engine().unwrap()));
+            wb.delete(b"a", 100_u64.into()).unwrap();
+            wb.delete(b"b", 101_u64.into()).unwrap();
+            let region_info_provider = Arc::new(MockRegionInfoProvider::new(vec![]));
+            let task = GcTask::OrphanVersions {
+                wb,
+                region_info_provider,
+                id: 0,
+            };
+            runner.run(task);
+        });
+
+        // Wait gc_handle to start.
+        thread::sleep(Duration::from_millis(500));
+        let ingest_task_completed = Arc::new(AtomicBool::new(false));
+        let ingest_task_completed_clone = ingest_task_completed.clone();
+        let ingest_handle = thread::spawn(move || {
+            let kv_engine = engine.kv_engine().unwrap();
+            let _ingest_latch_guard = kv_engine.acquire_ingest_latch(Range {
+                start_key: b"a",
+                end_key: b"b",
+            });
+            ingest_task_completed_clone.store(true, Ordering::SeqCst);
+        });
+        thread::sleep(Duration::from_millis(500));
+        // The ingest task must remain pending as _gc_latch_guard is holding the latch.
+        assert!(
+            !ingest_task_completed.load(Ordering::SeqCst),
+            "Ingest task completed before dropping the GC latch guard"
+        );
+        fail::remove("after_gc_orphan_versions_ingest_latch_acquired");
+        thread::sleep(Duration::from_millis(500));
+        gc_handle.join().expect("Gc thread panicked");
+        ingest_handle.join().expect("Ingest thread panicked");
+        // The ingest task must have finished as _gc_latch_guard has released the latch.
+        assert!(
+            ingest_task_completed.load(Ordering::SeqCst),
+            "Ingest task did not complete as expected"
+        );
     }
 }

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -2886,7 +2886,6 @@ mod tests {
         let prefixed_engine = PrefixedEngine(engine.clone());
         let (tx, _rx) = mpsc::channel();
         let cfg = GcConfig::default();
-        let coprocessor_host = CoprocessorHost::default();
         let mut runner = GcRunnerCore::new(
             store_id,
             prefixed_engine.clone(),
@@ -2895,7 +2894,6 @@ mod tests {
                 .0
                 .tracker("gc-worker".to_owned()),
             cfg,
-            coprocessor_host,
         );
 
         let kv_engine = engine.kv_engine().unwrap();
@@ -2945,7 +2943,6 @@ mod tests {
         let prefixed_engine = PrefixedEngine(engine.clone());
         let (tx, _rx) = mpsc::channel();
         let cfg = GcConfig::default();
-        let coprocessor_host = CoprocessorHost::default();
         let mut runner = GcRunnerCore::new(
             store_id,
             prefixed_engine.clone(),
@@ -2954,7 +2951,6 @@ mod tests {
                 .0
                 .tracker("gc-worker".to_owned()),
             cfg,
-            coprocessor_host,
         );
 
         let engine_clone = engine.clone();

--- a/tests/failpoints/cases/mod.rs
+++ b/tests/failpoints/cases/mod.rs
@@ -33,6 +33,7 @@ mod test_replica_stale_read;
 mod test_server;
 mod test_snap;
 mod test_split_region;
+mod test_sst_ingest;
 mod test_sst_recovery;
 mod test_stale_peer;
 mod test_stale_read;

--- a/tests/failpoints/cases/test_sst_ingest.rs
+++ b/tests/failpoints/cases/test_sst_ingest.rs
@@ -1,0 +1,468 @@
+// Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::{
+    sync::{
+        mpsc::{sync_channel, Receiver, RecvTimeoutError},
+        Arc,
+    },
+    thread,
+    thread::JoinHandle,
+    time::Duration,
+};
+
+use engine_traits::MiscExt;
+use grpcio::{ChannelBuilder, Environment};
+use kvproto::{
+    kvrpcpb::{Context, Op},
+    metapb::{Peer, Region},
+    tikvpb::TikvClient,
+};
+use test_pd_client::TestPdClient;
+use test_raftstore::*;
+use tikv::server::gc_worker::TestGcRunner;
+use tikv_util::HandyRwLock;
+
+// Prepares test data for verifying the behavior of the compaction filter.
+//
+// This function creates 3 regions and simulates some key-value writes with
+// timestamps. Specifically, it splits the keyspace into the following regions:
+// - Region A: Covers the range `[-infinite, zb)`, where key `za` has values
+//   written at timestamps 101 and 103.
+// - Region B: Covers the range `[zb, zc)`, where key `zb` has values written at
+//   timestamps 101 and 103.
+// - Region C: Covers the range `[zc, +infinite)`.
+//
+// The function also flushes the data to disk for debugging purposes, allowing
+// tools like `tikv-ctl` to inspect the on-disk data.
+fn prepare_data_used_by_compaction_filter(
+    client: &TikvClient,
+    ctx: &Context,
+    cluster: &mut Cluster<ServerCluster>,
+) {
+    let large_value = vec![b'x'; 300];
+
+    {
+        let keys = vec![b"a".to_vec(), b"b".to_vec()];
+        for start_ts in [101, 103] {
+            let commit_ts = start_ts + 1;
+
+            for pk in &keys {
+                let muts = vec![new_mutation(Op::Put, pk.as_slice(), &large_value)];
+                must_kv_prewrite(client, ctx.clone(), muts, pk.clone(), start_ts);
+            }
+            must_kv_commit(
+                client,
+                ctx.clone(),
+                keys.clone(),
+                start_ts,
+                commit_ts,
+                commit_ts,
+            );
+        }
+    }
+
+    // Region c needs to contain data to trigger the apply-snapshot process.
+    // However, this data will not trigger the compaction filter, resulting in
+    // only one version being created.
+    let pk = b"c";
+    let muts = vec![new_mutation(Op::Put, pk.as_slice(), &large_value)];
+    must_kv_prewrite(client, ctx.clone(), muts, pk.to_vec(), 101);
+    must_kv_commit(client, ctx.clone(), vec![pk.to_vec()], 101, 102, 102);
+
+    let region_a = cluster.get_region(b"a");
+    cluster.must_split(&region_a, "b".as_bytes());
+    let region_b = cluster.get_region(b"b");
+    cluster.must_split(&region_b, "c".as_bytes());
+    let _ = cluster.get_region(b"c");
+    cluster.check_regions_number(3);
+
+    // Flush data for debugging so that `tikv-ctl` can be used to inspect the data.
+    cluster
+        .get_engine(1)
+        .flush_cfs(&["default", "write"], true)
+        .unwrap();
+    cluster
+        .get_engine(2)
+        .flush_cfs(&["default", "write"], true)
+        .unwrap();
+    cluster
+        .get_engine(3)
+        .flush_cfs(&["default", "write"], true)
+        .unwrap();
+}
+
+fn setup_cluster(
+    region_to_migrate: &[u8],
+) -> (Cluster<ServerCluster>, Region, Peer, Arc<TestPdClient>) {
+    let env = Arc::new(Environment::new(1));
+    let (mut cluster, leader, ctx) = must_new_cluster_mul(3);
+    let channel =
+        ChannelBuilder::new(env).connect(&cluster.sim.rl().get_addr(leader.get_store_id()));
+    let client = TikvClient::new(channel);
+    let pd_client = cluster.pd_client.clone();
+    pd_client.disable_default_operator();
+
+    prepare_data_used_by_compaction_filter(&client, &ctx, &mut cluster);
+
+    // Get the region dynamically based on the `region_to_migrate` parameter.
+    let region = cluster.get_region(region_to_migrate);
+    let peer = region.get_peers()[1].clone();
+
+    (cluster, region, peer, pd_client)
+}
+
+fn start_region_migrate(
+    region_id: u64,
+    pd_client: Arc<TestPdClient>,
+    peer: Peer,
+) -> JoinHandle<()> {
+    thread::spawn(move || {
+        // Force SST ingestion instead of using RocksDB writes.
+        fail::cfg("apply_cf_without_ingest_false", "return").unwrap();
+        // Disabled for scenarios that are not relevant.
+        fail::cfg("before_clean_stale_ranges", "return").unwrap();
+
+        pd_client.must_remove_peer(region_id, peer.clone());
+        pd_client.must_add_peer(region_id, peer.clone());
+    })
+}
+
+fn start_compaction_filter(cluster: &Cluster<ServerCluster>, store_id: u64) -> JoinHandle<()> {
+    let gc_engine = cluster.get_engine(store_id);
+    thread::spawn(move || {
+        let mut gc_runner = TestGcRunner::new(200);
+        gc_runner.gc(&gc_engine);
+    })
+}
+
+fn verify_pending(rx: &Receiver<bool>, duration: u64) {
+    assert_eq!(
+        rx.recv_timeout(Duration::from_millis(duration)),
+        Err(RecvTimeoutError::Timeout)
+    );
+}
+
+fn verify_completed(rx: &Receiver<bool>) {
+    assert_eq!(rx.recv_timeout(Duration::from_millis(500)), Ok(true));
+}
+
+// Test whether ingestion blocks the compaction filter based on
+// whether they have overlapping keys.
+//
+// Steps:
+// - Prepare 3 regions with test data and ensure the environment is set up.
+// - Simulate a apply-snapshot process that acquires the range latch and pauses.
+// - Start the compaction filter GC and verify that it cannot acquire the latch
+//   while the apply-snapshot process holds it.
+// - Resume the apply-snapshot ingestion process and verify that the compaction
+//   filter GC can acquire the latch and complete its operation.
+fn blocked_by_ingest_test(region_to_migrate: &[u8], ingest_type: &str) {
+    let (cluster, region, peer, pd_client) = setup_cluster(region_to_migrate);
+    let region_id = region.id;
+
+    // If testing `clean_overlap_ingest`, skip `apply_snapshot`; otherwise, skip
+    // `clean_overlap_ingest`.
+    if ingest_type == "clean_overlap_ingest" {
+        fail::cfg("apply_snap_cleanup_range", "return").unwrap();
+        fail::cfg("manually_set_max_delete_count_by_key", "return").unwrap();
+    } else {
+        fail::cfg("before_clean_overlap_ranges", "return").unwrap();
+    }
+
+    // Start and pause the apply-snapshot process.
+    fail::cfg("after_apply_snapshot_ingest_latch_acquired", "pause").unwrap();
+    let apply_snap_handle = start_region_migrate(region_id, pd_client, peer.clone());
+
+    // Wait for snapshot to acquire the latch.
+    sleep_ms(500);
+
+    let (tx, rx) = sync_channel(0);
+    fail::cfg_callback("compaction_filter_ingest_latch_acquired_flush", move || {
+        // Ignore the return value because the ingest process triggers twice. At the
+        // second trigger, the channel might already be dropped, causing send to fail.
+        // However, this does not affect the test functionality.
+        let _ = tx.send(true);
+    })
+    .unwrap();
+
+    // Start GC, which might be blocked by the apply-snapshot thread, depending
+    // on whether the ranges overlap.
+    let gc_handle = start_compaction_filter(&cluster, peer.store_id);
+
+    if region_to_migrate != b"c" {
+        // Other regions overlap, so the GC thread will be blocked.
+        verify_pending(&rx, 500);
+    } else {
+        // Region c does not overlap with the snapshot process.
+        verify_completed(&rx);
+        fail::remove("after_apply_snapshot_ingest_latch_acquired");
+        gc_handle.join().expect("GC thread panicked");
+        apply_snap_handle
+            .join()
+            .expect("apply snapshot thread panicked");
+        fail::remove("compaction_filter_ingest_latch_acquired_flush");
+        return;
+    }
+
+    // Resume the snapshot process.
+    fail::remove("after_apply_snapshot_ingest_latch_acquired");
+    // Wait for the snapshot process to release the latch.
+    sleep_ms(500);
+    // The GC thread can continue after the snapshot process releases the latch.
+    verify_completed(&rx);
+    gc_handle.join().expect("GC thread panicked");
+    apply_snap_handle
+        .join()
+        .expect("apply snapshot thread panicked");
+    fail::remove("compaction_filter_ingest_latch_acquired_flush");
+}
+
+// Test Region A: Verify that the compaction filter is blocked because it
+// overlaps with the region's data.
+#[test]
+fn test_compaction_filter_blocked_by_snapshot_ingest_basic() {
+    blocked_by_ingest_test(b"a", "snapshot_ingest");
+}
+
+// Test Region B: Verify that the compaction filter is blocked because its
+// `end_key` matches the `Region.start_key` and overlaps with this region's
+// data.
+#[test]
+fn test_compaction_filter_blocked_by_snapshot_ingest_boundary() {
+    blocked_by_ingest_test(b"b", "snapshot_ingest");
+}
+
+// Test Region C: Verify that the compaction filter is not blocked because it
+// does not overlap with this region's data.
+#[test]
+fn test_compaction_filter_not_blocked_by_snapshot_ingest() {
+    blocked_by_ingest_test(b"c", "snapshot_ingest");
+}
+
+// Similar to `test_compaction_filter_blocked_by_snapshot_ingest_basic`, but
+// tests the `clean_overlap_range`.
+#[test]
+fn test_compaction_filter_blocked_by_clean_overlap_ingest_basic() {
+    blocked_by_ingest_test(b"a", "clean_overlap_ingest");
+}
+
+// Similar to `test_compaction_filter_blocked_by_snapshot_ingest_boundary`, but
+// tests the `clean_overlap_range`.
+#[test]
+fn test_compaction_filter_blocked_by_clean_overlap_ingest_boundary() {
+    blocked_by_ingest_test(b"b", "clean_overlap_ingest");
+}
+
+// Similar to `test_compaction_filter_not_blocked_by_snapshot_ingest`, but
+// tests the `clean_overlap_range`.
+#[test]
+fn test_compaction_filter_not_blocked_by_clean_overlap_ingest() {
+    blocked_by_ingest_test(b"c", "clean_overlap_ingest");
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// The following tests is similar to above tests, but tests the reverse scenario
+// where compaction filter blocks ingestion.
+///////////////////////////////////////////////////////////////////////////////
+
+fn blocks_ingest_test(region_to_migrate: &[u8], ingest_type: &str) {
+    let (cluster, region, peer, pd_client) = setup_cluster(region_to_migrate);
+
+    // Start and pause the GC thread.
+    fail::cfg("compaction_filter_ingest_latch_acquired_flush", "pause").unwrap();
+    let gc_handle = start_compaction_filter(&cluster, peer.store_id);
+
+    let (tx, rx) = sync_channel(0);
+    fail::cfg_callback("after_apply_snapshot_ingest_latch_acquired", move || {
+        // Ignore the return value because the ingest process triggers twice. At the
+        // second trigger, the channel might already be dropped, causing send to fail.
+        // However, this does not affect the test functionality.
+        let _ = tx.send(true);
+    })
+    .unwrap();
+
+    let region_id = region.id;
+
+    // If testing `clean_overlap_ingest`, skip `apply_snapshot`; otherwise, skip
+    // `clean_overlap_ingest`.
+    if ingest_type == "clean_overlap_ingest" {
+        fail::cfg("apply_snap_cleanup_range", "return").unwrap();
+        fail::cfg("manually_set_max_delete_count_by_key", "return").unwrap();
+    } else {
+        fail::cfg("before_clean_overlap_ranges", "return").unwrap();
+    }
+    // Start the apply-snapshot thread, which might be blocked by the GC thread,
+    // depending on whether the ranges overlap.
+    let apply_snap_handle = start_region_migrate(region_id, pd_client, peer.clone());
+    // Wait for snapshot to acquire the latch.
+    sleep_ms(500);
+    if region_to_migrate != b"c" {
+        // Other regions overlap, so the snapshot process will be blocked.
+        verify_pending(&rx, 500);
+    } else {
+        // Region c does not overlap with the GC thread.
+        verify_completed(&rx);
+        fail::remove("compaction_filter_ingest_latch_acquired_flush");
+        gc_handle.join().expect("GC thread panicked");
+        apply_snap_handle
+            .join()
+            .expect("apply-snapshot thread panicked");
+        fail::remove("after_apply_snapshot_ingest_latch_acquired");
+        return;
+    }
+
+    // Resume the compaction filter process.
+    fail::remove("compaction_filter_ingest_latch_acquired_flush");
+    // Wait for the GC thread to release the latch.
+    sleep_ms(500);
+    // The apply-snapshot thread can continue after the GC thread releases the
+    // latch.
+    verify_completed(&rx);
+    gc_handle.join().expect("GC thread panicked");
+    apply_snap_handle
+        .join()
+        .expect("apply snapshot thread panicked");
+    fail::remove("after_apply_snapshot_ingest_latch_acquired");
+}
+
+#[test]
+fn test_compaction_filter_blocks_snapshot_ingest_basic() {
+    blocks_ingest_test(b"a", "snapshot_ingest");
+}
+
+#[test]
+fn test_compaction_filter_blocks_snapshot_ingest_boundary() {
+    blocks_ingest_test(b"b", "snapshot_ingest");
+}
+
+#[test]
+fn test_compaction_filter_not_blocks_snapshot_ingest() {
+    blocks_ingest_test(b"c", "snapshot_ingest");
+}
+
+#[test]
+fn test_compaction_filter_blocks_clean_overlap_ingest_basic() {
+    blocks_ingest_test(b"a", "clean_overlap_ingest");
+}
+
+#[test]
+fn test_compaction_filter_blocks_clean_overlap_ingest_boundary() {
+    blocks_ingest_test(b"b", "clean_overlap_ingest");
+}
+
+#[test]
+fn test_compaction_filter_not_blocks_clean_overlap_ingest() {
+    blocks_ingest_test(b"c", "clean_overlap_ingest");
+}
+
+// This test verifies that when a region is migrated out and then migrated back,
+// the destroy-peer task must complete before the apply-snapshot task.
+//
+// Currently, since the region worker operates on a single thread, when a
+// region is migrated out and back again, the destroy-peer task is enqueued
+// before the apply-snapshot task, ensuring sequential execution without
+// concurrency.
+//
+// As the apply-snapshot ingestion uses RocksDB
+// IngestExternalFileOption.allow_write = true, concurrent writes are not
+// expected during apply-snapshot ingestion. Therefore, this test ensures that
+// there are no concurrent writes from destroy-peer during this process.
+#[test]
+fn test_apply_snapshot_must_wait_destroy_peer() {
+    let (mut cluster, ..) = must_new_cluster_mul(3);
+
+    cluster.must_put(b"k1", b"v1");
+    let peer = new_peer(2, 2);
+    let pk = b"k1".to_vec();
+    let region = cluster.get_region(&pk);
+    let region_id = region.get_id();
+    let pd_client = cluster.pd_client.clone();
+    pd_client.disable_default_operator();
+
+    // Start the destroy-peer process, which will pause at
+    // before_clean_stale_ranges.
+    let pd_client_clone1 = pd_client.clone();
+    let peer_clone1 = peer.clone();
+    let destroy_handle = thread::spawn(move || {
+        fail::cfg("before_clean_stale_ranges", "pause").unwrap();
+        pd_client_clone1.must_remove_peer(region_id, peer_clone1);
+    });
+    // Wait for the destroy-peer process to pause.
+    sleep_ms(500);
+
+    let (tx, rx) = sync_channel(0);
+    fail::cfg_callback("apply_snapshot_finished", move || {
+        tx.send(true).unwrap();
+    })
+    .unwrap();
+
+    let pd_client_clone2 = pd_client.clone();
+    let peer_clone2 = peer.clone();
+    let apply_handle = thread::spawn(move || {
+        pd_client_clone2.must_add_peer(region_id, peer_clone2);
+    });
+
+    // Verify that apply-snapshot is pending.
+    assert_eq!(
+        rx.recv_timeout(Duration::from_millis(500)),
+        Err(RecvTimeoutError::Timeout)
+    );
+
+    // Resume the destroy-peer process.
+    fail::remove("before_clean_stale_ranges");
+    // Verify that apply-snapshot is finished
+    assert_eq!(rx.recv_timeout(Duration::from_millis(1000)), Ok(true));
+    destroy_handle.join().expect("destroy handle panicked");
+    apply_handle.join().expect("apply handle panicked");
+}
+
+// This test ensures that the destroy-peer process will wait for the ongoing
+// foreground writes of the same region to finish.
+//
+// Since test_apply_snapshot_must_wait_destroy_peer() has already verified that
+// when a region is migrated out and then back, the apply-snapshot process will
+// wait for the destroy-peer process to complete first, it can be considered
+// that apply-snapshot will also wait for the ongoing foreground writes to
+// finish.
+#[test]
+fn test_destroy_peer_must_wait_ongoing_foreground_writes() {
+    let (mut cluster, ..) = must_new_cluster_mul(3);
+    // Use peer_id 3 since on_apply_write_cmd only works on peer 3.
+    let peer = new_peer(3, 3);
+    let pk = b"k1".to_vec();
+    let region = cluster.get_region(&pk);
+    let region_id = region.get_id();
+    let pd_client = cluster.pd_client.clone();
+    pd_client.disable_default_operator();
+
+    fail::cfg("on_apply_write_cmd", "pause").unwrap();
+    cluster.put(b"k1", b"v1").unwrap();
+    // Wait for foreground writes to pause.
+    sleep_ms(500);
+
+    let (tx, rx) = sync_channel(0);
+    fail::cfg_callback("raft_store_after_destroy_peer", move || {
+        tx.send(true).unwrap();
+    })
+    .unwrap();
+
+    // Start the destroy-peer process, which will pause at
+    // before_clean_stale_ranges.
+    let pd_client_clone1 = pd_client.clone();
+    let peer_clone1 = peer.clone();
+    let destroy_handle = thread::spawn(move || {
+        pd_client_clone1.must_remove_peer(region_id, peer_clone1);
+    });
+
+    // Verify that apply-snapshot is pending.
+    assert_eq!(
+        rx.recv_timeout(Duration::from_millis(500)),
+        Err(RecvTimeoutError::Timeout)
+    );
+
+    // Resume the foreground writes.
+    fail::remove("on_apply_write_cmd");
+    // Verify that apply-snapshot is finished
+    assert_eq!(rx.recv_timeout(Duration::from_millis(500)), Ok(true));
+    destroy_handle.join().expect("destroy thread panicked");
+}

--- a/tests/integrations/storage/test_titan.rs
+++ b/tests/integrations/storage/test_titan.rs
@@ -410,13 +410,14 @@ fn test_delete_files_in_range_for_titan() {
         .iter()
         .map(|s| s.as_str())
         .collect::<Vec<&str>>();
-    apply_sst_cf_files_by_ingest(&tmp_file_paths, &engines1.kv, CF_DEFAULT).unwrap();
+    apply_sst_cf_files_by_ingest(&tmp_file_paths, &engines1.kv, CF_DEFAULT, vec![], vec![])
+        .unwrap();
     let tmp_file_paths = cf_file_write.tmp_file_paths();
     let tmp_file_paths = tmp_file_paths
         .iter()
         .map(|s| s.as_str())
         .collect::<Vec<&str>>();
-    apply_sst_cf_files_by_ingest(&tmp_file_paths, &engines1.kv, CF_WRITE).unwrap();
+    apply_sst_cf_files_by_ingest(&tmp_file_paths, &engines1.kv, CF_WRITE, vec![], vec![]).unwrap();
 
     // Do scan on other DB.
     let mut r = Region::default();


### PR DESCRIPTION
This is a manual CP of #18096

This PR implements the proposal described in [issue #18081](https://github.com/tikv/tikv/issues/18081). With this change, the P99 apply wait duration is significantly reduced.

<img width="1311" alt="image" src="https://github.com/user-attachments/assets/95e643e7-bfbd-48b1-9c91-b65f870599d6" />


New metrics RocksDB-kv->Ingest SST allow_write:
![image](https://github.com/user-attachments/assets/2daebe95-96fb-46e0-b31f-a0ae4c249591)


## Summary

Enabled RocksDB’s allow_write option to reduce the latency impact of SST file ingestion on foreground operations, while introducing a range latch mechanism to ensure correctness.

## Key Changes
The specific changes include:
1. Enabled allow_write: The IngestExternalFileOptions.allow_write option was enabled by apply-snapshot ingest SST.
2. Introduced RangeLatch: Added RocksEngine.ingest_latch to dynamically acquire range locks during SST ingestion, preventing concurrent writes by Compaction Filter GC.

The reason for introducing a range latch is that in TiKV, operations such as applying snapshots during region creation, handling foreground writes in normal operation, and destroying peers are all executed sequentially. However, the Compaction Filter GC operates as a dedicated background thread, making it the only component that might run concurrently and write default CF with SST ingestion. To handle this potential concurrency, the RangeLatch ensures there are no overlapping ranges between these two concurrent operations, maintaining correctness.


<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18081

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
This PR implements the proposal described in [issue #18081](https://github.com/tikv/tikv/issues/18081). With this change, the P99 apply wait duration is significantly reduced.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
none
```
