### PR TITLE
import: track inflight ingests during write stall check

### DIFF
--- a/components/engine_panic/src/misc.rs
+++ b/components/engine_panic/src/misc.rs
@@ -55,7 +55,7 @@ impl MiscExt for PanicEngine {
         panic!()
     }
 
-    fn ingest_maybe_slowdown_writes(&self, cf: &str) -> Result<bool> {
+    fn ingest_maybe_slowdown_writes(&self, cf: &str, sst_cnt: u64) -> Result<bool> {
         panic!()
     }
 

--- a/components/engine_panic/src/misc.rs
+++ b/components/engine_panic/src/misc.rs
@@ -55,7 +55,7 @@ impl MiscExt for PanicEngine {
         panic!()
     }
 
-    fn ingest_maybe_slowdown_writes(&self, cf: &str, sst_cnt: u64) -> Result<bool> {
+    fn ingest_maybe_slowdown_writes(&self, cf: &str, inflight_ingest_cnt: u64) -> Result<bool> {
         panic!()
     }
 

--- a/components/engine_rocks/src/misc.rs
+++ b/components/engine_rocks/src/misc.rs
@@ -314,7 +314,10 @@ impl MiscExt for RocksEngine {
             .get_approximate_memtable_stats_cf(handle, &range))
     }
 
-    fn ingest_maybe_slowdown_writes(&self, cf: &str, sst_cnt: u64) -> Result<bool> {
+    // Checks if ingesting additional SSTs might trigger write slowdown, based
+    // on a conservative estimate of the L0 file count after ingesting the SSTs
+    // that are already inflight for ingestion.
+    fn ingest_maybe_slowdown_writes(&self, cf: &str, inflight_ingest_cnt: u64) -> Result<bool> {
         let handle = util::get_cf_handle(self.as_inner(), cf)?;
         if let Some(n) = util::get_cf_num_files_at_level(self.as_inner(), handle, 0) {
             let options = self.as_inner().get_options_cf(handle);
@@ -322,7 +325,10 @@ impl MiscExt for RocksEngine {
             let compaction_trigger = options.get_level_zero_file_num_compaction_trigger() as u64;
             // Leave enough buffer to tolerate heavy write workload,
             // which may flush some memtables in a short time.
-            if n + sst_cnt - 1 > u64::from(slowdown_trigger) / 2 && n >= compaction_trigger {
+            let worse_case_l0_file_count = n + inflight_ingest_cnt;
+            if worse_case_l0_file_count > u64::from(slowdown_trigger) / 2
+                && worse_case_l0_file_count >= compaction_trigger
+            {
                 return Ok(true);
             }
         }

--- a/components/engine_rocks/src/misc.rs
+++ b/components/engine_rocks/src/misc.rs
@@ -314,7 +314,7 @@ impl MiscExt for RocksEngine {
             .get_approximate_memtable_stats_cf(handle, &range))
     }
 
-    fn ingest_maybe_slowdown_writes(&self, cf: &str) -> Result<bool> {
+    fn ingest_maybe_slowdown_writes(&self, cf: &str, sst_cnt: u64) -> Result<bool> {
         let handle = util::get_cf_handle(self.as_inner(), cf)?;
         if let Some(n) = util::get_cf_num_files_at_level(self.as_inner(), handle, 0) {
             let options = self.as_inner().get_options_cf(handle);
@@ -322,7 +322,7 @@ impl MiscExt for RocksEngine {
             let compaction_trigger = options.get_level_zero_file_num_compaction_trigger() as u64;
             // Leave enough buffer to tolerate heavy write workload,
             // which may flush some memtables in a short time.
-            if n > u64::from(slowdown_trigger) / 2 && n >= compaction_trigger {
+            if n + sst_cnt - 1 > u64::from(slowdown_trigger) / 2 && n >= compaction_trigger {
                 return Ok(true);
             }
         }

--- a/components/engine_traits/src/misc.rs
+++ b/components/engine_traits/src/misc.rs
@@ -125,7 +125,7 @@ pub trait MiscExt: CfNamesExt + FlowControlFactorsExt + WriteBatchExt {
     /// memtables of the cf.
     fn get_approximate_memtable_stats_cf(&self, cf: &str, range: &Range<'_>) -> Result<(u64, u64)>;
 
-    fn ingest_maybe_slowdown_writes(&self, cf: &str) -> Result<bool>;
+    fn ingest_maybe_slowdown_writes(&self, cf: &str, sst_cnt: u64) -> Result<bool>;
 
     fn get_sst_key_ranges(&self, cf: &str, level: usize) -> Result<Vec<(Vec<u8>, Vec<u8>)>>;
 

--- a/components/engine_traits/src/misc.rs
+++ b/components/engine_traits/src/misc.rs
@@ -125,7 +125,7 @@ pub trait MiscExt: CfNamesExt + FlowControlFactorsExt + WriteBatchExt {
     /// memtables of the cf.
     fn get_approximate_memtable_stats_cf(&self, cf: &str, range: &Range<'_>) -> Result<(u64, u64)>;
 
-    fn ingest_maybe_slowdown_writes(&self, cf: &str, sst_cnt: u64) -> Result<bool>;
+    fn ingest_maybe_slowdown_writes(&self, cf: &str, inflight_ingest_cnt: u64) -> Result<bool>;
 
     fn get_sst_key_ranges(&self, cf: &str, level: usize) -> Result<Vec<(Vec<u8>, Vec<u8>)>>;
 

--- a/components/raftstore/src/store/worker/region.rs
+++ b/components/raftstore/src/store/worker/region.rs
@@ -602,7 +602,7 @@ where
             if plain_file_used(cf) {
                 continue;
             }
-            if self.engine.ingest_maybe_slowdown_writes(cf).expect("cf") {
+            if self.engine.ingest_maybe_slowdown_writes(cf, 1).expect("cf") {
                 return true;
             }
         }

--- a/components/raftstore/src/store/worker/region.rs
+++ b/components/raftstore/src/store/worker/region.rs
@@ -602,7 +602,7 @@ where
             if plain_file_used(cf) {
                 continue;
             }
-            if self.engine.ingest_maybe_slowdown_writes(cf, 1).expect("cf") {
+            if self.engine.ingest_maybe_slowdown_writes(cf, 0).expect("cf") {
                 return true;
             }
         }

--- a/components/test_sst_importer/src/util.rs
+++ b/components/test_sst_importer/src/util.rs
@@ -126,6 +126,13 @@ pub fn must_ingest_sst_error(client: &ImportSstClient, context: Context, meta: S
     assert!(resp.has_error(), "{:?}", resp);
 }
 
+pub fn ingest_sst(client: &ImportSstClient, context: Context, meta: SstMeta) -> IngestResponse {
+    let mut ingest_request = IngestRequest::default();
+    ingest_request.set_context(context);
+    ingest_request.set_sst(meta);
+    client.ingest(&ingest_request).unwrap()
+}
+
 pub fn check_ingested_kvs(tikv: &TikvClient, ctx: &Context, sst_range: (u8, u8)) {
     check_ingested_kvs_cf(tikv, ctx, "", sst_range);
 }

--- a/src/import/ingest.rs
+++ b/src/import/ingest.rs
@@ -28,19 +28,24 @@ use super::{pb_error_inc, raft_writer::wait_write};
 use crate::storage::{self, errors::extract_region_error_from_error};
 
 #[derive(Default)]
-pub(super) struct IngestLatch(Mutex<HashSet<PathBuf>>);
+pub(super) struct IngestLatch(Mutex<HashSet<(String /* CfName */, PathBuf)>>);
 
 impl IngestLatch {
     pub(super) fn acquire_lock(&self, meta: &SstMeta) -> Result<bool> {
         let mut slots = self.0.lock().unwrap();
         let p = sst_meta_to_path(meta)?;
-        Ok(slots.insert(p))
+        Ok(slots.insert((meta.get_cf_name(), p)))
     }
 
     pub(super) fn release_lock(&self, meta: &SstMeta) -> Result<bool> {
         let mut slots = self.0.lock().unwrap();
         let p = sst_meta_to_path(meta)?;
-        Ok(slots.remove(&p))
+        Ok(slots.remove(&(meta.get_cf_name(), p)))
+    }
+
+    pub(super) fn count_ssts_in_cf(&self, cfName: &str) -> usize {
+        let slots = self.0.lock().unwrap();
+        slots.iter().filter(|(cf, _)| cf == cfName).count()
     }
 }
 
@@ -94,6 +99,7 @@ fn check_write_stall<E: KvEngine>(
     tablets: &LocalTablets<E>,
     store_meta: &Option<Arc<Mutex<StoreMeta<E>>>>,
     importer: &SstImporter<E>,
+    incoming_write_cf_sst_cnt: u64,
 ) -> Option<errorpb::Error> {
     let tablet = match tablets.get(region_id) {
         Some(tablet) => tablet,
@@ -123,7 +129,9 @@ fn check_write_stall<E: KvEngine>(
     if let Some(ref store_meta) = store_meta {
         if let Some((region, _)) = store_meta.lock().unwrap().regions.get(&region_id) {
             if !importer.region_in_import_mode(region)
-                && tablet.ingest_maybe_slowdown_writes(CF_WRITE).expect("cf")
+                && tablet
+                    .ingest_maybe_slowdown_writes(CF_WRITE, incoming_write_cf_sst_cnt)
+                    .expect("cf")
             {
                 return reject_error(Some(region_id));
             }
@@ -134,7 +142,9 @@ fn check_write_stall<E: KvEngine>(
             return Some(errorpb);
         }
     } else if importer.get_mode() == SwitchMode::Normal
-        && tablet.ingest_maybe_slowdown_writes(CF_WRITE).expect("cf")
+        && tablet
+            .ingest_maybe_slowdown_writes(CF_WRITE, incoming_write_cf_sst_cnt)
+            .expect("cf")
     {
         match tablet.get_sst_key_ranges(CF_WRITE, 0) {
             Ok(l0_sst_ranges) => {
@@ -267,23 +277,18 @@ pub async fn ingest<E: Engine>(
         return Ok(resp);
     }
 
-    if let Some(errorpb) = check_write_stall(
-        req.get_context().get_region_id(),
-        tablets,
-        store_meta,
-        importer,
-    ) {
-        resp.set_error(errorpb);
-        return Ok(resp);
-    }
-
     let mut errorpb = errorpb::Error::default();
     let mut metas = vec![];
+    // Acquire locks for all SSTs before calling `check_write_stall`. This
+    // ensures that all incoming SSTs are tracked — both those that have already
+    // passed the stall check and those currently undergoing it.
     for meta in req.get_ssts() {
         if ingest_latch.acquire_lock(meta).unwrap_or(false) {
             metas.push(meta.clone());
         }
     }
+
+    // Abort if there is file conflict.
     if metas.len() < req.get_ssts().len() {
         for m in metas {
             ingest_latch.release_lock(&m).unwrap();
@@ -292,6 +297,22 @@ pub async fn ingest<E: Engine>(
         resp.set_error(errorpb);
         return Ok(resp);
     }
+
+    // Check if there is a write stall.
+    if let Some(errorpb) = check_write_stall(
+        req.get_context().get_region_id(),
+        tablets,
+        store_meta,
+        importer,
+        ingest_latch.count_ssts_in_cf(CF_WRITE),
+    ) {
+        for m in metas {
+            ingest_latch.release_lock(&m).unwrap();
+        }
+        resp.set_error(errorpb);
+        return Ok(resp);
+    }
+
     let res = ingest_files_impl(
         req.take_context(),
         req.take_ssts().into(),

--- a/src/import/ingest.rs
+++ b/src/import/ingest.rs
@@ -28,24 +28,25 @@ use super::{pb_error_inc, raft_writer::wait_write};
 use crate::storage::{self, errors::extract_region_error_from_error};
 
 #[derive(Default)]
-pub(super) struct IngestLatch(Mutex<HashSet<(String /* CfName */, PathBuf)>>);
+pub(super) struct IngestLatch(Mutex<HashSet<(String /* cf_name */, PathBuf)>>);
 
 impl IngestLatch {
     pub(super) fn acquire_lock(&self, meta: &SstMeta) -> Result<bool> {
         let mut slots = self.0.lock().unwrap();
         let p = sst_meta_to_path(meta)?;
-        Ok(slots.insert((meta.get_cf_name(), p)))
+        Ok(slots.insert((meta.get_cf_name().to_string(), p)))
     }
 
     pub(super) fn release_lock(&self, meta: &SstMeta) -> Result<bool> {
         let mut slots = self.0.lock().unwrap();
         let p = sst_meta_to_path(meta)?;
-        Ok(slots.remove(&(meta.get_cf_name(), p)))
+        Ok(slots.remove(&(meta.get_cf_name().to_string(), p)))
     }
 
-    pub(super) fn count_ssts_in_cf(&self, cfName: &str) -> usize {
+    pub(super) fn count_ssts_in_cf(&self, cf_name: &str) -> usize {
         let slots = self.0.lock().unwrap();
-        slots.iter().filter(|(cf, _)| cf == cfName).count()
+        let cnt = slots.iter().filter(|(cf, _)| cf == cf_name).count();
+        cnt
     }
 }
 
@@ -99,7 +100,7 @@ fn check_write_stall<E: KvEngine>(
     tablets: &LocalTablets<E>,
     store_meta: &Option<Arc<Mutex<StoreMeta<E>>>>,
     importer: &SstImporter<E>,
-    incoming_write_cf_sst_cnt: u64,
+    inflight_write_cf_sst_cnt: u64,
 ) -> Option<errorpb::Error> {
     let tablet = match tablets.get(region_id) {
         Some(tablet) => tablet,
@@ -130,7 +131,7 @@ fn check_write_stall<E: KvEngine>(
         if let Some((region, _)) = store_meta.lock().unwrap().regions.get(&region_id) {
             if !importer.region_in_import_mode(region)
                 && tablet
-                    .ingest_maybe_slowdown_writes(CF_WRITE, incoming_write_cf_sst_cnt)
+                    .ingest_maybe_slowdown_writes(CF_WRITE, inflight_write_cf_sst_cnt)
                     .expect("cf")
             {
                 return reject_error(Some(region_id));
@@ -143,7 +144,7 @@ fn check_write_stall<E: KvEngine>(
         }
     } else if importer.get_mode() == SwitchMode::Normal
         && tablet
-            .ingest_maybe_slowdown_writes(CF_WRITE, incoming_write_cf_sst_cnt)
+            .ingest_maybe_slowdown_writes(CF_WRITE, inflight_write_cf_sst_cnt)
             .expect("cf")
     {
         match tablet.get_sst_key_ranges(CF_WRITE, 0) {
@@ -159,7 +160,6 @@ fn check_write_stall<E: KvEngine>(
         }
         return reject_error(None);
     }
-
     None
 }
 
@@ -269,6 +269,7 @@ pub async fn ingest<E: Engine>(
     store_meta: &Option<Arc<Mutex<StoreMeta<E::Local>>>>,
     importer: &SstImporter<E::Local>,
     ingest_latch: &Arc<IngestLatch>,
+    ingest_admission_guard: &Arc<Mutex<()>>,
     label: &'static str,
 ) -> Result<IngestResponse> {
     let mut resp = IngestResponse::default();
@@ -279,16 +280,29 @@ pub async fn ingest<E: Engine>(
 
     let mut errorpb = errorpb::Error::default();
     let mut metas = vec![];
-    // Acquire locks for all SSTs before calling `check_write_stall`. This
-    // ensures that all incoming SSTs are tracked — both those that have already
-    // passed the stall check and those currently undergoing it.
-    for meta in req.get_ssts() {
-        if ingest_latch.acquire_lock(meta).unwrap_or(false) {
-            metas.push(meta.clone());
+    {
+        // Serialize admission checks to avoid race conditions between
+        // concurrent ingests.
+        let _guard = ingest_admission_guard.lock().unwrap();
+
+        // Check if there is a write stall.
+        if let Some(errorpb) = check_write_stall(
+            req.get_context().get_region_id(),
+            tablets,
+            store_meta,
+            importer,
+            ingest_latch.count_ssts_in_cf(CF_WRITE) as u64,
+        ) {
+            resp.set_error(errorpb);
+            return Ok(resp);
+        }
+
+        for meta in req.get_ssts() {
+            if ingest_latch.acquire_lock(meta).unwrap_or(false) {
+                metas.push(meta.clone());
+            }
         }
     }
-
-    // Abort if there is file conflict.
     if metas.len() < req.get_ssts().len() {
         for m in metas {
             ingest_latch.release_lock(&m).unwrap();
@@ -297,22 +311,6 @@ pub async fn ingest<E: Engine>(
         resp.set_error(errorpb);
         return Ok(resp);
     }
-
-    // Check if there is a write stall.
-    if let Some(errorpb) = check_write_stall(
-        req.get_context().get_region_id(),
-        tablets,
-        store_meta,
-        importer,
-        ingest_latch.count_ssts_in_cf(CF_WRITE),
-    ) {
-        for m in metas {
-            ingest_latch.release_lock(&m).unwrap();
-        }
-        resp.set_error(errorpb);
-        return Ok(resp);
-    }
-
     let res = ingest_files_impl(
         req.take_context(),
         req.take_ssts().into(),

--- a/tests/integrations/import/test_sst_service.rs
+++ b/tests/integrations/import/test_sst_service.rs
@@ -680,3 +680,50 @@ fn test_suspend_import() {
     let ssts = write(sst_range).unwrap();
     multi_ingest(ssts.get_metas()).unwrap();
 }
+
+#[test]
+fn test_concurrent_ingest_admission_control() {
+    let (_cluster, ctx, _tikv, import) = new_cluster_and_tikv_import_client();
+    let temp_dir = Builder::new().prefix("test_ingest_sst").tempdir().unwrap();
+    let sst_path = temp_dir.path().join("test.sst");
+    let mut metas = Vec::new();
+
+    // Upload multiple SST files targeting the write CF
+    for i in 0..10 {
+        let sst_range = (i * 10, (i + 1) * 10);
+        let (mut meta, data) = gen_sst_file(sst_path.clone(), sst_range);
+        meta.set_region_id(ctx.get_region_id());
+        meta.set_region_epoch(ctx.get_region_epoch().clone());
+        meta.set_cf_name("write".to_string());
+        send_upload_sst(&import, &meta, &data).unwrap();
+        metas.push(meta);
+    }
+
+    // Ingest in parallel. The admission control should limit the number of
+    // ingests that are allowed to proceed.
+    let handles: Vec<_> = metas
+        .into_iter()
+        .map(|meta| {
+            let import = import.clone();
+            let ctx = ctx.clone();
+            std::thread::spawn(move || ingest_sst(&import, ctx, meta))
+        })
+        .collect();
+
+    let mut success = 0;
+    let mut errors = Vec::new();
+    for handle in handles {
+        match handle.join().unwrap() {
+            ref resp if !resp.has_error() => success += 1,
+            resp => errors.push(resp.get_error().get_message().to_string()),
+        }
+    }
+    // With the test config (slowdown_trigger: 4, compaction_trigger: 4), we
+    // expect 4 ingests to succeed.
+    assert_eq!(success, 4);
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.contains("too many sst files are ingesting"))
+    );
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18452

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
This patch addresses #18452 by serializing the write stall check using 
a mutex and tracking inflight WriteCF SSTs. This ensures all concurrent
ingests are accounted for, making the L0 check more conservative and 
preventing over-admission.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test (
   - The test failed consistently without this fix.
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fix over-admission of SST ingest requests in highly concurrent scenarios.
```
