### PR TITLE
Optimize rocksdb mutex for large amount of SST files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3003,7 +3003,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/Connor1996/rust-rocksdb.git?branch=opt-mutex#e03327c44b47f2029daf84f6c81efb2724cf8ea7"
+source = "git+https://github.com/Connor1996/rust-rocksdb.git?branch=opt-mutex#1385cca0d9aca8119ba765ddc18b27deb46075c5"
 dependencies = [
  "bindgen 0.65.1",
  "bzip2-sys",
@@ -3022,7 +3022,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/Connor1996/rust-rocksdb.git?branch=opt-mutex#e03327c44b47f2029daf84f6c81efb2724cf8ea7"
+source = "git+https://github.com/Connor1996/rust-rocksdb.git?branch=opt-mutex#1385cca0d9aca8119ba765ddc18b27deb46075c5"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -4931,7 +4931,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/Connor1996/rust-rocksdb.git?branch=opt-mutex#e03327c44b47f2029daf84f6c81efb2724cf8ea7"
+source = "git+https://github.com/Connor1996/rust-rocksdb.git?branch=opt-mutex#1385cca0d9aca8119ba765ddc18b27deb46075c5"
 dependencies = [
  "libc 0.2.146",
  "librocksdb_sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3003,7 +3003,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/Connor1996/rust-rocksdb.git?branch=seperate-lock#c8a3bade9316295d30d1efd20ab5ee386ecc2152"
+source = "git+https://github.com/Connor1996/rust-rocksdb.git?branch=opt-mutex#e03327c44b47f2029daf84f6c81efb2724cf8ea7"
 dependencies = [
  "bindgen 0.65.1",
  "bzip2-sys",
@@ -3022,7 +3022,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/Connor1996/rust-rocksdb.git?branch=seperate-lock#c8a3bade9316295d30d1efd20ab5ee386ecc2152"
+source = "git+https://github.com/Connor1996/rust-rocksdb.git?branch=opt-mutex#e03327c44b47f2029daf84f6c81efb2724cf8ea7"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -4931,7 +4931,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/Connor1996/rust-rocksdb.git?branch=seperate-lock#c8a3bade9316295d30d1efd20ab5ee386ecc2152"
+source = "git+https://github.com/Connor1996/rust-rocksdb.git?branch=opt-mutex#e03327c44b47f2029daf84f6c81efb2724cf8ea7"
 dependencies = [
  "libc 0.2.146",
  "librocksdb_sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3003,7 +3003,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/Connor1996/rust-rocksdb.git?branch=seperate-lock#4e94494e0d6c09ae5d1a0bca74e61cf761b98817"
+source = "git+https://github.com/Connor1996/rust-rocksdb.git?branch=seperate-lock#c8a3bade9316295d30d1efd20ab5ee386ecc2152"
 dependencies = [
  "bindgen 0.65.1",
  "bzip2-sys",
@@ -3022,7 +3022,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/Connor1996/rust-rocksdb.git?branch=seperate-lock#4e94494e0d6c09ae5d1a0bca74e61cf761b98817"
+source = "git+https://github.com/Connor1996/rust-rocksdb.git?branch=seperate-lock#c8a3bade9316295d30d1efd20ab5ee386ecc2152"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -4931,7 +4931,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/Connor1996/rust-rocksdb.git?branch=seperate-lock#4e94494e0d6c09ae5d1a0bca74e61cf761b98817"
+source = "git+https://github.com/Connor1996/rust-rocksdb.git?branch=seperate-lock#c8a3bade9316295d30d1efd20ab5ee386ecc2152"
 dependencies = [
  "libc 0.2.146",
  "librocksdb_sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3003,7 +3003,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-7.5#63a07c7ded4e646300788b364d090828de76fe48"
+source = "git+https://github.com/Connor1996/rust-rocksdb.git?branch=seperate-lock#4e94494e0d6c09ae5d1a0bca74e61cf761b98817"
 dependencies = [
  "bindgen 0.65.1",
  "bzip2-sys",
@@ -3022,7 +3022,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-7.5#63a07c7ded4e646300788b364d090828de76fe48"
+source = "git+https://github.com/Connor1996/rust-rocksdb.git?branch=seperate-lock#4e94494e0d6c09ae5d1a0bca74e61cf761b98817"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -4931,7 +4931,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-7.5#63a07c7ded4e646300788b364d090828de76fe48"
+source = "git+https://github.com/Connor1996/rust-rocksdb.git?branch=seperate-lock#4e94494e0d6c09ae5d1a0bca74e61cf761b98817"
 dependencies = [
  "libc 0.2.146",
  "librocksdb_sys",

--- a/components/engine_rocks/Cargo.toml
+++ b/components/engine_rocks/Cargo.toml
@@ -57,10 +57,10 @@ tracker = { workspace = true }
 txn_types = { workspace = true }
 
 [dependencies.rocksdb]
-git = "https://github.com/tikv/rust-rocksdb.git"
+git = "https://github.com/Connor1996/rust-rocksdb.git"
 package = "rocksdb"
 features = ["encryption"]
-branch = "tikv-7.5"
+branch = "seperate-lock"
 
 [dev-dependencies]
 rand = "0.8"

--- a/components/engine_rocks/Cargo.toml
+++ b/components/engine_rocks/Cargo.toml
@@ -60,7 +60,7 @@ txn_types = { workspace = true }
 git = "https://github.com/Connor1996/rust-rocksdb.git"
 package = "rocksdb"
 features = ["encryption"]
-branch = "seperate-lock"
+branch = "opt-mutex"
 
 [dev-dependencies]
 rand = "0.8"


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #xxx

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note

```
