### PR TITLE
raftstore: fix incorrect and misleading index logging in StoreMsg of slowlog.

### DIFF
--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -943,6 +943,9 @@ where
         store_id: u64,
     },
 
+    // Compaction finished event
+    CompactedEvent(EK::CompactedEvent),
+
     // Clear region size and keys for all regions in the range, so we can force them to
     // re-calculate their size later.
     ClearRegionSizeInRange {
@@ -950,8 +953,6 @@ where
         end_key: Vec<u8>,
     },
 
-    // Compaction finished event
-    CompactedEvent(EK::CompactedEvent),
     Tick(StoreTick),
     Start {
         store: metapb::Store,

--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -1070,8 +1070,7 @@ mod tests {
         let result = StoreMsg::<RocksEngine>::VARIANTS
             .iter()
             .zip(distribution)
-            .filter(|(_, c)| *c > 0)
-            .next()
+            .find(|(_, c)| *c > 0)
             .unwrap();
         assert_eq!(result.1, unreachable_msg.discriminant());
         assert_eq!(*result.0, "StoreUnreachable");

--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -939,14 +939,15 @@ where
 {
     RaftMessage(Box<InspectedRaftMessage>),
 
+    StoreUnreachable {
+        store_id: u64,
+    },
+
     // Clear region size and keys for all regions in the range, so we can force them to
     // re-calculate their size later.
     ClearRegionSizeInRange {
         start_key: Vec<u8>,
         end_key: Vec<u8>,
-    },
-    StoreUnreachable {
-        store_id: u64,
     },
 
     // Compaction finished event
@@ -1052,5 +1053,37 @@ mod tests {
 
         // make sure the msg is small enough
         assert_eq!(mem::size_of::<PeerMsg<RocksEngine>>(), 32);
+    }
+
+    #[test]
+    fn test_validate_slowlog_of_store_msg() {
+        use engine_rocks::RocksEngine;
+        use strum::VariantNames;
+
+        use super::*;
+
+        #[allow(const_evaluatable_unchecked)]
+        let mut distribution = [0; StoreMsg::<RocksEngine>::COUNT];
+
+        let unreachable_msg: StoreMsg<RocksEngine> = StoreMsg::StoreUnreachable { store_id: 4 };
+        distribution[unreachable_msg.discriminant()] += 1;
+        let result = StoreMsg::<RocksEngine>::VARIANTS
+            .iter()
+            .zip(distribution)
+            .filter(|(_, c)| *c > 0)
+            .next()
+            .unwrap();
+        assert_eq!(result.1, unreachable_msg.discriminant());
+        assert_eq!(*result.0, "StoreUnreachable");
+
+        let gcsnap_msg: StoreMsg<RocksEngine> = StoreMsg::GcSnapshotFinish;
+        distribution[gcsnap_msg.discriminant()] += 1;
+        let mut filter = StoreMsg::<RocksEngine>::VARIANTS
+            .iter()
+            .zip(distribution)
+            .filter(|(_, c)| *c > 0);
+        assert_eq!(*filter.next().unwrap().0, "StoreUnreachable");
+        assert_eq!(*filter.next().unwrap().0, "GcSnapshotFinish");
+        assert!(filter.next().is_none());
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close https://github.com/tikv/tikv/issues/18561

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Fix incorrect and misleading index logging in StoreMsg of slowlog.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fix incorrect and misleading index logging in StoreMsg of slowlog.
```
