### PR TITLE
*: remove the logging for "sst ingest is too slow" to avoid latency jitters.

### DIFF
--- a/components/engine_panic/src/misc.rs
+++ b/components/engine_panic/src/misc.rs
@@ -59,10 +59,6 @@ impl MiscExt for PanicEngine {
         panic!()
     }
 
-    fn get_sst_key_ranges(&self, cf: &str, level: usize) -> Result<Vec<(Vec<u8>, Vec<u8>)>> {
-        panic!()
-    }
-
     fn get_engine_used_size(&self) -> Result<u64> {
         panic!()
     }

--- a/components/engine_rocks/src/misc.rs
+++ b/components/engine_rocks/src/misc.rs
@@ -497,8 +497,7 @@ impl MiscExt for RocksEngine {
 #[cfg(test)]
 mod tests {
     use engine_traits::{
-        ALL_CFS, CompactExt, DeleteStrategy, Iterable, Iterator, ManualCompactionOptions, Mutable,
-        SyncMutable, WriteBatchExt,
+        ALL_CFS, DeleteStrategy, Iterable, Iterator, Mutable, SyncMutable, WriteBatchExt,
     };
     use tempfile::Builder;
 

--- a/components/engine_rocks/src/misc.rs
+++ b/components/engine_rocks/src/misc.rs
@@ -334,24 +334,6 @@ impl MiscExt for RocksEngine {
         Ok(false)
     }
 
-    fn get_sst_key_ranges(&self, cf: &str, level: usize) -> Result<Vec<(Vec<u8>, Vec<u8>)>> {
-        let handle = util::get_cf_handle(self.as_inner(), cf)?;
-        let ret = self
-            .as_inner()
-            .get_column_family_meta_data(handle)
-            .get_level(level)
-            .get_files()
-            .iter()
-            .map(|sst_meta| {
-                (
-                    sst_meta.get_smallestkey().to_vec(),
-                    sst_meta.get_largestkey().to_vec(),
-                )
-            })
-            .collect();
-        Ok(ret)
-    }
-
     fn get_engine_used_size(&self) -> Result<u64> {
         let mut used_size: u64 = 0;
         for cf in self.cf_names() {
@@ -776,79 +758,6 @@ mod tests {
         )
         .unwrap();
         check_data(&db, &[cf], kvs_left.as_slice());
-    }
-
-    #[test]
-    fn test_get_sst_key_ranges() {
-        let path = Builder::new()
-            .prefix("test_get_sst_key_ranges")
-            .tempdir()
-            .unwrap();
-        let path_str = path.path().to_str().unwrap();
-
-        let mut opts = RocksDbOptions::default();
-        opts.create_if_missing(true);
-        opts.enable_multi_batch_write(true);
-
-        let mut cf_opts = RocksCfOptions::default();
-        // Prefix extractor(trim the timestamp at tail) for write cf.
-        cf_opts
-            .set_prefix_extractor(
-                "FixedSuffixSliceTransform",
-                crate::util::FixedSuffixSliceTransform::new(8),
-            )
-            .unwrap_or_else(|err| panic!("{:?}", err));
-        // Create prefix bloom filter for memtable.
-        cf_opts.set_memtable_prefix_bloom_size_ratio(0.1_f64);
-        cf_opts.set_level_compaction_dynamic_level_bytes(false);
-        let cf = "default";
-        let db = new_engine_opt(path_str, opts, vec![(cf, cf_opts)]).unwrap();
-        let mut wb = db.write_batch();
-        let kvs: Vec<(&[u8], &[u8])> = vec![
-            (b"k1", b"v1"),
-            (b"k2", b"v2"),
-            (b"k6", b"v3"),
-            (b"k7", b"v4"),
-        ];
-
-        for &(k, v) in kvs.as_slice() {
-            wb.put_cf(cf, k, v).unwrap();
-        }
-        wb.write().unwrap();
-
-        db.flush_cf(cf, true).unwrap();
-        let sst_range = db.get_sst_key_ranges(cf, 0).unwrap();
-        let expected = vec![(b"k1".to_vec(), b"k7".to_vec())];
-        assert_eq!(sst_range, expected);
-
-        let mut wb = db.write_batch();
-        let kvs: Vec<(&[u8], &[u8])> = vec![(b"k3", b"v1"), (b"k4", b"v2"), (b"k8", b"v3")];
-
-        for &(k, v) in kvs.as_slice() {
-            wb.put_cf(cf, k, v).unwrap();
-        }
-        wb.write().unwrap();
-
-        db.flush_cf(cf, true).unwrap();
-        let sst_range = db.get_sst_key_ranges(cf, 0).unwrap();
-        let expected = vec![
-            (b"k3".to_vec(), b"k8".to_vec()),
-            (b"k1".to_vec(), b"k7".to_vec()),
-        ];
-        assert_eq!(sst_range, expected);
-
-        db.compact_range_cf(
-            cf,
-            None,
-            None,
-            ManualCompactionOptions::new(false, 1, false),
-        )
-        .unwrap();
-        let sst_range = db.get_sst_key_ranges(cf, 0).unwrap();
-        assert_eq!(sst_range.len(), 0);
-        let sst_range = db.get_sst_key_ranges(cf, 1).unwrap();
-        let expected = vec![(b"k1".to_vec(), b"k8".to_vec())];
-        assert_eq!(sst_range, expected);
     }
 
     #[test]

--- a/components/engine_traits/src/misc.rs
+++ b/components/engine_traits/src/misc.rs
@@ -127,8 +127,6 @@ pub trait MiscExt: CfNamesExt + FlowControlFactorsExt + WriteBatchExt {
 
     fn ingest_maybe_slowdown_writes(&self, cf: &str) -> Result<bool>;
 
-    fn get_sst_key_ranges(&self, cf: &str, level: usize) -> Result<Vec<(Vec<u8>, Vec<u8>)>>;
-
     /// Gets total used size of rocksdb engine, including:
     /// * total size (bytes) of all SST files.
     /// * total size (bytes) of active and unflushed immutable memtables.

--- a/src/import/ingest.rs
+++ b/src/import/ingest.rs
@@ -136,17 +136,11 @@ fn check_write_stall<E: KvEngine>(
     } else if importer.get_mode() == SwitchMode::Normal
         && tablet.ingest_maybe_slowdown_writes(CF_WRITE).expect("cf")
     {
-        match tablet.get_sst_key_ranges(CF_WRITE, 0) {
-            Ok(l0_sst_ranges) => {
-                warn!(
-                    "sst ingest is too slow";
-                    "sst_ranges" => ?l0_sst_ranges,
-                );
-            }
-            Err(e) => {
-                error!("get sst key ranges failed"; "err" => ?e);
-            }
-        }
+        // See https://github.com/tikv/tikv/issues/18549:
+        // Previously, logging SST key ranges by calling `ingest_sst_key_ranges` caused
+        // latency spikes. The logging here has been refined to avoid such
+        // performance issues.
+        warn!("SST ingest is experiencing slowdowns");
         return reject_error(None);
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close https://github.com/tikv/tikv/issues/18549

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

To mitigate the latency jitters introduced by `get_sst_key_ranges` if there exists too many L0s in Rocksdb, this PR:
- Removes the logging for "sst ingest is too slow" to avoid latency jitters.
- Removes `get_sst_key_ranges` as this function is deadcode.

```commit-message
Removes the logging for "sst ingest is too slow" to avoid latency jitters.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Removes the logging for "sst ingest is too slow" to avoid latency jitters.
```
