### PR TITLE
PeerStorage: add TermCache caching recent terms to avoid unnecessary I/O ops.

### DIFF
--- a/components/raftstore-v2/src/operation/command/admin/compact_log.rs
+++ b/components/raftstore-v2/src/operation/command/admin/compact_log.rs
@@ -203,9 +203,9 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         // entries before `alive_cache_idx` instead of `alive_cache_idx + 1`.
         let mut cache_warmup_state = self.transfer_leader_state_mut().cache_warmup_state.take();
         let compact_idx = std::cmp::min(alive_cache_idx, applied_idx + 1);
+        self.entry_storage_mut().compact_term_cache(compact_idx);
         self.entry_storage_mut()
             .compact_entry_cache(compact_idx, cache_warmup_state.as_mut());
-        self.entry_storage_mut().compact_term_cache(compact_idx);
         self.transfer_leader_state_mut().cache_warmup_state = cache_warmup_state;
 
         let mut compact_idx = if force && replicated_idx > first_idx {
@@ -506,9 +506,9 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
 
         let mut cache_warmup_state = self.transfer_leader_state_mut().cache_warmup_state.take();
         self.entry_storage_mut()
-            .compact_entry_cache(res.compact_index, cache_warmup_state.as_mut());
-        self.entry_storage_mut()
             .compact_term_cache(res.compact_index);
+        self.entry_storage_mut()
+            .compact_entry_cache(res.compact_index, cache_warmup_state.as_mut());
         self.transfer_leader_state_mut().cache_warmup_state = cache_warmup_state;
 
         self.storage_mut()

--- a/components/raftstore-v2/src/operation/command/admin/compact_log.rs
+++ b/components/raftstore-v2/src/operation/command/admin/compact_log.rs
@@ -203,9 +203,10 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         // entries before `alive_cache_idx` instead of `alive_cache_idx + 1`.
         let mut cache_warmup_state = self.transfer_leader_state_mut().cache_warmup_state.take();
         let compact_idx = std::cmp::min(alive_cache_idx, applied_idx + 1);
-        self.entry_storage_mut().compact_term_cache(compact_idx);
         self.entry_storage_mut()
             .compact_entry_cache(compact_idx, cache_warmup_state.as_mut());
+        // No need to compact term cache since each cached term is consistent with
+        // persisted terms.
         self.transfer_leader_state_mut().cache_warmup_state = cache_warmup_state;
 
         let mut compact_idx = if force && replicated_idx > first_idx {
@@ -504,9 +505,9 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             }
         }
 
+        // No need to compact term cache since each cached term is consistent with
+        // persisted terms.
         let mut cache_warmup_state = self.transfer_leader_state_mut().cache_warmup_state.take();
-        self.entry_storage_mut()
-            .compact_term_cache(res.compact_index);
         self.entry_storage_mut()
             .compact_entry_cache(res.compact_index, cache_warmup_state.as_mut());
         self.transfer_leader_state_mut().cache_warmup_state = cache_warmup_state;

--- a/components/raftstore-v2/src/operation/command/admin/compact_log.rs
+++ b/components/raftstore-v2/src/operation/command/admin/compact_log.rs
@@ -205,8 +205,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         let compact_idx = std::cmp::min(alive_cache_idx, applied_idx + 1);
         self.entry_storage_mut()
             .compact_entry_cache(compact_idx, cache_warmup_state.as_mut());
-        // No need to compact term cache since each cached term is consistent with
-        // persisted terms.
+        self.entry_storage_mut().compact_term_cache(compact_idx);
         self.transfer_leader_state_mut().cache_warmup_state = cache_warmup_state;
 
         let mut compact_idx = if force && replicated_idx > first_idx {
@@ -505,11 +504,11 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             }
         }
 
-        // No need to compact term cache since each cached term is consistent with
-        // persisted terms.
         let mut cache_warmup_state = self.transfer_leader_state_mut().cache_warmup_state.take();
         self.entry_storage_mut()
             .compact_entry_cache(res.compact_index, cache_warmup_state.as_mut());
+        self.entry_storage_mut()
+            .compact_term_cache(res.compact_index);
         self.transfer_leader_state_mut().cache_warmup_state = cache_warmup_state;
 
         self.storage_mut()

--- a/components/raftstore-v2/src/operation/ready/mod.rs
+++ b/components/raftstore-v2/src/operation/ready/mod.rs
@@ -711,9 +711,18 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             }
         }
         let applying_index = committed_entries.last().unwrap().index;
-        let commit_to_current_term = committed_entries.last().unwrap().term == self.term();
+        let committed_term = committed_entries.last().unwrap().term;
+        let commit_to_current_term = committed_term == self.term();
         self.compact_log_context_mut()
             .set_last_applying_index(applying_index);
+        // Using the latest committed entry to update the term cache may slightly reduce
+        // query performance for recently appended indices, but it ensures
+        // that the term cache maintains the integrity and continuity of
+        // each term's lifecycle, making it safe and efficient for access
+        // and compaction.
+        self.storage_mut()
+            .entry_storage_mut()
+            .update_term_cache(applying_index, committed_term);
         if needs_evict_entry_cache(ctx.cfg.evict_cache_on_memory_ratio) {
             // Compact all cached entries instead of half evict.
             self.entry_storage_mut().evict_entry_cache(false);

--- a/components/raftstore/src/store/entry_storage.rs
+++ b/components/raftstore/src/store/entry_storage.rs
@@ -1573,7 +1573,7 @@ pub mod tests {
             cache.append(5, 2);
             cache.append(4, 2); // skip as rewrite with old idx
             cache.append(3, 2); // skip as rewrite with old idx
-            for i in 1..=10 {
+            for i in (1..=10).rev() {
                 cache.append(i + 5, 3);
             }
             for i in 1..=5 {
@@ -1632,6 +1632,14 @@ pub mod tests {
             assert_eq!(cache.entry(45), Some(11));
             cache.compact_to(12);
             assert_eq!(cache.entry(45), None);
+            // Append reversely, the first term should be cleared.
+            for i in (12..20).rev() {
+                cache.append(48 + i - 11, i);
+            }
+            assert_eq!(cache.entry(48), None);
+            assert_eq!(cache.entry(49), Some(12));
+            assert_eq!(cache.entry(56), Some(19));
+            assert_eq!(cache.entry(57), Some(19));
         }
         // Abnormal cases
         {

--- a/components/raftstore/src/store/entry_storage.rs
+++ b/components/raftstore/src/store/entry_storage.rs
@@ -1225,11 +1225,6 @@ impl<EK: KvEngine, ER: RaftEngine> EntryStorage<EK, ER> {
         };
 
         self.cache.append(self.region_id, self.peer_id, &entries);
-        // Using the last entry to update the term cache may slightly reduce query
-        // performance for recently appended indices, but it ensures that the
-        // term cache maintains the integrity and continuity of each term's
-        // lifecycle, making it safe and efficient for access and compaction.
-        self.term_cache.append(last_index, last_term);
 
         // Delete any previously appended log entries which never committed.
         task.set_append(Some(prev_last_index + 1), entries);
@@ -1400,6 +1395,10 @@ impl<EK: KvEngine, ER: RaftEngine> EntryStorage<EK, ER> {
 
     pub fn trace_cached_entries(&mut self, entries: CachedEntries) {
         self.cache.trace_cached_entries(entries);
+    }
+
+    pub fn update_term_cache(&mut self, index: u64, term: u64) {
+        self.term_cache.append(index, term);
     }
 
     pub fn clear(&mut self) {

--- a/components/raftstore/src/store/entry_storage.rs
+++ b/components/raftstore/src/store/entry_storage.rs
@@ -407,10 +407,10 @@ impl Drop for EntryCache {
 /// - term: The term number of a sequence of entries
 /// - start_index: The start raft log index that shares this term
 ///
-/// The cache maintains entries in descending order by index, allowing quick
-/// lookups of terms for any given log index. The small fixed capacity helps
-/// keep memory overhead minimal while caching the most relevant term
-/// information.
+/// The cache maintains entries in monotonically increasing order by term,
+/// allowing quick lookups of terms for any given log index. The small fixed
+/// capacity helps keep memory overhead minimal while caching the most relevant
+/// term information.
 struct TermCache {
     cache: VecDeque<(u64, u64)>, // (term, start_index)
     capacity: usize,

--- a/components/raftstore/src/store/entry_storage.rs
+++ b/components/raftstore/src/store/entry_storage.rs
@@ -1346,7 +1346,6 @@ impl<EK: KvEngine, ER: RaftEngine> EntryStorage<EK, ER> {
             // should be temporarily skipped. Otherwise, the warmup task may fail.
             return;
         }
-        self.term_cache.compact_to(idx);
         self.cache.compact_to(idx);
     }
 
@@ -1397,6 +1396,12 @@ impl<EK: KvEngine, ER: RaftEngine> EntryStorage<EK, ER> {
         self.cache.trace_cached_entries(entries);
     }
 
+    #[inline]
+    pub fn compact_term_cache(&mut self, idx: u64) {
+        self.term_cache.compact_to(idx);
+    }
+
+    #[inline]
     pub fn update_term_cache(&mut self, index: u64, term: u64) {
         self.term_cache.append(index, term);
     }

--- a/components/raftstore/src/store/entry_storage.rs
+++ b/components/raftstore/src/store/entry_storage.rs
@@ -1402,8 +1402,7 @@ impl<EK: KvEngine, ER: RaftEngine> EntryStorage<EK, ER> {
     #[inline]
     pub fn compact_term_cache(&mut self, idx: u64) {
         // Get the term of the given index.
-        let term = self.term(idx).unwrap();
-        self.term_cache.compact_to(term);
+        let _ = self.term(idx).map(|term| self.term_cache.compact_to(term));
     }
 
     #[inline]

--- a/components/raftstore/src/store/entry_storage.rs
+++ b/components/raftstore/src/store/entry_storage.rs
@@ -412,7 +412,7 @@ impl Drop for EntryCache {
 /// keep memory overhead minimal while caching the most relevant term
 /// information.
 struct TermCache {
-    cache: VecDeque<(u64, u64)>, // (term, latest_index)
+    cache: VecDeque<(u64, u64)>, // (term, start_index)
     capacity: usize,
 }
 

--- a/components/raftstore/src/store/entry_storage.rs
+++ b/components/raftstore/src/store/entry_storage.rs
@@ -1402,6 +1402,7 @@ impl<EK: KvEngine, ER: RaftEngine> EntryStorage<EK, ER> {
 
     pub fn clear(&mut self) {
         self.cache = EntryCache::default();
+        self.term_cache = TermCache::default();
     }
 
     pub fn read_scheduler(&self) -> Scheduler<ReadTask<EK>> {

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -5572,8 +5572,8 @@ where
                             &mut self.fsm.peer.transfer_leader_state.cache_warmup_state;
                         let peer_store = self.fsm.peer.raft_group.mut_store();
                         peer_store.set_apply_state(apply_state);
-                        peer_store.compact_entry_cache(last_index + 1, cache_warmup_state.as_mut());
                         peer_store.compact_term_cache(last_index + 1);
+                        peer_store.compact_entry_cache(last_index + 1, cache_warmup_state.as_mut());
                         peer_store.raft_state_mut().mut_hard_state().commit = last_index;
                         peer_store.raft_state_mut().last_index = last_index;
                     }

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -5573,6 +5573,7 @@ where
                         let peer_store = self.fsm.peer.raft_group.mut_store();
                         peer_store.set_apply_state(apply_state);
                         peer_store.compact_entry_cache(last_index + 1, cache_warmup_state.as_mut());
+                        peer_store.compact_term_cache(last_index + 1);
                         peer_store.raft_state_mut().mut_hard_state().commit = last_index;
                         peer_store.raft_state_mut().last_index = last_index;
                     }

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -1099,13 +1099,15 @@ where
             peer.raft_group.campaign()?;
         }
 
-        let (persisted_index, term) = (
+        let (persisted_index, committed_index, term) = (
             peer.raft_group.raft.raft_log.persisted,
+            peer.raft_group.raft.raft_log.committed,
             peer.raft_group.raft.term,
         );
         peer.mut_store().update_cache_persisted(persisted_index);
-        // For initilization, uses the persisted raft log to initialize the term cache.
-        peer.mut_store().update_term_cache(persisted_index, term);
+        // For initilization, uses the last committed raft log to initialize the term
+        // cache.
+        peer.mut_store().update_term_cache(committed_index, term);
         Ok(peer)
     }
 
@@ -3228,11 +3230,11 @@ where
             apply.on_schedule(&ctx.raft_metrics);
             self.mut_store()
                 .trace_cached_entries(apply.entries[0].clone());
-            // Using the latest committed entry to update the term cache may slightly reduce
-            // query performance for recently appended indices, but it ensures
-            // that the term cache maintains the integrity and continuity of
-            // each term's lifecycle, making it safe and efficient for access
-            // and compaction.
+            // Using the latest committed entry to update the term cache may
+            // slightly reduce `raft::Storage::term()` query performance for
+            // recently appended indices, but it ensures that the term cache
+            // maintains the integrity and continuity of each term's lifecycle,
+            // making it safe and efficient for access and compaction.
             self.mut_store()
                 .update_term_cache(commit_index, commit_term);
             if needs_evict_entry_cache(ctx.cfg.evict_cache_on_memory_ratio) {

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -1099,15 +1099,8 @@ where
             peer.raft_group.campaign()?;
         }
 
-        let (persisted_index, committed_index, term) = (
-            peer.raft_group.raft.raft_log.persisted,
-            peer.raft_group.raft.raft_log.committed,
-            peer.raft_group.raft.term,
-        );
+        let persisted_index = peer.raft_group.raft.raft_log.persisted;
         peer.mut_store().update_cache_persisted(persisted_index);
-        // For initialization, uses the last committed raft log to initialize the term
-        // cache.
-        peer.mut_store().update_term_cache(committed_index, term);
         Ok(peer)
     }
 

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -1105,7 +1105,7 @@ where
             peer.raft_group.raft.term,
         );
         peer.mut_store().update_cache_persisted(persisted_index);
-        // For initilization, uses the last committed raft log to initialize the term
+        // For initialization, uses the last committed raft log to initialize the term
         // cache.
         peer.mut_store().update_term_cache(committed_index, term);
         Ok(peer)

--- a/components/raftstore/src/store/peer_storage.rs
+++ b/components/raftstore/src/store/peer_storage.rs
@@ -652,6 +652,7 @@ where
 
     pub fn on_compact_raftlog(&mut self, idx: u64, state: Option<&mut CacheWarmupState>) {
         self.entry_storage.compact_entry_cache(idx, state);
+        self.entry_storage.compact_term_cache(idx);
         self.cancel_generating_snap(Some(idx));
     }
 

--- a/components/raftstore/src/store/peer_storage.rs
+++ b/components/raftstore/src/store/peer_storage.rs
@@ -651,9 +651,8 @@ where
     }
 
     pub fn on_compact_raftlog(&mut self, idx: u64, state: Option<&mut CacheWarmupState>) {
-        // No need to compact term cache since each cached term is consistent with
-        // persisted terms.
         self.entry_storage.compact_entry_cache(idx, state);
+        self.entry_storage.compact_term_cache(idx);
         self.cancel_generating_snap(Some(idx));
     }
 

--- a/components/raftstore/src/store/peer_storage.rs
+++ b/components/raftstore/src/store/peer_storage.rs
@@ -651,8 +651,10 @@ where
     }
 
     pub fn on_compact_raftlog(&mut self, idx: u64, state: Option<&mut CacheWarmupState>) {
-        self.entry_storage.compact_entry_cache(idx, state);
+        // Before compacting stale terms in advance to reduce the extra I/O costs on
+        // fetching terms.
         self.entry_storage.compact_term_cache(idx);
+        self.entry_storage.compact_entry_cache(idx, state);
         self.cancel_generating_snap(Some(idx));
     }
 

--- a/components/raftstore/src/store/peer_storage.rs
+++ b/components/raftstore/src/store/peer_storage.rs
@@ -1339,7 +1339,9 @@ pub mod tests {
         let mut write_task: WriteTask<KvTestEngine, _> =
             WriteTask::new(store.get_region_id(), store.peer_id, 1);
         store.append(ents[1..].to_vec(), &mut write_task);
-        store.update_cache_persisted(ents.last().unwrap().get_index());
+        let last_entry = ents.last().unwrap();
+        store.update_cache_persisted(last_entry.get_index());
+        store.update_term_cache(last_entry.get_index(), last_entry.get_term());
         store
             .apply_state_mut()
             .mut_truncated_state()

--- a/components/raftstore/src/store/peer_storage.rs
+++ b/components/raftstore/src/store/peer_storage.rs
@@ -651,9 +651,8 @@ where
     }
 
     pub fn on_compact_raftlog(&mut self, idx: u64, state: Option<&mut CacheWarmupState>) {
-        // Before compacting stale terms in advance to reduce the extra I/O costs on
-        // fetching terms.
-        self.entry_storage.compact_term_cache(idx);
+        // No need to compact term cache since each cached term is consistent with
+        // persisted terms.
         self.entry_storage.compact_entry_cache(idx, state);
         self.cancel_generating_snap(Some(idx));
     }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close https://github.com/tikv/tikv/issues/18588

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

This PR adds a `TermCache` to store recently accessed or updated Raft log terms, reducing unnecessary I/O reads on RaftEngine when queried log indices are evicted from the EntryCache. (PS: The TermCache introduces minimal additional memory usage—only ~20–30 MiB per TiKV node, even with 300k regions/peers.)
To be briefly:
- For Efficiency & Memory Usage: The `TermCache` maintains a small fixed capacity (8) for optimal performance and low memory overhead. Entries are stored in monotonically increasing order, where the first term is the oldest and the last term is the freshest.
- For Entry Structure: Each entry consists of `(term, start_index_of_this_term)`, ensuring quick lookups for term boundaries.
- For safety and consistency, the term of each committed Raft log is inserted into `TermCache` while updating its corresponding term start index.

```commit-message
This PR adds a `TermCache` to store recently accessed or updated Raft log terms, reducing unnecessary I/O reads on RaftEngine when queried log indices are evicted from the EntryCache.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

For stable testing, no bugs are found under `tpcc-1k` workloads:
![image](https://github.com/user-attachments/assets/72c35160-da68-4ba1-8781-b09fa97cf182)

As for the validation of this feature, it's proved that it will reduce unnecessary reads from `RaftEngine` if the relative entries are evicted or not found from `EntryCache`.
| Branch | Screenshots | 
| --- | --- |
| Master | ![image](https://github.com/user-attachments/assets/8f73a822-772c-4c9c-b106-88a4e00568f7) |
| This PR | ![image](https://github.com/user-attachments/assets/7692071c-9114-430b-a0d4-1232a38c0736) |



Performance Validation

The `tpcc-20k` benchmark confirms this change introduces no performance regression. In fact, it demonstrates consistent minor performance gains **averaging +3% throughput improvement**.
| branch | threads count | QPS | Latency - AVG(ms) | Latency - P99(ms) | Latency - P999(ms) |
| --- | --- | --- | --- | --- | --- |
| add-term-cache | 200 | 68754 | 2.77 | 38.2 | 74.0 |
| master | 200 | 66744 | 2.85 | 38.3 | 79.1 |
| add-term-cache | 100 | 62398 | 1.48 | 15.8 | 49.7 |
| master | 100 | 61554 | 1.50 | 15.6 | 49.7 | 


Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Adds a `TermCache` to store recently accessed or updated Raft log terms, reducing unnecessary I/O reads on RaftEngine when queried log indices are evicted from the EntryCache.
```
