### PR TITLE
Fix closure clippy warnings

### DIFF
--- a/components/backup-stream/src/subscription_track.rs
+++ b/components/backup-stream/src/subscription_track.rs
@@ -397,7 +397,7 @@ impl SubscriptionTracer {
     ) -> Option<impl RefMut<Key = u64, Value = ActiveSubscription> + '_> {
         self.0
             .get_mut(&region_id)
-            .and_then(|x| ActiveSubscriptionRef::try_from_dash(x))
+            .and_then(ActiveSubscriptionRef::try_from_dash)
     }
 }
 

--- a/components/causal_ts/src/tso.rs
+++ b/components/causal_ts/src/tso.rs
@@ -385,7 +385,7 @@ impl<C: PdClient + 'static> BatchTsoProvider<C> {
         let res = response
             .await
             .map_err(|_| box_err!("renew response channel is dropped"))
-            .and_then(|r| r.map_err(|err| Error::BatchRenew(err)));
+            .and_then(|r| r.map_err(Error::BatchRenew));
 
         TS_PROVIDER_TSO_BATCH_RENEW_DURATION_STATIC
             .get(res.borrow().into())

--- a/components/cloud/aws/src/util.rs
+++ b/components/cloud/aws/src/util.rs
@@ -177,7 +177,7 @@ impl ProvideCredentials for DefaultCredentialsProvider {
                     Box::pin(
                         self.default_provider
                             .provide_credentials()
-                            .map_err(|e| CredentialsErrorWrapper(e)),
+                            .map_err(CredentialsErrorWrapper),
                     )
                 },
                 "get_cred_on_premise",

--- a/components/cloud/azure/src/kms.rs
+++ b/components/cloud/azure/src/kms.rs
@@ -109,14 +109,14 @@ impl AzureKms {
                     certificate_path.clone(),
                     azure_cfg.client_certificate_password.clone(),
                 )
-                .map_err(|e| CloudError::Other(e))?,
+                .map_err(CloudError::Other)?,
                 ClientCertificateCredentialExt::build(
                     azure_cfg.tenant_id.clone(),
                     azure_cfg.client_id,
                     certificate_path,
                     azure_cfg.client_certificate_password,
                 )
-                .map_err(|e| CloudError::Other(e))?,
+                .map_err(CloudError::Other)?,
             );
             Self::new_with_credentials(config, keyvault_credential, hsm_credential)
         } else if let Some(client_secret) = azure_cfg.client_secret.clone() {

--- a/components/cloud/gcp/src/gcs.rs
+++ b/components/cloud/gcp/src/gcs.rs
@@ -435,7 +435,7 @@ impl GcsPrefixIter<'_> {
             .cli
             .make_request(req.map(|_e| Body::empty()), tame_gcs::Scopes::ReadOnly)
             .await
-            .map_err(|err| io::Error::other(err))?;
+            .map_err(io::Error::other)?;
         let resp = utils::read_from_http_body::<ListResponse>(res).await?;
         metrics::CLOUD_REQUEST_HISTOGRAM_VEC
             .with_label_values(&["gcp", "list"])

--- a/components/compact-log-backup/src/storage.rs
+++ b/components/compact-log-backup/src/storage.rs
@@ -707,7 +707,7 @@ impl<'a> MigrationStorageWrapper<'a> {
                     UnpinReader(Box::new(Cursor::new(&bytes))),
                     bytes.len() as u64
                 )
-                .map_err(|err| JustRetry(err))
+                .map_err(JustRetry)
         )
         .await
         .map_err(|err| err.0)?;

--- a/components/engine_rocks/src/checkpoint.rs
+++ b/components/engine_rocks/src/checkpoint.rs
@@ -38,7 +38,7 @@ impl Checkpointer for RocksEngineCheckpointer {
         file_system::delete_dir_if_exist(db_out_dir).unwrap();
         self.0
             .create_at(db_out_dir, titan_out_dir, log_size_for_flush)
-            .map_err(|e| r2e(e))
+            .map_err(r2e)
     }
 }
 

--- a/components/engine_rocks/src/misc.rs
+++ b/components/engine_rocks/src/misc.rs
@@ -75,6 +75,7 @@ impl RocksEngine {
                 } else {
                     data.push(it.key().to_vec());
                 }
+                #[allow(clippy::redundant_closure_call)]
                 let max_delete_count_by_key = (|| {
                     fail_point!("manually_set_max_delete_count_by_key", |_| { 0 });
                     MAX_DELETE_COUNT_BY_KEY

--- a/components/engine_rocks/src/properties.rs
+++ b/components/engine_rocks/src/properties.rs
@@ -209,8 +209,8 @@ impl RangeProperties {
             Ok(idx) => Some(idx),
             Err(next_idx) => next_idx.checked_sub(1),
         };
-        let start = start_offset.map_or_else(|| Default::default(), |x| self.offsets[x].1);
-        let end = end_offset.map_or_else(|| Default::default(), |x| self.offsets[x].1);
+        let start = start_offset.map_or_else(Default::default, |x| self.offsets[x].1);
+        let end = end_offset.map_or_else(Default::default, |x| self.offsets[x].1);
         assert!(end.size >= start.size && end.keys >= start.keys);
         (end.size - start.size, end.keys - start.keys)
     }

--- a/components/engine_traits/src/flush.rs
+++ b/components/engine_traits/src/flush.rs
@@ -211,11 +211,9 @@ impl PersistenceListener {
     /// be held during this method, so we should avoid do heavy things in it.
     pub fn on_memtable_sealed(&self, cf: String, smallest_seqno: u64, largest_seqno: u64) {
         let t = Instant::now_coarse();
-        (|| {
-            fail_point!("on_memtable_sealed", |t| {
-                assert_eq!(t.unwrap().as_str(), cf);
-            })
-        })();
+        fail_point!("on_memtable_sealed", |t| {
+            assert_eq!(t.unwrap().as_str(), cf);
+        });
         // The correctness relies on the assumption that there will be only one
         // thread writing to the DB and increasing apply index.
         // Apply index will be set within DB lock, so it's correct even with manual

--- a/components/external_storage/src/hdfs.rs
+++ b/components/external_storage/src/hdfs.rs
@@ -37,7 +37,7 @@ pub struct HdfsStorage {
 
 impl HdfsStorage {
     pub fn new(remote: &str, config: HdfsConfig) -> io::Result<HdfsStorage> {
-        let mut remote = Url::parse(remote).map_err(|e| io::Error::other(e))?;
+        let mut remote = Url::parse(remote).map_err(io::Error::other)?;
         if !remote.path().ends_with('/') {
             let mut new_path = remote.path().to_owned();
             new_path.push('/');

--- a/components/external_storage/src/local.rs
+++ b/components/external_storage/src/local.rs
@@ -37,6 +37,7 @@ impl LocalStorage {
     /// Create a new local storage in the given path.
     pub fn new(base: &Path) -> io::Result<LocalStorage> {
         info!("create local storage"; "base" => base.display());
+        #[allow(clippy::redundant_closure_call)]
         (|| {
             fail::fail_point!("create_local_storage_yield", |v| {
                 info!("inject create storage sleep time: {:?}ms", v);

--- a/components/in_memory_engine/src/background.rs
+++ b/components/in_memory_engine/src/background.rs
@@ -358,6 +358,7 @@ impl BgWorkManager {
         // blocking task.
         // TODO: Spawn non-blocking tasks and make full use of the ticker.
         let interval = Duration::from_millis(100);
+        #[allow(clippy::redundant_closure_call)]
         let check_load_pending_interval = (|| {
             fail_point!("ime_background_check_load_pending_interval", |t| {
                 let t = t.unwrap().parse::<u64>().unwrap();
@@ -1018,8 +1019,9 @@ impl BackgroundRunner {
                 }
             };
 
+            #[allow(clippy::redundant_closure_call)]
             let safe_point = (|| {
-                fail::fail_point!("ime_safe_point_in_loading", |t| {
+                fail_point!("ime_safe_point_in_loading", |t| {
                     t.unwrap().parse::<u64>().unwrap()
                 });
 

--- a/components/pd_client/src/client_v2.rs
+++ b/components/pd_client/src/client_v2.rs
@@ -317,6 +317,7 @@ impl CachedRawClient {
     /// Increases global version only when a new connection is established.
     /// Might panic if `wait_for_ready` isn't called up-front.
     async fn reconnect(&mut self) -> Result<bool> {
+        #[allow(clippy::redundant_closure_call)]
         let force = (|| {
             fail_point!("pd_client_force_reconnect", |_| true);
             self.channel().check_connectivity_state(true)
@@ -398,6 +399,7 @@ async fn reconnect_loop(
         error!("failed to connect pd"; "err" => ?e);
         return;
     }
+    #[allow(clippy::redundant_closure_call)]
     let backoff = (|| {
         fail_point!("pd_client_v2_backoff", |s| {
             use std::str::FromStr;

--- a/components/raftstore-v2/src/operation/command/admin/flashback.rs
+++ b/components/raftstore-v2/src/operation/command/admin/flashback.rs
@@ -90,11 +90,9 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         store_ctx: &mut StoreContext<EK, ER, T>,
         #[allow(unused_mut)] mut res: FlashbackResult,
     ) {
-        (|| {
-            fail_point!("keep_peer_fsm_flashback_state_false", |_| {
-                res.region_state.mut_region().set_is_in_flashback(false);
-            })
-        })();
+        fail_point!("keep_peer_fsm_flashback_state_false", |_| {
+            res.region_state.mut_region().set_is_in_flashback(false);
+        });
         slog::debug!(
             self.logger,
             "flashback update region";

--- a/components/raftstore-v2/src/operation/command/admin/merge/commit.rs
+++ b/components/raftstore-v2/src/operation/command/admin/merge/commit.rs
@@ -367,6 +367,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         store_ctx: &mut StoreContext<EK, ER, T>,
         req: RaftCmdRequest,
     ) -> Result<u64> {
+        #[allow(clippy::redundant_closure_call)]
         (|| fail::fail_point!("propose_commit_merge_1", store_ctx.store_id == 1, |_| {}))();
         let mut proposal_ctx = ProposalContext::empty();
         proposal_ctx.insert(ProposalContext::COMMIT_MERGE);
@@ -398,6 +399,7 @@ impl<EK: KvEngine, R: ApplyResReporter> Apply<EK, R> {
 
         let mut start_time = Instant::now_coarse();
         let mut wait_duration = None;
+        #[allow(clippy::redundant_closure_call)]
         let force_send = (|| {
             fail::fail_point!("force_send_catch_up_logs", |_| true);
             false

--- a/components/raftstore-v2/src/operation/command/mod.rs
+++ b/components/raftstore-v2/src/operation/command/mod.rs
@@ -886,6 +886,7 @@ impl<EK: KvEngine, R: ApplyResReporter> Apply<EK, R> {
         apply_res.sst_applied_index = self.take_sst_applied_index();
         let written_bytes = apply_res.metrics.written_bytes;
 
+        #[allow(clippy::redundant_closure_call)]
         let skip_report = || -> bool {
             fail_point!("before_report_apply_res", |_| { true });
             false

--- a/components/raftstore-v2/src/operation/life.rs
+++ b/components/raftstore-v2/src/operation/life.rs
@@ -298,6 +298,7 @@ impl Store {
         let region_id = msg.region.id;
         let raft_msg = empty_split_message(self.store_id(), &msg.region);
 
+        #[allow(clippy::redundant_closure_call)]
         (|| {
             fail::fail_point!(
                 "on_store_2_split_init_race_with_initial_message",

--- a/components/raftstore-v2/src/operation/ready/apply_trace.rs
+++ b/components/raftstore-v2/src/operation/ready/apply_trace.rs
@@ -528,6 +528,7 @@ impl<EK: KvEngine, ER: RaftEngine> Storage<EK, ER> {
             }
         };
         apply_state.set_applied_index(applied_index);
+        #[allow(clippy::redundant_closure_call)]
         (|| {
             // Make node reply from start.
             fail_point!("RESET_APPLY_INDEX_WHEN_RESTART", |_| {
@@ -722,6 +723,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             "region flush before close begin";
         );
         let region_id = self.region_id();
+        #[allow(clippy::redundant_closure_call)]
         let flush_threshold: u64 = (|| {
             fail_point!("flush_before_close_threshold", |t| {
                 t.unwrap().parse::<u64>().unwrap()

--- a/components/raftstore-v2/src/raft/peer.rs
+++ b/components/raftstore-v2/src/raft/peer.rs
@@ -194,7 +194,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             peer_cache: vec![],
             peer_heartbeats: HashMap::default(),
             compact_log_context: CompactLogContext::new(applied_index, persisted_applied),
-            merge_context: merge_context.map(|c| Box::new(c)),
+            merge_context: merge_context.map(Box::new),
             last_sent_snapshot_index: 0,
             raw_write_encoder: None,
             proposals: ProposalQueue::new(region_id, raft_group.raft.id),

--- a/components/raftstore-v2/src/worker/pd/misc.rs
+++ b/components/raftstore-v2/src/worker/pd/misc.rs
@@ -103,6 +103,7 @@ where
             }
         };
 
+        #[allow(clippy::redundant_closure_call)]
         let delay = (|| {
             fail::fail_point!("delay_update_max_ts", |_| true);
             false

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -4085,6 +4085,7 @@ where
                 .snapshot_recovery_maybe_finish_wait_apply(/* force= */ true);
         }
 
+        #[allow(clippy::redundant_closure_call)]
         (|| {
             fail_point!(
                 "before_destroy_peer_on_peer_1003",
@@ -7162,6 +7163,7 @@ where
 
     fn on_set_flashback_state(&mut self, region: metapb::Region) {
         // Update the region meta.
+        #[allow(clippy::redundant_closure_call)]
         self.update_region((|| {
             #[cfg(feature = "failpoints")]
             fail_point!("keep_peer_fsm_flashback_state_false", |_| {

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -2875,6 +2875,7 @@ impl<EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'_, EK, ER, T>
         // almost idle (no more pending regions on applying logs), it can be
         // regarded as the candidate for balancing leaders.
         if during_starting_stage {
+            #[allow(clippy::redundant_closure_call)]
             let completed_target_count = (|| {
                 fail_point!("on_mock_store_completed_target_count", |_| 0);
                 std::cmp::max(

--- a/components/raftstore/src/store/memory.rs
+++ b/components/raftstore/src/store/memory.rs
@@ -57,6 +57,7 @@ lazy_static! {
         MEMTRACE_ROOT.sub_trace(Id::Name("raft_entries"));
 }
 
+#[allow(clippy::redundant_closure_call)]
 pub fn get_memory_usage_entry_cache() -> u64 {
     (|| {
         fail_point!("mock_memory_usage_entry_cache", |t| {

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -4580,6 +4580,7 @@ where
                 // that we can not manage to get a valid split key. So, we
                 // trigger a compaction to handle it.
                 if e.to_string().contains(NO_VALID_SPLIT_KEY) {
+                    #[allow(clippy::redundant_closure_call)]
                     let safe_ts = (|| {
                         fail::fail_point!("safe_point_inject", |t| {
                             t.unwrap().parse::<u64>().unwrap()

--- a/components/raftstore/src/store/peer_storage.rs
+++ b/components/raftstore/src/store/peer_storage.rs
@@ -553,6 +553,7 @@ where
 
         match find_peer_by_id(&self.region, to) {
             Some(to_peer) => {
+                #[allow(clippy::redundant_closure_call)]
                 let max_snap_try_cnt = (|| {
                     fail_point!("ignore_snap_try_cnt", |_| usize::MAX);
                     MAX_SNAP_TRY_CNT
@@ -1088,9 +1089,7 @@ where
         // The `region` is updated after persisting in order to stay consistent with the
         // one in `StoreMeta::regions` (will be updated soon).
         // See comments in `apply_snapshot` for more details.
-        (|| {
-            fail_point!("before_set_region_on_peer_3", self.peer_id == 3, |_| {});
-        })();
+        fail_point!("before_set_region_on_peer_3", self.peer_id == 3, |_| {});
         self.set_region(res.region.clone());
     }
 }

--- a/components/raftstore/src/store/snap/io.rs
+++ b/components/raftstore/src/store/snap/io.rs
@@ -164,6 +164,7 @@ where
                              key_mgr: Option<Arc<DataKeyManager>>|
      -> Result<u64, Error> {
         let info = sst_writer.finish()?;
+        #[allow(clippy::redundant_closure_call)]
         (|| {
             fail_point!("inject_sst_file_corruption", |_| {
                 static CALLED: std::sync::atomic::AtomicBool =

--- a/components/raftstore/src/store/txn_ext.rs
+++ b/components/raftstore/src/store/txn_ext.rs
@@ -285,8 +285,8 @@ impl PeerPessimisticLocks {
         }
         let mut locks = Vec::new();
         let mut iter = self.map.range((
-            start.map_or(Bound::Unbounded, |k| Bound::Included(k)),
-            end.map_or(Bound::Unbounded, |k| Bound::Excluded(k)),
+            start.map_or(Bound::Unbounded, Bound::Included),
+            end.map_or(Bound::Unbounded, Bound::Excluded),
         ));
         while let Some((key, (lock, _))) = iter.next() {
             if filter(key, lock) {

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -1440,6 +1440,7 @@ where
                     }
                     // NodeState for this store.
                     {
+                        #[allow(clippy::redundant_closure_call)]
                         let state = (|| {
                             #[cfg(feature = "failpoints")]
                             fail_point!("manually_set_store_offline", |_| {

--- a/components/resolved_ts/src/endpoint.rs
+++ b/components/resolved_ts/src/endpoint.rs
@@ -588,7 +588,7 @@ where
                 opt.map(|(pd_ts, instant)| {
                     pd_ts.physical() + instant.saturating_elapsed().as_millis() as u64
                 })
-                .unwrap_or_else(|| TimeStamp::physical_now())
+                .unwrap_or_else(TimeStamp::physical_now)
             })
             .unwrap_or_else(|_| TimeStamp::physical_now())
     }

--- a/components/resource_control/src/service.rs
+++ b/components/resource_control/src/service.rs
@@ -282,15 +282,16 @@ impl ResourceManagerService {
             }
 
             let dur = if cfg!(feature = "failpoints") {
+                #[allow(clippy::redundant_closure_call)]
                 (|| {
                     fail::fail_point!("set_report_duration", |v| {
                         let dur = v
                             .expect("should provide delay time (in ms)")
                             .parse::<u64>()
                             .expect("should be number (in ms)");
-                        std::time::Duration::from_millis(dur)
+                        Duration::from_millis(dur)
                     });
-                    std::time::Duration::from_millis(100)
+                    Duration::from_millis(100)
                 })()
             } else {
                 BACKGROUND_RU_REPORT_DURATION

--- a/components/tidb_query_datatype/src/codec/collation/mod.rs
+++ b/components/tidb_query_datatype/src/codec/collation/mod.rs
@@ -144,13 +144,13 @@ pub trait Encoding {
 
     #[inline]
     fn lower(s: &str, writer: BytesWriter) -> BytesGuard {
-        let res = s.chars().flat_map(|ch| encoding::unicode_to_lower(ch));
+        let res = s.chars().flat_map(encoding::unicode_to_lower);
         writer.write_from_char_iter(res)
     }
 
     #[inline]
     fn upper(s: &str, writer: BytesWriter) -> BytesGuard {
-        let res = s.chars().flat_map(|ch| encoding::unicode_to_upper(ch));
+        let res = s.chars().flat_map(encoding::unicode_to_upper);
         writer.write_from_char_iter(res)
     }
 }

--- a/components/tidb_query_datatype/src/codec/mysql/json/path_expr.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/json/path_expr.rs
@@ -79,7 +79,7 @@ fn array_index_right(input: &str) -> IResult<&str, ArrayIndex> {
 fn array_index(input: &str) -> IResult<&str, ArraySelection> {
     map(
         alt((array_index_left, array_index_right, array_index_last)),
-        |index| ArraySelection::Index(index),
+        ArraySelection::Index,
     )(input)
 }
 
@@ -128,7 +128,7 @@ fn path_leg_array_selection(input: &str) -> IResult<&str, PathLeg> {
     let (input, _) = space0(input)?;
     let (input, leg) = map(
         alt((array_asterisk, array_range, array_index)),
-        |array_selection| PathLeg::ArraySelection(array_selection),
+        PathLeg::ArraySelection,
     )(input)
     .map_err(lift_error_to_failure)?;
     let (input, _) = space0(input)?;
@@ -187,7 +187,7 @@ fn path_leg_key(input: &str) -> IResult<&str, PathLeg> {
 
     map(
         alt((key_selection_key, key_selection_asterisk)),
-        |key_selection| PathLeg::Key(key_selection),
+        PathLeg::Key,
     )(input)
     .map_err(lift_error_to_failure)
 }

--- a/components/tidb_query_datatype/src/codec/mysql/time/interval.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/time/interval.rs
@@ -578,7 +578,7 @@ impl Interval {
         input: &str,
     ) -> Result<Duration> {
         let val = Self::parse_from_str_internal(ctx, unit, input, true)?
-            .ok_or_else(|| Error::datetime_function_overflow())?;
+            .ok_or_else(Error::datetime_function_overflow)?;
         use IntervalUnit::*;
         match unit {
             Microsecond | Second | Minute | Hour | Day | Week | Month | Quarter | Year => {

--- a/components/tidb_query_datatype/src/codec/mysql/time/mod.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/time/mod.rs
@@ -2228,20 +2228,20 @@ impl Time {
         let sec_dur = chrono::Duration::seconds(secs);
         let duration = sec_dur
             .checked_add(&chrono::Duration::nanoseconds(nanos))
-            .ok_or_else(|| Error::datetime_function_overflow())?;
+            .ok_or_else(Error::datetime_function_overflow)?;
         let time_type = self.get_time_type();
         let fsp = self.fsp() as i8;
         let mut new_time = if time_type == TimeType::Timestamp {
             let datetime = self
                 .try_into_chrono_datetime(ctx)?
                 .checked_add_signed(duration)
-                .ok_or_else(|| Error::datetime_function_overflow())?;
+                .ok_or_else(Error::datetime_function_overflow)?;
             Time::try_from_chrono_datetime(ctx, datetime, TimeType::Timestamp, fsp)?
         } else {
             let naive = self
                 .try_into_chrono_naive_datetime()?
                 .checked_add_signed(duration)
-                .ok_or_else(|| Error::datetime_function_overflow())?;
+                .ok_or_else(Error::datetime_function_overflow)?;
             Time::try_from_chrono_datetime(ctx, naive, time_type, fsp)?
         };
 

--- a/components/tidb_query_executors/src/index_scan_executor.rs
+++ b/components/tidb_query_executors/src/index_scan_executor.rs
@@ -116,7 +116,7 @@ impl<S: Storage, F: KvFormat> BatchIndexScanExecutor<S, F> {
 
         let schema: Vec<_> = columns_info
             .iter()
-            .map(|ci| field_type_from_column_info(ci))
+            .map(field_type_from_column_info)
             .collect();
 
         let columns_id_without_handle: Vec<_> = columns_info[..columns_info.len()

--- a/components/tikv_util/src/config.rs
+++ b/components/tikv_util/src/config.rs
@@ -211,7 +211,7 @@ impl FromStr for ReadableSize {
                 if size.chars().all(|c| char::is_ascii_digit(&c)) {
                     return size
                         .parse::<u64>()
-                        .map(|n| ReadableSize(n))
+                        .map(ReadableSize)
                         .map_err(|_| format!("invalid size string: {:?}", s));
                 }
                 UNIT

--- a/components/tikv_util/src/stream.rs
+++ b/components/tikv_util/src/stream.rs
@@ -237,12 +237,15 @@ where
     F: Future<Output = Result<T, E>>,
     E: RetryError,
 {
-    ext.max_retry_times = (|| {
-        fail::fail_point!("retry_count", |t| t
-            .and_then(|v| v.parse::<usize>().ok())
-            .unwrap_or(ext.max_retry_times));
-        ext.max_retry_times
-    })();
+    ext.max_retry_times = {
+        #[allow(clippy::redundant_closure_call)]
+        (|| {
+            fail::fail_point!("retry_count", |t| t
+                .and_then(|v| v.parse::<usize>().ok())
+                .unwrap_or(ext.max_retry_times));
+            ext.max_retry_times
+        })()
+    };
 
     retry_expr!(action(), ext).await
 }

--- a/src/coprocessor_v2/endpoint.rs
+++ b/src/coprocessor_v2/endpoint.rs
@@ -126,7 +126,7 @@ fn extract_region_error(error: &PluginError) -> Option<kvproto::errorpb::Error> 
     match error {
         PluginError::Other(_, other_err) => other_err
             .downcast_ref::<storage::Result<()>>()
-            .and_then(|e| storage::errors::extract_region_error::<()>(e)),
+            .and_then(storage::errors::extract_region_error::<()>),
         _ => None,
     }
 }

--- a/src/server/debug2.rs
+++ b/src/server/debug2.rs
@@ -841,7 +841,7 @@ impl<ER: RaftEngine> Debugger for DebuggerImplV2<ER> {
     fn get_store_ident(&self) -> Result<StoreIdent> {
         self.raft_engine
             .get_store_ident()
-            .map_err(|e| Error::EngineTrait(e))
+            .map_err(Error::EngineTrait)
             .and_then(|ident| match ident {
                 Some(ident) => Ok(ident),
                 None => Err(Error::NotFound("No store ident key".to_owned())),

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -441,11 +441,7 @@ impl<E: Engine> GcRunnerCore<E> {
         let count = keys.len();
         let range_start_key = keys.first().unwrap().clone();
         let range_end_key = {
-            let mut k = keys
-                .last()
-                .unwrap()
-                .to_raw()
-                .map_err(|e| EngineError::Codec(e))?;
+            let mut k = keys.last().unwrap().to_raw().map_err(EngineError::Codec)?;
             k.push(0);
             Key::from_raw(&k)
         };
@@ -562,11 +558,7 @@ impl<E: Engine> GcRunnerCore<E> {
     ) -> Result<(usize, usize)> {
         let range_start_key = keys.first().unwrap().clone();
         let range_end_key = {
-            let mut k = keys
-                .last()
-                .unwrap()
-                .to_raw()
-                .map_err(|e| EngineError::Codec(e))?;
+            let mut k = keys.last().unwrap().to_raw().map_err(EngineError::Codec)?;
             k.push(0);
             Key::from_raw(&k)
         };

--- a/src/server/raftkv2/mod.rs
+++ b/src/server/raftkv2/mod.rs
@@ -202,6 +202,7 @@ impl<EK: KvEngine, ER: RaftEngine> tikv_kv::Engine for RaftKv2<EK, ER> {
         let mut cmd = RaftCmdRequest::default();
         cmd.set_header(header);
         cmd.set_requests(vec![req].into());
+        #[allow(clippy::redundant_closure_call)]
         let res: tikv_kv::Result<()> = (|| {
             fail_point!("raftkv_async_snapshot_err", |_| {
                 Err(box_err!("injected error for async_snapshot"))
@@ -296,6 +297,7 @@ impl<EK: KvEngine, ER: RaftEngine> tikv_kv::Engine for RaftKv2<EK, ER> {
         let region_id = ctx.region_id;
         ASYNC_REQUESTS_COUNTER_VEC.write.all.inc();
 
+        #[allow(clippy::redundant_closure_call)]
         let inject_region_not_found = (|| {
             // If rid is some, only the specified region reports error.
             // If rid is None, all regions report error.

--- a/src/server/snap.rs
+++ b/src/server/snap.rs
@@ -61,6 +61,7 @@ const MIN_SNAP_SEND_SPEED: u64 = MIB;
 
 #[inline]
 fn get_snap_timeout(size: u64) -> Duration {
+    #[allow(clippy::redundant_closure_call)]
     let timeout = (|| {
         fail_point!("snap_send_duration_timeout", |t| -> Duration {
             let t = t.unwrap().parse::<u64>();

--- a/src/server/tablet_snap.rs
+++ b/src/server/tablet_snap.rs
@@ -431,7 +431,7 @@ async fn accept_missing(
 ) -> Result<u64> {
     let mut digest = Digest::default();
     let mut received_bytes: u64 = 0;
-    let mut key_importer = key_manager.as_deref().map(|m| DataKeyImporter::new(m));
+    let mut key_importer = key_manager.as_deref().map(DataKeyImporter::new);
     for name in missing_ssts {
         let chunk = match stream.next().await {
             Some(Ok(mut req)) if req.has_chunk() => req.take_chunk(),

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -3080,7 +3080,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         self.sched_raw_command(metadata, priority, CMD, async move {
             let key = F::encode_raw_key_owned(key, None);
             let cmd = RawCompareAndSwap::new(cf, key, previous_value, value, ttl, api_version, ctx);
-            Self::sched_raw_atomic_command(sched, cmd, Box::new(|res| callback(res)));
+            Self::sched_raw_atomic_command(sched, cmd, Box::new(callback));
         })
     }
 
@@ -3109,7 +3109,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         self.sched_raw_command(metadata, priority, CMD, async move {
             let modifies = Self::raw_batch_put_requests_to_modifies(cf, pairs, ttls, None);
             let cmd = RawAtomicStore::new(cf, modifies, ctx);
-            Self::sched_raw_atomic_command(sched, cmd, Box::new(|res| callback(res)));
+            Self::sched_raw_atomic_command(sched, cmd, Box::new(callback));
         })
     }
 
@@ -3134,7 +3134,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                 .map(|k| Self::raw_delete_request_to_modify(cf, k, None))
                 .collect();
             let cmd = RawAtomicStore::new(cf, modifies, ctx);
-            Self::sched_raw_atomic_command(sched, cmd, Box::new(|res| callback(res)));
+            Self::sched_raw_atomic_command(sched, cmd, Box::new(callback));
         })
     }
 
@@ -3263,7 +3263,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
             self.read_pool
                 .spawn_handle(future, priority, task_id, metadata, resource_limiter)
                 .map_err(|_| Error::from(ErrorInner::SchedTooBusy))
-                .and_then(|res| future::ready(res)),
+                .and_then(future::ready),
         )
     }
 

--- a/src/storage/mvcc/reader/scanner/mod.rs
+++ b/src/storage/mvcc/reader/scanner/mod.rs
@@ -334,8 +334,8 @@ impl<S: Snapshot> ScannerConfig<S> {
             .range(lower, upper)
             .fill_cache(self.fill_cache)
             .scan_mode(scan_mode)
-            .hint_min_ts(hint_min_ts.map(|ts| Bound::Included(ts)))
-            .hint_max_ts(hint_max_ts.map(|ts| Bound::Included(ts)))
+            .hint_min_ts(hint_min_ts.map(Bound::Included))
+            .hint_max_ts(hint_max_ts.map(Bound::Included))
             .build()?;
         Ok(cursor)
     }

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -1698,6 +1698,7 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         while let Some(ev) = res.next().await {
             match ev {
                 WriteEvent::Committed => {
+                    #[allow(clippy::redundant_closure_call)]
                     let early_return = (|| {
                         fail_point!("before_async_apply_prewrite_finish", |_| false);
                         true
@@ -1717,6 +1718,7 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
                     }
                 }
                 WriteEvent::Proposed => {
+                    #[allow(clippy::redundant_closure_call)]
                     let early_return = (|| {
                         fail_point!("before_pipelined_write_finish", |_| false);
                         true


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Partially fixes #8336

### What's Changed:
Fixed clippy warnings related to the redundant_closure and  redundant_closure_call

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code (does not change the logic, code refactoring only)

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
```release-note
None
```
