### PR TITLE
titan: Fix region size underestimation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3821,7 +3821,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#755d152ec4eb443039296ceecf9a072a1142e014"
+source = "git+https://github.com/hbisheng/rust-rocksdb?branch=titan-properties#bb5e150755ec04b5de46f77edf6de4e446e23656"
 dependencies = [
  "bindgen 0.65.1",
  "bzip2-sys",
@@ -3840,7 +3840,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tikv/rust-rocksdb.git#755d152ec4eb443039296ceecf9a072a1142e014"
+source = "git+https://github.com/hbisheng/rust-rocksdb?branch=titan-properties#bb5e150755ec04b5de46f77edf6de4e446e23656"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -5835,7 +5835,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#755d152ec4eb443039296ceecf9a072a1142e014"
+source = "git+https://github.com/hbisheng/rust-rocksdb?branch=titan-properties#bb5e150755ec04b5de46f77edf6de4e446e23656"
 dependencies = [
  "libc 0.2.151",
  "librocksdb_sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,7 +225,7 @@ sysinfo = { git = "https://github.com/tikv/sysinfo", branch = "0.26-fix-cpu" }
 #
 # After the PR to rust-rocksdb is merged, remember to comment this out and run `cargo update -p rocksdb`.
 # [patch.'https://github.com/tikv/rust-rocksdb']
-# rocksdb = { git = "https://github.com/your_github_id/rust-rocksdb", branch = "your_branch" }
+rocksdb = { git = "https://github.com/hbisheng/rust-rocksdb", branch = "titan-properties" }
 
 [workspace]
 # See https://github.com/rust-lang/rfcs/blob/master/text/2957-cargo-features2.md

--- a/components/engine_rocks/Cargo.toml
+++ b/components/engine_rocks/Cargo.toml
@@ -56,7 +56,8 @@ tracker = { workspace = true }
 txn_types = { workspace = true }
 
 [dependencies.rocksdb]
-git = "https://github.com/tikv/rust-rocksdb.git"
+git = "https://github.com/hbisheng/rust-rocksdb.git"
+branch = "titan-properties"
 package = "rocksdb"
 features = ["encryption"]
 

--- a/components/engine_rocks/src/properties.rs
+++ b/components/engine_rocks/src/properties.rs
@@ -37,7 +37,7 @@ fn get_entry_size(value: &[u8], entry_type: DBEntryType) -> std::result::Result<
     match entry_type {
         DBEntryType::Put => Ok(value.len() as u64),
         DBEntryType::BlobIndex => match TitanBlobIndex::decode(value) {
-            Ok(index) => Ok(index.blob_size + value.len() as u64),
+            Ok(index) => Ok(index.blob_raw_size + value.len() as u64),
             Err(_) => Err(()),
         },
         _ => Err(()),


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18600

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Previously, TiKV estimated region size using the compressed blob size, 
which could significantly underestimate the true size when the 
compression ratio was high. This caused delayed region splits and 
oversized regions.

This change updates the logic to use the uncompressed blob size, 
enabled by rust-rocksdb#834, for more accurate region size estimation 
when Titan is enabled.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fix region size underestimation when Titan is enabled.
```
