### PR TITLE
*: update raft-engine to optimize `fetch_entries_to`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5233,7 +5233,7 @@ dependencies = [
 [[package]]
 name = "raft-engine"
 version = "0.4.2"
-source = "git+https://github.com/LykxSassinator/raft-engine.git?branch=opt_fetch_entries#9d8e7987c0db1a034db441e5a787ca04cf5b52c1"
+source = "git+https://github.com/tikv/raft-engine.git#03f77d90c09793a6f79411ff5f88233715eb23da"
 dependencies = [
  "byteorder",
  "crc32fast",
@@ -5267,7 +5267,7 @@ dependencies = [
 [[package]]
 name = "raft-engine-ctl"
 version = "0.4.2"
-source = "git+https://github.com/LykxSassinator/raft-engine.git?branch=opt_fetch_entries#9d8e7987c0db1a034db441e5a787ca04cf5b52c1"
+source = "git+https://github.com/tikv/raft-engine.git#03f77d90c09793a6f79411ff5f88233715eb23da"
 dependencies = [
  "clap 3.1.6",
  "env_logger 0.10.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5233,7 +5233,7 @@ dependencies = [
 [[package]]
 name = "raft-engine"
 version = "0.4.2"
-source = "git+https://github.com/tikv/raft-engine.git#392f5e66f8286dc1b6d7cf69f2bc20ed72d40123"
+source = "git+https://github.com/LykxSassinator/raft-engine.git?branch=opt_fetch_entries#9d8e7987c0db1a034db441e5a787ca04cf5b52c1"
 dependencies = [
  "byteorder",
  "crc32fast",
@@ -5267,7 +5267,7 @@ dependencies = [
 [[package]]
 name = "raft-engine-ctl"
 version = "0.4.2"
-source = "git+https://github.com/tikv/raft-engine.git#392f5e66f8286dc1b6d7cf69f2bc20ed72d40123"
+source = "git+https://github.com/LykxSassinator/raft-engine.git?branch=opt_fetch_entries#9d8e7987c0db1a034db441e5a787ca04cf5b52c1"
 dependencies = [
  "clap 3.1.6",
  "env_logger 0.10.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,9 +226,6 @@ sysinfo = { git = "https://github.com/tikv/sysinfo", branch = "0.26-fix-cpu" }
 # After the PR to rust-rocksdb is merged, remember to comment this out and run `cargo update -p rocksdb`.
 # [patch.'https://github.com/tikv/rust-rocksdb']
 # rocksdb = { git = "https://github.com/your_github_id/rust-rocksdb", branch = "your_branch" }
-[patch.'https://github.com/tikv/raft-engine']
-raft-engine = { git = "https://github.com/LykxSassinator/raft-engine.git", branch = "opt_fetch_entries" }
-raft-engine-ctl = { git = "https://github.com/LykxSassinator/raft-engine.git", branch = "opt_fetch_entries" }
 
 [workspace]
 # See https://github.com/rust-lang/rfcs/blob/master/text/2957-cargo-features2.md

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ openssl-vendored = [
 # for testing configure propegate to other crates
 # https://stackoverflow.com/questions/41700543/can-we-share-test-utilites-between-crates
 testing = []
-docker_test = []  # Feature flag for Docker-specific tests
+docker_test = [] # Feature flag for Docker-specific tests
 
 [lib]
 name = "tikv"
@@ -226,6 +226,9 @@ sysinfo = { git = "https://github.com/tikv/sysinfo", branch = "0.26-fix-cpu" }
 # After the PR to rust-rocksdb is merged, remember to comment this out and run `cargo update -p rocksdb`.
 # [patch.'https://github.com/tikv/rust-rocksdb']
 # rocksdb = { git = "https://github.com/your_github_id/rust-rocksdb", branch = "your_branch" }
+[patch.'https://github.com/tikv/raft-engine']
+raft-engine = { git = "https://github.com/LykxSassinator/raft-engine.git", branch = "opt_fetch_entries" }
+raft-engine-ctl = { git = "https://github.com/LykxSassinator/raft-engine.git", branch = "opt_fetch_entries" }
 
 [workspace]
 # See https://github.com/rust-lang/rfcs/blob/master/text/2957-cargo-features2.md

--- a/deny.toml
+++ b/deny.toml
@@ -113,4 +113,4 @@ exceptions = [
 [sources]
 unknown-git = "deny"
 unknown-registry = "deny"
-allow-org = { github = ["tikv", "pingcap", "rust-lang", "LykxSassinator"] }
+allow-org = { github = ["tikv", "pingcap", "rust-lang"] }

--- a/deny.toml
+++ b/deny.toml
@@ -113,4 +113,4 @@ exceptions = [
 [sources]
 unknown-git = "deny"
 unknown-registry = "deny"
-allow-org = { github = ["tikv", "pingcap", "rust-lang"] }
+allow-org = { github = ["tikv", "pingcap", "rust-lang", "LykxSassinator"] }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close https://github.com/tikv/tikv/issues/18605

More details can be reviewed in https://github.com/tikv/raft-engine/pull/382.

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Optimizes `fetch_entries_to` in Raft-Engine to reduce contention and improve performance under mixed workloads.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Optimizes `fetch_entries_to` in Raft-Engine to reduce contention and improve performance under mixed workloads.
```
