### PR TITLE
config: avoid inherting unnecessary configs to RaftstoreConfig from the last config file

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4348,9 +4348,16 @@ impl TikvConfig {
     /// ```
     #[allow(deprecated)]
     pub fn compatible_adjust(&mut self, last_config: Option<&TikvConfig>) {
-        let (default_raft_store, default_coprocessor) = last_config
-            .map_or((RaftstoreConfig::default(), CopConfig::default()), |cfg| {
-                (cfg.raft_store.clone(), cfg.coprocessor.clone())
+        let (default_raft_store, default_coprocessor) =
+            last_config.map_or((RaftstoreConfig::default(), CopConfig::default()), |cfg| {
+                (
+                    RaftstoreConfig {
+                        region_max_size: cfg.raft_store.region_max_size,
+                        region_split_size: cfg.raft_store.region_split_size,
+                        ..cfg.raft_store.clone()
+                    },
+                    cfg.coprocessor.clone(),
+                )
             });
         if self.raft_store.region_max_size != default_raft_store.region_max_size {
             warn!(
@@ -7620,6 +7627,10 @@ mod tests {
         assert_eq!(
             cfg_from_file.coprocessor.region_split_keys,
             case2_cfg.coprocessor.region_split_keys
+        );
+        assert_eq!(
+            default_cfg.raft_store.raft_entry_max_size,
+            case2_cfg.raft_store.raft_entry_max_size
         );
 
         // Case 3: manually specify region-split-size, then make it compatible to the

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -7594,8 +7594,10 @@ mod tests {
         );
 
         // Case 2: persist and load the last tikv configurations, then make the current
-        // config compatible to it.
+        // config compatible to it. And it manually set `raft_entry_max_size` in
+        // Raftstore, but the new config does not set it.
         cfg.coprocessor.region_split_size = Some(ReadableSize::mb(16));
+        cfg.raft_store.raft_entry_max_size = ReadableSize::kb(16);
         validate_and_persist_config(&mut cfg, true).unwrap();
         let cfg_from_file = TikvConfig::from_file(
             &Path::new(&cfg.storage.data_dir).join(LAST_CONFIG_FILE),
@@ -7628,8 +7630,14 @@ mod tests {
             cfg_from_file.coprocessor.region_split_keys,
             case2_cfg.coprocessor.region_split_keys
         );
+        // Other configs in RaftstoreConfig should not
+        // inherit the last config.
         assert_eq!(
             default_cfg.raft_store.raft_entry_max_size,
+            case2_cfg.raft_store.raft_entry_max_size
+        );
+        assert_ne!(
+            cfg_from_file.raft_store.raft_entry_max_size,
             case2_cfg.raft_store.raft_entry_max_size
         );
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref https://github.com/tikv/tikv/issues/18503

The previous https://github.com/tikv/tikv/pull/18505 introduces the inheritage of `region-size` configurations. But it has introduced unexpected changes to `compatible_adjust`, which makes the new config inherit unexpected configurations from the last config file to `RaftstoreConfig`.

This PR is used to fix this issue.

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Avoid the inheritage of unexpected configurations from the last config file.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Avoid the inheritage of unexpected configurations from the last config file.
```
