### PR TITLE
titan: Estimate raw blob size based on Titan metrics

### DIFF
--- a/components/engine_rocks/src/properties.rs
+++ b/components/engine_rocks/src/properties.rs
@@ -9,7 +9,6 @@ use std::{
         Mutex,
         atomic::{AtomicU64, Ordering},
     },
-    u64,
 };
 
 use api_version::{ApiV2, KeyMode, KvFormat};

--- a/components/engine_rocks/src/properties.rs
+++ b/components/engine_rocks/src/properties.rs
@@ -44,6 +44,9 @@ pub const TITAN_MAX_COMPACTION_FACTOR: f64 = 5000.0;
 const FIVE_MINS_IN_SECONDS: u64 = 5 * 60;
 
 lazy_static! {
+    // A global smoother used to estimate the Titan blob compression factor over
+    // the last 5 minutes. The window size is 30, roughly matching the number of
+    // data points collected in 5 minutes assuming one data point every 10 secs.
     pub static ref TITAN_COMPRESSION_FACTOR_SMOOTHER: Mutex<Smoother<f64, 30, FIVE_MINS_IN_SECONDS, 0>> =
         Mutex::new(Smoother::<f64, 30, FIVE_MINS_IN_SECONDS, 0>::default());
     pub static ref TITAN_COMPRESSION_FACTOR: AtomicU64 = AtomicU64::new(f64::to_bits(1.0));

--- a/components/engine_rocks/src/properties.rs
+++ b/components/engine_rocks/src/properties.rs
@@ -9,6 +9,7 @@ use std::{
         Mutex,
         atomic::{AtomicU64, Ordering},
     },
+    u64,
 };
 
 use api_version::{ApiV2, KeyMode, KvFormat};
@@ -328,7 +329,7 @@ impl Default for RangePropertiesCollector {
             prop_size_index_distance: DEFAULT_PROP_SIZE_INDEX_DISTANCE,
             prop_keys_index_distance: DEFAULT_PROP_KEYS_INDEX_DISTANCE,
             titan_compression_factor: 1.0,
-            titan_max_blob_size: 0,
+            titan_max_blob_size: u64::MAX,
             should_reload_titan_stats: true,
         }
     }

--- a/components/engine_rocks/src/properties.rs
+++ b/components/engine_rocks/src/properties.rs
@@ -63,7 +63,7 @@ fn get_entry_size(
                 // Estimate the raw blob size using the Titan compression factor.
                 let estimation = (index.blob_size as f64 * titan_compression_factor) as u64;
                 let blob_raw_size = estimation.min(titan_max_blob_size).max(index.blob_size);
-                Ok(blob_raw_size as u64 + value.len() as u64)
+                Ok(blob_raw_size + value.len() as u64)
             }
             Err(_) => Err(()),
         },

--- a/components/engine_rocks/src/properties.rs
+++ b/components/engine_rocks/src/properties.rs
@@ -619,8 +619,6 @@ pub fn get_range_stats(
 
 #[cfg(test)]
 mod tests {
-    use std::u64;
-
     use api_version::RawValue;
     use engine_traits::{CF_WRITE, LARGE_CFS, MiscExt, SyncMutable};
     use rand::Rng;

--- a/components/engine_rocks/src/rocks_metrics.rs
+++ b/components/engine_rocks/src/rocks_metrics.rs
@@ -1,5 +1,7 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::sync::atomic::Ordering;
+
 use collections::HashMap;
 use engine_traits::{CF_DEFAULT, StatisticsReporter};
 use lazy_static::lazy_static;
@@ -10,7 +12,9 @@ use rocksdb::{
 };
 
 use crate::{
-    RocksStatistics, TITAN_BLOB_SIZE_ESTIMATOR, engine::RocksEngine, rocks_metrics_defs::*,
+    RocksStatistics, TITAN_COMPRESSION_FACTOR, TITAN_COMPRESSION_FACTOR_SMOOTHER,
+    TITAN_MAX_BLOB_SIZE_SEEN, TITAN_MAX_COMPACTION_FACTOR, engine::RocksEngine,
+    rocks_metrics_defs::*,
 };
 
 make_auto_flush_static_metric! {
@@ -1238,16 +1242,22 @@ pub fn flush_engine_statistics(statistics: &RocksStatistics, name: &str, is_tita
     }
     if is_titan {
         if let Some(v) = statistics.get_histogram(HistType::TitanValueSize) {
+            // Update the Titan compression factor, which is used to estimate
+            // blob raw size when building SST table properties.
             let keys_cnt = statistics.get_ticker_count(TickerType::TitanBlobFileNumKeysWritten);
             let compressed_size =
                 statistics.get_ticker_count(TickerType::TitanBlobFileBytesWritten);
             let estimated_raw_size = (v.average * keys_cnt as f64) as u64;
             if estimated_raw_size > 0 && compressed_size > 0 {
-                TITAN_BLOB_SIZE_ESTIMATOR.update_stats(
-                    estimated_raw_size,
-                    compressed_size,
-                    v.max as u64,
-                );
+                let compression_factor = (estimated_raw_size as f64 / compressed_size as f64)
+                    .clamp(1.0, TITAN_MAX_COMPACTION_FACTOR);
+                let mut smoother = TITAN_COMPRESSION_FACTOR_SMOOTHER.lock().unwrap();
+                smoother.observe(compression_factor);
+                TITAN_COMPRESSION_FACTOR.store(smoother.get_avg().to_bits(), Ordering::Relaxed);
+                TITAN_COMPRESSION_FACTOR_GAUGE.set(smoother.get_avg());
+            }
+            if v.max as u64 > TITAN_MAX_BLOB_SIZE_SEEN.load(Ordering::Relaxed) {
+                TITAN_MAX_BLOB_SIZE_SEEN.store(v.max as u64, Ordering::Relaxed);
             }
         }
 
@@ -1360,7 +1370,7 @@ lazy_static! {
         "tikv_engine_titandb_blob_file_discardable_ratio",
         "Size of obsolete blob file",
         &["db", "cf", "ratio"]
-    ).unwrap();    
+    ).unwrap();
 }
 
 // For ticker type
@@ -1727,9 +1737,9 @@ lazy_static! {
         "Histogram of titan iter touched blob file count",
         &["db", "type"]
     ).unwrap();
-    pub static ref TITAN_COMPRESSION_EXPANSION_FACTOR_GAUGE: Gauge = register_gauge!(
-        "tikv_engine_blob_compression_expansion_factor",
-        "Estimated compression expansion factor (raw_size / compressed_size) of Titan"
+    pub static ref TITAN_COMPRESSION_FACTOR_GAUGE: Gauge = register_gauge!(
+        "tikv_engine_blob_compression_factor",
+        "Estimated compression factor (raw_size / compressed_size) of Titan"
     ).unwrap();
 }
 

--- a/components/engine_rocks/src/rocks_metrics.rs
+++ b/components/engine_rocks/src/rocks_metrics.rs
@@ -1256,7 +1256,11 @@ pub fn flush_engine_statistics(statistics: &RocksStatistics, name: &str, is_tita
                 TITAN_COMPRESSION_FACTOR.store(smoother.get_avg().to_bits(), Ordering::Relaxed);
                 TITAN_COMPRESSION_FACTOR_GAUGE.set(smoother.get_avg());
             }
-            if v.max as u64 > TITAN_MAX_BLOB_SIZE_SEEN.load(Ordering::Relaxed) {
+
+            // Update the Titan max blob size seen, used to cap blob size
+            // estimation.
+            let current = TITAN_MAX_BLOB_SIZE_SEEN.load(Ordering::Relaxed);
+            if current == u64::MAX || v.max as u64 > current {
                 TITAN_MAX_BLOB_SIZE_SEEN.store(v.max as u64, Ordering::Relaxed);
             }
         }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18600

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
This PR introduces a mechanism to estimate Titan blob raw size based on
metrics collected from Titan during flush. 

A sliding window of recent (raw, compressed) size samples is used to 
compute an average expansion factor. This factor is then used to 
estimate the raw size of a blob when building SST table properties. 
This approach assumes that the compression ratio remains relatively 
stable for the workload.

Apparently this is not a perfect solution, but a workaround. A more 
direct solution—recording the uncompressed size in the blob index 
format—was previously proposed[1]. However, changing the data format 
would break backward compatibility and prevent rollbacks, which can be 
risky.

[1] https://github.com/tikv/titan/pull/334#issuecomment-3026813148
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
   - With this PR, the region-not-split issue did not reproduce in the scenario described in #18600. 
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Address region size underestimation by estimating Titan blob raw size from metrics.
```
