### PR TITLE
Revert "raftstore: break up awaken regions into small batch. (#18544)(#18586)"

### DIFF
--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -894,11 +894,8 @@ impl<'a, EK: KvEngine + 'static, ER: RaftEngine + 'static, T: Transport>
                     drop(syncer);
                 }
                 StoreMsg::GcSnapshotFinish => self.register_snap_mgr_gc_tick(),
-                StoreMsg::AwakenRegions {
-                    abnormal_stores,
-                    region_ids,
-                } => {
-                    self.on_wake_up_regions(abnormal_stores, region_ids);
+                StoreMsg::AwakenRegions { abnormal_stores } => {
+                    self.on_wake_up_regions(abnormal_stores);
                 }
             }
         }
@@ -2853,21 +2850,12 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
         self.register_compact_lock_cf_tick();
     }
 
-    fn on_wake_up_regions(&self, abnormal_stores: Vec<u64>, region_ids: Vec<u64>) {
+    fn on_wake_up_regions(&self, abnormal_stores: Vec<u64>) {
         info!("try to wake up all hibernated regions in this store";
             "to_all" => abnormal_stores.is_empty());
         let meta = self.ctx.store_meta.lock().unwrap();
-
-        for region_id in region_ids {
-            let region = {
-                match meta.regions.get(&region_id) {
-                    None => {
-                        // The region has been merged or removed from this store; skip processing.
-                        continue;
-                    }
-                    Some(r) => r,
-                }
-            };
+        for region_id in meta.regions.keys() {
+            let region = &meta.regions[region_id];
             // Check whether the current region is not found on abnormal stores. If so,
             // this region is not the target to be awaken.
             if !region_on_stores(region, &abnormal_stores) {
@@ -2882,7 +2870,7 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
             {
                 // Send MsgRegionWakeUp to Peer for awakening hibernated regions.
                 let mut message = RaftMessage::default();
-                message.set_region_id(region_id);
+                message.set_region_id(*region_id);
                 message.set_from_peer(peer.clone());
                 message.set_to_peer(peer);
                 message.set_region_epoch(region.get_region_epoch().clone());

--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -913,7 +913,6 @@ where
 
     AwakenRegions {
         abnormal_stores: Vec<u64>,
-        region_ids: Vec<u64>,
     },
 
     /// Message only used for test.

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -8,7 +8,7 @@ use std::{
     sync::{
         atomic::Ordering,
         mpsc::{self, Receiver, Sender, SyncSender},
-        Arc, Mutex, RwLock,
+        Arc, Mutex,
     },
     thread::{Builder, JoinHandle},
     time::{Duration, Instant},
@@ -953,7 +953,7 @@ where
     store_id: u64,
     pd_client: Arc<T>,
     router: RaftRouter<EK, ER>,
-    region_peers: Arc<RwLock<HashMap<u64, PeerStat>>>,
+    region_peers: HashMap<u64, PeerStat>,
     region_buckets: HashMap<u64, ReportBucket>,
     store_stat: StoreStat,
     is_hb_receiver_scheduled: bool,
@@ -1036,7 +1036,7 @@ where
             pd_client,
             router,
             is_hb_receiver_scheduled: false,
-            region_peers: Arc::new(RwLock::new(HashMap::default())),
+            region_peers: HashMap::default(),
             region_buckets: HashMap::default(),
             store_stat,
             start_ts: UnixSecs::now(),
@@ -1287,32 +1287,29 @@ where
         dr_autosync_status: Option<StoreDrAutoSyncStatus>,
     ) {
         let mut report_peers = HashMap::default();
-        {
-            let mut region_peers = self.region_peers.write().unwrap();
-            for (region_id, region_peer) in region_peers.iter_mut() {
-                let read_bytes = region_peer.read_bytes - region_peer.last_store_report_read_bytes;
-                let read_keys = region_peer.read_keys - region_peer.last_store_report_read_keys;
-                let query_stats = region_peer
-                    .query_stats
-                    .sub_query_stats(&region_peer.last_store_report_query_stats);
-                region_peer.last_store_report_read_bytes = region_peer.read_bytes;
-                region_peer.last_store_report_read_keys = region_peer.read_keys;
-                region_peer
-                    .last_store_report_query_stats
-                    .fill_query_stats(&region_peer.query_stats);
-                if read_bytes < hotspot_byte_report_threshold()
-                    && read_keys < hotspot_key_report_threshold()
-                    && query_stats.get_read_query_num() < hotspot_query_num_report_threshold()
-                {
-                    continue;
-                }
-                let mut read_stat = pdpb::PeerStat::default();
-                read_stat.set_region_id(*region_id);
-                read_stat.set_read_keys(read_keys);
-                read_stat.set_read_bytes(read_bytes);
-                read_stat.set_query_stats(query_stats.0);
-                report_peers.insert(*region_id, read_stat);
+        for (region_id, region_peer) in &mut self.region_peers {
+            let read_bytes = region_peer.read_bytes - region_peer.last_store_report_read_bytes;
+            let read_keys = region_peer.read_keys - region_peer.last_store_report_read_keys;
+            let query_stats = region_peer
+                .query_stats
+                .sub_query_stats(&region_peer.last_store_report_query_stats);
+            region_peer.last_store_report_read_bytes = region_peer.read_bytes;
+            region_peer.last_store_report_read_keys = region_peer.read_keys;
+            region_peer
+                .last_store_report_query_stats
+                .fill_query_stats(&region_peer.query_stats);
+            if read_bytes < hotspot_byte_report_threshold()
+                && read_keys < hotspot_key_report_threshold()
+                && query_stats.get_read_query_num() < hotspot_query_num_report_threshold()
+            {
+                continue;
             }
+            let mut read_stat = pdpb::PeerStat::default();
+            read_stat.set_region_id(*region_id);
+            read_stat.set_read_keys(read_keys);
+            read_stat.set_read_bytes(read_bytes);
+            read_stat.set_query_stats(query_stats.0);
+            report_peers.insert(*region_id, read_stat);
         }
 
         stats = collect_report_read_peer_stats(HOTSPOT_REPORT_CAPACITY, report_peers, stats);
@@ -1402,7 +1399,6 @@ where
 
         let scheduler = self.scheduler.clone();
         let router = self.router.clone();
-        let region_peers = self.region_peers.clone();
         let mut snap_mgr = self.snap_mgr.clone();
         let resp = self
             .pd_client
@@ -1460,39 +1456,13 @@ where
                             }
                         }
                     }
-                    // Force awaken all hibernated regions if there are slow stores in this
-                    // cluster. To mitigate the impact of stalls when awakening too many regions,
-                    // we break up all regions into small batches.
+                    // Forcely awaken all hibernated regions if there existed slow stores in this
+                    // cluster.
                     if let Some(awaken_regions) = resp.awaken_regions.take() {
                         info!("forcely awaken hibernated regions in this store");
-                        let abnormal_stores = awaken_regions.get_abnormal_stores().to_vec();
-                        // The chunk_size of 1024 is an empirical batch size that balances
-                        // between generating too many `StoreMsg::AwakenRegions` messages and
-                        // keeping each batch small enough to avoid stalling Raftstore for
-                        // extended periods.
-                        let chunk_size = 1024;
-                        let mut region_ids = Vec::with_capacity(chunk_size);
-
-                        for (id, _) in region_peers.read().unwrap().iter() {
-                            region_ids.push(*id);
-
-                            // Send batch when it reaches the chunk size
-                            if region_ids.len() >= chunk_size {
-                                let _ = router.send_store_msg(StoreMsg::AwakenRegions {
-                                    abnormal_stores: abnormal_stores.clone(),
-                                    region_ids: std::mem::take(&mut region_ids),
-                                });
-                                region_ids.reserve(chunk_size);
-                            }
-                        }
-
-                        // Send remaining regions if any
-                        if !region_ids.is_empty() {
-                            let _ = router.send_store_msg(StoreMsg::AwakenRegions {
-                                abnormal_stores,
-                                region_ids,
-                            });
-                        }
+                        let _ = router.send_store_msg(StoreMsg::AwakenRegions {
+                            abnormal_stores: awaken_regions.get_abnormal_stores().to_vec(),
+                        });
                     }
                     // Control grpc server.
                     if let Some(op) = resp.control_grpc.take() {
@@ -1799,17 +1769,17 @@ where
 
     fn handle_read_stats(&mut self, mut read_stats: ReadStats) {
         for (region_id, region_info) in read_stats.region_infos.iter_mut() {
-            {
-                let mut region_peers = self.region_peers.write().unwrap();
-                let peer_stat = region_peers.entry(*region_id).or_default();
-                peer_stat.read_bytes += region_info.flow.read_bytes as u64;
-                peer_stat.read_keys += region_info.flow.read_keys as u64;
-                self.store_stat.engine_total_bytes_read += region_info.flow.read_bytes as u64;
-                self.store_stat.engine_total_keys_read += region_info.flow.read_keys as u64;
-                peer_stat
-                    .query_stats
-                    .add_query_stats(&region_info.query_stats.0);
-            }
+            let peer_stat = self
+                .region_peers
+                .entry(*region_id)
+                .or_insert_with(PeerStat::default);
+            peer_stat.read_bytes += region_info.flow.read_bytes as u64;
+            peer_stat.read_keys += region_info.flow.read_keys as u64;
+            self.store_stat.engine_total_bytes_read += region_info.flow.read_bytes as u64;
+            self.store_stat.engine_total_keys_read += region_info.flow.read_keys as u64;
+            peer_stat
+                .query_stats
+                .add_query_stats(&region_info.query_stats.0);
             self.store_stat
                 .engine_total_query_num
                 .add_query_stats(&region_info.query_stats.0);
@@ -1824,11 +1794,11 @@ where
 
     fn handle_write_stats(&mut self, mut write_stats: WriteStats) {
         for (region_id, region_info) in write_stats.region_infos.iter_mut() {
-            {
-                let mut region_peers = self.region_peers.write().unwrap();
-                let peer_stat = region_peers.entry(*region_id).or_default();
-                peer_stat.query_stats.add_query_stats(&region_info.0);
-            }
+            let peer_stat = self
+                .region_peers
+                .entry(*region_id)
+                .or_insert_with(PeerStat::default);
+            peer_stat.query_stats.add_query_stats(&region_info.0);
             self.store_stat
                 .engine_total_query_num
                 .add_query_stats(&region_info.0);
@@ -1836,7 +1806,7 @@ where
     }
 
     fn handle_destroy_peer(&mut self, region_id: u64) {
-        match self.region_peers.write().unwrap().remove(&region_id) {
+        match self.region_peers.remove(&region_id) {
             None => {}
             Some(_) => info!("remove peer statistic record in pd"; "region_id" => region_id),
         }
@@ -2050,7 +2020,7 @@ where
     fn handle_fake_store_heartbeat(&mut self) {
         let mut stats = pdpb::StoreStats::default();
         stats.set_store_id(self.store_id);
-        stats.set_region_count(self.region_peers.read().unwrap().len() as u32);
+        stats.set_region_count(self.region_peers.len() as u32);
 
         let snap_stats = self.snap_mgr.stats();
         stats.set_sending_snap_count(snap_stats.sending_count as u32);
@@ -2369,8 +2339,10 @@ where
                     cpu_usage,
                 ) = {
                     let region_id = hb_task.region.get_id();
-                    let mut region_peers = self.region_peers.write().unwrap();
-                    let peer_stat = region_peers.entry(region_id).or_default();
+                    let peer_stat = self
+                        .region_peers
+                        .entry(region_id)
+                        .or_insert_with(PeerStat::default);
                     peer_stat.approximate_size = approximate_size;
                     peer_stat.approximate_keys = approximate_keys;
 


### PR DESCRIPTION
This reverts commit 501b9c2f922c0009228d04cb0a01708f20990166 since this enhancement is not a block feature for customs.

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close https://github.com/tikv/tikv/issues/18533
<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

Revert the previous work #18544.

```commit-message
None.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None.
```
