### PR TITLE
raftstore: invalidate follower read cache when region is destroyed

### DIFF
--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -1463,6 +1463,8 @@ impl RegionReadProgress {
                 coprocessor.on_update_safe_ts(core.region_id, ts, ts)
             }
         }
+        // Reset `read_index_safe_ts` to 0 after region merge, because the source region's `read_index_safe_ts` may lag from the target region's. 
+        self.read_index_safe_ts.store(0, AtomicOrdering::Release);
     }
 
     // Consume the provided `LeaderInfo` to update `safe_ts` and return whether the

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -1558,6 +1558,9 @@ impl RegionReadProgress {
     }
 
     pub fn update_read_index_safe_ts(&self, start_ts: u64) {
+        if start_ts == u64::MAX {
+            return;
+        }
         let core = self.core.lock().unwrap();
         if core.pause || core.discard {
             return;
@@ -2866,6 +2869,9 @@ mod tests {
         assert_eq!(rrp.read_index_safe_ts(), 15);
         // read index safe ts will not go backward
         rrp.update_read_index_safe_ts(10);
+        assert_eq!(rrp.read_index_safe_ts(), 15);
+        // read index will not be updated if the ts is max
+        rrp.update_read_index_safe_ts(u64::MAX);
         assert_eq!(rrp.read_index_safe_ts(), 15);
 
         // read index safe ts is set to 0 when pause and cannot be updated

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -1463,8 +1463,9 @@ impl RegionReadProgress {
                 coprocessor.on_update_safe_ts(core.region_id, ts, ts)
             }
         }
-        // Reset `read_index_safe_ts` to 0 after region merge, because the source region's `read_index_safe_ts` may lag from the target region's. 
-        self.read_index_safe_ts.store(0, AtomicOrdering::Release);
+        // Reset `read_index_safe_ts` to 0 after region merge, because the source
+        // region's `read_index_safe_ts` may lag from the target region's.
+        self.read_index_safe_ts.store(0, AtomicOrdering::SeqCst);
     }
 
     // Consume the provided `LeaderInfo` to update `safe_ts` and return whether the

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -1465,7 +1465,7 @@ impl RegionReadProgress {
         }
         // Reset `read_index_safe_ts` to 0 after region merge, because the source
         // region's `read_index_safe_ts` may lag from the target region's.
-        self.read_index_safe_ts.store(0, AtomicOrdering::SeqCst);
+        self.read_index_safe_ts.store(0, AtomicOrdering::Release);
     }
 
     // Consume the provided `LeaderInfo` to update `safe_ts` and return whether the
@@ -1573,7 +1573,7 @@ impl RegionReadProgress {
     }
 
     pub fn read_index_safe_ts(&self) -> u64 {
-        self.read_index_safe_ts.load(AtomicOrdering::Relaxed)
+        self.read_index_safe_ts.load(AtomicOrdering::Acquire)
     }
 
     // `safe_ts` is calculated from the `resolved_ts`, they are the same thing

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -2867,7 +2867,7 @@ mod tests {
         assert_eq!(rrp.read_index_safe_ts(), 10);
         rrp.update_read_index_safe_ts(15);
         assert_eq!(rrp.read_index_safe_ts(), 15);
-        // read index safe ts will not backward
+        // read index safe ts will not go backward
         rrp.update_read_index_safe_ts(10);
         assert_eq!(rrp.read_index_safe_ts(), 15);
 
@@ -2876,7 +2876,7 @@ mod tests {
         assert_eq!(rrp.read_index_safe_ts(), 0);
         rrp.update_read_index_safe_ts(20);
         assert_eq!(rrp.read_index_safe_ts(), 0);
-        
+
         // resume will reset read index safe ts and the update will work again
         rrp.resume();
         rrp.update_read_index_safe_ts(30);

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -1558,6 +1558,9 @@ impl RegionReadProgress {
     }
 
     pub fn update_read_index_safe_ts(&self, start_ts: u64) {
+        if start_ts == u64::MAX {
+            return;
+        }
         let core = self.core.lock().unwrap();
         if core.pause || core.discard {
             return;

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -1558,9 +1558,6 @@ impl RegionReadProgress {
     }
 
     pub fn update_read_index_safe_ts(&self, start_ts: u64) {
-        if start_ts == u64::MAX {
-            return;
-        }
         let core = self.core.lock().unwrap();
         if core.pause || core.discard {
             return;

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -1529,6 +1529,7 @@ impl RegionReadProgress {
         let mut core = self.core.lock().unwrap();
         core.pause = true;
         self.safe_ts.store(0, AtomicOrdering::Release);
+        self.read_index_safe_ts.store(0, AtomicOrdering::Release);
     }
 
     /// Discard incoming `read_state` item and stop updating `safe_ts`

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -1373,7 +1373,10 @@ pub struct RegionReadProgress {
     core: Mutex<RegionReadProgressCore>,
     // The fast path to read `safe_ts` without acquiring the mutex
     // on `core`
+    // Use `AcqRel` to ensure that the `safe_ts` is always visible to
+    // the readers after it is updated.
     safe_ts: AtomicU64,
+    // Use `AcqRel` same as `safe_ts`.
     pub read_index_safe_ts: AtomicU64,
 }
 

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -1524,7 +1524,7 @@ impl RegionReadProgress {
             find_store_id(&core.leader_info.peers, core.leader_info.leader_id)
     }
 
-    /// Reset `safe_ts` to 0 and stop updating it
+    /// Reset `safe_ts` and `read_index_safe_ts` to 0 and stop updating them
     pub fn pause(&self) {
         let mut core = self.core.lock().unwrap();
         core.pause = true;

--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -1208,6 +1208,7 @@ where
                             &mut snap_updated,
                             last_valid_ts,
                         ) {
+                            fail_point!("reading_from_follower_read_cache");
                             TLS_LOCAL_READ_METRICS.with(|m| {
                                 m.borrow_mut().local_executed_follower_read_requests.inc()
                             });

--- a/components/raftstore/src/store/worker/region.rs
+++ b/components/raftstore/src/store/worker/region.rs
@@ -775,6 +775,7 @@ where
                 // there might be a coprocessor request related to this range
                 self.insert_pending_delete_range(region_id, start_key, end_key);
                 self.clean_stale_ranges();
+                fail_point!("after_region_worker_destroy");
             }
         }
     }

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -1070,6 +1070,7 @@ impl<T: Simulator> Cluster<T> {
         let req = new_admin_request(region_id, region.get_region_epoch(), add_peer);
         self.async_request(req)
     }
+
     pub fn must_put(&mut self, key: &[u8], value: &[u8]) {
         self.must_put_cf(CF_DEFAULT, key, value);
     }

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -1070,7 +1070,6 @@ impl<T: Simulator> Cluster<T> {
         let req = new_admin_request(region_id, region.get_region_epoch(), add_peer);
         self.async_request(req)
     }
-
     pub fn must_put(&mut self, key: &[u8], value: &[u8]) {
         self.must_put_cf(CF_DEFAULT, key, value);
     }

--- a/components/test_raftstore/src/util.rs
+++ b/components/test_raftstore/src/util.rs
@@ -1897,3 +1897,13 @@ pub fn wait_down_peers<T: Simulator>(cluster: &Cluster<T>, count: u64, peer: Opt
         peers, count, peer
     );
 }
+
+pub fn get_region_read_index_safe_ts<T: Simulator>(
+    cluster: &Cluster<T>,
+    store_id: u64,
+    region_id: u64,
+) -> u64 {
+    let store_meta = cluster.store_metas.get(&store_id).unwrap().lock().unwrap();
+    let region_read_progress = store_meta.region_read_progress.get(&region_id).unwrap();
+    region_read_progress.read_index_safe_ts()
+}

--- a/tests/failpoints/cases/test_replica_read.rs
+++ b/tests/failpoints/cases/test_replica_read.rs
@@ -1124,7 +1124,7 @@ fn test_read_index_cache_region_split() {
         guards.push(guard);
     }
 
-    let all_peers = vec![
+    let all_peers = [
         left_region
             .get_peers()
             .iter()

--- a/tests/failpoints/cases/test_replica_read.rs
+++ b/tests/failpoints/cases/test_replica_read.rs
@@ -933,7 +933,7 @@ fn test_read_index_cache() {
 }
 
 #[test_case(test_raftstore::new_server_cluster)]
-fn test_read_index_cache_in_destroied_peer() {
+fn test_read_index_cache_in_destroyed_peer() {
     let cluster = Arc::new(Mutex::new(new_cluster(0, 4)));
     let pd_client = cluster.lock().unwrap().pd_client.clone();
 

--- a/tests/failpoints/cases/test_replica_read.rs
+++ b/tests/failpoints/cases/test_replica_read.rs
@@ -11,6 +11,8 @@ use engine_traits::{Peekable, RaftEngineReadOnly};
 use futures::executor::block_on;
 use kvproto::{
     kvrpcpb::{Context, KeyRange},
+    pdpb,
+    raft_cmdpb::CmdType,
     raft_serverpb::{PeerState, RaftMessage, RegionLocalState},
 };
 use pd_client::PdClient;
@@ -1054,8 +1056,6 @@ fn test_read_index_cache_in_destroied_peer() {
 
 #[test_case(test_raftstore::new_node_cluster)]
 fn test_read_index_cache_region_merge() {
-    use kvproto::{pdpb, raft_cmdpb::CmdType};
-
     let mut cluster = new_cluster(0, 5);
     // Use long election timeout and short lease.
     configure_for_lease_read(&mut cluster.cfg, Some(50), Some(200));


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: close #18570

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Set `read_index_safe_ts` to 0 when `RegionReadProgress` is paused to prevent unsafe follower read.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fix the issue that follower read may get wrong result through follower read cache.
```
