### PR TITLE
batch-system: fix router `check_do` lock contention

### DIFF
--- a/components/batch-system/src/router.rs
+++ b/components/batch-system/src/router.rs
@@ -102,7 +102,7 @@ where
     where
         F: FnMut(&BasicMailbox<N>) -> Option<R>,
     {
-        let mailbox = match self.normals.get_mut(&addr) {
+        let mailbox = match self.normals.get(&addr) {
             Some(mailbox) => mailbox,
             None => {
                 return CheckDoResult::NotExist;


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18713

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
The `check_do` method currently uses get_mut when only read access is
required. This unnecessary mutable borrow may cause severe lock
contention, especially since check_do is a hot path invoked on every
message sent to raftstore. Switching to a read-only borrow reduces
contention and improves tail latency.
```

### Check List

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
