### PR TITLE
raftstore: Remove redundant initial Raft state write for split regions

### DIFF
--- a/components/raftstore/src/store/metrics.rs
+++ b/components/raftstore/src/store/metrics.rs
@@ -484,13 +484,6 @@ lazy_static! {
             exponential_buckets(0.00001, 2.0, 32).unwrap() // 10us ~ 42949s.
         ).unwrap();
 
-    pub static ref PEER_CREATE_RAFT_DURATION_HISTOGRAM: Histogram =
-        register_histogram!(
-            "tikv_raftstore_peer_create_raft_write_duration_seconds",
-            "Bucketed histogram of peer create raft engine write duration",
-            exponential_buckets(0.00001, 2.0, 26).unwrap() // 10us ~ 671s.
-        ).unwrap();
-
     pub static ref STORE_IO_DURATION_HISTOGRAM: HistogramVec =
         register_histogram_vec!(
             "tikv_raftstore_io_duration_seconds",

--- a/components/raftstore/src/store/peer_storage.rs
+++ b/components/raftstore/src/store/peer_storage.rs
@@ -191,11 +191,6 @@ fn init_raft_state<EK: KvEngine, ER: RaftEngine>(
         raft_state.last_index = RAFT_INIT_LOG_INDEX;
         raft_state.mut_hard_state().set_term(RAFT_INIT_LOG_TERM);
         raft_state.mut_hard_state().set_commit(RAFT_INIT_LOG_INDEX);
-        let mut lb = engines.raft.log_batch(0);
-        lb.put_raft_state(region.get_id(), &raft_state)?;
-        let start = Instant::now();
-        engines.raft.consume(&mut lb, true)?;
-        PEER_CREATE_RAFT_DURATION_HISTOGRAM.observe(start.saturating_elapsed().as_secs_f64());
     }
     Ok(raft_state)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #18256

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
When creating new regions via split, writing an initial RaftLocalState
is unnecessary. Regardless of whether this state is persisted, callers
always observe the fixed initial state (last_index = 5, term = 5, commit = 5).
The RaftLocalState will be updated and persisted on subsequent raft log
appends, commit index advances, votes, or elections.

This change is safe under various scenarios:

1. On restart after calling init_raft_state, recovery is correct as the
   initial state is fixed.
2. If a log is appended, raft state and log are persisted atomically
   within the same write batch.
3. Peer removal via applying snapshot deletes raft state directly;
   reads are not performed.
4. Region splits or merges require prior commit, with raft state already
   updated and persisted.

Removing this redundant write improves tail latency without impacting
correctness.
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Integration test

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
