### PR TITLE
raftstore: fix flaky test test_evict_early_avoids_reject

### DIFF
--- a/tests/failpoints/cases/test_memory_usage_limit.rs
+++ b/tests/failpoints/cases/test_memory_usage_limit.rs
@@ -214,11 +214,7 @@ fn test_evict_early_avoids_reject() {
     // process.
     put_n_entries(&mut cluster, 10, 1024);
     wait_msg_counter(append_to_2.clone(), unreachable_to_2.clone(), 10, 0);
-    assert!(
-        append_to_2.load(Ordering::SeqCst) == 10 ||
-         // This value could be 11 if a no-op entry.
-        append_to_2.load(Ordering::SeqCst) == 11
-    );
+    assert_ge!(append_to_2.load(Ordering::SeqCst), 10);
     assert_eq!(unreachable_to_2.load(Ordering::SeqCst), 0);
 
     // Verify that `evict_entry_cache` was triggered by checking that the entry


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18257 

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Previously, the test assumed that at most one no-op AppendEntry RPC
would be sent during multiple writes, which occasionally led to test
failures. This assumption does not always hold, so the assertion has
been relaxed to tolerate multiple no-op AppendEntry RPCs.

Multiple no-op entries can be generated in the following scenario:
when the Leader sends a Heartbeat message to a Follower and immediately
follows it with an AppendEntry message, it may receive the Heartbeat
Response before the AppendResponse. If the Leader detects that the
Follower’s log is not matched upon receiving the Heartbeat Response,
it may proactively send a no-op AppendEntry to align logs. If this
pattern occurs repeatedly in tests, it can result in multiple no-op
entries, violating the original test assertion.

This change addresses the issue by loosening the condition to avoid
spurious test failures while preserving the correctness check.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
