### PR TITLE
Use conjunction for compaction thresholds

### DIFF
--- a/src/server/gc_worker/compaction_runner.rs
+++ b/src/server/gc_worker/compaction_runner.rs
@@ -625,7 +625,7 @@ impl<S: GcSafePointProvider, R: RegionInfoProvider + 'static, E: KvEngine>
             // Only consider deletes (tombstones)
             let ratio = num_tombstones as f64 / num_total_entries as f64;
             if num_tombstones < config.auto_compaction.tombstones_num_threshold
-                && ratio < config.auto_compaction.tombstones_percent_threshold as f64 / 100.0
+                || ratio < config.auto_compaction.tombstones_percent_threshold as f64 / 100.0
             {
                 return 0.0;
             }
@@ -636,7 +636,7 @@ impl<S: GcSafePointProvider, R: RegionInfoProvider + 'static, E: KvEngine>
         // just add deletes to redundant keys for scoring.
         let ratio = (num_tombstones + num_discardable) as f64 / num_total_entries as f64;
         if num_discardable < config.auto_compaction.redundant_rows_threshold
-            && ratio < config.auto_compaction.redundant_rows_percent_threshold as f64 / 100.0
+            || ratio < config.auto_compaction.redundant_rows_percent_threshold as f64 / 100.0
         {
             return 0.0;
         }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref #18727

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
A region is considered worth compacting if:
num_discardable > num_threshold *AND* discardable_ratio > percentage_threshold.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
