### PR TITLE
Unsafe Recovery: Remove a learner if it is in unsafe recovery demotion list

### DIFF
--- a/components/raftstore/src/store/unsafe_recovery.rs
+++ b/components/raftstore/src/store/unsafe_recovery.rs
@@ -444,15 +444,23 @@ pub fn demote_failed_voters_request(
         .get_peers()
         .iter()
         .filter_map(|peer| {
-            if failed_voter_ids.contains(&peer.get_id())
-                && peer.get_role() == metapb::PeerRole::Voter
-            {
-                let mut peer_clone = peer.clone();
-                peer_clone.set_role(metapb::PeerRole::Learner);
-                let mut cp = ChangePeer::default();
-                cp.set_change_type(ConfChangeType::AddLearnerNode);
-                cp.set_peer(peer_clone);
-                return Some(cp);
+            if failed_voter_ids.contains(&peer.get_id()) {
+                if peer.get_role() == metapb::PeerRole::Voter {
+                    let mut peer_clone = peer.clone();
+                    peer_clone.set_role(metapb::PeerRole::Learner);
+                    let mut cp = ChangePeer::default();
+                    cp.set_change_type(ConfChangeType::AddLearnerNode);
+                    cp.set_peer(peer_clone);
+                    return Some(cp);
+                } else if peer.get_role() == metapb::PeerRole::Learner {
+                    let mut cp = ChangePeer::default();
+                    cp.set_change_type(ConfChangeType::RemoveNode);
+                    let peer_clone = peer.clone();
+                    let mut cp = ChangePeer::default();
+                    cp.set_change_type(ConfChangeType::RemoveNode);
+                    cp.set_peer(peer_clone);
+                    return Some(cp);
+                }
             }
             None
         })


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18458

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Remove a learner if it is in unsafe recovery demotion list.

If a TiFlash learner is the most up-to-date peer during unsafe recovery, it will be tombstoned, and another
peer in the group will be forced as a leader. If we don't remove TiFlash learner from leader's Raft group's
member list, the learner will be considered as "down" thus need to be replaced. However, if there is only
one TiFlash node, this replacement will stuck since PD has 0 candidate node. To resolve this, we simply need
to remove the learner from the membership list.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
