### PR TITLE
tikv_util: fix RangeLatch invalid memory access

### DIFF
--- a/components/tikv_util/src/range_latch.rs
+++ b/components/tikv_util/src/range_latch.rs
@@ -97,9 +97,13 @@ impl RangeLatch {
 
                 // Now acquire the latch after releasing the write guard
                 let mutex_guard = mutex.lock().unwrap();
-                // Safety: `transmute` just change the lifetime, do not change the type.
-                // `_mutex_guard` points to the `Mutex<()>`, we need to make sure it will be dropped before the `Arc<Mutex<()>>` and the `RangeLatch` while `drop`.
-                // Then we can make sure the mutex guard doesn't point to released memory.
+                // Safety: `transmute` just change the lifetime, do not change 
+                // the type.
+                // `_mutex_guard` points to the `Mutex<()>`
+                // We need to make sure it will be dropped before the
+                // `Arc<Mutex<()>>` and the `RangeLatch` while `drop`.
+                // Then we can make sure the mutex guard doesn't point to
+                // released memory.
                 // We use `ManuallyDrop` to promise it.
 
                 #[allow(clippy::missing_transmute_annotations)]
@@ -127,8 +131,9 @@ pub struct RangeLatchGuard<'a> {
     start_key: Vec<u8>,
     /// Hold the mutex guard to prevent concurrent access to the same range.
     ///
-    /// Use `ManuallyDrop` to promise: 
-    /// `_mutex_guard` will be dropped before the `Arc<Mutex<()>>` and the `RangeLatch` while `drop`.
+    /// Use `ManuallyDrop` to promise:
+    /// `_mutex_guard` will be dropped before the `Arc<Mutex<()>>` and the
+    /// `RangeLatch` while `drop`.
     _mutex_guard: ManuallyDrop<std::sync::MutexGuard<'a, ()>>,
     /// Holds a reference to RangeLatch to release the latch when the guard is
     /// dropped.
@@ -137,12 +142,15 @@ pub struct RangeLatchGuard<'a> {
 
 impl Drop for RangeLatchGuard<'_> {
     fn drop(&mut self) {
-        // Safety: we call `ManuallyDrop::drop` to drop the mutex guard once and only once.
-        // So `_mutex_guard` will be released earlier than the `Arc<Mutex<()>>`.
-        // We drop `_mutex_guard` by hand, so dropping order depends on declaration order no longer matters.
+        // Safety: we call `ManuallyDrop::drop` to drop the mutex guard
+        // once and only once.
+        // So `_mutex_guard` will be released earlier than the
+        // `Arc<Mutex<()>>`. We drop `_mutex_guard` by hand, so dropping order
+        // depends on declaration order no longer matters.
         unsafe { ManuallyDrop::drop(&mut self._mutex_guard) };
         let mut range_latches = self.handle.range_latches.lock().unwrap();
-        // `range_latches.remove(&self.start_key);` will cause `Arc<Mutex()>>` dropped.
+        // `range_latches.remove(&self.start_key);` will cause
+        // `Arc<Mutex()>>` dropped.
         range_latches.remove(&self.start_key);
     }
 }

--- a/components/tikv_util/src/range_latch.rs
+++ b/components/tikv_util/src/range_latch.rs
@@ -3,6 +3,7 @@ use std::{
         BTreeMap,
         Bound::{Excluded, Unbounded},
     },
+    mem::ManuallyDrop,
     sync::{Arc, Mutex},
 };
 /// A structure used to manage range-based latch with mutual exclusion.
@@ -96,15 +97,16 @@ impl RangeLatch {
 
                 // Now acquire the latch after releasing the write guard
                 let mutex_guard = mutex.lock().unwrap();
-                // Safety: `_mutex_guard` is declared before `handle` in `KeyHandleGuard`.
-                // So the mutex guard will be released earlier than the `Arc<KeyHandle>`.
+                // Safety: `_mutex_guard` is declared before `handle` in `RangeLatchGuard`.
+                // So the mutex guard will be released earlier than the `Arc<RangeLatch>`.
                 // Then we can make sure the mutex guard doesn't point to released memory.
+                // Also, `_mutex_guard` points to the `Mutex<()>`, make sure it will be dropped before the `Arc<Mutex<()>>` in `drop`.
                 #[allow(clippy::missing_transmute_annotations)]
                 let mutex_guard = unsafe { std::mem::transmute(mutex_guard) };
 
                 return RangeLatchGuard {
                     start_key,
-                    _mutex_guard: mutex_guard,
+                    _mutex_guard: ManuallyDrop::new(mutex_guard),
                     handle: self,
                 };
             }
@@ -126,7 +128,7 @@ pub struct RangeLatchGuard<'a> {
     ///
     /// This field must be declared before `handle` so it will be dropped before
     /// `handle`.
-    _mutex_guard: std::sync::MutexGuard<'a, ()>,
+    _mutex_guard: ManuallyDrop<std::sync::MutexGuard<'a, ()>>,
     /// Holds a reference to RangeLatch to release the latch when the guard is
     /// dropped.
     handle: &'a RangeLatch,
@@ -134,7 +136,11 @@ pub struct RangeLatchGuard<'a> {
 
 impl Drop for RangeLatchGuard<'_> {
     fn drop(&mut self) {
+        // Safety: we call `ManuallyDrop::drop` to drop the mutex guard once and only once.
+        // So `_mutex_guard` will be released earlier than the `Arc<Mutex<()>>`.
+        unsafe { ManuallyDrop::drop(&mut self._mutex_guard) };
         let mut range_latches = self.handle.range_latches.lock().unwrap();
+        // `range_latches.remove(&self.start_key);` will cause `Arc<Mutex()>>` dropped.
         range_latches.remove(&self.start_key);
     }
 }
@@ -168,6 +174,7 @@ mod tests {
         drop(guard1);
         drop(guard2);
         drop(guard3);
+        drop(latch);
     }
 
     #[test]

--- a/components/tikv_util/src/range_latch.rs
+++ b/components/tikv_util/src/range_latch.rs
@@ -97,7 +97,7 @@ impl RangeLatch {
 
                 // Now acquire the latch after releasing the write guard
                 let mutex_guard = mutex.lock().unwrap();
-                // Safety: `transmute` just change the lifetime, do not change 
+                // Safety: `transmute` just change the lifetime, do not change
                 // the type.
                 // `_mutex_guard` points to the `Mutex<()>`
                 // We need to make sure it will be dropped before the


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18756 

Close #18671

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message

fix dangling pointer.

make sure `_mutex_guard` released earlier than `Arc<Mutex<()>>`.

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
