### PR TITLE
raftstore: use lock-free handling of CompactedEvent

### DIFF
--- a/components/engine_panic/src/compact.rs
+++ b/components/engine_panic/src/compact.rs
@@ -68,9 +68,9 @@ impl CompactedEvent for PanicCompactedEvent {
         panic!()
     }
 
-    fn calc_regions_declined_bytes(
+    fn calc_ranges_declined_bytes(
         self,
-        regions: &[(u64, Vec<u8>)], // region_id, end_key
+        ranges: &BTreeMap<Vec<u8>, u64>,
         bytes_threshold: u64,
     ) -> Vec<(u64, u64)> {
         panic!()

--- a/components/engine_panic/src/compact.rs
+++ b/components/engine_panic/src/compact.rs
@@ -52,6 +52,10 @@ impl CompactExt for PanicEngine {
 pub struct PanicCompactedEvent;
 
 impl CompactedEvent for PanicCompactedEvent {
+    fn get_key_range(&self) -> (Vec<u8>, Vec<u8>) {
+        panic!()
+    }
+
     fn total_bytes_declined(&self) -> u64 {
         panic!()
     }
@@ -64,9 +68,9 @@ impl CompactedEvent for PanicCompactedEvent {
         panic!()
     }
 
-    fn calc_ranges_declined_bytes(
+    fn calc_regions_declined_bytes(
         self,
-        ranges: &BTreeMap<Vec<u8>, u64>,
+        regions: &Vec<(u64, Vec<u8>)>, // region_id, end_key
         bytes_threshold: u64,
     ) -> Vec<(u64, u64)> {
         panic!()

--- a/components/engine_panic/src/compact.rs
+++ b/components/engine_panic/src/compact.rs
@@ -70,7 +70,7 @@ impl CompactedEvent for PanicCompactedEvent {
 
     fn calc_regions_declined_bytes(
         self,
-        regions: &Vec<(u64, Vec<u8>)>, // region_id, end_key
+        regions: &[(u64, Vec<u8>)], // region_id, end_key
         bytes_threshold: u64,
     ) -> Vec<(u64, u64)> {
         panic!()

--- a/components/engine_rocks/src/compact_listener.rs
+++ b/components/engine_rocks/src/compact_listener.rs
@@ -150,21 +150,23 @@ impl CompactedEvent for RocksCompactedEvent {
 
     fn calc_regions_declined_bytes(
         self,
-        regions: &Vec<(u64, Vec<u8>)>,
+        regions: &[(u64, Vec<u8>)],
         bytes_threshold: u64,
     ) -> Vec<(u64, u64)> {
         // Calculate declined bytes for each region.
         // `end_key` in influenced_regions are in incremental order.
         let mut region_declined_bytes = vec![];
+        let mut old_size;
+        let mut new_size;
         let mut last_end_key: Vec<u8> = vec![];
         for (region_id, end_key) in regions {
-            let mut old_size = 0;
+            old_size = 0;
             for prop in &self.input_props {
-                old_size += prop.get_approximate_size_in_range(&last_end_key, &end_key);
+                old_size += prop.get_approximate_size_in_range(&last_end_key, end_key);
             }
-            let mut new_size = 0;
+            new_size = 0;
             for prop in &self.output_props {
-                new_size += prop.get_approximate_size_in_range(&last_end_key, &end_key);
+                new_size += prop.get_approximate_size_in_range(&last_end_key, end_key);
             }
             last_end_key = end_key.clone();
 

--- a/components/engine_rocks/src/compact_listener.rs
+++ b/components/engine_rocks/src/compact_listener.rs
@@ -1,6 +1,14 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{cmp, path::Path, sync::Arc};
+use std::{
+    cmp,
+    collections::{
+        BTreeMap,
+        Bound::{Excluded, Included, Unbounded},
+    },
+    path::Path,
+    sync::Arc,
+};
 
 use collections::hash_set_with_capacity;
 use engine_traits::{CompactedEvent, CompactionJobInfo};
@@ -148,27 +156,37 @@ impl CompactedEvent for RocksCompactedEvent {
         self.output_level.to_string()
     }
 
-    fn calc_regions_declined_bytes(
+    fn calc_ranges_declined_bytes(
         self,
-        regions: &[(u64, Vec<u8>)],
+        ranges: &BTreeMap<Vec<u8>, u64>,
         bytes_threshold: u64,
     ) -> Vec<(u64, u64)> {
+        // Calculate influenced regions.
+        let mut influenced_regions = vec![];
+        for (end_key, region_id) in
+            ranges.range((Excluded(self.start_key), Included(self.end_key.clone())))
+        {
+            influenced_regions.push((region_id, end_key.clone()));
+        }
+        if let Some((end_key, region_id)) = ranges.range((Included(self.end_key), Unbounded)).next()
+        {
+            influenced_regions.push((region_id, end_key.clone()));
+        }
+
         // Calculate declined bytes for each region.
         // `end_key` in influenced_regions are in incremental order.
         let mut region_declined_bytes = vec![];
-        let mut old_size;
-        let mut new_size;
         let mut last_end_key: Vec<u8> = vec![];
-        for (region_id, end_key) in regions {
-            old_size = 0;
+        for (region_id, end_key) in influenced_regions {
+            let mut old_size = 0;
             for prop in &self.input_props {
-                old_size += prop.get_approximate_size_in_range(&last_end_key, end_key);
+                old_size += prop.get_approximate_size_in_range(&last_end_key, &end_key);
             }
-            new_size = 0;
+            let mut new_size = 0;
             for prop in &self.output_props {
-                new_size += prop.get_approximate_size_in_range(&last_end_key, end_key);
+                new_size += prop.get_approximate_size_in_range(&last_end_key, &end_key);
             }
-            last_end_key = end_key.clone();
+            last_end_key = end_key;
 
             // Filter some trivial declines for better performance.
             if old_size > new_size && old_size - new_size > bytes_threshold {

--- a/components/engine_traits/src/compact.rs
+++ b/components/engine_traits/src/compact.rs
@@ -106,7 +106,7 @@ pub trait CompactedEvent: Send {
     /// CompactedEvent
     fn calc_regions_declined_bytes(
         self,
-        regions: &Vec<(u64, Vec<u8>)>, // region_id, end_key
+        regions: &[(u64, Vec<u8>)], // region_id, end_key
         bytes_threshold: u64,
     ) -> Vec<(u64, u64)>;
 

--- a/components/engine_traits/src/compact.rs
+++ b/components/engine_traits/src/compact.rs
@@ -2,6 +2,8 @@
 
 //! Functionality related to compaction
 
+use std::collections::BTreeMap;
+
 use crate::{CfNamesExt, errors::Result};
 
 #[derive(Clone, Debug)]
@@ -104,9 +106,9 @@ pub trait CompactedEvent: Send {
 
     /// This takes self by value so that engine_rocks can move keys out of the
     /// CompactedEvent
-    fn calc_regions_declined_bytes(
+    fn calc_ranges_declined_bytes(
         self,
-        regions: &[(u64, Vec<u8>)], // region_id, end_key
+        ranges: &BTreeMap<Vec<u8>, u64>,
         bytes_threshold: u64,
     ) -> Vec<(u64, u64)>;
 

--- a/components/engine_traits/src/compact.rs
+++ b/components/engine_traits/src/compact.rs
@@ -2,8 +2,6 @@
 
 //! Functionality related to compaction
 
-use std::collections::BTreeMap;
-
 use crate::{CfNamesExt, errors::Result};
 
 #[derive(Clone, Debug)]
@@ -96,6 +94,8 @@ pub trait CompactExt: CfNamesExt {
 }
 
 pub trait CompactedEvent: Send {
+    fn get_key_range(&self) -> (Vec<u8>, Vec<u8>);
+
     fn total_bytes_declined(&self) -> u64;
 
     fn is_size_declining_trivial(&self, split_check_diff: u64) -> bool;
@@ -104,9 +104,9 @@ pub trait CompactedEvent: Send {
 
     /// This takes self by value so that engine_rocks can move keys out of the
     /// CompactedEvent
-    fn calc_ranges_declined_bytes(
+    fn calc_regions_declined_bytes(
         self,
-        ranges: &BTreeMap<Vec<u8>, u64>,
+        regions: &Vec<(u64, Vec<u8>)>, // region_id, end_key
         bytes_threshold: u64,
     ) -> Vec<(u64, u64)>;
 

--- a/components/raftstore-v2/src/batch/store.rs
+++ b/components/raftstore-v2/src/batch/store.rs
@@ -821,10 +821,10 @@ impl<EK: KvEngine, ER: RaftEngine> StoreSystem<EK, ER> {
         let split_check_scheduler = workers.background.start(
             "split-check",
             SplitCheckRunner::with_registry(
-                None,
                 tablet_registry.clone(),
                 router.clone(),
                 coprocessor_host.clone(),
+                None,
             ),
         );
 

--- a/components/raftstore/src/coprocessor/region_info_accessor.rs
+++ b/components/raftstore/src/coprocessor/region_info_accessor.rs
@@ -247,8 +247,9 @@ impl RoleObserver for RegionEventListener {
             role,
             initialized: role_change.initialized,
         };
-        let _ = self.scheduler
-            .schedule(RegionInfoQuery::RaftStoreEvent(event))
+        let _ = self
+            .scheduler
+            .schedule(RegionInfoQuery::RaftStoreEvent(event));
     }
 }
 
@@ -265,7 +266,8 @@ impl RegionHeartbeatObserver for RegionEventListener {
             activity: RegionActivity { region_stat },
         };
 
-        let _ = self.scheduler
+        let _ = self
+            .scheduler
             .schedule(RegionInfoQuery::RaftStoreEvent(event));
     }
 }

--- a/components/raftstore/src/coprocessor/region_info_accessor.rs
+++ b/components/raftstore/src/coprocessor/region_info_accessor.rs
@@ -232,9 +232,9 @@ impl RegionChangeObserver for RegionEventListener {
                 RaftStoreEvent::UpdateRegionBuckets { region, buckets }
             }
         };
-        self.scheduler
-            .schedule(RegionInfoQuery::RaftStoreEvent(event))
-            .unwrap();
+        let _ = self
+            .scheduler
+            .schedule(RegionInfoQuery::RaftStoreEvent(event));
     }
 }
 
@@ -247,9 +247,8 @@ impl RoleObserver for RegionEventListener {
             role,
             initialized: role_change.initialized,
         };
-        self.scheduler
+        let _ = self.scheduler
             .schedule(RegionInfoQuery::RaftStoreEvent(event))
-            .unwrap();
     }
 }
 
@@ -266,9 +265,8 @@ impl RegionHeartbeatObserver for RegionEventListener {
             activity: RegionActivity { region_stat },
         };
 
-        self.scheduler
-            .schedule(RegionInfoQuery::RaftStoreEvent(event))
-            .unwrap();
+        let _ = self.scheduler
+            .schedule(RegionInfoQuery::RaftStoreEvent(event));
     }
 }
 

--- a/components/raftstore/src/coprocessor/split_check/half.rs
+++ b/components/raftstore/src/coprocessor/split_check/half.rs
@@ -162,10 +162,10 @@ mod tests {
             ..Default::default()
         };
         let mut runnable = SplitCheckRunner::new(
-            None,
             engine.clone(),
             tx.clone(),
             CoprocessorHost::new(tx, cfg),
+            None,
         );
 
         // so split key will be z0005
@@ -211,10 +211,10 @@ mod tests {
             ..Default::default()
         };
         let mut runnable = SplitCheckRunner::new(
-            None,
             engine.clone(),
             tx.clone(),
             CoprocessorHost::new(tx, cfg),
+            None,
         );
 
         for i in 0..11 {
@@ -281,7 +281,7 @@ mod tests {
             ..Default::default()
         };
         let cop_host = CoprocessorHost::new(tx.clone(), cfg);
-        let mut runnable = SplitCheckRunner::new(None, engine.clone(), tx, cop_host.clone());
+        let mut runnable = SplitCheckRunner::new(engine.clone(), tx, cop_host.clone(), None);
 
         let key_gen = |k: &[u8], i: u64, mvcc: bool| {
             if !mvcc {
@@ -405,10 +405,10 @@ mod tests {
             ..Default::default()
         };
         let mut runnable = SplitCheckRunner::new(
-            None,
             engine.clone(),
             tx.clone(),
             CoprocessorHost::new(tx, cfg),
+            None,
         );
 
         // so bucket key will be all these keys

--- a/components/raftstore/src/coprocessor/split_check/keys.rs
+++ b/components/raftstore/src/coprocessor/split_check/keys.rs
@@ -289,10 +289,10 @@ mod tests {
         };
 
         let mut runnable = SplitCheckRunner::new(
-            None,
             engine.clone(),
             tx.clone(),
             CoprocessorHost::new(tx, cfg),
+            None,
         );
 
         // so split key will be z0080
@@ -414,10 +414,10 @@ mod tests {
         };
 
         let mut runnable = SplitCheckRunner::new(
-            None,
             engine.clone(),
             tx.clone(),
             CoprocessorHost::new(tx, cfg),
+            None,
         );
 
         put_data(&engine, 0, 90, false);
@@ -603,10 +603,10 @@ mod tests {
         };
 
         let mut runnable = SplitCheckRunner::new(
-            None,
             engine.clone(),
             tx.clone(),
             CoprocessorHost::new(tx.clone(), cfg.clone()),
+            None,
         );
 
         put_data(&engine, 0, 90, false);
@@ -633,7 +633,7 @@ mod tests {
         // exists, it will result in split by keys failed.
         cfg.region_max_size = Some(ReadableSize(region_size * 6 / 5));
         cfg.region_split_size = Some(ReadableSize(region_size * 4 / 5));
-        runnable = SplitCheckRunner::new(None, engine, tx.clone(), CoprocessorHost::new(tx, cfg));
+        runnable = SplitCheckRunner::new(engine, tx.clone(), CoprocessorHost::new(tx, cfg), None);
         runnable.run(SplitCheckTask::split_check(
             region.clone(),
             true,

--- a/components/raftstore/src/coprocessor/split_check/size.rs
+++ b/components/raftstore/src/coprocessor/split_check/size.rs
@@ -455,10 +455,10 @@ pub mod tests {
         };
 
         let mut runnable = SplitCheckRunner::new(
-            None,
             engine.clone(),
             tx.clone(),
             CoprocessorHost::new(tx, cfg),
+            None,
         );
 
         // so split key will be [z0006]
@@ -594,7 +594,7 @@ pub mod tests {
             }
         };
         let cop_host = CoprocessorHost::new(tx.clone(), cfg);
-        let mut runnable = SplitCheckRunner::new(None, engine.clone(), tx, cop_host.clone());
+        let mut runnable = SplitCheckRunner::new(engine.clone(), tx, cop_host.clone(), None);
         for i in 0..1000 {
             // if not mvcc, kv size is (6+1)*2 = 14, given bucket size is 3000, expect each
             // bucket has about 210 keys if mvcc, kv size is about 18*2 = 36, expect each
@@ -775,10 +775,10 @@ pub mod tests {
         };
 
         let mut runnable = SplitCheckRunner::new(
-            None,
             engine.clone(),
             tx.clone(),
             CoprocessorHost::new(tx.clone(), cfg.clone()),
+            None,
         );
 
         for cf in LARGE_CFS {
@@ -816,10 +816,10 @@ pub mod tests {
             engine_test::kv::new_engine_opt(path_str, DbOptions::default(), cfs_opts).unwrap();
 
         let mut runnable = SplitCheckRunner::new(
-            None,
             engine.clone(),
             tx.clone(),
             CoprocessorHost::new(tx, cfg),
+            None,
         );
 
         // Flush a sst of CF_LOCK with range properties.

--- a/components/raftstore/src/coprocessor/split_check/table.rs
+++ b/components/raftstore/src/coprocessor/split_check/table.rs
@@ -335,7 +335,7 @@ mod tests {
 
         // Try to ignore the ApproximateRegionSize
         let coprocessor = CoprocessorHost::new(stx, cfg);
-        let mut runnable = SplitCheckRunner::new(None, engine.clone(), tx, coprocessor);
+        let mut runnable = SplitCheckRunner::new(engine.clone(), tx, coprocessor, None);
 
         type Case = (Option<Vec<u8>>, Option<Vec<u8>>, Option<i64>);
         let mut check_cases = |cases: Vec<Case>| {

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -3435,8 +3435,6 @@ mod tests {
     use engine_rocks::{RangeOffsets, RangeProperties, RocksCompactedEvent};
     use engine_traits::CompactedEvent;
 
-    use super::*;
-
     #[test]
     fn test_calc_region_declined_bytes() {
         let prop = RangeProperties {
@@ -3464,6 +3462,8 @@ mod tests {
                 ),
             ],
         };
+        let (prop_start_key, prop_end_key) =
+            (prop.smallest_key().unwrap(), prop.largest_key().unwrap());
         let event = RocksCompactedEvent {
             cf: "default".to_owned(),
             output_level: 3,
@@ -3474,13 +3474,14 @@ mod tests {
             input_props: vec![prop],
             output_props: vec![],
         };
+        let (start_key, end_key) = event.get_key_range();
+        assert_eq!((start_key, end_key), (prop_start_key, prop_end_key));
 
-        let mut region_ranges = BTreeMap::new();
-        region_ranges.insert(b"a".to_vec(), 1);
-        region_ranges.insert(b"b".to_vec(), 2);
-        region_ranges.insert(b"c".to_vec(), 3);
+        let mut regions = Vec::new();
+        regions.push((2, b"b".to_vec()));
+        regions.push((3, b"c".to_vec()));
 
-        let declined_bytes = event.calc_ranges_declined_bytes(&region_ranges, 1024);
+        let declined_bytes = event.calc_regions_declined_bytes(&regions, 1024);
         let expected_declined_bytes = vec![(2, 8192), (3, 4096)];
         assert_eq!(declined_bytes, expected_declined_bytes);
     }

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -3477,10 +3477,7 @@ mod tests {
         let (start_key, end_key) = event.get_key_range();
         assert_eq!((start_key, end_key), (prop_start_key, prop_end_key));
 
-        let mut regions = Vec::new();
-        regions.push((2, b"b".to_vec()));
-        regions.push((3, b"c".to_vec()));
-
+        let regions = [(2, b"b".to_vec()), (3, b"c".to_vec())];
         let declined_bytes = event.calc_regions_declined_bytes(&regions, 1024);
         let expected_declined_bytes = vec![(2, 8192), (3, 4096)];
         assert_eq!(declined_bytes, expected_declined_bytes);

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -3432,6 +3432,8 @@ impl<EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'_, EK, ER, T>
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use engine_rocks::{RangeOffsets, RangeProperties, RocksCompactedEvent};
     use engine_traits::CompactedEvent;
 
@@ -3477,8 +3479,12 @@ mod tests {
         let (start_key, end_key) = event.get_key_range();
         assert_eq!((start_key, end_key), (prop_start_key, prop_end_key));
 
-        let regions = [(2, b"b".to_vec()), (3, b"c".to_vec())];
-        let declined_bytes = event.calc_regions_declined_bytes(&regions, 1024);
+        let mut region_ranges = BTreeMap::new();
+        region_ranges.insert(b"a".to_vec(), 1);
+        region_ranges.insert(b"b".to_vec(), 2);
+        region_ranges.insert(b"c".to_vec(), 3);
+
+        let declined_bytes = event.calc_ranges_declined_bytes(&region_ranges, 1024);
         let expected_declined_bytes = vec![(2, 8192), (3, 4096)];
         assert_eq!(declined_bytes, expected_declined_bytes);
     }

--- a/components/raftstore/src/store/worker/split_check.rs
+++ b/components/raftstore/src/store/worker/split_check.rs
@@ -927,7 +927,8 @@ impl<EK: KvEngine, S: StoreHandle> Runner<EK, S> {
                 .unwrap()
                 .get_regions_in_range(&start_key, &end_key)
             {
-                let regions = regions.iter().map(|r| (r.id, r.end_key.clone())).collect();
+                let regions: Vec<(u64, Vec<u8>)> =
+                    regions.iter().map(|r| (r.id, r.end_key.clone())).collect();
                 event.calc_regions_declined_bytes(&regions, region_split_check_diff / 16)
             } else {
                 vec![]

--- a/components/raftstore/src/store/worker/split_check.rs
+++ b/components/raftstore/src/store/worker/split_check.rs
@@ -5,7 +5,7 @@ use std::{
     collections::BinaryHeap,
     fmt::{self, Display, Formatter},
     mem,
-    sync::{Arc, Mutex},
+    sync::Arc,
 };
 
 use engine_traits::{
@@ -31,12 +31,10 @@ use crate::{
     coprocessor::{
         Config, CoprocessorHost, SplitCheckerHost,
         dispatcher::StoreHandle,
+        region_info_accessor::{RegionInfoAccessor, RegionInfoProvider},
         split_observer::{is_valid_split_key, strip_timestamp_if_exists},
     },
-    store::{
-        fsm::StoreMeta,
-        metrics::{COMPACTION_DECLINED_BYTES, COMPACTION_RELATED_REGION_COUNT},
-    },
+    store::metrics::{COMPACTION_DECLINED_BYTES, COMPACTION_RELATED_REGION_COUNT},
 };
 
 #[derive(PartialEq, Eq)]
@@ -464,40 +462,40 @@ where
 }
 
 pub struct Runner<EK: KvEngine, S> {
-    store_meta: Option<Arc<Mutex<StoreMeta>>>,
     // We can't just use `TabletRegistry` here, otherwise v1 may create many
     // invalid records and cause other problems.
     engine: Either<EK, TabletRegistry<EK>>,
     router: S,
     coprocessor: CoprocessorHost<EK>,
+    region_info_accessor: Option<RegionInfoAccessor>,
 }
 
 impl<EK: KvEngine, S: StoreHandle> Runner<EK, S> {
     pub fn new(
-        store_meta: Option<Arc<Mutex<StoreMeta>>>,
         engine: EK,
         router: S,
         coprocessor: CoprocessorHost<EK>,
+        region_info_accessor: Option<RegionInfoAccessor>,
     ) -> Runner<EK, S> {
         Runner {
-            store_meta,
             engine: Either::Left(engine),
             router,
             coprocessor,
+            region_info_accessor,
         }
     }
 
     pub fn with_registry(
-        store_meta: Option<Arc<Mutex<StoreMeta>>>,
         registry: TabletRegistry<EK>,
         router: S,
         coprocessor: CoprocessorHost<EK>,
+        region_info_accessor: Option<RegionInfoAccessor>,
     ) -> Runner<EK, S> {
         Runner {
-            store_meta,
             engine: Either::Right(registry),
             router,
             coprocessor,
+            region_info_accessor,
         }
     }
 
@@ -908,7 +906,9 @@ impl<EK: KvEngine, S: StoreHandle> Runner<EK, S> {
     }
 
     fn on_compaction_finished(&self, event: EK::CompactedEvent, region_split_check_diff: u64) {
-        if self.store_meta.is_none() || event.is_size_declining_trivial(region_split_check_diff) {
+        if self.region_info_accessor.is_none()
+            || event.is_size_declining_trivial(region_split_check_diff)
+        {
             return;
         }
 
@@ -919,13 +919,19 @@ impl<EK: KvEngine, S: StoreHandle> Runner<EK, S> {
 
         // region_split_check_diff / 16 is an experienced value.
         let mut region_declined_bytes = {
-            // TODO: Optimize performance for large numbers of regions.
-            // The current implementation locks store_meta for the duration of the
-            // calculation, which could become a bottleneck when there are many
-            // regions.
-            let store_meta = self.store_meta.clone().unwrap();
-            let meta = store_meta.lock().unwrap();
-            event.calc_ranges_declined_bytes(&meta.region_ranges, region_split_check_diff / 16)
+            // Calculate influenced regions.
+            let (start_key, end_key) = event.get_key_range();
+            if let Ok(regions) = self
+                .region_info_accessor
+                .as_ref()
+                .unwrap()
+                .get_regions_in_range(&start_key, &end_key)
+            {
+                let regions = regions.iter().map(|r| (r.id, r.end_key.clone())).collect();
+                event.calc_regions_declined_bytes(&regions, region_split_check_diff / 16)
+            } else {
+                vec![]
+            }
         };
 
         COMPACTION_RELATED_REGION_COUNT

--- a/components/raftstore/src/store/worker/split_check.rs
+++ b/components/raftstore/src/store/worker/split_check.rs
@@ -917,9 +917,9 @@ impl<EK: KvEngine, S: StoreHandle> Runner<EK, S> {
             .with_label_values(&[&output_level_str])
             .observe(event.total_bytes_declined() as f64);
 
-        // region_split_check_diff / 16 is an experienced value.
         let mut region_declined_bytes = {
-            // Calculate influenced regions.
+            // Get the target regions and convert the corresponding ranges into
+            // the target format. Then, calculate the influenced ranges.
             let (start_key, end_key) = event.get_key_range();
             if let Ok(regions) = self
                 .region_info_provider
@@ -931,6 +931,7 @@ impl<EK: KvEngine, S: StoreHandle> Runner<EK, S> {
                 regions.iter().for_each(|r| {
                     ranges.insert(keys::enc_end_key(r), r.id);
                 });
+                // region_split_check_diff / 16 is an experienced value.
                 event.calc_ranges_declined_bytes(&ranges, region_split_check_diff / 16)
             } else {
                 vec![]

--- a/components/raftstore/src/store/worker/split_check.rs
+++ b/components/raftstore/src/store/worker/split_check.rs
@@ -2,7 +2,7 @@
 
 use std::{
     cmp::Ordering,
-    collections::BinaryHeap,
+    collections::{BTreeMap, BinaryHeap},
     fmt::{self, Display, Formatter},
     mem,
     sync::Arc,
@@ -927,9 +927,11 @@ impl<EK: KvEngine, S: StoreHandle> Runner<EK, S> {
                 .unwrap()
                 .get_regions_in_range(&start_key, &end_key)
             {
-                let regions: Vec<(u64, Vec<u8>)> =
-                    regions.iter().map(|r| (r.id, r.end_key.clone())).collect();
-                event.calc_regions_declined_bytes(&regions, region_split_check_diff / 16)
+                let mut ranges = BTreeMap::<Vec<u8>, u64>::new();
+                regions.iter().for_each(|r| {
+                    ranges.insert(keys::enc_end_key(r), r.id);
+                });
+                event.calc_ranges_declined_bytes(&ranges, region_split_check_diff / 16)
             } else {
                 vec![]
             }

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -1010,7 +1010,7 @@ where
             engines.engines.kv.clone(),
             self.router.clone(),
             self.coprocessor_host.clone().unwrap(),
-            self.region_info_accessor.clone(),
+            Some(Arc::new(self.region_info_accessor.clone().unwrap())),
         );
         let split_check_scheduler = self
             .core

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -1007,10 +1007,10 @@ where
         let importer = Arc::new(importer);
 
         let split_check_runner = SplitCheckRunner::new(
-            Some(engines.store_meta.clone()),
             engines.engines.kv.clone(),
             self.router.clone(),
             self.coprocessor_host.clone().unwrap(),
+            self.region_info_accessor.clone(),
         );
         let split_check_scheduler = self
             .core

--- a/components/test_raftstore/src/node.rs
+++ b/components/test_raftstore/src/node.rs
@@ -352,7 +352,7 @@ impl Simulator for NodeCluster {
             engines.kv.clone(),
             router.clone(),
             coprocessor_host.clone(),
-            Some(region_info_accessor),
+            Some(Arc::new(region_info_accessor)),
         );
         let split_scheduler = bg_worker.start("test-split-check", split_check_runner);
         cfg_controller.register(

--- a/components/test_raftstore/src/node.rs
+++ b/components/test_raftstore/src/node.rs
@@ -300,7 +300,29 @@ impl Simulator for NodeCluster {
         self.snap_mgrs.insert(node_id, snap_mgr.clone());
 
         // Create coprocessor.
+        let enable_region_stats_mgr_cb: Arc<dyn Fn() -> bool + Send + Sync> =
+            if cfg.in_memory_engine.enable {
+                Arc::new(|| true)
+            } else {
+                Arc::new(|| false)
+            };
         let mut coprocessor_host = CoprocessorHost::new(router.clone(), cfg.coprocessor.clone());
+
+        // In-memory engine
+        let mut in_memory_engine_config = cfg.in_memory_engine.clone();
+        in_memory_engine_config.expected_region_size = cfg.coprocessor.region_split_size();
+        let in_memory_engine_config = Arc::new(VersionTrack::new(in_memory_engine_config));
+        let in_memory_engine_config_clone = in_memory_engine_config.clone();
+
+        let region_info_accessor = raftstore::RegionInfoAccessor::new(
+            &mut coprocessor_host,
+            enable_region_stats_mgr_cb,
+            Box::new(move || {
+                in_memory_engine_config_clone
+                    .value()
+                    .mvcc_amplification_threshold
+            }),
+        );
 
         if let Some(f) = self.post_create_coprocessor_host.as_ref() {
             f(node_id, &mut coprocessor_host);
@@ -327,10 +349,10 @@ impl Simulator for NodeCluster {
         let cfg_controller = ConfigController::new(cfg.tikv.clone());
 
         let split_check_runner = SplitCheckRunner::new(
-            Some(store_meta.clone()),
             engines.kv.clone(),
             router.clone(),
             coprocessor_host.clone(),
+            Some(region_info_accessor),
         );
         let split_scheduler = bg_worker.start("test-split-check", split_check_runner);
         cfg_controller.register(

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -668,10 +668,10 @@ impl ServerCluster {
         let pessimistic_txn_cfg = cfg.tikv.pessimistic_txn;
 
         let split_check_runner = SplitCheckRunner::new(
-            Some(store_meta.clone()),
             engines.kv.clone(),
             router.clone(),
             coprocessor_host.clone(),
+            Some(region_info_accessor.clone()),
         );
         let split_check_scheduler = bg_worker.start("split-check", split_check_runner);
         let split_config_manager =

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -671,7 +671,7 @@ impl ServerCluster {
             engines.kv.clone(),
             router.clone(),
             coprocessor_host.clone(),
-            Some(region_info_accessor.clone()),
+            Some(Arc::new(region_info_accessor.clone())),
         );
         let split_check_scheduler = bg_worker.start("split-check", split_check_runner);
         let split_config_manager =

--- a/tests/integrations/config/dynamic/split_check.rs
+++ b/tests/integrations/config/dynamic/split_check.rs
@@ -32,10 +32,10 @@ fn setup(
 ) -> (ConfigController, LazyWorker<Task<RocksEngine>>) {
     let (router, _) = sync_channel(1);
     let runner = Runner::new(
-        None,
         engine,
         router.clone(),
         CoprocessorHost::new(router, cfg.coprocessor.clone()),
+        None,
     );
     let share_worker = Worker::new("split-check-config");
     let mut worker = share_worker.lazy_build("split-check-config");


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #18532

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

This PR is an extend of #18565 and introduces `lock-free` handling of `CompactedEvent`, used to optimize the handling of `CompactedEvent`.

```commit-message
Introduces lock-free handling of CompactedEvent to avoid raftstore threads waiting the lock of `StoreMeta`.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Introduces lock-free handling of CompactedEvent to avoid raftstore threads waiting the lock of `StoreMeta`.
```
