### PR TITLE
storage: fix flow control not resuming after unsafe destroy range

### DIFF
--- a/src/storage/txn/flow_controller/singleton_flow_controller.rs
+++ b/src/storage/txn/flow_controller/singleton_flow_controller.rs
@@ -456,7 +456,7 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
                                 .log2();
 
                         let avg_pending_bytes = if let Some(long_term_pending_bytes) =
-                                cf_checker.long_term_pending_bytes.as_ref()
+                            cf_checker.long_term_pending_bytes.as_ref()
                         {
                             long_term_pending_bytes.get_avg()
                         } else {
@@ -464,35 +464,20 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
                         };
 
                         assert!(before < soft);
-                        if current_pending_bytes >= soft {
-                            // there is a pending bytes jump
+                        if current_pending_bytes >= soft || avg_pending_bytes >= soft {
+                            // There is a pending bytes jump. Flow control for
+                            // compaction bytes won't be re-enabled until the
+                            // pending bytes drop below the soft limit.
                             SCHED_THROTTLE_ACTION_COUNTER
                                 .with_label_values(&[cf, "pending_bytes_jump"])
                                 .inc();
                         } else {
-                            // If both the current pending bytes and long term
-                            // pending bytes are below soft limit, we can
-                            // re-enable compaction bytes based rate limiting.
-                            if avg_pending_bytes < soft {
-                                cf_checker.pending_bytes_before_unsafe_destroy_range = None;
-                                info!(
-                                    "re-enabled compaction pending bytes flow control";
-                                    "cf" => cf,
-                                );
-                                println!(
-                                    "re-enabled compaction pending bytes flow control"
-                                );
-                            }
+                            cf_checker.pending_bytes_before_unsafe_destroy_range = None;
+                            info!(
+                                "re-enabled compaction pending bytes flow control";
+                                "cf" => cf,
+                            );
                         }
-
-                        println!(
-                            "after unsafe destroy range: cf={}, before={}, current_pending_bytes={}, avg_pending_bytes={}, soft_limit={}",
-                            cf,
-                            before,
-                            current_pending_bytes,
-                            avg_pending_bytes,
-                            soft,
-                        );
 
                         info!(
                             "after unsafe destroy range";
@@ -534,9 +519,7 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
                         let (rate, cf_throttle_flags) = checker.update_statistics();
                         for (cf, val) in cf_throttle_flags {
                             SCHED_THROTTLE_CF_GAUGE.with_label_values(&[cf]).set(val);
-                            println!("SCHED_THROTTLE_CF_GAUGE cf {} set to {}", cf, val);
                         }
-                        println!("SCHED_WRITE_FLOW_GAUGE set to {}", rate);
                         SCHED_WRITE_FLOW_GAUGE.set(rate as i64);
                         deadline = std::time::Instant::now() + TICK_DURATION;
                     } else {
@@ -625,8 +608,7 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
             num = 0.0;
         }
         let checker = self.cf_checkers.get_mut(&cf).unwrap();
-        println!("on_pending_compaction_bytes_change_cf => cf: {}, pending_compaction_bytes: {}, checker.on_start_pending_bytes: {}, num: {}", 
-            cf, pending_compaction_bytes, checker.on_start_pending_bytes, num);
+
         // only be called by v1
         if let Some(long_term_pending_bytes) = checker.long_term_pending_bytes.as_mut() {
             long_term_pending_bytes.observe(num);
@@ -666,7 +648,6 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
                 false
             };
 
-            println!("on_pending_compaction_bytes_change_cf => ignore: {}", ignore);
             for checker in self.cf_checkers.values() {
                 if let Some(long_term_pending_bytes) = checker.long_term_pending_bytes.as_ref()
                     && num < long_term_pending_bytes.get_recent()
@@ -696,8 +677,6 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
             if ratio > RATIO_SCALE_FACTOR {
                 ratio = RATIO_SCALE_FACTOR;
             }
-
-            println!("ratio updated to {}, pending_compaction_bytes is {}", ratio, pending_compaction_bytes);
             self.discard_ratio.store(ratio, Ordering::Relaxed);
         }
     }
@@ -1323,35 +1302,33 @@ pub(super) mod tests {
             EngineFlowController::new(&FlowControlConfig::default(), stub.clone(), rx);
         let flow_controller = FlowController::Singleton(flow_controller);
 
-        // should handle zero pending compaction bytes properly
+        // Before unsafe destroy range, pending compaction bytes is 0.
         stub.0.pending_compaction_bytes.store(0, Ordering::Relaxed);
         send_flow_info(&tx, region_id);
         assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
-
-        // pending compaction bytes did not jump after unsafe destroy range
         tx.send(FlowInfo::BeforeUnsafeDestroyRange(region_id))
             .unwrap();
         assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
 
-        // after unsafe destroy range, pending compaction bytes only increase by a little bit.
+        // After unsafe destroy range, pending compaction bytes did not reach
+        // the threshold, so jump control should not be triggered.
         stub.0
             .pending_compaction_bytes
             .store(1024 * 1024 * 1024, Ordering::Relaxed);
         send_flow_info(&tx, region_id);
-
-        // pending compaction bytes jump after unsafe destroy range
         tx.send(FlowInfo::AfterUnsafeDestroyRange(region_id))
             .unwrap();
         assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
-        
-        // You sent a message above but it may not have been processed yet.
-        // Add some check here? 
-
+        // sleep a while to wait for the above message to be processed.
         std::thread::sleep(Duration::from_millis(100));
-        // exceeds the threshold, should perform throttle
+
+        // If pending_compaction_bytes increases and exceeds the threshold,
+        // should perform throttle.
         stub.0
             .pending_compaction_bytes
             .store(1000000000 * 1024 * 1024 * 1024, Ordering::Relaxed);
+        // call `send_flow_info` multiple times to bring up the average pending
+        // compaction bytes.
         send_flow_info(&tx, region_id);
         send_flow_info(&tx, region_id);
         send_flow_info(&tx, region_id);


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18728

Related PR: #17458
<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Fixes a corner case where flow control could stay disabled if `unsafe destroy range`
was executed when `pending_compaction_bytes` was zero. In this case, no compaction
events occurred to notify the controller that bytes had reached zero, leaving the
jump-control flag uncleared. Later compaction activity usually reports bytes > 0,
keeping flow control disabled indefinitely.

We now re-enable flow control when both the current and long-term average pending
compaction bytes are below the soft threshold after `unsafe destroy range`.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
