### PR TITLE
fix flaky test test_destroy_clean_up_logs_with_log_gc

### DIFF
--- a/tests/integrations/raftstore/test_tombstone.rs
+++ b/tests/integrations/raftstore/test_tombstone.rs
@@ -356,6 +356,9 @@ fn test_destroy_clean_up_logs_with_log_gc() {
     assert!(dest.is_empty(), "{:?}", dest);
 
     pd_client.must_add_peer(1, new_peer(3, 4));
+    // Clear stale leader cache after config change
+    // to avoid using outdated leader info
+    cluster.reset_leader_of_region(1);
     must_get_equal(&cluster.get_engine(3), b"k1", b"v1");
     cluster.must_put(b"k3", b"v3");
     must_get_equal(&cluster.get_engine(3), b"k3", b"v3");
@@ -371,6 +374,7 @@ fn test_destroy_clean_up_logs_with_log_gc() {
     assert!(dest.is_empty(), "{:?}", dest);
 
     pd_client.must_add_peer(1, new_peer(3, 5));
+    cluster.reset_leader_of_region(1);
     must_get_equal(&cluster.get_engine(3), b"k1", b"v1");
     cluster.must_put(b"k4", b"v4");
     must_get_equal(&cluster.get_engine(3), b"k4", b"v4");


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number:  Ref #17402 Close #17401

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
fix flaky test` test_destroy_clean_up_logs_with_log_gc`.
Clear leader region info before `must_put` to flush the cache to prevent put requests from using the old leader cache information.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
fix flaky test `test_destroy_clean_up_logs_with_log_gc`.
```
