### PR TITLE
coprocessor: Add `RegionStorageAccessor` to provide store for secondary regions in cop-task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7240,6 +7240,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "api_version",
+ "async-trait",
  "byteorder",
  "derive_more 0.99.3",
  "error_code",
@@ -7249,6 +7250,7 @@ dependencies = [
  "log_wrappers",
  "prometheus",
  "prometheus-static-metric",
+ "raft",
  "serde_json",
  "thiserror 1.0.40",
  "tikv_util",

--- a/components/raftstore/src/coprocessor/region_info_accessor.rs
+++ b/components/raftstore/src/coprocessor/region_info_accessor.rs
@@ -1081,6 +1081,16 @@ impl MockRegionInfoProvider {
                 .collect_vec(),
         ))
     }
+
+    pub fn set_role(&self, region_id: u64, role: StateRole) {
+        let mut region_infos = self.0.lock().unwrap();
+        if let Some(region_info) = region_infos
+            .iter_mut()
+            .find(|info| info.region.get_id() == region_id)
+        {
+            region_info.role = role;
+        }
+    }
 }
 
 impl Clone for MockRegionInfoProvider {

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -500,6 +500,7 @@ where
                 ),
             ),
             engines.kv.clone(),
+            self.region_info_accessor.clone(),
             self.region_info_accessor.as_ref().unwrap().region_leaders(),
         );
 

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -376,6 +376,7 @@ impl ServerCluster {
         let mut raft_kv = RaftKv::new(
             sim_router.clone(),
             engines.kv.clone(),
+            Some(region_info_accessor.clone()),
             region_info_accessor.region_leaders(),
         );
 
@@ -927,7 +928,7 @@ impl Cluster<ServerCluster> {
             ctx.set_peer(leader);
             ctx.set_region_epoch(epoch);
 
-            let mut storage = self.sim.rl().storages.get(&store_id).unwrap().clone();
+            let mut storage = self.must_get_raft_engine(store_id);
             let snap_ctx = SnapContext {
                 pb_ctx: &ctx,
                 ..snap_ctx.clone()
@@ -941,6 +942,10 @@ impl Cluster<ServerCluster> {
             thread::sleep(Duration::from_millis(200));
         }
         panic!("failed to get snapshot of region {}", region_id);
+    }
+
+    pub fn must_get_raft_engine(&self, store_id: u64) -> SimulateEngine {
+        self.sim.rl().storages.get(&store_id).unwrap().clone()
     }
 
     pub fn raft_extension(&self, node_id: u64) -> SimulateRaftExtension {

--- a/components/tidb_query_common/Cargo.toml
+++ b/components/tidb_query_common/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 [dependencies]
 anyhow = "1.0"
 api_version = { workspace = true }
+async-trait = "0.1"
 derive_more = "0.99.3"
 error_code = { workspace = true }
 futures = "0.3"
@@ -17,6 +18,7 @@ lazy_static = "1.3"
 log_wrappers = { workspace = true }
 prometheus = { version = "0.13", features = ["nightly"] }
 prometheus-static-metric = "0.5"
+raft = { workspace = true }
 serde_json = "1.0"
 thiserror = "1.0"
 tikv_util = { workspace = true }

--- a/components/tidb_query_common/src/storage/mod.rs
+++ b/components/tidb_query_common/src/storage/mod.rs
@@ -119,6 +119,8 @@ pub trait RegionStorageAccessor: Sync {
     /// If found, `FindRegionResult::Found`, which contains the region and its
     /// role will be returned.
     /// Otherwise, `FindRegionResult::NotFound` will be returned.
+    /// The argument `key` should be the comparable format, you should use
+    /// `Key::from_raw` encode the raw key.
     async fn find_region_by_key(&self, key: &[u8]) -> Result<FindRegionResult>;
     /// Get the local storage for the specified region.
     /// It receives a region and a list of key ranges which need to be scanned.

--- a/components/tidb_query_common/src/storage/mod.rs
+++ b/components/tidb_query_common/src/storage/mod.rs
@@ -75,8 +75,18 @@ pub enum FindRegionResult {
     /// A region that contains the specified key is found.
     Found { region: Region, role: StateRole },
     /// No region that contains the specified key is found.
-    /// The field `next_region_start` indicates the start key of the next region
-    /// for the specified key.
+    /// The field `next_region_start` indicates the start key of the nearest
+    /// region in the local store after the specified key.
+    /// For example, if the regions are distributed in the local store as
+    /// follows: | ------------- [a, b) ------- c ------ [d, e) ------------- |
+    ///                            |            |          |
+    ///                         region1        key       region2
+    /// Because the region of the key is found in the local store,
+    /// NotFound { next_region_start: "d" } will be returned.
+    /// It is useful to get the "hole" after the specified key in the local
+    /// store, and the caller can use it to determine whether the following keys
+    /// can be located in the local store or not without accessing the
+    /// storage.
     NotFound { next_region_start: Option<Vec<u8>> },
 }
 

--- a/components/tidb_query_common/src/storage/mod.rs
+++ b/components/tidb_query_common/src/storage/mod.rs
@@ -107,17 +107,25 @@ impl FindRegionResult {
     }
 }
 
-/// The abstract interface for accessing more region storages inside a
-/// cop-executor.
+/// The abstract interface for accessing some secondary region storages in the
+/// cop-task.
+/// For example, in the `IndexLookUp` executor can use it to find the regions
+/// and storages where the primary keys are located.
 #[async_trait]
 pub trait RegionStorageAccessor: Sync {
     type Storage;
 
+    /// Find the region that contains the specified key.
+    /// If found, `FindRegionResult::Found`, which contains the region and its
+    /// role will be returned.
+    /// Otherwise, `FindRegionResult::NotFound` will be returned.
     async fn find_region_by_key(&self, key: &[u8]) -> Result<FindRegionResult>;
+    /// Get the local storage for the specified region.
+    /// It receives a region and a list of key ranges which need to be scanned.
     async fn get_local_region_storage(
         &self,
         region: &Region,
-        _key_ranges: &[KeyRange],
+        key_ranges: &[KeyRange],
     ) -> Result<Self::Storage>;
 }
 

--- a/components/tikv_kv/src/lib.rs
+++ b/components/tikv_kv/src/lib.rs
@@ -486,6 +486,9 @@ pub trait Engine: Send + Clone + 'static {
     /// engine may update its statistics.
     fn hint_change_in_range(&self, _start_key: Vec<u8>, _end_key: Vec<u8>) {}
 
+    /// seek the regions from the specified key
+    /// The argument `from` should be the comparable format, you should use
+    /// `Key::from_raw` encode the raw key.
     fn seek_region(&self, _from: &[u8], _callback: SeekRegionCallback) -> Result<()> {
         Err(box_err!("not supported"))
     }

--- a/components/tikv_kv/src/lib.rs
+++ b/components/tikv_kv/src/lib.rs
@@ -46,10 +46,14 @@ use kvproto::{
     errorpb::Error as ErrorHeader,
     import_sstpb::SstMeta,
     kvrpcpb::{Context, DiskFullOpt, ExtraOp as TxnExtraOp, KeyRange},
+    metapb::{Peer, RegionEpoch},
     raft_cmdpb,
 };
 use pd_client::BucketMeta;
-use raftstore::store::{PessimisticLockPair, TxnExt};
+use raftstore::{
+    SeekRegionCallback,
+    store::{PessimisticLockPair, TxnExt},
+};
 use thiserror::Error;
 use tikv_util::{
     deadline::Deadline, escape, future::block_on_timeout, memory::HeapSize, time::ThreadReadId,
@@ -322,6 +326,14 @@ impl WriteEvent {
     }
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct SecondaryRegionOverride {
+    pub region_id: u64,
+    pub region_epoch: RegionEpoch,
+    pub peer: Peer,
+    pub check_term: Option<u64>,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct SnapContext<'a> {
     pub pb_ctx: &'a Context,
@@ -335,6 +347,15 @@ pub struct SnapContext<'a> {
     pub key_ranges: Vec<KeyRange>,
     // Marks that this snapshot request is allowed in the flashback state.
     pub allowed_in_flashback: bool,
+    // secondary_region_override overrides some context fields in the `pb_ctx` for the secondary
+    // regions.
+    // The "secondary region" means the regions that are not the source region
+    // in a request.
+    // For example, if a cop-task contains a `IndexLookUp` executor which needs to
+    // access look up the primary rows,
+    // it will set this field to get the secondary region snapshot
+    // in lookup phase.
+    pub secondary_region_override: Option<SecondaryRegionOverride>,
 }
 
 /// Engine defines the common behaviour for a storage engine type.
@@ -464,6 +485,10 @@ pub trait Engine: Send + Clone + 'static {
     /// the engine there is probably a notable difference in range, so
     /// engine may update its statistics.
     fn hint_change_in_range(&self, _start_key: Vec<u8>, _end_key: Vec<u8>) {}
+
+    fn seek_region(&self, _from: &[u8], _callback: SeekRegionCallback) -> Result<()> {
+        Err(box_err!("not supported"))
+    }
 }
 
 /// A Snapshot is a consistent view of the underlying engine at a given point in

--- a/components/tikv_kv/src/rocksdb_engine.rs
+++ b/components/tikv_kv/src/rocksdb_engine.rs
@@ -26,7 +26,10 @@ use futures::{
     stream,
 };
 use kvproto::{kvrpcpb::Context, metapb, raft_cmdpb};
-use raftstore::coprocessor::CoprocessorHost;
+use raftstore::{
+    SeekRegionCallback,
+    coprocessor::{CoprocessorHost, RegionInfoProvider},
+};
 use tempfile::{Builder, TempDir};
 use tikv_util::worker::{Runnable, Scheduler, Worker};
 use txn_types::{Key, Value};
@@ -94,6 +97,7 @@ pub struct RocksEngine<RE = FakeExtension> {
     engines: Engines<BaseRocksEngine, BaseRocksEngine>,
     not_leader: Arc<AtomicBool>,
     coprocessor: CoprocessorHost<BaseRocksEngine>,
+    region_info_provider: Option<Arc<Box<dyn RegionInfoProvider>>>,
     ext: RE,
 }
 
@@ -105,6 +109,7 @@ impl<RE> RocksEngine<RE> {
             engines: self.engines,
             not_leader: self.not_leader,
             coprocessor: self.coprocessor,
+            region_info_provider: None,
             ext,
         }
     }
@@ -142,6 +147,7 @@ impl RocksEngine {
             not_leader: Arc::new(AtomicBool::new(false)),
             engines,
             coprocessor: CoprocessorHost::default(),
+            region_info_provider: None,
             ext: FakeExtension,
         })
     }
@@ -206,6 +212,14 @@ impl<RE> RocksEngine<RE> {
             .map(Into::into)
             .collect::<Vec<_>>();
         Ok(batch)
+    }
+
+    pub fn set_region_info_provider(&mut self, provider: impl RegionInfoProvider + 'static) {
+        self.region_info_provider = Some(Arc::new(Box::new(provider)))
+    }
+
+    pub fn clear_region_info_provider(&mut self) {
+        self.region_info_provider = None;
     }
 }
 
@@ -319,6 +333,15 @@ impl<RE: RaftExtension + 'static> Engine for RocksEngine<RE> {
     type IMSnapshotRes = impl Future<Output = Result<Self::Snap>> + Send;
     fn async_in_memory_snapshot(&mut self, ctx: SnapContext<'_>) -> Self::IMSnapshotRes {
         self.async_snapshot(ctx)
+    }
+
+    fn seek_region(&self, from: &[u8], callback: SeekRegionCallback) -> Result<()> {
+        match self.region_info_provider {
+            Some(ref accessor) => accessor
+                .seek_region(from, callback)
+                .map_err(|e| box_err!(e)),
+            None => Err(box_err!("region_info_accessor is not available")),
+        }
     }
 }
 

--- a/components/tikv_util/src/deadline.rs
+++ b/components/tikv_util/src/deadline.rs
@@ -21,7 +21,7 @@ impl std::fmt::Display for DeadlineError {
 }
 
 /// A handy structure for checking deadline.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct Deadline {
     deadline: Instant,
 }

--- a/src/coprocessor/dag/mod.rs
+++ b/src/coprocessor/dag/mod.rs
@@ -124,6 +124,9 @@ where
 {
     type Storage = TikvStorage<R::Storage>;
 
+    /// find the region by the specified key.
+    /// The argument `key` should be the comparable format, you should use
+    /// `Key::from_raw` encode the raw key.
     async fn find_region_by_key(&self, key: &[u8]) -> storage::Result<FindRegionResult> {
         self.store_accessor.find_region_by_key(key).await
     }

--- a/src/coprocessor/dag/mod.rs
+++ b/src/coprocessor/dag/mod.rs
@@ -6,9 +6,16 @@ use std::{marker::PhantomData, sync::Arc};
 
 use api_version::KvFormat;
 use async_trait::async_trait;
-use kvproto::coprocessor::{KeyRange, Response};
+use kvproto::{
+    coprocessor::{KeyRange, Response},
+    metapb::Region,
+};
 use protobuf::Message;
-use tidb_query_common::{execute_stats::ExecSummary, storage::IntervalRange};
+use tidb_query_common::{
+    execute_stats::ExecSummary,
+    storage,
+    storage::{FindRegionResult, IntervalRange, RegionStorageAccessor},
+};
 use tikv_alloc::trace::MemoryTraceGuard;
 use tipb::{DagRequest, SelectResponse, StreamResponse};
 
@@ -19,10 +26,16 @@ use crate::{
     tikv_util::quota_limiter::QuotaLimiter,
 };
 
-pub struct DagHandlerBuilder<S: Store + 'static, F: KvFormat> {
+pub struct DagHandlerBuilder<R, S, F>
+where
+    R: RegionStorageAccessor<Storage = S>,
+    S: Store + 'static,
+    F: KvFormat,
+{
     req: DagRequest,
     ranges: Vec<KeyRange>,
     store: S,
+    secondary_storage_accessor: Option<R>,
     data_version: Option<u64>,
     deadline: Deadline,
     batch_row_limit: usize,
@@ -33,11 +46,17 @@ pub struct DagHandlerBuilder<S: Store + 'static, F: KvFormat> {
     _phantom: PhantomData<F>,
 }
 
-impl<S: Store + 'static, F: KvFormat> DagHandlerBuilder<S, F> {
+impl<R, S, F> DagHandlerBuilder<R, S, F>
+where
+    R: RegionStorageAccessor<Storage = S>,
+    S: Store + 'static,
+    F: KvFormat,
+{
     pub fn new(
         req: DagRequest,
         ranges: Vec<KeyRange>,
         store: S,
+        secondary_storage_accessor: Option<R>,
         deadline: Deadline,
         batch_row_limit: usize,
         is_streaming: bool,
@@ -49,6 +68,7 @@ impl<S: Store + 'static, F: KvFormat> DagHandlerBuilder<S, F> {
             req,
             ranges,
             store,
+            secondary_storage_accessor,
             data_version: None,
             deadline,
             batch_row_limit,
@@ -72,6 +92,7 @@ impl<S: Store + 'static, F: KvFormat> DagHandlerBuilder<S, F> {
             self.req,
             self.ranges,
             self.store,
+            self.secondary_storage_accessor,
             self.data_version,
             self.deadline,
             self.is_cache_enabled,
@@ -81,6 +102,43 @@ impl<S: Store + 'static, F: KvFormat> DagHandlerBuilder<S, F> {
             self.quota_limiter,
         )?
         .into_boxed())
+    }
+}
+
+/// Wraps the internal accessor to provide the accessor for the secondary
+/// TikvStorage.
+pub struct SecondaryTiKVStorageAccessor<R> {
+    store_accessor: R,
+}
+
+impl<R> SecondaryTiKVStorageAccessor<R> {
+    pub fn from_store_accessor(store_accessor: R) -> Self {
+        SecondaryTiKVStorageAccessor { store_accessor }
+    }
+}
+
+#[async_trait]
+impl<R> RegionStorageAccessor for SecondaryTiKVStorageAccessor<R>
+where
+    R: RegionStorageAccessor<Storage: Store>,
+{
+    type Storage = TikvStorage<R::Storage>;
+
+    async fn find_region_by_key(&self, key: &[u8]) -> storage::Result<FindRegionResult> {
+        self.store_accessor.find_region_by_key(key).await
+    }
+
+    async fn get_local_region_storage(
+        &self,
+        region: &Region,
+        key_ranges: &[KeyRange],
+    ) -> storage::Result<Self::Storage> {
+        let store = self
+            .store_accessor
+            .get_local_region_storage(region, key_ranges)
+            .await?;
+        let check_can_be_cached = store.is_check_has_newer_ts_data();
+        Ok(Self::Storage::new(store, check_can_be_cached))
     }
 }
 
@@ -94,6 +152,7 @@ impl BatchDagHandler {
         req: DagRequest,
         ranges: Vec<KeyRange>,
         store: S,
+        secondary_storage_accessor: Option<impl RegionStorageAccessor<Storage = S>>,
         data_version: Option<u64>,
         deadline: Deadline,
         is_cache_enabled: bool,
@@ -102,11 +161,14 @@ impl BatchDagHandler {
         paging_size: Option<u64>,
         quota_limiter: Arc<QuotaLimiter>,
     ) -> Result<Self> {
+        let secondary_storage_accessor =
+            secondary_storage_accessor.map(SecondaryTiKVStorageAccessor::from_store_accessor);
         Ok(Self {
             runner: tidb_query_executors::runner::BatchExecutorsRunner::from_request::<_, F>(
                 req,
                 ranges,
                 TikvStorage::new(store, is_cache_enabled),
+                secondary_storage_accessor,
                 deadline,
                 streaming_batch_limit,
                 is_streaming,

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -1059,6 +1059,9 @@ impl<E: Engine> SecondarySnapStoreAccessor<E> {
 impl<E: Engine> RegionStorageAccessor for SecondarySnapStoreAccessor<E> {
     type Storage = SnapshotStore<E::IMSnap>;
 
+    /// find the region by the specified key.
+    /// The argument `key` should be the comparable format, you should use
+    /// `Key::from_raw` encode the raw key.
     async fn find_region_by_key(&self, key: &[u8]) -> StorageResult<FindRegionResult> {
         let key_in_vec = key.to_vec();
         let (tx, rx) = oneshot::channel();

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -1033,21 +1033,20 @@ impl<E: Engine> SecondarySnapStoreAccessor<E> {
             None => return None,
         };
 
-        if pb_ctx.get_isolation_level() != kvrpcpb::IsolationLevel::Si
-            || pb_ctx.get_stale_read()
-            || pb_ctx.get_replica_read()
+        if pb_ctx.get_isolation_level() == kvrpcpb::IsolationLevel::Si
+            && !pb_ctx.get_stale_read()
+            && !pb_ctx.get_replica_read()
         {
             // Some scenes are not supported before an effective argument, including:
             // - stale-read & replica-read, TODO: support it later
             // - non-SI isolation level, TODO: support it later
-            return None;
+            return Some(Self {
+                store_id,
+                req_ctx,
+                _phantom: PhantomData,
+            });
         }
-
-        Some(Self {
-            store_id,
-            req_ctx,
-            _phantom: PhantomData,
-        })
+        None
     }
 
     #[inline]

--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -35,14 +35,13 @@ pub mod readpool_impl;
 mod statistics;
 mod tracker;
 
-use std::sync::Arc;
+use std::{ops::Deref, sync::Arc};
 
 use async_trait::async_trait;
 pub use checksum::checksum_crc64_xor;
 use engine_traits::PerfLevel;
 use kvproto::{coprocessor as coppb, kvrpcpb};
 use lazy_static::lazy_static;
-use metrics::ReqTag;
 use rand::prelude::*;
 use tidb_query_common::execute_stats::ExecSummary;
 use tikv_alloc::{Id, MemoryTrace, MemoryTraceGuard, mem_trace};
@@ -97,14 +96,11 @@ pub trait RequestHandler: Send {
 type RequestHandlerBuilder<Snap> =
     Box<dyn for<'a> FnOnce(Snap, &ReqContext) -> Result<Box<dyn RequestHandler>> + Send>;
 
-/// Encapsulate the `kvrpcpb::Context` to provide some extra properties.
-#[derive(Debug, Clone)]
-pub struct ReqContext {
-    /// The tag of the request
-    pub tag: ReqTag,
-
+/// The inner state of ReqContext.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ReqContextInner {
     /// The rpc context carried in the request
-    pub context: Arc<kvrpcpb::Context>,
+    pub context: kvrpcpb::Context,
 
     /// Scan ranges of this request
     pub ranges: Vec<coppb::KeyRange>,
@@ -150,19 +146,9 @@ pub struct ReqContext {
     pub allowed_in_flashback: bool,
 }
 
-impl HeapSize for ReqContext {
-    fn approximate_heap_size(&self) -> usize {
-        self.context.approximate_heap_size()
-            + self.ranges.approximate_heap_size()
-            + self.peer.as_ref().map_or(0, |p| p.len())
-            + self.lower_bound.approximate_heap_size()
-            + self.upper_bound.approximate_heap_size()
-    }
-}
-
-impl ReqContext {
+impl ReqContextInner {
+    #[inline]
     pub fn new(
-        tag: ReqTag,
         mut context: kvrpcpb::Context,
         ranges: Vec<coppb::KeyRange>,
         max_handle_duration: Duration,
@@ -171,6 +157,7 @@ impl ReqContext {
         txn_start_ts: TimeStamp,
         cache_match_version: Option<u64>,
         perf_level: PerfLevel,
+        allowed_in_flashback: bool,
     ) -> Self {
         let mut deadline_duration = max_handle_duration;
         if context.max_execution_duration_ms > 0 {
@@ -188,8 +175,7 @@ impl ReqContext {
             None => vec![],
         };
         Self {
-            tag,
-            context: Arc::new(context),
+            context,
             deadline,
             peer,
             is_desc_scan,
@@ -201,14 +187,13 @@ impl ReqContext {
             lower_bound,
             upper_bound,
             perf_level,
-            allowed_in_flashback: false,
+            allowed_in_flashback,
         }
     }
 
     #[cfg(test)]
     pub fn default_for_test() -> Self {
         Self::new(
-            ReqTag::test,
             Default::default(),
             Vec::new(),
             Duration::from_secs(100),
@@ -217,7 +202,71 @@ impl ReqContext {
             TimeStamp::max(),
             None,
             PerfLevel::EnableCount,
+            false,
         )
+    }
+}
+
+/// ReqContext provides the context for the coprocessor request.
+/// It Encapsulate the `kvrpcpb::Context` to provide some extra properties.
+/// It is immutable and can be shared across threads.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ReqContext(Arc<ReqContextInner>);
+
+impl Deref for ReqContext {
+    type Target = Arc<ReqContextInner>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl HeapSize for ReqContext {
+    fn approximate_heap_size(&self) -> usize {
+        self.0.context.approximate_heap_size()
+            + self.0.ranges.approximate_heap_size()
+            + self.0.peer.as_ref().map_or(0, |p| p.len())
+            + self.0.lower_bound.approximate_heap_size()
+            + self.0.upper_bound.approximate_heap_size()
+    }
+}
+
+impl From<ReqContextInner> for ReqContext {
+    fn from(inner: ReqContextInner) -> Self {
+        Self(Arc::new(inner))
+    }
+}
+
+impl ReqContext {
+    #[inline]
+    pub fn new(
+        context: kvrpcpb::Context,
+        ranges: Vec<coppb::KeyRange>,
+        max_handle_duration: Duration,
+        peer: Option<String>,
+        is_desc_scan: Option<bool>,
+        txn_start_ts: TimeStamp,
+        cache_match_version: Option<u64>,
+        perf_level: PerfLevel,
+        allowed_in_flashback: bool,
+    ) -> Self {
+        ReqContextInner::new(
+            context,
+            ranges,
+            max_handle_duration,
+            peer,
+            is_desc_scan,
+            txn_start_ts,
+            cache_match_version,
+            perf_level,
+            allowed_in_flashback,
+        )
+        .into()
+    }
+
+    #[cfg(test)]
+    pub fn default_for_test() -> Self {
+        ReqContextInner::default_for_test().into()
     }
 
     pub fn build_task_id(&self) -> u64 {
@@ -257,7 +306,6 @@ mod tests {
         max_handle_duration: Duration,
     ) -> ReqContext {
         ReqContext::new(
-            ReqTag::test,
             context,
             Vec::new(),
             max_handle_duration,
@@ -266,21 +314,21 @@ mod tests {
             TimeStamp::max(),
             None,
             PerfLevel::EnableCount,
+            false,
         )
     }
 
     #[test]
     fn test_build_task_id() {
-        let mut ctx = ReqContext::default_for_test();
+        let mut inner = ReqContextInner::default_for_test();
         let start_ts: u64 = 0x05C6_1BFA_2648_324A;
-
-        let mut pb_ctx = ctx.context.as_ref().clone();
-        pb_ctx.set_task_id(1);
-        ctx.context = Arc::new(pb_ctx.clone());
+        inner.txn_start_ts = start_ts.into();
+        inner.context.set_task_id(1);
+        let ctx: ReqContext = inner.clone().into();
         assert_eq!(ctx.build_task_id(), 0x0001_1BFA_2648_324A);
 
-        pb_ctx.set_task_id(0);
-        ctx.context = Arc::new(pb_ctx.clone());
+        inner.context.set_task_id(0);
+        let ctx: ReqContext = inner.clone().into();
         assert_eq!(ctx.build_task_id(), start_ts);
     }
 
@@ -305,5 +353,60 @@ mod tests {
             .deadline
             .check()
             .expect("deadline should not exceed");
+    }
+
+    #[test]
+    fn test_req_ctx_new_match_inner() {
+        let pb_ctx = kvrpcpb::Context {
+            region_id: 12345,
+            ..Default::default()
+        };
+        let ranges = vec![coppb::KeyRange {
+            start: vec![1, 2, 3],
+            end: vec![4, 5, 6],
+            ..Default::default()
+        }];
+        let max_handle_duration = Duration::from_secs(100);
+        let peer = Some(String::from("1223"));
+        let is_desc_scan = Some(true);
+        let txn_start_ts = TimeStamp::new(9898);
+        let cache_match_version = Some(42);
+        let perf_level = PerfLevel::EnableCount;
+        let allow_in_flashback = true;
+
+        let mut inner = ReqContextInner::new(
+            pb_ctx.clone(),
+            ranges.clone(),
+            max_handle_duration,
+            peer.clone(),
+            is_desc_scan,
+            txn_start_ts,
+            cache_match_version,
+            perf_level,
+            allow_in_flashback,
+        );
+
+        let ctx = ReqContext::new(
+            pb_ctx,
+            ranges,
+            max_handle_duration,
+            peer,
+            is_desc_scan,
+            txn_start_ts,
+            cache_match_version,
+            perf_level,
+            allow_in_flashback,
+        );
+
+        // deadlines are not exactly equal, just compare the delta
+        assert!(
+            ctx.deadline.inner().duration_since(inner.deadline.inner()) < Duration::from_secs(1),
+            "{:?} - {:?} > 1s",
+            ctx.deadline,
+            inner.deadline
+        );
+        inner.deadline = ctx.deadline;
+        // test ReqContextInner::new and ReqContext::new should match
+        assert_eq!(ctx.0.as_ref().clone(), inner);
     }
 }

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -1554,7 +1554,7 @@ mod test {
     fn convert_write_batch_to_request_raftkv1(ctx: &Context, batch: WriteData) -> RaftCmdRequest {
         let reqs: Vec<Request> = batch.modifies.into_iter().map(Into::into).collect();
         let txn_extra = batch.extra;
-        let mut header = raftkv::new_request_header(ctx);
+        let mut header = raftkv::new_request_header(ctx, None);
         if batch.avoid_batch {
             header.set_uuid(uuid::Uuid::new_v4().as_bytes().to_vec());
         }

--- a/src/server/raftkv/mod.rs
+++ b/src/server/raftkv/mod.rs
@@ -40,8 +40,10 @@ use raft::{
 };
 pub use raft_extension::RaftRouterWrap;
 use raftstore::{
+    RegionInfoAccessor, SeekRegionCallback,
     coprocessor::{
-        Coprocessor, CoprocessorHost, ReadIndexObserver, dispatcher::BoxReadIndexObserver,
+        Coprocessor, CoprocessorHost, ReadIndexObserver, RegionInfoProvider,
+        dispatcher::BoxReadIndexObserver,
     },
     errors::Error as RaftServerError,
     router::{LocalReadRouter, RaftStoreRouter, ReadContext},
@@ -51,7 +53,7 @@ use raftstore::{
     },
 };
 use thiserror::Error;
-use tikv_kv::{OnAppliedCb, WriteEvent, write_modifies};
+use tikv_kv::{OnAppliedCb, SecondaryRegionOverride, WriteEvent, write_modifies};
 use tikv_util::{
     callback::must_call,
     future::{paired_future_callback, paired_must_called_future_callback},
@@ -165,13 +167,33 @@ where
 }
 
 #[inline]
-pub fn new_request_header(ctx: &Context) -> RaftRequestHeader {
+pub fn new_request_header(
+    ctx: &Context,
+    extra_snap_override: Option<&SecondaryRegionOverride>,
+) -> RaftRequestHeader {
     let mut header = RaftRequestHeader::default();
-    header.set_region_id(ctx.get_region_id());
-    header.set_peer(ctx.get_peer().clone());
-    header.set_region_epoch(ctx.get_region_epoch().clone());
-    if ctx.get_term() != 0 {
-        header.set_term(ctx.get_term());
+    match extra_snap_override {
+        Some(&SecondaryRegionOverride {
+            region_id,
+            ref region_epoch,
+            ref peer,
+            check_term,
+        }) => {
+            header.set_region_id(region_id);
+            header.set_peer(peer.clone());
+            header.set_region_epoch(region_epoch.clone());
+            if let Some(term) = check_term {
+                header.set_term(term);
+            }
+        }
+        _ => {
+            header.set_region_id(ctx.get_region_id());
+            header.set_peer(ctx.get_peer().clone());
+            header.set_region_epoch(ctx.get_region_epoch().clone());
+            if ctx.get_term() != 0 {
+                header.set_term(ctx.get_term());
+            }
+        }
     }
     header.set_sync_log(ctx.get_sync_log());
     header.set_replica_read(ctx.get_replica_read());
@@ -185,7 +207,7 @@ pub fn new_request_header(ctx: &Context) -> RaftRequestHeader {
 
 #[inline]
 pub fn new_flashback_req(ctx: &Context, ty: AdminCmdType) -> RaftCmdRequest {
-    let header = new_request_header(ctx);
+    let header = new_request_header(ctx, None);
     let mut req = RaftCmdRequest::default();
     req.set_header(header);
     req.mut_header()
@@ -356,6 +378,7 @@ where
     router: RaftRouterWrap<S, E>,
     engine: E,
     txn_extra_scheduler: Option<Arc<dyn TxnExtraScheduler>>,
+    region_info_accessor: Option<RegionInfoAccessor>,
     region_leaders: Arc<RwLock<HashSet<u64>>>,
 }
 
@@ -365,11 +388,17 @@ where
     S: RaftStoreRouter<E> + LocalReadRouter<E> + 'static,
 {
     /// Create a RaftKv using specified configuration.
-    pub fn new(router: S, engine: E, region_leaders: Arc<RwLock<HashSet<u64>>>) -> RaftKv<E, S> {
+    pub fn new(
+        router: S,
+        engine: E,
+        region_info_accessor: Option<RegionInfoAccessor>,
+        region_leaders: Arc<RwLock<HashSet<u64>>>,
+    ) -> RaftKv<E, S> {
         RaftKv {
             router: RaftRouterWrap::new(router),
             engine,
             txn_extra_scheduler: None,
+            region_info_accessor,
             region_leaders,
         }
     }
@@ -507,7 +536,7 @@ where
 
         let reqs: Vec<Request> = batch.modifies.into_iter().map(Into::into).collect();
         let txn_extra = batch.extra;
-        let mut header = new_request_header(ctx);
+        let mut header = new_request_header(ctx, None);
         if batch.avoid_batch {
             header.set_uuid(uuid::Uuid::new_v4().as_bytes().to_vec());
         }
@@ -668,6 +697,15 @@ where
                 warn!("unsafe destroy range: failed sending ClearRegionSizeInRange"; "err" => ?e);
             });
     }
+
+    fn seek_region(&self, from: &[u8], callback: SeekRegionCallback) -> kv::Result<()> {
+        match self.region_info_accessor {
+            Some(ref accessor) => accessor
+                .seek_region(from, callback)
+                .map_err(|e| box_err!(e)),
+            None => Err(box_err!("region_info_accessor is not available")),
+        }
+    }
 }
 
 fn async_snapshot<E, S>(
@@ -697,7 +735,7 @@ where
     let begin_instant = Instant::now();
     let (cb, f) = paired_must_called_future_callback(drop_snapshot_callback);
 
-    let mut header = new_request_header(ctx.pb_ctx);
+    let mut header = new_request_header(ctx.pb_ctx, ctx.secondary_region_override.as_ref());
     let mut flags = 0;
     let need_encoded_start_ts = ctx.start_ts.is_none_or(|ts| !ts.is_zero());
     if ctx.pb_ctx.get_stale_read() && need_encoded_start_ts {

--- a/src/server/raftkv2/mod.rs
+++ b/src/server/raftkv2/mod.rs
@@ -181,7 +181,7 @@ impl<EK: KvEngine, ER: RaftEngine> tikv_kv::Engine for RaftKv2<EK, ER> {
         ASYNC_REQUESTS_COUNTER_VEC.snapshot.all.inc();
         let begin_instant = Instant::now();
 
-        let mut header = new_request_header(ctx.pb_ctx);
+        let mut header = new_request_header(ctx.pb_ctx, ctx.secondary_region_override.as_ref());
         let mut flags = 0;
         let need_encoded_start_ts = ctx.start_ts.is_none_or(|ts| !ts.is_zero());
         if ctx.pb_ctx.get_stale_read() && need_encoded_start_ts {
@@ -307,7 +307,7 @@ impl<EK: KvEngine, ER: RaftEngine> tikv_kv::Engine for RaftKv2<EK, ER> {
         })();
 
         let begin_instant = Instant::now_coarse();
-        let mut header = Box::new(new_request_header(ctx));
+        let mut header = Box::new(new_request_header(ctx, None));
         let mut flags = 0;
         if batch.extra.one_pc {
             flags |= WriteBatchFlags::ONE_PC.bits();

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -30,6 +30,9 @@ pub trait Store: Send {
     /// Whether there was data > ts during previous incremental gets.
     fn incremental_get_met_newer_ts_data(&self) -> NewerTsCheckState;
 
+    /// Whether checks the newer ts data
+    fn is_check_has_newer_ts_data(&self) -> bool;
+
     /// Fetch the provided set of keys.
     fn batch_get(
         &self,
@@ -344,6 +347,11 @@ impl<S: Snapshot> Store for SnapshotStore<S> {
         }
     }
 
+    #[inline]
+    fn is_check_has_newer_ts_data(&self) -> bool {
+        self.check_has_newer_ts_data
+    }
+
     fn batch_get(
         &self,
         keys: &[Key],
@@ -452,13 +460,38 @@ impl<S: Snapshot> SnapshotStore<S> {
     }
 
     #[inline]
+    pub fn get_start_ts(&self) -> TimeStamp {
+        self.start_ts
+    }
+
+    #[inline]
     pub fn set_isolation_level(&mut self, isolation_level: IsolationLevel) {
         self.isolation_level = isolation_level;
     }
 
     #[inline]
+    pub fn get_isolation_level(&self) -> IsolationLevel {
+        self.isolation_level
+    }
+
+    #[inline]
     pub fn set_bypass_locks(&mut self, locks: TsSet) {
         self.bypass_locks = locks;
+    }
+
+    #[inline]
+    pub fn get_by_pass_locks(&self) -> TsSet {
+        self.bypass_locks.clone()
+    }
+
+    #[inline]
+    pub fn get_access_locks(&self) -> TsSet {
+        self.access_locks.clone()
+    }
+
+    #[inline]
+    pub fn is_fill_cache(&self) -> bool {
+        self.fill_cache
     }
 
     fn verify_range(&self, lower_bound: &Option<Key>, upper_bound: &Option<Key>) -> Result<()> {
@@ -549,6 +582,10 @@ impl Store for FixtureStore {
     #[inline]
     fn incremental_get_met_newer_ts_data(&self) -> NewerTsCheckState {
         NewerTsCheckState::Unknown
+    }
+
+    fn is_check_has_newer_ts_data(&self) -> bool {
+        false
     }
 
     #[inline]

--- a/tests/benches/coprocessor_executors/integrated/util.rs
+++ b/tests/benches/coprocessor_executors/integrated/util.rs
@@ -6,6 +6,7 @@ use api_version::ApiV1;
 use criterion::{black_box, measurement::Measurement};
 use kvproto::coprocessor::KeyRange;
 use test_coprocessor::*;
+use tidb_query_common::storage::StubAccessor;
 use tidb_query_datatype::expr::EvalConfig;
 use tikv::{
     coprocessor::dag::TikvStorage,
@@ -75,6 +76,7 @@ where
             tidb_query_executors::runner::build_executors::<_, ApiV1>(
                 black_box(executors.to_vec()),
                 black_box(TikvStorage::new(ToTxnStore::<T>::to_store(store), false)),
+                StubAccessor::none(),
                 black_box(ranges.to_vec()),
                 black_box(Arc::new(EvalConfig::default())),
                 black_box(false),

--- a/tests/benches/coprocessor_executors/util/mod.rs
+++ b/tests/benches/coprocessor_executors/util/mod.rs
@@ -12,6 +12,7 @@ use api_version::ApiV1;
 use criterion::{black_box, measurement::Measurement};
 use kvproto::coprocessor::KeyRange;
 use test_coprocessor::*;
+use tidb_query_common::storage::StubAccessor;
 use tikv::{
     coprocessor::RequestHandler,
     storage::{RocksEngine, Store as TxnStore},
@@ -42,10 +43,11 @@ pub fn build_dag_handler<TargetTxnStore: TxnStore + 'static>(
     let mut dag = DagRequest::default();
     dag.set_executors(executors.to_vec().into());
 
-    tikv::coprocessor::dag::DagHandlerBuilder::<_, ApiV1>::new(
+    tikv::coprocessor::dag::DagHandlerBuilder::<_, _, ApiV1>::new(
         black_box(dag),
         black_box(ranges.to_vec()),
         black_box(ToTxnStore::<TargetTxnStore>::to_store(store)),
+        StubAccessor::none(),
         tikv_util::deadline::Deadline::from_now(std::time::Duration::from_secs(10)),
         64,
         false,

--- a/tests/benches/misc/raftkv/mod.rs
+++ b/tests/benches/misc/raftkv/mod.rs
@@ -184,6 +184,7 @@ fn bench_async_snapshot(b: &mut test::Bencher) {
     let mut kv = RaftKv::new(
         SyncBenchRouter::new(region.clone(), db.clone()),
         db,
+        None,
         Arc::new(RwLock::new(HashSet::default())),
     );
 
@@ -218,6 +219,7 @@ fn bench_async_write(b: &mut test::Bencher) {
     let kv = RaftKv::new(
         SyncBenchRouter::new(region.clone(), db.clone()),
         db,
+        None,
         Arc::new(RwLock::new(HashSet::default())),
     );
 

--- a/tests/integrations/mod.rs
+++ b/tests/integrations/mod.rs
@@ -3,6 +3,7 @@
 #![feature(test)]
 #![feature(box_patterns)]
 #![feature(custom_test_frameworks)]
+#![feature(assert_matches)]
 #![test_runner(test_util::run_tests)]
 
 extern crate test;

--- a/tests/integrations/raftstore/test_snap.rs
+++ b/tests/integrations/raftstore/test_snap.rs
@@ -1283,13 +1283,10 @@ fn test_extra_snapshot_override() {
     let r0 = pd_client.get_region_info(b"a").unwrap();
     let r0_leader = r0.leader.as_ref().unwrap();
     let mut r2 = pd_client.get_region_info(b"c").unwrap();
-    let mut r2_leader = r2.leader.as_ref().unwrap();
-    if r0_leader.get_store_id() != r2_leader.get_store_id() {
-        r2.leader = Some(find_peer(&r2, r0_leader.get_store_id()).unwrap().clone());
-        r2_leader = r2.leader.as_ref().unwrap();
-        pd_client.transfer_leader(r2.get_id(), r2_leader.clone(), vec![]);
-        pd_client.region_leader_must_be(r2.get_id(), r2_leader.clone());
-    }
+    r2.leader = Some(find_peer(&r2, r0_leader.get_store_id()).unwrap().clone());
+    let r2_leader = r2.leader.as_ref().unwrap();
+    pd_client.transfer_leader(r2.get_id(), r2_leader.clone(), vec![]);
+    pd_client.region_leader_must_be(r2.get_id(), r2_leader.clone());
 
     // constructs a snap_ctx with the base info region 0.
     let pb_ctx = {

--- a/tests/integrations/raftstore/test_snap.rs
+++ b/tests/integrations/raftstore/test_snap.rs
@@ -1,6 +1,7 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::{
+    assert_matches::assert_matches,
     fs,
     path::PathBuf,
     sync::{
@@ -17,9 +18,12 @@ use file_system::{IoOp, IoType};
 use futures::executor::block_on;
 use grpcio::{self, ChannelBuilder, Environment};
 use kvproto::{
+    kvrpcpb,
+    kvrpcpb::KeyRange,
     raft_serverpb::{ExtraMessageType, RaftMessage, RaftSnapshotData},
     tikvpb::TikvClient,
 };
+use pd_client::PdClient;
 use protobuf::Message as M1;
 use raft::eraftpb::{Message, MessageType, Snapshot};
 use raftstore::{
@@ -33,6 +37,9 @@ use test_raftstore::*;
 use test_raftstore_macro::test_case;
 use test_raftstore_v2::WrapFactory;
 use tikv::server::{snap::send_snap, tablet_snap::send_snap as send_snap_v2};
+use tikv_kv::{
+    Engine, Error, ErrorInner, SecondaryRegionOverride, SnapContext, Snapshot as _, SnapshotExt,
+};
 use tikv_util::{
     HandyRwLock,
     config::*,
@@ -1259,4 +1266,141 @@ fn test_node_apply_snapshot_by_or_without_ingest() {
             std::thread::sleep(Duration::from_millis(50));
         }
     }
+}
+
+#[test_case(test_raftstore::new_server_cluster)]
+fn test_extra_snapshot_override() {
+    let mut cluster = new_cluster(0, 3);
+    configure_for_snapshot(&mut cluster.cfg);
+    cluster.run_conf_change();
+    let pd_client = cluster.pd_client.clone();
+    for key in [b"a", b"b", b"c", b"d"] {
+        let region = pd_client.get_region_info(key).unwrap();
+        cluster.must_split(&region, key);
+    }
+
+    // make sure leaders of region0 and region2 are in the same store
+    let r0 = pd_client.get_region_info(b"a").unwrap();
+    let r0_leader = r0.leader.as_ref().unwrap();
+    let mut r2 = pd_client.get_region_info(b"c").unwrap();
+    let mut r2_leader = r2.leader.as_ref().unwrap();
+    if r0_leader.get_store_id() != r2_leader.get_store_id() {
+        r2.leader = Some(find_peer(&r2, r0_leader.get_store_id()).unwrap().clone());
+        r2_leader = r2.leader.as_ref().unwrap();
+        pd_client.transfer_leader(r2.get_id(), r2_leader.clone(), vec![]);
+        pd_client.region_leader_must_be(r2.get_id(), r2_leader.clone());
+    }
+
+    // constructs a snap_ctx with the base info region 0.
+    let pb_ctx = {
+        let mut ctx = kvrpcpb::Context::default();
+        ctx.set_region_id(r0.get_id());
+        ctx.set_region_epoch(r0.get_region_epoch().clone());
+        ctx.set_peer(r0_leader.clone());
+        ctx.set_term(10000);
+        ctx
+    };
+
+    let mut snap_ctx = SnapContext {
+        pb_ctx: &pb_ctx,
+        start_ts: Some(get_tso(pd_client.as_ref()).into()),
+        key_ranges: vec![KeyRange {
+            start_key: b"c1".to_vec(),
+            end_key: b"c2".to_vec(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    // when `extra_snap_override`, should use the override region info
+    snap_ctx.secondary_region_override = Some(SecondaryRegionOverride {
+        region_id: r2.get_id(),
+        region_epoch: r2.get_region_epoch().clone(),
+        peer: r2_leader.clone(),
+        // test None term will not check the term in snapshot
+        check_term: None,
+    });
+    let snap = cluster
+        .must_get_raft_engine(r0_leader.get_store_id())
+        .snapshot(snap_ctx.clone())
+        .unwrap();
+    let r2_term = snap.ext().get_term().unwrap().get();
+    assert_eq!(snap.get_region().clone(), r2.region.clone());
+
+    // If`extra_snap_override`.`term` is set with an invalid value, should return an
+    // error.
+    snap_ctx
+        .secondary_region_override
+        .as_mut()
+        .unwrap()
+        .check_term = Some(r2_term - 2);
+    let err = cluster
+        .must_get_raft_engine(r0_leader.get_store_id())
+        .snapshot(snap_ctx.clone())
+        .err()
+        .unwrap();
+    assert_matches!(err, Error(box ErrorInner::Request(header)) if header.stale_command.is_some());
+    snap_ctx
+        .secondary_region_override
+        .as_mut()
+        .unwrap()
+        .check_term = None;
+
+    // If `extra_snap_override`.`term` is set with a valid value, should return
+    // a snapshot.
+    snap_ctx
+        .secondary_region_override
+        .as_mut()
+        .unwrap()
+        .check_term = Some(r2_term);
+    let snap = cluster
+        .must_get_raft_engine(r0_leader.get_store_id())
+        .snapshot(snap_ctx.clone())
+        .unwrap();
+    assert_eq!(snap.get_region().clone(), r2.region.clone());
+    snap_ctx
+        .secondary_region_override
+        .as_mut()
+        .unwrap()
+        .check_term = None;
+
+    // test invalid req_epoch will return an error
+    let mut req_epoch = r2.get_region_epoch().clone();
+    req_epoch.version -= 1;
+    snap_ctx
+        .secondary_region_override
+        .as_mut()
+        .unwrap()
+        .region_epoch = req_epoch;
+    let err = cluster
+        .must_get_raft_engine(r0_leader.get_store_id())
+        .snapshot(snap_ctx.clone())
+        .err()
+        .unwrap();
+    assert_matches!(err, Error(box ErrorInner::Request(header)) if header.epoch_not_match.is_some());
+    snap_ctx
+        .secondary_region_override
+        .as_mut()
+        .unwrap()
+        .region_epoch = r2.get_region_epoch().clone();
+
+    // test no-leader request will return an error
+    let r2_old_leader = r2_leader.clone();
+    let r2_leader = r2
+        .peers
+        .iter()
+        .find(|p| p.get_id() != r2_old_leader.get_id())
+        .unwrap()
+        .clone();
+    pd_client.transfer_leader(r2.get_id(), r2_leader.clone(), vec![]);
+    pd_client.region_leader_must_be(r2.get_id(), r2_leader.clone());
+    r2.leader = Some(r2_leader.clone());
+    snap_ctx.secondary_region_override.as_mut().unwrap().peer = r2_old_leader.clone();
+    assert!(!snap_ctx.pb_ctx.replica_read);
+    let err = cluster
+        .must_get_raft_engine(r0_leader.get_store_id())
+        .snapshot(snap_ctx.clone())
+        .err()
+        .unwrap();
+    assert_matches!(err, Error(box ErrorInner::Request(header)) if header.not_leader.is_some());
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18812

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
- Introduce a new trait: `RegionStorageAccessor` to access the snapshot for secondary regions in cop-task
- Add a new function `seek_region` to `Engine` so that it can seek regions when executor is running.
- Introduce `SecondarySnapStoreAccessor` to impl  `RegionStorageAccessor`.
- Make the `ReqContext` a immutable value that can be shared accross threads safely
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
