### PR TITLE
backup-stream/tempfiles: set max buffer size for tempfiles

### DIFF
--- a/components/backup-stream/src/tempfiles.rs
+++ b/components/backup-stream/src/tempfiles.rs
@@ -340,7 +340,8 @@ impl TempFilePool {
         if let Some(f) = &self.override_swapout {
             return Ok(SwappedOut::Dynamic(f(&abs_path)));
         }
-        let file = OsFile::from_std(SyncOsFile::create(&abs_path)?);
+        let mut file = OsFile::from_std(SyncOsFile::create(&abs_path)?);
+        file.set_max_buf_size(self.config().write_buffer_size);
 
         let pfile = match &self.backup_encryption_manager.opt_data_key_manager() {
             Some(enc) => SwappedOut::Encrypted(


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref #18719 

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Now, in `tempfiles` mod, default buffer size of opened in-disk files was reduced to `write_buf_size` (default 4096).
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
|This PR|Master|
|-|-|
|<img width="1892" height="526" alt="image" src="https://github.com/user-attachments/assets/95fcb40a-ec8f-4456-a0f6-f36dee71d340" />|<img width="1888" height="554" alt="image" src="https://github.com/user-attachments/assets/822097cb-55da-46dd-a9bb-6c6da062f9cc" />|
The memory still grows due to there are many `Cctx` of zstd. This problem might be solved in the future. 
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Reduced the memory usage when log backup enabled and many regions in cluster.
```
