### PR TITLE
resource_metering: Aggregate RawRecords before picking topN records

### DIFF
--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -2927,7 +2927,7 @@ mod tests {
                             region_id: 1,
                             peer_id: 0,
                             key_ranges: vec![],
-                            extra_attachment: b"a".to_vec(),
+                            extra_attachment: Arc::new(b"a".to_vec()),
                         }),
                         RawRecord {
                             cpu_time: 111,

--- a/components/raftstore/src/store/worker/split_controller.rs
+++ b/components/raftstore/src/store/worker/split_controller.rs
@@ -1409,7 +1409,7 @@ mod tests {
                 region_id,
                 peer_id: 0,
                 key_ranges: vec![(key_range.start_key.clone(), key_range.end_key.clone())],
-                extra_attachment: vec![],
+                extra_attachment: Arc::new(vec![]),
             });
             raw_records.records.insert(
                 key_range_tag.clone(),
@@ -1840,14 +1840,14 @@ mod tests {
             region_id: 1,
             peer_id: 0,
             key_ranges: vec![(b"a".to_vec(), b"b".to_vec())],
-            extra_attachment: vec![],
+            extra_attachment: Arc::new(vec![]),
         });
         let cd_key_range_tag = Arc::new(TagInfos {
             store_id: 0,
             region_id: 1,
             peer_id: 0,
             key_ranges: vec![(b"c".to_vec(), b"d".to_vec())],
-            extra_attachment: vec![],
+            extra_attachment: Arc::new(vec![]),
         });
         let multiple_key_ranges_tag = Arc::new(TagInfos {
             store_id: 0,
@@ -1857,14 +1857,14 @@ mod tests {
                 (b"a".to_vec(), b"b".to_vec()),
                 (b"c".to_vec(), b"d".to_vec()),
             ],
-            extra_attachment: vec![],
+            extra_attachment: Arc::new(vec![]),
         });
         let empty_key_range_tag = Arc::new(TagInfos {
             store_id: 0,
             region_id: 1,
             peer_id: 0,
             key_ranges: vec![],
-            extra_attachment: vec![],
+            extra_attachment: Arc::new(vec![]),
         });
 
         let test_cases = vec![

--- a/components/resource_metering/src/lib.rs
+++ b/components/resource_metering/src/lib.rs
@@ -295,7 +295,7 @@ pub struct TagInfos {
     pub peer_id: u64,
     // Only a read request contains the key ranges.
     pub key_ranges: Vec<(Vec<u8>, Vec<u8>)>,
-    pub extra_attachment: Vec<u8>,
+    pub extra_attachment: Arc<Vec<u8>>,
 }
 
 impl TagInfos {
@@ -306,7 +306,7 @@ impl TagInfos {
             peer_id: peer.get_id(),
             region_id: context.get_region_id(),
             key_ranges: vec![],
-            extra_attachment: Vec::from(context.get_resource_group_tag()),
+            extra_attachment: Arc::new(Vec::from(context.get_resource_group_tag())),
         }
     }
 
@@ -321,7 +321,7 @@ impl TagInfos {
             peer_id: peer.get_id(),
             region_id: context.get_region_id(),
             key_ranges,
-            extra_attachment: Vec::from(context.get_resource_group_tag()),
+            extra_attachment: Arc::new(Vec::from(context.get_resource_group_tag())),
         }
     }
 }
@@ -348,7 +348,7 @@ mod tests {
                     region_id: 2,
                     peer_id: 3,
                     key_ranges: vec![],
-                    extra_attachment: b"12345".to_vec(),
+                    extra_attachment: Arc::new(b"12345".to_vec()),
                 }),
                 resource_tag_factory,
             };

--- a/components/resource_metering/src/model.rs
+++ b/components/resource_metering/src/model.rs
@@ -84,8 +84,8 @@ impl Default for RawRecords {
 }
 
 impl RawRecords {
-    /// Returns RawRecord aggregated by tidb passed tag.
-    pub fn aggregate_by_tidb_tag(&self) -> HashMap<Vec<u8>, RawRecord>
+    /// Returns RawRecord aggregated by extra tag.
+    pub fn aggregate_by_extra_tag(&self) -> HashMap<Vec<u8>, RawRecord>
     {
         let mut raw_map : HashMap<Vec<u8>, RawRecord> = HashMap::default();
         // Aggregate
@@ -409,7 +409,7 @@ mod tests {
             duration: Duration::from_secs(1),
             records: raw_map,
         };
-        let agg_map = raw.aggregate_by_tidb_tag();
+        let agg_map = raw.aggregate_by_extra_tag();
         assert_eq!(records.records.len(), 0);
         records.new_append(raw.begin_unix_time_secs, agg_map.iter());
         assert_eq!(records.records.len(), 3);
@@ -469,7 +469,7 @@ mod tests {
             records,
         };
 
-        let agg_map = rs.aggregate_by_tidb_tag();
+        let agg_map = rs.aggregate_by_extra_tag();
         let kth = find_kth_cpu_time(agg_map.iter(), 2);
         let (top, evicted) = (
             agg_map.iter().filter(move |(_, v)| v.cpu_time > kth),
@@ -560,7 +560,7 @@ mod tests {
             },
         );
 
-        let agg_map = raw_records.aggregate_by_tidb_tag();
+        let agg_map = raw_records.aggregate_by_extra_tag();
         let kth = find_kth_cpu_time(agg_map.iter(), 1);
         // top.len() == 0
         // evicted.len() == 3

--- a/components/resource_metering/src/model.rs
+++ b/components/resource_metering/src/model.rs
@@ -680,7 +680,7 @@ mod tests {
         };
 
         let agg_map = rs.aggregate_by_extra_tag();
-        assert_eq!(agg_map.into_iter().count(), 3);
+        assert_eq!(agg_map.iter().count(), 3);
         assert_eq!(agg_map.get(&tag1.extra_attachment).unwrap().cpu_time, 111 + 1110 + 4440);
         assert_eq!(agg_map.get(&tag2.extra_attachment).unwrap().cpu_time, 555 + 7770);
         assert_eq!(agg_map.get(&tag3.extra_attachment).unwrap().cpu_time, 777);

--- a/components/resource_metering/src/model.rs
+++ b/components/resource_metering/src/model.rs
@@ -576,6 +576,7 @@ mod tests {
         assert!(!records.is_empty());
     }
 
+    #[test]
     fn test_raw_records_agg() {
         let tag1 = Arc::new(TagInfos {
             store_id: 0,

--- a/components/resource_metering/src/model.rs
+++ b/components/resource_metering/src/model.rs
@@ -405,8 +405,9 @@ mod tests {
             duration: Duration::from_secs(1),
             records: raw_map,
         };
+        let agg_map = raw.aggregate_by_tidb_tag();
         assert_eq!(records.records.len(), 0);
-        records.append(raw.begin_unix_time_secs, raw.records.iter());
+        records.new_append(raw.begin_unix_time_secs, agg_map.iter());
         assert_eq!(records.records.len(), 3);
     }
 

--- a/components/resource_metering/src/model.rs
+++ b/components/resource_metering/src/model.rs
@@ -564,7 +564,7 @@ mod tests {
         // evicted.len() == 3
         let (top, evicted) = (
             agg_map.iter().filter(move |(_, v)| v.cpu_time > kth),
-            agg_map.iter().filter(move |(_, v)| v.cpu_time <= kth)
+            agg_map.iter().filter(move |(_, v)| v.cpu_time <= kth),
         );
 
         let mut records = Records::default();
@@ -670,7 +670,7 @@ mod tests {
                 read_keys: 8880,
                 write_keys: 9990,
             },
-        ); 
+        );
         let rs = RawRecords {
             begin_unix_time_secs: 1,
             duration: Duration::from_secs(1),
@@ -686,7 +686,7 @@ mod tests {
         assert_eq!(
             agg_map.get(&tag2.extra_attachment).unwrap().cpu_time,
             555 + 7770
-        );        
+        );
         assert_eq!(agg_map.get(&tag3.extra_attachment).unwrap().cpu_time, 777);
     }
 }

--- a/components/resource_metering/src/model.rs
+++ b/components/resource_metering/src/model.rs
@@ -1,11 +1,15 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::{
-    cell::Cell, collections::HashMap, sync::{
-        atomic::{AtomicU32, Ordering::Relaxed}, Arc
-    }, time::{Duration, SystemTime, UNIX_EPOCH}
+    cell::Cell,
+    sync::{
+        Arc,
+        atomic::{AtomicU32, Ordering::Relaxed},
+    },
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
+use collections::HashMap;
 use kvproto::resource_usage_agent::{GroupTagRecord, GroupTagRecordItem, ResourceUsageRecord};
 use tikv_util::warn;
 

--- a/components/resource_metering/src/model.rs
+++ b/components/resource_metering/src/model.rs
@@ -626,7 +626,7 @@ mod tests {
         });        
         let mut records = HashMap::default();
         records.insert(
-            tag1,
+            tag1.clone(),
             RawRecord {
                 cpu_time: 111,
                 read_keys: 222,
@@ -634,7 +634,7 @@ mod tests {
             },
         );
         records.insert(
-            tag2,
+            tag2.clone(),
             RawRecord {
                 cpu_time: 444,
                 read_keys: 555,
@@ -642,7 +642,7 @@ mod tests {
             },
         );
         records.insert(
-            tag3,
+            tag3.clone(),
             RawRecord {
                 cpu_time: 777,
                 read_keys: 888,

--- a/components/resource_metering/src/model.rs
+++ b/components/resource_metering/src/model.rs
@@ -577,4 +577,112 @@ mod tests {
         });
         assert!(!records.is_empty());
     }
+
+    fn test_raw_records_agg() {
+        let tag1 = Arc::new(TagInfos {
+            store_id: 0,
+            region_id: 0,
+            peer_id: 0,
+            key_ranges: vec![],
+            extra_attachment: b"a".to_vec(),
+        });
+        let tag2 = Arc::new(TagInfos {
+            store_id: 0,
+            region_id: 0,
+            peer_id: 0,
+            key_ranges: vec![],
+            extra_attachment: b"b".to_vec(),
+        });
+        let tag3 = Arc::new(TagInfos {
+            store_id: 0,
+            region_id: 0,
+            peer_id: 0,
+            key_ranges: vec![],
+            extra_attachment: b"c".to_vec(),
+        });
+        /// tag4's extra tag is equal to tag1's
+        let tag4 = Arc::new(TagInfos {
+            store_id: 0,
+            region_id: 2,
+            peer_id: 0,
+            key_ranges: vec![],
+            extra_attachment: b"a".to_vec(),
+        });
+        /// tag5's extra tag is equal to tag1's
+        let tag5 = Arc::new(TagInfos {
+            store_id: 0,
+            region_id: 3,
+            peer_id: 0,
+            key_ranges: vec![],
+            extra_attachment: b"a".to_vec(),
+        });
+        /// tag6's extra tag is equal to tag2's
+        let tag6 = Arc::new(TagInfos {
+            store_id: 0,
+            region_id: 5,
+            peer_id: 0,
+            key_ranges: vec![],
+            extra_attachment: b"b".to_vec(),
+        });        
+        let mut records = HashMap::default();
+        records.insert(
+            tag1,
+            RawRecord {
+                cpu_time: 111,
+                read_keys: 222,
+                write_keys: 333,
+            },
+        );
+        records.insert(
+            tag2,
+            RawRecord {
+                cpu_time: 444,
+                read_keys: 555,
+                write_keys: 666,
+            },
+        );
+        records.insert(
+            tag3,
+            RawRecord {
+                cpu_time: 777,
+                read_keys: 888,
+                write_keys: 999,
+            },
+        );
+        records.insert(
+            tag4,
+            RawRecord {
+                cpu_time: 1110,
+                read_keys: 2220,
+                write_keys: 3330,
+            },
+        );
+        records.insert(
+            tag5,
+            RawRecord {
+                cpu_time: 4440,
+                read_keys: 5550,
+                write_keys: 6660,
+            },
+        );
+        records.insert(
+            tag6,
+            RawRecord {
+                cpu_time: 7770,
+                read_keys: 8880,
+                write_keys: 9990,
+            },
+        );        
+        let rs = RawRecords {
+            begin_unix_time_secs: 1,
+            duration: Duration::from_secs(1),
+            records,
+        };
+
+        let agg_map = rs.aggregate_by_extra_tag();
+        assert_eq!(agg_map.count(), 3);
+        assert_eq!(agg_map.get(&tag1.extra_attachment).unwrap().cpu_time, 111 + 1110 + 4440);
+        assert_eq!(agg_map.get(&tag2.extra_attachment).unwrap().cpu_time, 555 + 7770);
+        assert_eq!(agg_map.get(&tag3.extra_attachment).unwrap().cpu_time, 777);
+    }    
 }

--- a/components/resource_metering/src/model.rs
+++ b/components/resource_metering/src/model.rs
@@ -531,12 +531,19 @@ mod tests {
             },
         );
 
+        let agg_map = raw_records.aggregate_by_tidb_tag();
+
+        let kth = self.find_kth_cpu_time(agg_map.iter(), 1);
+        self.records.new_append(ts, agg_map.iter().filter(move |(_, v)| v.cpu_time > kth));        
         // top.len() == 0
         // evicted.len() == 3
-        let (top, evicted) = raw_records.top_k(1);
+        let (top, evicted) = (
+            agg_map.iter().filter(move |(_, v)| v.cpu_time > kth),
+            agg_map.iter().filter(move |(_, v)| v.cpu_time <= kth)
+        );
 
         let mut records = Records::default();
-        records.append(0, top);
+        records.new_append(0, top);
         let others = records.others.entry(0).or_default();
         evicted.for_each(|(_, v)| {
             others.merge(v);

--- a/components/resource_metering/src/model.rs
+++ b/components/resource_metering/src/model.rs
@@ -361,21 +361,21 @@ mod tests {
             region_id: 0,
             peer_id: 0,
             key_ranges: vec![],
-            extra_attachment: Arc::new(b"a".to_vec()),
+            extra_attachment: b"a".to_vec().into(),
         });
         let tag2 = Arc::new(TagInfos {
             store_id: 0,
             region_id: 0,
             peer_id: 0,
             key_ranges: vec![],
-            extra_attachment: Arc::new(b"b".to_vec()),
+            extra_attachment: b"b".to_vec().into(),
         });
         let tag3 = Arc::new(TagInfos {
             store_id: 0,
             region_id: 0,
             peer_id: 0,
             key_ranges: vec![],
-            extra_attachment: Arc::new(b"c".to_vec()),
+            extra_attachment: b"c".to_vec().into(),
         });
         let mut records = Records::default();
         let mut raw_map = HashMap::default();
@@ -421,21 +421,21 @@ mod tests {
             region_id: 0,
             peer_id: 0,
             key_ranges: vec![],
-            extra_attachment: Arc::new(b"a".to_vec()),
+            extra_attachment: b"a".to_vec().into(),
         });
         let tag2 = Arc::new(TagInfos {
             store_id: 0,
             region_id: 0,
             peer_id: 0,
             key_ranges: vec![],
-            extra_attachment: Arc::new(b"b".to_vec()),
+            extra_attachment: b"b".to_vec().into(),
         });
         let tag3 = Arc::new(TagInfos {
             store_id: 0,
             region_id: 0,
             peer_id: 0,
             key_ranges: vec![],
-            extra_attachment: Arc::new(b"c".to_vec()),
+            extra_attachment: b"c".to_vec().into(),
         });
         let mut records = HashMap::default();
         records.insert(
@@ -511,21 +511,21 @@ mod tests {
             region_id: 0,
             peer_id: 0,
             key_ranges: vec![],
-            extra_attachment: Arc::new(b"a".to_vec()),
+            extra_attachment: b"a".to_vec().into(),
         });
         let tag2 = Arc::new(TagInfos {
             store_id: 0,
             region_id: 0,
             peer_id: 0,
             key_ranges: vec![],
-            extra_attachment: Arc::new(b"b".to_vec()),
+            extra_attachment: b"b".to_vec().into(),
         });
         let tag3 = Arc::new(TagInfos {
             store_id: 0,
             region_id: 0,
             peer_id: 0,
             key_ranges: vec![],
-            extra_attachment: Arc::new(b"c".to_vec()),
+            extra_attachment: b"c".to_vec().into(),
         });
 
         // Keep cpu_time same for all tags.
@@ -583,21 +583,21 @@ mod tests {
             region_id: 0,
             peer_id: 0,
             key_ranges: vec![],
-            extra_attachment: Arc::new(b"a".to_vec()),
+            extra_attachment: b"a".to_vec().into(),
         });
         let tag2 = Arc::new(TagInfos {
             store_id: 0,
             region_id: 0,
             peer_id: 0,
             key_ranges: vec![],
-            extra_attachment: Arc::new(b"b".to_vec()),
+            extra_attachment: b"b".to_vec().into(),
         });
         let tag3 = Arc::new(TagInfos {
             store_id: 0,
             region_id: 0,
             peer_id: 0,
             key_ranges: vec![],
-            extra_attachment: Arc::new(b"c".to_vec()),
+            extra_attachment: b"c".to_vec().into(),
         });
         // tag4's extra tag is equal to tag1's
         let tag4 = Arc::new(TagInfos {
@@ -605,7 +605,7 @@ mod tests {
             region_id: 2,
             peer_id: 0,
             key_ranges: vec![],
-            extra_attachment: Arc::new(b"a".to_vec()),
+            extra_attachment: b"a".to_vec().into(),
         });
         // tag5's extra tag is equal to tag1's
         let tag5 = Arc::new(TagInfos {
@@ -613,7 +613,7 @@ mod tests {
             region_id: 3,
             peer_id: 0,
             key_ranges: vec![],
-            extra_attachment: Arc::new(b"a".to_vec()),
+            extra_attachment: b"a".to_vec().into(),
         });
         // tag6's extra tag is equal to tag2's
         let tag6 = Arc::new(TagInfos {
@@ -621,7 +621,7 @@ mod tests {
             region_id: 5,
             peer_id: 0,
             key_ranges: vec![],
-            extra_attachment: Arc::new(b"b".to_vec()),
+            extra_attachment: b"b".to_vec().into(),
         });        
         let mut records = HashMap::default();
         records.insert(

--- a/components/resource_metering/src/model.rs
+++ b/components/resource_metering/src/model.rs
@@ -361,21 +361,21 @@ mod tests {
             region_id: 0,
             peer_id: 0,
             key_ranges: vec![],
-            extra_attachment: b"a".to_vec().into(),
+            extra_attachment: Arc::new(b"a".to_vec()),
         });
         let tag2 = Arc::new(TagInfos {
             store_id: 0,
             region_id: 0,
             peer_id: 0,
             key_ranges: vec![],
-            extra_attachment: b"b".to_vec().into(),
+            extra_attachment: Arc::new(b"b".to_vec()),
         });
         let tag3 = Arc::new(TagInfos {
             store_id: 0,
             region_id: 0,
             peer_id: 0,
             key_ranges: vec![],
-            extra_attachment: b"c".to_vec().into(),
+            extra_attachment: Arc::new(b"c".to_vec()),
         });
         let mut records = Records::default();
         let mut raw_map = HashMap::default();
@@ -421,21 +421,21 @@ mod tests {
             region_id: 0,
             peer_id: 0,
             key_ranges: vec![],
-            extra_attachment: b"a".to_vec().into(),
+            extra_attachment: Arc::new(b"a".to_vec()),
         });
         let tag2 = Arc::new(TagInfos {
             store_id: 0,
             region_id: 0,
             peer_id: 0,
             key_ranges: vec![],
-            extra_attachment: b"b".to_vec().into(),
+            extra_attachment: Arc::new(b"b".to_vec()),
         });
         let tag3 = Arc::new(TagInfos {
             store_id: 0,
             region_id: 0,
             peer_id: 0,
             key_ranges: vec![],
-            extra_attachment: b"c".to_vec().into(),
+            extra_attachment: Arc::new(b"c".to_vec()),
         });
         let mut records = HashMap::default();
         records.insert(
@@ -511,21 +511,21 @@ mod tests {
             region_id: 0,
             peer_id: 0,
             key_ranges: vec![],
-            extra_attachment: b"a".to_vec().into(),
+            extra_attachment: Arc::new(b"a".to_vec()),
         });
         let tag2 = Arc::new(TagInfos {
             store_id: 0,
             region_id: 0,
             peer_id: 0,
             key_ranges: vec![],
-            extra_attachment: b"b".to_vec().into(),
+            extra_attachment: Arc::new(b"b".to_vec()),
         });
         let tag3 = Arc::new(TagInfos {
             store_id: 0,
             region_id: 0,
             peer_id: 0,
             key_ranges: vec![],
-            extra_attachment: b"c".to_vec().into(),
+            extra_attachment: Arc::new(b"c".to_vec()),
         });
 
         // Keep cpu_time same for all tags.
@@ -583,21 +583,21 @@ mod tests {
             region_id: 0,
             peer_id: 0,
             key_ranges: vec![],
-            extra_attachment: b"a".to_vec().into(),
+            extra_attachment: Arc::new(b"a".to_vec()),
         });
         let tag2 = Arc::new(TagInfos {
             store_id: 0,
             region_id: 0,
             peer_id: 0,
             key_ranges: vec![],
-            extra_attachment: b"b".to_vec().into(),
+            extra_attachment: Arc::new(b"b".to_vec()),
         });
         let tag3 = Arc::new(TagInfos {
             store_id: 0,
             region_id: 0,
             peer_id: 0,
             key_ranges: vec![],
-            extra_attachment: b"c".to_vec().into(),
+            extra_attachment: Arc::new(b"c".to_vec()),
         });
         // tag4's extra tag is equal to tag1's
         let tag4 = Arc::new(TagInfos {
@@ -605,7 +605,7 @@ mod tests {
             region_id: 2,
             peer_id: 0,
             key_ranges: vec![],
-            extra_attachment: b"a".to_vec().into(),
+            extra_attachment: Arc::new(b"a".to_vec()),
         });
         // tag5's extra tag is equal to tag1's
         let tag5 = Arc::new(TagInfos {
@@ -613,7 +613,7 @@ mod tests {
             region_id: 3,
             peer_id: 0,
             key_ranges: vec![],
-            extra_attachment: b"a".to_vec().into(),
+            extra_attachment: Arc::new(b"a".to_vec()),
         });
         // tag6's extra tag is equal to tag2's
         let tag6 = Arc::new(TagInfos {
@@ -621,7 +621,7 @@ mod tests {
             region_id: 5,
             peer_id: 0,
             key_ranges: vec![],
-            extra_attachment: b"b".to_vec().into(),
+            extra_attachment: Arc::new(b"b".to_vec()),
         });        
         let mut records = HashMap::default();
         records.insert(
@@ -679,7 +679,7 @@ mod tests {
         };
 
         let agg_map = rs.aggregate_by_extra_tag();
-        assert_eq!(agg_map.iter().count(), 3);
+        assert_eq!(agg_map.len(), 3);
         assert_eq!(agg_map.get(&tag1.extra_attachment).unwrap().cpu_time, 111 + 1110 + 4440);
         assert_eq!(agg_map.get(&tag2.extra_attachment).unwrap().cpu_time, 555 + 7770);
         assert_eq!(agg_map.get(&tag3.extra_attachment).unwrap().cpu_time, 777);

--- a/components/resource_metering/src/model.rs
+++ b/components/resource_metering/src/model.rs
@@ -98,11 +98,11 @@ impl RawRecords {
             if value.is_none() {
                 raw_map.insert(
                     tag.clone(),
-                    record.clone(),
+                    *record,
                 );
                 continue;
             }
-            value.unwrap().merge(&record);
+            value.unwrap().merge(record);
         }
         raw_map
     }
@@ -600,7 +600,7 @@ mod tests {
             key_ranges: vec![],
             extra_attachment: b"c".to_vec(),
         });
-        /// tag4's extra tag is equal to tag1's
+        // tag4's extra tag is equal to tag1's
         let tag4 = Arc::new(TagInfos {
             store_id: 0,
             region_id: 2,
@@ -608,7 +608,7 @@ mod tests {
             key_ranges: vec![],
             extra_attachment: b"a".to_vec(),
         });
-        /// tag5's extra tag is equal to tag1's
+        // tag5's extra tag is equal to tag1's
         let tag5 = Arc::new(TagInfos {
             store_id: 0,
             region_id: 3,
@@ -616,7 +616,7 @@ mod tests {
             key_ranges: vec![],
             extra_attachment: b"a".to_vec(),
         });
-        /// tag6's extra tag is equal to tag2's
+        // tag6's extra tag is equal to tag2's
         let tag6 = Arc::new(TagInfos {
             store_id: 0,
             region_id: 5,
@@ -680,7 +680,7 @@ mod tests {
         };
 
         let agg_map = rs.aggregate_by_extra_tag();
-        assert_eq!(agg_map.count(), 3);
+        assert_eq!(agg_map.into_iter().count(), 3);
         assert_eq!(agg_map.get(&tag1.extra_attachment).unwrap().cpu_time, 111 + 1110 + 4440);
         assert_eq!(agg_map.get(&tag2.extra_attachment).unwrap().cpu_time, 555 + 7770);
         assert_eq!(agg_map.get(&tag3.extra_attachment).unwrap().cpu_time, 777);

--- a/components/resource_metering/src/model.rs
+++ b/components/resource_metering/src/model.rs
@@ -20,7 +20,10 @@ thread_local! {
 }
 
 /// Find the kth cpu time in the iterator.
-pub fn find_kth_cpu_time<'a>(iter: impl Iterator<Item = (&'a Arc<Vec<u8>>, &'a RawRecord)>, k: usize) -> u32 {
+pub fn find_kth_cpu_time<'a>(
+    iter: impl Iterator<Item = (&'a Arc<Vec<u8>>, &'a RawRecord)>,
+    k: usize,
+) -> u32 {
     let mut buf = STATIC_BUF.with(|b| b.take());
     buf.clear();
     for (_, record) in iter {
@@ -85,9 +88,8 @@ impl Default for RawRecords {
 
 impl RawRecords {
     /// Returns RawRecord aggregated by extra tag.
-    pub fn aggregate_by_extra_tag(&self) -> HashMap<Arc<Vec<u8>>, RawRecord>
-    {
-        let mut raw_map : HashMap<Arc<Vec<u8>>, RawRecord> = HashMap::default();
+    pub fn aggregate_by_extra_tag(&self) -> HashMap<Arc<Vec<u8>>, RawRecord> {
+        let mut raw_map: HashMap<Arc<Vec<u8>>, RawRecord> = HashMap::default();
         for (tag_info, record) in self.records.iter() {
             let tag = &tag_info.extra_attachment;
             if tag.is_empty() {
@@ -95,10 +97,7 @@ impl RawRecords {
             }
             let value = raw_map.get_mut(tag);
             if value.is_none() {
-                raw_map.insert(
-                    tag.clone(),
-                    *record,
-                );
+                raw_map.insert(tag.clone(), *record);
                 continue;
             }
             value.unwrap().merge(record);
@@ -262,7 +261,7 @@ impl Records {
                 record.write_keys_list.push(raw_record.write_keys);
             }
         }
-    }    
+    }
 
     /// Clear all internal data.
     pub fn clear(&mut self) {
@@ -472,7 +471,7 @@ mod tests {
         let kth = find_kth_cpu_time(agg_map.iter(), 2);
         let (top, evicted) = (
             agg_map.iter().filter(move |(_, v)| v.cpu_time > kth),
-            agg_map.iter().filter(move |(_, v)| v.cpu_time <= kth)
+            agg_map.iter().filter(move |(_, v)| v.cpu_time <= kth),
         );
         let others = evicted
             .map(|(_, v)| v)
@@ -488,7 +487,7 @@ mod tests {
         let kth = find_kth_cpu_time(agg_map.iter(), 0);
         let (top, evicted) = (
             agg_map.iter().filter(move |(_, v)| v.cpu_time > kth),
-            agg_map.iter().filter(move |(_, v)| v.cpu_time <= kth)
+            agg_map.iter().filter(move |(_, v)| v.cpu_time <= kth),
         );
         // let top = top.collect::<Vec<(&Arc<TagInfos>, &RawRecord)>>();
         let others = evicted
@@ -622,7 +621,7 @@ mod tests {
             peer_id: 0,
             key_ranges: vec![],
             extra_attachment: Arc::new(b"b".to_vec()),
-        });        
+        });
         let mut records = HashMap::default();
         records.insert(
             tag1.clone(),
@@ -671,7 +670,7 @@ mod tests {
                 read_keys: 8880,
                 write_keys: 9990,
             },
-        );        
+        ); 
         let rs = RawRecords {
             begin_unix_time_secs: 1,
             duration: Duration::from_secs(1),
@@ -680,8 +679,14 @@ mod tests {
 
         let agg_map = rs.aggregate_by_extra_tag();
         assert_eq!(agg_map.len(), 3);
-        assert_eq!(agg_map.get(&tag1.extra_attachment).unwrap().cpu_time, 111 + 1110 + 4440);
-        assert_eq!(agg_map.get(&tag2.extra_attachment).unwrap().cpu_time, 555 + 7770);
+        assert_eq!(
+            agg_map.get(&tag1.extra_attachment).unwrap().cpu_time,
+            111 + 1110 + 4440
+        );
+        assert_eq!(
+            agg_map.get(&tag2.extra_attachment).unwrap().cpu_time,
+            555 + 7770
+        );        
         assert_eq!(agg_map.get(&tag3.extra_attachment).unwrap().cpu_time, 777);
-    }    
+    }
 }

--- a/components/resource_metering/src/model.rs
+++ b/components/resource_metering/src/model.rs
@@ -204,7 +204,7 @@ impl From<Records> for Vec<ResourceUsageRecord> {
 
 impl Records {
     /// Append aggregated [RawRecords] into [Records].
-    pub fn new_append<'a>(
+    pub fn append<'a>(
         &mut self,
         ts: u64,
         iter: impl Iterator<Item = (&'a Vec<u8>, &'a RawRecord)>,
@@ -411,7 +411,7 @@ mod tests {
         };
         let agg_map = raw.aggregate_by_extra_tag();
         assert_eq!(records.records.len(), 0);
-        records.new_append(raw.begin_unix_time_secs, agg_map.iter());
+        records.append(raw.begin_unix_time_secs, agg_map.iter());
         assert_eq!(records.records.len(), 3);
     }
 
@@ -570,7 +570,7 @@ mod tests {
         );
 
         let mut records = Records::default();
-        records.new_append(0, top);
+        records.append(0, top);
         let others = records.others.entry(0).or_default();
         evicted.for_each(|(_, v)| {
             others.merge(v);

--- a/components/resource_metering/src/model.rs
+++ b/components/resource_metering/src/model.rs
@@ -686,7 +686,7 @@ mod tests {
         );
         assert_eq!(
             agg_map.get(&tag2.extra_attachment).unwrap().cpu_time,
-            555 + 7770
+            444 + 7770
         );
         assert_eq!(agg_map.get(&tag3.extra_attachment).unwrap().cpu_time, 777);
     }

--- a/components/resource_metering/src/model.rs
+++ b/components/resource_metering/src/model.rs
@@ -451,7 +451,7 @@ mod tests {
             records,
         };
 
-        let agg_map = raw_records.aggregate_by_tidb_tag();
+        let agg_map = rs.aggregate_by_tidb_tag();
         let kth = self.find_kth_cpu_time(agg_map.iter(), 2);
         let (top, evicted) = (
             agg_map.iter().filter(move |(_, v)| v.cpu_time > kth),

--- a/components/resource_metering/src/recorder/mod.rs
+++ b/components/resource_metering/src/recorder/mod.rs
@@ -445,7 +445,7 @@ mod tests {
         assert_eq!(records.records.len(), 1);
         assert_eq!(
             &records.records.keys().next().unwrap().extra_attachment,
-            &[1]
+            &Arc::new([1])
         );
 
         // deregister collector
@@ -510,7 +510,7 @@ mod tests {
         assert_eq!(records.records.len(), 1);
         assert_eq!(
             &records.records.keys().next().unwrap().extra_attachment,
-            &[1]
+            &Arc::new([1])
         );
         assert_eq!(records, {
             collector2.records.lock().unwrap().take().unwrap()
@@ -565,7 +565,7 @@ mod tests {
         assert_eq!(records.records.len(), 1);
         assert_eq!(
             &records.records.keys().next().unwrap().extra_attachment,
-            &[1]
+            &Arc::new([1])
         );
         assert_eq!(records, {
             observer.records.lock().unwrap().take().unwrap()

--- a/components/resource_metering/src/recorder/mod.rs
+++ b/components/resource_metering/src/recorder/mod.rs
@@ -364,9 +364,14 @@ mod tests {
             records: &mut RawRecords,
             _thread_stores: &mut HashMap<Pid, LocalStorage>,
         ) {
-            let mut tag = TagInfos::default();
-            tag.extra_attachment.push(1);
-            records.records.entry(Arc::new(tag)).or_default().cpu_time = 2;
+            let tag = Arc::new(TagInfos {
+                store_id: 0,
+                region_id: 0,
+                peer_id: 0,
+                key_ranges: vec![],
+                extra_attachment: [1].to_vec().into(),
+            });
+            records.records.entry(tag).or_default().cpu_time = 2;
         }
 
         fn pause(
@@ -445,7 +450,7 @@ mod tests {
         assert_eq!(records.records.len(), 1);
         assert_eq!(
             &records.records.keys().next().unwrap().extra_attachment,
-            &Arc::new([1])
+            &Arc::new([1].to_vec())
         );
 
         // deregister collector
@@ -510,7 +515,7 @@ mod tests {
         assert_eq!(records.records.len(), 1);
         assert_eq!(
             &records.records.keys().next().unwrap().extra_attachment,
-            &Arc::new([1])
+            &Arc::new([1].to_vec())
         );
         assert_eq!(records, {
             collector2.records.lock().unwrap().take().unwrap()
@@ -565,7 +570,7 @@ mod tests {
         assert_eq!(records.records.len(), 1);
         assert_eq!(
             &records.records.keys().next().unwrap().extra_attachment,
-            &Arc::new([1])
+            &Arc::new([1].to_vec())
         );
         assert_eq!(records, {
             observer.records.lock().unwrap().take().unwrap()

--- a/components/resource_metering/src/recorder/sub_recorder/cpu.rs
+++ b/components/resource_metering/src/recorder/sub_recorder/cpu.rs
@@ -130,7 +130,7 @@ mod tests {
             region_id: 0,
             peer_id: 0,
             key_ranges: vec![],
-            extra_attachment: b"abc".to_vec(),
+            extra_attachment: Arc::new(b"abc".to_vec()),
         });
         let store = LocalStorage {
             attached_tag: SharedTagInfos::new(info),

--- a/components/resource_metering/src/reporter/mod.rs
+++ b/components/resource_metering/src/reporter/mod.rs
@@ -101,12 +101,12 @@ impl Reporter {
         let ts = records.begin_unix_time_secs;
         let agg_map = records.aggregate_by_extra_tag();
         if self.config.max_resource_groups >= agg_map.len() {
-            self.records.new_append(ts, agg_map.iter());
+            self.records.append(ts, agg_map.iter());
             return;
         }
 
         let kth = find_kth_cpu_time(agg_map.iter(), self.config.max_resource_groups);
-        self.records.new_append(ts, agg_map.iter().filter(move |(_, v)| v.cpu_time > kth));
+        self.records.append(ts, agg_map.iter().filter(move |(_, v)| v.cpu_time > kth));
         let others = self.records.others.entry(ts).or_default();
         agg_map.iter().filter(move |(_, v)| v.cpu_time <= kth).for_each(|(_, v)| {
             others.merge(v);

--- a/components/resource_metering/src/reporter/mod.rs
+++ b/components/resource_metering/src/reporter/mod.rs
@@ -105,7 +105,7 @@ impl Reporter {
             return;
         }
 
-        let kth = self.find_kth_cpu_time(agg_map.iter());
+        let kth = self.find_kth_cpu_time(agg_map.iter(), self.config.max_resource_groups);
         self.records.new_append(ts, agg_map.iter().filter(move |(_, v)| v.cpu_time > kth));
         let others = self.records.others.entry(ts).or_default();
         agg_map.iter().filter(move |(_, v)| v.cpu_time <= kth).for_each(|(_, v)| {
@@ -113,8 +113,7 @@ impl Reporter {
         });
     }
 
-    fn find_kth_cpu_time<'a>(&self, iter: impl Iterator<Item = (&'a Vec<u8>, &'a RawRecord)>) -> u32 {
-        let k = self.config.max_resource_groups;
+    fn find_kth_cpu_time<'a>(&self, iter: impl Iterator<Item = (&'a Vec<u8>, &'a RawRecord)>, k: usize) -> u32 {
         let mut buf = STATIC_BUF.with(|b| b.take());
         buf.clear();
         for (_, record) in iter {

--- a/components/resource_metering/src/reporter/mod.rs
+++ b/components/resource_metering/src/reporter/mod.rs
@@ -290,7 +290,7 @@ mod tests {
                 region_id: 0,
                 peer_id: 0,
                 key_ranges: vec![],
-                extra_attachment: b"12345".to_vec().into(),
+                extra_attachment: Arc::new(b"12345".to_vec()),
             }),
             RawRecord {
                 cpu_time: 1,
@@ -336,7 +336,7 @@ mod tests {
                 region_id: 0,
                 peer_id: 0,
                 key_ranges: vec![],
-                extra_attachment: b"12345".to_vec().into(),
+                extra_attachment: Arc::new(b"12345".to_vec()),
             }),
             RawRecord {
                 cpu_time: 1,

--- a/components/resource_metering/src/reporter/mod.rs
+++ b/components/resource_metering/src/reporter/mod.rs
@@ -7,7 +7,6 @@ pub mod pubsub;
 pub mod single_target;
 
 use std::{
-    cell::Cell,
     fmt::{self, Display, Formatter},
     sync::Arc,
 };

--- a/components/resource_metering/src/reporter/mod.rs
+++ b/components/resource_metering/src/reporter/mod.rs
@@ -103,14 +103,14 @@ impl Reporter {
 
         let kth = find_kth_cpu_time(agg_map.iter(), self.config.max_resource_groups);
         self.records
-            .append(ts, agg_map.iter().filter(move |(_, v)| v.cpu_time > kth));        
+            .append(ts, agg_map.iter().filter(move |(_, v)| v.cpu_time > kth));
         let others = self.records.others.entry(ts).or_default();
         agg_map
             .iter()
             .filter(move |(_, v)| v.cpu_time <= kth)
             .for_each(|(_, v)| {
                 others.merge(v);
-            });        
+            });
     }
 
     fn handle_config_change(&mut self, config: Config) {

--- a/components/resource_metering/src/reporter/mod.rs
+++ b/components/resource_metering/src/reporter/mod.rs
@@ -21,12 +21,12 @@ use tikv_util::{
 };
 
 use crate::{
+    Config, DataSink, RawRecords, Records, find_kth_cpu_time,
     recorder::{CollectorGuard, CollectorRegHandle},
     reporter::{
         collector_impl::CollectorImpl,
         data_sink_reg::{DataSinkId, DataSinkReg, DataSinkRegHandle},
     },
-    Config, DataSink, RawRecords, Records, find_kth_cpu_time
 };
 
 /// A structure for reporting statistics through [Client].
@@ -102,13 +102,17 @@ impl Reporter {
         }
 
         let kth = find_kth_cpu_time(agg_map.iter(), self.config.max_resource_groups);
-        self.records.append(ts, agg_map.iter().filter(move |(_, v)| v.cpu_time > kth));
+        self.records
+            .append(ts, agg_map.iter().filter(move |(_, v)| v.cpu_time > kth));        
         let others = self.records.others.entry(ts).or_default();
-        agg_map.iter().filter(move |(_, v)| v.cpu_time <= kth).for_each(|(_, v)| {
-            others.merge(v);
-        });
+        agg_map
+            .iter()
+            .filter(move |(_, v)| v.cpu_time <= kth)
+            .for_each(|(_, v)| {
+                others.merge(v);
+            });        
     }
-    
+
     fn handle_config_change(&mut self, config: Config) {
         self.config = config;
     }
@@ -247,7 +251,7 @@ mod tests {
     };
 
     use super::*;
-    use crate::{error::Result, RawRecord, TagInfos};
+    use crate::{RawRecord, TagInfos, error::Result};
 
     #[derive(Default, Clone)]
     struct MockDataSink {

--- a/components/resource_metering/src/reporter/mod.rs
+++ b/components/resource_metering/src/reporter/mod.rs
@@ -29,10 +29,6 @@ use crate::{
     Config, DataSink, RawRecords, Records, find_kth_cpu_time
 };
 
-thread_local! {
-    static STATIC_BUF: Cell<Vec<u32>> = const {Cell::new(vec![])};
-}
-
 /// A structure for reporting statistics through [Client].
 ///
 /// `Reporter` implements [Runnable] and [RunnableWithTimer] to handle [Task]s

--- a/components/resource_metering/src/reporter/mod.rs
+++ b/components/resource_metering/src/reporter/mod.rs
@@ -99,7 +99,7 @@ impl Reporter {
 
     fn handle_records(&mut self, records: Arc<RawRecords>) {
         let ts = records.begin_unix_time_secs;
-        let agg_map = records.aggregate_by_tidb_tag();
+        let agg_map = records.aggregate_by_extra_tag();
         if self.config.max_resource_groups >= agg_map.len() {
             self.records.new_append(ts, agg_map.iter());
             return;

--- a/components/resource_metering/src/reporter/mod.rs
+++ b/components/resource_metering/src/reporter/mod.rs
@@ -290,7 +290,7 @@ mod tests {
                 region_id: 0,
                 peer_id: 0,
                 key_ranges: vec![],
-                extra_attachment: b"12345".to_vec(),
+                extra_attachment: b"12345".to_vec().into(),
             }),
             RawRecord {
                 cpu_time: 1,
@@ -336,7 +336,7 @@ mod tests {
                 region_id: 0,
                 peer_id: 0,
                 key_ranges: vec![],
-                extra_attachment: b"12345".to_vec(),
+                extra_attachment: b"12345".to_vec().into(),
             }),
             RawRecord {
                 cpu_time: 1,


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18844 

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Add an aggregator to aggregate RawRecords by the extra tag before picking topN records.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
Test the TPCH10 benchmark, and check the other time drops from 38% to 0.0033%.
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
It improves the accuracy of data collected for topsql.
```
