### PR TITLE
sst_importer: print the source chain for Error::CannotReadExternalStorage

### DIFF
--- a/components/sst_importer/src/errors.rs
+++ b/components/sst_importer/src/errors.rs
@@ -1,7 +1,11 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::{
-    error::Error as StdError, io::Error as IoError, num::ParseIntError, path::PathBuf, result,
+    error::{Error as StdError, Report},
+    io::Error as IoError,
+    num::ParseIntError,
+    path::PathBuf,
+    result,
     time::Duration,
 };
 
@@ -77,7 +81,7 @@ pub enum Error {
     #[error("{0}")]
     Engine(Box<dyn StdError + Send + Sync + 'static>),
 
-    #[error("Cannot read {url}/{name} into {}: {err}", local_path.display())]
+    #[error("Cannot read {url}/{name} into {}: {}", local_path.display(), Report::new(err))]
     CannotReadExternalStorage {
         url: String,
         name: String,

--- a/components/sst_importer/src/lib.rs
+++ b/components/sst_importer/src/lib.rs
@@ -2,6 +2,7 @@
 
 //! Importing RocksDB SST files into TiKV
 #![feature(min_specialization)]
+#![feature(error_reporter)]
 
 #[macro_use]
 extern crate serde_derive;

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -426,7 +426,7 @@ impl<E: KvEngine> SstImporter<E> {
                     "download failed";
                     "meta" => ?meta,
                     "name" => name,
-                    "err" => ?e,
+                    "err" => %e,
                 );
                 Err(e)
             }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18840

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

> Executed the instructions in #18840 and get the following WARN log. Note the additional message after "streaming error".
>
> ```
> [2025/08/19 14:50:42.692 +08:00] [WARN] [sst_importer.rs:425] ["download failed"] [err="Cannot read http://127.0.0.1:9001/backup//1/16_61_10828033e81c46d84886eb5810b2733f323ed94f50687970b83a6d58608a9a85_1755253693331_write.sst into /data/UuIemUj/tikv-0/data/import/.temp/57879d23-6408-4c81-9623-b84f7dc28f3d_136_1_64_write_2.sst: streaming error: minimum throughput was specified at 1 B/s, but throughput of 0 B/s was observed"] [name=1/16_61_10828033e81c46d84886eb5810b2733f323ed94f50687970b83a6d58608a9a85_1755253693331_write.sst] [meta="uuid: 57879D2364084C819623B84F7DC28F3D range { start: 7480000000000000725F72 end: 7480000000000000725F72FFFFFFFFFFFFFFFFFFFF } length: 1851 cf_name: \"write\" region_id: 136 region_epoch { conf_ver: 1 version: 64 } cipher_iv: 43ADF7FC07210995D453C838574BD757"] [thread_id=129]
> ```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
