### PR TITLE
compact_log_backup: use max ts among all storage checkpoint ts

### DIFF
--- a/components/compact-log-backup/src/exec_hooks/consistency.rs
+++ b/components/compact-log-backup/src/exec_hooks/consistency.rs
@@ -39,7 +39,9 @@ async fn load_storage_checkpoint(storage: &dyn ExternalStorage) -> Result<Option
             };
             let res = match i {
                 None => Some(ts),
-                Some(ts0) => Some(ts.min(ts0)),
+                // Any checkpoint stored in storage is a verified checkpoint TS.
+                // Choose the max value among them is still safe.
+                Some(ts0) => Some(ts.max(ts0)),
             };
             Ok(res)
         })


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18847

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Now, `consistency` hook checks the storage checkpoint by the max value among them.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fixed a bug that may cause compact log backup cannot be started after clutster scaled in.
```
