### PR TITLE
compact_log_backup: optimize compact

### DIFF
--- a/cmd/tikv-ctl/src/cmd.rs
+++ b/cmd/tikv-ctl/src/cmd.rs
@@ -701,10 +701,19 @@ pub enum Cmd {
             long,
             default_value = "16M",
             help(
-                "specify the minimal compaction size in bytes, if backup data of a region doesn't reach this threshold, it won't be compacted"
+                "specify the minimal compaction size in bytes for default cf, if backup data of a region doesn't reach this threshold, it won't be compacted"
             )
         )]
-        minimal_compaction_size: ReadableSize,
+        minimal_compaction_size_default: ReadableSize,
+
+        #[structopt(
+            long,
+            default_value = "4M",
+            help(
+                "specify the minimal compaction size in bytes for write cf, if backup data of a region doesn't reach this threshold, it won't be compacted"
+            )
+        )]
+        minimal_compaction_size_write: ReadableSize,
     },
     /// Get the state of a region's RegionReadProgress.
     GetRegionReadProgress {

--- a/cmd/tikv-ctl/src/main.rs
+++ b/cmd/tikv-ctl/src/main.rs
@@ -405,7 +405,8 @@ fn main() {
             compression_level,
             name,
             force_regenerate,
-            minimal_compaction_size,
+            minimal_compaction_size_default,
+            minimal_compaction_size_write,
         } => {
             let tmp_engine =
                 TemporaryRocks::new(&cfg).expect("failed to create temp engine for writing SSTs.");
@@ -481,7 +482,10 @@ fn main() {
             } else {
                 Some(compact_log_hooks::checkpoint::Checkpoint::default())
             };
-            let skip_small_compaction = SkipSmallCompaction::new(minimal_compaction_size.0);
+            let skip_small_compaction = SkipSmallCompaction::new(
+                minimal_compaction_size_default.0,
+                minimal_compaction_size_write.0,
+            );
             let hooks = (
                 (
                     (log_to_term, checkpoint),

--- a/components/compact-log-backup/src/exec_hooks/skip_small_compaction.rs
+++ b/components/compact-log-backup/src/exec_hooks/skip_small_compaction.rs
@@ -2,28 +2,63 @@
 
 use tikv_util::info;
 
-use crate::execute::hooking::{CId, ExecHooks, SubcompactionStartCtx};
+use crate::{
+    execute::hooking::{CId, ExecHooks, SubcompactionStartCtx},
+    util,
+};
 
 /// A hook that skips small compaction.
 ///
 /// The size threshold is compared with "original KV size":
 /// the length of each key value pairs in its original form.
 pub struct SkipSmallCompaction {
-    size_threshold: u64,
+    size_threshold_default: u64,
+    size_threshold_write: u64,
 }
 
 impl SkipSmallCompaction {
     /// Creates a new `SkipSmallCompaction` hook.
-    pub fn new(size_threshold: u64) -> Self {
-        Self { size_threshold }
+    pub fn new(size_threshold_default: u64, size_threshold_write: u64) -> Self {
+        Self {
+            size_threshold_default,
+            size_threshold_write,
+        }
     }
 }
 
 impl ExecHooks for SkipSmallCompaction {
     fn before_a_subcompaction_start(&mut self, _cid: CId, cx: SubcompactionStartCtx<'_>) {
-        if cx.subc.size < self.size_threshold {
-            info!("Skipped a small compaction."; 
-                "size" => cx.subc.size, "threshold" => self.size_threshold);
+        let size_threshold = if util::is_write_cf(cx.subc.cf) {
+            self.size_threshold_write
+        } else {
+            self.size_threshold_default
+        };
+        if cx.subc.size < size_threshold {
+            let mut hs = [0; 6];
+            for input in &cx.subc.inputs {
+                if input.key_value_size < 128 {
+                    hs[0] += 1;
+                } else if input.key_value_size < 512 {
+                    hs[1] += 1;
+                } else if input.key_value_size < 2048 {
+                    hs[2] += 1;
+                } else if input.key_value_size < 32768 {
+                    hs[3] += 1;
+                } else if input.key_value_size < 524288 {
+                    hs[4] += 1;
+                } else {
+                    hs[5] += 1;
+                }
+            }
+            info!("Skipped a small compaction.";
+                "h1" => hs[0],
+                "h2" => hs[1],
+                "h3" => hs[2],
+                "h4" => hs[3],
+                "h5" => hs[4],
+                "h6" => hs[5],
+                "size" => cx.subc.size,
+                "threshold" => size_threshold);
             cx.skip();
         }
     }

--- a/components/compact-log-backup/src/execute/test.rs
+++ b/components/compact-log-backup/src/execute/test.rs
@@ -321,7 +321,7 @@ async fn test_filter_out_small_compactions() {
     let exec = create_compaction(st.backend());
 
     tokio::task::spawn_blocking(move || {
-        exec.run((SkipSmallCompaction::new(27800), SaveMeta::default()))
+        exec.run((SkipSmallCompaction::new(27800, 6950), SaveMeta::default()))
     })
     .await
     .unwrap()

--- a/components/compact-log-backup/src/storage.rs
+++ b/components/compact-log-backup/src/storage.rs
@@ -593,7 +593,7 @@ impl MetaEditFilters {
     fn should_fully_skip(&self, meta: &str) -> bool {
         self.0
             .get(meta)
-            .map(|v| v.all_data_files_compacted || v.destructed_self)
+            .map(|v| v.no_data_files_to_be_compacted || v.destructed_self)
             .unwrap_or(false)
     }
 
@@ -623,7 +623,7 @@ struct MetaEditFilter {
     // FileName -> Offset
     segments: HashMap<String, BTreeSet<u64>>,
     destructed_self: bool,
-    all_data_files_compacted: bool,
+    no_data_files_to_be_compacted: bool,
 }
 
 impl MetaEditFilter {
@@ -632,7 +632,7 @@ impl MetaEditFilter {
             full_files: Default::default(),
             segments: Default::default(),
             destructed_self: em.destruct_self,
-            all_data_files_compacted: em.all_data_files_compacted,
+            no_data_files_to_be_compacted: em.all_data_files_compacted,
         };
         this.full_files
             .extend(em.take_delete_physical_files().into_iter());

--- a/components/compact-log-backup/src/util.rs
+++ b/components/compact-log-backup/src/util.rs
@@ -145,6 +145,12 @@ pub fn cf_name(s: &str) -> CfName {
     }
 }
 
+/// Compare a str with a [`engine_traits::CfName`]\(`&'static str`).
+/// Return true if it is the same as [`engine_traits::CF_WRITE`].
+pub fn is_write_cf(s: &str) -> bool {
+    s == CF_WRITE
+}
+
 /// A wrapper that make a `u64` always be displayed as {:016X}.
 #[derive(Debug)]
 struct HexU64(u64);


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18843

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
1. Reduce the threshold for write-cf to be compacted
2. Ignore very small files (which are almost impossible to be compacted) to reduce the amount of metadata read
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
