### PR TITLE
compact_log_backup: offload reading meta to diff cpus

### DIFF
--- a/components/compact-log-backup/src/compaction/meta.rs
+++ b/components/compact-log-backup/src/compaction/meta.rs
@@ -7,6 +7,7 @@ use std::{
 use external_storage::ExternalStorage;
 use futures::stream::TryStreamExt;
 use kvproto::brpb::{self, DeleteSpansOfFile};
+use tikv_util::{time::InstantExt, warn};
 
 use super::{
     EpochHint, Subcompaction, SubcompactionCollectKey, SubcompactionResult, UnformedSubcompaction,
@@ -254,9 +255,9 @@ impl CompactionRunInfoBuilder {
         &mut self.compaction
     }
 
-    pub async fn write_migration(&self, s: &dyn ExternalStorage) -> Result<()> {
-        let migration = self.migration_of(self.find_expiring_files(s).await?);
-        let wrapped_storage = MigrationStorageWrapper::new(s);
+    pub async fn write_migration(&self, s: Arc<dyn ExternalStorage>) -> Result<()> {
+        let migration = self.migration_of(self.find_expiring_files(s.clone()).await?);
+        let wrapped_storage = MigrationStorageWrapper::new(s.as_ref());
         wrapped_storage.write(migration.into()).await?;
         Ok(())
     }
@@ -282,10 +283,10 @@ impl CompactionRunInfoBuilder {
 
     async fn find_expiring_files(
         &self,
-        s: &dyn ExternalStorage,
+        s: Arc<dyn ExternalStorage>,
     ) -> Result<Vec<ExpiringFilesOfMeta>> {
         let ext = LoadFromExt::default();
-        let mut storage = StreamMetaStorage::load_from_ext(s, ext).await?;
+        let mut storage = StreamMetaStorage::load_from_ext(&s, ext).await?;
 
         let mut result = vec![];
         while let Some(item) = storage.try_next().await? {
@@ -367,6 +368,8 @@ impl EpochHint {
 
 #[cfg(test)]
 mod test {
+    use std::sync::Arc;
+
     use external_storage::ExternalStorage;
     use kvproto::brpb;
 
@@ -377,7 +380,7 @@ mod test {
     };
 
     impl CompactionRunInfoBuilder {
-        async fn mig(&self, s: &dyn ExternalStorage) -> crate::Result<brpb::Migration> {
+        async fn mig(&self, s: Arc<dyn ExternalStorage>) -> crate::Result<brpb::Migration> {
             Ok(self.migration_of(self.find_expiring_files(s).await?))
         }
     }
@@ -399,14 +402,14 @@ mod test {
         let subc = Subcompaction::singleton(m.physical_files[0].files[0].clone());
         let res = cr.run(subc, Default::default()).await.unwrap();
         coll.add_subcompaction(&res);
-        let mig = coll.mig(st.storage().as_ref()).await.unwrap();
+        let mig = coll.mig(st.storage().clone()).await.unwrap();
         assert_eq!(mig.edit_meta.len(), 1);
         assert!(!mig.edit_meta[0].destruct_self);
 
         let mut coll = CompactionRunInfoBuilder::default();
         let subc = Subcompaction::of_many(m.physical_files[0].files.iter().cloned());
         coll.add_subcompaction(&SubcompactionResult::of(subc));
-        let mig = coll.mig(st.storage().as_ref()).await.unwrap();
+        let mig = coll.mig(st.storage().clone()).await.unwrap();
         assert_eq!(mig.edit_meta.len(), 1);
         assert!(mig.edit_meta[0].destruct_self);
 
@@ -465,7 +468,7 @@ mod test {
         coll.add_subcompaction(&SubcompactionResult::of(subc1));
         coll.add_subcompaction(&SubcompactionResult::of(subc2));
         coll.add_subcompaction(&SubcompactionResult::of(subc3));
-        let mig = coll.mig(st.storage().as_ref()).await.unwrap();
+        let mig = coll.mig(st.storage().clone()).await.unwrap();
         assert_eq!(mig.edit_meta.len(), 2);
         let check = |me: &brpb::MetaEdit| match me.get_path() {
             "v1/backupmeta/1.meta" => {

--- a/components/compact-log-backup/src/compaction/meta.rs
+++ b/components/compact-log-backup/src/compaction/meta.rs
@@ -7,7 +7,6 @@ use std::{
 use external_storage::ExternalStorage;
 use futures::stream::TryStreamExt;
 use kvproto::brpb::{self, DeleteSpansOfFile};
-use tikv_util::{time::InstantExt, warn};
 
 use super::{
     EpochHint, Subcompaction, SubcompactionCollectKey, SubcompactionResult, UnformedSubcompaction,

--- a/components/compact-log-backup/src/execute/hooking.rs
+++ b/components/compact-log-backup/src/execute/hooking.rs
@@ -1,6 +1,6 @@
 // Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::cell::Cell;
+use std::{cell::Cell, sync::Arc};
 
 pub use engine_traits::SstCompressionType;
 use external_storage::ExternalStorage;
@@ -44,7 +44,7 @@ pub struct AfterFinishCtx<'a> {
     /// The target external storage of this compaction.
     ///
     /// For now, it is always the same as the source storage.
-    pub storage: &'a dyn ExternalStorage,
+    pub storage: &'a Arc<dyn ExternalStorage>,
 }
 
 #[derive(Clone, Copy)]


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18884

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
This PR spawns read s3 file tasks to remote threads.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
Before:
```
{"level":"INFO","caller":"save_meta.rs:174","message":"Migration written.","time":"2025/08/26 08:15:25.388 +00:00","thread_id":1,"duration":"878.241073919s"}
```
After:
```
{"level":"INFO","caller":"save_meta.rs:174","message":"Migration written.","time":"2025/08/27 09:11:16.222 +00:00","thread_id":1,"duration":"521.078651373s"}
```
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
