### PR TITLE
raftstore: avoid re-entering hibernate state even if be waked up by `AwakenRegions`

### DIFF
--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -2350,6 +2350,11 @@ where
 
         let mut res = None;
         if self.ctx.cfg.hibernate_regions {
+            fail_point!(
+                "on_raft_base_tick_check_missing_ticks",
+                self.fsm.missing_ticks >= self.ctx.cfg.raft_max_election_timeout_ticks,
+                |_| {}
+            );
             if self.fsm.hibernate_state.group_state() == GroupState::Idle {
                 // missing_ticks should be less than election timeout ticks otherwise
                 // follower may tick more than an election timeout in chaos state.

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -2961,7 +2961,7 @@ where
             Ok(())
         } else {
             if msg_type == MessageType::MsgReadIndex {
-                // This can be a message that sent when it's still a follower. Nevertheleast,
+                // This can be a message that sent when it's still a follower. Nevertheless,
                 // it's meaningless to continue to handle the request as callbacks are cleared.
                 if self.fsm.peer.is_leader()
                     && (msg.get_message().get_from() == raft::INVALID_ID
@@ -2970,7 +2970,7 @@ where
                     self.ctx.raft_metrics.message_dropped.stale_msg.inc();
                     return Ok(());
                 // Or if the peer is forcely awaken by PD and waited to trigger
-                // a new election, the lease udpating should be rejected. It
+                // a new election, the lease updating should be rejected. It
                 // could make the safety for handling `Read` by
                 // lease.
                 } else if self.fsm.reject_lease_ticks.0 > 0 {
@@ -3196,7 +3196,7 @@ where
         match msg.get_extra_msg().get_type() {
             ExtraMessageType::MsgRegionWakeUp | ExtraMessageType::MsgCheckStalePeer => {
                 if msg.get_extra_msg().forcely_awaken {
-                    // Forcely awaken this region by manually setting the GroupState
+                    // Forcibly awaken this region by manually setting the GroupState
                     // into `Chaos` with adding `raft_max_election_timeout_tick` to
                     // `reject_lease_ticks`, to trigger a new voting in the
                     // Raft Group immediately. Meanwhile, it avoids the peer
@@ -7272,7 +7272,7 @@ where
 
     /// Check the reject lease ticks of this peer.
     ///
-    /// If the peer is forcely awaken by PD, it will returns the timeout ticks
+    /// If the peer is forcely awaken by PD, it will return the timeout ticks
     /// of rejecting lease.
     fn on_check_reject_lease_ticks(&mut self) -> usize {
         let (reject_lease_ticks_ttl, reject_lease_ticks) = self.fsm.reject_lease_ticks;

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -7125,7 +7125,7 @@ where
         let (reject_lease_ticks_ttl, reject_lease_ticks) = self.fsm.reject_lease_ticks;
         fail_point!(
             "on_raft_base_tick_check_rejected_lease_ticks",
-            reject_lease_ticks_ttl == 0
+            reject_lease_ticks_ttl == 1
                 && reject_lease_ticks >= self.ctx.cfg.raft_max_election_timeout_ticks,
             |_| { 0 }
         );

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -166,7 +166,9 @@ where
     /// ticks have not timed out, all incoming leader renew lease requests will
     /// be rejected to ensure new election safety.
     ///
-    /// This will be reset to (0, 0) once the role changes or ticks expire.
+    /// The first one is time-to-expire, the second one is the max number of
+    /// ticks. This will be reset to (0, 0) once the role changes or ticks
+    /// expire.
     reject_lease_ticks: (usize, usize),
     hibernate_state: HibernateState,
     stopped: bool,

--- a/tests/failpoints/cases/test_hibernate.rs
+++ b/tests/failpoints/cases/test_hibernate.rs
@@ -244,7 +244,7 @@ fn test_forcely_awaken_hibenrate_regions() {
         ))
         .unwrap();
     assert_eq!(
-        rx.recv_timeout(Duration::from_secs(10)).unwrap(),
+        rx.recv_timeout(Duration::from_secs(1)).unwrap(),
         base_tick_ms
     );
     fail::remove("on_raft_base_tick_check_rejected_lease_ticks");

--- a/tests/failpoints/cases/test_hibernate.rs
+++ b/tests/failpoints/cases/test_hibernate.rs
@@ -231,7 +231,6 @@ fn test_forcely_awaken_hibenrate_regions() {
         tx.send(base_tick_ms).unwrap()
     })
     .unwrap();
-    println!("Try to awaken regions");
     router
         .send_raft_message(create_region_wakeup_msg(
             3,


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close https://github.com/tikv/tikv/issues/18916

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

While the "AwakenRegions" mechanism (added for #16368) successfully handles I/O hang scenarios by triggering leader elections, a newly identified corner case prevents its full effectiveness. When a peer's `missing_ticks` remains below `max_election_timeout_ticks`, the region remains stuck in a "hibernate" state and rejects new leader elections, compromising high availability.

And after reviewing the current implementation, the existing logic delays election triggers for hibernated regions until `missing_ticks` >= `max_election_timeout_ticks`. This allows a "hibernate" region to block elections even thought it receives the "AwakenRegion" message.

TO address this bug, this PR enhances the "Awaken" mechanism with adding `max_election_timeout_tick` to the corresponding region to immediately trigger elections when:
- The region is in a hibernated state
- The "AwakenRegions" mechanism is activated
- The peer is election-eligible (by `.tick()`)

Meanwhile, for addressing the corner case where there might exists multi leaders if there existing network partition issue, it introduces a new trait `reject_lease_ticks` to `PeerFsm`, to make the forcely awaken `Peer` holds the new leader election until the old leader's lease timeout or reaching the limit of `reject_lease_ticks`.

```commit-message
This PR address the bug where some hibernate regions could not trigger a new election immediately due to `missing_ticks` < `max_election_timeout_ticks`.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
This PR address the bug where some hibernate regions could not trigger a new election immediately due to `missing_ticks` < `max_election_timeout_ticks`.
```
