### PR TITLE
cdc: also consider the memory quota usage when abort idle connection

### DIFF
--- a/components/cdc/src/service.rs
+++ b/components/cdc/src/service.rs
@@ -533,6 +533,7 @@ impl Service {
             conn_id,
             cancel_tx,
             forward_exit_rx,
+            self.memory_quota.clone(),
         );
     }
 
@@ -548,6 +549,7 @@ impl Service {
         conn_id: ConnId,
         cancel_tx: tokio::sync::oneshot::Sender<()>,
         mut forward_exit_rx: tokio::sync::oneshot::Receiver<()>,
+        memory_quota: Arc<MemoryQuota>,
     ) {
         let last_flush_time_clone = last_flush_time.clone();
         let peer_clone = peer.clone();
@@ -594,7 +596,10 @@ impl Service {
                         };
 
                         // Check if last flush was more than the deregister threshold
-                        if elapsed > Duration::from_secs(_idle_threshold) {
+                        // To prevent the case that the connection idle since there are a lot of
+                        // incremental scan tasks queueing so won't send events, also check on the
+                        // memory usage, if the memory quota is almost used up, we abort the connection.
+                        if elapsed > Duration::from_secs(_idle_threshold) && memory_quota.used_ratio() >= 0.999 {
                             error!("cdc connection idle for too long, aborting connection";
                                    "downstream" => peer_clone.clone(),
                                    "conn_id" => ?conn_id,


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18915, Ref #18169

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
When try to abort a idle connection, also consider the memory usage, only abort it if the memory usage is almost full to prevent that one connection is normal, but all incremental scan tasks are pending so cannot send events.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
