### PR TITLE
cargo-deny: ignore RUSTSEC-2025-0057

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -7,23 +7,12 @@ deny = [
     # Hash functions
     # We allow md5 for AWS S3 object lock feature which requires
     # computting object's md5.
-    { name = "md5", wrappers = [
-        "aws",
-    ] },
-    { name = "md-5", wrappers = [
-        "aws-smithy-checksums",
-    ] },
-    { name = "sha1", wrappers = [
-        "aws-smithy-checksums",
-    ] },
+    { name = "md5", wrappers = ["aws"] },
+    { name = "md-5", wrappers = ["aws-smithy-checksums"]},
+    { name = "sha1", wrappers = ["aws-smithy-checksums"]},
     { name = "sha-1" },
     # We allow sha2 for oauth2 and aws rust sdk crate, because it does use sha2 in TiKV use case.
-    { name = "sha2", wrappers = [
-        "oauth2",
-        "aws-sigv4",
-        "aws-smithy-checksums",
-        "aws-sdk-s3",
-    ] },
+    { name = "sha2", wrappers = ["oauth2", "aws-sigv4", "aws-smithy-checksums", "aws-sdk-s3"] },
     { name = "sha3" },
     # Symmetric encryption
     { name = "aes" },
@@ -38,22 +27,14 @@ deny = [
     { name = "ecdsa" },
     { name = "ed25519" },
     # Message authentication codes
-    { name = "hmac", wrappers = [
-        "aws-sigv4",
-        "aws-sdk-s3",
-    ] },
+    { name = "hmac", wrappers = ["aws-sigv4", "aws-sdk-s3"]},
     # We prefer the system native TLS or OpenSSL.
     { name = "rustls" },
     { name = "ring" },
     # Ban trait crates from RustCrypto.
     { name = "aead" },
     { name = "cipher" },
-    { name = "digest", wrappers = [
-        "sha2",
-        "md-5",
-        "sha1",
-        "hmac",
-    ] },
+    { name = "digest", wrappers = ["sha2", "md-5", "sha1", "hmac"] },
     { name = "password-hash" },
     { name = "signature" },
 ]
@@ -121,16 +102,7 @@ ignore = [
 version = 2
 private = { ignore = false }
 # Allow licenses in Category A
-allow = [
-    "0BSD",
-    "Apache-2.0",
-    "BSD-3-Clause",
-    "CC0-1.0",
-    "ISC",
-    "MIT",
-    "Zlib",
-    "Unicode-3.0",
-]
+allow = ["0BSD", "Apache-2.0", "BSD-3-Clause", "CC0-1.0", "ISC", "MIT", "Zlib", "Unicode-3.0"]
 exceptions = [
     # unicode-ident includes data generated from Unicode Character Database
     # which is licensed under Unicode-DFS-2016.
@@ -146,3 +118,4 @@ exceptions = [
 unknown-git = "deny"
 unknown-registry = "deny"
 allow-org = { github = ["tikv", "pingcap", "rust-lang"] }
+


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #16328

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Ignore "RUSTSEC-2025-0057" temporarily. We are evaluating
alternatives to replace FxHash. Currently, this package is stable
and there are no known exploitable vulnerabilities affecting our
use case.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None.
```
