### PR TITLE
resource_control: disable the buggy auto priority quota limiter

### DIFF
--- a/components/resource_control/src/lib.rs
+++ b/components/resource_control/src/lib.rs
@@ -29,9 +29,7 @@ pub mod config;
 mod resource_limiter;
 pub use resource_limiter::ResourceLimiter;
 use tikv_util::worker::Worker;
-use worker::{
-    BACKGROUND_LIMIT_ADJUST_DURATION, GroupQuotaAdjustWorker, PriorityLimiterAdjustWorker,
-};
+use worker::{BACKGROUND_LIMIT_ADJUST_DURATION, GroupQuotaAdjustWorker};
 
 mod metrics;
 pub mod worker;
@@ -57,10 +55,12 @@ pub fn start_periodic_tasks(
     // spawn a task to auto adjust background quota limiter and priority quota
     // limiter.
     let mut worker = GroupQuotaAdjustWorker::new(mgr.clone(), io_bandwidth);
-    let mut priority_worker = PriorityLimiterAdjustWorker::new(mgr.clone());
+    // We disable the priority worker by default because the current adjust
+    // algorithm is buggy. We may reenable it only we find a better algorithm.
+    // let mut priority_worker = PriorityLimiterAdjustWorker::new(mgr.clone());
     bg_worker.spawn_interval_task(BACKGROUND_LIMIT_ADJUST_DURATION, move || {
         worker.adjust_quota();
-        priority_worker.adjust();
+        // priority_worker.adjust();
     });
     // spawn a task to periodically upload resource usage statistics to PD.
     bg_worker.spawn_async_task(async move {

--- a/components/resource_control/src/resource_group.rs
+++ b/components/resource_control/src/resource_group.rs
@@ -1265,24 +1265,5 @@ pub(crate) mod tests {
             &mgr.get_resource_limiter("test1", "stats", 0).unwrap(),
             &default_limiter
         ));
-        assert!(Arc::ptr_eq(
-            &mgr.get_resource_limiter("test1", "query", 0).unwrap(),
-            &mgr.priority_limiters[0]
-        ));
-        assert!(Arc::ptr_eq(
-            &mgr.get_resource_limiter("test1", "query", LOW_PRIORITY as u64)
-                .unwrap(),
-            &mgr.priority_limiters[2]
-        ));
-
-        assert!(Arc::ptr_eq(
-            &mgr.get_resource_limiter("default", "query", LOW_PRIORITY as u64)
-                .unwrap(),
-            &mgr.priority_limiters[2]
-        ));
-        assert!(Arc::ptr_eq(
-            &mgr.get_resource_limiter("unknown", "query", 0).unwrap(),
-            &mgr.priority_limiters[1]
-        ));
     }
 }

--- a/components/resource_control/src/resource_group.rs
+++ b/components/resource_control/src/resource_group.rs
@@ -277,7 +277,9 @@ impl ResourceGroupManager {
     // resource group.
     #[inline]
     fn enable_priority_limiter(&self) -> bool {
-        self.get_group_count() > 1
+        // TODO: reenable it once when we fix https://github.com/tikv/tikv/issues/18939
+        // self.get_group_count() > 1
+        false
     }
 
     // Always return the background resource limiter if any;


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18939

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
disable the buggy auto priority quota limiter
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
