### PR TITLE
coprocessor: support `IndexLookUp` in `BatchExecutorsRunner`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7771,7 +7771,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "tipb"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/tipb.git#cf70966bef25e205cb845c19265301542d1238d1"
+source = "git+https://github.com/pingcap/tipb.git#85a019a5df23fa11f93c53ebf7fc05462813df1e"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/components/test_coprocessor/src/dag.rs
+++ b/components/test_coprocessor/src/dag.rs
@@ -1,5 +1,7 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::mem;
+
 use kvproto::{
     coprocessor::{KeyRange, Request},
     kvrpcpb::Context,
@@ -10,7 +12,7 @@ use tikv::coprocessor::REQ_TYPE_DAG;
 use tikv_util::codec::number::NumberEncoder;
 use tipb::{
     Aggregation, ByItem, Chunk, ColumnInfo, DagRequest, ExecType, Executor, Expr, ExprType,
-    IndexScan, Limit, Selection, TableScan, TopN,
+    IndexLookUp, IndexScan, IntermediateOutputChannel, Limit, Selection, TableScan, TopN,
 };
 use txn_types::TimeStamp;
 
@@ -27,6 +29,7 @@ pub struct DagSelect {
     pub output_offsets: Option<Vec<u32>>,
     pub paging_size: Option<u64>,
     pub start_ts: Option<u64>,
+    pub intermediate_outputs: Vec<IntermediateOutputChannel>,
 }
 
 impl DagSelect {
@@ -51,6 +54,7 @@ impl DagSelect {
             output_offsets: None,
             paging_size: None,
             start_ts: None,
+            intermediate_outputs: vec![],
         }
     }
 
@@ -79,7 +83,48 @@ impl DagSelect {
             output_offsets: None,
             paging_size: None,
             start_ts: None,
+            intermediate_outputs: vec![],
         }
+    }
+
+    pub fn index_lookup(mut self, table: &Table, handle_offset: Vec<u32>) -> DagSelect {
+        if let Some(l) = self.limit.take() {
+            let mut exec = Executor::default();
+            exec.set_tp(ExecType::TypeLimit);
+            exec.set_limit({
+                let mut limit = Limit::default();
+                limit.set_limit(l);
+                limit
+            });
+            self.execs.push(exec);
+        }
+        let exec_len = self.execs.len() + 2;
+        self.execs[exec_len - 3].set_parent_idx(exec_len as u32 - 1);
+        let table_scan_dag = Self::from(table);
+        self.execs.push(table_scan_dag.execs[0].clone());
+        self.execs.push({
+            let mut exec = Executor::default();
+            exec.set_tp(ExecType::TypeIndexLookUp);
+            exec.set_index_lookup({
+                let mut index_lookup = IndexLookUp::default();
+                index_lookup.set_index_handle_offsets(handle_offset);
+                index_lookup
+            });
+            exec
+        });
+        self.intermediate_outputs.push({
+            let mut channel = IntermediateOutputChannel::default();
+            channel.set_executor_idx(exec_len as u32 - 1);
+            if let Some(output_offsets) = self.output_offsets.take() {
+                channel.set_output_offsets(output_offsets);
+            } else {
+                channel.set_output_offsets((0..self.cols.len() as u32).collect());
+            }
+            channel
+        });
+        self.cols = table_scan_dag.cols;
+        self.output_offsets = table_scan_dag.output_offsets;
+        self
     }
 
     #[must_use]
@@ -274,6 +319,7 @@ impl DagSelect {
             (0..self.cols.len() as u32).collect()
         };
         dag.set_output_offsets(output_offsets);
+        dag.set_intermediate_output_channels(mem::take(&mut self.intermediate_outputs).into());
 
         let mut req = Request::default();
         req.set_start_ts(self.start_ts.unwrap_or_else(|| next_id() as u64));

--- a/components/test_coprocessor/src/dag.rs
+++ b/components/test_coprocessor/src/dag.rs
@@ -244,6 +244,17 @@ impl DagSelect {
     }
 
     #[must_use]
+    pub fn projection(mut self, exprs: Vec<Expr>) -> DagSelect {
+        let mut exec = Executor::default();
+        exec.set_tp(ExecType::TypeProjection);
+        let mut projection = tipb::Projection::default();
+        projection.set_exprs(exprs.into());
+        exec.set_projection(projection);
+        self.execs.push(exec);
+        self
+    }
+
+    #[must_use]
     pub fn desc(mut self, desc: bool) -> DagSelect {
         self.execs[0].mut_tbl_scan().set_desc(desc);
         self

--- a/components/tidb_query_common/src/execute_stats.rs
+++ b/components/tidb_query_common/src/execute_stats.rs
@@ -45,6 +45,13 @@ pub struct ExecSummaryCollectorEnabled {
     counts: ExecSummary,
 }
 
+impl ExecSummaryCollectorEnabled {
+    #[inline]
+    pub fn get_output_index(&self) -> usize {
+        self.output_index
+    }
+}
+
 impl ExecSummaryCollector for ExecSummaryCollectorEnabled {
     type DurationRecorder = tikv_util::time::Instant;
 
@@ -96,14 +103,6 @@ impl ExecSummaryCollector for ExecSummaryCollectorDisabled {
 
     #[inline]
     fn collect(&mut self, _target: &mut [ExecSummary]) {}
-}
-
-/// Combines an `ExecSummaryCollector` with another type. This inner type `T`
-/// typically `Executor`/`BatchExecutor`, such that `WithSummaryCollector<C, T>`
-/// would implement the same trait and collects the statistics into `C`.
-pub struct WithSummaryCollector<C: ExecSummaryCollector, T> {
-    pub summary_collector: C,
-    pub inner: T,
 }
 
 /// Execution statistics to be flowed between parent and child executors at once

--- a/components/tidb_query_datatype/src/codec/chunk/chunk.rs
+++ b/components/tidb_query_datatype/src/codec/chunk/chunk.rs
@@ -79,8 +79,8 @@ impl Chunk {
         RowIterator::new(self)
     }
 
-    #[cfg(test)]
-    pub fn decode(
+    /// Only use for test
+    pub fn decode_for_test(
         buf: &mut tikv_util::codec::BytesSlice<'_>,
         field_types: &[FieldType],
     ) -> Result<Chunk> {
@@ -90,7 +90,7 @@ impl Chunk {
         for ft in field_types {
             chunk
                 .columns
-                .push(Column::decode(buf, ft.as_accessor().tp())?);
+                .push(Column::decode_for_test(buf, ft.as_accessor().tp())?);
         }
         Ok(chunk)
     }
@@ -145,7 +145,7 @@ pub struct RowIterator<'a> {
 }
 
 impl<'a> RowIterator<'a> {
-    fn new(chunk: &'a Chunk) -> RowIterator<'a> {
+    pub fn new(chunk: &'a Chunk) -> RowIterator<'a> {
         RowIterator { c: chunk, idx: 0 }
     }
 }
@@ -359,7 +359,7 @@ mod tests {
         }
         let mut data = vec![];
         data.write_chunk(&chunk).unwrap();
-        let got = Chunk::decode(&mut data.as_slice(), &fields).unwrap();
+        let got = Chunk::decode_for_test(&mut data.as_slice(), &fields).unwrap();
         assert_eq!(got.num_cols(), fields.len());
         assert_eq!(got.num_rows(), rows);
         for row_id in 0..rows {

--- a/components/tidb_query_datatype/src/codec/chunk/column.rs
+++ b/components/tidb_query_datatype/src/codec/chunk/column.rs
@@ -1017,8 +1017,11 @@ impl Column {
         self.len() == 0
     }
 
-    #[cfg(test)]
-    pub fn decode(buf: &mut tikv_util::codec::BytesSlice<'_>, tp: FieldTypeTp) -> Result<Column> {
+    /// Only used for test
+    pub fn decode_for_test(
+        buf: &mut tikv_util::codec::BytesSlice<'_>,
+        tp: FieldTypeTp,
+    ) -> Result<Column> {
         let length = buf.read_u32_le()? as usize;
         let mut col = Column::new(tp, length);
         col.length = length;

--- a/components/tidb_query_datatype/src/codec/chunk/mod.rs
+++ b/components/tidb_query_datatype/src/codec/chunk/mod.rs
@@ -4,7 +4,7 @@ mod chunk;
 mod column;
 
 pub use self::{
-    chunk::{Chunk, ChunkEncoder},
+    chunk::{Chunk, ChunkEncoder, RowIterator},
     column::{ChunkColumnEncoder, Column},
 };
 pub use crate::codec::{Error, Result};

--- a/components/tidb_query_executors/src/fast_hash_aggr_executor.rs
+++ b/components/tidb_query_executors/src/fast_hash_aggr_executor.rs
@@ -55,8 +55,11 @@ impl<Src: BatchExecutor> BatchExecutor for BatchFastHashAggregationExecutor<Src>
     }
 
     #[inline]
-    fn take_intermediate_results(&mut self, results: &mut [Vec<BatchExecuteResult>]) -> Result<()> {
-        self.0.take_intermediate_results(results)
+    fn consume_and_fill_intermediate_results(
+        &mut self,
+        results: &mut [Vec<BatchExecuteResult>],
+    ) -> Result<()> {
+        self.0.consume_and_fill_intermediate_results(results)
     }
 
     #[inline]

--- a/components/tidb_query_executors/src/fast_hash_aggr_executor.rs
+++ b/components/tidb_query_executors/src/fast_hash_aggr_executor.rs
@@ -50,6 +50,16 @@ impl<Src: BatchExecutor> BatchExecutor for BatchFastHashAggregationExecutor<Src>
     }
 
     #[inline]
+    fn intermediate_schema(&self, index: usize) -> Result<&[FieldType]> {
+        self.0.intermediate_schema(index)
+    }
+
+    #[inline]
+    fn take_intermediate_results(&mut self, results: &mut [Vec<BatchExecuteResult>]) -> Result<()> {
+        self.0.take_intermediate_results(results)
+    }
+
+    #[inline]
     async fn next_batch(&mut self, scan_rows: usize) -> BatchExecuteResult {
         self.0.next_batch(scan_rows).await
     }

--- a/components/tidb_query_executors/src/index_lookup_executor.rs
+++ b/components/tidb_query_executors/src/index_lookup_executor.rs
@@ -7,13 +7,13 @@ use std::{
     sync::Arc,
 };
 
-use api_version::KvFormat;
+use api_version::{ApiV1, KvFormat};
 use async_trait::async_trait;
 use kvproto::{coprocessor::KeyRange, metapb};
 use tidb_query_common::{
     Error,
     error::Result,
-    execute_stats::{ExecSummaryCollectorEnabled, ExecuteStats, WithSummaryCollector},
+    execute_stats::{ExecSummaryCollectorEnabled, ExecuteStats},
     storage::{FindRegionResult, IntervalRange, RegionStorageAccessor, StateRole, Storage},
 };
 use tidb_query_datatype::{
@@ -28,12 +28,12 @@ use tikv_util::{
     Either,
     Either::{Left, Right},
 };
-use tipb::{ColumnInfo, FieldType};
+use tipb::{ColumnInfo, FieldType, IndexLookUp, TableScan};
 use txn_types::Key;
 
 use crate::{
     BatchTableScanExecutor,
-    interface::{BatchExecIsDrain, BatchExecuteResult, BatchExecutor},
+    interface::{BatchExecIsDrain, BatchExecuteResult, BatchExecutor, WithSummaryCollector},
     util::scan_executor::field_type_from_column_info,
 };
 
@@ -43,26 +43,25 @@ struct IndexScanState {
     row_count: usize,
 }
 
-struct TableLookUpState<Iter: TableTaskIterator, F: KvFormat> {
+struct TableLookUpState<Iter, S: Storage, F: KvFormat> {
     table_task_iter: Option<Iter>,
-    table_scan: Option<
-        WithSummaryCollector<ExecSummaryCollectorEnabled, BatchTableScanExecutor<Iter::Storage, F>>,
-    >,
+    table_scan:
+        Option<WithSummaryCollector<ExecSummaryCollectorEnabled, BatchTableScanExecutor<S, F>>>,
 }
 
-enum IndexLookUpPhase<Iter: TableTaskIterator, F: KvFormat> {
+enum IndexLookUpPhase<Iter, S: Storage, F: KvFormat> {
     IndexScan(IndexScanState),
-    TableLookUp(TableLookUpState<Iter, F>),
+    TableLookUp(TableLookUpState<Iter, S, F>),
     Done,
 }
 
-impl<Iter: TableTaskIterator, F: KvFormat> Default for IndexLookUpPhase<Iter, F> {
+impl<Iter, S: Storage, F: KvFormat> Default for IndexLookUpPhase<Iter, S, F> {
     fn default() -> Self {
         IndexLookUpPhase::IndexScan(IndexScanState::default())
     }
 }
 
-impl<Iter: TableTaskIterator, F: KvFormat> IndexLookUpPhase<Iter, F> {
+impl<Iter, S: Storage, F: KvFormat> IndexLookUpPhase<Iter, S, F> {
     fn mut_index_scan_or_err(&mut self) -> Result<&mut IndexScanState> {
         match self {
             IndexLookUpPhase::IndexScan(ref mut s) => Ok(s),
@@ -70,7 +69,7 @@ impl<Iter: TableTaskIterator, F: KvFormat> IndexLookUpPhase<Iter, F> {
         }
     }
 
-    fn mut_table_lookup_or_err(&mut self) -> Result<&mut TableLookUpState<Iter, F>> {
+    fn mut_table_lookup_or_err(&mut self) -> Result<&mut TableLookUpState<Iter, S, F>> {
         match self {
             IndexLookUpPhase::TableLookUp(ref mut s) => Ok(s),
             _ => Err(other_err!("The current phase is not TableLookUp")),
@@ -78,14 +77,14 @@ impl<Iter: TableTaskIterator, F: KvFormat> IndexLookUpPhase<Iter, F> {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct TableScanParams {
-    columns_info: Vec<ColumnInfo>,
-    primary_column_ids: Vec<i64>,
-    primary_prefix_column_ids: Vec<i64>,
+    pub columns_info: Vec<ColumnInfo>,
+    pub primary_column_ids: Vec<i64>,
+    pub primary_prefix_column_ids: Vec<i64>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct IndexLayout {
     pub handle_types: Vec<FieldType>,
     pub handle_offsets: Vec<usize>,
@@ -95,7 +94,7 @@ pub struct BatchIndexLookUpExecutor<S, Src, Builder, F>
 where
     S: Storage,
     Src: BatchExecutor<StorageStats = S::Statistics>,
-    Builder: TableTaskIterBuilder<Iterator: TableTaskIterator<Storage = S>>,
+    Builder: TableTaskIterBuilder,
     F: KvFormat,
 {
     src: Src,
@@ -109,8 +108,79 @@ where
     table_task_iter_builder: Option<Builder>,
     table_scan_params: TableScanParams,
 
-    phase: IndexLookUpPhase<Builder::Iterator, F>,
+    phase: IndexLookUpPhase<Builder::Iterator, S, F>,
     intermediate_results: Vec<BatchExecuteResult>,
+    intermediate_channel_index: usize,
+}
+
+#[inline]
+pub fn build_index_lookup_executor<
+    S: Storage + 'static,
+    Handle: RowHandle + 'static,
+    F: KvFormat,
+>(
+    config: Arc<EvalConfig>,
+    src: impl BatchExecutor<StorageStats = S::Statistics> + 'static,
+    mut index_lookup: IndexLookUp,
+    mut tbl_scan: TableScan,
+    accessor: Option<impl RegionStorageAccessor<Storage = S> + 'static>,
+    intermediate_channel_index: usize,
+) -> Result<impl BatchExecutor<StorageStats = S::Statistics>> {
+    if index_lookup.get_keep_order() {
+        return Err(other_err!(
+            "IndexLookupExecutor does not support keep order currently"
+        ));
+    }
+
+    let src_schema = src.schema();
+    let handle_offsets = index_lookup
+        .take_index_handle_offsets()
+        .into_iter()
+        .map(|offset| offset as usize)
+        .collect::<Vec<_>>();
+
+    let handle_types = handle_offsets
+        .iter()
+        .map(|&offset| src_schema[offset].clone())
+        .collect();
+
+    Ok(BatchIndexLookUpExecutor::<_, _, _, F>::new(
+        config,
+        src,
+        TableScanParams {
+            columns_info: tbl_scan.take_columns().into(),
+            primary_column_ids: tbl_scan.take_primary_column_ids(),
+            primary_prefix_column_ids: tbl_scan.take_primary_prefix_column_ids(),
+        },
+        accessor.map(|acc| {
+            AccessorTableTaskIterBuilder::<_, Handle>::new(
+                tbl_scan.get_table_id(),
+                acc,
+                IndexLayout {
+                    handle_types,
+                    handle_offsets,
+                },
+            )
+        }),
+        intermediate_channel_index,
+    ))
+}
+
+// We assign a dummy type `Box<dyn Storage<Statistics = ()>>` so that we can
+// omit the type when calling `check_supported`.
+impl
+    BatchIndexLookUpExecutor<
+        Box<dyn Storage<Statistics = ()>>,
+        Box<dyn BatchExecutor<StorageStats = ()>>,
+        Box<dyn TableTaskIterBuilder<Iterator = ()>>,
+        ApiV1,
+    >
+{
+    /// Checks whether this executor can be used.
+    #[inline]
+    pub fn check_supported(_descriptor: &IndexLookUp) -> Result<()> {
+        Ok(())
+    }
 }
 
 impl<S, Src, Builder, F> BatchIndexLookUpExecutor<S, Src, Builder, F>
@@ -120,14 +190,13 @@ where
     Builder: TableTaskIterBuilder<Iterator: TableTaskIterator<Storage = S>>,
     F: KvFormat,
 {
-    // TODO: remove #[allow(dead_code)] after new function is used
-    #[allow(dead_code)]
     #[inline]
     pub fn new(
         config: Arc<EvalConfig>,
         src: Src,
         table_scan_params: TableScanParams,
         table_task_iter_builder: Option<Builder>,
+        intermediate_channel_index: usize,
     ) -> Self {
         let force_no_index_lookup =
             if config.paging_size.is_some() || table_task_iter_builder.is_none() {
@@ -159,7 +228,33 @@ where
             table_task_iter_builder,
             phase: IndexLookUpPhase::default(),
             table_scan_params,
+            intermediate_channel_index,
         }
+    }
+
+    #[cfg(test)]
+    pub fn into_index_child(self) -> Src {
+        self.src
+    }
+
+    #[inline]
+    pub fn config(&self) -> Arc<EvalConfig> {
+        self.config.clone()
+    }
+
+    #[inline]
+    pub fn get_table_scan_params(&self) -> &TableScanParams {
+        &self.table_scan_params
+    }
+
+    #[inline]
+    pub fn get_table_task_builder(&self) -> Option<&Builder> {
+        self.table_task_iter_builder.as_ref()
+    }
+
+    #[inline]
+    pub fn intermediate_channel_index(&self) -> usize {
+        self.intermediate_channel_index
     }
 
     #[inline]
@@ -358,6 +453,32 @@ where
     // TODO: A concurrent execution implementation so that the index-scan and
     // table-lookup does not block each-other.
     #[inline]
+    fn intermediate_schema(&self, index: usize) -> Result<&[FieldType]> {
+        if index == self.intermediate_channel_index {
+            Ok(self.src.schema())
+        } else {
+            self.src.intermediate_schema(index)
+        }
+    }
+
+    #[inline]
+    fn take_intermediate_results(&mut self, results: &mut [Vec<BatchExecuteResult>]) -> Result<()> {
+        match results.get_mut(self.intermediate_channel_index) {
+            Some(v) => {
+                if !self.intermediate_results.is_empty() {
+                    v.append(&mut self.intermediate_results);
+                }
+                self.src.take_intermediate_results(results)
+            }
+            _ => Err(other_err!(
+                "intermediate_channel_index {} exceeds the bound: {}",
+                self.intermediate_channel_index,
+                results.len()
+            )),
+        }
+    }
+
+    #[inline]
     async fn next_batch(&mut self, scan_rows: usize) -> BatchExecuteResult {
         if scan_rows == 0 {
             return Self::err_result(other_err!("scan_rows cannot be 0"));
@@ -401,13 +522,26 @@ where
 
 /// produce table tasks for the index lookup executor
 pub trait TableTaskIterBuilder: Send {
-    type Iterator: TableTaskIterator;
+    type Iterator;
     // builds an iterator to produce table tasks
     fn build_iterator(
         &self,
         ctx: &mut EvalContext,
         results: Vec<BatchExecuteResult>,
     ) -> Result<Self::Iterator>;
+}
+
+impl<T: TableTaskIterBuilder + ?Sized> TableTaskIterBuilder for Box<T> {
+    type Iterator = T::Iterator;
+
+    #[inline]
+    fn build_iterator(
+        &self,
+        ctx: &mut EvalContext,
+        results: Vec<BatchExecuteResult>,
+    ) -> Result<Self::Iterator> {
+        (**self).build_iterator(ctx, results)
+    }
 }
 
 pub struct AccessorTableTaskIterBuilder<Accessor, Handle>
@@ -426,8 +560,6 @@ where
     Accessor: RegionStorageAccessor<Storage: Storage>,
     Handle: RowHandle,
 {
-    // TODO: remove #[allow(dead_code)] after new function is used
-    #[allow(dead_code)]
     #[inline]
     pub fn new(table_id: i64, accessor: Accessor, index_layout: IndexLayout) -> Self {
         AccessorTableTaskIterBuilder {
@@ -436,6 +568,18 @@ where
             index_layout,
             _phantom: std::marker::PhantomData,
         }
+    }
+
+    #[inline]
+    #[cfg(test)]
+    pub fn table_id(&self) -> i64 {
+        self.table_id
+    }
+
+    #[inline]
+    #[cfg(test)]
+    pub fn get_index_layout(&self) -> &IndexLayout {
+        &self.index_layout
     }
 }
 
@@ -839,8 +983,8 @@ where
 }
 
 #[cfg(test)]
-mod tests {
-    use std::{collections::HashSet, iter, ops::DerefMut, sync::Mutex};
+pub mod tests {
+    use std::{collections::HashSet, iter};
 
     use anyhow::anyhow;
     use api_version::ApiV1;
@@ -849,7 +993,7 @@ mod tests {
     use tidb_query_common::{
         error::StorageError,
         storage::{
-            FindRegionResult, OwnedKvPair, PointRange, Result as StorageResult, StateRole,
+            StateRole,
             test_fixture::{ErrorBuilder, FixtureStorage},
         },
     };
@@ -864,195 +1008,12 @@ mod tests {
         },
         expr::{EvalContext, EvalWarnings, Flag},
     };
-    use tikv_util::store::check_key_in_region;
 
     use super::*;
     use crate::{
         interface::{BatchExecIsDrain, BatchExecuteResult},
-        util::mock_executor::MockExecutor,
+        util::mock_executor::{MockExecutor, MockRegionStorageAccessor, MockStorage},
     };
-
-    #[derive(Debug, Clone, PartialEq)]
-    struct MockStorage(Region, Vec<KeyRange>);
-
-    impl Storage for MockStorage {
-        type Statistics = ();
-
-        fn begin_scan(
-            &mut self,
-            _is_backward_scan: bool,
-            _is_key_only: bool,
-            _range: IntervalRange,
-        ) -> StorageResult<()> {
-            unimplemented!()
-        }
-
-        fn scan_next(&mut self) -> StorageResult<Option<OwnedKvPair>> {
-            unimplemented!()
-        }
-
-        fn get(
-            &mut self,
-            _is_key_only: bool,
-            _range: PointRange,
-        ) -> StorageResult<Option<OwnedKvPair>> {
-            unimplemented!()
-        }
-
-        fn met_uncacheable_data(&self) -> Option<bool> {
-            unimplemented!()
-        }
-
-        fn collect_statistics(&mut self, _dest: &mut Self::Statistics) {
-            unimplemented!()
-        }
-    }
-
-    #[derive(Default, Debug, Clone)]
-    struct MockAccessorExpect {
-        find_region: Option<(Vec<u8>, Option<FindRegionResult>)>,
-        expect_get_local_region_storage: Option<bool>,
-    }
-
-    #[derive(Clone)]
-    enum MockRegionStorageAccessor {
-        Expect(Arc<Mutex<MockAccessorExpect>>),
-        Data(Vec<(Region, StateRole)>),
-    }
-
-    impl MockRegionStorageAccessor {
-        fn with_expect_mode() -> Self {
-            Self::Expect(Arc::new(Mutex::new(MockAccessorExpect {
-                ..Default::default()
-            })))
-        }
-
-        fn with_regions_data(data: Vec<(Region, StateRole)>) -> Self {
-            assert!(data.is_sorted_by(|a, b| { a.0.start_key < b.0.start_key }));
-            Self::Data(data)
-        }
-
-        fn with_expect<T>(&self, f: impl Fn(&mut MockAccessorExpect) -> T) -> T {
-            match self {
-                Self::Expect(e) => {
-                    let mut expect = e.lock().unwrap();
-                    f(expect.deref_mut())
-                }
-                _ => panic!("not in expect mode"),
-            }
-        }
-
-        fn expect_find_region(&self, key: Vec<u8>, region: Region, role: StateRole) {
-            self.with_expect(|expect| {
-                assert!(expect.find_region.is_none());
-                expect.find_region = Some((
-                    key.clone(),
-                    Some(FindRegionResult::Found {
-                        region: region.clone(),
-                        role,
-                    }),
-                ));
-            });
-        }
-
-        fn expect_region_not_found(&self, key: Vec<u8>, next_region_start: Option<Vec<u8>>) {
-            self.with_expect(|expect| {
-                assert!(expect.find_region.is_none());
-                expect.find_region = Some((
-                    key.clone(),
-                    Some(FindRegionResult::NotFound {
-                        next_region_start: next_region_start.clone(),
-                    }),
-                ));
-            });
-        }
-
-        fn expect_find_region_error(&self, key: Vec<u8>) {
-            self.with_expect(|expect| {
-                assert!(expect.find_region.is_none());
-                expect.find_region = Some((key.clone(), None));
-            });
-        }
-
-        fn expect_get_local_region_storage(&self, success: bool) {
-            self.with_expect(|expect| {
-                assert!(expect.expect_get_local_region_storage.is_none());
-                expect.expect_get_local_region_storage = Some(success);
-            });
-        }
-
-        fn assert_no_exceptions(&self) {
-            self.with_expect(|expect| {
-                assert!(expect.find_region.is_none());
-                assert!(expect.expect_get_local_region_storage.is_none());
-            });
-        }
-    }
-
-    #[async_trait]
-    impl RegionStorageAccessor for MockRegionStorageAccessor {
-        type Storage = MockStorage;
-
-        async fn find_region_by_key(&self, key: &[u8]) -> StorageResult<FindRegionResult> {
-            match self {
-                Self::Expect(_) => {
-                    let find_result = self.with_expect(|expect| -> Option<FindRegionResult> {
-                        let (expect_key, find_result) = expect.find_region.take().unwrap();
-                        assert_eq!(expect_key, key.to_vec());
-                        find_result
-                    });
-
-                    if let Some(result) = find_result {
-                        Ok(result)
-                    } else {
-                        Err(StorageError::from(anyhow!("mock find region error")))
-                    }
-                }
-                Self::Data(data) => {
-                    let mut result = FindRegionResult::NotFound {
-                        next_region_start: None,
-                    };
-                    for (region, role) in data.iter() {
-                        if region.get_end_key().is_empty() || region.get_end_key() >= key {
-                            if check_key_in_region(key, region) {
-                                result = FindRegionResult::Found {
-                                    region: region.clone(),
-                                    role: *role,
-                                };
-                            } else {
-                                result = FindRegionResult::NotFound {
-                                    next_region_start: Some(region.get_start_key().to_vec()),
-                                };
-                            }
-                            break;
-                        }
-                    }
-                    Ok(result)
-                }
-            }
-        }
-
-        async fn get_local_region_storage(
-            &self,
-            region: &Region,
-            key_ranges: &[KeyRange],
-        ) -> StorageResult<Self::Storage> {
-            match self {
-                Self::Expect(_) => {
-                    let success = self.with_expect(|expect| -> bool {
-                        expect.expect_get_local_region_storage.take().unwrap()
-                    });
-
-                    if success {
-                        Ok(MockStorage(region.clone(), key_ranges.to_vec()))
-                    } else {
-                        Err(StorageError::from(anyhow!("mock get storage error")))
-                    }
-                }
-                Self::Data(_) => Ok(MockStorage(region.clone(), key_ranges.to_vec())),
-            }
-        }
-    }
 
     const TEST_TABLE_ID: i64 = 13579;
 
@@ -1757,6 +1718,7 @@ mod tests {
                 primary_prefix_column_ids: vec![],
             },
             builder,
+            2,
         )
     }
 
@@ -2323,5 +2285,146 @@ mod tests {
             BatchExecIsDrain::Remain,
             0,
         );
+    }
+
+    #[test]
+    fn test_take_intermediate_results() {
+        let mut index_lookup = new_index_lookup_executor_for_test(
+            EvalConfig::default_for_test(),
+            build_int_array_results(vec![vec![]]),
+            None,
+            int_handle_table_columns(vec![FieldTypeTp::LongLong], 0),
+        );
+
+        assert_eq!(index_lookup.intermediate_channel_index, 2);
+        assert!(index_lookup.intermediate_results.is_empty());
+
+        index_lookup.intermediate_results = build_int_array_results(vec![vec![1, 2], vec![3]]);
+
+        // when the channel len does not match, return error
+        let err = index_lookup
+            .take_intermediate_results(&mut [vec![], vec![]])
+            .unwrap_err();
+        assert!(err.to_string().contains("exceeds the bound"));
+
+        // take results successfully
+        let mut channels = vec![vec![], vec![], vec![], vec![]];
+        index_lookup
+            .take_intermediate_results(&mut channels)
+            .unwrap();
+        assert!(index_lookup.intermediate_results.is_empty());
+        assert!(channels[0].is_empty());
+        assert!(channels[1].is_empty());
+        assert!(channels[3].is_empty());
+        let results = &mut channels[2];
+        assert_eq!(results.len(), 2);
+        check_int_column_batch_execute_result(
+            &mut results[0],
+            vec![1, 2],
+            BatchExecIsDrain::Remain,
+            0,
+        );
+        check_int_column_batch_execute_result(&mut results[1], vec![3], BatchExecIsDrain::Drain, 0);
+
+        // take results should append to existing results
+        index_lookup.intermediate_results = build_int_array_results(vec![vec![7, 4]]);
+        index_lookup
+            .take_intermediate_results(&mut channels)
+            .unwrap();
+        assert!(index_lookup.intermediate_results.is_empty());
+        assert!(channels[0].is_empty());
+        assert!(channels[1].is_empty());
+        assert!(channels[3].is_empty());
+        let results = &mut channels[2];
+        assert_eq!(results.len(), 3);
+        check_int_column_batch_execute_result(
+            &mut results[2],
+            vec![7, 4],
+            BatchExecIsDrain::Drain,
+            0,
+        );
+
+        // take results should also take the child executor's intermediate
+        // results
+        index_lookup.src.intermediate_schema = Some((1, vec![FieldType::from(FieldTypeTp::Long)]));
+        index_lookup
+            .src
+            .set_next_intermediate_results(build_int_array_results(vec![vec![100]]));
+        index_lookup
+            .take_intermediate_results(&mut channels)
+            .unwrap();
+        assert!(channels[0].is_empty());
+        assert!(channels[3].is_empty());
+        assert_eq!(channels[2].len(), 3);
+        assert_eq!(channels[1].len(), 1);
+        let results = &mut channels[1];
+        assert_eq!(results.len(), 1);
+        check_int_column_batch_execute_result(
+            &mut results[0],
+            vec![100],
+            BatchExecIsDrain::Drain,
+            0,
+        );
+
+        index_lookup.intermediate_results = build_int_array_results(vec![vec![300]]);
+        index_lookup
+            .src
+            .set_next_intermediate_results(build_int_array_results(vec![vec![200]]));
+        index_lookup
+            .take_intermediate_results(&mut channels)
+            .unwrap();
+        assert!(channels[0].is_empty());
+        assert!(channels[3].is_empty());
+        let results = &mut channels[2];
+        assert_eq!(results.len(), 4);
+        check_int_column_batch_execute_result(
+            &mut results[3],
+            vec![300],
+            BatchExecIsDrain::Drain,
+            0,
+        );
+        let results = &mut channels[1];
+        assert_eq!(results.len(), 2);
+        check_int_column_batch_execute_result(
+            &mut results[1],
+            vec![200],
+            BatchExecIsDrain::Drain,
+            0,
+        );
+    }
+
+    #[test]
+    fn test_intermediate_schema() {
+        let mut index_lookup = new_index_lookup_executor_for_test(
+            EvalConfig::default_for_test(),
+            build_int_array_results(vec![vec![]]),
+            None,
+            int_handle_table_columns(vec![FieldTypeTp::LongLong], 0),
+        );
+
+        let schema1 = vec![
+            FieldType::from(FieldTypeTp::Long),
+            FieldType::from(FieldTypeTp::VarChar),
+        ];
+        let schema2 = vec![FieldType::from(FieldTypeTp::Long)];
+
+        assert_eq!(index_lookup.intermediate_channel_index, 2);
+        index_lookup.src.schema = schema1.clone();
+        index_lookup.src.intermediate_schema = Some((1, schema2.clone()));
+
+        // test missing intermediate schema
+        assert!(
+            index_lookup
+                .intermediate_schema(0)
+                .unwrap_err()
+                .to_string()
+                .contains("no intermediate schema for index")
+        );
+
+        // test index lookup's intermediate schema
+        assert_eq!(schema1, index_lookup.intermediate_schema(2).unwrap());
+
+        // test index lookup's child's intermediate schema
+        assert_eq!(schema2, index_lookup.intermediate_schema(1).unwrap());
     }
 }

--- a/components/tidb_query_executors/src/index_scan_executor.rs
+++ b/components/tidb_query_executors/src/index_scan_executor.rs
@@ -166,6 +166,16 @@ impl<S: Storage, F: KvFormat> BatchExecutor for BatchIndexScanExecutor<S, F> {
     }
 
     #[inline]
+    fn intermediate_schema(&self, index: usize) -> Result<&[FieldType]> {
+        self.0.intermediate_schema(index)
+    }
+
+    #[inline]
+    fn take_intermediate_results(&mut self, results: &mut [Vec<BatchExecuteResult>]) -> Result<()> {
+        self.0.take_intermediate_results(results)
+    }
+
+    #[inline]
     async fn next_batch(&mut self, scan_rows: usize) -> BatchExecuteResult {
         self.0.next_batch(scan_rows).await
     }

--- a/components/tidb_query_executors/src/index_scan_executor.rs
+++ b/components/tidb_query_executors/src/index_scan_executor.rs
@@ -171,8 +171,11 @@ impl<S: Storage, F: KvFormat> BatchExecutor for BatchIndexScanExecutor<S, F> {
     }
 
     #[inline]
-    fn take_intermediate_results(&mut self, results: &mut [Vec<BatchExecuteResult>]) -> Result<()> {
-        self.0.take_intermediate_results(results)
+    fn consume_and_fill_intermediate_results(
+        &mut self,
+        results: &mut [Vec<BatchExecuteResult>],
+    ) -> Result<()> {
+        self.0.consume_and_fill_intermediate_results(results)
     }
 
     #[inline]

--- a/components/tidb_query_executors/src/interface.rs
+++ b/components/tidb_query_executors/src/interface.rs
@@ -6,14 +6,29 @@
 //! Batch executor common structures.
 
 use async_trait::async_trait;
-pub use tidb_query_common::execute_stats::{
-    ExecSummaryCollector, ExecuteStats, WithSummaryCollector,
-};
+pub use tidb_query_common::execute_stats::{ExecSummaryCollector, ExecuteStats};
 use tidb_query_common::{
     Result, execute_stats::ExecSummaryCollectorEnabled, storage::IntervalRange,
 };
 use tidb_query_datatype::{codec::batch::LazyBatchColumnVec, expr::EvalWarnings};
 use tipb::FieldType;
+
+/// Combines an `ExecSummaryCollector` with another type. This inner type `T`
+/// typically `Executor`/`BatchExecutor`, such that `WithSummaryCollector<C, T>`
+/// would implement the same trait and collects the statistics into `C`.
+pub struct WithSummaryCollector<C: ExecSummaryCollector, T> {
+    pub summary_collector: C,
+    pub inner: T,
+    #[cfg(test)]
+    pub inner_type: &'static str,
+}
+
+impl<C: ExecSummaryCollector, T> WithSummaryCollector<C, T> {
+    #[cfg(test)]
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+}
 
 /// The interface for pull-based executors. It is similar to the Volcano
 /// Iterator model, but pulls data in batch and stores data by column.
@@ -23,6 +38,12 @@ pub trait BatchExecutor: Send {
 
     /// Gets the schema of the output.
     fn schema(&self) -> &[FieldType];
+
+    /// Gets the schema of intermediate result
+    fn intermediate_schema(&self, index: usize) -> Result<&[FieldType]>;
+
+    /// Takes intermediate results from executors
+    fn take_intermediate_results(&mut self, results: &mut [Vec<BatchExecuteResult>]) -> Result<()>;
 
     /// Pulls next several rows of data (stored by column).
     ///
@@ -66,6 +87,8 @@ pub trait BatchExecutor: Send {
         WithSummaryCollector {
             summary_collector: ExecSummaryCollectorEnabled::new(output_index),
             inner: self,
+            #[cfg(test)]
+            inner_type: std::any::type_name::<Self>(),
         }
     }
 }
@@ -76,6 +99,16 @@ impl<T: BatchExecutor + ?Sized> BatchExecutor for Box<T> {
 
     fn schema(&self) -> &[FieldType] {
         (**self).schema()
+    }
+
+    #[inline]
+    fn intermediate_schema(&self, index: usize) -> Result<&[FieldType]> {
+        (**self).intermediate_schema(index)
+    }
+
+    #[inline]
+    fn take_intermediate_results(&mut self, results: &mut [Vec<BatchExecuteResult>]) -> Result<()> {
+        (**self).take_intermediate_results(results)
     }
 
     async fn next_batch(&mut self, scan_rows: usize) -> BatchExecuteResult {
@@ -107,6 +140,16 @@ impl<C: ExecSummaryCollector + Send, T: BatchExecutor> BatchExecutor
 
     fn schema(&self) -> &[FieldType] {
         self.inner.schema()
+    }
+
+    #[inline]
+    fn intermediate_schema(&self, index: usize) -> Result<&[FieldType]> {
+        self.inner.intermediate_schema(index)
+    }
+
+    #[inline]
+    fn take_intermediate_results(&mut self, results: &mut [Vec<BatchExecuteResult>]) -> Result<()> {
+        self.inner.take_intermediate_results(results)
     }
 
     async fn next_batch(&mut self, scan_rows: usize) -> BatchExecuteResult {

--- a/components/tidb_query_executors/src/interface.rs
+++ b/components/tidb_query_executors/src/interface.rs
@@ -42,8 +42,11 @@ pub trait BatchExecutor: Send {
     /// Gets the schema of intermediate result
     fn intermediate_schema(&self, index: usize) -> Result<&[FieldType]>;
 
-    /// Takes intermediate results from executors
-    fn take_intermediate_results(&mut self, results: &mut [Vec<BatchExecuteResult>]) -> Result<()>;
+    /// Consumes the inner intermediate results and fills the arguments vector.
+    fn consume_and_fill_intermediate_results(
+        &mut self,
+        results: &mut [Vec<BatchExecuteResult>],
+    ) -> Result<()>;
 
     /// Pulls next several rows of data (stored by column).
     ///
@@ -107,8 +110,11 @@ impl<T: BatchExecutor + ?Sized> BatchExecutor for Box<T> {
     }
 
     #[inline]
-    fn take_intermediate_results(&mut self, results: &mut [Vec<BatchExecuteResult>]) -> Result<()> {
-        (**self).take_intermediate_results(results)
+    fn consume_and_fill_intermediate_results(
+        &mut self,
+        results: &mut [Vec<BatchExecuteResult>],
+    ) -> Result<()> {
+        (**self).consume_and_fill_intermediate_results(results)
     }
 
     async fn next_batch(&mut self, scan_rows: usize) -> BatchExecuteResult {
@@ -148,8 +154,11 @@ impl<C: ExecSummaryCollector + Send, T: BatchExecutor> BatchExecutor
     }
 
     #[inline]
-    fn take_intermediate_results(&mut self, results: &mut [Vec<BatchExecuteResult>]) -> Result<()> {
-        self.inner.take_intermediate_results(results)
+    fn consume_and_fill_intermediate_results(
+        &mut self,
+        results: &mut [Vec<BatchExecuteResult>],
+    ) -> Result<()> {
+        self.inner.consume_and_fill_intermediate_results(results)
     }
 
     async fn next_batch(&mut self, scan_rows: usize) -> BatchExecuteResult {

--- a/components/tidb_query_executors/src/lib.rs
+++ b/components/tidb_query_executors/src/lib.rs
@@ -43,8 +43,8 @@ mod util;
 
 pub use self::{
     fast_hash_aggr_executor::BatchFastHashAggregationExecutor,
-    index_scan_executor::BatchIndexScanExecutor, limit_executor::BatchLimitExecutor,
-    partition_top_n_executor::BatchPartitionTopNExecutor,
+    index_lookup_executor::BatchIndexLookUpExecutor, index_scan_executor::BatchIndexScanExecutor,
+    limit_executor::BatchLimitExecutor, partition_top_n_executor::BatchPartitionTopNExecutor,
     projection_executor::BatchProjectionExecutor, selection_executor::BatchSelectionExecutor,
     simple_aggr_executor::BatchSimpleAggregationExecutor,
     slow_hash_aggr_executor::BatchSlowHashAggregationExecutor,

--- a/components/tidb_query_executors/src/limit_executor.rs
+++ b/components/tidb_query_executors/src/limit_executor.rs
@@ -22,6 +22,11 @@ impl<Src: BatchExecutor> BatchLimitExecutor<Src> {
             is_src_scan_executor,
         })
     }
+
+    #[cfg(test)]
+    pub fn into_child(self) -> Src {
+        self.src
+    }
 }
 
 #[async_trait]
@@ -31,6 +36,16 @@ impl<Src: BatchExecutor> BatchExecutor for BatchLimitExecutor<Src> {
     #[inline]
     fn schema(&self) -> &[FieldType] {
         self.src.schema()
+    }
+
+    #[inline]
+    fn intermediate_schema(&self, index: usize) -> Result<&[FieldType]> {
+        self.src.intermediate_schema(index)
+    }
+
+    #[inline]
+    fn take_intermediate_results(&mut self, results: &mut [Vec<BatchExecuteResult>]) -> Result<()> {
+        self.src.take_intermediate_results(results)
     }
 
     #[inline]

--- a/components/tidb_query_executors/src/limit_executor.rs
+++ b/components/tidb_query_executors/src/limit_executor.rs
@@ -44,8 +44,11 @@ impl<Src: BatchExecutor> BatchExecutor for BatchLimitExecutor<Src> {
     }
 
     #[inline]
-    fn take_intermediate_results(&mut self, results: &mut [Vec<BatchExecuteResult>]) -> Result<()> {
-        self.src.take_intermediate_results(results)
+    fn consume_and_fill_intermediate_results(
+        &mut self,
+        results: &mut [Vec<BatchExecuteResult>],
+    ) -> Result<()> {
+        self.src.consume_and_fill_intermediate_results(results)
     }
 
     #[inline]

--- a/components/tidb_query_executors/src/partition_top_n_executor.rs
+++ b/components/tidb_query_executors/src/partition_top_n_executor.rs
@@ -306,6 +306,16 @@ impl<Src: BatchExecutor> BatchExecutor for BatchPartitionTopNExecutor<Src> {
         self.src.schema()
     }
 
+    #[inline]
+    fn intermediate_schema(&self, index: usize) -> Result<&[FieldType]> {
+        self.src.intermediate_schema(index)
+    }
+
+    #[inline]
+    fn take_intermediate_results(&mut self, results: &mut [Vec<BatchExecuteResult>]) -> Result<()> {
+        self.src.take_intermediate_results(results)
+    }
+
     /// Implementation of BatchExecutor::next_batch
     /// Memory Control Analysis:
     /// 1. if n > paging_size(1024), this operator won't do anything and just

--- a/components/tidb_query_executors/src/partition_top_n_executor.rs
+++ b/components/tidb_query_executors/src/partition_top_n_executor.rs
@@ -312,8 +312,11 @@ impl<Src: BatchExecutor> BatchExecutor for BatchPartitionTopNExecutor<Src> {
     }
 
     #[inline]
-    fn take_intermediate_results(&mut self, results: &mut [Vec<BatchExecuteResult>]) -> Result<()> {
-        self.src.take_intermediate_results(results)
+    fn consume_and_fill_intermediate_results(
+        &mut self,
+        results: &mut [Vec<BatchExecuteResult>],
+    ) -> Result<()> {
+        self.src.consume_and_fill_intermediate_results(results)
     }
 
     /// Implementation of BatchExecutor::next_batch

--- a/components/tidb_query_executors/src/projection_executor.rs
+++ b/components/tidb_query_executors/src/projection_executor.rs
@@ -155,8 +155,11 @@ impl<Src: BatchExecutor> BatchExecutor for BatchProjectionExecutor<Src> {
     }
 
     #[inline]
-    fn take_intermediate_results(&mut self, results: &mut [Vec<BatchExecuteResult>]) -> Result<()> {
-        self.src.take_intermediate_results(results)
+    fn consume_and_fill_intermediate_results(
+        &mut self,
+        results: &mut [Vec<BatchExecuteResult>],
+    ) -> Result<()> {
+        self.src.consume_and_fill_intermediate_results(results)
     }
 
     #[inline]

--- a/components/tidb_query_executors/src/projection_executor.rs
+++ b/components/tidb_query_executors/src/projection_executor.rs
@@ -54,6 +54,11 @@ fn get_schema_from_exprs(child_schema: &[FieldType], exprs: &[RpnExpression]) ->
 
 impl<Src: BatchExecutor> BatchProjectionExecutor<Src> {
     #[cfg(test)]
+    pub fn into_child(self) -> Src {
+        self.src
+    }
+
+    #[cfg(test)]
     pub fn new_for_test(src: Src, exprs: Vec<RpnExpression>) -> Self {
         let schema = get_schema_from_exprs(src.schema(), &exprs);
         let exprs_len = exprs.len();

--- a/components/tidb_query_executors/src/projection_executor.rs
+++ b/components/tidb_query_executors/src/projection_executor.rs
@@ -150,6 +150,16 @@ impl<Src: BatchExecutor> BatchExecutor for BatchProjectionExecutor<Src> {
     }
 
     #[inline]
+    fn intermediate_schema(&self, index: usize) -> Result<&[FieldType]> {
+        self.src.intermediate_schema(index)
+    }
+
+    #[inline]
+    fn take_intermediate_results(&mut self, results: &mut [Vec<BatchExecuteResult>]) -> Result<()> {
+        self.src.take_intermediate_results(results)
+    }
+
+    #[inline]
     async fn next_batch(&mut self, scan_rows: usize) -> BatchExecuteResult {
         let mut src_result = self.src.next_batch(scan_rows).await;
         let child_schema = self.src.schema();

--- a/components/tidb_query_executors/src/runner.rs
+++ b/components/tidb_query_executors/src/runner.rs
@@ -843,7 +843,7 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
     }
 
     #[inline]
-    fn take_and_encode_intermediate_results(
+    fn consume_and_encode_intermediate_results(
         &mut self,
         chunks: &mut [Vec<Chunk>],
         ctx: &mut EvalContext,
@@ -929,8 +929,11 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
 
         warnings.merge(&mut result.warnings);
         if !self.intermediate_channels.is_empty() {
-            let (r_len, bytes_len) =
-                self.take_and_encode_intermediate_results(intermediate_chunks, ctx, is_streaming)?;
+            let (r_len, bytes_len) = self.consume_and_encode_intermediate_results(
+                intermediate_chunks,
+                ctx,
+                is_streaming,
+            )?;
             record_len += r_len;
             read_bytes_len += bytes_len;
         }
@@ -1670,7 +1673,7 @@ mod tests {
     }
 
     #[test]
-    fn test_take_and_encode_intermediate_results() {
+    fn test_consume_and_encode_intermediate_results() {
         let mut runner = build_simple_runner_for_test();
         runner.intermediate_channels = vec![
             runner::IntermediateOutputChannel {
@@ -1779,7 +1782,7 @@ mod tests {
         let mut ctx = EvalContext::default();
         let mut chunks = vec![vec![exist_chk], vec![]];
         let (record_len, bytes_len) = runner
-            .take_and_encode_intermediate_results(&mut chunks, &mut ctx, false)
+            .consume_and_encode_intermediate_results(&mut chunks, &mut ctx, false)
             .unwrap();
 
         assert_eq!(record_len, 9);

--- a/components/tidb_query_executors/src/runner.rs
+++ b/components/tidb_query_executors/src/runner.rs
@@ -1,6 +1,6 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{convert::TryFrom, sync::Arc};
+use std::{convert::TryFrom, iter, sync::Arc};
 
 use api_version::KvFormat;
 use fail::fail_point;
@@ -15,6 +15,7 @@ use tidb_query_common::{
 };
 use tidb_query_datatype::{
     EvalType, FieldTypeAccessor,
+    codec::table::IntHandle,
     expr::{EvalConfig, EvalContext, EvalWarnings},
 };
 use tikv_util::{
@@ -41,8 +42,17 @@ const BATCH_INITIAL_SIZE: usize = 32;
 // benchmarks.
 pub use tidb_query_expr::types::BATCH_MAX_SIZE;
 
+use crate::{index_lookup_executor::build_index_lookup_executor, interface::BatchExecuteResult};
+
 // TODO: Maybe there can be some better strategy. Needs benchmarks and tunes.
 const BATCH_GROW_FACTOR: usize = 2;
+
+#[derive(Clone, Debug, PartialEq)]
+struct IntermediateOutputChannel {
+    encode_type: EncodeType,
+    output_offsets: Vec<u32>,
+    schema: Vec<FieldType>,
+}
 
 pub struct BatchExecutorsRunner<SS> {
     /// The deadline of this handler. For each check point (e.g. each iteration)
@@ -79,6 +89,13 @@ pub struct BatchExecutorsRunner<SS> {
     paging_size: Option<u64>,
 
     quota_limiter: Arc<QuotaLimiter>,
+
+    /// Information for intermediate output channels.
+    /// For example, the `BatchIndexLookupExecutor` may output the index scan
+    /// results if the primary rows cannot be founded in the local store.
+    intermediate_channels: Vec<IntermediateOutputChannel>,
+    /// Reserved for intermediate results, used to avoid re-allocation.
+    reserved_intermediate_results: Vec<Vec<BatchExecuteResult>>,
 }
 
 // We assign a dummy type `()` so that we can omit the type when calling
@@ -136,6 +153,11 @@ impl BatchExecutorsRunner<()> {
                     BatchProjectionExecutor::check_supported(descriptor)
                         .map_err(|e| other_err!("BatchProjectionExecutor: {}", e))?;
                 }
+                ExecType::TypeIndexLookUp => {
+                    let descriptor = ed.get_index_lookup();
+                    BatchIndexLookUpExecutor::check_supported(descriptor)
+                        .map_err(|e| other_err!("BatchIndexLookUpExecutor: {}", e))?;
+                }
                 ExecType::TypeJoin => {
                     return Err(other_err!("Join executor not implemented"));
                 }
@@ -163,6 +185,15 @@ impl BatchExecutorsRunner<()> {
                 ExecType::TypeExpand2 => {
                     return Err(other_err!("Expand2 executor not implemented"));
                 }
+                ExecType::TypeBroadcastQuery => {
+                    return Err(other_err!("TypeBroadcastQuery executor not implemented"));
+                }
+                ExecType::TypeCteSink => {
+                    return Err(other_err!("TypeCteSink executor not implemented"));
+                }
+                ExecType::TypeCteSource => {
+                    return Err(other_err!("TypeCteSource executor not implemented"));
+                }
             }
         }
 
@@ -178,12 +209,14 @@ fn is_arrow_encodable<'a>(mut schema: impl Iterator<Item = &'a FieldType>) -> bo
 #[allow(clippy::explicit_counter_loop)]
 pub fn build_executors<S: Storage + 'static, F: KvFormat>(
     executor_descriptors: Vec<tipb::Executor>,
+    intermediate_output_descriptors: &[tipb::IntermediateOutputChannel],
     storage: S,
-    _extra_storage_accessor: Option<impl RegionStorageAccessor<Storage = S>>,
+    extra_storage_accessor: Option<impl RegionStorageAccessor<Storage = S> + 'static>,
     ranges: Vec<KeyRange>,
     config: Arc<EvalConfig>,
     is_scanned_range_aware: bool,
 ) -> Result<Box<dyn BatchExecutor<StorageStats = S::Statistics>>> {
+    let executors_len = executor_descriptors.len();
     let mut executor_descriptors = executor_descriptors.into_iter();
     let mut first_ed = executor_descriptors
         .next()
@@ -246,8 +279,24 @@ pub fn build_executors<S: Storage + 'static, F: KvFormat>(
         }
     };
 
-    for mut ed in executor_descriptors {
+    let mut next_parent_index = if first_ed.get_parent_idx() > 0 {
+        first_ed.get_parent_idx() as usize
+    } else {
+        1
+    };
+
+    let mut children = vec![];
+    for item in executor_descriptors.enumerate() {
         summary_slot_index += 1;
+        if summary_slot_index != next_parent_index {
+            if children.is_empty() {
+                children.reserve(next_parent_index - summary_slot_index);
+            }
+            children.push(item);
+            continue;
+        }
+
+        let mut ed = item.1;
 
         executor = match ed.get_tp() {
             ExecType::TypeSelection => {
@@ -407,6 +456,53 @@ pub fn build_executors<S: Storage + 'static, F: KvFormat>(
                     )
                 }
             }
+            ExecType::TypeIndexLookUp => {
+                if children.len() != 1 {
+                    return Err(other_err!(
+                        "IndexLookUp should have one child executor, but got {}",
+                        children.len()
+                    ));
+                }
+
+                let (_, mut child) = children.pop().unwrap();
+                if child.get_tp() != ExecType::TypeTableScan {
+                    return Err(other_err!(
+                        "IndexLookup's child should be TableScan, but got {:?}",
+                        child.get_tp()
+                    ));
+                }
+
+                let channel_ids = intermediate_output_descriptors
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, ch)| {
+                        ch.has_executor_idx() && ch.get_executor_idx() == summary_slot_index as u32
+                    })
+                    .map(|(i, _)| i)
+                    .collect_vec();
+                if channel_ids.len() != 1 {
+                    return Err(other_err!(
+                        "IndexLookup should have exactly one intermediate output channel, but got {}, {:?}",
+                        channel_ids.len(),
+                        channel_ids
+                    ));
+                }
+
+                let tbl_scan = child.take_tbl_scan();
+                if !tbl_scan.get_primary_column_ids().is_empty() {
+                    return Err(other_err!("Common handle is not supported in index lookup"));
+                } else {
+                    let e = build_index_lookup_executor::<_, IntHandle, F>(
+                        config.clone(),
+                        executor,
+                        ed.take_index_lookup(),
+                        tbl_scan,
+                        extra_storage_accessor.clone(),
+                        channel_ids[0],
+                    )?;
+                    Box::new(e.collect_summary(summary_slot_index))
+                }
+            }
             _ => {
                 return Err(other_err!(
                     "Unexpected non-first executor {:?}",
@@ -414,6 +510,30 @@ pub fn build_executors<S: Storage + 'static, F: KvFormat>(
                 ));
             }
         };
+
+        if !children.is_empty() {
+            return Err(other_err!(
+                "Children not handled for executor: {:?}, index: {}",
+                ed.get_tp(),
+                summary_slot_index
+            ));
+        }
+
+        next_parent_index = match ed.get_parent_idx() as usize {
+            // 0 means the natural next executor.
+            0 => summary_slot_index + 1,
+            parent_idx if parent_idx > summary_slot_index && parent_idx < executors_len => {
+                parent_idx
+            }
+            parent_idx => {
+                return Err(other_err!(
+                    "Invalid parent index: {} for executor at index {}",
+                    parent_idx,
+                    summary_slot_index
+                ));
+            }
+        };
+
         is_src_scan_executor = false;
     }
 
@@ -425,7 +545,7 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
         mut req: DagRequest,
         ranges: Vec<KeyRange>,
         storage: S,
-        extra_storage_accessor: Option<impl RegionStorageAccessor<Storage = S>>,
+        extra_storage_accessor: Option<impl RegionStorageAccessor<Storage = S> + 'static>,
         deadline: Deadline,
         stream_row_limit: usize,
         is_streaming: bool,
@@ -437,9 +557,10 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
         let mut config = EvalConfig::from_request(&req)?;
         config.paging_size = paging_size;
         let config = Arc::new(config);
-
+        let intermediate_output_descriptors = req.take_intermediate_output_channels();
         let out_most_executor = build_executors::<_, F>(
             req.take_executors().into(),
+            &intermediate_output_descriptors,
             storage,
             extra_storage_accessor,
             ranges,
@@ -449,30 +570,61 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
                                                     * end where last scan is finished */
         )?;
 
-        // Check output offsets
+        let req_encode_type = req.get_encode_type();
+        let get_encode_type_with_check =
+            |schema: &[FieldType], output_offsets: &[u32]| -> Result<EncodeType> {
+                // Check output offsets
+                let schema_len = schema.len();
+                for offset in output_offsets {
+                    if (*offset as usize) >= schema_len {
+                        return Err(other_err!(
+                            "Invalid output offset (schema has {} columns, access index {})",
+                            schema_len,
+                            offset
+                        ));
+                    }
+                }
+
+                // Only check output schema field types
+                let new_schema = output_offsets.iter().map(|&i| &schema[i as usize]);
+                Ok(if !is_arrow_encodable(new_schema) {
+                    EncodeType::TypeDefault
+                } else {
+                    req_encode_type
+                })
+            };
+
         let output_offsets = req.take_output_offsets();
-        let schema_len = out_most_executor.schema().len();
-        for offset in &output_offsets {
-            if (*offset as usize) >= schema_len {
-                return Err(other_err!(
-                    "Invalid output offset (schema has {} columns, access index {})",
-                    schema_len,
-                    offset
-                ));
-            }
-        }
-
-        // Only check output schema field types
-        let new_schema = output_offsets
-            .iter()
-            .map(|&i| &out_most_executor.schema()[i as usize]);
-        let encode_type = if !is_arrow_encodable(new_schema) {
-            EncodeType::TypeDefault
-        } else {
-            req.get_encode_type()
-        };
-
+        let encode_type = get_encode_type_with_check(out_most_executor.schema(), &output_offsets)?;
         let exec_stats = ExecuteStats::new(executors_len);
+        let intermediate_channels = if !intermediate_output_descriptors.is_empty() {
+            let mut channels = Vec::with_capacity(intermediate_output_descriptors.len());
+            for (idx, mut ch) in intermediate_output_descriptors.into_iter().enumerate() {
+                if !ch.has_executor_idx() || ch.get_executor_idx() >= executors_len as u32 {
+                    return Err(other_err!(
+                        "Invalid intermediate output channel idx: {}, executors len: {}",
+                        if ch.has_executor_idx() {
+                            format!("{}", ch.get_executor_idx())
+                        } else {
+                            "None".to_string()
+                        },
+                        executors_len
+                    ));
+                }
+
+                let schema = out_most_executor.intermediate_schema(idx)?.to_vec();
+                let encode_type = get_encode_type_with_check(&schema, ch.get_output_offsets())?;
+                let output_offsets = ch.take_output_offsets();
+                channels.push(IntermediateOutputChannel {
+                    encode_type,
+                    output_offsets,
+                    schema,
+                });
+            }
+            channels
+        } else {
+            vec![]
+        };
 
         Ok(Self {
             deadline,
@@ -485,6 +637,8 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
             encode_type,
             paging_size,
             quota_limiter,
+            intermediate_channels,
+            reserved_intermediate_results: vec![],
         })
     }
 
@@ -492,6 +646,26 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
         fail_point!("copr_batch_initial_size", |r| r
             .map_or(1, |e| e.parse().unwrap()));
         BATCH_INITIAL_SIZE
+    }
+
+    #[inline]
+    fn set_response_intermediate_outputs(
+        &self,
+        sel_resp: &mut SelectResponse,
+        chunks: Vec<Vec<Chunk>>,
+    ) {
+        sel_resp.set_intermediate_outputs(
+            self.intermediate_channels
+                .iter()
+                .zip(chunks)
+                .map(|(ch, chunks)| {
+                    let mut inter_output = tipb::IntermediateOutput::default();
+                    inter_output.set_encode_type(ch.encode_type);
+                    inter_output.set_chunks(chunks.into());
+                    inter_output
+                })
+                .collect(),
+        )
     }
 
     /// handle_request returns the response of selection and an optional range,
@@ -506,16 +680,24 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
         let mut warnings = self.config.new_eval_warnings();
         let mut ctx = EvalContext::new(self.config.clone());
         let mut record_all = 0;
+        let mut intermediate_output_chunks = if self.intermediate_channels.is_empty() {
+            vec![]
+        } else {
+            iter::repeat_with(Vec::new)
+                .take(self.intermediate_channels.len())
+                .collect_vec()
+        };
 
         loop {
             let mut chunk = Chunk::default();
             let mut sample = self.quota_limiter.new_sample(true);
-            let (drained, record_len) = {
+            let (drained, record_len, read_bytes_len) = {
                 let (cpu_time, res) = sample
                     .observe_cpu_async(self.internal_handle_request(
                         false,
                         batch_size,
                         &mut chunk,
+                        &mut intermediate_output_chunks,
                         &mut warnings,
                         &mut ctx,
                     ))
@@ -523,8 +705,9 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
                 sample.add_cpu_time(cpu_time);
                 res?
             };
-            if chunk.has_rows_data() {
-                sample.add_read_bytes(chunk.get_rows_data().len());
+
+            if read_bytes_len > 0 {
+                sample.add_read_bytes(read_bytes_len);
             }
 
             let quota_delay = self.quota_limiter.consume_sample(sample, true).await;
@@ -535,8 +718,11 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
             }
 
             if record_len > 0 {
-                chunks.push(chunk);
                 record_all += record_len;
+            }
+
+            if chunk.has_rows_data() {
+                chunks.push(chunk);
             }
 
             if drained.stop() || self.paging_size.is_some_and(|p| record_all >= p as usize) {
@@ -553,6 +739,12 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
                 let mut sel_resp = SelectResponse::default();
                 sel_resp.set_chunks(chunks.into());
                 sel_resp.set_encode_type(self.encode_type);
+                if !self.intermediate_channels.is_empty() {
+                    self.set_response_intermediate_outputs(
+                        &mut sel_resp,
+                        intermediate_output_chunks,
+                    );
+                }
 
                 // TODO: output_counts should not be i64. Let's fix it in Coprocessor DAG V2.
                 sel_resp.set_output_counts(
@@ -592,6 +784,12 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
     pub async fn handle_streaming_request(
         &mut self,
     ) -> Result<(Option<(StreamResponse, IntervalRange)>, bool)> {
+        if !self.intermediate_channels.is_empty() {
+            return Err(other_err!(
+                "Intermediate result is not supported in streaming request"
+            ));
+        }
+
         let mut warnings = self.config.new_eval_warnings();
 
         let (mut record_len, mut is_drained) = (0, false);
@@ -603,11 +801,12 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
         while record_len < self.stream_row_limit && !is_drained {
             let mut current_chunk = Chunk::default();
             // TODO: Streaming coprocessor on TiKV is just not enabled in TiDB now.
-            let (drained, len) = self
+            let (drained, len, _) = self
                 .internal_handle_request(
                     true,
                     batch_size.min(self.stream_row_limit - record_len),
                     &mut current_chunk,
+                    &mut [],
                     &mut warnings,
                     &mut ctx,
                 )
@@ -643,64 +842,99 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
         }
     }
 
+    #[inline]
+    fn take_and_encode_intermediate_results(
+        &mut self,
+        chunks: &mut [Vec<Chunk>],
+        ctx: &mut EvalContext,
+        is_streaming: bool,
+    ) -> Result<(usize, usize)> {
+        if self.reserved_intermediate_results.is_empty() {
+            self.reserved_intermediate_results = iter::repeat_with(Vec::new)
+                .take(self.intermediate_channels.len())
+                .collect();
+        }
+
+        let mut intermediate_record_len = 0;
+        let mut chk_byte_size = 0;
+        self.out_most_executor
+            .take_intermediate_results(&mut self.reserved_intermediate_results)?;
+        for (i, results) in self.reserved_intermediate_results.iter_mut().enumerate() {
+            if results.is_empty() {
+                continue;
+            }
+
+            let ch = &self.intermediate_channels[i];
+            for mut r in results.drain(..) {
+                let local_rows_len = r.logical_rows.len();
+                if local_rows_len > 0 {
+                    let mut chk = Chunk::default();
+                    encode_result_to_chunk(
+                        ctx,
+                        is_streaming,
+                        ch.encode_type,
+                        &ch.schema,
+                        &ch.output_offsets,
+                        &mut r,
+                        &mut chk,
+                    )?;
+                    intermediate_record_len += local_rows_len;
+                    chk_byte_size += chk.get_rows_data().len();
+                    chunks[i].push(chk);
+                }
+            }
+        }
+        Ok((intermediate_record_len, chk_byte_size))
+    }
+
     async fn internal_handle_request(
         &mut self,
         is_streaming: bool,
         batch_size: usize,
         chunk: &mut Chunk,
+        intermediate_chunks: &mut [Vec<Chunk>],
         warnings: &mut EvalWarnings,
         ctx: &mut EvalContext,
-    ) -> Result<(BatchExecIsDrain, usize)> {
+    ) -> Result<(BatchExecIsDrain, usize, usize)> {
         let mut record_len = 0;
+        let mut read_bytes_len = 0;
 
         self.deadline.check()?;
 
         let mut result = self.out_most_executor.next_batch(batch_size).await;
-
-        let is_drained = result.is_drained?;
+        let is_drained = match result.is_drained {
+            Err(err) => return Err(err),
+            Ok(is_drained) => is_drained,
+        };
 
         if !result.logical_rows.is_empty() {
             assert_eq!(
                 result.physical_columns.columns_len(),
                 self.out_most_executor.schema().len()
             );
-            {
-                let data = chunk.mut_rows_data();
-                // Although `schema()` can be deeply nested, it is ok since we process data in
-                // batch.
-                if is_streaming || self.encode_type == EncodeType::TypeDefault {
-                    data.reserve(
-                        result
-                            .physical_columns
-                            .maximum_encoded_size(&result.logical_rows, &self.output_offsets),
-                    );
-                    result.physical_columns.encode(
-                        &result.logical_rows,
-                        &self.output_offsets,
-                        self.out_most_executor.schema(),
-                        data,
-                        ctx,
-                    )?;
-                } else {
-                    data.reserve(
-                        result
-                            .physical_columns
-                            .maximum_encoded_size_chunk(&result.logical_rows, &self.output_offsets),
-                    );
-                    result.physical_columns.encode_chunk(
-                        &result.logical_rows,
-                        &self.output_offsets,
-                        self.out_most_executor.schema(),
-                        data,
-                        ctx,
-                    )?;
-                }
-            }
+            encode_result_to_chunk(
+                ctx,
+                is_streaming,
+                self.encode_type,
+                self.out_most_executor.schema(),
+                &self.output_offsets,
+                &mut result,
+                chunk,
+            )?;
             record_len += result.logical_rows.len();
+            if chunk.has_rows_data() {
+                read_bytes_len += chunk.get_rows_data().len();
+            }
         }
 
         warnings.merge(&mut result.warnings);
-        Ok((is_drained, record_len))
+        if !self.intermediate_channels.is_empty() {
+            let (r_len, bytes_len) =
+                self.take_and_encode_intermediate_results(intermediate_chunks, ctx, is_streaming)?;
+            record_len += r_len;
+            read_bytes_len += bytes_len;
+        }
+        Ok((is_drained, record_len, read_bytes_len))
     }
 
     fn make_stream_response(
@@ -732,6 +966,46 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
 }
 
 #[inline]
+fn encode_result_to_chunk(
+    ctx: &mut EvalContext,
+    is_streaming: bool,
+    encode_type: EncodeType,
+    schema: &[FieldType],
+    output_offsets: &[u32],
+    result: &mut BatchExecuteResult,
+    chunk: &mut Chunk,
+) -> Result<()> {
+    let data = chunk.mut_rows_data();
+    // Although `schema()` can be deeply nested, it is ok since we process data in
+    // batch.
+    if is_streaming || encode_type == EncodeType::TypeDefault {
+        data.reserve(
+            result
+                .physical_columns
+                .maximum_encoded_size(&result.logical_rows, output_offsets),
+        );
+        result
+            .physical_columns
+            .encode(&result.logical_rows, output_offsets, schema, data, ctx)?;
+    } else {
+        data.reserve(
+            result
+                .physical_columns
+                .maximum_encoded_size_chunk(&result.logical_rows, output_offsets),
+        );
+        result.physical_columns.encode_chunk(
+            &result.logical_rows,
+            output_offsets,
+            schema,
+            data,
+            ctx,
+        )?;
+    }
+
+    Ok(())
+}
+
+#[inline]
 fn batch_grow_factor() -> usize {
     fail_point!("copr_batch_grow_size", |r| r
         .map_or(1, |e| e.parse().unwrap()));
@@ -745,5 +1019,1056 @@ fn grow_batch_size(batch_size: &mut usize) {
         if *batch_size > BATCH_MAX_SIZE {
             *batch_size = BATCH_MAX_SIZE
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{any::type_name, time::Duration};
+
+    use api_version::ApiV1;
+    use futures::executor::block_on;
+    use kvproto::metapb::Region;
+    use tidb_query_common::execute_stats::ExecSummaryCollectorEnabled;
+    use tidb_query_datatype::{
+        FieldTypeTp,
+        codec::{
+            Datum,
+            batch::LazyBatchColumnVec,
+            chunk,
+            data_type::{Real, VectorValue},
+            datum,
+            mysql::{Time, TimeType},
+        },
+        expr::{Flag, SqlMode},
+    };
+    use tipb::*;
+    use tipb_helper::ExprDefBuilder;
+
+    use super::*;
+    use crate::{
+        index_lookup_executor::{AccessorTableTaskIterBuilder, IndexLayout, TableScanParams},
+        interface::WithSummaryCollector,
+        util::{
+            mock_executor::{MockExecutor, MockRegionStorageAccessor, MockStorage},
+            scan_executor::field_type_from_column_info,
+        },
+    };
+
+    fn check_chunk(
+        ctx: &mut EvalContext,
+        expect_rows: Vec<Vec<Datum>>,
+        chk: Chunk,
+        field_types: &[FieldType],
+        encode_type: EncodeType,
+    ) {
+        let mut expect_rows_iter = expect_rows.into_iter();
+        let mut rows_data = chk.get_rows_data();
+        assert!(!rows_data.is_empty());
+        match encode_type {
+            EncodeType::TypeDefault => {
+                let mut datum_iter = datum::decode(&mut rows_data).unwrap().into_iter();
+                for expect_row in expect_rows_iter {
+                    let mut actual_row = Vec::with_capacity(field_types.len());
+                    for field_type in field_types {
+                        let mut datum = datum_iter.next().unwrap();
+                        if field_type.tp() == FieldTypeTp::Date
+                            || field_type.tp() == FieldTypeTp::DateTime
+                            || field_type.tp() == FieldTypeTp::Timestamp
+                        {
+                            if let Datum::U64(n) = &mut datum {
+                                let t = Time::from_packed_u64(
+                                    ctx,
+                                    *n,
+                                    TimeType::try_from(field_type.tp()).unwrap(),
+                                    0,
+                                )
+                                .unwrap();
+                                datum = Datum::Time(t);
+                            } else {
+                                panic!("expect u64, got {:?}", datum);
+                            }
+                        }
+                        actual_row.push(datum);
+                    }
+                    assert_eq!(expect_row, actual_row);
+                }
+                assert!(datum_iter.next().is_none());
+            }
+            EncodeType::TypeChunk => {
+                let rows = chunk::Chunk::decode_for_test(&mut rows_data, field_types).unwrap();
+                let row_iter = chunk::RowIterator::new(&rows);
+                for row in row_iter {
+                    assert_eq!(row.len(), field_types.len());
+                    let actual_row = (0..field_types.len())
+                        .map(|i| row.get_datum(i, &field_types[i]).unwrap())
+                        .collect_vec();
+                    let expect_row = expect_rows_iter.next().unwrap();
+                    assert_eq!(expect_row, actual_row);
+                }
+                assert!(expect_rows_iter.next().is_none());
+            }
+            _ => {
+                panic!("unsupported encode type {:?}", encode_type);
+            }
+        }
+    }
+
+    type BoxedExecutor = Box<dyn BatchExecutor<StorageStats = ()>>;
+
+    type IndexScanExecutor = BatchIndexScanExecutor<MockStorage, ApiV1>;
+
+    fn index_scan_descriptor(
+        table_id: i64,
+        index_id: i64,
+        columns_info: Vec<ColumnInfo>,
+    ) -> Executor {
+        let mut exec = Executor::default();
+        exec.set_tp(ExecType::TypeIndexScan);
+        let mut idx_scan = IndexScan::default();
+        idx_scan.set_table_id(table_id);
+        idx_scan.set_index_id(index_id);
+        idx_scan.set_columns(columns_info.into());
+        exec.set_idx_scan(idx_scan);
+        exec
+    }
+
+    fn table_scan_descriptor(table_id: i64, columns_info: Vec<ColumnInfo>) -> Executor {
+        let mut exec = Executor::default();
+        exec.set_tp(ExecType::TypeTableScan);
+        let mut tbl_scan = TableScan::default();
+        tbl_scan.set_table_id(table_id);
+        tbl_scan.set_columns(columns_info.into());
+        exec.set_tbl_scan(tbl_scan);
+        exec
+    }
+
+    type IndexLookupExecutor = BatchIndexLookUpExecutor<
+        MockStorage,
+        BoxedExecutor,
+        AccessorTableTaskIterBuilder<MockRegionStorageAccessor, IntHandle>,
+        ApiV1,
+    >;
+
+    fn index_lookup_descriptor(index_handle_offsets: Vec<u32>) -> Executor {
+        use tipb::{ExecType, IndexLookUp};
+        let mut exec = Executor::default();
+        exec.set_tp(ExecType::TypeIndexLookUp);
+        let mut idx_lookup = IndexLookUp::default();
+        idx_lookup.set_index_handle_offsets(index_handle_offsets);
+        exec.set_index_lookup(idx_lookup);
+        exec
+    }
+
+    type LimitExecutor = BatchLimitExecutor<BoxedExecutor>;
+
+    fn limit_descriptor(limit: u64) -> Executor {
+        let mut exec = Executor::default();
+        exec.set_tp(ExecType::TypeLimit);
+        let mut limit_exec = Limit::default();
+        limit_exec.set_limit(limit);
+        exec.set_limit(limit_exec);
+        exec
+    }
+
+    type SelectionExecutor = BatchSelectionExecutor<BoxedExecutor>;
+
+    fn selection_descriptor(conditions: Vec<Expr>) -> Executor {
+        let mut exec = Executor::default();
+        exec.set_tp(ExecType::TypeSelection);
+        let mut selection = Selection::default();
+        selection.set_conditions(conditions.into());
+        exec.set_selection(selection);
+        exec
+    }
+
+    fn column_with_type(col_id: i64, tp: FieldTypeTp) -> ColumnInfo {
+        let mut col = ColumnInfo::default();
+        col.set_column_id(col_id);
+        col.set_tp(tp as i32);
+        col
+    }
+
+    fn cast_as_summary<T: BatchExecutor<StorageStats = ()>>(
+        executor: Box<dyn BatchExecutor<StorageStats = ()>>,
+    ) -> Box<WithSummaryCollector<ExecSummaryCollectorEnabled, T>> {
+        unsafe {
+            let exec = Box::into_raw(executor)
+                as *mut WithSummaryCollector<ExecSummaryCollectorEnabled, T>;
+            let summary = Box::from_raw(exec);
+            assert_eq!(type_name::<T>(), summary.inner_type);
+            summary
+        }
+    }
+
+    fn build_runner_for_test(req: DagRequest) -> Result<BatchExecutorsRunner<()>> {
+        BatchExecutorsRunner::from_request::<_, ApiV1>(
+            req,
+            vec![],
+            MockStorage(Region::default(), vec![]),
+            Some(MockRegionStorageAccessor::with_expect_mode()),
+            Deadline::from_now(Duration::from_secs(300)),
+            1024,
+            false,
+            None,
+            Arc::new(QuotaLimiter::default()),
+        )
+    }
+
+    fn build_simple_runner_for_test() -> BatchExecutorsRunner<()> {
+        let mut dag = DagRequest::default();
+        dag.set_executors(
+            vec![table_scan_descriptor(
+                1,
+                vec![column_with_type(1, FieldTypeTp::Long)],
+            )]
+            .into(),
+        );
+        dag.set_output_offsets(vec![0]);
+        dag.set_encode_type(EncodeType::TypeChunk);
+        build_runner_for_test(dag).unwrap()
+    }
+
+    fn build_simple_result_for_test(cols: Vec<VectorValue>) -> BatchExecuteResult {
+        let logical_rows = if cols.is_empty() {
+            vec![]
+        } else {
+            (0..cols[0].len()).collect()
+        };
+        BatchExecuteResult {
+            physical_columns: LazyBatchColumnVec::from(cols),
+            logical_rows,
+            warnings: EvalWarnings::default(),
+            is_drained: Ok(BatchExecIsDrain::Remain),
+        }
+    }
+
+    fn build_int_result_for_test(vals: Vec<i64>) -> BatchExecuteResult {
+        build_simple_result_for_test(vec![VectorValue::Int(
+            vals.iter().map(|&v| Some(v)).collect_vec().into(),
+        )])
+    }
+
+    fn build_n_rows_int_result(base: i64, n: i64) -> BatchExecuteResult {
+        build_int_result_for_test((0..n).map(|v| v + base).collect())
+    }
+
+    #[test]
+    fn test_build_index_lookup_executors() {
+        let index_columns = vec![
+            column_with_type(2, FieldTypeTp::String),
+            column_with_type(1, FieldTypeTp::LongLong),
+        ];
+        let table_columns = vec![
+            column_with_type(1, FieldTypeTp::LongLong),
+            column_with_type(2, FieldTypeTp::String),
+        ];
+        let descriptors = vec![
+            index_scan_descriptor(123, 456, index_columns.clone()),
+            {
+                let mut descriptor = limit_descriptor(128);
+                descriptor.set_parent_idx(3);
+                descriptor
+            },
+            table_scan_descriptor(456, table_columns.clone()),
+            index_lookup_descriptor(vec![1]),
+            selection_descriptor(vec![
+                ExprDefBuilder::column_ref(0, FieldTypeTp::LongLong).build(),
+            ]),
+        ];
+
+        let intermediate_output_channels = vec![
+            {
+                let mut ch = tipb::IntermediateOutputChannel::default();
+                ch.set_executor_idx(2);
+                ch.set_output_offsets(vec![2, 3]);
+                ch
+            },
+            {
+                let mut ch = tipb::IntermediateOutputChannel::default();
+                ch.set_executor_idx(3);
+                ch.set_output_offsets(vec![2, 3]);
+                ch
+            },
+        ];
+
+        let mut cfg = EvalConfig::default();
+        cfg.set_sql_mode(SqlMode::NO_ZERO_DATE | SqlMode::INVALID_DATES);
+        cfg.set_flag(Flag::IN_UPDATE_OR_DELETE_STMT);
+        cfg.set_div_precision_incr(1);
+
+        fn build_executors_for_test(
+            cfg: &EvalConfig,
+            descriptors: Vec<Executor>,
+            intermediate_output_channels: &[tipb::IntermediateOutputChannel],
+        ) -> Result<Box<dyn BatchExecutor<StorageStats = ()>>> {
+            build_executors::<_, ApiV1>(
+                descriptors,
+                intermediate_output_channels,
+                MockStorage(Region::default(), vec![]),
+                Some(MockRegionStorageAccessor::with_expect_mode()),
+                vec![],
+                Arc::new(cfg.clone()),
+                false,
+            )
+        }
+
+        let mut executor =
+            build_executors_for_test(&cfg, descriptors.clone(), &intermediate_output_channels)
+                .unwrap();
+
+        // intermediate_schema 1 should work
+        assert_eq!(
+            executor.intermediate_schema(1).unwrap(),
+            index_columns
+                .iter()
+                .map(field_type_from_column_info)
+                .collect_vec()
+                .as_slice()
+        );
+
+        // other intermediate_schema should return error
+        let err = executor.intermediate_schema(0).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("The intermediate schema is not found until root executor, index: 0")
+        );
+        let err = executor.intermediate_schema(2).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("The intermediate schema is not found until root executor, index: 2")
+        );
+
+        let check_index_lookup_executor = |executor: &IndexLookupExecutor| {
+            // schema should use the table scan's schema
+            assert_eq!(
+                executor.schema(),
+                table_columns
+                    .iter()
+                    .map(field_type_from_column_info)
+                    .collect_vec()
+                    .as_slice()
+            );
+
+            // cfg should equal
+            let config = executor.config();
+            assert_eq!(config.flag, cfg.flag);
+            assert_eq!(config.div_precision_increment, cfg.div_precision_increment);
+            assert_eq!(config.sql_mode, cfg.sql_mode);
+
+            // check table scan params
+            assert_eq!(
+                &TableScanParams {
+                    columns_info: table_columns.clone(),
+                    primary_column_ids: vec![],
+                    primary_prefix_column_ids: vec![],
+                },
+                executor.get_table_scan_params()
+            );
+
+            // check table task iter builder
+            let builder = executor.get_table_task_builder().unwrap();
+            assert_eq!(456, builder.table_id());
+            assert_eq!(
+                &IndexLayout {
+                    handle_types: vec![field_type_from_column_info(index_columns.get(1).unwrap())],
+                    handle_offsets: vec![1],
+                },
+                builder.get_index_layout()
+            );
+
+            // check intermediate channel index
+            assert_eq!(1, executor.intermediate_channel_index());
+        };
+
+        // check the executors from top to down:
+        // Selection <- IndexLookUp <- Limit <- IndexScan
+        let summary = cast_as_summary::<SelectionExecutor>(executor);
+        assert_eq!(4, summary.summary_collector.get_output_index());
+        executor = summary.into_inner().into_child();
+        let summary = cast_as_summary::<IndexLookupExecutor>(executor);
+        assert_eq!(3, summary.summary_collector.get_output_index());
+        let index_lookup = summary.into_inner();
+        check_index_lookup_executor(&index_lookup);
+        executor = index_lookup.into_index_child();
+        let summary = cast_as_summary::<LimitExecutor>(executor);
+        assert_eq!(1, summary.summary_collector.get_output_index());
+        executor = summary.into_inner().into_child();
+        let summary = cast_as_summary::<IndexScanExecutor>(executor);
+        assert_eq!(0, summary.summary_collector.get_output_index());
+
+        // intermediate channels don't match
+        assert!(
+            build_executors_for_test(&cfg, descriptors.clone(), &[])
+                .err()
+                .unwrap()
+                .to_string()
+                .contains("IndexLookup should have exactly one intermediate output channel")
+        );
+        assert!(
+            build_executors_for_test(
+                &cfg,
+                descriptors.clone(),
+                &[intermediate_output_channels[0].clone()],
+            )
+            .err()
+            .unwrap()
+            .to_string()
+            .contains("IndexLookup should have exactly one intermediate output channel")
+        );
+        assert!(
+            build_executors_for_test(
+                &cfg,
+                descriptors.clone(),
+                &[intermediate_output_channels[1].clone(), {
+                    let mut ch = tipb::IntermediateOutputChannel::default();
+                    ch.set_executor_idx(3);
+                    ch.set_output_offsets(vec![2, 3]);
+                    ch
+                }],
+            )
+            .err()
+            .unwrap()
+            .to_string()
+            .contains("IndexLookup should have exactly one intermediate output channel")
+        );
+
+        // the IndexLookup's probe side has more than 1 executor
+        let err = build_executors_for_test(
+            &cfg,
+            vec![
+                index_scan_descriptor(123, 456, index_columns.clone()),
+                {
+                    let mut descriptor = limit_descriptor(128);
+                    descriptor.set_parent_idx(4);
+                    descriptor
+                },
+                table_scan_descriptor(456, table_columns.clone()),
+                limit_descriptor(10),
+                index_lookup_descriptor(vec![1]),
+                selection_descriptor(vec![
+                    ExprDefBuilder::column_ref(0, FieldTypeTp::LongLong).build(),
+                ]),
+            ],
+            &intermediate_output_channels,
+        )
+        .err()
+        .unwrap();
+        assert!(
+            err.to_string()
+                .contains("IndexLookUp should have one child executor, but got 2")
+        );
+
+        // the IndexLookup's probe side executor is not TableScan
+        let mut err_descriptors = descriptors.clone();
+        err_descriptors[2] = index_scan_descriptor(123, 123, index_columns.clone());
+        assert!(
+            build_executors_for_test(&cfg, err_descriptors, &intermediate_output_channels)
+                .err()
+                .unwrap()
+                .to_string()
+                .contains("IndexLookup's child should be TableScan, but got TypeIndexScan")
+        );
+    }
+
+    #[test]
+    fn test_build_runner_with_index_lookup() {
+        let index_columns = vec![
+            column_with_type(3, FieldTypeTp::String),
+            column_with_type(1, FieldTypeTp::LongLong),
+            column_with_type(5, FieldTypeTp::Geometry),
+        ];
+        let table_columns = vec![
+            column_with_type(1, FieldTypeTp::LongLong),
+            column_with_type(2, FieldTypeTp::Float),
+            column_with_type(3, FieldTypeTp::String),
+            column_with_type(4, FieldTypeTp::Timestamp),
+            column_with_type(5, FieldTypeTp::Geometry),
+        ];
+        let descriptors = vec![
+            {
+                let mut descriptor = index_scan_descriptor(123, 456, index_columns.clone());
+                descriptor.set_parent_idx(2);
+                descriptor
+            },
+            table_scan_descriptor(456, table_columns.clone()),
+            index_lookup_descriptor(vec![1]),
+        ];
+
+        let mut req = DagRequest::default();
+        req.set_executors(descriptors.clone().into());
+        req.set_output_offsets(vec![0, 3]);
+        req.set_intermediate_output_channels(
+            vec![{
+                let mut ch = tipb::IntermediateOutputChannel::default();
+                ch.set_executor_idx(2);
+                ch.set_output_offsets(vec![1, 0]);
+                ch
+            }]
+            .into(),
+        );
+        req.set_encode_type(EncodeType::TypeChunk);
+        // normal build
+        let runner = build_runner_for_test(req.clone()).unwrap();
+        assert_eq!(runner.encode_type, EncodeType::TypeChunk);
+        assert_eq!(runner.output_offsets, vec![0, 3]);
+        let mut expected_intermediate_channels = vec![runner::IntermediateOutputChannel {
+            encode_type: EncodeType::TypeChunk,
+            output_offsets: vec![1, 0],
+            schema: index_columns
+                .iter()
+                .map(field_type_from_column_info)
+                .collect(),
+        }];
+        assert_eq!(runner.intermediate_channels, expected_intermediate_channels);
+        assert_eq!(0, runner.reserved_intermediate_results.len());
+
+        // main output falls back to default encode
+        req.set_output_offsets(vec![0, 4]);
+        let runner = build_runner_for_test(req.clone()).unwrap();
+        assert_eq!(runner.encode_type, EncodeType::TypeDefault);
+        assert_eq!(runner.output_offsets, vec![0, 4]);
+        assert_eq!(runner.intermediate_channels, expected_intermediate_channels);
+        assert_eq!(0, runner.reserved_intermediate_results.len());
+
+        // intermediate output falls back to default encode
+        req.set_output_offsets(vec![0, 3]);
+        req.mut_intermediate_output_channels()
+            .get_mut(0)
+            .unwrap()
+            .set_output_offsets(vec![2, 0]);
+        let runner = build_runner_for_test(req.clone()).unwrap();
+        assert_eq!(runner.encode_type, EncodeType::TypeChunk);
+        assert_eq!(runner.output_offsets, vec![0, 3]);
+        expected_intermediate_channels[0].encode_type = EncodeType::TypeDefault;
+        expected_intermediate_channels[0].output_offsets = vec![2, 0];
+        assert_eq!(runner.intermediate_channels, expected_intermediate_channels);
+        assert_eq!(0, runner.reserved_intermediate_results.len());
+
+        // both fall back to default encode
+        req.set_output_offsets(vec![0, 4]);
+        let runner = build_runner_for_test(req.clone()).unwrap();
+        assert_eq!(runner.encode_type, EncodeType::TypeDefault);
+        assert_eq!(runner.output_offsets, vec![0, 4]);
+        assert_eq!(runner.intermediate_channels, expected_intermediate_channels);
+        assert_eq!(0, runner.reserved_intermediate_results.len());
+
+        // an intermediate channel doesn't refer to any executor
+        req.mut_intermediate_output_channels().push({
+            let mut ch = tipb::IntermediateOutputChannel::default();
+            ch.set_executor_idx(3);
+            ch.set_output_offsets(vec![0]);
+            ch
+        });
+        let err = build_runner_for_test(req.clone()).err().unwrap();
+        assert!(
+            err.to_string()
+                .contains("Invalid intermediate output channel idx: 3")
+        );
+        req.mut_intermediate_output_channels()[1].clear_executor_idx();
+        let err = build_runner_for_test(req.clone()).err().unwrap();
+        assert!(
+            err.to_string()
+                .contains("Invalid intermediate output channel idx: None")
+        );
+    }
+
+    fn parse_timestamp(s: &str) -> Time {
+        Time::parse_timestamp(&mut EvalContext::default(), s, 0, false).unwrap()
+    }
+
+    #[test]
+    fn test_encode_result_to_chunk() {
+        let mut cfg = EvalConfig::default();
+        // set the time zone to test the time zone conversion
+        cfg.set_time_zone_by_offset(3 * 3600).unwrap();
+        let mut ctx = EvalContext::new(Arc::new(cfg));
+
+        let field_types: Vec<FieldType> = vec![
+            FieldTypeTp::LongLong.into(),
+            FieldTypeTp::String.into(),
+            FieldTypeTp::LongLong.into(),
+            FieldTypeTp::Timestamp.into(),
+        ];
+        let output_offsets = vec![3, 0, 1];
+        let output_field_types = output_offsets
+            .iter()
+            .map(|&i| field_types[i as usize].clone())
+            .collect_vec();
+
+        let mut result = BatchExecuteResult {
+            physical_columns: LazyBatchColumnVec::from(vec![
+                VectorValue::Int(vec![Some(1), Some(2), Some(3), Some(4), Some(5)].into()),
+                VectorValue::Bytes(
+                    vec![
+                        Some(b"1a".to_vec()),
+                        Some(b"2b".to_vec()),
+                        Some(b"3c".to_vec()),
+                        Some(b"4d".to_vec()),
+                        Some(b"5e".to_vec()),
+                    ]
+                    .into(),
+                ),
+                VectorValue::Int(vec![Some(11), Some(21), Some(31), Some(14), Some(15)].into()),
+                VectorValue::DateTime(
+                    vec![
+                        Some(parse_timestamp("2021-07-01 01:02:01")),
+                        Some(parse_timestamp("2021-07-01 01:02:02")),
+                        Some(parse_timestamp("2021-07-01 01:02:03")),
+                        Some(parse_timestamp("2021-07-01 01:02:04")),
+                        Some(parse_timestamp("2021-07-01 01:02:05")),
+                    ]
+                    .into(),
+                ),
+            ]),
+            logical_rows: vec![4, 1, 2],
+            warnings: EvalWarnings::default(),
+            is_drained: Ok(BatchExecIsDrain::Remain),
+        };
+
+        let expected_rows = vec![
+            vec![
+                Datum::Time(parse_timestamp("2021-07-01 01:02:05")),
+                Datum::I64(5),
+                Datum::Bytes(b"5e".to_vec()),
+            ],
+            vec![
+                Datum::Time(parse_timestamp("2021-07-01 01:02:02")),
+                Datum::I64(2),
+                Datum::Bytes(b"2b".to_vec()),
+            ],
+            vec![
+                Datum::Time(parse_timestamp("2021-07-01 01:02:03")),
+                Datum::I64(3),
+                Datum::Bytes(b"3c".to_vec()),
+            ],
+        ];
+
+        let mut check_encode_with_type = |tp| {
+            let mut chk = Chunk::default();
+            encode_result_to_chunk(
+                &mut ctx,
+                false,
+                tp,
+                &field_types,
+                &output_offsets,
+                &mut result,
+                &mut chk,
+            )
+            .unwrap();
+            check_chunk(
+                &mut ctx,
+                expected_rows.clone(),
+                chk,
+                &output_field_types,
+                tp,
+            )
+        };
+
+        check_encode_with_type(EncodeType::TypeDefault);
+        check_encode_with_type(EncodeType::TypeChunk);
+    }
+
+    #[test]
+    fn test_take_and_encode_intermediate_results() {
+        let mut runner = build_simple_runner_for_test();
+        runner.intermediate_channels = vec![
+            runner::IntermediateOutputChannel {
+                encode_type: EncodeType::TypeDefault,
+                output_offsets: vec![0, 2],
+                schema: vec![
+                    FieldTypeTp::Long.into(),
+                    FieldTypeTp::Float.into(),
+                    FieldTypeTp::String.into(),
+                ],
+            },
+            runner::IntermediateOutputChannel {
+                encode_type: EncodeType::TypeChunk,
+                output_offsets: vec![2, 1],
+                schema: vec![
+                    FieldTypeTp::String.into(),
+                    FieldTypeTp::Long.into(),
+                    FieldTypeTp::Timestamp.into(),
+                ],
+            },
+        ];
+
+        let output_types = [
+            vec![FieldTypeTp::Long.into(), FieldTypeTp::String.into()],
+            vec![FieldTypeTp::Timestamp.into(), FieldTypeTp::Long.into()],
+        ];
+
+        let mut executor1 = MockExecutor::new(
+            vec![FieldTypeTp::Long.into()],
+            vec![BatchExecuteResult {
+                physical_columns: LazyBatchColumnVec::empty(),
+                logical_rows: vec![],
+                warnings: EvalWarnings::default(),
+                is_drained: Ok(BatchExecIsDrain::Remain),
+            }],
+        );
+        executor1.intermediate_schema = Some((1, runner.intermediate_channels[1].schema.clone()));
+        executor1.set_next_intermediate_results(vec![build_simple_result_for_test(vec![
+            VectorValue::Bytes(
+                vec![
+                    Some(b"10a".to_vec()),
+                    Some(b"20b".to_vec()),
+                    Some(b"30c".to_vec()),
+                ]
+                .into(),
+            ),
+            VectorValue::Int(vec![Some(101), Some(102), Some(103)].into()),
+            VectorValue::DateTime(
+                vec![
+                    Some(parse_timestamp("2025-07-01 01:02:01")),
+                    Some(parse_timestamp("2025-07-01 01:02:02")),
+                    Some(parse_timestamp("2025-07-01 01:02:03")),
+                ]
+                .into(),
+            ),
+        ])]);
+
+        let mut executor0 = MockExecutor::new_with_child(executor1);
+        executor0.intermediate_schema = Some((0, runner.intermediate_channels[0].schema.clone()));
+        executor0.set_next_intermediate_results(vec![
+            build_simple_result_for_test(vec![
+                VectorValue::Int(vec![Some(1), Some(2), Some(3)].into()),
+                VectorValue::Real(
+                    vec![
+                        Real::new(2.1).ok(),
+                        Real::new(2.2).ok(),
+                        Real::new(2.3).ok(),
+                    ]
+                    .into(),
+                ),
+                VectorValue::Bytes(
+                    vec![
+                        Some(b"1a".to_vec()),
+                        Some(b"2b".to_vec()),
+                        Some(b"3c".to_vec()),
+                    ]
+                    .into(),
+                ),
+            ]),
+            // empty result should not encode to chunk
+            build_simple_result_for_test(vec![]),
+            build_simple_result_for_test(vec![
+                VectorValue::Int(vec![Some(11), Some(12), Some(13)].into()),
+                VectorValue::Real(
+                    vec![
+                        Real::new(12.1).ok(),
+                        Real::new(12.2).ok(),
+                        Real::new(12.3).ok(),
+                    ]
+                    .into(),
+                ),
+                VectorValue::Bytes(
+                    vec![
+                        Some(b"1d".to_vec()),
+                        Some(b"2e".to_vec()),
+                        Some(b"3f".to_vec()),
+                    ]
+                    .into(),
+                ),
+            ]),
+        ]);
+
+        let mut exist_chk = Chunk::default();
+        exist_chk.mut_rows_data().push(97);
+        runner.out_most_executor = Box::new(executor0);
+        let mut ctx = EvalContext::default();
+        let mut chunks = vec![vec![exist_chk], vec![]];
+        let (record_len, bytes_len) = runner
+            .take_and_encode_intermediate_results(&mut chunks, &mut ctx, false)
+            .unwrap();
+
+        assert_eq!(record_len, 9);
+        assert_eq!(
+            bytes_len,
+            chunks[0][1].get_rows_data().len()
+                + chunks[0][2].get_rows_data().len()
+                + chunks[1][0].get_rows_data().len()
+        );
+        assert_eq!(chunks[0].len(), 3);
+        assert_eq!(chunks[1].len(), 1);
+
+        // exist chunk should not change
+        assert_eq!(chunks[0][0].get_rows_data(), &[97]);
+        check_chunk(
+            &mut ctx,
+            vec![
+                vec![Datum::I64(1), Datum::Bytes(b"1a".to_vec())],
+                vec![Datum::I64(2), Datum::Bytes(b"2b".to_vec())],
+                vec![Datum::I64(3), Datum::Bytes(b"3c".to_vec())],
+            ],
+            chunks[0][1].clone(),
+            &output_types[0],
+            runner.intermediate_channels[0].encode_type,
+        );
+        check_chunk(
+            &mut ctx,
+            vec![
+                vec![Datum::I64(11), Datum::Bytes(b"1d".to_vec())],
+                vec![Datum::I64(12), Datum::Bytes(b"2e".to_vec())],
+                vec![Datum::I64(13), Datum::Bytes(b"3f".to_vec())],
+            ],
+            chunks[0][2].clone(),
+            &output_types[0],
+            runner.intermediate_channels[0].encode_type,
+        );
+        check_chunk(
+            &mut ctx,
+            vec![
+                vec![
+                    Datum::Time(parse_timestamp("2025-07-01 01:02:01")),
+                    Datum::I64(101),
+                ],
+                vec![
+                    Datum::Time(parse_timestamp("2025-07-01 01:02:02")),
+                    Datum::I64(102),
+                ],
+                vec![
+                    Datum::Time(parse_timestamp("2025-07-01 01:02:03")),
+                    Datum::I64(103),
+                ],
+            ],
+            chunks[1][0].clone(),
+            &output_types[1],
+            runner.intermediate_channels[1].encode_type,
+        );
+        // reserved_intermediate_results should be cleared
+        runner.reserved_intermediate_results.iter().for_each(|r| {
+            assert!(r.is_empty());
+        });
+    }
+
+    #[test]
+    fn test_set_response_intermediate_outputs() {
+        let mut runner = build_simple_runner_for_test();
+        runner.intermediate_channels = vec![
+            runner::IntermediateOutputChannel {
+                encode_type: EncodeType::TypeDefault,
+                output_offsets: vec![1, 0],
+                schema: vec![FieldTypeTp::Long.into(), FieldTypeTp::Float.into()],
+            },
+            runner::IntermediateOutputChannel {
+                encode_type: EncodeType::TypeChunk,
+                output_offsets: vec![0],
+                schema: vec![FieldTypeTp::Timestamp.into()],
+            },
+        ];
+
+        let mut resp = SelectResponse::default();
+        let chunks = vec![
+            vec![
+                {
+                    let mut chk = Chunk::default();
+                    chk.mut_rows_data().extend_from_slice(&[1, 2, 3]);
+                    chk
+                },
+                {
+                    let mut chk = Chunk::default();
+                    chk.mut_rows_data().extend_from_slice(&[11, 12, 13, 14]);
+                    chk
+                },
+            ],
+            vec![{
+                let mut chk = Chunk::default();
+                chk.mut_rows_data().extend_from_slice(&[21, 22]);
+                chk
+            }],
+        ];
+        runner.set_response_intermediate_outputs(&mut resp, chunks);
+        assert_eq!(2, resp.get_intermediate_outputs().len());
+        let output0 = &resp.get_intermediate_outputs()[0];
+        assert_eq!(EncodeType::TypeDefault, output0.get_encode_type());
+        assert_eq!(vec![1, 2, 3], output0.get_chunks()[0].get_rows_data());
+        assert_eq!(
+            vec![11, 12, 13, 14],
+            output0.get_chunks()[1].get_rows_data()
+        );
+        let output1 = &resp.get_intermediate_outputs()[1];
+        assert_eq!(EncodeType::TypeChunk, output1.get_encode_type());
+        assert_eq!(vec![21, 22], output1.get_chunks()[0].get_rows_data());
+    }
+
+    #[test]
+    fn test_handle_request() {
+        let mut runner = build_simple_runner_for_test();
+        let mut ctx = EvalContext {
+            cfg: runner.config.clone(),
+            ..Default::default()
+        };
+        let field_types = vec![FieldTypeTp::Long.into()];
+        let mut mock_executor = MockExecutor::new(
+            field_types.clone(),
+            vec![
+                // first loop, empty main result, some intermediate results
+                build_simple_result_for_test(vec![]),
+                // second loop, main result with 3 rows, some intermediate results
+                build_n_rows_int_result(0, 3),
+                // third loop, main result with 2 rows, no intermediate result
+                {
+                    let mut r = build_n_rows_int_result(10, 2);
+                    r.is_drained = Ok(BatchExecIsDrain::Drain);
+                    r
+                },
+            ],
+        );
+        mock_executor.intermediate_schema = Some((0, field_types.clone()));
+        mock_executor.intermediate_results = vec![
+            // first loop, 2 intermediate result with 1 and 2 rows
+            vec![
+                build_n_rows_int_result(1000, 1),
+                build_n_rows_int_result(1010, 2),
+            ],
+            // second loop, 1 intermediate result with 3 rows
+            vec![build_n_rows_int_result(1100, 3)],
+            // third loop, no intermediate result
+        ]
+        .into_iter();
+
+        runner.out_most_executor = Box::new(mock_executor);
+        runner.intermediate_channels = vec![runner::IntermediateOutputChannel {
+            encode_type: EncodeType::TypeChunk,
+            output_offsets: vec![0],
+            schema: field_types.clone(),
+        }];
+        let (mut resp, range) = block_on(runner.handle_request()).unwrap();
+        // no paging
+        assert!(range.is_none());
+        // check the main result
+        let main_chunks = resp.take_chunks();
+        assert_eq!(2, main_chunks.len());
+        check_chunk(
+            &mut ctx,
+            vec![
+                vec![Datum::I64(0)],
+                vec![Datum::I64(1)],
+                vec![Datum::I64(2)],
+            ],
+            main_chunks[0].clone(),
+            &field_types,
+            resp.get_encode_type(),
+        );
+        check_chunk(
+            &mut ctx,
+            vec![vec![Datum::I64(10)], vec![Datum::I64(11)]],
+            main_chunks[1].clone(),
+            &field_types,
+            resp.get_encode_type(),
+        );
+        // check the intermediate result
+        assert_eq!(1, resp.get_intermediate_outputs().len());
+        let mut outputs = resp.take_intermediate_outputs().to_vec();
+        let chunks = outputs[0].take_chunks().to_vec();
+        let encode_type = outputs[0].get_encode_type();
+        assert_eq!(3, chunks.len());
+        check_chunk(
+            &mut ctx,
+            vec![vec![Datum::I64(1000)]],
+            chunks[0].clone(),
+            &field_types,
+            encode_type,
+        );
+        check_chunk(
+            &mut ctx,
+            vec![vec![Datum::I64(1010)], vec![Datum::I64(1011)]],
+            chunks[1].clone(),
+            &field_types,
+            encode_type,
+        );
+        check_chunk(
+            &mut ctx,
+            vec![
+                vec![Datum::I64(1100)],
+                vec![Datum::I64(1101)],
+                vec![Datum::I64(1102)],
+            ],
+            chunks[2].clone(),
+            &field_types,
+            encode_type,
+        );
+
+        // test paging
+        let mut paging_runner = build_simple_runner_for_test();
+        paging_runner.paging_size = Some(5);
+        let mut mock_executor = MockExecutor::new(
+            field_types.clone(),
+            vec![
+                // first loop, 1 row
+                build_n_rows_int_result(0, 1),
+                // second loop, 1 row
+                build_n_rows_int_result(10, 1),
+                // third loop, 1 row
+                build_n_rows_int_result(100, 1),
+            ],
+        );
+        let expected_range: IntervalRange = (b"a".to_vec(), b"c".to_vec()).into();
+        mock_executor.scanned_range = Some(expected_range.clone());
+        mock_executor.intermediate_schema = Some((0, field_types.clone()));
+        mock_executor.intermediate_results = vec![
+            // first loop, 1 intermediate result with 1 row
+            vec![build_n_rows_int_result(1000, 1)],
+            // second loop, 2 intermediate result with 2 rows
+            vec![
+                build_n_rows_int_result(1100, 1),
+                build_n_rows_int_result(1200, 1),
+            ],
+            // third loop, 1 intermediate result with 1 row
+            vec![build_n_rows_int_result(1300, 1)],
+        ]
+        .into_iter();
+        paging_runner.out_most_executor = Box::new(mock_executor);
+        paging_runner.intermediate_channels = vec![runner::IntermediateOutputChannel {
+            encode_type: EncodeType::TypeChunk,
+            output_offsets: vec![0],
+            schema: field_types.clone(),
+        }];
+        let (mut resp, range) = block_on(paging_runner.handle_request()).unwrap();
+        assert_eq!(Some(expected_range), range);
+        let main_chunks = resp.take_chunks();
+        // the results should stop for paging in the second loop
+        assert_eq!(2, main_chunks.len());
+        check_chunk(
+            &mut ctx,
+            vec![vec![Datum::I64(0)]],
+            main_chunks[0].clone(),
+            &field_types,
+            resp.get_encode_type(),
+        );
+        check_chunk(
+            &mut ctx,
+            vec![vec![Datum::I64(10)]],
+            main_chunks[1].clone(),
+            &field_types,
+            resp.get_encode_type(),
+        );
+        let mut outputs = resp.take_intermediate_outputs();
+        assert_eq!(1, outputs.len());
+        let chunks = outputs[0].take_chunks().to_vec();
+        let encode_type = outputs[0].get_encode_type();
+        assert_eq!(3, chunks.len());
+        check_chunk(
+            &mut ctx,
+            vec![vec![Datum::I64(1000)]],
+            chunks[0].clone(),
+            &field_types,
+            encode_type,
+        );
+        check_chunk(
+            &mut ctx,
+            vec![vec![Datum::I64(1100)]],
+            chunks[1].clone(),
+            &field_types,
+            encode_type,
+        );
+        check_chunk(
+            &mut ctx,
+            vec![vec![Datum::I64(1200)]],
+            chunks[2].clone(),
+            &field_types,
+            encode_type,
+        );
     }
 }

--- a/components/tidb_query_executors/src/runner.rs
+++ b/components/tidb_query_executors/src/runner.rs
@@ -858,7 +858,7 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
         let mut intermediate_record_len = 0;
         let mut chk_byte_size = 0;
         self.out_most_executor
-            .take_intermediate_results(&mut self.reserved_intermediate_results)?;
+            .consume_and_fill_intermediate_results(&mut self.reserved_intermediate_results)?;
         for (i, results) in self.reserved_intermediate_results.iter_mut().enumerate() {
             if results.is_empty() {
                 continue;

--- a/components/tidb_query_executors/src/selection_executor.rs
+++ b/components/tidb_query_executors/src/selection_executor.rs
@@ -186,8 +186,11 @@ impl<Src: BatchExecutor> BatchExecutor for BatchSelectionExecutor<Src> {
     }
 
     #[inline]
-    fn take_intermediate_results(&mut self, results: &mut [Vec<BatchExecuteResult>]) -> Result<()> {
-        self.src.take_intermediate_results(results)
+    fn consume_and_fill_intermediate_results(
+        &mut self,
+        results: &mut [Vec<BatchExecuteResult>],
+    ) -> Result<()> {
+        self.src.consume_and_fill_intermediate_results(results)
     }
 
     #[inline]

--- a/components/tidb_query_executors/src/selection_executor.rs
+++ b/components/tidb_query_executors/src/selection_executor.rs
@@ -45,6 +45,11 @@ impl<Src: BatchExecutor> BatchSelectionExecutor<Src> {
         }
     }
 
+    #[cfg(test)]
+    pub fn into_child(self) -> Src {
+        self.src
+    }
+
     pub fn new(config: Arc<EvalConfig>, src: Src, conditions_def: Vec<Expr>) -> Result<Self> {
         let mut conditions = Vec::with_capacity(conditions_def.len());
         let mut ctx = EvalContext::new(config);
@@ -173,6 +178,16 @@ impl<Src: BatchExecutor> BatchExecutor for BatchSelectionExecutor<Src> {
     fn schema(&self) -> &[FieldType] {
         // The selection executor's schema comes from its child.
         self.src.schema()
+    }
+
+    #[inline]
+    fn intermediate_schema(&self, index: usize) -> Result<&[FieldType]> {
+        self.src.intermediate_schema(index)
+    }
+
+    #[inline]
+    fn take_intermediate_results(&mut self, results: &mut [Vec<BatchExecuteResult>]) -> Result<()> {
+        self.src.take_intermediate_results(results)
     }
 
     #[inline]

--- a/components/tidb_query_executors/src/simple_aggr_executor.rs
+++ b/components/tidb_query_executors/src/simple_aggr_executor.rs
@@ -35,6 +35,16 @@ impl<Src: BatchExecutor> BatchExecutor for BatchSimpleAggregationExecutor<Src> {
     }
 
     #[inline]
+    fn intermediate_schema(&self, index: usize) -> Result<&[FieldType]> {
+        self.0.intermediate_schema(index)
+    }
+
+    #[inline]
+    fn take_intermediate_results(&mut self, results: &mut [Vec<BatchExecuteResult>]) -> Result<()> {
+        self.0.take_intermediate_results(results)
+    }
+
+    #[inline]
     async fn next_batch(&mut self, scan_rows: usize) -> BatchExecuteResult {
         self.0.next_batch(scan_rows).await
     }

--- a/components/tidb_query_executors/src/simple_aggr_executor.rs
+++ b/components/tidb_query_executors/src/simple_aggr_executor.rs
@@ -40,8 +40,11 @@ impl<Src: BatchExecutor> BatchExecutor for BatchSimpleAggregationExecutor<Src> {
     }
 
     #[inline]
-    fn take_intermediate_results(&mut self, results: &mut [Vec<BatchExecuteResult>]) -> Result<()> {
-        self.0.take_intermediate_results(results)
+    fn consume_and_fill_intermediate_results(
+        &mut self,
+        results: &mut [Vec<BatchExecuteResult>],
+    ) -> Result<()> {
+        self.0.consume_and_fill_intermediate_results(results)
     }
 
     #[inline]

--- a/components/tidb_query_executors/src/slow_hash_aggr_executor.rs
+++ b/components/tidb_query_executors/src/slow_hash_aggr_executor.rs
@@ -48,8 +48,11 @@ impl<Src: BatchExecutor> BatchExecutor for BatchSlowHashAggregationExecutor<Src>
     }
 
     #[inline]
-    fn take_intermediate_results(&mut self, results: &mut [Vec<BatchExecuteResult>]) -> Result<()> {
-        self.0.take_intermediate_results(results)
+    fn consume_and_fill_intermediate_results(
+        &mut self,
+        results: &mut [Vec<BatchExecuteResult>],
+    ) -> Result<()> {
+        self.0.consume_and_fill_intermediate_results(results)
     }
 
     #[inline]

--- a/components/tidb_query_executors/src/slow_hash_aggr_executor.rs
+++ b/components/tidb_query_executors/src/slow_hash_aggr_executor.rs
@@ -43,6 +43,16 @@ impl<Src: BatchExecutor> BatchExecutor for BatchSlowHashAggregationExecutor<Src>
     }
 
     #[inline]
+    fn intermediate_schema(&self, index: usize) -> Result<&[FieldType]> {
+        self.0.intermediate_schema(index)
+    }
+
+    #[inline]
+    fn take_intermediate_results(&mut self, results: &mut [Vec<BatchExecuteResult>]) -> Result<()> {
+        self.0.take_intermediate_results(results)
+    }
+
+    #[inline]
     async fn next_batch(&mut self, scan_rows: usize) -> BatchExecuteResult {
         self.0.next_batch(scan_rows).await
     }

--- a/components/tidb_query_executors/src/stream_aggr_executor.rs
+++ b/components/tidb_query_executors/src/stream_aggr_executor.rs
@@ -36,6 +36,16 @@ impl<Src: BatchExecutor> BatchExecutor for BatchStreamAggregationExecutor<Src> {
     }
 
     #[inline]
+    fn intermediate_schema(&self, index: usize) -> Result<&[FieldType]> {
+        self.0.intermediate_schema(index)
+    }
+
+    #[inline]
+    fn take_intermediate_results(&mut self, results: &mut [Vec<BatchExecuteResult>]) -> Result<()> {
+        self.0.take_intermediate_results(results)
+    }
+
+    #[inline]
     async fn next_batch(&mut self, scan_rows: usize) -> BatchExecuteResult {
         self.0.next_batch(scan_rows).await
     }

--- a/components/tidb_query_executors/src/stream_aggr_executor.rs
+++ b/components/tidb_query_executors/src/stream_aggr_executor.rs
@@ -41,8 +41,11 @@ impl<Src: BatchExecutor> BatchExecutor for BatchStreamAggregationExecutor<Src> {
     }
 
     #[inline]
-    fn take_intermediate_results(&mut self, results: &mut [Vec<BatchExecuteResult>]) -> Result<()> {
-        self.0.take_intermediate_results(results)
+    fn consume_and_fill_intermediate_results(
+        &mut self,
+        results: &mut [Vec<BatchExecuteResult>],
+    ) -> Result<()> {
+        self.0.consume_and_fill_intermediate_results(results)
     }
 
     #[inline]

--- a/components/tidb_query_executors/src/table_scan_executor.rs
+++ b/components/tidb_query_executors/src/table_scan_executor.rs
@@ -127,8 +127,11 @@ impl<S: Storage, F: KvFormat> BatchExecutor for BatchTableScanExecutor<S, F> {
     }
 
     #[inline]
-    fn take_intermediate_results(&mut self, results: &mut [Vec<BatchExecuteResult>]) -> Result<()> {
-        self.0.take_intermediate_results(results)
+    fn consume_and_fill_intermediate_results(
+        &mut self,
+        results: &mut [Vec<BatchExecuteResult>],
+    ) -> Result<()> {
+        self.0.consume_and_fill_intermediate_results(results)
     }
 
     #[inline]

--- a/components/tidb_query_executors/src/table_scan_executor.rs
+++ b/components/tidb_query_executors/src/table_scan_executor.rs
@@ -122,6 +122,16 @@ impl<S: Storage, F: KvFormat> BatchExecutor for BatchTableScanExecutor<S, F> {
     }
 
     #[inline]
+    fn intermediate_schema(&self, index: usize) -> Result<&[FieldType]> {
+        self.0.intermediate_schema(index)
+    }
+
+    #[inline]
+    fn take_intermediate_results(&mut self, results: &mut [Vec<BatchExecuteResult>]) -> Result<()> {
+        self.0.take_intermediate_results(results)
+    }
+
+    #[inline]
     async fn next_batch(&mut self, scan_rows: usize) -> BatchExecuteResult {
         self.0.next_batch(scan_rows).await
     }

--- a/components/tidb_query_executors/src/top_n_executor.rs
+++ b/components/tidb_query_executors/src/top_n_executor.rs
@@ -259,6 +259,16 @@ impl<Src: BatchExecutor> BatchExecutor for BatchTopNExecutor<Src> {
     }
 
     #[inline]
+    fn intermediate_schema(&self, index: usize) -> Result<&[FieldType]> {
+        self.src.intermediate_schema(index)
+    }
+
+    #[inline]
+    fn take_intermediate_results(&mut self, results: &mut [Vec<BatchExecuteResult>]) -> Result<()> {
+        self.src.take_intermediate_results(results)
+    }
+
+    #[inline]
     async fn next_batch(&mut self, scan_rows: usize) -> BatchExecuteResult {
         assert!(!self.is_ended);
 

--- a/components/tidb_query_executors/src/top_n_executor.rs
+++ b/components/tidb_query_executors/src/top_n_executor.rs
@@ -264,8 +264,11 @@ impl<Src: BatchExecutor> BatchExecutor for BatchTopNExecutor<Src> {
     }
 
     #[inline]
-    fn take_intermediate_results(&mut self, results: &mut [Vec<BatchExecuteResult>]) -> Result<()> {
-        self.src.take_intermediate_results(results)
+    fn consume_and_fill_intermediate_results(
+        &mut self,
+        results: &mut [Vec<BatchExecuteResult>],
+    ) -> Result<()> {
+        self.src.consume_and_fill_intermediate_results(results)
     }
 
     #[inline]

--- a/components/tidb_query_executors/src/util/aggr_executor.rs
+++ b/components/tidb_query_executors/src/util/aggr_executor.rs
@@ -312,6 +312,16 @@ impl<Src: BatchExecutor, I: AggregationExecutorImpl<Src>> BatchExecutor
     }
 
     #[inline]
+    fn intermediate_schema(&self, index: usize) -> Result<&[FieldType]> {
+        self.entities.src.intermediate_schema(index)
+    }
+
+    #[inline]
+    fn take_intermediate_results(&mut self, results: &mut [Vec<BatchExecuteResult>]) -> Result<()> {
+        self.entities.src.take_intermediate_results(results)
+    }
+
+    #[inline]
     async fn next_batch(&mut self, _scan_rows: usize) -> BatchExecuteResult {
         assert!(!self.is_ended);
 

--- a/components/tidb_query_executors/src/util/aggr_executor.rs
+++ b/components/tidb_query_executors/src/util/aggr_executor.rs
@@ -317,8 +317,13 @@ impl<Src: BatchExecutor, I: AggregationExecutorImpl<Src>> BatchExecutor
     }
 
     #[inline]
-    fn take_intermediate_results(&mut self, results: &mut [Vec<BatchExecuteResult>]) -> Result<()> {
-        self.entities.src.take_intermediate_results(results)
+    fn consume_and_fill_intermediate_results(
+        &mut self,
+        results: &mut [Vec<BatchExecuteResult>],
+    ) -> Result<()> {
+        self.entities
+            .src
+            .consume_and_fill_intermediate_results(results)
     }
 
     #[inline]

--- a/components/tidb_query_executors/src/util/mock_executor.rs
+++ b/components/tidb_query_executors/src/util/mock_executor.rs
@@ -1,11 +1,26 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::{
+    ops::DerefMut,
+    sync::{Arc, Mutex},
+};
+
+use anyhow::anyhow;
 use async_trait::async_trait;
-use tidb_query_common::storage::IntervalRange;
+use kvproto::{coprocessor::KeyRange, metapb::Region};
+use tidb_query_common::{
+    Result,
+    error::StorageError,
+    storage::{
+        FindRegionResult, IntervalRange, OwnedKvPair, PointRange, RegionStorageAccessor,
+        Result as StorageResult, StateRole, Storage,
+    },
+};
 use tidb_query_datatype::{
     codec::{batch::LazyBatchColumnVec, data_type::VectorValue},
     expr::EvalWarnings,
 };
+use tikv_util::{box_err, store::check_key_in_region};
 use tipb::FieldType;
 
 use crate::interface::*;
@@ -15,8 +30,12 @@ use crate::interface::*;
 ///
 /// Normally this should be only used in tests.
 pub struct MockExecutor {
-    schema: Vec<FieldType>,
-    results: std::vec::IntoIter<BatchExecuteResult>,
+    pub schema: Vec<FieldType>,
+    pub results: std::vec::IntoIter<BatchExecuteResult>,
+    pub intermediate_schema: Option<(usize, Vec<FieldType>)>,
+    pub intermediate_results: std::vec::IntoIter<Vec<BatchExecuteResult>>,
+    pub child: Option<Box<MockExecutor>>,
+    pub scanned_range: Option<IntervalRange>,
 }
 
 impl MockExecutor {
@@ -25,7 +44,26 @@ impl MockExecutor {
         Self {
             schema,
             results: results.into_iter(),
+            intermediate_schema: None,
+            intermediate_results: std::vec::IntoIter::default(),
+            child: None,
+            scanned_range: None,
         }
+    }
+
+    pub fn new_with_child(child: MockExecutor) -> Self {
+        Self {
+            schema: child.schema.clone(),
+            results: vec![].into_iter(),
+            intermediate_schema: None,
+            intermediate_results: std::vec::IntoIter::default(),
+            child: Some(Box::new(child)),
+            scanned_range: None,
+        }
+    }
+
+    pub fn set_next_intermediate_results(&mut self, results: Vec<BatchExecuteResult>) {
+        self.intermediate_results = vec![results].into_iter();
     }
 }
 
@@ -37,8 +75,35 @@ impl BatchExecutor for MockExecutor {
         &self.schema
     }
 
+    fn intermediate_schema(&self, index: usize) -> Result<&[FieldType]> {
+        if let Some((idx, schema)) = &self.intermediate_schema {
+            if *idx == index {
+                return Ok(schema);
+            }
+        }
+        if let Some(child) = &self.child {
+            return child.intermediate_schema(index);
+        }
+        Err(box_err!("no intermediate schema for index {}", index))
+    }
+
+    fn take_intermediate_results(&mut self, results: &mut [Vec<BatchExecuteResult>]) -> Result<()> {
+        if let Some((idx, _)) = &self.intermediate_schema {
+            if let Some(mut next) = self.intermediate_results.next() {
+                results[*idx].append(&mut next);
+            }
+        }
+        if let Some(child) = &mut self.child {
+            child.take_intermediate_results(results)?
+        }
+        Ok(())
+    }
+
     async fn next_batch(&mut self, _scan_rows: usize) -> BatchExecuteResult {
-        self.results.next().unwrap()
+        match &mut self.child {
+            Some(child) => child.next_batch(_scan_rows).await,
+            None => self.results.next().unwrap(),
+        }
     }
 
     fn collect_exec_stats(&mut self, _dest: &mut ExecuteStats) {
@@ -50,8 +115,10 @@ impl BatchExecutor for MockExecutor {
     }
 
     fn take_scanned_range(&mut self) -> IntervalRange {
-        // Do nothing
-        unreachable!()
+        match &mut self.child {
+            Some(child) => child.take_scanned_range(),
+            None => self.scanned_range.take().unwrap(),
+        }
     }
 
     fn can_be_cached(&self) -> bool {
@@ -81,6 +148,18 @@ impl BatchExecutor for MockScanExecutor {
 
     fn schema(&self) -> &[FieldType] {
         &self.schema
+    }
+
+    fn intermediate_schema(&self, _index: usize) -> Result<&[FieldType]> {
+        unreachable!()
+    }
+
+    fn take_intermediate_results(
+        &mut self,
+        _results: &mut [Vec<BatchExecuteResult>],
+    ) -> Result<()> {
+        // Do nothing
+        Ok(())
     }
 
     async fn next_batch(&mut self, scan_rows: usize) -> BatchExecuteResult {
@@ -123,5 +202,187 @@ impl BatchExecutor for MockScanExecutor {
 
     fn can_be_cached(&self) -> bool {
         false
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct MockStorage(pub Region, pub Vec<KeyRange>);
+
+impl Storage for MockStorage {
+    type Statistics = ();
+
+    fn begin_scan(
+        &mut self,
+        _is_backward_scan: bool,
+        _is_key_only: bool,
+        _range: IntervalRange,
+    ) -> StorageResult<()> {
+        unimplemented!()
+    }
+
+    fn scan_next(&mut self) -> StorageResult<Option<OwnedKvPair>> {
+        unimplemented!()
+    }
+
+    fn get(
+        &mut self,
+        _is_key_only: bool,
+        _range: PointRange,
+    ) -> StorageResult<Option<OwnedKvPair>> {
+        unimplemented!()
+    }
+
+    fn met_uncacheable_data(&self) -> Option<bool> {
+        unimplemented!()
+    }
+
+    fn collect_statistics(&mut self, _dest: &mut Self::Statistics) {
+        unimplemented!()
+    }
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct MockAccessorExpect {
+    find_region: Option<(Vec<u8>, Option<FindRegionResult>)>,
+    expect_get_local_region_storage: Option<bool>,
+}
+
+#[derive(Clone)]
+pub enum MockRegionStorageAccessor {
+    Expect(Arc<Mutex<MockAccessorExpect>>),
+    Data(Vec<(Region, StateRole)>),
+}
+
+impl MockRegionStorageAccessor {
+    pub fn with_expect_mode() -> Self {
+        Self::Expect(Arc::new(Mutex::new(MockAccessorExpect {
+            ..Default::default()
+        })))
+    }
+
+    pub fn with_regions_data(data: Vec<(Region, StateRole)>) -> Self {
+        assert!(data.is_sorted_by(|a, b| { a.0.start_key < b.0.start_key }));
+        Self::Data(data)
+    }
+
+    pub fn with_expect<T>(&self, f: impl Fn(&mut MockAccessorExpect) -> T) -> T {
+        match self {
+            Self::Expect(e) => {
+                let mut expect = e.lock().unwrap();
+                f(expect.deref_mut())
+            }
+            _ => panic!("not in expect mode"),
+        }
+    }
+
+    pub fn expect_find_region(&self, key: Vec<u8>, region: Region, role: StateRole) {
+        self.with_expect(|expect| {
+            assert!(expect.find_region.is_none());
+            expect.find_region = Some((
+                key.clone(),
+                Some(FindRegionResult::Found {
+                    region: region.clone(),
+                    role,
+                }),
+            ));
+        });
+    }
+
+    pub fn expect_region_not_found(&self, key: Vec<u8>, next_region_start: Option<Vec<u8>>) {
+        self.with_expect(|expect| {
+            assert!(expect.find_region.is_none());
+            expect.find_region = Some((
+                key.clone(),
+                Some(FindRegionResult::NotFound {
+                    next_region_start: next_region_start.clone(),
+                }),
+            ));
+        });
+    }
+
+    pub fn expect_find_region_error(&self, key: Vec<u8>) {
+        self.with_expect(|expect| {
+            assert!(expect.find_region.is_none());
+            expect.find_region = Some((key.clone(), None));
+        });
+    }
+
+    pub fn expect_get_local_region_storage(&self, success: bool) {
+        self.with_expect(|expect| {
+            assert!(expect.expect_get_local_region_storage.is_none());
+            expect.expect_get_local_region_storage = Some(success);
+        });
+    }
+
+    pub fn assert_no_exceptions(&self) {
+        self.with_expect(|expect| {
+            assert!(expect.find_region.is_none());
+            assert!(expect.expect_get_local_region_storage.is_none());
+        });
+    }
+}
+
+#[async_trait]
+impl RegionStorageAccessor for MockRegionStorageAccessor {
+    type Storage = MockStorage;
+
+    async fn find_region_by_key(&self, key: &[u8]) -> StorageResult<FindRegionResult> {
+        match self {
+            Self::Expect(_) => {
+                let find_result = self.with_expect(|expect| -> Option<FindRegionResult> {
+                    let (expect_key, find_result) = expect.find_region.take().unwrap();
+                    assert_eq!(expect_key, key.to_vec());
+                    find_result
+                });
+
+                if let Some(result) = find_result {
+                    Ok(result)
+                } else {
+                    Err(StorageError::from(anyhow!("mock find region error")))
+                }
+            }
+            Self::Data(data) => {
+                let mut result = FindRegionResult::NotFound {
+                    next_region_start: None,
+                };
+                for (region, role) in data.iter() {
+                    if region.get_end_key().is_empty() || region.get_end_key() >= key {
+                        if check_key_in_region(key, region) {
+                            result = FindRegionResult::Found {
+                                region: region.clone(),
+                                role: *role,
+                            };
+                        } else {
+                            result = FindRegionResult::NotFound {
+                                next_region_start: Some(region.get_start_key().to_vec()),
+                            };
+                        }
+                        break;
+                    }
+                }
+                Ok(result)
+            }
+        }
+    }
+
+    async fn get_local_region_storage(
+        &self,
+        region: &Region,
+        key_ranges: &[KeyRange],
+    ) -> StorageResult<Self::Storage> {
+        match self {
+            Self::Expect(_) => {
+                let success = self.with_expect(|expect| -> bool {
+                    expect.expect_get_local_region_storage.take().unwrap()
+                });
+
+                if success {
+                    Ok(MockStorage(region.clone(), key_ranges.to_vec()))
+                } else {
+                    Err(StorageError::from(anyhow!("mock get storage error")))
+                }
+            }
+            Self::Data(_) => Ok(MockStorage(region.clone(), key_ranges.to_vec())),
+        }
     }
 }

--- a/components/tidb_query_executors/src/util/mock_executor.rs
+++ b/components/tidb_query_executors/src/util/mock_executor.rs
@@ -87,14 +87,17 @@ impl BatchExecutor for MockExecutor {
         Err(box_err!("no intermediate schema for index {}", index))
     }
 
-    fn take_intermediate_results(&mut self, results: &mut [Vec<BatchExecuteResult>]) -> Result<()> {
+    fn consume_and_fill_intermediate_results(
+        &mut self,
+        results: &mut [Vec<BatchExecuteResult>],
+    ) -> Result<()> {
         if let Some((idx, _)) = &self.intermediate_schema {
             if let Some(mut next) = self.intermediate_results.next() {
                 results[*idx].append(&mut next);
             }
         }
         if let Some(child) = &mut self.child {
-            child.take_intermediate_results(results)?
+            child.consume_and_fill_intermediate_results(results)?
         }
         Ok(())
     }
@@ -154,7 +157,7 @@ impl BatchExecutor for MockScanExecutor {
         unreachable!()
     }
 
-    fn take_intermediate_results(
+    fn consume_and_fill_intermediate_results(
         &mut self,
         _results: &mut [Vec<BatchExecuteResult>],
     ) -> Result<()> {

--- a/components/tidb_query_executors/src/util/scan_executor.rs
+++ b/components/tidb_query_executors/src/util/scan_executor.rs
@@ -171,6 +171,23 @@ impl<S: Storage, I: ScanExecutorImpl, F: KvFormat> BatchExecutor for ScanExecuto
     }
 
     #[inline]
+    fn intermediate_schema(&self, index: usize) -> Result<&[FieldType]> {
+        Err(other_err!(
+            "The intermediate schema is not found until root executor, index: {}",
+            index
+        ))
+    }
+
+    #[inline]
+    fn take_intermediate_results(
+        &mut self,
+        _results: &mut [Vec<BatchExecuteResult>],
+    ) -> Result<()> {
+        // Do nothing.
+        Ok(())
+    }
+
+    #[inline]
     async fn next_batch(&mut self, scan_rows: usize) -> BatchExecuteResult {
         assert!(!self.is_ended);
         assert!(scan_rows > 0);

--- a/components/tidb_query_executors/src/util/scan_executor.rs
+++ b/components/tidb_query_executors/src/util/scan_executor.rs
@@ -179,7 +179,7 @@ impl<S: Storage, I: ScanExecutorImpl, F: KvFormat> BatchExecutor for ScanExecuto
     }
 
     #[inline]
-    fn take_intermediate_results(
+    fn consume_and_fill_intermediate_results(
         &mut self,
         _results: &mut [Vec<BatchExecuteResult>],
     ) -> Result<()> {

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -2487,7 +2487,7 @@ mod tests {
     }
 
     #[test]
-    fn test_secondary_snap_store_accessor_locate_region_by_key() {
+    fn test_extra_snap_store_accessor_locate_region_by_key() {
         set_tls_engine(TestEngineBuilder::new().build().unwrap());
         defer! {
             unsafe {destroy_tls_engine::<RocksEngine>()}
@@ -2798,7 +2798,7 @@ mod tests {
         let def_req = default_req_ctx_support_snap_accessor();
         let store_id = def_req.context.get_peer().get_store_id();
         let store_accessor = ExtraSnapStoreAccessor::<RocksEngine>::new(def_req.into()).unwrap();
-        let storage_accessor = dag::SecondaryTiKVStorageAccessor::<
+        let storage_accessor = dag::ExtraTiKVStorageAccessor::<
             ExtraSnapStoreAccessor<RocksEngine>,
         >::from_store_accessor(store_accessor);
 

--- a/tests/benches/coprocessor_executors/integrated/util.rs
+++ b/tests/benches/coprocessor_executors/integrated/util.rs
@@ -75,6 +75,7 @@ where
         crate::util::bencher::BatchNextAllBencher::new(|| {
             tidb_query_executors::runner::build_executors::<_, ApiV1>(
                 black_box(executors.to_vec()),
+                &[],
                 black_box(TikvStorage::new(ToTxnStore::<T>::to_store(store), false)),
                 StubAccessor::none(),
                 black_box(ranges.to_vec()),

--- a/tests/benches/coprocessor_executors/util/fixture.rs
+++ b/tests/benches/coprocessor_executors/util/fixture.rs
@@ -7,7 +7,7 @@ use criterion::measurement::Measurement;
 use rand::{Rng, SeedableRng, seq::SliceRandom};
 use rand_xorshift::XorShiftRng;
 use test_coprocessor::*;
-use tidb_query_common::storage::IntervalRange;
+use tidb_query_common::{Result, storage::IntervalRange};
 use tidb_query_datatype::{
     FieldTypeTp,
     codec::{
@@ -291,6 +291,20 @@ impl BatchExecutor for BatchFixtureExecutor {
     #[inline]
     fn schema(&self) -> &[FieldType] {
         &self.schema
+    }
+
+    #[inline]
+    fn intermediate_schema(&self, _index: usize) -> Result<&[FieldType]> {
+        unreachable!()
+    }
+
+    #[inline]
+    fn take_intermediate_results(
+        &mut self,
+        _results: &mut [Vec<BatchExecuteResult>],
+    ) -> Result<()> {
+        // Do nothing
+        Ok(())
     }
 
     #[inline]

--- a/tests/benches/coprocessor_executors/util/fixture.rs
+++ b/tests/benches/coprocessor_executors/util/fixture.rs
@@ -299,7 +299,7 @@ impl BatchExecutor for BatchFixtureExecutor {
     }
 
     #[inline]
-    fn take_intermediate_results(
+    fn consume_and_fill_intermediate_results(
         &mut self,
         _results: &mut [Vec<BatchExecuteResult>],
     ) -> Result<()> {

--- a/tests/integrations/coprocessor/test_select.rs
+++ b/tests/integrations/coprocessor/test_select.rs
@@ -6,15 +6,16 @@ use engine_traits::CF_LOCK;
 use kvproto::{
     coprocessor::{Request, Response, StoreBatchTask, StoreBatchTaskResponse},
     kvrpcpb::{Context, IsolationLevel},
+    metapb::{Peer, Region},
 };
 use protobuf::Message;
-use raftstore::store::Bucket;
+use raftstore::{coprocessor::region_info_accessor::MockRegionInfoProvider, store::Bucket};
 use test_coprocessor::*;
 use test_raftstore::*;
 use test_raftstore_macro::test_case;
 use test_storage::*;
 use tidb_query_datatype::{
-    codec::{Datum, datum},
+    codec::{Datum, datum, table::encode_row_key},
     expr::EvalContext,
 };
 use tikv::{
@@ -22,6 +23,7 @@ use tikv::{
     server::Config,
     storage::TestEngineBuilder,
 };
+use tikv_kv::{RocksEngine, destroy_tls_engine, set_tls_engine, with_tls_engine};
 use tikv_util::{
     HandyRwLock,
     codec::number::*,
@@ -2391,4 +2393,97 @@ fn test_select_time_details() {
 
     let time_details_v2 = resp.get_exec_details_v2().get_time_detail_v2();
     assert!(time_details_v2.process_wall_time_ns != 0, "{:?}", resp);
+}
+
+#[test]
+fn test_index_lookup_select() {
+    set_tls_engine(TestEngineBuilder::new().build().unwrap());
+    defer! {
+         unsafe {destroy_tls_engine::<RocksEngine>()}
+    }
+
+    let product = ProductTable::new();
+    let data = vec![
+        (1, Some("name:0"), 2),
+        (2, Some("name:4"), 3),
+        (4, Some("name:3"), 1),
+        (5, Some("name:1"), 4),
+    ];
+    let index_scan_peer = {
+        let mut peer = Peer::default();
+        peer.set_id(1);
+        peer.set_store_id(1);
+        peer
+    };
+
+    let region = {
+        let mut peer = index_scan_peer.clone();
+        peer.set_id(10);
+        let mut r = Region::default();
+        r.set_id(10);
+        // only handle [2, 4] can be found in the local region.
+        r.set_start_key(Key::from_raw(&encode_row_key(product.table_id(), 2)).into_encoded());
+        r.set_end_key(Key::from_raw(&encode_row_key(product.table_id(), 5)).into_encoded());
+        r.set_peers(vec![peer].into());
+        r
+    };
+
+    let (_, endpoint, _) = unsafe {
+        with_tls_engine(|e: &mut RocksEngine| {
+            e.set_region_info_provider(MockRegionInfoProvider::new(vec![region]));
+            init_data_with_details(
+                Context::default(),
+                e.clone(),
+                &product,
+                &data,
+                true,
+                &Config::default(),
+            )
+        })
+    };
+    let mut ctx = Context::default();
+    ctx.set_peer(index_scan_peer);
+    let req = DagSelect::from_index(&product, &product["name"])
+        .index_lookup(&product, vec![2])
+        .build_with(ctx, &[0]);
+    let mut resp = handle_select(&endpoint, req);
+    // check the primary row results that can be found locally.
+    let chunks = resp.take_chunks().to_vec();
+    let rows: Vec<_> = DagChunkSpliter::new(chunks, 3).collect();
+    assert_eq!(
+        vec![
+            vec![
+                Datum::I64(2),
+                Datum::Bytes(b"name:4".to_vec()),
+                Datum::I64(3),
+            ],
+            vec![
+                Datum::I64(4),
+                Datum::Bytes(b"name:3".to_vec()),
+                Datum::I64(1),
+            ],
+        ],
+        rows
+    );
+
+    // check the index results that cannot perform index-lookup locally.
+    let mut intermediate_outputs = resp.take_intermediate_outputs();
+    assert_eq!(1, intermediate_outputs.len());
+    let intermediate_chunks = intermediate_outputs[0].take_chunks().to_vec();
+    let intermediate_rows: Vec<_> = DagChunkSpliter::new(intermediate_chunks, 3).collect();
+    assert_eq!(
+        vec![
+            vec![
+                Datum::Bytes(b"name:0".to_vec()),
+                Datum::I64(2),
+                Datum::I64(1)
+            ],
+            vec![
+                Datum::Bytes(b"name:1".to_vec()),
+                Datum::I64(4),
+                Datum::I64(5)
+            ],
+        ],
+        intermediate_rows
+    );
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18942
<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
- Add two methods `intermediate_schema` and `take_intermediate_results` to support outputting intermediate results.
- `BatchExecutorsRunner` supports to parse `IndexLookUp` and driving it for intermediate and final results.
- Add some tests
- Rename some struct name from `SecondaryRegionXXXProvider` to `ExtraRegionXXXProvider`, which are left to rename in the previous PR.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
