### PR TITLE
config: add more check for inspect_network_interval

### DIFF
--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -492,12 +492,6 @@ impl Config {
                 "server.inspect-network-interval can't be less than 10ms and not zero."
             ));
         }
-
-        if self.inspect_network_interval.gt(&ReadableDuration::secs(3)) {
-            return Err(box_err!(
-                "server.inspect-network-interval can't be greater than 3s."
-            ));
-        }
         Ok(())
     }
 

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -486,12 +486,18 @@ impl Config {
         if self
             .inspect_network_interval
             .lt(&ReadableDuration::millis(10))
+            && self.inspect_network_interval.0 != Duration::from_millis(0)
         {
             return Err(box_err!(
-                "server.inspect-network-interval can't be less than 10ms."
+                "server.inspect-network-interval can't be less than 10ms and not zero."
             ));
         }
 
+        if self.inspect_network_interval.gt(&ReadableDuration::secs(3)) {
+            return Err(box_err!(
+                "server.inspect-network-interval can't be greater than 3s."
+            ));
+        }
         Ok(())
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref https://github.com/tikv/tikv/issues/18797

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Should allow user set inspect_network_interval zero. Zero represents disable inspection.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
