### PR TITLE
raftstore: fix abnormally fetching terms when destroy peer asynchronously

### DIFF
--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -2524,12 +2524,12 @@ where
                     "peer_id" => self.fsm.peer_id(),
                     "res" => ?res,
                 );
-                if self.fsm.peer.wait_data || self.fsm.peer.pending_remove {
-                    // Extra: no needs to apply if the peer is already pending on removing.
+                if self.fsm.peer.wait_data {
                     return;
                 }
                 self.on_ready_result(&mut res.exec_res, &res.metrics);
-                if self.fsm.stopped {
+                if self.fsm.stopped || self.fsm.peer.pending_remove {
+                    // Extra: no needs to apply if the peer is already pending on removing.
                     return;
                 }
                 let applied_index = res.apply_state.applied_index;

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -1540,15 +1540,6 @@ where
     }
 
     fn on_significant_msg(&mut self, msg: Box<SignificantMsg<EK::Snapshot>>) {
-        if self.fsm.peer.pending_remove
-            && !matches!(msg, box SignificantMsg::ReadyToDestroyPeer { .. })
-        {
-            // If this peer is marked for removal, skip handling other SignificantMsg
-            // variants, except for SignificantMsg::ReadyToDestroyPeer, which is
-            // responsible for executing the final cleanup steps of peer
-            // destruction.
-            return;
-        }
         match *msg {
             SignificantMsg::SnapshotStatus {
                 to_peer_id, status, ..

--- a/tests/failpoints/cases/test_stale_read.rs
+++ b/tests/failpoints/cases/test_stale_read.rs
@@ -468,7 +468,7 @@ fn test_read_after_peer_destroyed() {
     // Validate the async destroy progress.
     let check_state_on_raft_gc_log_tick = "check_state_on_raft_gc_log_tick";
     let (gc_tx, gc_rx) = mpsc::sync_channel(1);
-    fail::cfg_callback(destroy_peer_fp, move || {
+    fail::cfg_callback(check_state_on_raft_gc_log_tick, move || {
         gc_tx.send(check_state_on_raft_gc_log_tick).unwrap();
     })
     .unwrap();

--- a/tests/failpoints/cases/test_stale_read.rs
+++ b/tests/failpoints/cases/test_stale_read.rs
@@ -465,6 +465,19 @@ fn test_read_after_peer_destroyed() {
     sleep_ms(200);
     fail::remove(destroy_peer_fp);
 
+    // Validate the async destroy progress.
+    let check_state_on_raft_gc_log_tick = "check_state_on_raft_gc_log_tick";
+    let (gc_tx, gc_rx) = mpsc::sync_channel(1);
+    fail::cfg_callback(destroy_peer_fp, move || {
+        gc_tx.send(check_state_on_raft_gc_log_tick).unwrap();
+    })
+    .unwrap();
+    assert_eq!(
+        gc_rx.recv_timeout(Duration::from_secs(5)).unwrap(),
+        check_state_on_raft_gc_log_tick
+    );
+    fail::remove(check_state_on_raft_gc_log_tick);
+
     let resp = rx.recv_timeout(Duration::from_millis(200)).unwrap();
     assert!(
         resp.get_header().get_error().has_region_not_found(),


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close https://github.com/tikv/tikv/issues/18983

Fix the bug introduced by the previous work https://github.com/tikv/tikv/pull/18805, which makes the `raftstore` thread panic on accessing the raft logs already destroyed by `region-worker` in `on_raft_log_gc_tick(...)`, responsible for destroying peer asynchronously.

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Address the bug that the `raftstore` thread is panic on accessing raft logs of asynchronously destroyed peer in `on_raft_log_gc_tick()`.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None.
```
