### PR TITLE
coprocessor: check memory locks in `ExtraSnapStoreAccessor`

### DIFF
--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -160,38 +160,7 @@ impl<E: Engine> Endpoint<E> {
     }
 
     fn check_memory_locks(&self, req_ctx: &ReqContext) -> Result<()> {
-        let start_ts = req_ctx.txn_start_ts;
-        if !req_ctx.context.get_stale_read() {
-            self.concurrency_manager
-                .update_max_ts(start_ts, || format!("coprocessor-{}", start_ts))?;
-        }
-        if need_check_locks(req_ctx.context.get_isolation_level()) {
-            let begin_instant = Instant::now();
-            for range in &req_ctx.ranges {
-                let start_key = txn_types::Key::from_raw_maybe_unbounded(range.get_start());
-                let end_key = txn_types::Key::from_raw_maybe_unbounded(range.get_end());
-                self.concurrency_manager
-                    .read_range_check(start_key.as_ref(), end_key.as_ref(), |key, lock| {
-                        Lock::check_ts_conflict(
-                            Cow::Borrowed(lock),
-                            key,
-                            start_ts,
-                            &req_ctx.bypass_locks,
-                            req_ctx.context.get_isolation_level(),
-                        )
-                    })
-                    .map_err(|e| {
-                        MEM_LOCK_CHECK_HISTOGRAM_VEC_STATIC
-                            .locked
-                            .observe(begin_instant.saturating_elapsed().as_secs_f64());
-                        MvccError::from(e)
-                    })?;
-            }
-            MEM_LOCK_CHECK_HISTOGRAM_VEC_STATIC
-                .unlocked
-                .observe(begin_instant.saturating_elapsed().as_secs_f64());
-        }
-        Ok(())
+        check_memory_locks_for_ranges(&self.concurrency_manager, req_ctx, &req_ctx.ranges)
     }
 
     /// Parse the raw `Request` to create `RequestHandlerBuilder` and
@@ -284,6 +253,7 @@ impl<E: Engine> Endpoint<E> {
 
                 let batch_row_limit = self.get_batch_row_limit(is_streaming);
                 let quota_limiter = self.quota_limiter.clone();
+                let concurrency_manager = self.concurrency_manager.clone();
                 handler_builder = Box::new(move |snap, req_ctx| {
                     let data_version = snap.ext().get_data_version();
                     let store = SnapshotStore::new(
@@ -299,11 +269,14 @@ impl<E: Engine> Endpoint<E> {
                         0 => None,
                         i => Some(i),
                     };
+
+                    let extra_store_accessor =
+                        ExtraSnapStoreAccessor::<E>::new(req_ctx.clone(), concurrency_manager);
                     dag::DagHandlerBuilder::<_, _, F>::new(
                         dag,
                         req_ctx.ranges.clone(),
                         store,
-                        ExtraSnapStoreAccessor::<E>::new(req_ctx.clone()),
+                        extra_store_accessor,
                         req_ctx.deadline,
                         batch_row_limit,
                         is_streaming,
@@ -928,6 +901,44 @@ impl<E: Engine> Endpoint<E> {
     }
 }
 
+fn check_memory_locks_for_ranges(
+    concurrency_manager: &ConcurrencyManager,
+    req_ctx: &ReqContext,
+    key_ranges: &[coppb::KeyRange],
+) -> Result<()> {
+    let start_ts = req_ctx.txn_start_ts;
+    if !req_ctx.context.get_stale_read() {
+        concurrency_manager.update_max_ts(start_ts, || format!("coprocessor-{}", start_ts))?;
+    }
+    if need_check_locks(req_ctx.context.get_isolation_level()) {
+        let begin_instant = Instant::now();
+        for range in key_ranges {
+            let start_key = txn_types::Key::from_raw_maybe_unbounded(range.get_start());
+            let end_key = txn_types::Key::from_raw_maybe_unbounded(range.get_end());
+            concurrency_manager
+                .read_range_check(start_key.as_ref(), end_key.as_ref(), |key, lock| {
+                    Lock::check_ts_conflict(
+                        Cow::Borrowed(lock),
+                        key,
+                        start_ts,
+                        &req_ctx.bypass_locks,
+                        req_ctx.context.get_isolation_level(),
+                    )
+                })
+                .map_err(|e| {
+                    MEM_LOCK_CHECK_HISTOGRAM_VEC_STATIC
+                        .locked
+                        .observe(begin_instant.saturating_elapsed().as_secs_f64());
+                    MvccError::from(e)
+                })?;
+        }
+        MEM_LOCK_CHECK_HISTOGRAM_VEC_STATIC
+            .unlocked
+            .observe(begin_instant.saturating_elapsed().as_secs_f64());
+    }
+    Ok(())
+}
+
 macro_rules! make_error_response_common {
     ($resp:expr, $tag:expr, $e:expr) => {{
         match $e {
@@ -1013,10 +1024,11 @@ fn make_error_response(e: Error) -> coppb::Response {
 /// For example, if a cop-task contains a `IndexLookUp` executor which needs to
 /// access look up the primary rows, it will use this accessor to locate and get
 /// the snapshot of the regions which these primary rows located.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct ExtraSnapStoreAccessor<E> {
     store_id: u64,
     req_ctx: ReqContext,
+    concurrency_manager: ConcurrencyManager,
     _phantom: PhantomData<fn() -> E>,
 }
 
@@ -1025,7 +1037,7 @@ impl<E: Engine> ExtraSnapStoreAccessor<E> {
     /// Please note that not all scenes are supported.
     /// If the current request is not supported, a `None` value will be
     /// returned to force the request to access the source region only.
-    pub fn new(req_ctx: ReqContext) -> Option<Self> {
+    pub fn new(req_ctx: ReqContext, concurrency_manager: ConcurrencyManager) -> Option<Self> {
         let pb_ctx = &req_ctx.context;
         let store_id = match pb_ctx.peer.as_ref() {
             // Though it is possible that the request carries a wrong store_id, we can still use
@@ -1044,6 +1056,7 @@ impl<E: Engine> ExtraSnapStoreAccessor<E> {
             return Some(Self {
                 store_id,
                 req_ctx,
+                concurrency_manager,
                 _phantom: PhantomData,
             });
         }
@@ -1098,7 +1111,7 @@ impl<E: Engine> RegionStorageAccessor for ExtraSnapStoreAccessor<E> {
     async fn get_local_region_storage(
         &self,
         region: &metapb::Region,
-        _key_range: &[coppb::KeyRange],
+        key_range: &[coppb::KeyRange],
     ) -> StorageResult<Self::Storage> {
         let peer = match find_peer(region, self.store_id) {
             Some(peer) => peer.clone(),
@@ -1111,6 +1124,7 @@ impl<E: Engine> RegionStorageAccessor for ExtraSnapStoreAccessor<E> {
             }
         };
 
+        check_memory_locks_for_ranges(&self.concurrency_manager, &self.req_ctx, key_range)?;
         let pb_ctx = &self.req_ctx.context;
         let start_ts = self.req_ctx.txn_start_ts;
         let snap_ctx = SnapContext {
@@ -1162,12 +1176,13 @@ impl<E: Engine> RegionStorageAccessor for ExtraSnapStoreAccessor<E> {
 #[cfg(test)]
 mod tests {
     use std::{
+        assert_matches::assert_matches,
         sync::{Mutex, atomic, mpsc},
         thread, vec,
     };
 
     use futures::executor::{block_on, block_on_stream};
-    use kvproto::kvrpcpb::IsolationLevel;
+    use kvproto::kvrpcpb::{IsolationLevel, LockInfo};
     use protobuf::Message;
     use raft::StateRole;
     use raftstore::coprocessor::region_info_accessor::MockRegionInfoProvider;
@@ -2462,28 +2477,29 @@ mod tests {
         type StoreAccessor = ExtraSnapStoreAccessor<RocksEngine>;
         // construct a ReqContext that support to access another snapshot in a request
         let req_ctx = default_req_ctx_support_snap_accessor();
+        let cm = ConcurrencyManager::new_for_test(1.into());
 
         // accessor support case
         let mut ctx = req_ctx.clone();
-        assert!(StoreAccessor::new(ctx.into()).is_some());
+        assert!(StoreAccessor::new(ctx.into(), cm.clone()).is_some());
 
         // does not support Rc / RcCheckTs
         ctx = req_ctx.clone();
         ctx.context.set_isolation_level(IsolationLevel::Rc);
-        assert!(StoreAccessor::new(ctx.into()).is_none());
+        assert!(StoreAccessor::new(ctx.into(), cm.clone()).is_none());
         ctx = req_ctx.clone();
         ctx.context.set_isolation_level(IsolationLevel::RcCheckTs);
-        assert!(StoreAccessor::new(ctx.into()).is_none());
+        assert!(StoreAccessor::new(ctx.into(), cm.clone()).is_none());
 
         // does not support stale read
         ctx = req_ctx.clone();
         ctx.context.set_stale_read(true);
-        assert!(StoreAccessor::new(ctx.into()).is_none());
+        assert!(StoreAccessor::new(ctx.into(), cm.clone()).is_none());
 
         // does not support replica read
         ctx = req_ctx.clone();
         ctx.context.set_replica_read(true);
-        assert!(StoreAccessor::new(ctx.into()).is_none());
+        assert!(StoreAccessor::new(ctx.into(), cm.clone()).is_none());
     }
 
     #[test]
@@ -2521,7 +2537,11 @@ mod tests {
         }
 
         type StoreAccessor = ExtraSnapStoreAccessor<RocksEngine>;
-        let accessor = StoreAccessor::new(default_req_ctx_support_snap_accessor().into()).unwrap();
+        let accessor = StoreAccessor::new(
+            default_req_ctx_support_snap_accessor().into(),
+            ConcurrencyManager::new_for_test(1.into()),
+        )
+        .unwrap();
 
         // key is before any region, not found
         assert_eq!(
@@ -2603,7 +2623,11 @@ mod tests {
 
         impl TestCtx {
             fn new_accessor(&self) -> StoreAccessor {
-                StoreAccessor::new(self.get_req_ctx()).unwrap()
+                StoreAccessor::new(
+                    self.get_req_ctx(),
+                    ConcurrencyManager::new_for_test(1.into()),
+                )
+                .unwrap()
             }
 
             fn get_req_ctx(&self) -> ReqContext {
@@ -2797,7 +2821,11 @@ mod tests {
         }
         let def_req = default_req_ctx_support_snap_accessor();
         let store_id = def_req.context.get_peer().get_store_id();
-        let store_accessor = ExtraSnapStoreAccessor::<RocksEngine>::new(def_req.into()).unwrap();
+        let store_accessor = ExtraSnapStoreAccessor::<RocksEngine>::new(
+            def_req.into(),
+            ConcurrencyManager::new_for_test(1.into()),
+        )
+        .unwrap();
         let storage_accessor = dag::ExtraTiKVStorageAccessor::<
             ExtraSnapStoreAccessor<RocksEngine>,
         >::from_store_accessor(store_accessor);
@@ -2827,5 +2855,64 @@ mod tests {
 
         // should always disable check_can_be_cached
         assert!(storage.met_uncacheable_data().is_none());
+    }
+
+    #[test]
+    fn test_extra_snap_accessor_check_memory_locks() {
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+        let region = metapb::Region {
+            id: 1,
+            start_key: b"".to_vec(),
+            end_key: b"".to_vec(),
+            peers: vec![metapb::Peer {
+                id: 1,
+                store_id: 100,
+                ..Default::default()
+            }]
+            .into(),
+            ..Default::default()
+        };
+        engine.set_region_info_provider(MockRegionInfoProvider::new(vec![region.clone()]));
+        set_tls_engine(engine);
+        defer! {
+            unsafe {destroy_tls_engine::<RocksEngine>()}
+        }
+
+        let cm = ConcurrencyManager::new_for_test(1.into());
+        let mut req = default_req_ctx_support_snap_accessor();
+        req.txn_start_ts = 100.into();
+        let accessor = ExtraSnapStoreAccessor::<RocksEngine>::new(req.into(), cm.clone()).unwrap();
+
+        let key = Key::from_raw(b"key");
+        let guard = block_on(cm.lock_key(&key));
+        guard.with_lock(|lock| {
+            *lock = Some(txn_types::Lock::new(
+                LockType::Put,
+                b"key".to_vec(),
+                10.into(),
+                100,
+                Some(vec![]),
+                0.into(),
+                1,
+                20.into(),
+                false,
+            ));
+        });
+
+        let err = block_on(accessor.get_local_region_storage(
+            &region,
+            &[coppb::KeyRange {
+                start: b"key".to_vec(),
+                end: b"key0".to_vec(),
+                ..Default::default()
+            }],
+        ))
+        .map_err(Error::from)
+        .err()
+        .unwrap();
+        assert_matches!(err, Error::Locked(LockInfo { key, .. }) if {
+            assert_eq!(key, b"key".to_vec());
+            true
+        });
     }
 }

--- a/tests/integrations/raftstore/test_snap.rs
+++ b/tests/integrations/raftstore/test_snap.rs
@@ -1274,6 +1274,7 @@ fn test_extra_snapshot_override() {
     configure_for_snapshot(&mut cluster.cfg);
     cluster.run_conf_change();
     let pd_client = cluster.pd_client.clone();
+    pd_client.disable_default_operator();
     for key in [b"a", b"b", b"c", b"d"] {
         let region = pd_client.get_region_info(key).unwrap();
         cluster.must_split(&region, key);


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18949

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Check the memory locks in `ExtraSnapStoreAccessor:: get_local_region_storage` to make sure the `IndexLookUp` can get the consistency rows for 1pc or async commit.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
