### PR TITLE
coprocessor: Support basic summary and metrics for push down IndexLookUp

### DIFF
--- a/components/tidb_query_common/src/metrics.rs
+++ b/components/tidb_query_common/src/metrics.rs
@@ -22,6 +22,8 @@ make_auto_flush_static_metric! {
         stream_aggr,
         top_n,
         limit,
+        batch_index_lookup,
+        batch_index_lookup_table_scan,
     }
 
     pub struct LocalCoprExecutorCount: LocalIntCounter {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #19007

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

- Added two types of executors displayed in chart "Total DAG Executors", `batch_index_lookup` indicates the `BatchIndexLookUp` and `batch_index_lookup_table_scan` indicates the `BatchTableScan` built in `BatchIndexLookUp`

<img width="2874" height="1114" alt="image" src="https://github.com/user-attachments/assets/b0824615-3aed-4ec0-98b5-d31d82fe5df6" />

- Support to display the right summary (actRows and execution info) of `BatchIndexLookUp` inner `BatchTableScan`:
<img width="3022" height="966" alt="image" src="https://github.com/user-attachments/assets/6dd5be0c-b5f6-4580-a83f-b622e78b87f1" />


```commit-message
Support basic summary and metrics for push down IndexLookUp
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
