### PR TITLE
raftstore: handle `ReadyToDestroyPeer` with incorrect order if the sender is delayed.

### DIFF
--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -583,6 +583,7 @@ where
     /// `clear_stat` records the statistics of duration when clear raft state
     /// and data in kvdb.
     ReadyToDestroyPeer {
+        to_peer_id: u64,
         merged_by_target: bool,
         clear_stat: PeerClearMetaStat,
     },

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -691,18 +691,14 @@ impl SplitCheckTrigger {
     }
 }
 
-bitflags! {
-    /// A bitmap contains some useful flags to represent different reason for pending remove.
-    pub struct PendingRemoveReason: u8 {
-        const MERGE   = 0b0000_0001;
-        const DESTROY = 0b0000_0010;
-    }
-}
-
-impl PendingRemoveReason {
-    pub fn is_destroy(&self) -> bool {
-        *self == Self::DESTROY
-    }
+/// A enum contains some useful state to represent different reason for
+/// pending remove.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PendingRemoveReason {
+    NotRemoved = 0,
+    Merge,
+    Destroy,
 }
 
 #[derive(Getters, MutGetters)]
@@ -1379,7 +1375,7 @@ where
         //   is Some and should be set to None.
         self.apply_snap_ctx = None;
 
-        self.pending_remove = Some(PendingRemoveReason::DESTROY);
+        self.pending_remove = Some(PendingRemoveReason::Destroy);
 
         Some(DestroyPeerJob {
             initialized: self.get_store().is_initialized(),

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -3385,7 +3385,7 @@ where
         self.write_router
             .check_new_persisted(ctx, self.persisted_number);
 
-        if self.pending_remove.is_some() {
+        if self.pending_remove.is_none() {
             // If `pending_remove` is true, no need to call `on_persist_ready` to
             // update persist index.
             let pre_persist_index = self.raft_group.raft.raft_log.persisted;

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -691,6 +691,20 @@ impl SplitCheckTrigger {
     }
 }
 
+bitflags! {
+    /// A bitmap contains some useful flags to represent different reason for pending remove.
+    pub struct PendingRemoveReason: u8 {
+        const MERGE   = 0b0000_0001;
+        const DESTROY = 0b0000_0010;
+    }
+}
+
+impl PendingRemoveReason {
+    pub fn is_destroy(&self) -> bool {
+        *self == Self::DESTROY
+    }
+}
+
 #[derive(Getters, MutGetters)]
 pub struct Peer<EK, ER>
 where
@@ -734,11 +748,11 @@ where
     /// Indicates whether the peer should be woken up.
     pub should_wake_up: bool,
     /// Whether this peer is destroyed asynchronously.
-    /// If it's true,
+    /// If it's Some(...),
     /// - when merging, its data in storeMeta will be removed early by the
     ///   target peer.
     /// - all read requests must be rejected.
-    pub pending_remove: bool,
+    pub pending_remove: Option<PendingRemoveReason>,
     /// Currently it's used to indicate whether the witness -> non-witess
     /// convertion operation is complete. The meaning of completion is that
     /// this peer must contain the applied data, then PD can consider that
@@ -1013,7 +1027,7 @@ where
             split_check_trigger: SplitCheckTrigger::default(),
             delete_keys_hint: 0,
             leader_unreachable: false,
-            pending_remove: false,
+            pending_remove: None,
             wait_data,
             request_index: last_index,
             delay_clean_data: false,
@@ -1308,7 +1322,7 @@ where
     /// Tries to destroy itself. Returns a job (if needed) to do more cleaning
     /// tasks.
     pub fn maybe_destroy<T>(&mut self, ctx: &PollContext<EK, ER, T>) -> Option<DestroyPeerJob> {
-        if self.pending_remove {
+        if self.pending_remove.is_some() {
             info!(
                 "is being destroyed, skip";
                 "region_id" => self.region_id,
@@ -1365,7 +1379,7 @@ where
         //   is Some and should be set to None.
         self.apply_snap_ctx = None;
 
-        self.pending_remove = true;
+        self.pending_remove = Some(PendingRemoveReason::DESTROY);
 
         Some(DestroyPeerJob {
             initialized: self.get_store().is_initialized(),
@@ -1675,7 +1689,7 @@ where
             pessimistic_locks.version = self.region().get_region_epoch().get_version();
         }
 
-        if !self.pending_remove {
+        if self.pending_remove.is_none() {
             host.on_region_changed(
                 self.region(),
                 RegionChangeEvent::Update(reason),
@@ -2786,7 +2800,7 @@ where
         &mut self,
         ctx: &mut PollContext<EK, ER, T>,
     ) -> Option<ReadyResult> {
-        if self.pending_remove {
+        if self.pending_remove.is_some() {
             return None;
         }
 
@@ -3371,7 +3385,7 @@ where
         self.write_router
             .check_new_persisted(ctx, self.persisted_number);
 
-        if !self.pending_remove {
+        if self.pending_remove.is_some() {
             // If `pending_remove` is true, no need to call `on_persist_ready` to
             // update persist index.
             let pre_persist_index = self.raft_group.raft.raft_log.persisted;
@@ -3815,7 +3829,7 @@ where
     }
 
     fn maybe_update_read_progress(&self, reader: &mut ReadDelegate, progress: ReadProgress) {
-        if self.pending_remove {
+        if self.pending_remove.is_some() {
             return;
         }
         debug!(
@@ -3870,7 +3884,7 @@ where
         mut err_resp: RaftCmdResponse,
         mut disk_full_opt: DiskFullOpt,
     ) -> bool {
-        if self.pending_remove {
+        if self.pending_remove.is_some() {
             return false;
         }
 
@@ -5482,7 +5496,7 @@ where
 
     /// Check if the command will be likely to pass all the check and propose.
     pub fn will_likely_propose(&mut self, cmd: &RaftCmdRequest) -> bool {
-        !self.pending_remove
+        self.pending_remove.is_none()
             && self.is_leader()
             && self.pending_merge_state.is_none()
             && self.prepare_merge_fence == 0
@@ -5570,7 +5584,7 @@ where
 
             if self.raft_group.raft.raft_log.applied >= *target_index
                 || force
-                || self.pending_remove
+                || self.pending_remove.is_some()
             {
                 info!("snapshot recovery wait apply finished";
                     "region_id" => self.region().get_id(),

--- a/components/raftstore/src/store/worker/region.rs
+++ b/components/raftstore/src/store/worker/region.rs
@@ -895,6 +895,7 @@ where
                         let _ = self.router.significant_send(
                             region_id,
                             SignificantMsg::ReadyToDestroyPeer {
+                                to_peer_id: peer_id,
                                 merged_by_target: keep_data,
                                 clear_stat,
                             },

--- a/tests/failpoints/cases/test_titan.rs
+++ b/tests/failpoints/cases/test_titan.rs
@@ -138,6 +138,15 @@ fn test_titan() {
     // lv6: file0 [k1: ref_to_blob_file, k3: v]
     let db = cluster.engines[&3].kv.as_inner();
     let defaultcf = db.cf_handle(CF_DEFAULT).unwrap();
+    test_util::eventually(
+        std::time::Duration::from_millis(100),
+        std::time::Duration::from_millis(2000),
+        || {
+            db.get_property_int_cf(defaultcf, "rocksdb.num-files-at-level5")
+                .unwrap()
+                == 0
+        },
+    );
     assert_eq!(
         0,
         db.get_property_int_cf(defaultcf, "rocksdb.num-files-at-level5")

--- a/tests/failpoints/cases/test_titan.rs
+++ b/tests/failpoints/cases/test_titan.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use engine_rocks::BlobRunMode;
 use engine_traits::{CF_DEFAULT, CompactExt, ManualCompactionOptions, MiscExt};
 use test_raftstore::*;
@@ -157,9 +155,8 @@ fn test_titan() {
     cluster
         .pd_client
         .must_add_peer(region1.get_id(), peer.clone());
-    cluster
-        .try_transfer_leader_with_timeout(region1.get_id(), peer.clone(), Duration::from_secs(5))
-        .unwrap();
+    fail::remove("after_delete_files_in_range");
+    cluster.must_transfer_leader(region1.get_id(), peer.clone());
     assert_eq!(cluster.must_get(b"k1").unwrap(), b"v".repeat(20000));
     cluster.must_put(b"k11", &b"v".repeat(30000));
     assert_eq!(cluster.must_get(b"k11").unwrap(), b"v".repeat(30000));

--- a/tests/failpoints/cases/test_titan.rs
+++ b/tests/failpoints/cases/test_titan.rs
@@ -92,6 +92,15 @@ fn test_titan() {
     }
     assert!(blob_file_reclaimed);
     cluster.engines[&3].kv.flush_cf(CF_DEFAULT, true).unwrap();
+    test_util::eventually(
+        std::time::Duration::from_millis(100),
+        std::time::Duration::from_millis(3000),
+        || {
+            db.get_property_int_cf(defaultcf, "rocksdb.num-files-at-level0")
+                .unwrap()
+                == 1
+        },
+    );
     assert_eq!(
         1,
         db.get_property_int_cf(defaultcf, "rocksdb.num-files-at-level0")
@@ -140,7 +149,7 @@ fn test_titan() {
     let defaultcf = db.cf_handle(CF_DEFAULT).unwrap();
     test_util::eventually(
         std::time::Duration::from_millis(100),
-        std::time::Duration::from_millis(2000),
+        std::time::Duration::from_millis(3000),
         || {
             db.get_property_int_cf(defaultcf, "rocksdb.num-files-at-level5")
                 .unwrap()


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #19004

Fix the bug introduced by the previous work https://github.com/tikv/tikv/pull/18805 and https://github.com/tikv/tikv/pull/18984, which makes the `raftstore` thread panic on the assertation that a new peer with the same peer-id of the pending removing peer handled the `ReadyToDestroyPeer` unexpectedly.

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Address the corner case that the `raftstore` thread is panic on handling `ReadyToDestroyPeer `.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None.
```
