### PR TITLE
cherry-pick : server: graceful shutdown tikv-impl (#18930)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3683,7 +3683,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#258e68e813aa1af3a9817ce87630e2ec638851cd"
+source = "git+https://github.com/pingcap/kvproto.git#d79d11002599aa56a89dac801547d7d81d6ba40e"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/components/raftstore-v2/src/batch/store.rs
+++ b/components/raftstore-v2/src/batch/store.rs
@@ -820,6 +820,7 @@ impl<EK: KvEngine, ER: RaftEngine> StoreSystem<EK, ER> {
             self.logger.clone(),
             self.shutdown.clone(),
             cfg.clone(),
+            Arc::new(AtomicBool::new(false)),
         )?);
 
         let split_check_scheduler = workers.background.start(
@@ -947,6 +948,11 @@ impl<EK: KvEngine, ER: RaftEngine> StoreSystem<EK, ER> {
             .unwrap()
             .refresh_config_worker
             .scheduler()
+    }
+
+    pub fn pd_scheduler(&self) -> Scheduler<pd::Task> {
+        assert!(self.workers.is_some());
+        self.workers.as_ref().unwrap().pd.scheduler()
     }
 
     pub fn shutdown(&mut self) {

--- a/components/raftstore-v2/src/worker/pd/mod.rs
+++ b/components/raftstore-v2/src/worker/pd/mod.rs
@@ -99,6 +99,9 @@ pub enum Task {
         tick_id: u64,
         duration: RaftstoreDuration,
     },
+    GracefulShutdownState {
+        state: bool,
+    },
 }
 
 impl Display for Task {
@@ -179,6 +182,9 @@ impl Display for Task {
                 "update slowness statistics: tick_id {}, duration {:?}",
                 tick_id, duration
             ),
+            Task::GracefulShutdownState { state } => {
+                write!(f, "graceful shutdown state: {}", state)
+            }
         }
     }
 }
@@ -227,6 +233,8 @@ where
     shutdown: Arc<AtomicBool>,
     #[allow(dead_code)]
     cfg: Arc<VersionTrack<Config>>,
+
+    graceful_shutdown_state: Arc<AtomicBool>,
 }
 
 impl<EK, ER, T> Runner<EK, ER, T>
@@ -252,6 +260,7 @@ where
         logger: Logger,
         shutdown: Arc<AtomicBool>,
         cfg: Arc<VersionTrack<Config>>,
+        graceful_shutdown_state: Arc<AtomicBool>,
     ) -> Result<Self, std::io::Error> {
         let store_heartbeat_interval = cfg.value().pd_store_heartbeat_tick_interval.0;
         let mut stats_monitor = PdStatsMonitor::new(
@@ -285,6 +294,7 @@ where
             logger,
             shutdown,
             cfg,
+            graceful_shutdown_state,
         })
     }
 }
@@ -348,6 +358,7 @@ where
             Task::UpdateSlownessStats { tick_id, duration } => {
                 self.handle_update_slowness_stats(tick_id, duration)
             }
+            Task::GracefulShutdownState { state } => self.handle_graceful_shutdown_state(state),
         }
     }
 }

--- a/components/raftstore-v2/src/worker/pd/slowness.rs
+++ b/components/raftstore-v2/src/worker/pd/slowness.rs
@@ -1,6 +1,9 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::time::{Duration, Instant};
+use std::{
+    sync::atomic::Ordering,
+    time::{Duration, Instant},
+};
 
 use engine_traits::{KvEngine, RaftEngine};
 use fail::fail_point;
@@ -11,8 +14,10 @@ use health_controller::{
 use kvproto::pdpb;
 use pd_client::PdClient;
 use raftstore::store::{metrics::*, Config};
+use slog::warn;
 
 use super::Runner;
+use crate::router::{StoreMsg, StoreTick};
 pub struct SlownessStatistics {
     /// Detector to detect NetIo&DiskIo jitters.
     slow_cause: Trend,
@@ -82,6 +87,15 @@ where
             tikv_util::time::duration_to_us(duration.sum()),
             Instant::now(),
         );
+    }
+
+    pub fn handle_graceful_shutdown_state(&mut self, state: bool) {
+        self.graceful_shutdown_state.store(state, Ordering::SeqCst);
+        let msg = StoreMsg::Tick(StoreTick::PdStoreHeartbeat);
+        if let Err(e) = self.router.send_control(msg) {
+            warn!(self.logger, "pd worker send graceful shutdown state failed";
+                    "err" => ?e);
+        }
     }
 
     pub fn handle_slowness_stats_tick(&mut self) {

--- a/components/raftstore-v2/src/worker/pd/store.rs
+++ b/components/raftstore-v2/src/worker/pd/store.rs
@@ -1,6 +1,9 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{cmp, sync::Arc};
+use std::{
+    cmp,
+    sync::{atomic::Ordering, Arc},
+};
 
 use collections::{HashMap, HashSet};
 use engine_traits::{KvEngine, RaftEngine};
@@ -267,6 +270,8 @@ where
 
         // Update slowness statistics
         self.update_slowness_in_store_stats(&mut stats, last_query_sum);
+
+        stats.set_is_stopping(self.graceful_shutdown_state.load(Ordering::SeqCst));
 
         let resp = self.pd_client.store_heartbeat(stats, store_report, None);
         let logger = self.logger.clone();

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -11,7 +11,7 @@ use std::{
     mem,
     ops::{Deref, DerefMut},
     sync::{
-        atomic::{AtomicU64, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
         Arc, Mutex,
     },
     time::{Duration, Instant, SystemTime},
@@ -1663,6 +1663,11 @@ impl<EK: KvEngine, ER: RaftEngine> RaftBatchSystem<EK, ER> {
             .scheduler()
     }
 
+    pub fn pd_scheduler(&self) -> Scheduler<PdTask<EK>> {
+        assert!(self.workers.is_some());
+        self.workers.as_ref().unwrap().pd_worker.scheduler()
+    }
+
     // TODO: reduce arguments
     pub fn spawn<T: Transport + 'static, C: PdClient + 'static>(
         &mut self,
@@ -1960,6 +1965,7 @@ impl<EK: KvEngine, ER: RaftEngine> RaftBatchSystem<EK, ER> {
             coprocessor_host,
             causal_ts_provider,
             grpc_service_mgr,
+            Arc::new(AtomicBool::new(false)),
         );
         assert!(workers.pd_worker.start(pd_runner));
 

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -72,9 +72,12 @@ use raftstore::{
     router::{CdcRaftRouter, ServerRaftStoreRouter},
     store::{
         config::RaftstoreConfigManager,
-        fsm,
-        fsm::store::{
-            RaftBatchSystem, RaftRouter, StoreMeta, MULTI_FILES_SNAPSHOT_FEATURE, PENDING_MSG_CAP,
+        fsm::{
+            self,
+            store::{
+                RaftBatchSystem, RaftRouter, StoreMeta, MULTI_FILES_SNAPSHOT_FEATURE,
+                PENDING_MSG_CAP,
+            },
         },
         memory::MEMTRACE_ROOT as MEMTRACE_RAFTSTORE,
         snapshot_backup::PrepareDiskSnapObserver,
@@ -166,6 +169,7 @@ fn run_impl<CER, F>(
     // Must be called after `TikvServer::init`.
     let memory_limit = tikv.core.config.memory_usage_limit.unwrap().0;
     let high_water = (tikv.core.config.memory_usage_high_water * memory_limit as f64) as u64;
+    let config_controller = tikv.cfg_controller.clone().unwrap();
     register_memory_usage_high_water(high_water);
 
     tikv.core.check_conflict_addr();
@@ -196,6 +200,7 @@ fn run_impl<CER, F>(
                 Some(engines),
                 kv_statistics,
                 raft_statistics,
+                config_controller,
                 Some(service_event_tx),
             )
         });
@@ -208,6 +213,10 @@ fn run_impl<CER, F>(
                 }
                 ServiceEvent::ResumeGrpc => {
                     tikv.resume();
+                }
+                ServiceEvent::GracefulShutdown => {
+                    tikv.graceful_shutdown();
+                    break;
                 }
                 ServiceEvent::Exit => {
                     break;
@@ -1576,7 +1585,7 @@ where
         if status_enabled {
             let mut status_server = match StatusServer::new(
                 self.core.config.server.status_thread_pool_size,
-                self.cfg_controller.take().unwrap(),
+                self.cfg_controller.clone().unwrap(),
                 Arc::new(self.core.config.security.clone()),
                 self.engines.as_ref().unwrap().engine.raft_extension(),
                 self.resource_manager.clone(),
@@ -1645,6 +1654,62 @@ where
                 "failed to resume the server";
                 "err" => ?e
             );
+        }
+    }
+
+    fn graceful_shutdown(&mut self) {
+        let now = Instant::now();
+        self.set_state(true);
+        self.wait_for_leader_eviction(now);
+        // set state to false to trigger a storeheartbeat and let PD remove the
+        // evict-leader scheduler.
+        self.set_state(false);
+        std::thread::sleep(Duration::from_millis(200));
+        info!("Graceful shutdown completed");
+    }
+
+    fn wait_for_leader_eviction(&self, now: Instant) {
+        let timeout = self
+            .cfg_controller
+            .as_ref()
+            .unwrap()
+            .get_current()
+            .server
+            .graceful_shutdown_timeout
+            .0;
+        let region_info_accessor = self.region_info_accessor.as_ref().unwrap();
+        let check_interval = Duration::from_secs(1);
+
+        loop {
+            let leaders_count = region_info_accessor.region_leaders().read().unwrap().len();
+
+            if leaders_count == 0 {
+                info!("All leaders evicted, completing graceful shutdown");
+                break;
+            }
+
+            if now.saturating_elapsed() >= timeout {
+                warn!(
+                    "Graceful shutdown timeout reached with {} leaders remaining",
+                    leaders_count
+                );
+                break;
+            }
+
+            info!("Waiting for leader eviction"; 
+                  "leaders_count" => leaders_count, 
+                  "elapsed" => ?now.saturating_elapsed());
+            std::thread::sleep(check_interval);
+        }
+    }
+
+    fn set_state(&self, state: bool) {
+        if let Some(server) = &self.servers {
+            let scheduler = server.raft_server.pd_scheduler();
+            let task = raftstore::store::PdTask::GracefulShutdownState { state };
+            if let Err(e) = scheduler.schedule(task) {
+                warn!("Failed to set graceful shutdown state for PD worker"; "error" => ?e);
+            }
         }
     }
 }

--- a/components/server/src/server2.rs
+++ b/components/server/src/server2.rs
@@ -151,6 +151,7 @@ fn run_impl<CER: ConfiguredRaftEngine, F: KvFormat>(
     // Must be called after `TikvServer::init`.
     let memory_limit = tikv.core.config.memory_usage_limit.unwrap().0;
     let high_water = (tikv.core.config.memory_usage_high_water * memory_limit as f64) as u64;
+    let config_controller = tikv.cfg_controller.clone().unwrap();
     register_memory_usage_high_water(high_water);
 
     tikv.core.check_conflict_addr();
@@ -180,6 +181,7 @@ fn run_impl<CER: ConfiguredRaftEngine, F: KvFormat>(
                 None as Option<Engines<RocksEngine, CER>>,
                 kv_statistics,
                 raft_statistics,
+                config_controller,
                 Some(service_event_tx),
             )
         });
@@ -192,6 +194,10 @@ fn run_impl<CER: ConfiguredRaftEngine, F: KvFormat>(
                 }
                 ServiceEvent::ResumeGrpc => {
                     tikv.resume();
+                }
+                ServiceEvent::GracefulShutdown => {
+                    tikv.graceful_shutdown();
+                    break;
                 }
                 ServiceEvent::Exit => {
                     break;
@@ -1500,6 +1506,54 @@ where
                 "failed to resume the server";
                 "err" => ?e
             );
+        }
+    }
+
+    fn graceful_shutdown(&mut self) {
+        let now = Instant::now();
+        self.set_state(true);
+        self.wait_for_leader_eviction(now);
+        self.set_state(false);
+        std::thread::sleep(Duration::from_millis(200));
+        info!("Graceful shutdown completed");
+    }
+
+    fn wait_for_leader_eviction(&self, now: Instant) {
+        let timeout = self.core.config.server.graceful_shutdown_timeout.0;
+        let region_info_accessor = self.region_info_accessor.as_ref().unwrap();
+        let check_interval = Duration::from_secs(1);
+
+        loop {
+            let leaders_count = region_info_accessor.region_leaders().read().unwrap().len();
+
+            if leaders_count == 0 {
+                info!("All leaders evicted, completing graceful shutdown");
+                break;
+            }
+
+            if now.saturating_elapsed() >= timeout {
+                warn!(
+                    "Graceful shutdown timeout reached with {} leaders remaining",
+                    leaders_count
+                );
+                break;
+            }
+
+            info!("Waiting for leader eviction"; 
+                  "leaders_count" => leaders_count, 
+                  "elapsed" => ?now.saturating_elapsed());
+            std::thread::sleep(check_interval);
+        }
+    }
+
+    fn set_state(&self, state: bool) {
+        if let Some(node) = self.node.as_ref() {
+            let system = node.system();
+            let task = raftstore_v2::PdTask::GracefulShutdownState { state };
+
+            if let Err(e) = system.pd_scheduler().schedule(task) {
+                warn!("Failed to set graceful shutdown state for PD worker"; "error" => ?e);
+            }
         }
     }
 }

--- a/components/service/src/service_event.rs
+++ b/components/service/src/service_event.rs
@@ -7,7 +7,8 @@ pub enum ServiceEvent {
     // For grpc service.
     PauseGrpc,
     ResumeGrpc,
-    // ...
+    // For graceful shutdown.
+    GracefulShutdown,
     Exit,
 }
 
@@ -16,6 +17,7 @@ impl fmt::Debug for ServiceEvent {
         match self {
             ServiceEvent::PauseGrpc => f.debug_tuple("PauseGrpc").finish(),
             ServiceEvent::ResumeGrpc => f.debug_tuple("ResumeGrpc").finish(),
+            ServiceEvent::GracefulShutdown => f.debug_tuple("GracefulShutdown").finish(),
             ServiceEvent::Exit => f.debug_tuple("Exit").finish(),
         }
     }

--- a/src/server/raft_server.rs
+++ b/src/server/raft_server.rs
@@ -236,6 +236,10 @@ where
         self.system.refresh_config_scheduler()
     }
 
+    pub fn pd_scheduler(&self) -> Scheduler<PdTask<EK>> {
+        self.system.pd_scheduler()
+    }
+
     /// Gets a transmission end of a channel which is used to send `Msg` to the
     /// raftstore.
     pub fn get_router(&self) -> RaftRouter<EK, ER> {

--- a/src/server/raftkv2/node.rs
+++ b/src/server/raftkv2/node.rs
@@ -176,6 +176,10 @@ where
         self.store.clone()
     }
 
+    pub fn system(&self) -> &StoreSystem<EK, ER> {
+        &self.system.as_ref().unwrap().1
+    }
+
     // TODO: support updating dynamic configuration.
 
     // TODO: check api version.

--- a/tests/integrations/config/graceful_shutdown_config.rs
+++ b/tests/integrations/config/graceful_shutdown_config.rs
@@ -1,0 +1,28 @@
+// Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::time::Duration;
+
+use tikv::config::TikvConfig;
+
+#[test]
+fn test_graceful_shutdown_config_defaults() {
+    let config = TikvConfig::default();
+
+    // Test default values
+    assert_eq!(
+        config.server.graceful_shutdown_timeout.0,
+        Duration::from_secs(20)
+    );
+}
+
+#[test]
+fn test_graceful_shutdown_config_serialization() {
+    let mut config = TikvConfig::default();
+    config.server.graceful_shutdown_timeout = tikv_util::config::ReadableDuration::secs(25);
+
+    // Test TOML serialization (basic structure test)
+    let toml_value = toml::Value::try_from(&config.server).unwrap();
+    let server_table = toml_value.as_table().unwrap();
+
+    assert!(server_table.contains_key("graceful-shutdown-timeout"));
+}

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -42,6 +42,7 @@ use tikv::{
 use tikv_util::config::{LogFormat, ReadableDuration, ReadableSchedule, ReadableSize};
 
 mod dynamic;
+mod graceful_shutdown_config;
 mod test_config_client;
 
 #[test]


### PR DESCRIPTION
close tikv/tikv#17221

When a SIGTERM signal is received, TiKV tells PD it's stopping by StoreHeartbeat. PD then try to move all the leaders from that TiKV instance before it fully shuts down.

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #17221

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
When a SIGTERM signal is received, TiKV tells PD it's stopping by StoreHeartbeat. PD then try to move all the leaders from that TiKV instance before it fully shuts down.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note

```
