### PR TITLE
cdc: fixing a TiKV assertion panic that can happen when CDC is enabled

### DIFF
--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -381,9 +381,10 @@ impl Delegate {
                             "region_id" => self.region_id,
                         );
                     }
-                    // There could be stale locks in the lock_tracker due to scenarios such as the overlapped
-                    // write/rollback issue (#18498). We can safely ignore such stale locks, while keeping
-                    // the invariant of monotonically increasing start_ts and generation.
+                    // There could be stale locks in the lock_tracker due to scenarios such as the
+                    // overlapped write/rollback issue (#18498). We can safely
+                    // ignore such stale locks, while keeping the invariant of
+                    // monotonically increasing start_ts and generation.
                     assert!(x.get().ts <= start_ts.ts);
                     assert!(x.get().generation <= start_ts.generation);
                     x.get_mut().ts = start_ts.ts;


### PR DESCRIPTION
Issue Number: Close #18498 

What's Changed:

```
This assertion failure happens due to a discrepancy between Raft engine state machine and how CDC is processing Raft commands. When there are overlapped writes with rollbacks which happens between primary and secondary keys, CDC ended-up having duplicate locks in its lock tracker when there isn't a PUT command on the WRITE_CF to release the lock.
```

```
The bug occurs when:
1. T1 prewrites and commits key K (start_ts=100, commit_ts=110)
    → CF_WRITE[K@110] contains T1's committed write
2. T2 prewrites key K as a SECONDARY key (start_ts=111)
   → CF_LOCK[K] contains T2's lock
   → CDC calls push_lock for T2
3. T2 rolls back key K
   → Finds overlapped_write from T1 at commit_ts=110
   → Since K is NOT T2's primary: protected=false
   → make_rollback() returns None (no CF_WRITE entry!)
   → Only deletes from CF_LOCK
   → CDC ignores the DELETE operation
4. T3 prewrites key K
   → Triggers resolve_lock which removes T2's stale lock from CF_LOCK
   → No CDC notification
5. CDC processes T3's prewrite
   → Calls push_lock for T3
   → Finds T2's stale lock still in lock_tracker
   → Assertion fails: different start_ts
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [x] Need to cherry-pick to the release branch

### Check List

Tests

- [ ] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Following is a load test that encountered this issue, still non-deterministic, but happened often enough to verify.

```
SHOW CREATE TABLE test.mockBootstrap;
+---------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Table         | Create Table                                                                                                                                                                                                                                                                                                    |
+---------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| mockBootstrap | CREATE TABLE `mockBootstrap` (
  `id` varchar(150) NOT NULL,
  `strCol` varchar(150) DEFAULT NULL,
  `dateCol` bigint DEFAULT NULL,
  PRIMARY KEY (`id`) /*T![clustered_index] CLUSTERED */,
  KEY `strCol` (`strCol`),
  KEY `dateCol` (`dateCol`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin |
+---------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

The load was generated using the [k6 framework](https://grafana.com/docs/loki/latest/send-data/k6/), with the following code (rest of the code is omitted for brevity). The key to hitting this was very high frequency inserts + secondary indexes, which caused overlapping writes with rollbacks.

```
export default function() {
    const timestamp = Date.now();
    const id = `urn:li:bootstrap:${Date.now()}`;
    const randomString = getRandomString(8);

    const sql = `INSERT INTO mockBootstrap (id, strCol, dateCol) `
        + `values (?, ?, ?) `
        + `ON DUPLICATE KEY UPDATE id = ?, strCol = ?, dateCol = ?`;

    db_config.executeSql(sql, [id, randomString, timestamp, id, randomString, timestamp]);
}
```
Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
None
```
