### PR TITLE
rafstore: fix incorrect handling of `ApplyRes` when peer is under destroying.

### DIFF
--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -1214,7 +1214,7 @@ where
     }
 
     fn on_casual_msg(&mut self, msg: Box<CasualMessage<EK>>) {
-        if self.fsm.peer.pending_remove == Some(PendingRemoveReason::Destroy) {
+        if self.fsm.peer.pending_remove == Some(PendingRemoveReason::ReadyToDestroy) {
             // It means that the peer will be asynchronously removed, it's no
             // need to execute the consequentail CasualMessages.
             return;
@@ -2593,10 +2593,10 @@ where
                 }
                 self.on_ready_result(&mut res.exec_res, &res.metrics);
                 if self.fsm.stopped
-                    || self.fsm.peer.pending_remove == Some(PendingRemoveReason::Destroy)
+                    || self.fsm.peer.pending_remove == Some(PendingRemoveReason::ReadyToDestroy)
                 {
                     // In PR#18805 we introduced asynchronous peer destruction. A peer
-                    // with `PendingRemoveReason::Destroy` is a stale peer that has been
+                    // with `PendingRemoveReason::ReadyToDestroy` is a stale peer that has been
                     // marked for removal and will be cleaned up by an async worker.
                     // Similarly, `stopped` means the peer is stopped. In either case we should
                     // ignore subsequent apply results for this peer — this preserves the semantics
@@ -4125,8 +4125,9 @@ where
     fn destroy_peer(&mut self, merged_by_target: bool) -> bool {
         self.ctx.coprocessor_host.on_destroy_peer(self.region());
         fail_point!("destroy_peer");
-        // Mark itself as pending_remove
-        self.fsm.peer.pending_remove = Some(PendingRemoveReason::Destroy);
+        // Mark itself `PendingRemoveReason::ReadyToDestroy` to represent that this peer
+        // is ready to be removed.
+        self.fsm.peer.pending_remove = Some(PendingRemoveReason::ReadyToDestroy);
 
         // try to decrease the RAFT_ENABLE_UNPERSISTED_APPLY_GAUGE count.
         self.fsm.peer.disable_apply_unpersisted_log(0);
@@ -4284,9 +4285,9 @@ where
     ) -> bool {
         assert_eq!(
             self.fsm.peer.pending_remove,
-            Some(PendingRemoveReason::Destroy),
+            Some(PendingRemoveReason::ReadyToDestroy),
             "terminate the peer under pending_remove state, exepcted {:?} actual {:?} ",
-            Some(PendingRemoveReason::Destroy),
+            Some(PendingRemoveReason::ReadyToDestroy),
             self.fsm.peer.pending_remove,
         );
         // Clean remains if needs and notify all pending requests to exit.

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -2588,22 +2588,20 @@ where
                     "peer_id" => self.fsm.peer_id(),
                     "res" => ?res,
                 );
-                if self.fsm.peer.wait_data
+                if self.fsm.peer.wait_data {
+                    return;
+                }
+                self.on_ready_result(&mut res.exec_res, &res.metrics);
+                if self.fsm.stopped
                     || self.fsm.peer.pending_remove == Some(PendingRemoveReason::Destroy)
                 {
                     // In PR#18805 we introduced asynchronous peer destruction. A peer
                     // with `PendingRemoveReason::Destroy` is a stale peer that has been
                     // marked for removal and will be cleaned up by an async worker.
-                    // Similarly, `wait_data` means the peer is waiting for snapshot or
-                    // apply work to finish. In either case we should ignore subsequent
-                    // apply results for this peer — this preserves the semantics of the
-                    // original synchronous-destroy path and avoids applying results for
-                    // a peer that is effectively slated for removal or not ready to
-                    // accept them.
-                    return;
-                }
-                self.on_ready_result(&mut res.exec_res, &res.metrics);
-                if self.fsm.stopped {
+                    // Similarly, `stopped` means the peer is stopped. In either case we should
+                    // ignore subsequent apply results for this peer — this preserves the semantics
+                    // of the original synchronous-destroy path and avoids applying results for a
+                    // peer that is effectively slated for removal or already stopped.
                     return;
                 }
                 let applied_index = res.apply_state.applied_index;

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -1664,6 +1664,12 @@ where
         region: metapb::Region,
         reason: RegionChangeReason,
     ) {
+        fail_point!(
+            "raftstore_set_region_after_change_peer",
+            self.peer.get_store_id() == 3 && reason == RegionChangeReason::ChangePeer,
+            |_| {}
+        );
+
         if self.region().get_region_epoch().get_version() < region.get_region_epoch().get_version()
         {
             // Epoch version changed, disable read on the local reader for this region.


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: close https://github.com/tikv/tikv/issues/19034, ref https://github.com/tikv/tikv/issues/19004

Fix the bug introduced by the previous work https://github.com/tikv/tikv/pull/19015, which makes the under destroying peer could not handle `ApplyRes::(...)` as expected. Without this updates, some in-memory states of destroyed peers could not be updated timely.

With this bugfix, the `resolved-ts` can be promoted as expected:
<img width="5872" height="2266" alt="image" src="https://github.com/user-attachments/assets/758e1846-414e-4ba7-a08a-23e3859ad4aa" />

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Fix the bug introduced by the previous work PR#19015, which makes the under destroying peer could not handle `ApplyRes::(...)` as expected.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
