### PR TITLE
backup_stream: encode ts related field into meta file path (#18482) 

### DIFF
--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -809,7 +809,7 @@ where
         router.unregister_task(task)
     }
 
-    fn prepare_min_ts(&self) -> future![TimeStamp] {
+    fn prepare_min_ts(&self) -> future![(TimeStamp, TimeStamp)] {
         let pd_cli = self.pd_client.clone();
         let cm = self.concurrency_manager.clone();
         async move {
@@ -820,11 +820,16 @@ where
                 .unwrap_or_default();
             cm.update_max_ts(pd_tso, "backup-stream").unwrap();
             let min_ts = cm.global_min_lock_ts().unwrap_or(TimeStamp::max());
-            Ord::min(pd_tso, min_ts)
+            (Ord::min(pd_tso, min_ts), pd_tso)
         }
     }
 
-    fn do_flush(&self, task: String, resolved: ResolvedRegions) -> future![Result<()>] {
+    fn do_flush(
+        &self,
+        task: String,
+        resolved: ResolvedRegions,
+        flush_ts: TimeStamp,
+    ) -> future![Result<()>] {
         let router = self.range_router.clone();
         let store_id = self.store_id;
         let mut flush_ob = self.flush_observer();
@@ -841,6 +846,7 @@ where
                 store_id,
                 resolved_regions: &resolved,
                 resolved_ts: new_rts,
+                flush_ts,
             };
             if let Some(rts) = router.do_flush(cx).await {
                 info!("flushing and refreshing checkpoint ts.";
@@ -862,11 +868,11 @@ where
             let handler_res = self.range_router.get_task_handler(&task);
             // This should only happen in testing, it would be to unwrap...
             let _ = handler_res.unwrap().set_flushing_status_cas(false, true);
-            let mts = self.prepare_min_ts().await;
+            let (mts, fts) = self.prepare_min_ts().await;
             let sched = self.scheduler.clone();
             self.region_op(ObserveOp::ResolveRegions {
                 callback: Box::new(move |res| {
-                    try_send!(sched, Task::ExecFlush(task, res));
+                    try_send!(sched, Task::ExecFlush(task, res, fts));
                 }),
                 min_ts: mts,
             })
@@ -876,12 +882,12 @@ where
 
     pub fn on_flush(&self, task: String) {
         self.pool.block_on(async move {
-            let mts = self.prepare_min_ts().await;
+            let (mts, flush_ts) = self.prepare_min_ts().await;
             let sched = self.scheduler.clone();
-            info!("min_ts prepared for flushing"; "min_ts" => %mts);
+            info!("min_ts prepared for flushing"; "min_ts" => %mts, "flush_ts" => %flush_ts);
             self.region_op(ObserveOp::ResolveRegions {
                 callback: Box::new(move |res| {
-                    try_send!(sched, Task::ExecFlush(task, res));
+                    try_send!(sched, Task::ExecFlush(task, res, flush_ts));
                 }),
                 min_ts: mts,
             })
@@ -889,14 +895,15 @@ where
         })
     }
 
-    fn on_exec_flush(&mut self, task: String, resolved: ResolvedRegions) {
+    fn on_exec_flush(&mut self, task: String, resolved: ResolvedRegions, flush_ts: TimeStamp) {
         self.checkpoint_mgr.freeze();
-        self.pool
-            .spawn(root!("flush"; self.do_flush(task, resolved).map(|r| {
+        self.pool.spawn(
+            root!("flush"; self.do_flush(task, resolved, flush_ts).map(|r| {
                 if let Err(err) = r {
                     err.report("during updating flush status")
                 }
-            })));
+            })),
+        );
     }
 
     fn update_global_checkpoint(&self, task: String) -> future![()] {
@@ -1041,7 +1048,7 @@ where
                 }
             }
             Task::MarkFailover(t) => self.failover_time = Some(t),
-            Task::ExecFlush(task, min_ts) => self.on_exec_flush(task, min_ts),
+            Task::ExecFlush(task, min_ts, flush_ts) => self.on_exec_flush(task, min_ts, flush_ts),
             Task::RegionCheckpointsOp(s) => self.handle_region_checkpoints_op(s),
             Task::UpdateGlobalCheckpoint(task) => self.on_update_global_checkpoint(task),
         }
@@ -1104,7 +1111,7 @@ where
                     metrics::MISC_EVENTS.skip_resolve_no_subscription.inc();
                     return;
                 }
-                let min_ts = self.pool.block_on(self.prepare_min_ts());
+                let (min_ts, _) = self.pool.block_on(self.prepare_min_ts());
                 let start_time = Instant::now();
                 // We need to reschedule the `Resolve` task to queue, because the subscription
                 // is asynchronous -- there may be transactions committed before
@@ -1271,7 +1278,7 @@ pub enum Task {
     Flush(String),
     /// Execute the flush with the calculated resolved result.
     /// This is an internal command only issued by the `Flush` task.
-    ExecFlush(String, ResolvedRegions),
+    ExecFlush(String, ResolvedRegions, TimeStamp),
     /// The command for getting region checkpoints.
     RegionCheckpointsOp(RegionCheckpointOperation),
     /// update global-checkpoint-ts to storage.
@@ -1386,10 +1393,11 @@ impl fmt::Debug for Task {
                 .debug_tuple("MarkFailover")
                 .field(&format_args!("{:?} ago", t.saturating_elapsed()))
                 .finish(),
-            Self::ExecFlush(arg0, arg1) => f
+            Self::ExecFlush(arg0, arg1, arg2) => f
                 .debug_tuple("ExecFlush")
                 .field(arg0)
                 .field(&arg1.global_checkpoint())
+                .field(&arg2)
                 .finish(),
             Self::RegionCheckpointsOp(s) => f.debug_tuple("GetRegionCheckpoints").field(s).finish(),
             Self::UpdateGlobalCheckpoint(task) => {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

close tikv/tikv#18497, ref pingcap/tidb#61318


<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
backup_stream: encode ts related field into meta file path.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
