### PR TITLE
grpc: support grpc_max_connection_idle and grpc_max_connection_age

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -222,6 +222,19 @@
 ## Time to wait before closing the connection without receiving KeepAlive ping Ack.
 # grpc-keepalive-timeout = "3s"
 
+## gRPC connection maximum idle time. Connections will be closed after being idle for this duration.
+## Default value: 2 hours, set to 0 to disable.
+# grpc-max-connection-idle = "2h"
+
+## gRPC connection maximum age. Connections will be closed after existing for this duration.
+## Default value: 0, set to 0 to disable.
+# grpc-max-connection-age = "0s"
+
+## gRPC connection maximum age grace period. When a connection reaches its maximum age,
+## it will wait for existing requests to complete during this grace period before closing.
+## Default value: 0, set to 0 for no grace period.
+# grpc-max-connection-age-grace = "0s"
+
 ## Set maximum message length in bytes that gRPC can send. `-1` means unlimited.
 # max-grpc-send-msg-len = 10485760
 

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -65,6 +65,9 @@ const DEFAULT_GRPC_MEMORY_POOL_QUOTA: u64 = isize::MAX as u64;
 const DEFAULT_GRPC_STREAM_INITIAL_WINDOW_SIZE: u64 = 2 * 1024 * 1024;
 const DEFAULT_GRPC_GZIP_COMPRESSION_LEVEL: usize = 2;
 const DEFAULT_GRPC_MIN_MESSAGE_SIZE_TO_COMPRESS: usize = 4096;
+const DEFAULT_GRPC_MAX_CONNECTION_IDLE: ReadableDuration = ReadableDuration::hours(2);
+const DEFAULT_GRPC_MAX_CONNECTION_AGE: ReadableDuration = ReadableDuration::secs(0);
+const DEFAULT_GRPC_MAX_CONNECTION_AGE_GRACE: ReadableDuration = ReadableDuration::secs(0);
 
 // Number of rows in each chunk.
 const DEFAULT_ENDPOINT_BATCH_ROW_LIMIT: usize = 64;
@@ -185,6 +188,12 @@ pub struct Config {
     pub grpc_keepalive_time: ReadableDuration,
     #[online_config(skip)]
     pub grpc_keepalive_timeout: ReadableDuration,
+    #[online_config(skip)]
+    pub grpc_max_connection_idle: ReadableDuration,
+    #[online_config(skip)]
+    pub grpc_max_connection_age: ReadableDuration,
+    #[online_config(skip)]
+    pub grpc_max_connection_age_grace: ReadableDuration,
     /// How many snapshots can be sent concurrently.
     pub concurrent_send_snap_limit: usize,
     /// How many snapshots can be recv concurrently.
@@ -324,6 +333,9 @@ impl Default for Config {
             // than 10 senconds.
             grpc_keepalive_time: ReadableDuration::secs(10),
             grpc_keepalive_timeout: ReadableDuration::secs(3),
+            grpc_max_connection_idle: DEFAULT_GRPC_MAX_CONNECTION_IDLE,
+            grpc_max_connection_age: DEFAULT_GRPC_MAX_CONNECTION_AGE,
+            grpc_max_connection_age_grace: DEFAULT_GRPC_MAX_CONNECTION_AGE_GRACE,
             concurrent_send_snap_limit: 32,
             concurrent_recv_snap_limit: 32,
             end_point_concurrency: None, // deprecated

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -1,6 +1,7 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::{
+    ffi::CString,
     net::{IpAddr, SocketAddr},
     str::FromStr,
     sync::Arc,
@@ -122,8 +123,20 @@ where
             .http2_max_ping_strikes(i32::MAX) // For pings without data from clients.
             .keepalive_time(self.cfg.value().grpc_keepalive_time.into())
             .keepalive_timeout(self.cfg.value().grpc_keepalive_timeout.into())
+            .raw_cfg_int(
+                CString::new("grpc.max_connection_idle_ms").unwrap(),
+                self.cfg.value().grpc_max_connection_idle.as_millis() as i32
+            )
+            .raw_cfg_int(
+                CString::new("grpc.max_connection_age_ms").unwrap(),
+                self.cfg.value().grpc_max_connection_age.as_millis() as i32
+            )
+            .raw_cfg_int(
+                CString::new("grpc.max_connection_age_grace_ms").unwrap(),
+                self.cfg.value().grpc_max_connection_age_grace.as_millis() as i32
+            )
+            .default_compression_algorithm(self.cfg.value().grpc_compression_algorithm())
             .default_gzip_compression_level(self.cfg.value().grpc_gzip_compression_level)
-            .default_compression_level(compression_level)
             .build_args();
 
         let sb = ServerBuilder::new(Arc::clone(&env))


### PR DESCRIPTION


### What is changed and how it works?

Issue Number: Close #19045

What's Changed:
Added support for gRPC connection lifecycle management parameters to improve connection handling and prevent conn leaks in TiKV.

```commit-message

grpc: support grpc_max_connection_idle and grpc_max_connection_age

Added three new configuration parameters to manage gRPC connection lifecycle:
- grpc-max-connection-idle: Controls maximum idle time for connections (default: 2 hour)
- grpc-max-connection-age: Controls maximum lifetime for connections (default: 0) 
- grpc-max-connection-age-grace: Controls grace period for existing requests when connection reaches maximum age (default: 0)

These changes allow TiKV to better manage gRPC connection lifecycle, helping to prevent resource leaks and ensuring connections are refreshed periodically for improved system stability and security.

Signed-off-by: yin.yin@horizon.cc

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

