### PR TITLE
Revert "aws: disable stalled stream protection for S3Storage (#18875)(#18979)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -649,7 +649,6 @@ dependencies = [
  "http-body 0.4.5",
  "http-body 1.0.0",
  "http-body-util",
- "hyper",
  "itoa 1.0.1",
  "num-integer",
  "pin-project-lite",

--- a/components/cloud/aws/Cargo.toml
+++ b/components/cloud/aws/Cargo.toml
@@ -50,7 +50,6 @@ uuid = { version = "0.8", features = ["v4"] }
 
 [dev-dependencies]
 aws-smithy-runtime = { version = "1.4.0", features = ["test-util", "client"] }
-aws-smithy-types = { version = "1", features = ["hyper-0-14-x", "http-body-0-4-x"] }
 base64 = "0.13"
 futures = "0.3"
 tokio = { version = "1.5", features = ["macros"] }

--- a/components/cloud/aws/src/s3.rs
+++ b/components/cloud/aws/src/s3.rs
@@ -10,7 +10,7 @@ use async_trait::async_trait;
 use aws_config::{sts::AssumeRoleProvider, BehaviorVersion, Region, SdkConfig};
 use aws_credential_types::{provider::ProvideCredentials, Credentials};
 use aws_sdk_s3::{
-    config::{HttpClient, StalledStreamProtectionConfig},
+    config::HttpClient,
     operation::get_object::GetObjectError,
     types::{CompletedMultipartUpload, CompletedPart},
     Client,
@@ -255,9 +255,8 @@ impl S3Storage {
         let bucket_region = none_to_empty(config.bucket.region.clone());
         let bucket_endpoint = none_to_empty(config.bucket.endpoint.clone());
 
-        let mut loader = aws_config::defaults(BehaviorVersion::latest())
-            .stalled_stream_protection(StalledStreamProtectionConfig::disabled())
-            .credentials_provider(creds);
+        let mut loader =
+            aws_config::defaults(BehaviorVersion::latest()).credentials_provider(creds);
 
         loader = util::configure_region(loader, &bucket_region)?;
         loader = util::configure_endpoint(loader, &bucket_endpoint);
@@ -1146,61 +1145,6 @@ mod tests {
         client.assert_requests_match(&[]);
     }
 
-    /// Ensures that stalled stream protection does not kick in to kill a
-    /// rate-limited connection.
-    ///
-    /// This test simulates a GetObject response with 7s delay, which will cause
-    /// a StreamingError(ThroughputBelowMinimum) error if stalled stream
-    /// protection is enabled.
-    #[tokio::test]
-    async fn test_s3_storage_without_stalled_stream_protection() {
-        let bucket_name = StringNonEmpty::required("mybucket".to_string()).unwrap();
-        let mut bucket = BucketConf::default(bucket_name);
-        bucket.region = StringNonEmpty::opt("ap-southeast-2".to_string());
-        bucket.prefix = StringNonEmpty::opt("myprefix".to_string());
-        let config = Config::default(bucket);
-
-        let (mut delayed_response_sender, delayed_response_body) = hyper::body::Body::channel();
-        let client = StaticReplayClient::new(vec![
-            ReplayEvent::new(
-                http::Request::builder()
-                    .method("GET")
-                    .uri(Uri::from_static(
-                        "https://mybucket.s3.ap-southeast-2.amazonaws.com/myprefix/mykey?x-id=GetObject",
-                    ))
-                    .body(SdkBody::empty())
-                    .unwrap(),
-                http::Response::builder()
-                    .status(200)
-                    .body(delayed_response_body.into())
-                    .unwrap(),
-            ),
-        ]);
-
-        let creds = Credentials::from_keys("abc".to_string(), "xyz".to_string(), None);
-        let s = S3Storage::new_with_creds_client(config.clone(), client.clone(), creds).unwrap();
-
-        let mut reader = s.get("mykey");
-        let mut buf = Vec::new();
-        let send_delayed_response_task = tokio::spawn(async move {
-            // The sleep cannot be less than 6s. We need to ensure the throughput is 0 B/s
-            // for over 6s to trigger stalled stream protection.
-            tokio::time::sleep(Duration::from_secs(7)).await;
-            delayed_response_sender
-                .send_data("abcd".into())
-                .await
-                .unwrap();
-        });
-
-        let ret = reader.read_to_end(&mut buf).await.unwrap();
-        send_delayed_response_task.await.unwrap();
-        assert_eq!(ret, 4);
-        assert_eq!(buf, b"abcd");
-
-        client.assert_requests_match(&[]);
-    }
-
-    #[ignore = "s3 test env is unavailable"]
     #[tokio::test]
     #[cfg(FALSE)]
     // FIXME: enable this (or move this to an integration test) if we've got a


### PR DESCRIPTION


This reverts commit 518cb06d50cb491278e5a8befc3efeca3baabb47.

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #xxx

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note

```
