### PR TITLE
cdc: adjust assertion when merge locks

### DIFF
--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -460,9 +460,11 @@ impl Delegate {
                     BTreeMapEntry::Vacant(x) => {
                         x.insert(start_ts);
                     }
-                    BTreeMapEntry::Occupied(x) => {
-                        assert_eq!(x.get().ts, start_ts.ts);
+                    BTreeMapEntry::Occupied(mut x) => {
+                        assert!(x.get().ts <= start_ts.ts);
                         assert!(x.get().generation <= start_ts.generation);
+                        x.get_mut().ts = start_ts.ts;
+                        x.get_mut().generation = start_ts.generation;
                     }
                 },
                 PendingLock::Untrack { key, start_ts } => {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #19048 

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
fix potential panic which may happen when subscribe the region and meet rollback and prewrite entry
```

Similar to the #19025, but the region is subscribed after the rollback prewrite entry stored into the disk and before the prewrite the same key.
```

The bug may occurs when:
1. T1 prewrites and commits key K (start_ts=100, commit_ts=110)
    → CF_WRITE[K@110] contains T1's committed write

2. T2 prewrites key K as a SECONDARY key (start_ts=111), and CDC subscribe the region 
   → CF_LOCK[K] contains T2's lock
   → CF_LOCK[K@111] scanned out when doing incremental scan by the `scan_locks_from_storage`
   → CDC incremental scan finished and set to the resolver by the `finish_scan_locks`

4. T2 rolls back key K
   → Finds overlapped_write from T1 at commit_ts=110
   → Since K is NOT T2's primary: protected=false
   → make_rollback() returns None (no CF_WRITE entry!)
   → Only deletes from CF_LOCK
   → CDC ignores the DELETE operation

5. T3 prewrites key K
   → Triggers resolve_lock which removes T2's stale lock from CF_LOCK
   → No CDC notification

6. CDC processes T3's prewrite
   → Calls push_lock for T3
   → Finds T2's stale lock still in lock_tracker
   → Assertion fails: different start_ts
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
fix potential panic which may happen when subscribe the region and meet rollback and prewrite entry
```
