### PR TITLE
compact_log_backup: read meta from checkpoint

### DIFF
--- a/components/compact-log-backup/src/compaction/meta.rs
+++ b/components/compact-log-backup/src/compaction/meta.rs
@@ -234,8 +234,8 @@ impl CompactionRunInfoBuilder {
         self.files.is_empty()
     }
 
-    pub fn add_subcompaction(&mut self, c: &SubcompactionResult) {
-        for file in &c.origin.inputs {
+    pub fn add_origin_subcompaction(&mut self, c: &Subcompaction) {
+        for file in &c.inputs {
             if !self.files.contains_key(&file.id.name) {
                 self.files
                     .insert(Arc::clone(&file.id.name), Default::default());
@@ -245,9 +245,13 @@ impl CompactionRunInfoBuilder {
                 .unwrap()
                 .insert(SortByOffset(file.id.clone()));
         }
-        self.compaction.artifacts_hash ^= c.origin.crc64();
-        self.compaction.input_min_ts = self.compaction.input_min_ts.min(c.origin.input_min_ts);
-        self.compaction.input_max_ts = self.compaction.input_max_ts.max(c.origin.input_max_ts);
+        self.compaction.artifacts_hash ^= c.crc64();
+        self.compaction.input_min_ts = self.compaction.input_min_ts.min(c.input_min_ts);
+        self.compaction.input_max_ts = self.compaction.input_max_ts.max(c.input_max_ts);
+    }
+
+    pub fn add_subcompaction(&mut self, c: &SubcompactionResult) {
+        self.add_origin_subcompaction(&c.origin);
     }
 
     pub fn mut_meta(&mut self) -> &mut brpb::LogFileCompaction {

--- a/components/compact-log-backup/src/exec_hooks/checkpoint.rs
+++ b/components/compact-log-backup/src/exec_hooks/checkpoint.rs
@@ -9,7 +9,7 @@ use tikv_util::{info, time::Instant, warn};
 use crate::{
     ErrorKind, OtherErrExt, Result, TraceResultExt,
     compaction::META_OUT_REL,
-    execute::hooking::{BeforeStartCtx, CId, ExecHooks, SubcompactionStartCtx},
+    execute::hooking::{BeforeStartCtx, CId, ExecHooks, SkipReason, SubcompactionStartCtx},
 };
 
 #[derive(Default)]
@@ -75,7 +75,7 @@ impl ExecHooks for Checkpoint {
         if self.loaded.contains(&hash) {
             info!("Checkpoint: skipping a subcompaction because we have found it."; 
                 "subc" => %cx.subc, "hash" => %format_args!("{:16X}", hash));
-            cx.skip();
+            cx.skip(SkipReason::AlreadyDone);
         }
     }
 }

--- a/components/compact-log-backup/src/exec_hooks/skip_small_compaction.rs
+++ b/components/compact-log-backup/src/exec_hooks/skip_small_compaction.rs
@@ -2,7 +2,7 @@
 
 use tikv_util::info;
 
-use crate::execute::hooking::{CId, ExecHooks, SubcompactionStartCtx};
+use crate::execute::hooking::{CId, ExecHooks, SkipReason, SubcompactionStartCtx};
 
 /// A hook that skips small compaction.
 ///
@@ -24,7 +24,7 @@ impl ExecHooks for SkipSmallCompaction {
         if cx.subc.size < self.size_threshold {
             info!("Skipped a small compaction."; 
                 "size" => cx.subc.size, "threshold" => self.size_threshold);
-            cx.skip();
+            cx.skip(SkipReason::NoNeedToDo);
         }
     }
 }

--- a/components/compact-log-backup/src/execute/mod.rs
+++ b/components/compact-log-backup/src/execute/mod.rs
@@ -34,6 +34,7 @@ use crate::{
     ErrorKind,
     compaction::{SubcompactionResult, exec::SubcompactionExecArg},
     errors::{Result, TraceResultExt},
+    execute::hooking::SubcompactionSkippedCtx,
     util,
 };
 
@@ -199,7 +200,7 @@ impl Execution {
 
             let c = c?;
             let cid = CId(id);
-            let skip = Cell::new(false);
+            let skip = Cell::new(None);
             let cx = SubcompactionStartCtx {
                 subc: &c,
                 load_stat_diff: &lstat,
@@ -207,7 +208,9 @@ impl Execution {
                 skip: &skip,
             };
             hooks.before_a_subcompaction_start(cid, cx);
-            if skip.get() {
+            if let Some(reason) = skip.get() {
+                let skipped_cx = SubcompactionSkippedCtx { subc: &c, reason };
+                hooks.on_subcompaction_skipped(skipped_cx).await;
                 continue;
             }
 

--- a/components/compact-log-backup/src/execute/test.rs
+++ b/components/compact-log-backup/src/execute/test.rs
@@ -110,6 +110,10 @@ async fn test_exec_simple() {
     let (id, mig) = migs.pop().unwrap();
     assert_eq!(id, 1);
     assert_eq!(mig.edit_meta.len(), 3);
+    for meta in mig.edit_meta.iter() {
+        assert!(meta.all_data_files_compacted);
+        assert!(meta.destruct_self);
+    }
     assert_eq!(mig.compactions.len(), 1);
     let subc = st
         .load_subcompactions(mig.compactions[0].get_artifacts())
@@ -185,6 +189,10 @@ async fn test_checkpointing() {
     let (id, mig) = migs.pop().unwrap();
     assert_eq!(id, 1);
     assert_eq!(mig.edit_meta.len(), 3);
+    for meta in mig.edit_meta.iter() {
+        assert!(meta.all_data_files_compacted);
+        assert!(meta.destruct_self);
+    }
     assert_eq!(mig.compactions.len(), 1);
     let subc = st
         .load_subcompactions(mig.compactions[0].get_artifacts())


### PR DESCRIPTION
…t updates

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #19069

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
This PR makes `compact-log-backup` fills the migration with subcompactions skipped by checkpoint.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fixed a bug that may cause `restore point` be slower when checkpoint was triggered.
```
