### PR TITLE
txn: embed share locks into lock info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3692,7 +3692,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/you06/kvproto?branch=8.5-shared-lock/embed-lock#69e8bd84ce9bfe49b37025c70d871f1f8ca29883"
+source = "git+https://github.com/pingcap/kvproto.git?branch=tidb-8.5-with-shared-lock#99dcd0a331b0d45c58db41a7769f7d082ade37c2"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,8 +219,8 @@ sysinfo = { git = "https://github.com/tikv/sysinfo", branch = "0.26-fix-cpu" }
 # When you modify TiKV cooperatively with kvproto, this will be useful to submit the PR to TiKV and the PR to
 # kvproto at the same time.
 # After the PR to kvproto is merged, remember to comment this out and run `cargo update -p kvproto`.
-[patch.'https://github.com/pingcap/kvproto']
-kvproto = { git = "https://github.com/you06/kvproto", branch = "8.5-shared-lock/embed-lock" }
+# [patch.'https://github.com/pingcap/kvproto']
+# kvproto = { git = "https://github.com/your_github_id/kvproto", branch = "your_branch" }
 #
 # After the PR to rust-rocksdb is merged, remember to comment this out and run `cargo update -p rocksdb`.
 # [patch.'https://github.com/tikv/rust-rocksdb']

--- a/components/txn_types/src/lock.rs
+++ b/components/txn_types/src/lock.rs
@@ -637,8 +637,8 @@ impl Lock {
             LockType::Shared => {
                 let shared_locks: Option<Vec<_>> = self.shared_lock_txns_info.map(|info| {
                     info.txn_info_segments
-                        .iter()
-                        .map(|(_, lock)| match lock {
+                        .values()
+                        .map(|lock| match lock {
                             Either::Left(encoded) => Lock::parse(encoded).unwrap(),
                             Either::Right(lock) => lock.clone(),
                         })
@@ -654,7 +654,7 @@ impl Lock {
                         .collect()
                 });
                 (Op::SharedLock, shared_locks)
-            },
+            }
         };
         info.set_lock_type(lock_type);
         if let Some(shared_lock_infos) = shared_lock_infos {

--- a/tests/failpoints/cases/test_storage.rs
+++ b/tests/failpoints/cases/test_storage.rs
@@ -1904,9 +1904,7 @@ fn test_shared_exclusive_lock_conflict() {
         storage
             .sched_txn_command(
                 commands::Prewrite::new(
-                    vec![
-                        Mutation::make_lock(Key::from_raw(&shared_key)),
-                    ],
+                    vec![Mutation::make_lock(Key::from_raw(&shared_key))],
                     pk.clone(),
                     start_ts.into(),
                     3000,
@@ -1919,9 +1917,7 @@ fn test_shared_exclusive_lock_conflict() {
                     AssertionLevel::Off,
                     Context::default(),
                 ),
-                Box::new(
-                    move |res: storage::Result<PrewriteResult>| done_tx.send(res).unwrap(),
-                ),
+                Box::new(move |res: storage::Result<PrewriteResult>| done_tx.send(res).unwrap()),
             )
             .unwrap();
         done_rx.recv_timeout(Duration::from_secs(5)).unwrap()
@@ -2072,11 +2068,14 @@ fn test_shared_exclusive_lock_conflict() {
                 assert_eq!(shared_lock.get_primary_lock(), &pk);
                 let start_ts = shared_lock.get_lock_version();
                 assert!([80, 100].contains(&start_ts));
-                assert_eq!(shared_lock.get_lock_type(), match start_ts {
-                    80 => kvrpcpb::Op::SharedPessimisticLock,
-                    100 => kvrpcpb::Op::SharedLock,
-                    _ => unreachable!(),
-                });
+                assert_eq!(
+                    shared_lock.get_lock_type(),
+                    match start_ts {
+                        80 => kvrpcpb::Op::SharedPessimisticLock,
+                        100 => kvrpcpb::Op::SharedLock,
+                        _ => unreachable!(),
+                    }
+                );
             }
         }
         other => panic!("unexpected lock error: {:?}", other),


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #19087

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
This PR embeds the share locks into lock info for client resolving usage.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
