### PR TITLE
ci: add new github action workflow

### DIFF
--- a/.github/workflows/tikv-clippy-darwin-amd64.yml
+++ b/.github/workflows/tikv-clippy-darwin-amd64.yml
@@ -216,7 +216,7 @@ jobs:
               repo: context.repo.repo,
               sha: sha,
               state: 'failure',
-              context: 'idc-jenkins-ci-tikv/clippy-darwin-amd64',
+              context: 'ci-tikv/clippy-darwin-amd64',
               description: 'Clippy check failed',
               target_url: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
             });


### PR DESCRIPTION
Use GitHub Actions to replace the old Jenkins jobs on the PingCAP-QE/ci.git
- original jenkins job: https://ci.pingcap.net/job/tikv-ghpr-clippy-darwin-amd64/