### PR TITLE
copr: support common handle for index_lookup_executor

### DIFF
--- a/components/tidb_query_datatype/src/codec/batch/lazy_column_vec.rs
+++ b/components/tidb_query_datatype/src/codec/batch/lazy_column_vec.rs
@@ -19,12 +19,20 @@ pub struct LazyBatchColumnVec {
     /// For decoded columns, they may be in different types. If the column is in
     /// type `LazyBatchColumn::Raw`, it means that it is not decoded.
     columns: Vec<LazyBatchColumn>,
+
+    /// extra_common_handle_keys is used internally between executors to
+    /// exchange the common handle keys when needed, e.g. for index lookup
+    /// to lookup table rows.
+    extra_common_handle_keys: Option<Vec<Vec<u8>>>,
 }
 
 impl From<Vec<LazyBatchColumn>> for LazyBatchColumnVec {
     #[inline]
     fn from(columns: Vec<LazyBatchColumn>) -> Self {
-        LazyBatchColumnVec { columns }
+        LazyBatchColumnVec {
+            columns,
+            extra_common_handle_keys: None,
+        }
     }
 }
 
@@ -33,6 +41,7 @@ impl From<Vec<VectorValue>> for LazyBatchColumnVec {
     fn from(columns: Vec<VectorValue>) -> Self {
         LazyBatchColumnVec {
             columns: columns.into_iter().map(LazyBatchColumn::from).collect(),
+            extra_common_handle_keys: None,
         }
     }
 }
@@ -47,6 +56,7 @@ impl LazyBatchColumnVec {
     pub fn empty() -> Self {
         Self {
             columns: Vec::new(),
+            extra_common_handle_keys: None,
         }
     }
 
@@ -61,6 +71,10 @@ impl LazyBatchColumnVec {
                 .iter()
                 .map(|c| c.clone_empty(capacity))
                 .collect(),
+            extra_common_handle_keys: self
+                .extra_common_handle_keys
+                .as_ref()
+                .map(|_| Vec::with_capacity(capacity)),
         }
     }
 
@@ -74,7 +88,10 @@ impl LazyBatchColumnVec {
             let column = LazyBatchColumn::raw_with_capacity(0);
             columns.push(column);
         }
-        Self { columns }
+        Self {
+            columns,
+            extra_common_handle_keys: None,
+        }
     }
 
     /// Returns the number of columns.
@@ -198,6 +215,31 @@ impl LazyBatchColumnVec {
     /// Returns the inner columns as a mutable slice.
     pub fn as_mut_slice(&mut self) -> &mut [LazyBatchColumn] {
         self.columns.as_mut_slice()
+    }
+
+    #[inline]
+    pub fn mut_extra_common_handle_keys(&mut self) -> &mut Vec<Vec<u8>> {
+        if self.extra_common_handle_keys.is_none() {
+            self.extra_common_handle_keys = Some(vec![]);
+        }
+        self.extra_common_handle_keys.as_mut().unwrap()
+    }
+
+    #[inline]
+    pub fn has_extra_common_handle_keys(&self) -> bool {
+        self.extra_common_handle_keys.is_some()
+    }
+
+    #[inline]
+    pub fn get_extra_common_handle_key(&self, i: usize) -> Option<&[u8]> {
+        self.extra_common_handle_keys
+            .as_ref()
+            .and_then(|v| v.get(i).map(|key| key.as_slice()))
+    }
+
+    #[inline]
+    pub fn take_extra_common_handle_keys(&mut self) -> Option<Vec<Vec<u8>>> {
+        self.extra_common_handle_keys.take()
     }
 }
 

--- a/components/tidb_query_datatype/src/codec/table.rs
+++ b/components/tidb_query_datatype/src/codec/table.rs
@@ -1,6 +1,6 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{cmp, convert::TryInto, fmt::Debug, io::Write, sync::Arc};
+use std::{cmp, convert::TryInto, fmt::Debug, io::Write, mem, sync::Arc};
 
 use api_version::KvFormat;
 use codec::prelude::*;
@@ -188,7 +188,7 @@ pub fn encode_row_key(table_id: i64, handle: i64) -> Vec<u8> {
     key
 }
 
-pub fn encode_common_handle_for_test(table_id: i64, handle: &[u8]) -> Vec<u8> {
+pub fn encode_common_handle(table_id: i64, handle: &[u8]) -> Vec<u8> {
     let mut key = Vec::with_capacity(PREFIX_LEN + handle.len());
     key.append_table_record_prefix(table_id).unwrap();
     key.extend(handle);
@@ -555,14 +555,13 @@ pub fn generate_index_data_for_test(
 /// RowHandle is trait to provide a common interface for different types of row
 /// handles.
 pub trait RowHandle: Eq + Ord + Clone + Debug + Send + Sync {
-    /// creates a new handle from LazyBatchColumnVec
+    /// creates a new handles from LazyBatchColumnVec
     fn from_lazy_batch_column_vec(
-        ctx: &EvalContext,
-        rows: &LazyBatchColumnVec,
-        row_offset: usize,
-        col_offsets: &[usize],
-        col_types: &[FieldType],
-    ) -> Result<Self>;
+        vec: &mut LazyBatchColumnVec,
+        rows: &[usize],
+        handle_offsets: &[usize],
+        handle_types: &[FieldType],
+    ) -> Result<Vec<Self>>;
     /// encode the row key for the handle in the give physical table ID.
     /// The return row key is in a raw format without mvcc comparable encoding.
     fn encode_row_key(&self, table_id: i64) -> Vec<u8>;
@@ -593,31 +592,31 @@ impl From<i64> for IntHandle {
 impl RowHandle for IntHandle {
     #[inline]
     fn from_lazy_batch_column_vec(
-        _ctx: &EvalContext,
-        vec: &LazyBatchColumnVec,
-        row_offset: usize,
-        col_offsets: &[usize],
-        col_types: &[FieldType],
-    ) -> Result<Self> {
-        if col_offsets.len() != 1 || col_types.len() != 1 {
+        vec: &mut LazyBatchColumnVec,
+        rows: &[usize],
+        handle_offsets: &[usize],
+        handle_types: &[FieldType],
+    ) -> Result<Vec<Self>> {
+        if handle_offsets.len() != 1 || handle_types.len() != 1 {
             return Err(box_err!(
                 "The IntHandle columns len should be 1, but got col_offsets: {}, col_types: {}",
-                col_offsets.len(),
-                col_types.len()
+                handle_offsets.len(),
+                handle_types.len()
             ));
         }
 
-        let col_offset = col_offsets[0];
-        if col_offset > vec.columns_len() {
+        let handle_offset = handle_offsets[0];
+        if handle_offset > vec.columns_len() {
             return Err(box_err!(
-                "The column offset for IntHandle {} is out of range, the column count is {}",
-                col_offset,
+                "The handle offset for IntHandle {} is out of range, the column count is {}",
+                handle_offset,
                 vec.columns_len()
             ));
         }
 
+        let handle_type = &handle_types[0];
         if !matches!(
-            col_types[0].tp(),
+            handle_type.tp(),
             FieldTypeTp::Tiny
                 | FieldTypeTp::Short
                 | FieldTypeTp::Long
@@ -626,23 +625,31 @@ impl RowHandle for IntHandle {
         ) {
             return Err(box_err!(
                 "The column type for IntHandle should be int types, but got {:?}",
-                col_types[0].tp()
+                handle_types[0].tp()
             ));
         }
 
-        let col = &vec[col_offset];
+        let col = &mut vec[handle_offset];
         if !col.is_decoded() {
-            return Err(box_err!("column {} not decoded", col_offsets[0]));
+            return Err(box_err!("column {} not decoded", handle_offset));
         }
-        match col.decoded().get_scalar_ref(row_offset) {
-            ScalarValueRef::Int(Some(&val)) => Ok(IntHandle(val)),
-            scalar => Err(box_err!(
-                "column {} at row {} is not valid, col_type: {:?}, expect Int, but is other type or None",
-                col_offset,
-                row_offset,
-                scalar.eval_type()
-            )),
+
+        let mut handles = Vec::with_capacity(rows.len());
+        for &row_offset in rows {
+            let handle = match col.decoded().get_scalar_ref(row_offset) {
+                ScalarValueRef::Int(Some(&val)) => IntHandle(val),
+                scalar => {
+                    return Err(box_err!(
+                        "column {} at row {} is not valid, col_type: {:?}, expect Int, but is other type or None",
+                        handle_offset,
+                        row_offset,
+                        scalar.eval_type()
+                    ));
+                }
+            };
+            handles.push(handle);
         }
+        Ok(handles)
     }
 
     #[inline]
@@ -663,6 +670,56 @@ impl RowHandle for IntHandle {
     }
 }
 
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct CommonHandle(Vec<u8>);
+
+impl RowHandle for CommonHandle {
+    fn from_lazy_batch_column_vec(
+        vec: &mut LazyBatchColumnVec,
+        rows: &[usize],
+        _handle_offsets: &[usize],
+        _handle_types: &[FieldType],
+    ) -> Result<Vec<Self>> {
+        if let Some(mut keys) = vec.take_extra_common_handle_keys() {
+            let keys_len = keys.len();
+            let mut handles = Vec::with_capacity(keys_len);
+            for &row_offset in rows {
+                if row_offset >= keys_len {
+                    return Err(box_err!(
+                        "Row offset: {} exceeds the keys len: {}",
+                        row_offset,
+                        keys_len
+                    ));
+                }
+                let key = mem::take(&mut keys[row_offset]);
+                if key.is_empty() {
+                    return Err(box_err!(
+                        "The extra common handle key at row offset {} is empty",
+                        row_offset
+                    ));
+                }
+                handles.push(Self(key));
+            }
+            return Ok(handles);
+        }
+        Err(box_err!("The extra common handle keys are not valid"))
+    }
+
+    fn encode_row_key(&self, table_id: i64) -> Vec<u8> {
+        encode_common_handle(table_id, &self.0)
+    }
+
+    fn encode_point_range_end(&self, table_id: i64) -> Vec<u8> {
+        let mut key = encode_common_handle(table_id, &self.0);
+        key.push(0);
+        key
+    }
+
+    fn is_next_of(&self, _: &Self) -> bool {
+        false
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::iter::FromIterator;
@@ -674,8 +731,9 @@ mod tests {
 
     use super::*;
     use crate::codec::{
+        batch::LazyBatchColumn,
         data_type::{Real, VectorValue},
-        datum::{self, Datum},
+        datum::{self, Datum, DatumEncoder},
     };
 
     const TABLE_ID: i64 = 1;
@@ -983,42 +1041,56 @@ mod tests {
             .into(),
         );
 
-        let vec =
-            LazyBatchColumnVec::from(vec![byte_values, int_values1, real_values, int_values2]);
-        let create_handle = |col_offset, row_offset| {
+        let create_handles = |handle_offset, rows_offsets| {
+            let mut vec = LazyBatchColumnVec::from(vec![
+                byte_values.clone(),
+                int_values1.clone(),
+                real_values.clone(),
+                int_values2.clone(),
+            ]);
             IntHandle::from_lazy_batch_column_vec(
-                &EvalContext::default(),
-                &vec,
-                row_offset,
-                &[col_offset],
+                &mut vec,
+                rows_offsets,
+                &[handle_offset],
                 &[FieldTypeTp::Long.into()],
             )
         };
 
         // valid
-        assert_eq!(create_handle(1, 0).unwrap().as_i64(), 123);
-        assert_eq!(create_handle(1, 2).unwrap().as_i64(), 234);
-        assert_eq!(create_handle(1, 3).unwrap().as_i64(), 567);
-        assert_eq!(create_handle(3, 0).unwrap().as_i64(), 1001);
-        assert_eq!(create_handle(3, 1).unwrap().as_i64(), 1002);
+        assert_eq!(
+            create_handles(1, &[2, 0, 3]).unwrap(),
+            vec![
+                IntHandle::from(234),
+                IntHandle::from(123),
+                IntHandle::from(567)
+            ]
+        );
+        assert_eq!(
+            create_handles(3, &[0, 1]).unwrap(),
+            vec![IntHandle::from(1001), IntHandle::from(1002),]
+        );
 
         // invalid data
-        create_handle(0, 0).unwrap_err();
-        create_handle(1, 1).unwrap_err();
-        create_handle(3, 2).unwrap_err();
-        create_handle(2, 0).unwrap_err();
-        create_handle(3, 3).unwrap_err();
+        create_handles(0, &[0]).unwrap_err();
+        create_handles(1, &[1]).unwrap_err();
+        create_handles(3, &[2]).unwrap_err();
+        create_handles(2, &[0]).unwrap_err();
+        create_handles(3, &[3]).unwrap_err();
+        create_handles(1, &[2, 1]).unwrap_err();
 
         // test col_offsets and col_types
-        let create_handle = |col_offsets, col_types: &[FieldTypeTp]| {
-            let tps = col_types.iter().map(|tp| (*tp).into()).collect::<Vec<_>>();
-            IntHandle::from_lazy_batch_column_vec(
-                &EvalContext::default(),
-                &vec,
-                0,
-                col_offsets,
-                &tps,
-            )
+        let create_handles = |handle_offsets: &[usize], handle_types: &[FieldTypeTp]| {
+            let mut vec = LazyBatchColumnVec::from(vec![
+                byte_values.clone(),
+                int_values1.clone(),
+                real_values.clone(),
+                int_values2.clone(),
+            ]);
+            let tps = handle_types
+                .iter()
+                .map(|tp| (*tp).into())
+                .collect::<Vec<_>>();
+            IntHandle::from_lazy_batch_column_vec(&mut vec, &[0], handle_offsets, &tps)
         };
 
         // valid col types
@@ -1029,7 +1101,7 @@ mod tests {
             FieldTypeTp::LongLong,
             FieldTypeTp::Int24,
         ] {
-            assert_eq!(create_handle(&[1], &[*tp]).unwrap().as_i64(), 123);
+            assert_eq!(create_handles(&[1], &[*tp]).unwrap()[0], IntHandle(123));
         }
 
         // invalid col types
@@ -1055,7 +1127,7 @@ mod tests {
             FieldTypeTp::LongBlob,
             FieldTypeTp::TiDbVectorFloat32,
         ] {
-            let err = create_handle(&[1], &[*tp]).unwrap_err();
+            let err = create_handles(&[1], &[*tp]).unwrap_err();
             assert!(
                 err.to_string()
                     .contains("The column type for IntHandle should be int types")
@@ -1069,12 +1141,31 @@ mod tests {
             (vec![1], vec![FieldTypeTp::Long, FieldTypeTp::Long]),
             (vec![0, 1], vec![FieldTypeTp::Long, FieldTypeTp::Long]),
         ] {
-            let err = create_handle(offsets, types).unwrap_err();
+            let err = create_handles(offsets, types).unwrap_err();
             assert!(
                 err.to_string()
                     .contains("The IntHandle columns len should be 1")
             );
         }
+
+        // test mut be decoded
+        let mut col = LazyBatchColumn::raw_with_capacity(4);
+        for i in 0..4 {
+            let mut datum_raw = Vec::new();
+            datum_raw
+                .write_datum(&mut EvalContext::default(), &[Datum::I64(100 + i)], false)
+                .unwrap();
+            col.mut_raw().push(&datum_raw);
+        }
+        let mut vec = LazyBatchColumnVec::from(vec![col]);
+        let err = IntHandle::from_lazy_batch_column_vec(
+            &mut vec,
+            &[3, 2, 1],
+            &[0],
+            &[FieldTypeTp::LongLong.into()],
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("column 0 not decoded"));
     }
 
     #[test]
@@ -1089,6 +1180,7 @@ mod tests {
         ] {
             let h = IntHandle::from(id);
             let key = h.encode_row_key(table_id);
+            assert_eq!(key.len(), RECORD_ROW_KEY_LEN);
             assert_eq!(decode_table_id(&key).unwrap(), table_id);
             assert_eq!(decode_int_handle(&key).unwrap(), id);
             let point_range_end = h.encode_point_range_end(table_id);
@@ -1103,5 +1195,92 @@ mod tests {
         assert!(!IntHandle::from(2).is_next_of(&IntHandle::from(3)));
         assert!(!IntHandle::from(3).is_next_of(&IntHandle::from(1)));
         assert!(!IntHandle::from(4).is_next_of(&IntHandle::from(6)));
+
+        // test as_i64
+        assert_eq!(IntHandle::from(42).as_i64(), 42);
+    }
+
+    #[test]
+    fn test_common_handle_from_lazy_batch_column_vec() {
+        let mut vec = LazyBatchColumnVec::from(vec![VectorValue::Int(
+            vec![Some(123), None, Some(234), Some(567)].into(),
+        )]);
+
+        // valid case
+        vec.mut_extra_common_handle_keys().append(&mut vec![
+            vec![1u8, 2u8, 3u8],
+            vec![11u8, 12u8, 13u8],
+            vec![21u8, 22u8],
+            vec![31u8],
+        ]);
+        let handles =
+            CommonHandle::from_lazy_batch_column_vec(&mut vec, &[3, 0, 1], &[], &[]).unwrap();
+        assert_eq!(
+            handles,
+            vec![
+                CommonHandle(vec![31u8]),
+                CommonHandle(vec![1u8, 2u8, 3u8]),
+                CommonHandle(vec![11u8, 12u8, 13u8]),
+            ]
+        );
+
+        // invalid case, row offset out of bounds
+        vec.mut_extra_common_handle_keys().append(&mut vec![
+            vec![1u8, 2u8, 3u8],
+            vec![11u8, 12u8, 13u8],
+            vec![21u8, 22u8],
+            vec![31u8],
+        ]);
+        let err =
+            CommonHandle::from_lazy_batch_column_vec(&mut vec, &[0, 4], &[], &[]).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Row offset: 4 exceeds the keys len: 4")
+        );
+
+        // invalid case: none extra_common_handle_keys
+        vec.take_extra_common_handle_keys();
+        let err = CommonHandle::from_lazy_batch_column_vec(&mut vec, &[0], &[], &[]).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("The extra common handle keys are not valid")
+        );
+
+        // invalid case: empty key
+        vec.mut_extra_common_handle_keys().append(&mut vec![
+            vec![1u8, 2u8, 3u8],
+            vec![],
+            vec![21u8, 22u8],
+        ]);
+        let err =
+            CommonHandle::from_lazy_batch_column_vec(&mut vec, &[0, 1], &[], &[]).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("The extra common handle key at row offset 1 is empty")
+        );
+    }
+
+    #[test]
+    fn test_common_handle_methods() {
+        let handle = CommonHandle(vec![3u8, 4u8, 9u8]);
+
+        // encode_row_key
+        let key = handle.encode_row_key(789);
+        assert_eq!(key.len(), PREFIX_LEN + handle.0.len());
+        assert_eq!(decode_table_id(&key).unwrap(), 789);
+        assert_eq!(decode_common_handle(&key).unwrap(), vec![3u8, 4u8, 9u8]);
+
+        // encode_point_range_end
+        let point_range_end = handle.encode_point_range_end(789);
+        assert_eq!(point_range_end.len(), PREFIX_LEN + handle.0.len() + 1);
+        assert_eq!(decode_table_id(&point_range_end).unwrap(), 789);
+        assert_eq!(
+            decode_common_handle(&point_range_end).unwrap(),
+            vec![3u8, 4u8, 9u8, 0u8]
+        );
+
+        // is_next_of should always return false
+        assert!(!CommonHandle(vec![3u8, 4u8, 10u8]).is_next_of(&handle));
+        assert!(!CommonHandle(vec![3u8, 4u8, 9u8, 0u8]).is_next_of(&handle));
     }
 }

--- a/components/tidb_query_executors/src/index_scan_executor.rs
+++ b/components/tidb_query_executors/src/index_scan_executor.rs
@@ -55,6 +55,7 @@ impl<S: Storage, F: KvFormat> BatchIndexScanExecutor<S, F> {
         is_backward: bool,
         unique: bool,
         is_scanned_range_aware: bool,
+        is_fill_extra_common_handle_key: bool,
     ) -> Result<Self> {
         // Note 1: `unique = true` doesn't completely mean that it is a unique index
         // scan. Instead it just means that we can use point-get for this index.
@@ -142,6 +143,7 @@ impl<S: Storage, F: KvFormat> BatchIndexScanExecutor<S, F> {
             pid_column_cnt,
             physical_table_id_column_cnt,
             index_version: -1,
+            fill_extra_common_handle_key: is_fill_extra_common_handle_key,
         };
         let wrapper = ScanExecutor::new(ScanExecutorOptions {
             imp,
@@ -222,6 +224,10 @@ struct IndexScanExecutorImpl {
     columns_id_without_handle: Vec<i64>,
 
     columns_id_for_common_handle: Vec<i64>,
+
+    /// If true, also fill the `extra_common_handle_keys` in
+    /// `LazyBatchColumnVec` for each row.
+    fill_extra_common_handle_key: bool,
 
     /// The strategy to decode handles.
     /// Handle will be always placed in the last column.
@@ -498,6 +504,11 @@ impl IndexScanExecutorImpl {
                 // Otherwise, if the handle is common handle, we extract it from the key.
                 let end_index =
                     columns.columns_len() - self.pid_column_cnt - self.physical_table_id_column_cnt;
+                if self.fill_extra_common_handle_key {
+                    columns
+                        .mut_extra_common_handle_keys()
+                        .push(key_payload.to_vec());
+                }
                 Self::extract_columns_from_datum_format(
                     &mut key_payload,
                     &mut columns[self.columns_id_without_handle.len()..end_index],
@@ -618,6 +629,19 @@ impl IndexScanExecutorImpl {
     ) -> Result<()> {
         let (decode_handle, decode_pid, restore_data) =
             self.build_operations(key_payload, value)?;
+        if self.fill_extra_common_handle_key {
+            match decode_handle {
+                DecodeHandleOp::CommonHandle(key) => {
+                    columns.mut_extra_common_handle_keys().push(key.to_vec());
+                }
+                op => {
+                    return Err(other_err!(
+                        "invalid op {:?} for fill_extra_common_handle_key",
+                        op
+                    ));
+                }
+            }
+        }
 
         if self.physical_table_id_column_cnt > 0 {
             match decode_pid {
@@ -1028,6 +1052,7 @@ mod tests {
                 true,
                 false,
                 false,
+                false,
             )
             .unwrap();
 
@@ -1083,6 +1108,7 @@ mod tests {
                 key_ranges,
                 0,
                 true,
+                false,
                 false,
                 false,
             )
@@ -1145,6 +1171,7 @@ mod tests {
                 true,
                 false,
                 false,
+                false,
             )
             .unwrap();
 
@@ -1188,6 +1215,7 @@ mod tests {
                 key_ranges,
                 0,
                 true,
+                false,
                 false,
                 false,
             )
@@ -1239,6 +1267,7 @@ mod tests {
                 ],
                 key_ranges,
                 0,
+                false,
                 false,
                 false,
                 false,
@@ -1319,6 +1348,7 @@ mod tests {
                 false,
                 false,
                 false,
+                false,
             )
             .unwrap();
 
@@ -1375,6 +1405,7 @@ mod tests {
                 0,
                 false,
                 true,
+                false,
                 false,
             )
             .unwrap();
@@ -1459,7 +1490,7 @@ mod tests {
         value_prefix.write_u16(common_handle.len() as u16).unwrap();
 
         // Common handle
-        value_prefix.extend(common_handle);
+        value_prefix.extend(common_handle.clone());
 
         let index_data = datum::encode_key(&mut EvalContext::default(), &datums[0..2]).unwrap();
         let key = table::encode_index_seek_key(TABLE_ID, INDEX_ID, &index_data);
@@ -1486,6 +1517,7 @@ mod tests {
             false,
             true,
             false,
+            true,
         )
         .unwrap();
 
@@ -1517,6 +1549,8 @@ mod tests {
             result.physical_columns[2].decoded().to_real_vec(),
             &[Real::new(4.0).ok()]
         );
+        let extra_common_handle_keys = result.physical_columns.take_extra_common_handle_keys();
+        assert_eq!(extra_common_handle_keys, Some(vec![common_handle]));
 
         let value = value_prefix;
         let store = FixtureStorage::from(vec![(key, value)]);
@@ -1528,6 +1562,7 @@ mod tests {
             1,
             false,
             true,
+            false,
             false,
         )
         .unwrap();
@@ -1604,7 +1639,7 @@ mod tests {
 
         let index_data = datum::encode_key(&mut EvalContext::default(), &datums[0..1]).unwrap();
         let mut key = table::encode_index_seek_key(TABLE_ID, INDEX_ID, &index_data);
-        key.extend(common_handle);
+        key.extend(common_handle.clone());
 
         let key_ranges = vec![{
             let mut range = KeyRange::default();
@@ -1625,6 +1660,7 @@ mod tests {
             false,
             false,
             false,
+            true,
         )
         .unwrap();
 
@@ -1656,6 +1692,8 @@ mod tests {
             result.physical_columns[2].decoded().to_real_vec(),
             &[Real::new(4.0).ok()]
         );
+        let extra_common_handle_keys = result.physical_columns.take_extra_common_handle_keys();
+        assert_eq!(extra_common_handle_keys, Some(vec![common_handle]));
     }
 
     #[test]
@@ -1724,6 +1762,7 @@ mod tests {
             0,
             false,
             true,
+            false,
             false,
         )
         .unwrap();
@@ -1819,6 +1858,7 @@ mod tests {
             false,
             true,
             false,
+            false,
         )
         .unwrap();
 
@@ -1912,6 +1952,7 @@ mod tests {
             false,
             true,
             false,
+            true,
         )
         .unwrap();
 
@@ -1942,6 +1983,13 @@ mod tests {
         assert_eq!(
             result.physical_columns[2].decoded().to_real_vec(),
             &[Real::new(4.0).ok()]
+        );
+        let extra_common_handle_keys = result.physical_columns.take_extra_common_handle_keys();
+        assert_eq!(
+            extra_common_handle_keys,
+            Some(vec![
+                datum::encode_key(&mut EvalContext::default(), &datums[2..]).unwrap(),
+            ])
         );
     }
 
@@ -2004,7 +2052,7 @@ mod tests {
         value_prefix.write_u16(common_handle.len() as u16).unwrap();
 
         // Common handle
-        value_prefix.extend(common_handle);
+        value_prefix.extend(common_handle.clone());
 
         // Partition ID
         let pid = 7;
@@ -2038,6 +2086,7 @@ mod tests {
             false,
             true,
             false,
+            true,
         )
         .unwrap();
 
@@ -2074,6 +2123,8 @@ mod tests {
             result.physical_columns[3].decoded().to_int_vec(),
             &[Some(pid)]
         );
+        let extra_common_handle_keys = result.physical_columns.take_extra_common_handle_keys();
+        assert_eq!(extra_common_handle_keys, Some(vec![common_handle]));
     }
 
     #[test]
@@ -2095,6 +2146,7 @@ mod tests {
             pid_column_cnt: 0,
             physical_table_id_column_cnt: 0,
             index_version: -1,
+            fill_extra_common_handle_key: false,
         };
         let mut columns = idx_exe.build_column_vec(10);
         idx_exe
@@ -2145,6 +2197,7 @@ mod tests {
             pid_column_cnt: 0,
             physical_table_id_column_cnt: 0,
             index_version: -1,
+            fill_extra_common_handle_key: false,
         };
         columns = idx_exe.build_column_vec(10);
         idx_exe
@@ -2195,6 +2248,7 @@ mod tests {
             pid_column_cnt: 0,
             physical_table_id_column_cnt: 0,
             index_version: -1,
+            fill_extra_common_handle_key: false,
         };
         columns = idx_exe.build_column_vec(10);
         idx_exe
@@ -2253,6 +2307,7 @@ mod tests {
             pid_column_cnt: 0,
             physical_table_id_column_cnt: 0,
             index_version: -1,
+            fill_extra_common_handle_key: false,
         };
         columns = idx_exe.build_column_vec(10);
         idx_exe
@@ -2333,6 +2388,7 @@ mod tests {
             pid_column_cnt: 0,
             physical_table_id_column_cnt: 0,
             index_version: -1,
+            fill_extra_common_handle_key: false,
         };
         let mut columns = idx_exe.build_column_vec(10);
         idx_exe
@@ -2383,6 +2439,7 @@ mod tests {
             pid_column_cnt: 0,
             physical_table_id_column_cnt: 0,
             index_version: -1,
+            fill_extra_common_handle_key: false,
         };
         columns = idx_exe.build_column_vec(10);
         idx_exe
@@ -2438,6 +2495,7 @@ mod tests {
             pid_column_cnt: 0,
             physical_table_id_column_cnt: 0,
             index_version: -1,
+            fill_extra_common_handle_key: false,
         };
         columns = idx_exe.build_column_vec(10);
         idx_exe
@@ -2498,6 +2556,7 @@ mod tests {
             pid_column_cnt: 0,
             physical_table_id_column_cnt: 0,
             index_version: -1,
+            fill_extra_common_handle_key: false,
         };
         columns = idx_exe.build_column_vec(10);
         idx_exe
@@ -2621,6 +2680,7 @@ mod tests {
             pid_column_cnt: 0,
             physical_table_id_column_cnt: 0,
             index_version: -1,
+            fill_extra_common_handle_key: false,
         };
         let mut columns = idx_exe.build_column_vec(10);
         idx_exe
@@ -2664,6 +2724,7 @@ mod tests {
             columns[5].raw().last().unwrap().read_datum().unwrap(),
             Datum::Bytes("A ".as_bytes().to_vec())
         );
+
         idx_exe
             .process_kv_pair(
                 &[
@@ -2737,6 +2798,7 @@ mod tests {
             pid_column_cnt: 0,
             physical_table_id_column_cnt: 0,
             index_version: -1,
+            fill_extra_common_handle_key: false,
         };
         columns = idx_exe.build_column_vec(10);
         idx_exe
@@ -2853,6 +2915,7 @@ mod tests {
             pid_column_cnt: 0,
             physical_table_id_column_cnt: 0,
             index_version: -1,
+            fill_extra_common_handle_key: false,
         };
         columns = idx_exe.build_column_vec(10);
         idx_exe
@@ -2969,6 +3032,7 @@ mod tests {
             pid_column_cnt: 0,
             physical_table_id_column_cnt: 0,
             index_version: -1,
+            fill_extra_common_handle_key: false,
         };
         columns = idx_exe.build_column_vec(10);
         idx_exe
@@ -3085,6 +3149,7 @@ mod tests {
             pid_column_cnt: 0,
             physical_table_id_column_cnt: 0,
             index_version: -1,
+            fill_extra_common_handle_key: false,
         };
         columns = idx_exe.build_column_vec(10);
         idx_exe
@@ -3214,6 +3279,7 @@ mod tests {
             pid_column_cnt: 0,
             physical_table_id_column_cnt: 0,
             index_version: -1,
+            fill_extra_common_handle_key: false,
         };
         columns = idx_exe.build_column_vec(10);
         idx_exe
@@ -3366,6 +3432,7 @@ mod tests {
             pid_column_cnt: 0,
             physical_table_id_column_cnt: 1,
             index_version: -1,
+            fill_extra_common_handle_key: false,
         };
         let mut columns = idx_exe.build_column_vec(10);
         idx_exe
@@ -3434,6 +3501,7 @@ mod tests {
             pid_column_cnt: 0,
             physical_table_id_column_cnt: 1,
             index_version: -1,
+            fill_extra_common_handle_key: false,
         };
         let mut columns = idx_exe.build_column_vec(10);
         idx_exe
@@ -3489,6 +3557,7 @@ mod tests {
             pid_column_cnt: 0,
             physical_table_id_column_cnt: 0,
             index_version: -1,
+            fill_extra_common_handle_key: false,
         };
         let mut columns = idx_exe.build_column_vec(1);
         idx_exe

--- a/components/tidb_query_executors/src/table_scan_executor.rs
+++ b/components/tidb_query_executors/src/table_scan_executor.rs
@@ -1382,13 +1382,13 @@ mod tests {
         }
 
         let handle = datum::encode_key(&mut EvalContext::default(), &handle).unwrap();
-        let key = table::encode_common_handle_for_test(TABLE_ID, &handle);
+        let key = table::encode_common_handle(TABLE_ID, &handle);
         let value = table::encode_row(&mut EvalContext::default(), row, &column_ids).unwrap();
 
         // Constructs a range that includes the constructed key.
         let mut key_range = KeyRange::default();
-        let begin = table::encode_common_handle_for_test(TABLE_ID - 1, &handle);
-        let end = table::encode_common_handle_for_test(TABLE_ID + 1, &handle);
+        let begin = table::encode_common_handle(TABLE_ID - 1, &handle);
+        let end = table::encode_common_handle(TABLE_ID + 1, &handle);
         key_range.set_start(begin);
         key_range.set_end(end);
 
@@ -1563,13 +1563,13 @@ mod tests {
 
         let handle = datum::encode_key(&mut EvalContext::default(), &handle).unwrap();
 
-        let key = table::encode_common_handle_for_test(TABLE_ID, &handle);
+        let key = table::encode_common_handle(TABLE_ID, &handle);
         let value = table::encode_row(&mut EvalContext::default(), row, &column_ids).unwrap();
 
         // Constructs a range that includes the constructed key.
         let mut key_range = KeyRange::default();
-        let begin = table::encode_common_handle_for_test(TABLE_ID - 1, &handle);
-        let end = table::encode_common_handle_for_test(TABLE_ID + 1, &handle);
+        let begin = table::encode_common_handle(TABLE_ID - 1, &handle);
+        let end = table::encode_common_handle(TABLE_ID + 1, &handle);
         key_range.set_start(begin);
         key_range.set_end(end);
 

--- a/tests/benches/coprocessor_executors/index_scan/util.rs
+++ b/tests/benches/coprocessor_executors/index_scan/util.rs
@@ -46,6 +46,7 @@ impl<T: TxnStore + 'static> scan_bencher::ScanExecutorBuilder for BatchIndexScan
             black_box(false),
             black_box(unique),
             black_box(false),
+            black_box(false),
         )
         .unwrap();
         // There is a step of building scanner in the first `next()` which cost time,


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #19158

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
copr: support common handle for index_lookup_executor
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
