### PR TITLE
s3: handle rusoto internal error 6.5

### DIFF
--- a/components/cloud/aws/src/s3.rs
+++ b/components/cloud/aws/src/s3.rs
@@ -13,7 +13,7 @@ use futures_util::{
     stream::TryStreamExt,
 };
 pub use kvproto::brpb::{Bucket as InputBucket, CloudDynamic, S3 as InputConfig};
-use rusoto_core::{request::DispatchSignedRequest, ByteStream, RusotoError};
+use rusoto_core::{request::DispatchSignedRequest, ByteStream, HttpDispatchError, RusotoError};
 use rusoto_credential::{ProvideAwsCredentials, StaticProvider};
 use rusoto_s3::{util::AddressingStyle, *};
 use thiserror::Error;
@@ -436,7 +436,19 @@ impl<'client> S3Uploader<'client> {
         .map_err(|_| {
             RusotoError::ParseError("timeout after 15mins for complete in s3 storage".to_owned())
         })?;
-        res.map(|_| ())
+        res.and_then(|output| {
+            if output.bucket.is_none()
+                && output.e_tag.is_none()
+                && output.key.is_none()
+                && output.location.is_none()
+            {
+                Err(RusotoError::HttpDispatch(HttpDispatchError::new(
+                    "failed to parse the complete multipart upload output".to_owned(),
+                )))
+            } else {
+                Ok(())
+            }
+        })
     }
 
     /// Aborts the multipart upload process, deletes all uploaded parts.
@@ -679,7 +691,12 @@ mod tests {
             MockRequestDispatcher::with_status(200),
             MockRequestDispatcher::with_status(200),
             MockRequestDispatcher::with_status(200),
-            MockRequestDispatcher::with_status(200),
+            MockRequestDispatcher::with_status(200).with_body(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+               <root>
+                 <Bucket>bucket</Bucket>
+               </root>"#,
+            ),
         ]);
 
         let credentials_provider =
@@ -781,6 +798,68 @@ mod tests {
         .unwrap();
         fail::remove(s3_sleep_injected_fp);
         fail::remove(s3_timeout_injected_fp);
+    }
+
+    #[test]
+    fn test_s3_complete_multipart_upload_internal_error() {
+        let magic_contents = "abcd";
+        let bucket_name = StringNonEmpty::required("bucket".to_string()).unwrap();
+        let mut bucket = BucketConf::default(bucket_name);
+        bucket.region = StringNonEmpty::opt("ap-southeast-1".to_string());
+        bucket.prefix = StringNonEmpty::opt("prefix".to_string());
+        let mut config = Config::default(bucket);
+        config.force_path_style = false;
+        config.multi_part_size = 3;
+
+        let dispatcher = MultipleMockRequestDispatcher::new(vec![
+            MockRequestDispatcher::with_status(200)
+                .with_request_checker(|req: &SignedRequest| {
+                    assert_eq!(req.method, "POST");
+                    assert!(req.params.contains_key("uploads"));
+                })
+                .with_body(
+                    r#"<?xml version="1.0" encoding="UTF-8"?>
+               <root>
+                 <UploadId>1</UploadId>
+               </root>"#,
+                ),
+            MockRequestDispatcher::with_status(200).with_request_checker(|req: &SignedRequest| {
+                assert_eq!(req.method, "PUT");
+                assert!(req.params.contains_key("partNumber"));
+                assert!(req.params.contains_key("uploadId"));
+            }),
+            MockRequestDispatcher::with_status(200).with_request_checker(|req: &SignedRequest| {
+                assert_eq!(req.method, "PUT");
+                assert!(req.params.contains_key("partNumber"));
+                assert!(req.params.contains_key("uploadId"));
+            }),
+            MockRequestDispatcher::with_status(200).with_request_checker(|req: &SignedRequest| {
+                assert_eq!(req.method, "POST");
+                assert!(req.params.contains_key("uploadId"));
+                assert!(!req.params.contains_key("partNumber"))
+            }),
+            MockRequestDispatcher::with_status(200)
+                .with_request_checker(|req: &SignedRequest| {
+                    assert_eq!(req.method, "POST");
+                    assert!(req.params.contains_key("uploadId"));
+                    assert!(!req.params.contains_key("partNumber"))
+                })
+                .with_body(
+                    r#"<?xml version="1.0" encoding="UTF-8"?>
+               <root>
+                 <Bucket>bucket</Bucket>
+               </root>"#,
+                ),
+        ]);
+        let credentials_provider =
+            StaticProvider::new_minimal("abc".to_string(), "xyz".to_string());
+        let s = S3Storage::new_creds_dispatcher(config, dispatcher, credentials_provider).unwrap();
+        block_on_external_io(s.put(
+            "key",
+            PutResource(Box::new(magic_contents.as_bytes())),
+            magic_contents.len() as u64,
+        ))
+        .unwrap();
     }
 
     #[test]


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #19119

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
handle rusoto complete multipart upload internal error
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
fix the issue that the backup file may be failed to upload by s3-multipart-upload API
```
