### PR TITLE
Makefile: use rustc to detect arch instead of uname -p

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,14 +83,11 @@ ROCKSDB_SYS_PORTABLE=0
 RUST_TEST_THREADS ?= 2
 endif
 
-# Disable SSE on ARM
-ifeq ($(shell uname -p),aarch64)
-ROCKSDB_SYS_SSE=0
-endif
-ifeq ($(shell uname -p),arm)
-ROCKSDB_SYS_SSE=0
-endif
-ifeq ($(shell uname -p),arm64)
+# Enable SSE only on x86/x86_64
+# Use rustc to detect arch as uname -p is not portable (can return "unknown" on some distros)
+ifneq ($(findstring 86,$(shell rustc -vV | grep host)),)
+ROCKSDB_SYS_SSE=1
+else
 ROCKSDB_SYS_SSE=0
 endif
 
@@ -99,9 +96,9 @@ ifneq ($(ROCKSDB_SYS_PORTABLE),0)
 ENABLE_FEATURES += portable
 endif
 
-# Enable sse4.2 by default unless disable explicitly
+# Enable sse4.2 if on x86/x86_64 unless disabled explicitly
 # Note this env var is also tested by scripts/check-sse4_2.sh
-ifneq ($(ROCKSDB_SYS_SSE),0)
+ifeq ($(ROCKSDB_SYS_SSE),1)
 ENABLE_FEATURES += sse
 endif
 


### PR DESCRIPTION
## Summary
- Replace `uname -p` with `rustc -vV` for architecture detection when determining SSE support
- `uname -p` is not portable and returns "unknown" on some distributions (e.g., Debian 11)
- Detects x86/x86_64 by checking if the rustc host target contains "86"

Issue Number: close #13574

## Changes
- Removed three separate `uname -p` checks for ARM architectures (aarch64, arm, arm64)
- Added single `rustc -vV | grep host` check to detect x86/x86_64
- Changed logic from "disable SSE on ARM" to "enable SSE only on x86"

## Test Plan
- [x] Verified `ROCKSDB_SYS_SSE=0` on ARM64 Mac (aarch64-apple-darwin)
- [x] Verified logic correctly identifies x86_64 targets as containing "86"

```release-note
NONE
```