### PR TITLE
raftstore: reset region approximate size/keys stats when it becomes leader (#19181)

### DIFF
--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -2176,6 +2176,9 @@ where
         if let Some(r) = role {
             if StateRole::Leader == r {
                 self.fsm.missing_ticks = 0;
+                // reset region approximate size/keys stats to avoid region
+                // heartbeat with outdated stats.
+                self.fsm.peer.split_check_trigger.on_clear_region_size();
                 self.register_split_region_check_tick();
                 self.fsm.peer.heartbeat_pd(self.ctx);
                 self.register_pd_heartbeat_tick();

--- a/components/test_pd_client/src/pd.rs
+++ b/components/test_pd_client/src/pd.rs
@@ -840,10 +840,18 @@ impl PdCluster {
         }
         self.leaders.insert(region.get_id(), leader.clone());
 
-        self.region_approximate_size
-            .insert(region.get_id(), region_stat.approximate_size);
-        self.region_approximate_keys
-            .insert(region.get_id(), region_stat.approximate_keys);
+        // only update region approximate size/keys when the stats data > 0.
+        // 0 value means the stats data is uninitialized.
+        // The equvalent logic in pd is: https://github.com/tikv/pd/blob/23550ebb90464948a2d6539d9dc9d6d067924d79/pkg/core/region.go#L275
+        if region_stat.approximate_size > 0 {
+            self.region_approximate_size
+                .insert(region.get_id(), region_stat.approximate_size);
+        }
+        if region_stat.approximate_keys > 0 {
+            self.region_approximate_keys
+                .insert(region.get_id(), region_stat.approximate_keys);
+        }
+
         self.region_last_report_ts
             .insert(region.get_id(), region_stat.last_report_ts);
         self.region_last_report_term.insert(region.get_id(), term);

--- a/tests/integrations/raftstore/test_region_heartbeat.rs
+++ b/tests/integrations/raftstore/test_region_heartbeat.rs
@@ -201,3 +201,72 @@ fn test_region_heartbeat_term() {
     }
     panic!("reported term should be updated");
 }
+
+/// `test_region_heartbeat_leader_change` test when region leadership changes,
+/// region approximate size/keys should be reset so pd won't receive outdated
+/// stats data. See: https://github.com/tikv/tikv/issues/19180 for more details.
+#[test]
+fn test_region_heartbeat_leader_change() {
+    let mut cluster = new_server_cluster(0, 3);
+    cluster.cfg.raft_store.right_derive_when_split = true;
+    cluster.cfg.raft_store.split_region_check_tick_interval = ReadableDuration::millis(100);
+    // Set a very big interval to avoid regular heartbeat.
+    cluster.cfg.raft_store.pd_heartbeat_tick_interval = ReadableDuration::secs(1000);
+    cluster.cfg.raft_store.region_split_check_diff = Some(ReadableSize(10));
+    let pd_client = cluster.pd_client.clone();
+    pd_client.disable_default_operator();
+    let region_id = cluster.run_conf_change();
+
+    let mut range = 1..;
+    put_till_size(&mut cluster, 1000, &mut range);
+    sleep_ms(100);
+
+    // add a peer to trigger region heartbeat.
+    pd_client.must_add_peer(region_id, new_peer(2, 2));
+    test_util::eventually(
+        Duration::from_millis(100),
+        Duration::from_millis(3000),
+        || {
+            let size = cluster
+                .pd_client
+                .get_region_approximate_size(region_id)
+                .unwrap_or_default();
+            size >= 1000
+        },
+    );
+
+    cluster.must_transfer_leader(region_id, new_peer(2, 2));
+
+    put_till_size(&mut cluster, 1000, &mut range);
+    sleep_ms(100);
+
+    // add a new peer to trigger heartbeat pd.
+    pd_client.must_add_peer(region_id, new_peer(3, 3));
+    test_util::eventually(
+        Duration::from_millis(100),
+        Duration::from_millis(3000),
+        || {
+            let size = cluster
+                .pd_client
+                .get_region_approximate_size(region_id)
+                .unwrap_or_default();
+            size >= 2000
+        },
+    );
+    let approximate_size = cluster
+        .pd_client
+        .get_region_approximate_size(region_id)
+        .unwrap_or_default();
+
+    // transfer leader back to the old leader and the region approximate size
+    // should not change.
+    cluster.must_transfer_leader(region_id, new_peer(1, 1));
+    sleep_ms(100);
+    // after `must_transfer_leader` the new leader must have already sent a new
+    // region heartbeat.
+    let size = cluster
+        .pd_client
+        .get_region_approximate_size(region_id)
+        .unwrap_or_default();
+    assert_eq!(size, approximate_size);
+}


### PR DESCRIPTION

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #19180

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Reset region's approximate size/keys stats when peer becomes leader. This can avoid peer report outdated stats to pd and caused unnecessary balance scheduling.

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
