### PR TITLE
br: support SdkError::ServiceError as retryable errors

### DIFF
--- a/components/cloud/aws/src/util.rs
+++ b/components/cloud/aws/src/util.rs
@@ -203,10 +203,11 @@ impl ProvideCredentials for DefaultCredentialsProvider {
 
 #[cfg(test)]
 mod tests {
-    #[allow(unused_imports)]
-    use super::*;
     use aws_smithy_runtime_api::http::StatusCode;
     use aws_smithy_types::body::SdkBody;
+
+    #[allow(unused_imports)]
+    use super::*;
 
     #[test]
     fn test_is_retryable_response_error_5xx() {
@@ -242,7 +243,8 @@ mod tests {
 
     #[test]
     fn test_is_retryable_service_error_5xx() {
-        // Test that ServiceError with 5xx status codes are retryable (e.g., S3 SlowDown)
+        // Test that ServiceError with 5xx status codes are retryable (e.g., S3
+        // SlowDown)
         let response = HttpResponse::new(StatusCode::try_from(503).unwrap(), SdkBody::empty());
         let err = SdkError::<(), _>::service_error((), response);
         assert!(is_retryable(&err));


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

Add `SdkError::ServiceError` to the `is_retryable`, allowing to retry S3 puts when AWS returns HTTP 503 Slow Down errors.

<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #19196 

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Treat SdkError::ServiceError as retryable, to handle AWS S3 Slow Down response 
```
