### PR TITLE
raftstore: do not hibernate region after restarts when it needs leader commit index

### DIFF
--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -2405,6 +2405,11 @@ where
             |_| {}
         );
         fail_point!(
+            "on_raft_base_tick_idle_1003",
+            self.fsm.hibernate_state.group_state() == GroupState::Idle && self.fsm.peer_id() == 1003,
+            |_| {}
+        );
+        fail_point!(
             "on_raft_base_tick_chaos",
             self.fsm.hibernate_state.group_state() == GroupState::Chaos,
             |_| {}

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -1690,6 +1690,8 @@ where
                 && !self.is_leader()
                 // Keep ticking if it's waiting for snapshot.
                 && !self.wait_data
+                // Keep ticking if it's waiting for leader committed index to catch up post restart.
+                && !self.needs_update_last_leader_committed_idx()
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close https://github.com/tikv/tikv/issues/18233

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

Post TiKV restarts, the region follower requires catching up with the leader on the latest committed index to decide if it has caught up and is ready for serving. But sometimes the region could enter hibernate state too soon before it receives the committed index from the leader in here: https://github.com/tikv/tikv/blob/b4c7c02b29f503fe555a394ae9f130433dfc11f3/components/raftstore/src/store/fsm/peer.rs#L2521

The fix is to not hibernate if the follower has not yet got a readiness decision and is still waiting for the leader commit index.

```commit-message
raftstore: do not hibernate region after restarts when it needs leader commit index
```
Before the fix, regions can be stuck in busy apply for minutes:

<img width="794" height="213" alt="Screenshot 2025-12-18 at 11 26 16 AM" src="https://github.com/user-attachments/assets/e7b5b617-e8d7-4cd5-9209-9c6aed30bfc5" />


After the fix, restarts are fast and no regions are stuck anymore:

<img width="789" height="213" alt="Screenshot 2025-12-18 at 11 26 29 AM" src="https://github.com/user-attachments/assets/09074467-005c-4a7f-b505-ea4eea62f22b" />

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
