### PR TITLE
*: upgrade cargo-deny version

### DIFF
--- a/scripts/deny
+++ b/scripts/deny
@@ -2,8 +2,12 @@
 
 set -euo pipefail
 
+# use a standalone rust version to build and run deny to decouple from the code build environment
+RUST_VERSION="1.92.0"
+rustup toolchain install $RUST_VERSION --profile minimal --no-self-update
+
 # Update cargo-deny to the 0.15.1 version to fix the issue reported by https://github.com/tikv/tikv/pull/17987.
-cargo install --locked cargo-deny@0.18.2 2> /dev/null || echo "Install cargo-deny failed"
-cargo deny -V
-cargo deny fetch all
-cargo deny check --show-stats
+cargo +${RUST_VERSION} install --locked cargo-deny@0.18.9 2> /dev/null || echo "Install cargo-deny failed"
+cargo +${RUST_VERSION} deny -V
+cargo +${RUST_VERSION} deny fetch all
+cargo +${RUST_VERSION} deny check --show-stats


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #16328

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
1. upgrade cargo-deny to 0.18.9
2. use a standalone rust version to build cargo deny
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
