### PR TITLE
*: upgrade cargo-deny version to make it compatible to further developments.

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -41,11 +41,9 @@ deny = [
 multiple-versions = "allow"
 
 [advisories]
-vulnerability = "deny"
-unmaintained = "allow" # FIXME: Deny it.
-unsound = "deny"
+version = 2
 yanked = "deny"
-notice = "warn"
+unmaintained = 'workspace'
 ignore = [
     # Ignore time 0.1 RUSTSEC-2020-0071 as 1) we have taken measures (see
     # clippy.toml) to mitigate the issue and 2) time 0.1 has no fix availble.
@@ -91,6 +89,14 @@ ignore = [
     # also upgrade the OpenSSL to v3.x which causes performance degradation.
     # See https://github.com/openssl/openssl/issues/17064
     "RUSTSEC-2025-0022",
+    # Ignore following warnings/errors temporarily. We are evaluating alternatives
+    # to replace them. Currently, these packages are stable and there are no known
+    # exploitable vulnerabilities affecting our use case.
+    "RUSTSEC-2025-0057",
+    "RUSTSEC-2021-0146",
+    "RUSTSEC-2023-0081",
+    "RUSTSEC-2024-0388",
+    "RUSTSEC-2024-0436",
 ]
 
 # TiKV is licensed under Apache 2.0, according to ASF 3RD PARTY LICENSE POLICY,
@@ -98,8 +104,7 @@ ignore = [
 # under certain conditions.
 # See https://www.apache.org/legal/resolved.html.
 [licenses]
-unlicensed = "deny"
-copyleft = "deny"
+version = 2
 private = { ignore = false }
 # Allow licenses in Category A
 allow = ["0BSD", "Apache-2.0", "BSD-3-Clause", "CC0-1.0", "ISC", "MIT", "Zlib", "Unicode-3.0"]

--- a/scripts/deny
+++ b/scripts/deny
@@ -2,8 +2,13 @@
 
 set -euo pipefail
 
+# use a standalone rust version to build and run deny to decouple from the code build environment
+RUST_VERSION="1.92.0"
+
+rustup toolchain install $RUST_VERSION --profile minimal --no-self-update
+
 # Update cargo-deny to the 0.15.1 version to fix the issue reported by https://github.com/tikv/tikv/pull/17987.
-cargo install --locked cargo-deny@0.15.1 2> /dev/null || echo "Install cargo-deny failed"
-cargo deny -V
-cargo deny fetch all
-cargo deny check --show-stats
+cargo +${RUST_VERSION} install --locked cargo-deny@0.18.9 2> /dev/null || echo "Install cargo-deny failed"
+cargo +${RUST_VERSION} deny -V
+cargo +${RUST_VERSION} deny fetch all
+cargo +${RUST_VERSION} deny check --show-stats


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref https://github.com/tikv/tikv/issues/19249

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

This PR is a manual cherry-pick of https://github.com/tikv/tikv/pull/19233, used to make the `cargo-deny` compatible to further developments temporarily.

In this PR, some stale packages are marked with `error` by the upgraded `cargo-deny`. And since these packages are not remarked with security vulnerabilities, we have chosen to ignore these errors for now.

```commit-message
Upgrades the `cargo-deny` version and ignore some errors.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None.
```
