### PR TITLE
copr: support new global index key value format V2

### DIFF
--- a/components/tidb_query_executors/src/index_scan_executor.rs
+++ b/components/tidb_query_executors/src/index_scan_executor.rs
@@ -73,13 +73,9 @@ impl<S: Storage, F: KvFormat> BatchIndexScanExecutor<S, F> {
         // last one is real). We accept this kind of request for compatibility
         // considerations, but will be forbidden soon.
         //
-        // Deprecated, now only `table::EXTRA_PHYSICAL_TABLE_ID_COL_ID` is used by
-        // TiDB. See https://github.com/pingcap/tidb/pull/53974 and
-        // https://github.com/tikv/tikv/pull/17141.
         // Note 4: When process global indexes, an extra partition ID
-        // column with column ID `table::EXTRA_PARTITION_ID_COL_ID` will append
-        // to column info to indicate which partiton handles belong to.
-        // See https://github.com/pingcap/parser/pull/1010 for more information.
+        // column with column ID `table::EXTRA_PHYSICAL_TABLE_ID_COL_ID` will
+        // append to column info to indicate which partition id handles belong to.
         //
         // Note 5: When process a partitioned table's index under
         // tidb_partition_prune_mode = 'dynamic' and with either an active transaction
@@ -530,6 +526,11 @@ impl IndexScanExecutorImpl {
 
         match self.decode_handle_strategy {
             NoDecode => {
+                // Note: V2 key-only partition ID only exists for IntHandle
+                // global indexes, when !PKIsHandle, and TiDB always sends
+                // the handle column for those, so this path is only reached
+                // for local indexes where decode_table_id correctly returns
+                // the partition's table ID.
                 if self.physical_table_id_column_cnt > 0 {
                     self.process_physical_table_id_column(key, columns)?;
                 }
@@ -799,6 +800,10 @@ impl IndexScanExecutorImpl {
             }
 
             let dispatcher = match self.decode_handle_strategy {
+                // V2 key-only partition ID only exists for IntHandle global
+                // indexes && !PKIsHandle, and TiDB always sends the handle
+                // column for those, so NoDecode never needs to parse
+                // partition ID from the key.
                 NoDecode => DecodeHandleOp::Nop,
                 DecodeIntHandle if tail_len < 8 => {
                     // This is a non-unique index, we should extract the int handle from the key.


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Ref #19262

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:
Global Index V1 added the partition id to the key, to make non-unique global indexes on non-clustered partitioned tables handle duplicate _tidb_rowid's between partitions.
V2 removes the partition id from the value part.

V1 and V2 is separated, since V1 can still use the same index read functions, that rely on the partition id in the value, while v2 needs to use the partition id encoded in the key part instead.


```commit-message
copr: Non-unique global indexes for non-clustered tables are now only storing the partition id in the key instead of the value (or both as in V1).
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Non-unique global indexes for non-clustered tables are now only storing the partition id in the key instead of the value (or both as in V1).
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved partition identifier handling during global index scanning for partitioned tables, ensuring correct partition information propagation throughout query execution.
  * Enhanced compatibility with both V1 and V2 global index formats when processing indexed queries on partitioned tables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->