### PR TITLE
*: fix clippy by ignoring RUSTSEC-2026-0002 (#19271)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -97,6 +97,10 @@ ignore = [
     "RUSTSEC-2023-0081",
     "RUSTSEC-2024-0388",
     "RUSTSEC-2024-0436",
+    # aws-sdk-s3 transitively depends on lru 0.12.x, which triggers
+    # RUSTSEC-2026-0002 (Stacked Borrows UB). Upstream dependency
+    # constraints prevent upgrading at the moment.
+    "RUSTSEC-2026-0002",
 ]
 
 # TiKV is licensed under Apache 2.0, according to ASF 3RD PARTY LICENSE POLICY,


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #19249

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Fix the CI by ignoring `RUSTSEC-2026-0002`.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

`make clippy` before this PR:

```
error[unsound]: `IterMut` violates Stacked Borrows by invalidating internal pointer
    ┌─ /home/you06/workspace/nfs-exports/rust/tikv/Cargo.lock:296:1
    │
296 │ lru 0.12.5 registry+https://github.com/rust-lang/crates.io-index
    │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unsound advisory detected
    │
    ├ ID: RUSTSEC-2026-0002
    ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0002
    ├ Affected versions of this crate contain a soundness issue in the `IterMut`
      iterator implementation. The `IterMut::next` and `IterMut::next_back`
      methods temporarily create an exclusive reference to the key when
      dereferencing the internal node pointer.
      
      This invalidates the shared pointer held by the internal `HashMap`,
      violating Stacked Borrows rules.
    ├ Announcement: https://github.com/jeromefroe/lru-rs/pull/224
    ├ Solution: Upgrade to >=0.16.3 (try `cargo update -p lru`)

...

 advisories FAILED: 1 errors, 5 warnings, 14 notes
           bans ok: 0 errors, 0 warnings, 14 notes
       licenses ok: 0 errors, 2 warnings, 631 notes
        sources ok: 0 errors, 0 warnings, 22 notes
make: *** [Makefile:373: clippy] Error 1
```

`make clippy` with this PR:

```
 advisories ok: 0 errors, 5 warnings, 16 notes
       bans ok: 0 errors, 0 warnings, 14 notes
   licenses ok: 0 errors, 2 warnings, 631 notes
    sources ok: 0 errors, 0 warnings, 22 notes
    Finished dev [unoptimized] target(s) in 0.71s
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
