### PR TITLE
crossbeam-skiplist: fix RefRange iterator memory leak

### DIFF
--- a/components/concurrency_manager/tests/memory_usage.rs
+++ b/components/concurrency_manager/tests/memory_usage.rs
@@ -70,3 +70,133 @@ fn test_memory_usage() {
 
     println!("{:?}", tikv_alloc::fetch_stats());
 }
+
+// Stress test for crossbeam-skiplist RefRange memory leak.
+// Run with:
+// cargo test -p concurrency_manager --test memory_usage --release --
+// stress_skipmap_range_iter --ignored --nocapture
+#[test]
+#[ignore]
+fn stress_skipmap_range_iter() {
+    use std::{
+        sync::{
+            Arc,
+            atomic::{AtomicBool, AtomicU64, Ordering},
+        },
+        time::{Duration, Instant},
+    };
+
+    use crossbeam_skiplist::SkipMap;
+
+    let map = Arc::new(SkipMap::<u64, u64>::new());
+    let ops = Arc::new(AtomicU64::new(0));
+    let stop = Arc::new(AtomicBool::new(false));
+    let key_space = 10000_u64;
+    let duration_secs = 10_u64;
+    let idle_secs = 5_u64;
+    let threads = thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(4);
+
+    println!(
+        "config: threads={} key_space={} duration={}s idle={}s",
+        threads, key_space, duration_secs, idle_secs
+    );
+
+    let start = Instant::now();
+    let monitor = {
+        let map = map.clone();
+        let ops = ops.clone();
+        let stop = stop.clone();
+        thread::spawn(move || {
+            while !stop.load(Ordering::Relaxed) {
+                thread::sleep(Duration::from_secs(1));
+                let allocated = tikv_alloc::fetch_stats()
+                    .ok()
+                    .and_then(|stats| stats)
+                    .and_then(|stats| {
+                        stats
+                            .iter()
+                            .find(|(k, _)| *k == "allocated")
+                            .map(|(_, v)| *v)
+                    })
+                    .unwrap_or(0);
+                println!(
+                    "t={:.0}s ops={} len={} alloc={}MB",
+                    start.elapsed().as_secs_f64(),
+                    ops.load(Ordering::Relaxed),
+                    map.len(),
+                    allocated / 1024 / 1024
+                );
+            }
+        })
+    };
+
+    let handles: Vec<_> = (0..threads)
+        .map(|_| {
+            let map = map.clone();
+            let ops = ops.clone();
+            let stop = stop.clone();
+            thread::spawn(move || {
+                while !stop.load(Ordering::Relaxed) {
+                    for i in 0..key_space {
+                        map.insert(i, i);
+                    }
+                    for entry in map.range(0..key_space) {
+                        std::hint::black_box(entry.value());
+                    }
+                    for i in 0..key_space {
+                        map.remove(&i);
+                    }
+                    ops.fetch_add(1, Ordering::Relaxed);
+                }
+            })
+        })
+        .collect();
+
+    thread::sleep(Duration::from_secs(duration_secs));
+    stop.store(true, Ordering::Relaxed);
+
+    for h in handles {
+        h.join().unwrap();
+    }
+
+    println!("workload done, waiting {}s for GC...", idle_secs);
+    for _ in 0..idle_secs {
+        thread::sleep(Duration::from_secs(1));
+        let _ = map.get(&0);
+        let allocated = tikv_alloc::fetch_stats()
+            .ok()
+            .and_then(|stats| stats)
+            .and_then(|stats| {
+                stats
+                    .iter()
+                    .find(|(k, _)| *k == "allocated")
+                    .map(|(_, v)| *v)
+            })
+            .unwrap_or(0);
+        println!(
+            "idle: len={} alloc={}MB",
+            map.len(),
+            allocated / 1024 / 1024
+        );
+    }
+
+    monitor.join().unwrap();
+    let allocated = tikv_alloc::fetch_stats()
+        .ok()
+        .and_then(|stats| stats)
+        .and_then(|stats| {
+            stats
+                .iter()
+                .find(|(k, _)| *k == "allocated")
+                .map(|(_, v)| *v)
+        })
+        .unwrap_or(0);
+    println!(
+        "final: ops={} len={} alloc={}MB",
+        ops.load(Ordering::Relaxed),
+        map.len(),
+        allocated / 1024 / 1024
+    );
+}

--- a/components/crossbeam-skiplist/src/base.rs
+++ b/components/crossbeam-skiplist/src/base.rs
@@ -2030,7 +2030,11 @@ where
                 None => self.range.end_bound(),
             };
             if below_upper_bound(&bound, h.key().borrow()) {
-                self.head.clone_from(&next_head);
+                if let Some(e) = mem::replace(&mut self.head, next_head.clone()) {
+                    unsafe {
+                        e.node.decrement(guard);
+                    }
+                }
                 next_head
             } else {
                 unsafe {
@@ -2057,7 +2061,11 @@ where
                 None => self.range.start_bound(),
             };
             if above_lower_bound(&bound, t.key().borrow()) {
-                self.tail.clone_from(&next_tail);
+                if let Some(e) = mem::replace(&mut self.tail, next_tail.clone()) {
+                    unsafe {
+                        e.node.decrement(guard);
+                    }
+                }
                 next_tail
             } else {
                 unsafe {


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Close #19285

What's Changed:

Fix a memory leak in `crossbeam-skiplist`'s `RefRange` iterator.

`RefRange::next()` and `next_back()` were using `clone_from()` to update `self.head`/`self.tail`. Since `RefEntry` has no `Drop` implementation (by design - callers must explicitly call `release()`), the old entry was dropped without decrementing its refcount, causing permanent memory leaks.
Note that the the comment of `RefEntry` says
```
/// You *must* call `release` to free this type, otherwise the node will be
/// leaked. This is because releasing the entry requires a `Guard`.
```

This bug affects any code using `SkipMap::range()` iterators. In TiKV, this manifests as memory leaks in `LockTable` when `check_range()` or `find_first()` are called.

```rust
// Before (buggy):
self.head.clone_from(&next_head);  // Old entry dropped without decrement!

// After (fixed):
if let Some(e) = mem::replace(&mut self.head, next_head.clone()) {
    unsafe { e.node.decrement(guard); }  // Properly decrement old entry
}
```

The fix matches the pattern already used in `RefIter::next()`.

Stress test results (10 seconds, range iteration + insert/remove cycle):

```
before fix:
t=10s ops=11710 len=3422 alloc=613MB
after fix:
t=10s ops=11786 len=7530 alloc=3MB
```


```commit-message
Fix RefRange::next() and next_back() to properly decrement old self.head/self.tail refcount.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [x] Need to cherry-pick to the release branch

### Check List

Tests

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
Fix a memory leak in crossbeam-skiplist's RefRange iterator that caused LockTable memory to grow unboundedly when using range queries.
```