### PR TITLE
expression: fix TIMESTAMP being invalid due to double timezone check in `to_packed_u64`

### DIFF
--- a/components/tidb_query_datatype/src/codec/mysql/time/mod.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/time/mod.rs
@@ -2050,10 +2050,9 @@ impl Time {
         if self.get_time_type() == TimeType::Timestamp {
             // Convert the timestamp to UTC
             let ts = self.try_into_chrono_datetime(ctx)?.naive_utc();
-            // Do not call `check` via the normal constructor.
-            // `check` uses ctx.time_zone, but this value is already in UTC.
-            // Running `check` again would apply the timezone offset twice and may make it
-            // invalid.
+            // Do not call `Time::try_from_chrono_datetime` here (it calls
+            // `TimeArgs::check`). The value is already in UTC. `check` would
+            // apply `ctx.time_zone` again and may make it invalid.
             self = Time::unchecked_new(TimeArgs {
                 year: ts.year() as u32,
                 month: ts.month(),


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close https://github.com/tikv/tikv/issues/19287

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
fix TIMESTAMP being invalid due to double timezone check in `to_packed_u64`
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fix the incorrect invalid datetime error caused by applying timezone offset twice during datetime packing.
```
