### PR TITLE
txn: shared lock uses same FLAG with lock

### DIFF
--- a/components/txn_types/src/lock.rs
+++ b/components/txn_types/src/lock.rs
@@ -47,7 +47,8 @@ const PESSIMISTIC_LOCK_WITH_CONFLICT_PREFIX: u8 = b'F';
 const GENERATION_PREFIX: u8 = b'g';
 const SHARED_LOCK_TXNS_INFO_PREFIX: u8 = b'h';
 const SHARED_LOCK_FLAGS_PREFIX: u8 = b'i';
-// Used with FLAG_LOCK to identify SharedLocks encoding: [FLAG_LOCK][SHARED_LOCK_PREFIX].
+// Used with FLAG_LOCK to identify SharedLocks encoding:
+// [FLAG_LOCK][SHARED_LOCK_PREFIX].
 const SHARED_LOCK_PREFIX: u8 = b'M';
 
 impl LockType {
@@ -1824,11 +1825,9 @@ mod tests {
             Ok(LockType::Shared)
         ));
         decode_lock_type(&[]).unwrap_err();
-        // Single FLAG_LOCK without SHARED_LOCK_PREFIX should be decoded as Lock, not Shared
-        assert!(matches!(
-            decode_lock_type(&[FLAG_LOCK]),
-            Ok(LockType::Lock)
-        ));
+        // Single FLAG_LOCK without SHARED_LOCK_PREFIX should be decoded as Lock, not
+        // Shared
+        assert!(matches!(decode_lock_type(&[FLAG_LOCK]), Ok(LockType::Lock)));
         // FLAG_LOCK with wrong prefix should be decoded as Lock, not Shared
         assert!(matches!(
             decode_lock_type(&[FLAG_LOCK, b'X']),


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #19087

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Replace the single-byte FLAG_SHARED ('H') with a two-byte prefix FLAG_LOCK + SHARED_LOCK_PREFIX ('L' + 'M') for SharedLocks encoding.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
