### PR TITLE
cdc: remove assertion on the seek_for_valid_write

### DIFF
--- a/src/storage/mvcc/reader/scanner/mod.rs
+++ b/src/storage/mvcc/reader/scanner/mod.rs
@@ -501,12 +501,14 @@ where
                 // successfully. The lock TS of such a lock is smaller than the commit TS of the
                 // latest write record.
                 // See https://github.com/tikv/tikv/issues/11187
-                let latest_write_ts = Key::decode_ts_from(write_cursor.key(&mut statistics.write))?;
-                if after_ts < latest_write_ts {
-                    warn!("found the user key of which ts > after_ts. There may be exist an unexpected stale non-pessimistic lock";
+                let latest_write_commit_ts =
+                    Key::decode_ts_from(write_cursor.key(&mut statistics.write))?;
+                if after_ts < latest_write_commit_ts {
+                    warn!("found the user key of which ts > after_ts. There may exist an unexpected stale non-pessimistic lock";
                         "user_key" => %user_key,
                         "after_ts" => after_ts,
-                        "latest_write_ts" => latest_write_ts,
+                        "latest_write_commit_ts" => latest_write_commit_ts,
+                        "latest_write_start_ts" => write_ref.start_ts,
                         "write_type" => ?write_ref.write_type,
                     );
                 }

--- a/src/storage/mvcc/reader/scanner/mod.rs
+++ b/src/storage/mvcc/reader/scanner/mod.rs
@@ -503,7 +503,7 @@ where
                 // See https://github.com/tikv/tikv/issues/11187
                 let latest_write_ts = Key::decode_ts_from(write_cursor.key(&mut statistics.write))?;
                 if after_ts < latest_write_ts {
-                    warn!("found the user key of which ts > after_ts. There may be exist an unexpected pessimistic lock";
+                    warn!("found the user key of which ts > after_ts. There may be exist an unexpected stale non-pessimistic lock";
                         "user_key" => %user_key,
                         "after_ts" => after_ts,
                         "latest_write_ts" => latest_write_ts,

--- a/src/storage/mvcc/reader/scanner/mod.rs
+++ b/src/storage/mvcc/reader/scanner/mod.rs
@@ -496,10 +496,20 @@ where
         }
         match write_ref.write_type {
             WriteType::Put | WriteType::Delete => {
-                assert_ge!(
-                    after_ts,
-                    Key::decode_ts_from(write_cursor.key(&mut statistics.write))?
-                );
+                // After a pessimistic transaction is committed,
+                // a non-pessimistic lock of the same transaction can be also prewritten
+                // successfully. The lock TS of such a lock is smaller than the commit TS of the
+                // latest write record.
+                // See https://github.com/tikv/tikv/issues/11187
+                let latest_write_ts = Key::decode_ts_from(write_cursor.key(&mut statistics.write))?;
+                if after_ts < latest_write_ts {
+                    warn!("found the user key of which ts > after_ts. There may be exist an unexpected pessimistic lock";
+                        "user_key" => %user_key,
+                        "after_ts" => after_ts,
+                        "latest_write_ts" => latest_write_ts,
+                        "write_type" => ?write_ref.write_type,
+                    );
+                }
                 ret = Some(write_ref.to_owned());
                 break;
             }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref https://github.com/tikv/tikv/issues/11187 close #19404

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Use warn instead of assertion on the seek_for_valid_write.
https://github.com/tikv/tikv/pull/16252 should fix the panic by specifying ranges, but it only fixes versions above v8.0.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [x] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
remove assertion on the non-pessimistic lock to avoid TiKV panic
```
