### PR TITLE
coprocessor: fix panic when _tidb_commit_ts column is placed before PK handle columns

### DIFF
--- a/components/tidb_query_executors/src/table_scan_executor.rs
+++ b/components/tidb_query_executors/src/table_scan_executor.rs
@@ -320,7 +320,7 @@ impl ScanExecutorImpl for TableScanExecutorImpl {
 
             // Fill last `handle_index - 1` columns.
             for i in last_index..*handle_index {
-                if Some(i) == physical_table_id_column_idx {
+                if Some(i) == physical_table_id_column_idx || Some(i) == commit_ts_column_idx {
                     columns.push(LazyBatchColumn::decoded_with_capacity_and_tp(
                         scan_rows,
                         EvalType::Int,

--- a/tests/integrations/coprocessor/test_select.rs
+++ b/tests/integrations/coprocessor/test_select.rs
@@ -2535,3 +2535,80 @@ fn test_index_lookup_select() {
         intermediate_rows
     );
 }
+
+#[test]
+fn test_select_with_commit_ts() {
+    use futures::executor::block_on;
+    use tidb_query_datatype::{FieldTypeAccessor, FieldTypeTp};
+
+    let data = vec![
+        (1, Some("name:0"), 2),
+        (2, Some("name:4"), 3),
+        (4, Some("name:3"), 1),
+        (5, Some("name:1"), 4),
+    ];
+
+    let product = ProductTable::new();
+    let (store, endpoint, _) = init_with_data_ext(&product, &data);
+    let storage = store.get_storage().get_storage();
+
+    for commit_ts_at_first in [true, false] {
+        let mut commit_ts_col = tipb::ColumnInfo::default();
+        commit_ts_col.set_column_id(tidb_query_datatype::codec::table::EXTRA_COMMIT_TS_COL_ID);
+        commit_ts_col
+            .as_mut_accessor()
+            .set_tp(FieldTypeTp::LongLong);
+
+        let mut select = DagSelect::from(&product);
+        let columns = select
+            .execs
+            .get_mut(0)
+            .unwrap()
+            .mut_tbl_scan()
+            .mut_columns();
+        if commit_ts_at_first {
+            // To test the issue https://github.com/tikv/tikv/issues/19299
+            // when _tidb_commit_ts column is placed before PK handle should not panic.
+            columns.insert(0, commit_ts_col);
+        } else {
+            columns.push(commit_ts_col);
+        }
+        select.output_offsets = Some(vec![0, 1, 2, 3]);
+
+        let req = select.build();
+        let mut resp = handle_select(&endpoint, req);
+        let spliter = DagChunkSpliter::new(resp.take_chunks().into(), 4);
+        for (row, (id, name, cnt)) in spliter.zip(data.iter().copied()) {
+            let key = encode_row_key(product.table_id(), id);
+            let (entry, _) = block_on(storage.get_entry(
+                Context::default(),
+                Key::from_raw(&key),
+                TimeStamp::max(),
+                true,
+            ))
+            .unwrap();
+            let commit_ts = entry.unwrap().commit_ts.unwrap().into_inner() as i64;
+
+            let name_datum = name.map(|s| s.as_bytes()).into();
+            let expected = if commit_ts_at_first {
+                vec![
+                    Datum::I64(commit_ts),
+                    Datum::I64(id),
+                    name_datum,
+                    cnt.into(),
+                ]
+            } else {
+                vec![
+                    Datum::I64(id),
+                    name_datum,
+                    cnt.into(),
+                    Datum::I64(commit_ts),
+                ]
+            };
+            let expected_encoded =
+                datum::encode_value(&mut EvalContext::default(), &expected).unwrap();
+            let result_encoded = datum::encode_value(&mut EvalContext::default(), &row).unwrap();
+            assert_eq!(result_encoded, &*expected_encoded);
+        }
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #19299

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
fix panic when _tidb_commit_ts column is placed before PK handle columns
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
