### PR TITLE
*: support `need_commit_ts` for TiKV command batch_get_command

### DIFF
--- a/components/test_storage/src/sync_storage.rs
+++ b/components/test_storage/src/sync_storage.rs
@@ -201,7 +201,7 @@ impl<E: Engine, F: KvFormat> SyncTestStorage<E, F> {
                 .batch_get_command(requests, ids, trackers, p.clone(), Instant::now()),
         )?;
         let mut values = vec![];
-        for value in p.take_data().into_iter() {
+        for value in p.take_values().into_iter() {
             values.push(value?);
         }
         Ok(values)
@@ -408,7 +408,7 @@ impl<E: Engine, F: KvFormat> SyncTestStorage<E, F> {
         let p = GetConsumer::new();
         block_on(self.store.raw_batch_get_command(requests, ids, p.clone()))?;
         let mut values = vec![];
-        for value in p.take_data().into_iter() {
+        for value in p.take_values().into_iter() {
             values.push(value?);
         }
         Ok(values)

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -814,7 +814,9 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
     ///
     /// Only writes that are committed before their respective `start_ts` are
     /// visible.
-    pub fn batch_get_command<P: 'static + ResponseBatchConsumer<(Option<Vec<u8>>, Statistics)>>(
+    pub fn batch_get_command<
+        P: 'static + ResponseBatchConsumer<(Option<ValueEntry>, Statistics)>,
+    >(
         &self,
         requests: Vec<GetRequest>,
         ids: Vec<u64>,
@@ -874,6 +876,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
 
                 for ((mut req, id), tracker) in requests.into_iter().zip(ids).zip(trackers) {
                     set_tls_tracker_token(tracker);
+                    let need_commit_ts = req.get_need_commit_ts();
                     let mut ctx = req.take_context();
                     let deadline = Self::get_deadline(&ctx);
                     let source = ctx.take_request_source();
@@ -931,6 +934,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                         fill_cache,
                         bypass_locks,
                         access_locks,
+                        need_commit_ts,
                         region_id,
                         id,
                         source,
@@ -948,6 +952,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                         fill_cache,
                         bypass_locks,
                         access_locks,
+                        need_commit_ts,
                         region_id,
                         id,
                         source,
@@ -978,7 +983,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                                 .build()
                             {
                                 Ok(mut point_getter) => {
-                                    let v = point_getter.get(&key);
+                                    let v = point_getter.get_entry(&key, need_commit_ts);
                                     let stat = point_getter.take_statistics();
                                     metrics::tls_collect_read_flow(
                                         region_id,
@@ -988,9 +993,9 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                                         buckets.as_ref(),
                                     );
                                     statistics.add(&stat);
-                                    let value_size = v
-                                        .as_ref()
-                                        .map_or(0, |v| v.as_ref().map_or(0, |v1| v1.len()) as u64);
+                                    let value_size = v.as_ref().map_or(0, |v| {
+                                        v.as_ref().map_or(0, |v1| v1.value.len()) as u64
+                                    });
                                     record_network_out_bytes(value_size);
                                     record_logical_read_bytes(statistics.processed_size as u64);
                                     consumer.consume(
@@ -2084,7 +2089,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
     }
 
     /// Get the values of a set of raw keys, return a list of `Result`s.
-    pub fn raw_batch_get_command<P: 'static + ResponseBatchConsumer<Option<Vec<u8>>>>(
+    pub fn raw_batch_get_command<P: 'static + ResponseBatchConsumer<Option<ValueEntry>>>(
         &self,
         gets: Vec<RawGetRequest>,
         ids: Vec<u64>,
@@ -2185,6 +2190,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                                         id,
                                         store
                                             .raw_get_key_value(cf, &key, &mut stats)
+                                            .map(|v| v.map(ValueEntry::from_value))
                                             .map_err(Error::from),
                                         begin_instant,
                                         ctx.take_request_source(),
@@ -4228,7 +4234,7 @@ pub mod test_util {
 
     pub struct GetResult {
         id: u64,
-        res: Result<Option<Vec<u8>>>,
+        res: Result<Option<ValueEntry>>,
     }
 
     #[derive(Clone)]
@@ -4243,11 +4249,18 @@ pub mod test_util {
             }
         }
 
-        pub fn take_data(self) -> Vec<Result<Option<Vec<u8>>>> {
+        pub fn take_data(self) -> Vec<Result<Option<ValueEntry>>> {
             let mut data = self.data.lock().unwrap();
             let mut results = std::mem::take(&mut *data);
             results.sort_by_key(|k| k.id);
             results.into_iter().map(|v| v.res).collect()
+        }
+
+        pub fn take_values(self) -> Vec<Result<Option<Vec<u8>>>> {
+            self.take_data()
+                .into_iter()
+                .map(|r| r.map(|opt| opt.map(|entry| entry.value)))
+                .collect()
         }
     }
 
@@ -4257,11 +4270,11 @@ pub mod test_util {
         }
     }
 
-    impl ResponseBatchConsumer<(Option<Vec<u8>>, Statistics)> for GetConsumer {
+    impl ResponseBatchConsumer<(Option<ValueEntry>, Statistics)> for GetConsumer {
         fn consume(
             &self,
             id: u64,
-            res: Result<(Option<Vec<u8>>, Statistics)>,
+            res: Result<(Option<ValueEntry>, Statistics)>,
             _: Instant,
             _source: String,
             _resource_priority: ResourcePriority,
@@ -4273,11 +4286,11 @@ pub mod test_util {
         }
     }
 
-    impl ResponseBatchConsumer<Option<Vec<u8>>> for GetConsumer {
+    impl ResponseBatchConsumer<Option<ValueEntry>> for GetConsumer {
         fn consume(
             &self,
             id: u64,
-            res: Result<Option<Vec<u8>>>,
+            res: Result<Option<ValueEntry>>,
             _: Instant,
             _source: String,
             _resource_priority: ResourcePriority,
@@ -5285,7 +5298,7 @@ mod tests {
             Instant::now(),
         ))
         .unwrap();
-        let mut x = consumer.take_data();
+        let mut x = consumer.take_values();
         expect_error(
             |e| match e {
                 Error(box ErrorInner::Txn(TxnError(box TxnErrorInner::Mvcc(mvcc::Error(
@@ -5329,7 +5342,7 @@ mod tests {
         .unwrap();
 
         let x: Vec<Option<Vec<u8>>> = consumer
-            .take_data()
+            .take_values()
             .into_iter()
             .map(|x| x.unwrap())
             .collect();
@@ -5341,6 +5354,112 @@ mod tests {
                 Some(b"aa".to_vec()),
                 Some(b"bb".to_vec()),
             ]
+        );
+    }
+
+    fn create_get_request_with_need_commit_ts(
+        key: &[u8],
+        start_ts: u64,
+        need_commit_ts: bool,
+    ) -> GetRequest {
+        let mut req = create_get_request(key, start_ts);
+        req.set_need_commit_ts(need_commit_ts);
+        req
+    }
+
+    #[test]
+    fn test_batch_get_command_need_commit_ts() {
+        let storage = TestStorageBuilderApiV1::new(MockLockManager::new())
+            .build()
+            .unwrap();
+        let (tx, rx) = channel();
+        // Commit one key so that we can verify commit_ts is returned when requested.
+        storage
+            .sched_txn_command(
+                commands::Prewrite::with_defaults(
+                    vec![Mutation::make_put(Key::from_raw(b"c"), b"cc".to_vec())],
+                    b"c".to_vec(),
+                    10.into(),
+                ),
+                expect_ok_callback(tx.clone(), 0),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+        storage
+            .sched_txn_command(
+                commands::Commit::new(
+                    vec![Key::from_raw(b"c")],
+                    10.into(),
+                    20.into(),
+                    None,
+                    Context::default(),
+                ),
+                expect_ok_callback(tx.clone(), 1),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+
+        // Leave one key locked so that we can verify committed_locks is ignored when
+        // need_commit_ts is true.
+        storage
+            .sched_txn_command(
+                commands::Prewrite::with_defaults(
+                    vec![Mutation::make_put(Key::from_raw(b"l"), b"ll".to_vec())],
+                    b"l".to_vec(),
+                    50.into(),
+                ),
+                expect_ok_callback(tx, 2),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+
+        let mut ctx_with_committed_lock = Context::default();
+        ctx_with_committed_lock.set_committed_locks(vec![50]);
+
+        let mut read_through_lock = create_get_request_with_need_commit_ts(b"l", 60, false);
+        read_through_lock.set_context(ctx_with_committed_lock.clone());
+
+        let mut lock_conflict = create_get_request_with_need_commit_ts(b"l", 60, true);
+        lock_conflict.set_context(ctx_with_committed_lock);
+
+        let consumer = GetConsumer::new();
+        block_on(storage.batch_get_command(
+            vec![
+                create_get_request_with_need_commit_ts(b"c", 100, true),
+                read_through_lock,
+                lock_conflict,
+            ],
+            vec![1, 2, 3],
+            vec![INVALID_TRACKER_TOKEN; 3],
+            consumer.clone(),
+            Instant::now(),
+        ))
+        .unwrap();
+
+        let mut results = consumer.take_data().into_iter();
+
+        // Committed key: should return commit_ts.
+        let committed = results.next().unwrap().unwrap().unwrap();
+        assert_eq!(committed.value, b"cc".to_vec());
+        assert_eq!(committed.commit_ts.unwrap().into_inner(), 20);
+
+        // Locked key with need_commit_ts = false: should read through committed_locks
+        // and return value with no commit_ts.
+        let locked = results.next().unwrap().unwrap().unwrap();
+        assert_eq!(locked.value, b"ll".to_vec());
+        assert!(locked.commit_ts.is_none());
+
+        // Locked key with need_commit_ts = true: committed_locks should be ignored and
+        // return lock error.
+        let res = results.next().unwrap();
+        expect_error(
+            |e| match e {
+                Error(box ErrorInner::Txn(TxnError(box TxnErrorInner::Mvcc(mvcc::Error(
+                    box mvcc::ErrorInner::KeyIsLocked(..),
+                ))))) => {}
+                e => panic!("unexpected error chain: {:?}", e),
+            },
+            res.map(|_| ()),
         );
     }
 
@@ -6883,7 +7002,7 @@ mod tests {
         let consumer = GetConsumer::new();
         block_on(storage.raw_batch_get_command(cmds, ids, consumer.clone())).unwrap();
         let x: Vec<Option<Vec<u8>>> = consumer
-            .take_data()
+            .take_values()
             .into_iter()
             .map(|x| x.unwrap())
             .collect();
@@ -10417,7 +10536,7 @@ mod tests {
             Instant::now(),
         ))
         .unwrap();
-        let res = consumer.take_data();
+        let res = consumer.take_values();
         assert_eq!(res.len(), 1);
         assert_eq!(res[0].as_ref().unwrap(), &Some(v1.clone()));
         // scan

--- a/tests/integrations/server/kv_service.rs
+++ b/tests/integrations/server/kv_service.rs
@@ -3739,8 +3739,8 @@ fn test_batch_get_with_need_commit_ts() {
     must_kv_prewrite(&client, ctx.clone(), vec![mutation], k3.clone(), 1000);
 
     let mut req = BatchGetRequest::default();
-    let mut new_ctx = ctx.clone();
-    new_ctx.set_committed_locks(vec![1000]);
+    let mut ctx = ctx.clone();
+    ctx.set_committed_locks(vec![1000]);
     req.set_context(ctx.clone());
     req.set_version(5000);
     req.set_keys(vec![k1.clone(), k2.clone(), k3.clone(), k4.clone()].into());
@@ -3769,9 +3769,9 @@ fn test_batch_get_with_need_commit_ts() {
     let mut req = BatchGetRequest::default();
     req.set_context(ctx.clone());
     req.set_version(5000);
-    req.set_keys(vec![k1.clone(), k2.clone()].into());
+    req.set_keys(vec![k1.clone(), k2.clone(), k3.clone()].into());
     let resp = client.kv_batch_get(&req).unwrap();
-    assert_eq!(resp.pairs.len(), 2);
+    assert_eq!(resp.pairs.len(), 3);
     let pair1 = &resp.pairs[0];
     assert_eq!(pair1.key, b"k1");
     assert_eq!(pair1.value, b"v1");
@@ -3780,4 +3780,10 @@ fn test_batch_get_with_need_commit_ts() {
     assert_eq!(pair2.key, b"k2");
     assert_eq!(pair2.value, b"v2");
     assert_eq!(pair2.commit_ts, 0);
+    let pair3 = &resp.pairs[2];
+    assert_eq!(pair3.key, b"k3");
+    // without `need_commit_ts` set, it can read the value of the lock in
+    // committed_locks
+    assert_eq!(pair3.value, b"v33");
+    assert_eq!(pair3.commit_ts, 0);
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #19102

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
support `need_commit_ts` for TiKV command batch_get_command
```

This PR fix two places:

- Case: test_batch_get_with_need_commit_ts, to set the right context to test the committed_locks case
- The previous PR: #19103 forgot to handle *: support `need_commit_ts` for TiKV command batch_get_command, this PR completes it.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
