### PR TITLE
pd: report hot read cpu in heartbeat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3773,7 +3773,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git?rev=c5ab144dc6c7b4eb2091270b3f06e8ccc1b47c8a#c5ab144dc6c7b4eb2091270b3f06e8ccc1b47c8a"
+source = "git+https://github.com/pingcap/kvproto.git#c5ab144dc6c7b4eb2091270b3f06e8ccc1b47c8a"
 dependencies = [
  "bytes",
  "futures 0.3.15",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3773,7 +3773,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/lhy1024/kvproto?rev=b27f7093ef5f10f02f721689b41a7b0862fa4463#b27f7093ef5f10f02f721689b41a7b0862fa4463"
+source = "git+https://github.com/pingcap/kvproto.git?rev=c5ab144dc6c7b4eb2091270b3f06e8ccc1b47c8a#c5ab144dc6c7b4eb2091270b3f06e8ccc1b47c8a"
 dependencies = [
  "bytes",
  "futures 0.3.15",
@@ -8075,7 +8075,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3773,7 +3773,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#9f0ac2fc9a1a6bb8337e01ff72d6b864802698b6"
+source = "git+https://github.com/lhy1024/kvproto?rev=b27f7093ef5f10f02f721689b41a7b0862fa4463#b27f7093ef5f10f02f721689b41a7b0862fa4463"
 dependencies = [
  "bytes",
  "futures 0.3.15",
@@ -8075,7 +8075,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -220,8 +220,8 @@ sysinfo = { git = "https://github.com/tikv/sysinfo", branch = "0.26-fix-cpu" }
 # When you modify TiKV cooperatively with kvproto, this will be useful to submit the PR to TiKV and the PR to
 # kvproto at the same time.
 # After the PR to kvproto is merged, remember to comment this out and run `cargo update -p kvproto`.
-# [patch.'https://github.com/pingcap/kvproto']
-# kvproto = { git = "https://github.com/your_github_id/kvproto", branch = "your_branch" }
+[patch.'https://github.com/pingcap/kvproto']
+kvproto = { git = "https://github.com/lhy1024/kvproto", rev = "b27f7093ef5f10f02f721689b41a7b0862fa4463" }
 #
 # After the PR to rust-rocksdb is merged, remember to comment this out and run `cargo update -p rocksdb`.
 # [patch.'https://github.com/tikv/rust-rocksdb']

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -375,7 +375,7 @@ grpcio-health = { version = "0.10.4", default-features = false, features = [
   "protobuf-codec",
 ] }
 tipb = { git = "https://github.com/pingcap/tipb.git" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", rev = "c5ab144dc6c7b4eb2091270b3f06e8ccc1b47c8a" }
+kvproto = { git = "https://github.com/pingcap/kvproto.git" }
 yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
 tokio-timer = { git = "https://github.com/tikv/tokio", branch = "tokio-timer-hotfix" }
 tokio-executor = { git = "https://github.com/tikv/tokio", branch = "tokio-timer-hotfix" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -220,8 +220,8 @@ sysinfo = { git = "https://github.com/tikv/sysinfo", branch = "0.26-fix-cpu" }
 # When you modify TiKV cooperatively with kvproto, this will be useful to submit the PR to TiKV and the PR to
 # kvproto at the same time.
 # After the PR to kvproto is merged, remember to comment this out and run `cargo update -p kvproto`.
-[patch.'https://github.com/pingcap/kvproto']
-kvproto = { git = "https://github.com/lhy1024/kvproto", rev = "b27f7093ef5f10f02f721689b41a7b0862fa4463" }
+# [patch.'https://github.com/pingcap/kvproto']
+# kvproto = { git = "https://github.com/your_github_id/kvproto", branch = "your_branch" }
 #
 # After the PR to rust-rocksdb is merged, remember to comment this out and run `cargo update -p rocksdb`.
 # [patch.'https://github.com/tikv/rust-rocksdb']
@@ -375,7 +375,7 @@ grpcio-health = { version = "0.10.4", default-features = false, features = [
   "protobuf-codec",
 ] }
 tipb = { git = "https://github.com/pingcap/tipb.git" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git" }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", rev = "c5ab144dc6c7b4eb2091270b3f06e8ccc1b47c8a" }
 yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
 tokio-timer = { git = "https://github.com/tikv/tokio", branch = "tokio-timer-hotfix" }
 tokio-executor = { git = "https://github.com/tikv/tokio", branch = "tokio-timer-hotfix" }

--- a/components/pd_client/src/client.rs
+++ b/components/pd_client/src/client.rs
@@ -606,6 +606,7 @@ impl PdClient for RpcClient {
         req.set_approximate_size(region_stat.approximate_size);
         req.set_approximate_keys(region_stat.approximate_keys);
         req.set_cpu_usage(region_stat.cpu_usage);
+        req.set_cpu_stats(region_stat.cpu_stats);
         if let Some(s) = replication_status {
             req.set_replication_status(s);
         }

--- a/components/pd_client/src/lib.rs
+++ b/components/pd_client/src/lib.rs
@@ -61,7 +61,7 @@ pub struct RegionStat {
     // cpu_usage is the CPU time usage of the leader region since the last heartbeat,
     // which is calculated by cpu_time_delta/heartbeat_reported_interval.
     pub cpu_usage: u64,
-    // cpu_stats contains detailed CPU usage for the leader region.
+    // cpu_stats contains detailed CPU usage for the leader.
     pub cpu_stats: pdpb::CpuStats,
 }
 

--- a/components/pd_client/src/lib.rs
+++ b/components/pd_client/src/lib.rs
@@ -61,6 +61,8 @@ pub struct RegionStat {
     // cpu_usage is the CPU time usage of the leader region since the last heartbeat,
     // which is calculated by cpu_time_delta/heartbeat_reported_interval.
     pub cpu_usage: u64,
+    // cpu_stats contains detailed CPU usage for the leader region.
+    pub cpu_stats: pdpb::CpuStats,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/components/pd_client/src/lib.rs
+++ b/components/pd_client/src/lib.rs
@@ -58,10 +58,12 @@ pub struct RegionStat {
     pub approximate_size: u64,
     pub approximate_keys: u64,
     pub last_report_ts: UnixSecs,
-    // cpu_usage is the CPU time usage of the leader region since the last heartbeat,
-    // which is calculated by cpu_time_delta/heartbeat_reported_interval.
+    // Deprecated in kvproto (`pdpb.RegionHeartbeatRequest.cpu_usage`).
+    // Keep this for backward compatibility while rolling upgrades are in progress.
+    // New PD-side logic should prefer `cpu_stats`.
     pub cpu_usage: u64,
-    // cpu_stats contains detailed CPU usage for the leader.
+    // cpu_stats contains detailed CPU usage for the leader and is the preferred
+    // field for PD-side read CPU accounting.
     pub cpu_stats: pdpb::CpuStats,
 }
 

--- a/components/raftstore-v2/src/worker/pd/mod.rs
+++ b/components/raftstore-v2/src/worker/pd/mod.rs
@@ -217,6 +217,8 @@ where
     region_buckets: HashMap<u64, region::ReportBucket>,
     // region_id -> total_cpu_time_ms (since last region heartbeat)
     region_cpu_records: HashMap<u64, u32>,
+    // region_id -> total_cpu_time_ms (since last store heartbeat)
+    region_cpu_records_store: HashMap<u64, u32>,
     is_hb_receiver_scheduled: bool,
 
     // For update_max_timestamp.
@@ -291,6 +293,7 @@ where
             region_peers: HashMap::default(),
             region_buckets: HashMap::default(),
             region_cpu_records: HashMap::default(),
+            region_cpu_records_store: HashMap::default(),
             is_hb_receiver_scheduled: false,
             concurrency_manager,
             causal_ts_provider,

--- a/components/raftstore-v2/src/worker/pd/mod.rs
+++ b/components/raftstore-v2/src/worker/pd/mod.rs
@@ -216,9 +216,9 @@ where
     region_peers: HashMap<u64, region::PeerStat>,
     region_buckets: HashMap<u64, region::ReportBucket>,
     // region_id -> total_cpu_time_ms (since last region heartbeat)
-    region_cpu_records: HashMap<u64, u32>,
+    region_cpu_records_since_region_heartbeat: HashMap<u64, u32>,
     // region_id -> total_cpu_time_ms (since last store heartbeat)
-    region_cpu_records_store: HashMap<u64, u32>,
+    region_cpu_records_since_store_heartbeat: HashMap<u64, u32>,
     is_hb_receiver_scheduled: bool,
 
     // For update_max_timestamp.
@@ -292,8 +292,8 @@ where
             store_stat: store::StoreStat::default(),
             region_peers: HashMap::default(),
             region_buckets: HashMap::default(),
-            region_cpu_records: HashMap::default(),
-            region_cpu_records_store: HashMap::default(),
+            region_cpu_records_since_region_heartbeat: HashMap::default(),
+            region_cpu_records_since_store_heartbeat: HashMap::default(),
             is_hb_receiver_scheduled: false,
             concurrency_manager,
             causal_ts_provider,

--- a/components/raftstore-v2/src/worker/pd/mod.rs
+++ b/components/raftstore-v2/src/worker/pd/mod.rs
@@ -215,9 +215,11 @@ where
     // For region.
     region_peers: HashMap<u64, region::PeerStat>,
     region_buckets: HashMap<u64, region::ReportBucket>,
-    // region_id -> total_cpu_time_ms (since last region heartbeat)
+    // region_id -> total_cpu_time_ms accumulated for RegionHeartbeat reporting.
+    // This map is consumed/cleared by the region-heartbeat path.
     region_cpu_records_since_region_heartbeat: HashMap<u64, u32>,
-    // region_id -> total_cpu_time_ms (since last store heartbeat)
+    // region_id -> total_cpu_time_ms accumulated for StoreHeartbeat peer_stats.
+    // This map is consumed/cleared by real store heartbeats (not fake ones).
     region_cpu_records_since_store_heartbeat: HashMap<u64, u32>,
     is_hb_receiver_scheduled: bool,
 

--- a/components/raftstore-v2/src/worker/pd/store.rs
+++ b/components/raftstore-v2/src/worker/pd/store.rs
@@ -57,6 +57,12 @@ fn hotspot_query_num_report_threshold() -> u64 {
     HOTSPOT_QUERY_RATE_THRESHOLD * 10
 }
 
+fn hotspot_cpu_usage_report_threshold() -> u64 {
+    const HOTSPOT_CPU_USAGE_THRESHOLD: u64 = 1;
+    fail_point!("mock_hotspot_threshold", |_| { 0 });
+    HOTSPOT_CPU_USAGE_THRESHOLD
+}
+
 pub struct StoreStat {
     pub engine_total_bytes_read: u64,
     pub engine_total_keys_read: u64,
@@ -130,7 +136,7 @@ fn collect_report_read_peer_stats(
     mut report_read_stats: HashMap<u64, pdpb::PeerStat>,
     mut stats: pdpb::StoreStats,
 ) -> pdpb::StoreStats {
-    if report_read_stats.len() < capacity * 3 {
+    if report_read_stats.len() < capacity * 4 {
         for (_, read_stat) in report_read_stats {
             stats.peer_stats.push(read_stat);
         }
@@ -139,6 +145,7 @@ fn collect_report_read_peer_stats(
     let mut keys_topn_report = TopN::new(capacity);
     let mut bytes_topn_report = TopN::new(capacity);
     let mut stats_topn_report = TopN::new(capacity);
+    let mut cpu_topn_report = TopN::new(capacity);
     for read_stat in report_read_stats.values() {
         let mut cmp_stat = PeerCmpReadStat::default();
         cmp_stat.region_id = read_stat.region_id;
@@ -151,6 +158,9 @@ fn collect_report_read_peer_stats(
         let mut query_cmp_stat = cmp_stat.clone();
         query_cmp_stat.report_stat = get_read_query_num(read_stat.get_query_stats());
         stats_topn_report.push(query_cmp_stat);
+        let mut cpu_cmp_stat = cmp_stat;
+        cpu_cmp_stat.report_stat = read_stat.get_cpu_stats().get_unified_read();
+        cpu_topn_report.push(cpu_cmp_stat);
     }
 
     for x in keys_topn_report {
@@ -166,6 +176,12 @@ fn collect_report_read_peer_stats(
     }
 
     for x in stats_topn_report {
+        if let Some(report_stat) = report_read_stats.remove(&x.region_id) {
+            stats.peer_stats.push(report_stat);
+        }
+    }
+
+    for x in cpu_topn_report {
         if let Some(report_stat) = report_read_stats.remove(&x.region_id) {
             stats.peer_stats.push(report_stat);
         }
@@ -190,12 +206,29 @@ where
         store_report: Option<pdpb::StoreReport>,
     ) {
         let mut report_peers = HashMap::default();
+        let now = UnixSecs::now();
+        let interval_seconds = now
+            .into_inner()
+            .saturating_sub(self.store_stat.last_report_ts.into_inner());
         for (region_id, region_peer) in &mut self.region_peers {
             let read_bytes = region_peer.read_bytes - region_peer.last_store_report_read_bytes;
             let read_keys = region_peer.read_keys - region_peer.last_store_report_read_keys;
             let query_stats = region_peer
                 .query_stats
                 .sub_query_stats(&region_peer.last_store_report_query_stats);
+            let cpu_usage = if interval_seconds > 0 {
+                let cpu_time_duration = Duration::from_millis(
+                    self.region_cpu_records_store.remove(region_id).unwrap_or(0) as u64,
+                );
+                ((cpu_time_duration.as_secs_f64() * 100.0) / interval_seconds as f64) as u64
+            } else {
+                0
+            };
+            let cpu_usage = if cpu_usage < hotspot_cpu_usage_report_threshold() {
+                0
+            } else {
+                cpu_usage
+            };
             region_peer.last_store_report_read_bytes = region_peer.read_bytes;
             region_peer.last_store_report_read_keys = region_peer.read_keys;
             region_peer
@@ -204,6 +237,7 @@ where
             if read_bytes < hotspot_byte_report_threshold()
                 && read_keys < hotspot_key_report_threshold()
                 && query_stats.get_read_query_num() < hotspot_query_num_report_threshold()
+                && cpu_usage < hotspot_cpu_usage_report_threshold()
             {
                 continue;
             }
@@ -212,6 +246,9 @@ where
             read_stat.set_read_keys(read_keys);
             read_stat.set_read_bytes(read_bytes);
             read_stat.set_query_stats(query_stats.0);
+            let mut cpu_stats = pdpb::CpuStats::default();
+            cpu_stats.set_unified_read(cpu_usage);
+            read_stat.set_cpu_stats(cpu_stats);
             report_peers.insert(*region_id, read_stat);
         }
 
@@ -261,7 +298,7 @@ where
             // normal state.
             self.store_stat.last_report_ts
         } else {
-            UnixSecs::now()
+            now
         };
         self.store_stat.region_bytes_written.flush();
         self.store_stat.region_keys_written.flush();

--- a/components/raftstore-v2/src/worker/pd/store.rs
+++ b/components/raftstore-v2/src/worker/pd/store.rs
@@ -257,6 +257,8 @@ where
                 report_peers.insert(*region_id, read_stat);
             }
 
+            // Drain orphan CPU records for regions no longer tracked in `region_peers`.
+            self.region_cpu_records_since_store_heartbeat.clear();
             stats = collect_report_read_peer_stats(HOTSPOT_REPORT_CAPACITY, report_peers, stats);
         }
         let (capacity, used_size, available) = self.collect_engine_size();

--- a/components/raftstore-v2/src/worker/pd/store.rs
+++ b/components/raftstore-v2/src/worker/pd/store.rs
@@ -219,11 +219,14 @@ where
                     .sub_query_stats(&region_peer.last_store_report_query_stats);
                 let cpu_usage = if interval_seconds > 0 {
                     let cpu_time_duration = Duration::from_millis(
-                        self.region_cpu_records_store.remove(region_id).unwrap_or(0) as u64,
+                        self.region_cpu_records_since_store_heartbeat
+                            .remove(region_id)
+                            .unwrap_or(0) as u64,
                     );
                     ((cpu_time_duration.as_secs_f64() * 100.0) / interval_seconds as f64) as u64
                 } else {
-                    self.region_cpu_records_store.remove(region_id);
+                    self.region_cpu_records_since_store_heartbeat
+                        .remove(region_id);
                     0
                 };
                 let cpu_usage = if cpu_usage < hotspot_cpu_usage_report_threshold() {

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -1306,7 +1306,8 @@ where
             {
                 let mut region_peers = self.region_peers.write().unwrap();
                 for (region_id, region_peer) in region_peers.iter_mut() {
-                    let read_bytes = region_peer.read_bytes - region_peer.last_store_report_read_bytes;
+                    let read_bytes =
+                        region_peer.read_bytes - region_peer.last_store_report_read_bytes;
                     let read_keys = region_peer.read_keys - region_peer.last_store_report_read_keys;
                     let query_stats = region_peer
                         .query_stats
@@ -2027,11 +2028,7 @@ where
         // Send Region CPU info to AutoSplitController inside the stats_monitor.
         self.stats_monitor.maybe_send_cpu_stats(&records);
         calculate_region_cpu_records(self.store_id, records.clone(), &mut self.region_cpu_records);
-        calculate_region_cpu_records(
-            self.store_id,
-            records,
-            &mut self.region_cpu_records_store,
-        );
+        calculate_region_cpu_records(self.store_id, records, &mut self.region_cpu_records_store);
     }
 
     fn handle_report_min_resolved_ts(&self, store_id: u64, min_resolved_ts: u64) {

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -1026,9 +1026,11 @@ where
     stats_monitor: StatsMonitor<WrappedScheduler<EK>>,
     store_heartbeat_interval: Duration,
 
-    // region_id -> total_cpu_time_ms (since last region heartbeat)
+    // region_id -> total_cpu_time_ms accumulated for RegionHeartbeat reporting.
+    // This map is consumed/cleared by the region-heartbeat path.
     region_cpu_records_since_region_heartbeat: HashMap<u64, u32>,
-    // region_id -> total_cpu_time_ms (since last store heartbeat)
+    // region_id -> total_cpu_time_ms accumulated for StoreHeartbeat peer_stats.
+    // This map is consumed/cleared by real store heartbeats (not fake ones).
     region_cpu_records_since_store_heartbeat: HashMap<u64, u32>,
 
     concurrency_manager: ConcurrencyManager,

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -933,7 +933,7 @@ fn hotspot_query_num_report_threshold() -> u64 {
 }
 
 #[inline]
-fn should_report_read_peer(
+fn should_report_hotspot_read_peer(
     read_bytes: u64,
     read_keys: u64,
     query_stats: &QueryStats,
@@ -982,7 +982,7 @@ fn collect_report_peers_for_store_heartbeat(
         region_peer
             .last_store_report_query_stats
             .fill_query_stats(&region_peer.query_stats);
-        if !should_report_read_peer(read_bytes, read_keys, &query_stats, cpu_usage) {
+        if !should_report_hotspot_read_peer(read_bytes, read_keys, &query_stats, cpu_usage) {
             continue;
         }
         let mut read_stat = pdpb::PeerStat::default();
@@ -2970,18 +2970,18 @@ mod tests {
     }
 
     #[test]
-    fn test_should_report_read_peer_cpu_threshold() {
+    fn test_should_report_hotspot_read_peer_cpu_threshold() {
         let query_stats = QueryStats::default();
         let threshold = hotspot_cpu_usage_report_threshold();
         if threshold > 0 {
-            assert!(!should_report_read_peer(
+            assert!(!should_report_hotspot_read_peer(
                 0,
                 0,
                 &query_stats,
                 threshold.saturating_sub(1),
             ));
         }
-        assert!(should_report_read_peer(0, 0, &query_stats, threshold));
+        assert!(should_report_hotspot_read_peer(0, 0, &query_stats, threshold));
     }
 
     #[test]

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -2981,7 +2981,12 @@ mod tests {
                 threshold.saturating_sub(1),
             ));
         }
-        assert!(should_report_hotspot_read_peer(0, 0, &query_stats, threshold));
+        assert!(should_report_hotspot_read_peer(
+            0,
+            0,
+            &query_stats,
+            threshold
+        ));
     }
 
     #[test]

--- a/components/raftstore/src/store/worker/split_controller.rs
+++ b/components/raftstore/src/store/worker/split_controller.rs
@@ -22,7 +22,9 @@ use tikv_util::{
     debug, info,
     metrics::ThreadInfoStatistics,
     store::{QueryStats, is_read_query},
-    thread_name_prefix::{GRPC_SERVER_THREAD, UNIFIED_READ_POOL_THREAD, matches_thread_name_prefix},
+    thread_name_prefix::{
+        GRPC_SERVER_THREAD, UNIFIED_READ_POOL_THREAD, matches_thread_name_prefix,
+    },
     time::Instant,
     warn,
 };

--- a/components/raftstore/src/store/worker/split_controller.rs
+++ b/components/raftstore/src/store/worker/split_controller.rs
@@ -22,7 +22,7 @@ use tikv_util::{
     debug, info,
     metrics::ThreadInfoStatistics,
     store::{QueryStats, is_read_query},
-    thread_name_prefix::{GRPC_SERVER_THREAD, UNIFIED_READ_POOL_THREAD},
+    thread_name_prefix::{GRPC_SERVER_THREAD, UNIFIED_READ_POOL_THREAD, matches_thread_name_prefix},
     time::Instant,
     warn,
 };
@@ -748,7 +748,7 @@ impl AutoSplitController {
         thread_stats
             .get_cpu_usages()
             .iter()
-            .filter(|(thread_name, _)| thread_name.contains(name))
+            .filter(|(thread_name, _)| matches_thread_name_prefix(thread_name, name))
             .fold(0, |cpu_usage_sum, (_, cpu_usage)| {
                 // `cpu_usage` is in [0, 100].
                 cpu_usage_sum + cpu_usage

--- a/components/tikv_util/src/thread_name_prefix.rs
+++ b/components/tikv_util/src/thread_name_prefix.rs
@@ -57,7 +57,22 @@ pub const CDC_THREAD: &str = "cdc";
 
 pub const PD_WORKER_THREAD: &str = "pd-worker";
 
-pub const UNIFIED_READ_POOL_THREAD: &str = "unified-read";
+// Keep the legacy prefix to preserve existing monitoring; it will be truncated by Linux.
+pub const UNIFIED_READ_POOL_THREAD: &str = "unified-read-pool";
+
+const LINUX_THREAD_NAME_MAX_LEN: usize = 15;
+
+#[inline]
+pub fn matches_thread_name_prefix(thread_name: &str, prefix: &str) -> bool {
+    if thread_name.contains(prefix) {
+        return true;
+    }
+    if prefix.len() <= LINUX_THREAD_NAME_MAX_LEN {
+        return false;
+    }
+    // Thread name prefixes are ASCII; byte slicing is safe here.
+    thread_name.contains(&prefix[..LINUX_THREAD_NAME_MAX_LEN])
+}
 
 pub const DEBUGGER_THREAD: &str = "debugger";
 

--- a/components/tikv_util/src/thread_name_prefix.rs
+++ b/components/tikv_util/src/thread_name_prefix.rs
@@ -157,6 +157,15 @@ pub const STATUS_SERVER_THREAD: &str = "status-server";
 
 const LINUX_THREAD_NAME_MAX_LEN: usize = 15;
 
+/// Returns whether `thread_name` belongs to a thread name family whose prefix
+/// is `prefix`.
+///
+/// On Linux, thread names observed via `/proc` come from the `comm` field,
+/// which is truncated to at most 15 visible characters. For long TiKV prefixes
+/// (for example, `"unified-read-pool"`), the observed thread name may only
+/// contain the first 15 bytes of the prefix. We therefore match both:
+/// 1. the full prefix (normal case), and
+/// 2. the 15-byte truncated prefix (Linux truncation case).
 #[inline]
 pub fn matches_thread_name_prefix(thread_name: &str, prefix: &str) -> bool {
     if thread_name.starts_with(prefix) {
@@ -165,7 +174,7 @@ pub fn matches_thread_name_prefix(thread_name: &str, prefix: &str) -> bool {
     if prefix.len() <= LINUX_THREAD_NAME_MAX_LEN {
         return false;
     }
-    // Thread name prefixes are ASCII; byte slicing is safe here.
+    // Thread name prefixes are ASCII constants in TiKV; byte slicing is safe.
     thread_name.starts_with(&prefix[..LINUX_THREAD_NAME_MAX_LEN])
 }
 

--- a/deny.toml
+++ b/deny.toml
@@ -96,6 +96,10 @@ ignore = [
     # RUSTSEC-2026-0002 (Stacked Borrows UB). Upstream dependency
     # constraints prevent upgrading at the moment.
     "RUSTSEC-2026-0002",
+    # time >=0.3.47 fixes RUSTSEC-2026-0009, but upgrading from 0.3.41
+    # currently conflicts with raft-engine's pinned serde (=1.0.194).
+    # We will remove this once raft-engine / serde constraints are relaxed.
+    "RUSTSEC-2026-0009",
 ]
 
 # TiKV is licensed under Apache 2.0, according to ASF 3RD PARTY LICENSE POLICY,

--- a/src/read_pool.rs
+++ b/src/read_pool.rs
@@ -26,7 +26,7 @@ use thiserror::Error;
 use tikv_util::{
     resource_control::TaskMetadata,
     sys::{SysQuota, cpu_time::ProcessStat},
-    thread_name_prefix::UNIFIED_READ_POOL_THREAD,
+    thread_name_prefix::{UNIFIED_READ_POOL_THREAD, matches_thread_name_prefix},
     time::Instant,
     worker::{Runnable, RunnableWithTimer, Scheduler, Worker},
     yatp_pool::{self, CleanupMethod, FuturePool, PoolTicker, YatpPoolBuilder},
@@ -598,7 +598,7 @@ impl ReadPoolCpuTimeTracker {
         for &tid in &tids {
             if let Ok(stat) = full_thread_stat(pid, tid) {
                 // Look for unified read pool thread name pattern
-                if stat.command.contains(UNIFIED_READ_POOL_THREAD) {
+                if matches_thread_name_prefix(&stat.command, UNIFIED_READ_POOL_THREAD) {
                     // Sum utime + stime (user + system time)
                     current_total_cpu_time += stat.utime + stat.stime;
                 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close https://github.com/tikv/tikv/issues/19373

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
 Improve hotspot read accounting by reporting per-region unified-read CPU in `cpu_stats`, preventing CPU stat loss across region/store heartbeat paths, and fixing Linux thread-name truncation
  matching for read CPU attribution.
- Add `cpu_stats` propagation on the Region heartbeat reporting path (`RegionStat` -> PD request).
  - Keep `cpu_usage` as a compatibility field (deprecated in kvproto) for rolling upgrades.
  - Split region CPU accumulators into two maps:
    - `since_region_heartbeat`
    - `since_store_heartbeat`
    so one heartbeat path no longer drains CPU data required by the other.
  - Include unified-read CPU in Store heartbeat peer_stats, and add CPU into hotspot filtering and TopN selection.
    TopN dimensions are expanded from 3 to 4 (keys/bytes/query/cpu).
  - Do not consume peer deltas / CPU records on fake store heartbeats, preserving full intervals for the next real heartbeat.
  - Clean up both CPU maps when peers are destroyed, and clear orphan CPU records.
  - Add prefix matching utility for Linux 15-char thread-name truncation to fix read CPU attribution for long prefixes (for example `unified-read-pool`).
  - Add unit tests for CPU thresholding, TopN collection, zero-interval handling, map cleanup, and thread-name prefix matching.
  - Update kvproto revision (with cpu_stats-related fields), and add a temporary denylist entry for `RUSTSEC-2026-0009` in `deny.toml` due to current `time` upgrade constraints with raft-engine/serde
  pinning.
```

### Related changes



### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test


### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CPU statistics are now attached to region and store heartbeats, used for hotspot detection, Top-N CPU reporting, and gated reporting.

* **Chores**
  * Dependency for kvproto pinned to a specific revision for reproducible builds.
  * Improved thread-name prefix matching for CPU aggregation.
  * Per-region CPU accounting split to support distinct heartbeat/reporting flows.

* **Tests**
  * Unit tests added for per-region state removal, CPU-threshold reporting, and thread-name prefix behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->