### PR TITLE
tracker: enrich write RPC scan_detail

### DIFF
--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -1882,6 +1882,27 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         let deadline = task.cmd().deadline();
         let write_result = Self::handle_task(self.clone(), snapshot, task, sched_details).await;
 
+        // Feed MVCC scan stats into the per-request tracker before any callback/early
+        // response can be triggered, so the gRPC layer can include them in
+        // `ExecDetailsV2.scan_detail_v2`.
+        let mvcc_total_versions = sched_details.stat.write.total_op_count() as u64;
+        let mvcc_processed_versions = sched_details.stat.write.processed_keys as u64;
+        let mvcc_processed_versions_size = sched_details.stat.processed_size as u64;
+        GLOBAL_TRACKERS.with_tracker(tracker_token, |tracker| {
+            tracker.metrics.mvcc_total_versions = tracker
+                .metrics
+                .mvcc_total_versions
+                .saturating_add(mvcc_total_versions);
+            tracker.metrics.mvcc_processed_versions = tracker
+                .metrics
+                .mvcc_processed_versions
+                .saturating_add(mvcc_processed_versions);
+            tracker.metrics.mvcc_processed_versions_size = tracker
+                .metrics
+                .mvcc_processed_versions_size
+                .saturating_add(mvcc_processed_versions_size);
+        });
+
         let mut write_result = match deadline
             .check()
             .map_err(StorageError::from)

--- a/tests/integrations/server/kv_service.rs
+++ b/tests/integrations/server/kv_service.rs
@@ -2685,11 +2685,11 @@ fn test_commands_write_detail() {
     pessimistic_lock_req.set_primary_lock(k.clone());
     pessimistic_lock_req.set_lock_ttl(3000);
     let pessimistic_lock_resp = client.kv_pessimistic_lock(&pessimistic_lock_req).unwrap();
-    check_scan_detail(
-        pessimistic_lock_resp
-            .get_exec_details_v2()
-            .get_scan_detail_v2(),
-    );
+    let pessimistic_lock_scan_detail = pessimistic_lock_resp
+        .get_exec_details_v2()
+        .get_scan_detail_v2();
+    check_scan_detail(pessimistic_lock_scan_detail);
+    assert!(pessimistic_lock_scan_detail.get_total_versions() > 0);
     check_write_detail(
         pessimistic_lock_resp
             .get_exec_details_v2()
@@ -2739,8 +2739,8 @@ fn test_commands_write_detail() {
     );
 
     let mut check_txn_status_req = CheckTxnStatusRequest::default();
-    check_txn_status_req.set_context(ctx);
-    check_txn_status_req.set_primary_key(k);
+    check_txn_status_req.set_context(ctx.clone());
+    check_txn_status_req.set_primary_key(k.clone());
     check_txn_status_req.set_lock_ts(20);
     check_txn_status_req.set_rollback_if_not_exist(true);
     let check_txn_status_resp = client.kv_check_txn_status(&check_txn_status_req).unwrap();
@@ -2756,6 +2756,26 @@ fn test_commands_write_detail() {
             .get_process_nanos()
             > 0
     );
+
+    // Verify MVCC scan stats are carried into exec details for txn write RPCs.
+    // Use an optimistic prewrite (for_update_ts == 0) after the key has a committed
+    // version, so it will check write CF and produce non-zero `total_versions`.
+    let mut mutation = Mutation::default();
+    mutation.set_op(Op::Put);
+    mutation.set_key(k.clone());
+    mutation.set_value(b"value2".to_vec());
+    let mut optimistic_prewrite_req = PrewriteRequest::default();
+    optimistic_prewrite_req.set_mutations(vec![mutation].into());
+    optimistic_prewrite_req.set_context(ctx);
+    optimistic_prewrite_req.set_primary_lock(k);
+    optimistic_prewrite_req.set_start_version(40);
+    optimistic_prewrite_req.set_lock_ttl(3000);
+    let optimistic_prewrite_resp = client.kv_prewrite(&optimistic_prewrite_req).unwrap();
+    let optimistic_prewrite_scan_detail = optimistic_prewrite_resp
+        .get_exec_details_v2()
+        .get_scan_detail_v2();
+    check_scan_detail(optimistic_prewrite_scan_detail);
+    assert!(optimistic_prewrite_scan_detail.get_total_versions() > 0);
 }
 
 #[test_case(test_raftstore::must_new_cluster_and_kv_client)]


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: close #18871

What's Changed:
- Propagate MVCC scan statistics collected in txn scheduler into the per-request tracker for txn write RPCs (prewrite/commit/pessimistic lock/...) and merge them into `ExecDetailsV2.scan_detail_v2`.
- No kvproto/protobuf changes; existing perf fields in scan_detail (snapshot time, RocksDB block/cache counters) are preserved.

Slow log output comparison (extracted from `tidb-slow.log`):

```
baseline:
  slowest_prewrite.scan_detail: get_snapshot_time: 5.45us, rocksdb: {block: {}}

patched:
  slowest_prewrite.scan_detail: total_keys: 126, get_snapshot_time: 18.5us, rocksdb: {block: {}}
```

Why `processed_versions` / `processed_versions_size` are often 0 for write RPCs:
- `ScanDetailV2.processed_versions` maps to `Statistics.write.processed_keys` ("user-visible keys"), and `processed_versions_size` maps to `Statistics.processed_size`.
- Txn write commands mainly read write CF for conflict/lock checking, which increments op counters (`get/seek/next` -> `total_versions/total_keys`) but usually doesn't count as "processed keys" nor "processed size", so only `total_versions/total_keys` is expected to be non-zero in most SQL workloads.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Manual test:
- Compares baseline vs patched slow log scan_detail.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
Enhance write-path transaction RPC scan_detail in slow logs by reporting MVCC scan statistics (e.g. total_keys).
```
