### PR TITLE
metrics: optimize perf_context metric in Grafana dashboard

### DIFF
--- a/metrics/grafana/tikv_details.dashboard.py
+++ b/metrics/grafana/tikv_details.dashboard.py
@@ -2355,22 +2355,23 @@ def RaftPropose() -> RowPanel:
                     target(
                         expr=expr_histogram_quantile(
                             0.99,
-                            "tikv_raftstore_store_perf_context_time_duration_secs",
-                            by_labels=["type"],
-                            is_optional_quantile=True,
-                        ),
-                        legend_format="store-{{type}}-" + OPTIONAL_QUANTILE_INPUT,
-                        additional_groupby=True,
-                    ),
-                    target(
-                        expr=expr_histogram_quantile(
-                            0.99,
                             "tikv_raftstore_apply_perf_context_time_duration_secs",
                             by_labels=["type"],
                             is_optional_quantile=True,
                         ),
                         legend_format="apply-{{type}}-" + OPTIONAL_QUANTILE_INPUT,
                         additional_groupby=True,
+                    ),
+                    target(
+                        expr=expr_histogram_quantile(
+                            0.99,
+                            "tikv_raftstore_store_perf_context_time_duration_secs",
+                            by_labels=["type"],
+                            is_optional_quantile=True,
+                        ),
+                        legend_format="store-{{type}}-" + OPTIONAL_QUANTILE_INPUT,
+                        additional_groupby=True,
+                        hide=True,
                     ),
                 ],
             ),

--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -25107,21 +25107,6 @@
           "targets": [
             {
               "datasource": "${DS_TEST-CLUSTER}",
-              "expr": "histogram_quantile($optional_quantile,(\n    sum(rate(\n    tikv_raftstore_store_perf_context_time_duration_secs_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (type, le, $additional_groupby) \n    \n    \n))  ",
-              "format": "time_series",
-              "hide": false,
-              "instant": false,
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "store-{{type}}-$optional_quantile {{$additional_groupby}}",
-              "metric": "",
-              "query": "histogram_quantile($optional_quantile,(\n    sum(rate(\n    tikv_raftstore_store_perf_context_time_duration_secs_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (type, le, $additional_groupby) \n    \n    \n))  ",
-              "refId": "",
-              "step": 10,
-              "target": ""
-            },
-            {
-              "datasource": "${DS_TEST-CLUSTER}",
               "expr": "histogram_quantile($optional_quantile,(\n    sum(rate(\n    tikv_raftstore_apply_perf_context_time_duration_secs_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (type, le, $additional_groupby) \n    \n    \n))  ",
               "format": "time_series",
               "hide": false,
@@ -25131,6 +25116,21 @@
               "legendFormat": "apply-{{type}}-$optional_quantile {{$additional_groupby}}",
               "metric": "",
               "query": "histogram_quantile($optional_quantile,(\n    sum(rate(\n    tikv_raftstore_apply_perf_context_time_duration_secs_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (type, le, $additional_groupby) \n    \n    \n))  ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "histogram_quantile($optional_quantile,(\n    sum(rate(\n    tikv_raftstore_store_perf_context_time_duration_secs_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (type, le, $additional_groupby) \n    \n    \n))  ",
+              "format": "time_series",
+              "hide": true,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "store-{{type}}-$optional_quantile {{$additional_groupby}}",
+              "metric": "",
+              "query": "histogram_quantile($optional_quantile,(\n    sum(rate(\n    tikv_raftstore_store_perf_context_time_duration_secs_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (type, le, $additional_groupby) \n    \n    \n))  ",
               "refId": "",
               "step": 10,
               "target": ""

--- a/metrics/grafana/tikv_details.json.sha256
+++ b/metrics/grafana/tikv_details.json.sha256
@@ -1,1 +1,1 @@
-80df7fb603395e1afd4485a2ab405f3f51ca22f76b2efa4bfb20e9b34efc3246  ./metrics/grafana/tikv_details.json
+2566beed7cfa7f9578910ac5bf0b304cb1339ad7d66098baf7816975218cddba  ./metrics/grafana/tikv_details.json


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: ref #15990

This PR reorders and hides the `store_perf_context` metric in the "Perf Context duration" panel.

**Problem:**
The `tikv_raftstore_store_perf_context_time_duration_secs` metric was placed above `tikv_raftstore_apply_perf_context_time_duration_secs`. Since TiKV defaults to raft-engine (`raft_engine.enable = true`), this metric produces no data. Users often edit the first expression expecting to see changes, but nothing happens because they're editing the wrong (empty) metric.

**Solution:**
- Move `store_perf_context` below `apply_perf_context`
- Hide `store_perf_context` by default (still available for users using RocksDB)

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
None
```