### PR TITLE
cpor: check commit ts is present  in `RangesScanner` when it is required

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1161,9 +1161,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.7.2"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bytes-utils"
@@ -7290,6 +7290,8 @@ dependencies = [
  "prometheus-static-metric",
  "raft",
  "serde_json",
+ "slog",
+ "slog-global",
  "thiserror 1.0.40",
  "tikv_util",
  "time 0.1.43",

--- a/components/tidb_query_common/Cargo.toml
+++ b/components/tidb_query_common/Cargo.toml
@@ -20,6 +20,8 @@ prometheus = { version = "0.13", features = ["nightly"] }
 prometheus-static-metric = "0.5"
 raft = { workspace = true }
 serde_json = "1.0"
+slog = { workspace = true }
+slog-global = { workspace = true }
 thiserror = "1.0"
 tikv_util = { workspace = true }
 time = { workspace = true }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #19334

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
check commit ts is present  in `RangesScanner` when it is required
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validate and surface an error when a requested commit timestamp is missing; improved error logging during row scanning.

* **Chores**
  * Added structured logging dependencies to enhance error tracking.

* **Tests**
  * Updated test fixtures and scan behavior to support toggling and mocking of commit timestamps for more robust coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->