### PR TITLE
*: speed up dev builds by setting codegen-units=256

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -421,7 +421,7 @@ opt-level = 1
 [profile.dev]
 opt-level = 0
 debug = 0
-codegen-units = 4
+codegen-units = 256
 lto = false
 incremental = true
 panic = 'unwind'


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close None

See more at: https://ship-with-cargo.slides.0xpoe.dev/17


| codegen-units | Dev Build Time |
|---------------|------------|
| 4           | 3:11       |
| 256        |  <span v-mark="{ color: 'green', type: 'circle' }">2:55</span>   |

The default value changed to 256 in 2020 when incremental compilation is enabled.

What's Changed:

```commit-message
The default value changed to 256 in 2020 when incremental compilation is enabled.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
