### PR TITLE
add min wait between two compaction rounds

### DIFF
--- a/src/server/gc_worker/compaction_runner.rs
+++ b/src/server/gc_worker/compaction_runner.rs
@@ -297,12 +297,17 @@ impl<S: GcSafePointProvider, R: RegionInfoProvider + 'static, E: KvEngine>
                 tracker.reset_if_needed();
             }
 
-            // Sleep for remaining time in check interval, or start next round immediately
-            if elapsed < check_interval {
-                let remaining_sleep = check_interval - elapsed;
-                if self.sleep_or_stop(remaining_sleep) {
-                    break;
-                }
+            // Ensure a minimum gap between compaction rounds so the MVCC read
+            // tracker has time to accumulate meaningful stats after the reset.
+            const MIN_GAP_BETWEEN_ROUNDS: Duration = Duration::from_secs(20);
+            let remaining_sleep = if elapsed < check_interval {
+                check_interval - elapsed
+            } else {
+                Duration::ZERO
+            };
+            let sleep_duration = remaining_sleep.max(MIN_GAP_BETWEEN_ROUNDS);
+            if self.sleep_or_stop(sleep_duration) {
+                break;
             }
         }
         debug!("compaction-runner stopped");

--- a/src/server/gc_worker/compaction_runner.rs
+++ b/src/server/gc_worker/compaction_runner.rs
@@ -312,10 +312,8 @@ impl<S: GcSafePointProvider, R: RegionInfoProvider + 'static, E: KvEngine>
             } else {
                 remaining_sleep
             };
-            if sleep_duration > Duration::ZERO {
-                if self.sleep_or_stop(sleep_duration) {
-                    break;
-                }
+            if sleep_duration > Duration::ZERO && self.sleep_or_stop(sleep_duration) {
+                break;
             }
         }
         debug!("compaction-runner stopped");


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #19362 
<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compaction scheduling when read-aware features are enabled by enforcing a minimum 20-second interval between compaction rounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->