### PR TITLE
Cherry-pick pr-19374 to fix wrong commit_ts in Get/TableScan when latest write is Op_Lock

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -101,6 +101,9 @@ ignore = [
     # RUSTSEC-2026-0002 (Stacked Borrows UB). Upstream dependency
     # constraints prevent upgrading at the moment.
     "RUSTSEC-2026-0002",
+    # aws-sdk-s3/aws-config currently pin a dependency chain that keeps
+    # time at 0.3.20. Upgrading time to >=0.3.47 currently conflicts with
+    # raft-engine's serde =1.0.194 requirement in this branch.
     "RUSTSEC-2026-0009",
 ]
 

--- a/src/storage/mvcc/reader/point_getter.rs
+++ b/src/storage/mvcc/reader/point_getter.rs
@@ -327,6 +327,10 @@ impl<S: Snapshot> PointGetter<S> {
         }
 
         let mut write = WriteRef::parse(self.write_cursor.value(&mut self.statistics.write))?;
+        // Commit ts of `write` when it is loaded by `last_change` shortcut via
+        // `get_cf`. In that case write cursor still points to a newer version
+        // and its ts must not be used.
+        let mut loaded_write_commit_ts = None;
         let mut owned_value: Vec<u8>; // To work around lifetime problem
         loop {
             if !write.check_gc_fence_as_latest_version(self.ts) {
@@ -336,8 +340,12 @@ impl<S: Snapshot> PointGetter<S> {
             match write.write_type {
                 WriteType::Put => {
                     let key_commit_ts = if load_commit_ts {
-                        let cursor_key = self.write_cursor.key(&mut self.statistics.write);
-                        Some(Key::decode_ts_from(cursor_key)?)
+                        if let Some(ts) = loaded_write_commit_ts {
+                            Some(ts)
+                        } else {
+                            let cursor_key = self.write_cursor.key(&mut self.statistics.write);
+                            Some(Key::decode_ts_from(cursor_key)?)
+                        }
                     } else {
                         None
                     };
@@ -378,6 +386,7 @@ impl<S: Snapshot> PointGetter<S> {
                                 Some(v) => owned_value = v,
                                 None => return Ok(None),
                             }
+                            loaded_write_commit_ts = Some(commit_ts);
                             self.statistics.write.get += 1;
                             write = WriteRef::parse(&owned_value)?;
                             assert!(
@@ -399,6 +408,7 @@ impl<S: Snapshot> PointGetter<S> {
             if !self.write_cursor.next(&mut self.statistics.write) {
                 return Ok(None);
             }
+            loaded_write_commit_ts = None;
             // No need to compare user key because it uses prefix seek.
             write = WriteRef::parse(self.write_cursor.value(&mut self.statistics.write))?;
         }
@@ -1439,5 +1449,176 @@ mod tests {
         // the lock should be seen as conflict
         let err = must_get_entry_err(&mut getter, key, true);
         assert_matches!(err.0, box ErrorInner::KeyIsLocked { .. });
+    }
+
+    #[test]
+    fn test_point_get_load_commit_ts_with_top_lock_versions() {
+        let mut engine = new_sample_engine();
+        let mut getter = new_point_getter(&mut engine, 200.into());
+        // `foo2` has many committed `LOCK` writes on top of one visible `PUT` at
+        // commit_ts = 5.
+        must_get_entry(&mut getter, b"foo2", true, b"foo2", Some(5));
+    }
+
+    #[test]
+    fn test_point_get_load_commit_ts_with_lt_seek_bound_lock_versions_above_put() {
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+
+        must_prewrite_put(&mut engine, b"k", b"v", b"k", 1);
+        must_commit(&mut engine, b"k", 1, 1);
+
+        let lock_count = SEEK_BOUND - 1;
+        for ts in 2..=lock_count + 1 {
+            must_prewrite_lock(&mut engine, b"k", b"k", ts);
+            must_commit(&mut engine, b"k", ts, ts);
+        }
+
+        // Sanity check it won't take the `last_change` seek shortcut.
+        let snapshot = engine.snapshot(Default::default()).unwrap();
+        let top_lock_ts = lock_count + 1;
+        let write_value = snapshot
+            .get_cf(CF_WRITE, &Key::from_raw(b"k").append_ts(top_lock_ts.into()))
+            .unwrap()
+            .unwrap();
+        let write = WriteRef::parse(&write_value).unwrap();
+        assert_eq!(write.write_type, WriteType::Lock);
+        match write.last_change {
+            LastChange::Exist {
+                last_change_ts,
+                estimated_versions_to_last_change,
+            } => {
+                assert_eq!(last_change_ts, 1.into());
+                assert!(estimated_versions_to_last_change < SEEK_BOUND);
+            }
+            other => panic!("unexpected last_change: {:?}", other),
+        }
+
+        let mut getter = new_point_getter(&mut engine, (top_lock_ts + 10).into());
+        must_get_entry(&mut getter, b"k", true, b"v", Some(1));
+    }
+
+    #[test]
+    fn test_point_get_load_commit_ts_with_ge_seek_bound_lock_versions_above_put() {
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+
+        must_prewrite_put(&mut engine, b"k", b"v", b"k", 1);
+        must_commit(&mut engine, b"k", 1, 1);
+
+        let lock_count = SEEK_BOUND + 1;
+        for ts in 2..=lock_count + 1 {
+            must_prewrite_lock(&mut engine, b"k", b"k", ts);
+            must_commit(&mut engine, b"k", ts, ts);
+        }
+
+        // Sanity check it will take the `last_change` seek shortcut.
+        let snapshot = engine.snapshot(Default::default()).unwrap();
+        let top_lock_ts = lock_count + 1;
+        let write_value = snapshot
+            .get_cf(CF_WRITE, &Key::from_raw(b"k").append_ts(top_lock_ts.into()))
+            .unwrap()
+            .unwrap();
+        let write = WriteRef::parse(&write_value).unwrap();
+        assert_eq!(write.write_type, WriteType::Lock);
+        match write.last_change {
+            LastChange::Exist {
+                last_change_ts,
+                estimated_versions_to_last_change,
+            } => {
+                assert_eq!(last_change_ts, 1.into());
+                assert!(estimated_versions_to_last_change >= SEEK_BOUND);
+            }
+            other => panic!("unexpected last_change: {:?}", other),
+        }
+
+        let mut getter = new_point_getter(&mut engine, (top_lock_ts + 10).into());
+        must_get_entry(&mut getter, b"k", true, b"v", Some(1));
+    }
+
+    #[test]
+    fn test_point_get_load_commit_ts_with_lt_seek_bound_lock_versions_above_delete() {
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+
+        must_prewrite_put(&mut engine, b"k", b"v", b"k", 1);
+        must_commit(&mut engine, b"k", 1, 1);
+        must_prewrite_delete(&mut engine, b"k", b"k", 2);
+        must_commit(&mut engine, b"k", 2, 2);
+
+        let lock_count = SEEK_BOUND - 1;
+        for ts in 3..=lock_count + 2 {
+            must_prewrite_lock(&mut engine, b"k", b"k", ts);
+            must_commit(&mut engine, b"k", ts, ts);
+        }
+
+        // Sanity check it won't take the `last_change` seek shortcut.
+        let snapshot = engine.snapshot(Default::default()).unwrap();
+        let top_lock_ts = lock_count + 2;
+        let write_value = snapshot
+            .get_cf(CF_WRITE, &Key::from_raw(b"k").append_ts(top_lock_ts.into()))
+            .unwrap()
+            .unwrap();
+        let write = WriteRef::parse(&write_value).unwrap();
+        assert_eq!(write.write_type, WriteType::Lock);
+        match write.last_change {
+            LastChange::Exist {
+                last_change_ts,
+                estimated_versions_to_last_change,
+            } => {
+                assert_eq!(last_change_ts, 2.into());
+                assert!(estimated_versions_to_last_change < SEEK_BOUND);
+            }
+            other => panic!("unexpected last_change: {:?}", other),
+        }
+
+        let mut getter = new_point_getter(&mut engine, (top_lock_ts + 10).into());
+        assert!(
+            getter
+                .get_entry(&Key::from_raw(b"k"), true)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_point_get_load_commit_ts_with_ge_seek_bound_lock_versions_above_delete() {
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+
+        must_prewrite_put(&mut engine, b"k", b"v", b"k", 1);
+        must_commit(&mut engine, b"k", 1, 1);
+        must_prewrite_delete(&mut engine, b"k", b"k", 2);
+        must_commit(&mut engine, b"k", 2, 2);
+
+        let lock_count = SEEK_BOUND + 1;
+        for ts in 3..=lock_count + 2 {
+            must_prewrite_lock(&mut engine, b"k", b"k", ts);
+            must_commit(&mut engine, b"k", ts, ts);
+        }
+
+        // Sanity check it will take the `last_change` seek shortcut.
+        let snapshot = engine.snapshot(Default::default()).unwrap();
+        let top_lock_ts = lock_count + 2;
+        let write_value = snapshot
+            .get_cf(CF_WRITE, &Key::from_raw(b"k").append_ts(top_lock_ts.into()))
+            .unwrap()
+            .unwrap();
+        let write = WriteRef::parse(&write_value).unwrap();
+        assert_eq!(write.write_type, WriteType::Lock);
+        match write.last_change {
+            LastChange::Exist {
+                last_change_ts,
+                estimated_versions_to_last_change,
+            } => {
+                assert_eq!(last_change_ts, 2.into());
+                assert!(estimated_versions_to_last_change >= SEEK_BOUND);
+            }
+            other => panic!("unexpected last_change: {:?}", other),
+        }
+
+        let mut getter = new_point_getter(&mut engine, (top_lock_ts + 10).into());
+        assert!(
+            getter
+                .get_entry(&Key::from_raw(b"k"), true)
+                .unwrap()
+                .is_none()
+        );
     }
 }

--- a/src/storage/mvcc/reader/scanner/backward.rs
+++ b/src/storage/mvcc/reader/scanner/backward.rs
@@ -370,9 +370,6 @@ impl<S: Snapshot> BackwardKvScanner<S> {
                 ));
                 Key::decode_ts_from(current_key)?
             };
-            if self.cfg.load_commit_ts {
-                loaded_commit_ts = Some(current_ts);
-            }
             if current_ts <= last_checked_commit_ts {
                 // We reach the last handled key
                 return self.handle_last_version(last_version, user_key, loaded_commit_ts);
@@ -386,6 +383,9 @@ impl<S: Snapshot> BackwardKvScanner<S> {
 
             match write.write_type {
                 WriteType::Put => {
+                    if self.cfg.load_commit_ts {
+                        loaded_commit_ts = Some(current_ts);
+                    }
                     let write = write.to_owned();
                     return Ok(Some(ValueEntry::new(
                         self.reverse_load_data_by_write(write, user_key)?,
@@ -1256,6 +1256,34 @@ mod tests {
         assert_eq!(statistics.write.next, 0);
         assert_eq!(statistics.write.prev, 0);
         assert_eq!(statistics.processed_size, 0);
+    }
+
+    #[test]
+    fn test_load_commit_ts_with_top_lock_versions() {
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+
+        // One visible PUT and many newer committed LOCK writes on top.
+        must_prewrite_put(&mut engine, b"k", b"v", b"k", 1);
+        must_commit(&mut engine, b"k", 1, 1);
+        for ts in 2..=(REVERSE_SEEK_BOUND + 4) {
+            must_prewrite_lock(&mut engine, b"k", b"k", ts);
+            must_commit(&mut engine, b"k", ts, ts);
+        }
+
+        let snapshot = engine.snapshot(Default::default()).unwrap();
+        let mut scanner = ScannerBuilder::new(snapshot, (REVERSE_SEEK_BOUND + 2).into())
+            .desc(true)
+            .range(None, None)
+            .set_load_commit_ts(true)
+            .build()
+            .unwrap();
+
+        let (key, entry) = scanner.next_entry().unwrap().unwrap();
+        assert_eq!(key, Key::from_raw(b"k"));
+        assert_eq!(entry.value, b"v".to_vec());
+        // commit_ts should come from the returned PUT version, not newer LOCK versions.
+        assert_eq!(entry.commit_ts.unwrap().into_inner(), 1);
+        assert!(scanner.next_entry().unwrap().is_none());
     }
 
     /// Range is left open right closed.

--- a/src/storage/mvcc/reader/scanner/mod.rs
+++ b/src/storage/mvcc/reader/scanner/mod.rs
@@ -614,7 +614,7 @@ pub(crate) fn load_data_by_lock<S: Snapshot, I: Iterator>(
 mod tests {
     use engine_rocks::ReadPerfInstant;
     use engine_traits::MiscExt;
-    use txn_types::OldValue;
+    use txn_types::{LastChange, OldValue};
 
     use super::*;
     use crate::storage::{
@@ -1180,5 +1180,94 @@ mod tests {
         // meet lock, load_commit_ts is set, so even access_locks is set, it should be
         // ignored
         scanner.next_entry().unwrap_err();
+    }
+
+    #[test]
+    fn test_scan_with_load_commit_ts_top_lock_versions_across_seek_bound_and_delete() {
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+
+        let lock_count_lt = SEEK_BOUND - 1;
+        let lock_count_ge = SEEK_BOUND + 1;
+
+        let keys_put = [b"k1".as_slice(), b"k2".as_slice()];
+        let lock_counts_put = [lock_count_lt, lock_count_ge];
+        for (&key, &lock_count) in keys_put.iter().zip(lock_counts_put.iter()) {
+            must_prewrite_put(&mut engine, key, key, key, 1);
+            must_commit(&mut engine, key, 1, 1);
+            for ts in 2..=lock_count + 1 {
+                must_prewrite_lock(&mut engine, key, key, ts);
+                must_commit(&mut engine, key, ts, ts);
+            }
+        }
+
+        let keys_delete = [b"k3".as_slice(), b"k4".as_slice()];
+        let lock_counts_delete = [lock_count_lt, lock_count_ge];
+        for (&key, &lock_count) in keys_delete.iter().zip(lock_counts_delete.iter()) {
+            must_prewrite_put(&mut engine, key, key, key, 1);
+            must_commit(&mut engine, key, 1, 1);
+            must_prewrite_delete(&mut engine, key, key, 2);
+            must_commit(&mut engine, key, 2, 2);
+            for ts in 3..=lock_count + 2 {
+                must_prewrite_lock(&mut engine, key, key, ts);
+                must_commit(&mut engine, key, ts, ts);
+            }
+        }
+
+        // Sanity check `last_change` and the seek-bound threshold for the top LOCK
+        // records.
+        let check_snapshot = engine.snapshot(Default::default()).unwrap();
+
+        let check_top_lock = |key: &[u8], top_ts: u64, last_change_ts: u64, expect_ge: bool| {
+            let write_value = check_snapshot
+                .get_cf(
+                    engine_traits::CF_WRITE,
+                    &Key::from_raw(key).append_ts(top_ts.into()),
+                )
+                .unwrap()
+                .unwrap();
+            let write = WriteRef::parse(&write_value).unwrap();
+            assert_eq!(write.write_type, WriteType::Lock);
+            match write.last_change {
+                LastChange::Exist {
+                    last_change_ts: ts,
+                    estimated_versions_to_last_change,
+                } => {
+                    assert_eq!(ts, last_change_ts.into());
+                    if expect_ge {
+                        assert!(estimated_versions_to_last_change >= SEEK_BOUND);
+                    } else {
+                        assert!(estimated_versions_to_last_change < SEEK_BOUND);
+                    }
+                }
+                other => panic!("unexpected last_change: {:?}", other),
+            }
+        };
+
+        check_top_lock(b"k1", lock_count_lt + 1, 1, false);
+        check_top_lock(b"k2", lock_count_ge + 1, 1, true);
+        check_top_lock(b"k3", lock_count_lt + 2, 2, false);
+        check_top_lock(b"k4", lock_count_ge + 2, 2, true);
+
+        let snapshot = engine.snapshot(Default::default()).unwrap();
+        let mut scanner = ScannerBuilder::new(snapshot, 100.into())
+            .fill_cache(false)
+            .range(None, None)
+            .desc(false)
+            .set_load_commit_ts(true)
+            .build()
+            .unwrap();
+
+        // `k3` and `k4` are deleted, so they must be skipped.
+        let (key, entry) = scanner.next_entry().unwrap().unwrap();
+        assert_eq!(key, Key::from_raw(b"k1"));
+        assert_eq!(entry.value, b"k1".to_vec());
+        assert_eq!(entry.commit_ts.unwrap().into_inner(), 1);
+
+        let (key, entry) = scanner.next_entry().unwrap().unwrap();
+        assert_eq!(key, Key::from_raw(b"k2"));
+        assert_eq!(entry.value, b"k2".to_vec());
+        assert_eq!(entry.commit_ts.unwrap().into_inner(), 1);
+
+        assert!(scanner.next_entry().unwrap().is_none());
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #19312

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Cherry-pick pr-19374 to fix wrong commit_ts in Get/TableScan when latest write is Op_Lock
```
