### PR TITLE
txn: add more tests for shared lock

### DIFF
--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -2060,6 +2060,81 @@ pub mod tests {
     }
 
     #[test]
+    fn test_scan_locks_shared_limit_across_keys_keeps_smallest_ts() {
+        let path = tempfile::Builder::new()
+            .prefix("_test_storage_mvcc_reader_scan_locks_shared_limit_across_keys")
+            .tempdir()
+            .unwrap();
+        let path = path.path().to_str().unwrap();
+        let region = make_region(1, vec![], vec![]);
+        let db = open_db(path, true);
+        let mut engine = RegionEngine::new(&db, &region);
+
+        // Put one exclusive lock key before the shared-lock key.
+        engine.prewrite(
+            Mutation::make_put(Key::from_raw(b"exclusive_lock_key"), b"v".to_vec()),
+            b"exclusive_lock_key",
+            50,
+        );
+
+        // Put one shared-lock key with multiple sub-locks in unsorted timestamps.
+        let mut shared_locks = SharedLocks::new();
+        for ts in [8_u64, 2_u64, 6_u64, 1_u64] {
+            let lock = Lock::new(
+                LockType::Pessimistic,
+                format!("pk_{}", ts).into_bytes(),
+                ts.into(),
+                100,
+                None,
+                TimeStamp::zero(),
+                0,
+                TimeStamp::zero(),
+                false,
+            );
+            shared_locks.insert_lock(lock).unwrap();
+        }
+        let shared_key = Key::from_raw(b"shared_lock_key");
+        engine.write(vec![Modify::Put(
+            CF_LOCK,
+            shared_key.clone(),
+            shared_locks.to_bytes(),
+        )]);
+
+        // Limit=3 means 1 exclusive lock + 2 shared sub-locks. This forces
+        // truncation inside the shared container.
+        let snap = RegionSnapshot::<RocksSnapshot>::from_raw(db.clone(), region.clone());
+        let mut reader = MvccReader::new(snap, None, false);
+        let (locks, has_remain) = reader
+            .scan_locks_from_storage(None, None, |_, _| true, 3)
+            .unwrap();
+
+        assert!(has_remain);
+        assert_eq!(locks.len(), 2);
+        assert_eq!(locks[0].0, Key::from_raw(b"exclusive_lock_key"));
+        assert_eq!(locks[1].0, shared_key);
+        assert!(matches!(locks[0].1, Either::Left(_)));
+
+        let total_locks: usize = locks
+            .iter()
+            .map(|(_, lock_or_shared_locks)| match lock_or_shared_locks {
+                Either::Left(_) => 1,
+                Either::Right(shared) => shared.len(),
+            })
+            .sum();
+        assert_eq!(total_locks, 3);
+
+        let mut retained_shared_ts = match &locks[1].1 {
+            Either::Right(shared) => shared
+                .iter_ts()
+                .map(|ts| ts.into_inner())
+                .collect::<Vec<_>>(),
+            Either::Left(_) => panic!("expected shared locks on shared_lock_key"),
+        };
+        retained_shared_ts.sort_unstable();
+        assert_eq!(retained_shared_ts, vec![1, 2]);
+    }
+
+    #[test]
     fn test_scan_latest_user_keys() {
         let path = tempfile::Builder::new()
             .prefix("_test_storage_mvcc_reader_scan_latest_user_keys")

--- a/src/storage/txn/actions/cleanup.rs
+++ b/src/storage/txn/actions/cleanup.rs
@@ -141,6 +141,8 @@ pub mod tests {
     #[cfg(test)]
     use kvproto::kvrpcpb::PrewriteRequestPessimisticAction::*;
     use txn_types::TimeStamp;
+    #[cfg(test)]
+    use txn_types::{Lock, LockType};
 
     use super::*;
     use crate::storage::{
@@ -240,6 +242,40 @@ pub mod tests {
                 .unwrap();
             must_not_have_write(engine, key, gc_fence);
         }
+    }
+
+    #[cfg(test)]
+    fn make_shared_sub_lock(primary: &[u8], start_ts: TimeStamp) -> Lock {
+        Lock::new(
+            LockType::Lock,
+            primary.to_vec(),
+            start_ts,
+            0,
+            None,
+            TimeStamp::zero(),
+            0,
+            TimeStamp::zero(),
+            false,
+        )
+    }
+
+    #[cfg(test)]
+    fn put_shared_lock<E: Engine>(engine: &mut E, key: &[u8], locks: Vec<Lock>) {
+        use txn_types::SharedLocks;
+
+        let lock_count = locks.len();
+        let mut shared_locks = SharedLocks::new();
+        for lock in locks {
+            shared_locks.insert_lock(lock).unwrap();
+        }
+        assert_eq!(shared_locks.len(), lock_count);
+
+        let mut txn = MvccTxn::new(
+            TimeStamp::zero(),
+            ConcurrencyManager::new_for_test(TimeStamp::zero()),
+        );
+        txn.put_shared_locks(Key::from_raw(key), &shared_locks, true);
+        write(engine, &Context::default(), txn.into_modifies());
     }
 
     #[test]
@@ -412,5 +448,78 @@ pub mod tests {
             assert!(released.pessimistic);
         }
         must_unlocked(&mut engine, shared_lock_key);
+    }
+
+    #[test]
+    fn test_cleanup_shared_lock_reads_pending_lock_bytes() {
+        use tikv_util::Either;
+
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+
+        let raw_key = b"shared-cleanup-pending";
+        let key = Key::from_raw(raw_key);
+        let start_ts_1 = TimeStamp::new(10);
+        let start_ts_2 = TimeStamp::new(20);
+
+        put_shared_lock(
+            &mut engine,
+            raw_key,
+            vec![
+                make_shared_sub_lock(b"pk1", start_ts_1),
+                make_shared_sub_lock(b"pk2", start_ts_2),
+            ],
+        );
+
+        let snapshot = engine.snapshot(Default::default()).unwrap();
+        let cm = ConcurrencyManager::new_for_test(TimeStamp::new(50));
+        let mut txn = MvccTxn::new(TimeStamp::zero(), cm);
+        let mut reader = SnapshotReader::new(TimeStamp::zero(), snapshot, true);
+
+        txn.start_ts = start_ts_1;
+        reader.start_ts = start_ts_1;
+        assert!(
+            cleanup(&mut txn, &mut reader, key.clone(), TimeStamp::zero(), true,)
+                .unwrap()
+                .is_none()
+        );
+
+        let pending_lock_bytes = txn
+            .get_pending_lock_bytes(&key)
+            .and_then(|pending| pending)
+            .expect("missing pending shared lock after first cleanup");
+        let mut pending_shared_locks = match txn_types::parse_lock(pending_lock_bytes).unwrap() {
+            Either::Right(shared_locks) => shared_locks,
+            Either::Left(_) => panic!("expected shared lock state after first cleanup"),
+        };
+        assert_eq!(pending_shared_locks.len(), 1);
+        assert!(
+            pending_shared_locks
+                .get_lock(&start_ts_1)
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            pending_shared_locks
+                .get_lock(&start_ts_2)
+                .unwrap()
+                .is_some()
+        );
+
+        txn.start_ts = start_ts_2;
+        reader.start_ts = start_ts_2;
+        let released = cleanup(&mut txn, &mut reader, key.clone(), TimeStamp::zero(), true)
+            .unwrap()
+            .unwrap();
+        assert_eq!(released.key, key);
+        assert_eq!(released.start_ts, start_ts_2);
+        assert!(released.commit_ts.is_zero());
+        assert!(released.pessimistic);
+
+        assert!(matches!(txn.get_pending_lock_bytes(&key), Some(None)));
+
+        write(&engine, &Context::default(), txn.into_modifies());
+        must_get_rollback_ts(&mut engine, raw_key, start_ts_1);
+        must_get_rollback_ts(&mut engine, raw_key, start_ts_2);
+        must_unlocked(&mut engine, raw_key);
     }
 }

--- a/src/storage/txn/actions/commit.rs
+++ b/src/storage/txn/actions/commit.rs
@@ -800,6 +800,93 @@ pub mod tests {
     }
 
     #[test]
+    fn test_commit_shared_lock_reads_pending_lock_bytes() {
+        use tikv_util::Either;
+
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+
+        let raw_key = b"shared-commit-pending";
+        let key = Key::from_raw(raw_key);
+        let start_ts_1 = TimeStamp::new(10);
+        let start_ts_2 = TimeStamp::new(20);
+        let commit_ts_1 = TimeStamp::new(30);
+        let commit_ts_2 = TimeStamp::new(40);
+
+        put_shared_lock(
+            &mut engine,
+            raw_key,
+            vec![
+                make_shared_sub_lock(raw_key, start_ts_1),
+                make_shared_sub_lock(raw_key, start_ts_2),
+            ],
+        );
+
+        let snapshot = engine.snapshot(Default::default()).unwrap();
+        let cm = ConcurrencyManager::new_for_test(commit_ts_2);
+        let mut txn = MvccTxn::new(TimeStamp::zero(), cm);
+        let mut reader = SnapshotReader::new(TimeStamp::zero(), snapshot, true);
+
+        txn.start_ts = start_ts_1;
+        reader.start_ts = start_ts_1;
+        assert!(
+            commit(&mut txn, &mut reader, key.clone(), commit_ts_1, None)
+                .unwrap()
+                .is_none()
+        );
+
+        let pending_lock_bytes = txn
+            .get_pending_lock_bytes(&key)
+            .and_then(|pending| pending)
+            .expect("missing pending shared lock after first commit");
+        let mut pending_shared_locks = match txn_types::parse_lock(pending_lock_bytes).unwrap() {
+            Either::Right(shared_locks) => shared_locks,
+            Either::Left(_) => panic!("expected shared lock state after first commit"),
+        };
+        assert_eq!(pending_shared_locks.len(), 1);
+        assert!(
+            pending_shared_locks
+                .get_lock(&start_ts_1)
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            pending_shared_locks
+                .get_lock(&start_ts_2)
+                .unwrap()
+                .is_some()
+        );
+
+        txn.start_ts = start_ts_2;
+        reader.start_ts = start_ts_2;
+        let released = commit(&mut txn, &mut reader, key.clone(), commit_ts_2, None)
+            .unwrap()
+            .unwrap();
+        assert_eq!(released.key, key);
+        assert_eq!(released.start_ts, start_ts_2);
+        assert_eq!(released.commit_ts, commit_ts_2);
+        assert!(released.pessimistic);
+
+        assert!(matches!(txn.get_pending_lock_bytes(&key), Some(None)));
+
+        write(&engine, &Context::default(), txn.into_modifies());
+        must_written(
+            &mut engine,
+            raw_key,
+            start_ts_1,
+            commit_ts_1,
+            WriteType::Lock,
+        );
+        must_written(
+            &mut engine,
+            raw_key,
+            start_ts_2,
+            commit_ts_2,
+            WriteType::Lock,
+        );
+        must_unlocked(&mut engine, raw_key);
+    }
+
+    #[test]
     fn test_commit_stale_pessimistic_lock_preserves_other_shared_locks() {
         use tikv_util::Either;
         use txn_types::SharedLocks;

--- a/src/storage/txn/commands/resolve_lock.rs
+++ b/src/storage/txn/commands/resolve_lock.rs
@@ -191,7 +191,9 @@ mod tests {
         TestEngineBuilder,
         kv::Engine,
         lock_manager::MockLockManager,
-        mvcc::tests::{must_get_rollback_ts, must_unlocked, write},
+        mvcc::tests::{
+            must_get_commit_ts, must_get_rollback_ts, must_load_shared_lock, must_unlocked, write,
+        },
         txn::{
             commands::{WriteCommand, WriteContext},
             scheduler::DEFAULT_EXECUTION_DURATION_LIMIT,
@@ -292,6 +294,53 @@ mod tests {
 
         // After resolving both locks, the key should be unlocked (no locks
         // remaining).
+        must_unlocked(&mut engine, key);
+    }
+
+    #[test]
+    fn test_resolve_shared_locks_same_key_mixed_commit_and_rollback() {
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+        let key = b"shared-resolve-mixed";
+        let pk1 = b"pk1";
+        let pk2 = b"pk2";
+        let pk3 = b"pk3";
+
+        // Construct one key with three shared sub-locks.
+        must_acquire_shared_pessimistic_lock(&mut engine, key, pk1, 10, 15, 3000);
+        must_shared_prewrite_lock(&mut engine, key, pk1, 10, 15);
+        must_acquire_shared_pessimistic_lock(&mut engine, key, pk2, 20, 25, 3000);
+        must_shared_prewrite_lock(&mut engine, key, pk2, 20, 25);
+        must_acquire_shared_pessimistic_lock(&mut engine, key, pk3, 30, 35, 3000);
+        must_shared_prewrite_lock(&mut engine, key, pk3, 30, 35);
+
+        let mut shared_locks = must_load_shared_lock(&mut engine, key);
+        assert_eq!(shared_locks.len(), 3);
+        let lock10 = shared_locks.get_lock(&10.into()).unwrap().unwrap().clone();
+        let lock20 = shared_locks.get_lock(&20.into()).unwrap().unwrap().clone();
+
+        // Resolve mixed statuses in one batch on the same key.
+        let mut txn_status = HashMap::default();
+        txn_status.insert(10.into(), 0.into()); // rollback
+        txn_status.insert(20.into(), 25.into()); // commit
+        let key_locks = vec![(Key::from_raw(key), lock10), (Key::from_raw(key), lock20)];
+        run_resolve_lock(&mut engine, txn_status, key_locks);
+
+        must_get_rollback_ts(&mut engine, key, 10);
+        must_get_commit_ts(&mut engine, key, 20, 25);
+
+        // The unresolved sibling sub-lock must remain after the mixed batch.
+        shared_locks = must_load_shared_lock(&mut engine, key);
+        assert_eq!(shared_locks.len(), 1);
+        assert!(shared_locks.get_lock(&10.into()).unwrap().is_none());
+        assert!(shared_locks.get_lock(&20.into()).unwrap().is_none());
+        let lock30 = shared_locks.get_lock(&30.into()).unwrap().unwrap().clone();
+
+        // Resolve the final sub-lock and ensure key is fully unlocked.
+        let mut txn_status = HashMap::default();
+        txn_status.insert(30.into(), 0.into());
+        run_resolve_lock(&mut engine, txn_status, vec![(Key::from_raw(key), lock30)]);
+
+        must_get_rollback_ts(&mut engine, key, 30);
         must_unlocked(&mut engine, key);
     }
 }

--- a/src/storage/txn/commands/resolve_lock_readphase.rs
+++ b/src/storage/txn/commands/resolve_lock_readphase.rs
@@ -113,21 +113,57 @@ impl<S: Snapshot> ReadCommand<S> for ResolveLockReadPhase {
 
 #[cfg(test)]
 mod tests {
+    use std::{collections::HashSet, sync::Arc};
+
+    use concurrency_manager::ConcurrencyManager;
     use kvproto::kvrpcpb::Context;
 
     use super::*;
-    use crate::storage::{TestEngineBuilder, kv::Engine, txn::tests::*};
+    use crate::storage::{
+        TestEngineBuilder,
+        kv::Engine,
+        lock_manager::MockLockManager,
+        mvcc::tests::{must_load_shared_lock, must_unlocked, write},
+        txn::{
+            commands::{WriteCommand, WriteContext},
+            tests::*,
+            txn_status_cache::TxnStatusCache,
+        },
+    };
 
     fn run_resolve_lock_read_phase<E: Engine>(
         engine: &mut E,
         txn_status: HashMap<TimeStamp, TimeStamp>,
+        scan_key: Option<Key>,
     ) -> ProcessResult {
         let snapshot = engine.snapshot(Default::default()).unwrap();
         let mut statistics = Statistics::default();
-        ResolveLockReadPhase::new(txn_status, None, Context::default())
+        ResolveLockReadPhase::new(txn_status, scan_key, Context::default())
             .cmd
             .process_read(snapshot, &mut statistics)
             .unwrap()
+    }
+
+    fn run_resolve_lock_write_phase<E: Engine>(
+        engine: &mut E,
+        command: ResolveLock,
+    ) -> ProcessResult {
+        let ctx = Context::default();
+        let snapshot = engine.snapshot(Default::default()).unwrap();
+        let cm = ConcurrencyManager::new_for_test(TimeStamp::new(100));
+        let lock_mgr = MockLockManager::new();
+        let write_context = WriteContext {
+            lock_mgr: &lock_mgr,
+            concurrency_manager: cm,
+            extra_op: Default::default(),
+            statistics: &mut Default::default(),
+            async_apply_prewrite: false,
+            raw_ext: None,
+            txn_status_cache: Arc::new(TxnStatusCache::new_for_test()),
+        };
+        let result = command.process_write(snapshot, write_context).unwrap();
+        write(engine, &ctx, result.to_be_write.modifies);
+        result.pr
     }
 
     #[test]
@@ -147,7 +183,7 @@ mod tests {
         let mut txn_status = HashMap::default();
         txn_status.insert(20.into(), 30.into());
         txn_status.insert(40.into(), 0.into());
-        let pr = run_resolve_lock_read_phase(&mut engine, txn_status);
+        let pr = run_resolve_lock_read_phase(&mut engine, txn_status, None);
         match pr {
             ProcessResult::NextCommand {
                 cmd: Command::ResolveLock(next),
@@ -173,5 +209,88 @@ mod tests {
             }
             _ => panic!("expected resolve lock command"),
         }
+    }
+
+    #[test]
+    fn test_resolve_lock_readphase_large_single_shared_key_progress() {
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+        let key = b"resolve-lock-large-shared";
+        let sub_lock_count = RESOLVE_LOCK_BATCH_SIZE + 64;
+
+        let mut txn_status = HashMap::default();
+        for i in 0..sub_lock_count {
+            let start_ts = TimeStamp::new(100 + i as u64);
+            let primary = format!("pk-{i}");
+            must_acquire_shared_pessimistic_lock(
+                &mut engine,
+                key,
+                primary.as_bytes(),
+                start_ts,
+                start_ts,
+                3000,
+            );
+            must_shared_prewrite_lock(&mut engine, key, primary.as_bytes(), start_ts, start_ts);
+            txn_status.insert(start_ts, TimeStamp::zero());
+        }
+
+        assert_eq!(
+            must_load_shared_lock(&mut engine, key).len(),
+            sub_lock_count
+        );
+
+        let expected_key = Key::from_raw(key);
+        let mut seen_read_batches: HashSet<Vec<u64>> = HashSet::default();
+        let mut scan_key = None;
+        let mut read_rounds = 0;
+        loop {
+            read_rounds += 1;
+            assert!(
+                read_rounds <= sub_lock_count + 1,
+                "resolve-lock read/write loop did not terminate"
+            );
+
+            let read_pr =
+                run_resolve_lock_read_phase(&mut engine, txn_status.clone(), scan_key.clone());
+            let resolve_cmd = match read_pr {
+                ProcessResult::Res => break,
+                ProcessResult::NextCommand {
+                    cmd: Command::ResolveLock(next),
+                } => next,
+                _ => panic!("unexpected process result from resolve-lock read phase"),
+            };
+
+            let mut batch = Vec::with_capacity(resolve_cmd.key_locks.len());
+            for (k, lock) in &resolve_cmd.key_locks {
+                assert_eq!(k, &expected_key);
+                batch.push(lock.ts.into_inner());
+            }
+            batch.sort_unstable();
+            assert!(
+                seen_read_batches.insert(batch.clone()),
+                "duplicate unresolved subset observed between iterations: {:?}",
+                batch
+            );
+
+            let write_pr = run_resolve_lock_write_phase(&mut engine, resolve_cmd);
+            match write_pr {
+                ProcessResult::Res => break,
+                ProcessResult::NextCommand {
+                    cmd: Command::ResolveLockReadPhase(next),
+                } => {
+                    scan_key = next.scan_key;
+                }
+                _ => panic!("unexpected process result from resolve-lock write phase"),
+            }
+        }
+
+        assert!(
+            seen_read_batches.len() > 1,
+            "test did not exercise multi-batch resolve-lock read phase"
+        );
+        assert!(matches!(
+            run_resolve_lock_read_phase(&mut engine, txn_status, None),
+            ProcessResult::Res
+        ));
+        must_unlocked(&mut engine, key);
     }
 }

--- a/src/storage/txn/commands/txn_heart_beat.rs
+++ b/src/storage/txn/commands/txn_heart_beat.rs
@@ -98,42 +98,14 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for TxnHeartBeat {
 
                 lock
             }
-            Some(Either::Right(mut shared_locks))
-                if shared_locks.contains_start_ts(self.start_ts) =>
-            {
-                let lock = shared_locks
-                    .get_lock(&self.start_ts)
-                    .map_err(MvccError::from)?
-                    .expect("lock should exist since contains_start_ts returned true")
-                    .clone();
-                let mut updated_lock = lock.clone();
-                let mut updated = false;
-
-                if updated_lock.ttl < self.advise_ttl {
-                    updated_lock.ttl = self.advise_ttl;
-                    updated = true;
-                }
-
-                // only for non-async-commit pipelined transactions, we can update the
-                // min_commit_ts
-                if !updated_lock.use_async_commit
-                    && updated_lock.generation > 0
-                    && self.min_commit_ts > 0
-                    && updated_lock.min_commit_ts < self.min_commit_ts.into()
-                {
-                    return Err(box_err!(
-                        "pipelined transaction should not hold shared locks"
-                    ));
-                }
-
-                if updated {
-                    shared_locks
-                        .update_lock(updated_lock.clone())
-                        .map_err(MvccError::from)?;
-                    txn.put_shared_locks(self.primary_key.clone(), &shared_locks, false);
-                }
-
-                updated_lock
+            Some(Either::Right(shared_locks)) if shared_locks.contains_start_ts(self.start_ts) => {
+                // Reject the request because a shared locked key cannot be the primary key of a
+                // transaction according to the design and transaction heartbeats are only sent
+                // for the primary key.
+                return Err(MvccError::from(MvccErrorInner::PrimaryMismatch(
+                    shared_locks.into_lock_info(self.primary_key.into_raw()?),
+                ))
+                .into());
             }
             _ => {
                 return Err(MvccError::from(MvccErrorInner::TxnNotFound {
@@ -170,7 +142,7 @@ pub mod tests {
     use std::sync::Arc;
 
     use concurrency_manager::ConcurrencyManager;
-    use kvproto::kvrpcpb::Context;
+    use kvproto::kvrpcpb::{Context, Op};
     use tikv_util::deadline::Deadline;
 
     use super::*;
@@ -178,21 +150,20 @@ pub mod tests {
         Engine,
         kv::TestEngineBuilder,
         lock_manager::MockLockManager,
-        mvcc::tests::*,
+        mvcc::{self, tests::*},
         txn::{
-            commands::WriteCommand, scheduler::DEFAULT_EXECUTION_DURATION_LIMIT, tests::*,
+            self, commands::WriteCommand, scheduler::DEFAULT_EXECUTION_DURATION_LIMIT, tests::*,
             txn_status_cache::TxnStatusCache,
         },
     };
 
-    pub fn must_success<E: Engine>(
+    fn txn_heart_beat<E: Engine>(
         engine: &mut E,
         primary_key: &[u8],
         start_ts: impl Into<TimeStamp>,
         advise_ttl: u64,
-        expect_ttl: u64,
-    ) {
-        let ctx = Context::default();
+        min_commit_ts: u64,
+    ) -> Result<WriteResult> {
         let snapshot = engine.snapshot(Default::default()).unwrap();
         let start_ts = start_ts.into();
         let cm = ConcurrencyManager::new_for_test(start_ts);
@@ -202,22 +173,31 @@ pub mod tests {
             start_ts,
             advise_ttl,
             deadline: Deadline::from_now(DEFAULT_EXECUTION_DURATION_LIMIT),
-            min_commit_ts: 0,
+            min_commit_ts,
         };
-        let result = command
-            .process_write(
-                snapshot,
-                WriteContext {
-                    lock_mgr: &MockLockManager::new(),
-                    concurrency_manager: cm,
-                    extra_op: Default::default(),
-                    statistics: &mut Default::default(),
-                    async_apply_prewrite: false,
-                    raw_ext: None,
-                    txn_status_cache: Arc::new(TxnStatusCache::new_for_test()),
-                },
-            )
-            .unwrap();
+        command.process_write(
+            snapshot,
+            WriteContext {
+                lock_mgr: &MockLockManager::new(),
+                concurrency_manager: cm,
+                extra_op: Default::default(),
+                statistics: &mut Default::default(),
+                async_apply_prewrite: false,
+                raw_ext: None,
+                txn_status_cache: Arc::new(TxnStatusCache::new_for_test()),
+            },
+        )
+    }
+
+    pub fn must_success<E: Engine>(
+        engine: &mut E,
+        primary_key: &[u8],
+        start_ts: impl Into<TimeStamp>,
+        advise_ttl: u64,
+        expect_ttl: u64,
+    ) {
+        let ctx = Context::default();
+        let result = txn_heart_beat(engine, primary_key, start_ts, advise_ttl, 0).unwrap();
         if let ProcessResult::TxnStatus {
             txn_status: TxnStatus::Uncommitted { lock, .. },
         } = result.pr
@@ -235,34 +215,67 @@ pub mod tests {
         start_ts: impl Into<TimeStamp>,
         advise_ttl: u64,
     ) {
-        let ctx = Context::default();
-        let snapshot = engine.snapshot(Default::default()).unwrap();
+        assert!(txn_heart_beat(engine, primary_key, start_ts, advise_ttl, 0).is_err());
+    }
+
+    fn load_shared_sub_lock<E: Engine>(
+        engine: &mut E,
+        key: &[u8],
+        start_ts: impl Into<TimeStamp>,
+    ) -> txn_types::Lock {
+        let mut shared_locks = must_load_shared_lock(engine, key);
+        shared_locks
+            .get_lock(&start_ts.into())
+            .unwrap()
+            .expect("shared sub-lock should exist")
+            .clone()
+    }
+
+    fn update_shared_sub_lock<E: Engine>(
+        engine: &mut E,
+        key: &[u8],
+        start_ts: impl Into<TimeStamp>,
+        mutator: impl FnOnce(&mut txn_types::Lock),
+    ) {
         let start_ts = start_ts.into();
+        let mut shared_locks = must_load_shared_lock(engine, key);
+        let mut lock = shared_locks
+            .get_lock(&start_ts)
+            .unwrap()
+            .expect("shared sub-lock should exist")
+            .clone();
+        mutator(&mut lock);
+        shared_locks.update_lock(lock).unwrap();
+
         let cm = ConcurrencyManager::new_for_test(start_ts);
-        let command = TxnHeartBeat {
-            ctx,
-            primary_key: Key::from_raw(primary_key),
-            start_ts,
-            advise_ttl,
-            deadline: Deadline::from_now(DEFAULT_EXECUTION_DURATION_LIMIT),
-            min_commit_ts: 0,
-        };
-        assert!(
-            command
-                .process_write(
-                    snapshot,
-                    WriteContext {
-                        lock_mgr: &MockLockManager::new(),
-                        concurrency_manager: cm,
-                        extra_op: Default::default(),
-                        statistics: &mut Default::default(),
-                        async_apply_prewrite: false,
-                        raw_ext: None,
-                        txn_status_cache: Arc::new(TxnStatusCache::new_for_test()),
-                    },
-                )
-                .is_err()
-        );
+        let mut txn = MvccTxn::new(start_ts, cm);
+        txn.put_shared_locks(Key::from_raw(key), &shared_locks, false);
+        write(engine, &Context::default(), txn.into_modifies());
+    }
+
+    fn must_primary_mismatch(err: txn::Error, key: &[u8]) {
+        match err {
+            txn::Error(box txn::ErrorInner::Mvcc(mvcc::Error(
+                box mvcc::ErrorInner::PrimaryMismatch(lock_info),
+            ))) => {
+                assert_eq!(lock_info.key, key);
+                assert_eq!(lock_info.lock_type, Op::SharedLock);
+            }
+            e => panic!("unexpected error: {:?}", e),
+        }
+    }
+
+    fn must_heartbeat_err<E: Engine>(
+        engine: &mut E,
+        primary_key: &[u8],
+        start_ts: impl Into<TimeStamp>,
+        advise_ttl: u64,
+        min_commit_ts: u64,
+    ) -> txn::Error {
+        match txn_heart_beat(engine, primary_key, start_ts, advise_ttl, min_commit_ts) {
+            Ok(_) => panic!("expected TxnHeartBeat to fail"),
+            Err(err) => err,
+        }
     }
 
     #[test]
@@ -360,5 +373,47 @@ pub mod tests {
         } else {
             unreachable!();
         }
+    }
+
+    #[test]
+    fn test_txn_heartbeat_rejects_shared_lock_key() {
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+        let key = b"k1";
+        let primary = b"pk";
+        let start_ts = 10;
+
+        must_acquire_shared_pessimistic_lock(&mut engine, key, primary, start_ts, start_ts, 100);
+        let lock_before = load_shared_sub_lock(&mut engine, key, start_ts);
+
+        let err = must_heartbeat_err(&mut engine, key, start_ts, 200, 0);
+        must_primary_mismatch(err, key);
+
+        let lock_after = load_shared_sub_lock(&mut engine, key, start_ts);
+        assert_eq!(lock_after.ttl, lock_before.ttl);
+        assert_eq!(lock_after.min_commit_ts, lock_before.min_commit_ts);
+        assert_eq!(lock_after.generation, lock_before.generation);
+    }
+
+    #[test]
+    fn test_txn_heartbeat_rejects_shared_lock_with_pipelined_fields() {
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+        let key = b"k1";
+        let primary = b"pk";
+        let start_ts = 10;
+
+        must_acquire_shared_pessimistic_lock(&mut engine, key, primary, start_ts, start_ts, 100);
+        update_shared_sub_lock(&mut engine, key, start_ts, |lock| {
+            lock.generation = 1;
+            lock.min_commit_ts = 20.into();
+        });
+        let lock_before = load_shared_sub_lock(&mut engine, key, start_ts);
+
+        let err = must_heartbeat_err(&mut engine, key, start_ts, 250, 30);
+        must_primary_mismatch(err, key);
+
+        let lock_after = load_shared_sub_lock(&mut engine, key, start_ts);
+        assert_eq!(lock_after.ttl, lock_before.ttl);
+        assert_eq!(lock_after.min_commit_ts, lock_before.min_commit_ts);
+        assert_eq!(lock_after.generation, lock_before.generation);
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #19087

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Add more tests for shared-lock feature, which covers the following scenarios:
- ResolveLock mixed commit/rollback
- Commit/Cleanup pending visibility
- ResolveLockReadPhase large-set progress
- TxnHeartBeat rejection
- Scan-lock hard limit across mixed keys
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for shared lock handling in transaction cleanup, commit operations, and lock resolution.
  * Added integration tests for multi-batch resolve-lock read-phase operations with large numbers of sub-locks.

* **Bug Fixes**
  * Fixed transaction heartbeat behavior to properly reject operations when a shared lock exists, returning a PrimaryMismatch error instead of attempting updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->