### PR TITLE
txn: support shared lock for lock wait table (#19271)

### DIFF
--- a/src/server/lock_manager/mod.rs
+++ b/src/server/lock_manager/mod.rs
@@ -290,7 +290,10 @@ impl LockManagerTrait for LockManager {
 
         // If it is the first lock the transaction tries to lock, it won't cause
         // deadlock.
-        if !is_first_lock {
+        // The lock waiting for shared lock is not tracked yet, because the shared lock
+        // may grow after this detection. After we implement the shrinking of
+        // shared lock, we can track it then.
+        if !is_first_lock && wait_info.lock_info.lock_type != kvproto::kvrpcpb::Op::SharedLock {
             self.detector_scheduler
                 .detect(start_ts, wait_info, diag_ctx);
         }

--- a/src/storage/lock_manager/lock_wait_context.rs
+++ b/src/storage/lock_manager/lock_wait_context.rs
@@ -419,6 +419,7 @@ mod tests {
                     ..Default::default()
                 },
                 should_not_exist: false,
+                is_shared_lock: false,
                 lock_wait_token: token,
                 req_states: ctx.get_shared_states().clone(),
                 legacy_wake_up_index: None,

--- a/src/storage/lock_manager/lock_waiting_queue.rs
+++ b/src/storage/lock_manager/lock_waiting_queue.rs
@@ -94,6 +94,8 @@ pub struct LockWaitEntry {
     // `parameters` provides parameter for a request, but `should_not_exist` is specified key-wise.
     // Put it in a separated field.
     pub should_not_exist: bool,
+    /// Whether the lock currently blocking this entry is a shared lock.
+    pub is_shared_lock: bool,
     pub lock_wait_token: LockWaitToken,
     pub req_states: Arc<LockWaitContextSharedState>,
     pub legacy_wake_up_index: Option<usize>,
@@ -320,17 +322,18 @@ impl<L: LockManager> LockWaitQueues<L> {
     /// will be returned and the caller will be responsible for executing it.
     /// The future waits until `wake_up_delay_duration` is elapsed since the
     /// most recent waking-up, and then wakes up all lock waiting entries that
-    /// exists at the time when the latest waking-up happens. The future
-    /// will return a `LockWaitEntry` if a resumable entry is popped out
-    /// from the queue while executing, and in this case the caller will be
-    /// responsible to wake it up.
+    /// exists at the time when the latest waking-up happens. The future will
+    /// return a `LockWaitEntry` if a resumable entry is popped out from the
+    /// queue while executing, and in this case the caller will be responsible
+    /// to wake it up. When the head of the queue is a shared lock wait, all
+    /// consecutive shared lock waits are returned together in the vector.
     pub fn pop_for_waking_up(
         &self,
         key: &Key,
         conflicting_start_ts: TimeStamp,
         conflicting_commit_ts: TimeStamp,
         wake_up_delay_duration_ms: u64,
-    ) -> Option<(Box<LockWaitEntry>, Option<DelayedNotifyAllFuture>)> {
+    ) -> (Vec<Box<LockWaitEntry>>, Option<DelayedNotifyAllFuture>) {
         self.pop_for_waking_up_impl(
             key,
             conflicting_start_ts,
@@ -339,14 +342,16 @@ impl<L: LockManager> LockWaitQueues<L> {
         )
     }
 
+    #[allow(clippy::vec_box)]
     fn pop_for_waking_up_impl(
         &self,
         key: &Key,
         conflicting_start_ts: TimeStamp,
         conflicting_commit_ts: TimeStamp,
         wake_up_delay_duration_ms: Option<u64>,
-    ) -> Option<(Box<LockWaitEntry>, Option<DelayedNotifyAllFuture>)> {
-        let mut result = None;
+    ) -> (Vec<Box<LockWaitEntry>>, Option<DelayedNotifyAllFuture>) {
+        let mut popped_entries: Vec<Box<LockWaitEntry>> = Vec::new();
+        let mut popped_future: Option<DelayedNotifyAllFuture> = None;
         // For statistics.
         let mut removed_waiters = 0usize;
 
@@ -361,20 +366,45 @@ impl<L: LockManager> LockWaitQueues<L> {
             if let Some((_, lock_wait_entry)) = v.queue.pop() {
                 removed_waiters += 1;
 
+                let mut group_entries = Vec::with_capacity(4);
+                let mut schedule_delayed_wake_up = false;
+
                 if !lock_wait_entry.parameters.allow_lock_with_conflict {
-                    // If a pessimistic lock request in legacy mode is woken up, increase the
-                    // counter.
                     v.legacy_wake_up_index += 1;
-                    let notify_all_future = match wake_up_delay_duration_ms {
+                    schedule_delayed_wake_up = true;
+                }
+
+                let shared_group = lock_wait_entry.is_shared_lock;
+                group_entries.push(lock_wait_entry);
+
+                if shared_group {
+                    while let Some((_, front)) = v.queue.peek() {
+                        if !front.is_shared_lock {
+                            break;
+                        }
+                        let (_, shared_entry) = v.queue.pop().unwrap();
+                        removed_waiters += 1;
+                        if !shared_entry.parameters.allow_lock_with_conflict {
+                            v.legacy_wake_up_index += 1;
+                            schedule_delayed_wake_up = true;
+                        }
+                        group_entries.push(shared_entry);
+                    }
+                }
+
+                let notify_all_future = if schedule_delayed_wake_up {
+                    match wake_up_delay_duration_ms {
                         Some(delay) if !v.queue.is_empty() => {
                             self.handle_delayed_wake_up(v, key, delay)
                         }
                         _ => None,
-                    };
-                    result = Some((lock_wait_entry, notify_all_future));
+                    }
                 } else {
-                    result = Some((lock_wait_entry, None));
-                }
+                    None
+                };
+
+                popped_future = notify_all_future;
+                popped_entries = group_entries;
             }
 
             self.inner
@@ -394,7 +424,7 @@ impl<L: LockManager> LockWaitQueues<L> {
             LOCK_WAIT_QUEUE_ENTRIES_GAUGE_VEC.keys.dec();
         }
 
-        result
+        (popped_entries, popped_future)
     }
 
     /// Schedule delayed waking up on the specified key.
@@ -772,6 +802,7 @@ mod tests {
                 lock_hash,
                 parameters,
                 should_not_exist: false,
+                is_shared_lock: false,
                 lock_wait_token: token,
                 req_states: dummy_ctx.get_shared_states().clone(),
                 legacy_wake_up_index: None,
@@ -804,10 +835,25 @@ mod tests {
             encountered_lock_ts: impl Into<TimeStamp>,
             resumable: bool,
         ) -> TestLockWaitEntryHandle {
-            let lock_info_pb = self.make_lock_info_pb(key, encountered_lock_ts);
+            self.mock_lock_wait_with_shared(key, start_ts, encountered_lock_ts, resumable, false)
+        }
+
+        fn mock_lock_wait_with_shared(
+            &self,
+            key: &[u8],
+            start_ts: impl Into<TimeStamp>,
+            encountered_lock_ts: impl Into<TimeStamp>,
+            resumable: bool,
+            shared: bool,
+        ) -> TestLockWaitEntryHandle {
+            let mut lock_info_pb = self.make_lock_info_pb(key, encountered_lock_ts);
+            if shared {
+                lock_info_pb.set_lock_type(kvrpcpb::Op::SharedLock);
+            }
             let (mut entry, handle) =
                 self.make_mock_lock_wait_entry(key, start_ts, lock_info_pb.clone());
             entry.parameters.allow_lock_with_conflict = resumable;
+            entry.is_shared_lock = shared;
             self.push_lock_wait(entry, lock_info_pb);
             handle
         }
@@ -821,16 +867,15 @@ mod tests {
             conflicting_start_ts: impl Into<TimeStamp>,
             conflicting_commit_ts: impl Into<TimeStamp>,
         ) -> Box<LockWaitEntry> {
-            let (entry, f) = self
-                .pop_for_waking_up_impl(
-                    &Key::from_raw(key),
-                    conflicting_start_ts.into(),
-                    conflicting_commit_ts.into(),
-                    None,
-                )
-                .unwrap();
-            assert!(f.is_none());
-            entry
+            let (mut entries, future) = self.pop_for_waking_up_impl(
+                &Key::from_raw(key),
+                conflicting_start_ts.into(),
+                conflicting_commit_ts.into(),
+                None,
+            );
+            assert_eq!(entries.len(), 1);
+            assert!(future.is_none());
+            entries.pop().unwrap()
         }
 
         fn must_pop_none(
@@ -839,13 +884,14 @@ mod tests {
             conflicting_start_ts: impl Into<TimeStamp>,
             conflicting_commit_ts: impl Into<TimeStamp>,
         ) {
-            let res = self.pop_for_waking_up_impl(
+            let (entries, future) = self.pop_for_waking_up_impl(
                 &Key::from_raw(key),
                 conflicting_start_ts.into(),
                 conflicting_commit_ts.into(),
                 Some(1),
             );
-            assert!(res.is_none());
+            assert!(entries.is_empty());
+            assert!(future.is_none());
         }
 
         fn must_pop_with_delayed_notify(
@@ -854,15 +900,14 @@ mod tests {
             conflicting_start_ts: impl Into<TimeStamp>,
             conflicting_commit_ts: impl Into<TimeStamp>,
         ) -> (Box<LockWaitEntry>, DelayedNotifyAllFuture) {
-            let (res, f) = self
-                .pop_for_waking_up_impl(
-                    &Key::from_raw(key),
-                    conflicting_start_ts.into(),
-                    conflicting_commit_ts.into(),
-                    Some(50),
-                )
-                .unwrap();
-            (res, f.unwrap())
+            let (mut entries, future) = self.pop_for_waking_up_impl(
+                &Key::from_raw(key),
+                conflicting_start_ts.into(),
+                conflicting_commit_ts.into(),
+                Some(50),
+            );
+            assert_eq!(entries.len(), 1);
+            (entries.pop().unwrap(), future.unwrap())
         }
 
         fn must_pop_with_no_delayed_notify(
@@ -871,16 +916,15 @@ mod tests {
             conflicting_start_ts: impl Into<TimeStamp>,
             conflicting_commit_ts: impl Into<TimeStamp>,
         ) -> Box<LockWaitEntry> {
-            let (res, f) = self
-                .pop_for_waking_up_impl(
-                    &Key::from_raw(key),
-                    conflicting_start_ts.into(),
-                    conflicting_commit_ts.into(),
-                    Some(50),
-                )
-                .unwrap();
-            assert!(f.is_none());
-            res
+            let (mut entries, future) = self.pop_for_waking_up_impl(
+                &Key::from_raw(key),
+                conflicting_start_ts.into(),
+                conflicting_commit_ts.into(),
+                Some(50),
+            );
+            assert_eq!(entries.len(), 1);
+            assert!(future.is_none());
+            entries.pop().unwrap()
         }
 
         fn get_delayed_notify_id(&self, key: &[u8]) -> Option<u64> {
@@ -904,6 +948,11 @@ mod tests {
     impl LockWaitEntry {
         fn check_key(&self, expected_key: &[u8]) -> &Self {
             assert_eq!(self.key, Key::from_raw(expected_key));
+            self
+        }
+
+        fn check_shared(&self, expected: bool) -> &Self {
+            assert_eq!(self.is_shared_lock, expected);
             self
         }
 
@@ -1233,6 +1282,39 @@ mod tests {
                 .delayed_notify_all(&Key::from_raw(b"k1"), 1)
                 .is_none()
         );
+        queues.must_not_contain_key(b"k1");
+        assert_eq!(queues.entry_count(), 0);
+    }
+
+    #[test]
+    fn test_pop_shared_group() {
+        let queues = LockWaitQueues::new(MockLockManager::new());
+        assert_eq!(queues.entry_count(), 0);
+
+        queues.mock_lock_wait_with_shared(b"k1", 10, 5, false, true);
+        queues.mock_lock_wait_with_shared(b"k1", 11, 5, false, true);
+        queues.mock_lock_wait_with_shared(b"k1", 12, 5, false, true);
+        queues.mock_lock_wait_with_shared(b"k1", 20, 5, false, false);
+        assert_eq!(queues.entry_count(), 4);
+
+        let (entries, future) =
+            queues.pop_for_waking_up_impl(&Key::from_raw(b"k1"), 5.into(), 6.into(), Some(50));
+        assert_eq!(entries.len(), 3);
+        let mut start_ts_set = vec![];
+        for entry in &entries {
+            entry.check_shared(true);
+            start_ts_set.push(entry.parameters.start_ts.into_inner());
+        }
+        start_ts_set.sort_by(|a, b| a.cmp(b));
+        assert_eq!(start_ts_set, vec![10, 11, 12]);
+        assert!(future.is_some());
+
+        let (next_entries, next_future) =
+            queues.pop_for_waking_up_impl(&Key::from_raw(b"k1"), 7.into(), 8.into(), Some(50));
+        assert_eq!(next_entries.len(), 1);
+        next_entries[0].check_shared(false).check_start_ts(20);
+        assert!(next_future.is_none());
+
         queues.must_not_contain_key(b"k1");
         assert_eq!(queues.entry_count(), 0);
     }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -4057,6 +4057,28 @@ pub mod test_util {
         return_values: bool,
         check_existence: bool,
     ) -> PessimisticLockCommand {
+        let keys = keys
+            .into_iter()
+            .map(|(k, b)| (k, b, false))
+            .collect::<Vec<_>>();
+        new_acquire_pessimistic_lock_command_with_pk_with_shared(
+            keys,
+            pk,
+            start_ts,
+            for_update_ts,
+            return_values,
+            check_existence,
+        )
+    }
+
+    pub fn new_acquire_pessimistic_lock_command_with_pk_with_shared(
+        keys: Vec<(Key, bool, bool)>,
+        pk: Option<&[u8]>,
+        start_ts: impl Into<TimeStamp>,
+        for_update_ts: impl Into<TimeStamp>,
+        return_values: bool,
+        check_existence: bool,
+    ) -> PessimisticLockCommand {
         let primary = pk
             .map(|k| k.to_vec())
             .unwrap_or_else(|| keys[0].0.clone().to_raw().unwrap());
@@ -7990,7 +8012,10 @@ mod tests {
             storage
                 .sched_txn_command(
                     commands::AcquirePessimisticLock::new(
-                        vec![(Key::from_raw(b"a"), false), (Key::from_raw(b"b"), false)],
+                        vec![
+                            (Key::from_raw(b"a"), false, false),
+                            (Key::from_raw(b"b"), false, false),
+                        ],
                         b"a".to_vec(),
                         20.into(),
                         3000,
@@ -9910,7 +9935,10 @@ mod tests {
         storage
             .sched_txn_command(
                 commands::AcquirePessimisticLock::new(
-                    vec![(Key::from_raw(b"foo"), false), (Key::from_raw(&k), false)],
+                    vec![
+                        (Key::from_raw(b"foo"), false, false),
+                        (Key::from_raw(&k), false, false),
+                    ],
                     k.clone(),
                     20.into(),
                     3000,
@@ -10002,7 +10030,7 @@ mod tests {
                 storage
                     .sched_txn_command(
                         commands::AcquirePessimisticLock::new(
-                            vec![(k.clone(), false)],
+                            vec![(k.clone(), false, false)],
                             k.to_raw().unwrap(),
                             lock_ts.into(),
                             3000,
@@ -10595,7 +10623,7 @@ mod tests {
         storage
             .sched_txn_command(
                 commands::AcquirePessimisticLock::new(
-                    vec![(key1.clone(), false)],
+                    vec![(key1.clone(), false, false)],
                     k1.to_vec(),
                     1.into(),
                     0,
@@ -10618,7 +10646,7 @@ mod tests {
         storage
             .sched_txn_command(
                 commands::AcquirePessimisticLock::new(
-                    vec![(key2.clone(), false)],
+                    vec![(key2.clone(), false, false)],
                     k2.to_vec(),
                     10.into(),
                     0,
@@ -10852,7 +10880,9 @@ mod tests {
             ],
 
             command: AcquirePessimisticLock::new(
-                keys.iter().map(|&it| (Key::from_raw(it), true)).collect(),
+                keys.iter()
+                    .map(|&it| (Key::from_raw(it), true, false))
+                    .collect(),
                 keys[0].to_vec(),
                 TimeStamp::new(10),
                 0,
@@ -10878,7 +10908,9 @@ mod tests {
             ],
 
             command: AcquirePessimisticLock::new(
-                keys.iter().map(|&it| (Key::from_raw(it), true)).collect(),
+                keys.iter()
+                    .map(|&it| (Key::from_raw(it), true, false))
+                    .collect(),
                 keys[0].to_vec(),
                 TimeStamp::new(10),
                 0,

--- a/src/storage/txn/commands/acquire_pessimistic_lock.rs
+++ b/src/storage/txn/commands/acquire_pessimistic_lock.rs
@@ -36,7 +36,8 @@ command! {
         }
         content => {
             /// The set of keys to lock.
-            keys: Vec<(Key, bool)>,
+            /// (Key, bool, bool) means (key, should_not_exist, is_shared_lock)
+            keys: Vec<(Key, bool, bool)>,
             /// The primary lock. Secondary locks (from `keys`) will refer to the primary lock.
             primary: Vec<u8>,
             /// The transaction timestamp.
@@ -71,7 +72,7 @@ impl CommandExt for AcquirePessimisticLock {
     fn write_bytes(&self) -> usize {
         self.keys
             .iter()
-            .map(|(key, _)| key.as_encoded().len())
+            .map(|(key, ..)| key.as_encoded().len())
             .sum()
     }
 
@@ -99,7 +100,7 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for AcquirePessimisticLock 
         let mut encountered_locks = vec![];
         let need_old_value = context.extra_op == ExtraOp::ReadOldValue;
         let mut old_values = OldValues::default();
-        for (k, should_not_exist) in keys {
+        for (k, should_not_exist, _is_shared) in keys {
             match acquire_pessimistic_lock(
                 &mut txn,
                 &mut reader,

--- a/src/storage/txn/commands/acquire_pessimistic_lock_resumed.rs
+++ b/src/storage/txn/commands/acquire_pessimistic_lock_resumed.rs
@@ -352,6 +352,7 @@ mod tests {
             lock_hash,
             parameters,
             should_not_exist: false,
+            is_shared_lock: false,
             lock_wait_token: token,
             legacy_wake_up_index: Some(0),
             req_states,

--- a/src/storage/txn/commands/mod.rs
+++ b/src/storage/txn/commands/mod.rs
@@ -217,9 +217,10 @@ impl From<PessimisticLockRequest> for TypedCommand<StorageResult<PessimisticLock
             .take_mutations()
             .into_iter()
             .map(|x| match x.get_op() {
-                Op::PessimisticLock => (
+                Op::PessimisticLock | Op::SharedPessimisticLock => (
                     Key::from_raw(x.get_key()),
                     x.get_assertion() == Assertion::NotExist,
+                    x.get_op() == Op::SharedPessimisticLock,
                 ),
                 _ => panic!("mismatch Op in pessimistic lock mutations"),
             })

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -1064,24 +1064,41 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
             .load(Ordering::Relaxed);
 
         released_locks.into_iter().for_each(|released_lock| {
-            let (lock_wait_entry, delay_wake_up_future) =
-                match self.inner.lock_wait_queues.pop_for_waking_up(
-                    &released_lock.key,
-                    released_lock.start_ts,
-                    released_lock.commit_ts,
-                    wake_up_delay_duration_ms,
-                ) {
-                    Some(e) => e,
-                    None => return,
-                };
-
-            if lock_wait_entry.parameters.allow_lock_with_conflict {
-                resumable_wake_up_list.push(lock_wait_entry);
-            } else {
-                legacy_wake_up_list.push((lock_wait_entry, released_lock));
+            let (entries, delay_future) = self.inner.lock_wait_queues.pop_for_waking_up(
+                &released_lock.key,
+                released_lock.start_ts,
+                released_lock.commit_ts,
+                wake_up_delay_duration_ms,
+            );
+            if entries.is_empty() {
+                return;
             }
-            if let Some(f) = delay_wake_up_future {
+
+            if let Some(f) = delay_future {
                 delay_wake_up_futures.push(f);
+            }
+
+            let multi_entries = entries.len() > 1;
+
+            for lock_wait_entry in entries {
+                // With multi entries, only shared lock's waiters can be awaken up.
+                debug_assert!(
+                    lock_wait_entry.is_shared_lock || !multi_entries,
+                    "when multiple entries exist, all must be shared locks"
+                );
+                if lock_wait_entry.parameters.allow_lock_with_conflict {
+                    resumable_wake_up_list.push(lock_wait_entry);
+                } else {
+                    legacy_wake_up_list.push((
+                        lock_wait_entry,
+                        ReleasedLock::new(
+                            released_lock.start_ts,
+                            released_lock.commit_ts,
+                            released_lock.key.clone(),
+                            released_lock.pessimistic,
+                        ),
+                    ));
+                }
             }
         });
 
@@ -1392,6 +1409,7 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         write_result: WriteResult,
         sched_details: &mut SchedulerDetails,
         txn_ext: Option<Arc<TxnExt>>,
+        is_shared_lock_cmd: bool,
     ) -> Option<(WriteResult, TaskMetadata<'a>)> {
         let WriteResult {
             ctx,
@@ -1481,6 +1499,7 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
             tag,
             CommandKind::acquire_pessimistic_lock | CommandKind::acquire_pessimistic_lock_resumed
         ) && txn_scheduler.pessimistic_lock_mode() == PessimisticLockMode::InMemory
+            && !is_shared_lock_cmd
             && txn_scheduler.try_write_in_memory_pessimistic_locks(
                 txn_ext.as_deref(),
                 &mut to_be_write,
@@ -1832,6 +1851,11 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         let mut task_meta_data = TaskMetadata::from_ctx(task.cmd().resource_control_ctx());
         let pipelined = task.cmd().can_be_pipelined()
             && self.pessimistic_lock_mode() == PessimisticLockMode::Pipelined;
+        let is_shared_lock_cmd = if let Command::AcquirePessimisticLock(ref cmd) = task.cmd() {
+            cmd.keys.iter().any(|k| k.2)
+        } else {
+            false
+        };
         let txn_ext = snapshot.ext().get_txn_ext().cloned();
         let deadline = task.cmd().deadline();
         let write_result = Self::handle_task(self.clone(), snapshot, task, sched_details).await;
@@ -1874,6 +1898,7 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
                 write_result,
                 sched_details,
                 txn_ext.clone(),
+                is_shared_lock_cmd,
             )
         {
             write_result = write_result_res;
@@ -1991,6 +2016,7 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         let mut slot = self.inner.get_task_slot(cid);
         let task_ctx = slot.get_mut(&cid).unwrap();
         let cb = task_ctx.cb.take().unwrap();
+        let is_shared_lock = lock_info.lock_info_pb.lock_type == kvrpcpb::Op::SharedLock;
 
         let ctx = LockWaitContext::new(
             lock_info.key.clone(),
@@ -2010,6 +2036,7 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
             lock_hash: lock_info.lock_digest.hash,
             parameters: lock_info.parameters,
             should_not_exist: lock_info.should_not_exist,
+            is_shared_lock,
             lock_wait_token,
             req_states: ctx.get_shared_states().clone(),
             legacy_wake_up_index: None,
@@ -2024,13 +2051,15 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         lock_info: WriteResultLockInfo,
         cb: PessimisticLockKeyCallback,
     ) -> Box<LockWaitEntry> {
+        assert!(lock_info.lock_info_pb.lock_type != kvrpcpb::Op::SharedLock);
         Box::new(LockWaitEntry {
             key: lock_info.key,
             lock_hash: lock_info.lock_digest.hash,
             parameters: lock_info.parameters,
             should_not_exist: lock_info.should_not_exist,
+            is_shared_lock: false,
             lock_wait_token: lock_info.lock_wait_token,
-            // This must be called after an execution fo AcquirePessimisticLockResumed, in which
+            // This must be called after an execution of AcquirePessimisticLockResumed, in which
             // case there must be a valid req_state.
             req_states: lock_info.req_states.unwrap(),
             legacy_wake_up_index: None,
@@ -2300,7 +2329,7 @@ mod tests {
             )
             .into(),
             commands::AcquirePessimisticLock::new(
-                vec![(Key::from_raw(b"k"), false)],
+                vec![(Key::from_raw(b"k"), false, false)],
                 b"k".to_vec(),
                 10.into(),
                 0,

--- a/tests/failpoints/cases/test_storage.rs
+++ b/tests/failpoints/cases/test_storage.rs
@@ -947,7 +947,7 @@ fn test_async_apply_prewrite_impl<E: Engine, F: KvFormat>(
         storage
             .sched_txn_command(
                 commands::AcquirePessimisticLock::new(
-                    vec![(Key::from_raw(key), false)],
+                    vec![(Key::from_raw(key), false, false)],
                     key.to_vec(),
                     start_ts,
                     0,
@@ -1288,7 +1288,7 @@ fn test_async_apply_prewrite_1pc_impl<E: Engine, F: KvFormat>(
         storage
             .sched_txn_command(
                 commands::AcquirePessimisticLock::new(
-                    vec![(Key::from_raw(key), false)],
+                    vec![(Key::from_raw(key), false, false)],
                     key.to_vec(),
                     start_ts,
                     0,


### PR DESCRIPTION
cherry pick #19271 to release-8.5 branch

----

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #19087

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Handle the shared lock in the lock wait table.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
