### PR TITLE
metrics: show real disk used size and keep logical used hidden metric

### DIFF
--- a/metrics/grafana/tikv_details.dashboard.py
+++ b/metrics/grafana/tikv_details.dashboard.py
@@ -233,18 +233,34 @@ def Cluster() -> RowPanel:
     layout.row(
         [
             graph_panel(
-                title="Store size",
-                description="The storage size per TiKV instance",
+                title="Disk used size",
+                description="The real disk used size per TiKV instance: capacity - available",
                 yaxes=yaxes(left_format=UNITS.BYTES_IEC),
                 fill=1,
                 stack=True,
                 legend=graph_legend(max=False),
                 targets=[
                     target(
+                        expr=expr_operator(
+                            expr_sum(
+                                "tikv_store_size_bytes",
+                                label_selectors=['type="capacity"'],
+                            ),
+                            "-",
+                            expr_sum(
+                                "tikv_store_size_bytes",
+                                label_selectors=['type="available"'],
+                            ),
+                        ),
+                        legend_format=r"{{instance}}",
+                    ),
+                    target(
                         expr=expr_sum(
                             "tikv_store_size_bytes",
-                            label_selectors=['type = "used"'],
+                            label_selectors=['type="used"'],
                         ),
+                        legend_format=r"{{instance}}-logical-used",
+                        hide=True,
                     ),
                 ],
             ),

--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -453,7 +453,7 @@
           "bars": false,
           "cacheTimeout": null,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "The storage size per TiKV instance",
+          "description": "The real disk used size per TiKV instance: capacity - available",
           "editable": true,
           "error": false,
           "fieldConfig": {
@@ -523,7 +523,7 @@
           "targets": [
             {
               "datasource": "${DS_TEST-CLUSTER}",
-              "expr": "sum((\n    tikv_store_size_bytes\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type = \"used\"}\n    \n)) by (instance) ",
+              "expr": "(sum((\n    tikv_store_size_bytes\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"capacity\"}\n    \n)) by (instance)  - sum((\n    tikv_store_size_bytes\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"available\"}\n    \n)) by (instance) )",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -531,7 +531,22 @@
               "intervalFactor": 1,
               "legendFormat": "{{instance}}",
               "metric": "",
-              "query": "sum((\n    tikv_store_size_bytes\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type = \"used\"}\n    \n)) by (instance) ",
+              "query": "(sum((\n    tikv_store_size_bytes\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"capacity\"}\n    \n)) by (instance)  - sum((\n    tikv_store_size_bytes\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"available\"}\n    \n)) by (instance) )",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum((\n    tikv_store_size_bytes\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"used\"}\n    \n)) by (instance) ",
+              "format": "time_series",
+              "hide": true,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{instance}}-logical-used",
+              "metric": "",
+              "query": "sum((\n    tikv_store_size_bytes\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"used\"}\n    \n)) by (instance) ",
               "refId": "",
               "step": 10,
               "target": ""
@@ -540,7 +555,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Store size",
+          "title": "Disk used size",
           "tooltip": {
             "msResolution": true,
             "shared": true,

--- a/metrics/grafana/tikv_details.json.sha256
+++ b/metrics/grafana/tikv_details.json.sha256
@@ -1,1 +1,1 @@
-2566beed7cfa7f9578910ac5bf0b304cb1339ad7d66098baf7816975218cddba  ./metrics/grafana/tikv_details.json
+70616f64e8b8cf2e7427b1b33e25042866275f51516bc529db791beda89f10e3  ./metrics/grafana/tikv_details.json

--- a/metrics/grafana/tikv_summary.json
+++ b/metrics/grafana/tikv_summary.json
@@ -66,7 +66,7 @@
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
           "decimals": 1,
-          "description": "The storage size per TiKV instance",
+          "description": "The real disk used size per TiKV instance: capacity - available",
           "editable": true,
           "error": false,
           "fill": 5,
@@ -106,11 +106,20 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(tikv_store_size_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", type=\"used\"}) by (instance)",
+              "expr": "sum(tikv_store_size_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", type=\"capacity\"}) by (instance) - sum(tikv_store_size_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", type=\"available\"}) by (instance)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}}",
               "refId": "A",
+              "step": 10
+            },
+            {
+              "expr": "sum(tikv_store_size_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", type=\"used\"}) by (instance)",
+              "format": "time_series",
+              "hide": true,
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}}-logical-used",
+              "refId": "B",
               "step": 10
             }
           ],
@@ -118,7 +127,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Store size",
+          "title": "Disk used size",
           "tooltip": {
             "msResolution": false,
             "shared": true,
@@ -2315,7 +2324,7 @@
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
           "decimals": 1,
-          "description": "The storage size per TiKV instance",
+          "description": "The real disk used size per TiKV instance: capacity - available",
           "editable": true,
           "error": false,
           "fill": 5,
@@ -2355,11 +2364,20 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(tikv_store_size_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", type=\"used\"}) by (instance)",
+              "expr": "sum(tikv_store_size_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", type=\"capacity\"}) by (instance) - sum(tikv_store_size_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", type=\"available\"}) by (instance)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}}",
               "refId": "A",
+              "step": 10
+            },
+            {
+              "expr": "sum(tikv_store_size_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", type=\"used\"}) by (instance)",
+              "format": "time_series",
+              "hide": true,
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}}-logical-used",
+              "refId": "B",
               "step": 10
             }
           ],
@@ -2367,7 +2385,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Store size",
+          "title": "Disk used size",
           "tooltip": {
             "msResolution": false,
             "shared": true,


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close https://github.com/tikv/tikv/issues/19417

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
metrics: show real disk used size and keep logical used hidden metric
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
none
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected disk usage metrics to accurately calculate physical space used as capacity minus available

* **Refactor**
  * Renamed and reorganized Grafana dashboard panels for improved clarity (e.g., "Disk used size", "Raft IO", "QPS")
  * Updated metric expressions and labels for consistency and accuracy
  * Added new monitoring panels for enhanced operational visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->