### PR TITLE
txn: add shared lock handling for all schedulers (#19304)

### DIFF
--- a/components/txn_types/src/lib.rs
+++ b/components/txn_types/src/lib.rs
@@ -12,7 +12,7 @@ use error_code::{self, ErrorCode, ErrorCodeExt};
 use kvproto::kvrpcpb;
 pub use lock::{
     check_ts_conflict, check_ts_conflict_for_replica_read, decode_lock_start_ts, decode_lock_type,
-    parse_lock, Lock, LockOrSharedLocks, LockType, PessimisticLock, TxnLockRef,
+    parse_lock, Lock, LockOrSharedLocks, LockType, PessimisticLock, SharedLocks, TxnLockRef,
 };
 use thiserror::Error;
 pub use timestamp::{TimeStamp, TsSet, TSO_PHYSICAL_SHIFT_BITS};

--- a/components/txn_types/src/lock.rs
+++ b/components/txn_types/src/lock.rs
@@ -53,6 +53,7 @@ impl LockType {
             Mutation::Put(..) | Mutation::Insert(..) => Some(LockType::Put),
             Mutation::Delete(..) => Some(LockType::Delete),
             Mutation::Lock(..) => Some(LockType::Lock),
+            Mutation::SharedLock(..) => Some(LockType::Lock),
             Mutation::CheckNotExists(..) => None,
         }
     }
@@ -371,7 +372,7 @@ fn check_ts_conflict_si(
     };
 
     if lock.ts > ts || lock.lock_type == LockType::Lock || lock.is_pessimistic_lock() {
-        // Ignore lock when lock.ts > ts or lock's type is Lock or Pessimistic
+        // Ignore lock when lock.ts > ts or lock's type is Lock, Shared, or Pessimistic
         return Ok(());
     }
 
@@ -743,18 +744,18 @@ impl SharedLocks {
     /// the bytes into a `Lock` and caches it in-place by replacing
     /// the entry with `Either::Right(Lock)`. Subsequent calls return the cached
     /// `Lock` without reparsing.
-    pub fn get_lock(&mut self, ts: &TimeStamp) -> Option<&Lock> {
+    pub fn get_lock(&mut self, ts: &TimeStamp) -> Result<Option<&Lock>> {
         if let Some(either) = self.txn_info_segments.get_mut(ts) {
             match either {
                 Either::Left(encoded) => {
-                    let lock = Lock::parse(encoded).expect("failed to parse shared lock txn info");
+                    let lock = Lock::parse(encoded)?;
                     *either = Either::Right(lock);
-                    either.as_ref().right()
+                    Ok(either.as_ref().right())
                 }
-                Either::Right(lock) => Some(lock),
+                Either::Right(lock) => Ok(Some(lock)),
             }
         } else {
-            None
+            Ok(None)
         }
     }
 
@@ -790,6 +791,59 @@ impl SharedLocks {
         }
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.txn_info_segments.is_empty()
+    }
+
+    /// Remove the shared lock for the given start_ts.
+    /// Returns the removed lock, or None if not found.
+    pub fn remove_lock(&mut self, ts: &TimeStamp) -> Result<Option<Lock>> {
+        match self.txn_info_segments.remove(ts) {
+            None => Ok(None),
+            Some(Either::Right(lock)) => Ok(Some(lock)),
+            Some(Either::Left(encoded)) => {
+                let lock = Lock::parse(&encoded)?;
+                Ok(Some(lock))
+            }
+        }
+    }
+
+    /// Update or insert a shared lock. Uses the lock's start_ts as the key.
+    pub fn update_lock(&mut self, lock: Lock) -> Result<()> {
+        let ts = lock.ts;
+        self.txn_info_segments.insert(ts, Either::Right(lock));
+        Ok(())
+    }
+
+    /// Filters shared locks, keeping only those for which `f` returns true.
+    pub fn filter_shared_locks<F>(&mut self, mut f: F) -> Result<()>
+    where
+        F: FnMut(&Lock) -> bool,
+    {
+        let mut to_remove = Vec::new();
+
+        for (ts, either) in self.txn_info_segments.iter_mut() {
+            let keep = match either {
+                Either::Right(lock) => f(lock),
+                Either::Left(encoded) => {
+                    let lock = Lock::parse(encoded)?;
+                    let keep = f(&lock);
+                    *either = Either::Right(lock);
+                    keep
+                }
+            };
+
+            if !keep {
+                to_remove.push(*ts);
+            }
+        }
+
+        for ts in to_remove {
+            self.txn_info_segments.remove(&ts);
+        }
+        Ok(())
+    }
+
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut b = Vec::with_capacity(self.pre_allocate_size());
         b.push(LockType::Shared.to_u8());
@@ -819,6 +873,23 @@ impl SharedLocks {
                         }
                 })
                 .sum::<usize>()
+    }
+
+    pub fn into_lock_info(self, raw_key: Vec<u8>) -> LockInfo {
+        let mut info = LockInfo::default();
+        info.lock_type = Op::SharedLock;
+        let shared_locks: Vec<_> = self
+            .txn_info_segments
+            .values()
+            .map(|lock| match lock {
+                Either::Left(encoded) => Lock::parse(encoded).unwrap(),
+                Either::Right(lock) => lock.clone(),
+            })
+            .map(|lock| lock.into_lock_info(raw_key.clone()))
+            .collect();
+        info.set_shared_lock_infos(shared_locks.into());
+        info.set_key(raw_key);
+        info
     }
 }
 
@@ -1431,13 +1502,22 @@ mod tests {
         )
         .unwrap_err();
         check_ts_conflict(
-            Cow::Owned(Either::Left(lock)),
+            Cow::Owned(Either::Left(lock.clone())),
             &key,
             160.into(),
             &empty,
             IsolationLevel::Si,
         )
         .unwrap_err();
+
+        check_ts_conflict(
+            Cow::Owned(Either::Right(SharedLocks::new())),
+            &key,
+            160.into(),
+            &empty,
+            IsolationLevel::Si,
+        )
+        .unwrap();
     }
 
     #[test]
@@ -1847,23 +1927,29 @@ mod tests {
         shared_locks.put_shared_lock(txn2_prewrite_lock);
 
         assert_eq!(shared_locks.len(), 2);
-        assert_eq!(shared_locks.get_lock(&txn1_ts).unwrap().ts, txn1_ts);
         assert_eq!(
-            shared_locks.get_lock(&txn1_ts).unwrap().lock_type,
+            shared_locks.get_lock(&txn1_ts).unwrap().unwrap().ts,
+            txn1_ts
+        );
+        assert_eq!(
+            shared_locks.get_lock(&txn1_ts).unwrap().unwrap().lock_type,
             LockType::Pessimistic
         );
-        assert_eq!(shared_locks.get_lock(&txn2_ts).unwrap().ts, txn2_ts);
         assert_eq!(
-            shared_locks.get_lock(&txn2_ts).unwrap().lock_type,
+            shared_locks.get_lock(&txn2_ts).unwrap().unwrap().ts,
+            txn2_ts
+        );
+        assert_eq!(
+            shared_locks.get_lock(&txn2_ts).unwrap().unwrap().lock_type,
             LockType::Lock
         );
 
-        let found = shared_locks.get_lock(&txn1_ts).unwrap();
+        let found = shared_locks.get_lock(&txn1_ts).unwrap().unwrap();
         assert_eq!(found.primary, b"txn1".to_vec());
         assert_eq!(found.ts, txn1_ts);
         assert_eq!(found.lock_type, LockType::Pessimistic);
 
         let missing_ts: TimeStamp = 42.into();
-        assert!(shared_locks.get_lock(&missing_ts).is_none());
+        assert!(shared_locks.get_lock(&missing_ts).unwrap().is_none());
     }
 }

--- a/components/txn_types/src/types.rs
+++ b/components/txn_types/src/types.rs
@@ -345,15 +345,18 @@ pub enum Mutation {
     ///
     /// Returns `kvrpcpb::KeyError::AlreadyExists` if the key already exists.
     CheckNotExists(Key, Assertion),
+    /// Set a shared lock on `Key`.
+    SharedLock(Key, Assertion),
 }
 
 impl HeapSize for Mutation {
     fn approximate_heap_size(&self) -> usize {
         match self {
             Mutation::Put(kv, _) | Mutation::Insert(kv, _) => kv.approximate_heap_size(),
-            Mutation::Delete(k, _) | Mutation::CheckNotExists(k, _) | Mutation::Lock(k, _) => {
-                k.approximate_heap_size()
-            }
+            Mutation::Delete(k, _)
+            | Mutation::CheckNotExists(k, _)
+            | Mutation::Lock(k, _)
+            | Mutation::SharedLock(k, _) => k.approximate_heap_size(),
         }
     }
 }
@@ -390,6 +393,9 @@ impl Display for Mutation {
             Mutation::CheckNotExists(key, assertion) => {
                 write!(f, "CheckNotExists key:{:?} assertion:{:?}", key, assertion)
             }
+            Mutation::SharedLock(key, assertion) => {
+                write!(f, "SharedLock key:{:?} assertion:{:?}", key, assertion)
+            }
         }
     }
 }
@@ -402,6 +408,7 @@ impl Mutation {
             Mutation::Lock(ref key, _) => key,
             Mutation::Insert((ref key, _), _) => key,
             Mutation::CheckNotExists(ref key, _) => key,
+            Mutation::SharedLock(ref key, _) => key,
         }
     }
 
@@ -409,7 +416,7 @@ impl Mutation {
         match self {
             Mutation::Put(..) => MutationType::Put,
             Mutation::Delete(..) => MutationType::Delete,
-            Mutation::Lock(..) => MutationType::Lock,
+            Mutation::Lock(..) | Mutation::SharedLock(..) => MutationType::Lock,
             Mutation::Insert(..) => MutationType::Insert,
             _ => MutationType::Other,
         }
@@ -422,6 +429,7 @@ impl Mutation {
             Mutation::Lock(key, _) => (key, None),
             Mutation::Insert((key, value), _) => (key, Some(value)),
             Mutation::CheckNotExists(key, _) => (key, None),
+            Mutation::SharedLock(key, _) => (key, None),
         }
     }
 
@@ -436,6 +444,10 @@ impl Mutation {
         matches!(self, Mutation::CheckNotExists(_, _))
     }
 
+    pub fn is_shared_lock(&self) -> bool {
+        matches!(self, Mutation::SharedLock(_, _))
+    }
+
     pub fn get_assertion(&self) -> Assertion {
         *match self {
             Mutation::Put(_, assertion) => assertion,
@@ -443,6 +455,7 @@ impl Mutation {
             Mutation::Lock(_, assertion) => assertion,
             Mutation::Insert(_, assertion) => assertion,
             Mutation::CheckNotExists(_, assertion) => assertion,
+            Mutation::SharedLock(_, assertion) => assertion,
         }
     }
 
@@ -453,6 +466,7 @@ impl Mutation {
             Mutation::Lock(_, ref mut assertion) => assertion,
             Mutation::Insert(_, ref mut assertion) => assertion,
             Mutation::CheckNotExists(_, ref mut assertion) => assertion,
+            Mutation::SharedLock(_, ref mut assertion) => assertion,
         } = assertion;
     }
 
@@ -480,6 +494,11 @@ impl Mutation {
     pub fn make_check_not_exists(key: Key) -> Self {
         Mutation::CheckNotExists(key, Assertion::None)
     }
+
+    /// Creates a SharedLock mutation with none assertion.
+    pub fn make_shared_lock(key: Key) -> Self {
+        Mutation::SharedLock(key, Assertion::None)
+    }
 }
 
 impl From<kvrpcpb::Mutation> for Mutation {
@@ -497,6 +516,9 @@ impl From<kvrpcpb::Mutation> for Mutation {
             ),
             kvrpcpb::Op::CheckNotExists => {
                 Mutation::CheckNotExists(Key::from_raw(m.get_key()), m.get_assertion())
+            }
+            kvrpcpb::Op::SharedLock => {
+                Mutation::SharedLock(Key::from_raw(m.get_key()), m.get_assertion())
             }
             _ => panic!("mismatch Op in prewrite mutations"),
         }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1755,15 +1755,14 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                     statistics.add(&reader.statistics);
                     let (read_locks, _) = read_res?;
                     let mut locks = Vec::with_capacity(read_locks.len());
-                    for (key, lock) in read_locks.into_iter() {
-                        let lock = match lock {
-                            Either::Left(lock) => lock,
-                            Either::Right(_shared_locks) => unimplemented!(
-                                "SharedLocks returned from scan_locks is not supported here"
-                            ),
+                    for (key, lock_or_shared_locks) in read_locks.into_iter() {
+                        let lock_info = match lock_or_shared_locks {
+                            Either::Left(lock) => {
+                                lock.into_lock_info(key.into_raw().map_err(txn::Error::from)?)
+                            }
+                            Either::Right(shared_locks) => shared_locks
+                                .into_lock_info(key.into_raw().map_err(txn::Error::from)?),
                         };
-                        let lock_info =
-                            lock.into_lock_info(key.into_raw().map_err(txn::Error::from)?);
                         locks.push(lock_info);
                     }
 
@@ -12255,6 +12254,72 @@ mod tests {
                     must_locked(&mut storage.engine, key.as_slice(), start_ts);
                 }
             }
+        }
+    }
+
+    #[test]
+    fn test_scan_lock_with_shared_lock() {
+        let storage = TestStorageBuilderApiV1::new(MockLockManager::new())
+            .build()
+            .unwrap();
+        let (tx, rx) = channel();
+        let key = Key::from_raw(b"shared-lock");
+        let pk1 = b"shared-pk-1".to_vec();
+        let pk2 = b"shared-pk-2".to_vec();
+
+        for (start_ts, primary) in [(10, pk1.clone()), (20, pk2.clone())] {
+            storage
+                .sched_txn_command(
+                    new_acquire_pessimistic_lock_command_with_pk_with_shared(
+                        vec![(key.clone(), false, true)],
+                        Some(primary.as_slice()),
+                        start_ts,
+                        start_ts + 1,
+                        false,
+                        false,
+                    ),
+                    expect_ok_callback(tx.clone(), 0),
+                )
+                .unwrap();
+            rx.recv().unwrap();
+        }
+        storage
+            .sched_txn_command(
+                commands::PrewritePessimistic::with_defaults(
+                    vec![(
+                        txn_types::Mutation::make_shared_lock(key),
+                        DoPessimisticCheck,
+                    )],
+                    pk2.clone(),
+                    20.into(),
+                    21.into(),
+                ),
+                expect_ok_callback(tx, 0),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+
+        let locks =
+            block_on(storage.scan_lock(Context::default(), 30.into(), None, None, 10)).unwrap();
+        assert_eq!(locks.len(), 1);
+        let lock = &locks[0];
+        assert_eq!(lock.get_key(), b"shared-lock");
+        assert_eq!(lock.get_lock_type(), Op::SharedLock);
+
+        let mut shared_locks = HashMap::default();
+        for lock in lock.get_shared_lock_infos() {
+            shared_locks.insert(lock.get_lock_version(), lock);
+        }
+        assert_eq!(shared_locks.len(), 2);
+
+        for (ts, for_update_ts, primary, op) in
+            [(10, 11, pk1, Op::PessimisticLock), (20, 21, pk2, Op::Lock)]
+        {
+            let shared_lock = shared_locks.get(&ts).expect("shared lock missing");
+            assert_eq!(shared_lock.get_key(), b"shared-lock");
+            assert_eq!(shared_lock.get_primary_lock(), primary.as_slice());
+            assert_eq!(shared_lock.get_lock_type(), op);
+            assert_eq!(shared_lock.get_lock_for_update_ts(), for_update_ts);
         }
     }
 }

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -890,4 +890,15 @@ pub mod tests {
             expect
         );
     }
+
+    pub fn must_load_shared_lock<E: Engine>(engine: &mut E, key: &[u8]) -> txn_types::SharedLocks {
+        use tikv_util::Either;
+        let snapshot = engine.snapshot(Default::default()).unwrap();
+        let mut reader = MvccReader::new(snapshot, None, true);
+        let lock_or_shared = reader.load_lock(&Key::from_raw(key)).unwrap().unwrap();
+        match lock_or_shared {
+            Either::Right(shared_locks) => shared_locks,
+            Either::Left(_) => panic!("Expected SharedLocks, got Lock"),
+        }
+    }
 }

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -343,16 +343,24 @@ impl<S: EngineSnapshot> MvccReader<S> {
                         return Ok(None);
                     }
                 }
-                let lock = txn_types::parse_lock(cursor.value(&mut self.statistics.lock))?;
-                let lock_ref = match &lock {
-                    Either::Left(lock) => lock,
-                    Either::Right(_shared_locks) => unimplemented!(
-                        "SharedLocks returned from txn_types::parse_lock is not supported here"
-                    ),
-                };
-                if filter(&key, TxnLockRef::Persisted(lock_ref)) {
-                    self.statistics.lock.processed_keys += 1;
-                    return Ok(Some((key, lock)));
+                let mut lock_or_shared_locks =
+                    txn_types::parse_lock(cursor.value(&mut self.statistics.lock))?;
+                match &mut lock_or_shared_locks {
+                    Either::Left(l) => {
+                        if filter(&key, TxnLockRef::Persisted(l)) {
+                            self.statistics.lock.processed_keys += 1;
+                            return Ok(Some((key, lock_or_shared_locks)));
+                        }
+                    }
+                    Either::Right(shared_locks) => {
+                        shared_locks.filter_shared_locks(|shared_lock| {
+                            filter(&key, TxnLockRef::Persisted(shared_lock))
+                        })?;
+                        if !shared_locks.is_empty() {
+                            self.statistics.lock.processed_keys += 1;
+                            return Ok(Some((key, lock_or_shared_locks)));
+                        }
+                    }
                 }
                 cursor.next(&mut self.statistics.lock);
             }
@@ -741,21 +749,24 @@ impl<S: EngineSnapshot> MvccReader<S> {
                 }
             }
 
-            let lock = txn_types::parse_lock(cursor.value(&mut self.statistics.lock))?;
-            let lock_ref = match &lock {
-                Either::Left(lock) => lock,
-                Either::Right(_shared_locks) => {
-                    unimplemented!(
-                        "SharedLocks returned from txn_types::parse_lock is not supported here"
-                    )
+            let mut lock_or_shared_locks =
+                txn_types::parse_lock(cursor.value(&mut self.statistics.lock))?;
+            match &mut lock_or_shared_locks {
+                Either::Left(l) => {
+                    if filter(&key, l) {
+                        locks.push((key, lock_or_shared_locks));
+                    }
                 }
-            };
-            if filter(&key, lock_ref) {
-                locks.push((key, lock));
-                if limit > 0 && locks.len() == limit {
-                    has_remain = true;
-                    break;
+                Either::Right(shared_locks) => {
+                    shared_locks.filter_shared_locks(|shared_lock| filter(&key, shared_lock))?;
+                    if !shared_locks.is_empty() {
+                        locks.push((key, lock_or_shared_locks));
+                    }
                 }
+            }
+            if limit > 0 && locks.len() == limit {
+                has_remain = true;
+                break;
             }
             cursor.next(&mut self.statistics.lock);
         }
@@ -1152,6 +1163,7 @@ pub mod tests {
                 false,
                 TimeStamp::zero(),
                 true,
+                false,
                 false,
                 false,
             )

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -143,6 +143,25 @@ impl MvccTxn {
         self.modifies.push(Modify::PessimisticLock(key, lock))
     }
 
+    /// Write shared locks for a key. Serializes the SharedLocks and writes to
+    /// CF_LOCK.
+    pub(crate) fn put_shared_locks(
+        &mut self,
+        key: Key,
+        shared_locks: &txn_types::SharedLocks,
+        is_new: bool,
+    ) {
+        if is_new {
+            // For new shared locks, add lock info for lock observer.
+            self.new_locks
+                .push(shared_locks.clone().into_lock_info(key.to_raw().unwrap()));
+        }
+        let value = shared_locks.to_bytes();
+        let write = Modify::Put(CF_LOCK, key, value);
+        self.write_size += write.size();
+        self.modifies.push(write);
+    }
+
     /// Append a modify that unlocks the key. If the lock is removed due to
     /// committing, a non-zero `commit_ts` needs to be provided; otherwise if
     /// the lock is removed due to rolling back, `commit_ts` must be set to
@@ -229,6 +248,30 @@ impl MvccTxn {
         self.new_locks.clear();
         self.locks_for_1pc.clear();
         self.guards.clear();
+    }
+
+    /// Get pending lock modification for a key from the txn's modifies.
+    /// This is useful when processing multiple sub-locks of the same key
+    /// in a single batch, where subsequent operations need to see the
+    /// pending writes from previous operations.
+    ///
+    /// Returns:
+    /// - `None`: no pending modification for this key
+    /// - `Some(None)`: the lock was deleted (unlock_key was called)
+    /// - `Some(Some(bytes))`: there's a pending Put to CF_LOCK
+    pub fn get_pending_lock_bytes(&self, key: &Key) -> Option<Option<&[u8]>> {
+        for modify in self.modifies.iter().rev() {
+            match modify {
+                Modify::Put(cf, k, v) if *cf == CF_LOCK && k == key => {
+                    return Some(Some(v.as_slice()));
+                }
+                Modify::Delete(cf, k) if *cf == CF_LOCK && k == key => {
+                    return Some(None);
+                }
+                _ => {}
+            }
+        }
+        None
     }
 }
 

--- a/src/storage/txn/actions/acquire_pessimistic_lock.rs
+++ b/src/storage/txn/actions/acquire_pessimistic_lock.rs
@@ -52,6 +52,7 @@ pub fn acquire_pessimistic_lock<S: Snapshot>(
     need_old_value: bool,
     lock_only_if_exists: bool,
     allow_lock_with_conflict: bool,
+    is_shared_lock_req: bool,
 ) -> MvccResult<(PessimisticLockKeyResult, OldValue)> {
     fail_point!("acquire_pessimistic_lock", |err| Err(
         crate::storage::mvcc::txn::make_txn_error(err, &key, reader.start_ts).into()
@@ -108,129 +109,180 @@ pub fn acquire_pessimistic_lock<S: Snapshot>(
     }
 
     let mut val = None;
-    if let Some(lock) = reader.load_lock(&key)? {
-        let lock = match lock {
-            Either::Left(lock) => lock,
-            Either::Right(_shared_locks) => {
-                unimplemented!("SharedLocks returned from load_lock is not supported here")
-            }
-        };
-        if lock.ts != reader.start_ts {
-            return Err(ErrorInner::KeyIsLocked(lock.into_lock_info(key.into_raw()?)).into());
-        }
-        if !lock.is_pessimistic_lock() {
-            return Err(ErrorInner::LockTypeNotMatch {
-                start_ts: reader.start_ts,
-                key: key.into_raw()?,
-                pessimistic: false,
-            }
-            .into());
-        }
+    let current_lock = reader.load_lock(&key)?;
+    let mut current_shared_locks: Option<txn_types::SharedLocks> = None;
+    if let Some(lock_or_shared) = current_lock {
+        match lock_or_shared {
+            Either::Left(lock) => {
+                if is_shared_lock_req {
+                    // Shared lock request blocked by exclusive lock
+                    return Err(
+                        ErrorInner::KeyIsLocked(lock.into_lock_info(key.into_raw()?)).into(),
+                    );
+                }
+                // Exclusive lock request with existing exclusive lock - original logic
+                if lock.ts != reader.start_ts {
+                    return Err(
+                        ErrorInner::KeyIsLocked(lock.into_lock_info(key.into_raw()?)).into(),
+                    );
+                }
+                if !lock.is_pessimistic_lock() {
+                    return Err(ErrorInner::LockTypeNotMatch {
+                        start_ts: reader.start_ts,
+                        key: key.into_raw()?,
+                        pessimistic: false,
+                    }
+                    .into());
+                }
 
-        let requested_for_update_ts = for_update_ts;
-        let locked_with_conflict_ts =
-            if allow_lock_with_conflict && for_update_ts < lock.for_update_ts {
-                // If the key is already locked by the same transaction with larger
-                // for_update_ts, and the current request has
-                // `allow_lock_with_conflict` set, we must consider
-                // these possibilities:
-                // * A previous request successfully locked the key with conflict, but the
-                //   response is lost due to some errors such as RPC failures. In this case, we
-                //   return like the current request's result is locked_with_conflict, for
-                //   idempotency concern.
-                // * The key is locked by a newer request with larger for_update_ts, and the
-                //   current request is stale. We can't distinguish this case with the above
-                //   one, but we don't need to handle this case since no one would need the
-                //   current request's result anymore.
+                let requested_for_update_ts = for_update_ts;
+                let locked_with_conflict_ts =
+                    if allow_lock_with_conflict && for_update_ts < lock.for_update_ts {
+                        need_load_value = true;
+                        for_update_ts = lock.for_update_ts;
+                        Some(lock.for_update_ts)
+                    } else {
+                        None
+                    };
 
-                // Load value if locked_with_conflict, so that when the client (TiDB) need to
-                // read the value during statement retry, it will be possible to read the value
-                // from cache instead of RPC.
-                need_load_value = true;
-                for_update_ts = lock.for_update_ts;
-                Some(lock.for_update_ts)
-            } else {
-                None
-            };
+                if need_load_value || need_check_existence || should_not_exist {
+                    let write = reader.get_write_with_commit_ts(&key, for_update_ts)?;
+                    if let Some((write, commit_ts)) = write {
+                        check_data_constraint(
+                            reader,
+                            should_not_exist,
+                            &write,
+                            commit_ts,
+                            &key,
+                        )
+                        .or_else(|e| {
+                            if is_already_exist(&e) && commit_ts > requested_for_update_ts {
+                                let conflict_info = ConflictInfo {
+                                    conflict_start_ts: write.start_ts,
+                                    conflict_commit_ts: commit_ts,
+                                };
+                                return Err(conflict_info.into_write_conflict_error(
+                                    reader.start_ts,
+                                    primary.to_vec(),
+                                    key.to_raw()?,
+                                ));
+                            }
+                            Err(e)
+                        })?;
 
-        if need_load_value || need_check_existence || should_not_exist {
-            let write = reader.get_write_with_commit_ts(&key, for_update_ts)?;
-            if let Some((write, commit_ts)) = write {
-                // Here `get_write_with_commit_ts` returns only the latest PUT if it exists and
-                // is not deleted. It's still ok to pass it into `check_data_constraint`.
-                check_data_constraint(reader, should_not_exist, &write, commit_ts, &key).or_else(
-                    |e| {
-                        if is_already_exist(&e) && commit_ts > requested_for_update_ts {
-                            // If `allow_lock_with_conflict` is set and there is write conflict,
-                            // and the constraint check doesn't pass on the latest version,
-                            // return a WriteConflict error instead of AlreadyExist, to inform the
-                            // client to retry.
-                            // Note the conflict_info may be not consistent with the
-                            // `locked_with_conflict_ts` we got before.
-                            // This is possible if the key is locked by a newer request with
-                            // larger for_update_ts, in which case the result of this request
-                            // doesn't matter at all. So we don't need
-                            // to care about it.
-                            let conflict_info = ConflictInfo {
-                                conflict_start_ts: write.start_ts,
-                                conflict_commit_ts: commit_ts,
-                            };
-                            return Err(conflict_info.into_write_conflict_error(
-                                reader.start_ts,
-                                primary.to_vec(),
-                                key.to_raw()?,
-                            ));
+                        if need_load_value {
+                            val = Some(reader.load_data(&key, write)?);
+                        } else if need_check_existence {
+                            val = Some(vec![]);
                         }
-                        Err(e)
-                    },
+                    }
+                }
+                // Previous write is not loaded.
+                let (prev_write_loaded, prev_write) = (false, None);
+                let old_value = load_old_value(
+                    need_old_value,
+                    need_load_value,
+                    val.as_ref(),
+                    reader,
+                    &key,
+                    for_update_ts,
+                    prev_write_loaded,
+                    prev_write,
                 )?;
 
-                if need_load_value {
-                    val = Some(reader.load_data(&key, write)?);
-                } else if need_check_existence {
-                    val = Some(vec![]);
+                // Overwrite the lock with small for_update_ts
+                if for_update_ts > lock.for_update_ts {
+                    let lock = PessimisticLock {
+                        primary: primary.into(),
+                        start_ts: reader.start_ts,
+                        ttl: lock_ttl,
+                        for_update_ts,
+                        min_commit_ts,
+                        last_change: lock.last_change.clone(),
+                        is_locked_with_conflict: lock.is_pessimistic_lock_with_conflict(),
+                    };
+                    txn.put_pessimistic_lock(key, lock, false);
+                } else {
+                    MVCC_DUPLICATE_CMD_COUNTER_VEC
+                        .acquire_pessimistic_lock
+                        .inc();
                 }
+                return Ok((
+                    PessimisticLockKeyResult::new_success(
+                        need_value,
+                        need_check_existence,
+                        locked_with_conflict_ts,
+                        val,
+                    ),
+                    old_value,
+                ));
+            }
+            Either::Right(mut shared_locks) => {
+                if !is_shared_lock_req {
+                    let lock_info = shared_locks.into_lock_info(key.into_raw()?);
+                    return Err(ErrorInner::KeyIsLocked(lock_info).into());
+                }
+                // Shared lock request with existing shared locks
+                if shared_locks.contains_start_ts(reader.start_ts) {
+                    let lock = shared_locks
+                        .get_lock(&reader.start_ts)?
+                        .expect("lock should exist since contains_start_ts returned true")
+                        .clone();
+                    if !lock.is_pessimistic_lock() {
+                        return Err(ErrorInner::LockTypeNotMatch {
+                            start_ts: reader.start_ts,
+                            key: key.into_raw()?,
+                            pessimistic: false,
+                        }
+                        .into());
+                    }
+                    // Overwrite if for_update_ts is larger
+                    if for_update_ts > lock.for_update_ts {
+                        let new_lock = txn_types::Lock::new(
+                            txn_types::LockType::Pessimistic,
+                            primary.to_vec(),
+                            reader.start_ts,
+                            lock_ttl,
+                            None,
+                            for_update_ts,
+                            0,
+                            min_commit_ts,
+                            false,
+                        )
+                        .set_last_change(lock.last_change.clone());
+                        let mut updated_shared_locks = shared_locks;
+                        updated_shared_locks.update_lock(new_lock)?;
+                        txn.put_shared_locks(key.clone(), &updated_shared_locks, false);
+                    } else {
+                        MVCC_DUPLICATE_CMD_COUNTER_VEC
+                            .acquire_pessimistic_lock
+                            .inc();
+                    }
+                    let (prev_write_loaded, prev_write) = (false, None);
+                    let old_value = load_old_value(
+                        need_old_value,
+                        need_load_value,
+                        val.as_ref(),
+                        reader,
+                        &key,
+                        for_update_ts,
+                        prev_write_loaded,
+                        prev_write,
+                    )?;
+                    return Ok((
+                        PessimisticLockKeyResult::new_success(
+                            need_value,
+                            need_check_existence,
+                            None,
+                            val,
+                        ),
+                        old_value,
+                    ));
+                }
+                // Fall through to add a new lock to existing shared locks
+                current_shared_locks = Some(shared_locks);
             }
         }
-        // Previous write is not loaded.
-        let (prev_write_loaded, prev_write) = (false, None);
-        let old_value = load_old_value(
-            need_old_value,
-            need_load_value,
-            val.as_ref(),
-            reader,
-            &key,
-            for_update_ts,
-            prev_write_loaded,
-            prev_write,
-        )?;
-
-        // Overwrite the lock with small for_update_ts
-        if for_update_ts > lock.for_update_ts {
-            let lock = PessimisticLock {
-                primary: primary.into(),
-                start_ts: reader.start_ts,
-                ttl: lock_ttl,
-                for_update_ts,
-                min_commit_ts,
-                last_change: lock.last_change.clone(),
-                is_locked_with_conflict: lock.is_pessimistic_lock_with_conflict(),
-            };
-            txn.put_pessimistic_lock(key, lock, false);
-        } else {
-            MVCC_DUPLICATE_CMD_COUNTER_VEC
-                .acquire_pessimistic_lock
-                .inc();
-        }
-        return Ok((
-            PessimisticLockKeyResult::new_success(
-                need_value,
-                need_check_existence,
-                locked_with_conflict_ts,
-                val,
-            ),
-            old_value,
-        ));
     }
 
     let mut conflict_info = None;
@@ -369,26 +421,45 @@ pub fn acquire_pessimistic_lock<S: Snapshot>(
         prev_write_loaded,
         prev_write,
     )?;
-    let lock = PessimisticLock {
-        primary: primary.into(),
-        start_ts: reader.start_ts,
-        ttl: lock_ttl,
-        for_update_ts,
-        min_commit_ts,
-        last_change,
-        is_locked_with_conflict: conflict_info.is_some(),
-    };
 
-    // When lock_only_if_exists is false, always acquire pessimistic lock, otherwise
-    // do it when val exists
-    if !lock_only_if_exists || val.is_some() {
-        txn.put_pessimistic_lock(key, lock, true);
-    } else if let Some(conflict_info) = conflict_info {
-        return Err(conflict_info.into_write_conflict_error(
-            reader.start_ts,
+    if is_shared_lock_req {
+        let new_lock = txn_types::Lock::new(
+            txn_types::LockType::Pessimistic,
             primary.to_vec(),
-            key.into_raw()?,
-        ));
+            reader.start_ts,
+            lock_ttl,
+            None,
+            for_update_ts,
+            0,
+            min_commit_ts,
+            false,
+        )
+        .set_last_change(last_change);
+        let mut shared_locks = current_shared_locks.unwrap_or_default();
+        shared_locks.update_lock(new_lock)?;
+        txn.put_shared_locks(key, &shared_locks, true);
+    } else {
+        let lock = PessimisticLock {
+            primary: primary.into(),
+            start_ts: reader.start_ts,
+            ttl: lock_ttl,
+            for_update_ts,
+            min_commit_ts,
+            last_change,
+            is_locked_with_conflict: conflict_info.is_some(),
+        };
+
+        // When lock_only_if_exists is false, always acquire pessimistic lock, otherwise
+        // do it when val exists
+        if !lock_only_if_exists || val.is_some() {
+            txn.put_pessimistic_lock(key, lock, true);
+        } else if let Some(conflict_info) = conflict_info {
+            return Err(conflict_info.into_write_conflict_error(
+                reader.start_ts,
+                primary.to_vec(),
+                key.into_raw()?,
+            ));
+        }
     }
     // TODO don't we need to commit the modifies in txn?
 
@@ -441,7 +512,7 @@ pub mod tests {
     use kvproto::kvrpcpb::Context;
     #[cfg(test)]
     use kvproto::kvrpcpb::PrewriteRequestPessimisticAction::*;
-    use txn_types::{Lock, TimeStamp};
+    use txn_types::{Lock, SharedLocks, TimeStamp};
 
     use super::*;
     use crate::storage::{
@@ -492,6 +563,7 @@ pub mod tests {
             false,
             lock_only_if_exists,
             true,
+            false,
         );
         if res.is_ok() {
             let modifies = txn.into_modifies();
@@ -562,6 +634,7 @@ pub mod tests {
             min_commit_ts,
             false,
             lock_only_if_exists,
+            false,
             false,
         )
         .unwrap();
@@ -745,6 +818,39 @@ pub mod tests {
             false,
             lock_only_if_exists,
             false,
+            false,
+        )
+        .unwrap_err()
+    }
+
+    pub fn must_err_shared_lock<E: Engine>(
+        engine: &mut E,
+        key: &[u8],
+        pk: &[u8],
+        start_ts: impl Into<TimeStamp>,
+        for_update_ts: impl Into<TimeStamp>,
+    ) -> MvccError {
+        let snapshot = engine.snapshot(Default::default()).unwrap();
+        let min_commit_ts = TimeStamp::zero();
+        let cm = ConcurrencyManager::new(min_commit_ts);
+        let start_ts = start_ts.into();
+        let mut txn = MvccTxn::new(start_ts, cm);
+        let mut reader = SnapshotReader::new(start_ts, snapshot, true);
+        acquire_pessimistic_lock(
+            &mut txn,
+            &mut reader,
+            Key::from_raw(key),
+            pk,
+            false,
+            0,
+            for_update_ts.into(),
+            false,
+            false,
+            min_commit_ts,
+            false,
+            false,
+            false,
+            true,
         )
         .unwrap_err()
     }
@@ -767,6 +873,63 @@ pub mod tests {
         assert_eq!(lock.for_update_ts, for_update_ts.into());
         assert!(lock.is_pessimistic_lock());
         lock
+    }
+
+    pub fn must_acquire_shared_pessimistic_lock<E: Engine>(
+        engine: &mut E,
+        key: &[u8],
+        pk: &[u8],
+        start_ts: impl Into<TimeStamp>,
+        for_update_ts: impl Into<TimeStamp>,
+        lock_ttl: u64,
+    ) -> PessimisticLockKeyResult {
+        let ctx = Context::default();
+        let snapshot = engine.snapshot(Default::default()).unwrap();
+        let min_commit_ts = TimeStamp::zero();
+        let start_ts = start_ts.into();
+        let for_update_ts = for_update_ts.into();
+        let cm = ConcurrencyManager::new(min_commit_ts);
+        let mut txn = MvccTxn::new(start_ts, cm);
+        let mut reader = SnapshotReader::new(start_ts, snapshot, true);
+        let res = acquire_pessimistic_lock(
+            &mut txn,
+            &mut reader,
+            Key::from_raw(key),
+            pk,
+            false,
+            lock_ttl,
+            for_update_ts,
+            false,
+            false,
+            min_commit_ts,
+            false,
+            false,
+            false,
+            true,
+        )
+        .unwrap();
+        let modifies = txn.into_modifies();
+        if !modifies.is_empty() {
+            engine
+                .write(&ctx, WriteData::from_modifies(modifies))
+                .unwrap();
+        }
+        res.0
+    }
+
+    #[cfg(test)]
+    fn load_shared_locks<E: Engine>(engine: &mut E, key: &[u8]) -> SharedLocks {
+        use tikv_util::Either;
+        let snapshot = engine.snapshot(Default::default()).unwrap();
+        let mut reader = MvccReader::new(snapshot, None, true);
+        let lock_or_shared = reader
+            .load_lock(&Key::from_raw(key))
+            .unwrap()
+            .expect("lock should exist");
+        match lock_or_shared {
+            Either::Right(shared_locks) => shared_locks,
+            Either::Left(_) => panic!("Expected SharedLocks, got exclusive Lock"),
+        }
     }
 
     #[test]
@@ -1358,6 +1521,7 @@ pub mod tests {
                         need_old_value,
                         false,
                         false,
+                        false,
                     )
                     .unwrap();
                     assert_eq!(old_value, OldValue::None);
@@ -1410,6 +1574,7 @@ pub mod tests {
             need_old_value,
             false,
             false,
+            false,
         )
         .unwrap();
         assert_eq!(
@@ -1443,6 +1608,7 @@ pub mod tests {
             false,
             min_commit_ts,
             true,
+            false,
             false,
             false,
         )
@@ -1487,6 +1653,7 @@ pub mod tests {
                             *need_check_existence,
                             min_commit_ts,
                             need_old_value,
+                            false,
                             false,
                             false,
                         )?;
@@ -1543,6 +1710,7 @@ pub mod tests {
             need_old_value,
             false,
             false,
+            false,
         )
         .unwrap_err();
 
@@ -1576,6 +1744,7 @@ pub mod tests {
             check_existence,
             min_commit_ts,
             need_old_value,
+            false,
             false,
             false,
         )
@@ -2539,5 +2708,141 @@ pub mod tests {
         .unwrap()
         .assert_locked_with_conflict(Some(b"v2"), 50);
         must_pessimistic_locked(&mut engine, b"k2", 40, 50);
+    }
+
+    #[test]
+    fn test_acquire_shared_lock_creates_shared_entry() {
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+        let key = b"shared-create";
+        let pk = b"shared-create-pk";
+        let start_ts = TimeStamp::from(5);
+        let for_update_ts = TimeStamp::from(15);
+
+        let result = must_acquire_shared_pessimistic_lock(
+            &mut engine,
+            key,
+            pk,
+            start_ts,
+            for_update_ts,
+            2000,
+        );
+        assert!(matches!(result, PessimisticLockKeyResult::Empty));
+
+        let mut shared_locks = load_shared_locks(&mut engine, key);
+        assert_eq!(shared_locks.len(), 1);
+
+        let sub_lock = shared_locks
+            .get_lock(&start_ts)
+            .unwrap()
+            .expect("sub lock should exist");
+        assert_eq!(sub_lock.lock_type, txn_types::LockType::Pessimistic);
+        assert_eq!(sub_lock.primary, pk);
+        assert_eq!(sub_lock.for_update_ts, for_update_ts);
+    }
+
+    #[test]
+    fn test_acquire_shared_lock_merges_existing_entries() {
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+        let key = b"shared-merge";
+        let pk_one = b"shared-merge-pk1";
+        let pk_two = b"shared-merge-pk2";
+        let start_one = TimeStamp::from(10);
+        let start_two = TimeStamp::from(12);
+        let for_update_one = TimeStamp::from(20);
+        let for_update_two = TimeStamp::from(18);
+
+        must_acquire_shared_pessimistic_lock(
+            &mut engine,
+            key,
+            pk_one,
+            start_one,
+            for_update_one,
+            1500,
+        );
+        must_acquire_shared_pessimistic_lock(
+            &mut engine,
+            key,
+            pk_two,
+            start_two,
+            for_update_two,
+            2500,
+        );
+
+        let mut shared_locks = load_shared_locks(&mut engine, key);
+        assert_eq!(shared_locks.len(), 2);
+
+        let first = shared_locks
+            .get_lock(&start_one)
+            .unwrap()
+            .expect("first sub lock missing");
+        assert_eq!(first.lock_type, txn_types::LockType::Pessimistic);
+        assert_eq!(first.for_update_ts, for_update_one);
+        assert_eq!(first.primary, pk_one);
+
+        let second = shared_locks
+            .get_lock(&start_two)
+            .unwrap()
+            .expect("second sub lock missing");
+        assert_eq!(second.lock_type, txn_types::LockType::Pessimistic);
+        assert_eq!(second.for_update_ts, for_update_two);
+        assert_eq!(second.primary, pk_two);
+    }
+
+    #[test]
+    fn test_acquire_shared_lock_idempotent_for_same_txn() {
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+        let key = b"shared-idempotent";
+        let pk = b"shared-idempotent-pk";
+        let start_ts = TimeStamp::from(25);
+        let for_update_ts = TimeStamp::from(35);
+        let new_for_update_ts = TimeStamp::from(45);
+
+        must_acquire_shared_pessimistic_lock(&mut engine, key, pk, start_ts, for_update_ts, 3000);
+        must_acquire_shared_pessimistic_lock(
+            &mut engine,
+            key,
+            pk,
+            start_ts,
+            new_for_update_ts,
+            3000,
+        );
+
+        let mut shared_locks = load_shared_locks(&mut engine, key);
+        assert_eq!(shared_locks.len(), 1);
+
+        let sub_lock = shared_locks
+            .get_lock(&start_ts)
+            .unwrap()
+            .expect("sub lock should exist");
+        assert_eq!(sub_lock.lock_type, txn_types::LockType::Pessimistic);
+        assert_eq!(sub_lock.primary, pk);
+        // the for_update_ts should be updated to the new one.
+        assert_eq!(sub_lock.for_update_ts, new_for_update_ts);
+    }
+
+    #[test]
+    fn test_lock_upgrade_and_downgrade_blocked() {
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+        let shared_key = b"shared-lock";
+        let exclusive_key = b"exclusive-lock";
+        let pk = b"shared-lock-pk";
+        let start_ts = TimeStamp::from(25);
+        let for_update_ts = TimeStamp::from(35);
+        let new_for_update_ts = TimeStamp::from(45);
+
+        // shared lock cannot propagate to exclusive lock
+        must_acquire_shared_pessimistic_lock(
+            &mut engine,
+            shared_key,
+            pk,
+            start_ts,
+            for_update_ts,
+            3000,
+        );
+        must_err(&mut engine, shared_key, pk, start_ts, new_for_update_ts);
+
+        // exclusive lock cannot downgrade to shared lock
+        must_acquire_pessimistic_lock(&mut engine, exclusive_key, pk, start_ts, for_update_ts);
+        must_err_shared_lock(&mut engine, exclusive_key, pk, start_ts, new_for_update_ts);
     }
 }

--- a/src/storage/txn/actions/check_txn_status.rs
+++ b/src/storage/txn/actions/check_txn_status.rs
@@ -2,7 +2,7 @@
 
 use tikv_kv::SnapshotExt;
 // #[PerformanceCriticalPath]
-use txn_types::{Key, Lock, TimeStamp, Write, WriteType};
+use txn_types::{Key, Lock, SharedLocks, TimeStamp, Write, WriteType};
 
 use crate::storage::{
     mvcc::{
@@ -306,6 +306,8 @@ pub fn rollback_lock(
     is_pessimistic_txn: bool,
     collapse_rollback: bool,
 ) -> Result<Option<ReleasedLock>> {
+    // Lock is never shared in the current branch's architecture - shared locks use
+    // SharedLocks type
     let overlapped_write = match reader.get_txn_commit_record(&key)? {
         TxnCommitRecord::None { overlapped_write } => overlapped_write,
         TxnCommitRecord::SingleRecord { write, commit_ts }
@@ -354,6 +356,70 @@ pub fn rollback_lock(
     }
 
     Ok(txn.unlock_key(key, is_pessimistic_txn, TimeStamp::zero()))
+}
+
+/// `rollback_shared_lock` likes `rollback_lock` but for shared locks. It
+/// considers reader.start_ts as the lock ts, removes the corresponding lock
+/// from the `shared_lock`, and writes a rollback if necessary. It does not
+/// write the `shared_lock` back to txn so that the caller can rollback multiple
+/// sub-locks and then call `txn.update_shared_locked_key` once in the end.
+pub fn rollback_shared_lock(
+    txn: &mut MvccTxn,
+    reader: &mut SnapshotReader<impl Snapshot>,
+    key: Key,
+    mut shared_locks: SharedLocks,
+    lock_ts: TimeStamp,
+    collapse_rollback: bool,
+) -> Result<Option<ReleasedLock>> {
+    let lock = match shared_locks.remove_lock(&lock_ts)? {
+        Some(l) => l,
+        None => {
+            // misuse of rollback_shared_lock? maybe print a warning with stack?
+            return Ok(None);
+        }
+    };
+
+    let overlapped_write = match reader.get_txn_commit_record(&key)? {
+        TxnCommitRecord::None { overlapped_write } => overlapped_write,
+        TxnCommitRecord::SingleRecord { write, commit_ts }
+            if write.write_type != WriteType::Rollback =>
+        {
+            panic!(
+                "txn record found but not expected: {:?} {} {:?} {:?} [region_id={}]",
+                write,
+                commit_ts,
+                txn,
+                lock,
+                reader.reader.snapshot_ext().get_region_id().unwrap_or(0)
+            )
+        }
+        _ => {
+            return if shared_locks.is_empty() {
+                Ok(txn.unlock_key(key, true, TimeStamp::zero()))
+            } else {
+                txn.put_shared_locks(key.clone(), &shared_locks, false);
+                Ok(None)
+            };
+        }
+    };
+
+    // `protected` is always false for a shared lock
+    assert!(!key.is_encoded_from(&lock.primary));
+    assert!(lock.generation == 0);
+    if let Some(write) = make_rollback(reader.start_ts, false, overlapped_write) {
+        txn.put_write(key.clone(), reader.start_ts, write.as_ref().to_bytes());
+    }
+
+    if collapse_rollback {
+        collapse_prev_rollback(txn, reader, &key)?;
+    }
+
+    if shared_locks.is_empty() {
+        Ok(txn.unlock_key(key, true, TimeStamp::zero()))
+    } else {
+        txn.put_shared_locks(key.clone(), &shared_locks, false);
+        Ok(None)
+    }
 }
 
 pub fn collapse_prev_rollback(

--- a/src/storage/txn/actions/cleanup.rs
+++ b/src/storage/txn/actions/cleanup.rs
@@ -9,7 +9,7 @@ use crate::storage::{
         ErrorInner, Key, MvccTxn, ReleasedLock, Result as MvccResult, SnapshotReader, TimeStamp,
     },
     txn::actions::check_txn_status::{
-        check_txn_status_missing_lock, rollback_lock, MissingLockAction,
+        check_txn_status_missing_lock, rollback_lock, rollback_shared_lock, MissingLockAction,
     },
     Snapshot, TxnStatus,
 };
@@ -32,14 +32,37 @@ pub fn cleanup<S: Snapshot>(
         crate::storage::mvcc::txn::make_txn_error(err, &key, reader.start_ts).into()
     ));
 
-    match reader.load_lock(&key)? {
+    // Check for pending lock modifications first. This is important when
+    // processing multiple sub-locks of the same key in a single batch (e.g.,
+    // in resolve_lock). Each operation needs to see the pending writes from
+    // previous operations in the same batch.
+    let lock_state = match txn.get_pending_lock_bytes(&key) {
+        Some(None) => {
+            // Lock was deleted by a previous operation in this batch
+            None
+        }
+        Some(Some(bytes)) => {
+            // Use pending lock state
+            Some(txn_types::parse_lock(bytes)?)
+        }
+        None => {
+            // No pending modification, read from snapshot
+            reader.load_lock(&key)?
+        }
+    };
+
+    match lock_state {
         Some(Either::Left(ref lock)) if lock.ts == reader.start_ts => {
             // If current_ts is not 0, check the Lock's TTL.
             // If the lock is not expired, do not rollback it but report key is locked.
-            if !current_ts.is_zero() && lock.ts.physical() + lock.ttl >= current_ts.physical() {
-                return Err(
-                    ErrorInner::KeyIsLocked(lock.clone().into_lock_info(key.into_raw()?)).into(),
-                );
+            if !current_ts.is_zero() {
+                let expire_time = lock.ts.physical() + lock.ttl;
+                if expire_time >= current_ts.physical() {
+                    return Err(ErrorInner::KeyIsLocked(
+                        lock.clone().into_lock_info(key.into_raw()?),
+                    )
+                    .into());
+                }
             }
             rollback_lock(
                 txn,
@@ -50,21 +73,43 @@ pub fn cleanup<S: Snapshot>(
                 !protect_rollback,
             )
         }
-        Some(Either::Right(_shared_locks)) => {
-            unimplemented!("SharedLocks returned from load_lock is not supported here")
-        }
-        l => {
-            let l = l.map(|lock| match lock {
-                Either::Left(lock) => lock,
-                Either::Right(_shared_locks) => {
-                    unimplemented!("SharedLocks returned from load_lock is not supported here")
+        Some(Either::Right(mut shared_locks))
+            if shared_locks.contains_start_ts(reader.start_ts) =>
+        {
+            // If current_ts is not 0, check the Lock's TTL.
+            // If the lock is not expired, do not rollback it but report key is locked.
+            if !current_ts.is_zero() {
+                let expire_time = match shared_locks.get_lock(&reader.start_ts)? {
+                    Some(l) => l.ts.physical() + l.ttl,
+                    _ => unreachable!(), // since contains_start_ts returned true
+                };
+                if expire_time >= current_ts.physical() {
+                    return Err(ErrorInner::KeyIsLocked(
+                        shared_locks.into_lock_info(key.into_raw()?),
+                    )
+                    .into());
                 }
-            });
+            }
+            rollback_shared_lock(
+                txn,
+                reader,
+                key,
+                shared_locks,
+                reader.start_ts,
+                !protect_rollback,
+            )
+        }
+        lock_or_shared_locks => {
+            let lock =
+                lock_or_shared_locks.and_then(|lock_or_shared_locks| match lock_or_shared_locks {
+                    Either::Left(lock) => Some(lock),
+                    Either::Right(_) => None,
+                });
             match check_txn_status_missing_lock(
                 txn,
                 reader,
                 key.clone(),
-                l,
+                lock,
                 MissingLockAction::rollback_protect(protect_rollback),
                 false,
             )? {
@@ -101,11 +146,15 @@ pub mod tests {
     #[cfg(test)]
     use crate::storage::{
         mvcc::tests::{
-            must_get_rollback_protected, must_get_rollback_ts, must_locked, must_unlocked,
-            must_written,
+            must_get_rollback_protected, must_get_rollback_ts, must_load_shared_lock, must_locked,
+            must_unlocked, must_written,
         },
+        txn::actions::tests::must_shared_prewrite_lock,
         txn::commands::txn_heart_beat,
-        txn::tests::{must_acquire_pessimistic_lock, must_pessimistic_prewrite_put},
+        txn::tests::{
+            must_acquire_pessimistic_lock, must_acquire_shared_pessimistic_lock,
+            must_pessimistic_prewrite_put,
+        },
         TestEngineBuilder,
     };
     use crate::storage::{
@@ -258,5 +307,110 @@ pub mod tests {
         );
         must_succeed(&mut engine, k, ts(13, 1), ts(120, 0));
         must_get_rollback_protected(&mut engine, k, ts(13, 1), true);
+    }
+
+    #[test]
+    fn test_cleanup_shared_lock() {
+        let ts = TimeStamp::compose;
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+        let pk = b"pk";
+        let shared_lock_key = b"shared";
+
+        // Case 1: shared pessimistic lock cleaned up after TTL expiration.
+        must_acquire_shared_pessimistic_lock(
+            &mut engine,
+            shared_lock_key,
+            pk,
+            ts(20, 0),
+            ts(25, 0),
+            10,
+        );
+        let shared_lock = must_load_shared_lock(&mut engine, shared_lock_key);
+        assert_eq!(shared_lock.len(), 1);
+
+        must_err(&mut engine, shared_lock_key, ts(20, 0), ts(30, 0));
+        must_succeed(&mut engine, shared_lock_key, ts(20, 0), ts(40, 0));
+        must_unlocked(&mut engine, shared_lock_key);
+        must_get_rollback_protected(&mut engine, shared_lock_key, ts(20, 0), false);
+
+        // Case 2: prewritten shared lock cleaned up after TTL expiration.
+        must_acquire_shared_pessimistic_lock(
+            &mut engine,
+            shared_lock_key,
+            pk,
+            ts(30, 0),
+            ts(35, 0),
+            10,
+        );
+        must_shared_prewrite_lock(&mut engine, shared_lock_key, pk, ts(30, 0), ts(35, 0));
+
+        let mut shared_lock = must_load_shared_lock(&mut engine, shared_lock_key);
+        assert_eq!(shared_lock.len(), 1);
+        let sub_lock = shared_lock.get_lock(&ts(30, 0)).unwrap().unwrap();
+        assert_eq!(sub_lock.lock_type, txn_types::LockType::Lock);
+        assert_eq!(sub_lock.ttl, 10);
+
+        must_err(&mut engine, shared_lock_key, ts(30, 0), ts(40, 0));
+        must_succeed(&mut engine, shared_lock_key, ts(30, 0), ts(45, 0));
+        must_unlocked(&mut engine, shared_lock_key);
+        must_get_rollback_protected(&mut engine, shared_lock_key, ts(30, 0), false);
+    }
+
+    #[test]
+    fn test_cleanup_shared_lock_returns_released_lock() {
+        let ts = TimeStamp::compose;
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+        let pk = b"pk";
+        let shared_lock_key = b"shared-release";
+
+        must_acquire_shared_pessimistic_lock(
+            &mut engine,
+            shared_lock_key,
+            pk,
+            ts(40, 0),
+            ts(45, 0),
+            10,
+        );
+        must_acquire_shared_pessimistic_lock(
+            &mut engine,
+            shared_lock_key,
+            pk,
+            ts(50, 0),
+            ts(55, 0),
+            10,
+        );
+        let shared_lock = must_load_shared_lock(&mut engine, shared_lock_key);
+        assert_eq!(shared_lock.len(), 2);
+
+        for start_ts in [40, 50] {
+            let last_lock = start_ts == 50;
+            let snapshot = engine.snapshot(Default::default()).unwrap();
+            let current_ts = ts(start_ts + 20, 0);
+            let start_ts = ts(start_ts, 0);
+            let cm = ConcurrencyManager::new(current_ts);
+            let mut txn = MvccTxn::new(start_ts, cm);
+            let mut reader = SnapshotReader::new(start_ts, snapshot, true);
+            let released = cleanup(
+                &mut txn,
+                &mut reader,
+                Key::from_raw(shared_lock_key),
+                current_ts,
+                true,
+            )
+            .unwrap();
+            write(&engine, &Context::default(), txn.into_modifies());
+            must_get_rollback_protected(&mut engine, shared_lock_key, start_ts, false);
+
+            if !last_lock {
+                assert!(released.is_none());
+                continue;
+            }
+            assert!(released.is_some());
+            let released = released.unwrap();
+            assert_eq!(released.start_ts, start_ts);
+            assert!(released.commit_ts.is_zero());
+            assert!(released.pessimistic);
+        }
+        must_unlocked(&mut engine, shared_lock_key);
     }
 }

--- a/src/storage/txn/actions/commit.rs
+++ b/src/storage/txn/actions/commit.rs
@@ -22,8 +22,86 @@ pub fn commit<S: Snapshot>(
         crate::storage::mvcc::txn::make_txn_error(err, &key, reader.start_ts,).into()
     ));
 
-    let (mut lock, commit) = match reader.load_lock(&key)? {
-        Some(Either::Left(lock)) if lock.ts == reader.start_ts => {
+    // Check for pending lock modifications first. This is important when
+    // processing multiple sub-locks of the same key in a single batch (e.g.,
+    // in resolve_lock). Each operation needs to see the pending writes from
+    // previous operations in the same batch.
+    let lock_state = match txn.get_pending_lock_bytes(&key) {
+        Some(None) => {
+            // Lock was deleted by a previous operation in this batch
+            None
+        }
+        Some(Some(bytes)) => {
+            // Use pending lock state
+            Some(txn_types::parse_lock(bytes)?)
+        }
+        None => {
+            // No pending modification, read from snapshot
+            reader.load_lock(&key)?
+        }
+    };
+
+    let (mut lock, shared_locks, commit) = match lock_state {
+        Some(lock_or_shared) => {
+            let (lock, shared_locks) = match lock_or_shared {
+                Either::Left(lock) if lock.ts == reader.start_ts => (lock, None),
+                Either::Right(mut shared_locks) => {
+                    // Remove our transaction's lock from shared locks
+                    match shared_locks.remove_lock(&reader.start_ts)? {
+                        Some(l) => (l, Some(shared_locks)),
+                        None => {
+                            return match reader.get_txn_commit_record(&key)?.info() {
+                                Some((_, WriteType::Rollback)) | None => {
+                                    MVCC_CONFLICT_COUNTER.commit_lock_not_found.inc();
+                                    info!(
+                                        "txn conflict (lock not found)";
+                                        "key" => %key,
+                                        "start_ts" => reader.start_ts,
+                                        "commit_ts" => commit_ts,
+                                    );
+                                    Err(ErrorInner::TxnLockNotFound {
+                                        start_ts: reader.start_ts,
+                                        commit_ts,
+                                        key: key.into_raw()?,
+                                    }
+                                    .into())
+                                }
+                                Some((_, WriteType::Put))
+                                | Some((_, WriteType::Delete))
+                                | Some((_, WriteType::Lock)) => {
+                                    MVCC_DUPLICATE_CMD_COUNTER_VEC.commit.inc();
+                                    Ok(None)
+                                }
+                            };
+                        }
+                    }
+                }
+                _ => {
+                    return match reader.get_txn_commit_record(&key)?.info() {
+                        Some((_, WriteType::Rollback)) | None => {
+                            MVCC_CONFLICT_COUNTER.commit_lock_not_found.inc();
+                            info!(
+                                "txn conflict (lock not found)";
+                                "key" => %key,
+                                "start_ts" => reader.start_ts,
+                                "commit_ts" => commit_ts,
+                            );
+                            Err(ErrorInner::TxnLockNotFound {
+                                start_ts: reader.start_ts,
+                                commit_ts,
+                                key: key.into_raw()?,
+                            }
+                            .into())
+                        }
+                        Some((_, WriteType::Put))
+                        | Some((_, WriteType::Delete))
+                        | Some((_, WriteType::Lock)) => {
+                            MVCC_DUPLICATE_CMD_COUNTER_VEC.commit.inc();
+                            Ok(None)
+                        }
+                    };
+                }
+            };
             // A lock with larger min_commit_ts than current commit_ts can't be committed
             if commit_ts < lock.min_commit_ts {
                 info!(
@@ -55,13 +133,11 @@ pub fn commit<S: Snapshot>(
                     "start_ts" => reader.start_ts,
                     "commit_ts" => commit_ts,
                 );
-                (lock, false)
+                // Preserve shared_locks so other transactions' sub-locks are not lost
+                (lock, shared_locks, false)
             } else {
-                (lock, true)
+                (lock, shared_locks, true)
             }
-        }
-        Some(Either::Right(_shared_locks)) => {
-            unimplemented!("SharedLocks returned from load_lock is not supported here")
         }
         _ => {
             return match reader.get_txn_commit_record(&key)?.info() {
@@ -97,7 +173,17 @@ pub fn commit<S: Snapshot>(
         // Rollback a stale pessimistic lock. This function must be called by
         // resolve-lock in this case.
         assert!(lock.is_pessimistic_lock());
-        return Ok(txn.unlock_key(key, lock.is_pessimistic_txn(), TimeStamp::zero()));
+        return match shared_locks {
+            Some(shared_locks) => {
+                if shared_locks.is_empty() {
+                    Ok(txn.unlock_key(key, true, TimeStamp::zero()))
+                } else {
+                    txn.put_shared_locks(key, &shared_locks, false);
+                    Ok(None)
+                }
+            }
+            None => Ok(txn.unlock_key(key, lock.is_pessimistic_txn(), TimeStamp::zero())),
+        };
     }
 
     let mut write = Write::new(
@@ -116,7 +202,17 @@ pub fn commit<S: Snapshot>(
     }
 
     txn.put_write(key.clone(), commit_ts, write.as_ref().to_bytes());
-    Ok(txn.unlock_key(key, lock.is_pessimistic_txn(), commit_ts))
+    match shared_locks {
+        Some(shared_locks) => {
+            if shared_locks.is_empty() {
+                Ok(txn.unlock_key(key, true, commit_ts))
+            } else {
+                txn.put_shared_locks(key, &shared_locks, false);
+                Ok(None)
+            }
+        }
+        None => Ok(txn.unlock_key(key, lock.is_pessimistic_txn(), commit_ts)),
+    }
 }
 
 pub mod tests {
@@ -126,7 +222,7 @@ pub mod tests {
     use kvproto::kvrpcpb::PrewriteRequestPessimisticAction::*;
     use tikv_kv::SnapContext;
     #[cfg(test)]
-    use txn_types::{LastChange, TimeStamp};
+    use txn_types::{LastChange, Lock, LockType, TimeStamp};
 
     use super::*;
     #[cfg(test)]
@@ -143,9 +239,42 @@ pub mod tests {
         TestEngineBuilder, TxnStatus,
     };
     use crate::storage::{
-        mvcc::{tests::*, MvccTxn},
+        mvcc::{tests::*, MvccReader, MvccTxn},
         Engine,
     };
+
+    #[cfg(test)]
+    fn make_shared_sub_lock(primary: &[u8], start_ts: TimeStamp) -> Lock {
+        Lock::new(
+            LockType::Lock,
+            primary.to_vec(),
+            start_ts,
+            0,
+            None,
+            TimeStamp::zero(),
+            0,
+            TimeStamp::zero(),
+            false,
+        )
+    }
+
+    #[cfg(test)]
+    fn put_shared_lock<E: Engine>(engine: &mut E, key: &[u8], locks: Vec<Lock>) {
+        use txn_types::SharedLocks;
+        let lock_count = locks.len();
+        let mut shared_locks = SharedLocks::new();
+        for lock in locks {
+            shared_locks.update_lock(lock).unwrap();
+        }
+        assert_eq!(shared_locks.len(), lock_count);
+        let mut txn = MvccTxn::new(
+            TimeStamp::zero(),
+            ConcurrencyManager::new(TimeStamp::zero()),
+        );
+        txn.put_shared_locks(Key::from_raw(key), &shared_locks, true);
+        let ctx = Context::default();
+        write(engine, &ctx, txn.into_modifies());
+    }
 
     pub fn must_succeed<E: Engine>(
         engine: &mut E,
@@ -406,5 +535,151 @@ pub mod tests {
         must_written(&mut engine, k1, 10, 20, WriteType::Put);
         must_not_have_write(&mut engine, k2, 20);
         must_not_have_write(&mut engine, k2, 10);
+    }
+
+    #[test]
+    fn test_commit_shared_lock_keeps_remaining_entries() {
+        use tikv_util::Either;
+        use txn_types::SharedLocks;
+
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+
+        let key = b"shared-lock-key";
+        let start_ts1 = TimeStamp::new(10);
+        let start_ts2 = TimeStamp::new(20);
+        let commit_ts_1 = TimeStamp::new(30);
+        let commit_ts_2 = TimeStamp::new(40);
+
+        put_shared_lock(
+            &mut engine,
+            key,
+            vec![
+                make_shared_sub_lock(key, start_ts1),
+                make_shared_sub_lock(key, start_ts2),
+            ],
+        );
+
+        fn load_shared_locks<E: Engine>(engine: &mut E, key: &[u8]) -> Option<SharedLocks> {
+            let snapshot = engine.snapshot(Default::default()).unwrap();
+            let mut reader = MvccReader::new(snapshot, None, true);
+            match reader.load_lock(&Key::from_raw(key)).unwrap()? {
+                Either::Right(shared_locks) => Some(shared_locks),
+                Either::Left(_) => None,
+            }
+        }
+
+        let mut current_locks = load_shared_locks(&mut engine, key).unwrap();
+        assert_eq!(current_locks.len(), 2);
+        assert!(current_locks.get_lock(&start_ts1).unwrap().is_some());
+        assert!(current_locks.get_lock(&start_ts2).unwrap().is_some());
+
+        let mut simulated_locks = current_locks.clone();
+        let _ = simulated_locks.remove_lock(&start_ts1).unwrap();
+        assert_eq!(simulated_locks.len(), 1);
+
+        // commit start_ts1
+        assert!(must_succeed(&mut engine, key, start_ts1, commit_ts_1).is_none());
+        must_written(&mut engine, key, start_ts1, commit_ts_1, WriteType::Lock);
+        let mut current_locks = load_shared_locks(&mut engine, key).unwrap();
+        assert_eq!(current_locks.len(), 1);
+        assert!(current_locks.get_lock(&start_ts1).unwrap().is_none());
+        assert!(current_locks.get_lock(&start_ts2).unwrap().is_some());
+
+        // commit start_ts2
+        let released_lock = must_succeed(&mut engine, key, start_ts2, commit_ts_2).unwrap();
+        assert_eq!(released_lock.key, Key::from_raw(key));
+        assert_eq!(released_lock.start_ts, start_ts2);
+        assert_eq!(released_lock.commit_ts, commit_ts_2);
+        must_written(&mut engine, key, start_ts2, commit_ts_2, WriteType::Lock);
+        // lock is removed when no shared lock entries are left.
+        assert!(load_shared_locks(&mut engine, key).is_none());
+    }
+
+    #[test]
+    fn test_commit_stale_pessimistic_lock_preserves_other_shared_locks() {
+        use tikv_util::Either;
+        use txn_types::SharedLocks;
+
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+
+        let key = b"shared-pessimistic-key";
+        let pessimistic_ts = TimeStamp::new(10);
+        let prewrite_ts = TimeStamp::new(20);
+        let commit_ts = TimeStamp::new(30);
+
+        // Create a pessimistic lock (stale - never prewritten)
+        let pessimistic_lock = Lock::new(
+            LockType::Pessimistic,
+            key.to_vec(),
+            pessimistic_ts,
+            0,                     // ttl
+            None,                  // short_value
+            pessimistic_ts.next(), // for_update_ts (non-zero makes it pessimistic txn)
+            0,                     // txn_size
+            TimeStamp::zero(),
+            false,
+        );
+
+        // Create a prewrite lock (from another transaction)
+        let prewrite_lock = make_shared_sub_lock(key, prewrite_ts);
+
+        // Put both locks into SharedLocks
+        put_shared_lock(&mut engine, key, vec![pessimistic_lock, prewrite_lock]);
+
+        fn load_shared_locks<E: Engine>(engine: &mut E, key: &[u8]) -> Option<SharedLocks> {
+            let snapshot = engine.snapshot(Default::default()).unwrap();
+            let mut reader = MvccReader::new(snapshot, None, true);
+            match reader.load_lock(&Key::from_raw(key)).unwrap()? {
+                Either::Right(shared_locks) => Some(shared_locks),
+                Either::Left(_) => None,
+            }
+        }
+
+        // Verify initial state: both locks exist
+        let mut current_locks = load_shared_locks(&mut engine, key).unwrap();
+        assert_eq!(current_locks.len(), 2);
+        assert!(current_locks.get_lock(&pessimistic_ts).unwrap().is_some());
+        assert!(current_locks.get_lock(&prewrite_ts).unwrap().is_some());
+
+        // Try to commit the pessimistic lock.
+        // Since it's a stale pessimistic lock (never prewritten), commit should
+        // roll it back but preserve the other lock.
+        assert!(must_succeed(&mut engine, key, pessimistic_ts, commit_ts).is_none());
+
+        // The pessimistic lock should be rolled back (released), not committed.
+        // Note: The current buggy behavior may return None here because unlock_key
+        // is called with the wrong parameters.
+        // After fix, this should return Some(ReleasedLock) with commit_ts = 0.
+
+        // Critical assertion: The prewrite lock (ts=20) should still exist!
+        let remaining_locks = load_shared_locks(&mut engine, key);
+        assert!(
+            remaining_locks.is_some(),
+            "BUG: SharedLocks was deleted entirely! The prewrite lock (ts=20) was lost."
+        );
+
+        let mut remaining = remaining_locks.unwrap();
+        assert_eq!(
+            remaining.len(),
+            1,
+            "Expected 1 remaining lock, got {}",
+            remaining.len()
+        );
+
+        // The pessimistic lock should be gone
+        assert!(
+            remaining.get_lock(&pessimistic_ts).unwrap().is_none(),
+            "Pessimistic lock (ts=10) should have been removed"
+        );
+
+        // The prewrite lock should still be there
+        assert!(
+            remaining.get_lock(&prewrite_ts).unwrap().is_some(),
+            "BUG: Prewrite lock (ts=20) was lost when rolling back the stale pessimistic lock"
+        );
+
+        // No commit record should be written for the pessimistic lock
+        // (it was rolled back, not committed)
+        must_not_have_write(&mut engine, key, commit_ts);
     }
 }

--- a/src/storage/txn/actions/flashback_to_version.rs
+++ b/src/storage/txn/actions/flashback_to_version.rs
@@ -1,11 +1,15 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
 use tikv_util::Either;
-use txn_types::{Key, Lock, LockType, TimeStamp, Write, WriteType};
+use txn_types::{Key, Lock, LockType, SharedLocks, TimeStamp, Write, WriteType};
 
 use crate::storage::{
     mvcc::{self, MvccReader, MvccTxn, SnapshotReader, MAX_TXN_WRITE_SIZE},
-    txn::{self, actions::check_txn_status::rollback_lock, Result as TxnResult},
+    txn::{
+        self,
+        actions::check_txn_status::{rollback_lock, rollback_shared_lock},
+        Result as TxnResult,
+    },
     Snapshot,
 };
 
@@ -16,7 +20,7 @@ pub fn flashback_to_version_read_lock(
     next_lock_key: Key,
     end_key: Option<&Key>,
     flashback_start_ts: TimeStamp,
-) -> TxnResult<Vec<(Key, Lock)>> {
+) -> TxnResult<Vec<(Key, Either<Lock, SharedLocks>)>> {
     let result = reader.scan_locks_from_storage(
         Some(&next_lock_key),
         end_key,
@@ -25,18 +29,7 @@ pub fn flashback_to_version_read_lock(
         FLASHBACK_BATCH_SIZE,
     );
     let (key_locks, _) = result?;
-    Ok(key_locks
-        .into_iter()
-        .map(|(key, lock)| {
-            let lock = match lock {
-                Either::Left(lock) => lock,
-                Either::Right(_shared_locks) => unimplemented!(
-                    "SharedLocks returned from scan_locks_from_storage is not supported here"
-                ),
-            };
-            (key, lock)
-        })
-        .collect())
+    Ok(key_locks)
 }
 
 pub fn flashback_to_version_read_write(
@@ -75,23 +68,48 @@ pub fn flashback_to_version_read_write(
 pub fn rollback_locks(
     txn: &mut MvccTxn,
     snapshot: impl Snapshot,
-    key_locks: Vec<(Key, Lock)>,
+    key_locks: Vec<(Key, Either<Lock, SharedLocks>)>,
 ) -> TxnResult<Option<Key>> {
     let mut reader = SnapshotReader::new(txn.start_ts, snapshot, false);
-    for (key, lock) in key_locks {
+    for (key, lock_or_shared) in key_locks {
         if txn.write_size() >= MAX_TXN_WRITE_SIZE {
             return Ok(Some(key));
         }
-        // To guarantee rollback with start ts of the locks
-        reader.start_ts = lock.ts;
-        rollback_lock(
-            txn,
-            &mut reader,
-            key.clone(),
-            &lock,
-            lock.is_pessimistic_txn(),
-            true,
-        )?;
+        match lock_or_shared {
+            Either::Left(lock) => {
+                // To guarantee rollback with start ts of the locks
+                reader.start_ts = lock.ts;
+                rollback_lock(
+                    txn,
+                    &mut reader,
+                    key.clone(),
+                    &lock,
+                    lock.is_pessimistic_txn(),
+                    true,
+                )?;
+            }
+            Either::Right(mut shared_locks) => {
+                // The `shared_locks` is built from read phase and only contains sub-locks
+                // to be rolled back (lock.ts != flashback_start_ts). Since
+                // flashback itself doesn't acquire shared locks, all sub-locks shall be
+                // rolled back in this step.
+                let timestamps: Vec<_> = shared_locks.iter_ts().cloned().collect();
+                for lock_ts in timestamps {
+                    reader.start_ts = lock_ts;
+                    rollback_shared_lock(
+                        txn,
+                        &mut reader,
+                        key.clone(),
+                        shared_locks.clone(),
+                        lock_ts,
+                        true,
+                    )?;
+                    // Synchronize local state so subsequent iterations pass the correct
+                    // shared_locks (with already-processed locks removed).
+                    let _ = shared_locks.remove_lock(&lock_ts);
+                }
+            }
+        }
     }
     Ok(None)
 }
@@ -212,28 +230,37 @@ pub fn commit_flashback_key(
     flashback_commit_ts: TimeStamp,
 ) -> TxnResult<()> {
     if let Some(lock) = reader.load_lock(key_to_commit)? {
-        let mut lock = match lock {
-            Either::Left(lock) => lock,
-            Either::Right(_shared_locks) => {
-                unimplemented!("SharedLocks returned from load_lock is not supported here")
+        let is_pessimistic_txn = match lock {
+            Either::Left(mut lock) => {
+                txn.put_write(
+                    key_to_commit.clone(),
+                    flashback_commit_ts,
+                    Write::new(
+                        WriteType::from_lock_type(lock.lock_type).unwrap(),
+                        flashback_start_ts,
+                        lock.short_value.take(),
+                    )
+                    .set_last_change(lock.last_change.clone())
+                    .set_txn_source(lock.txn_source)
+                    .as_ref()
+                    .to_bytes(),
+                );
+                lock.is_pessimistic_txn()
+            }
+            Either::Right(_) => {
+                txn.put_write(
+                    key_to_commit.clone(),
+                    flashback_commit_ts,
+                    Write::new(WriteType::Lock, flashback_start_ts, None)
+                        .as_ref()
+                        .to_bytes(),
+                );
+                true
             }
         };
-        txn.put_write(
-            key_to_commit.clone(),
-            flashback_commit_ts,
-            Write::new(
-                WriteType::from_lock_type(lock.lock_type).unwrap(),
-                flashback_start_ts,
-                lock.short_value.take(),
-            )
-            .set_last_change(lock.last_change.clone())
-            .set_txn_source(lock.txn_source)
-            .as_ref()
-            .to_bytes(),
-        );
         txn.unlock_key(
             key_to_commit.clone(),
-            lock.is_pessimistic_txn(),
+            is_pessimistic_txn,
             flashback_commit_ts,
         );
     } else {
@@ -256,22 +283,18 @@ pub fn check_flashback_commit(
 ) -> TxnResult<bool> {
     match reader.load_lock(key_to_commit)? {
         // If the lock exists, it means the flashback hasn't been finished.
-        Some(lock) => {
-            let lock = match lock {
-                Either::Left(lock) => lock,
-                Either::Right(_shared_locks) => {
-                    unimplemented!("SharedLocks returned from load_lock is not supported here")
+        Some(lock_or_shared_locks) => {
+            if let Either::Left(lock) = lock_or_shared_locks.as_ref() {
+                if lock.ts == flashback_start_ts {
+                    return Ok(false);
                 }
-            };
-            if lock.ts == flashback_start_ts {
-                return Ok(false);
             }
             error!(
                 "check flashback commit exception: lock record mismatched";
                 "key_to_commit" => log_wrappers::Value::key(key_to_commit.as_encoded()),
                 "flashback_start_ts" => flashback_start_ts,
                 "flashback_commit_ts" => flashback_commit_ts,
-                "lock" => ?lock,
+                "lock" => ?lock_or_shared_locks,
             );
         }
         // If the lock doesn't exist and the flashback commit record exists, it means the flashback
@@ -331,7 +354,10 @@ pub mod tests {
                 commit::tests::must_succeed as must_commit,
                 tests::{must_prewrite_delete, must_prewrite_put, must_rollback},
             },
-            tests::{must_acquire_pessimistic_lock, must_pessimistic_prewrite_put_err},
+            tests::{
+                must_acquire_pessimistic_lock, must_acquire_shared_pessimistic_lock,
+                must_pessimistic_prewrite_put_err,
+            },
         },
         Engine, TestEngineBuilder,
     };
@@ -708,5 +734,41 @@ pub mod tests {
                 .unwrap(),
             Key::from_raw(prewrite_key)
         );
+    }
+
+    #[test]
+    fn test_flashback_write_to_version_rollback_shared_locks() {
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+        let k = b"k";
+        let pk1 = b"pk1";
+        let pk2 = b"pk2";
+        let (v1, v2) = (b"v1", b"v2");
+        // Prewrite and commit Put(k -> v1) with stat_ts = 10, commit_ts = 15.
+        must_prewrite_put(&mut engine, k, v1, k, 10);
+        must_commit(&mut engine, k, 10, 15);
+        // Prewrite and commit Put(k -> v2) with stat_ts = 20, commit_ts = 25.
+        must_prewrite_put(&mut engine, k, v2, k, 20);
+        must_commit(&mut engine, k, 20, 25);
+
+        // Acquire two shared pessimistic locks on the same key from different
+        // transactions.
+        must_acquire_shared_pessimistic_lock(&mut engine, k, pk1, 30, 30, 3000);
+        must_acquire_shared_pessimistic_lock(&mut engine, k, pk2, 35, 35, 3000);
+
+        // Flashback to version 17 with start_ts = 40, commit_ts = 45.
+        // This should rollback both shared locks:
+        // - Put 2 rollback records to write CF
+        // - Update shared_locks once (after first rollback, when one lock remains)
+        // - Delete the lock on `k` (after second rollback, when shared_locks becomes
+        //   empty)
+        // Total: 4 modifies
+        assert_eq!(must_rollback_lock(&mut engine, k, 40), 4);
+        assert_eq!(
+            must_flashback_write_to_version(&mut engine, k, 17, 40, 45),
+            1
+        );
+
+        // After flashback, the key should have the value at version 17, which is v1.
+        must_get(&mut engine, k, 50, v1);
     }
 }

--- a/src/storage/txn/actions/prewrite.rs
+++ b/src/storage/txn/actions/prewrite.rs
@@ -104,6 +104,15 @@ pub fn prewrite_with_generation<S: Snapshot>(
             mutation.check_lock(lock, pessimistic_action, expected_for_update_ts, generation)?
         }
         None if matches!(pessimistic_action, DoPessimisticCheck) => {
+            if mutation.is_shared_lock {
+                // Shared lock prewrite must have an existing shared pessimistic lock
+                return Err(ErrorInner::PessimisticLockNotFound {
+                    start_ts: reader.start_ts,
+                    key: mutation.key.into_raw()?,
+                    reason: PessimisticLockNotFoundReason::LockMissingAmendFail,
+                }
+                .into());
+            }
             // pipelined DML can't go into this. Otherwise, assertions may need to be
             // skipped for non-first flushes.
             assert_eq!(generation, 0);
@@ -305,6 +314,7 @@ struct PrewriteMutation<'a> {
 
     should_not_exist: bool,
     should_not_write: bool,
+    is_shared_lock: bool,
     assertion: Assertion,
     txn_props: &'a TransactionProperties<'a>,
 }
@@ -325,6 +335,7 @@ impl<'a> PrewriteMutation<'a> {
         }
 
         let should_not_exist = mutation.should_not_exists();
+        let is_shared_lock = mutation.is_shared_lock();
         let mutation_type = mutation.mutation_type();
         let lock_type = LockType::from_mutation(&mutation);
         let assertion = mutation.get_assertion();
@@ -343,6 +354,7 @@ impl<'a> PrewriteMutation<'a> {
 
             should_not_exist,
             should_not_write,
+            is_shared_lock,
             assertion,
             txn_props,
         })

--- a/src/storage/txn/actions/tests.rs
+++ b/src/storage/txn/actions/tests.rs
@@ -988,6 +988,38 @@ pub fn must_prewrite_lock_err<E: Engine>(
     .unwrap_err();
 }
 
+pub fn must_shared_prewrite_lock<E: Engine>(
+    engine: &mut E,
+    key: &[u8],
+    pk: &[u8],
+    ts: impl Into<TimeStamp>,
+    for_update_ts: impl Into<TimeStamp>,
+) {
+    let ctx = Context::default();
+    let snapshot = engine.snapshot(Default::default()).unwrap();
+    let for_update_ts = for_update_ts.into();
+    let cm = ConcurrencyManager::new(for_update_ts);
+    let ts = ts.into();
+    let mut txn = MvccTxn::new(ts, cm);
+    let mut reader = SnapshotReader::new(ts, snapshot, true);
+
+    let mutation = Mutation::make_shared_lock(Key::from_raw(key));
+    prewrite(
+        &mut txn,
+        &mut reader,
+        &default_txn_props(ts, pk, for_update_ts),
+        mutation,
+        &None,
+        DoPessimisticCheck,
+        None,
+    )
+    .unwrap();
+
+    engine
+        .write(&ctx, WriteData::from_modifies(txn.into_modifies()))
+        .unwrap();
+}
+
 pub fn must_pessimistic_prewrite_lock<E: Engine>(
     engine: &mut E,
     key: &[u8],

--- a/src/storage/txn/commands/acquire_pessimistic_lock.rs
+++ b/src/storage/txn/commands/acquire_pessimistic_lock.rs
@@ -100,7 +100,7 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for AcquirePessimisticLock 
         let mut encountered_locks = vec![];
         let need_old_value = context.extra_op == ExtraOp::ReadOldValue;
         let mut old_values = OldValues::default();
-        for (k, should_not_exist, _is_shared) in keys {
+        for (k, should_not_exist, is_shared_lock) in keys {
             match acquire_pessimistic_lock(
                 &mut txn,
                 &mut reader,
@@ -115,6 +115,7 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for AcquirePessimisticLock 
                 need_old_value,
                 self.lock_only_if_exists,
                 self.allow_lock_with_conflict,
+                is_shared_lock,
             ) {
                 Ok((key_res, old_value)) => {
                     res.push(key_res);

--- a/src/storage/txn/commands/acquire_pessimistic_lock_resumed.rs
+++ b/src/storage/txn/commands/acquire_pessimistic_lock_resumed.rs
@@ -32,6 +32,7 @@ use crate::storage::{
 pub struct ResumedPessimisticLockItem {
     pub key: Key,
     pub should_not_exist: bool,
+    pub is_shared_lock: bool,
     pub params: PessimisticLockParameters,
     pub lock_wait_token: LockWaitToken,
     pub req_states: Arc<LockWaitContextSharedState>,
@@ -107,6 +108,7 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for AcquirePessimisticLockR
             let ResumedPessimisticLockItem {
                 key,
                 should_not_exist,
+                is_shared_lock,
                 params,
                 lock_wait_token,
                 req_states,
@@ -151,6 +153,7 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for AcquirePessimisticLockR
                 need_old_value,
                 params.lock_only_if_exists,
                 true,
+                is_shared_lock,
             ) {
                 Ok((key_res, old_value)) => {
                     res.push(key_res);
@@ -219,6 +222,7 @@ impl AcquirePessimisticLockResumed {
                 ResumedPessimisticLockItem {
                     key: item.key,
                     should_not_exist: item.should_not_exist,
+                    is_shared_lock: item.is_shared_lock,
                     params: item.parameters,
                     lock_wait_token: item.lock_wait_token,
                     req_states: item.req_states,

--- a/src/storage/txn/commands/check_secondary_locks.rs
+++ b/src/storage/txn/commands/check_secondary_locks.rs
@@ -174,17 +174,18 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for CheckSecondaryLocks {
                     released_lock = lock_released;
                     (status, need_rollback, rollback_overlapped_write)
                 }
-                Some(Either::Right(_shared_locks)) => {
-                    unimplemented!("SharedLocks returned from load_lock is not supported here")
-                }
+                // Async commit transactions don't write shared locks, so if we get SharedLocks,
+                // check the write CF for the commit record directly.
+                Some(Either::Right(_)) => check_determined_txn_status(&mut reader, &key)?,
                 // Searches the write CF for the commit record of the lock and returns the commit
                 // timestamp (0 if the lock is not committed).
                 l => {
-                    mismatch_lock = l.map(|lock| match lock {
-                        Either::Left(lock) => lock,
-                        Either::Right(_shared_locks) => unimplemented!(
-                            "SharedLocks returned from load_lock is not supported here"
-                        ),
+                    // SharedLocks is already handled by the previous match arm, so this is
+                    // unreachable.
+                    mismatch_lock = l.map(|lock_or_shared_locks| {
+                        lock_or_shared_locks
+                            .left()
+                            .expect("SharedLocks is handled above, should not reach here")
                     });
                     check_determined_txn_status(&mut reader, &key)?
                 }

--- a/src/storage/txn/commands/check_txn_status.rs
+++ b/src/storage/txn/commands/check_txn_status.rs
@@ -7,14 +7,14 @@ use txn_types::{Key, TimeStamp};
 use crate::storage::{
     kv::WriteData,
     lock_manager::LockManager,
-    mvcc::{MvccTxn, SnapshotReader},
+    mvcc::{ErrorInner, MvccTxn, SnapshotReader},
     txn::{
+        Error, Result,
         actions::check_txn_status::*,
         commands::{
             Command, CommandExt, ReaderWithStats, ReleasedLocks, ResponsePolicy, TypedCommand,
             WriteCommand, WriteContext, WriteResult,
         },
-        Result,
     },
     ProcessResult, Snapshot, TxnStatus,
 };
@@ -126,25 +126,35 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for CheckTxnStatus {
                 self.verify_is_primary,
                 self.rollback_if_not_exist,
             )?,
-            Some(Either::Right(_shared_locks)) => {
-                unimplemented!("SharedLocks returned from load_lock is not supported here")
+            Some(Either::Right(shared_locks)) => {
+                // a shared-locked key cannot be the primary key of a transaction thus reject
+                // the request directly.
+                warn!("reject check_txn_status on shared lock";
+                    "lock_ts" => self.lock_ts,
+                    "key" => ?&self.primary_key,
+                );
+                return Err(Error::from_mvcc(ErrorInner::PrimaryMismatch(
+                    shared_locks.into_lock_info(self.primary_key.into_raw()?),
+                )));
             }
-            l => (
-                check_txn_status_missing_lock(
-                    &mut txn,
-                    &mut reader,
-                    self.primary_key,
-                    l.map(|lock| match lock {
-                        Either::Left(lock) => lock,
-                        Either::Right(_shared_locks) => unimplemented!(
-                            "SharedLocks returned from load_lock is not supported here"
-                        ),
-                    }),
-                    MissingLockAction::rollback(self.rollback_if_not_exist),
-                    self.resolving_pessimistic_lock,
-                )?,
-                None,
-            ),
+            l => {
+                // Either no lock or lock with different ts - extract lock if present
+                let lock = l.and_then(|lock_or_shared| match lock_or_shared {
+                    Either::Left(lock) => Some(lock),
+                    Either::Right(_) => None, // SharedLocks already handled above
+                });
+                (
+                    check_txn_status_missing_lock(
+                        &mut txn,
+                        &mut reader,
+                        self.primary_key,
+                        lock,
+                        MissingLockAction::rollback(self.rollback_if_not_exist),
+                        self.resolving_pessimistic_lock,
+                    )?,
+                    None,
+                )
+            }
         };
 
         let mut released_locks = ReleasedLocks::new();
@@ -1295,6 +1305,10 @@ pub mod tests {
             b"k2",
             kvrpcpb::Op::Put,
         );
+
+        must_acquire_shared_pessimistic_lock(&mut engine, b"k2", b"k3", 2, 2, 100);
+        let e = must_err(&mut engine, b"k2", 1, 3, 3, true, false, true);
+        check_error(e, b"k2", b"", kvrpcpb::Op::SharedLock);
     }
 
     #[test]

--- a/src/storage/txn/commands/flashback_to_version_read_phase.rs
+++ b/src/storage/txn/commands/flashback_to_version_read_phase.rs
@@ -3,7 +3,8 @@
 // #[PerformanceCriticalPath]
 use std::ops::Bound;
 
-use txn_types::{Key, Lock, TimeStamp};
+use tikv_util::Either;
+use txn_types::{Key, Lock, SharedLocks, TimeStamp};
 
 use crate::storage::{
     metrics::{CommandKind, KV_COMMAND_COUNTER_VEC_STATIC},
@@ -24,7 +25,7 @@ use crate::storage::{
 pub enum FlashbackToVersionState {
     RollbackLock {
         next_lock_key: Key,
-        key_locks: Vec<(Key, Lock)>,
+        key_locks: Vec<(Key, Either<Lock, SharedLocks>)>,
     },
     Prewrite {
         key_to_lock: Key,

--- a/src/storage/txn/commands/flush.rs
+++ b/src/storage/txn/commands/flush.rs
@@ -54,7 +54,9 @@ impl CommandExt for Flush {
                     bytes += key.as_encoded().len();
                     bytes += value.len();
                 }
-                Mutation::Delete(ref key, _) | Mutation::Lock(ref key, _) => {
+                Mutation::Delete(ref key, _)
+                | Mutation::Lock(ref key, _)
+                | Mutation::SharedLock(ref key, _) => {
                     bytes += key.as_encoded().len();
                 }
                 Mutation::CheckNotExists(..) => (),

--- a/src/storage/txn/commands/mod.rs
+++ b/src/storage/txn/commands/mod.rs
@@ -575,10 +575,13 @@ fn find_mvcc_infos_by_key<S: Snapshot>(
 ) -> Result<LockWritesVals> {
     let mut writes = vec![];
     let mut values = vec![];
-    let lock = reader.load_lock(key)?.map(|lock| match lock {
-        Either::Left(lock) => lock,
-        Either::Right(_shared_locks) => {
-            unimplemented!("SharedLocks returned from load_lock is not supported here")
+    let lock = reader.load_lock(key)?.and_then(|lock| match lock {
+        Either::Left(lock) => Some(lock),
+        // For SharedLocks, we return the first lock for debug purposes.
+        // This function is only used for collecting MVCC info for debugging.
+        Either::Right(mut shared_locks) => {
+            let first_ts = shared_locks.iter_ts().next().cloned();
+            first_ts.and_then(|ts| shared_locks.get_lock(&ts).ok().flatten().cloned())
         }
     });
     loop {

--- a/src/storage/txn/commands/pessimistic_rollback.rs
+++ b/src/storage/txn/commands/pessimistic_rollback.rs
@@ -9,7 +9,7 @@ use txn_types::{Key, TimeStamp};
 use crate::storage::{
     kv::WriteData,
     lock_manager::LockManager,
-    mvcc::{MvccTxn, Result as MvccResult, SnapshotReader},
+    mvcc::{Error as MvccError, MvccTxn, Result as MvccResult, SnapshotReader},
     txn::{
         commands::{
             Command, CommandExt, PessimisticRollbackReadPhase, ReaderWithStats, ReleasedLocks,
@@ -79,19 +79,43 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for PessimisticRollback {
                 .into()
             ));
             let released_lock: MvccResult<_> = if let Some(lock) = reader.load_lock(&key)? {
-                let lock = match lock {
-                    Either::Left(lock) => lock,
-                    Either::Right(_shared_locks) => {
-                        unimplemented!("SharedLocks returned from load_lock is not supported here")
+                match lock {
+                    Either::Left(lock) => {
+                        if lock.is_pessimistic_lock()
+                            && lock.ts == self.start_ts
+                            && lock.for_update_ts <= self.for_update_ts
+                        {
+                            Ok(txn.unlock_key(key, true, TimeStamp::zero()))
+                        } else {
+                            Ok(None)
+                        }
                     }
-                };
-                if lock.is_pessimistic_lock()
-                    && lock.ts == self.start_ts
-                    && lock.for_update_ts <= self.for_update_ts
-                {
-                    Ok(txn.unlock_key(key, true, TimeStamp::zero()))
-                } else {
-                    Ok(None)
+                    Either::Right(mut shared_locks) => {
+                        // First check if the lock exists and meets conditions
+                        let should_rollback = shared_locks
+                            .get_lock(&self.start_ts)
+                            .map_err(MvccError::from)?
+                            .map(|lock| {
+                                lock.is_pessimistic_lock()
+                                    && lock.for_update_ts <= self.for_update_ts
+                            })
+                            .unwrap_or(false);
+
+                        if should_rollback {
+                            // Remove the lock
+                            shared_locks
+                                .remove_lock(&self.start_ts)
+                                .map_err(MvccError::from)?;
+                            if shared_locks.is_empty() {
+                                Ok(txn.unlock_key(key, true, TimeStamp::zero()))
+                            } else {
+                                txn.put_shared_locks(key, &shared_locks, false);
+                                Ok(None)
+                            }
+                        } else {
+                            Ok(None)
+                        }
+                    }
                 }
             } else {
                 Ok(None)
@@ -245,5 +269,27 @@ pub mod tests {
         must_success(&mut engine, k, 3, 3);
         must_success(&mut engine, k, 3, 4);
         must_success(&mut engine, k, 3, 5);
+    }
+
+    #[test]
+    fn test_rollback_shared_pessimistic_lock() {
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+        let key = b"shared-rollback";
+        let pk1 = b"pk1";
+        let pk2 = b"pk2";
+
+        // Acquire two shared pessimistic locks on the same key.
+        must_acquire_shared_pessimistic_lock(&mut engine, key, pk1, 10, 30, 3000);
+        must_acquire_shared_pessimistic_lock(&mut engine, key, pk2, 20, 20, 3000);
+
+        // Rolling back one shared pessimistic lock keeps the other entry.
+        must_success(&mut engine, key, 10, 30);
+        let mut shared_lock = must_load_shared_lock(&mut engine, key);
+        assert_eq!(shared_lock.len(), 1);
+        assert!(shared_lock.get_lock(&20.into()).unwrap().is_some());
+
+        // Rolling back the last entry removes the lock entirely.
+        must_success(&mut engine, key, 20, 20);
+        must_unlocked(&mut engine, key);
     }
 }

--- a/src/storage/txn/commands/prewrite.rs
+++ b/src/storage/txn/commands/prewrite.rs
@@ -238,7 +238,9 @@ impl CommandExt for Prewrite {
                     bytes += key.as_encoded().len();
                     bytes += value.len();
                 }
-                Mutation::Delete(ref key, _) | Mutation::Lock(ref key, _) => {
+                Mutation::Delete(ref key, _)
+                | Mutation::Lock(ref key, _)
+                | Mutation::SharedLock(ref key, _) => {
                     bytes += key.as_encoded().len();
                 }
                 Mutation::CheckNotExists(..) => (),
@@ -455,7 +457,9 @@ impl CommandExt for PrewritePessimistic {
                     bytes += key.as_encoded().len();
                     bytes += value.len();
                 }
-                Mutation::Delete(ref key, _) | Mutation::Lock(ref key, _) => {
+                Mutation::Delete(ref key, _)
+                | Mutation::Lock(ref key, _)
+                | Mutation::SharedLock(ref key, _) => {
                     bytes += key.as_encoded().len();
                 }
                 Mutation::CheckNotExists(..) => (),
@@ -1010,7 +1014,9 @@ mod tests {
         mvcc::{tests::*, Error as MvccError, ErrorInner as MvccErrorInner},
         txn::{
             actions::{
-                acquire_pessimistic_lock::tests::must_pessimistic_locked,
+                acquire_pessimistic_lock::tests::{
+                    must_acquire_shared_pessimistic_lock, must_pessimistic_locked,
+                },
                 tests::{
                     must_pessimistic_prewrite_put_async_commit, must_prewrite_delete,
                     must_prewrite_put, must_prewrite_put_async_commit,
@@ -2985,5 +2991,55 @@ mod tests {
         must_locked(&mut engine, k1, 10);
         must_locked(&mut engine, k2, 10);
         must_locked(&mut engine, k3, 10);
+    }
+
+    #[test]
+    fn test_shared_lock_prewrite_cannot_amend_pessimistic_lock() {
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+        let cm = ConcurrencyManager::new(1.into());
+        let mut statistics = Statistics::default();
+
+        let key = b"shared-lock-key";
+        let cmd = PrewritePessimistic::with_defaults(
+            vec![(
+                Mutation::make_shared_lock(Key::from_raw(key)),
+                DoPessimisticCheck,
+            )],
+            key.to_vec(),
+            10.into(),
+            10.into(),
+        );
+        // cannot amend pessimistic lock when there is no shared lock.
+        let err = prewrite_command(&mut engine, cm.clone(), &mut statistics, cmd).unwrap_err();
+        assert!(matches!(
+            err,
+            Error(box ErrorInner::Mvcc(MvccError(box MvccErrorInner::PessimisticLockNotFound {
+                ..
+            })))
+        ));
+
+        // Create a shared lock belonging to another transaction
+        must_acquire_shared_pessimistic_lock(&mut engine, key, key, 11u64, 11u64, 2000);
+        must_load_shared_lock(&mut engine, key);
+
+        let cmd = PrewritePessimistic::with_defaults(
+            vec![(
+                Mutation::make_shared_lock(Key::from_raw(key)),
+                DoPessimisticCheck,
+            )],
+            key.to_vec(),
+            10.into(),
+            10.into(),
+        );
+        // cannot amend pessimistic lock when there is shared lock belong to another
+        // transaction.
+        let err = prewrite_command(&mut engine, cm, &mut statistics, cmd).unwrap_err();
+        assert!(matches!(
+            err,
+            Error(box ErrorInner::Mvcc(MvccError(box MvccErrorInner::PessimisticLockNotFound {
+                ..
+            })))
+        ));
+        must_load_shared_lock(&mut engine, key);
     }
 }

--- a/src/storage/txn/commands/resolve_lock.rs
+++ b/src/storage/txn/commands/resolve_lock.rs
@@ -93,6 +93,8 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for ResolveLock {
         let mut released_locks = ReleasedLocks::new();
         let mut known_txn_status = vec![];
         for (current_key, current_lock) in key_locks {
+            // No special casing for shared locks here, `cleanup` and `commit` will handle
+            // them.
             txn.start_ts = current_lock.ts;
             reader.start_ts = current_lock.ts;
             let commit_ts = *txn_status
@@ -175,3 +177,121 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for ResolveLock {
 // value length. The write batch will be around 32KB if we scan 256 keys each
 // time.
 pub const RESOLVE_LOCK_BATCH_SIZE: usize = 256;
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use concurrency_manager::ConcurrencyManager;
+    use kvproto::kvrpcpb::Context;
+    use tikv_util::deadline::Deadline;
+
+    use super::*;
+    use crate::storage::{
+        TestEngineBuilder,
+        kv::Engine,
+        lock_manager::MockLockManager,
+        mvcc::tests::{must_get_rollback_ts, must_unlocked, write},
+        txn::{
+            commands::{WriteCommand, WriteContext},
+            scheduler::DEFAULT_EXECUTION_DURATION_LIMIT,
+            tests::{must_acquire_shared_pessimistic_lock, must_shared_prewrite_lock},
+            txn_status_cache::TxnStatusCache,
+        },
+    };
+
+    fn run_resolve_lock<E: Engine>(
+        engine: &mut E,
+        txn_status: HashMap<TimeStamp, TimeStamp>,
+        key_locks: Vec<(Key, Lock)>,
+    ) {
+        let ctx = Context::default();
+        let snapshot = engine.snapshot(Default::default()).unwrap();
+        let cm = ConcurrencyManager::new(TimeStamp::new(100));
+        let command = ResolveLock {
+            ctx: ctx.clone(),
+            txn_status,
+            scan_key: None,
+            key_locks,
+            deadline: Deadline::from_now(DEFAULT_EXECUTION_DURATION_LIMIT),
+        };
+        let lock_mgr = MockLockManager::new();
+        let write_context = WriteContext {
+            lock_mgr: &lock_mgr,
+            concurrency_manager: cm,
+            extra_op: Default::default(),
+            statistics: &mut Default::default(),
+            async_apply_prewrite: false,
+            raw_ext: None,
+            txn_status_cache: Arc::new(TxnStatusCache::new_for_test()),
+        };
+        let result = command.process_write(snapshot, write_context).unwrap();
+        write(engine, &ctx, result.to_be_write.modifies);
+    }
+
+    /// This test demonstrates a bug where resolving multiple sub-locks from the
+    /// same SharedLocks in a single batch results in incorrect behavior.
+    ///
+    /// The bug occurs because:
+    /// 1. ResolveLockReadPhase flattens SharedLocks into individual (Key, Lock)
+    ///    pairs
+    /// 2. ResolveLock processes each pair in a loop using the SAME snapshot
+    /// 3. Each iteration reads the ORIGINAL SharedLocks (all sub-locks present)
+    /// 4. Each iteration removes ONE sub-lock and writes the remaining
+    /// 5. Since the snapshot doesn't see pending writes, each iteration
+    ///    overwrites the previous one
+    /// 6. The LAST write wins, leaving incorrect locks
+    ///
+    /// Example:
+    /// - SharedLocks on key: [ts=10, ts=20], both need rollback
+    /// - Iteration 1: reads [10,20], removes 10, writes [20]
+    /// - Iteration 2: reads [10,20] (same snapshot!), removes 20, writes [10]
+    /// - Final result: [10] (should be empty!)
+    #[test]
+    fn test_resolve_multiple_shared_locks_same_key() {
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+        let key = b"shared-resolve-key";
+        let pk1 = b"pk1";
+        let pk2 = b"pk2";
+
+        // Create SharedLocks with two sub-locks: ts=10 and ts=20
+        must_acquire_shared_pessimistic_lock(&mut engine, key, pk1, 10, 15, 3000);
+        must_shared_prewrite_lock(&mut engine, key, pk1, 10, 15);
+        must_acquire_shared_pessimistic_lock(&mut engine, key, pk2, 20, 25, 3000);
+        must_shared_prewrite_lock(&mut engine, key, pk2, 20, 25);
+
+        // Load the SharedLocks to get the Lock structures
+        let snapshot = engine.snapshot(Default::default()).unwrap();
+        let mut reader = crate::storage::mvcc::MvccReader::new(snapshot, None, true);
+        let lock_or_shared = reader.load_lock(&Key::from_raw(key)).unwrap().unwrap();
+        let mut shared_locks = match lock_or_shared {
+            tikv_util::Either::Right(sl) => sl,
+            _ => panic!("expected SharedLocks"),
+        };
+        assert_eq!(shared_locks.len(), 2);
+
+        // Extract individual locks (simulating what ResolveLockReadPhase does)
+        let lock1 = shared_locks.get_lock(&10.into()).unwrap().unwrap().clone();
+        let lock2 = shared_locks.get_lock(&20.into()).unwrap().unwrap().clone();
+
+        // Build txn_status: rollback both transactions
+        let mut txn_status = HashMap::default();
+        txn_status.insert(10.into(), 0.into()); // rollback ts=10
+        txn_status.insert(20.into(), 0.into()); // rollback ts=20
+
+        // Simulate what happens when ResolveLock processes both locks from the
+        // same SharedLocks in a single batch. The key_locks contains the same
+        // key twice with different locks.
+        let key_locks = vec![(Key::from_raw(key), lock1), (Key::from_raw(key), lock2)];
+
+        run_resolve_lock(&mut engine, txn_status, key_locks);
+
+        // Both transactions should have rollback records
+        must_get_rollback_ts(&mut engine, key, 10);
+        must_get_rollback_ts(&mut engine, key, 20);
+
+        // After resolving both locks, the key should be unlocked (no locks
+        // remaining).
+        must_unlocked(&mut engine, key);
+    }
+}

--- a/src/storage/txn/commands/resolve_lock_readphase.rs
+++ b/src/storage/txn/commands/resolve_lock_readphase.rs
@@ -1,9 +1,8 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-// #[PerformanceCriticalPath]
 use collections::HashMap;
 use tikv_util::Either;
-use txn_types::{Key, Lock, TimeStamp};
+use txn_types::{Key, TimeStamp};
 
 use crate::storage::{
     mvcc::MvccReader,
@@ -56,31 +55,44 @@ impl<S: Snapshot> ReadCommand<S> for ResolveLockReadPhase {
         let result = reader.scan_locks_from_storage(
             self.scan_key.as_ref(),
             None,
+            // Filter function: for Lock, check if ts is in txn_status;
+            // for SharedLocks, the filter is applied during scan and returns only matching locks
             |_, lock| txn_status.contains_key(&lock.ts),
             RESOLVE_LOCK_BATCH_SIZE,
         );
         statistics.add(&reader.statistics);
         let (kv_pairs, has_remain) = result?;
-        let kv_pairs: Vec<(Key, Lock)> = kv_pairs
-            .into_iter()
-            .map(|(key, lock)| {
-                let lock = match lock {
-                    Either::Left(lock) => lock,
-                    Either::Right(_shared_locks) => unimplemented!(
-                        "SharedLocks returned from scan_locks_from_storage is not supported here"
-                    ),
-                };
-                (key, lock)
-            })
-            .collect();
-        tls_collect_keyread_histogram_vec(tag.get_str(), kv_pairs.len() as f64);
 
-        if kv_pairs.is_empty() {
+        // Flatten the result: convert LockOrSharedLocks to Vec<(Key, Lock)>
+        let mut flatten_pairs = Vec::with_capacity(kv_pairs.len());
+        for (key, lock_or_shared) in kv_pairs {
+            match lock_or_shared {
+                Either::Left(lock) => {
+                    flatten_pairs.push((key, lock));
+                }
+                Either::Right(mut shared_locks) => {
+                    // For SharedLocks, iterate through all locks that match txn_status
+                    let ts_to_process: Vec<_> = shared_locks
+                        .iter_ts()
+                        .filter(|ts| txn_status.contains_key(ts))
+                        .cloned()
+                        .collect();
+                    for ts in ts_to_process {
+                        if let Some(lock) = shared_locks.get_lock(&ts).unwrap() {
+                            flatten_pairs.push((key.clone(), lock.clone()));
+                        }
+                    }
+                }
+            }
+        }
+        tls_collect_keyread_histogram_vec(tag.get_str(), flatten_pairs.len() as f64);
+
+        if flatten_pairs.is_empty() {
             Ok(ProcessResult::Res)
         } else {
             let next_scan_key = if has_remain {
                 // There might be more locks.
-                kv_pairs.last().map(|(k, _lock)| k.clone())
+                flatten_pairs.last().map(|(k, _lock)| k.clone())
             } else {
                 // All locks are scanned
                 None
@@ -90,11 +102,76 @@ impl<S: Snapshot> ReadCommand<S> for ResolveLockReadPhase {
                 deadline: self.deadline,
                 txn_status,
                 scan_key: next_scan_key,
-                key_locks: kv_pairs,
+                key_locks: flatten_pairs,
             };
             Ok(ProcessResult::NextCommand {
                 cmd: Command::ResolveLock(next_cmd),
             })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use kvproto::kvrpcpb::Context;
+
+    use super::*;
+    use crate::storage::{TestEngineBuilder, kv::Engine, txn::tests::*};
+
+    fn run_resolve_lock_read_phase<E: Engine>(
+        engine: &mut E,
+        txn_status: HashMap<TimeStamp, TimeStamp>,
+    ) -> ProcessResult {
+        let snapshot = engine.snapshot(Default::default()).unwrap();
+        let mut statistics = Statistics::default();
+        ResolveLockReadPhase::new(txn_status, None, Context::default())
+            .cmd
+            .process_read(snapshot, &mut statistics)
+            .unwrap()
+    }
+
+    #[test]
+    fn test_resolve_lock_read_shared_pessimistic() {
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+        let key = b"read-shared-pessimistic";
+        let pk1 = b"pk1";
+        let pk2 = b"pk2";
+
+        must_acquire_shared_pessimistic_lock(&mut engine, key, pk1, 10, 30, 3000);
+        must_shared_prewrite_lock(&mut engine, key, pk1, 10, 15);
+        must_acquire_shared_pessimistic_lock(&mut engine, key, pk2, 20, 20, 3000);
+        must_shared_prewrite_lock(&mut engine, key, pk2, 20, 25);
+        must_acquire_shared_pessimistic_lock(&mut engine, key, pk2, 40, 40, 3000);
+        must_shared_prewrite_lock(&mut engine, key, pk2, 40, 45);
+
+        let mut txn_status = HashMap::default();
+        txn_status.insert(20.into(), 30.into());
+        txn_status.insert(40.into(), 0.into());
+        let pr = run_resolve_lock_read_phase(&mut engine, txn_status);
+        match pr {
+            ProcessResult::NextCommand {
+                cmd: Command::ResolveLock(next),
+            } => {
+                assert_eq!(next.key_locks.len(), 2);
+                let expected_key = Key::from_raw(key);
+
+                let locks_by_start_ts: HashMap<_, _> = next
+                    .key_locks
+                    .iter()
+                    .map(|(k, lock)| {
+                        assert_eq!(k, &expected_key);
+                        // In current branch, Lock type is never shared - shared locks use
+                        // SharedLocks type
+                        (lock.ts, lock)
+                    })
+                    .collect();
+
+                assert_eq!(locks_by_start_ts.len(), 2);
+                assert!(!locks_by_start_ts.contains_key(&10.into()));
+                assert!(locks_by_start_ts.contains_key(&20.into()));
+                assert!(locks_by_start_ts.contains_key(&40.into()));
+            }
+            _ => panic!("expected resolve lock command"),
         }
     }
 }

--- a/src/storage/txn/commands/rollback.rs
+++ b/src/storage/txn/commands/rollback.rs
@@ -86,7 +86,11 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for Rollback {
 mod tests {
     use kvproto::kvrpcpb::PrewriteRequestPessimisticAction::*;
 
-    use crate::storage::{txn::tests::*, TestEngineBuilder};
+    use crate::storage::{
+        mvcc::tests::{must_get_rollback_protected, must_load_shared_lock, must_unlocked},
+        txn::tests::*,
+        TestEngineBuilder,
+    };
 
     #[test]
     fn rollback_lock_with_existing_rollback() {
@@ -100,5 +104,34 @@ mod tests {
 
         must_pessimistic_prewrite_put(&mut engine, k2, v, k1, 10, 10, SkipPessimisticCheck);
         must_rollback(&mut engine, k2, 10, false);
+    }
+
+    #[test]
+    fn rollback_shared_lock() {
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+        let key = b"shared-lock";
+        let pk1 = b"pk1";
+        let pk2 = b"pk2";
+        let start_ts1 = 10.into();
+        let start_ts2 = 20.into();
+
+        must_acquire_shared_pessimistic_lock(&mut engine, key, pk1, start_ts1, 30, 3000);
+        must_acquire_shared_pessimistic_lock(&mut engine, key, pk2, start_ts2, 40, 3000);
+
+        let mut shared_lock = must_load_shared_lock(&mut engine, key);
+        assert_eq!(shared_lock.len(), 2);
+
+        must_rollback(&mut engine, key, start_ts1, false);
+        must_get_rollback_protected(&mut engine, key, start_ts1, false);
+
+        shared_lock = must_load_shared_lock(&mut engine, key);
+        assert_eq!(shared_lock.len(), 1);
+        assert!(shared_lock.get_lock(&start_ts1).unwrap().is_none());
+        assert!(shared_lock.get_lock(&start_ts2).unwrap().is_some());
+
+        must_rollback(&mut engine, key, start_ts2, false);
+        must_unlocked(&mut engine, key);
+
+        must_get_rollback_protected(&mut engine, key, start_ts2, false);
     }
 }

--- a/src/storage/txn/commands/txn_heart_beat.rs
+++ b/src/storage/txn/commands/txn_heart_beat.rs
@@ -98,8 +98,42 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for TxnHeartBeat {
 
                 lock
             }
-            Some(Either::Right(_shared_locks)) => {
-                unimplemented!("SharedLocks returned from load_lock is not supported here")
+            Some(Either::Right(mut shared_locks))
+                if shared_locks.contains_start_ts(self.start_ts) =>
+            {
+                let lock = shared_locks
+                    .get_lock(&self.start_ts)
+                    .map_err(MvccError::from)?
+                    .expect("lock should exist since contains_start_ts returned true")
+                    .clone();
+                let mut updated_lock = lock.clone();
+                let mut updated = false;
+
+                if updated_lock.ttl < self.advise_ttl {
+                    updated_lock.ttl = self.advise_ttl;
+                    updated = true;
+                }
+
+                // only for non-async-commit pipelined transactions, we can update the
+                // min_commit_ts
+                if !updated_lock.use_async_commit
+                    && updated_lock.generation > 0
+                    && self.min_commit_ts > 0
+                    && updated_lock.min_commit_ts < self.min_commit_ts.into()
+                {
+                    return Err(box_err!(
+                        "pipelined transaction should not hold shared locks"
+                    ));
+                }
+
+                if updated {
+                    shared_locks
+                        .update_lock(updated_lock.clone())
+                        .map_err(MvccError::from)?;
+                    txn.put_shared_locks(self.primary_key.clone(), &shared_locks, false);
+                }
+
+                updated_lock
             }
             _ => {
                 return Err(MvccError::from(MvccErrorInner::TxnNotFound {

--- a/src/storage/txn/mod.rs
+++ b/src/storage/txn/mod.rs
@@ -256,8 +256,9 @@ impl ErrorCodeExt for Error {
 pub mod tests {
     pub use actions::{
         acquire_pessimistic_lock::tests::{
-            must_err as must_acquire_pessimistic_lock_err,
+            must_acquire_shared_pessimistic_lock, must_err as must_acquire_pessimistic_lock_err,
             must_err_return_value as must_acquire_pessimistic_lock_return_value_err,
+            must_err_shared_lock as must_acquire_pessimistic_lock_shared_err,
             must_pessimistic_locked, must_succeed as must_acquire_pessimistic_lock,
             must_succeed_allow_lock_with_conflict as must_acquire_pessimistic_lock_allow_lock_with_conflict,
             must_succeed_for_large_txn as must_acquire_pessimistic_lock_for_large_txn,

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -2051,6 +2051,9 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         lock_info: WriteResultLockInfo,
         cb: PessimisticLockKeyCallback,
     ) -> Box<LockWaitEntry> {
+        // the resuming process may contains lock info from other transactions, so
+        // this assertion need to be changed when force locking is compatible with
+        // shared locks.
         assert!(lock_info.lock_info_pb.lock_type != kvrpcpb::Op::SharedLock);
         Box::new(LockWaitEntry {
             key: lock_info.key,

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -209,9 +209,7 @@ impl TxnEntry {
             } => {
                 let l = match txn_types::parse_lock(value).unwrap() {
                     Either::Left(lock) => lock,
-                    Either::Right(_shared_locks) => unimplemented!(
-                        "SharedLocks returned from txn_types::parse_lock is not supported here"
-                    ),
+                    Either::Right(_shared_locks) => return e,
                 };
                 *value = l.set_last_change(LastChange::Unknown).to_bytes();
             }

--- a/tests/failpoints/cases/test_storage.rs
+++ b/tests/failpoints/cases/test_storage.rs
@@ -32,7 +32,7 @@ use tikv::{
         config_manager::StorageConfigManger,
         kv::{Error as KvError, ErrorInner as KvErrorInner, SnapContext, SnapshotExt},
         lock_manager::MockLockManager,
-        mvcc::{Error as MvccError, ErrorInner as MvccErrorInner},
+        mvcc::{Error as MvccError, ErrorInner as MvccErrorInner, MvccReader},
         test_util::*,
         txn::{
             commands,
@@ -42,7 +42,7 @@ use tikv::{
         Error as StorageError, ErrorInner as StorageErrorInner, *,
     },
 };
-use tikv_util::{future::paired_future_callback, worker::dummy_scheduler, HandyRwLock};
+use tikv_util::{future::paired_future_callback, worker::dummy_scheduler, Either, HandyRwLock};
 use txn_types::{Key, Mutation, TimeStamp};
 
 #[test_case(test_raftstore::new_server_cluster)]
@@ -1834,4 +1834,460 @@ fn test_raw_put_deadline() {
     let put_resp = client.raw_put(&put_req).unwrap();
     assert!(!put_resp.has_region_error(), "{:?}", put_resp);
     must_get_equal(&cluster.get_engine(1), b"k3", b"v3");
+}
+
+#[test]
+#[allow(unused)]
+fn test_shared_exclusive_lock_conflict() {
+    let storage = TestStorageBuilderApiV1::new(MockLockManager::new())
+        .build()
+        .unwrap();
+    let shared_key = b"shared-lock-key".to_vec();
+    let pk = b"shared-lock-pk".to_vec();
+
+    let acquire_lock = |start_ts: u64, is_shared_lock: bool| {
+        let (done_tx, done_rx) = channel();
+        storage
+            .sched_txn_command(
+                new_acquire_pessimistic_lock_command_with_pk_with_shared(
+                    vec![(Key::from_raw(&shared_key), false, is_shared_lock)],
+                    Some(&pk),
+                    start_ts,
+                    start_ts,
+                    false,
+                    false,
+                ),
+                Box::new(
+                    move |res: storage::Result<
+                        std::result::Result<PessimisticLockResults, StorageError>,
+                    >| done_tx.send(res).unwrap(),
+                ),
+            )
+            .unwrap();
+        done_rx
+    };
+
+    let prewrite = |start_ts: u64, is_shared: bool| {
+        let (done_tx, done_rx) = channel::<i32>();
+        storage
+            .sched_txn_command(
+                commands::PrewritePessimistic::new(
+                    vec![(
+                        if is_shared {
+                            Mutation::make_shared_lock(Key::from_raw(&shared_key))
+                        } else {
+                            Mutation::make_lock(Key::from_raw(&shared_key))
+                        },
+                        DoPessimisticCheck,
+                    )],
+                    pk.clone(),
+                    start_ts.into(),
+                    3000,
+                    start_ts.into(),
+                    1,
+                    TimeStamp::default(),
+                    TimeStamp::default(),
+                    None,
+                    false,
+                    AssertionLevel::Off,
+                    vec![],
+                    Context::default(),
+                ),
+                expect_ok_callback(done_tx, 0),
+            )
+            .unwrap();
+        done_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+    };
+
+    let prewrite_optimistic = |start_ts: u64| {
+        let (done_tx, done_rx) = channel();
+        storage
+            .sched_txn_command(
+                commands::Prewrite::new(
+                    vec![Mutation::make_lock(Key::from_raw(&shared_key))],
+                    pk.clone(),
+                    start_ts.into(),
+                    3000,
+                    false,
+                    1,
+                    TimeStamp::default(),
+                    TimeStamp::default(),
+                    None,
+                    false,
+                    AssertionLevel::Off,
+                    Context::default(),
+                ),
+                Box::new(move |res: storage::Result<PrewriteResult>| done_tx.send(res).unwrap()),
+            )
+            .unwrap();
+        done_rx.recv_timeout(Duration::from_secs(5)).unwrap()
+    };
+
+    let commit = |start_ts: u64, commit_ts: u64| {
+        let (done_tx, done_rx) = channel::<i32>();
+        storage
+            .sched_txn_command(
+                commands::Commit::new(
+                    vec![Key::from_raw(&shared_key)],
+                    start_ts.into(),
+                    commit_ts.into(),
+                    Context::default(),
+                ),
+                expect_ok_callback(done_tx, 0),
+            )
+            .unwrap();
+        done_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+    };
+
+    let load_shared_lock = || {
+        let mut engine = storage.get_engine();
+        let snapshot = engine.snapshot(Default::default()).unwrap();
+        let mut reader = MvccReader::new(snapshot, None, true);
+        match reader
+            .load_lock(&Key::from_raw(&shared_key))
+            .unwrap()
+            .expect("shared lock should exist")
+        {
+            tikv_util::Either::Right(shared_locks) => shared_locks,
+            tikv_util::Either::Left(_) => panic!("expected shared locks, found exclusive lock"),
+        }
+    };
+
+    acquire_lock(10, true).recv().unwrap().unwrap();
+    let mut shared_lock = load_shared_lock();
+    assert_eq!(shared_lock.len(), 1);
+    assert!(
+        shared_lock
+            .get_lock(&TimeStamp::from(10))
+            .unwrap()
+            .is_some()
+    );
+
+    // exclusive lock blocked.
+    let exclusive_lock = acquire_lock(30, false);
+    exclusive_lock
+        .recv_timeout(Duration::from_millis(100))
+        .unwrap_err();
+
+    // Re-acquiring the same transaction should be idempotent.
+    acquire_lock(10, true).recv().unwrap().unwrap();
+    let shared_lock = load_shared_lock();
+    assert_eq!(shared_lock.len(), 1);
+
+    // A different transaction should be merged into the same shared lock entry.
+    acquire_lock(20, true).recv().unwrap().unwrap();
+    let mut shared_lock = load_shared_lock();
+    assert_eq!(shared_lock.len(), 2);
+    assert!(
+        shared_lock
+            .get_lock(&TimeStamp::from(10))
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        shared_lock
+            .get_lock(&TimeStamp::from(20))
+            .unwrap()
+            .is_some()
+    );
+
+    exclusive_lock
+        .recv_timeout(Duration::from_millis(100))
+        .unwrap_err();
+
+    prewrite(10, true);
+    prewrite(20, true);
+    commit(10, 15);
+    commit(20, 25);
+
+    // acquire pessimistic lock return conflict after all shared lock txns are
+    // committed.
+    assert!(matches!(
+        exclusive_lock
+            .recv_timeout(Duration::from_millis(100))
+            .unwrap()
+            .unwrap_err(),
+        storage::Error(box ErrorInner::Txn(TxnError(box TxnErrorInner::Mvcc(mvcc::Error(
+            box mvcc::ErrorInner::WriteConflict { .. },
+        ))))),
+    ));
+
+    // acquire pessimistic lock again after exclusive lock failed.
+    acquire_lock(40, false)
+        .recv_timeout(Duration::from_secs(5))
+        .unwrap()
+        .unwrap();
+
+    // shared locks should be blocked by exclusive lock.
+    let shared_lock1 = acquire_lock(50, true);
+    let shared_lock2 = acquire_lock(60, true);
+    shared_lock1
+        .recv_timeout(Duration::from_millis(100))
+        .unwrap_err();
+    shared_lock2
+        .recv_timeout(Duration::from_millis(100))
+        .unwrap_err();
+
+    prewrite(40, false);
+    commit(40, 70);
+
+    // acquire shared lock return conflict after exclusive lock is committed.
+    for shared_lock in &[shared_lock1, shared_lock2] {
+        assert!(matches!(
+            shared_lock
+                .recv_timeout(Duration::from_millis(100))
+                .unwrap()
+                .unwrap_err(),
+            storage::Error(box ErrorInner::Txn(TxnError(box TxnErrorInner::Mvcc(mvcc::Error(
+                box mvcc::ErrorInner::WriteConflict { .. },
+            ))))),
+        ));
+    }
+
+    // Now exclusive lock is committed, new shared locks can be acquired.
+    acquire_lock(80, true).recv().unwrap().unwrap();
+    acquire_lock(90, true).recv().unwrap().unwrap();
+    acquire_lock(100, true).recv().unwrap().unwrap();
+    prewrite(90, true);
+    commit(90, 120);
+    prewrite(100, true);
+
+    // start_ts  status
+    // 80        shared pessimistic lock
+    // 90        committed
+    // 100       shared prewrite lock
+    let prewrite_result = prewrite_optimistic(110).unwrap();
+    assert_eq!(prewrite_result.locks.len(), 1);
+    match prewrite_result.locks[0].as_ref().unwrap_err() {
+        storage::Error(box ErrorInner::Txn(TxnError(box TxnErrorInner::Mvcc(mvcc::Error(
+            box mvcc::ErrorInner::KeyIsLocked(lock),
+        ))))) => {
+            assert_eq!(lock.get_lock_type(), kvrpcpb::Op::SharedLock);
+            let shared_lock_infos = lock.get_shared_lock_infos();
+            assert_eq!(shared_lock_infos.len(), 2);
+            for shared_lock in shared_lock_infos {
+                assert_eq!(shared_lock.get_key(), &shared_key);
+                assert_eq!(shared_lock.get_primary_lock(), &pk);
+                let start_ts = shared_lock.get_lock_version();
+                assert!([80, 100].contains(&start_ts));
+                assert_eq!(
+                    shared_lock.get_lock_type(),
+                    match start_ts {
+                        80 => kvrpcpb::Op::PessimisticLock,
+                        100 => kvrpcpb::Op::Lock,
+                        _ => unreachable!(),
+                    }
+                );
+            }
+        }
+        other => panic!("unexpected lock error: {:?}", other),
+    }
+}
+
+#[test]
+#[allow(unused)]
+fn test_resolve_shared_locks() {
+    let storage = TestStorageBuilderApiV1::new(MockLockManager::new())
+        .build()
+        .unwrap();
+    let shared_key = b"resolve-shared-lock".to_vec();
+    let pk = b"resolve-shared-lock-pk".to_vec();
+
+    let acquire_lock = |start_ts: u64, is_shared: bool| {
+        let (done_tx, done_rx) = channel();
+        storage
+            .sched_txn_command(
+                new_acquire_pessimistic_lock_command_with_pk_with_shared(
+                    vec![(Key::from_raw(&shared_key), false, is_shared)],
+                    Some(&pk.clone()),
+                    start_ts,
+                    start_ts,
+                    false,
+                    false,
+                ),
+                Box::new(
+                    move |res: storage::Result<
+                        std::result::Result<PessimisticLockResults, StorageError>,
+                    >| done_tx.send(res).unwrap(),
+                ),
+            )
+            .unwrap();
+        done_rx
+    };
+
+    for ts in [10, 20] {
+        acquire_lock(ts, true).recv().unwrap().unwrap();
+    }
+    let exclusive_lock = acquire_lock(30, false);
+    exclusive_lock.try_recv().unwrap_err();
+
+    let load_lock = || {
+        let snapshot = storage.get_engine().snapshot(Default::default()).unwrap();
+        let mut reader = MvccReader::new(snapshot, None, true);
+        reader.load_lock(&Key::from_raw(&shared_key)).unwrap()
+    };
+
+    let mut shared_locks = match load_lock().unwrap() {
+        Either::Right(shared_locks) => shared_locks,
+        _ => panic!("expected SharedLocks"),
+    };
+    assert_eq!(shared_locks.len(), 2);
+
+    let resolve_lock = |txn_status: HashMap<TimeStamp, TimeStamp>,
+                        key_locks: Vec<(Key, txn_types::Lock)>| {
+        let (tx, rx) = channel();
+        storage
+            .sched_txn_command(
+                commands::ResolveLock::new(txn_status, None, key_locks, Context::default()),
+                expect_ok_callback(tx, 0),
+            )
+            .unwrap();
+        rx.recv_timeout(Duration::from_secs(5)).unwrap();
+    };
+
+    let mut txn_status = HashMap::default();
+    txn_status.insert(TimeStamp::from(10), 0.into());
+    resolve_lock(
+        txn_status,
+        vec![(
+            Key::from_raw(&shared_key),
+            shared_locks.get_lock(&10.into()).unwrap().unwrap().clone(),
+        )],
+    );
+    let mut shared_locks = match load_lock().unwrap() {
+        Either::Right(shared_locks) => shared_locks,
+        _ => panic!("expected SharedLocks"),
+    };
+    assert_eq!(shared_locks.len(), 1);
+    assert!(shared_locks.contains_start_ts(20.into()));
+    exclusive_lock.try_recv().unwrap_err();
+
+    let mut txn_status = HashMap::default();
+    txn_status.insert(TimeStamp::from(20), 0.into());
+    resolve_lock(
+        txn_status,
+        vec![(
+            Key::from_raw(&shared_key),
+            shared_locks.get_lock(&20.into()).unwrap().unwrap().clone(),
+        )],
+    );
+    assert!(load_lock().is_none());
+    exclusive_lock.try_recv().unwrap();
+}
+
+#[test]
+fn test_scan_lock_shared_lock_infos_filtered_by_max_ts() {
+    let storage = TestStorageBuilderApiV1::new(MockLockManager::new())
+        .build()
+        .unwrap();
+    let key = b"scan-shared-lock-key".to_vec();
+    let pk = b"scan-shared-lock-pk".to_vec();
+
+    let pessimistic_lock_shared_lock = |start_ts: u64| {
+        let (done_tx, done_rx) = channel();
+        storage
+            .sched_txn_command(
+                new_acquire_pessimistic_lock_command_with_pk_with_shared(
+                    vec![(Key::from_raw(&key), false, true)],
+                    Some(&pk),
+                    start_ts,
+                    start_ts + 1,
+                    false,
+                    false,
+                ),
+                Box::new(
+                    move |res: storage::Result<
+                        std::result::Result<PessimisticLockResults, StorageError>,
+                    >| done_tx.send(res).unwrap(),
+                ),
+            )
+            .unwrap();
+        done_rx
+            .recv_timeout(Duration::from_secs(5))
+            .unwrap()
+            .unwrap()
+            .unwrap();
+    };
+
+    let prewrite_shared_lock = |start_ts: u64| {
+        let (done_tx, done_rx) = channel::<i32>();
+        storage
+            .sched_txn_command(
+                commands::PrewritePessimistic::new(
+                    vec![(
+                        Mutation::make_shared_lock(Key::from_raw(&key)),
+                        DoPessimisticCheck,
+                    )],
+                    pk.clone(),
+                    start_ts.into(),
+                    3000,
+                    (start_ts + 1).into(),
+                    1,
+                    TimeStamp::default(),
+                    TimeStamp::default(),
+                    None,
+                    false,
+                    AssertionLevel::Off,
+                    vec![],
+                    Context::default(),
+                ),
+                expect_ok_callback(done_tx, 0),
+            )
+            .unwrap();
+        done_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+    };
+
+    let scan_lock_start_ts_set = |max_ts: u64| -> Vec<(u64, Op)> {
+        let mut locks = block_on(storage.scan_lock(
+            Context::default(),
+            max_ts.into(),
+            Some(Key::from_raw(&key)),
+            None,
+            100,
+        ))
+        .unwrap();
+        assert_eq!(locks.len(), 1);
+        let lock = locks.pop().unwrap();
+        assert_eq!(lock.get_key(), &key);
+        assert_eq!(lock.get_lock_type(), Op::SharedLock);
+        let mut start_ts_set: Vec<_> = lock
+            .get_shared_lock_infos()
+            .iter()
+            .map(|l| (l.get_lock_version(), l.get_lock_type()))
+            .collect();
+        start_ts_set.sort_by_key(|(ts, _)| *ts);
+        start_ts_set
+    };
+
+    pessimistic_lock_shared_lock(10);
+    pessimistic_lock_shared_lock(20);
+    pessimistic_lock_shared_lock(30);
+
+    assert_eq!(scan_lock_start_ts_set(15), vec![(10, Op::PessimisticLock)]);
+    assert_eq!(
+        scan_lock_start_ts_set(25),
+        vec![(10, Op::PessimisticLock), (20, Op::PessimisticLock)]
+    );
+    assert_eq!(
+        scan_lock_start_ts_set(35),
+        vec![
+            (10, Op::PessimisticLock),
+            (20, Op::PessimisticLock),
+            (30, Op::PessimisticLock)
+        ]
+    );
+
+    prewrite_shared_lock(10);
+    prewrite_shared_lock(20);
+    prewrite_shared_lock(30);
+
+    assert_eq!(scan_lock_start_ts_set(15), vec![(10, Op::Lock)]);
+    assert_eq!(
+        scan_lock_start_ts_set(25),
+        vec![(10, Op::Lock), (20, Op::Lock)]
+    );
+    assert_eq!(
+        scan_lock_start_ts_set(35),
+        vec![(10, Op::Lock), (20, Op::Lock), (30, Op::Lock)]
+    );
 }


### PR DESCRIPTION
## Summary
- Cherry-pick of #19304 to release-8.5
- Adds shared lock handling across all transaction schedulers including acquire_pessimistic_lock, commit, cleanup, check_txn_status, rollback, pessimistic_rollback, resolve_lock, prewrite, scan_lock, and more
- Adds SharedLocks methods (is_empty, remove_lock, update_lock), MvccTxn::put_shared_locks, Mutation::SharedLock variant, and is_shared_lock_req parameter to acquire_pessimistic_lock
- Depends on #19389 (WORK01) and #19405 (WORK02) which are already merged

## Test plan
- [x] `make clippy` passes
- [x] `make build` passes
- [ ] CI tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)