### PR TITLE
add new actual disk-used metric

### DIFF
--- a/components/pd_client/src/metrics.rs
+++ b/components/pd_client/src/metrics.rs
@@ -47,6 +47,9 @@ make_static_metric! {
     }
 
     pub label_enum StoreSizeEventType {
+        // `used` is filesystem used bytes derived from statvfs (`total - free`).
+        // `engine_used` is TiKV-estimated engine usage (kept for compatibility as
+        // it used to be reported as `used` historically).
         capacity,
         available,
         used,
@@ -54,6 +57,7 @@ make_static_metric! {
         raft_size,
         kv_size,
         import_size,
+        engine_used,
     }
 
     pub struct StoreSizeEventIntrVec: IntGauge {

--- a/components/raftstore-v2/src/worker/pd/store.rs
+++ b/components/raftstore-v2/src/worker/pd/store.rs
@@ -493,7 +493,7 @@ where
         // size manually.
         #[cfg(any(test, feature = "testexport"))]
         {
-            let (capacity, available) = disk::get_disk_space_stats("./").unwrap();
+            let (capacity, available, _) = disk::get_disk_space_stats("./").unwrap();
 
             disk::set_disk_capacity(capacity);
             disk::set_disk_used_size(capacity - available);

--- a/components/server/src/common.rs
+++ b/components/server/src/common.rs
@@ -221,7 +221,7 @@ impl TikvServerCore {
             }
         }
 
-        let (disk_cap, disk_avail) =
+        let (disk_cap, disk_avail, _) =
             disk::get_disk_space_stats(&self.config.storage.data_dir).unwrap();
         let mut capacity = disk_cap;
         if self.config.raft_store.capacity.0 > 0 {
@@ -242,7 +242,7 @@ impl TikvServerCore {
         let separated_raft_mount_path =
             path_in_diff_mount_point(&self.config.storage.data_dir, &raft_data_dir);
         if separated_raft_mount_path {
-            let (raft_disk_cap, raft_disk_avail) =
+            let (raft_disk_cap, raft_disk_avail, _) =
                 disk::get_disk_space_stats(&raft_data_dir).unwrap();
             // reserve space for raft engine if raft engine is deployed separately
             let raft_reserved_size =
@@ -977,7 +977,22 @@ impl DiskUsageChecker {
     /// `raft_used_size` is the used size of raft engine.
     ///
     /// Returns the disk usage status of the whole disk, kv engine and raft
-    /// engine, the whole disk capacity and available size.
+    /// engine, the whole disk capacity and available size, and the filesystem
+    /// used size derived from statvfs.
+    ///
+    /// - `capacity`: the disk capacity used by TiKV for checking/reporting. It
+    ///   may be clamped by `raft_store.capacity`.
+    /// - `available`: the remaining space TiKV can still use before hitting
+    ///   `capacity`, computed as `min(capacity - kvdb_used_size,
+    ///   statvfs.available_space())`.
+    /// - `actual_disk_used`: filesystem used bytes computed from statvfs as
+    ///   `total_space - free_space`.
+    ///
+    /// Note: `free_space` may be larger than `available_space` on filesystems
+    /// (like ext4) that reserve blocks for root users. In that case,
+    /// `actual_disk_used + available_space < total_space`. When there is no
+    /// reservation (so `free_space == available_space`), the sum equals
+    /// `total_space`.
     pub fn inspect(
         &self,
         kvdb_used_size: u64,
@@ -988,6 +1003,7 @@ impl DiskUsageChecker {
         disk::DiskUsage, // raft disk status
         u64,             // whole capacity
         u64,             // whole available
+        u64,             // actual_disk_used
     ) {
         // By default, the almost full threshold of kv engine is half of the
         // configured value.
@@ -1013,9 +1029,10 @@ impl DiskUsageChecker {
                             disk::DiskUsage::Normal,
                             0,
                             0,
+                            0,
                         );
                     }
-                    Ok((cap, avail)) => {
+                    Ok((cap, avail, _)) => {
                         if !self.separated_raft_auxiliary_mount_path {
                             // If the auxiliary directory of raft engine is not separated from
                             // kv engine, returns u64::MAX to indicate that the disk space of
@@ -1040,7 +1057,7 @@ impl DiskUsageChecker {
                                         );
                                         (0_u64, 0_u64)
                                     }
-                                    Ok((total, avail)) => (total, avail),
+                                    Ok((total, avail, _)) => (total, avail),
                                 };
                             (cap + auxiliary_disk_cap, avail + auxiliary_disk_avail)
                         } else {
@@ -1062,7 +1079,7 @@ impl DiskUsageChecker {
             }
         };
         // Check the disk space of kv engine.
-        let (disk_cap, disk_avail) = match disk::get_disk_space_stats(&self.kvdb_path) {
+        let (disk_cap, disk_avail, disk_free) = match disk::get_disk_space_stats(&self.kvdb_path) {
             Err(e) => {
                 error!(
                     "get disk stat for kv store failed";
@@ -1075,10 +1092,12 @@ impl DiskUsageChecker {
                     disk::DiskUsage::Normal,
                     0,
                     0,
+                    0,
                 );
             }
-            Ok((total, avail)) => (total, avail),
+            Ok((total, avail, free)) => (total, avail, free),
         };
+        let actual_disk_used = disk_cap.saturating_sub(disk_free);
         let capacity = if self.config_disk_capacity == 0 || disk_cap < self.config_disk_capacity {
             disk_cap
         } else {
@@ -1099,6 +1118,7 @@ impl DiskUsageChecker {
             raft_disk_status,
             capacity,
             available,
+            actual_disk_used,
         )
     }
 }

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -1534,7 +1534,7 @@ where
                     snap_size + kv_size + placeholder_size
                 };
                 // Check the disk usage and update the disk usage status.
-                let (cur_disk_status, cur_kv_disk_status, raft_disk_status, capacity, available) = disk_usage_checker.inspect(used_size, raft_size);
+                let (cur_disk_status, cur_kv_disk_status, raft_disk_status, capacity, available, actual_disk_used) = disk_usage_checker.inspect(used_size, raft_size);
                 let prev_disk_status = disk::get_disk_status(0); //0 no need care about failpoint.
                 if prev_disk_status != cur_disk_status {
                     warn!(
@@ -1557,8 +1557,11 @@ where
                 }
                 // Update disk capacity, used size and available size.
                 disk::set_disk_capacity(capacity);
+                // `DISK_USED_SIZE` is TiKV-estimated engine usage (kv/raft/snap/placeholder).
                 disk::set_disk_used_size(used_size);
                 disk::set_disk_available_size(available);
+                // `DISK_ACTUAL_USED_SIZE` is filesystem used bytes: total - free.
+                disk::set_disk_actual_used_size(actual_disk_used);
 
                 // Update metrics.
                 STORE_SIZE_EVENT_INT_VEC.raft_size.set(raft_size as i64);
@@ -1567,7 +1570,12 @@ where
 
                 STORE_SIZE_EVENT_INT_VEC.capacity.set(capacity as i64);
                 STORE_SIZE_EVENT_INT_VEC.available.set(available as i64);
-                STORE_SIZE_EVENT_INT_VEC.used.set(used_size as i64);
+                // `used` is filesystem used bytes derived from statvfs.
+                // `engine_used` is TiKV-estimated engine usage (historically reported as `used`).
+                // On filesystems reserving blocks for privileged users, `free > available`,
+                // so `used + available < capacity` may hold.
+                STORE_SIZE_EVENT_INT_VEC.used.set(actual_disk_used as i64);
+                STORE_SIZE_EVENT_INT_VEC.engine_used.set(used_size as i64);
             })
     }
 

--- a/components/server/src/server2.rs
+++ b/components/server/src/server2.rs
@@ -1308,7 +1308,7 @@ where
                     snap_size + kv_size + placeholder_size
                 };
                 // Check the disk usage and update the disk usage status.
-                let (cur_disk_status, cur_kv_disk_status, raft_disk_status, capacity, available) = disk_usage_checker.inspect(used_size, raft_size);
+                let (cur_disk_status, cur_kv_disk_status, raft_disk_status, capacity, available, actual_disk_used) = disk_usage_checker.inspect(used_size, raft_size);
                 let prev_disk_status = disk::get_disk_status(0); //0 no need care about failpoint.
                 if prev_disk_status != cur_disk_status {
                     warn!(
@@ -1331,8 +1331,11 @@ where
                 }
                 // Update disk capacity, used size and available size.
                 disk::set_disk_capacity(capacity);
+                // `DISK_USED_SIZE` is TiKV-estimated engine usage (kv/raft/snap/placeholder).
                 disk::set_disk_used_size(used_size);
                 disk::set_disk_available_size(available);
+                // `DISK_ACTUAL_USED_SIZE` is filesystem used bytes: total - free.
+                disk::set_disk_actual_used_size(actual_disk_used);
 
                 // Update metrics.
                 STORE_SIZE_EVENT_INT_VEC.raft_size.set(raft_size as i64);
@@ -1341,7 +1344,12 @@ where
 
                 STORE_SIZE_EVENT_INT_VEC.capacity.set(capacity as i64);
                 STORE_SIZE_EVENT_INT_VEC.available.set(available as i64);
-                STORE_SIZE_EVENT_INT_VEC.used.set(used_size as i64);
+                // `used` is filesystem used bytes derived from statvfs.
+                // `engine_used` is TiKV-estimated engine usage (historically reported as `used`).
+                // On filesystems reserving blocks for privileged users, `free > available`,
+                // so `used + available < capacity` may hold.
+                STORE_SIZE_EVENT_INT_VEC.used.set(actual_disk_used as i64);
+                STORE_SIZE_EVENT_INT_VEC.engine_used.set(used_size as i64);
             })
     }
 

--- a/components/test_raftstore/src/node.rs
+++ b/components/test_raftstore/src/node.rs
@@ -371,7 +371,7 @@ impl Simulator for NodeCluster {
                     let kv_size = util::get_engine_cfs_used_size(rocks_engine.as_ref())
                         .expect("get kv engine size");
                     let used_size = snap_size + kv_size;
-                    let (capacity, available) = disk::get_disk_space_stats(&data_dir).unwrap();
+                    let (capacity, available, _) = disk::get_disk_space_stats(&data_dir).unwrap();
 
                     disk::set_disk_capacity(capacity);
                     disk::set_disk_used_size(used_size);

--- a/components/tikv_util/src/sys/disk.rs
+++ b/components/tikv_util/src/sys/disk.rs
@@ -7,11 +7,16 @@ use std::{
 use fail::fail_point;
 pub use kvproto::disk_usage::DiskUsage;
 
-// The following variables are used to store the disk capacity, used size, and
-// available size.
+// The following variables are used to store the disk capacity and two used
+// sizes:
+// - DISK_USED_SIZE: TiKV-estimated engine usage (kv/raft/snap/placeholder)
+//   reported by the storage stats worker.
+// - DISK_ACTUAL_USED_SIZE: filesystem used bytes derived from statvfs
+//   (`total_space - free_space`).
 static DISK_CAPACITY: AtomicU64 = AtomicU64::new(0);
 static DISK_USED_SIZE: AtomicU64 = AtomicU64::new(0);
 static DISK_AVAILABLE_SIZE: AtomicU64 = AtomicU64::new(0);
+static DISK_ACTUAL_USED_SIZE: AtomicU64 = AtomicU64::new(0);
 
 // DISK_RESERVED_SPACE means if left space is less than this, tikv will
 // turn to maintenance mode. There are another 2 value derived from this,
@@ -50,6 +55,16 @@ pub fn set_disk_available_size(v: u64) {
 #[inline]
 pub fn get_disk_available_size() -> u64 {
     DISK_AVAILABLE_SIZE.load(Ordering::Acquire)
+}
+
+#[inline]
+pub fn set_disk_actual_used_size(v: u64) {
+    DISK_ACTUAL_USED_SIZE.store(v, Ordering::Release)
+}
+
+#[inline]
+pub fn get_disk_actual_used_size() -> u64 {
+    DISK_ACTUAL_USED_SIZE.load(Ordering::Acquire)
 }
 
 #[inline]
@@ -122,15 +137,28 @@ pub fn get_disk_status(_store_id: u64) -> DiskUsage {
     }
 }
 
-pub fn get_disk_space_stats<P: AsRef<Path>>(path: P) -> std::io::Result<(u64, u64)> {
+// Returns (total_space, available_space, free_space) from statvfs.
+//
+// Note: `free_space` may be larger than `available_space` when the filesystem
+// reserves blocks for privileged users. Filesystem used bytes can be derived as
+// `total_space - free_space`. When there is no reservation (so `free_space ==
+// available_space`), `used + available_space == total_space`. Otherwise
+// `used + available_space < total_space`.
+pub fn get_disk_space_stats<P: AsRef<Path>>(path: P) -> std::io::Result<(u64, u64, u64)> {
     fail_point!("mock_disk_space_stats", |stats| {
         let stats = stats.unwrap();
         let values = stats.split(',').collect::<Vec<_>>();
-        Ok((
-            values[0].parse::<u64>().unwrap(),
-            values[1].parse::<u64>().unwrap(),
-        ))
+        let total = values[0].parse::<u64>().unwrap();
+        let avail = values[1].parse::<u64>().unwrap();
+        // If `free` is omitted, assume there is no reserved block and use
+        // `avail` as `free`.
+        let free = values.get(2).map_or(avail, |v| v.parse::<u64>().unwrap());
+        Ok((total, avail, free))
     });
     let disk_stats = fs2::statvfs(path)?;
-    Ok((disk_stats.total_space(), disk_stats.available_space()))
+    Ok((
+        disk_stats.total_space(),
+        disk_stats.available_space(),
+        disk_stats.free_space(),
+    ))
 }

--- a/components/tikv_util/src/sys/mod.rs
+++ b/components/tikv_util/src/sys/mod.rs
@@ -420,7 +420,7 @@ mqueue /dev/mqueue mqueue rw,relatime 0 0
 
     #[test]
     fn test_get_disk_space_stats() {
-        let (capacity, available) = disk::get_disk_space_stats("./").unwrap();
+        let (capacity, available, _) = disk::get_disk_space_stats("./").unwrap();
         assert!(capacity > 0);
         assert!(available > 0);
         assert!(capacity >= available);

--- a/metrics/grafana/tikv_details.dashboard.py
+++ b/metrics/grafana/tikv_details.dashboard.py
@@ -246,6 +246,13 @@ def Cluster() -> RowPanel:
                             label_selectors=['type = "used"'],
                         ),
                     ),
+                    target(
+                        expr=expr_sum(
+                            "tikv_store_size_bytes",
+                            label_selectors=['type = "engine_used"'],
+                        ),
+                        legend_format=r"{{instance}}-engine",
+                    ),
                 ],
             ),
             graph_panel(

--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -535,6 +535,21 @@
               "refId": "",
               "step": 10,
               "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum((\n    tikv_store_size_bytes\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type = \"engine_used\"}\n    \n)) by (instance) ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{instance}}-engine",
+              "metric": "",
+              "query": "sum((\n    tikv_store_size_bytes\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type = \"engine_used\"}\n    \n)) by (instance) ",
+              "refId": "",
+              "step": 10,
+              "target": ""
             }
           ],
           "thresholds": [],

--- a/metrics/grafana/tikv_details.json.sha256
+++ b/metrics/grafana/tikv_details.json.sha256
@@ -1,1 +1,1 @@
-2566beed7cfa7f9578910ac5bf0b304cb1339ad7d66098baf7816975218cddba  ./metrics/grafana/tikv_details.json
+4819232d9f00ea5e0b6cfe1673f0d5135a131ea692678fe644df1c114cdcee05  ./metrics/grafana/tikv_details.json

--- a/metrics/grafana/tikv_summary.json
+++ b/metrics/grafana/tikv_summary.json
@@ -112,6 +112,14 @@
               "legendFormat": "{{instance}}",
               "refId": "A",
               "step": 10
+            },
+            {
+              "expr": "sum(tikv_store_size_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", type=\"engine_used\"}) by (instance)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}}-engine",
+              "refId": "B",
+              "step": 10
             }
           ],
           "thresholds": [],
@@ -2360,6 +2368,14 @@
               "intervalFactor": 2,
               "legendFormat": "{{instance}}",
               "refId": "A",
+              "step": 10
+            },
+            {
+              "expr": "sum(tikv_store_size_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", type=\"engine_used\"}) by (instance)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}}-engine",
+              "refId": "B",
               "step": 10
             }
           ],


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #xxx

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Swap `tikv_store_size_bytes{type="used"}` to report OS-level filesystem used bytes (`statvfs total - free`, matching `df` "Used"). The previous TiKV engine sum (kv/raft/snap/placeholder) moves to a new label `{type="engine_used"}`. PD heartbeat `used_size` is unchanged.

  - Extend `get_disk_space_stats` to return `(total, available, free)`.
  - Add `DISK_ACTUAL_USED_SIZE` atomic and `engine_used` metric variant.
  - Extend `DiskUsageChecker::inspect()` with `actual_disk_used` return.
  - Add `engine_used` series to "Store size" Grafana panels.

Note: on filesystems that reserve blocks for privileged users (e.g.ext4), `free > available`, so `used + available < capacity` may hold. `actual_disk_used` is not clamped by `raft_store.capacity`.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [x] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced disk usage reporting to distinguish between actual filesystem usage and TiKV engine-estimated usage
  * Added new `engine_used` metric to track engine disk consumption separately

* **Monitoring & Dashboards**
  * Updated dashboard visualizations to display engine usage metrics alongside existing disk usage metrics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->