### PR TITLE
storage, engine_traits: replace unsafe code and panicking assertions with safe error handling

### DIFF
--- a/components/engine_traits/src/peekable.rs
+++ b/components/engine_traits/src/peekable.rs
@@ -50,14 +50,14 @@ pub trait Peekable {
 
     /// Read a value and return it as a protobuf message.
     fn get_msg<M: protobuf::Message + Default>(&self, key: &[u8]) -> Result<Option<M>> {
-        let value = self.get_value(key)?;
-        if value.is_none() {
-            return Ok(None);
+        match self.get_value(key)? {
+            Some(value) => {
+                let mut m = M::default();
+                m.merge_from_bytes(&value)?;
+                Ok(Some(m))
+            }
+            None => Ok(None),
         }
-
-        let mut m = M::default();
-        m.merge_from_bytes(&value.unwrap())?;
-        Ok(Some(m))
     }
 
     /// Read a value and return it as a protobuf message.
@@ -66,13 +66,13 @@ pub trait Peekable {
         cf: &str,
         key: &[u8],
     ) -> Result<Option<M>> {
-        let value = self.get_value_cf(cf, key)?;
-        if value.is_none() {
-            return Ok(None);
+        match self.get_value_cf(cf, key)? {
+            Some(value) => {
+                let mut m = M::default();
+                m.merge_from_bytes(&value)?;
+                Ok(Some(m))
+            }
+            None => Ok(None),
         }
-
-        let mut m = M::default();
-        m.merge_from_bytes(&value.unwrap())?;
-        Ok(Some(m))
     }
 }

--- a/src/storage/mvcc/consistency_check.rs
+++ b/src/storage/mvcc/consistency_check.rs
@@ -64,19 +64,9 @@ impl<E: KvEngine> Mvcc<E> {
 impl<E: KvEngine> ConsistencyCheckObserver<E> for Mvcc<E> {
     fn update_context(&self, context: &mut Vec<u8>) -> bool {
         context.push(ConsistencyCheckMethod::Mvcc as u8);
-        context.reserve(8);
-        let len = context.len();
-
         let mut safe_point = self.local_safe_point.load(AtomicOrdering::Acquire);
         safe_point = get_safe_point_for_check(safe_point);
-        unsafe {
-            context.set_len(len + 8);
-            std::ptr::copy_nonoverlapping(
-                safe_point.to_le_bytes().as_ptr(),
-                &mut context[len] as _,
-                8,
-            );
-        }
+        context.extend_from_slice(&safe_point.to_le_bytes());
         // Skiped all other observers.
         true
     }

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -593,13 +593,15 @@ impl<S: EngineSnapshot> MvccReader<S> {
                                 };
                                 self.statistics.write.get += 1;
                                 let write = WriteRef::parse(&value)?.to_owned();
-                                assert!(
-                                    write.write_type == WriteType::Put
-                                        || write.write_type == WriteType::Delete,
-                                    "Write record pointed by last_change_ts {} should be Put or Delete, but got {:?}",
-                                    commit_ts,
-                                    write.write_type,
-                                );
+                                if write.write_type != WriteType::Put
+                                    && write.write_type != WriteType::Delete
+                                {
+                                    return Err(box_err!(
+                                        "Write record pointed by last_change_ts {} should be Put or Delete, but got {:?}",
+                                        commit_ts,
+                                        write.write_type
+                                    ));
+                                }
                                 seek_res = Some((commit_ts, write));
                                 continue;
                             }
@@ -694,7 +696,9 @@ impl<S: EngineSnapshot> MvccReader<S> {
 
     /// Return the first committed key for which `start_ts` equals to `ts`
     pub fn seek_ts(&mut self, ts: TimeStamp) -> Result<Option<Key>> {
-        assert!(self.scan_mode.is_some());
+        if self.scan_mode.is_none() {
+            return Err(box_err!("seek_ts requires scan_mode to be set"));
+        }
         self.create_write_cursor()?;
 
         let cursor = self.write_cursor.as_mut().unwrap();


### PR DESCRIPTION
## What is changed and how it works

Replace unsafe code and production-path `assert!`/`unwrap` with safe alternatives:

1. **consistency_check.rs** — `update_context` used `unsafe { set_len + ptr::copy_nonoverlapping }` to append 8 bytes to a Vec. Replaced with safe `extend_from_slice`, which has identical behavior.

2. **reader.rs `get_write_with_commit_ts`** — When `last_change_ts` points to a write record whose type is neither Put nor Delete, the original `assert!` would crash the entire TiKV node. Replaced with `Err` return so callers can handle data corruption gracefully.

3. **reader.rs `seek_ts`** — `scan_mode` not set triggers `assert!` panic. Replaced with `Err` return.

4. **peekable.rs** — `get_msg`/`get_msg_cf` used `is_none()` + `.unwrap()` anti-pattern. Replaced with idiomatic `match`.

## Related issue(s)

Issue Number: ref #18498

## Check List

- [x] Bug fix (non-breaking change which fixes an issue)

### Tests

- [x] Unit test
  - `consistency_check::tests` — 3/3 passed (including `test_update_context` which directly covers the modified code)
  - `mvcc::reader` — 79/79 passed

### Side effects

- No behavioral change on normal code paths
- Error paths now return `Err` instead of panicking

```release-note
Replace unsafe memory operations and panicking assertions with safe error handling in MVCC consistency check and reader, improving robustness under data corruption scenarios.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling in storage reader to return errors instead of panics for invalid write records and missing scan configurations.

* **Refactor**
  * Enhanced code robustness by replacing pattern matching with safer alternatives and removing unsafe memory operations in storage consistency checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->