### PR TITLE
config: reject Titan + TTL co-enabled configuration after resolution

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6571,6 +6571,56 @@ mod tests {
     }
 
     #[test]
+    fn test_titan_ttl_incompatible_after_resolution() {
+        // Regression test: when titan.enabled is None in the current config but
+        // last_cfg has titan.enabled = Some(true), the resolved value should be
+        // Some(true). Combined with enable_ttl = true, this must be rejected.
+        // Previously, validate() ran before titan.enabled was resolved, so the
+        // TTL+Titan check was bypassed when titan.enabled was still None.
+
+        // Case 1: titan.enabled inherited from last_cfg as Some(true)
+        {
+            let (mut cfg, dir) = TikvConfig::with_tmp().unwrap();
+            // Simulate an existing Titan-enabled instance by persisting a config
+            // with titan.enabled = Some(true).
+            cfg.rocksdb.titan.enabled = Some(true);
+            persist_config(&cfg).unwrap();
+            let (storage, ..) = new_engines::<ApiV1>(cfg);
+            drop(storage);
+
+            // Now load a fresh config (titan.enabled = None) with TTL enabled.
+            let mut cfg = TikvConfig::from_file(&dir.path().join("config.toml"), None).unwrap();
+            assert_eq!(cfg.rocksdb.titan.enabled, None);
+            cfg.storage.enable_ttl = true;
+            let result = validate_and_persist_config(&mut cfg, false);
+            assert!(result.is_err(), "should reject TTL with resolved Titan");
+            assert!(
+                result.unwrap_err().contains("Titan is incompatible with TTL"),
+                "error message should mention Titan-TTL incompatibility"
+            );
+        }
+
+        // Case 2: titan.enabled explicitly Some(true) with TTL — caught by validate()
+        {
+            let (mut cfg, _dir) = TikvConfig::with_tmp().unwrap();
+            cfg.rocksdb.titan.enabled = Some(true);
+            cfg.storage.enable_ttl = true;
+            let result = validate_and_persist_config(&mut cfg, false);
+            assert!(result.is_err(), "should reject explicit Titan + TTL");
+        }
+
+        // Case 3: titan.enabled = None, no last_cfg, TTL enabled — titan resolves
+        // to false (due to TTL), so this should succeed.
+        {
+            let (mut cfg, _dir) = TikvConfig::with_tmp().unwrap();
+            assert_eq!(cfg.rocksdb.titan.enabled, None);
+            cfg.storage.enable_ttl = true;
+            validate_and_persist_config(&mut cfg, false).unwrap();
+            assert_eq!(cfg.rocksdb.titan.enabled, Some(false));
+        }
+    }
+
+    #[test]
     fn test_change_store_scheduler_worker_pool_size() {
         let (mut cfg, _dir) = TikvConfig::with_tmp().unwrap();
         cfg.storage.scheduler_worker_pool_size = 4;


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

The validation in `TikvConfig::validate()` checks for Titan + TTL incompatibility, but it runs before `optional_default_cfg_adjust_with()` resolves `titan.enabled` from `None` to `Some(true)`. This means the check is bypassed when `titan.enabled` is inherited from `last_cfg` or auto-enabled for existing clusters with Titan data.

Add a post-resolution check in `optional_default_cfg_adjust_with()` to reject the configuration when both Titan and TTL are enabled, regardless of how Titan was resolved.

Issue Number: close #19432

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Reject Titan + TTL co-enabled configuration after resolution
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [x] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fix a bug in configuration validation to prevent a rare case when TTL and Titan can be bot enabled. When both are enabled simultaneously, the system now returns a detailed error message with clear instructions on how to resolve the conflict through either disabling Titan or performing a data migration before enabling TTL.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added configuration validation to prevent conflicting TTL and Titan settings. When both are enabled simultaneously, the system now returns a detailed error message with clear instructions on how to resolve the conflict through either disabling Titan or performing a data migration before enabling TTL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->