### PR TITLE
resource_control: let background task types compatible with legacy 'lightning' type

### DIFF
--- a/components/resource_control/src/resource_group.rs
+++ b/components/resource_control/src/resource_group.rs
@@ -372,10 +372,10 @@ impl ResourceGroup {
             HashSet::from_iter(group.get_background_settings().get_job_types().to_owned());
         // The request source name of lightning and import into is changed from
         // "lightning" to "import" in https://github.com/pingcap/tidb/pull/66795.
-        // Here, we add "import" if "lihgtning" is configured to handle legacy
+        // Here, we add "import" if "lightning" is configured to handle legacy
         // configurations.
         if background_source_types.contains("lightning") {
-            background_source_types.insert("import".to_string());
+            background_source_types.insert("import".into());
         }
         let fallback_default =
             !group.has_background_settings() && group.name != DEFAULT_RESOURCE_GROUP_NAME;
@@ -1273,7 +1273,7 @@ pub(crate) mod tests {
             &default_limiter
         ));
 
-        // test legacy task_type "lightning" can be coverted to "import".
+        // test legacy task_type "lightning" can be converted to "import".
         let lightning_group = new_background_resource_group_ru(
             "lightning".into(),
             200,


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #17531

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Convert legacy 'lightning' type to 'import' in resource_control background task configuration.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
