### PR TITLE
storage, txn: move compare-and-delete into its own API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3771,7 +3771,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/healthwaite/kvproto?branch=compare-and-delete-new-api#2cabec2065fa99d2b605672612371e93e583c4ae"
+source = "git+https://github.com/healthwaite/kvproto?branch=compare-and-delete-new-api#c085800e56b7c23769d66b2d44849a696f8002fd"
 dependencies = [
  "bytes",
  "futures 0.3.15",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3771,7 +3771,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/healthwaite/kvproto?branch=compare-and-delete-new-api#bfd3991a8882632bf67ec3aa2410561783e62f36"
+source = "git+https://github.com/healthwaite/kvproto?branch=compare-and-delete-new-api#2cabec2065fa99d2b605672612371e93e583c4ae"
 dependencies = [
  "bytes",
  "futures 0.3.15",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3771,7 +3771,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/healthwaite/kvproto?branch=compare-and-delete-new-api#543cb7e0cce287dafb8f8d7d1870ff9549e0f331"
+source = "git+https://github.com/healthwaite/kvproto?branch=compare-and-delete-new-api#aa96cd9d1fc8adb12750b9fa6c88304a75304ed3"
 dependencies = [
  "bytes",
  "futures 0.3.15",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3771,7 +3771,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/healthwaite/kvproto?branch=compare-and-delete-new-api#aa96cd9d1fc8adb12750b9fa6c88304a75304ed3"
+source = "git+https://github.com/healthwaite/kvproto?branch=compare-and-delete-new-api#bfd3991a8882632bf67ec3aa2410561783e62f36"
 dependencies = [
  "bytes",
  "futures 0.3.15",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3771,7 +3771,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#e3b325474572ee1dcadd5c64a6a0b5719fc2eba2"
+source = "git+https://github.com/healthwaite/kvproto?branch=compare-and-delete-new-api#543cb7e0cce287dafb8f8d7d1870ff9549e0f331"
 dependencies = [
  "bytes",
  "futures 0.3.15",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -220,8 +220,9 @@ sysinfo = { git = "https://github.com/tikv/sysinfo", branch = "0.26-fix-cpu" }
 # When you modify TiKV cooperatively with kvproto, this will be useful to submit the PR to TiKV and the PR to
 # kvproto at the same time.
 # After the PR to kvproto is merged, remember to comment this out and run `cargo update -p kvproto`.
-# [patch.'https://github.com/pingcap/kvproto']
-# kvproto = { git = "https://github.com/your_github_id/kvproto", branch = "your_branch" }
+[patch.'https://github.com/pingcap/kvproto']
+kvproto = { git = "https://github.com/healthwaite/kvproto", branch = "compare-and-delete-new-api" }
+
 #
 # After the PR to rust-rocksdb is merged, remember to comment this out and run `cargo update -p rocksdb`.
 # [patch.'https://github.com/tikv/rust-rocksdb']

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,7 +222,6 @@ sysinfo = { git = "https://github.com/tikv/sysinfo", branch = "0.26-fix-cpu" }
 # After the PR to kvproto is merged, remember to comment this out and run `cargo update -p kvproto`.
 [patch.'https://github.com/pingcap/kvproto']
 kvproto = { git = "https://github.com/healthwaite/kvproto", branch = "compare-and-delete-new-api" }
-
 #
 # After the PR to rust-rocksdb is merged, remember to comment this out and run `cargo update -p rocksdb`.
 # [patch.'https://github.com/tikv/rust-rocksdb']

--- a/components/cdc/tests/integrations/test_cdc.rs
+++ b/components/cdc/tests/integrations/test_cdc.rs
@@ -247,6 +247,36 @@ fn test_cdc_rawkv_basic() {
         }
         other => panic!("unknown event {:?}", other),
     }
+
+    // Do a compare and swap
+    let (k, v) = (b"rkey1".to_vec(), b"value".to_vec());
+    suite.must_kv_compare_and_swap(1, k, v, b"new_value".to_vec());
+    let mut events = receive_event(false).events.to_vec();
+    assert_eq!(events.len(), 1, "{:?}", events);
+
+    match events.pop().unwrap().event.unwrap() {
+        Event_oneof_event::Entries(entries) => {
+            assert_eq!(entries.entries.len(), 1);
+            assert_eq!(entries.entries[0].get_type(), EventLogType::Committed);
+            assert_eq!(entries.entries[0].get_op_type(), EventRowOpType::Put);
+        }
+        other => panic!("unknown event {:?}", other),
+    }
+
+    // Do a compare and delete
+    let (k, v) = (b"rkey1".to_vec(), b"new_value".to_vec());
+    suite.must_kv_compare_and_delete(1, k, v);
+    let mut events = receive_event(false).events.to_vec();
+    assert_eq!(events.len(), 1, "{:?}", events);
+
+    match events.pop().unwrap().event.unwrap() {
+        Event_oneof_event::Entries(entries) => {
+            assert_eq!(entries.entries.len(), 1);
+            assert_eq!(entries.entries[0].get_type(), EventLogType::Committed);
+            assert_eq!(entries.entries[0].get_op_type(), EventRowOpType::Delete);
+        }
+        other => panic!("unknown event {:?}", other),
+    }
 }
 
 #[test]

--- a/components/cdc/tests/integrations/test_cdc.rs
+++ b/components/cdc/tests/integrations/test_cdc.rs
@@ -247,36 +247,6 @@ fn test_cdc_rawkv_basic() {
         }
         other => panic!("unknown event {:?}", other),
     }
-
-    // Do a compare and swap
-    let (k, v) = (b"rkey1".to_vec(), b"value".to_vec());
-    suite.must_kv_compare_and_swap(1, k, v, b"new_value".to_vec());
-    let mut events = receive_event(false).events.to_vec();
-    assert_eq!(events.len(), 1, "{:?}", events);
-
-    match events.pop().unwrap().event.unwrap() {
-        Event_oneof_event::Entries(entries) => {
-            assert_eq!(entries.entries.len(), 1);
-            assert_eq!(entries.entries[0].get_type(), EventLogType::Committed);
-            assert_eq!(entries.entries[0].get_op_type(), EventRowOpType::Put);
-        }
-        other => panic!("unknown event {:?}", other),
-    }
-
-    // Do a compare and delete
-    let (k, v) = (b"rkey1".to_vec(), b"new_value".to_vec());
-    suite.must_kv_compare_and_delete(1, k, v);
-    let mut events = receive_event(false).events.to_vec();
-    assert_eq!(events.len(), 1, "{:?}", events);
-
-    match events.pop().unwrap().event.unwrap() {
-        Event_oneof_event::Entries(entries) => {
-            assert_eq!(entries.entries.len(), 1);
-            assert_eq!(entries.entries[0].get_type(), EventLogType::Committed);
-            assert_eq!(entries.entries[0].get_op_type(), EventRowOpType::Delete);
-        }
-        other => panic!("unknown event {:?}", other),
-    }
 }
 
 #[test]

--- a/components/cdc/tests/mod.rs
+++ b/components/cdc/tests/mod.rs
@@ -367,6 +367,60 @@ impl TestSuite {
         assert!(rawkv_resp.error.is_empty(), "{:?}", rawkv_resp.get_error());
     }
 
+    pub fn must_kv_compare_and_swap(
+        &mut self,
+        region_id: u64,
+        key: Vec<u8>,
+        expect: Vec<u8>,
+        value: Vec<u8>,
+    ) {
+        let mut cas_req = RawCasRequest::default();
+        cas_req.set_context(self.get_context(region_id));
+        cas_req.set_key(key);
+        cas_req.set_value(value);
+        cas_req.set_previous_value(expect.clone());
+        cas_req.set_ttl(u64::MAX);
+
+        let cas_resp = self
+            .get_tikv_client(region_id)
+            .raw_compare_and_swap(&cas_req)
+            .unwrap();
+        assert!(
+            !cas_resp.has_region_error(),
+            "{:?}",
+            cas_resp.get_region_error()
+        );
+        assert!(cas_resp.error.is_empty(), "{:?}", cas_resp.get_error());
+        assert!(
+            cas_resp.get_previous_value() == expect,
+            "previous value mismatch"
+        );
+        assert!(cas_resp.get_succeed(), "compare and swap failed");
+    }
+
+    pub fn must_kv_compare_and_delete(&mut self, region_id: u64, key: Vec<u8>, expect: Vec<u8>) {
+        let mut cad_req = RawCadRequest::default();
+        cad_req.set_context(self.get_context(region_id));
+        cad_req.set_key(key);
+        cad_req.set_previous_value(expect.clone());
+
+        let cad_resp = self
+            .get_tikv_client(region_id)
+            .raw_compare_and_delete(&cad_req)
+            .unwrap();
+        assert!(
+            !cad_resp.has_region_error(),
+            "{:?}",
+            cad_resp.get_region_error()
+        );
+        assert!(cad_resp.error.is_empty(), "{:?}", cad_resp.get_error());
+        assert!(
+            cad_resp.get_previous_value() == expect,
+            "previous value mismatch"
+        );
+        assert!(cad_resp.get_succeed(), "compare and delete failed");
+    }
+
     pub fn must_kv_commit(
         &mut self,
         region_id: u64,

--- a/components/cdc/tests/mod.rs
+++ b/components/cdc/tests/mod.rs
@@ -367,61 +367,6 @@ impl TestSuite {
         assert!(rawkv_resp.error.is_empty(), "{:?}", rawkv_resp.get_error());
     }
 
-    pub fn must_kv_compare_and_swap(
-        &mut self,
-        region_id: u64,
-        key: Vec<u8>,
-        expect: Vec<u8>,
-        value: Vec<u8>,
-    ) {
-        let mut cas_req = RawCasRequest::default();
-        cas_req.set_context(self.get_context(region_id));
-        cas_req.set_key(key);
-        cas_req.set_value(value);
-        cas_req.set_previous_value(expect.clone());
-        cas_req.set_ttl(u64::MAX);
-
-        let cas_resp = self
-            .get_tikv_client(region_id)
-            .raw_compare_and_swap(&cas_req)
-            .unwrap();
-        assert!(
-            !cas_resp.has_region_error(),
-            "{:?}",
-            cas_resp.get_region_error()
-        );
-        assert!(cas_resp.error.is_empty(), "{:?}", cas_resp.get_error());
-        assert!(
-            cas_resp.get_previous_value() == expect,
-            "previous value mismatch"
-        );
-        assert!(cas_resp.get_succeed(), "compare and swap failed");
-    }
-
-    pub fn must_kv_compare_and_delete(&mut self, region_id: u64, key: Vec<u8>, expect: Vec<u8>) {
-        let mut cas_req = RawCasRequest::default();
-        cas_req.set_context(self.get_context(region_id));
-        cas_req.set_key(key);
-        cas_req.set_previous_value(expect.clone());
-        cas_req.set_delete(true);
-
-        let cas_resp = self
-            .get_tikv_client(region_id)
-            .raw_compare_and_swap(&cas_req)
-            .unwrap();
-        assert!(
-            !cas_resp.has_region_error(),
-            "{:?}",
-            cas_resp.get_region_error()
-        );
-        assert!(cas_resp.error.is_empty(), "{:?}", cas_resp.get_error());
-        assert!(
-            cas_resp.get_previous_value() == expect,
-            "previous value mismatch"
-        );
-        assert!(cas_resp.get_succeed(), "compare and delete failed");
-    }
-
     pub fn must_kv_commit(
         &mut self,
         region_id: u64,

--- a/components/test_storage/src/assert_storage.rs
+++ b/components/test_storage/src/assert_storage.rs
@@ -1030,21 +1030,7 @@ impl<E: Engine, F: KvFormat> AssertionStorage<E, F> {
     ) {
         let result = self
             .store
-            .raw_compare_and_swap_atomic(self.ctx.clone(), cf, key, previous_value, value, 0, false)
-            .unwrap();
-        assert_eq!(result, expect);
-    }
-
-    pub fn raw_compare_and_swap_atomic_delete_ok(
-        &self,
-        cf: String,
-        key: Vec<u8>,
-        previous_value: Option<Vec<u8>>,
-        expect: (Option<Vec<u8>>, bool),
-    ) {
-        let result = self
-            .store
-            .raw_compare_and_swap_atomic(self.ctx.clone(), cf, key, previous_value, vec![], 0, true)
+            .raw_compare_and_swap_atomic(self.ctx.clone(), cf, key, previous_value, value, 0)
             .unwrap();
         assert_eq!(result, expect);
     }
@@ -1057,7 +1043,7 @@ impl<E: Engine, F: KvFormat> AssertionStorage<E, F> {
         value: Vec<u8>,
     ) {
         self.store
-            .raw_compare_and_swap_atomic(self.ctx.clone(), cf, key, previous_value, value, 0, false)
+            .raw_compare_and_swap_atomic(self.ctx.clone(), cf, key, previous_value, value, 0)
             .unwrap_err();
     }
 

--- a/components/test_storage/src/assert_storage.rs
+++ b/components/test_storage/src/assert_storage.rs
@@ -1047,6 +1047,31 @@ impl<E: Engine, F: KvFormat> AssertionStorage<E, F> {
             .unwrap_err();
     }
 
+    pub fn raw_compare_and_delete_atomic_ok(
+        &self,
+        cf: String,
+        key: Vec<u8>,
+        previous_value: Vec<u8>,
+        expect: (Option<Vec<u8>>, bool),
+    ) {
+        let result = self
+            .store
+            .raw_compare_and_delete_atomic(self.ctx.clone(), cf, key, previous_value)
+            .unwrap();
+        assert_eq!(result, expect);
+    }
+
+    pub fn raw_compare_and_delete_atomic_err(
+        &self,
+        cf: String,
+        key: Vec<u8>,
+        previous_value: Vec<u8>,
+    ) {
+        self.store
+            .raw_compare_and_delete_atomic(self.ctx.clone(), cf, key, previous_value)
+            .unwrap_err();
+    }
+
     pub fn raw_batch_put_atomic_ok(&self, cf: String, pairs: Vec<KvPair>) {
         let ttls = vec![0; pairs.len()];
         self.store

--- a/components/test_storage/src/sync_storage.rs
+++ b/components/test_storage/src/sync_storage.rs
@@ -503,6 +503,19 @@ impl<E: Engine, F: KvFormat> SyncTestStorage<E, F> {
         .unwrap()
     }
 
+    pub fn raw_compare_and_delete_atomic(
+        &self,
+        ctx: Context,
+        cf: String,
+        key: Vec<u8>,
+        previous_value: Vec<u8>,
+    ) -> Result<(Option<Vec<u8>>, bool)> {
+        wait_op!(|cb| self
+            .store
+            .raw_compare_and_delete_atomic(ctx, cf, key, previous_value, cb))
+        .unwrap()
+    }
+
     pub fn raw_batch_put_atomic(
         &self,
         ctx: Context,

--- a/components/test_storage/src/sync_storage.rs
+++ b/components/test_storage/src/sync_storage.rs
@@ -490,7 +490,6 @@ impl<E: Engine, F: KvFormat> SyncTestStorage<E, F> {
         previous_value: Option<Vec<u8>>,
         value: Vec<u8>,
         ttl: u64,
-        delete: bool,
     ) -> Result<(Option<Vec<u8>>, bool)> {
         wait_op!(|cb| self.store.raw_compare_and_swap_atomic(
             ctx,
@@ -499,8 +498,7 @@ impl<E: Engine, F: KvFormat> SyncTestStorage<E, F> {
             previous_value,
             value,
             ttl,
-            cb,
-            delete
+            cb
         ))
         .unwrap()
     }

--- a/src/server/metrics.rs
+++ b/src/server/metrics.rs
@@ -50,6 +50,7 @@ make_auto_flush_static_metric! {
         raw_batch_delete,
         raw_get_key_ttl,
         raw_compare_and_swap,
+        raw_compare_and_delete,
         raw_checksum,
         unsafe_destroy_range,
         register_lock_observer,

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -1540,6 +1540,7 @@ fn handle_batch_commands_request<E: Engine, L: LockManager, F: KvFormat>(
         RawDeleteRange, future_raw_delete_range(storage), raw_delete_range;
         RawBatchScan, future_raw_batch_scan(storage), raw_batch_scan;
         RawCoprocessor, future_raw_coprocessor(copr_v2, storage), coprocessor;
+        RawCompareAndSwap, future_raw_compare_and_swap(storage), raw_compare_and_swap;
         RawCompareAndDelete, future_raw_compare_and_delete(storage), raw_compare_and_delete;
         PessimisticLock, future_acquire_pessimistic_lock(storage), kv_pessimistic_lock;
         PessimisticRollback, future_pessimistic_rollback(storage), kv_pessimistic_rollback;

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -2291,7 +2291,6 @@ fn future_raw_compare_and_swap<E: Engine, L: LockManager, F: KvFormat>(
     } else {
         Some(req.take_previous_value())
     };
-
     let res = storage.raw_compare_and_swap_atomic(
         req.take_context(),
         req.take_cf(),
@@ -2300,7 +2299,6 @@ fn future_raw_compare_and_swap<E: Engine, L: LockManager, F: KvFormat>(
         req.take_value(),
         req.get_ttl(),
         cb,
-        req.get_delete(),
     );
     async move {
         let v = match res {

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -2294,6 +2294,15 @@ fn future_raw_compare_and_swap<E: Engine, L: LockManager, F: KvFormat>(
     storage: &Storage<E, L, F>,
     mut req: RawCasRequest,
 ) -> impl Future<Output = ServerResult<RawCasResponse>> {
+    #[allow(deprecated)]
+    if req.get_delete() {
+        let mut resp = RawCasResponse::default();
+        resp.set_error(
+            "RawCASRequest.delete is deprecated - use RawCompareAndDelete instead".to_owned(),
+        );
+        return async move { Ok(resp) }.left_future();
+    }
+
     let (cb, f) = paired_future_callback();
     let previous_value = if req.get_previous_not_exist() {
         None
@@ -2332,6 +2341,7 @@ fn future_raw_compare_and_swap<E: Engine, L: LockManager, F: KvFormat>(
         }
         Ok(resp)
     }
+    .right_future()
 }
 
 fn future_raw_compare_and_delete<E: Engine, L: LockManager, F: KvFormat>(
@@ -2968,6 +2978,49 @@ mod tests {
         };
         poll_future_notify(task);
         assert_eq!(block_on(rx1).unwrap(), 200);
+    }
+
+    #[test]
+    fn test_raw_cas_rejects_deprecated_delete_flag() {
+        // A RawCASRequest with `delete=true` must be rejected with an explicit error
+        // rather than silently executing as a plain CAS write.
+        let storage = crate::storage::TestStorageBuilderApiV1::new(
+            crate::storage::lock_manager::MockLockManager::new(),
+        )
+        .build()
+        .unwrap();
+        let mut req = RawCasRequest::default();
+        req.set_context(Context::default());
+        req.set_key(b"k".to_vec());
+        req.set_value(b"v".to_vec());
+        #[allow(deprecated)]
+        req.set_delete(true);
+        let resp = block_on(future_raw_compare_and_swap(&storage, req)).unwrap();
+        let err = resp.get_error();
+        assert!(!err.is_empty());
+        assert!(err.contains("RawCompareAndDelete"));
+        assert!(!resp.get_succeed());
+    }
+
+    #[test]
+    fn test_raw_cas_delete_false_bypasses_guard() {
+        // A RawCASRequest with `delete=false` (the default) must not be rejected by
+        // the deprecated-flag guard.
+        let storage = crate::storage::TestStorageBuilderApiV1::new(
+            crate::storage::lock_manager::MockLockManager::new(),
+        )
+        .build()
+        .unwrap();
+        let mut req = RawCasRequest::default();
+        req.set_context(Context::default());
+        req.set_key(b"k".to_vec());
+        req.set_value(b"v".to_vec());
+        #[allow(deprecated)]
+        req.set_delete(false);
+        req.set_previous_not_exist(true);
+        let resp = block_on(future_raw_compare_and_swap(&storage, req)).unwrap();
+        assert!(resp.get_error().is_empty());
+        assert!(resp.get_succeed());
     }
 
     #[test]

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -487,6 +487,13 @@ impl<E: Engine, L: LockManager, F: KvFormat> Tikv for Service<E, L, F> {
     );
 
     handle_request!(
+        raw_compare_and_delete,
+        future_raw_compare_and_delete,
+        RawCadRequest,
+        RawCadResponse
+    );
+
+    handle_request!(
         raw_checksum,
         future_raw_checksum,
         RawChecksumRequest,
@@ -1533,6 +1540,7 @@ fn handle_batch_commands_request<E: Engine, L: LockManager, F: KvFormat>(
         RawDeleteRange, future_raw_delete_range(storage), raw_delete_range;
         RawBatchScan, future_raw_batch_scan(storage), raw_batch_scan;
         RawCoprocessor, future_raw_coprocessor(copr_v2, storage), coprocessor;
+        RawCompareAndDelete, future_raw_compare_and_delete(storage), raw_compare_and_delete;
         PessimisticLock, future_acquire_pessimistic_lock(storage), kv_pessimistic_lock;
         PessimisticRollback, future_pessimistic_rollback(storage), kv_pessimistic_rollback;
         BroadcastTxnStatus, future_broadcast_txn_status(storage), broadcast_txn_status;
@@ -2306,6 +2314,43 @@ fn future_raw_compare_and_swap<E: Engine, L: LockManager, F: KvFormat>(
             Err(e) => Err(e),
         };
         let mut resp = RawCasResponse::default();
+        if let Some(err) = extract_region_error(&v) {
+            resp.set_region_error(err);
+        } else {
+            match v {
+                Ok((val, succeed)) => {
+                    if let Some(val) = val {
+                        resp.set_previous_value(val);
+                    } else {
+                        resp.set_previous_not_exist(true);
+                    }
+                    resp.set_succeed(succeed);
+                }
+                Err(e) => resp.set_error(format!("{}", e)),
+            }
+        }
+        Ok(resp)
+    }
+}
+
+fn future_raw_compare_and_delete<E: Engine, L: LockManager, F: KvFormat>(
+    storage: &Storage<E, L, F>,
+    mut req: RawCadRequest,
+) -> impl Future<Output = ServerResult<RawCadResponse>> {
+    let (cb, f) = paired_future_callback();
+    let res = storage.raw_compare_and_delete_atomic(
+        req.take_context(),
+        req.take_cf(),
+        req.take_key(),
+        req.take_previous_value(),
+        cb,
+    );
+    async move {
+        let v = match res {
+            Ok(()) => f.await?,
+            Err(e) => Err(e),
+        };
+        let mut resp = RawCadResponse::default();
         if let Some(err) = extract_region_error(&v) {
             resp.set_region_error(err);
         } else {

--- a/src/storage/metrics.rs
+++ b/src/storage/metrics.rs
@@ -166,6 +166,7 @@ make_auto_flush_static_metric! {
         raw_batch_delete,
         raw_get_key_ttl,
         raw_compare_and_swap,
+        raw_compare_and_delete,
         raw_atomic_store,
         raw_checksum,
     }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -3191,7 +3191,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         self.sched_raw_command(metadata, priority, CMD, async move {
             let key = F::encode_raw_key_owned(key, None);
             let cmd = RawCompareAndSwap::new(cf, key, previous_value, value, ttl, api_version, ctx);
-            Self::sched_raw_atomic_command(sched, cmd, Box::new(callback));
+            Self::sched_raw_atomic_command(sched, cmd, callback);
         })
     }
 
@@ -3214,7 +3214,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         self.sched_raw_command(metadata, priority, CMD, async move {
             let key = F::encode_raw_key_owned(key, None);
             let cmd = RawCompareAndDelete::new(cf, key, previous_value, api_version, ctx);
-            Self::sched_raw_atomic_command(sched, cmd, Box::new(callback));
+            Self::sched_raw_atomic_command(sched, cmd, callback);
         })
     }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -138,7 +138,7 @@ use crate::{
         test_util::latest_feature_gate,
         txn::{
             Command, Error as TxnError, ErrorInner as TxnErrorInner,
-            commands::{RawAtomicStore, RawCompareAndSwap, TypedCommand},
+            commands::{RawAtomicStore, RawCompareAndDelete, RawCompareAndSwap, TypedCommand},
             flow_controller::{EngineFlowController, FlowController},
             scheduler::TxnScheduler,
             txn_status_cache::{TxnState, TxnStatusCache},
@@ -449,6 +449,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                 | CommandKind::raw_batch_delete
                 | CommandKind::raw_get_key_ttl
                 | CommandKind::raw_compare_and_swap
+                | CommandKind::raw_compare_and_delete
                 | CommandKind::raw_atomic_store
                 | CommandKind::raw_checksum
         )
@@ -3190,6 +3191,29 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         self.sched_raw_command(metadata, priority, CMD, async move {
             let key = F::encode_raw_key_owned(key, None);
             let cmd = RawCompareAndSwap::new(cf, key, previous_value, value, ttl, api_version, ctx);
+            Self::sched_raw_atomic_command(sched, cmd, Box::new(callback));
+        })
+    }
+
+    pub fn raw_compare_and_delete_atomic(
+        &self,
+        ctx: Context,
+        cf: String,
+        key: Vec<u8>,
+        previous_value: Vec<u8>,
+        callback: Callback<(Option<Value>, bool)>,
+    ) -> Result<()> {
+        const CMD: CommandKind = CommandKind::raw_compare_and_delete;
+        let api_version = self.api_version;
+        Self::check_api_version(api_version, ctx.api_version, CMD, [&key])?;
+        let cf = Self::rawkv_cf(&cf, api_version)?;
+
+        let sched = self.get_scheduler();
+        let priority = ctx.get_priority();
+        let metadata = TaskMetadata::from_ctx(ctx.get_resource_control_context());
+        self.sched_raw_command(metadata, priority, CMD, async move {
+            let key = F::encode_raw_key_owned(key, None);
+            let cmd = RawCompareAndDelete::new(cf, key, previous_value, api_version, ctx);
             Self::sched_raw_atomic_command(sched, cmd, Box::new(callback));
         })
     }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -8072,8 +8072,8 @@ mod tests {
 
         let key = b"r\0delete_key";
 
-        // Test 1: delete existing key with matching previous_value — should succeed.
-        // Setup: put "v1".
+        // Test 1: delete existing key with matching previous_value — should succeed
+        // Setup: put "v1"
         let expected = (None, true);
         storage
             .raw_compare_and_swap_atomic(
@@ -8088,7 +8088,7 @@ mod tests {
             .unwrap();
         rx.recv().unwrap();
 
-        // Delete "v1" — previous_value matches, should succeed.
+        // Delete "v1" — previous_value matches, should succeed
         let expected = (Some(b"v1".to_vec()), true);
         storage
             .raw_compare_and_delete_atomic(
@@ -8108,24 +8108,11 @@ mod tests {
                 .is_none()
         );
 
-        // Verify key is deleted.
+        // Verify key is deleted
         expect_none(block_on(storage.raw_get(ctx.clone(), "".to_string(), key.to_vec())).unwrap());
-        expect_multi_values(
-            vec![],
-            block_on(storage.raw_scan(
-                ctx.clone(),
-                "".to_string(),
-                b"r".to_vec(),
-                Some(b"rz".to_vec()),
-                20,
-                false,
-                false,
-            ))
-            .unwrap(),
-        );
 
-        // Test 2: delete existing key with incorrect previous_value — should fail.
-        // Setup: put "v2".
+        // Test 2: delete existing key with incorrect previous_value — should fail
+        // Setup: put "v2"
         let expected = (None, true);
         storage
             .raw_compare_and_swap_atomic(
@@ -8140,7 +8127,7 @@ mod tests {
             .unwrap();
         rx.recv().unwrap();
 
-        // Attempt delete with incorrect previous_value "v1" — should fail.
+        // Attempt delete with incorrect previous_value "v1" — should fail
         let expected = (Some(b"v2".to_vec()), false);
         storage
             .raw_compare_and_delete_atomic(
@@ -8160,14 +8147,14 @@ mod tests {
                 .is_none()
         );
 
-        // Verify key still has "v2".
+        // Verify key is still "v2"
         expect_value(
             b"v2".to_vec(),
             block_on(storage.raw_get(ctx.clone(), "".to_string(), key.to_vec())).unwrap(),
         );
 
-        // Test 3: delete key whose value is an empty byte string — should succeed.
-        // Setup: overwrite with empty value via CAS.
+        // Test 3: delete key whose value is an empty byte string — should succeed
+        // Setup: overwrite with empty value via CAS
         let expected = (Some(b"v2".to_vec()), true);
         storage
             .raw_compare_and_swap_atomic(
@@ -8182,7 +8169,7 @@ mod tests {
             .unwrap();
         rx.recv().unwrap();
 
-        // Delete with matching empty previous_value — should succeed.
+        // Delete with matching empty previous_value — should succeed
         let expected = (Some(b"".to_vec()), true);
         storage
             .raw_compare_and_delete_atomic(
@@ -8202,7 +8189,7 @@ mod tests {
                 .is_none()
         );
 
-        // Verify key is gone.
+        // Verify key is gone
         expect_none(block_on(storage.raw_get(ctx.clone(), "".to_string(), key.to_vec())).unwrap());
     }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -3180,6 +3180,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         const CMD: CommandKind = CommandKind::raw_compare_and_swap;
         let api_version = self.api_version;
         Self::check_api_version(api_version, ctx.api_version, CMD, [&key])?;
+        check_key_size!(Some(&key).into_iter(), self.max_key_size, callback);
         let cf = Self::rawkv_cf(&cf, api_version)?;
 
         if !F::IS_TTL_ENABLED && ttl != 0 {
@@ -3206,6 +3207,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         const CMD: CommandKind = CommandKind::raw_compare_and_delete;
         let api_version = self.api_version;
         Self::check_api_version(api_version, ctx.api_version, CMD, [&key])?;
+        check_key_size!(Some(&key).into_iter(), self.max_key_size, callback);
         let cf = Self::rawkv_cf(&cf, api_version)?;
 
         let sched = self.get_scheduler();

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -8056,6 +8056,161 @@ mod tests {
     }
 
     #[test]
+    fn test_raw_compare_and_delete() {
+        test_kv_format_impl!(test_raw_compare_and_delete_impl);
+    }
+
+    fn test_raw_compare_and_delete_impl<F: KvFormat>() {
+        let storage = TestStorageBuilder::<_, _, F>::new(MockLockManager::new())
+            .build()
+            .unwrap();
+        let (tx, rx) = channel();
+        let ctx = Context {
+            api_version: F::CLIENT_TAG,
+            ..Default::default()
+        };
+
+        let key = b"r\0delete_key";
+
+        // Test 1: delete existing key with matching previous_value — should succeed.
+        // Setup: put "v1".
+        let expected = (None, true);
+        storage
+            .raw_compare_and_swap_atomic(
+                ctx.clone(),
+                "".to_string(),
+                key.to_vec(),
+                None,
+                b"v1".to_vec(),
+                0,
+                expect_value_callback(tx.clone(), 0, expected),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+
+        // Delete "v1" — previous_value matches, should succeed.
+        let expected = (Some(b"v1".to_vec()), true);
+        storage
+            .raw_compare_and_delete_atomic(
+                ctx.clone(),
+                "".to_string(),
+                key.to_vec(),
+                b"v1".to_vec(),
+                expect_value_callback(tx.clone(), 0, expected),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+        thread::sleep(Duration::from_millis(100));
+        assert!(
+            storage
+                .get_concurrency_manager()
+                .global_min_lock_ts()
+                .is_none()
+        );
+
+        // Verify key is deleted.
+        expect_none(
+            block_on(storage.raw_get(ctx.clone(), "".to_string(), key.to_vec())).unwrap(),
+        );
+        expect_multi_values(
+            vec![],
+            block_on(storage.raw_scan(
+                ctx.clone(),
+                "".to_string(),
+                b"r".to_vec(),
+                Some(b"rz".to_vec()),
+                20,
+                false,
+                false,
+            ))
+            .unwrap(),
+        );
+
+        // Test 2: delete existing key with wrong previous_value — should fail.
+        // Setup: put "v2".
+        let expected = (None, true);
+        storage
+            .raw_compare_and_swap_atomic(
+                ctx.clone(),
+                "".to_string(),
+                key.to_vec(),
+                None,
+                b"v2".to_vec(),
+                0,
+                expect_value_callback(tx.clone(), 0, expected),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+
+        // Attempt delete with wrong previous_value "v1" — should fail.
+        let expected = (Some(b"v2".to_vec()), false);
+        storage
+            .raw_compare_and_delete_atomic(
+                ctx.clone(),
+                "".to_string(),
+                key.to_vec(),
+                b"v1".to_vec(),
+                expect_value_callback(tx.clone(), 0, expected),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+        thread::sleep(Duration::from_millis(100));
+        assert!(
+            storage
+                .get_concurrency_manager()
+                .global_min_lock_ts()
+                .is_none()
+        );
+
+        // Verify key still has "v2".
+        expect_value(
+            b"v2".to_vec(),
+            block_on(storage.raw_get(ctx.clone(), "".to_string(), key.to_vec())).unwrap(),
+        );
+
+        // Test 3: delete key whose value is an empty byte string — should succeed.
+        // Setup: overwrite with empty value via CAS.
+        let expected = (Some(b"v2".to_vec()), true);
+        storage
+            .raw_compare_and_swap_atomic(
+                ctx.clone(),
+                "".to_string(),
+                key.to_vec(),
+                Some(b"v2".to_vec()),
+                b"".to_vec(),
+                0,
+                expect_value_callback(tx.clone(), 0, expected),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+
+        // Delete with matching empty previous_value — should succeed.
+        let expected = (Some(b"".to_vec()), true);
+        storage
+            .raw_compare_and_delete_atomic(
+                ctx.clone(),
+                "".to_string(),
+                key.to_vec(),
+                b"".to_vec(),
+                expect_value_callback(tx, 0, expected),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+        thread::sleep(Duration::from_millis(100));
+        assert!(
+            storage
+                .get_concurrency_manager()
+                .global_min_lock_ts()
+                .is_none()
+        );
+
+        // Verify key is gone.
+        expect_none(
+            block_on(storage.raw_get(ctx.clone(), "".to_string(), key.to_vec())).unwrap(),
+        );
+    }
+
+    #[test]
     fn test_scan_lock_with_memory_lock() {
         for in_memory_pessimistic_lock_enabled in [false, true] {
             let txn_ext = Arc::new(TxnExt::default());

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -8109,9 +8109,7 @@ mod tests {
         );
 
         // Verify key is deleted.
-        expect_none(
-            block_on(storage.raw_get(ctx.clone(), "".to_string(), key.to_vec())).unwrap(),
-        );
+        expect_none(block_on(storage.raw_get(ctx.clone(), "".to_string(), key.to_vec())).unwrap());
         expect_multi_values(
             vec![],
             block_on(storage.raw_scan(
@@ -8126,7 +8124,7 @@ mod tests {
             .unwrap(),
         );
 
-        // Test 2: delete existing key with wrong previous_value — should fail.
+        // Test 2: delete existing key with incorrect previous_value — should fail.
         // Setup: put "v2".
         let expected = (None, true);
         storage
@@ -8142,7 +8140,7 @@ mod tests {
             .unwrap();
         rx.recv().unwrap();
 
-        // Attempt delete with wrong previous_value "v1" — should fail.
+        // Attempt delete with incorrect previous_value "v1" — should fail.
         let expected = (Some(b"v2".to_vec()), false);
         storage
             .raw_compare_and_delete_atomic(
@@ -8205,9 +8203,7 @@ mod tests {
         );
 
         // Verify key is gone.
-        expect_none(
-            block_on(storage.raw_get(ctx.clone(), "".to_string(), key.to_vec())).unwrap(),
-        );
+        expect_none(block_on(storage.raw_get(ctx.clone(), "".to_string(), key.to_vec())).unwrap());
     }
 
     #[test]

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -3175,7 +3175,6 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         value: Vec<u8>,
         ttl: u64,
         callback: Callback<(Option<Value>, bool)>,
-        delete: bool,
     ) -> Result<()> {
         const CMD: CommandKind = CommandKind::raw_compare_and_swap;
         let api_version = self.api_version;
@@ -3190,17 +3189,8 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         let metadata = TaskMetadata::from_ctx(ctx.get_resource_control_context());
         self.sched_raw_command(metadata, priority, CMD, async move {
             let key = F::encode_raw_key_owned(key, None);
-            let cmd = RawCompareAndSwap::new(
-                cf,
-                key,
-                previous_value,
-                value,
-                ttl,
-                api_version,
-                delete,
-                ctx,
-            );
-            Self::sched_raw_atomic_command(sched, cmd, callback);
+            let cmd = RawCompareAndSwap::new(cf, key, previous_value, value, ttl, api_version, ctx);
+            Self::sched_raw_atomic_command(sched, cmd, Box::new(callback));
         })
     }
 
@@ -7879,7 +7869,6 @@ mod tests {
                 b"v".to_vec(),
                 0,
                 expect_value_callback(tx.clone(), 0, expected),
-                false,
             )
             .unwrap();
         rx.recv().unwrap();
@@ -7895,7 +7884,6 @@ mod tests {
                 b"v1".to_vec(),
                 0,
                 expect_value_callback(tx.clone(), 0, expected),
-                false,
             )
             .unwrap();
         rx.recv().unwrap();
@@ -7911,7 +7899,6 @@ mod tests {
                 b"v2".to_vec(),
                 0,
                 expect_value_callback(tx.clone(), 0, expected),
-                false,
             )
             .unwrap();
         rx.recv().unwrap();
@@ -7927,7 +7914,6 @@ mod tests {
                 b"v2".to_vec(),
                 0,
                 expect_value_callback(tx.clone(), 0, expected),
-                false,
             )
             .unwrap();
         rx.recv().unwrap();
@@ -7988,7 +7974,6 @@ mod tests {
                 b"v4".to_vec(),
                 0,
                 expect_value_callback(tx.clone(), 0, expected),
-                false,
             )
             .unwrap();
         rx.recv().unwrap();
@@ -8015,7 +8000,6 @@ mod tests {
                 b"v".to_vec(),
                 0,
                 expect_value_callback(tx, 0, expected),
-                false,
             )
             .unwrap();
         rx.recv().unwrap();
@@ -8044,197 +8028,6 @@ mod tests {
                 false,
             ))
             .unwrap(),
-        );
-    }
-
-    #[test]
-    fn test_raw_compare_and_swap_delete() {
-        test_kv_format_impl!(test_raw_compare_and_swap_delete_impl);
-    }
-
-    fn test_raw_compare_and_swap_delete_impl<F: KvFormat>() {
-        let storage = TestStorageBuilder::<_, _, F>::new(MockLockManager::new())
-            .build()
-            .unwrap();
-        let (tx, rx) = channel();
-        let ctx = Context {
-            api_version: F::CLIENT_TAG,
-            ..Default::default()
-        };
-
-        let key = b"r\0delete_key";
-
-        // Test 1: CAS delete with existing_val=v1, expected_val=v1 (should succeed)
-        // Setup: put v1
-        let expected = (None, true);
-        storage
-            .raw_compare_and_swap_atomic(
-                ctx.clone(),
-                "".to_string(),
-                key.to_vec(),
-                None,
-                b"v1".to_vec(),
-                0,
-                expect_value_callback(tx.clone(), 0, expected),
-                false,
-            )
-            .unwrap();
-        rx.recv().unwrap();
-
-        // Test: delete v1
-        let expected = (Some(b"v1".to_vec()), true);
-        storage
-            .raw_compare_and_swap_atomic(
-                ctx.clone(),
-                "".to_string(),
-                key.to_vec(),
-                Some(b"v1".to_vec()),
-                b"dummy".to_vec(), // value ignored for deletes
-                0,
-                expect_value_callback(tx.clone(), 0, expected),
-                true,
-            )
-            .unwrap();
-        rx.recv().unwrap();
-        thread::sleep(Duration::from_millis(100));
-        assert!(
-            storage
-                .get_concurrency_manager()
-                .global_min_lock_ts()
-                .is_none()
-        );
-
-        // Verify key is deleted
-        expect_none(block_on(storage.raw_get(ctx.clone(), "".to_string(), key.to_vec())).unwrap());
-
-        // Test 2: CAS delete with existing_val=v2, expected_val=v1 (should fail)
-        // Setup: put v2
-        let expected = (None, true);
-        storage
-            .raw_compare_and_swap_atomic(
-                ctx.clone(),
-                "".to_string(),
-                key.to_vec(),
-                None,
-                b"v2".to_vec(),
-                0,
-                expect_value_callback(tx.clone(), 0, expected),
-                false,
-            )
-            .unwrap();
-        rx.recv().unwrap();
-
-        // Test: try to delete with wrong expected value
-        let expected = (Some(b"v2".to_vec()), false);
-        storage
-            .raw_compare_and_swap_atomic(
-                ctx.clone(),
-                "".to_string(),
-                key.to_vec(),
-                Some(b"v1".to_vec()),
-                b"dummy".to_vec(),
-                0,
-                expect_value_callback(tx.clone(), 0, expected),
-                true,
-            )
-            .unwrap();
-        rx.recv().unwrap();
-        thread::sleep(Duration::from_millis(100));
-        assert!(
-            storage
-                .get_concurrency_manager()
-                .global_min_lock_ts()
-                .is_none()
-        );
-
-        // Verify key still has v2
-        expect_value(
-            b"v2".to_vec(),
-            block_on(storage.raw_get(ctx.clone(), "".to_string(), key.to_vec())).unwrap(),
-        );
-
-        // Clean up: delete v2
-        storage
-            .raw_batch_delete_atomic(
-                ctx.clone(),
-                "".to_string(),
-                vec![key.to_vec()],
-                expect_ok_callback(tx.clone(), 0),
-            )
-            .unwrap();
-        rx.recv().unwrap();
-
-        // Test 3: CAS delete with existing_val=nil, expected_val=nil (should succeed as
-        // noop)
-        let expected = (None, true);
-        storage
-            .raw_compare_and_swap_atomic(
-                ctx.clone(),
-                "".to_string(),
-                key.to_vec(),
-                None,
-                b"dummy".to_vec(),
-                0,
-                expect_value_callback(tx.clone(), 0, expected),
-                true,
-            )
-            .unwrap();
-        rx.recv().unwrap();
-        thread::sleep(Duration::from_millis(100));
-        assert!(
-            storage
-                .get_concurrency_manager()
-                .global_min_lock_ts()
-                .is_none()
-        );
-
-        // Verify key is still nil
-        expect_none(block_on(storage.raw_get(ctx.clone(), "".to_string(), key.to_vec())).unwrap());
-
-        // Test 4: CAS delete with existing_val=v1, expected_val=nil (should fail)
-        // Setup: put v1
-        let expected = (None, true);
-        storage
-            .raw_compare_and_swap_atomic(
-                ctx.clone(),
-                "".to_string(),
-                key.to_vec(),
-                None,
-                b"v1".to_vec(),
-                0,
-                expect_value_callback(tx.clone(), 0, expected),
-                false,
-            )
-            .unwrap();
-        rx.recv().unwrap();
-
-        // Test: try to delete expecting nil
-        let expected = (Some(b"v1".to_vec()), false);
-        storage
-            .raw_compare_and_swap_atomic(
-                ctx.clone(),
-                "".to_string(),
-                key.to_vec(),
-                None,
-                b"dummy".to_vec(),
-                0,
-                expect_value_callback(tx, 0, expected),
-                true,
-            )
-            .unwrap();
-        rx.recv().unwrap();
-        thread::sleep(Duration::from_millis(100));
-        assert!(
-            storage
-                .get_concurrency_manager()
-                .global_min_lock_ts()
-                .is_none()
-        );
-
-        // Verify key still has v1
-        expect_value(
-            b"v1".to_vec(),
-            block_on(storage.raw_get(ctx, "".to_string(), key.to_vec())).unwrap(),
         );
     }
 

--- a/src/storage/txn/commands/compare_and_delete.rs
+++ b/src/storage/txn/commands/compare_and_delete.rs
@@ -46,10 +46,11 @@ impl CommandExt for RawCompareAndDelete {
     tag!(raw_compare_and_delete);
     gen_lock!(key);
 
-    // Note: the size returned is an underestimate of the actual bytes written for API V2,
-    // since the key is appended with a timestamp. This underestimation is consistent with
-    // the other write_bytes() implementations (e.g atomic_store.rs and compare_and_swap.rs).
-    // If this needs fixing it should be fixed everywhere for consistency.
+    // Note: the size returned is an underestimate of the actual bytes written for
+    // API V2, since the key is appended with a timestamp. This underestimation
+    // is consistent with the other write_bytes() implementations (e.g
+    // atomic_store.rs and compare_and_swap.rs). If this needs fixing it should
+    // be fixed everywhere for consistency.
     fn write_bytes(&self) -> usize {
         if self.api_version == ApiVersion::V2 {
             self.key.as_encoded().len() + ApiV2::ENCODED_LOGICAL_DELETE.len()

--- a/src/storage/txn/commands/compare_and_delete.rs
+++ b/src/storage/txn/commands/compare_and_delete.rs
@@ -46,10 +46,12 @@ impl CommandExt for RawCompareAndDelete {
     tag!(raw_compare_and_delete);
     gen_lock!(key);
 
+    // Note: the size returned is an underestimate of the actual bytes written for API V2,
+    // since the key is appended with a timestamp. This underestimation is consistent with
+    // the other write_bytes() implementations (e.g atomic_store.rs and compare_and_swap.rs).
+    // If this needs fixing it should be fixed everywhere for consistency.
     fn write_bytes(&self) -> usize {
         if self.api_version == ApiVersion::V2 {
-            // In API V2, the key is appended with a timestamp when performing delete, so we
-            // need to account for that.
             self.key.as_encoded().len() + ApiV2::ENCODED_LOGICAL_DELETE.len()
         } else {
             self.key.as_encoded().len()

--- a/src/storage/txn/commands/compare_and_delete.rs
+++ b/src/storage/txn/commands/compare_and_delete.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
 
 // #[PerformanceCriticalPath]
-use api_version::ApiV2;
+use api_version::{ApiV2, KvFormat};
 use engine_traits::CfName;
 use kvproto::kvrpcpb::ApiVersion;
 use raw::RawStore;
@@ -319,7 +319,7 @@ mod tests {
     /// lock-guard output for `RawCompareAndDelete`.
     ///
     /// Specifically:
-    /// - For V1/V1Ttl: a `Modify::Delete` at the plain (untimstamped) key.
+    /// - For V1/V1Ttl: a `Modify::Delete` at the plain (un-timestamped) key.
     /// - For V2: a `Modify::Put` at `key@ts` containing
     ///   `ENCODED_LOGICAL_DELETE`, plus exactly one lock guard at
     ///   `RAW_KEY_PREFIX@key_guard_ts`.

--- a/src/storage/txn/commands/compare_and_delete.rs
+++ b/src/storage/txn/commands/compare_and_delete.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
 
 // #[PerformanceCriticalPath]
-use api_version::{ApiV2, KvFormat};
+use api_version::ApiV2;
 use engine_traits::CfName;
 use kvproto::kvrpcpb::ApiVersion;
 use raw::RawStore;
@@ -238,8 +238,8 @@ mod tests {
             Context::default(),
         );
         let (prev_val, succeed) =
-            sched_cas_command(&mut engine, cm.clone(), cas_cmd,
-        ts_provider.clone()).unwrap(); assert!(prev_val.is_none());
+            sched_cas_command(&mut engine, cm.clone(), cas_cmd, ts_provider.clone()).unwrap();
+        assert!(prev_val.is_none());
         assert!(succeed);
 
         // Attempt to delete with wrong previous_value — should fail.
@@ -251,9 +251,9 @@ mod tests {
             Context::default(),
         );
         let (prev_val, succeed) =
-            sched_cad_command(&mut engine, cm.clone(), cmd,
-        ts_provider.clone()).unwrap(); assert_eq!(prev_val,
-        Some(b"v1".to_vec())); assert!(!succeed);
+            sched_cad_command(&mut engine, cm.clone(), cmd, ts_provider.clone()).unwrap();
+        assert_eq!(prev_val, Some(b"v1".to_vec()));
+        assert!(!succeed);
 
         // Delete with correct previous_value — should succeed.
         let cmd = RawCompareAndDelete::new(
@@ -264,9 +264,9 @@ mod tests {
             Context::default(),
         );
         let (prev_val, succeed) =
-            sched_cad_command(&mut engine, cm.clone(), cmd,
-        ts_provider.clone()).unwrap(); assert_eq!(prev_val,
-        Some(b"v1".to_vec())); assert!(succeed);
+            sched_cad_command(&mut engine, cm.clone(), cmd, ts_provider.clone()).unwrap();
+        assert_eq!(prev_val, Some(b"v1".to_vec()));
+        assert!(succeed);
 
         // Attempt to delete again — key no longer exists, should fail.
         let cmd = RawCompareAndDelete::new(
@@ -277,8 +277,8 @@ mod tests {
             Context::default(),
         );
         let (prev_val, succeed) =
-            sched_cad_command(&mut engine, cm.clone(), cmd,
-        ts_provider.clone()).unwrap(); assert!(prev_val.is_none());
+            sched_cad_command(&mut engine, cm.clone(), cmd, ts_provider.clone()).unwrap();
+        assert!(prev_val.is_none());
         assert!(!succeed);
 
         // Insert a key with an empty value
@@ -320,8 +320,9 @@ mod tests {
     ///
     /// Specifically:
     /// - For V1/V1Ttl: a `Modify::Delete` at the plain (untimstamped) key.
-    /// - For V2: a `Modify::Put` at `key@ts` containing `ENCODED_LOGICAL_DELETE`,
-    ///   plus exactly one lock guard at `RAW_KEY_PREFIX@key_guard_ts`.
+    /// - For V2: a `Modify::Put` at `key@ts` containing
+    ///   `ENCODED_LOGICAL_DELETE`, plus exactly one lock guard at
+    ///   `RAW_KEY_PREFIX@key_guard_ts`.
     fn test_cad_process_write_impl<F: KvFormat>() {
         let mut engine = TestEngineBuilder::new().build().unwrap();
         let ts_provider = super::super::test_util::gen_ts_provider(F::TAG);
@@ -384,10 +385,8 @@ mod tests {
             );
         } else {
             // V1/V1Ttl: plain Delete at the untimstamped key, no lock guards.
-            let expected_modifies = vec![Modify::Delete(
-                CF_DEFAULT,
-                F::encode_raw_key(raw_key, None),
-            )];
+            let expected_modifies =
+                vec![Modify::Delete(CF_DEFAULT, F::encode_raw_key(raw_key, None))];
             assert_eq!(write_result.to_be_write.modifies, expected_modifies);
             assert!(write_result.lock_guards.is_empty());
         }

--- a/src/storage/txn/commands/compare_and_delete.rs
+++ b/src/storage/txn/commands/compare_and_delete.rs
@@ -215,6 +215,10 @@ mod tests {
         test_kv_format_impl!(test_cad_basic_impl);
     }
 
+    /// Note: for API V2, TestEngine don't support MVCC reading, so
+    /// `pre_propose` observer is ignored, and no timestamp will be append
+    /// to key. The full test of `RawCompareAndSwap` is in
+    /// `src/storage/mod.rs`.
     fn test_cad_basic_impl<F: KvFormat>() {
         let mut engine = TestEngineBuilder::new().build().unwrap();
         let ts_provider = super::super::test_util::gen_ts_provider(F::TAG);
@@ -234,8 +238,8 @@ mod tests {
             Context::default(),
         );
         let (prev_val, succeed) =
-            sched_cas_command(&mut engine, cm.clone(), cas_cmd, ts_provider.clone()).unwrap();
-        assert!(prev_val.is_none());
+            sched_cas_command(&mut engine, cm.clone(), cas_cmd,
+        ts_provider.clone()).unwrap(); assert!(prev_val.is_none());
         assert!(succeed);
 
         // Attempt to delete with wrong previous_value — should fail.
@@ -247,9 +251,9 @@ mod tests {
             Context::default(),
         );
         let (prev_val, succeed) =
-            sched_cad_command(&mut engine, cm.clone(), cmd, ts_provider.clone()).unwrap();
-        assert_eq!(prev_val, Some(b"v1".to_vec()));
-        assert!(!succeed);
+            sched_cad_command(&mut engine, cm.clone(), cmd,
+        ts_provider.clone()).unwrap(); assert_eq!(prev_val,
+        Some(b"v1".to_vec())); assert!(!succeed);
 
         // Delete with correct previous_value — should succeed.
         let cmd = RawCompareAndDelete::new(
@@ -260,9 +264,9 @@ mod tests {
             Context::default(),
         );
         let (prev_val, succeed) =
-            sched_cad_command(&mut engine, cm.clone(), cmd, ts_provider.clone()).unwrap();
-        assert_eq!(prev_val, Some(b"v1".to_vec()));
-        assert!(succeed);
+            sched_cad_command(&mut engine, cm.clone(), cmd,
+        ts_provider.clone()).unwrap(); assert_eq!(prev_val,
+        Some(b"v1".to_vec())); assert!(succeed);
 
         // Attempt to delete again — key no longer exists, should fail.
         let cmd = RawCompareAndDelete::new(
@@ -273,8 +277,8 @@ mod tests {
             Context::default(),
         );
         let (prev_val, succeed) =
-            sched_cad_command(&mut engine, cm.clone(), cmd, ts_provider.clone()).unwrap();
-        assert!(prev_val.is_none());
+            sched_cad_command(&mut engine, cm.clone(), cmd,
+        ts_provider.clone()).unwrap(); assert!(prev_val.is_none());
         assert!(!succeed);
 
         // Insert a key with an empty value
@@ -316,17 +320,10 @@ mod tests {
     ///
     /// Specifically:
     /// - For V1/V1Ttl: a `Modify::Delete` at the plain (untimstamped) key.
-    /// - For V2: a `Modify::Put` at `key@ts` containing
-    ///   `ENCODED_LOGICAL_DELETE`, plus exactly one lock guard at
-    ///   `RAW_KEY_PREFIX@key_guard_ts`.
-    ///
-    /// Note: for API V2, TestEngine doesn't support MVCC reading, so the
-    /// `pre_propose` observer is ignored and no timestamp is appended to the
-    /// key during the setup CAS. The full integration test is in
-    /// `src/storage/mod.rs`.
+    /// - For V2: a `Modify::Put` at `key@ts` containing `ENCODED_LOGICAL_DELETE`,
+    ///   plus exactly one lock guard at `RAW_KEY_PREFIX@key_guard_ts`.
     fn test_cad_process_write_impl<F: KvFormat>() {
         let mut engine = TestEngineBuilder::new().build().unwrap();
-        // ts_provider starts at 100 for V2; None for V1/V1Ttl.
         let ts_provider = super::super::test_util::gen_ts_provider(F::TAG);
         let cm = concurrency_manager::ConcurrencyManager::new_for_test(1.into());
         let raw_key = b"rk";
@@ -387,8 +384,10 @@ mod tests {
             );
         } else {
             // V1/V1Ttl: plain Delete at the untimstamped key, no lock guards.
-            let expected_modifies =
-                vec![Modify::Delete(CF_DEFAULT, F::encode_raw_key(raw_key, None))];
+            let expected_modifies = vec![Modify::Delete(
+                CF_DEFAULT,
+                F::encode_raw_key(raw_key, None),
+            )];
             assert_eq!(write_result.to_be_write.modifies, expected_modifies);
             assert!(write_result.lock_guards.is_empty());
         }

--- a/src/storage/txn/commands/compare_and_delete.rs
+++ b/src/storage/txn/commands/compare_and_delete.rs
@@ -216,7 +216,7 @@ mod tests {
     }
 
     /// Note: for API V2, TestEngine don't support MVCC reading, so
-    /// `pre_propose` observer is ignored, and no timestamp will be append
+    /// `pre_propose` observer is ignored, and no timestamp will be appended
     /// to key. The full test of `RawCompareAndSwap` is in
     /// `src/storage/mod.rs`.
     fn test_cad_basic_impl<F: KvFormat>() {
@@ -384,7 +384,6 @@ mod tests {
                 &encoded_lock_key
             );
         } else {
-            // V1/V1Ttl: plain Delete at the untimstamped key, no lock guards.
             let expected_modifies =
                 vec![Modify::Delete(CF_DEFAULT, F::encode_raw_key(raw_key, None))];
             assert_eq!(write_result.to_be_write.modifies, expected_modifies);

--- a/src/storage/txn/commands/compare_and_delete.rs
+++ b/src/storage/txn/commands/compare_and_delete.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
 
 // #[PerformanceCriticalPath]
-use api_version::{ApiV2, KvFormat};
+use api_version::ApiV2;
 use engine_traits::CfName;
 use kvproto::kvrpcpb::ApiVersion;
 use raw::RawStore;
@@ -125,7 +125,7 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for RawCompareAndDelete {
 mod tests {
     use std::sync::Arc;
 
-    use api_version::{ApiV2, test_kv_format_impl};
+    use api_version::{ApiV2, KvFormat, test_kv_format_impl};
     use causal_ts::CausalTsProviderImpl;
     use concurrency_manager::ConcurrencyManager;
     use engine_traits::CF_DEFAULT;

--- a/src/storage/txn/commands/compare_and_delete.rs
+++ b/src/storage/txn/commands/compare_and_delete.rs
@@ -146,37 +146,19 @@ mod tests {
         cmd: TypedCommand<(Option<Value>, bool)>,
         ts_provider: Option<Arc<CausalTsProviderImpl>>,
     ) -> Result<(Option<Value>, bool)> {
-        let snap = engine.snapshot(Default::default())?;
-        use kvproto::kvrpcpb::ExtraOp;
-        let mut statistic = Statistics::default();
-
-        let raw_ext = block_on(get_raw_ext(ts_provider, cm.clone(), true, &cmd.cmd)).unwrap();
-        let context = WriteContext {
-            lock_mgr: &MockLockManager::new(),
-            concurrency_manager: cm,
-            extra_op: ExtraOp::Noop,
-            statistics: &mut statistic,
-            async_apply_prewrite: false,
-            raw_ext,
-            txn_status_cache: Arc::new(TxnStatusCache::new_for_test()),
-        };
-        let ret = cmd.cmd.process_write(snap, context)?;
-        match ret.pr {
-            ProcessResult::RawCompareAndSwapRes {
-                previous_value,
-                succeed,
-            } => {
-                if succeed {
-                    let ctx = Context::default();
-                    engine.write(&ctx, ret.to_be_write).unwrap();
-                }
-                Ok((previous_value, succeed))
-            }
-            _ => unreachable!(),
-        }
+        sched_compare_command(engine, cm, cmd, ts_provider)
     }
 
-    pub fn sched_cas_command<E: Engine>(
+    fn sched_cas_command<E: Engine>(
+        engine: &mut E,
+        cm: ConcurrencyManager,
+        cmd: TypedCommand<(Option<Value>, bool)>,
+        ts_provider: Option<Arc<CausalTsProviderImpl>>,
+    ) -> Result<(Option<Value>, bool)> {
+        sched_compare_command(engine, cm, cmd, ts_provider)
+    }
+
+    fn sched_compare_command<E: Engine>(
         engine: &mut E,
         cm: ConcurrencyManager,
         cmd: TypedCommand<(Option<Value>, bool)>,

--- a/src/storage/txn/commands/compare_and_delete.rs
+++ b/src/storage/txn/commands/compare_and_delete.rs
@@ -1,0 +1,396 @@
+// Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
+
+// #[PerformanceCriticalPath]
+use api_version::{ApiV2, KvFormat};
+use engine_traits::CfName;
+use kvproto::kvrpcpb::ApiVersion;
+use raw::RawStore;
+use tikv_kv::Statistics;
+use txn_types::{Key, Value};
+
+use crate::storage::{
+    ProcessResult, Snapshot,
+    kv::{Modify, WriteData},
+    lock_manager::LockManager,
+    raw,
+    txn::{
+        Result,
+        commands::{
+            Command, CommandExt, ReleasedLocks, ResponsePolicy, TypedCommand, WriteCommand,
+            WriteContext, WriteResult,
+        },
+    },
+};
+
+command! {
+    /// RawCompareAndDelete checks whether the previous value of the key equals to the given value.
+    /// If they are equal, delete the key. The bool indicates whether they are equal.
+    /// The previous value is always returned regardless of whether the key is deleted.
+    RawCompareAndDelete:
+        cmd_ty => (Option<Value>, bool),
+        display => { "kv::command::raw_compare_and_delete {:?}", (ctx), }
+        content => {
+            cf: CfName,
+            key: Key,
+            previous_value: Value,
+            api_version: ApiVersion,
+        }
+        in_heap => {
+            key,
+            previous_value,
+        }
+}
+
+impl CommandExt for RawCompareAndDelete {
+    ctx!();
+    tag!(raw_compare_and_delete);
+    gen_lock!(key);
+
+    fn write_bytes(&self) -> usize {
+        if self.api_version == ApiVersion::V2 {
+            // In API V2, the key is appended with a timestamp when performing delete, so we
+            // need to account for that.
+            self.key.as_encoded().len() + ApiV2::ENCODED_LOGICAL_DELETE.len()
+        } else {
+            self.key.as_encoded().len()
+        }
+    }
+}
+
+impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for RawCompareAndDelete {
+    fn process_write(self, snapshot: S, wctx: WriteContext<'_, L>) -> Result<WriteResult> {
+        let (cf, mut key, previous_value, ctx, raw_ext) = (
+            self.cf,
+            self.key,
+            self.previous_value,
+            self.ctx,
+            wctx.raw_ext,
+        );
+
+        let mut data = vec![];
+        let old_value = RawStore::new(snapshot, self.api_version).raw_get_key_value(
+            cf,
+            &key,
+            &mut Statistics::default(),
+        )?;
+
+        let (pr, lock_guards) = if old_value.as_ref() == Some(&previous_value) {
+            if let Some(ref raw_ext) = raw_ext {
+                key = key.append_ts(raw_ext.ts);
+            }
+
+            let m = match self.api_version {
+                ApiVersion::V2 => Modify::Put(cf, key, ApiV2::ENCODED_LOGICAL_DELETE.to_vec()),
+                _ => Modify::Delete(cf, key),
+            };
+            data.push(m);
+            (
+                ProcessResult::RawCompareAndSwapRes {
+                    previous_value: old_value,
+                    succeed: true,
+                },
+                raw_ext.into_iter().map(|r| r.key_guard).collect(),
+            )
+        } else {
+            (
+                ProcessResult::RawCompareAndSwapRes {
+                    previous_value: old_value,
+                    succeed: false,
+                },
+                vec![],
+            )
+        };
+        fail_point!("txn_commands_compare_and_delete");
+        let rows = data.len();
+        let mut to_be_write = WriteData::from_modifies(data);
+        to_be_write.set_allowed_on_disk_almost_full();
+        Ok(WriteResult {
+            ctx,
+            to_be_write,
+            rows,
+            pr,
+            lock_info: vec![],
+            released_locks: ReleasedLocks::new(),
+            new_acquired_locks: vec![],
+            lock_guards,
+            response_policy: ResponsePolicy::OnApplied,
+            known_txn_status: vec![],
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use api_version::{ApiV2, test_kv_format_impl};
+    use causal_ts::CausalTsProviderImpl;
+    use concurrency_manager::ConcurrencyManager;
+    use engine_traits::CF_DEFAULT;
+    use futures::executor::block_on;
+    use kvproto::kvrpcpb::Context;
+    use txn_types::Value;
+
+    use super::*;
+    use crate::storage::{
+        Engine, Statistics, TestEngineBuilder,
+        lock_manager::MockLockManager,
+        txn::{scheduler::get_raw_ext, txn_status_cache::TxnStatusCache},
+    };
+
+    fn sched_cad_command<E: Engine>(
+        engine: &mut E,
+        cm: ConcurrencyManager,
+        cmd: TypedCommand<(Option<Value>, bool)>,
+        ts_provider: Option<Arc<CausalTsProviderImpl>>,
+    ) -> Result<(Option<Value>, bool)> {
+        let snap = engine.snapshot(Default::default())?;
+        use kvproto::kvrpcpb::ExtraOp;
+        let mut statistic = Statistics::default();
+
+        let raw_ext = block_on(get_raw_ext(ts_provider, cm.clone(), true, &cmd.cmd)).unwrap();
+        let context = WriteContext {
+            lock_mgr: &MockLockManager::new(),
+            concurrency_manager: cm,
+            extra_op: ExtraOp::Noop,
+            statistics: &mut statistic,
+            async_apply_prewrite: false,
+            raw_ext,
+            txn_status_cache: Arc::new(TxnStatusCache::new_for_test()),
+        };
+        let ret = cmd.cmd.process_write(snap, context)?;
+        match ret.pr {
+            ProcessResult::RawCompareAndSwapRes {
+                previous_value,
+                succeed,
+            } => {
+                if succeed {
+                    let ctx = Context::default();
+                    engine.write(&ctx, ret.to_be_write).unwrap();
+                }
+                Ok((previous_value, succeed))
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn sched_cas_command<E: Engine>(
+        engine: &mut E,
+        cm: ConcurrencyManager,
+        cmd: TypedCommand<(Option<Value>, bool)>,
+        ts_provider: Option<Arc<CausalTsProviderImpl>>,
+    ) -> Result<(Option<Value>, bool)> {
+        let snap = engine.snapshot(Default::default())?;
+        use kvproto::kvrpcpb::ExtraOp;
+        let mut statistic = Statistics::default();
+
+        let raw_ext = block_on(get_raw_ext(ts_provider, cm.clone(), true, &cmd.cmd)).unwrap();
+        let context = WriteContext {
+            lock_mgr: &MockLockManager::new(),
+            concurrency_manager: cm,
+            extra_op: ExtraOp::Noop,
+            statistics: &mut statistic,
+            async_apply_prewrite: false,
+            raw_ext,
+            txn_status_cache: Arc::new(TxnStatusCache::new_for_test()),
+        };
+        let ret = cmd.cmd.process_write(snap, context)?;
+        match ret.pr {
+            ProcessResult::RawCompareAndSwapRes {
+                previous_value,
+                succeed,
+            } => {
+                if succeed {
+                    let ctx = Context::default();
+                    engine.write(&ctx, ret.to_be_write).unwrap();
+                }
+                Ok((previous_value, succeed))
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn test_cad_basic() {
+        test_kv_format_impl!(test_cad_basic_impl);
+    }
+
+    fn test_cad_basic_impl<F: KvFormat>() {
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+        let ts_provider = super::super::test_util::gen_ts_provider(F::TAG);
+        let cm = concurrency_manager::ConcurrencyManager::new_for_test(1.into());
+        let key = b"rk";
+
+        let encoded_key = F::encode_raw_key(key, None);
+
+        // First, insert a value using CAS (set key to "v1").
+        let cas_cmd = super::super::RawCompareAndSwap::new(
+            CF_DEFAULT,
+            encoded_key.clone(),
+            None,
+            b"v1".to_vec(),
+            0,
+            F::TAG,
+            Context::default(),
+        );
+        let (prev_val, succeed) =
+            sched_cas_command(&mut engine, cm.clone(), cas_cmd, ts_provider.clone()).unwrap();
+        assert!(prev_val.is_none());
+        assert!(succeed);
+
+        // Attempt to delete with wrong previous_value — should fail.
+        let cmd = RawCompareAndDelete::new(
+            CF_DEFAULT,
+            encoded_key.clone(),
+            b"v_wrong".to_vec(),
+            F::TAG,
+            Context::default(),
+        );
+        let (prev_val, succeed) =
+            sched_cad_command(&mut engine, cm.clone(), cmd, ts_provider.clone()).unwrap();
+        assert_eq!(prev_val, Some(b"v1".to_vec()));
+        assert!(!succeed);
+
+        // Delete with correct previous_value — should succeed.
+        let cmd = RawCompareAndDelete::new(
+            CF_DEFAULT,
+            encoded_key.clone(),
+            b"v1".to_vec(),
+            F::TAG,
+            Context::default(),
+        );
+        let (prev_val, succeed) =
+            sched_cad_command(&mut engine, cm.clone(), cmd, ts_provider.clone()).unwrap();
+        assert_eq!(prev_val, Some(b"v1".to_vec()));
+        assert!(succeed);
+
+        // Attempt to delete again — key no longer exists, should fail.
+        let cmd = RawCompareAndDelete::new(
+            CF_DEFAULT,
+            encoded_key.clone(),
+            b"v1".to_vec(),
+            F::TAG,
+            Context::default(),
+        );
+        let (prev_val, succeed) =
+            sched_cad_command(&mut engine, cm.clone(), cmd, ts_provider.clone()).unwrap();
+        assert!(prev_val.is_none());
+        assert!(!succeed);
+
+        // Insert a key with an empty value
+        let cas_cmd = super::super::RawCompareAndSwap::new(
+            CF_DEFAULT,
+            encoded_key.clone(),
+            None,
+            b"".to_vec(),
+            0,
+            F::TAG,
+            Context::default(),
+        );
+        let (prev_val, succeed) =
+            sched_cas_command(&mut engine, cm.clone(), cas_cmd, ts_provider.clone()).unwrap();
+        assert!(prev_val.is_none());
+        assert!(succeed);
+
+        // Attempt to delete with correct previous_value — should succeed.
+        let cmd = RawCompareAndDelete::new(
+            CF_DEFAULT,
+            encoded_key.clone(),
+            b"".to_vec(),
+            F::TAG,
+            Context::default(),
+        );
+        let (prev_val, succeed) =
+            sched_cad_command(&mut engine, cm.clone(), cmd, ts_provider.clone()).unwrap();
+        assert_eq!(prev_val, Some(b"".to_vec()));
+        assert!(succeed);
+    }
+
+    #[test]
+    fn test_cad_process_write() {
+        test_kv_format_impl!(test_cad_process_write_impl);
+    }
+
+    /// Tests that `process_write` produces the correct low-level `Modify` and
+    /// lock-guard output for `RawCompareAndDelete`.
+    ///
+    /// Specifically:
+    /// - For V1/V1Ttl: a `Modify::Delete` at the plain (untimstamped) key.
+    /// - For V2: a `Modify::Put` at `key@ts` containing
+    ///   `ENCODED_LOGICAL_DELETE`, plus exactly one lock guard at
+    ///   `RAW_KEY_PREFIX@key_guard_ts`.
+    ///
+    /// Note: for API V2, TestEngine doesn't support MVCC reading, so the
+    /// `pre_propose` observer is ignored and no timestamp is appended to the
+    /// key during the setup CAS. The full integration test is in
+    /// `src/storage/mod.rs`.
+    fn test_cad_process_write_impl<F: KvFormat>() {
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+        // ts_provider starts at 100 for V2; None for V1/V1Ttl.
+        let ts_provider = super::super::test_util::gen_ts_provider(F::TAG);
+        let cm = concurrency_manager::ConcurrencyManager::new_for_test(1.into());
+        let raw_key = b"rk";
+        let raw_value = b"valuek";
+
+        // Write a value into the engine so there is something to compare against.
+        // For V2 this consumes ts 100 (key_guard) and 101 (write ts), so the
+        // subsequent CAD call will use ts 102 (key_guard) and 103 (write ts).
+        let cas_cmd = super::super::RawCompareAndSwap::new(
+            CF_DEFAULT,
+            F::encode_raw_key(raw_key, None),
+            None,
+            raw_value.to_vec(),
+            0,
+            F::TAG,
+            Context::default(),
+        );
+        sched_cas_command(&mut engine, cm.clone(), cas_cmd, ts_provider.clone()).unwrap();
+
+        // Now invoke process_write directly for the CAD command.
+        let cmd = RawCompareAndDelete::new(
+            CF_DEFAULT,
+            F::encode_raw_key(raw_key, None),
+            raw_value.to_vec(),
+            F::TAG,
+            Context::default(),
+        );
+        let mut statistic = Statistics::default();
+        let snap = engine.snapshot(Default::default()).unwrap();
+        let raw_ext = block_on(get_raw_ext(ts_provider, cm.clone(), true, &cmd.cmd)).unwrap();
+        let context = WriteContext {
+            lock_mgr: &MockLockManager::new(),
+            concurrency_manager: cm,
+            extra_op: kvproto::kvrpcpb::ExtraOp::Noop,
+            statistics: &mut statistic,
+            async_apply_prewrite: false,
+            raw_ext,
+            txn_status_cache: Arc::new(TxnStatusCache::new_for_test()),
+        };
+        let cmd: Command = cmd.into();
+        let write_result = cmd.process_write(snap, context).unwrap();
+
+        if F::TAG == ApiVersion::V2 {
+            // V2: logical-delete tombstone written as a Put at key@write_ts (103).
+            let expected_modifies = vec![Modify::Put(
+                CF_DEFAULT,
+                F::encode_raw_key(raw_key, Some(103.into())),
+                ApiV2::ENCODED_LOGICAL_DELETE.to_vec(),
+            )];
+            assert_eq!(write_result.to_be_write.modifies, expected_modifies);
+            // Exactly one lock guard acquired at key_guard_ts (102).
+            assert_eq!(write_result.lock_guards.len(), 1);
+            let lock_raw_key = vec![api_version::api_v2::RAW_KEY_PREFIX];
+            let encoded_lock_key = ApiV2::encode_raw_key(&lock_raw_key, Some(102.into()));
+            assert_eq!(
+                write_result.lock_guards.first().unwrap().key(),
+                &encoded_lock_key
+            );
+        } else {
+            // V1/V1Ttl: plain Delete at the untimstamped key, no lock guards.
+            let expected_modifies =
+                vec![Modify::Delete(CF_DEFAULT, F::encode_raw_key(raw_key, None))];
+            assert_eq!(write_result.to_be_write.modifies, expected_modifies);
+            assert!(write_result.lock_guards.is_empty());
+        }
+    }
+}

--- a/src/storage/txn/commands/compare_and_swap.rs
+++ b/src/storage/txn/commands/compare_and_swap.rs
@@ -1,7 +1,7 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
 // #[PerformanceCriticalPath]
-use api_version::{ApiV2, KvFormat, RawValue, match_template_api_version};
+use api_version::{KvFormat, RawValue, match_template_api_version};
 use engine_traits::{CfName, raw_ttl::ttl_to_expire_ts};
 use kvproto::kvrpcpb::ApiVersion;
 use raw::RawStore;
@@ -27,9 +27,6 @@ command! {
     /// RawCompareAndSwap checks whether the previous value of the key equals to the given value.
     /// If they are equal, write the new value. The bool indicates whether they are equal.
     /// The previous value is always returned regardless of whether the new value is set.
-    ///
-    /// If `delete` is true and the comparison succeeds, then we'll delete the key.
-    /// The `value` field is ignored for deletes.
     RawCompareAndSwap:
         cmd_ty => (Option<Value>, bool),
         display => { "kv::command::raw_compare_and_swap {:?}", (ctx), }
@@ -40,7 +37,6 @@ command! {
             value: Value,
             ttl: u64,
             api_version: ApiVersion,
-            delete: bool,
         }
         in_heap => {
             key,
@@ -55,28 +51,19 @@ impl CommandExt for RawCompareAndSwap {
     gen_lock!(key);
 
     fn write_bytes(&self) -> usize {
-        if self.delete {
-            if self.api_version == ApiVersion::V2 {
-                self.key.as_encoded().len() + ApiV2::ENCODED_LOGICAL_DELETE.len()
-            } else {
-                self.key.as_encoded().len()
-            }
-        } else {
-            self.key.as_encoded().len() + self.value.len()
-        }
+        self.key.as_encoded().len() + self.value.len()
     }
 }
 
 impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for RawCompareAndSwap {
     fn process_write(self, snapshot: S, wctx: WriteContext<'_, L>) -> Result<WriteResult> {
-        let (cf, mut key, value, previous_value, ctx, raw_ext, delete) = (
+        let (cf, mut key, value, previous_value, ctx, raw_ext) = (
             self.cf,
             self.key,
             self.value,
             self.previous_value,
             self.ctx,
             wctx.raw_ext,
-            self.delete,
         );
 
         let mut data = vec![];
@@ -87,60 +74,31 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for RawCompareAndSwap {
         )?;
 
         let (pr, lock_guards) = if old_value == previous_value {
-            if delete {
-                // Delete case: delete the key if there's actually a value to delete
-                let lock_guards = if previous_value.is_some() {
-                    if let Some(ref raw_ext) = raw_ext {
-                        key = key.append_ts(raw_ext.ts);
-                    }
-
-                    let m = match self.api_version {
-                        ApiVersion::V2 => {
-                            Modify::Put(cf, key, ApiV2::ENCODED_LOGICAL_DELETE.to_vec())
-                        }
-                        _ => Modify::Delete(cf, key),
-                    };
-                    data.push(m);
-                    raw_ext.into_iter().map(|r| r.key_guard).collect()
-                } else {
-                    vec![]
-                };
-
-                (
-                    ProcessResult::RawCompareAndSwapRes {
-                        previous_value: old_value,
-                        succeed: true,
-                    },
-                    lock_guards,
-                )
-            } else {
-                // Put case: write the new value
-                let raw_value = RawValue {
-                    user_value: value,
-                    expire_ts: ttl_to_expire_ts(self.ttl),
-                    is_delete: false,
-                };
-                let encoded_raw_value = match_template_api_version!(
-                    API,
-                    match self.api_version {
-                        ApiVersion::API => API::encode_raw_value_owned(raw_value),
-                    }
-                );
-
-                if let Some(ref raw_ext) = raw_ext {
-                    key = key.append_ts(raw_ext.ts);
+            let raw_value = RawValue {
+                user_value: value,
+                expire_ts: ttl_to_expire_ts(self.ttl),
+                is_delete: false,
+            };
+            let encoded_raw_value = match_template_api_version!(
+                API,
+                match self.api_version {
+                    ApiVersion::API => API::encode_raw_value_owned(raw_value),
                 }
+            );
 
-                let m = Modify::Put(cf, key, encoded_raw_value);
-                data.push(m);
-                (
-                    ProcessResult::RawCompareAndSwapRes {
-                        previous_value: old_value,
-                        succeed: true,
-                    },
-                    raw_ext.into_iter().map(|r| r.key_guard).collect(),
-                )
+            if let Some(ref raw_ext) = raw_ext {
+                key = key.append_ts(raw_ext.ts);
             }
+
+            let m = Modify::Put(cf, key, encoded_raw_value);
+            data.push(m);
+            (
+                ProcessResult::RawCompareAndSwapRes {
+                    previous_value: old_value,
+                    succeed: true,
+                },
+                raw_ext.into_iter().map(|r| r.key_guard).collect(),
+            )
         } else {
             (
                 ProcessResult::RawCompareAndSwapRes {
@@ -211,7 +169,6 @@ mod tests {
             b"v1".to_vec(),
             0,
             F::TAG,
-            false,
             Context::default(),
         );
         let (prev_val, succeed) =
@@ -226,7 +183,6 @@ mod tests {
             b"v2".to_vec(),
             1,
             F::TAG,
-            false,
             Context::default(),
         );
         let (prev_val, succeed) =
@@ -236,134 +192,16 @@ mod tests {
 
         let cmd = RawCompareAndSwap::new(
             CF_DEFAULT,
-            encoded_key.clone(),
+            encoded_key,
             Some(b"v1".to_vec()),
             b"v3".to_vec(),
             2,
             F::TAG,
-            false,
-            Context::default(),
-        );
-        let (prev_val, succeed) =
-            sched_command(&mut engine, cm.clone(), cmd, ts_provider.clone()).unwrap();
-        assert_eq!(prev_val, Some(b"v1".to_vec()));
-        assert!(succeed);
-
-        // Test CAS delete operations
-
-        // Test 1: CAS delete with existing_val=v3, expected_val=v3 (should succeed)
-        let cmd = RawCompareAndSwap::new(
-            CF_DEFAULT,
-            encoded_key.clone(),
-            Some(b"v3".to_vec()),
-            b"dummy".to_vec(), // value ignored for deletes
-            0,
-            F::TAG,
-            true,
-            Context::default(),
-        );
-        let (prev_val, succeed) =
-            sched_command(&mut engine, cm.clone(), cmd, ts_provider.clone()).unwrap();
-        assert_eq!(prev_val, Some(b"v3".to_vec()));
-        assert!(succeed);
-
-        // Test 2: CAS delete with existing_val=v2, expected_val=v1 (should fail)
-        // Setup: put a new value first
-        let cmd = RawCompareAndSwap::new(
-            CF_DEFAULT,
-            encoded_key.clone(),
-            None,
-            b"v2".to_vec(),
-            0,
-            F::TAG,
-            false,
-            Context::default(),
-        );
-        let (prev_val, succeed) =
-            sched_command(&mut engine, cm.clone(), cmd, ts_provider.clone()).unwrap();
-        assert!(prev_val.is_none());
-        assert!(succeed);
-
-        // Test: CAS delete should fail because expected_val doesn't match
-        let cmd = RawCompareAndSwap::new(
-            CF_DEFAULT,
-            encoded_key.clone(),
-            Some(b"v1".to_vec()),
-            b"dummy".to_vec(),
-            0,
-            F::TAG,
-            true,
-            Context::default(),
-        );
-        let (prev_val, succeed) =
-            sched_command(&mut engine, cm.clone(), cmd, ts_provider.clone()).unwrap();
-        assert_eq!(prev_val, Some(b"v2".to_vec()));
-        assert!(!succeed);
-
-        // Test 3: CAS delete with existing_val=nil, expected_val=nil (should succeed as
-        // noop) Setup: delete the key first
-        let cmd = RawCompareAndSwap::new(
-            CF_DEFAULT,
-            encoded_key.clone(),
-            Some(b"v2".to_vec()),
-            b"dummy".to_vec(),
-            0,
-            F::TAG,
-            true,
-            Context::default(),
-        );
-        let (prev_val, succeed) =
-            sched_command(&mut engine, cm.clone(), cmd, ts_provider.clone()).unwrap();
-        assert_eq!(prev_val, Some(b"v2".to_vec()));
-        assert!(succeed);
-
-        // Test: CAS delete on nil key should succeed as noop
-        let cmd = RawCompareAndSwap::new(
-            CF_DEFAULT,
-            encoded_key.clone(),
-            None,
-            b"dummy".to_vec(),
-            0,
-            F::TAG,
-            true,
-            Context::default(),
-        );
-        let (prev_val, succeed) =
-            sched_command(&mut engine, cm.clone(), cmd, ts_provider.clone()).unwrap();
-        assert!(prev_val.is_none());
-        assert!(succeed);
-
-        // Test 4: CAS delete with existing_val=v1, expected_val=nil (should fail)
-        // Setup: put a value first
-        let cmd = RawCompareAndSwap::new(
-            CF_DEFAULT,
-            encoded_key.clone(),
-            None,
-            b"v1".to_vec(),
-            0,
-            F::TAG,
-            false,
-            Context::default(),
-        );
-        let (prev_val, succeed) =
-            sched_command(&mut engine, cm.clone(), cmd, ts_provider.clone()).unwrap();
-        assert!(prev_val.is_none());
-        assert!(succeed);
-
-        // Test: CAS delete should fail because expected_val doesn't match
-        let cmd = RawCompareAndSwap::new(
-            CF_DEFAULT,
-            encoded_key,
-            None,
-            b"dummy".to_vec(),
-            0,
-            F::TAG,
-            true,
             Context::default(),
         );
         let (prev_val, succeed) = sched_command(&mut engine, cm, cmd, ts_provider).unwrap();
         assert_eq!(prev_val, Some(b"v1".to_vec()));
-        assert!(!succeed);
+        assert!(succeed);
     }
 
     pub fn sched_command<E: Engine>(
@@ -392,7 +230,7 @@ mod tests {
                 previous_value,
                 succeed,
             } => {
-                if succeed && !ret.to_be_write.modifies.is_empty() {
+                if succeed {
                     let ctx = Context::default();
                     engine.write(&ctx, ret.to_be_write).unwrap();
                 }
@@ -427,7 +265,6 @@ mod tests {
             raw_value.to_vec(),
             ttl,
             F::TAG,
-            false,
             Context::default(),
         );
         let mut statistic = Statistics::default();

--- a/src/storage/txn/commands/mod.rs
+++ b/src/storage/txn/commands/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod check_secondary_locks;
 pub(crate) mod check_txn_status;
 pub(crate) mod cleanup;
 pub(crate) mod commit;
+pub(crate) mod compare_and_delete;
 pub(crate) mod compare_and_swap;
 pub(crate) mod flashback_to_version;
 pub(crate) mod flashback_to_version_read_phase;
@@ -42,6 +43,7 @@ pub use check_secondary_locks::CheckSecondaryLocks;
 pub use check_txn_status::CheckTxnStatus;
 pub use cleanup::Cleanup;
 pub use commit::Commit;
+pub use compare_and_delete::RawCompareAndDelete;
 pub use compare_and_swap::RawCompareAndSwap;
 use concurrency_manager::{ConcurrencyManager, KeyHandleGuard};
 pub use flashback_to_version::FlashbackToVersion;
@@ -110,6 +112,7 @@ pub enum Command {
     MvccByKey(MvccByKey),
     MvccByStartTs(MvccByStartTs),
     RawCompareAndSwap(RawCompareAndSwap),
+    RawCompareAndDelete(RawCompareAndDelete),
     RawAtomicStore(RawAtomicStore),
     FlashbackToVersionReadPhase(FlashbackToVersionReadPhase),
     FlashbackToVersion(FlashbackToVersion),
@@ -678,6 +681,7 @@ impl Command {
             Command::MvccByKey(t) => t,
             Command::MvccByStartTs(t) => t,
             Command::RawCompareAndSwap(t) => t,
+            Command::RawCompareAndDelete(t) => t,
             Command::RawAtomicStore(t) => t,
             Command::FlashbackToVersionReadPhase(t) => t,
             Command::FlashbackToVersion(t) => t,
@@ -706,6 +710,7 @@ impl Command {
             Command::MvccByKey(t) => t,
             Command::MvccByStartTs(t) => t,
             Command::RawCompareAndSwap(t) => t,
+            Command::RawCompareAndDelete(t) => t,
             Command::RawAtomicStore(t) => t,
             Command::FlashbackToVersionReadPhase(t) => t,
             Command::FlashbackToVersion(t) => t,
@@ -749,6 +754,7 @@ impl Command {
             Command::CheckSecondaryLocks(t) => t.process_write(snapshot, context),
             Command::Pause(t) => t.process_write(snapshot, context),
             Command::RawCompareAndSwap(t) => t.process_write(snapshot, context),
+            Command::RawCompareAndDelete(t) => t.process_write(snapshot, context),
             Command::RawAtomicStore(t) => t.process_write(snapshot, context),
             Command::FlashbackToVersion(t) => t.process_write(snapshot, context),
             Command::Flush(t) => t.process_write(snapshot, context),
@@ -857,6 +863,7 @@ impl HeapSize for Command {
                 Command::MvccByKey(t) => t.approximate_heap_size(),
                 Command::MvccByStartTs(t) => t.approximate_heap_size(),
                 Command::RawCompareAndSwap(t) => t.approximate_heap_size(),
+                Command::RawCompareAndDelete(t) => t.approximate_heap_size(),
                 Command::RawAtomicStore(t) => t.approximate_heap_size(),
                 Command::FlashbackToVersionReadPhase(t) => t.approximate_heap_size(),
                 Command::FlashbackToVersion(t) => t.approximate_heap_size(),

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -2270,7 +2270,9 @@ pub async fn get_raw_ext(
 ) -> Result<Option<RawExt>, Error> {
     if causal_ts_provider.is_some() {
         match cmd {
-            Command::RawCompareAndSwap(_) | Command::RawAtomicStore(_) => {
+            Command::RawCompareAndSwap(_)
+            | Command::RawAtomicStore(_)
+            | Command::RawCompareAndDelete(_) => {
                 if !max_ts_synced {
                     return Err(ErrorInner::RawKvMaxTimestampNotSynced {
                         region_id: cmd.ctx().get_region_id(),

--- a/tests/failpoints/cases/test_storage.rs
+++ b/tests/failpoints/cases/test_storage.rs
@@ -1490,7 +1490,6 @@ fn test_atomic_cas_lock_by_latch() {
             b"v1".to_vec(),
             0,
             cb,
-            false,
         )
         .unwrap();
     thread::sleep(Duration::from_secs(1));
@@ -1507,7 +1506,6 @@ fn test_atomic_cas_lock_by_latch() {
             b"v2".to_vec(),
             0,
             cb,
-            false,
         )
         .unwrap();
     thread::sleep(Duration::from_secs(1));

--- a/tests/integrations/storage/test_raft_storage.rs
+++ b/tests/integrations/storage/test_raft_storage.rs
@@ -402,7 +402,6 @@ fn test_atomic_basic() {
             Some(b"v2".to_vec()),
             b"v3".to_vec(),
             0,
-            false,
         )
         .unwrap();
     assert!(!succeed);
@@ -415,7 +414,6 @@ fn test_atomic_basic() {
             Some(b"v1".to_vec()),
             b"v2".to_vec(),
             0,
-            false,
         )
         .unwrap();
     assert!(succeed);
@@ -424,26 +422,6 @@ fn test_atomic_basic() {
         .raw_get(ctx.clone(), "default".to_string(), b"k1".to_vec())
         .unwrap();
     assert_eq!(b"v2".to_vec(), value.unwrap());
-
-    // Test compare and swap with delete=true
-    let (prev_val, succeed) = storage
-        .raw_compare_and_swap_atomic(
-            ctx.clone(),
-            "default".to_string(),
-            b"k1".to_vec(),
-            Some(b"v2".to_vec()),
-            b"".to_vec(), // value is ignored when delete=true
-            0,
-            true, // delete=true
-        )
-        .unwrap();
-    assert!(succeed);
-    assert_eq!(prev_val, Some(b"v2".to_vec()));
-    let value = storage
-        .raw_get(ctx.clone(), "default".to_string(), b"k1".to_vec())
-        .unwrap();
-    assert!(value.is_none());
-
     storage
         .raw_batch_delete_atomic(ctx.clone(), "default".to_string(), vec![b"k1".to_vec()])
         .unwrap();

--- a/tests/integrations/storage/test_raft_storage.rs
+++ b/tests/integrations/storage/test_raft_storage.rs
@@ -422,6 +422,24 @@ fn test_atomic_basic() {
         .raw_get(ctx.clone(), "default".to_string(), b"k1".to_vec())
         .unwrap();
     assert_eq!(b"v2".to_vec(), value.unwrap());
+
+    // Test compare_and_delete_atomic
+    let (prev_val, succeed) = storage
+        .raw_compare_and_delete_atomic(
+            ctx.clone(),
+            "default".to_string(),
+            b"k1".to_vec(),
+            b"v2".to_vec(),
+        )
+        .unwrap();
+
+    assert!(succeed);
+    assert_eq!(prev_val, Some(b"v2".to_vec()));
+    let value = storage
+        .raw_get(ctx.clone(), "default".to_string(), b"k1".to_vec())
+        .unwrap();
+    assert!(value.is_none());
+
     storage
         .raw_batch_delete_atomic(ctx.clone(), "default".to_string(), vec![b"k1".to_vec()])
         .unwrap();

--- a/tests/integrations/storage/test_storage.rs
+++ b/tests/integrations/storage/test_storage.rs
@@ -1104,13 +1104,6 @@ fn test_txn_store_rawkv_api_version() {
                     (Some(b"value".to_vec()), true),
                 );
 
-                store.raw_compare_and_swap_atomic_delete_ok(
-                    cf.to_owned(),
-                    key.to_vec(),
-                    Some(b"new_value".to_vec()),
-                    (Some(b"new_value".to_vec()), true),
-                );
-
                 store.raw_batch_delete_atomic_ok(cf.to_owned(), vec![key.to_vec()]);
                 store.raw_batch_put_atomic_ok(
                     cf.to_owned(),

--- a/tests/integrations/storage/test_storage.rs
+++ b/tests/integrations/storage/test_storage.rs
@@ -1104,6 +1104,13 @@ fn test_txn_store_rawkv_api_version() {
                     (Some(b"value".to_vec()), true),
                 );
 
+                store.raw_compare_and_delete_atomic_ok(
+                    cf.to_owned(),
+                    key.to_vec(),
+                    b"new_value".to_vec(),
+                    (Some(b"new_value".to_vec()), true),
+                );
+
                 store.raw_batch_delete_atomic_ok(cf.to_owned(), vec![key.to_vec()]);
                 store.raw_batch_put_atomic_ok(
                     cf.to_owned(),
@@ -1140,6 +1147,12 @@ fn test_txn_store_rawkv_api_version() {
                     key.to_vec(),
                     None,
                     b"value".to_vec(),
+                );
+
+                store.raw_compare_and_delete_atomic_err(
+                    cf.to_owned(),
+                    key.to_vec(),
+                    b"new_value".to_vec(),
                 );
 
                 store.raw_batch_delete_atomic_err(cf.to_owned(), vec![key.to_vec()]);


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #19462

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

This commit re-implements compare-and-delete by creating a new `RawCompareAndDelete` API. Previously compare-and-delete piggy-backed on the `RawCompareAndSwap` API by introducing a `delete` flag into the `RawCASRequest` message. As described in issue #19462 this can cause silent data corruption if a newer client is talking to a server which doesn't support compare-and-delete. In this PR:
* Revert support from compare-and-delete semantics from the the `RawCompareAndSwap` code path.
* Implement the new `RawCompareAndDelete` API. This API deletes the key if `previous_value` matches the currently stored value. The implementation does the correct thing for all v1/v1ttl/v2.
* Re-work compare-and-delete tests which previous used `RawCompareAndSwap` with `delete` flag.
* `RawCompareAndSwap` was (presumably) erroneously missing from `handle_batch_commands_request` meaning requests could only be sent via unary RPC by the client. Add it.

This change provides first class support for compare-and-delete which means we get all the usual metrics:
<img width="4326" height="1137" alt="scheduler_raw_compare_and_delete" src="https://github.com/user-attachments/assets/6611a8c6-7cb2-44e4-9f4a-e17525231d81" />
<img width="3551" height="1315" alt="grpc_message_duration_compare_and_delete" src="https://github.com/user-attachments/assets/a92e1168-82f1-428b-bee4-c64711c77a02" />
<img width="3551" height="1315" alt="qps_compare_and_delete" src="https://github.com/user-attachments/assets/4b291440-9190-4261-861d-3b49c391b44b" />


```commit-message
This commit re-implements compare-and-delete by creating a new `RawCompareAndDelete` API.
Previously compare-and-delete piggy-backed on the `RawCompareAndSwap` API by introducing a
`delete` flag into the `RawCASRequest` message. As described in issue #19462 this can cause silent
data corruption if a newer client is talking to a server which doesn't support compare-and-delete.
```

NB this change requires a change to kvproto. The PR for it is here https://github.com/pingcap/kvproto/pull/1434. 

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Provides a new rawkv API `RawCompareAndDelete` to atomically remove a key if the value matches
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated raw compare-and-delete atomic operation and RPC.

* **Improvements**
  * Simplified compare-and-swap API by removing the delete flag and separating swap vs delete semantics.

* **Metrics**
  * Extended metrics to label and track the new compare-and-delete operation.

* **Tests**
  * Updated and added tests to cover compare-and-delete flows and adjusted CAS-related tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->