### PR TITLE
encryption: fix cascading priority deadlock in MultiMasterKeyBackend

### DIFF
--- a/components/encryption/src/master_key/mod.rs
+++ b/components/encryption/src/master_key/mod.rs
@@ -102,7 +102,7 @@ pub struct MultiMasterKeyBackend {
 
 #[derive(Default, Debug)]
 struct MultiMasterKeyBackendInner {
-    backends: Option<Vec<Box<dyn AsyncBackend>>>,
+    backends: Option<Arc<Vec<Box<dyn AsyncBackend>>>>,
     pub(crate) configs: Option<Vec<MasterKeyConfig>>,
 }
 impl MultiMasterKeyBackend {
@@ -156,25 +156,30 @@ impl MultiMasterKeyBackend {
 
         let mut write_guard = self.inner.write().await;
         if write_guard.configs.as_ref() != Some(&master_keys_configs) {
-            write_guard.backends = Some(create_master_key_backends(
+            write_guard.backends = Some(Arc::new(create_master_key_backends(
                 &master_keys_configs,
                 create_backend_fn,
-            )?);
+            )?));
             write_guard.configs = Some(master_keys_configs);
         }
         Ok(())
     }
 
     pub async fn encrypt(&self, plaintext: &[u8]) -> Result<EncryptedContent> {
-        let read_guard = self.inner.read().await;
-        if read_guard.backends.is_none() {
-            return Err(log_and_error(
-                "internal error: multi master key backend not initialized when encrypting",
-            ));
-        }
+        let backends = {
+            let read_guard = self.inner.read().await;
+            match read_guard.backends.as_ref() {
+                Some(b) => Arc::clone(b),
+                None => {
+                    return Err(log_and_error(
+                        "internal error: multi master key backend not initialized when encrypting",
+                    ));
+                }
+            }
+        };
         let mut errors = Vec::new();
 
-        for master_key_backend in read_guard.backends.as_ref().unwrap() {
+        for master_key_backend in backends.iter() {
             match master_key_backend.encrypt_async(plaintext).await {
                 Ok(res) => return Ok(res),
                 Err(e) => errors.push(format!("Backend failed to encrypt with error: {}", e)),
@@ -185,15 +190,20 @@ impl MultiMasterKeyBackend {
         Err(log_and_error(&combined_error))
     }
     pub async fn decrypt(&self, ciphertext: &EncryptedContent) -> Result<Vec<u8>> {
-        let read_guard = self.inner.read().await;
-        if read_guard.backends.is_none() {
-            return Err(log_and_error(
-                "internal error: multi master key backend not initialized when decrypting",
-            ));
-        }
+        let backends = {
+            let read_guard = self.inner.read().await;
+            match read_guard.backends.as_ref() {
+                Some(b) => Arc::clone(b),
+                None => {
+                    return Err(log_and_error(
+                        "internal error: multi master key backend not initialized when decrypting",
+                    ));
+                }
+            }
+        };
         let mut errors = Vec::new();
 
-        for master_key_backend in read_guard.backends.as_ref().unwrap() {
+        for master_key_backend in backends.iter() {
             match master_key_backend.decrypt_async(ciphertext).await {
                 Ok(res) => return Ok(res),
                 Err(e) => errors.push(format!("Backend failed to decrypt with error: {}", e)),
@@ -448,7 +458,7 @@ pub mod tests {
         ];
 
         inner.configs = Some(configs);
-        inner.backends = Some(backends);
+        inner.backends = Some(Arc::new(backends));
 
         let backend = MultiMasterKeyBackend {
             inner: Arc::new(RwLock::new(inner)),


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #19467

Problem Summary:
`MultiMasterKeyBackend::encrypt()` and `decrypt()` hold a `tokio::sync::RwLock` 
read guard across `.await` points (KMS network I/O). Due to Tokio's write-preferring 
fairness policy, a pending write lock request (from `update_from_config_if_needed`) 
blocks all subsequent read requests, causing cascading priority deadlock that stalls 
the entire encryption/decryption pipeline.

### What is changed and how it works?

Changed the `backends` field type from `Option<Vec<Box<dyn AsyncBackend>>>` to 
`Option<Arc<Vec<Box<dyn AsyncBackend>>>>`. In `encrypt()` and `decrypt()`, the 
read lock is now released immediately after cloning the `Arc` reference (O(1) 
operation), before any `.await` network I/O is performed.

This eliminates the window where a slow reader can block a pending writer, which 
in turn blocks all subsequent readers.

### Check List

- [x] Code changes follow TiKV coding style
- [x] Tests updated to match new `Arc` wrapper
- [x] No public API changes

```commit-message
Fix cascading priority deadlock in MultiMasterKeyBackend via Tokio RwLock
during KMS network I/O.

The encrypt() and decrypt() methods held a tokio::sync::RwLock read guard
across .await points for KMS network requests. Due to Tokio's write-preferring
fairness policy, if update_from_config_if_needed() enqueued a write lock
request during slow network I/O, all subsequent encrypt/decrypt calls would
be blocked behind the pending writer, causing system-wide throughput collapse.

Fix: Snapshot the backends list via Arc::clone() and release the read guard
before performing any async network I/O.

* Change backends type to Option<Arc<Vec<Box<dyn AsyncBackend>>>>
* Release read lock before .await in encrypt() and decrypt()
* Wrap new backends with Arc::new() in update_from_config_if_needed()
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal management of encryption backends to use shared, thread-safe references for safer concurrent access.
  * Encryption/decryption paths now clone backend references under read lock and iterate after releasing the lock to reduce contention and avoid unsafe unwraps.
  * Tests updated to match the new backend storage approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
This PR is used to fix cascading priority deadlock in `MultiMasterKeyBackend` via `Tokio::RwLock` during KMS network I/O.
```