### PR TITLE
update Cargo.toml kvproto.branch to release-8.1 for pull-check-deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1162,9 +1162,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.7.2"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bytes-utils"
@@ -3906,11 +3906,11 @@ dependencies = [
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.8",
+ "regex-automata 0.4.3",
 ]
 
 [[package]]
@@ -4263,12 +4263,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "overload",
- "winapi 0.3.9",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4552,12 +4551,6 @@ name = "outref"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "page_size"
@@ -5035,7 +5028,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.0",
  "rand_xorshift",
- "regex-syntax 0.8.2",
+ "regex-syntax",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -5585,7 +5578,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata 0.4.3",
- "regex-syntax 0.8.2",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -5595,8 +5588,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92b73c2a1770c255c240eaa4ee600df1704a38dc3feaa6e949e7fcd4f8dc09f9"
 dependencies = [
  "byteorder",
- "regex-syntax 0.6.29",
- "utf8-ranges",
 ]
 
 [[package]]
@@ -5607,7 +5598,7 @@ checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.2",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -5615,12 +5606,6 @@ name = "regex-lite"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30b661b2f27137bdbc16f00eda72866a92bb28af1753ffbd56744fb6e2e9cd8e"
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -8022,9 +8007,9 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -8047,9 +8032,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8058,9 +8043,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -8079,9 +8064,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-serde"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
 dependencies = [
  "serde",
  "tracing-core",
@@ -8089,14 +8074,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.18"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata 0.4.3",
  "serde",
  "serde_json",
  "sharded-slab",
@@ -8239,12 +8224,6 @@ name = "utf16_iter"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
-name = "utf8-ranges"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
 
 [[package]]
 name = "utf8_iter"
@@ -8514,6 +8493,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8557,6 +8542,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets 0.52.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -325,6 +325,7 @@ azure = { path = "components/cloud/azure" }
 backup = { path = "components/backup", default-features = false }
 backup-stream = { path = "components/backup-stream", default-features = false }
 batch-system = { path = "components/batch-system" }
+bytes = "1.11"
 case_macros = { path = "components/case_macros" }
 causal_ts = { path = "components/causal_ts" }
 cdc = { path = "components/cdc", default-features = false }

--- a/cmd/tikv-server/Cargo.toml
+++ b/cmd/tikv-server/Cargo.toml
@@ -46,7 +46,7 @@ tikv = { workspace = true }
 tikv_util = { workspace = true }
 toml = "0.5"
 tracing-active-tree = { workspace = true, optional = true }
-tracing-subscriber = { version = "0.3.17", default-features = false, features = [ "registry", "smallvec" ], optional = true }
+tracing-subscriber = { version = "0.3.20", default-features = false, features = [ "registry", "smallvec" ], optional = true }
 
 [build-dependencies]
 cc = "1.0"

--- a/components/backup-stream/Cargo.toml
+++ b/components/backup-stream/Cargo.toml
@@ -28,7 +28,7 @@ harness = true
 [dependencies]
 async-compression = { version = "0.3.14", features = ["tokio", "zstd"] }
 async-trait = { version = "0.1" }
-bytes = "1"
+bytes = { workspace = true }
 chrono = { workspace = true }
 concurrency_manager = { workspace = true }
 crossbeam = "0.8"

--- a/components/cloud/aws/Cargo.toml
+++ b/components/cloud/aws/Cargo.toml
@@ -23,7 +23,7 @@ aws-smithy-runtime-api = { version = "1", features = [], default-features = fals
 aws-smithy-types = { version = "1", features = ["byte-stream-poll-next"] }
 
 base64 = "0.13.0"
-bytes = "1.0"
+bytes = { workspace = true }
 cloud = { workspace = true }
 fail = "0.5"
 futures = "0.3"

--- a/components/codec/Cargo.toml
+++ b/components/codec/Cargo.toml
@@ -14,7 +14,7 @@ thiserror = "1.0"
 tikv_alloc = { workspace = true }
 
 [dev-dependencies]
-bytes = "1.0"
+bytes = { workspace = true }
 panic_hook = { workspace = true }
 protobuf = "2"
 rand = "0.8"

--- a/components/encryption/Cargo.toml
+++ b/components/encryption/Cargo.toml
@@ -14,7 +14,7 @@ sm4 = ["openssl/vendored"]
 [dependencies]
 async-trait = "0.1"
 byteorder = "1.2"
-bytes = "1.0"
+bytes = { workspace = true }
 cloud = { workspace = true }
 crc32fast = "1.2"
 crossbeam = "0.8"

--- a/components/raftstore-v2/Cargo.toml
+++ b/components/raftstore-v2/Cargo.toml
@@ -27,7 +27,7 @@ test-engines-panic = [
 
 [dependencies]
 batch-system = { workspace = true }
-bytes = "1.0"
+bytes = { workspace = true }
 causal_ts = { workspace = true }
 collections = { workspace = true }
 concurrency_manager = { workspace = true }

--- a/components/raftstore/Cargo.toml
+++ b/components/raftstore/Cargo.toml
@@ -23,7 +23,7 @@ test-engines-panic = ["engine_test/test-engines-panic"]
 batch-system = { workspace = true }
 bitflags = "1.0.1"
 byteorder = "1.2"
-bytes = "1.0"
+bytes = { workspace = true }
 causal_ts = { workspace = true }
 chrono = { workspace = true }
 collections = { workspace = true }

--- a/components/region_cache_memory_engine/Cargo.toml
+++ b/components/region_cache_memory_engine/Cargo.toml
@@ -12,7 +12,7 @@ testexport = []
 engine_traits = { workspace = true }
 collections = { workspace = true }
 skiplist-rs = { git = "https://github.com/tikv/skiplist-rs.git", branch = "main" }
-bytes = "1.0"
+bytes = { workspace = true }
 crossbeam = "0.8"
 futures = { version = "0.3", features = ["compat"] }
 tikv_util = { workspace = true }

--- a/components/tikv_util/Cargo.toml
+++ b/components/tikv_util/Cargo.toml
@@ -14,7 +14,7 @@ test-cgroup = []
 async-speed-limit = "0.4.2"
 backtrace = "0.3.9"
 byteorder = "1.2"
-bytes = "1.0"
+bytes = { workspace = true }
 chrono = { workspace = true }
 codec = { workspace = true }
 collections = { workspace = true }

--- a/deny.toml
+++ b/deny.toml
@@ -9,7 +9,8 @@ deny = [
     # computting object's md5.
     { name = "md5", wrappers = ["aws"] },
     { name = "md-5", wrappers = ["aws-smithy-checksums"]},
-    { name = "sha1", wrappers = ["aws-smithy-checksums"]},
+    # time 0.2 pulls sha1 through stdweb's proc-macro on wasm-only targets.
+    { name = "sha1", wrappers = ["aws-smithy-checksums", "stdweb-internal-macros"]},
     { name = "sha-1" },
     # We allow sha2 for oauth2 and aws rust sdk crate, because it does use sha2 in TiKV use case.
     { name = "sha2", wrappers = ["oauth2", "aws-sigv4", "aws-smithy-checksums", "aws-sdk-s3"] },
@@ -34,24 +35,23 @@ deny = [
     # Ban trait crates from RustCrypto.
     { name = "aead" },
     { name = "cipher" },
-    { name = "digest", wrappers = ["sha2", "md-5", "sha1", "hmac"] },
+    # aws-smithy-checksums reaches digest through crc-fast in newer releases.
+    { name = "digest", wrappers = ["sha2", "md-5", "sha1", "hmac", "crc-fast"] },
     { name = "password-hash" },
     { name = "signature" },
 ]
 multiple-versions = "allow"
 
 [advisories]
-vulnerability = "deny"
-unmaintained = "allow" # FIXME: Deny it.
-unsound = "deny"
+version = 2
 yanked = "deny"
-notice = "warn"
+unmaintained = 'workspace'
 ignore = [
     # Ignore time 0.1 RUSTSEC-2020-0071 as 1) we have taken measures (see
-    # clippy.toml) to mitigate the issue and 2) time 0.1 has no fix availble.
+    # clippy.toml) to mitigate the issue and 2) time 0.1 has no fix available.
     #
-    # NB: Upgrading to time 0.3 do fix the issue but it's an imcompatible
-    # versoin which removes some necessary APIs (`time::precise_time_ns`) that
+    # NB: Upgrading to time 0.3 does fix the issue, but it's an incompatible
+    # version which removes some necessary APIs (`time::precise_time_ns`) that
     # are required by TiKV.
     # See https://github.com/time-rs/time/blob/8067540c/CHANGELOG.md#L703
     "RUSTSEC-2020-0071",
@@ -73,10 +73,6 @@ ignore = [
     #
     # TODO: Upgrade clap to v4.x.
     "RUSTSEC-2021-0145",
-    # Ignore RUSTSEC-2024-0006 as it only included by "rusoto_credential" crate.
-    #
-    # TODO: Upgrade shlex@0.1.1 to v1.3.x.
-    "RUSTSEC-2024-0006",
     # Ignore RUSTSEC-2025-0004, as it will trigger a recursive upgrade of OpenSSL
     # to version 3.x.
     #
@@ -91,6 +87,27 @@ ignore = [
     # also upgrade the OpenSSL to v3.x which causes performance degradation.
     # See https://github.com/openssl/openssl/issues/17064
     "RUSTSEC-2025-0022",
+    # Ignore RUSTSEC-2024-0436, as there is no widely used replacement of
+    # package 'paste', and the package itself is very stable.
+    "RUSTSEC-2024-0436",
+    # Ignore RUSTSEC-2025-0057 temporarily. We are evaluating alternatives to
+    # replace FxHash. Currently, this package is stable and there are no known
+    # exploitable vulnerabilities affecting our use case.
+    "RUSTSEC-2025-0057",
+    # Ignore following warnings/errors temporarily. We are evaluating
+    # alternatives to replace them. Currently, these packages are stable and
+    # there are no known exploitable vulnerabilities affecting our use case.
+    "RUSTSEC-2021-0146",
+    "RUSTSEC-2023-0081",
+    "RUSTSEC-2024-0388",
+    # aws-sdk-s3 transitively depends on lru 0.12.x, which triggers
+    # RUSTSEC-2026-0002 (Stacked Borrows UB). Upstream dependency constraints
+    # prevent upgrading it at the moment.
+    "RUSTSEC-2026-0002",
+    # RUSTSEC-2026-0009 is fixed by a larger time/serde dependency refresh on
+    # newer branches. That upgrade is not compatible with the current 8.1
+    # dependency constraints, so ignore it here for now.
+    "RUSTSEC-2026-0009",
 ]
 
 # TiKV is licensed under Apache 2.0, according to ASF 3RD PARTY LICENSE POLICY,
@@ -98,8 +115,7 @@ ignore = [
 # under certain conditions.
 # See https://www.apache.org/legal/resolved.html.
 [licenses]
-unlicensed = "deny"
-copyleft = "deny"
+version = 2
 private = { ignore = false }
 # Allow licenses in Category A
 allow = ["0BSD", "Apache-2.0", "BSD-3-Clause", "CC0-1.0", "ISC", "MIT", "Zlib", "Unicode-3.0"]

--- a/scripts/deny
+++ b/scripts/deny
@@ -2,8 +2,12 @@
 
 set -euo pipefail
 
+# use a standalone rust version to build and run deny to decouple from the code build environment
+RUST_VERSION="1.92.0"
+rustup toolchain install $RUST_VERSION --profile minimal --no-self-update
+
 # Update cargo-deny to the 0.15.1 version to fix the issue reported by https://github.com/tikv/tikv/pull/17987.
-cargo install --locked cargo-deny@0.15.1 2> /dev/null || echo "Install cargo-deny failed"
-cargo deny -V
-cargo deny fetch all
-cargo deny check --show-stats
+cargo +${RUST_VERSION} install --locked cargo-deny@0.18.9 2> /dev/null || echo "Install cargo-deny failed"
+cargo +${RUST_VERSION} deny -V
+cargo +${RUST_VERSION} deny fetch all
+cargo +${RUST_VERSION} deny check --show-stats


### PR DESCRIPTION
1. Pin `kvproto` to `release-8.1` in `Cargo.toml` so `pull-check-deps` passes on the `release-8.1` branch.
2. cherry-pick from https://github.com/tikv/tikv/pull/19475/

### What is changed and how it works?

Issue Number: close #19477

What's Changed:

```commit-message
release-8.1: pin kvproto dependency branch to release-8.1 for pull-check-deps
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
None
```