### PR TITLE
tikv_alloc: remove thread from thread_arena_map when thread exits

### DIFF
--- a/components/tikv_alloc/src/jemalloc.rs
+++ b/components/tikv_alloc/src/jemalloc.rs
@@ -3,7 +3,7 @@
 // The implementation of this crate when jemalloc is turned on
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     ptr::{self, NonNull},
     slice,
     sync::Mutex,
@@ -132,8 +132,14 @@ pub unsafe fn add_thread_memory_accessor() {
 }
 
 pub fn remove_thread_memory_accessor() {
+    let tid = thread::current().id();
+
     let mut thread_memory_map = THREAD_MEMORY_MAP.lock().unwrap();
-    thread_memory_map.remove(&thread::current().id());
+    thread_memory_map.remove(&tid);
+    drop(thread_memory_map);
+
+    let mut thread_arena_map = THREAD_ARENA_MAP.lock().unwrap();
+    thread_arena_map.remove(&tid);
 }
 
 use std::thread::ThreadId;
@@ -231,9 +237,14 @@ pub fn iterate_arena_allocation_stats(mut f: impl FnMut(&str, u64, u64, u64)) {
     // skip advancing the epoch here.
     let thread_arena_map = THREAD_ARENA_MAP.lock().unwrap();
     let mut collected = HashMap::<&str, (u64, u64, u64)>::with_capacity(thread_arena_map.len());
+    let mut seen = HashSet::<(&str, usize)>::with_capacity(thread_arena_map.len());
     for (_, (name, index)) in thread_arena_map.iter() {
+        let thread_name = trim_thread_suffix(name);
+        if !seen.insert((thread_name, *index)) {
+            continue;
+        }
         let stats = fetch_arena_stats(*index);
-        let ent = collected.entry(trim_thread_suffix(name)).or_default();
+        let ent = collected.entry(thread_name).or_default();
         ent.0 += stats.0;
         ent.1 += stats.1;
         ent.2 += stats.2;
@@ -259,7 +270,9 @@ extern "C" fn write_cb(printer: *mut c_void, msg: *const c_char) {
 #[cfg(test)]
 mod tests {
     use crate::{
-        add_thread_memory_accessor, imp::THREAD_MEMORY_MAP, remove_thread_memory_accessor,
+        add_thread_memory_accessor,
+        imp::{THREAD_ARENA_MAP, THREAD_MEMORY_MAP},
+        remove_thread_memory_accessor,
     };
 
     fn assert_delta(name: impl std::fmt::Display, delta: f64, a: u64, b: u64) {
@@ -322,6 +335,66 @@ mod tests {
         drop(l);
         for th in threads.into_iter() {
             th.join().unwrap();
+        }
+    }
+
+    #[test]
+    fn test_remove_thread_memory_accessor_cleans_arena_map() {
+        let tid = std::thread::current().id();
+        let old_memory = THREAD_MEMORY_MAP.lock().unwrap().remove(&tid);
+        let old_arena = THREAD_ARENA_MAP.lock().unwrap().remove(&tid);
+
+        THREAD_ARENA_MAP
+            .lock()
+            .unwrap()
+            .insert(tid, ("test-remove-thread-memory-accessor".to_owned(), 1));
+
+        remove_thread_memory_accessor();
+
+        assert!(THREAD_ARENA_MAP.lock().unwrap().get(&tid).is_none());
+
+        if let Some(entry) = old_memory {
+            THREAD_MEMORY_MAP.lock().unwrap().insert(tid, entry);
+        }
+        if let Some(entry) = old_arena {
+            THREAD_ARENA_MAP.lock().unwrap().insert(tid, entry);
+        }
+    }
+
+    #[cfg(feature = "mem-profiling")]
+    #[test]
+    fn test_iterate_arena_allocation_stats_dedups_same_arena() {
+        let tid = std::thread::current().id();
+        let other_tid = std::thread::spawn(|| std::thread::current().id())
+            .join()
+            .unwrap();
+        let old_current = THREAD_ARENA_MAP.lock().unwrap().remove(&tid);
+        let old_other = THREAD_ARENA_MAP.lock().unwrap().remove(&other_tid);
+
+        {
+            let mut arena_map = THREAD_ARENA_MAP.lock().unwrap();
+            arena_map.insert(tid, ("test-dedup-1".to_owned(), 0));
+            arena_map.insert(other_tid, ("test-dedup-2".to_owned(), 0));
+        }
+
+        let expected = super::fetch_arena_stats(0);
+        let mut collected = Vec::new();
+        super::iterate_arena_allocation_stats(|name, resident, mapped, retained| {
+            if name == "test-dedup" {
+                collected.push((resident, mapped, retained));
+            }
+        });
+
+        assert_eq!(collected, vec![expected]);
+
+        let mut arena_map = THREAD_ARENA_MAP.lock().unwrap();
+        arena_map.remove(&tid);
+        arena_map.remove(&other_tid);
+        if let Some(entry) = old_current {
+            arena_map.insert(tid, entry);
+        }
+        if let Some(entry) = old_other {
+            arena_map.insert(other_tid, entry);
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #19478

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Fix inaccurate `tikv_allocator_thread_stats` reporting in the jemalloc-backed
  allocator metrics.

  `tikv_allocator_thread_stats` is derived from per-arena jemalloc stats grouped
  by
  trimmed thread name. The collector could over-report in two cases:

  1. `THREAD_ARENA_MAP` entries were not removed when a thread exited, so stale
     arena stats could remain visible in the metric.
  2. Arena stats were summed without deduplicating `(thread_name, arena_index)`,
     so the same arena could be counted more than once for one logical thread
     group.

  This patch fixes both issues by removing the current thread from
  `THREAD_ARENA_MAP` in `remove_thread_memory_accessor()` and deduplicating
  arena
  indices during `iterate_arena_allocation_stats()`
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented double-counting in memory allocation statistics by deduplicating entries that map to the same arena after trimming thread identifiers.
  * Ensured thread memory tracking is fully removed when a thread is cleared so stale entries no longer persist.

* **Tests**
  * Added tests to confirm thread memory tracking is cleaned up correctly.
  * Added tests verifying allocation-statistics deduplication yields a single reported entry for equivalent mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->