### PR TITLE
raftstore: skip early heartbeat after split to fix empty pending_peers

### DIFF
--- a/components/raftstore-v2/src/operation/command/admin/split.rs
+++ b/components/raftstore-v2/src/operation/command/admin/split.rs
@@ -933,12 +933,12 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             let control = self.split_flow_control_mut();
             control.approximate_size = split_init.approximate_size;
             control.approximate_keys = split_init.approximate_keys;
-            // Skip heartbeat here: the peer is still a Candidate after
-            // campaign(), so pending_peers would be reported as
-            // empty (progress is only available for Leaders). The
-            // first heartbeat will be sent from on_role_changed()
-            // after the election completes, with correct pending_peers
-            // information.
+            // Skip heartbeat here: the peer may still be in Candidate state
+            // or not yet be Leader immediately after campaign(), so
+            // pending_peers would be reported as empty (progress is only
+            // available for Leaders). The first heartbeat will be sent from
+            // on_role_changed() after the election completes, with correct
+            // pending_peers information.
         }
 
         if split_init.check_split {

--- a/components/raftstore-v2/src/operation/command/admin/split.rs
+++ b/components/raftstore-v2/src/operation/command/admin/split.rs
@@ -933,9 +933,12 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             let control = self.split_flow_control_mut();
             control.approximate_size = split_init.approximate_size;
             control.approximate_keys = split_init.approximate_keys;
-            // The new peer is likely to become leader, send a heartbeat immediately to
-            // reduce client query miss.
-            self.region_heartbeat_pd(store_ctx);
+            // Skip heartbeat here: the peer is still a Candidate after
+            // campaign(), so pending_peers would be reported as
+            // empty (progress is only available for Leaders). The
+            // first heartbeat will be sent from on_role_changed()
+            // after the election completes, with correct pending_peers
+            // information.
         }
 
         if split_init.check_split {

--- a/components/raftstore-v2/tests/integrations/test_split.rs
+++ b/components/raftstore-v2/tests/integrations/test_split.rs
@@ -3,6 +3,8 @@
 use std::time::Duration;
 
 use engine_traits::{CF_RAFT, Peekable, RaftEngineReadOnly};
+use futures::executor::block_on;
+use pd_client::PdClient;
 use raftstore::store::{INIT_EPOCH_VER, RAFT_INIT_LOG_INDEX};
 use tikv_util::store::new_peer;
 use txn_types::{Key, TimeStamp};
@@ -195,3 +197,57 @@ fn test_split() {
 // - created peer with pending snapshot
 // - created peer with persisting snapshot
 // - created peer with persisted snapshot
+
+/// Test that after split, the new region correctly reports its leader to PD.
+/// This verifies that the heartbeat is sent after the leader election completes
+/// (from on_role_changed), not prematurely during post_split_init when the peer
+/// may still be a Candidate and pending_peers would be incorrectly reported.
+#[test]
+fn test_split_region_heartbeat_to_pd() {
+    let cluster = Cluster::with_node_count(1, None);
+    let store_id = cluster.node(0).id();
+    let router = &cluster.routers[0];
+
+    let region_id = 2;
+    let region = router.region_detail(region_id);
+    let peer = region.get_peers()[0].clone();
+    router.wait_applied_to_current_term(region_id, Duration::from_secs(3));
+
+    // Split region 2 into region 2 ["", "k22"] and region 1000 ["k22", ""]
+    let split_region_id = 1000;
+    let (left, right) = split_region(
+        router,
+        region,
+        peer,
+        split_region_id,
+        new_peer(store_id, 10),
+        Some(b"k11"),
+        Some(b"k33"),
+        b"k22",
+        b"k22",
+        false,
+    );
+
+    // Verify both regions have leaders reported to PD.
+    // The split_region helper already waits 1 second for split to complete,
+    // which is enough time for leader election and heartbeat.
+    for (rid, expected_peer_id) in [(region_id, peer.get_id()), (split_region_id, 10)] {
+        let mut found = false;
+        for _ in 0..10 {
+            let resp = block_on(cluster.node(0).pd_client().get_region_leader_by_id(rid)).unwrap();
+            if let Some((r, p)) = resp {
+                assert_eq!(r.get_id(), rid);
+                assert_eq!(p.get_id(), expected_peer_id);
+                assert_eq!(p.get_store_id(), store_id);
+                found = true;
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        assert!(found, "region {} should have leader reported to PD", rid);
+    }
+
+    // Verify region boundaries are correct
+    assert_eq!(left.get_end_key(), b"k22");
+    assert_eq!(right.get_start_key(), b"k22");
+}

--- a/components/raftstore-v2/tests/integrations/test_split.rs
+++ b/components/raftstore-v2/tests/integrations/test_split.rs
@@ -211,6 +211,7 @@ fn test_split_region_heartbeat_to_pd() {
     let region_id = 2;
     let region = router.region_detail(region_id);
     let peer = region.get_peers()[0].clone();
+    let peer_id = peer.get_id();
     router.wait_applied_to_current_term(region_id, Duration::from_secs(3));
 
     // Split region 2 into region 2 ["", "k22"] and region 1000 ["k22", ""]
@@ -231,7 +232,7 @@ fn test_split_region_heartbeat_to_pd() {
     // Verify both regions have leaders reported to PD.
     // The split_region helper already waits 1 second for split to complete,
     // which is enough time for leader election and heartbeat.
-    for (rid, expected_peer_id) in [(region_id, peer.get_id()), (split_region_id, 10)] {
+    for (rid, expected_peer_id) in [(region_id, peer_id), (split_region_id, 10)] {
         let mut found = false;
         for _ in 0..10 {
             let resp = block_on(cluster.node(0).pd_client().get_region_leader_by_id(rid)).unwrap();

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -4836,9 +4836,12 @@ where
                 new_peer.peer.set_approximate_size(share_size);
                 new_peer.peer.set_approximate_keys(share_keys);
                 *new_peer.peer.txn_ext.pessimistic_locks.write() = locks;
-                // The new peer is likely to become leader, send a heartbeat immediately to
-                // reduce client query miss.
-                new_peer.peer.heartbeat_pd(self.ctx);
+                // Skip heartbeat here: the peer is still a Candidate after
+                // maybe_campaign(), so pending_peers would be reported as empty
+                // (raft progress is only available for Leaders). The first
+                // heartbeat will be sent from on_role_changed()
+                // after the election completes, with correct
+                // pending_peers information.
             }
 
             new_peer.peer.activate(self.ctx);

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -4836,12 +4836,15 @@ where
                 new_peer.peer.set_approximate_size(share_size);
                 new_peer.peer.set_approximate_keys(share_keys);
                 *new_peer.peer.txn_ext.pessimistic_locks.write() = locks;
-                // Skip heartbeat here: the peer is still a Candidate after
-                // maybe_campaign(), so pending_peers would be reported as empty
-                // (raft progress is only available for Leaders). The first
-                // heartbeat will be sent from on_role_changed()
-                // after the election completes, with correct
-                // pending_peers information.
+                // Skip heartbeat here: after maybe_campaign() the peer may
+                // still be in the middle of election (e.g.
+                // Candidate), so Raft progress
+                // and thus pending_peers are not yet reliably reflecting the
+                // final leader's view. The first heartbeat will
+                // be sent from on_role_changed() after the
+                // election completes, when the peer is
+                // confirmed as Leader and PD can record both the correct leader
+                // and pending_peers.
             }
 
             new_peer.peer.activate(self.ctx);


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Close #19483

What's Changed:

After a region split, the new peer calls `campaign()` and becomes a Candidate. TiKV immediately sends a PD heartbeat, but `collect_pending_peers()` returns an empty vector for Candidates because Raft's `status.progress` is only available for Leaders. This causes PD to report `PendingPeers = []` for a region that hasn't finished its leader election, which misleads BR's `hasHealthyRegion()` check during PiTR restore, leading to `NotLeader`/`EpochNotMatch` errors.

This PR removes the premature heartbeat from post-split initialization in both raftstore-v1 and raftstore-v2. The first heartbeat will instead be sent from `on_role_changed()` after the election completes, with correct `pending_peers` information.

```commit-message
After a region split, the new peer calls campaign() and becomes a
Candidate. Sending a heartbeat to PD at this point reports empty
pending_peers because Raft progress is only available for Leaders.
This causes BR's hasHealthyRegion() to incorrectly consider the
region ready, leading to NotLeader/EpochNotMatch errors during PITR
restore.

Remove the heartbeat from post-split init in both raftstore-v1 and
raftstore-v2. The first heartbeat will instead be sent from
on_role_changed() after the election completes, with correct
pending_peers information.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests

- [ ] Unit test
- [x] Manual test (add detailed scripts or steps below)
- Verified during PiTR restore on a production-scale cluster. After this fix, `NotLeader` errors from BR-initiated pre-splits are eliminated.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
Fix inaccurate pending_peers reporting after region split that could cause BR PiTR restore failures with NotLeader/EpochNotMatch errors.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure initial heartbeat to the placement driver is deferred until a new peer fully assumes leadership, improving consistency of region status reporting after splits and reducing client query misses.

* **Tests**
  * Added an integration test validating post-split leader reporting and region key boundaries as observed by the placement driver.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->