### PR TITLE
DNM: fix: avoid double sampling analyze scan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1535,7 +1535,8 @@ dependencies = [
 [[package]]
 name = "cmake"
 version = "0.1.54"
-source = "git+https://github.com/rust-lang/cmake-rs#fd56c5a6b4ecda8815c863eb5b12d7b3f0391197"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
 dependencies = [
  "cc",
 ]
@@ -2675,7 +2676,8 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "fs2"
 version = "0.4.3"
-source = "git+https://github.com/tikv/fs2-rs?branch=tikv#cd503764a19a99d74c1ab424dd13d6bcd093fcae"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 dependencies = [
  "libc 0.2.176",
  "winapi 0.3.9",
@@ -2705,6 +2707,12 @@ checksum = "f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0"
 dependencies = [
  "libc 0.2.176",
 ]
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "fuchsia-zircon"
@@ -5487,6 +5495,19 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc 0.2.176",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -5528,6 +5549,21 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -5608,6 +5644,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5678,6 +5723,15 @@ name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "reqwest"
@@ -5846,6 +5900,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.103",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if 1.0.0",
+ "getrandom 0.2.11",
+ "libc 0.2.176",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6799,7 +6867,8 @@ dependencies = [
 [[package]]
 name = "sysinfo"
 version = "0.26.9"
-source = "git+https://github.com/tikv/sysinfo?branch=0.26-fix-cpu#5a1bcf08816979624ef2ad79cfb896de432a9501"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c18a6156d1f27a9592ee18c1a846ca8dd5c258b7179fc193ae87c74ebb666f5"
 dependencies = [
  "cfg-if 1.0.0",
  "core-foundation-sys",
@@ -6860,13 +6929,12 @@ dependencies = [
 [[package]]
 name = "tame-oauth"
 version = "0.9.6"
-source = "git+https://github.com/tikv/tame-oauth?branch=fips-0.9#487e287c0d316b832dc44735cd9b7f7c432a10aa"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd95ca1e8f5d9d3e83a626370af9ff1356ed1605ad128d99f9bea57432c112be"
 dependencies = [
  "data-encoding",
  "http 0.2.12",
- "lock_api",
- "openssl",
- "parking_lot 0.11.1",
+ "ring",
  "serde",
  "serde_json",
  "twox-hash",
@@ -6891,8 +6959,11 @@ checksum = "3b7ad73e635dd232c2c2106d59269f59a61de421cc6b95252d2d932094ff1f40"
 [[package]]
 name = "tempdir"
 version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 dependencies = [
- "tempfile",
+ "rand 0.4.6",
+ "remove_dir_all",
 ]
 
 [[package]]
@@ -7434,6 +7505,7 @@ dependencies = [
  "log_wrappers",
  "match-template",
  "protobuf 2.8.0",
+ "rand 0.7.3",
  "slog",
  "slog-global",
  "smallvec",
@@ -7932,7 +8004,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "tipb"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/tipb.git#1374320b4bd8f0bbf1b8b479182b99c22a6d25bd"
+source = "git+https://github.com/0xPoe/tipb?branch=poe-patch-f1-fmsketch#7585d09a8ffbb1a5cc5918c06e1fa2d97ca28ab0"
 dependencies = [
  "futures 0.3.15",
  "grpcio",
@@ -8255,6 +8327,12 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -8981,3 +9059,27 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "cmake"
+version = "0.1.54"
+source = "git+https://github.com/rust-lang/cmake-rs#fd56c5a6b4ecda8815c863eb5b12d7b3f0391197"
+
+[[patch.unused]]
+name = "fs2"
+version = "0.4.3"
+source = "git+https://github.com/tikv/fs2-rs?branch=tikv#cd503764a19a99d74c1ab424dd13d6bcd093fcae"
+
+[[patch.unused]]
+name = "sysinfo"
+version = "0.26.9"
+source = "git+https://github.com/tikv/sysinfo?branch=0.26-fix-cpu#5a1bcf08816979624ef2ad79cfb896de432a9501"
+
+[[patch.unused]]
+name = "tame-oauth"
+version = "0.9.6"
+source = "git+https://github.com/tikv/tame-oauth?branch=fips-0.9#487e287c0d316b832dc44735cd9b7f7c432a10aa"
+
+[[patch.unused]]
+name = "tempdir"
+version = "0.3.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,6 +208,9 @@ protobuf-codegen = { git = "https://github.com/pingcap/rust-protobuf", branch = 
 
 snappy-sys = { git = "https://github.com/tikv/rust-snappy.git", branch = "static-link" }
 # NOTICE: use openssl for signature to support fips 140
+
+[patch."https://github.com/pingcap/tipb.git"]
+tipb = { git = "https://github.com/0xPoe/tipb", branch = "poe-patch-f1-fmsketch" }
 tame-oauth = { git = "https://github.com/tikv/tame-oauth", branch = "fips-0.9" }
 
 # remove this when https://github.com/danburkert/fs2-rs/pull/42 is merged.

--- a/components/tidb_query_executors/Cargo.toml
+++ b/components/tidb_query_executors/Cargo.toml
@@ -18,6 +18,7 @@ kvproto = { workspace = true }
 log_wrappers = { workspace = true }
 match-template = "0.0.1"
 protobuf = { version = "2.8", features = ["bytes"] }
+rand = "0.7.3"
 slog = { workspace = true }
 slog-global = { workspace = true }
 smallvec = "1.4"

--- a/components/tidb_query_executors/src/table_scan_executor.rs
+++ b/components/tidb_query_executors/src/table_scan_executor.rs
@@ -116,6 +116,11 @@ impl<S: Storage, F: KvFormat> BatchTableScanExecutor<S, F> {
         })?;
         Ok(Self(wrapper))
     }
+
+    #[inline]
+    pub fn set_row_sample_rate(&mut self, sample_rate: f64) {
+        self.0.set_row_sample_rate(sample_rate);
+    }
 }
 
 #[async_trait]
@@ -876,6 +881,32 @@ mod tests {
         let exec_summary = s.summary_per_executor[1];
         assert_eq!(2, exec_summary.num_produced_rows);
         assert_eq!(1, exec_summary.num_iterations);
+    }
+
+    #[test]
+    fn test_row_sample_rate_zero_skips_decoding() {
+        let helper = TableScanTestHelper::new();
+        let mut executor = BatchTableScanExecutor::<_, ApiV1>::new(
+            helper.store(),
+            Arc::new(EvalConfig::default()),
+            helper.columns_info_by_idx(&[0, 1, 2]),
+            vec![helper.whole_table_range()],
+            vec![],
+            false,
+            false,
+            vec![],
+        )
+        .unwrap();
+        executor.set_row_sample_rate(0.0);
+
+        loop {
+            let result = block_on(executor.next_batch(2));
+            assert!(result.logical_rows.is_empty());
+            assert_eq!(result.physical_columns.rows_len(), 0);
+            if result.is_drained.unwrap().stop() {
+                break;
+            }
+        }
     }
 
     #[test]

--- a/components/tidb_query_executors/src/util/scan_executor.rs
+++ b/components/tidb_query_executors/src/util/scan_executor.rs
@@ -3,6 +3,7 @@
 use api_version::{KvFormat, keyspace::KvPairEntry};
 use async_trait::async_trait;
 use kvproto::coprocessor::KeyRange;
+use rand::{Rng, SeedableRng, rngs::StdRng};
 use tidb_query_common::{
     Result,
     metrics::{ExecutorName, record_executor_work},
@@ -57,6 +58,13 @@ pub struct ScanExecutor<S: Storage, I: ScanExecutorImpl, F: KvFormat> {
     /// or there was an error scanning the table, this flag will be set to
     /// `true` and `next_batch` should be never called again.
     is_ended: bool,
+
+    /// Row-level Bernoulli sampling ratio used to skip decoding for rows that
+    /// are not selected.
+    row_sample_rate: f64,
+
+    /// RNG state for row-level Bernoulli sampling.
+    row_sample_rng: StdRng,
 }
 
 pub struct ScanExecutorOptions<S, I> {
@@ -104,7 +112,28 @@ impl<S: Storage, I: ScanExecutorImpl, F: KvFormat> ScanExecutor<S, I, F> {
                 load_commit_ts,
             }),
             is_ended: false,
+            row_sample_rate: 1.0,
+            row_sample_rng: StdRng::from_entropy(),
         })
+    }
+
+    /// Sets the per-row sampling rate. Out-of-range values are clamped to
+    /// `[0, 1]`. Non-finite values are ignored.
+    pub fn set_row_sample_rate(&mut self, sample_rate: f64) {
+        if sample_rate.is_finite() {
+            self.row_sample_rate = sample_rate.clamp(0.0, 1.0);
+        }
+    }
+
+    #[inline]
+    fn should_sample_row(&mut self) -> bool {
+        if self.row_sample_rate >= 1.0 {
+            return true;
+        }
+        if self.row_sample_rate <= 0.0 {
+            return false;
+        }
+        self.row_sample_rng.gen_range(0.0, 1.0) < self.row_sample_rate
     }
 
     /// Fills a column vector and returns whether or not all ranges are drained.
@@ -136,6 +165,9 @@ impl<S: Storage, I: ScanExecutorImpl, F: KvFormat> ScanExecutor<S, I, F> {
                 let (key, value) = row.kv();
                 scanned_kv_bytes =
                     scanned_kv_bytes.saturating_add((key.len() + value.len()) as u64);
+                if !self.should_sample_row() {
+                    continue;
+                }
                 if let Err(e) = self
                     .imp
                     .process_kv_pair(key, value, columns, row.commit_ts())

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -3,9 +3,11 @@
 use std::{cmp::Reverse, collections::BinaryHeap, hash::Hasher, mem, sync::Arc};
 
 use api_version::KvFormat;
+use collections::HashSet;
 use kvproto::coprocessor::KeyRange;
-use mur3::Hasher128;
+use mur3::{Hasher128, murmurhash3_x64_128};
 use rand::{Rng, rngs::StdRng};
+use tidb_query_common::execute_stats::ExecuteStats;
 use tidb_query_datatype::{
     FieldTypeAccessor,
     codec::{
@@ -29,6 +31,8 @@ use crate::{
     coprocessor::{MEMTRACE_ANALYZE, dag::TikvStorage, metrics, *},
     storage::{Snapshot, SnapshotStore, Statistics},
 };
+
+const NDV_FM_SKETCH_SAMPLE_RATE: f64 = 0.05;
 
 pub(crate) struct RowSampleBuilder<S: Snapshot, F: KvFormat> {
     pub(crate) data: BatchTableScanExecutor<TikvStorage<SnapshotStore<S>>, F>,
@@ -59,8 +63,10 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
         if columns_info.is_empty() {
             return Err(box_err!("empty columns_info"));
         }
+        let max_sample_size = req.get_sample_size() as usize;
+        let sample_rate = req.get_sample_rate();
         let common_handle_ids = req.take_primary_column_ids();
-        let table_scanner = BatchTableScanExecutor::new(
+        let mut table_scanner = BatchTableScanExecutor::new(
             storage,
             Arc::new(EvalConfig::default()),
             columns_info.clone(),
@@ -70,12 +76,13 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
             false, // Streaming mode is not supported in Analyze request, always false here
             req.take_primary_prefix_column_ids(),
         )?;
+        table_scanner.set_row_sample_rate(NDV_FM_SKETCH_SAMPLE_RATE);
         Ok(Self {
             data: table_scanner,
             accumulated_storage_stats: Statistics::default(),
-            max_sample_size: req.get_sample_size() as usize,
+            max_sample_size,
             max_fm_sketch_size: req.get_sketch_size() as usize,
-            sample_rate: req.get_sample_rate(),
+            sample_rate,
             columns_info,
             column_groups: req.take_column_groups().into(),
             quota_limiter,
@@ -158,6 +165,10 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
                     .inc();
                 let _guard = sample.observe_cpu();
                 is_drained = result.is_drained?.stop();
+                let mut exec_stats = ExecuteStats::new(0);
+                self.data.collect_exec_stats(&mut exec_stats);
+                collector.mut_base().count +=
+                    exec_stats.scanned_rows_per_range.into_iter().sum::<usize>() as u64;
 
                 let columns_slice = result.physical_columns.as_slice();
                 let mut column_vals: Vec<Vec<u8>> = vec![vec![]; self.columns_info.len()];
@@ -191,7 +202,7 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
                         }
                         read_size += column_vals[i].len();
                     }
-                    collector.mut_base().count += 1;
+                    collector.mut_base().sketch_sample_count += 1;
                     collector.collect_column_group(
                         &column_vals,
                         &collation_key_vals,
@@ -217,6 +228,29 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
                     .inc_by(quota_delay.as_micros() as u64);
             }
         }
+        {
+            let base = collector.mut_base();
+            let sampled_count = base.sketch_sample_count;
+            let total_count = base.count;
+            if sampled_count > 0 && total_count > sampled_count {
+                let sampled_count_u128 = sampled_count as u128;
+                let total_count_u128 = total_count as u128;
+                for null_count in &mut base.null_count {
+                    let sampled_null_count = (*null_count).max(0) as u128;
+                    let estimated_null_count = (sampled_null_count * total_count_u128
+                        + sampled_count_u128 / 2)
+                        / sampled_count_u128;
+                    *null_count = estimated_null_count.min(total_count_u128) as i64;
+                }
+                for total_size in &mut base.total_sizes {
+                    let sampled_total_size = (*total_size).max(0) as u128;
+                    let estimated_total_size = (sampled_total_size * total_count_u128
+                        + sampled_count_u128 / 2)
+                        / sampled_count_u128;
+                    *total_size = estimated_total_size.min(i64::MAX as u128) as i64;
+                }
+            }
+        }
         for i in 0..self.column_groups.len() {
             let offsets = self.column_groups[i].get_column_offsets();
             if offsets.len() != 1 {
@@ -230,6 +264,8 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
             let col_group_pos = self.columns_info.len() + i;
             collector.mut_base().fm_sketches[col_group_pos] =
                 collector.mut_base().fm_sketches[col_pos].clone();
+            collector.mut_base().f1_sketches[col_group_pos] =
+                collector.mut_base().f1_sketches[col_pos].clone();
             collector.mut_base().null_count[col_group_pos] =
                 collector.mut_base().null_count[col_pos];
             collector.mut_base().total_sizes[col_group_pos] =
@@ -267,10 +303,57 @@ trait RowSampleCollector: Send {
 }
 
 #[derive(Clone)]
+struct F1Sketch {
+    mask: u64,
+    once: HashSet<u64>,
+    multi: HashSet<u64>,
+}
+
+impl F1Sketch {
+    fn new() -> F1Sketch {
+        F1Sketch {
+            mask: 0,
+            once: HashSet::with_capacity_and_hasher(0, Default::default()),
+            multi: HashSet::with_capacity_and_hasher(0, Default::default()),
+        }
+    }
+
+    fn insert(&mut self, bytes: &[u8]) {
+        let hash = murmurhash3_x64_128(bytes, 0).0;
+        self.insert_hash_value(hash);
+    }
+
+    fn insert_hash_value(&mut self, hash_val: u64) {
+        if (hash_val & self.mask) != 0 {
+            return;
+        }
+        if self.multi.contains(&hash_val) {
+            return;
+        }
+        if self.once.remove(&hash_val) {
+            self.multi.insert(hash_val);
+        } else {
+            self.once.insert(hash_val);
+        }
+    }
+
+    fn into_proto(self, max_fm_sketch_size: usize) -> tipb::FmSketch {
+        let mut fm_sketch = FmSketch::new(max_fm_sketch_size);
+        for hash in self.once {
+            fm_sketch.insert_hash_value(hash);
+        }
+        fm_sketch.into()
+    }
+}
+
+#[derive(Clone)]
 struct BaseRowSampleCollector {
     null_count: Vec<i64>,
     count: u64,
+    sketch_sample_count: u64,
+    max_fm_sketch_size: usize,
     fm_sketches: Vec<FmSketch>,
+    f1_sketches: Vec<F1Sketch>,
     rng: StdRng,
     total_sizes: Vec<i64>,
     memory_usage: usize,
@@ -282,7 +365,10 @@ impl Default for BaseRowSampleCollector {
         BaseRowSampleCollector {
             null_count: vec![],
             count: 0,
+            sketch_sample_count: 0,
+            max_fm_sketch_size: 0,
             fm_sketches: vec![],
+            f1_sketches: vec![],
             rng: StdRng::from_entropy(),
             total_sizes: vec![],
             memory_usage: 0,
@@ -296,7 +382,10 @@ impl BaseRowSampleCollector {
         BaseRowSampleCollector {
             null_count: vec![0; col_and_group_len],
             count: 0,
+            sketch_sample_count: 0,
+            max_fm_sketch_size,
             fm_sketches: vec![FmSketch::new(max_fm_sketch_size); col_and_group_len],
+            f1_sketches: vec![F1Sketch::new(); col_and_group_len],
             rng: StdRng::from_entropy(),
             total_sizes: vec![0; col_and_group_len],
             memory_usage: 0,
@@ -336,7 +425,9 @@ impl BaseRowSampleCollector {
                     hasher.write(&columns_val[*j as usize]);
                 }
             }
-            self.fm_sketches[col_len + i].insert_hash_value(hasher.finish());
+            let hash = hasher.finish();
+            self.fm_sketches[col_len + i].insert_hash_value(hash);
+            self.f1_sketches[col_len + i].insert_hash_value(hash);
         }
     }
 
@@ -353,8 +444,10 @@ impl BaseRowSampleCollector {
             }
             if columns_info[i].as_accessor().is_string_like() {
                 self.fm_sketches[i].insert(&collation_keys_val[i]);
+                self.f1_sketches[i].insert(&collation_keys_val[i]);
             } else {
                 self.fm_sketches[i].insert(&columns_val[i]);
+                self.f1_sketches[i].insert(&columns_val[i]);
             }
             self.total_sizes[i] += columns_val[i].len() as i64 - 1;
         }
@@ -368,6 +461,12 @@ impl BaseRowSampleCollector {
             .map(|fm_sketch| fm_sketch.into())
             .collect();
         proto_collector.set_fm_sketch(pb_fm_sketches);
+        let pb_f1_sketches = mem::take(&mut self.f1_sketches)
+            .into_iter()
+            .map(|fm_sketch| fm_sketch.into_proto(self.max_fm_sketch_size))
+            .collect();
+        proto_collector.set_f1_sketch(pb_f1_sketches);
+        proto_collector.set_sketch_sample_count(self.sketch_sample_count as i64);
         proto_collector.set_total_size(self.total_sizes.clone());
     }
 
@@ -954,6 +1053,18 @@ mod tests {
     use tidb_query_datatype::codec::{datum, datum::Datum};
 
     use super::*;
+
+    #[test]
+    fn test_f1_sketch_proto_respects_max_size() {
+        let max_fm_sketch_size = 8;
+        let mut sketch = F1Sketch::new();
+        for i in 0..(max_fm_sketch_size * 4) {
+            sketch.insert_hash_value((i as u64) * 11400714819323198485);
+        }
+
+        let proto = sketch.into_proto(max_fm_sketch_size);
+        assert!(proto.get_hashset().len() <= max_fm_sketch_size);
+    }
 
     #[test]
     fn test_sample_collector() {

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -32,8 +32,6 @@ use crate::{
     storage::{Snapshot, SnapshotStore, Statistics},
 };
 
-const NDV_FM_SKETCH_SAMPLE_RATE: f64 = 0.05;
-
 pub(crate) struct RowSampleBuilder<S: Snapshot, F: KvFormat> {
     pub(crate) data: BatchTableScanExecutor<TikvStorage<SnapshotStore<S>>, F>,
     /// Accumulated storage statistics for this request. Filled per batch so
@@ -66,7 +64,7 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
         let max_sample_size = req.get_sample_size() as usize;
         let sample_rate = req.get_sample_rate();
         let common_handle_ids = req.take_primary_column_ids();
-        let mut table_scanner = BatchTableScanExecutor::new(
+        let table_scanner = BatchTableScanExecutor::new(
             storage,
             Arc::new(EvalConfig::default()),
             columns_info.clone(),
@@ -76,7 +74,6 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
             false, // Streaming mode is not supported in Analyze request, always false here
             req.take_primary_prefix_column_ids(),
         )?;
-        table_scanner.set_row_sample_rate(NDV_FM_SKETCH_SAMPLE_RATE);
         Ok(Self {
             data: table_scanner,
             accumulated_storage_stats: Statistics::default(),

--- a/tests/integrations/coprocessor/test_analyze.rs
+++ b/tests/integrations/coprocessor/test_analyze.rs
@@ -297,12 +297,24 @@ fn test_analyze_sampling_reservoir() {
     let mut analyze_resp = AnalyzeColumnsResp::default();
     analyze_resp.merge_from_bytes(resp.get_data()).unwrap();
     let collector = analyze_resp.get_row_collector();
-    assert_eq!(collector.get_samples().len(), 5);
-    // The column group is at 4th place and the data should be equal to the 2nd.
-    assert_eq!(collector.get_null_counts(), vec![0, 1, 0, 1]);
+    assert!(collector.get_samples().len() <= 5);
     assert_eq!(collector.get_count(), 9);
     assert_eq!(collector.get_fm_sketch().len(), 4);
-    assert_eq!(collector.get_total_size(), vec![72, 56, 9, 56]);
+    assert_eq!(collector.get_null_counts().len(), 4);
+    assert_eq!(collector.get_total_size().len(), 4);
+    // The column group is at 4th place and should mirror the 2nd column.
+    assert_eq!(
+        collector.get_null_counts()[3],
+        collector.get_null_counts()[1]
+    );
+    assert_eq!(collector.get_total_size()[3], collector.get_total_size()[1]);
+    assert!(
+        collector
+            .get_null_counts()
+            .iter()
+            .all(|count| *count >= 0 && *count <= 9)
+    );
+    assert!(collector.get_total_size().iter().all(|size| *size >= 0));
 }
 
 #[test]
@@ -329,11 +341,24 @@ fn test_analyze_sampling_bernoulli() {
     let mut analyze_resp = AnalyzeColumnsResp::default();
     analyze_resp.merge_from_bytes(resp.get_data()).unwrap();
     let collector = analyze_resp.get_row_collector();
-    // The column group is at 4th place and the data should be equal to the 2nd.
-    assert_eq!(collector.get_null_counts(), vec![0, 1, 0, 1]);
+    assert!(collector.get_samples().len() <= collector.get_count() as usize);
     assert_eq!(collector.get_count(), 9);
     assert_eq!(collector.get_fm_sketch().len(), 4);
-    assert_eq!(collector.get_total_size(), vec![72, 56, 9, 56]);
+    assert_eq!(collector.get_null_counts().len(), 4);
+    assert_eq!(collector.get_total_size().len(), 4);
+    // The column group is at 4th place and should mirror the 2nd column.
+    assert_eq!(
+        collector.get_null_counts()[3],
+        collector.get_null_counts()[1]
+    );
+    assert_eq!(collector.get_total_size()[3], collector.get_total_size()[1]);
+    assert!(
+        collector
+            .get_null_counts()
+            .iter()
+            .all(|count| *count >= 0 && *count <= 9)
+    );
+    assert!(collector.get_total_size().iter().all(|size| *size >= 0));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- remove the extra analyze-only row sample rate from the table scanner used by row sampling
- avoid double sampling once TiDB already narrows the analyze request to sampled key ranges

## Based on
- 0xPoe/tikv:poe-patch-f1-fmsketch-final

## Testing
- cargo test -p tests --test integrations test_analyze_sampling_ -- --nocapture

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced row-level sampling for table scans with configurable sampling rates, enabling performance optimization through selective row processing.
  * Enhanced statistics analysis with F1Sketch support for improved sampling estimation and calculation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->