### PR TITLE
remove individual background rate limiter

### DIFF
--- a/components/resource_control/src/metrics.rs
+++ b/components/resource_control/src/metrics.rs
@@ -6,20 +6,19 @@ use prometheus::*;
 lazy_static! {
     pub static ref BACKGROUND_QUOTA_LIMIT_VEC: IntGaugeVec = register_int_gauge_vec!(
         "tikv_resource_control_background_quota_limiter",
-        "The quota limiter of background resource groups per resource type",
-        &["resource_group", "type"]
+        "The quota limiter for all background tasks (aggregated across all background resource groups) per resource type",
+        &["type"]
     )
     .unwrap();
     pub static ref BACKGROUND_RESOURCE_CONSUMPTION: IntCounterVec = register_int_counter_vec!(
         "tikv_resource_control_background_resource_consumption",
-        "Total resource consumed of background resource groups per resource type",
-        &["resource_group", "type"]
+        "Total resource consumed by all background tasks (aggregated across all background resource groups) per resource type",
+        &["type"]
     )
     .unwrap();
-    pub static ref BACKGROUND_TASKS_WAIT_DURATION: IntCounterVec = register_int_counter_vec!(
+    pub static ref BACKGROUND_TASKS_WAIT_DURATION: IntCounter = register_int_counter!(
         "tikv_resource_control_background_task_wait_duration",
-        "Total wait duration of background tasks per resource group",
-        &["resource_group"]
+        "Total wait duration of all background tasks (aggregated across all background resource groups)"
     )
     .unwrap();
     pub static ref PRIORITY_QUOTA_LIMIT_VEC: IntGaugeVec = register_int_gauge_vec!(
@@ -50,10 +49,9 @@ lazy_static! {
     .unwrap();
 }
 
-pub fn deregister_metrics(name: &str) {
-    for ty in ["cpu", "io"] {
-        _ = BACKGROUND_QUOTA_LIMIT_VEC.remove_label_values(&[name, ty]);
-        _ = BACKGROUND_RESOURCE_CONSUMPTION.remove_label_values(&[name, ty]);
-    }
-    _ = BACKGROUND_TASKS_WAIT_DURATION.remove_label_values(&[name]);
+pub fn deregister_metrics(_name: &str) {
+    // BACKGROUND_QUOTA_LIMIT_VEC, BACKGROUND_RESOURCE_CONSUMPTION, and
+    // BACKGROUND_TASKS_WAIT_DURATION are no longer per-group: all background
+    // groups share a single global limiter and always emit metrics under the
+    // fixed label "background". There are no per-group series to clean up here.
 }

--- a/components/resource_control/src/metrics.rs
+++ b/components/resource_control/src/metrics.rs
@@ -48,10 +48,3 @@ lazy_static! {
     )
     .unwrap();
 }
-
-pub fn deregister_metrics(_name: &str) {
-    // BACKGROUND_QUOTA_LIMIT_VEC, BACKGROUND_RESOURCE_CONSUMPTION, and
-    // BACKGROUND_TASKS_WAIT_DURATION are no longer per-group: all background
-    // groups share a single global limiter and always emit metrics under the
-    // fixed label "background". There are no per-group series to clean up here.
-}

--- a/components/resource_control/src/resource_group.rs
+++ b/components/resource_control/src/resource_group.rs
@@ -62,13 +62,10 @@ pub struct ResourceGroupManager {
     // the count of all groups, a fast path because call `DashMap::len` is a little slower.
     group_count: AtomicU64,
     registry: RwLock<Vec<Arc<ResourceController>>>,
-    // auto incremental version generator used for mark the background
-    // resource limiter has changed.
-    version_generator: AtomicU64,
     // the shared resource limiter of each priority
     priority_limiters: [Arc<ResourceLimiter>; TaskPriority::PRIORITY_COUNT],
     // single shared limiter for all background tasks.
-    pub bg_limiter: Arc<ResourceLimiter>,
+    bg_limiter: Arc<ResourceLimiter>,
     // lastest config.
     config: Arc<VersionTrack<Config>>,
 }
@@ -101,7 +98,6 @@ impl ResourceGroupManager {
             resource_groups: Default::default(),
             group_count: AtomicU64::new(0),
             registry: Default::default(),
-            version_generator: AtomicU64::new(0),
             priority_limiters,
             bg_limiter,
             config: Arc::new(VersionTrack::new(config)),

--- a/components/resource_control/src/resource_group.rs
+++ b/components/resource_control/src/resource_group.rs
@@ -27,7 +27,7 @@ use tikv_util::{
 };
 use yatp::queue::priority::TaskPriorityProvider;
 
-use crate::{config::Config, metrics::deregister_metrics, resource_limiter::ResourceLimiter};
+use crate::{config::Config, resource_limiter::ResourceLimiter};
 
 // a read task cost at least 50us.
 const DEFAULT_PRIORITY_PER_READ_TASK: u64 = 50;
@@ -64,8 +64,9 @@ pub struct ResourceGroupManager {
     registry: RwLock<Vec<Arc<ResourceController>>>,
     // the shared resource limiter of each priority
     priority_limiters: [Arc<ResourceLimiter>; TaskPriority::PRIORITY_COUNT],
-    // single shared limiter for all background tasks.
     bg_limiter: Arc<ResourceLimiter>,
+    // cached: true when at least one group has background settings configured.
+    has_background: AtomicBool,
     // lastest config.
     config: Arc<VersionTrack<Config>>,
 }
@@ -88,7 +89,7 @@ impl ResourceGroupManager {
             ))
         });
         let bg_limiter = Arc::new(ResourceLimiter::new(
-            "background".to_owned(),
+            DEFAULT_RESOURCE_GROUP_NAME.to_owned(),
             f64::INFINITY,
             f64::INFINITY,
             0,
@@ -100,6 +101,7 @@ impl ResourceGroupManager {
             registry: Default::default(),
             priority_limiters,
             bg_limiter,
+            has_background: AtomicBool::new(false),
             config: Arc::new(VersionTrack::new(config)),
         };
 
@@ -172,6 +174,21 @@ impl ResourceGroupManager {
             .resource_groups
             .iter()
             .any(|g| !g.background_source_types.is_empty());
+        let prev = self.has_background.swap(any_has_bg, Ordering::Release);
+        // When the last background group is removed, reset the shared limiter to
+        // unlimited so that a later re-add does not inherit stale throttled rates.
+        if prev && !any_has_bg {
+            use crate::resource_limiter::ResourceType;
+            self.bg_limiter
+                .get_limiter(ResourceType::Cpu)
+                .set_rate_limit(f64::INFINITY);
+            self.bg_limiter
+                .get_limiter(ResourceType::Io)
+                .set_rate_limit(f64::INFINITY);
+            self.bg_limiter
+                .get_write_io_limiter()
+                .set_rate_limit(f64::INFINITY);
+        }
         self.registry.read().iter().for_each(|controller| {
             controller.set_has_background(any_has_bg);
         });
@@ -191,7 +208,6 @@ impl ResourceGroupManager {
             controller.remove_resource_group(group_name.as_bytes());
         });
         if self.resource_groups.remove(&group_name).is_some() {
-            deregister_metrics(name);
             info!("remove resource group"; "name"=> name);
             self.group_count.fetch_sub(1, Ordering::Relaxed);
         }
@@ -208,7 +224,6 @@ impl ResourceGroupManager {
             let ret = f(k, &v.group);
             if !ret {
                 removed_names.push(k.clone());
-                deregister_metrics(k);
             }
             ret
         });
@@ -220,6 +235,7 @@ impl ResourceGroupManager {
             });
             self.group_count
                 .fetch_sub(removed_names.len() as u64, Ordering::Relaxed);
+            self.update_has_background();
         }
     }
 
@@ -362,9 +378,7 @@ impl ResourceGroupManager {
     }
 
     pub fn has_background_groups(&self) -> bool {
-        self.resource_groups
-            .iter()
-            .any(|kv| !kv.value().background_source_types.is_empty())
+        self.has_background.load(Ordering::Acquire)
     }
 }
 
@@ -388,15 +402,6 @@ impl ResourceGroup {
             background_source_types,
             fallback_default,
         }
-    }
-
-    pub(crate) fn get_ru_quota(&self) -> u64 {
-        assert!(self.group.has_r_u_settings());
-        self.group
-            .get_r_u_settings()
-            .get_r_u()
-            .get_settings()
-            .get_fill_rate()
     }
 
     fn get_background_resource_limiter(

--- a/components/resource_control/src/resource_group.rs
+++ b/components/resource_control/src/resource_group.rs
@@ -67,6 +67,8 @@ pub struct ResourceGroupManager {
     version_generator: AtomicU64,
     // the shared resource limiter of each priority
     priority_limiters: [Arc<ResourceLimiter>; TaskPriority::PRIORITY_COUNT],
+    // single shared limiter for all background tasks.
+    pub bg_limiter: Arc<ResourceLimiter>,
     // lastest config.
     config: Arc<VersionTrack<Config>>,
 }
@@ -88,12 +90,20 @@ impl ResourceGroupManager {
                 false,
             ))
         });
+        let bg_limiter = Arc::new(ResourceLimiter::new(
+            "background".to_owned(),
+            f64::INFINITY,
+            f64::INFINITY,
+            0,
+            true,
+        ));
         let manager = Self {
             resource_groups: Default::default(),
             group_count: AtomicU64::new(0),
             registry: Default::default(),
             version_generator: AtomicU64::new(0),
             priority_limiters,
+            bg_limiter,
             config: Arc::new(VersionTrack::new(config)),
         };
 
@@ -149,12 +159,7 @@ impl ResourceGroupManager {
             controller.add_resource_group(group_name.clone().into_bytes(), ru_quota, rg.priority);
         });
         info!("add resource group"; "name"=> &rg.name, "ru" => rg.get_r_u_settings().get_r_u().get_settings().get_fill_rate());
-        // try to reuse the quota limit when update resource group settings.
-        let prev_limiter = self
-            .resource_groups
-            .get(&rg.name)
-            .and_then(|g| g.limiter.clone());
-        let limiter = self.build_resource_limiter(&rg, prev_limiter);
+        let limiter = self.build_resource_limiter(&rg);
 
         if self
             .resource_groups
@@ -176,22 +181,9 @@ impl ResourceGroupManager {
         });
     }
 
-    fn build_resource_limiter(
-        &self,
-        rg: &PbResourceGroup,
-        old_limiter: Option<Arc<ResourceLimiter>>,
-    ) -> Option<Arc<ResourceLimiter>> {
+    fn build_resource_limiter(&self, rg: &PbResourceGroup) -> Option<Arc<ResourceLimiter>> {
         if !rg.get_background_settings().get_job_types().is_empty() {
-            old_limiter.or_else(|| {
-                let version = self.version_generator.fetch_add(1, Ordering::Relaxed);
-                Some(Arc::new(ResourceLimiter::new(
-                    rg.name.clone(),
-                    f64::INFINITY,
-                    f64::INFINITY,
-                    version,
-                    true,
-                )))
-            })
+            Some(self.bg_limiter.clone())
         } else {
             None
         }
@@ -367,6 +359,16 @@ impl ResourceGroupManager {
         &self,
     ) -> &[Arc<ResourceLimiter>; TaskPriority::PRIORITY_COUNT] {
         &self.priority_limiters
+    }
+
+    pub fn get_background_limiter(&self) -> Arc<ResourceLimiter> {
+        self.bg_limiter.clone()
+    }
+
+    pub fn has_background_groups(&self) -> bool {
+        self.resource_groups
+            .iter()
+            .any(|kv| !kv.value().background_source_types.is_empty())
     }
 }
 

--- a/components/resource_control/src/resource_group.rs
+++ b/components/resource_control/src/resource_group.rs
@@ -404,6 +404,14 @@ impl ResourceGroup {
         }
     }
 
+    pub fn get_ru_quota(&self) -> u64 {
+        self.group
+            .get_r_u_settings()
+            .get_r_u()
+            .get_settings()
+            .get_fill_rate()
+    }
+
     fn get_background_resource_limiter(
         &self,
         request_source: &str,

--- a/components/resource_control/src/resource_group.rs
+++ b/components/resource_control/src/resource_group.rs
@@ -404,6 +404,7 @@ impl ResourceGroup {
         }
     }
 
+    #[cfg(test)]
     pub fn get_ru_quota(&self) -> u64 {
         self.group
             .get_r_u_settings()

--- a/components/resource_control/src/resource_group.rs
+++ b/components/resource_control/src/resource_group.rs
@@ -261,6 +261,7 @@ impl ResourceGroupManager {
             let ru_quota = Self::get_ru_setting(&g.value().group, controller.is_read);
             controller.add_resource_group(g.key().clone().into_bytes(), ru_quota, g.group.priority);
         }
+        controller.set_has_background(self.has_background.load(Ordering::Acquire));
         controller
     }
 

--- a/components/resource_control/src/service.rs
+++ b/components/resource_control/src/service.rs
@@ -13,7 +13,9 @@ use pd_client::{
     meta_storage::{Checked, Get, MetaStorageClient, Sourced, Watch},
 };
 use serde::{Deserialize, Serialize};
-use tikv_util::{error, info, resource_control::DEFAULT_RESOURCE_GROUP_NAME, timer::GLOBAL_TIMER_HANDLE, warn};
+use tikv_util::{
+    error, info, resource_control::DEFAULT_RESOURCE_GROUP_NAME, timer::GLOBAL_TIMER_HANDLE, warn,
+};
 
 use crate::{ResourceGroupManager, resource_limiter::ResourceType};
 

--- a/components/resource_control/src/service.rs
+++ b/components/resource_control/src/service.rs
@@ -13,7 +13,7 @@ use pd_client::{
     meta_storage::{Checked, Get, MetaStorageClient, Sourced, Watch},
 };
 use serde::{Deserialize, Serialize};
-use tikv_util::{error, info, timer::GLOBAL_TIMER_HANDLE, warn};
+use tikv_util::{error, info, resource_control::DEFAULT_RESOURCE_GROUP_NAME, timer::GLOBAL_TIMER_HANDLE, warn};
 
 use crate::{ResourceGroupManager, resource_limiter::ResourceType};
 
@@ -212,11 +212,11 @@ impl ResourceManagerService {
 
             // Non-existence or version change means this is a brand new limiter,
             // so no need to sub the old statistics.
-            let (cpu_consumed, io_consumed) = if let Some(ref last_stats) = last_bg_statistics
+            let (cpu_consumed, io_consumed) = if let Some(last_stats) = last_bg_statistics
                 .as_ref()
                 .filter(|s| s.version == statistic.version)
             {
-                if statistic == **last_stats {
+                if statistic == *last_stats {
                     let _ = GLOBAL_TIMER_HANDLE
                         .delay(std::time::Instant::now() + BACKGROUND_RU_REPORT_DURATION)
                         .compat()
@@ -245,7 +245,7 @@ impl ResourceManagerService {
             let all_reqs = req.mut_requests();
             // report ru statistics.
             let mut bucket_req = TokenBucketRequest::default();
-            bucket_req.set_resource_group_name("background".to_owned());
+            bucket_req.set_resource_group_name(DEFAULT_RESOURCE_GROUP_NAME.to_owned());
             bucket_req.set_is_background(true);
             let report_consumption = bucket_req.mut_consumption_since_last_request();
 

--- a/components/resource_control/src/service.rs
+++ b/components/resource_control/src/service.rs
@@ -1,10 +1,6 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-    time::Duration,
-};
+use std::{collections::HashSet, sync::Arc, time::Duration};
 
 use futures::{StreamExt, compat::Future01CompatExt, stream};
 use kvproto::{
@@ -187,37 +183,13 @@ impl ResourceManagerService {
 
     // report ru metrics periodically.
     pub async fn report_ru_metrics(&self) {
-        let mut last_group_statistics_map: HashMap<String, ReportStatistic> = HashMap::new();
+        let mut last_bg_statistics: Option<ReportStatistic> = None;
         // load controller config firstly.
         let config = self.load_controller_config().await;
         info!("load controller config"; "config" => ?config);
 
         loop {
-            let background_groups: Vec<_> = self
-                .manager
-                .resource_groups
-                .iter()
-                .filter_map(|kv| {
-                    let g = kv.value();
-                    g.limiter.clone().map(|limiter| {
-                        let io_statistics = limiter.get_limit_statistics(ResourceType::Io);
-                        let cpu_statistics = limiter.get_limit_statistics(ResourceType::Cpu);
-
-                        (
-                            g.group.name.clone(),
-                            ReportStatistic {
-                                // io statistics and cpu statistics should have the same version.
-                                version: io_statistics.version,
-                                read_bytes_consumed: io_statistics.read_consumed,
-                                write_bytes_consumed: io_statistics.write_consumed,
-                                cpu_consumed: cpu_statistics.total_consumed,
-                            },
-                        )
-                    })
-                })
-                .collect();
-
-            if background_groups.is_empty() {
+            if !self.manager.has_background_groups() {
                 let _ = GLOBAL_TIMER_HANDLE
                     .delay(std::time::Instant::now() + BACKGROUND_RU_REPORT_DURATION)
                     .compat()
@@ -225,55 +197,69 @@ impl ResourceManagerService {
                 continue;
             }
 
+            // All background groups share a single limiter; read it once and
+            // report under the fixed label "background".
+            let limiter = self.manager.get_background_limiter();
+            let io_statistics = limiter.get_limit_statistics(ResourceType::Io);
+            let cpu_statistics = limiter.get_limit_statistics(ResourceType::Cpu);
+            let statistic = ReportStatistic {
+                // io statistics and cpu statistics should have the same version.
+                version: io_statistics.version,
+                read_bytes_consumed: io_statistics.read_consumed,
+                write_bytes_consumed: io_statistics.write_consumed,
+                cpu_consumed: cpu_statistics.total_consumed,
+            };
+
+            // Non-existence or version change means this is a brand new limiter,
+            // so no need to sub the old statistics.
+            let (cpu_consumed, io_consumed) = if let Some(ref last_stats) = last_bg_statistics
+                .as_ref()
+                .filter(|s| s.version == statistic.version)
+            {
+                if statistic == **last_stats {
+                    let _ = GLOBAL_TIMER_HANDLE
+                        .delay(std::time::Instant::now() + BACKGROUND_RU_REPORT_DURATION)
+                        .compat()
+                        .await;
+                    continue;
+                }
+                (
+                    statistic.cpu_consumed - last_stats.cpu_consumed,
+                    (
+                        statistic.read_bytes_consumed - last_stats.read_bytes_consumed,
+                        statistic.write_bytes_consumed - last_stats.write_bytes_consumed,
+                    ),
+                )
+            } else {
+                (
+                    statistic.cpu_consumed,
+                    (
+                        statistic.read_bytes_consumed,
+                        statistic.write_bytes_consumed,
+                    ),
+                )
+            };
+            last_bg_statistics = Some(statistic);
+
             let mut req = TokenBucketsRequest::default();
             let all_reqs = req.mut_requests();
-            for (name, statistic) in background_groups.into_iter() {
-                // Non-existence or version change means this is a brand new limiter, so no need
-                // to sub the old statistics.
-                let (cpu_consumed, io_consumed) = if let Some(last_stats) =
-                    last_group_statistics_map
-                        .get(&name)
-                        .filter(|stats| statistic.version == stats.version)
-                {
-                    if statistic == *last_stats {
-                        continue;
-                    }
-                    (
-                        statistic.cpu_consumed - last_stats.cpu_consumed,
-                        (
-                            statistic.read_bytes_consumed - last_stats.read_bytes_consumed,
-                            statistic.write_bytes_consumed - last_stats.write_bytes_consumed,
-                        ),
-                    )
-                } else {
-                    (
-                        statistic.cpu_consumed,
-                        (
-                            statistic.read_bytes_consumed,
-                            statistic.write_bytes_consumed,
-                        ),
-                    )
-                };
-                // replace the previous statistics.
-                last_group_statistics_map.insert(name.clone(), statistic);
-                // report ru statistics.
-                let mut req = TokenBucketRequest::default();
-                req.set_resource_group_name(name.clone());
-                req.set_is_background(true);
-                let report_consumption = req.mut_consumption_since_last_request();
+            // report ru statistics.
+            let mut bucket_req = TokenBucketRequest::default();
+            bucket_req.set_resource_group_name("background".to_owned());
+            bucket_req.set_is_background(true);
+            let report_consumption = bucket_req.mut_consumption_since_last_request();
 
-                let read_total = config.read_cpu_ms_cost * cpu_consumed as f64
-                    + config.read_cost_per_byte * io_consumed.0 as f64;
-                let write_total = config.write_cost_per_byte * io_consumed.1 as f64;
+            let read_total = config.read_cpu_ms_cost * cpu_consumed as f64
+                + config.read_cost_per_byte * io_consumed.0 as f64;
+            let write_total = config.write_cost_per_byte * io_consumed.1 as f64;
 
-                report_consumption.set_r_r_u(read_total);
-                report_consumption.set_w_r_u(write_total);
-                report_consumption.set_read_bytes(io_consumed.0 as f64);
-                report_consumption.set_write_bytes(io_consumed.1 as f64);
-                report_consumption.set_total_cpu_time_ms(cpu_consumed as f64);
+            report_consumption.set_r_r_u(read_total);
+            report_consumption.set_w_r_u(write_total);
+            report_consumption.set_read_bytes(io_consumed.0 as f64);
+            report_consumption.set_write_bytes(io_consumed.1 as f64);
+            report_consumption.set_total_cpu_time_ms(cpu_consumed as f64);
 
-                all_reqs.push(req);
-            }
+            all_reqs.push(bucket_req);
 
             if !all_reqs.is_empty()
                 && let Err(e) = self.pd_client.report_ru_metrics(req).await
@@ -555,7 +541,7 @@ pub mod tests {
         background_worker.spawn_async_task(async move {
             s_clone.report_ru_metrics().await;
         });
-        // Mock consume.
+        // Mock consume on the shared background limiter.
         let bg_limiter = s
             .manager
             .get_background_resource_limiter(BACKGROUND_WORKER_THREAD, "br")
@@ -571,22 +557,18 @@ pub mod tests {
         );
         // Wait for report ru metrics.
         std::thread::sleep(Duration::from_millis(100));
-        // Mock update version.
-        let bg = new_resource_group_ru(BACKGROUND_WORKER_THREAD.into(), 1000, 15);
-        s.manager.add_resource_group(bg);
 
+        // Add a second background group; all groups share the same limiter.
         let background_group = new_background_resource_group_ru(
-            BACKGROUND_WORKER_THREAD.into(),
+            "lightning_group".into(),
             500,
             8,
             vec!["lightning".into()],
         );
         s.manager.add_resource_group(background_group);
-        let new_bg_limiter = s
-            .manager
-            .get_background_resource_limiter(BACKGROUND_WORKER_THREAD, "lightning")
-            .unwrap();
-        new_bg_limiter.consume(
+        // Consuming through either group's limiter goes to the same shared
+        // limiter; the next report will reflect the delta.
+        bg_limiter.consume(
             Duration::from_secs(5),
             IoBytes {
                 read: 2000,

--- a/components/resource_control/src/worker.rs
+++ b/components/resource_control/src/worker.rs
@@ -183,8 +183,18 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
             return;
         }
 
-        self.do_adjust(ResourceType::Cpu, dur_secs, bg_util_limit, bg_resource_threshold);
-        self.do_adjust(ResourceType::Io, dur_secs, bg_util_limit, bg_resource_threshold);
+        self.do_adjust(
+            ResourceType::Cpu,
+            dur_secs,
+            bg_util_limit,
+            bg_resource_threshold,
+        );
+        self.do_adjust(
+            ResourceType::Io,
+            dur_secs,
+            bg_util_limit,
+            bg_resource_threshold,
+        );
         self.adjust_write_io_by_compaction_pressure();
     }
 
@@ -225,8 +235,7 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
         }
         let background_consumed = (stats_delta / dur_secs).total_consumed as f64;
 
-        let background_util =
-            (background_consumed / resource_stats.total_quota * 100.0) as u64;
+        let background_util = (background_consumed / resource_stats.total_quota * 100.0) as u64;
         let resource_util = resource_stats.current_used / resource_stats.total_quota * 100.0;
         BACKGROUND_TASK_RESOURCE_UTILIZATION_VEC
             .with_label_values(&[resource_type.as_str()])
@@ -274,7 +283,8 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
 
     /// Adjust the write-only IO limiter based on compaction pressure.
     /// When pressure >= threshold, linearly scale write IO from ceiling to
-    /// floor. Below threshold, write IO ramps up 10% per tick capped at ceiling.
+    /// floor. Below threshold, write IO ramps up 10% per tick capped at
+    /// ceiling.
     fn adjust_write_io_by_compaction_pressure(&self) {
         let pressure = self.compaction_pending_bytes_ratio.load(Ordering::Relaxed) as f64;
         let config = self.resource_ctl.get_config().value().clone();
@@ -297,7 +307,9 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
             (ceiling * (1.0 - pressure_ratio) + floor * pressure_ratio).max(floor)
         };
 
-        self.bg_limiter.get_write_io_limiter().set_rate_limit(new_limit);
+        self.bg_limiter
+            .get_write_io_limiter()
+            .set_rate_limit(new_limit);
     }
 }
 
@@ -1203,8 +1215,7 @@ mod tests {
         grp_a.mut_background_settings().set_utilization_limit(80);
         resource_ctl.add_resource_group(grp_a);
 
-        let grp_b =
-            new_background_resource_group_ru("group_b".into(), 1000, 8, vec!["br".into()]);
+        let grp_b = new_background_resource_group_ru("group_b".into(), 1000, 8, vec!["br".into()]);
         resource_ctl.add_resource_group(grp_b);
 
         let limiter_a = resource_ctl
@@ -1238,14 +1249,20 @@ mod tests {
             limiter_a.get_limiter(ResourceType::Cpu).get_rate_limit(),
             5.6 * MICROS_PER_SEC,
         );
-        check(limiter_a.get_limiter(ResourceType::Io).get_rate_limit(), 7000.0);
+        check(
+            limiter_a.get_limiter(ResourceType::Io).get_rate_limit(),
+            7000.0,
+        );
 
         // limiter_b is the same Arc so it reflects the same rates.
         check(
             limiter_b.get_limiter(ResourceType::Cpu).get_rate_limit(),
             5.6 * MICROS_PER_SEC,
         );
-        check(limiter_b.get_limiter(ResourceType::Io).get_rate_limit(), 7000.0);
+        check(
+            limiter_b.get_limiter(ResourceType::Io).get_rate_limit(),
+            7000.0,
+        );
 
         // Under heavy load (100% CPU) the budget scales down to min_floor for
         // the single global limiter — not independently per group.
@@ -1260,6 +1277,9 @@ mod tests {
             limiter_a.get_limiter(ResourceType::Cpu).get_rate_limit(),
             1.0 * MICROS_PER_SEC,
         );
-        check(limiter_a.get_limiter(ResourceType::Io).get_rate_limit(), 2000.0);
+        check(
+            limiter_a.get_limiter(ResourceType::Io).get_rate_limit(),
+            2000.0,
+        );
     }
 }

--- a/components/resource_control/src/worker.rs
+++ b/components/resource_control/src/worker.rs
@@ -104,6 +104,9 @@ pub struct GroupQuotaAdjustWorker<R> {
     bg_limiter: Arc<ResourceLimiter>,
     // Previous statistics snapshot per resource type for delta computation.
     prev_stats: [GroupStatistics; ResourceType::COUNT],
+    // Whether the previous tick had background groups. Used to detect the
+    // empty->non-empty transition and discard stale accumulated consumption.
+    prev_had_background: bool,
 }
 
 impl GroupQuotaAdjustWorker<SysQuotaGetter> {
@@ -140,6 +143,7 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
             compaction_pending_bytes_ratio,
             bg_limiter,
             prev_stats: array::from_fn(|_| GroupStatistics::default()),
+            prev_had_background: false,
         }
     }
 
@@ -180,7 +184,19 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
             .set(bg_util_limit as i64);
 
         if !self.resource_ctl.has_background_groups() {
+            self.prev_had_background = false;
             return;
+        }
+        if !self.prev_had_background {
+            // Flush consumption that accumulated while the limiter ran unlimited
+            // during the empty period, and drain the CPU delta so the first real
+            // tick sees a clean baseline.
+            self.prev_stats = [
+                self.bg_limiter.get_limit_statistics(ResourceType::Cpu),
+                self.bg_limiter.get_limit_statistics(ResourceType::Io),
+            ];
+            let _ = self.resource_quota_getter.get_current_stats(ResourceType::Cpu);
+            self.prev_had_background = true;
         }
 
         self.do_adjust(

--- a/components/resource_control/src/worker.rs
+++ b/components/resource_control/src/worker.rs
@@ -195,7 +195,9 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
                 self.bg_limiter.get_limit_statistics(ResourceType::Cpu),
                 self.bg_limiter.get_limit_statistics(ResourceType::Io),
             ];
-            let _ = self.resource_quota_getter.get_current_stats(ResourceType::Cpu);
+            let _ = self
+                .resource_quota_getter
+                .get_current_stats(ResourceType::Cpu);
             self.prev_had_background = true;
         }
 

--- a/components/resource_control/src/worker.rs
+++ b/components/resource_control/src/worker.rs
@@ -226,12 +226,10 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
             std::mem::replace(&mut self.prev_stats[resource_type as usize], total_stats);
         let stats_delta = total_stats - last_stats;
         BACKGROUND_RESOURCE_CONSUMPTION
-            .with_label_values(&["background", resource_type.as_str()])
+            .with_label_values(&[resource_type.as_str()])
             .inc_by(stats_delta.total_consumed);
         if resource_type == ResourceType::Cpu {
-            BACKGROUND_TASKS_WAIT_DURATION
-                .with_label_values(&["background"])
-                .inc_by(stats_delta.total_wait_dur_us);
+            BACKGROUND_TASKS_WAIT_DURATION.inc_by(stats_delta.total_wait_dur_us);
         }
         let background_consumed = (stats_delta / dur_secs).total_consumed as f64;
 
@@ -277,7 +275,7 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
             .get_limiter(resource_type)
             .set_rate_limit(new_budget);
         BACKGROUND_QUOTA_LIMIT_VEC
-            .with_label_values(&["background", resource_type.as_str()])
+            .with_label_values(&[resource_type.as_str()])
             .set(new_budget as i64);
     }
 

--- a/components/resource_control/src/worker.rs
+++ b/components/resource_control/src/worker.rs
@@ -2,7 +2,6 @@
 
 use std::{
     array,
-    collections::{HashMap, HashSet},
     io::Result as IoResult,
     sync::{
         Arc,
@@ -96,12 +95,15 @@ impl ResourceStatsProvider for SysQuotaGetter {
 }
 
 pub struct GroupQuotaAdjustWorker<R> {
-    prev_stats_by_group: [HashMap<String, GroupStatistics>; ResourceType::COUNT],
     last_adjust_time: Instant,
     resource_ctl: Arc<ResourceGroupManager>,
     resource_quota_getter: R,
     // Shared compaction pressure (0-100+) written by EnginesResourceInfo::update().
     compaction_pending_bytes_ratio: Arc<AtomicU32>,
+    // Single shared limiter for all background tasks.
+    bg_limiter: Arc<ResourceLimiter>,
+    // Previous statistics snapshot per resource type for delta computation.
+    prev_stats: [GroupStatistics; ResourceType::COUNT],
 }
 
 impl GroupQuotaAdjustWorker<SysQuotaGetter> {
@@ -130,13 +132,14 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
         resource_quota_getter: R,
         compaction_pending_bytes_ratio: Arc<AtomicU32>,
     ) -> Self {
-        let prev_stats_by_group = array::from_fn(|_| HashMap::default());
+        let bg_limiter = resource_ctl.get_background_limiter();
         Self {
-            prev_stats_by_group,
             last_adjust_time: Instant::now_coarse(),
             resource_ctl,
             resource_quota_getter,
             compaction_pending_bytes_ratio,
+            bg_limiter,
+            prev_stats: array::from_fn(|_| GroupStatistics::default()),
         }
     }
 
@@ -176,49 +179,13 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
             .with_label_values(&["limit"])
             .set(bg_util_limit as i64);
 
-        let mut background_groups: Vec<_> = self
-            .resource_ctl
-            .resource_groups
-            .iter()
-            .filter_map(|kv| {
-                let g = kv.value();
-                g.limiter.as_ref().map(|limiter| GroupStats {
-                    name: g.group.name.clone(),
-                    ru_quota: g.get_ru_quota() as f64,
-                    limiter: limiter.clone(),
-                })
-            })
-            .collect();
-        if background_groups.is_empty() {
+        if !self.resource_ctl.has_background_groups() {
             return;
         }
 
-        self.do_adjust(
-            ResourceType::Cpu,
-            dur_secs,
-            bg_util_limit,
-            bg_resource_threshold,
-            &mut background_groups,
-        );
-        self.do_adjust(
-            ResourceType::Io,
-            dur_secs,
-            bg_util_limit,
-            bg_resource_threshold,
-            &mut background_groups,
-        );
-
-        // Adjust write IO limiter based on compaction pressure.
-        self.adjust_write_io_by_compaction_pressure(&background_groups, dur_secs);
-
-        // clean up deleted group stats
-        if self.prev_stats_by_group[0].len() != background_groups.len() {
-            let name_set: HashSet<_> =
-                HashSet::from_iter(background_groups.iter().map(|g| &g.name));
-            for stat_map in &mut self.prev_stats_by_group {
-                stat_map.retain(|k, _v| !name_set.contains(k));
-            }
-        }
+        self.do_adjust(ResourceType::Cpu, dur_secs, bg_util_limit, bg_resource_threshold);
+        self.do_adjust(ResourceType::Io, dur_secs, bg_util_limit, bg_resource_threshold);
+        self.adjust_write_io_by_compaction_pressure();
     }
 
     fn do_adjust(
@@ -227,7 +194,6 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
         dur_secs: f64,
         utilization_limit: u64,
         bg_resource_threshold: f64,
-        bg_group_stats: &mut [GroupStats],
     ) {
         let resource_stats = match self.resource_quota_getter.get_current_stats(resource_type) {
             Ok(r) => r,
@@ -236,69 +202,44 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
                 return;
             }
         };
-        // if total resource quota is unlimited, set all groups' limit to unlimited.
+        // if total resource quota is unlimited, set background limit to unlimited.
         if resource_stats.total_quota <= f64::EPSILON {
-            for g in bg_group_stats {
-                g.limiter
-                    .get_limiter(resource_type)
-                    .set_rate_limit(f64::INFINITY);
-            }
+            self.bg_limiter
+                .get_limiter(resource_type)
+                .set_rate_limit(f64::INFINITY);
             return;
         }
 
-        // Collect statistics for metrics.
-        let mut total_ru_quota = 0.0;
-        let mut background_consumed_total = 0.0;
-        for g in bg_group_stats.iter_mut() {
-            total_ru_quota += g.ru_quota;
-            let total_stats = g.limiter.get_limit_statistics(resource_type);
-            let last_stats = self.prev_stats_by_group[resource_type as usize]
-                .insert(g.name.clone(), total_stats)
-                .unwrap_or_default();
-            let stats_delta = if total_stats.version == last_stats.version {
-                total_stats - last_stats
-            } else {
-                total_stats
-            };
-            BACKGROUND_RESOURCE_CONSUMPTION
-                .with_label_values(&[&g.name, resource_type.as_str()])
-                .inc_by(stats_delta.total_consumed);
-            if resource_type == ResourceType::Cpu {
-                BACKGROUND_TASKS_WAIT_DURATION
-                    .with_label_values(&[&g.name])
-                    .inc_by(stats_delta.total_wait_dur_us);
-            }
-            let stats_per_sec = stats_delta / dur_secs;
-            background_consumed_total += stats_per_sec.total_consumed as f64;
+        // Collect statistics for metrics from the single global limiter.
+        let total_stats = self.bg_limiter.get_limit_statistics(resource_type);
+        let last_stats =
+            std::mem::replace(&mut self.prev_stats[resource_type as usize], total_stats);
+        let stats_delta = total_stats - last_stats;
+        BACKGROUND_RESOURCE_CONSUMPTION
+            .with_label_values(&["background", resource_type.as_str()])
+            .inc_by(stats_delta.total_consumed);
+        if resource_type == ResourceType::Cpu {
+            BACKGROUND_TASKS_WAIT_DURATION
+                .with_label_values(&["background"])
+                .inc_by(stats_delta.total_wait_dur_us);
         }
+        let background_consumed = (stats_delta / dur_secs).total_consumed as f64;
 
         let background_util =
-            (background_consumed_total / resource_stats.total_quota * 100.0) as u64;
+            (background_consumed / resource_stats.total_quota * 100.0) as u64;
         let resource_util = resource_stats.current_used / resource_stats.total_quota * 100.0;
         BACKGROUND_TASK_RESOURCE_UTILIZATION_VEC
             .with_label_values(&[resource_type.as_str()])
             .set(background_util as i64);
 
-        if total_ru_quota <= f64::EPSILON {
-            return;
-        }
-
         let util_limit_percent = (utilization_limit as f64 / 100.0).min(1.0);
         let target = resource_stats.total_quota * util_limit_percent;
 
-        // Sum current background limits; treat infinity as an equal share of
-        // the target (initial state before first adjustment).
-        let current_total_bg_limit: f64 = bg_group_stats
-            .iter()
-            .map(|g| {
-                let limit = g.limiter.get_limiter(resource_type).get_rate_limit();
-                if limit.is_infinite() {
-                    target / bg_group_stats.len() as f64
-                } else {
-                    limit
-                }
-            })
-            .sum();
+        // Treat infinity as target (initial state before first adjustment).
+        let current_limit = {
+            let l = self.bg_limiter.get_limiter(resource_type).get_rate_limit();
+            if l.is_infinite() { target } else { l }
+        };
 
         // Minimum: 1 CPU core for CPU, 10% of total for IO.
         let min_floor = match resource_type {
@@ -307,60 +248,43 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
         }
         .min(target);
 
-        let mut new_total_bg_budget = target;
+        let mut new_budget = target;
         if resource_util > bg_resource_threshold {
             // System is overloaded. Linearly scale budget from target down to
             // min_floor as utilization goes from threshold (70%) to 100%.
-            // This aggressively throttles background regardless of how much
-            // it's consuming, freeing resources for online traffic.
             let pressure =
                 (resource_util - bg_resource_threshold) / (100.0 - bg_resource_threshold);
-            new_total_bg_budget = target * (1.0 - pressure) + min_floor * pressure;
-        } else if current_total_bg_limit > target {
+            new_budget = target * (1.0 - pressure) + min_floor * pressure;
+        } else if current_limit > target {
             // Background limit exceeds its allowed share; reset to target.
-            new_total_bg_budget = target;
-        } else if current_total_bg_limit < 0.9 * target
-            && resource_util < 0.9 * bg_resource_threshold
-        {
+            new_budget = target;
+        } else if current_limit < 0.9 * target && resource_util < 0.9 * bg_resource_threshold {
             // System is idle; increase limit incrementally from current limit.
-            new_total_bg_budget = current_total_bg_limit + 0.1 * current_total_bg_limit;
+            new_budget = current_limit * 1.1;
         }
 
-        let new_total_bg_budget = new_total_bg_budget.clamp(min_floor, target);
-
-        // Distribute proportionally by RU quota.
-        for g in bg_group_stats.iter() {
-            let limit = new_total_bg_budget * (g.ru_quota / total_ru_quota);
-            g.limiter.get_limiter(resource_type).set_rate_limit(limit);
-            BACKGROUND_QUOTA_LIMIT_VEC
-                .with_label_values(&[&g.name, resource_type.as_str()])
-                .set(limit as i64);
-        }
+        let new_budget = new_budget.clamp(min_floor, target);
+        self.bg_limiter
+            .get_limiter(resource_type)
+            .set_rate_limit(new_budget);
+        BACKGROUND_QUOTA_LIMIT_VEC
+            .with_label_values(&["background", resource_type.as_str()])
+            .set(new_budget as i64);
     }
 
     /// Adjust the write-only IO limiter based on compaction pressure.
     /// When pressure >= threshold, linearly scale write IO from ceiling to
-    /// floor. Below threshold, write IO is unlimited (infinity).
-    ///
-    /// Ceiling and floor are read from config (bg_write_io_ceiling,
-    /// bg_write_io_floor) in MB/s.
-    fn adjust_write_io_by_compaction_pressure(
-        &self,
-        bg_group_stats: &[GroupStats],
-        _dur_secs: f64,
-    ) {
+    /// floor. Below threshold, write IO ramps up 10% per tick capped at ceiling.
+    fn adjust_write_io_by_compaction_pressure(&self) {
         let pressure = self.compaction_pending_bytes_ratio.load(Ordering::Relaxed) as f64;
         let config = self.resource_ctl.get_config().value().clone();
         let threshold = config.bg_compaction_pressure_threshold.clamp(1.0, 99.0);
         let ceiling = config.bg_write_io_ceiling.0 as f64; // bytes/s
         let floor = config.bg_write_io_floor.0 as f64; // bytes/s
 
-        let total_budget = if pressure < threshold {
+        let new_limit = if pressure < threshold {
             // Below threshold: ramp up current limit by 10%, capped at ceiling.
-            let current_limit = bg_group_stats
-                .first()
-                .map(|g| g.limiter.get_write_io_limiter().get_rate_limit())
-                .unwrap_or(ceiling);
+            let current_limit = self.bg_limiter.get_write_io_limiter().get_rate_limit();
             if current_limit.is_infinite() || current_limit >= ceiling {
                 ceiling
             } else {
@@ -370,26 +294,11 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
             // Linear interpolation from ceiling to floor as pressure goes from
             // threshold to 100%.
             let pressure_ratio = ((pressure - threshold) / (100.0 - threshold)).clamp(0.0, 1.0);
-            let total_budget = ceiling * (1.0 - pressure_ratio) + floor * pressure_ratio;
-            total_budget.max(floor)
+            (ceiling * (1.0 - pressure_ratio) + floor * pressure_ratio).max(floor)
         };
 
-        // Distribute proportionally by RU quota.
-        let total_ru_quota: f64 = bg_group_stats.iter().map(|g| g.ru_quota).sum();
-        if total_ru_quota <= f64::EPSILON {
-            return;
-        }
-        for g in bg_group_stats {
-            let limit = total_budget * (g.ru_quota / total_ru_quota);
-            g.limiter.get_write_io_limiter().set_rate_limit(limit);
-        }
+        self.bg_limiter.get_write_io_limiter().set_rate_limit(new_limit);
     }
-}
-
-struct GroupStats {
-    name: String,
-    limiter: Arc<ResourceLimiter>,
-    ru_quota: f64,
 }
 
 /// PriorityLimiterAdjustWorker automically adjust the quota of each priority
@@ -817,7 +726,8 @@ mod tests {
         worker.adjust_quota();
         check_limiter_rates(&limiter, 3.63, 5500.0);
 
-        // --- Multi-group: proportional distribution by RU quota ---
+        // Adding a second background group does not change the limiter —
+        // all background groups share the single global bg_limiter.
         let bg = new_background_resource_group_ru(
             BACKGROUND_WORKER_THREAD.into(),
             1000,
@@ -825,69 +735,25 @@ mod tests {
             vec!["br".into()],
         );
         resource_ctl.add_resource_group(bg);
-        let bg_limiter = resource_ctl
+        let bg_limiter2 = resource_ctl
             .get_background_resource_limiter(BACKGROUND_WORKER_THREAD, "br")
             .unwrap();
+        // Both groups return the same shared limiter.
+        assert!(Arc::ptr_eq(&limiter, &bg_limiter2));
 
-        // default ru=2000, bg ru=1000 → shares: 2/3, 1/3
-        // No load: default at 3.63M, bg at infinity → target/2 = 2.8M
-        // current_total = 3.63M + 2.8M = 6.43M > target (5.6M) → budget = target = 5.6M
-        // default: 5.6 * 2/3 ≈ 3.733, bg: 5.6/3 ≈ 1.867
-        // IO: current_total = 5500 + 3500 = 9000 > 7000 → budget = 7000
-        // default: 7000 * 2/3 ≈ 4667, bg: 7000/3 ≈ 2333
+        // No load: current at 3.63M < 0.9*target (5.04M) and util < 63% → incremental.
+        // budget = 3.63 * 1.1 = 3.993
+        // IO: 5500 * 1.1 = 6050
         reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter_rates(&limiter, 3.733, 4666.7);
-        check_limiter_rates(&bg_limiter, 1.867, 2333.3);
+        check_limiter_rates(&limiter, 3.993, 6050.0);
 
-        // Over 70% (100% CPU, 95% IO): budget scales down from target.
-        // CPU: pressure = 1.0. budget = min_floor = 1.0M
-        //   default: 1.0M * 2/3 ≈ 0.667, bg: 1.0M/3 ≈ 0.333
+        // Over 70% (100% CPU, 95% IO): budget scales down.
+        // CPU: pressure = 1.0. budget = min_floor = 1.0
         // IO: pressure = 25/30 = 5/6. budget = 7000*(1/6) + 1000*(5/6) = 2000
-        //   default: 2000 * 2/3 ≈ 1333.3, bg: 2000/3 ≈ 666.7
         reset_quota(&mut worker, 8.0, 9500.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter_rates(&limiter, 0.667, 1333.3);
-        check_limiter_rates(&bg_limiter, 0.333, 666.7);
-
-        // --- Limiter version change ---
-        let bg = new_resource_group_ru(BACKGROUND_WORKER_THREAD.into(), 1000, 15);
-        resource_ctl.add_resource_group(bg);
-
-        let new_bg = new_background_resource_group_ru(
-            BACKGROUND_WORKER_THREAD.into(),
-            1000,
-            15,
-            vec!["br".into()],
-        );
-        resource_ctl.add_resource_group(new_bg);
-        let new_bg_limiter = resource_ctl
-            .get_background_resource_limiter(BACKGROUND_WORKER_THREAD, "br")
-            .unwrap();
-        assert_ne!(&*bg_limiter as *const _, &*new_bg_limiter as *const _);
-        assert!(
-            new_bg_limiter
-                .get_limit_statistics(ResourceType::Cpu)
-                .version
-                > bg_limiter.get_limit_statistics(ResourceType::Cpu).version
-        );
-        let cpu_stats = new_bg_limiter.get_limit_statistics(ResourceType::Cpu);
-        assert_eq!(cpu_stats.total_consumed, 0);
-        assert_eq!(cpu_stats.total_wait_dur_us, 0);
-        let io_stats = new_bg_limiter.get_limit_statistics(ResourceType::Io);
-        assert_eq!(io_stats.total_consumed, 0);
-        assert_eq!(io_stats.total_wait_dur_us, 0);
-
-        // New bg limiter at infinity → target/2 = 2.8M.
-        // default at 0.667M. current_total = 0.667M + 2.8M = 3.467M
-        // 3.467M < 5.04M → incremental: budget = 3.467 * 1.1 = 3.8137M
-        // default: 3.8137 * 2/3 ≈ 2.542, new_bg: 3.8137/3 ≈ 1.271
-        // IO: default 1333.3, bg inf→3500, total=4833.3 < 6300 → 4833.3*1.1=5316.6
-        // default: 5316.6 * 2/3 ≈ 3544.4, new_bg: 5316.6/3 ≈ 1772.2
-        reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
-        worker.adjust_quota();
-        check_limiter_rates(&limiter, 2.542, 3544.4);
-        check_limiter_rates(&new_bg_limiter, 1.271, 1772.2);
+        check_limiter_rates(&limiter, 1.0, 2000.0);
     }
 
     #[test]
@@ -938,7 +804,7 @@ mod tests {
         }
 
         // CPU target = 8 * 0.7 = 5.6 cores, IO target = 10000 * 0.7 = 7000
-        // Only bg_worker has a limiter; fg groups are not in bg_group_stats.
+        // fg groups have no background settings; only bg_worker triggers adjustment.
 
         // --- Initial: no load → budget = target ---
         reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
@@ -1309,5 +1175,91 @@ mod tests {
         reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
         worker.adjust_quota();
         check(limiter.get_write_io_limiter().get_rate_limit(), ceiling);
+    }
+
+    // Verify that with multiple background groups the budget is set globally on
+    // a single shared limiter, not split proportionally across groups.
+    //
+    // Old behaviour: 2 groups with RU 2000 and 1000 would receive 2/3 and 1/3
+    // of the total budget.
+    // New behaviour: both groups return the same Arc<ResourceLimiter> and the
+    // full budget is applied to it once.
+    #[test]
+    fn test_global_budget_not_split_across_groups() {
+        let resource_ctl = Arc::new(ResourceGroupManager::default());
+
+        // 8 CPU cores, 10000 bytes/s IO bandwidth.
+        let test_provider = TestResourceStatsProvider::new(8.0, 10000.0);
+        let compaction_pending_bytes_ratio = Arc::new(AtomicU32::new(0));
+        let mut worker = GroupQuotaAdjustWorker::with_quota_getter(
+            resource_ctl.clone(),
+            test_provider,
+            compaction_pending_bytes_ratio,
+        );
+
+        // Add two background groups with different RU quotas.
+        let mut grp_a =
+            new_background_resource_group_ru("group_a".into(), 2000, 8, vec!["br".into()]);
+        grp_a.mut_background_settings().set_utilization_limit(80);
+        resource_ctl.add_resource_group(grp_a);
+
+        let grp_b =
+            new_background_resource_group_ru("group_b".into(), 1000, 8, vec!["br".into()]);
+        resource_ctl.add_resource_group(grp_b);
+
+        let limiter_a = resource_ctl
+            .get_background_resource_limiter("group_a", "br")
+            .unwrap();
+        let limiter_b = resource_ctl
+            .get_background_resource_limiter("group_b", "br")
+            .unwrap();
+
+        // Both groups must point to the same global limiter.
+        assert!(Arc::ptr_eq(&limiter_a, &limiter_b));
+
+        // util_limit = 80% capped to 70% by bg_resource_threshold.
+        // CPU target = 8 * 0.7 = 5.6 cores, IO target = 10000 * 0.7 = 7000.
+        // Under no load the full target is applied to the single limiter.
+        worker.resource_quota_getter.cpu_used = 0.0;
+        worker.resource_quota_getter.io_used = 0.0;
+        worker.last_adjust_time = Instant::now_coarse() - Duration::from_secs(1);
+        worker.adjust_quota();
+
+        #[track_caller]
+        fn check(val: f64, expected: f64) {
+            assert!(
+                expected * 0.99 < val && val < expected * 1.01,
+                "actual: {val}, expected: {expected}"
+            );
+        }
+
+        // Full budget, not 2/3 of it.
+        check(
+            limiter_a.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            5.6 * MICROS_PER_SEC,
+        );
+        check(limiter_a.get_limiter(ResourceType::Io).get_rate_limit(), 7000.0);
+
+        // limiter_b is the same Arc so it reflects the same rates.
+        check(
+            limiter_b.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            5.6 * MICROS_PER_SEC,
+        );
+        check(limiter_b.get_limiter(ResourceType::Io).get_rate_limit(), 7000.0);
+
+        // Under heavy load (100% CPU) the budget scales down to min_floor for
+        // the single global limiter — not independently per group.
+        worker.resource_quota_getter.cpu_used = 8.0;
+        worker.resource_quota_getter.io_used = 9500.0;
+        worker.last_adjust_time = Instant::now_coarse() - Duration::from_secs(1);
+        worker.adjust_quota();
+
+        // CPU: pressure = 1.0 → budget = min_floor = 1.0 core.
+        // IO: pressure = (95-70)/30 = 5/6 → budget = 7000/6 + 1000*5/6 ≈ 2000.
+        check(
+            limiter_a.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            1.0 * MICROS_PER_SEC,
+        );
+        check(limiter_a.get_limiter(ResourceType::Io).get_rate_limit(), 2000.0);
     }
 }

--- a/metrics/grafana/tikv_details.dashboard.py
+++ b/metrics/grafana/tikv_details.dashboard.py
@@ -10538,7 +10538,7 @@ def ResourceControl() -> RowPanel:
                     target(
                         expr=expr_sum_rate(
                             "tikv_resource_control_background_task_wait_duration",
-                            by_labels=["instance", "resource_group"],
+                            by_labels=["instance"],
                         ),
                     ),
                 ],

--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -82805,15 +82805,15 @@
           "targets": [
             {
               "datasource": "${DS_TEST-CLUSTER}",
-              "expr": "sum(rate(\n    tikv_resource_control_background_task_wait_duration\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (instance, resource_group) ",
+              "expr": "sum(rate(\n    tikv_resource_control_background_task_wait_duration\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (instance) ",
               "format": "time_series",
               "hide": false,
               "instant": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{instance}}-{{resource_group}}",
+              "legendFormat": "{{instance}}",
               "metric": "",
-              "query": "sum(rate(\n    tikv_resource_control_background_task_wait_duration\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (instance, resource_group) ",
+              "query": "sum(rate(\n    tikv_resource_control_background_task_wait_duration\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (instance) ",
               "refId": "",
               "step": 10,
               "target": ""

--- a/metrics/grafana/tikv_details.json.sha256
+++ b/metrics/grafana/tikv_details.json.sha256
@@ -1,1 +1,1 @@
-4f9781a5713706fa67ad9a809cceb8543bcc7d3c6970321626d33b0b26637c2a  ./metrics/grafana/tikv_details.json
+19b3579fce35b7733db9b399c2537eef3741294357f3f06a3c81687c39bd97df  ./metrics/grafana/tikv_details.json


### PR DESCRIPTION
Moving to a global rate limiter instead of separate rate limit for each resource group
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #19497

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Unit test results
1. Run sysbench
2. run analyze table
3. verified that background CPU utilization is captured correctly. 
<img width="1312" height="590" alt="Screenshot 2026-03-30 at 8 59 45 PM" src="https://github.com/user-attachments/assets/e2b52f22-a732-4ec9-a144-12826001f2ba" />

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note

The Prometheus metric `tikv_resource_control_background_task_wait_duration` no longer carries a `resource_group` label; it is now a flat counter aggregated across all background groups. Dashboards or alerts that filter or group by `resource_group` on this metric must be updated. The in-tree TiKV-Details Grafana dashboard has been updated accordingly.  
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Background limiting unified: a single shared limiter now governs all background groups; quotas and compaction pressure are applied globally rather than per-group.
  - Background metrics and reporting aggregated: background metrics and wait-duration are emitted as aggregated series (no per-group labels); metric deregistration removed.
  - Shared limiter resets to unlimited when no background groups remain.

- **New Features**
  - Public APIs to get the shared background limiter and to check for any background groups.

- **Tests**
  - Updated to verify shared-limiter behavior and global budget semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->