### PR TITLE
*: add new skills for review and cherry-pick

### DIFF
--- a/.agents/skills/cherry-pick-resolve-conflict/SKILL.md
+++ b/.agents/skills/cherry-pick-resolve-conflict/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: cherry-pick-resolve-conflict
+description: Cherry-pick one specific git commit into the current TiKV branch with strict already-applied pre-checks, conflict resolution based on full code understanding, TiKV-specific validation, and deep review only if the pick is applied. Use when asked to apply a single commit SHA onto this repository, especially when conflicts are likely or the change is production-critical.
+---
+
+# Cherry-pick Resolve Conflict
+
+## Goal
+
+Cherry-pick one commit safely and repeatably in TiKV: check if it is already applied, avoid rerere, resolve conflicts with real subsystem understanding, run the repository’s required checks, and deep-review the effective change only if the pick is applied.
+
+## Inputs
+
+- `commit_sha`: the source commit to cherry-pick
+
+## TiKV-Specific Rules
+
+- Require a clean working tree before starting. Do not stash or discard unrelated user changes.
+- Never rely on `git rerere` for conflict resolution.
+- Read `AGENTS.md` and use TiKV’s repository entrypoints from `Makefile`.
+- Treat `make format` and `make clippy` as authoritative repository checks, not raw `cargo fmt` or raw `cargo clippy`.
+- If `make clippy` fails in `scripts/deny`, record that separately from Clippy lint results because `scripts/clippy-all` may not have run yet.
+- Prefer targeted test execution when you can identify the affected subsystem. If the touched area is broad or the right target is unclear, escalate to broader test coverage.
+
+## Workflow
+
+1. Preconditions
+
+- Require a clean working tree before starting: `git status --porcelain` must be empty.
+- If the tree is dirty, stop and ask the user how they want to proceed. Never discard unrelated changes.
+
+2. Collect commit info
+
+- `git show -s --format='%H%n%s' <commit_sha>`
+- Pick a stable `grep_key` from the subject line. Prefer PR numbers like `#1234`, otherwise choose another unique token.
+
+3. Pre-check
+
+- `git log --oneline --grep '<grep_key>'`
+- If the output clearly shows the change is already on the current branch, skip the cherry-pick.
+
+4. Cherry-pick
+
+- `git cherry-pick -x <commit_sha>`
+
+5. Resolve conflicts if needed
+
+- Inspect conflicts with `git status`.
+- Before editing conflict markers, fully understand what the picked commit changes:
+  - Read the full patch: `git show <commit_sha>`
+  - Identify the intended behavior change, invariant, or bug fix
+  - Separate core logic changes from mechanical fallout such as imports or signature propagation
+- Read the conflicting TiKV code paths in full before editing. Do not resolve by symbol-name guessing.
+- For non-trivial or semantic conflicts, identify which prior commit on the current branch caused the divergence:
+  - Use `git blame -w` on `HEAD` for the relevant ours-side lines
+  - Record the responsible commit SHA and subject
+  - Compare that commit’s intent with the cherry-picked change and resolve to preserve the correct combined behavior
+- For trivial or mechanical conflicts, keep resolution localized and do not spend time on provenance unless behavior is ambiguous.
+- After resolving:
+  - `git add <paths>`
+  - `make format`
+  - `git cherry-pick --continue`
+- If Git reports an empty patch during or after resolution:
+  - `git cherry-pick --skip`
+  - Treat it as `skipped (empty patch)`
+
+6. Validate if applied
+
+If the result is `picked` or `picked (conflicts resolved)`, validation is required.
+
+- Always run:
+  - `cargo check --all`
+  - `make clippy`
+- Run tests that match the touched subsystem:
+  - Prefer `env EXTRA_CARGO_ARGS=$TESTNAME make test_with_nextest` when you can name a focused test target
+  - Use `./scripts/test $TESTNAME -- --nocapture` when a specific Rust test name is already known
+  - If the change affects shared core paths such as `src/storage`, `src/server`, `components/raftstore`, `components/raftstore-v2`, `components/cdc`, or the correct focused target is unclear, run `make test`
+- If any validation fails:
+  - investigate the root cause
+  - distinguish code regressions from missing prerequisite commits, dependency-security failures, or environment/toolchain blockers
+  - do not paper over failures with unrelated edits
+
+7. Deep review only if applied
+
+- Only if the cherry-pick is applied should you perform a deep review of the effective change.
+- In this repository, use the local `deep-review` skill after the pick so the final report covers problem summary, solution mechanics, findings, and TiKV-specific validation gaps.
+
+## Output Summary Template
+
+```markdown
+- Result: `picked` / `picked (conflicts resolved)` / `skipped (already applied)` / `skipped (empty patch)` / `blocked (dirty worktree)`
+- Pre-check:
+  - `git log --oneline --grep "<grep_key>"`: [matched / no match]
+- Cherry-pick:
+  - Command: `git cherry-pick -x <commit_sha>`
+  - Conflicts: [none | list files]
+- Conflict analysis (only for non-trivial or semantic conflicts):
+  - Ours-side provenance: `<prior_commit_sha>` - <prior_subject> (from `git blame -w`)
+  - Intent check: [compatible / conflicting] with rationale
+- Resolve notes:
+  - [What changed, why, and evidence]
+- Validation:
+  - `make format`: [pass / fail / blocked / not run]
+  - `cargo check --all`: [pass / fail / blocked]
+  - Focused tests or `make test`: [pass / fail / not run]
+  - `make clippy`: [pass / fail / blocked]
+  - `scripts/deny` within `make clippy`: [pass / fail / not reached]
+  - `scripts/clippy-all` within `make clippy`: [pass / fail / not reached]
+```

--- a/.agents/skills/deep-review/SKILL.md
+++ b/.agents/skills/deep-review/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: deep-review
+description: Deep, production-critical review workflow for TiKV changes. Use when asked to review a PR, branch, commit range, or diff in this repository and produce a markdown review report with findings, risk analysis, and TiKV-specific validation results.
+---
+
+# Deep Review
+
+## Goal
+
+Produce a production-critical review for TiKV that:
+
+- explains the problem being solved
+- explains how the change works in concrete code terms
+- identifies correctness, safety, performance, and operability risks
+- follows TiKV repository rules from `AGENTS.md`
+- writes the review to a markdown file under the target folder
+- runs the repo-prescribed formatting and lint checks from `./Makefile`
+
+## Inputs and Defaults
+
+- Determine the repository root and run all commands from that root.
+- Determine the target output folder.
+- If the target folder is not provided, use `./target`.
+- If the filename is not provided, use `review-report-YYYYMMDD-<summary>.md`.
+- Do not overwrite an existing report. Choose a distinct filename instead.
+
+## TiKV-Specific Rules
+
+- Treat `make format` and `make clippy` as the authoritative static checks because TiKV’s `Makefile` adds required setup and repository-specific scripts.
+- Do not substitute raw `cargo clippy` for `make clippy` unless the user explicitly asks for a narrower check.
+- Read `AGENTS.md` before judging engineering-rule compliance.
+- When unfamiliar code appears, read the surrounding subsystem rather than inferring from symbol names alone.
+- Respect a dirty worktree. Never revert unrelated user changes while fixing review-discovered issues.
+
+## Workflow
+
+1. Confirm inputs
+   - Identify the repository root, target output folder, and output filename.
+   - If the review scope is not explicit, use the current branch diff against `origin/HEAD`.
+
+2. Collect the change set
+   - Prefer the diff provided by the user.
+   - Otherwise run `git diff origin/HEAD...HEAD` from the repository root.
+   - If `origin/HEAD` is unavailable or the diff command fails, stop and ask for guidance.
+
+3. Understand the intent
+   - Read the PR description, issue link, commit messages, or nearby code comments when available.
+   - State the concrete system problem the change is trying to solve.
+   - If intent is still unclear, infer from code and label the inference as an assumption.
+
+4. Read the affected TiKV subsystems
+   - Follow changed code into the owning modules, not just the diff hunk.
+   - Typical subsystems include:
+     - `src/storage`, `src/storage/mvcc`, `src/storage/txn`
+     - `src/server`
+     - `components/raftstore`, `components/raftstore-v2`
+     - `components/cdc`
+     - `components/pd_client`
+     - `tests/`
+   - Read enough nearby code to understand invariants, concurrency assumptions, error propagation, and test coverage.
+
+5. Explain how the change works
+   - Walk through each non-trivial logic change.
+   - Explain control flow, data flow, state transitions, and failure paths in plain language.
+   - Reference concrete files, symbols, and lines when discussing findings.
+
+6. Evaluate costs and negative impacts
+   - Explicitly assess:
+     - correctness
+     - security
+     - robustness and failure modes
+     - compatibility and behavioral shifts
+     - CPU cost
+     - memory cost
+     - log volume or log-signal quality
+     - operability and debuggability
+     - cognitive load and maintainability
+
+7. Run TiKV static validation from `./Makefile`
+   - Run `make format` from the repository root.
+   - Then run `make clippy` from the repository root.
+   - Treat the `Makefile` behavior as part of the review:
+     - `make format` runs `pre-format`, which installs `rustfmt` and bootstraps the pinned `cargo-sort` version before running `cargo fmt` and `cargo sort`
+     - `make clippy` runs repository checks including redact-log, log-style, dashboards, docker-build, license, deny, and finally `scripts/clippy-all`
+   - If `make format` or `make clippy` reports code issues in the working tree:
+     - inspect the failing files
+     - fix the errors when the fix is local and safe
+     - rerun the failing command
+   - If `make clippy` fails in `scripts/deny`, record that separately from Rust lint results because `clippy-all` may not have run yet.
+   - If the failure is environmental, toolchain-related, or blocked by unavailable external dependencies:
+     - record the exact blocker in the report
+     - do not claim the code passed
+   - Do not revert unrelated user changes while making fixes.
+
+8. Check engineering rules
+   - Verify alignment with `AGENTS.md`, especially:
+     - repository-specific build and test entrypoints
+     - required validation expectations such as `make dev`
+     - PR-title, issue-link, and release-note requirements when relevant to the review
+
+9. Write the review output
+   - Write a markdown report under the target folder.
+   - If no findings exist, say so explicitly.
+   - Still document residual risks, assumptions, and any validation gaps.
+
+## Review Output Template
+
+```markdown
+### Deep Review
+
+#### Problem Summary
+- [Explain the concrete problem the change targets]
+
+#### Solution Walkthrough
+- [Explain how the change solves the problem; cover all non-obvious logic]
+
+#### Findings (ordered by severity)
+- [Issue or risk with file/line references]
+
+#### Costs and Negative Impacts
+- Correctness:
+- Security:
+- Compatibility:
+- Robustness:
+- Operability:
+- Cognitive Load:
+- CPU:
+- Memory:
+- Log Volume:
+
+#### Static Validation
+- `make format`:
+- `make clippy`:
+
+#### Engineering Rules Check
+- [List code or process mismatches against `AGENTS.md`, or "None"]
+
+#### Questions and Assumptions
+- [List unknowns or assumptions made]
+
+#### Suggested Tests / Validation
+- [Targeted tests or checks to validate behavior]
+```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1161,9 +1161,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.7.2"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bytes-utils"

--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,7 @@ endif
 
 # If both python and python3 are installed, it will choose python as a preferred option.
 PYTHON := $(shell command -v python 2> /dev/null || command -v python3 2> /dev/null)
+CARGO_SORT_VERSION ?= 1.0.9
 
 # Almost all the rules in this Makefile are PHONY
 # Declaring a rule as PHONY could improve correctness
@@ -345,7 +346,9 @@ unset-override:
 
 pre-format: unset-override
 	@rustup component add rustfmt
-	@which cargo-sort &> /dev/null || cargo +nightly install -q cargo-sort@1.0.9
+	@if ! command -v cargo-sort >/dev/null 2>&1 || ! cargo-sort --version 2>/dev/null | grep -q "^cargo-sort $(CARGO_SORT_VERSION)$$"; then \
+		cargo +nightly install -q cargo-sort@$(CARGO_SORT_VERSION); \
+	fi
 
 format: pre-format
 	@cargo fmt

--- a/deny.toml
+++ b/deny.toml
@@ -88,15 +88,10 @@ ignore = [
     # replace FxHash. Currently, this package is stable and there are no known
     # exploitable vulnerabilities affecting our use case.
     "RUSTSEC-2025-0057",
-    # Ignore RUSTSEC-2026-0002 temporarily. This advisory comes from the
-    # aws-sdk-s3 -> lru 0.12.x dependency chain, and the published fix requires
-    # a breaking upgrade to lru >= 0.16.3 that is not available as a lockfile
-    # only update in the current AWS SDK version.
-    "RUSTSEC-2026-0002",
     # Ignore RUSTSEC-2026-0009 temporarily. This advisory comes from the
-    # transitive cloud SDK dependency chain pulling in time 0.3.41. The fixed
+    # transitive cloud SDK dependency chain pulling in time 0.3.47. The fixed
     # time release requires serde 1.0.220 through serde_core, but the current
-    # raft-engine revision in this workspace still hard-pins serde = 1.0.194,
+    # raft-engine revision in this workspace still hard-pins serde = 1.0.228,
     # so this cannot be resolved with a lockfile-only update.
     "RUSTSEC-2026-0009",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -92,6 +92,17 @@ ignore = [
     # replace FxHash. Currently, this package is stable and there are no known
     # exploitable vulnerabilities affecting our use case.
     "RUSTSEC-2025-0057",
+    # Ignore RUSTSEC-2026-0002 temporarily. This advisory comes from the
+    # aws-sdk-s3 -> lru 0.12.x dependency chain, and the published fix requires
+    # a breaking upgrade to lru >= 0.16.3 that is not available as a lockfile
+    # only update in the current AWS SDK version.
+    "RUSTSEC-2026-0002",
+    # Ignore RUSTSEC-2026-0009 temporarily. This advisory comes from the
+    # transitive cloud SDK dependency chain pulling in time 0.3.41. The fixed
+    # time release requires serde 1.0.220 through serde_core, but the current
+    # raft-engine revision in this workspace still hard-pins serde = 1.0.194,
+    # so this cannot be resolved with a lockfile-only update.
+    "RUSTSEC-2026-0009",
 ]
 
 # TiKV is licensed under Apache 2.0, according to ASF 3RD PARTY LICENSE POLICY,


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?


<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref https://github.com/tikv/tikv/issues/19463

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

Add TiKV-local deep-review and cherry-pick-resolve-conflict skills under .agents/skills/ so the repository has explicit workflows for production review and conflict-heavy cherry-picks.

Pin the cargo-sort version used by make format so the repository installs the intended tool version instead of accepting older binaries that fail on this workspace layout.

Update Cargo.lock to bytes 1.11.1 to clear RUSTSEC-2026-0007, and document temporary cargo-deny ignores for RUSTSEC-2026-0002 and RUSTSEC-2026-0009 while the current aws-sdk-s3 and raft-engine dependency pins still block direct upgrades.

```commit-message
Add new skills for review and cherry-pick.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None.
```

### Deep Review

#### Problem Summary
- The staged change set has two goals: add TiKV-local agent skills for deep review and cherry-pick conflict handling under `.agents/skills/`, and restore deterministic local validation by pinning the `cargo-sort` version used by `make format`, updating `bytes` in `Cargo.lock`, and documenting two temporary `cargo-deny` advisory ignores that are still blocked by upstream dependency constraints.
- The worktree also contains unrelated untracked local artifacts and a stub Rust source file that are not part of the staged PR candidate.

#### Solution Walkthrough
- [`.agents/skills/deep-review/SKILL.md`](../.agents/skills/deep-review/SKILL.md) adds a TiKV-specific review workflow that requires `make format` and `make clippy`, explains how to interpret `scripts/deny` vs `scripts/clippy-all`, and records report expectations for production-critical review.
- [`.agents/skills/cherry-pick-resolve-conflict/SKILL.md`](../.agents/skills/cherry-pick-resolve-conflict/SKILL.md) adds a TiKV-specific cherry-pick workflow with conflict provenance checks, TiKV validation commands, and a handoff to the local `deep-review` skill after a successful pick.
- [`Makefile:169`](../Makefile) introduces `CARGO_SORT_VERSION ?= 1.0.9`, and [`Makefile:347`](../Makefile) updates `pre-format` to reinstall `cargo-sort` when the installed version does not match the pinned one. This fixes the local failure mode where `cargo-sort 1.0.7` trips over the excluded `components/test_coprocessor_plugin` directory.
- [`Cargo.lock:1163`](../Cargo.lock) updates `bytes` from `1.7.2` to `1.11.1`, which removes the `RUSTSEC-2026-0007` advisory that was previously blocking `cargo-deny`.
- [`deny.toml:95`](../deny.toml) adds temporary ignores for `RUSTSEC-2026-0002` and `RUSTSEC-2026-0009`, with rationale that the fixes are currently blocked by the pinned `aws-sdk-s3 = "=1.40.0"` chain and `raft-engine`’s `serde = 1.0.194` pin respectively.

#### Findings (ordered by severity)
- Low: `src/server/service/rpc_context.rs:3` is an untracked stub that references `Peer` without any surrounding imports, module wiring, or implementation. It is not PR-ready and should remain excluded from this change set unless it is completed.
- Low: `ctrl_grpc_server.patch`, `opt_minimal_file_ingest.patch`, `metrics/grafana/__pycache__/`, and the two untracked dashboard JSON files are local artifacts rather than reviewable product changes. They should stay out of the PR to avoid noise and accidental churn.
- No staged-code findings were identified in the PR candidate itself after validation.

#### Costs and Negative Impacts
- Correctness: Low risk in the staged set. The `Makefile` change only narrows the accepted `cargo-sort` version, and the lockfile update is targeted to one crate.
- Security: Mixed. `bytes` is upgraded to remove one active advisory, but `deny.toml` now tolerates two unresolved advisories until upstream dependency constraints are relaxed.
- Compatibility: No runtime compatibility change is visible from the staged set.
- Robustness: Improved local reproducibility for `make format`; `make clippy` no longer fails hard on the previously reported advisories.
- Operability: Improved for developers because repo-prescribed checks now pass in this environment once the pinned formatter tool is installed.
- Cognitive Load: Slightly higher because the repo now owns two more local skills and two additional temporary advisory exceptions.
- CPU: Negligible.
- Memory: Negligible.
- Log Volume: No meaningful change.

#### Static Validation
- `make format`: Pass.
- `make clippy`: Pass. `scripts/deny` and `scripts/clippy-all` both complete successfully. The run still emits existing `cargo-deny` warnings about registry index lookup and existing deprecation warnings from `tikv_util`, but exits `0`.

#### Engineering Rules Check
- No code-level mismatch against `AGENTS.md` was found in the staged change set.
- The PR process still needs a real issue reference to satisfy [`.github/pull_request_template.md`](../.github/pull_request_template.md). No issue number was provided in this session.

#### Questions and Assumptions
- Assume the PR should include only the staged files: `.agents/skills/cherry-pick-resolve-conflict/SKILL.md`, `.agents/skills/deep-review/SKILL.md`, `Cargo.lock`, `Makefile`, and `deny.toml`.
- Assume the untracked patch files, dashboard artifacts, `__pycache__`, and `src/server/service/rpc_context.rs` are local-only and should not be staged.
- Assume temporarily ignoring `RUSTSEC-2026-0002` and `RUSTSEC-2026-0009` is acceptable until the AWS SDK and `raft-engine` constraints can be moved.

#### Suggested Tests / Validation
- When the dependency pins are ready to move, replace the temporary `deny.toml` ignores with real upgrades for the `aws-sdk-s3 -> lru` and `time -> serde_core` chains.
- Before opening the PR upstream, fill in a real `Issue Number:` line in the TiKV PR template.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a cherry-pick conflict-resolution workflow for TiKV agents, outlining end-to-end steps and validation guidance.
  * Added a deep-review workflow for thorough PR/diff analysis, reporting, and static-check guidance.

* **Chores**
  * Made cargo-sort version configurable with conditional version checks before installing.
  * Updated security advisory ignore list to include one additional RustSec advisory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->