### PR TITLE
server: add per-connection batch command metrics

### DIFF
--- a/src/server/metrics.rs
+++ b/src/server/metrics.rs
@@ -275,6 +275,18 @@ lazy_static! {
         exponential_buckets(5e-5, 2.0, 22).unwrap() // 50us ~ 104s
     )
     .unwrap();
+    pub static ref GRPC_BATCH_COMMANDS_INCOMING_REQUEST_COUNTER_VEC: IntCounterVec = register_int_counter_vec!(
+        "tikv_grpc_batch_commands_incoming_request_total",
+        "Total number of incoming inner requests in batch commands.",
+        &["source", "conn"]
+    )
+    .unwrap();
+    pub static ref GRPC_BATCH_COMMANDS_OUTGOING_REQUEST_COUNTER_VEC: IntCounterVec = register_int_counter_vec!(
+        "tikv_grpc_batch_commands_outgoing_request_total",
+        "Total number of outgoing inner requests in batch commands.",
+        &["source", "conn"]
+    )
+    .unwrap();
     pub static ref SERVER_INFO_GAUGE_VEC: IntGaugeVec = register_int_gauge_vec!(
         "tikv_server_info",
         "Indicate the tikv server info, and the value is the server startup timestamp(s).",

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -72,6 +72,8 @@ use crate::{
 const GRPC_MSG_MAX_BATCH_SIZE: usize = 128;
 const GRPC_MSG_NOTIFY_SIZE: usize = 8;
 
+const BATCH_CONN_IDX_METADATA_KEY: &str = "tikv-batch-conn-index";
+
 pub trait RaftGrpcMessageFilter: Send + Sync {
     fn should_reject_raft_message(&self, _: &RaftMessage) -> bool;
     fn should_reject_snapshot(&self) -> bool;
@@ -1040,9 +1042,31 @@ impl<E: Engine, L: LockManager, F: KvFormat> Tikv for Service<E, L, F> {
     ) {
         forward_duplex!(self.proxy, batch_commands, ctx, stream, sink);
 
+        let peer = ctx.peer();
+        let conn = ctx.request_headers().iter().find_map(|(k, v)| {
+            (k == BATCH_CONN_IDX_METADATA_KEY)
+                .then(|| str::from_utf8(v).unwrap_or_default())
+                .filter(|conn| !conn.is_empty())
+        });
+        let counter_labels = conn.map(|conn| (peer.clone(), conn.to_owned()));
+        let (incoming_req_counter, outgoing_req_counter) =
+            counter_labels
+                .as_ref()
+                .map_or((None, None), |(peer, conn)| {
+                    (
+                        Some(
+                            GRPC_BATCH_COMMANDS_INCOMING_REQUEST_COUNTER_VEC
+                                .with_label_values(&[peer, conn]),
+                        ),
+                        Some(
+                            GRPC_BATCH_COMMANDS_OUTGOING_REQUEST_COUNTER_VEC
+                                .with_label_values(&[peer, conn]),
+                        ),
+                    )
+                });
+
         let (tx, rx) = unbounded(WakePolicy::TillReach(GRPC_MSG_NOTIFY_SIZE));
         let ctx = Arc::new(ctx);
-        let peer = ctx.peer();
         let storage = self.storage.clone();
         let copr = self.copr.clone();
         let copr_v2 = self.copr_v2.clone();
@@ -1056,9 +1080,13 @@ impl<E: Engine, L: LockManager, F: KvFormat> Tikv for Service<E, L, F> {
             self.health_feedback_seq.clone(),
             self.health_feedback_interval,
         );
+        let incoming_req_counter = incoming_req_counter.clone();
         let request_handler = stream.try_for_each(move |mut req| {
             let request_ids = req.take_request_ids();
             let requests: Vec<_> = req.take_requests().into();
+            if let Some(counter) = incoming_req_counter.as_ref() {
+                counter.inc_by(requests.len() as u64);
+            }
             let queue = storage.get_readpool_queue_per_worker();
             let mut batcher = batch_builder.build(queue, request_ids.len());
             GRPC_REQ_BATCH_COMMANDS_SIZE.observe(requests.len() as f64);
@@ -1120,14 +1148,41 @@ impl<E: Engine, L: LockManager, F: KvFormat> Tikv for Service<E, L, F> {
             }
         });
 
+        let cleanup_counter_labels = counter_labels.clone();
         let send_task = async move {
-            if let Err(e) = sink.send_all(&mut response_retriever).await {
-                let e = RpcStatus::with_message(RpcStatusCode::INVALID_ARGUMENT, e.to_string());
-                sink.fail(e).await?;
-            } else {
+            let result = async {
+                while let Some(item) = response_retriever.next().await {
+                    match item {
+                        Ok((resp, flags)) => {
+                            let response_count = resp.get_request_ids().len() as u64;
+                            sink.send((resp, flags)).await?;
+                            if let Some(counter) = outgoing_req_counter.as_ref() {
+                                counter.inc_by(response_count);
+                            }
+                        }
+                        Err(e) => {
+                            let e = RpcStatus::with_message(
+                                RpcStatusCode::INVALID_ARGUMENT,
+                                e.to_string(),
+                            );
+                            sink.fail(e).await?;
+                            return Ok(());
+                        }
+                    }
+                }
                 sink.close().await?;
+                Ok(())
             }
-            Ok(())
+            .await;
+
+            if let Some((peer, conn)) = cleanup_counter_labels.as_ref() {
+                _ = GRPC_BATCH_COMMANDS_INCOMING_REQUEST_COUNTER_VEC
+                    .remove_label_values(&[peer, conn]);
+                _ = GRPC_BATCH_COMMANDS_OUTGOING_REQUEST_COUNTER_VEC
+                    .remove_label_values(&[peer, conn]);
+            }
+
+            result
         }
         .map_err(|e: grpcio::Error| {
             info!("kv rpc failed";


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #xxx

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
It introduces two counters for incoming and outgoing inner requests, labeled by
the grpc peer string and batch connection index when tikv-batch-conn-index (ref:
https://github.com/tikv/client-go/pull/1931) is present and non-empty. The
counters track inner requests inside batch command payloads rather than the
outer batch RPCs, and outgoing requests are counted only after responses are
successfully written to the stream.

Because the peer label includes the full grpc peer string, including the remote
port, the implementation also removes the corresponding label sets when the
batch command stream ends. This keeps different TiDB instances on the same host
distinguishable while avoiding unbounded metric cardinality from reconnects.
```

<img width="1431" height="447" alt="2026-04-02_003537" src="https://github.com/user-attachments/assets/ede3e556-41ff-4fd4-8479-1aef150686f7" />

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced batch request monitoring with new metrics for tracking incoming and outgoing batch operations, including per-connection visibility and automatic metric cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->