### PR TITLE
Dynamic resource group isolation

### DIFF
--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -251,6 +251,9 @@ async fn save_backup_file_worker<EK: KvEngine>(
                 msg.files.save(&storage),
                 msg.resource_limiter.clone(),
                 false,
+                false,
+                None,
+                0,
             )
             .await
             {
@@ -1073,6 +1076,9 @@ impl<E: Engine, R: RegionInfoProvider + Clone + 'static> Endpoint<E, R> {
                             ),
                             resource_limiter.clone(),
                             false,
+                            false,
+                            None,
+                            0,
                         )
                         .await
                     };

--- a/components/resource_control/src/config.rs
+++ b/components/resource_control/src/config.rs
@@ -12,9 +12,14 @@ pub struct Config {
     #[online_config(skip)]
     pub enabled: bool,
     pub priority_ctl_strategy: PriorityCtlStrategy,
-    /// Overall resource utilization percentage above which background tasks
-    /// are throttled. Also caps the background utilization limit.
-    pub bg_resource_threshold: f64,
+    /// CPU utilization percentage at which background task throttling begins.
+    /// Background budget scales linearly from full down to zero between this
+    /// value and fg_cpu_throttle_threshold.
+    pub bg_cpu_throttle_threshold: f64,
+    /// CPU utilization percentage at which foreground task protection kicks in:
+    /// background tasks are fully throttled to their minimum floor and the
+    /// background utilization limit is capped here.
+    pub fg_cpu_throttle_threshold: f64,
     /// Compaction pressure percentage at which background write IO throttling
     /// begins. Dynamically configurable at runtime.
     pub bg_compaction_pressure_threshold: f64,
@@ -24,6 +29,38 @@ pub struct Config {
     /// Minimum write IO rate that background tasks are always allowed,
     /// even under maximum compaction pressure.
     pub bg_write_io_floor: ReadableSize,
+    /// When true, enables fair two-phase scheduling for reads: groups whose
+    /// current-minute RU rate exceeds their historical baseline are placed in
+    /// phase 1 (deprioritised in the yatp priority queue) relative to groups
+    /// within their baseline (phase 0). Protects sustained workloads from
+    /// sudden traffic spikes without hard-rejecting requests.
+    pub enable_fair_scheduling: bool,
+    /// When true, enables Tier-1 admission control for reads: high-priority
+    /// read requests from groups that are over their RU baseline are shed
+    /// (SchedTooBusy) when CPU exceeds fg_cpu_throttle_threshold.
+    pub enable_read_admission_control: bool,
+    /// When true, enables Tier-1 admission control for writes: high-priority
+    /// write requests from groups that are over their RU baseline are shed
+    /// (SchedTooBusy) when CPU exceeds fg_cpu_throttle_threshold.
+    pub enable_write_admission_control: bool,
+    /// Size of the sliding window (in minutes) used to compute per-group
+    /// historical RU baselines for fair scheduling and admission control.
+    /// The window is divided into 30-second buckets (2 per minute). Minimum 2,
+    /// maximum 60. Not hot-reloadable; changing requires a restart.
+    #[online_config(skip)]
+    pub historical_usage_window_mins: u64,
+    /// Percentage of headroom above the historical RU baseline before a group
+    /// is considered "over baseline" for two-phase scheduling and CPU
+    /// utilization throttling. For example, 20.0 means a group must exceed
+    /// 1.2× its historical rate to be deprioritized or rate-limited.
+    /// Default: 20.0 (20%).
+    pub baseline_burst_pct: f64,
+    /// Maximum number of requests that can concurrently sit in the admission
+    /// control delay phase (reads and writes combined). When this limit is
+    /// reached, additional over-baseline requests are rejected immediately
+    /// (SchedTooBusy) rather than delayed. Set to 0 to disable the limit
+    /// (unlimited delayed requests). Default: 10_000.
+    pub admission_max_delayed_count: u64,
 }
 
 impl Default for Config {
@@ -31,10 +68,17 @@ impl Default for Config {
         Self {
             enabled: true,
             priority_ctl_strategy: PriorityCtlStrategy::Moderate,
-            bg_resource_threshold: 70.0,
+            bg_cpu_throttle_threshold: 60.0,
+            fg_cpu_throttle_threshold: 70.0,
             bg_compaction_pressure_threshold: 70.0,
             bg_write_io_ceiling: ReadableSize::gb(100),
             bg_write_io_floor: ReadableSize::mb(10),
+            enable_fair_scheduling: false,
+            enable_read_admission_control: false,
+            enable_write_admission_control: false,
+            historical_usage_window_mins: 15,
+            baseline_burst_pct: 20.0,
+            admission_max_delayed_count: 10_000,
         }
     }
 }

--- a/components/resource_control/src/future.rs
+++ b/components/resource_control/src/future.rs
@@ -15,9 +15,15 @@ use tikv_util::{time::Instant, timer::GLOBAL_TIMER_HANDLE, warn};
 use tokio_timer::Delay;
 
 use crate::{
-    resource_group::{ResourceConsumeType, ResourceController},
+    resource_group::{ResourceConsumeType, ResourceController, ResourceGroupManager},
     resource_limiter::{ResourceLimiter, ResourceType},
 };
+
+#[inline]
+fn cpu_timer() -> impl FnOnce() -> Duration {
+    let start = std::time::Instant::now();
+    move || start.elapsed()
+}
 
 const MAX_WAIT_DURATION: Duration = Duration::from_secs(10);
 
@@ -55,8 +61,19 @@ impl<F: Future> Future for ControlledFuture<F> {
 }
 
 // `LimitedFuture` wraps a Future with ResourceLimiter, it will automatically
-// get statistics of the cpu time and io bytes consumed by the future, and do
-// async waiting according the configuration of the ResourceLimiter.
+// track the cpu time and io bytes consumed by the future.
+//
+// Two modes controlled by `measure_only`:
+//
+// `measure_only = false` (default, used by background jobs like backup/import):
+//   Measures CPU+IO per poll and sleeps proportionally to token-bucket debt.
+//   Pre-delay pays off existing debt before starting; post-delay sleeps after
+//   each pending poll. This throttles the task inside the thread pool.
+//
+// `measure_only = true` (used by read/write pools):
+//   Measures CPU+IO per poll and builds token-bucket debt, but NEVER sleeps.
+//   Throttling is handled pre-pool by `admission_decision` which reads the
+//   accumulated debt before submitting the next request.
 #[pin_project]
 pub struct LimitedFuture<F: Future> {
     #[pin]
@@ -69,12 +86,20 @@ pub struct LimitedFuture<F: Future> {
     #[pin]
     post_delay: OptionalFuture<Compat01As03<Delay>>,
     resource_limiter: Arc<ResourceLimiter>,
+    skip_compaction_pressure: bool,
     // if the future is first polled, we need to let it consume a 0 value
     // to compensate the debt of previously finished tasks.
     is_first_poll: bool,
-    // Skip the compaction pressure write IO limiter. Set to true for
-    // operations like SST ingestion that don't cause compaction.
-    skip_compaction_pressure: bool,
+    // When true: measure CPU/IO and build token-bucket debt, but never sleep.
+    // When false: existing behavior — sleep inside the pool to throttle.
+    measure_only: bool,
+    // For measure-only mode: feed RuTracker + token-bucket via record_ru_consumption.
+    resource_mgr: Option<Arc<ResourceGroupManager>>,
+    // Known write bytes for this request (from cmd.write_bytes()), used as the
+    // write component of io_bytes passed to consume() instead of /proc iostat.
+    // Avoids syscall overhead and thread-level IO noise from compaction on the
+    // same thread. Zero means fall back to IoBytesTracker (e.g. reads, background).
+    write_bytes: u64,
 }
 
 impl<F: Future> LimitedFuture<F> {
@@ -82,14 +107,20 @@ impl<F: Future> LimitedFuture<F> {
         f: F,
         resource_limiter: Arc<ResourceLimiter>,
         skip_compaction_pressure: bool,
+        measure_only: bool,
+        resource_mgr: Option<Arc<ResourceGroupManager>>,
+        write_bytes: u64,
     ) -> Self {
         Self {
             f,
             pre_delay: None.into(),
             post_delay: None.into(),
             resource_limiter,
-            is_first_poll: true,
             skip_compaction_pressure,
+            is_first_poll: true,
+            measure_only,
+            resource_mgr,
+            write_bytes,
         }
     }
 }
@@ -99,7 +130,10 @@ impl<F: Future> Future for LimitedFuture<F> {
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let mut this = self.project();
-        if *this.is_first_poll {
+
+        // Pre-delay: pay off existing token-bucket debt before starting work.
+        // Skipped in measure-only mode — foreground pools never sleep in-pool.
+        if *this.is_first_poll && !*this.measure_only {
             debug_assert!(this.pre_delay.finished && this.post_delay.finished);
             *this.is_first_poll = false;
             let wait_dur = this
@@ -119,6 +153,8 @@ impl<F: Future> Future for LimitedFuture<F> {
                 )
                 .into();
             }
+        } else if *this.is_first_poll {
+            *this.is_first_poll = false;
         }
         if !this.post_delay.finished {
             assert!(this.pre_delay.finished);
@@ -130,8 +166,7 @@ impl<F: Future> Future for LimitedFuture<F> {
                 return Poll::Pending;
             }
         }
-        // get io stats is very expensive, so we only do so if only io control is
-        // enabled.
+        // get io stats is very expensive, so we only do so if io control is enabled.
         let mut io_tracker = if this
             .resource_limiter
             .get_limiter(ResourceType::Io)
@@ -142,20 +177,32 @@ impl<F: Future> Future for LimitedFuture<F> {
         } else {
             None
         };
-        let start = Instant::now();
+        let elapsed = cpu_timer();
         let res = this.f.poll(cx);
-        let dur = start.saturating_elapsed();
-        let io_bytes = io_tracker
+        let dur = elapsed();
+        let mut io_bytes = io_tracker
             .as_mut()
             .and_then(|tracker| tracker.update())
             .unwrap_or_else(IoBytes::default);
+        // Only count write_bytes when the future completes to avoid
+        // double-counting across multiple pending polls.
+        if *this.write_bytes > 0 && res.is_ready() {
+            io_bytes.write = *this.write_bytes;
+        }
         let mut wait_dur = this.resource_limiter.consume(
             dur,
             io_bytes,
             res.is_pending(),
             *this.skip_compaction_pressure,
         );
-        if wait_dur == Duration::ZERO || res.is_ready() {
+        // Feed RuTracker so admission_decision has baseline data.
+        // Only for foreground limiters — background jobs shouldn't shift the baseline.
+        if !this.resource_limiter.is_background()
+            && let Some(mgr) = &this.resource_mgr
+        {
+            mgr.record_ru_consumption(this.resource_limiter.name(), dur.as_micros() as u64);
+        }
+        if wait_dur == Duration::ZERO || res.is_ready() || *this.measure_only {
             return res;
         }
         if wait_dur > MAX_WAIT_DURATION {
@@ -173,8 +220,8 @@ impl<F: Future> Future for LimitedFuture<F> {
     }
 }
 
-/// `OptionalFuture` is similar to futures::OptionFuture, but provide an extra
-/// `finished` flag to determine if the future requires poll.
+/// `OptionalFuture` is similar to futures::OptionFuture, but provides an extra
+/// `finished` flag to determine if the future requires polling.
 #[pin_project]
 struct OptionalFuture<F> {
     #[pin]
@@ -214,9 +261,20 @@ pub async fn with_resource_limiter<F: Future>(
     f: F,
     limiter: Option<Arc<ResourceLimiter>>,
     skip_compaction_pressure: bool,
+    measure_only: bool,
+    resource_mgr: Option<Arc<ResourceGroupManager>>,
+    write_bytes: u64,
 ) -> F::Output {
     if let Some(limiter) = limiter {
-        LimitedFuture::new(f, limiter, skip_compaction_pressure).await
+        LimitedFuture::new(
+            f,
+            limiter,
+            skip_compaction_pressure,
+            measure_only,
+            resource_mgr,
+            write_bytes,
+        )
+        .await
     } else {
         f.await
     }
@@ -280,7 +338,10 @@ mod tests {
             <F as Future>::Output: Send,
         {
             let (sender, receiver) = channel::<()>();
-            let fut = NotifyFuture::new(LimitedFuture::new(f, limiter, false), sender);
+            let fut = NotifyFuture::new(
+                LimitedFuture::new(f, limiter, false, false, None, 0),
+                sender,
+            );
             pool.spawn(fut).unwrap();
             receiver.recv().unwrap();
         }

--- a/components/resource_control/src/lib.rs
+++ b/components/resource_control/src/lib.rs
@@ -7,7 +7,8 @@ use pd_client::RpcClient;
 
 mod resource_group;
 pub use resource_group::{
-    MIN_PRIORITY_UPDATE_INTERVAL, ResourceConsumeType, ResourceController, ResourceGroupManager,
+    AdmissionDecision, DelaySlotGuard, MIN_PRIORITY_UPDATE_INTERVAL, ResourceConsumeType,
+    ResourceController, ResourceGroupManager,
 };
 pub use tikv_util::resource_control::*;
 
@@ -28,7 +29,7 @@ pub mod config;
 mod resource_limiter;
 pub use resource_limiter::ResourceLimiter;
 use tikv_util::worker::Worker;
-use worker::{BACKGROUND_LIMIT_ADJUST_DURATION, GroupQuotaAdjustWorker};
+use worker::{GroupQuotaAdjustWorker, QUOTA_ADJUST_DURATION};
 
 mod metrics;
 pub mod worker;
@@ -59,7 +60,7 @@ pub fn start_periodic_tasks(
     // We disable the priority worker by default because the current adjust
     // algorithm is buggy. We may reenable it only we find a better algorithm.
     // let mut priority_worker = PriorityLimiterAdjustWorker::new(mgr.clone());
-    bg_worker.spawn_interval_task(BACKGROUND_LIMIT_ADJUST_DURATION, move || {
+    bg_worker.spawn_interval_task(QUOTA_ADJUST_DURATION, move || {
         worker.adjust_quota();
         // priority_worker.adjust();
     });

--- a/components/resource_control/src/metrics.rs
+++ b/components/resource_control/src/metrics.rs
@@ -6,7 +6,7 @@ use prometheus::*;
 lazy_static! {
     pub static ref BACKGROUND_QUOTA_LIMIT_VEC: IntGaugeVec = register_int_gauge_vec!(
         "tikv_resource_control_background_quota_limiter",
-        "The quota limiter for all background tasks (aggregated across all background resource groups) per resource type",
+        "The quota limiter for all background tasks per resource type",
         &["type"]
     )
     .unwrap();
@@ -47,4 +47,71 @@ lazy_static! {
         &["type"]
     )
     .unwrap();
+
+    pub static ref TWO_PHASE_THROTTLED_REQUESTS: IntCounterVec = register_int_counter_vec!(
+        "tikv_resource_control_two_phase_throttled_requests_total",
+        "Total requests assigned to phase 1 (RU rate above 15-min baseline) per resource group",
+        &["resource_group"]
+    )
+    .unwrap();
+
+    pub static ref GROUP_RU_HISTORICAL_RATE: GaugeVec = register_gauge_vec!(
+        "tikv_resource_control_group_ru_historical_rate",
+        "Historical CPU utilization % per resource group (sliding window average)",
+        &["resource_group"]
+    )
+    .unwrap();
+
+    pub static ref GROUP_RU_CURRENT_RATE: GaugeVec = register_gauge_vec!(
+        "tikv_resource_control_group_ru_current_rate",
+        "Current CPU utilization % per resource group (latest bucket)",
+        &["resource_group"]
+    )
+    .unwrap();
+
+    pub static ref GROUP_QUOTA_LIMIT_VEC: GaugeVec = register_gauge_vec!(
+        "tikv_resource_control_group_quota_limit",
+        "Current rate limit per resource group per resource type (CPU as utilization %, 0 means unlimited)",
+        &["resource_group", "type"]
+    )
+    .unwrap();
+
+    pub static ref ADMISSION_CURRENTLY_DELAYED: IntGauge = register_int_gauge!(
+        "tikv_resource_control_admission_currently_delayed",
+        "Current number of requests sitting in admission control delay"
+    )
+    .unwrap();
+
+    pub static ref ADMISSION_DELAYED_REQUESTS: IntCounterVec = register_int_counter_vec!(
+        "tikv_resource_control_admission_delayed_requests_total",
+        "Total requests delayed by admission control per resource group",
+        &["resource_group"]
+    )
+    .unwrap();
+    pub static ref ADMISSION_REJECTED_REQUESTS: IntCounterVec = register_int_counter_vec!(
+        "tikv_resource_control_admission_rejected_requests_total",
+        "Total requests rejected by admission control per resource group",
+        &["resource_group"]
+    )
+    .unwrap();
+    pub static ref ADMISSION_DELAY_DURATION: HistogramVec = register_histogram_vec!(
+        "tikv_resource_control_admission_delay_duration_seconds",
+        "Histogram of delay duration imposed by admission control",
+        &["resource_group"],
+        exponential_buckets(1e-4, 2.0, 20).unwrap() // 100us ~ 52s
+    )
+    .unwrap();
+}
+
+pub fn deregister_metrics(name: &str) {
+    _ = TWO_PHASE_THROTTLED_REQUESTS.remove_label_values(&[name]);
+    _ = GROUP_QUOTA_LIMIT_VEC.remove_label_values(&[name, "cpu"]);
+    _ = GROUP_RU_HISTORICAL_RATE.remove_label_values(&[name]);
+    _ = GROUP_RU_CURRENT_RATE.remove_label_values(&[name]);
+    _ = ADMISSION_DELAYED_REQUESTS.remove_label_values(&[name]);
+    _ = ADMISSION_REJECTED_REQUESTS.remove_label_values(&[name]);
+    _ = ADMISSION_DELAY_DURATION.remove_label_values(&[name]);
+    _ = ADMISSION_DELAYED_REQUESTS.remove_label_values(&["background"]);
+    _ = ADMISSION_REJECTED_REQUESTS.remove_label_values(&["background"]);
+    _ = ADMISSION_DELAY_DURATION.remove_label_values(&["background"]);
 }

--- a/components/resource_control/src/resource_group.rs
+++ b/components/resource_control/src/resource_group.rs
@@ -6,9 +6,9 @@ use std::{
     collections::HashSet,
     sync::{
         Arc, Mutex,
-        atomic::{AtomicBool, AtomicU64, Ordering},
+        atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering},
     },
-    time::Duration,
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use collections::HashMap;
@@ -27,7 +27,12 @@ use tikv_util::{
 };
 use yatp::queue::priority::TaskPriorityProvider;
 
-use crate::{config::Config, resource_limiter::ResourceLimiter};
+use crate::{
+    config::Config,
+    metrics,
+    metrics::{TWO_PHASE_THROTTLED_REQUESTS, deregister_metrics},
+    resource_limiter::{ResourceLimiter, ResourceType},
+};
 
 // a read task cost at least 50us.
 const DEFAULT_PRIORITY_PER_READ_TASK: u64 = 50;
@@ -51,9 +56,259 @@ const HIGH_PRIORITY: u32 = 16;
 // virtual time overflow.
 const RESET_VT_THRESHOLD: u64 = (u64::MAX >> 4) / 2;
 
+/// Duration of each bucket in the RuTracker ring buffer.
+const RU_BUCKET_SECS: u64 = 30;
+
+/// Sliding-window RU consumption tracker for both Tier-1 admission control
+/// and two-phase scheduling phase decisions.
+///
+/// Tracks actual CPU µs consumed (via `consume_penalty`) across reads and
+/// writes in a configurable ring buffer of 30-second buckets. Window size is
+/// set from `historical_usage_window_mins` (× 2 buckets per minute). Using real
+/// RU rather than virtual
+/// time avoids weight-skewing: a high-weight group accumulates VT faster
+/// without necessarily consuming more CPU.
+pub struct RuTracker {
+    /// Ring buffer of completed 30-second bucket totals (oldest at `head`).
+    buckets: Vec<u64>,
+    /// RU accumulated in the currently-open (incomplete) bucket.
+    /// Atomic so that `record_ru_consumption` can add without taking the Mutex.
+    current_bucket: AtomicU64,
+    /// Unix seconds at which the current bucket started.
+    bucket_start_secs: u64,
+    /// Index of the oldest completed bucket.
+    head: usize,
+    /// Number of completed buckets (≤ buckets.len()).
+    completed: usize,
+    /// Cached historical rate (RU/s), updated by `online_adjust_resource_quota`
+    /// every ~10s.
+    cached_historical_rate: f64,
+    /// Consecutive ramp-up epochs where new_limit >= 2x hist. Must reach
+    /// MIN_RAMP_UP_EPOCHS before the limit is fully lifted to INFINITY.
+    ramp_up_epochs: u32,
+}
+
+impl RuTracker {
+    /// Create a new tracker with `num_buckets` 30-second slots.
+    pub fn new(now_secs: u64, num_buckets: usize) -> Self {
+        let num_buckets = num_buckets.max(2); // need at least 2 to warm up
+        Self {
+            buckets: vec![0u64; num_buckets],
+            current_bucket: AtomicU64::new(0),
+            bucket_start_secs: now_secs,
+            head: 0,
+            completed: 0,
+            cached_historical_rate: 0.0,
+            ramp_up_epochs: 0,
+        }
+    }
+
+    pub fn now_secs() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+    }
+
+    #[inline]
+    fn num_buckets(&self) -> usize {
+        self.buckets.len()
+    }
+
+    /// Record `ru` in the current bucket (lock-free atomic add).
+    pub fn record(&self, ru: u64) {
+        self.current_bucket.fetch_add(ru, Ordering::Relaxed);
+    }
+
+    /// Advance to `now_secs` and record `ru`. Used by tests and callers
+    /// that hold exclusive access.
+    #[cfg(test)]
+    pub fn is_warmed_up(&self) -> bool {
+        self.completed >= 2
+    }
+
+    #[cfg(test)]
+    pub fn record_at(&mut self, ru: u64, now_secs: u64) {
+        self.advance(now_secs);
+        self.current_bucket.fetch_add(ru, Ordering::Relaxed);
+    }
+
+    fn advance(&mut self, now_secs: u64) {
+        let n = self.num_buckets();
+        let elapsed = now_secs.saturating_sub(self.bucket_start_secs);
+        let buckets_to_advance = (elapsed / RU_BUCKET_SECS) as usize;
+        if buckets_to_advance == 0 {
+            return;
+        }
+        if buckets_to_advance >= n {
+            // Gap larger than the window: everything aged out.
+            self.buckets.iter_mut().for_each(|b| *b = 0);
+            self.head = 0;
+            self.completed = 0;
+            self.current_bucket.store(0, Ordering::Relaxed);
+        } else {
+            // Commit the current bucket to the ring, then zero the rest.
+            let write_pos = (self.head + self.completed) % n;
+            self.buckets[write_pos] = self.current_bucket.swap(0, Ordering::Relaxed);
+            if self.completed < n {
+                self.completed += 1;
+            } else {
+                self.head = (self.head + 1) % n;
+            }
+            // Zero out the remaining (buckets_to_advance - 1) slots.
+            for _ in 1..buckets_to_advance {
+                let slot = (self.head + self.completed) % n;
+                self.buckets[slot] = 0;
+                if self.completed < n {
+                    self.completed += 1;
+                } else {
+                    self.head = (self.head + 1) % n;
+                }
+            }
+        }
+        self.bucket_start_secs += buckets_to_advance as u64 * RU_BUCKET_SECS;
+    }
+
+    /// RU/s rate estimated from the current partial bucket and the most recent
+    /// completed bucket. Using both avoids stale readings — the last completed
+    /// bucket alone can be up to 60s old at the end of the current 30s window.
+    ///
+    /// rate = (current_bucket + last_completed) / (elapsed_in_current + 30s)
+    pub fn current_rate(&self, now_secs: u64) -> f64 {
+        let elapsed = now_secs
+            .saturating_sub(self.bucket_start_secs)
+            .min(RU_BUCKET_SECS) as f64;
+        let last_completed = if self.completed > 0 {
+            let newest_slot = (self.head + self.completed - 1) % self.num_buckets();
+            self.buckets[newest_slot]
+        } else {
+            0
+        };
+        let window = elapsed + RU_BUCKET_SECS as f64;
+        (self.current_bucket.load(Ordering::Relaxed) + last_completed) as f64 / window
+    }
+
+    /// Average RU/s rate over all completed buckets (long-term baseline).
+    /// Average RU/s baseline. If the system has been up longer than the full
+    /// historical window, always divide by the full window (not just completed
+    /// buckets). This means a tracker that just started (e.g. spike with no
+    /// prior traffic) has historical=0 and any traffic is immediately detected
+    /// as over baseline, rather than letting new traffic inflate its own
+    /// baseline.
+    pub fn historical_rate(&self, system_start_secs: u64, now_secs: u64) -> f64 {
+        let window_secs = self.num_buckets() as u64 * RU_BUCKET_SECS;
+        let system_uptime = now_secs.saturating_sub(system_start_secs);
+        if system_uptime >= window_secs {
+            // System older than window — use full window as denominator.
+            // Missing buckets count as zero, diluting any fresh traffic.
+            if self.completed == 0 {
+                return 0.0;
+            }
+            let total: u64 = self.buckets.iter().take(self.completed).sum();
+            total as f64 / (self.num_buckets() as f64 * RU_BUCKET_SECS as f64)
+        } else {
+            if self.completed == 0 {
+                return 0.0;
+            }
+            let total: u64 = self.buckets.iter().take(self.completed).sum();
+            // Divide by elapsed system uptime (not just filled buckets) so the
+            // historical rate ramps up smoothly rather than jumping immediately
+            // to the full rate after the first bucket completes.
+            let denom = (system_uptime as f64).max(RU_BUCKET_SECS as f64);
+            total as f64 / denom
+        }
+    }
+
+    /// Returns true if no RU has been recorded: all completed buckets and the
+    /// current bucket are zero. Used to garbage-collect stale ru_trackers
+    /// entries.
+    pub fn is_idle(&self) -> bool {
+        self.current_bucket.load(Ordering::Relaxed) == 0 && self.buckets.iter().all(|&b| b == 0)
+    }
+
+    /// Refresh the cached historical rate. Called periodically from
+    /// `online_adjust_resource_quota` (~every 10s) so the inline hot path
+    /// avoids iterating all buckets.
+    pub fn refresh_cached_historical_rate(&mut self, system_start_secs: u64, now_secs: u64) {
+        self.cached_historical_rate = self.historical_rate(system_start_secs, now_secs);
+    }
+}
+
+/// Encodes a two-phase scheduling priority.
+///
+/// Bit position of the phase bit within the 64-bit encoded priority.
+/// Format: `[4-bit group_priority | 1-bit phase | 59-bit tag]`
+const PRIORITY_TAG_BITS: u32 = 59;
+
+/// Whether a task is within or over its historical RU baseline.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PriorityPhase {
+    /// Within baseline — given scheduling preference over phase-1 tasks.
+    WithinBaseline = 0,
+    /// Over baseline — deprioritised relative to within-baseline tasks.
+    OverBaseline = 1,
+}
+
+/// Format: `[4-bit group_priority | 1-bit phase | 59-bit tag]`
+///
+/// Phase 0 (within baseline) always sorts before phase 1 (over baseline)
+/// within the same group priority tier. Using only 1 bit for phase leaves
+/// 59 bits for the VT tag, matching `RESET_VT_THRESHOLD` (`2^59`).
+fn encode_two_phase_priority(group_priority: u32, phase: PriorityPhase, tag: u64) -> u64 {
+    assert!((1..=16).contains(&group_priority));
+    let tag = tag & ((1u64 << PRIORITY_TAG_BITS) - 1);
+    let phase_bit = (phase as u64) << PRIORITY_TAG_BITS;
+    (!((group_priority - 1) as u64) << 60) | phase_bit | tag
+}
+
+/// Returns true if the encoded priority value represents a phase-1 task.
+#[inline]
+fn is_phase1(priority: u64) -> bool {
+    (priority >> PRIORITY_TAG_BITS) & 1 == 1
+}
 pub enum ResourceConsumeType {
     CpuTime(Duration),
     IoBytes(u64),
+}
+
+/// Result of the Tier-1 admission control check for a single request.
+#[derive(Debug, PartialEq)]
+pub enum AdmissionDecision {
+    /// No throttling needed; let the request proceed immediately.
+    Allow,
+    /// Delay the request by the given duration. The caller **must** call
+    /// [`ResourceGroupManager::release_delay_slot`] once the delay is over
+    /// (or the delayed future is dropped/cancelled).
+    Delay(Duration),
+    /// Reject the request outright (SchedTooBusy). Returned when the number
+    /// of concurrently delayed requests exceeds `admission_max_delayed_count`.
+    Reject,
+}
+
+/// RAII guard that releases an admission-control delay slot on drop.
+/// Ensures the `delayed_req_count` counter is decremented even if the
+/// future is cancelled during the sleep.
+pub struct DelaySlotGuard {
+    mgr: Option<Arc<ResourceGroupManager>>,
+}
+
+impl DelaySlotGuard {
+    fn new(mgr: Arc<ResourceGroupManager>) -> Self {
+        Self { mgr: Some(mgr) }
+    }
+
+    /// Explicitly release the slot and disarm the guard so Drop is a no-op.
+    pub fn release(&mut self) {
+        if let Some(mgr) = self.mgr.take() {
+            mgr.release_delay_slot();
+        }
+    }
+}
+
+impl Drop for DelaySlotGuard {
+    fn drop(&mut self) {
+        self.release();
+    }
 }
 
 /// ResourceGroupManager manages the metadata of each resource group.
@@ -69,6 +324,23 @@ pub struct ResourceGroupManager {
     has_background: AtomicBool,
     // lastest config.
     config: Arc<VersionTrack<Config>>,
+    // Per-group RU consumption trackers for Tier-1 high-priority throttling.
+    // Per-group sliding-window tracker and token-bucket limiter.
+    // Rate on the limiter is set to `fraction × historical_rate` each tick.
+    // The Arc allows handing out limiter references to LimitedFuture wrappers
+    // in the read/write pools without copying the limiter state.
+    ru_trackers: DashMap<String, Mutex<(RuTracker, Arc<ResourceLimiter>)>>,
+    // Number of requests currently held in the admission-control delay phase.
+    delayed_req_count: AtomicI64,
+    // Unix seconds when this manager was created. Used to determine whether
+    // the system has been up long enough that new trackers should be treated
+    // as if they missed the entire historical window (baseline = 0).
+    start_secs: u64,
+    // True when background CPU budget is at the minimum floor (1 core) AND
+    // background consumption is within that floor. Foreground throttling
+    // only engages when this flag is set, ensuring background is fully
+    // squeezed before foreground traffic is touched.
+    bg_cpu_at_floor: AtomicBool,
 }
 
 impl Default for ResourceGroupManager {
@@ -99,10 +371,14 @@ impl ResourceGroupManager {
             resource_groups: Default::default(),
             group_count: AtomicU64::new(0),
             registry: Default::default(),
+            delayed_req_count: AtomicI64::new(0),
             priority_limiters,
             bg_limiter,
             has_background: AtomicBool::new(false),
             config: Arc::new(VersionTrack::new(config)),
+            ru_trackers: Default::default(),
+            start_secs: RuTracker::now_secs(),
+            bg_cpu_at_floor: AtomicBool::new(false),
         };
 
         // init the default resource group by default.
@@ -210,6 +486,7 @@ impl ResourceGroupManager {
         if self.resource_groups.remove(&group_name).is_some() {
             info!("remove resource group"; "name"=> name);
             self.group_count.fetch_sub(1, Ordering::Relaxed);
+            deregister_metrics(&group_name);
         }
         self.update_has_background();
     }
@@ -255,7 +532,7 @@ impl ResourceGroupManager {
     }
 
     pub fn derive_controller(&self, name: String, is_read: bool) -> Arc<ResourceController> {
-        let controller = Arc::new(ResourceController::new(name, is_read));
+        let controller = Arc::new(ResourceController::new(name, is_read, self.config.clone()));
         self.registry.write().push(controller.clone());
         for g in &self.resource_groups {
             let ru_quota = Self::get_ru_setting(&g.value().group, controller.is_read);
@@ -266,8 +543,36 @@ impl ResourceGroupManager {
     }
 
     pub fn advance_min_virtual_time(&self) {
+        // Push RU-based phase state into every controller before updating VT,
+        // so get_priority() sees fresh is_over_baseline flags this tick.
+        if self.config.value().enable_fair_scheduling {
+            self.update_group_phases();
+        }
         for controller in self.registry.read().iter() {
             controller.update_min_virtual_time();
+        }
+    }
+
+    /// Iterates all tracked groups and pushes `is_over_baseline` into each
+    /// registered `ResourceController`.  Called every ~1 second from
+    /// `advance_min_virtual_time` when `enable_fair_scheduling` is on.
+    fn update_group_phases(&self) {
+        let now_secs = RuTracker::now_secs();
+        for entry in &self.ru_trackers {
+            let group_bytes = entry.key().as_bytes();
+            let mut guard = entry.value().lock().unwrap();
+            // Roll the ring buffer forward so phase classification uses
+            // up-to-date bucket boundaries, not stale partial data.
+            guard.0.advance(now_secs);
+            let over = guard
+                .1
+                .get_limiter(ResourceType::Cpu)
+                .get_rate_limit()
+                .is_finite();
+            drop(guard);
+            for controller in self.registry.read().iter() {
+                controller.set_group_phase(group_bytes, over);
+            }
         }
     }
 
@@ -288,51 +593,347 @@ impl ResourceGroupManager {
                 ResourceConsumeType::IoBytes(ctx.get_penalty().write_bytes as u64),
             );
         }
+        // RU tracking for foreground admission control is handled by
+        // LimitedFuture (measure-only mode) which calls record_ru_consumption
+        // with actual CPU measured per poll.
     }
 
-    // only enable priority quota limiter when there is at least 1 user-defined
-    // resource group.
-    #[inline]
-    fn enable_priority_limiter(&self) -> bool {
-        // TODO: reenable it once when we fix https://github.com/tikv/tikv/issues/18939
-        // self.get_group_count() > 1
-        false
+    /// Record `ru` units consumed by `group` into the sliding-window tracker
+    /// and consume tokens from the group's rate limiter.
+    pub fn record_ru_consumption(&self, group: &str, ru: u64) {
+        let now = RuTracker::now_secs();
+        // 2 buckets per minute (30s each) to match RU_BUCKET_SECS.
+        let num_buckets = (self.config.value().historical_usage_window_mins.max(2) as usize) * 2;
+        let entry = self.ru_trackers.entry(group.to_owned()).or_insert_with(|| {
+            Mutex::new((
+                RuTracker::new(now, num_buckets),
+                Arc::new(ResourceLimiter::new(
+                    group.to_owned(),
+                    f64::INFINITY,
+                    f64::INFINITY,
+                    0,
+                    false,
+                )),
+            ))
+        });
+        // Lock-free: only atomically adds to current_bucket.
+        // advance() is called separately by online_adjust_resource_quota under the
+        // lock.
+        entry.lock().unwrap().0.record(ru);
     }
 
-    // Always return the background resource limiter if any;
-    // Only return the foregroup limiter when priority is enabled.
+    /// Called by `PriorityLimiterAdjustWorker` every ~1 second with the
+    /// latest process-level CPU utilisation percentage.
+    ///
+    /// Throttle-down: linearly reduces the allowed fraction of historical rate
+    /// for groups that are over their baseline. At `fg_cpu_throttle_threshold`
+    /// (70%) fraction = 1.0 (no throttle), at 90% CPU fraction = 0.8
+    /// (target). Called by the background adjust worker after computing the
+    /// new background CPU budget. `at_floor` should be true when the budget
+    /// has been clamped to the minimum floor AND background consumption
+    /// is within that floor.
+    pub fn set_bg_cpu_at_floor(&self, at_floor: bool) {
+        self.bg_cpu_at_floor.store(at_floor, Ordering::Relaxed);
+    }
+
+    /// Returns true when background CPU is fully throttled (at floor)
+    /// and its consumption is within the floor budget.
+    pub fn is_bg_cpu_at_floor(&self) -> bool {
+        self.bg_cpu_at_floor.load(Ordering::Relaxed)
+    }
+
+    /// Returns true when all foreground groups have unlimited (infinite)
+    /// CPU rate limits, i.e. foreground has fully ramped up.
+    pub fn is_foreground_fully_ramped_up(&self) -> bool {
+        for entry in &self.ru_trackers {
+            let guard = entry.lock().unwrap();
+            if guard
+                .1
+                .get_limiter(ResourceType::Cpu)
+                .get_rate_limit()
+                .is_finite()
+            {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Only groups whose current rate exceeds their historical rate are
+    /// limited.
+    ///
+    /// Ramp-up: when CPU drops below threshold, recover ×1.1/tick until
+    /// NO_LIMIT is restored.
+    pub fn online_adjust_resource_quota(&self, pct: f64) {
+        const TARGET_CPU: f64 = 90.0;
+        const RAMP_FACTOR: f64 = 1.2;
+        const MIN_RAMP_UP_EPOCHS: u32 = 2;
+
+        let throttle_threshold = self.config.value().fg_cpu_throttle_threshold;
+        let leeway_threshold = throttle_threshold * 0.9;
+        let burst_factor = 1.0 + self.config.value().baseline_burst_pct / 100.0;
+        let now = RuTracker::now_secs();
+
+        // Advance all trackers to `now` and refresh cached historical rates
+        // up front so update_group_phases and the throttling logic below
+        // always see fresh baseline data.
+        for entry in &self.ru_trackers {
+            let mut guard = entry.lock().unwrap();
+            guard.0.advance(now);
+            guard.0.refresh_cached_historical_rate(self.start_secs, now);
+            let name = guard.1.name();
+
+            metrics::GROUP_RU_HISTORICAL_RATE
+                .with_label_values(&[name])
+                .set((guard.0.cached_historical_rate / 1_000_000.0) * 100.0);
+            metrics::GROUP_RU_CURRENT_RATE
+                .with_label_values(&[name])
+                .set((guard.0.current_rate(now) / 1_000_000.0) * 100.0);
+        }
+
+        if pct > throttle_threshold && self.is_bg_cpu_at_floor() {
+            // Linearly scale limit from current rate (at threshold) down to
+            // historical rate (at TARGET_CPU).
+            // pressure: 0.0 at threshold → 1.0 at TARGET_CPU.
+            let pressure =
+                ((pct - throttle_threshold) / (TARGET_CPU - throttle_threshold)).clamp(0.0, 1.0);
+
+            for entry in &self.ru_trackers {
+                let mut guard = entry.lock().unwrap();
+                let hist = guard.0.cached_historical_rate;
+                let current = guard.0.current_rate(now);
+                let burst_target = hist * burst_factor;
+                if hist > 0.0 && current > burst_target {
+                    // rate slides from current (pressure=0) to burst_target (pressure=1).
+                    let rate = current + (burst_target - current) * pressure;
+                    let current_limit = guard.1.get_limiter(ResourceType::Cpu).get_rate_limit();
+                    // Only tighten the limit — never loosen in the throttle branch.
+                    // Ramp-up is the only path that increases limits.
+                    if current_limit.is_infinite() || rate < current_limit {
+                        guard.0.ramp_up_epochs = 0;
+                        guard
+                            .1
+                            .get_limiter(ResourceType::Cpu)
+                            .set_rate_limit(rate.max(1.0));
+                    }
+                }
+            }
+        } else if pct < leeway_threshold {
+            // CPU below start threshold — ramp up by RAMP_FACTOR each tick.
+            // Only lift to INFINITY after MIN_RAMP_UP_EPOCHS consecutive epochs
+            // where the limit has grown past 2x hist, to avoid premature release.
+            for entry in &self.ru_trackers {
+                let mut guard = entry.lock().unwrap();
+                let current_limit = guard.1.get_limiter(ResourceType::Cpu).get_rate_limit();
+                if current_limit.is_finite() {
+                    let hist = guard.0.cached_historical_rate;
+                    let new_limit = current_limit * RAMP_FACTOR;
+                    if hist <= 0.0 || new_limit >= 2.0 * hist {
+                        guard.0.ramp_up_epochs += 1;
+                        if guard.0.ramp_up_epochs >= MIN_RAMP_UP_EPOCHS {
+                            guard.0.ramp_up_epochs = 0;
+                            guard
+                                .1
+                                .get_limiter(ResourceType::Cpu)
+                                .set_rate_limit(f64::INFINITY);
+                        }
+                    } else {
+                        guard.0.ramp_up_epochs = 0;
+                        guard
+                            .1
+                            .get_limiter(ResourceType::Cpu)
+                            .set_rate_limit(new_limit);
+                    }
+                }
+            }
+        }
+
+        // Emit current rate limit per resource group.
+        for entry in &self.ru_trackers {
+            let guard = entry.lock().unwrap();
+            let limit = guard.1.get_limiter(ResourceType::Cpu).get_rate_limit();
+            let val = if limit.is_finite() {
+                (limit / 1_000_000.0) * 100.0
+            } else {
+                0.0
+            };
+            metrics::GROUP_QUOTA_LIMIT_VEC
+                .with_label_values(&[guard.1.name(), "cpu"])
+                .set(val);
+        }
+
+        // Evict idle ru_trackers entries to prevent unbounded growth from
+        // removed or renamed groups. Advance first so stale partial buckets
+        // are flushed before the idle check.
+        self.ru_trackers.retain(|_, entry| {
+            let inner = entry.get_mut().unwrap();
+            inner.0.advance(now);
+            !inner.0.is_idle()
+        });
+    }
+
+    /// Returns the token-bucket debt delay for `group`, or `None` if no
+    /// throttling is active.
+    ///
+    /// Conditions for a non-zero delay (all must hold):
+    ///   1. `enable_read_admission_control` / `enable_write_admission_control`
+    ///      on
+    ///   2. Rate-limit is active (not NO_LIMIT sentinel)
+    ///   3. Tracker has warmed up (≥2 completed 1-min buckets)
+    ///   4. Token-bucket has accumulated debt (group exceeded its allowed rate)
+    pub fn compute_admission_delay(
+        &self,
+        resource_limiter: &ResourceLimiter,
+        is_read: bool,
+    ) -> Option<Duration> {
+        // Always consume tokens so the token-bucket debt stays accurate
+        // for scheduling decisions. Only return the delay when admission
+        // control is enabled (or for background limiters, always).
+        let delay = resource_limiter.admission_delay(is_read);
+        if !resource_limiter.is_background() {
+            let config = self.config.value();
+            let ac_enabled = if is_read {
+                config.enable_read_admission_control
+            } else {
+                config.enable_write_admission_control
+            };
+            if !ac_enabled {
+                return None;
+            }
+        }
+        if delay.is_zero() { None } else { Some(delay) }
+    }
+
+    /// Unified admission-control decision for a request from `group`.
+    ///
+    /// Combines token-bucket rate-limiter debt (`resource_limiter`) with
+    /// RU-baseline overage delay into a single pre-pool sleep duration.
+    /// Covers background, low-priority, and resource-group throttling for
+    /// both reads (`is_read=true`) and writes (`is_read=false`).
+    ///
+    /// Returns:
+    /// - [`AdmissionDecision::Allow`] — no throttling needed.
+    /// - [`AdmissionDecision::Delay(d)`] — caller should sleep `d` then
+    ///   proceed, and **must** call [`release_delay_slot`] afterwards.
+    /// - [`AdmissionDecision::Reject`] — too many requests are already delayed;
+    ///   reject immediately.
+    pub fn admission_decision(
+        &self,
+        is_read: bool,
+        resource_limiter: &ResourceLimiter,
+    ) -> AdmissionDecision {
+        let group = resource_limiter.name();
+        let delay = self
+            .compute_admission_delay(resource_limiter, is_read)
+            .unwrap_or(std::time::Duration::ZERO);
+        if delay.is_zero() {
+            return AdmissionDecision::Allow;
+        }
+        let metric_label = if resource_limiter.is_background() {
+            "background"
+        } else {
+            group
+        };
+        let max = self.config.value().admission_max_delayed_count;
+        let prev = self.delayed_req_count.fetch_add(1, Ordering::Relaxed);
+        metrics::ADMISSION_CURRENTLY_DELAYED.set(prev + 1);
+        if max > 0 && prev >= max as i64 {
+            self.delayed_req_count.fetch_sub(1, Ordering::Relaxed);
+            metrics::ADMISSION_CURRENTLY_DELAYED.set(prev);
+            crate::metrics::ADMISSION_REJECTED_REQUESTS
+                .with_label_values(&[metric_label])
+                .inc();
+            return AdmissionDecision::Reject;
+        }
+        crate::metrics::ADMISSION_DELAYED_REQUESTS
+            .with_label_values(&[metric_label])
+            .inc();
+        crate::metrics::ADMISSION_DELAY_DURATION
+            .with_label_values(&[metric_label])
+            .observe(delay.as_secs_f64());
+        AdmissionDecision::Delay(delay)
+    }
+
+    /// Release a delay slot acquired by [`admission_decision`] returning
+    /// [`AdmissionDecision::Delay`]. Must be called exactly once per `Delay`
+    /// decision, whether the request completes normally or is cancelled.
+    pub fn release_delay_slot(&self) {
+        let prev = self.delayed_req_count.fetch_sub(1, Ordering::Relaxed);
+        metrics::ADMISSION_CURRENTLY_DELAYED.set(prev - 1);
+    }
+
+    /// Returns an RAII guard that calls [`release_delay_slot`] on drop.
+    /// Use this to ensure the slot is released even if the future is
+    /// cancelled during the admission-control sleep.
+    pub fn delay_slot_guard(self: &Arc<Self>) -> DelaySlotGuard {
+        DelaySlotGuard::new(Arc::clone(self))
+    }
+
+    /// Returns the per-group admission-control limiter for `group`, creating
+    /// the entry if it does not yet exist. Used by `with_resource_limiter`
+    /// (measure-only mode) in the read/write pools so `LimitedFuture` can
+    /// build token-bucket debt for pre-pool `admission_decision`.
+    pub fn get_foreground_group_limiter(&self, group: &str) -> Arc<ResourceLimiter> {
+        let now = RuTracker::now_secs();
+        // 2 buckets per minute (30s each) to match RU_BUCKET_SECS.
+        let num_buckets = (self.config.value().historical_usage_window_mins.max(2) as usize) * 2;
+        self.ru_trackers
+            .entry(group.to_owned())
+            .or_insert_with(|| {
+                Mutex::new((
+                    RuTracker::new(now, num_buckets),
+                    Arc::new(ResourceLimiter::new(
+                        group.to_owned(),
+                        f64::INFINITY,
+                        f64::INFINITY,
+                        0,
+                        false,
+                    )),
+                ))
+            })
+            .lock()
+            .unwrap()
+            .1
+            .clone()
+    }
+
+    /// Returns the appropriate `ResourceLimiter` for `with_resource_limiter`:
+    /// - Background tasks → background limiter
+    /// - Foreground tasks (any priority) → per-group limiter from `ru_trackers`
     pub fn get_resource_limiter(
         &self,
         rg: &str,
         request_source: &str,
-        override_priority: u64,
+        _override_priority: u64,
     ) -> Option<Arc<ResourceLimiter>> {
-        let (limiter, group_priority) =
-            self.get_background_resource_limiter_with_priority(rg, request_source);
+        let (limiter, _) = self.get_background_resource_limiter_with_priority(rg, request_source);
         if limiter.is_some() {
             return limiter;
         }
-
-        // if there is only 1 resource group, priority quota limiter is useless so just
-        // return None for better performance.
-        if !self.enable_priority_limiter() {
+        if self.get_group_count() <= 1 {
             return None;
         }
-
-        // request priority has higher priority, 0 means priority is not set.
-        let mut task_priority = override_priority as u32;
-        if task_priority == 0 {
-            task_priority = group_priority;
-        }
-        Some(self.priority_limiters[TaskPriority::from(task_priority) as usize].clone())
+        // Only create a foreground limiter for known groups; unknown or removed
+        // groups fall back to "default" to avoid leaking ru_trackers entries.
+        let group_name = if self.resource_groups.contains_key(rg) {
+            rg
+        } else {
+            DEFAULT_RESOURCE_GROUP_NAME
+        };
+        Some(self.get_foreground_group_limiter(group_name))
     }
 
     // return a ResourceLimiter for background tasks only.
+    // Returns None if request_source does not match a configured background job
+    // type.
     pub fn get_background_resource_limiter(
         &self,
         rg: &str,
         request_source: &str,
     ) -> Option<Arc<ResourceLimiter>> {
+        if request_source.is_empty() {
+            return None;
+        }
         self.get_background_resource_limiter_with_priority(rg, request_source)
             .0
     }
@@ -462,6 +1063,8 @@ pub struct ResourceController {
     customized: AtomicBool,
     // whether any resource group has background settings configured
     has_background: AtomicBool,
+    // Shared config. Read on the hot path to check enable_fair_scheduling.
+    config: Arc<VersionTrack<Config>>,
 }
 
 // we are ensure to visit the `last_rest_vt_time` by only 1 thread so it's
@@ -470,7 +1073,7 @@ unsafe impl Send for ResourceController {}
 unsafe impl Sync for ResourceController {}
 
 impl ResourceController {
-    fn new(name: String, is_read: bool) -> Self {
+    fn new(name: String, is_read: bool, config: Arc<VersionTrack<Config>>) -> Self {
         Self {
             name,
             is_read,
@@ -480,11 +1083,16 @@ impl ResourceController {
             last_rest_vt_time: Cell::new(Instant::now_coarse()),
             customized: AtomicBool::new(false),
             has_background: AtomicBool::new(false),
+            config,
         }
     }
 
     pub fn new_for_test(name: String, is_read: bool) -> Self {
-        let controller = Self::new(name, is_read);
+        let controller = Self::new(
+            name,
+            is_read,
+            Arc::new(VersionTrack::new(Config::default())),
+        );
         // add the "default" resource group.
         controller.add_resource_group(
             DEFAULT_RESOURCE_GROUP_NAME.as_bytes().to_owned(),
@@ -541,6 +1149,9 @@ impl ResourceController {
             weight,
             virtual_time: AtomicU64::new(self.last_min_vt.load(Ordering::Acquire)),
             vt_delta_for_get,
+            // New groups start in phase 0; ResourceGroupManager updates this
+            // each second once the RuTracker has enough history.
+            is_over_baseline: AtomicBool::new(false),
         };
 
         // maybe update existed group
@@ -610,6 +1221,17 @@ impl ResourceController {
         self.resource_group(name).consume(resource)
     }
 
+    /// Updates the two-phase `is_over_baseline` flag for a single group.
+    /// Called each second by `ResourceGroupManager::update_group_phases`.
+    pub fn set_group_phase(&self, group: &[u8], over_baseline: bool) {
+        let consumptions = self.resource_consumptions.read();
+        if let Some(tracker) = consumptions.get(group) {
+            tracker
+                .is_over_baseline
+                .store(over_baseline, Ordering::Relaxed);
+        }
+    }
+
     pub fn update_min_virtual_time(&self) {
         let start = Instant::now_coarse();
         let mut min_vt = u64::MAX;
@@ -662,7 +1284,8 @@ impl ResourceController {
 
     pub fn get_priority(&self, name: &[u8], pri: CommandPri) -> u64 {
         let level = Self::command_pri_to_level(pri);
-        self.resource_group(name).get_priority(level, None, true)
+        self.resource_group(name)
+            .get_priority(level, None, true, self.is_two_phase_enabled())
     }
 
     /// Returns the priority for the given task metadata without incrementing
@@ -675,7 +1298,14 @@ impl ResourceController {
         } else {
             Some(metadata.override_priority())
         };
-        group.get_priority(level, override_priority, false)
+        group.get_priority(level, override_priority, false, self.is_two_phase_enabled())
+    }
+
+    /// Returns true when fair two-phase scheduling is active (read controller
+    /// with enable_fair_scheduling enabled).
+    #[inline]
+    fn is_two_phase_enabled(&self) -> bool {
+        self.is_read && self.config.value().enable_fair_scheduling
     }
 
     fn command_pri_to_level(pri: CommandPri) -> usize {
@@ -690,7 +1320,7 @@ impl ResourceController {
 impl TaskPriorityProvider for ResourceController {
     fn priority_of(&self, extras: &yatp::queue::Extras) -> u64 {
         let metadata = TaskMetadata::from(extras.metadata());
-        self.resource_group(metadata.group_name()).get_priority(
+        let p = self.resource_group(metadata.group_name()).get_priority(
             extras.current_level() as usize,
             if metadata.override_priority() == 0 {
                 None
@@ -698,7 +1328,16 @@ impl TaskPriorityProvider for ResourceController {
                 Some(metadata.override_priority())
             },
             true,
-        )
+            self.is_two_phase_enabled(),
+        );
+        if is_phase1(p)
+            && let Ok(name) = std::str::from_utf8(metadata.group_name())
+        {
+            TWO_PHASE_THROTTLED_REQUESTS
+                .with_label_values(&[name])
+                .inc();
+        }
+        p
     }
 }
 
@@ -719,24 +1358,47 @@ struct GroupPriorityTracker {
     virtual_time: AtomicU64,
     // the constant delta value for each `get_priority` call,
     vt_delta_for_get: u64,
+    // Two-phase scheduling: true when this group's current-minute RU rate
+    // exceeds its historical baseline (set by ResourceGroupManager each second).
+    // Phase 1 tasks are deprioritised relative to phase-0 (within-baseline) tasks.
+    is_over_baseline: AtomicBool,
 }
 
 impl GroupPriorityTracker {
     /// Computes the scheduling priority for a task at the given level.
+    ///
     /// When `advance_vt` is true, atomically increments the virtual time
     /// (used when actually scheduling a task). When false, reads virtual
     /// time without advancing it (used for priority comparison only).
-    fn get_priority(&self, level: usize, override_priority: Option<u32>, advance_vt: bool) -> u64 {
+    ///
+    /// When `two_phase` is true and `is_over_baseline` is set, the task is
+    /// placed in phase 1 (deprioritised); otherwise it runs in phase 0.
+    /// `is_over_baseline` is updated each second by `ResourceGroupManager`
+    /// from real CPU µs tracked across reads and writes via `consume_penalty`.
+    fn get_priority(
+        &self,
+        level: usize,
+        override_priority: Option<u32>,
+        advance_vt: bool,
+        two_phase: bool,
+    ) -> u64 {
         let task_extra_priority = TASK_EXTRA_FACTOR_BY_LEVEL[level] * 1000 * self.weight;
-        let vt = (if advance_vt && self.vt_delta_for_get > 0 {
-            self.virtual_time
-                .fetch_add(self.vt_delta_for_get, Ordering::Relaxed)
-                + self.vt_delta_for_get
-        } else {
-            self.virtual_time.load(Ordering::Relaxed) + self.vt_delta_for_get
-        }) + task_extra_priority;
         let priority = override_priority.unwrap_or(self.group_priority);
-        concat_priority_vt(priority, vt)
+        let vt_delta = self.vt_delta_for_get;
+
+        let vt = if advance_vt && vt_delta > 0 {
+            self.virtual_time.fetch_add(vt_delta, Ordering::Relaxed) + vt_delta
+        } else {
+            self.virtual_time.load(Ordering::Relaxed) + vt_delta
+        } + task_extra_priority;
+
+        if two_phase && self.is_over_baseline.load(Ordering::Relaxed) {
+            encode_two_phase_priority(priority, PriorityPhase::OverBaseline, vt)
+        } else if two_phase {
+            encode_two_phase_priority(priority, PriorityPhase::WithinBaseline, vt)
+        } else {
+            concat_priority_vt(priority, vt)
+        }
     }
 
     #[inline]
@@ -767,6 +1429,7 @@ impl GroupPriorityTracker {
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use file_system::IoBytes;
     use yatp::queue::Extras;
 
     use super::*;
@@ -1249,6 +1912,150 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn test_encode_two_phase_priority_ordering() {
+        // Phase 0 (reservation) must sort before phase 1 (weight) for the
+        // same group_priority and a larger tag value.
+        let phase0 =
+            encode_two_phase_priority(MEDIUM_PRIORITY, PriorityPhase::WithinBaseline, 9999);
+        let phase1 = encode_two_phase_priority(MEDIUM_PRIORITY, PriorityPhase::OverBaseline, 1);
+        assert!(
+            phase0 < phase1,
+            "phase 0 must be higher priority than phase 1"
+        );
+
+        // Within phase 0, lower tag = higher priority.
+        let p0_low = encode_two_phase_priority(MEDIUM_PRIORITY, PriorityPhase::WithinBaseline, 100);
+        let p0_high =
+            encode_two_phase_priority(MEDIUM_PRIORITY, PriorityPhase::WithinBaseline, 200);
+        assert!(p0_low < p0_high);
+
+        // group_priority still dominates across phases.
+        let high_phase1 =
+            encode_two_phase_priority(HIGH_PRIORITY, PriorityPhase::OverBaseline, u64::MAX >> 8);
+        let low_phase0 = encode_two_phase_priority(LOW_PRIORITY, PriorityPhase::WithinBaseline, 0);
+        assert!(high_phase1 < low_phase0);
+    }
+
+    #[test]
+    fn test_two_phase_scheduling_ru_based() {
+        // Two-phase scheduling driven by real RU (CPU µs) from ResourceGroupManager.
+        let mut cfg = Config::default();
+        cfg.enable_fair_scheduling = true;
+        let mgr = ResourceGroupManager::new(cfg);
+
+        let steady = new_resource_group_ru("steady".into(), 1000, MEDIUM_PRIORITY);
+        let spike = new_resource_group_ru("spike".into(), 1000, MEDIUM_PRIORITY);
+        mgr.add_resource_group(steady);
+        mgr.add_resource_group(spike);
+
+        let ctl = mgr.derive_controller("read".into(), true);
+
+        // Warm up steady's RuTracker: 2 completed 30s buckets with consistent rate.
+        let t0 = RuTracker::now_secs();
+        {
+            let e = mgr
+                .ru_trackers
+                .entry("steady".to_owned())
+                .or_insert_with(|| {
+                    Mutex::new((
+                        RuTracker::new(t0, 30),
+                        Arc::new(ResourceLimiter::new(
+                            "".into(),
+                            f64::INFINITY,
+                            f64::INFINITY,
+                            0,
+                            false,
+                        )),
+                    ))
+                });
+            let mut tr = e.lock().unwrap();
+            tr.0.record_at(6000, t0 + 15);
+            tr.0.record_at(0, t0 + 30); // close bucket 0: 6000 µs
+            tr.0.record_at(6000, t0 + 45);
+            tr.0.record_at(0, t0 + 60); // close bucket 1: 6000 µs → stable baseline
+        }
+        // "spike" has no tracker → is_over_baseline stays false (no history).
+
+        // Push phases into controller.
+        mgr.advance_min_virtual_time();
+
+        // steady: both buckets equal → current_rate == historical_rate → NOT over
+        // baseline. spike: no tracker → also not over baseline.
+        // Neither should be in phase 1 at steady state.
+        {
+            let groups = ctl.resource_consumptions.read();
+            let steady_over = groups
+                .get(b"steady".as_ref())
+                .unwrap()
+                .is_over_baseline
+                .load(Ordering::Relaxed);
+            let spike_over = groups
+                .get(b"spike".as_ref())
+                .unwrap()
+                .is_over_baseline
+                .load(Ordering::Relaxed);
+            assert!(!steady_over, "steady at baseline should be phase 0");
+            assert!(!spike_over, "spike with no history should be phase 0");
+        }
+
+        // Now simulate a spike for "spike": current bucket >> historical.
+        {
+            let e = mgr
+                .ru_trackers
+                .entry("spike".to_owned())
+                .or_insert_with(|| {
+                    Mutex::new((
+                        RuTracker::new(t0, 30),
+                        Arc::new(ResourceLimiter::new(
+                            "".into(),
+                            f64::INFINITY,
+                            f64::INFINITY,
+                            0,
+                            false,
+                        )),
+                    ))
+                });
+            let mut tr = e.lock().unwrap();
+            tr.0.record_at(3000, t0 + 30);
+            tr.0.record_at(0, t0 + 60); // close bucket [t0+30,t0+60): 3000µs baseline
+            tr.0.record_at(12000, t0 + 90); // current open bucket: 12000µs spike (left open)
+        }
+        // Trigger a CPU utilization tick to refresh cached_historical_rate
+        // on all trackers. Set bg_cpu_at_floor so the throttle branch fires
+        // and limits groups that are over baseline.
+        mgr.set_bg_cpu_at_floor(true);
+        mgr.online_adjust_resource_quota(75.0);
+        mgr.advance_min_virtual_time();
+
+        {
+            let groups = ctl.resource_consumptions.read();
+            let spike_over = groups
+                .get(b"spike".as_ref())
+                .unwrap()
+                .is_over_baseline
+                .load(Ordering::Relaxed);
+            assert!(spike_over, "spike bucket1 > bucket0 → should be phase 1");
+        }
+
+        // Phase ordering: steady (phase 0) must sort before spike (phase 1).
+        let groups = ctl.resource_consumptions.read();
+        let steady_pri = groups
+            .get(b"steady".as_ref())
+            .unwrap()
+            .get_priority(1, None, false, true);
+        let spike_pri = groups
+            .get(b"spike".as_ref())
+            .unwrap()
+            .get_priority(1, None, false, true);
+        assert!(!is_phase1(steady_pri), "steady should be phase 0");
+        assert!(is_phase1(spike_pri), "spike should be phase 1");
+        assert!(
+            steady_pri < spike_pri,
+            "phase 0 must schedule before phase 1"
+        );
+    }
+
+    #[test]
     fn test_get_resource_limiter() {
         let mgr = ResourceGroupManager::default();
 
@@ -1266,9 +2073,14 @@ pub(crate) mod tests {
             .clone()
             .unwrap();
 
+        // Only 1 group (default): foreground always returns None.
         assert!(mgr.get_resource_limiter("default", "query", 0).is_none());
         assert!(
             mgr.get_resource_limiter("default", "query", HIGH_PRIORITY as u64)
+                .is_none()
+        );
+        assert!(
+            mgr.get_resource_limiter("default", "query", LOW_PRIORITY as u64)
                 .is_none()
         );
 
@@ -1315,9 +2127,177 @@ pub(crate) mod tests {
             &default_limiter
         ));
 
+        // Background path still takes priority for "stats" source.
         assert!(Arc::ptr_eq(
             &mgr.get_resource_limiter("test1", "stats", 0).unwrap(),
             &default_limiter
         ));
+
+        // Multiple groups: all foreground priorities get the per-group limiter.
+        // The same limiter is returned regardless of priority level.
+        let fg_limiter = mgr
+            .get_resource_limiter("test1", "query", LOW_PRIORITY as u64)
+            .unwrap();
+        assert!(Arc::ptr_eq(
+            &mgr.get_resource_limiter("test1", "query", HIGH_PRIORITY as u64)
+                .unwrap(),
+            &fg_limiter,
+        ));
+        assert!(Arc::ptr_eq(
+            &mgr.get_resource_limiter("test1", "query", 0).unwrap(),
+            &fg_limiter,
+        ));
+    }
+
+    #[test]
+    fn test_ru_tracker() {
+        let t0: u64 = 1_000_000;
+
+        const BUCKETS: usize = 15;
+        let mut tracker = RuTracker::new(t0, BUCKETS);
+        assert!(!tracker.is_warmed_up());
+        // No data at all: current_rate = (0 + 0) / (0 + 60) = 0.
+        assert_eq!(tracker.current_rate(t0), 0.0);
+        assert_eq!(tracker.historical_rate(t0, t0), 0.0);
+
+        // Record 6000 RU in the first 30s bucket.
+        tracker.record_at(6000, t0 + 15);
+
+        // Advance past the first bucket boundary (30s) — completes bucket 0.
+        tracker.record_at(0, t0 + 30);
+        assert_eq!(tracker.completed, 1);
+        // At t0+30: current_bucket=0, elapsed=0, last_completed=6000
+        // rate = (0 + 6000) / (0 + 30) = 200 RU/s
+        assert!((tracker.current_rate(t0 + 30) - 200.0).abs() < 0.01);
+        assert!(!tracker.is_warmed_up()); // needs ≥2 buckets
+
+        // Advance another 30s with 3000 RU — completes bucket 1.
+        tracker.record_at(3000, t0 + 45);
+        tracker.record_at(0, t0 + 60);
+        assert_eq!(tracker.completed, 2);
+        assert!(tracker.is_warmed_up());
+        // At t0+60: current_bucket=0, elapsed=0, last_completed=3000
+        // rate = (0 + 3000) / (0 + 30) = 100 RU/s
+        assert!((tracker.current_rate(t0 + 60) - 100.0).abs() < 0.01);
+        // At t0+75 (15s into next bucket, no new RU): current_bucket=0, elapsed=15
+        // rate = (0 + 3000) / (15 + 30) = 66.67 RU/s
+        assert!((tracker.current_rate(t0 + 75) - 66.67).abs() < 0.1);
+        // historical_rate = (6000+3000) / (2*30) = 150 RU/s
+        assert!((tracker.historical_rate(t0, t0 + 60) - 150.0).abs() < 0.01);
+
+        // Ring buffer: advance 20 more minutes (fully evicts all data).
+        let t_far = t0 + 60 * 20;
+        tracker.record_at(0, t_far);
+        // Gap exceeds window → ring reset, no completed buckets.
+        assert_eq!(tracker.completed, 0);
+        assert_eq!(tracker.current_bucket.load(Ordering::Relaxed), 0);
+
+        // Re-populate after the big gap and fill the entire ring.
+        for i in 1..=BUCKETS {
+            tracker.record_at(100, t_far + (i as u64) * RU_BUCKET_SECS);
+        }
+        assert_eq!(tracker.completed, BUCKETS);
+    }
+
+    #[test]
+    fn test_admission_decision() {
+        let mut cfg = Config::default();
+        cfg.enable_read_admission_control = true;
+        cfg.admission_max_delayed_count = 10; // low limit to test rejection path
+        let mgr = ResourceGroupManager::new(cfg);
+        // Add a second group so the code path is active.
+        mgr.add_resource_group(new_resource_group_ru("spike".into(), 1000, HIGH_PRIORITY));
+        let spike_limiter = mgr.get_foreground_group_limiter("spike");
+
+        // Seed initial RU so the tracker is not idle (prevents eviction by
+        // online_adjust_resource_quota's retain call).
+        let t0 = RuTracker::now_secs();
+        mgr.record_ru_consumption("spike", 1);
+
+        // CPU below threshold → Allow (stays NO_LIMIT, no throttling).
+        mgr.online_adjust_resource_quota(50.0); // below 80%
+        assert_eq!(
+            mgr.admission_decision(true, &spike_limiter),
+            AdmissionDecision::Allow
+        );
+
+        // CPU above threshold but no warmed-up tracker data → stays NO_LIMIT → Allow.
+        mgr.online_adjust_resource_quota(90.0);
+        assert_eq!(
+            mgr.admission_decision(true, &spike_limiter),
+            AdmissionDecision::Allow
+        );
+
+        // Warm up the tracker: 2 completed buckets. Set up BEFORE calling
+        // online_adjust_resource_quota so historical_rate() is non-zero when the
+        // limiter rate is configured.
+        {
+            let entry = mgr.ru_trackers.get("spike").unwrap();
+            let mut guard = entry.lock().unwrap();
+            guard.0.record_at(6000, t0 + 30);
+            guard.0.record_at(0, t0 + 60); // close bucket 0: 6000 RU (baseline)
+            guard.0.record_at(12000, t0 + 90); // open bucket: 12000 RU spike (left open)
+            // historical ≈ 6000/30 = 200 RU/s (only completed buckets), current
+            // ≈ 400
+        }
+        // Now set CPU — first throttle entry: initializes fraction from spike ratio,
+        // then sets absolute rate = historical × fraction per group.
+        // bg_cpu_at_floor must be true for the throttle branch to fire.
+        mgr.set_bg_cpu_at_floor(true);
+        mgr.online_adjust_resource_quota(90.0);
+        // Consume a burst well above the rate to build token-bucket debt.
+        {
+            let entry = mgr.ru_trackers.get("spike").unwrap();
+            let guard = entry.lock().unwrap();
+            // 10_000 µs consumed against ~133 RU/s rate → several seconds of debt.
+            guard.1.consume(
+                Duration::from_micros(10_000),
+                IoBytes::default(),
+                false,
+                true,
+            );
+        }
+        // Debt is non-zero → Delay.
+        assert!(matches!(
+            mgr.admission_decision(true, &spike_limiter),
+            AdmissionDecision::Delay(_)
+        ));
+        // One slot acquired above; release it.
+        mgr.release_delay_slot();
+
+        // Exhaust the delay slots: acquire 10 (the configured max).
+        for _ in 0..10 {
+            assert!(matches!(
+                mgr.admission_decision(true, &spike_limiter),
+                AdmissionDecision::Delay(_)
+            ));
+        }
+        // 11th request: over the limit → Reject.
+        assert_eq!(
+            mgr.admission_decision(true, &spike_limiter),
+            AdmissionDecision::Reject
+        );
+        // Release all slots.
+        for _ in 0..10 {
+            mgr.release_delay_slot();
+        }
+
+        // Drop CPU into leeway zone (72-80%): multiplier holds, still delays.
+        mgr.online_adjust_resource_quota(75.0);
+        assert!(matches!(
+            mgr.admission_decision(true, &spike_limiter),
+            AdmissionDecision::Delay(_)
+        ));
+
+        // Drop CPU below leeway_start (72%): fraction ramps up ×1.1/tick.
+        // After enough ticks it reaches 5× → NO_LIMIT → rates set to infinity
+        // → token bucket debt clears → Allow.
+        for _ in 0..60 {
+            mgr.online_adjust_resource_quota(50.0);
+        }
+        assert_eq!(
+            mgr.admission_decision(true, &spike_limiter),
+            AdmissionDecision::Allow
+        );
     }
 }

--- a/components/resource_control/src/resource_limiter.rs
+++ b/components/resource_control/src/resource_limiter.rs
@@ -37,7 +37,7 @@ impl fmt::Debug for ResourceType {
 }
 
 pub struct ResourceLimiter {
-    _name: String,
+    name: String,
     version: u64,
     limiters: [QuotaLimiter; ResourceType::COUNT],
     // Dedicated write-only IO limiter for compaction pressure throttling.
@@ -78,13 +78,17 @@ impl ResourceLimiter {
             None
         };
         Self {
-            _name: name,
+            name,
             version,
             limiters: [cpu_limiter, io_limiter],
             write_io_limiter: QuotaLimiter::new(f64::INFINITY),
             is_background,
             wait_histogram,
         }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
     }
 
     pub fn is_background(&self) -> bool {
@@ -113,6 +117,27 @@ impl ResourceLimiter {
             h.observe(wait_dur.as_secs_f64());
         }
         wait_dur
+    }
+
+    /// Returns the current token-bucket debt the caller should wait before
+    /// entering the thread pool. Reads accumulated debt via `consume(0, ...)`
+    /// which returns the existing debt when the rate limit is finite, without
+    /// adding new token consumption.
+    ///
+    /// For write requests (`is_read = false`), the write-specific IO limiter
+    /// debt is also considered alongside CPU and combined IO debt.
+    ///
+    /// Note: `write_io_limiter` and the combined IO limiter are only rate-set
+    /// for background limiters (via `do_adjust`); for foreground per-group
+    /// limiters their rates remain at `f64::INFINITY`, so their debt is
+    /// always zero and only CPU debt drives the delay in practice.
+    pub fn admission_delay(&self, is_read: bool) -> Duration {
+        self.consume(
+            Duration::ZERO,
+            IoBytes::default(),
+            true,
+            is_read, // skip_compaction_pressure = true for reads (skip write_io_limiter)
+        )
     }
 
     pub async fn async_consume(
@@ -205,7 +230,7 @@ impl QuotaLimiter {
     }
 
     fn consume(&self, value: u64, wait: bool) -> Duration {
-        if value == 0 {
+        if value == 0 && self.limiter.speed_limit().is_infinite() {
             return Duration::ZERO;
         }
         let mut dur = self.limiter.consume_duration(value as usize);

--- a/components/resource_control/src/worker.rs
+++ b/components/resource_control/src/worker.rs
@@ -14,7 +14,6 @@ use file_system::{IoBytes, IoType, fetch_io_bytes};
 use prometheus::Histogram;
 use strum::EnumCount;
 use tikv_util::{
-    debug,
     resource_control::{DEFAULT_RESOURCE_GROUP_NAME, TaskPriority},
     sys::{SysQuota, cpu_time::ProcessStat},
     thread_name_prefix::{SCHEDULE_WORKER_PRIORITY_THREAD, UNIFIED_READ_POOL_THREAD},
@@ -29,7 +28,7 @@ use crate::{
     resource_limiter::{GroupStatistics, ResourceLimiter, ResourceType},
 };
 
-pub const BACKGROUND_LIMIT_ADJUST_DURATION: Duration = Duration::from_secs(10);
+pub const QUOTA_ADJUST_DURATION: Duration = Duration::from_secs(10);
 
 const MICROS_PER_SEC: f64 = 1_000_000.0;
 // the minimal schedule wait duration due to the overhead of queue.
@@ -158,6 +157,33 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
         }
         self.last_adjust_time = now;
 
+        // Fetch CPU stats once so background and foreground use a consistent
+        // snapshot and we avoid double-reading /proc/stat.
+        let cpu_stats = match self
+            .resource_quota_getter
+            .get_current_stats(ResourceType::Cpu)
+        {
+            Ok(s) => s,
+            Err(e) => {
+                warn!("get process total cpu failed; skip adjustment."; "err" => ?e);
+                return;
+            }
+        };
+        let cpu_util = if cpu_stats.total_quota > f64::EPSILON {
+            cpu_stats.current_used / cpu_stats.total_quota * 100.0
+        } else {
+            0.0
+        };
+
+        self.background_adjust_quota(dur_secs, &cpu_stats);
+        self.foreground_adjust_quota(cpu_util);
+    }
+
+    fn foreground_adjust_quota(&mut self, cpu_util: f64) {
+        self.resource_ctl.online_adjust_resource_quota(cpu_util);
+    }
+
+    fn background_adjust_quota(&mut self, dur_secs: f64, cpu_stats: &ResourceUsageStats) {
         let mut bg_util_limit = self
             .resource_ctl
             .get_resource_group(DEFAULT_RESOURCE_GROUP_NAME)
@@ -167,23 +193,19 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
         if bg_util_limit == 0 {
             bg_util_limit = 100;
         }
-        let bg_resource_threshold = self
-            .resource_ctl
-            .get_config()
-            .value()
-            .bg_resource_threshold
-            .clamp(1.0, 99.0);
-        // Cap utilization limit to bg_resource_threshold. Background
-        // tasks should never consume more than this fraction of total resources.
-        // When CPU utilization exceeds the threshold, the headroom goes negative
-        // and the background rate limit is reduced.
-        bg_util_limit = bg_util_limit.min(bg_resource_threshold as u64);
-
-        BACKGROUND_TASK_RESOURCE_UTILIZATION_VEC
-            .with_label_values(&["limit"])
-            .set(bg_util_limit as i64);
+        let (bg_scale_start, fg_cpu_throttle_threshold) = {
+            let config = self.resource_ctl.get_config().value();
+            let start = config.bg_cpu_throttle_threshold.clamp(1.0, 99.0);
+            let end = config.fg_cpu_throttle_threshold.clamp(start, 99.0);
+            (start, end)
+        };
+        // Cap utilization limit to fg_cpu_throttle_threshold. Background tasks should
+        // never consume more than this fraction of total resources. Scale-down
+        // begins at bg_scale_start and reaches min_floor at fg_cpu_throttle_threshold.
+        bg_util_limit = bg_util_limit.min(fg_cpu_throttle_threshold as u64);
 
         if !self.resource_ctl.has_background_groups() {
+            self.resource_ctl.set_bg_cpu_at_floor(true);
             self.prev_had_background = false;
             return;
         }
@@ -201,34 +223,48 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
             self.prev_had_background = true;
         }
 
-        self.do_adjust(
+        self.background_adjust_resource_quota(
             ResourceType::Cpu,
             dur_secs,
             bg_util_limit,
-            bg_resource_threshold,
+            bg_scale_start,
+            fg_cpu_throttle_threshold,
+            Some(cpu_stats),
         );
-        self.do_adjust(
+        self.background_adjust_resource_quota(
             ResourceType::Io,
             dur_secs,
             bg_util_limit,
-            bg_resource_threshold,
+            bg_scale_start,
+            fg_cpu_throttle_threshold,
+            None,
         );
         self.adjust_write_io_by_compaction_pressure();
     }
 
-    fn do_adjust(
+    fn background_adjust_resource_quota(
         &mut self,
         resource_type: ResourceType,
         dur_secs: f64,
         utilization_limit: u64,
-        bg_resource_threshold: f64,
+        bg_scale_start: f64,
+        fg_cpu_throttle_threshold: f64,
+        // Pre-fetched stats for CPU (avoids a second /proc/stat read); None for
+        // IO, which always fetches fresh bytes-transferred counters.
+        prefetched_stats: Option<&ResourceUsageStats>,
     ) {
-        let resource_stats = match self.resource_quota_getter.get_current_stats(resource_type) {
-            Ok(r) => r,
-            Err(e) => {
-                warn!("get resource statistics info failed, skip adjust"; "type" => ?resource_type, "err" => ?e);
-                return;
-            }
+        let fetched;
+        let resource_stats = if let Some(s) = prefetched_stats {
+            s
+        } else {
+            fetched = match self.resource_quota_getter.get_current_stats(resource_type) {
+                Ok(r) => r,
+                Err(e) => {
+                    warn!("get resource statistics info failed, skip adjust"; "type" => ?resource_type, "err" => ?e);
+                    return;
+                }
+            };
+            &fetched
         };
         // if total resource quota is unlimited, set background limit to unlimited.
         if resource_stats.total_quota <= f64::EPSILON {
@@ -274,16 +310,20 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
         .min(target);
 
         let mut new_budget = target;
-        if resource_util > bg_resource_threshold {
-            // System is overloaded. Linearly scale budget from target down to
-            // min_floor as utilization goes from threshold (70%) to 100%.
-            let pressure =
-                (resource_util - bg_resource_threshold) / (100.0 - bg_resource_threshold);
+        if resource_util > bg_scale_start {
+            // Linearly scale budget from target down to min_floor as utilization
+            // goes from bg_scale_start to fg_cpu_throttle_threshold.
+            let range = (fg_cpu_throttle_threshold - bg_scale_start).max(1.0);
+            let pressure = ((resource_util - bg_scale_start) / range).clamp(0.0, 1.0);
             new_budget = target * (1.0 - pressure) + min_floor * pressure;
+            // Only tighten: never increase the limit in the throttle branch.
+            if new_budget > current_limit {
+                new_budget = current_limit;
+            }
         } else if current_limit > target {
             // Background limit exceeds its allowed share; reset to target.
             new_budget = target;
-        } else if current_limit < 0.9 * target && resource_util < 0.9 * bg_resource_threshold {
+        } else if current_limit < 0.9 * target && resource_util < 0.9 * bg_scale_start {
             // System is idle; increase limit incrementally from current limit.
             new_budget = current_limit * 1.1;
         }
@@ -295,6 +335,13 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
         BACKGROUND_QUOTA_LIMIT_VEC
             .with_label_values(&[resource_type.as_str()])
             .set(new_budget as i64);
+
+        // Update the "background at floor" flag so foreground throttling
+        // only kicks in after background has been fully squeezed.
+        if resource_type == ResourceType::Cpu {
+            let at_floor = new_budget <= min_floor && background_consumed <= new_budget;
+            self.resource_ctl.set_bg_cpu_at_floor(at_floor);
+        }
     }
 
     /// Adjust the write-only IO limiter based on compaction pressure.
@@ -482,10 +529,6 @@ impl<R: ResourceStatsProvider> PriorityLimiterAdjustWorker<R> {
             limits[i - 1] = limit;
             expect_cpu_time_total -= level_expected[i];
         }
-        debug!("adjsut cpu limiter by priority"; "cpu_quota" => process_cpu_stats.total_quota,
-            "process_cpu" => process_cpu_stats.current_used, "expected_cpu" => ?level_expected,
-            "cpu_costs" => ?cpu_duration, "limits" => ?limits,
-            "limit_cpu_total" => expect_pool_cpu_total, "pool_cpu_cost" => real_cpu_total);
     }
 }
 
@@ -697,9 +740,10 @@ mod tests {
             check(limiter.get_limiter(ResourceType::Io).get_rate_limit(), io);
         }
 
-        // util_limit configured at 80% but capped to 70%.
+        // util_limit configured at 80% but capped to fg_cpu_throttle_threshold=70%.
         // CPU target = 8 * 0.7 = 5.6 cores, IO target = 10000 * 0.7 = 7000
         // CPU min_floor = 1 core, IO min_floor = 1000
+        // bg_scale_start=60%, fg_cpu_throttle_threshold=70% (scale range: 60→70).
 
         // No load: initial infinity → treated as target → budget = target.
         reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
@@ -711,48 +755,43 @@ mod tests {
         worker.adjust_quota();
         check_limiter_rates(&limiter, 5.6, 7000.0);
 
-        // Under target (50% CPU): resource_util < 70%, current == target,
+        // Under target (50% CPU): resource_util < 60%, current == target,
         // so none of the branches fire → budget = target.
         reset_quota(&mut worker, 4.0, 2000.0, Duration::from_secs(1));
         worker.adjust_quota();
         check_limiter_rates(&limiter, 5.6, 7000.0);
 
-        // Above 70% (80% CPU, 80% IO): resource_util > 70 branch fires.
-        // Budget linearly interpolates from target to min_floor.
-        // CPU: pressure = (80-70)/(100-70) = 1/3. budget = 5.6*(1-1/3) + 1.0*(1/3) ≈
-        // 4.067 IO: pressure = (80-70)/(100-70) = 1/3. budget = 7000*(2/3) +
-        // 1000*(1/3) ≈ 5000
+        // 80% CPU, 80% IO: resource_util > 60% (bg_scale_start).
+        // pressure = (80-60)/(70-60) = 2.0 clamped to 1.0 → min_floor.
+        // CPU: budget = min_floor = 1.0. IO: budget = min_floor = 1000.
         reset_quota(&mut worker, 6.4, 8000.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter_rates(&limiter, 4.067, 5000.0);
+        check_limiter_rates(&limiter, 1.0, 1000.0);
 
-        // 100% CPU, 95% IO: heavier pressure.
-        // CPU: pressure = (100-70)/30 = 1.0. budget = 5.6*0 + 1.0*1.0 = 1.0 (min_floor)
-        // IO: pressure = (95-70)/30 = 25/30 = 5/6. budget = 7000*(1/6) + 1000*(5/6) ≈
-        // 2000
+        // 100% CPU, 95% IO: pressure still clamped 1.0 → min_floor.
         reset_quota(&mut worker, 8.0, 9500.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter_rates(&limiter, 1.0, 2000.0);
+        check_limiter_rates(&limiter, 1.0, 1000.0);
 
         // Still at 100% CPU, 95% IO: same result (deterministic, no decay).
         reset_quota(&mut worker, 8.0, 9500.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter_rates(&limiter, 1.0, 2000.0);
+        check_limiter_rates(&limiter, 1.0, 1000.0);
 
-        // 85% CPU, 80% IO: moderate pressure.
-        // CPU: pressure = (85-70)/30 = 0.5. budget = 5.6*0.5 + 1.0*0.5 = 3.3
-        // IO: pressure = (80-70)/30 = 1/3. budget = 7000*(2/3) + 1000*(1/3) = 5000
-        reset_quota(&mut worker, 6.8, 8000.0, Duration::from_secs(1));
+        // 65% CPU, 65% IO: in the scale range (60-70%).
+        // CPU: pressure = 0.5, computed = 3.3. But current_limit=1.0 (min_floor)
+        // and 3.3 > 1.0 → only-tighten clamps to 1.0.
+        // IO: same logic → stays 1000.
+        reset_quota(&mut worker, 5.2, 6500.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter_rates(&limiter, 3.3, 5000.0);
+        check_limiter_rates(&limiter, 1.0, 1000.0);
 
-        // Load drops (50% CPU, 20% IO): resource_util < 63%, current < 0.9*target
-        // → incremental increase: budget = current * 1.1
-        // CPU: 3.3 * 1.1 = 3.63
-        // IO: 5000 * 1.1 = 5500
+        // Load drops (50% CPU, 20% IO): resource_util < 54% (0.9*60%), current <
+        // 0.9*target → incremental increase: budget = current * 1.1
+        // CPU: 1.0 * 1.1 = 1.1. IO: 1000 * 1.1 = 1100
         reset_quota(&mut worker, 4.0, 2000.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter_rates(&limiter, 3.63, 5500.0);
+        check_limiter_rates(&limiter, 1.1, 1100.0);
 
         // Adding a second background group does not change the limiter —
         // all background groups share the single global bg_limiter.
@@ -769,19 +808,19 @@ mod tests {
         // Both groups return the same shared limiter.
         assert!(Arc::ptr_eq(&limiter, &bg_limiter2));
 
-        // No load: current at 3.63M < 0.9*target (5.04M) and util < 63% → incremental.
-        // budget = 3.63 * 1.1 = 3.993
-        // IO: 5500 * 1.1 = 6050
+        // No load: current at 1.1M < 0.9*target (5.04M) and util < 63% → incremental.
+        // budget = 1.1 * 1.1 = 1.21
+        // IO: 1100 * 1.1 = 1210
         reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter_rates(&limiter, 3.993, 6050.0);
+        check_limiter_rates(&limiter, 1.21, 1210.0);
 
-        // Over 70% (100% CPU, 95% IO): budget scales down.
+        // Over 70% (100% CPU, 95% IO): budget scales down to min_floor.
         // CPU: pressure = 1.0. budget = min_floor = 1.0
-        // IO: pressure = 25/30 = 5/6. budget = 7000*(1/6) + 1000*(5/6) = 2000
+        // IO: pressure = (95-60)/(70-60) = 3.5 clamped 1.0. budget = min_floor = 1000.
         reset_quota(&mut worker, 8.0, 9500.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter_rates(&limiter, 1.0, 2000.0);
+        check_limiter_rates(&limiter, 1.0, 1000.0);
     }
 
     #[test]
@@ -795,7 +834,8 @@ mod tests {
         }
 
         // 1 background group with no explicit utilization limit.
-        // bg_util_limit defaults to 100, capped to 70 by bg_resource_threshold.
+        // bg_util_limit defaults to 100, capped to 70 by fg_cpu_throttle_threshold.
+        // bg_scale_start=60%, fg_cpu_throttle_threshold=70%.
         let bg = new_background_resource_group_ru("bg_worker".into(), 5000, 8, vec!["br".into()]);
         resource_ctl.add_resource_group(bg);
         let limiter = resource_ctl
@@ -846,9 +886,9 @@ mod tests {
             7000.0,
         );
 
-        // --- Saturate CPU (100%, 80% IO) → budget scales down from target ---
-        // CPU: pressure = (100-70)/30 = 1.0. budget = min_floor = 1.0
-        // IO: pressure = (80-70)/30 = 1/3. budget = 7000*(2/3) + 1000*(1/3) = 5000
+        // --- Saturate CPU (100%, 80% IO) → budget scales to min_floor ---
+        // CPU: pressure = (100-60)/(70-60) = 4.0 clamped 1.0 → min_floor = 1.0
+        // IO: pressure = (80-60)/(70-60) = 2.0 clamped 1.0 → min_floor = 1000
         reset_quota(&mut worker, 8.0, 8000.0, Duration::from_secs(1));
         worker.adjust_quota();
         check(
@@ -857,13 +897,13 @@ mod tests {
         );
         check(
             limiter.get_limiter(ResourceType::Io).get_rate_limit(),
-            5000.0,
+            1000.0,
         );
 
         // --- Unsaturate CPU (25%) → budget recovers incrementally ---
-        // CPU: resource_util = 25% < 63, current 1.0M < 5.04M → budget = 1.0 * 1.1 =
-        // 1.1 IO: resource_util = 20% < 63, current 5000 < 6300 → budget = 5000
-        // * 1.1 = 5500
+        // CPU: resource_util = 25% < 54% (0.9*60%), current 1.0M < 5.04M → 1.0 * 1.1 =
+        // 1.1 IO: resource_util = 20% < 54%, current 1000 < 6300 → 1000 * 1.1 =
+        // 1100
         reset_quota(&mut worker, 2.0, 2000.0, Duration::from_secs(1));
         worker.adjust_quota();
         check(
@@ -872,21 +912,22 @@ mod tests {
         );
         check(
             limiter.get_limiter(ResourceType::Io).get_rate_limit(),
-            5500.0,
+            1100.0,
         );
 
-        // --- 85% CPU, 80% IO: moderate pressure ---
-        // CPU: pressure = (85-70)/30 = 0.5. budget = 5.6*0.5 + 1.0*0.5 = 3.3
-        // IO: pressure = (80-70)/30 = 1/3. budget = 7000*(2/3) + 1000*(1/3) = 5000
-        reset_quota(&mut worker, 6.8, 8000.0, Duration::from_secs(1));
+        // --- 65% CPU, 65% IO: in scale range (60-70%) ---
+        // CPU: pressure = 0.5, computed = 3.3M. current_limit=1.1M < 3.3M → only
+        // tighten → stays 1.1M. IO: computed = 4000, current=1100 < 4000 →
+        // stays 1100.
+        reset_quota(&mut worker, 5.2, 6500.0, Duration::from_secs(1));
         worker.adjust_quota();
         check(
             limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
-            3.3 * MICROS_PER_SEC,
+            1.1 * MICROS_PER_SEC,
         );
         check(
             limiter.get_limiter(ResourceType::Io).get_rate_limit(),
-            5000.0,
+            1100.0,
         );
     }
 
@@ -1053,6 +1094,85 @@ mod tests {
         worker.last_adjust_time = Instant::now_coarse() - Duration::from_millis(500);
         worker.adjust();
         check_limiter(f64::INFINITY, 3.2, 3.2);
+    }
+
+    /// Verifies background load-shedding:
+    ///
+    /// - 0–60% CPU   : background full
+    /// - 60–70% CPU  : background linearly throttled to min_floor
+    /// - >70% CPU    : background at min_floor
+    #[test]
+    fn test_tiered_load_shedding() {
+        let resource_ctl = Arc::new(ResourceGroupManager::default());
+
+        let bg = new_background_resource_group_ru("bg".into(), 1000, 8, vec!["br".into()]);
+        resource_ctl.add_resource_group(bg);
+        let bg_limiter = resource_ctl
+            .get_background_resource_limiter("bg", "br")
+            .unwrap();
+
+        let compaction_pending_bytes_ratio = Arc::new(AtomicU32::new(0));
+        let mut bg_worker = GroupQuotaAdjustWorker::with_quota_getter(
+            resource_ctl.clone(),
+            TestResourceStatsProvider::new(8.0, 10000.0),
+            compaction_pending_bytes_ratio,
+        );
+
+        const BG_TARGET: f64 = 5.6;
+        const BG_FLOOR: f64 = 1.0;
+
+        #[track_caller]
+        fn approx(val: f64, expected: f64) {
+            assert!(
+                (val.is_infinite() && expected.is_infinite())
+                    || (expected * 0.99 < val && val < expected * 1.01),
+                "actual: {val}, expected: {expected}"
+            );
+        }
+
+        macro_rules! tick {
+            ($cpu:expr) => {{
+                bg_worker.resource_quota_getter.cpu_used = $cpu;
+                bg_worker.last_adjust_time = Instant::now_coarse() - Duration::from_secs(10);
+                bg_worker.adjust_quota();
+            }};
+        }
+
+        // 50% CPU — below bg_scale_start (60%): bg=full.
+        tick!(4.0);
+        approx(
+            bg_limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            BG_TARGET * MICROS_PER_SEC,
+        );
+
+        // 65% CPU — mid bg range: pressure = 0.5.
+        tick!(5.2);
+        approx(
+            bg_limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            3.3 * MICROS_PER_SEC,
+        );
+
+        // 70% CPU — bg fully throttled.
+        tick!(5.6);
+        approx(
+            bg_limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            BG_FLOOR * MICROS_PER_SEC,
+        );
+
+        // 80% CPU — still at min_floor.
+        tick!(6.4);
+        approx(
+            bg_limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            BG_FLOOR * MICROS_PER_SEC,
+        );
+
+        // Recovery: CPU drops to 50%.
+        tick!(4.0);
+        let bg_rate = bg_limiter.get_limiter(ResourceType::Cpu).get_rate_limit();
+        assert!(
+            bg_rate > BG_FLOOR * MICROS_PER_SEC && bg_rate < BG_TARGET * MICROS_PER_SEC,
+            "bg should be recovering, got {bg_rate}"
+        );
     }
 
     #[test]
@@ -1287,15 +1407,17 @@ mod tests {
         worker.last_adjust_time = Instant::now_coarse() - Duration::from_secs(1);
         worker.adjust_quota();
 
-        // CPU: pressure = 1.0 → budget = min_floor = 1.0 core.
-        // IO: pressure = (95-70)/30 = 5/6 → budget = 7000/6 + 1000*5/6 ≈ 2000.
+        // CPU: resource_util=100%, bg_scale_start=60%, fg_cpu_throttle_threshold=70%.
+        // pressure = (100-60)/(70-60) = 4.0 clamped to 1.0 → min_floor = 1.0 core.
+        // IO: resource_util=95%, pressure = (95-60)/(70-60) = 3.5 clamped to 1.0 →
+        // min_floor = 1000.
         check(
             limiter_a.get_limiter(ResourceType::Cpu).get_rate_limit(),
             1.0 * MICROS_PER_SEC,
         );
         check(
             limiter_a.get_limiter(ResourceType::Io).get_rate_limit(),
-            2000.0,
+            1000.0,
         );
     }
 }

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -638,6 +638,7 @@ where
                 pd_sender.clone(),
                 engines.engine.clone(),
                 resource_ctl,
+                self.resource_manager.clone(),
                 CleanupMethod::Remote(self.core.background_worker.remote()),
                 true,
             ))

--- a/components/server/src/server2.rs
+++ b/components/server/src/server2.rs
@@ -507,6 +507,7 @@ where
                 pd_sender.clone(),
                 engines.engine.clone(),
                 resource_ctl,
+                self.resource_manager.clone(),
                 CleanupMethod::Remote(self.core.background_worker.remote()),
                 true,
             ))

--- a/metrics/grafana/tikv_details.dashboard.py
+++ b/metrics/grafana/tikv_details.dashboard.py
@@ -10702,6 +10702,149 @@ def ResourceControl() -> RowPanel:
     return layout.row_panel
 
 
+def LoadShedding() -> RowPanel:
+    layout = Layout(title="Load Shedding")
+    # Row 1: RU rates per group
+    layout.row(
+        [
+            graph_panel(
+                title="CPU Utilization % per Resource Group",
+                description="Historical baseline and current CPU utilization % per resource group (100% = 1 core).",
+                yaxes=yaxes(left_format=UNITS.PERCENT_FORMAT),
+                targets=[
+                    target(
+                        expr=expr_sum(
+                            "tikv_resource_control_group_ru_historical_rate",
+                            by_labels=["resource_group"],
+                        ).extra(" > 0"),
+                        legend_format="historical-{{resource_group}}",
+                    ),
+                    target(
+                        expr=expr_sum(
+                            "tikv_resource_control_group_ru_current_rate",
+                            by_labels=["resource_group"],
+                        ).extra(" > 0"),
+                        legend_format="current-{{resource_group}}",
+                    ),
+                ],
+            ),
+            graph_panel(
+                title="Background Resource Utilization",
+                description="Total resource utilization percentage of background tasks.",
+                yaxes=yaxes(left_format=UNITS.PERCENT_FORMAT),
+                targets=[
+                    target(
+                        expr=expr_sum(
+                            "tikv_resource_control_bg_resource_utilization",
+                            by_labels=["type"],
+                        ).extra(" > 0"),
+                    ),
+                ],
+            ),
+        ]
+    )
+    # Row 2: Quota limits
+    layout.row(
+        [
+            graph_panel(
+                title="Resource Group Quota Limit",
+                description="Current rate limit per resource group (0 = unlimited, hidden).",
+                targets=[
+                    target(
+                        expr=expr_sum(
+                            "tikv_resource_control_group_quota_limit",
+                            by_labels=["resource_group", "type"],
+                        ).extra(" > 0"),
+                    ),
+                ],
+            ),
+            graph_panel(
+                title="Background Quota Limit",
+                description="Current quota limit for background resource groups.",
+                targets=[
+                    target(
+                        expr=expr_sum(
+                            "tikv_resource_control_background_quota_limiter",
+                            by_labels=["resource_group", "type"],
+                        ).extra(" > 0"),
+                    ),
+                ],
+            ),
+        ]
+    )
+    # Row 3: Deprioritized/delayed/rejected + currently delayed
+    layout.row(
+        [
+            graph_panel(
+                title="Deprioritized / Delayed / Rejected Requests",
+                description="Rate of deprioritized (phase 1), delayed, and rejected requests.",
+                yaxes=yaxes(left_format=UNITS.OPS_PER_SEC),
+                targets=[
+                    target(
+                        expr=expr_sum_rate(
+                            "tikv_resource_control_two_phase_throttled_requests_total",
+                            by_labels=["resource_group"],
+                        ).extra(" > 0"),
+                        legend_format="deprioritized-{{resource_group}}",
+                    ),
+                    target(
+                        expr=expr_sum_rate(
+                            "tikv_resource_control_admission_delayed_requests_total",
+                            by_labels=["resource_group", "is_background"],
+                        ).extra(" > 0"),
+                        legend_format="delayed-{{resource_group}}-{{is_background}}",
+                    ),
+                    target(
+                        expr=expr_sum_rate(
+                            "tikv_resource_control_admission_rejected_requests_total",
+                            by_labels=["resource_group", "is_background"],
+                        ).extra(" > 0"),
+                        legend_format="rejected-{{resource_group}}-{{is_background}}",
+                    ),
+                ],
+            ),
+            graph_panel(
+                title="Currently Delayed Requests",
+                description="Number of requests currently sitting in admission control delay.",
+                targets=[
+                    target(
+                        expr=expr_sum(
+                            "tikv_resource_control_admission_currently_delayed",
+                        ).extra(" > 0"),
+                    ),
+                ],
+            ),
+        ]
+    )
+    # Row 4: Delay duration + background wait duration
+    layout.row(
+        [
+            graph_panel_histogram_quantiles(
+                title="Admission Delay Duration",
+                description="Delay duration imposed by foreground admission control.",
+                yaxes=yaxes(left_format=UNITS.SECONDS),
+                metric="tikv_resource_control_admission_delay_duration_seconds",
+                label_selectors=['is_background="false"'],
+                by_labels=["resource_group"],
+            ),
+            graph_panel(
+                title="Background Task Wait Duration",
+                description="Total wait duration of background tasks per resource group.",
+                yaxes=yaxes(left_format=UNITS.MICRO_SECONDS),
+                targets=[
+                    target(
+                        expr=expr_sum_rate(
+                            "tikv_resource_control_background_task_wait_duration",
+                            by_labels=["resource_group"],
+                        ).extra(" > 0"),
+                    ),
+                ],
+            ),
+        ]
+    )
+    return layout.row_panel
+
+
 def TikvConfig() -> RowPanel:
     layout = Layout(title="Config")
     # RocksDB DB Configuration Table
@@ -10837,6 +10980,7 @@ dashboard = Dashboard(
         Memory(),
         # Infrequently Used
         ResourceControl(),
+        LoadShedding(),
         StatusServer(),
         Encryption(),
         TTL(),

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -15,7 +15,7 @@ use concurrency_manager::ConcurrencyManager;
 use engine_traits::PerfLevel;
 use futures::{
     channel::{mpsc, oneshot},
-    future::Either,
+    future::{BoxFuture, Either},
     prelude::*,
 };
 use kvproto::{coprocessor as coppb, errorpb, kvrpcpb, kvrpcpb::CommandPri, metapb};
@@ -613,7 +613,7 @@ impl<E: Engine> Endpoint<E> {
                 .map(move |res| {
                     let _ = tx.send(res);
                 });
-        let res = self.read_pool_spawn_with_memory_quota_check(
+        let spawn_fut_result = self.read_pool_spawn_with_memory_quota_check(
             allocated_bytes,
             future,
             priority,
@@ -622,7 +622,7 @@ impl<E: Engine> Endpoint<E> {
             resource_limiter,
         );
         async move {
-            res?;
+            spawn_fut_result?.await?;
             rx.map_err(|_| Error::MaxPendingTasksExceeded).await?
         }
     }
@@ -906,7 +906,7 @@ impl<E: Engine> Endpoint<E> {
                     warn!("coprocessor stream send error"; "error" => %e);
                 });
 
-        self.read_pool_spawn_with_memory_quota_check(
+        let spawn_fut = self.read_pool_spawn_with_memory_quota_check(
             allocated_bytes,
             future,
             priority,
@@ -914,7 +914,18 @@ impl<E: Engine> Endpoint<E> {
             metadata,
             resource_limiter,
         )?;
-        Ok(rx)
+        // Transparent to caller: embed admission delay into the stream itself.
+        // On first poll, drives spawn_fut (sleep if delayed, then submit to
+        // yatp). On error yields one error item. Then chains with rx items.
+        let stream = futures::stream::once(Box::pin(async move {
+            spawn_fut
+                .await
+                .err()
+                .map(|_| Err(Error::MaxPendingTasksExceeded))
+        }))
+        .filter_map(futures::future::ready)
+        .chain(rx);
+        Ok(stream)
     }
 
     /// Parses and handles a stream request. Returns a stream that produce each
@@ -954,7 +965,7 @@ impl<E: Engine> Endpoint<E> {
         task_id: u64,
         metadata: TaskMetadata<'_>,
         resource_limiter: Option<Arc<ResourceLimiter>>,
-    ) -> Result<()>
+    ) -> Result<BoxFuture<'static, Result<()>>>
     where
         F: Future<Output = ()> + Send + 'static,
     {
@@ -965,9 +976,11 @@ impl<E: Engine> Endpoint<E> {
             // Release quota after handle completed.
             drop(owned_quota);
         });
-        self.read_pool
+        Ok(self
+            .read_pool
             .spawn(fut, priority, task_id, metadata, resource_limiter)
-            .map_err(|_| Error::MaxPendingTasksExceeded)
+            .map(|r| r.map_err(|_| Error::MaxPendingTasksExceeded))
+            .boxed())
     }
 }
 

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -710,7 +710,7 @@ macro_rules! impl_write {
                                     writer.write(batch)?;
                                     Ok(writer)
                                 };
-                                with_resource_limiter(f, limiter.clone(), true)
+                                with_resource_limiter(f, limiter.clone(), true, false, None, 0)
                                     .await
                                     .map(|w| (w, limiter))
                             },
@@ -728,7 +728,8 @@ macro_rules! impl_write {
                     };
 
                     let metas: Result<_> =
-                        with_resource_limiter(finish_fn, resource_limiter, true).await;
+                        with_resource_limiter(finish_fn, resource_limiter, true, false, None, 0)
+                            .await;
                     let metas = match metas {
                         Ok(r) => r,
                         Err(e) => return (Err(e), None),
@@ -1054,6 +1055,9 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
                 ),
                 resource_limiter,
                 true,
+                false,
+                None,
+                0,
             )
             .await;
             let mut resp = DownloadResponse::default();
@@ -1191,6 +1195,9 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
                 ),
                 resource_limiter,
                 true,
+                false,
+                None,
+                0,
             )
             .await;
 
@@ -1316,6 +1323,9 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
                 ),
                 resource_limiter,
                 true,
+                false,
+                None,
+                0,
             )
             .await;
 

--- a/src/read_pool.rs
+++ b/src/read_pool.rs
@@ -14,13 +14,14 @@ use std::{
 use file_system::{IoType, set_io_type};
 use futures::{
     channel::oneshot,
-    future::{FutureExt, TryFutureExt},
+    future::{BoxFuture, FutureExt, TryFutureExt},
 };
 use kvproto::{errorpb, kvrpcpb::CommandPri};
 use online_config::{ConfigChange, ConfigManager, ConfigValue, Result as CfgResult};
 use prometheus::{Histogram, IntCounter, IntGauge, core::Metric};
 use resource_control::{
-    ControlledFuture, ResourceController, ResourceLimiter, TaskPriority, with_resource_limiter,
+    AdmissionDecision, ControlledFuture, ResourceController, ResourceGroupManager, ResourceLimiter,
+    TaskPriority, with_resource_limiter,
 };
 use thiserror::Error;
 use tikv_util::{
@@ -69,6 +70,7 @@ pub enum ReadPool {
         max_tasks: usize,
         pool_size: usize,
         resource_ctl: Option<Arc<ResourceController>>,
+        resource_manager: Option<Arc<ResourceGroupManager>>,
         time_slice_inspector: Arc<TimeSliceInspector>,
     },
 }
@@ -92,6 +94,7 @@ impl ReadPool {
                 max_tasks,
                 pool_size,
                 resource_ctl,
+                resource_manager,
                 time_slice_inspector,
             } => ReadPoolHandle::Yatp {
                 remote: pool.remote().clone(),
@@ -100,6 +103,7 @@ impl ReadPool {
                 max_tasks: *max_tasks,
                 pool_size: *pool_size,
                 resource_ctl: resource_ctl.clone(),
+                resource_manager: resource_manager.clone(),
                 time_slice_inspector: time_slice_inspector.clone(),
             },
         }
@@ -120,8 +124,68 @@ pub enum ReadPoolHandle {
         max_tasks: usize,
         pool_size: usize,
         resource_ctl: Option<Arc<ResourceController>>,
+        resource_manager: Option<Arc<ResourceGroupManager>>,
         time_slice_inspector: Arc<TimeSliceInspector>,
     },
+}
+
+/// Runs admission control then, if the task is allowed through, enqueues it.
+/// Admission is checked before the capacity/eviction check so that a rejected
+/// or timed-out delayed task never causes an already-queued task to be dropped.
+async fn admission_and_enqueue(
+    resource_manager: Option<Arc<ResourceGroupManager>>,
+    resource_limiter: Option<Arc<ResourceLimiter>>,
+    task_priority: TaskPriority,
+    gauge: IntGauge,
+    max_tasks: usize,
+    remote: Remote<TaskCell>,
+    task_cell: TaskCell,
+    running_tasks: Vec<IntGauge>,
+    resource_ctl: Option<Arc<ResourceController>>,
+    estimated_priority: u64,
+) -> Result<(), ReadPoolError> {
+    // Admission control runs before any eviction so that a rejected or
+    // timed-out delayed task never causes an already-queued task to be dropped.
+    let delay = match (resource_manager.as_deref(), resource_limiter.as_deref()) {
+        (Some(rm), Some(limiter)) => match rm.admission_decision(true, limiter) {
+            AdmissionDecision::Reject => return Err(ReadPoolError::Rejected),
+            AdmissionDecision::Delay(d) => {
+                if task_priority == TaskPriority::High {
+                    warn!("admission delay on high-priority read task";
+                          "group" => limiter.name(),
+                          "delay" => ?d);
+                }
+                Some((d, resource_manager))
+            }
+            AdmissionDecision::Allow => None,
+        },
+        _ => None,
+    };
+    if let Some((d, slot)) = delay {
+        let mut _guard = slot.as_ref().map(|rm| rm.delay_slot_guard());
+        futures_timer::Delay::new(d).await;
+        if let Some(guard) = _guard.as_mut() {
+            guard.release();
+        }
+    }
+    // After admission (and any sleep), check pool capacity and evict if needed.
+    if gauge.get() as usize >= max_tasks {
+        if let Some(ref _resource_ctl) = resource_ctl {
+            if let Some(mut evicted) = remote.try_evict_lowest(estimated_priority) {
+                let evicted_prio = priority_from_task_meta(evicted.mut_extras().metadata());
+                running_tasks[evicted_prio as usize].dec();
+                UNIFIED_READ_POOL_EVICTED_TASKS.inc();
+                drop(evicted);
+            } else {
+                return Err(ReadPoolError::UnifiedReadPoolFull);
+            }
+        } else {
+            return Err(ReadPoolError::UnifiedReadPoolFull);
+        }
+    }
+    gauge.inc();
+    remote.spawn(task_cell);
+    Ok(())
 }
 
 impl ReadPoolHandle {
@@ -132,7 +196,7 @@ impl ReadPoolHandle {
         task_id: u64,
         metadata: TaskMetadata<'_>,
         resource_limiter: Option<Arc<ResourceLimiter>>,
-    ) -> Result<(), ReadPoolError>
+    ) -> BoxFuture<'static, Result<(), ReadPoolError>>
     where
         F: Future<Output = ()> + Send + 'static,
     {
@@ -147,76 +211,56 @@ impl ReadPoolHandle {
                     CommandPri::Normal => read_pool_normal,
                     CommandPri::Low => read_pool_low,
                 };
-
-                pool.spawn(f)?;
+                let res = pool.spawn(f).map_err(ReadPoolError::from);
+                futures::future::ready(res).boxed()
             }
             ReadPoolHandle::Yatp {
                 remote,
                 running_tasks,
                 max_tasks,
                 resource_ctl,
+                resource_manager,
                 ..
             } => {
                 let task_priority = TaskPriority::from(metadata.override_priority());
                 let running_task_gauge = running_tasks[task_priority as usize].clone();
-                // Note that the running task number limit is not strict.
-                // If several tasks are spawned at the same time while the running task number
-                // is close to the limit, they may all pass this check and the number of running
-                // tasks may exceed the limit.
-                if running_task_gauge.get() as usize >= *max_tasks {
-                    // When resource control is enabled, attempt to evict the
-                    // lowest-priority queued task if the incoming task has
-                    // strictly higher priority. This implements queue fairness:
-                    // important tasks can preempt less important queued tasks
-                    // when the pool is full.
-                    if let Some(ref ctl) = resource_ctl {
-                        let estimated_priority = ctl.peek_priority_of(&metadata, priority);
-                        if let Some(mut evicted) = remote.try_evict_lowest(estimated_priority) {
-                            // Decrement the running_tasks counter for the
-                            // evicted task's priority level. The evicted task's
-                            // future (which contains the running_tasks.dec()
-                            // closure) will be dropped without executing.
-                            let evicted_prio =
-                                priority_from_task_meta(evicted.mut_extras().metadata());
-                            running_tasks[evicted_prio as usize].dec();
-                            UNIFIED_READ_POOL_EVICTED_TASKS.inc();
-                            // Dropping the evicted TaskCell destroys the future
-                            // inside it. That future holds the oneshot::Sender
-                            // used by spawn_handle (or by coprocessor's manual
-                            // channel). When the sender is dropped the
-                            // corresponding receiver gets a Canceled error,
-                            // which callers surface as SchedTooBusy /
-                            // ServerIsBusy back to the client.
-                            drop(evicted);
-                            // Fall through to enqueue the new task below.
-                        } else {
-                            return Err(ReadPoolError::UnifiedReadPoolFull);
-                        }
-                    } else {
-                        return Err(ReadPoolError::UnifiedReadPoolFull);
+
+                let is_background = resource_limiter.as_ref().is_some_and(|l| l.is_background());
+                let fixed_level = if is_background {
+                    // Background tasks always run at low priority in the pool.
+                    Some(2)
+                } else {
+                    match priority {
+                        CommandPri::High => Some(0),
+                        CommandPri::Normal => None,
+                        CommandPri::Low => Some(2),
                     }
-                }
-                running_task_gauge.inc();
-                let fixed_level = match priority {
-                    CommandPri::High => Some(0),
-                    CommandPri::Normal => None,
-                    CommandPri::Low => Some(2),
                 };
                 let group_name = metadata.group_name().to_owned();
+                let estimated_priority = resource_ctl
+                    .as_ref()
+                    .map_or(u64::MAX, |ctl| ctl.peek_priority_of(&metadata, priority));
                 let mut extras = Extras::new_multilevel(task_id, fixed_level);
                 extras.set_metadata(metadata.to_vec());
+                // Clone gauge: one for inc (after admission), one inside the
+                // future for dec (when the task completes).
+                let gauge_for_spawn = running_task_gauge.clone();
                 let task_cell = if let Some(resource_ctl) = resource_ctl {
+                    let inner = ControlledFuture::new(
+                        f.map(move |_| {
+                            running_task_gauge.dec();
+                        }),
+                        resource_ctl.clone(),
+                        group_name.clone(),
+                    );
                     TaskCell::new(
                         TlsTrackedFuture::new(with_resource_limiter(
-                            ControlledFuture::new(
-                                f.map(move |_| {
-                                    running_task_gauge.dec();
-                                }),
-                                resource_ctl.clone(),
-                                group_name,
-                            ),
-                            resource_limiter,
-                            false,
+                            inner,
+                            resource_limiter.clone(),
+                            true, // skip compaction pressure for foreground jobs
+                            true, // measure-only: build debt, never sleep inside pool
+                            resource_manager.clone(),
+                            0, // read path: no write bytes
                         )),
                         extras,
                     )
@@ -228,10 +272,21 @@ impl ReadPoolHandle {
                         extras,
                     )
                 };
-                remote.spawn(task_cell);
+                admission_and_enqueue(
+                    resource_manager.clone(),
+                    resource_limiter,
+                    task_priority,
+                    gauge_for_spawn,
+                    *max_tasks,
+                    remote.clone(),
+                    task_cell,
+                    running_tasks.to_vec(),
+                    resource_ctl.clone(),
+                    estimated_priority,
+                )
+                .boxed()
             }
         }
-        Ok(())
     }
 
     pub fn spawn_handle<F, T>(
@@ -247,7 +302,7 @@ impl ReadPoolHandle {
         T: Send + 'static,
     {
         let (tx, rx) = oneshot::channel::<T>();
-        let res = self.spawn(
+        let spawn_fut = self.spawn(
             f.map(move |res| {
                 let _ = tx.send(res);
             }),
@@ -257,7 +312,7 @@ impl ReadPoolHandle {
             resource_limiter,
         );
         async move {
-            res?;
+            spawn_fut.await?;
             rx.map_err(ReadPoolError::from).await
         }
     }
@@ -483,6 +538,7 @@ pub fn build_yatp_read_pool<E: Engine, R: FlowStatsReporter>(
     reporter: R,
     engine: E,
     resource_ctl: Option<Arc<ResourceController>>,
+    resource_manager: Option<Arc<ResourceGroupManager>>,
     cleanup_method: CleanupMethod,
     enable_task_wait_metrics: bool,
 ) -> ReadPool {
@@ -492,6 +548,7 @@ pub fn build_yatp_read_pool<E: Engine, R: FlowStatsReporter>(
         reporter,
         engine,
         resource_ctl,
+        resource_manager,
         cleanup_method,
         unified_read_pool_name,
         enable_task_wait_metrics,
@@ -503,6 +560,7 @@ pub fn build_yatp_read_pool_with_name<E: Engine, R: FlowStatsReporter>(
     reporter: R,
     engine: E,
     resource_ctl: Option<Arc<ResourceController>>,
+    resource_manager: Option<Arc<ResourceGroupManager>>,
     cleanup_method: CleanupMethod,
     unified_read_pool_name: String,
     enable_task_wait_metrics: bool,
@@ -556,6 +614,7 @@ pub fn build_yatp_read_pool_with_name<E: Engine, R: FlowStatsReporter>(
             .saturating_mul(config.max_thread_count),
         pool_size: config.max_thread_count,
         resource_ctl,
+        resource_manager,
         time_slice_inspector,
     }
 }
@@ -916,6 +975,9 @@ pub enum ReadPoolError {
     #[error("Unified read pool is full")]
     UnifiedReadPoolFull,
 
+    #[error("Request rejected by admission control")]
+    Rejected,
+
     #[error("{0}")]
     Canceled(#[from] oneshot::Canceled),
 }
@@ -983,6 +1045,7 @@ mod tests {
             DummyReporter,
             engine,
             None,
+            None,
             CleanupMethod::InPlace,
             name.to_owned(),
             false,
@@ -1002,23 +1065,20 @@ mod tests {
         let (task3, _tx3) = gen_task();
         let (task4, _tx4) = gen_task();
 
-        handle
-            .spawn(task1, CommandPri::Normal, 1, TaskMetadata::default(), None)
+        block_on(handle.spawn(task1, CommandPri::Normal, 1, TaskMetadata::default(), None))
             .unwrap();
-        handle
-            .spawn(task2, CommandPri::Normal, 2, TaskMetadata::default(), None)
+        block_on(handle.spawn(task2, CommandPri::Normal, 2, TaskMetadata::default(), None))
             .unwrap();
 
         thread::sleep(Duration::from_millis(300));
-        match handle.spawn(task3, CommandPri::Normal, 3, TaskMetadata::default(), None) {
+        match block_on(handle.spawn(task3, CommandPri::Normal, 3, TaskMetadata::default(), None)) {
             Err(ReadPoolError::UnifiedReadPoolFull) => {}
             _ => panic!("should return full error"),
         }
         tx1.send(()).unwrap();
 
         thread::sleep(Duration::from_millis(300));
-        handle
-            .spawn(task4, CommandPri::Normal, 4, TaskMetadata::default(), None)
+        block_on(handle.spawn(task4, CommandPri::Normal, 4, TaskMetadata::default(), None))
             .unwrap();
         assert_eq!(
             UNIFIED_READ_POOL_RUNNING_TASKS
@@ -1044,6 +1104,7 @@ mod tests {
             DummyReporter,
             engine,
             None,
+            None,
             CleanupMethod::InPlace,
             false,
         );
@@ -1063,15 +1124,13 @@ mod tests {
         let (task4, _tx4) = gen_task();
         let (task5, _tx5) = gen_task();
 
-        handle
-            .spawn(task1, CommandPri::Normal, 1, TaskMetadata::default(), None)
+        block_on(handle.spawn(task1, CommandPri::Normal, 1, TaskMetadata::default(), None))
             .unwrap();
-        handle
-            .spawn(task2, CommandPri::Normal, 2, TaskMetadata::default(), None)
+        block_on(handle.spawn(task2, CommandPri::Normal, 2, TaskMetadata::default(), None))
             .unwrap();
 
         thread::sleep(Duration::from_millis(300));
-        match handle.spawn(task3, CommandPri::Normal, 3, TaskMetadata::default(), None) {
+        match block_on(handle.spawn(task3, CommandPri::Normal, 3, TaskMetadata::default(), None)) {
             Err(ReadPoolError::UnifiedReadPoolFull) => {}
             _ => panic!("should return full error"),
         }
@@ -1079,12 +1138,11 @@ mod tests {
         handle.scale_pool_size(3);
         assert_eq!(handle.get_normal_pool_size(), 3);
 
-        handle
-            .spawn(task4, CommandPri::Normal, 4, TaskMetadata::default(), None)
+        block_on(handle.spawn(task4, CommandPri::Normal, 4, TaskMetadata::default(), None))
             .unwrap();
 
         thread::sleep(Duration::from_millis(300));
-        match handle.spawn(task5, CommandPri::Normal, 5, TaskMetadata::default(), None) {
+        match block_on(handle.spawn(task5, CommandPri::Normal, 5, TaskMetadata::default(), None)) {
             Err(ReadPoolError::UnifiedReadPoolFull) => {}
             _ => panic!("should return full error"),
         }
@@ -1106,6 +1164,7 @@ mod tests {
             DummyReporter,
             engine,
             None,
+            None,
             CleanupMethod::InPlace,
             false,
         );
@@ -1125,15 +1184,13 @@ mod tests {
         let (task4, _tx4) = gen_task();
         let (task5, _tx5) = gen_task();
 
-        handle
-            .spawn(task1, CommandPri::Normal, 1, TaskMetadata::default(), None)
+        block_on(handle.spawn(task1, CommandPri::Normal, 1, TaskMetadata::default(), None))
             .unwrap();
-        handle
-            .spawn(task2, CommandPri::Normal, 2, TaskMetadata::default(), None)
+        block_on(handle.spawn(task2, CommandPri::Normal, 2, TaskMetadata::default(), None))
             .unwrap();
 
         thread::sleep(Duration::from_millis(300));
-        match handle.spawn(task3, CommandPri::Normal, 3, TaskMetadata::default(), None) {
+        match block_on(handle.spawn(task3, CommandPri::Normal, 3, TaskMetadata::default(), None)) {
             Err(ReadPoolError::UnifiedReadPoolFull) => {}
             _ => panic!("should return full error"),
         }
@@ -1154,12 +1211,11 @@ mod tests {
         handle.scale_pool_size(1);
         assert_eq!(handle.get_normal_pool_size(), 1);
 
-        handle
-            .spawn(task4, CommandPri::Normal, 4, TaskMetadata::default(), None)
+        block_on(handle.spawn(task4, CommandPri::Normal, 4, TaskMetadata::default(), None))
             .unwrap();
 
         thread::sleep(Duration::from_millis(300));
-        match handle.spawn(task5, CommandPri::Normal, 5, TaskMetadata::default(), None) {
+        match block_on(handle.spawn(task5, CommandPri::Normal, 5, TaskMetadata::default(), None)) {
             Err(ReadPoolError::UnifiedReadPoolFull) => {}
             _ => panic!("should return full error"),
         }
@@ -1250,6 +1306,7 @@ mod tests {
             DummyReporter,
             engine,
             None,
+            None,
             CleanupMethod::InPlace,
             false,
         );
@@ -1322,12 +1379,12 @@ mod tests {
 
         for control in [false, true] {
             let name = format!("test_yatp_task_poll_duration_metric_{}", control);
-            let resource_manager = if control {
-                let resource_manager = ResourceGroupManager::default();
-                let resource_ctl = resource_manager.derive_controller(name.clone(), true);
-                Some(resource_ctl)
+            let (resource_ctl, resource_manager) = if control {
+                let rm = Arc::new(ResourceGroupManager::default());
+                let ctl = rm.derive_controller(name.clone(), true);
+                (Some(ctl), Some(rm))
             } else {
-                None
+                (None, None)
             };
             let config = UnifiedReadPoolConfig {
                 min_thread_count: 1,
@@ -1342,6 +1399,7 @@ mod tests {
                 &config,
                 DummyReporter,
                 engine,
+                resource_ctl,
                 resource_manager,
                 CleanupMethod::InPlace,
                 name.clone(),
@@ -1362,11 +1420,9 @@ mod tests {
             let (task1, tx1) = gen_task();
             let (task2, tx2) = gen_task();
 
-            handle
-                .spawn(task1, CommandPri::Normal, 1, TaskMetadata::default(), None)
+            block_on(handle.spawn(task1, CommandPri::Normal, 1, TaskMetadata::default(), None))
                 .unwrap();
-            handle
-                .spawn(task2, CommandPri::Normal, 2, TaskMetadata::default(), None)
+            block_on(handle.spawn(task2, CommandPri::Normal, 2, TaskMetadata::default(), None))
                 .unwrap();
 
             tx1.send(()).unwrap();
@@ -1415,7 +1471,7 @@ mod tests {
         //   eviction comparison. "high_group" (priority=16) produces a numerically
         //   smaller value than "low_group" (priority=1), meaning it is scheduled first
         //   and can evict low_group tasks.
-        let resource_manager = ResourceGroupManager::default();
+        let resource_manager = Arc::new(ResourceGroupManager::default());
         let low_group = new_resource_group_ru("low_group".into(), 5000, 1);
         resource_manager.add_resource_group(low_group);
         let high_group = new_resource_group_ru("high_group".into(), 5000, 16);
@@ -1437,6 +1493,7 @@ mod tests {
             DummyReporter,
             engine,
             Some(resource_ctl),
+            Some(resource_manager),
             CleanupMethod::InPlace,
             name.to_owned(),
             false,
@@ -1467,15 +1524,14 @@ mod tests {
         let task1 = async move {
             let _ = block_rx.recv();
         };
-        handle
-            .spawn(
-                task1,
-                CommandPri::Normal,
-                1,
-                TaskMetadata::from_ctx(&low_ctx),
-                None,
-            )
-            .unwrap();
+        block_on(handle.spawn(
+            task1,
+            CommandPri::Normal,
+            1,
+            TaskMetadata::from_ctx(&low_ctx),
+            None,
+        ))
+        .unwrap();
 
         // Wait for task1 to be picked up and block the worker.
         thread::sleep(Duration::from_millis(300));
@@ -1486,43 +1542,40 @@ mod tests {
         let (task3, _tx3) = gen_task();
         let (task4, _tx4) = gen_task();
 
-        handle
-            .spawn(
-                task2,
-                CommandPri::Normal,
-                2,
-                TaskMetadata::from_ctx(&low_ctx),
-                None,
-            )
-            .unwrap();
-        handle
-            .spawn(
-                task3,
-                CommandPri::Normal,
-                3,
-                TaskMetadata::from_ctx(&low_ctx),
-                None,
-            )
-            .unwrap();
-        handle
-            .spawn(
-                task4,
-                CommandPri::Normal,
-                4,
-                TaskMetadata::from_ctx(&low_ctx),
-                None,
-            )
-            .unwrap();
+        block_on(handle.spawn(
+            task2,
+            CommandPri::Normal,
+            2,
+            TaskMetadata::from_ctx(&low_ctx),
+            None,
+        ))
+        .unwrap();
+        block_on(handle.spawn(
+            task3,
+            CommandPri::Normal,
+            3,
+            TaskMetadata::from_ctx(&low_ctx),
+            None,
+        ))
+        .unwrap();
+        block_on(handle.spawn(
+            task4,
+            CommandPri::Normal,
+            4,
+            TaskMetadata::from_ctx(&low_ctx),
+            None,
+        ))
+        .unwrap();
 
         // Verify pool is full: spawning another low-priority task should fail.
         let (task_low5, _tx_low5) = gen_task();
-        match handle.spawn(
+        match block_on(handle.spawn(
             task_low5,
             CommandPri::Normal,
             5,
             TaskMetadata::from_ctx(&low_ctx),
             None,
-        ) {
+        )) {
             Err(ReadPoolError::UnifiedReadPoolFull) => {}
             other => panic!(
                 "expected UnifiedReadPoolFull for low-priority task, got {:?}",
@@ -1539,15 +1592,14 @@ mod tests {
             ..Default::default()
         };
 
-        handle
-            .spawn(
-                task_high,
-                CommandPri::High,
-                6,
-                TaskMetadata::from_ctx(&high_ctx),
-                None,
-            )
-            .expect("high-priority task should succeed via eviction");
+        block_on(handle.spawn(
+            task_high,
+            CommandPri::High,
+            6,
+            TaskMetadata::from_ctx(&high_ctx),
+            None,
+        ))
+        .expect("high-priority task should succeed via eviction");
 
         // The eviction metric should have been incremented.
         assert!(

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1958,7 +1958,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         self.sched
             .get_sched_pool()
             // NOTE: we don't support background resource control for raw api.
-            .spawn("", metadata, pri, future)
+            .spawn("", metadata, pri, future, 0)
             .map_err(|_| Error::from(ErrorInner::SchedTooBusy))
     }
 
@@ -3379,12 +3379,15 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
             err.set_server_is_busy(busy_err);
             return FuturesEither::Left(future::err(Error::from(ErrorInner::Kv(err.into()))));
         }
-        FuturesEither::Right(
-            self.read_pool
+
+        let metadata = metadata.deep_clone();
+        let read_pool = self.read_pool.clone();
+        FuturesEither::Right(async move {
+            read_pool
                 .spawn_handle(future, priority, task_id, metadata, resource_limiter)
                 .map_err(|_| Error::from(ErrorInner::SchedTooBusy))
-                .and_then(future::ready),
-        )
+                .await?
+        })
     }
 
     pub fn update_txn_status_cache(

--- a/src/storage/txn/sched_pool.rs
+++ b/src/storage/txn/sched_pool.rs
@@ -117,6 +117,7 @@ impl PriorityQueue {
         metadata: TaskMetadata<'_>,
         priority_level: CommandPri,
         f: impl futures::Future<Output = ()> + Send + 'static,
+        write_bytes: u64,
     ) -> Result<(), Full> {
         let fixed_level = match priority_level {
             CommandPri::High => Some(0),
@@ -126,18 +127,22 @@ impl PriorityQueue {
         // TODO: maybe use a better way to generate task_id
         let task_id = rand::random::<u64>();
         let group_name = metadata.group_name().to_owned();
-        let resource_limiter = self.resource_mgr.get_resource_limiter(
-            unsafe { std::str::from_utf8_unchecked(&group_name) },
-            request_source,
-            metadata.override_priority() as u64,
-        );
+        let override_priority = metadata.override_priority() as u64;
         let mut extras = Extras::new_multilevel(task_id, fixed_level);
         extras.set_metadata(metadata.to_vec());
+        let resource_limiter = self.resource_mgr.get_resource_limiter(
+            std::str::from_utf8(&group_name).unwrap_or_default(),
+            request_source,
+            override_priority,
+        );
         self.worker_pool.spawn_with_extras(
             with_resource_limiter(
                 ControlledFuture::new(f, self.resource_ctl.clone(), group_name),
                 resource_limiter,
-                false,
+                true, // skip compaction pressure for foreground jobs
+                true, // measure-only: build debt, never sleep inside pool
+                Some(self.resource_mgr.clone()),
+                write_bytes,
             ),
             extras,
         )
@@ -229,6 +234,7 @@ impl SchedPool {
         metadata: TaskMetadata<'_>,
         priority_level: CommandPri,
         f: impl futures::Future<Output = ()> + Send + 'static,
+        write_bytes: u64,
     ) -> Result<(), Full> {
         match self.queue_type {
             QueueType::Vanilla => self.vanilla.spawn(priority_level, f),
@@ -240,6 +246,7 @@ impl SchedPool {
                         metadata,
                         priority_level,
                         f,
+                        write_bytes,
                     )
                 } else {
                     fail_point!("single_queue_pool_task");

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -251,6 +251,9 @@ struct TxnSchedulerInner<L: LockManager> {
     // all tasks are executed in this pool
     sched_worker_pool: SchedPool,
 
+    // resource group manager for Tier-1 high-priority throttle on writes.
+    resource_manager: Option<Arc<ResourceGroupManager>>,
+
     // used to control write flow
     running_write_bytes: CachePadded<AtomicUsize>,
 
@@ -465,6 +468,7 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
                 resource_ctl,
                 resource_manager.clone(),
             ),
+            resource_manager: resource_manager.clone(),
             control_mutex: Arc::new(tokio::sync::Mutex::new(false)),
             lock_mgr,
             concurrency_manager,
@@ -522,6 +526,56 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         });
     }
 
+    /// Returns true if admission control consumed the command (reject or
+    /// delay); the caller should return without further processing.
+    fn apply_admission_control(
+        &self,
+        cmd: &Command,
+    ) -> Option<resource_control::AdmissionDecision> {
+        let rm = self.inner.resource_manager.as_ref()?;
+        let rc_ctx = cmd.resource_control_ctx();
+        let rg = rc_ctx.get_resource_group_name();
+        let request_source = cmd.ctx().request_source.clone();
+        let limiter =
+            rm.get_resource_limiter(rg, &request_source, rc_ctx.get_override_priority())?;
+        Some(rm.admission_decision(false, &limiter))
+    }
+
+    /// Spawns an async task on the sched pool that sleeps for `delay` then
+    /// calls `schedule_command`. The latch is acquired only after the sleep so
+    /// the delay does not block concurrent writers with overlapping keys.
+    fn schedule_after_admission_delay(
+        &self,
+        cmd: Command,
+        callback: StorageCallback,
+        delay: Duration,
+    ) {
+        let tag = cmd.tag();
+        let sched = self.clone();
+        let cb = SchedulerTaskCallback::NormalRequestCallback(callback);
+        let metadata = TaskMetadata::from_ctx(cmd.resource_control_ctx());
+        let priority = cmd.priority();
+        let write_bytes = cmd.write_bytes() as u64;
+        let request_source = cmd.ctx().request_source.clone();
+        let mem_quota = self.inner.memory_quota.clone();
+        let rm = self.inner.resource_manager.as_ref().unwrap().clone();
+        let execution = async move {
+            let mut guard = rm.delay_slot_guard();
+            futures_timer::Delay::new(delay).await;
+            guard.release();
+            let cid = sched.inner.gen_id();
+            if let Ok(task) = Task::allocate(cid, cmd, mem_quota) {
+                sched.schedule_command(task, cb, None);
+            } else {
+                Self::fail_with_busy(tag, cb);
+            }
+        };
+        self.inner
+            .sched_worker_pool
+            .spawn(&request_source, metadata, priority, execution, write_bytes)
+            .unwrap();
+    }
+
     pub(in crate::storage) fn run_cmd(&self, cmd: Command, callback: StorageCallback) {
         let tag = cmd.tag();
         // write flow control
@@ -532,6 +586,19 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         if cmd.need_flow_control() && self.inner.too_busy(cmd.ctx().region_id) {
             Self::fail_with_busy(tag, callback.into());
             return;
+        }
+        // Admission control before latch acquisition so a delayed command does
+        // not block concurrent writers sharing the same keys.
+        match self.apply_admission_control(&cmd) {
+            Some(resource_control::AdmissionDecision::Reject) => {
+                Self::fail_with_busy(tag, callback.into());
+                return;
+            }
+            Some(resource_control::AdmissionDecision::Delay(delay)) => {
+                self.schedule_after_admission_delay(cmd, callback, delay);
+                return;
+            }
+            _ => {}
         }
         let cid = self.inner.gen_id();
         if let Ok(task) = Task::allocate(cid, cmd, self.inner.memory_quota.clone()) {
@@ -662,6 +729,7 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
                 TaskMetadata::from_ctx(cmd.resource_control_ctx()),
                 cmd.priority(),
                 execution,
+                cmd.write_bytes() as u64,
             )
             .unwrap();
     }
@@ -681,9 +749,15 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
                 // when many queuing tasks fail successively.
                 let this = self.clone();
                 self.get_sched_pool()
-                    .spawn(&request_source, metadata, pri, async move {
-                        this.finish_with_err(cid, err, None);
-                    })
+                    .spawn(
+                        &request_source,
+                        metadata,
+                        pri,
+                        async move {
+                            this.finish_with_err(cid, err, None);
+                        },
+                        0,
+                    )
                     .unwrap();
             }
         }
@@ -722,7 +796,9 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         let sched = self.clone();
         let metadata = TaskMetadata::from_ctx(task.cmd().resource_control_ctx());
         let request_source = task.cmd().ctx().request_source.clone();
+        let request_source_for_spawn = request_source.clone();
         let priority = task.cmd().priority();
+        let write_bytes = task.cmd().write_bytes();
         let future_tracker =
             TlsFutureTracker::new(task.tracker_token(), task.cmd().tag(), task.cid());
         let execution = async move {
@@ -730,7 +806,6 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
             if sched.check_task_deadline_exceeded(&task, None) {
                 return;
             }
-
             let tag = task.cmd().tag();
             SCHED_STAGE_COUNTER_VEC.get(tag).snapshot.inc();
 
@@ -807,7 +882,13 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         });
         SCHED_TXN_RUNNING_COMMANDS.inc();
         self.get_sched_pool()
-            .spawn(&request_source, metadata, priority, execution)
+            .spawn(
+                &request_source_for_spawn,
+                metadata,
+                priority,
+                execution,
+                write_bytes as u64,
+            )
             .unwrap();
     }
 
@@ -1143,9 +1224,15 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         } else {
             let lock_wait_queues = self.inner.lock_wait_queues.clone();
             self.get_sched_pool()
-                .spawn(request_source, metadata, CommandPri::High, async move {
-                    lock_wait_queues.update_lock_wait(new_acquired_locks);
-                })
+                .spawn(
+                    request_source,
+                    metadata,
+                    CommandPri::High,
+                    async move {
+                        lock_wait_queues.update_lock_wait(new_acquired_locks);
+                    },
+                    0,
+                )
                 .unwrap();
         }
     }
@@ -1163,40 +1250,52 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         let metadata1 = metadata.deep_clone();
         let rsource = request_source.to_string();
         self.get_sched_pool()
-            .spawn(request_source, metadata, CommandPri::High, async move {
-                for (lock_info, released_lock) in legacy_wake_up_list {
-                    let cb = lock_info.key_cb.unwrap().into_inner();
-                    let e = StorageError::from(Error::from(MvccError::from(
-                        MvccErrorInner::WriteConflict {
-                            start_ts: lock_info.parameters.start_ts,
-                            conflict_start_ts: released_lock.start_ts,
-                            conflict_commit_ts: released_lock.commit_ts,
-                            key: released_lock.key.into_raw().unwrap(),
-                            primary: lock_info.parameters.primary,
-                            reason: kvrpcpb::WriteConflictReason::PessimisticRetry,
-                        },
-                    )));
-                    cb(Err(e.into()), false);
-                }
+            .spawn(
+                request_source,
+                metadata,
+                CommandPri::High,
+                async move {
+                    for (lock_info, released_lock) in legacy_wake_up_list {
+                        let cb = lock_info.key_cb.unwrap().into_inner();
+                        let e = StorageError::from(Error::from(MvccError::from(
+                            MvccErrorInner::WriteConflict {
+                                start_ts: lock_info.parameters.start_ts,
+                                conflict_start_ts: released_lock.start_ts,
+                                conflict_commit_ts: released_lock.commit_ts,
+                                key: released_lock.key.into_raw().unwrap(),
+                                primary: lock_info.parameters.primary,
+                                reason: kvrpcpb::WriteConflictReason::PessimisticRetry,
+                            },
+                        )));
+                        cb(Err(e.into()), false);
+                    }
 
-                for f in delayed_wake_up_futures {
-                    let self2 = self1.clone();
-                    let metadata2 = metadata1.clone();
-                    self1
-                        .get_sched_pool()
-                        .spawn(&rsource, metadata2, CommandPri::High, async move {
-                            let res = f.await;
-                            if let Some(resumable_lock_wait_entry) = res {
-                                self2.schedule_awakened_pessimistic_locks(
-                                    None,
-                                    None,
-                                    smallvec![resumable_lock_wait_entry],
-                                );
-                            }
-                        })
-                        .unwrap();
-                }
-            })
+                    for f in delayed_wake_up_futures {
+                        let self2 = self1.clone();
+                        let metadata2 = metadata1.clone();
+                        self1
+                            .get_sched_pool()
+                            .spawn(
+                                &rsource,
+                                metadata2,
+                                CommandPri::High,
+                                async move {
+                                    let res = f.await;
+                                    if let Some(resumable_lock_wait_entry) = res {
+                                        self2.schedule_awakened_pessimistic_locks(
+                                            None,
+                                            None,
+                                            smallvec![resumable_lock_wait_entry],
+                                        );
+                                    }
+                                },
+                                0,
+                            )
+                            .unwrap();
+                    }
+                },
+                0,
+            )
             .unwrap();
     }
 

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -918,10 +918,17 @@ fn test_serde_custom_tikv_config() {
     value.resource_control = ResourceControlConfig {
         enabled: false,
         priority_ctl_strategy: PriorityCtlStrategy::Aggressive,
-        bg_resource_threshold: 70.0,
+        bg_cpu_throttle_threshold: 60.0,
+        fg_cpu_throttle_threshold: 70.0,
         bg_compaction_pressure_threshold: 70.0,
         bg_write_io_ceiling: ReadableSize::gb(100),
         bg_write_io_floor: ReadableSize::mb(10),
+        enable_fair_scheduling: false,
+        enable_read_admission_control: false,
+        enable_write_admission_control: false,
+        historical_usage_window_mins: 15,
+        baseline_burst_pct: 20.0,
+        admission_max_delayed_count: 10_000,
     };
 
     let custom = read_file_in_project_dir("integrations/config/test-custom.toml");

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -694,7 +694,14 @@ split.split-contained-score = 0.5
 [resource-control]
 enabled = false
 priority-ctl-strategy = "aggressive"
-bg-resource-threshold = 70.0
+bg-cpu-throttle-threshold = 60.0
+fg-cpu-throttle-threshold = 70.0
 bg-compaction-pressure-threshold = 70.0
 bg-write-io-ceiling = "100GB"
 bg-write-io-floor = "10MB"
+enable-fair-scheduling = false
+enable-read-admission-control = false
+enable-write-admission-control = false
+historical-usage-window-mins = 15
+baseline-burst-pct = 20.0
+admission-max-delayed-count = 10000


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

Issue Number: Close #19607

### What is changed and how it works?
## Summary

  Implements per-group historical RU (Request Unit) tracking to protect sustained workloads
  from traffic spikes via two mechanisms: scheduling-based priority and tiered load shedding.

  ### 1. Scheduling-Based Priority

  Assigns priority to read requests based on whether a resource group's current RU rate
  exceeds its historical baseline. Groups within baseline get **phase 0** (higher priority);
  groups over baseline get **phase 1** (lower priority) in the yatp scheduling queue.

  - Priority encoding: `[4-bit group_priority | 1-bit phase | 59-bit virtual_time_tag]`
  - Phase 0 always sorts before phase 1 within the same group priority
  - Only effective when the unified read pool is contended (queue not empty)
  - **Limitation**: cannot protect against CPU saturation from non-read-pool sources
    (gRPC threads, write scheduler, compaction), since it only reorders within the read
    pool queue

  Controlled by: `enable-fair-scheduling` (default: `false`)

  ### 2. Load Shedding

  Progressively sheds load when CPU utilization rises, in two stages:

  **Stage 1 — Background traffic** (BR, Lightning, stats):
  Throttled first via CPU-proportional rate limiting between `bg-cpu-start-threshold` and
  `bg-cpu-end-threshold`. Write IO is independently throttled based on compaction pressure.

  **Stage 2 — Foreground traffic**:
  When CPU stays above threshold despite background throttling, admission control delays or
  rejects foreground requests from groups exceeding their historical RU baseline. This works
  across both the read pool and write scheduler, unlike scheduling-based priority.

  - Read requests delayed before entering the unified read pool
  - Write requests delayed before executing in the scheduler (after latch acquired)
  - Delay duration = `max(token_bucket_debt, RU_baseline_overage_delay)`
  - reject request if number of request delayed is more than then admission-max-delayed-count

  ### RU Tracking

  Per-group RU consumption is tracked in a sliding-window ring buffer used by both
  scheduling priority and load shedding:

  - **Bucket size**: 30 seconds
  - **Historical window**: configurable via `ru-historical-window-mins` (default: 15 min
    = 30 buckets). Not hot-reloadable.
  - **Current rate**: computed inline on the request path from the current partial bucket +
    last completed bucket (~30-60s window) for fast spike detection
  - **Historical rate**: cached every ~10s in `update_cpu_utilization` to avoid iterating
    all buckets on the hot path
  - **Warm-up**: requires 2 completed buckets (≥60s) before baseline comparisons activate
  - **Idle cleanup**: stale tracker entries (all buckets zero) are evicted every ~10s
  - **Priority assignment**: `is_over_baseline = current_rate > cached_historical_rate`
    determines phase 0 vs phase 1 for scheduling, and triggers admission delay for load
    shedding

  ### Configuration Reference (`[resource-control]`)

  ## New Configuration Options (`[resource-control]`)

| Config | Default | Hot-reloadable | Description |
|--------|---------|----------------|-------------|
| `bg-cpu-throttle-threshold` | `60.0` | Yes | CPU utilization % at which background task throttling begins. Background budget scales linearly from full down to zero between this value and `bg-cpu-end-threshold`. |
| `fg-cpu-throttle-threshold` | `70.0` | Yes | CPU utilization % at which background tasks are fully throttled to their minimum floor. Also caps the background utilization limit. |
| `enable-fair-scheduling` | `false` | Yes | Enables two-phase RU-based scheduling for reads. Groups whose current RU rate exceeds their historical baseline (+ `baseline-burst-pct` headroom) are deprioritized in the yatp priority queue. |
| `enable-read-admission-control` | `false` | Yes | Enables admission control for reads. Over-baseline read requests are delayed or rejected when CPU exceeds thresholds. |
| `enable-write-admission-control` | `false` | Yes | Enables admission control for writes. Over-baseline write requests are delayed or rejected when CPU exceeds thresholds. |
| `ru-historical-window-mins` | `15` | **No** (restart required) | Size of the sliding window (in minutes) used to compute per-group historical RU baselines. Divided into 30-second buckets. Min 2, max 60. |
| `baseline-burst-pct` | `20.0` | Yes | Percentage of headroom above the historical RU baseline before a group is considered "over baseline." E.g., `20.0` means a group must exceed 1.2× its historical rate to be deprioritized or rate-limited. |
| `admission-max-delayed-count` | `10000` | Yes | Maximum number of requests that can concurrently sit in admission control delay. When exceeded, additional over-baseline requests are rejected immediately. Set to `0` for unlimited. |

  
  ### New Metrics

  | Metric | Type | Labels | Description |
  |---|---|---|---|
  | `tikv_resource_control_admission_delayed_requests_total` | counter | `resource_group`, `is_background` | Requests delayed by admission control |
  | `tikv_resource_control_admission_rejected_requests_total` | counter | `resource_group`, `is_background` | Requests rejected by admission control |
  | `tikv_resource_control_admission_delay_duration_seconds` | histogram | `resource_group`, `is_background` | Delay duration imposed by admission control |
  | `tikv_resource_control_two_phase_throttled_requests_total` | counter | `resource_group` | Requests assigned to phase 1 (over baseline) |



<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->


<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

https://docs.google.com/document/d/1wKY7NcnWi0UEhhRWQNy17lNSVFuQuiu3cVZYd7fzluE/edit?tab=t.0


Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note

Introduce dynamic resource group isolation to protect sustained workloads from
traffic spikes. When CPU utilization is high, TiKV now deprioritizes requests
from groups that exceed their historical RU baselines in the yatp scheduler
(phase-based priority), and optionally delays or rejects over-baseline foreground
requests at high CPU load (admission control). Controlled by new config flags:
`enable-fair-scheduling`, `enable-read-admission-control`,
`enable-write-admission-control`, `ru-historical-window-mins`,
`bg-cpu-start-threshold`, `fg-cpu-start-threshold`,
`baseline-burst-pct`, and `admission-max-delayed-count`.
All flags default to off/disabled, making this a no-op unless explicitly enabled.

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RU-baseline admission control for reads/writes with Allow/Delay/Reject, delay-slot gating, two-phase scheduling, and task-level rejection.

* **Configuration**
  * Replaced single background threshold with CPU start/end thresholds; added toggles for fair scheduling, read/write admission, historical-window, and max-delayed-count.

* **Metrics**
  * Added metrics for two‑phase throttling, per-group RU historical/current rates, admission delayed/rejected counts, and admission delay durations.

* **Refactor**
  * Background quota scaling moved to a two-threshold, piecewise-linear CPU model; scheduling/priorities updated for over‑baseline work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->