### PR TITLE
coprocessor: support paging_size_bytes for byte-budget paging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4422,7 +4422,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#b7a415182b4fe2230f371e2eaa484976d2e05b13"
+source = "git+https://github.com/JmPotato/kvproto?branch=demo/ru-paging-size#a6a24f97e54ff33b7c81f78edde6c3dece2c8a05"
 dependencies = [
  "bytes",
  "futures 0.3.15",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4692,9 +4692,9 @@ dependencies = [
 
 [[package]]
 name = "memmap2"
-version = "0.9.3"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45fd3a57831bf88bc63f8cebc0cf956116276e97fef3966103e96416209f7c92"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc 0.2.176",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4422,7 +4422,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/JmPotato/kvproto?branch=demo/ru-paging-size#a6a24f97e54ff33b7c81f78edde6c3dece2c8a05"
+source = "git+https://github.com/pingcap/kvproto.git#a15c348f8713e5c492b6dfb41224c464b5824979"
 dependencies = [
  "bytes",
  "futures 0.3.15",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,6 +222,12 @@ tempdir = { path = "patches/tempdir" }
 cmake = { git = "https://github.com/rust-lang/cmake-rs" }
 
 sysinfo = { git = "https://github.com/tikv/sysinfo", branch = "0.26-fix-cpu" }
+# When you modify TiKV cooperatively with kvproto, this will be useful to submit the PR to TiKV and the PR to
+# kvproto at the same time.
+# After the PR to kvproto is merged, remember to comment this out and run `cargo update -p kvproto`.
+# [patch.'https://github.com/pingcap/kvproto']
+# kvproto = { git = "https://github.com/your_github_id/kvproto", branch = "your_branch" }
+#
 # After the PR to rust-rocksdb is merged, remember to comment this out and run `cargo update -p rocksdb`.
 # [patch.'https://github.com/tikv/rust-rocksdb']
 # rocksdb = { git = "https://github.com/your_github_id/rust-rocksdb", branch = "your_branch" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,8 +225,8 @@ sysinfo = { git = "https://github.com/tikv/sysinfo", branch = "0.26-fix-cpu" }
 # When you modify TiKV cooperatively with kvproto, this will be useful to submit the PR to TiKV and the PR to
 # kvproto at the same time.
 # After the PR to kvproto is merged, remember to comment this out and run `cargo update -p kvproto`.
-# [patch.'https://github.com/pingcap/kvproto']
-# kvproto = { git = "https://github.com/your_github_id/kvproto", branch = "your_branch" }
+[patch.'https://github.com/pingcap/kvproto']
+kvproto = { git = "https://github.com/JmPotato/kvproto", branch = "demo/ru-paging-size" }
 #
 # After the PR to rust-rocksdb is merged, remember to comment this out and run `cargo update -p rocksdb`.
 # [patch.'https://github.com/tikv/rust-rocksdb']

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,12 +222,6 @@ tempdir = { path = "patches/tempdir" }
 cmake = { git = "https://github.com/rust-lang/cmake-rs" }
 
 sysinfo = { git = "https://github.com/tikv/sysinfo", branch = "0.26-fix-cpu" }
-# When you modify TiKV cooperatively with kvproto, this will be useful to submit the PR to TiKV and the PR to
-# kvproto at the same time.
-# After the PR to kvproto is merged, remember to comment this out and run `cargo update -p kvproto`.
-[patch.'https://github.com/pingcap/kvproto']
-kvproto = { git = "https://github.com/JmPotato/kvproto", branch = "demo/ru-paging-size" }
-#
 # After the PR to rust-rocksdb is merged, remember to comment this out and run `cargo update -p rocksdb`.
 # [patch.'https://github.com/tikv/rust-rocksdb']
 # rocksdb = { git = "https://github.com/your_github_id/rust-rocksdb", branch = "your_branch" }

--- a/components/test_coprocessor/src/dag.rs
+++ b/components/test_coprocessor/src/dag.rs
@@ -28,6 +28,7 @@ pub struct DagSelect {
     pub key_ranges: Vec<KeyRange>,
     pub output_offsets: Option<Vec<u32>>,
     pub paging_size: Option<u64>,
+    pub paging_size_bytes: Option<u64>,
     pub start_ts: Option<u64>,
     pub intermediate_outputs: Vec<IntermediateOutputChannel>,
 }
@@ -53,6 +54,7 @@ impl DagSelect {
             key_ranges: vec![table.get_record_range_all()],
             output_offsets: None,
             paging_size: None,
+            paging_size_bytes: None,
             start_ts: None,
             intermediate_outputs: vec![],
         }
@@ -82,6 +84,7 @@ impl DagSelect {
             key_ranges: vec![range],
             output_offsets: None,
             paging_size: None,
+            paging_size_bytes: None,
             start_ts: None,
             intermediate_outputs: vec![],
         }
@@ -268,6 +271,13 @@ impl DagSelect {
     }
 
     #[must_use]
+    pub fn paging_size_bytes(mut self, paging_size_bytes: u64) -> DagSelect {
+        assert_ne!(paging_size_bytes, 0);
+        self.paging_size_bytes = Some(paging_size_bytes);
+        self
+    }
+
+    #[must_use]
     pub fn key_ranges(mut self, key_ranges: Vec<KeyRange>) -> DagSelect {
         self.key_ranges = key_ranges;
         self
@@ -338,6 +348,7 @@ impl DagSelect {
         req.set_data(dag.write_to_bytes().unwrap());
         req.set_ranges(self.key_ranges.into());
         req.set_paging_size(self.paging_size.unwrap_or(0));
+        req.set_paging_size_bytes(self.paging_size_bytes.unwrap_or(0));
         req.set_context(ctx);
         req
     }

--- a/components/tidb_query_common/src/storage/mod.rs
+++ b/components/tidb_query_common/src/storage/mod.rs
@@ -69,13 +69,13 @@ pub trait Storage: Send {
 
     fn collect_statistics(&mut self, dest: &mut Self::Statistics);
 
-    /// Returns the cumulative number of bytes scanned so far, without draining
-    /// any statistics. Used as the byte budget for `paging_size_bytes`.
+    /// Returns the cumulative number of bytes scanned so far, counting the
+    /// key and value of every returned entry. Unlike `collect_statistics`,
+    /// this is a non-draining read: the total keeps growing monotonically
+    /// across calls.
     ///
-    /// Implementations should count the same bytes that contribute to the MVCC
-    /// `processed_size` (encoded key + value of every returned entry), so the
-    /// page boundary aligns with the bytes used for RU accounting. Test
-    /// storages may approximate this.
+    /// How the key bytes are measured (e.g. raw or encoded form) is up to the
+    /// implementation.
     fn scanned_bytes(&self) -> usize;
 }
 

--- a/components/tidb_query_common/src/storage/mod.rs
+++ b/components/tidb_query_common/src/storage/mod.rs
@@ -68,6 +68,15 @@ pub trait Storage: Send {
     fn met_uncacheable_data(&self) -> Option<bool>;
 
     fn collect_statistics(&mut self, dest: &mut Self::Statistics);
+
+    /// Returns the cumulative number of bytes scanned so far, without draining
+    /// any statistics. Used as the byte budget for `paging_size_bytes`.
+    ///
+    /// Implementations should count the same bytes that contribute to the MVCC
+    /// `processed_size` (encoded key + value of every returned entry), so the
+    /// page boundary aligns with the bytes used for RU accounting. Test
+    /// storages may approximate this.
+    fn scanned_bytes(&self) -> usize;
 }
 
 impl<T: Storage + ?Sized> Storage for Box<T> {
@@ -102,6 +111,10 @@ impl<T: Storage + ?Sized> Storage for Box<T> {
 
     fn collect_statistics(&mut self, dest: &mut Self::Statistics) {
         (**self).collect_statistics(dest);
+    }
+
+    fn scanned_bytes(&self) -> usize {
+        (**self).scanned_bytes()
     }
 }
 

--- a/components/tidb_query_common/src/storage/scanner.rs
+++ b/components/tidb_query_common/src/storage/scanner.rs
@@ -507,8 +507,13 @@ mod tests {
     fn test_scanned_bytes() {
         let storage = create_storage();
 
-        // [foo, foo_3a) yields foo->1, foo_2->3, foo_3->5.
-        let ranges: Vec<Range> = vec![IntervalRange::from(("foo", "foo_3a")).into()];
+        // [foo, foo_3a) yields foo->1, foo_2->3, foo_3->5; the trailing point
+        // ranges exercise the get path with a hit and a miss.
+        let ranges: Vec<Range> = vec![
+            IntervalRange::from(("foo", "foo_3a")).into(),
+            PointRange::from("bar_2").into(),
+            PointRange::from("bar_3").into(),
+        ];
         let mut scanner = RangesScanner::<_, ApiV1>::new(RangesScannerOptions {
             storage,
             ranges,
@@ -532,9 +537,14 @@ mod tests {
         assert_eq!(&block_on(scanner.next()).unwrap().unwrap().key(), b"foo_3");
         assert_eq!(scanner.peek_scanned_bytes_sum(), 16);
 
-        // Draining does not change the (non-destructive) peeked total.
+        // Point-range hit: "bar_2" (5) + "4" (1) = 6, cumulative 22.
+        assert_eq!(&block_on(scanner.next()).unwrap().unwrap().key(), b"bar_2");
+        assert_eq!(scanner.peek_scanned_bytes_sum(), 22);
+
+        // Point-range miss adds nothing, and draining does not change the
+        // (non-destructive) peeked total.
         assert_eq!(block_on(scanner.next()).unwrap(), None);
-        assert_eq!(scanner.peek_scanned_bytes_sum(), 16);
+        assert_eq!(scanner.peek_scanned_bytes_sum(), 22);
     }
 
     #[test]

--- a/components/tidb_query_common/src/storage/scanner.rs
+++ b/components/tidb_query_common/src/storage/scanner.rs
@@ -28,12 +28,6 @@ pub struct RangesScanner<T, F> {
 
     scanned_rows_per_range: Vec<usize>,
 
-    /// Cumulative count of raw bytes (key + value lengths) scanned across all
-    /// ranges. Used as the byte budget for `paging_size_bytes`. Unlike
-    /// `scanned_rows_per_range`, this counter is never drained; it is only
-    /// ever peeked via `peek_scanned_bytes_sum`.
-    scanned_bytes: usize,
-
     // The following fields are only used for calculating scanned range. Scanned range is only
     // useful in streaming mode, where the client need to know the underlying physical data range
     // of each response slice, so that partial retry can be non-overlapping.
@@ -103,7 +97,6 @@ impl<T: Storage, F: KvFormat> RangesScanner<T, F> {
             is_key_only,
             load_commit_ts,
             scanned_rows_per_range: Vec::with_capacity(ranges_len),
-            scanned_bytes: 0,
             is_scanned_range_aware,
             current_range: IntervalRange {
                 lower_inclusive: Vec::with_capacity(KEY_BUFFER_CAPACITY),
@@ -175,7 +168,6 @@ impl<T: Storage, F: KvFormat> RangesScanner<T, F> {
                 if let Some(r) = self.scanned_rows_per_range.last_mut() {
                     *r += 1;
                 }
-                self.scanned_bytes += row.key.len() + row.value.len();
                 self.rescheduler.check_reschedule(force_check).await;
                 let kv = F::make_kv_pair((row.key, row.value, row.commit_ts.map(|n| n.into())))
                     .map_err(|e| StorageError(anyhow::Error::from(e)))?;
@@ -206,11 +198,12 @@ impl<T: Storage, F: KvFormat> RangesScanner<T, F> {
         self.scanned_rows_per_range.iter().sum()
     }
 
-    /// Returns the total number of bytes (raw key + value lengths) scanned so
-    /// far, without modifying internal state. Used as the byte budget for
-    /// `paging_size_bytes`.
+    /// Returns the total number of bytes scanned so far, without modifying
+    /// internal state. Delegates to the underlying storage, which counts the
+    /// same bytes as the MVCC `processed_size` (encoded key + value). Used as
+    /// the byte budget for `paging_size_bytes`.
     pub fn peek_scanned_bytes_sum(&self) -> usize {
-        self.scanned_bytes
+        self.storage.scanned_bytes()
     }
 
     /// Returns scanned range since last call.

--- a/components/tidb_query_common/src/storage/scanner.rs
+++ b/components/tidb_query_common/src/storage/scanner.rs
@@ -28,6 +28,12 @@ pub struct RangesScanner<T, F> {
 
     scanned_rows_per_range: Vec<usize>,
 
+    /// Cumulative count of raw bytes (key + value lengths) scanned across all
+    /// ranges. Used as the byte budget for `paging_size_bytes`. Unlike
+    /// `scanned_rows_per_range`, this counter is never drained; it is only
+    /// ever peeked via `peek_scanned_bytes_sum`.
+    scanned_bytes: usize,
+
     // The following fields are only used for calculating scanned range. Scanned range is only
     // useful in streaming mode, where the client need to know the underlying physical data range
     // of each response slice, so that partial retry can be non-overlapping.
@@ -97,6 +103,7 @@ impl<T: Storage, F: KvFormat> RangesScanner<T, F> {
             is_key_only,
             load_commit_ts,
             scanned_rows_per_range: Vec::with_capacity(ranges_len),
+            scanned_bytes: 0,
             is_scanned_range_aware,
             current_range: IntervalRange {
                 lower_inclusive: Vec::with_capacity(KEY_BUFFER_CAPACITY),
@@ -168,6 +175,7 @@ impl<T: Storage, F: KvFormat> RangesScanner<T, F> {
                 if let Some(r) = self.scanned_rows_per_range.last_mut() {
                     *r += 1;
                 }
+                self.scanned_bytes += row.key.len() + row.value.len();
                 self.rescheduler.check_reschedule(force_check).await;
                 let kv = F::make_kv_pair((row.key, row.value, row.commit_ts.map(|n| n.into())))
                     .map_err(|e| StorageError(anyhow::Error::from(e)))?;
@@ -196,6 +204,13 @@ impl<T: Storage, F: KvFormat> RangesScanner<T, F> {
     /// without clearing the internal state.
     pub fn peek_scanned_rows_sum(&self) -> usize {
         self.scanned_rows_per_range.iter().sum()
+    }
+
+    /// Returns the total number of bytes (raw key + value lengths) scanned so
+    /// far, without modifying internal state. Used as the byte budget for
+    /// `paging_size_bytes`.
+    pub fn peek_scanned_bytes_sum(&self) -> usize {
+        self.scanned_bytes
     }
 
     /// Returns scanned range since last call.
@@ -494,6 +509,40 @@ mod tests {
         scanner.collect_scanned_rows_per_range(&mut scanned_rows_per_range);
         assert_eq!(scanned_rows_per_range, vec![0]);
         scanned_rows_per_range.clear();
+    }
+
+    #[test]
+    fn test_scanned_bytes() {
+        let storage = create_storage();
+
+        // [foo, foo_3a) yields foo->1, foo_2->3, foo_3->5.
+        let ranges: Vec<Range> = vec![IntervalRange::from(("foo", "foo_3a")).into()];
+        let mut scanner = RangesScanner::<_, ApiV1>::new(RangesScannerOptions {
+            storage,
+            ranges,
+            scan_backward_in_range: false,
+            is_key_only: false,
+            is_scanned_range_aware: false,
+            load_commit_ts: false,
+        });
+
+        assert_eq!(scanner.peek_scanned_bytes_sum(), 0);
+
+        // "foo" (3) + "1" (1) = 4.
+        assert_eq!(&block_on(scanner.next()).unwrap().unwrap().key(), b"foo");
+        assert_eq!(scanner.peek_scanned_bytes_sum(), 4);
+
+        // "foo_2" (5) + "3" (1) = 6, cumulative 10.
+        assert_eq!(&block_on(scanner.next()).unwrap().unwrap().key(), b"foo_2");
+        assert_eq!(scanner.peek_scanned_bytes_sum(), 10);
+
+        // "foo_3" (5) + "5" (1) = 6, cumulative 16.
+        assert_eq!(&block_on(scanner.next()).unwrap().unwrap().key(), b"foo_3");
+        assert_eq!(scanner.peek_scanned_bytes_sum(), 16);
+
+        // Draining does not change the (non-destructive) peeked total.
+        assert_eq!(block_on(scanner.next()).unwrap(), None);
+        assert_eq!(scanner.peek_scanned_bytes_sum(), 16);
     }
 
     #[test]

--- a/components/tidb_query_common/src/storage/scanner.rs
+++ b/components/tidb_query_common/src/storage/scanner.rs
@@ -198,10 +198,9 @@ impl<T: Storage, F: KvFormat> RangesScanner<T, F> {
         self.scanned_rows_per_range.iter().sum()
     }
 
-    /// Returns the total number of bytes scanned so far, without modifying
-    /// internal state. Delegates to the underlying storage, which counts the
-    /// same bytes as the MVCC `processed_size` (encoded key + value). Used as
-    /// the byte budget for `paging_size_bytes`.
+    /// Returns the total number of bytes scanned so far (key plus value of
+    /// every returned entry), without modifying internal state. Delegates to
+    /// the underlying storage; see `Storage::scanned_bytes`.
     pub fn peek_scanned_bytes_sum(&self) -> usize {
         self.storage.scanned_bytes()
     }

--- a/components/tidb_query_common/src/storage/test_fixture.rs
+++ b/components/tidb_query_common/src/storage/test_fixture.rs
@@ -19,6 +19,7 @@ pub struct FixtureStorage {
     data_view_unsafe: Option<btree_map::Range<'static, Vec<u8>, FixtureValue>>,
     is_backward_scan: bool,
     is_key_only: bool,
+    scanned_bytes: usize,
 }
 
 impl FixtureStorage {
@@ -28,6 +29,7 @@ impl FixtureStorage {
             data_view_unsafe: None,
             is_backward_scan: false,
             is_key_only: false,
+            scanned_bytes: 0,
         }
     }
 }
@@ -85,12 +87,14 @@ impl super::Storage for FixtureStorage {
             None => Ok(None),
             Some((k, Ok(v))) => {
                 if !self.is_key_only {
+                    self.scanned_bytes += k.len() + v.len();
                     Ok(Some(OwnedKvPairEntry {
                         key: k.clone(),
                         value: v.clone(),
                         commit_ts: None,
                     }))
                 } else {
+                    self.scanned_bytes += k.len();
                     Ok(Some(OwnedKvPairEntry {
                         key: k.clone(),
                         value: Vec::new(),
@@ -113,12 +117,14 @@ impl super::Storage for FixtureStorage {
             None => Ok(None),
             Some(Ok(v)) => {
                 if !is_key_only {
+                    self.scanned_bytes += range.0.len() + v.len();
                     Ok(Some(OwnedKvPairEntry {
                         key: range.0,
                         value: v.clone(),
                         commit_ts: None,
                     }))
                 } else {
+                    self.scanned_bytes += range.0.len();
                     Ok(Some(OwnedKvPairEntry {
                         key: range.0,
                         value: Vec::new(),
@@ -134,6 +140,10 @@ impl super::Storage for FixtureStorage {
 
     fn met_uncacheable_data(&self) -> Option<bool> {
         None
+    }
+
+    fn scanned_bytes(&self) -> usize {
+        self.scanned_bytes
     }
 }
 

--- a/components/tidb_query_datatype/src/expr/ctx.rs
+++ b/components/tidb_query_datatype/src/expr/ctx.rs
@@ -73,7 +73,6 @@ pub struct EvalConfig {
 
     pub paging_size: Option<u64>,
     pub max_keys_read: Option<u64>,
-    pub paging_size_bytes: Option<u64>,
     pub div_precision_increment: u8,
     pub is_test: bool,
 }
@@ -116,7 +115,6 @@ impl EvalConfig {
             sql_mode: SqlMode::empty(),
             paging_size: None,
             max_keys_read: None,
-            paging_size_bytes: None,
             div_precision_increment: DEFAULT_DIV_FRAC_INCR,
             is_test: false,
         }

--- a/components/tidb_query_datatype/src/expr/ctx.rs
+++ b/components/tidb_query_datatype/src/expr/ctx.rs
@@ -73,6 +73,7 @@ pub struct EvalConfig {
 
     pub paging_size: Option<u64>,
     pub max_keys_read: Option<u64>,
+    pub paging_size_bytes: Option<u64>,
     pub div_precision_increment: u8,
     pub is_test: bool,
 }
@@ -115,6 +116,7 @@ impl EvalConfig {
             sql_mode: SqlMode::empty(),
             paging_size: None,
             max_keys_read: None,
+            paging_size_bytes: None,
             div_precision_increment: DEFAULT_DIV_FRAC_INCR,
             is_test: false,
         }

--- a/components/tidb_query_executors/src/fast_hash_aggr_executor.rs
+++ b/components/tidb_query_executors/src/fast_hash_aggr_executor.rs
@@ -78,6 +78,11 @@ impl<Src: BatchExecutor> BatchExecutor for BatchFastHashAggregationExecutor<Src>
     }
 
     #[inline]
+    fn peek_scanned_bytes_sum(&self) -> usize {
+        self.0.peek_scanned_bytes_sum()
+    }
+
+    #[inline]
     fn collect_storage_stats(&mut self, dest: &mut Self::StorageStats) {
         self.0.collect_storage_stats(dest);
     }

--- a/components/tidb_query_executors/src/index_lookup_executor.rs
+++ b/components/tidb_query_executors/src/index_lookup_executor.rs
@@ -221,11 +221,15 @@ where
     ) -> Self {
         let force_no_index_lookup = if config.paging_size.is_some()
             || config.max_keys_read.is_some()
+            || config.paging_size_bytes.is_some()
             || table_task_iter_builder.is_none()
         {
-            // We did not support index lookup when paging or max_keys_read is
-            // enabled due to buffering challenges.
-            // TODO: support paging and max_keys_read
+            // We did not support index lookup when paging, max_keys_read or
+            // paging_size_bytes is enabled due to buffering challenges: the
+            // buffered index-then-table-fetch pipeline only counts the index
+            // side, so the row/byte budgets would under-report the table-lookup
+            // scanning.
+            // TODO: support paging, max_keys_read and paging_size_bytes
             // some times we do not have table_task_iter_builder, such as
             // - CommonHandle
             // TODO: support CommonHandle
@@ -2338,6 +2342,19 @@ pub mod tests {
         // the response range and rows consistent on early stop.
         let mut cfg = EvalConfig::default_for_test();
         cfg.max_keys_read = Some(64);
+        let index_lookup = new_index_lookup_executor_for_test(
+            cfg,
+            build_int_array_results(vec![vec![1]]),
+            Some(MockTableTaskIterBuilder),
+            columns.clone(),
+        );
+        assert!(index_lookup.force_no_index_lookup);
+
+        // paging_size_bytes likewise disables index lookup: the byte budget is
+        // peeked from the index side only, so the buffered table fetch would be
+        // uncounted.
+        let mut cfg = EvalConfig::default_for_test();
+        cfg.paging_size_bytes = Some(4096);
         let index_lookup = new_index_lookup_executor_for_test(
             cfg,
             build_int_array_results(vec![vec![1]]),

--- a/components/tidb_query_executors/src/index_lookup_executor.rs
+++ b/components/tidb_query_executors/src/index_lookup_executor.rs
@@ -223,14 +223,11 @@ where
             || config.max_keys_read.is_some()
             || table_task_iter_builder.is_none()
         {
-            // We did not support index lookup when paging or max_keys_read is
-            // enabled due to buffering challenges: the buffered
-            // index-then-table-fetch pipeline only counts the index side, so
-            // the row budgets would under-report the table-lookup scanning.
-            // There is no paging_size_bytes condition here: the runner's
-            // range-resumable gating (can_resume_by_scanned_range_only) drops
-            // the byte budget for any plan containing IndexLookUp, so it can
-            // never reach this builder.
+            // No index lookup under paging or max_keys_read: the buffered
+            // index-then-table-fetch pipeline only counts the index side, so the
+            // row budgets would under-report the table lookup. paging_size_bytes
+            // needs no condition here — the runner already gates it off
+            // (can_resume_by_scanned_range_only) for any plan with IndexLookUp.
             // TODO: support paging and max_keys_read
             // some times we do not have table_task_iter_builder, such as
             // - CommonHandle

--- a/components/tidb_query_executors/src/index_lookup_executor.rs
+++ b/components/tidb_query_executors/src/index_lookup_executor.rs
@@ -558,6 +558,11 @@ where
     }
 
     #[inline]
+    fn peek_scanned_bytes_sum(&self) -> usize {
+        self.src.peek_scanned_bytes_sum()
+    }
+
+    #[inline]
     fn collect_storage_stats(&mut self, dest: &mut Self::StorageStats) {
         // TODO: support collecting storage stats for index lookup executors.
         self.src.collect_storage_stats(dest)

--- a/components/tidb_query_executors/src/index_lookup_executor.rs
+++ b/components/tidb_query_executors/src/index_lookup_executor.rs
@@ -562,6 +562,10 @@ where
 
     #[inline]
     fn peek_scanned_bytes_sum(&self) -> usize {
+        // Only the index-scan side (src); table-lookup bytes are not counted, so
+        // this undercounts for IndexLookUp. Safe only because byte-budget paging
+        // is gated off for any IndexLookUp plan (can_resume_by_scanned_range_only)
+        // and never reaches here — revisit before enabling the byte budget.
         self.src.peek_scanned_bytes_sum()
     }
 

--- a/components/tidb_query_executors/src/index_lookup_executor.rs
+++ b/components/tidb_query_executors/src/index_lookup_executor.rs
@@ -221,15 +221,17 @@ where
     ) -> Self {
         let force_no_index_lookup = if config.paging_size.is_some()
             || config.max_keys_read.is_some()
-            || config.paging_size_bytes.is_some()
             || table_task_iter_builder.is_none()
         {
-            // We did not support index lookup when paging, max_keys_read or
-            // paging_size_bytes is enabled due to buffering challenges: the
-            // buffered index-then-table-fetch pipeline only counts the index
-            // side, so the row/byte budgets would under-report the table-lookup
-            // scanning.
-            // TODO: support paging, max_keys_read and paging_size_bytes
+            // We did not support index lookup when paging or max_keys_read is
+            // enabled due to buffering challenges: the buffered
+            // index-then-table-fetch pipeline only counts the index side, so
+            // the row budgets would under-report the table-lookup scanning.
+            // There is no paging_size_bytes condition here: the runner's
+            // range-resumable gating (can_resume_by_scanned_range_only) drops
+            // the byte budget for any plan containing IndexLookUp, so it can
+            // never reach this builder.
+            // TODO: support paging and max_keys_read
             // some times we do not have table_task_iter_builder, such as
             // - CommonHandle
             // TODO: support CommonHandle
@@ -2342,19 +2344,6 @@ pub mod tests {
         // the response range and rows consistent on early stop.
         let mut cfg = EvalConfig::default_for_test();
         cfg.max_keys_read = Some(64);
-        let index_lookup = new_index_lookup_executor_for_test(
-            cfg,
-            build_int_array_results(vec![vec![1]]),
-            Some(MockTableTaskIterBuilder),
-            columns.clone(),
-        );
-        assert!(index_lookup.force_no_index_lookup);
-
-        // paging_size_bytes likewise disables index lookup: the byte budget is
-        // peeked from the index side only, so the buffered table fetch would be
-        // uncounted.
-        let mut cfg = EvalConfig::default_for_test();
-        cfg.paging_size_bytes = Some(4096);
         let index_lookup = new_index_lookup_executor_for_test(
             cfg,
             build_int_array_results(vec![vec![1]]),

--- a/components/tidb_query_executors/src/index_scan_executor.rs
+++ b/components/tidb_query_executors/src/index_scan_executor.rs
@@ -201,6 +201,11 @@ impl<S: Storage, F: KvFormat> BatchExecutor for BatchIndexScanExecutor<S, F> {
     }
 
     #[inline]
+    fn peek_scanned_bytes_sum(&self) -> usize {
+        self.0.peek_scanned_bytes_sum()
+    }
+
+    #[inline]
     fn collect_storage_stats(&mut self, dest: &mut Self::StorageStats) {
         self.0.collect_storage_stats(dest);
     }

--- a/components/tidb_query_executors/src/interface.rs
+++ b/components/tidb_query_executors/src/interface.rs
@@ -72,6 +72,11 @@ pub trait BatchExecutor: Send {
     /// state.
     fn peek_scanned_rows_sum(&self) -> usize;
 
+    /// Returns the total number of bytes scanned (sum of raw key and value
+    /// lengths), without modifying internal state. Used as the byte budget for
+    /// `paging_size_bytes`.
+    fn peek_scanned_bytes_sum(&self) -> usize;
+
     /// Collects underlying storage statistics accumulated during execution and
     /// prepares for next collection.
     ///
@@ -133,6 +138,10 @@ impl<T: BatchExecutor + ?Sized> BatchExecutor for Box<T> {
         (**self).peek_scanned_rows_sum()
     }
 
+    fn peek_scanned_bytes_sum(&self) -> usize {
+        (**self).peek_scanned_bytes_sum()
+    }
+
     fn collect_storage_stats(&mut self, dest: &mut Self::StorageStats) {
         (**self).collect_storage_stats(dest);
     }
@@ -185,6 +194,10 @@ impl<C: ExecSummaryCollector + Send, T: BatchExecutor> BatchExecutor
 
     fn peek_scanned_rows_sum(&self) -> usize {
         self.inner.peek_scanned_rows_sum()
+    }
+
+    fn peek_scanned_bytes_sum(&self) -> usize {
+        self.inner.peek_scanned_bytes_sum()
     }
 
     fn collect_storage_stats(&mut self, dest: &mut Self::StorageStats) {

--- a/components/tidb_query_executors/src/interface.rs
+++ b/components/tidb_query_executors/src/interface.rs
@@ -72,9 +72,9 @@ pub trait BatchExecutor: Send {
     /// state.
     fn peek_scanned_rows_sum(&self) -> usize;
 
-    /// Returns the total number of bytes scanned (sum of raw key and value
-    /// lengths), without modifying internal state. Used as the byte budget for
-    /// `paging_size_bytes`.
+    /// Returns the total number of bytes scanned (sum of encoded/mem-comparable
+    /// key and value lengths), without modifying internal state. Used as the
+    /// byte budget for `paging_size_bytes`.
     fn peek_scanned_bytes_sum(&self) -> usize;
 
     /// Collects underlying storage statistics accumulated during execution and

--- a/components/tidb_query_executors/src/interface.rs
+++ b/components/tidb_query_executors/src/interface.rs
@@ -72,9 +72,8 @@ pub trait BatchExecutor: Send {
     /// state.
     fn peek_scanned_rows_sum(&self) -> usize;
 
-    /// Returns the total number of bytes scanned (sum of encoded/mem-comparable
-    /// key and value lengths), without modifying internal state. Used as the
-    /// byte budget for `paging_size_bytes`.
+    /// Returns the total number of bytes scanned (key and value lengths of
+    /// every returned entry), without modifying internal state.
     fn peek_scanned_bytes_sum(&self) -> usize;
 
     /// Collects underlying storage statistics accumulated during execution and

--- a/components/tidb_query_executors/src/limit_executor.rs
+++ b/components/tidb_query_executors/src/limit_executor.rs
@@ -426,6 +426,11 @@ impl<Src: BatchExecutor> BatchExecutor for BatchLimitExecutor<Src> {
     }
 
     #[inline]
+    fn peek_scanned_bytes_sum(&self) -> usize {
+        self.src.peek_scanned_bytes_sum()
+    }
+
+    #[inline]
     fn collect_storage_stats(&mut self, dest: &mut Self::StorageStats) {
         self.src.collect_storage_stats(dest);
     }

--- a/components/tidb_query_executors/src/partition_top_n_executor.rs
+++ b/components/tidb_query_executors/src/partition_top_n_executor.rs
@@ -382,6 +382,11 @@ impl<Src: BatchExecutor> BatchExecutor for BatchPartitionTopNExecutor<Src> {
     }
 
     #[inline]
+    fn peek_scanned_bytes_sum(&self) -> usize {
+        self.src.peek_scanned_bytes_sum()
+    }
+
+    #[inline]
     fn collect_storage_stats(&mut self, dest: &mut Self::StorageStats) {
         self.src.collect_storage_stats(dest);
     }

--- a/components/tidb_query_executors/src/projection_executor.rs
+++ b/components/tidb_query_executors/src/projection_executor.rs
@@ -261,6 +261,11 @@ impl<Src: BatchExecutor> BatchExecutor for BatchProjectionExecutor<Src> {
     }
 
     #[inline]
+    fn peek_scanned_bytes_sum(&self) -> usize {
+        self.src.peek_scanned_bytes_sum()
+    }
+
+    #[inline]
     fn collect_storage_stats(&mut self, dest: &mut Self::StorageStats) {
         self.src.collect_storage_stats(dest);
     }

--- a/components/tidb_query_executors/src/runner.rs
+++ b/components/tidb_query_executors/src/runner.rs
@@ -1549,8 +1549,18 @@ mod tests {
         }
     }
 
+    /// `from_request` applies the range-only-resume gating to
+    /// `paging_size_bytes`: a plan containing a non-resumable executor
+    /// silently drops the byte budget (its runtime behavior is then the
+    /// "disabled" case of `test_paging_size_bytes_stop_conditions`), while a
+    /// range-resumable plan keeps it and gets a fully wired executor tree —
+    /// scanned-range tracking enabled (`take_scanned_range` would panic
+    /// otherwise) and the byte/row peeks flowing through the real
+    /// Projection -> Selection -> TableScan -> RangesScanner -> Storage
+    /// chain.
     #[test]
-    fn test_paging_size_bytes_disabled_for_non_range_resumable_plan() {
+    fn test_paging_size_bytes_gating_in_from_request() {
+        // A non-resumable executor (Limit) drops the byte budget.
         let mut dag = DagRequest::default();
         dag.set_executors(
             vec![
@@ -1561,53 +1571,49 @@ mod tests {
         );
         dag.set_output_offsets(vec![0]);
         dag.set_encode_type(EncodeType::TypeChunk);
-
-        let mut runner = build_runner_for_test_with_paging_size_bytes(dag, Some(1500)).unwrap();
+        let runner = build_runner_for_test_with_paging_size_bytes(dag, Some(1500)).unwrap();
         assert_eq!(runner.paging_size_bytes, None);
 
-        let mut mock_executor = MockExecutor::new(
-            vec![FieldTypeTp::Long.into()],
-            vec![
-                build_n_rows_int_result(0, 1),
-                build_n_rows_int_result(10, 1),
-                {
-                    let mut result = build_n_rows_int_result(100, 1);
-                    result.is_drained = Ok(BatchExecIsDrain::Drain);
-                    result
-                },
-            ],
-        );
-        mock_executor.set_scanned_bytes_per_batch(vec![1000, 1000, 1000]);
-        mock_executor.scanned_range = Some((b"a".to_vec(), b"z".to_vec()).into());
-        runner.out_most_executor = Box::new(mock_executor);
-
-        let (resp, range) = block_on(runner.handle_request()).unwrap();
-        assert_eq!(
-            3,
-            resp.get_chunks().len(),
-            "unsafe plans must not stop early by paging_size_bytes"
-        );
-        assert!(
-            range.is_none(),
-            "unsafe plans must drain normally instead of returning a byte-budget range"
-        );
-    }
-
-    #[test]
-    fn test_paging_size_bytes_kept_for_range_resumable_plan() {
+        // A range-resumable plan keeps the budget and is built ready to
+        // resume by scanned range.
         let mut dag = DagRequest::default();
         dag.set_executors(
-            vec![table_scan_descriptor(
-                1,
-                vec![column_with_type(1, FieldTypeTp::Long)],
-            )]
+            vec![
+                table_scan_descriptor(1, vec![column_with_type(1, FieldTypeTp::Long)]),
+                selection_descriptor(vec![
+                    ExprDefBuilder::column_ref(0, FieldTypeTp::Long).build(),
+                ]),
+                projection_descriptor(vec![
+                    ExprDefBuilder::column_ref(0, FieldTypeTp::Long).build(),
+                ]),
+            ]
             .into(),
         );
         dag.set_output_offsets(vec![0]);
         dag.set_encode_type(EncodeType::TypeChunk);
 
-        let runner = build_runner_for_test_with_paging_size_bytes(dag, Some(1500)).unwrap();
+        let data: &[(&'static [u8], &'static [u8])] = &[];
+        let mut runner = BatchExecutorsRunner::from_request::<_, ApiV1>(
+            dag,
+            vec![],
+            tidb_query_common::storage::test_fixture::FixtureStorage::from(data),
+            tidb_query_common::storage::StubAccessor::none(),
+            Deadline::from_now(Duration::from_secs(300)),
+            1024,
+            false,
+            None,
+            None,
+            Some(1500),
+            Arc::new(QuotaLimiter::default()),
+        )
+        .unwrap();
         assert_eq!(runner.paging_size_bytes, Some(1500));
+        // Peeks flow through the real executor chain; nothing scanned yet.
+        assert_eq!(runner.out_most_executor.peek_scanned_bytes_sum(), 0);
+        assert_eq!(runner.out_most_executor.peek_scanned_rows_sum(), 0);
+        // Must not panic: range tracking has to be enabled when only the
+        // byte budget is set.
+        let _ = runner.out_most_executor.take_scanned_range();
     }
 
     fn build_simple_result_for_test(cols: Vec<VectorValue>) -> BatchExecuteResult {
@@ -2725,204 +2731,82 @@ mod tests {
 
     // --- Tests for paging_size_bytes ---
 
-    /// paging_size_bytes stops the scan early once the cumulative scanned bytes
-    /// (peeked via `peek_scanned_bytes_sum`) reach the budget, mirroring
-    /// `max_keys_read` but on a byte budget instead of a row budget.
+    /// One matrix over the budget stop conditions of the `handle_request`
+    /// loop: which budget (row, byte, or none) stops the scan first, and
+    /// whether a resumable range is returned. The budgets are independent —
+    /// whichever threshold is reached first wins.
     #[test]
-    fn test_paging_size_bytes_stops_early() {
-        let field_types = vec![FieldTypeTp::Long.into()];
+    fn test_paging_size_bytes_stop_conditions() {
+        fn run_case(
+            paging_size: Option<u64>,
+            paging_size_bytes: Option<u64>,
+            bytes_per_batch: Vec<usize>,
+            expected_chunks: usize,
+            expect_range: bool,
+            case: &str,
+        ) {
+            let mut runner = build_simple_runner_for_test();
+            runner.paging_size = paging_size;
+            runner.paging_size_bytes = paging_size_bytes;
+            let mut mock_executor = MockExecutor::new(
+                vec![FieldTypeTp::Long.into()],
+                vec![
+                    build_n_rows_int_result(0, 1),
+                    build_n_rows_int_result(10, 1),
+                    {
+                        let mut result = build_n_rows_int_result(100, 1);
+                        result.is_drained = Ok(BatchExecIsDrain::Drain);
+                        result
+                    },
+                ],
+            );
+            mock_executor.set_scanned_bytes_per_batch(bytes_per_batch);
+            mock_executor.scanned_range = Some((b"a".to_vec(), b"z".to_vec()).into());
+            runner.out_most_executor = Box::new(mock_executor);
 
-        let mut runner = build_simple_runner_for_test();
-        runner.paging_size_bytes = Some(1500);
+            let (resp, range) = block_on(runner.handle_request()).unwrap();
+            assert_eq!(expected_chunks, resp.get_chunks().len(), "{}", case);
+            assert_eq!(expect_range, range.is_some(), "{}", case);
+        }
 
-        let mut mock_executor = MockExecutor::new(
-            field_types,
-            vec![
-                build_n_rows_int_result(0, 1),
-                build_n_rows_int_result(10, 1),
-                // Third batch should NOT be reached.
-                build_n_rows_int_result(100, 1),
-            ],
-        );
-        // 1000 bytes per batch: cumulative 1000, then 2000 (>= 1500 -> stop).
-        mock_executor.set_scanned_bytes_per_batch(vec![1000, 1000, 1000]);
-        mock_executor.scanned_range = Some((b"a".to_vec(), b"z".to_vec()).into());
-        runner.out_most_executor = Box::new(mock_executor);
-
-        let (resp, range) = block_on(runner.handle_request()).unwrap();
-        assert_eq!(
-            2,
-            resp.get_chunks().len(),
-            "Expected 2 chunks before the byte budget was hit"
-        );
-        assert!(
-            range.is_some(),
-            "Expected scanned range when stopped by paging_size_bytes"
-        );
-    }
-
-    /// When the executor drains before the byte budget is reached, all rows are
-    /// returned and the range is None (fully drained, not an early stop).
-    #[test]
-    fn test_paging_size_bytes_natural_drain_before_limit() {
-        let field_types = vec![FieldTypeTp::Long.into()];
-
-        let mut runner = build_simple_runner_for_test();
-        // Budget far higher than the total scanned bytes (300).
-        runner.paging_size_bytes = Some(100_000);
-
-        let mut mock_executor = MockExecutor::new(
-            field_types,
-            vec![
-                build_n_rows_int_result(0, 1),
-                build_n_rows_int_result(10, 2),
-                {
-                    let mut result = build_n_rows_int_result(100, 1);
-                    result.is_drained = Ok(BatchExecIsDrain::Drain);
-                    result
-                },
-            ],
-        );
-        mock_executor.set_scanned_bytes_per_batch(vec![100, 100, 100]);
-        runner.out_most_executor = Box::new(mock_executor);
-
-        let (resp, range) = block_on(runner.handle_request()).unwrap();
-        assert_eq!(
-            3,
-            resp.get_chunks().len(),
-            "All batches should be returned when the budget is not hit"
-        );
-        assert!(
-            range.is_none(),
-            "Range should be None when the executor drained before the budget"
-        );
-    }
-
-    /// paging_size_bytes = None must not limit scanning at all.
-    #[test]
-    fn test_paging_size_bytes_disabled() {
-        let field_types = vec![FieldTypeTp::Long.into()];
-
-        let mut runner = build_simple_runner_for_test();
-        runner.paging_size_bytes = None;
-
-        let mut mock_executor = MockExecutor::new(
-            field_types,
-            vec![build_n_rows_int_result(0, 3), {
-                let mut result = build_n_rows_int_result(10, 2);
-                result.is_drained = Ok(BatchExecIsDrain::Drain);
-                result
-            }],
-        );
-        // Even with large per-batch bytes, a disabled budget never stops early.
-        mock_executor.set_scanned_bytes_per_batch(vec![10_000, 10_000]);
-        runner.out_most_executor = Box::new(mock_executor);
-
-        let (resp, range) = block_on(runner.handle_request()).unwrap();
-        assert_eq!(
-            2,
-            resp.get_chunks().len(),
-            "All batches should be returned when paging_size_bytes is disabled"
-        );
-        assert!(range.is_none(), "Range should be None when fully drained");
-    }
-
-    /// When only the byte budget is set, the executor tree must still be
-    /// built scanned-range aware (otherwise `take_scanned_range` would panic
-    /// on the first byte-budget stop), and the byte peek must flow through
-    /// the real executor chain down to the storage.
-    #[test]
-    fn test_paging_size_bytes_enables_scanned_range_tracking() {
-        let mut dag = DagRequest::default();
-        dag.set_executors(
-            vec![
-                table_scan_descriptor(1, vec![column_with_type(1, FieldTypeTp::Long)]),
-                selection_descriptor(vec![
-                    ExprDefBuilder::column_ref(0, FieldTypeTp::Long).build(),
-                ]),
-                projection_descriptor(vec![
-                    ExprDefBuilder::column_ref(0, FieldTypeTp::Long).build(),
-                ]),
-            ]
-            .into(),
-        );
-        dag.set_output_offsets(vec![0]);
-        dag.set_encode_type(EncodeType::TypeChunk);
-
-        let data: &[(&'static [u8], &'static [u8])] = &[];
-        let mut runner = BatchExecutorsRunner::from_request::<_, ApiV1>(
-            dag,
-            vec![],
-            tidb_query_common::storage::test_fixture::FixtureStorage::from(data),
-            tidb_query_common::storage::StubAccessor::none(),
-            Deadline::from_now(Duration::from_secs(300)),
-            1024,
-            false,
-            None,
-            None,
+        // Both budgets set: 1000 + 1000 bytes >= 1500 stops the second batch
+        // while only 2 of the 100 budgeted rows are returned.
+        run_case(
+            Some(100),
             Some(1500),
-            Arc::new(QuotaLimiter::default()),
-        )
-        .unwrap();
-        assert_eq!(runner.paging_size_bytes, Some(1500));
-
-        // Peeks flow through the real Projection -> Selection -> TableScan ->
-        // RangesScanner -> Storage chain; nothing is scanned yet.
-        assert_eq!(runner.out_most_executor.peek_scanned_bytes_sum(), 0);
-        assert_eq!(runner.out_most_executor.peek_scanned_rows_sum(), 0);
-        // Must not panic: build_executors has to enable range tracking when
-        // only paging_size_bytes is set.
-        let _ = runner.out_most_executor.take_scanned_range();
-    }
-
-    /// paging_size and paging_size_bytes are independent budgets: whichever
-    /// threshold is reached first stops the scan.
-    #[test]
-    fn test_paging_size_bytes_with_row_paging_whichever_first() {
-        // Byte budget trips before the row budget.
-        let mut runner = build_simple_runner_for_test();
-        runner.paging_size = Some(100);
-        runner.paging_size_bytes = Some(1500);
-        let mut mock_executor = MockExecutor::new(
-            vec![FieldTypeTp::Long.into()],
-            vec![
-                build_n_rows_int_result(0, 1),
-                build_n_rows_int_result(10, 1),
-                build_n_rows_int_result(100, 1),
-            ],
-        );
-        mock_executor.set_scanned_bytes_per_batch(vec![1000, 1000, 1000]);
-        mock_executor.scanned_range = Some((b"a".to_vec(), b"z".to_vec()).into());
-        runner.out_most_executor = Box::new(mock_executor);
-        let (resp, range) = block_on(runner.handle_request()).unwrap();
-        assert_eq!(
+            vec![1000, 1000, 1000],
             2,
-            resp.get_chunks().len(),
-            "the byte budget should stop the scan first"
+            true,
+            "the byte budget should stop the scan first",
         );
-        assert!(range.is_some());
-
-        // Row budget trips before the byte budget.
-        let mut runner = build_simple_runner_for_test();
-        runner.paging_size = Some(1);
-        runner.paging_size_bytes = Some(1_000_000);
-        let mut mock_executor = MockExecutor::new(
-            vec![FieldTypeTp::Long.into()],
-            vec![
-                build_n_rows_int_result(0, 1),
-                build_n_rows_int_result(10, 1),
-                build_n_rows_int_result(100, 1),
-            ],
-        );
-        mock_executor.set_scanned_bytes_per_batch(vec![100, 100, 100]);
-        mock_executor.scanned_range = Some((b"a".to_vec(), b"z".to_vec()).into());
-        runner.out_most_executor = Box::new(mock_executor);
-        let (resp, range) = block_on(runner.handle_request()).unwrap();
-        assert_eq!(
+        // Both budgets set: the first batch already returns 1 >= 1 rows while
+        // the byte budget is far away.
+        run_case(
+            Some(1),
+            Some(1_000_000),
+            vec![100, 100, 100],
             1,
-            resp.get_chunks().len(),
-            "the row budget should stop the scan first"
+            true,
+            "the row budget should stop the scan first",
         );
-        assert!(range.is_some());
+        // Byte budget present but not reached: natural drain returns no range.
+        run_case(
+            None,
+            Some(100_000),
+            vec![100, 100, 100],
+            3,
+            false,
+            "natural drain before the byte budget must not return a range",
+        );
+        // Byte budget disabled: large increments must not stop the scan.
+        run_case(
+            None,
+            None,
+            vec![10_000, 10_000, 10_000],
+            3,
+            false,
+            "a disabled byte budget must not limit scanning",
+        );
     }
+
 }

--- a/components/tidb_query_executors/src/runner.rs
+++ b/components/tidb_query_executors/src/runner.rs
@@ -710,6 +710,12 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
             // state could be lost when the next page rebuilds the executor
             // tree from only the returned range.
             //
+            // For IndexLookUp this deliberately differs from paging_size and
+            // max_keys_read, which keep their budgets and degrade the pushdown
+            // via force_no_index_lookup: the byte budget is dropped and the
+            // pushdown is kept, so IndexLookUp plans do not participate in
+            // paging_size_bytes at all.
+            //
             // Be conservative here: new executor types are unsafe until they
             // explicitly prove that range-only continuation preserves results.
             // A future executor-aware paging protocol may relax this by
@@ -727,7 +733,6 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
         let mut config = EvalConfig::from_request(&req)?;
         config.paging_size = paging_size;
         config.max_keys_read = max_keys_read;
-        config.paging_size_bytes = paging_size_bytes;
         let config = Arc::new(config);
         let intermediate_output_descriptors = req.take_intermediate_output_channels();
         let out_most_executor = build_executors::<_, F>(
@@ -1559,7 +1564,6 @@ mod tests {
 
         let mut runner = build_runner_for_test_with_paging_size_bytes(dag, Some(1500)).unwrap();
         assert_eq!(runner.paging_size_bytes, None);
-        assert_eq!(runner.config.paging_size_bytes, None);
 
         let mut mock_executor = MockExecutor::new(
             vec![FieldTypeTp::Long.into()],
@@ -1604,7 +1608,6 @@ mod tests {
 
         let runner = build_runner_for_test_with_paging_size_bytes(dag, Some(1500)).unwrap();
         assert_eq!(runner.paging_size_bytes, Some(1500));
-        assert_eq!(runner.config.paging_size_bytes, Some(1500));
     }
 
     fn build_simple_result_for_test(cols: Vec<VectorValue>) -> BatchExecuteResult {

--- a/components/tidb_query_executors/src/runner.rs
+++ b/components/tidb_query_executors/src/runner.rs
@@ -120,9 +120,11 @@ pub struct BatchExecutorsRunner<SS> {
     /// `coprocessor.Request.paging_size_bytes`.
     ///
     /// When set, the runner stops once the cumulative bytes scanned by the
-    /// bottom-most scan executor (raw key + value lengths, peeked via
-    /// `BatchExecutor::peek_scanned_bytes_sum`) reach this threshold. Like
-    /// `max_keys_read`, the byte count covers every physically scanned KV
+    /// bottom-most scan executor (peeked via
+    /// `BatchExecutor::peek_scanned_bytes_sum`) reach this threshold. The byte
+    /// count mirrors the MVCC `processed_size` (encoded key + value of every
+    /// returned entry), so the page boundary aligns with the bytes used for RU
+    /// accounting. Like `max_keys_read`, it covers every physically scanned KV
     /// entry before any filtering, aggregation, or projection, so a full scan
     /// that returns few rows is still truncated by the actual data volume read.
     /// It is independent of `paging_size` and `max_keys_read`; whichever
@@ -867,8 +869,8 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
                 scanned_keys_total = self.out_most_executor.peek_scanned_rows_sum() as u64;
             }
 
-            // Likewise peek the accumulated scanned bytes (raw key + value) for
-            // paging_size_bytes without draining any state.
+            // Likewise peek the accumulated scanned bytes (MVCC processed_size:
+            // encoded key + value) for paging_size_bytes without draining state.
             if self.paging_size_bytes.is_some() {
                 scanned_bytes_all = self.out_most_executor.peek_scanned_bytes_sum();
             }

--- a/components/tidb_query_executors/src/runner.rs
+++ b/components/tidb_query_executors/src/runner.rs
@@ -1273,7 +1273,10 @@ mod tests {
     use api_version::ApiV1;
     use futures::executor::block_on;
     use kvproto::metapb::Region;
-    use tidb_query_common::execute_stats::ExecSummaryCollectorEnabled;
+    use tidb_query_common::{
+        execute_stats::ExecSummaryCollectorEnabled,
+        storage::{StubAccessor, test_fixture::FixtureStorage},
+    };
     use tidb_query_datatype::{
         FieldTypeTp,
         codec::{
@@ -1549,17 +1552,14 @@ mod tests {
         }
     }
 
-    /// `from_request` applies the range-only-resume gating to
-    /// `paging_size_bytes`: a plan containing a non-resumable executor
-    /// silently drops the byte budget (its runtime behavior is then the
-    /// "disabled" case of `test_paging_size_bytes_stop_conditions`), while a
-    /// range-resumable plan keeps it and gets a fully wired executor tree —
-    /// scanned-range tracking enabled (`take_scanned_range` would panic
-    /// otherwise) and the byte/row peeks flowing through the real
-    /// Projection -> Selection -> TableScan -> RangesScanner -> Storage
-    /// chain.
     #[test]
     fn test_paging_size_bytes_gating_in_from_request() {
+        // from_request applies the range-only-resume gating to
+        // paging_size_bytes: a plan containing a non-resumable executor
+        // silently drops the byte budget (its runtime behavior is then the
+        // "disabled" case of test_paging_size_bytes_stop_conditions), while a
+        // range-resumable plan keeps it and gets a fully wired executor tree.
+
         // A non-resumable executor (Limit) drops the byte budget.
         let mut dag = DagRequest::default();
         dag.set_executors(
@@ -1574,8 +1574,10 @@ mod tests {
         let runner = build_runner_for_test_with_paging_size_bytes(dag, Some(1500)).unwrap();
         assert_eq!(runner.paging_size_bytes, None);
 
-        // A range-resumable plan keeps the budget and is built ready to
-        // resume by scanned range.
+        // A range-resumable plan keeps the budget; the tree must be built
+        // scanned-range aware (take_scanned_range would panic otherwise) and
+        // the byte/row peeks must flow through the real Projection ->
+        // Selection -> TableScan -> RangesScanner -> Storage chain.
         let mut dag = DagRequest::default();
         dag.set_executors(
             vec![
@@ -1596,8 +1598,8 @@ mod tests {
         let mut runner = BatchExecutorsRunner::from_request::<_, ApiV1>(
             dag,
             vec![],
-            tidb_query_common::storage::test_fixture::FixtureStorage::from(data),
-            tidb_query_common::storage::StubAccessor::none(),
+            FixtureStorage::from(data),
+            StubAccessor::none(),
             Deadline::from_now(Duration::from_secs(300)),
             1024,
             false,
@@ -2731,12 +2733,12 @@ mod tests {
 
     // --- Tests for paging_size_bytes ---
 
-    /// One matrix over the budget stop conditions of the `handle_request`
-    /// loop: which budget (row, byte, or none) stops the scan first, and
-    /// whether a resumable range is returned. The budgets are independent —
-    /// whichever threshold is reached first wins.
     #[test]
     fn test_paging_size_bytes_stop_conditions() {
+        // One matrix over the budget stop conditions of the handle_request
+        // loop: which budget (row, byte, or none) stops the scan first, and
+        // whether a resumable range is returned. The budgets are independent
+        // — whichever threshold is reached first wins.
         fn run_case(
             paging_size: Option<u64>,
             paging_size_bytes: Option<u64>,
@@ -2777,7 +2779,7 @@ mod tests {
             vec![1000, 1000, 1000],
             2,
             true,
-            "the byte budget should stop the scan first",
+            "The byte budget should stop the scan first",
         );
         // Both budgets set: the first batch already returns 1 >= 1 rows while
         // the byte budget is far away.
@@ -2787,7 +2789,7 @@ mod tests {
             vec![100, 100, 100],
             1,
             true,
-            "the row budget should stop the scan first",
+            "The row budget should stop the scan first",
         );
         // Byte budget present but not reached: natural drain returns no range.
         run_case(
@@ -2796,7 +2798,7 @@ mod tests {
             vec![100, 100, 100],
             3,
             false,
-            "natural drain before the byte budget must not return a range",
+            "Natural drain before the byte budget must not return a range",
         );
         // Byte budget disabled: large increments must not stop the scan.
         run_case(
@@ -2805,8 +2807,7 @@ mod tests {
             vec![10_000, 10_000, 10_000],
             3,
             false,
-            "a disabled byte budget must not limit scanning",
+            "A disabled byte budget must not limit scanning",
         );
     }
-
 }

--- a/components/tidb_query_executors/src/runner.rs
+++ b/components/tidb_query_executors/src/runner.rs
@@ -119,7 +119,7 @@ pub struct BatchExecutorsRunner<SS> {
     /// Byte-budget counterpart of `paging_size`, received from
     /// `coprocessor.Request.paging_size_bytes`.
     ///
-    /// When set, the runner stops once the cumulative bytes scanned by the
+    /// When accepted, the runner stops once the cumulative bytes scanned by the
     /// bottom-most scan executor (peeked via
     /// `BatchExecutor::peek_scanned_bytes_sum`) reach this threshold. The byte
     /// count mirrors the MVCC `processed_size` (encoded key + value of every
@@ -129,6 +129,12 @@ pub struct BatchExecutorsRunner<SS> {
     /// that returns few rows is still truncated by the actual data volume read.
     /// It is independent of `paging_size` and `max_keys_read`; whichever
     /// threshold is reached first stops the scan.
+    ///
+    /// This is enabled only for executor trees that can be resumed by scanned
+    /// range alone. Stateful/blocking executors such as aggregation or TopN can
+    /// consume rows into internal state before producing output; stopping
+    /// outside those executors would drop that state between pages and
+    /// corrupt results.
     paging_size_bytes: Option<u64>,
 
     quota_limiter: Arc<QuotaLimiter>,
@@ -286,6 +292,28 @@ fn is_executor_under_parent_tp<'a>(
         left_executors = &left_executors[parent_idx + 1..];
     }
     Ok(false)
+}
+
+/// Returns whether the executor tree can safely continue execution from only
+/// a scanned key range. Assumes the first descriptor in the DAG plan is the
+/// leaf scan executor (TableScan or IndexScan), which is the standard
+/// leaf-to-root ordering used by TiDB.
+fn can_resume_by_scanned_range_only(exec_descriptors: &[tipb::Executor]) -> bool {
+    let Some((scan, rest)) = exec_descriptors.split_first() else {
+        return false;
+    };
+    if !matches!(
+        scan.get_tp(),
+        ExecType::TypeTableScan | ExecType::TypeIndexScan
+    ) {
+        return false;
+    }
+    rest.iter().all(|ed| {
+        matches!(
+            ed.get_tp(),
+            ExecType::TypeSelection | ExecType::TypeProjection
+        )
+    })
 }
 
 #[allow(clippy::explicit_counter_loop)]
@@ -671,6 +699,31 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
     ) -> Result<Self> {
         let executors_len = req.get_executors().len();
         let collect_exec_summary = req.get_collect_execution_summaries();
+        let paging_size_bytes = if paging_size_bytes.is_some()
+            && !can_resume_by_scanned_range_only(req.get_executors())
+        {
+            // Coprocessor paging resumes with only a scanned key range. That
+            // is sufficient for scan plus stateless operators, but not for
+            // executors with cross-batch state (aggregation, StreamAgg, TopN,
+            // partition TopN, Limit, IndexLookUp, etc.). If byte-budget paging stopped
+            // outside such an executor, rows already consumed into in-memory
+            // state could be lost when the next page rebuilds the executor
+            // tree from only the returned range.
+            //
+            // Be conservative here: new executor types are unsafe until they
+            // explicitly prove that range-only continuation preserves results.
+            // A future executor-aware paging protocol may relax this by
+            // letting stateful executors flush or serialize their continuation
+            // state before a byte-budget boundary.
+            //
+            // TODO(@JmPotato): add a metric (and/or a log) when the byte budget
+            // is dropped here, so the caller can tell "task drained naturally"
+            // apart from "budget ignored by capability gating" when debugging
+            // RU pre-charging.
+            None
+        } else {
+            paging_size_bytes
+        };
         let mut config = EvalConfig::from_request(&req)?;
         config.paging_size = paging_size;
         config.max_keys_read = max_keys_read;
@@ -1379,6 +1432,20 @@ mod tests {
         exec
     }
 
+    fn aggregation_descriptor() -> Executor {
+        let mut exec = Executor::default();
+        exec.set_tp(ExecType::TypeAggregation);
+        exec.set_aggregation(Aggregation::default());
+        exec
+    }
+
+    fn top_n_descriptor() -> Executor {
+        let mut exec = Executor::default();
+        exec.set_tp(ExecType::TypeTopN);
+        exec.set_top_n(TopN::default());
+        exec
+    }
+
     fn column_with_type(col_id: i64, tp: FieldTypeTp) -> ColumnInfo {
         let mut col = ColumnInfo::default();
         col.set_column_id(col_id);
@@ -1399,6 +1466,13 @@ mod tests {
     }
 
     fn build_runner_for_test(req: DagRequest) -> Result<BatchExecutorsRunner<()>> {
+        build_runner_for_test_with_paging_size_bytes(req, None)
+    }
+
+    fn build_runner_for_test_with_paging_size_bytes(
+        req: DagRequest,
+        paging_size_bytes: Option<u64>,
+    ) -> Result<BatchExecutorsRunner<()>> {
         BatchExecutorsRunner::from_request::<_, ApiV1>(
             req,
             vec![],
@@ -1409,7 +1483,7 @@ mod tests {
             false,
             None,
             None,
-            None,
+            paging_size_bytes,
             Arc::new(QuotaLimiter::default()),
         )
     }
@@ -1426,6 +1500,111 @@ mod tests {
         dag.set_output_offsets(vec![0]);
         dag.set_encode_type(EncodeType::TypeChunk);
         build_runner_for_test(dag).unwrap()
+    }
+
+    #[test]
+    fn test_paging_size_bytes_range_only_resume_capability() {
+        let table_scan = table_scan_descriptor(1, vec![column_with_type(1, FieldTypeTp::Long)]);
+        let selection = selection_descriptor(vec![
+            ExprDefBuilder::column_ref(0, FieldTypeTp::Long).build(),
+        ]);
+        let projection = projection_descriptor(vec![
+            ExprDefBuilder::column_ref(0, FieldTypeTp::Long).build(),
+        ]);
+
+        assert!(can_resume_by_scanned_range_only(&[
+            table_scan.clone(),
+            selection,
+            projection
+        ]));
+        assert!(can_resume_by_scanned_range_only(&[index_scan_descriptor(
+            1,
+            2,
+            vec![column_with_type(1, FieldTypeTp::Long)]
+        ),]));
+        assert!(!can_resume_by_scanned_range_only(&[]));
+        assert!(!can_resume_by_scanned_range_only(&[selection_descriptor(
+            vec![ExprDefBuilder::column_ref(0, FieldTypeTp::Long).build()]
+        )]));
+        assert!(!can_resume_by_scanned_range_only(&[
+            table_scan.clone(),
+            index_scan_descriptor(1, 2, vec![column_with_type(1, FieldTypeTp::Long)]),
+        ]));
+
+        for unsafe_executor in [
+            limit_descriptor(1),
+            aggregation_descriptor(),
+            top_n_descriptor(),
+            index_lookup_descriptor(vec![]),
+        ] {
+            assert!(!can_resume_by_scanned_range_only(&[
+                table_scan.clone(),
+                unsafe_executor
+            ]));
+        }
+    }
+
+    #[test]
+    fn test_paging_size_bytes_disabled_for_non_range_resumable_plan() {
+        let mut dag = DagRequest::default();
+        dag.set_executors(
+            vec![
+                table_scan_descriptor(1, vec![column_with_type(1, FieldTypeTp::Long)]),
+                limit_descriptor(10),
+            ]
+            .into(),
+        );
+        dag.set_output_offsets(vec![0]);
+        dag.set_encode_type(EncodeType::TypeChunk);
+
+        let mut runner = build_runner_for_test_with_paging_size_bytes(dag, Some(1500)).unwrap();
+        assert_eq!(runner.paging_size_bytes, None);
+        assert_eq!(runner.config.paging_size_bytes, None);
+
+        let mut mock_executor = MockExecutor::new(
+            vec![FieldTypeTp::Long.into()],
+            vec![
+                build_n_rows_int_result(0, 1),
+                build_n_rows_int_result(10, 1),
+                {
+                    let mut result = build_n_rows_int_result(100, 1);
+                    result.is_drained = Ok(BatchExecIsDrain::Drain);
+                    result
+                },
+            ],
+        );
+        mock_executor.set_scanned_bytes_per_batch(vec![1000, 1000, 1000]);
+        mock_executor.scanned_range = Some((b"a".to_vec(), b"z".to_vec()).into());
+        runner.out_most_executor = Box::new(mock_executor);
+
+        let (resp, range) = block_on(runner.handle_request()).unwrap();
+        assert_eq!(
+            3,
+            resp.get_chunks().len(),
+            "unsafe plans must not stop early by paging_size_bytes"
+        );
+        assert!(
+            range.is_none(),
+            "unsafe plans must drain normally instead of returning a byte-budget range"
+        );
+    }
+
+    #[test]
+    fn test_paging_size_bytes_kept_for_range_resumable_plan() {
+        let mut dag = DagRequest::default();
+        dag.set_executors(
+            vec![table_scan_descriptor(
+                1,
+                vec![column_with_type(1, FieldTypeTp::Long)],
+            )]
+            .into(),
+        );
+        dag.set_output_offsets(vec![0]);
+        dag.set_encode_type(EncodeType::TypeChunk);
+
+        let runner = build_runner_for_test_with_paging_size_bytes(dag, Some(1500)).unwrap();
+        assert_eq!(runner.paging_size_bytes, Some(1500));
+        assert_eq!(runner.config.paging_size_bytes, Some(1500));
     }
 
     fn build_simple_result_for_test(cols: Vec<VectorValue>) -> BatchExecuteResult {

--- a/components/tidb_query_executors/src/runner.rs
+++ b/components/tidb_query_executors/src/runner.rs
@@ -672,6 +672,7 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
         let mut config = EvalConfig::from_request(&req)?;
         config.paging_size = paging_size;
         config.max_keys_read = max_keys_read;
+        config.paging_size_bytes = paging_size_bytes;
         let config = Arc::new(config);
         let intermediate_output_descriptors = req.take_intermediate_output_channels();
         let out_most_executor = build_executors::<_, F>(

--- a/components/tidb_query_executors/src/runner.rs
+++ b/components/tidb_query_executors/src/runner.rs
@@ -116,6 +116,19 @@ pub struct BatchExecutorsRunner<SS> {
     /// sent over the network.
     max_keys_read: Option<u64>,
 
+    /// Byte-budget counterpart of `paging_size`, received from
+    /// `coprocessor.Request.paging_size_bytes`.
+    ///
+    /// When set, the runner stops once the cumulative bytes scanned by the
+    /// bottom-most scan executor (raw key + value lengths, peeked via
+    /// `BatchExecutor::peek_scanned_bytes_sum`) reach this threshold. Like
+    /// `max_keys_read`, the byte count covers every physically scanned KV
+    /// entry before any filtering, aggregation, or projection, so a full scan
+    /// that returns few rows is still truncated by the actual data volume read.
+    /// It is independent of `paging_size` and `max_keys_read`; whichever
+    /// threshold is reached first stops the scan.
+    paging_size_bytes: Option<u64>,
+
     quota_limiter: Arc<QuotaLimiter>,
 
     /// Information for intermediate output channels.
@@ -651,6 +664,7 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
         is_streaming: bool,
         paging_size: Option<u64>,
         max_keys_read: Option<u64>,
+        paging_size_bytes: Option<u64>,
         quota_limiter: Arc<QuotaLimiter>,
     ) -> Result<Self> {
         let executors_len = req.get_executors().len();
@@ -672,9 +686,13 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
             // Required whenever the runner may return a partial result:
             //   - streaming: caller fetches multiple pages
             //   - paging: paging_size limits rows per page
-            //   - max_keys_read: budget limit may stop the scan early
+            //   - max_keys_read: row budget may stop the scan early
+            //   - paging_size_bytes: byte budget may stop the scan early
             // If none of these apply the executor can skip range tracking.
-            is_streaming || paging_size.is_some() || max_keys_read.is_some(),
+            is_streaming
+                || paging_size.is_some()
+                || max_keys_read.is_some()
+                || paging_size_bytes.is_some(),
         )?;
 
         let req_encode_type = req.get_encode_type();
@@ -744,6 +762,7 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
             encode_type,
             paging_size,
             max_keys_read,
+            paging_size_bytes,
             quota_limiter,
             intermediate_channels,
             reserved_intermediate_results: None,
@@ -791,6 +810,9 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
         // Running total of physical KV keys scanned (sum of scanned_rows_per_range),
         // used for max_keys_read enforcement.
         let mut scanned_keys_total: u64 = 0;
+        // Running total of MVCC scanned bytes (processed_size) from the storage
+        // layer, peeked via peek_scanned_bytes_sum for paging_size_bytes.
+        let mut scanned_bytes_all: usize = 0;
         let mut intermediate_output_chunks = if self.intermediate_channels.is_empty() {
             vec![]
         } else {
@@ -844,6 +866,12 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
                 scanned_keys_total = self.out_most_executor.peek_scanned_rows_sum() as u64;
             }
 
+            // Likewise peek the accumulated scanned bytes (raw key + value) for
+            // paging_size_bytes without draining any state.
+            if self.paging_size_bytes.is_some() {
+                scanned_bytes_all = self.out_most_executor.peek_scanned_bytes_sum();
+            }
+
             if chunk.has_rows_data() {
                 chunks.push(chunk);
             }
@@ -851,6 +879,9 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
             if drained.stop()
                 || self.paging_size.is_some_and(|p| record_all >= p as usize)
                 || self.max_keys_read.is_some_and(|m| scanned_keys_total >= m)
+                || self
+                    .paging_size_bytes
+                    .is_some_and(|p| scanned_bytes_all >= p as usize)
             {
                 self.out_most_executor
                     .collect_exec_stats(&mut self.exec_stats);
@@ -863,14 +894,16 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
                 );
                 let range = if drained == BatchExecIsDrain::Drain {
                     None
-                } else {
+                } else if self.paging_size.is_some()
+                    || self.max_keys_read.is_some()
+                    || self.paging_size_bytes.is_some()
+                {
                     // It's not allowed to stop paging when BatchExecIsDrain::PagingDrain.
-                    // Return scanned range for paging or when max_keys_read stopped early.
-                    if self.paging_size.is_some() || self.max_keys_read.is_some() {
-                        Some(self.out_most_executor.take_scanned_range())
-                    } else {
-                        None
-                    }
+                    // Return the scanned range whenever the scan stopped early due to a
+                    // paging row/byte budget or max_keys_read, so the caller can resume.
+                    Some(self.out_most_executor.take_scanned_range())
+                } else {
+                    None
                 };
 
                 let mut sel_resp = SelectResponse::default();
@@ -1371,6 +1404,7 @@ mod tests {
             Deadline::from_now(Duration::from_secs(300)),
             1024,
             false,
+            None,
             None,
             None,
             Arc::new(QuotaLimiter::default()),
@@ -2502,5 +2536,109 @@ mod tests {
             range.is_none(),
             "Range should be None when executor drained before limit"
         );
+    }
+
+    // --- Tests for paging_size_bytes ---
+
+    /// paging_size_bytes stops the scan early once the cumulative scanned bytes
+    /// (peeked via `peek_scanned_bytes_sum`) reach the budget, mirroring
+    /// `max_keys_read` but on a byte budget instead of a row budget.
+    #[test]
+    fn test_paging_size_bytes_stops_early() {
+        let field_types = vec![FieldTypeTp::Long.into()];
+
+        let mut runner = build_simple_runner_for_test();
+        runner.paging_size_bytes = Some(1500);
+
+        let mut mock_executor = MockExecutor::new(
+            field_types,
+            vec![
+                build_n_rows_int_result(0, 1),
+                build_n_rows_int_result(10, 1),
+                // Third batch should NOT be reached.
+                build_n_rows_int_result(100, 1),
+            ],
+        );
+        // 1000 bytes per batch: cumulative 1000, then 2000 (>= 1500 -> stop).
+        mock_executor.set_scanned_bytes_per_batch(vec![1000, 1000, 1000]);
+        mock_executor.scanned_range = Some((b"a".to_vec(), b"z".to_vec()).into());
+        runner.out_most_executor = Box::new(mock_executor);
+
+        let (resp, range) = block_on(runner.handle_request()).unwrap();
+        assert_eq!(
+            2,
+            resp.get_chunks().len(),
+            "Expected 2 chunks before the byte budget was hit"
+        );
+        assert!(
+            range.is_some(),
+            "Expected scanned range when stopped by paging_size_bytes"
+        );
+    }
+
+    /// When the executor drains before the byte budget is reached, all rows are
+    /// returned and the range is None (fully drained, not an early stop).
+    #[test]
+    fn test_paging_size_bytes_natural_drain_before_limit() {
+        let field_types = vec![FieldTypeTp::Long.into()];
+
+        let mut runner = build_simple_runner_for_test();
+        // Budget far higher than the total scanned bytes (300).
+        runner.paging_size_bytes = Some(100_000);
+
+        let mut mock_executor = MockExecutor::new(
+            field_types,
+            vec![
+                build_n_rows_int_result(0, 1),
+                build_n_rows_int_result(10, 2),
+                {
+                    let mut result = build_n_rows_int_result(100, 1);
+                    result.is_drained = Ok(BatchExecIsDrain::Drain);
+                    result
+                },
+            ],
+        );
+        mock_executor.set_scanned_bytes_per_batch(vec![100, 100, 100]);
+        runner.out_most_executor = Box::new(mock_executor);
+
+        let (resp, range) = block_on(runner.handle_request()).unwrap();
+        assert_eq!(
+            3,
+            resp.get_chunks().len(),
+            "All batches should be returned when the budget is not hit"
+        );
+        assert!(
+            range.is_none(),
+            "Range should be None when the executor drained before the budget"
+        );
+    }
+
+    /// paging_size_bytes = None must not limit scanning at all.
+    #[test]
+    fn test_paging_size_bytes_disabled() {
+        let field_types = vec![FieldTypeTp::Long.into()];
+
+        let mut runner = build_simple_runner_for_test();
+        runner.paging_size_bytes = None;
+
+        let mut mock_executor = MockExecutor::new(
+            field_types,
+            vec![build_n_rows_int_result(0, 3), {
+                let mut result = build_n_rows_int_result(10, 2);
+                result.is_drained = Ok(BatchExecIsDrain::Drain);
+                result
+            }],
+        );
+        // Even with large per-batch bytes, a disabled budget never stops early.
+        mock_executor.set_scanned_bytes_per_batch(vec![10_000, 10_000]);
+        runner.out_most_executor = Box::new(mock_executor);
+
+        let (resp, range) = block_on(runner.handle_request()).unwrap();
+        assert_eq!(
+            2,
+            resp.get_chunks().len(),
+            "All batches should be returned when paging_size_bytes is disabled"
+        );
+        assert!(range.is_none(), "Range should be None when fully drained");
     }
 }

--- a/components/tidb_query_executors/src/runner.rs
+++ b/components/tidb_query_executors/src/runner.rs
@@ -2826,4 +2826,103 @@ mod tests {
         );
         assert!(range.is_none(), "Range should be None when fully drained");
     }
+
+    /// When only the byte budget is set, the executor tree must still be
+    /// built scanned-range aware (otherwise `take_scanned_range` would panic
+    /// on the first byte-budget stop), and the byte peek must flow through
+    /// the real executor chain down to the storage.
+    #[test]
+    fn test_paging_size_bytes_enables_scanned_range_tracking() {
+        let mut dag = DagRequest::default();
+        dag.set_executors(
+            vec![
+                table_scan_descriptor(1, vec![column_with_type(1, FieldTypeTp::Long)]),
+                selection_descriptor(vec![
+                    ExprDefBuilder::column_ref(0, FieldTypeTp::Long).build(),
+                ]),
+                projection_descriptor(vec![
+                    ExprDefBuilder::column_ref(0, FieldTypeTp::Long).build(),
+                ]),
+            ]
+            .into(),
+        );
+        dag.set_output_offsets(vec![0]);
+        dag.set_encode_type(EncodeType::TypeChunk);
+
+        let data: &[(&'static [u8], &'static [u8])] = &[];
+        let mut runner = BatchExecutorsRunner::from_request::<_, ApiV1>(
+            dag,
+            vec![],
+            tidb_query_common::storage::test_fixture::FixtureStorage::from(data),
+            tidb_query_common::storage::StubAccessor::none(),
+            Deadline::from_now(Duration::from_secs(300)),
+            1024,
+            false,
+            None,
+            None,
+            Some(1500),
+            Arc::new(QuotaLimiter::default()),
+        )
+        .unwrap();
+        assert_eq!(runner.paging_size_bytes, Some(1500));
+
+        // Peeks flow through the real Projection -> Selection -> TableScan ->
+        // RangesScanner -> Storage chain; nothing is scanned yet.
+        assert_eq!(runner.out_most_executor.peek_scanned_bytes_sum(), 0);
+        assert_eq!(runner.out_most_executor.peek_scanned_rows_sum(), 0);
+        // Must not panic: build_executors has to enable range tracking when
+        // only paging_size_bytes is set.
+        let _ = runner.out_most_executor.take_scanned_range();
+    }
+
+    /// paging_size and paging_size_bytes are independent budgets: whichever
+    /// threshold is reached first stops the scan.
+    #[test]
+    fn test_paging_size_bytes_with_row_paging_whichever_first() {
+        // Byte budget trips before the row budget.
+        let mut runner = build_simple_runner_for_test();
+        runner.paging_size = Some(100);
+        runner.paging_size_bytes = Some(1500);
+        let mut mock_executor = MockExecutor::new(
+            vec![FieldTypeTp::Long.into()],
+            vec![
+                build_n_rows_int_result(0, 1),
+                build_n_rows_int_result(10, 1),
+                build_n_rows_int_result(100, 1),
+            ],
+        );
+        mock_executor.set_scanned_bytes_per_batch(vec![1000, 1000, 1000]);
+        mock_executor.scanned_range = Some((b"a".to_vec(), b"z".to_vec()).into());
+        runner.out_most_executor = Box::new(mock_executor);
+        let (resp, range) = block_on(runner.handle_request()).unwrap();
+        assert_eq!(
+            2,
+            resp.get_chunks().len(),
+            "the byte budget should stop the scan first"
+        );
+        assert!(range.is_some());
+
+        // Row budget trips before the byte budget.
+        let mut runner = build_simple_runner_for_test();
+        runner.paging_size = Some(1);
+        runner.paging_size_bytes = Some(1_000_000);
+        let mut mock_executor = MockExecutor::new(
+            vec![FieldTypeTp::Long.into()],
+            vec![
+                build_n_rows_int_result(0, 1),
+                build_n_rows_int_result(10, 1),
+                build_n_rows_int_result(100, 1),
+            ],
+        );
+        mock_executor.set_scanned_bytes_per_batch(vec![100, 100, 100]);
+        mock_executor.scanned_range = Some((b"a".to_vec(), b"z".to_vec()).into());
+        runner.out_most_executor = Box::new(mock_executor);
+        let (resp, range) = block_on(runner.handle_request()).unwrap();
+        assert_eq!(
+            1,
+            resp.get_chunks().len(),
+            "the row budget should stop the scan first"
+        );
+        assert!(range.is_some());
+    }
 }

--- a/components/tidb_query_executors/src/runner.rs
+++ b/components/tidb_query_executors/src/runner.rs
@@ -116,25 +116,12 @@ pub struct BatchExecutorsRunner<SS> {
     /// sent over the network.
     max_keys_read: Option<u64>,
 
-    /// Byte-budget counterpart of `paging_size`, received from
-    /// `coprocessor.Request.paging_size_bytes`.
-    ///
-    /// When accepted, the runner stops once the cumulative bytes scanned by the
-    /// bottom-most scan executor (peeked via
-    /// `BatchExecutor::peek_scanned_bytes_sum`) reach this threshold. The byte
-    /// count mirrors the MVCC `processed_size` (encoded key + value of every
-    /// returned entry), so the page boundary aligns with the bytes used for RU
-    /// accounting. Like `max_keys_read`, it covers every physically scanned KV
-    /// entry before any filtering, aggregation, or projection, so a full scan
-    /// that returns few rows is still truncated by the actual data volume read.
-    /// It is independent of `paging_size` and `max_keys_read`; whichever
-    /// threshold is reached first stops the scan.
-    ///
-    /// This is enabled only for executor trees that can be resumed by scanned
-    /// range alone. Stateful/blocking executors such as aggregation or TopN can
-    /// consume rows into internal state before producing output; stopping
-    /// outside those executors would drop that state between pages and
-    /// corrupt results.
+    /// Byte-budget counterpart of `paging_size` (from
+    /// `coprocessor.Request.paging_size_bytes`): stop once the scanned bytes
+    /// reach this threshold. Counts MVCC `processed_size` (encoded key + value)
+    /// of every physically scanned entry, before any filtering, independent of
+    /// `paging_size`/`max_keys_read`. Only set for range-resumable trees; see
+    /// the gating in `from_request`.
     paging_size_bytes: Option<u64>,
 
     quota_limiter: Arc<QuotaLimiter>,
@@ -702,30 +689,18 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
         let paging_size_bytes = if paging_size_bytes.is_some()
             && !can_resume_by_scanned_range_only(req.get_executors())
         {
-            // Coprocessor paging resumes with only a scanned key range. That
-            // is sufficient for scan plus stateless operators, but not for
-            // executors with cross-batch state (aggregation, StreamAgg, TopN,
-            // partition TopN, Limit, IndexLookUp, etc.). If byte-budget paging stopped
-            // outside such an executor, rows already consumed into in-memory
-            // state could be lost when the next page rebuilds the executor
-            // tree from only the returned range.
+            // Range-only resume is safe for scan + stateless operators, but not
+            // for executors with cross-batch state (aggregation, TopN, Limit,
+            // IndexLookUp, etc.): stopping outside one would drop rows already
+            // buffered into in-memory state when the next page rebuilds the tree
+            // from the returned range. Treat unknown executor types as unsafe.
+            // (Unlike paging_size/max_keys_read, which degrade IndexLookUp via
+            // force_no_index_lookup; here we just drop the budget and keep the
+            // pushdown.)
             //
-            // For IndexLookUp this deliberately differs from paging_size and
-            // max_keys_read, which keep their budgets and degrade the pushdown
-            // via force_no_index_lookup: the byte budget is dropped and the
-            // pushdown is kept, so IndexLookUp plans do not participate in
-            // paging_size_bytes at all.
-            //
-            // Be conservative here: new executor types are unsafe until they
-            // explicitly prove that range-only continuation preserves results.
-            // A future executor-aware paging protocol may relax this by
-            // letting stateful executors flush or serialize their continuation
-            // state before a byte-budget boundary.
-            //
-            // TODO(@JmPotato): add a metric (and/or a log) when the byte budget
-            // is dropped here, so the caller can tell "task drained naturally"
-            // apart from "budget ignored by capability gating" when debugging
-            // RU pre-charging.
+            // TODO(@JmPotato): emit a metric/log when the budget is dropped, to
+            // tell "drained naturally" from "gated off" when debugging RU
+            // pre-charging.
             None
         } else {
             paging_size_bytes
@@ -1554,11 +1529,9 @@ mod tests {
 
     #[test]
     fn test_paging_size_bytes_gating_in_from_request() {
-        // from_request applies the range-only-resume gating to
-        // paging_size_bytes: a plan containing a non-resumable executor
-        // silently drops the byte budget (its runtime behavior is then the
-        // "disabled" case of test_paging_size_bytes_stop_conditions), while a
-        // range-resumable plan keeps it and gets a fully wired executor tree.
+        // from_request gates paging_size_bytes on range-only resumability: a
+        // non-resumable plan (Limit) drops the byte budget, a resumable one
+        // keeps it and gets a fully wired executor tree.
 
         // A non-resumable executor (Limit) drops the byte budget.
         let mut dag = DagRequest::default();

--- a/components/tidb_query_executors/src/selection_executor.rs
+++ b/components/tidb_query_executors/src/selection_executor.rs
@@ -245,6 +245,11 @@ impl<Src: BatchExecutor> BatchExecutor for BatchSelectionExecutor<Src> {
     }
 
     #[inline]
+    fn peek_scanned_bytes_sum(&self) -> usize {
+        self.src.peek_scanned_bytes_sum()
+    }
+
+    #[inline]
     fn collect_storage_stats(&mut self, dest: &mut Self::StorageStats) {
         self.src.collect_storage_stats(dest);
     }

--- a/components/tidb_query_executors/src/simple_aggr_executor.rs
+++ b/components/tidb_query_executors/src/simple_aggr_executor.rs
@@ -63,6 +63,11 @@ impl<Src: BatchExecutor> BatchExecutor for BatchSimpleAggregationExecutor<Src> {
     }
 
     #[inline]
+    fn peek_scanned_bytes_sum(&self) -> usize {
+        self.0.peek_scanned_bytes_sum()
+    }
+
+    #[inline]
     fn collect_storage_stats(&mut self, dest: &mut Self::StorageStats) {
         self.0.collect_storage_stats(dest);
     }

--- a/components/tidb_query_executors/src/slow_hash_aggr_executor.rs
+++ b/components/tidb_query_executors/src/slow_hash_aggr_executor.rs
@@ -71,6 +71,11 @@ impl<Src: BatchExecutor> BatchExecutor for BatchSlowHashAggregationExecutor<Src>
     }
 
     #[inline]
+    fn peek_scanned_bytes_sum(&self) -> usize {
+        self.0.peek_scanned_bytes_sum()
+    }
+
+    #[inline]
     fn collect_storage_stats(&mut self, dest: &mut Self::StorageStats) {
         self.0.collect_storage_stats(dest);
     }

--- a/components/tidb_query_executors/src/stream_aggr_executor.rs
+++ b/components/tidb_query_executors/src/stream_aggr_executor.rs
@@ -64,6 +64,11 @@ impl<Src: BatchExecutor> BatchExecutor for BatchStreamAggregationExecutor<Src> {
     }
 
     #[inline]
+    fn peek_scanned_bytes_sum(&self) -> usize {
+        self.0.peek_scanned_bytes_sum()
+    }
+
+    #[inline]
     fn collect_storage_stats(&mut self, dest: &mut Self::StorageStats) {
         self.0.collect_storage_stats(dest);
     }

--- a/components/tidb_query_executors/src/table_scan_executor.rs
+++ b/components/tidb_query_executors/src/table_scan_executor.rs
@@ -156,6 +156,11 @@ impl<S: Storage, F: KvFormat> BatchExecutor for BatchTableScanExecutor<S, F> {
     }
 
     #[inline]
+    fn peek_scanned_bytes_sum(&self) -> usize {
+        self.0.peek_scanned_bytes_sum()
+    }
+
+    #[inline]
     fn collect_storage_stats(&mut self, dest: &mut Self::StorageStats) {
         self.0.collect_storage_stats(dest);
     }

--- a/components/tidb_query_executors/src/top_n_executor.rs
+++ b/components/tidb_query_executors/src/top_n_executor.rs
@@ -352,6 +352,11 @@ impl<Src: BatchExecutor> BatchExecutor for BatchTopNExecutor<Src> {
     }
 
     #[inline]
+    fn peek_scanned_bytes_sum(&self) -> usize {
+        self.src.peek_scanned_bytes_sum()
+    }
+
+    #[inline]
     fn collect_storage_stats(&mut self, dest: &mut Self::StorageStats) {
         self.src.collect_storage_stats(dest);
     }

--- a/components/tidb_query_executors/src/util/aggr_executor.rs
+++ b/components/tidb_query_executors/src/util/aggr_executor.rs
@@ -368,6 +368,11 @@ impl<Src: BatchExecutor, I: AggregationExecutorImpl<Src>> BatchExecutor
     }
 
     #[inline]
+    fn peek_scanned_bytes_sum(&self) -> usize {
+        self.entities.src.peek_scanned_bytes_sum()
+    }
+
+    #[inline]
     fn collect_storage_stats(&mut self, dest: &mut Self::StorageStats) {
         self.entities.src.collect_storage_stats(dest);
     }

--- a/components/tidb_query_executors/src/util/mock_executor.rs
+++ b/components/tidb_query_executors/src/util/mock_executor.rs
@@ -46,7 +46,7 @@ pub struct MockExecutor {
     /// unaffected.
     scanned_bytes_per_batch: std::vec::IntoIter<usize>,
     /// Cumulative scanned bytes peeked via `peek_scanned_bytes_sum`; never
-    /// drained, mirroring `RangesScanner::scanned_bytes`.
+    /// drained, mirroring `Storage::scanned_bytes`.
     scanned_bytes: usize,
 }
 

--- a/components/tidb_query_executors/src/util/mock_executor.rs
+++ b/components/tidb_query_executors/src/util/mock_executor.rs
@@ -314,6 +314,10 @@ impl Storage for MockStorage {
     fn collect_statistics(&mut self, _dest: &mut Self::Statistics) {
         unimplemented!()
     }
+
+    fn scanned_bytes(&self) -> usize {
+        unimplemented!()
+    }
 }
 
 #[derive(Default, Debug, Clone)]

--- a/components/tidb_query_executors/src/util/mock_executor.rs
+++ b/components/tidb_query_executors/src/util/mock_executor.rs
@@ -41,6 +41,13 @@ pub struct MockExecutor {
     /// collection so that `scanned_rows_per_range` reflects physical key
     /// counts in tests that exercise `max_keys_read`.
     pending_scanned_rows: usize,
+    /// Per-batch scanned-byte increments consumed in order by `next_batch`.
+    /// Empty by default, so tests that don't exercise `paging_size_bytes` are
+    /// unaffected.
+    scanned_bytes_per_batch: std::vec::IntoIter<usize>,
+    /// Cumulative scanned bytes peeked via `peek_scanned_bytes_sum`; never
+    /// drained, mirroring `RangesScanner::scanned_bytes`.
+    scanned_bytes: usize,
 }
 
 impl MockExecutor {
@@ -54,6 +61,8 @@ impl MockExecutor {
             child: None,
             scanned_range: None,
             pending_scanned_rows: 0,
+            scanned_bytes_per_batch: std::vec::IntoIter::default(),
+            scanned_bytes: 0,
         }
     }
 
@@ -66,11 +75,18 @@ impl MockExecutor {
             child: Some(Box::new(child)),
             scanned_range: None,
             pending_scanned_rows: 0,
+            scanned_bytes_per_batch: std::vec::IntoIter::default(),
+            scanned_bytes: 0,
         }
     }
 
     pub fn set_next_intermediate_results(&mut self, results: Vec<BatchExecuteResult>) {
         self.intermediate_results = vec![results].into_iter();
+    }
+
+    /// Sets per-batch scanned-byte increments for `paging_size_bytes` tests.
+    pub fn set_scanned_bytes_per_batch(&mut self, bytes_per_batch: Vec<usize>) {
+        self.scanned_bytes_per_batch = bytes_per_batch.into_iter();
     }
 
     pub fn set_extra_common_handle_keys(&mut self, mut keys: Vec<Vec<Vec<u8>>>) {
@@ -128,6 +144,9 @@ impl BatchExecutor for MockExecutor {
             None => {
                 let result = self.results.next().unwrap();
                 self.pending_scanned_rows += result.logical_rows.len();
+                if let Some(b) = self.scanned_bytes_per_batch.next() {
+                    self.scanned_bytes += b;
+                }
                 result
             }
         }
@@ -146,6 +165,14 @@ impl BatchExecutor for MockExecutor {
     fn peek_scanned_rows_sum(&self) -> usize {
         let child_sum = self.child.as_ref().map_or(0, |c| c.peek_scanned_rows_sum());
         self.pending_scanned_rows + child_sum
+    }
+
+    fn peek_scanned_bytes_sum(&self) -> usize {
+        let child_sum = self
+            .child
+            .as_ref()
+            .map_or(0, |c| c.peek_scanned_bytes_sum());
+        self.scanned_bytes + child_sum
     }
 
     fn collect_storage_stats(&mut self, _dest: &mut Self::StorageStats) {
@@ -230,6 +257,10 @@ impl BatchExecutor for MockScanExecutor {
     }
 
     fn peek_scanned_rows_sum(&self) -> usize {
+        0
+    }
+
+    fn peek_scanned_bytes_sum(&self) -> usize {
         0
     }
 

--- a/components/tidb_query_executors/src/util/scan_executor.rs
+++ b/components/tidb_query_executors/src/util/scan_executor.rs
@@ -272,6 +272,11 @@ impl<S: Storage, I: ScanExecutorImpl, F: KvFormat> BatchExecutor for ScanExecuto
     }
 
     #[inline]
+    fn peek_scanned_bytes_sum(&self) -> usize {
+        self.scanner.peek_scanned_bytes_sum()
+    }
+
+    #[inline]
     fn collect_storage_stats(&mut self, dest: &mut Self::StorageStats) {
         self.scanner.collect_storage_stats(dest);
     }

--- a/components/tikv_kv/src/lib.rs
+++ b/components/tikv_kv/src/lib.rs
@@ -69,7 +69,7 @@ pub use self::{
     rocksdb_engine::{RocksEngine, RocksSnapshot},
     stats::{
         CfStatistics, FlowStatistics, FlowStatsReporter, LoadDataHint, RAW_VALUE_TOMBSTONE,
-        StageLatencyStats, Statistics, StatisticsSummary,
+        StageLatencyStats, Statistics, StatisticsSummary, kv_processed_size,
     },
 };
 

--- a/components/tikv_kv/src/stats.rs
+++ b/components/tikv_kv/src/stats.rs
@@ -202,6 +202,19 @@ impl CfStatistics {
     }
 }
 
+/// Returns the number of bytes a single returned user key-value pair
+/// contributes to [`Statistics::processed_size`]: the (mem-comparable) key
+/// length plus the value length.
+///
+/// This is the single definition shared by the MVCC readers that accumulate
+/// `processed_size` and by the coprocessor storage that tracks scanned bytes
+/// for `paging_size_bytes`, so the paging byte budget always stays aligned
+/// with the RU-accounted byte volume.
+#[inline]
+pub fn kv_processed_size(key_len: usize, value_len: usize) -> usize {
+    key_len + value_len
+}
+
 #[derive(Default, Debug)]
 pub struct Statistics {
     pub lock: CfStatistics,

--- a/components/tikv_kv/src/stats.rs
+++ b/components/tikv_kv/src/stats.rs
@@ -206,10 +206,10 @@ impl CfStatistics {
 /// contributes to [`Statistics::processed_size`]: the (mem-comparable) key
 /// length plus the value length.
 ///
-/// This is the single definition shared by the MVCC readers that accumulate
-/// `processed_size` and by the coprocessor storage that tracks scanned bytes
-/// for `paging_size_bytes`, so the paging byte budget always stays aligned
-/// with the RU-accounted byte volume.
+/// This is the single definition of the per-entry formula: every site that
+/// accumulates `processed_size`, or needs to mirror its accounting, should
+/// call this helper instead of spelling the formula out, so the call sites
+/// never drift from each other.
 #[inline]
 pub fn kv_processed_size(key_len: usize, value_len: usize) -> usize {
     key_len + value_len

--- a/components/tikv_kv/src/stats.rs
+++ b/components/tikv_kv/src/stats.rs
@@ -202,14 +202,9 @@ impl CfStatistics {
     }
 }
 
-/// Returns the number of bytes a single returned user key-value pair
-/// contributes to [`Statistics::processed_size`]: the (mem-comparable) key
-/// length plus the value length.
-///
-/// This is the single definition of the per-entry formula: every site that
-/// accumulates `processed_size`, or needs to mirror its accounting, should
-/// call this helper instead of spelling the formula out, so the call sites
-/// never drift from each other.
+/// Per-entry contribution to [`Statistics::processed_size`]: key length plus
+/// value length. The single source of truth for the formula, so every site
+/// that accumulates `processed_size` stays in sync.
 #[inline]
 pub fn kv_processed_size(key_len: usize, value_len: usize) -> usize {
     key_len + value_len

--- a/deny.toml
+++ b/deny.toml
@@ -139,6 +139,3 @@ exceptions = [
 unknown-git = "deny"
 unknown-registry = "deny"
 allow-org = { github = ["tikv", "pingcap", "rust-lang"] }
-# Temporary fork for the co-developed kvproto change, see the `[patch]` section
-# in Cargo.toml. Remove this once the kvproto PR is merged.
-allow-git = ["https://github.com/JmPotato/kvproto"]

--- a/deny.toml
+++ b/deny.toml
@@ -139,3 +139,6 @@ exceptions = [
 unknown-git = "deny"
 unknown-registry = "deny"
 allow-org = { github = ["tikv", "pingcap", "rust-lang"] }
+# Temporary fork for the co-developed kvproto change, see the `[patch]` section
+# in Cargo.toml. Remove this once the kvproto PR is merged.
+allow-git = ["https://github.com/JmPotato/kvproto"]

--- a/src/coprocessor/dag/mod.rs
+++ b/src/coprocessor/dag/mod.rs
@@ -43,6 +43,7 @@ where
     is_cache_enabled: bool,
     paging_size: Option<u64>,
     max_keys_read: Option<u64>,
+    paging_size_bytes: Option<u64>,
     quota_limiter: Arc<QuotaLimiter>,
     _phantom: PhantomData<F>,
 }
@@ -64,6 +65,7 @@ where
         is_cache_enabled: bool,
         paging_size: Option<u64>,
         max_keys_read: Option<u64>,
+        paging_size_bytes: Option<u64>,
         quota_limiter: Arc<QuotaLimiter>,
     ) -> Self {
         DagHandlerBuilder {
@@ -78,6 +80,7 @@ where
             is_cache_enabled,
             paging_size,
             max_keys_read,
+            paging_size_bytes,
             quota_limiter,
             _phantom: PhantomData,
         }
@@ -103,6 +106,7 @@ where
             self.is_streaming,
             self.paging_size,
             self.max_keys_read,
+            self.paging_size_bytes,
             self.quota_limiter,
         )?
         .into_boxed())
@@ -168,6 +172,7 @@ impl BatchDagHandler {
         is_streaming: bool,
         paging_size: Option<u64>,
         max_keys_read: Option<u64>,
+        paging_size_bytes: Option<u64>,
         quota_limiter: Arc<QuotaLimiter>,
     ) -> Result<Self> {
         let extra_storage_accessor =
@@ -183,6 +188,7 @@ impl BatchDagHandler {
                 is_streaming,
                 paging_size,
                 max_keys_read,
+                paging_size_bytes,
                 quota_limiter,
             )?,
             data_version,

--- a/src/coprocessor/dag/storage_impl.rs
+++ b/src/coprocessor/dag/storage_impl.rs
@@ -17,9 +17,11 @@ pub struct TikvStorage<S: Store> {
     cf_stats_backlog: Statistics,
     met_newer_ts_data_backlog: NewerTsCheckState,
     /// Cumulative scanned bytes (encoded key + value of every returned entry),
-    /// mirroring `Statistics::processed_size`. Never drained — only peeked via
-    /// `scanned_bytes` for the `paging_size_bytes` budget, separate from the
-    /// `collect_statistics` path.
+    /// mirroring `Statistics::processed_size`: counts only visible returned
+    /// entries, not skipped MVCC versions (old versions/tombstones/write
+    /// records) — i.e. processed_size, not physical MVCC scanned bytes. Never
+    /// drained; only peeked via `scanned_bytes` for the `paging_size_bytes`
+    /// budget, separate from the `collect_statistics` path.
     scanned_bytes: usize,
 }
 

--- a/src/coprocessor/dag/storage_impl.rs
+++ b/src/coprocessor/dag/storage_impl.rs
@@ -154,3 +154,71 @@ impl<S: Store> Storage for TikvStorage<S> {
         self.scanned_bytes
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use txn_types::ValueEntry;
+
+    use super::*;
+    use crate::storage::txn::FixtureStore;
+
+    /// `scanned_bytes` accumulates `kv_processed_size` (encoded key + value)
+    /// for both the interval-scan and the point-get paths, never resets, and
+    /// stays independent of the draining `collect_statistics` path.
+    #[test]
+    fn test_scanned_bytes_accumulation() {
+        let rows: &[(&[u8], &[u8])] = &[
+            (b"row_a", b"value_1"),
+            (b"row_b", b"v2"),
+            (b"row_c", b"another_value"),
+        ];
+        let data: BTreeMap<_, _> = rows
+            .iter()
+            .map(|(k, v)| (Key::from_raw(k), Ok(ValueEntry::from_value(v.to_vec()))))
+            .collect();
+        let mut storage = TikvStorage::new(FixtureStore::new(data), false);
+
+        assert_eq!(storage.scanned_bytes(), 0);
+
+        // Interval scan: every returned entry adds encoded key + value bytes.
+        storage
+            .begin_scan(
+                false,
+                false,
+                false,
+                IntervalRange::from(("row_a", "row_z")),
+            )
+            .unwrap();
+        let mut expected = 0;
+        for _ in 0..rows.len() {
+            let entry = storage.scan_next_entry().unwrap().unwrap();
+            expected += kv_processed_size(Key::from_raw(&entry.key).len(), entry.value.len());
+            assert_eq!(storage.scanned_bytes(), expected);
+        }
+        assert!(storage.scan_next_entry().unwrap().is_none());
+        assert_eq!(storage.scanned_bytes(), expected);
+
+        // Point get: a hit adds encoded key + value bytes, a miss adds
+        // nothing.
+        let hit = storage
+            .get_entry(false, false, PointRange::from("row_b"))
+            .unwrap()
+            .unwrap();
+        expected += kv_processed_size(Key::from_raw(b"row_b").len(), hit.value.len());
+        assert_eq!(storage.scanned_bytes(), expected);
+        assert!(
+            storage
+                .get_entry(false, false, PointRange::from("row_x"))
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(storage.scanned_bytes(), expected);
+
+        // Draining statistics must not reset the cumulative counter.
+        let mut stats = Statistics::default();
+        storage.collect_statistics(&mut stats);
+        assert_eq!(storage.scanned_bytes(), expected);
+    }
+}

--- a/src/coprocessor/dag/storage_impl.rs
+++ b/src/coprocessor/dag/storage_impl.rs
@@ -7,7 +7,7 @@ use txn_types::Key;
 
 use crate::{
     coprocessor::Error,
-    storage::{Scanner, Statistics, Store, mvcc::NewerTsCheckState},
+    storage::{Scanner, Statistics, Store, kv::kv_processed_size, mvcc::NewerTsCheckState},
 };
 
 /// A `Storage` implementation over TiKV's storage.
@@ -87,7 +87,7 @@ impl<S: Store> Storage for TikvStorage<S> {
             .map_err(Error::from)?;
         Ok(kv.map(|(k, v)| {
             // Mirror `Statistics::processed_size`: encoded key + value bytes.
-            self.scanned_bytes += k.len() + v.value.len();
+            self.scanned_bytes += kv_processed_size(k.len(), v.value.len());
             OwnedKvPairEntry {
                 key: k.into_raw().unwrap(),
                 value: v.value,
@@ -113,7 +113,7 @@ impl<S: Store> Storage for TikvStorage<S> {
         if let Some(e) = &entry {
             // Mirror `Statistics::processed_size` for point gets: encoded key +
             // value bytes.
-            self.scanned_bytes += encoded_key.len() + e.value.len();
+            self.scanned_bytes += kv_processed_size(encoded_key.len(), e.value.len());
         }
         Ok(entry.map(move |e| OwnedKvPairEntry {
             key,

--- a/src/coprocessor/dag/storage_impl.rs
+++ b/src/coprocessor/dag/storage_impl.rs
@@ -16,6 +16,12 @@ pub struct TikvStorage<S: Store> {
     scanner: Option<S::Scanner>,
     cf_stats_backlog: Statistics,
     met_newer_ts_data_backlog: NewerTsCheckState,
+    /// Cumulative bytes scanned (encoded key + value of every returned entry),
+    /// mirroring `Statistics::processed_size`. Unlike `cf_stats_backlog`, this
+    /// is never drained — it is only peeked via `scanned_bytes` to drive the
+    /// `paging_size_bytes` budget, so RU accounting via `collect_statistics`
+    /// stays on its own path.
+    scanned_bytes: usize,
 }
 
 impl<S: Store> TikvStorage<S> {
@@ -29,6 +35,7 @@ impl<S: Store> TikvStorage<S> {
             } else {
                 NewerTsCheckState::Unknown
             },
+            scanned_bytes: 0,
         }
     }
 }
@@ -78,10 +85,14 @@ impl<S: Store> Storage for TikvStorage<S> {
             .unwrap()
             .next_entry()
             .map_err(Error::from)?;
-        Ok(kv.map(|(k, v)| OwnedKvPairEntry {
-            key: k.into_raw().unwrap(),
-            value: v.value,
-            commit_ts: v.commit_ts.map(|ts| ts.into_inner()),
+        Ok(kv.map(|(k, v)| {
+            // Mirror `Statistics::processed_size`: encoded key + value bytes.
+            self.scanned_bytes += k.len() + v.value.len();
+            OwnedKvPairEntry {
+                key: k.into_raw().unwrap(),
+                value: v.value,
+                commit_ts: v.commit_ts.map(|ts| ts.into_inner()),
+            }
         }))
     }
 
@@ -94,10 +105,16 @@ impl<S: Store> Storage for TikvStorage<S> {
         // TODO: Default CF does not need to be accessed if KeyOnly.
         // TODO: No need to check newer ts data if self.scanner has met newer ts data.
         let key = range.0;
+        let encoded_key = Key::from_raw(&key);
         let entry = self
             .store
-            .incremental_get_entry(&Key::from_raw(&key), load_commit_ts)
+            .incremental_get_entry(&encoded_key, load_commit_ts)
             .map_err(Error::from)?;
+        if let Some(e) = &entry {
+            // Mirror `Statistics::processed_size` for point gets: encoded key +
+            // value bytes.
+            self.scanned_bytes += encoded_key.len() + e.value.len();
+        }
         Ok(entry.map(move |e| OwnedKvPairEntry {
             key,
             value: e.value,
@@ -130,5 +147,10 @@ impl<S: Store> Storage for TikvStorage<S> {
         }
         dest.add(&self.cf_stats_backlog);
         self.cf_stats_backlog = Statistics::default();
+    }
+
+    #[inline]
+    fn scanned_bytes(&self) -> usize {
+        self.scanned_bytes
     }
 }

--- a/src/coprocessor/dag/storage_impl.rs
+++ b/src/coprocessor/dag/storage_impl.rs
@@ -164,11 +164,11 @@ mod tests {
     use super::*;
     use crate::storage::txn::FixtureStore;
 
-    /// `scanned_bytes` accumulates `kv_processed_size` (encoded key + value)
-    /// for both the interval-scan and the point-get paths, never resets, and
-    /// stays independent of the draining `collect_statistics` path.
     #[test]
     fn test_scanned_bytes_accumulation() {
+        // scanned_bytes accumulates kv_processed_size (encoded key + value)
+        // for both the interval-scan and the point-get paths, never resets,
+        // and stays independent of the draining collect_statistics path.
         let rows: &[(&[u8], &[u8])] = &[
             (b"row_a", b"value_1"),
             (b"row_b", b"v2"),
@@ -184,12 +184,7 @@ mod tests {
 
         // Interval scan: every returned entry adds encoded key + value bytes.
         storage
-            .begin_scan(
-                false,
-                false,
-                false,
-                IntervalRange::from(("row_a", "row_z")),
-            )
+            .begin_scan(false, false, false, IntervalRange::from(("row_a", "row_z")))
             .unwrap();
         let mut expected = 0;
         for _ in 0..rows.len() {

--- a/src/coprocessor/dag/storage_impl.rs
+++ b/src/coprocessor/dag/storage_impl.rs
@@ -16,11 +16,10 @@ pub struct TikvStorage<S: Store> {
     scanner: Option<S::Scanner>,
     cf_stats_backlog: Statistics,
     met_newer_ts_data_backlog: NewerTsCheckState,
-    /// Cumulative bytes scanned (encoded key + value of every returned entry),
-    /// mirroring `Statistics::processed_size`. Unlike `cf_stats_backlog`, this
-    /// is never drained — it is only peeked via `scanned_bytes` to drive the
-    /// `paging_size_bytes` budget, so RU accounting via `collect_statistics`
-    /// stays on its own path.
+    /// Cumulative scanned bytes (encoded key + value of every returned entry),
+    /// mirroring `Statistics::processed_size`. Never drained — only peeked via
+    /// `scanned_bytes` for the `paging_size_bytes` budget, separate from the
+    /// `collect_statistics` path.
     scanned_bytes: usize,
 }
 

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -280,6 +280,14 @@ impl<E: Engine> Endpoint<E> {
                         0 => None,
                         i => Some(i),
                     };
+                    // paging_size_bytes is the byte-budget counterpart of paging_size:
+                    // 0 means disabled, otherwise the scan stops once accumulated MVCC
+                    // scanned bytes reach the limit. It is independent of both paging_size
+                    // and max_keys_read.
+                    let paging_size_bytes = match req.get_paging_size_bytes() {
+                        0 => None,
+                        i => Some(i),
+                    };
 
                     let extra_store_accessor =
                         ExtraSnapStoreAccessor::<E>::new(req_ctx.clone(), concurrency_manager);
@@ -294,6 +302,7 @@ impl<E: Engine> Endpoint<E> {
                         req.get_is_cache_enabled(),
                         paging_size,
                         max_keys_read,
+                        paging_size_bytes,
                         quota_limiter,
                     )
                     .data_version(data_version)

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -280,10 +280,8 @@ impl<E: Engine> Endpoint<E> {
                         0 => None,
                         i => Some(i),
                     };
-                    // paging_size_bytes is the byte-budget counterpart of paging_size:
-                    // 0 means disabled, otherwise the scan stops once accumulated MVCC
-                    // scanned bytes reach the limit. It is independent of both paging_size
-                    // and max_keys_read.
+                    // Byte-budget counterpart of paging_size: 0 disables it,
+                    // otherwise the scan stops once scanned bytes reach the limit.
                     let paging_size_bytes = match req.get_paging_size_bytes() {
                         0 => None,
                         i => Some(i),

--- a/src/storage/mvcc/reader/point_getter.rs
+++ b/src/storage/mvcc/reader/point_getter.rs
@@ -11,7 +11,7 @@ use txn_types::{
 };
 
 use crate::storage::{
-    kv::{Cursor, CursorBuilder, ScanMode, Snapshot, Statistics},
+    kv::{Cursor, CursorBuilder, ScanMode, Snapshot, Statistics, kv_processed_size},
     mvcc::{ErrorInner::WriteConflict, NewerTsCheckState, Result, default_not_found_error},
     need_check_locks,
 };
@@ -362,13 +362,15 @@ impl<S: Snapshot> PointGetter<S> {
                     match write.short_value {
                         Some(value) => {
                             // Value is carried in `write`.
-                            self.statistics.processed_size += user_key.len() + value.len();
+                            self.statistics.processed_size +=
+                                kv_processed_size(user_key.len(), value.len());
                             return Ok(Some(ValueEntry::new(value.to_vec(), key_commit_ts)));
                         }
                         None => {
                             let start_ts = write.start_ts;
                             let value = self.load_data_from_default_cf(start_ts, user_key)?;
-                            self.statistics.processed_size += user_key.len() + value.len();
+                            self.statistics.processed_size +=
+                                kv_processed_size(user_key.len(), value.len());
                             return Ok(Some(ValueEntry::new(value, key_commit_ts)));
                         }
                     }
@@ -466,12 +468,14 @@ impl<S: Snapshot> PointGetter<S> {
                 match lock.short_value {
                     Some(value) => {
                         // Value is carried in `lock`.
-                        self.statistics.processed_size += user_key.len() + value.len();
+                        self.statistics.processed_size +=
+                            kv_processed_size(user_key.len(), value.len());
                         Ok(Some(value.to_vec()))
                     }
                     None => {
                         let value = self.load_data_from_default_cf(lock.ts, user_key)?;
-                        self.statistics.processed_size += user_key.len() + value.len();
+                        self.statistics.processed_size +=
+                            kv_processed_size(user_key.len(), value.len());
                         Ok(Some(value))
                     }
                 }

--- a/src/storage/mvcc/reader/scanner/backward.rs
+++ b/src/storage/mvcc/reader/scanner/backward.rs
@@ -9,7 +9,7 @@ use txn_types::{Key, TimeStamp, Value, ValueEntry, Write, WriteRef, WriteType};
 
 use super::ScannerConfig;
 use crate::storage::{
-    kv::{Cursor, SEEK_BOUND, Snapshot, Statistics},
+    kv::{Cursor, SEEK_BOUND, Snapshot, Statistics, kv_processed_size},
     mvcc::{Error, ErrorInner::WriteConflict, NewerTsCheckState, Result},
     need_check_locks,
 };
@@ -211,7 +211,8 @@ impl<S: Snapshot> BackwardKvScanner<S> {
 
             if let Some(v) = result? {
                 self.statistics.write.processed_keys += 1;
-                self.statistics.processed_size += current_user_key.len() + v.value.len();
+                self.statistics.processed_size +=
+                    kv_processed_size(current_user_key.len(), v.value.len());
                 resource_metering::record_read_keys(1);
                 return Ok(Some((current_user_key, v)));
             }

--- a/src/storage/mvcc/reader/scanner/forward.rs
+++ b/src/storage/mvcc/reader/scanner/forward.rs
@@ -13,7 +13,7 @@ use txn_types::{
 use super::ScannerConfig;
 use crate::storage::{
     Cursor, Snapshot, Statistics,
-    kv::SEEK_BOUND,
+    kv::{SEEK_BOUND, kv_processed_size},
     mvcc::{ErrorInner::WriteConflict, NewerTsCheckState, Result},
     txn::{Result as TxnResult, TxnEntry, TxnEntryScanner},
 };
@@ -515,7 +515,7 @@ impl<S: Snapshot> ScanPolicy<S> for LatestKvPolicy {
     }
 
     fn output_size(&mut self, output: &Self::Output) -> usize {
-        output.0.len() + output.1.value.len()
+        kv_processed_size(output.0.len(), output.1.value.len())
     }
 }
 

--- a/tests/benches/coprocessor_executors/util/fixture.rs
+++ b/tests/benches/coprocessor_executors/util/fixture.rs
@@ -347,6 +347,11 @@ impl BatchExecutor for BatchFixtureExecutor {
     }
 
     #[inline]
+    fn peek_scanned_bytes_sum(&self) -> usize {
+        0
+    }
+
+    #[inline]
     fn collect_storage_stats(&mut self, _dest: &mut Self::StorageStats) {
         // Do nothing
     }

--- a/tests/benches/coprocessor_executors/util/mod.rs
+++ b/tests/benches/coprocessor_executors/util/mod.rs
@@ -54,6 +54,7 @@ pub fn build_dag_handler<TargetTxnStore: TxnStore + 'static>(
         false,
         None,
         None,
+        None,
         Arc::new(QuotaLimiter::default()),
     )
     .build()

--- a/tests/failpoints/cases/test_coprocessor.rs
+++ b/tests/failpoints/cases/test_coprocessor.rs
@@ -297,6 +297,78 @@ fn test_paging_scan() {
 }
 
 #[test]
+fn test_paging_scan_bytes() {
+    let data = vec![
+        (1, Some("name:0"), 2),
+        (2, Some("name:4"), 3),
+        (4, Some("name:3"), 1),
+        (5, Some("name:1"), 4),
+    ];
+
+    let product = ProductTable::new();
+    let (_, endpoint) = init_with_data(&product, &data);
+    // Force one row per batch so the byte budget is evaluated after every row,
+    // making the truncation point deterministic without depending on the exact
+    // per-row encoded size.
+    fail::cfg("copr_batch_initial_size", "return(1)").unwrap();
+    fail::cfg("copr_batch_grow_size", "return(1)").unwrap();
+    for desc in [false, true] {
+        // A 1-byte budget is exceeded after the first row's MVCC processed_size
+        // (encoded key + value, always > 1 byte), so the scan stops after exactly
+        // one row and hands back a resume range pointing past it.
+        let req = DagSelect::from(&product)
+            .paging_size_bytes(1)
+            .desc(desc)
+            .build();
+        let resp = handle_request(&endpoint, req);
+        let mut select_resp = SelectResponse::default();
+        select_resp.merge_from_bytes(resp.get_data()).unwrap();
+        let row_count = DagChunkSpliter::new(select_resp.take_chunks().into(), 3).count();
+        assert_eq!(row_count, 1, "byte budget must truncate to a single row");
+
+        // The resume range must start at the table boundary and stop within the
+        // single returned row's key range, so the caller can continue from there.
+        let res_range = resp.get_range();
+        let (res_start_key, res_end_key) = match desc {
+            true => (res_range.get_end(), res_range.get_start()),
+            false => (res_range.get_start(), res_range.get_end()),
+        };
+        let start_key = match desc {
+            true => product.get_record_range_one(i64::MAX),
+            false => product.get_record_range_one(i64::MIN),
+        };
+        let stop_id = match desc {
+            true => data[data.len() - 1].0,
+            false => data[0].0,
+        };
+        let end_key = product.get_record_range_one(stop_id);
+        assert_eq!(res_start_key, start_key.get_start());
+        assert_ge!(res_end_key, end_key.get_start());
+        assert_le!(res_end_key, end_key.get_end());
+
+        // A budget larger than the whole table must not truncate: the scan drains
+        // naturally and returns no resume range.
+        let req = DagSelect::from(&product)
+            .paging_size_bytes(u64::MAX)
+            .desc(desc)
+            .build();
+        let resp = handle_request(&endpoint, req);
+        let mut select_resp = SelectResponse::default();
+        select_resp.merge_from_bytes(resp.get_data()).unwrap();
+        let row_count = DagChunkSpliter::new(select_resp.take_chunks().into(), 3).count();
+        assert_eq!(
+            row_count,
+            data.len(),
+            "ample byte budget must return all rows"
+        );
+        assert!(
+            resp.range.is_none(),
+            "a draining scan must not set a resume range"
+        );
+    }
+}
+
+#[test]
 fn test_paging_scan_multi_ranges() {
     let data = vec![
         (1, Some("name:0"), 2),


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: ref #19710

Add byte-budget paging to the coprocessor DAG executor, complementing the existing row-count paging (`paging_size`) and the per-task key limit (`max_keys_read`, #19518). When `coprocessor.Request.paging_size_bytes` is set, TiKV stops scanning the current page once the cumulative scanned bytes reach the limit and returns the page boundary so the next page can resume — enabling RU pre-charging at byte granularity in PD's resource controller.

The implementation **reuses the peek-based early-stop infrastructure introduced for `max_keys_read` (#19518)**, so the two features are structurally aligned:

- **`endpoint.rs` / `dag/mod.rs`**: parse `paging_size_bytes` (`0` → `None`) and thread it through to `BatchExecutorsRunner`.
- **`runner.rs`**: add a `paging_size_bytes` field; in the paging loop, peek the accumulated scanned bytes **without draining** via a new `BatchExecutor::peek_scanned_bytes_sum`, mirroring `peek_scanned_rows_sum`. Stop when `drained || rows >= paging_size || keys >= max_keys_read || bytes >= paging_size_bytes`, and return the scanned range on early stop. RU accounting keeps using the unchanged `collect_storage_stats` path.
- **Capability gating (correctness)**: paging resumes from only a scanned key range, which cannot reconstruct cross-batch executor state (aggregation, StreamAgg, TopN, partition TopN, Limit, IndexLookUp). Stopping by byte budget outside such an executor would silently drop rows already consumed into in-memory state (e.g. an under-counted `count(*)`). `BatchExecutorsRunner::from_request` therefore accepts `paging_size_bytes` only when every executor in the DAG is range-resumable (TableScan/IndexScan plus Selection/Projection); otherwise the byte budget is dropped and the task drains normally, paying no range-tracking cost. New executor types stay unsafe until explicitly proven otherwise. A TODO tracks adding a metric/log so a dropped budget is observable to RU pre-charging.
- **`peek_scanned_bytes_sum`**: threaded through every `BatchExecutor` (delegating to the child), backed by a new non-draining `Storage::scanned_bytes()`.
- **Metric aligned with MVCC `processed_size`**: `TikvStorage` accumulates `encoded key + value` bytes per returned entry — exactly the bytes counted toward `Statistics::processed_size` (and therefore RU). The per-entry formula is unified into a single `tikv_kv::kv_processed_size()` helper shared by the MVCC readers and `TikvStorage`, so the paging budget can never drift from the RU-accounted byte volume. Counting on the scan input side means a full scan that returns few rows is still truncated by the data actually read.
- **Index lookup**: IndexLookUp plans do not participate in `paging_size_bytes` at all — the capability gating above drops the byte budget before executors are built, and the pushdown is kept. This deliberately differs from `paging_size` / `max_keys_read`, which keep their budgets and degrade the pushdown via `force_no_index_lookup`; the byte-budget leg of that guard (and its `EvalConfig` threading) was unreachable behind the gating and has been removed, with the contrast documented at both the gating site and the guard.
- **`Cargo.toml` / `Cargo.lock`**: use upstream `pingcap/kvproto@a15c348f8713e5c492b6dfb41224c464b5824979`, which carries both `paging_size_bytes` (field 17) and `max_keys_read` (field 16).
- **`Cargo.lock` CI hygiene**: update `memmap2` to `0.9.11`, the fixed release for `RUSTSEC-2026-0186`, so `cargo deny` passes without adding a new advisory ignore.

```commit-message
coprocessor: support paging_size_bytes for byte-budget paging

Add byte-budget paging alongside row-count paging in the DAG executor,
reusing the peek-based early-stop infrastructure from max_keys_read
(#19518). When paging_size_bytes is set, TiKV stops scanning the current
page once the cumulative MVCC scanned bytes (processed_size: encoded key +
value, peeked via BatchExecutor::peek_scanned_bytes_sum) reach the limit,
and returns the page boundary so the caller can resume. The per-entry
processed_size formula is unified into tikv_kv::kv_processed_size so the
paging budget stays aligned with RU accounting.

The byte budget is only accepted for executor trees that can resume from
a scanned key range alone (TableScan/IndexScan plus Selection/Projection);
plans with cross-batch executor state (aggregation, StreamAgg, TopN,
partition TopN, Limit, IndexLookUp) drop the budget and drain normally,
since a range-only continuation would lose in-memory state and corrupt
results. IndexLookUp plans thus do not participate in paging_size_bytes
at all: the budget is dropped and the pushdown is kept, deliberately
differing from paging_size/max_keys_read which keep their budgets and
degrade the pushdown instead.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
Support the paging_size_bytes option in TiKV's coprocessor: for range-resumable plans (scan plus stateless operators), a page stops once the scanned byte volume (aligned with MVCC processed_size) reaches the configured budget, complementing row-count paging for finer-grained resource control. Plans containing stateful executors (aggregation, TopN, IndexLookUp, etc.) ignore the byte budget and drain normally to preserve correctness.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Byte-based pagination: queries can stop early based on scanned bytes (new request parameter supported).
  * Scanned-bytes metrics: cumulative scanned-byte tracking and reporting surfaced across query execution and storage.
* **Tests**
  * Unit tests added to validate byte-budget paging and scanned-bytes reporting.
* **Chores**
  * Added advisory ignore entry for a Cargo advisory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
