### PR TITLE
Fix multipart S3 uploads, customizable log-backup multipart threshold (#19163)

### DIFF
--- a/components/backup-stream/src/router.rs
+++ b/components/backup-stream/src/router.rs
@@ -16,13 +16,8 @@ use std::{
 use dashmap::DashMap;
 use encryption::{BackupEncryptionManager, EncrypterReader, Iv, MultiMasterKeyBackend};
 use encryption_export::create_async_backend;
-<<<<<<< HEAD
-use engine_traits::{CfName, CF_DEFAULT, CF_LOCK, CF_WRITE};
-use external_storage::{create_storage, BackendConfig, ExternalStorage, UnpinReader};
-=======
 use engine_traits::{CF_DEFAULT, CF_LOCK, CF_WRITE, CfName};
 use external_storage::{BackendConfig, ExternalStorage, HdfsConfig, UnpinReader, create_storage};
->>>>>>> 4ff2839065 (Fix multipart S3 uploads, customizable log-backup multipart threshold (#19163))
 use file_system::Sha256Reader;
 use futures::io::Cursor;
 use kvproto::{

--- a/components/backup-stream/src/router.rs
+++ b/components/backup-stream/src/router.rs
@@ -16,8 +16,13 @@ use std::{
 use dashmap::DashMap;
 use encryption::{BackupEncryptionManager, EncrypterReader, Iv, MultiMasterKeyBackend};
 use encryption_export::create_async_backend;
+<<<<<<< HEAD
 use engine_traits::{CfName, CF_DEFAULT, CF_LOCK, CF_WRITE};
 use external_storage::{create_storage, BackendConfig, ExternalStorage, UnpinReader};
+=======
+use engine_traits::{CF_DEFAULT, CF_LOCK, CF_WRITE, CfName};
+use external_storage::{BackendConfig, ExternalStorage, HdfsConfig, UnpinReader, create_storage};
+>>>>>>> 4ff2839065 (Fix multipart S3 uploads, customizable log-backup multipart threshold (#19163))
 use file_system::Sha256Reader;
 use futures::io::Cursor;
 use kvproto::{
@@ -343,6 +348,7 @@ pub struct Config {
     pub temp_file_size_limit: u64,
     pub temp_file_memory_quota: u64,
     pub max_flush_interval: Duration,
+    pub s3_multi_part_size: usize,
 }
 
 impl From<BackupStreamConfig> for Config {
@@ -351,11 +357,13 @@ impl From<BackupStreamConfig> for Config {
         let temp_file_size_limit = value.file_size_limit.0;
         let temp_file_memory_quota = value.temp_file_memory_quota.0;
         let max_flush_interval = value.max_flush_interval.0;
+        let s3_multi_part_size = value.s3_multi_part_size.0 as usize;
         Self {
             prefix,
             temp_file_size_limit,
             temp_file_memory_quota,
             max_flush_interval,
+            s3_multi_part_size,
         }
     }
 }
@@ -413,6 +421,9 @@ pub struct RouterInner {
 
     /// Backup encryption manager
     backup_encryption_manager: BackupEncryptionManager,
+
+    /// S3 multi part size
+    s3_multi_part_size: AtomicUsize,
 }
 
 impl std::fmt::Debug for RouterInner {
@@ -440,6 +451,7 @@ impl RouterInner {
             temp_file_memory_quota: AtomicU64::new(config.temp_file_memory_quota),
             max_flush_interval: SyncRwLock::new(config.max_flush_interval),
             backup_encryption_manager,
+            s3_multi_part_size: AtomicUsize::new(config.s3_multi_part_size),
         }
     }
 
@@ -512,12 +524,17 @@ impl RouterInner {
         let cfg = self.tempfile_config_for_task(&task);
         let backup_encryption_manager =
             self.build_backup_encryption_manager_for_task(&task).await?;
+        let backend_config = BackendConfig {
+            s3_multi_part_size: self.s3_multi_part_size.load(Ordering::Relaxed),
+            hdfs_config: HdfsConfig::default(),
+        };
         let stream_task = StreamTaskHandler::new(
             task,
             ranges.clone(),
             merged_file_size_limit,
             cfg,
             backup_encryption_manager,
+            backend_config,
         )
         .await?;
         self.tasks.insert(task_name.clone(), Arc::new(stream_task));
@@ -996,13 +1013,11 @@ impl StreamTaskHandler {
         merged_file_size_limit: u64,
         temp_pool_cfg: tempfiles::Config,
         backup_encryption_manager: BackupEncryptionManager,
+        backend_config: BackendConfig,
     ) -> Result<Self> {
         let temp_dir = &temp_pool_cfg.swap_files;
         tokio::fs::create_dir_all(temp_dir).await?;
-        let storage = Arc::from(create_storage(
-            task.info.get_storage(),
-            BackendConfig::default(),
-        )?);
+        let storage = Arc::from(create_storage(task.info.get_storage(), backend_config)?);
         let start_ts = task.info.get_start_ts();
         Ok(Self {
             task,
@@ -2101,6 +2116,7 @@ mod tests {
                 temp_file_size_limit: 1024,
                 temp_file_memory_quota: 1024 * 2,
                 max_flush_interval: Duration::from_secs(300),
+                s3_multi_part_size: ReadableSize::mb(5).0 as usize,
             },
             BackupEncryptionManager::default(),
         );
@@ -2200,6 +2216,7 @@ mod tests {
                 temp_file_size_limit: 32,
                 temp_file_memory_quota: 32 * 2,
                 max_flush_interval: Duration::from_secs(300),
+                s3_multi_part_size: ReadableSize::mb(5).0 as usize,
             },
             BackupEncryptionManager::default(),
         );
@@ -2345,6 +2362,7 @@ mod tests {
             merged_file_size_limit,
             make_tempfiles_cfg(tmp_dir.path()),
             BackupEncryptionManager::default(),
+            BackendConfig::default(),
         )
         .await
         .unwrap();
@@ -2474,6 +2492,7 @@ mod tests {
                 temp_file_size_limit: 1,
                 temp_file_memory_quota: 2,
                 max_flush_interval: Duration::from_secs(300),
+                s3_multi_part_size: ReadableSize::mb(5).0 as usize,
             },
             BackupEncryptionManager::default(),
         ));
@@ -2513,6 +2532,7 @@ mod tests {
                 temp_file_size_limit: 32,
                 temp_file_memory_quota: 32 * 2,
                 max_flush_interval: Duration::from_secs(300),
+                s3_multi_part_size: ReadableSize::mb(5).0 as usize,
             },
             BackupEncryptionManager::default(),
         );
@@ -2556,6 +2576,7 @@ mod tests {
                 temp_file_size_limit: 1,
                 temp_file_memory_quota: 2,
                 max_flush_interval: Duration::from_secs(300),
+                s3_multi_part_size: ReadableSize::mb(5).0 as usize,
             },
             BackupEncryptionManager::default(),
         ));
@@ -2611,6 +2632,7 @@ mod tests {
                 temp_file_size_limit: 1,
                 temp_file_memory_quota: 2,
                 max_flush_interval: Duration::from_secs(300),
+                s3_multi_part_size: ReadableSize::mb(5).0 as usize,
             },
             BackupEncryptionManager::default(),
         ));
@@ -2748,6 +2770,7 @@ mod tests {
             0x100000,
             make_tempfiles_cfg(tmp_dir.path()),
             backup_encryption_manager,
+            BackendConfig::default(),
         )
         .await
         .unwrap();
@@ -2905,6 +2928,7 @@ mod tests {
                 temp_file_size_limit: 1,
                 temp_file_memory_quota: 2,
                 max_flush_interval: cfg.max_flush_interval.0,
+                s3_multi_part_size: cfg.s3_multi_part_size.0 as usize,
             },
             BackupEncryptionManager::default(),
         ));
@@ -2962,6 +2986,7 @@ mod tests {
                 temp_file_size_limit: 1000,
                 temp_file_memory_quota: 2,
                 max_flush_interval: Duration::from_secs(300),
+                s3_multi_part_size: ReadableSize::mb(5).0 as usize,
             },
             BackupEncryptionManager::default(),
         ));
@@ -3114,6 +3139,7 @@ mod tests {
             merged_file_size_limit,
             make_tempfiles_cfg(tempfile::tempdir().unwrap().path()),
             backup_encryption_manager.clone(),
+            BackendConfig::default(),
         )
         .await
         .unwrap();

--- a/components/cloud/aws/src/s3.rs
+++ b/components/cloud/aws/src/s3.rs
@@ -366,7 +366,9 @@ fn create_error_stream(
 
 /// A helper for uploading a large files to S3 storage.
 ///
-/// Note: this uploader does not support uploading files larger than 19.5 GiB.
+/// The uploader automatically adjusts part size to respect S3's 10000 part
+/// limit. Maximum file size is approximately (part_size * 10000), but the part
+/// size will be increased automatically if needed.
 struct S3Uploader<'client> {
     client: &'client Client,
 
@@ -446,6 +448,8 @@ fn get_content_md5(object_lock_enabled: bool, content: &[u8]) -> Option<String> 
 /// Specifies the minimum size to use multi-part upload.
 /// AWS S3 requires each part to be at least 5 MiB.
 const MINIMUM_PART_SIZE: usize = 5 * 1024 * 1024;
+/// S3 has a maximum of 10000 parts per multipart upload.
+const MAX_PARTS: u64 = 10000;
 
 impl<'client> S3Uploader<'client> {
     /// Creates a new uploader with a given target location and upload
@@ -472,7 +476,26 @@ impl<'client> S3Uploader<'client> {
         reader: &mut (dyn AsyncRead + Unpin + Send),
         est_len: u64,
     ) -> Result<(), UploadError> {
-        if est_len <= self.multi_part_size as u64 {
+        let effective_part_size = if est_len > self.multi_part_size as u64 {
+            let min_part_size_for_limit = est_len.div_ceil(MAX_PARTS);
+            let adjusted_size =
+                std::cmp::max(self.multi_part_size as u64, min_part_size_for_limit) as usize;
+
+            if adjusted_size != self.multi_part_size {
+                debug!(
+                    "adjusted multipart size from {} to {} bytes for file size {} bytes (estimated {} parts)",
+                    self.multi_part_size,
+                    adjusted_size,
+                    est_len,
+                    est_len.div_ceil(adjusted_size as u64)
+                );
+            }
+            adjusted_size
+        } else {
+            self.multi_part_size
+        };
+
+        if est_len <= effective_part_size as u64 {
             // For short files, execute one put_object to upload the entire thing.
             let mut data = Vec::with_capacity(est_len as usize);
             reader.read_to_end(&mut data).await?;
@@ -482,7 +505,7 @@ impl<'client> S3Uploader<'client> {
             // Otherwise, use multipart upload to improve robustness.
             self.upload_id = retry_and_count(|| self.begin(), "begin_upload").await?;
             let upload_res = async {
-                let mut buf = vec![0; self.multi_part_size];
+                let mut buf = vec![0; effective_part_size];
                 let mut part_number = 1;
                 loop {
                     let data_size = try_read_exact(reader, &mut buf).await?;
@@ -1426,5 +1449,42 @@ mod tests {
         assert_matches!(try_read_exact(&mut data, &mut buf).await, Ok(5));
         assert_eq!(&buf[..5], b"ogia.");
         assert_matches!(try_read_exact(&mut data, &mut buf).await, Ok(0));
+    }
+
+    #[test]
+    fn test_multipart_size_adjustment() {
+        const MAX_PARTS: u64 = 10000;
+        let multi_part_size = MINIMUM_PART_SIZE; // 5MB
+
+        // Test case 1: Small file, no adjustment needed
+        let est_len = 10u64 * 1024 * 1024; // 10MB
+        let min_part_size = est_len.div_ceil(MAX_PARTS);
+        let effective_size = std::cmp::max(multi_part_size as u64, min_part_size);
+        assert_eq!(effective_size, multi_part_size as u64);
+
+        // Test case 2: File that would exceed 10000 parts with 5MB part size
+        let est_len = 60u64 * 1024 * 1024 * 1024; // 60GB
+        let min_part_size = est_len.div_ceil(MAX_PARTS);
+        let effective_size = std::cmp::max(multi_part_size as u64, min_part_size);
+        // Should be at least 6MB to fit in 10000 parts
+        assert!(effective_size > multi_part_size as u64);
+        assert!(est_len.div_ceil(effective_size) <= MAX_PARTS);
+
+        // Test case 3: Very large file (100GB)
+        let est_len = 100 * 1024 * 1024 * 1024u64; // 100GB
+        let min_part_size = est_len.div_ceil(MAX_PARTS);
+        let effective_size = std::cmp::max(multi_part_size as u64, min_part_size);
+        // Should be at least ~10MB to fit in 10000 parts
+        assert!(effective_size > multi_part_size as u64);
+        assert!(est_len.div_ceil(effective_size) <= MAX_PARTS);
+
+        // Verify the estimated parts count
+        let estimated_parts = est_len.div_ceil(effective_size);
+        assert!(
+            estimated_parts <= MAX_PARTS,
+            "estimated parts {} exceeds maximum {}",
+            estimated_parts,
+            MAX_PARTS
+        );
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2946,6 +2946,7 @@ pub struct BackupStreamConfig {
     #[online_config(skip)]
     pub initial_scan_rate_limit: ReadableSize,
     pub initial_scan_concurrency: usize,
+    pub s3_multi_part_size: ReadableSize,
 }
 
 impl BackupStreamConfig {
@@ -2979,6 +2980,14 @@ impl BackupStreamConfig {
         if self.initial_scan_rate_limit.0 < 1024 {
             return Err("the `initial_scan_rate_limit` should be at least 1024 bytes".into());
         }
+        if self.s3_multi_part_size.0 > ReadableSize::gb(5).0 {
+            warn!(
+                "backup.s3_multi_part_size cannot larger than 5GB, change it to {:?}",
+                default_cfg.s3_multi_part_size
+            );
+            self.s3_multi_part_size = default_cfg.s3_multi_part_size;
+        }
+
         Ok(())
     }
 }
@@ -3008,6 +3017,7 @@ impl Default for BackupStreamConfig {
             initial_scan_rate_limit: ReadableSize::mb(60),
             initial_scan_concurrency: 6,
             temp_file_memory_quota: cache_size,
+            s3_multi_part_size: ReadableSize::mb(5),
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->
This is a cherry-pick of https://github.com/tikv/tikv/pull/19163
Make S3Uploader honor 10000 parts limit in multipart S3 uploads, by increasing the part size if necessary.
This prevents log backup blockage in the scenarios of high write pressure (e.g. during lightning ingestion).

Also, make the multipart upload threshold configurable for log backups (existing s3_multi_part_size
option only applies to snapshots now).
Issue Number: Close #19162 

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
- Make S3Uploader honor 10000 parts limit in multipart S3 uploads, by increasing the part size if necessary.
- Make the multipart upload threshold configurable for log backups
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note

```
