### PR TITLE
compact_log_backup: waiting migration for sync to make sure the compactions are all replicated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1687,6 +1687,7 @@ name = "compact-log-backup"
 version = "0.1.0"
 dependencies = [
  "async-compression",
+ "async-trait",
  "bytes",
  "chrono",
  "cloud",
@@ -1728,6 +1729,7 @@ dependencies = [
  "tracing",
  "tracing-active-tree",
  "txn_types",
+ "url",
  "uuid 0.8.2",
  "zstd 0.11.2+zstd.1.5.2",
 ]
@@ -4420,7 +4422,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#678ff92b1edd0cf321336a0ac4530edcb9686995"
+source = "git+https://github.com/leavrth/kvproto?branch=migration_synced_mark#7ac74f46e185468c6bc52dda71095c8cbbb870c6"
 dependencies = [
  "bytes",
  "futures 0.3.15",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,8 +222,8 @@ sysinfo = { git = "https://github.com/tikv/sysinfo", branch = "0.26-fix-cpu" }
 # When you modify TiKV cooperatively with kvproto, this will be useful to submit the PR to TiKV and the PR to
 # kvproto at the same time.
 # After the PR to kvproto is merged, remember to comment this out and run `cargo update -p kvproto`.
-# [patch.'https://github.com/pingcap/kvproto']
-# kvproto = { git = "https://github.com/your_github_id/kvproto", branch = "your_branch" }
+[patch.'https://github.com/pingcap/kvproto']
+kvproto = { git = "https://github.com/leavrth/kvproto", branch = "migration_synced_mark" }
 #
 # After the PR to rust-rocksdb is merged, remember to comment this out and run `cargo update -p rocksdb`.
 # [patch.'https://github.com/tikv/rust-rocksdb']

--- a/cmd/tikv-ctl/src/cmd.rs
+++ b/cmd/tikv-ctl/src/cmd.rs
@@ -728,6 +728,9 @@ pub enum Cmd {
             help("whether to enable GCP v2 external storage backend for compact-log-backup")
         )]
         gcp_v2_enable: bool,
+
+        #[structopt(long, help("whether to start from a replication external storage"))]
+        from_replication_storage: bool,
     },
     /// Get the state of a region's RegionReadProgress.
     GetRegionReadProgress {

--- a/cmd/tikv-ctl/src/main.rs
+++ b/cmd/tikv-ctl/src/main.rs
@@ -407,6 +407,7 @@ fn main() {
             prefetch_running_count,
             prefetch_buffer_count,
             gcp_v2_enable,
+            from_replication_storage,
         } => {
             let tmp_engine =
                 TemporaryRocks::new(&cfg).expect("failed to create temp engine for writing SSTs.");
@@ -437,6 +438,7 @@ fn main() {
                 prefetch_buffer_count,
                 compression,
                 compression_level,
+                from_replication_storage,
             };
             let mut exec = compact_log::Execution {
                 out_prefix: ccfg.recommended_prefix(&name),

--- a/components/backup-stream/src/router.rs
+++ b/components/backup-stream/src/router.rs
@@ -1992,7 +1992,7 @@ mod tests {
 
     use async_compression::tokio::bufread::ZstdDecoder;
     use encryption::{DecrypterReader, FileConfig, MasterKeyConfig, MultiMasterKeyBackend};
-    use external_storage::{BlobObject, ExternalData, NoopStorage};
+    use external_storage::{BlobObject, BlobObjectHeader, ExternalData, NoopStorage};
     use futures::{AsyncReadExt, future::LocalBoxFuture, stream::LocalBoxStream};
     use kvproto::{
         brpb::{CipherInfo, Noop, StorageBackend, StreamBackupTaskInfo},
@@ -2477,6 +2477,10 @@ mod tests {
         fn delete(&self, _name: &str) -> LocalBoxFuture<'_, io::Result<()>> {
             unreachable!()
         }
+
+        async fn head_object(&self, _name: &str) -> io::Result<BlobObjectHeader> {
+            unreachable!()
+        }
     }
 
     fn build_kv_event(base: i32, count: i32) -> ApplyEvents {
@@ -2881,6 +2885,10 @@ mod tests {
         }
 
         fn delete(&self, _name: &str) -> LocalBoxFuture<'_, io::Result<()>> {
+            unreachable!()
+        }
+
+        async fn head_object(&self, _name: &str) -> io::Result<BlobObjectHeader> {
             unreachable!()
         }
     }

--- a/components/cloud/aws/src/s3.rs
+++ b/components/cloud/aws/src/s3.rs
@@ -13,7 +13,7 @@ use aws_sdk_s3::{
     Client,
     config::{HttpClient, StalledStreamProtectionConfig},
     operation::get_object::GetObjectError,
-    types::{CompletedMultipartUpload, CompletedPart},
+    types::{CompletedMultipartUpload, CompletedPart, ReplicationStatus},
 };
 use bytes::Bytes;
 use cloud::{
@@ -780,6 +780,40 @@ impl BlobStorage for S3Storage {
     fn get_part(&self, name: &str, off: u64, len: u64) -> cloud::blob::BlobStream<'_> {
         // inclusive, bytes=0-499 -> [0, 499]
         self.get_range(name, Some(format!("bytes={}-{}", off, off + len - 1)))
+    }
+
+    async fn head_object(&self, name: &str) -> io::Result<cloud::blob::BlobObjectHeader> {
+        let key = self.maybe_prefix_key(name);
+        let bucket = self.config.bucket.bucket.clone();
+
+        let response = self
+            .client
+            .head_object()
+            .key(key)
+            .bucket((*bucket).clone())
+            .send()
+            .await
+            .map_err(|e| io::Error::other(e))?;
+
+        let replication_status = if let Some(status) = response.replication_status {
+            Some(match status {
+                ReplicationStatus::Complete
+                | ReplicationStatus::Completed
+                | ReplicationStatus::Replica => cloud::blob::ReplicationStatus::Replicated,
+                ReplicationStatus::Pending => cloud::blob::ReplicationStatus::Pending,
+                ReplicationStatus::Failed => return Err(io::Error::other("replication failed")),
+                _ => {
+                    return Err(io::Error::other(format!(
+                        "unknown replication status: {}",
+                        status
+                    )));
+                }
+            })
+        } else {
+            None
+        };
+
+        Ok(cloud::blob::BlobObjectHeader { replication_status })
     }
 }
 

--- a/components/cloud/azure/src/azblob.rs
+++ b/components/cloud/azure/src/azblob.rs
@@ -789,6 +789,12 @@ impl BlobStorage for AzureStorage {
     fn get_part(&self, name: &str, off: u64, len: u64) -> cloud::blob::BlobStream<'_> {
         self.get_range(name, Some(off..off + len))
     }
+
+    async fn head_object(&self, _name: &str) -> io::Result<cloud::blob::BlobObjectHeader> {
+        Ok(cloud::blob::BlobObjectHeader {
+            replication_status: None,
+        })
+    }
 }
 
 impl IterableStorage for AzureStorage {

--- a/components/cloud/gcp/src/gcs.rs
+++ b/components/cloud/gcp/src/gcs.rs
@@ -403,6 +403,12 @@ impl BlobStorage for GcsStorage {
         // inclusive, bytes=0-499 -> [0, 499]
         self.get_range(name, Some(format!("bytes={}-{}", off, off + len - 1)))
     }
+
+    async fn head_object(&self, _name: &str) -> io::Result<cloud::blob::BlobObjectHeader> {
+        Ok(cloud::blob::BlobObjectHeader {
+            replication_status: None,
+        })
+    }
 }
 
 struct GcsPrefixIter<'cli> {

--- a/components/cloud/gcp_v2/src/lib.rs
+++ b/components/cloud/gcp_v2/src/lib.rs
@@ -544,6 +544,12 @@ impl BlobStorage for GcsStorage {
     fn get_part(&self, name: &str, off: u64, len: u64) -> BlobStream<'_> {
         self.get_range(name, Some((off, len)))
     }
+
+    async fn head_object(&self, _name: &str) -> io::Result<cloud::blob::BlobObjectHeader> {
+        Ok(cloud::blob::BlobObjectHeader {
+            replication_status: None,
+        })
+    }
 }
 
 impl GcsStorage {

--- a/components/cloud/src/blob.rs
+++ b/components/cloud/src/blob.rs
@@ -37,6 +37,15 @@ impl<'a> From<Box<dyn AsyncRead + Send + Unpin + 'a>> for PutResource<'a> {
     }
 }
 
+#[derive(Clone)]
+pub enum ReplicationStatus {
+    Replicated,
+    Pending,
+}
+pub struct BlobObjectHeader {
+    pub replication_status: Option<ReplicationStatus>,
+}
+
 /// An abstraction for blob storage.
 /// Currently the same as ExternalStorage
 #[async_trait]
@@ -52,6 +61,9 @@ pub trait BlobStorage: 'static + Send + Sync {
 
     /// Read part of contents of the given path.
     fn get_part(&self, name: &str, off: u64, len: u64) -> BlobStream<'_>;
+
+    /// head the object to get the metadata.
+    async fn head_object(&self, name: &str) -> io::Result<BlobObjectHeader>;
 }
 
 pub trait DeletableStorage {
@@ -122,6 +134,10 @@ impl BlobStorage for Box<dyn BlobStorage> {
 
     fn get_part(&self, name: &str, off: u64, len: u64) -> BlobStream<'_> {
         (**self).get_part(name, off, len)
+    }
+
+    async fn head_object(&self, name: &str) -> io::Result<BlobObjectHeader> {
+        (**self).head_object(name).await
     }
 }
 

--- a/components/compact-log-backup/Cargo.toml
+++ b/components/compact-log-backup/Cargo.toml
@@ -65,9 +65,11 @@ uuid = { version = "0.8", features = ["v4", "serde"] }
 zstd = "0.11"
 
 [dev-dependencies]
+async-trait = "0.1"
 pprof = { version = "0.15", default-features = false, features = [
   "flamegraph",
   "protobuf-codec",
 ] }
 tempfile = "3.0"
 test_util = { workspace = true }
+url = "2"

--- a/components/compact-log-backup/src/compaction/meta.rs
+++ b/components/compact-log-backup/src/compaction/meta.rs
@@ -261,8 +261,12 @@ impl CompactionRunInfoBuilder {
         &mut self.compaction
     }
 
-    pub async fn write_migration(&self, s: Arc<dyn ExternalStorage>) -> Result<()> {
-        let migration = self.migration_of(self.find_expiring_files(s.clone()).await?);
+    pub async fn write_migration(
+        &self,
+        s: Arc<dyn ExternalStorage>,
+        ext: LoadFromExt<'_>,
+    ) -> Result<()> {
+        let migration = self.migration_of(self.find_expiring_files(s.clone(), ext).await?);
         let wrapped_storage = MigrationStorageWrapper::new(s.as_ref());
         wrapped_storage.write(migration.into()).await?;
         Ok(())
@@ -284,14 +288,15 @@ impl CompactionRunInfoBuilder {
             migration.edit_meta.push(medit);
         }
         migration.mut_compactions().push(self.compaction.clone());
+        migration.set_replicated(false);
         migration
     }
 
     async fn find_expiring_files(
         &self,
         s: Arc<dyn ExternalStorage>,
+        ext: LoadFromExt<'_>,
     ) -> Result<Vec<ExpiringFilesOfMeta>> {
-        let ext = LoadFromExt::default();
         let mut storage = StreamMetaStorage::load_from_ext(&s, ext).await?;
 
         let mut result = vec![];
@@ -382,12 +387,13 @@ mod test {
     use super::CompactionRunInfoBuilder;
     use crate::{
         compaction::{Subcompaction, SubcompactionResult, exec::SubcompactionExec},
+        storage::LoadFromExt,
         test_util::{KvGen, LogFileBuilder, TmpStorage, gen_min_max},
     };
 
     impl CompactionRunInfoBuilder {
         async fn mig(&self, s: Arc<dyn ExternalStorage>) -> crate::Result<brpb::Migration> {
-            Ok(self.migration_of(self.find_expiring_files(s).await?))
+            Ok(self.migration_of(self.find_expiring_files(s, LoadFromExt::default()).await?))
         }
     }
 

--- a/components/compact-log-backup/src/exec_hooks/save_meta.rs
+++ b/components/compact-log-backup/src/exec_hooks/save_meta.rs
@@ -169,7 +169,7 @@ impl ExecHooks for SaveMeta {
         self.collector.mut_meta().set_comments(comments);
         let begin = Instant::now();
         self.collector
-            .write_migration(Arc::clone(cx.storage))
+            .write_migration(Arc::clone(cx.storage), cx.ext.clone())
             .await?;
         info!("Migration written."; "duration" => ?begin.elapsed());
         Ok(())

--- a/components/compact-log-backup/src/execute/hooking.rs
+++ b/components/compact-log-backup/src/execute/hooking.rs
@@ -12,6 +12,7 @@ use crate::{
     errors::Result,
     execute::Execution,
     statistic::{CollectSubcompactionStatistic, LoadMetaStatistic},
+    storage::LoadFromExt,
 };
 
 pub struct NoHooks;
@@ -37,8 +38,10 @@ pub struct BeforeStartCtx<'a> {
     pub storage: &'a dyn ExternalStorage,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct AfterFinishCtx<'a> {
+    /// Reference to the extra config for loading metadata.
+    pub ext: LoadFromExt<'a>,
     /// The asynchronous runtime that we are about to use.
     pub async_rt: &'a Handle,
     /// The target external storage of this compaction.
@@ -175,7 +178,7 @@ impl<T: ExecHooks, U: ExecHooks> ExecHooks for (T, U) {
 
     async fn after_execution_finished(&mut self, cx: AfterFinishCtx<'_>) -> Result<()> {
         futures::future::try_join(
-            self.0.after_execution_finished(cx),
+            self.0.after_execution_finished(cx.clone()),
             self.1.after_execution_finished(cx),
         )
         .await?;

--- a/components/compact-log-backup/src/execute/mod.rs
+++ b/components/compact-log-backup/src/execute/mod.rs
@@ -61,6 +61,8 @@ pub struct ExecutionConfig {
     ///
     /// If `None`, we will use the default level of the selected algorithm.
     pub compression_level: Option<i32>,
+    /// Whether to start from a replication external storage.
+    pub from_replication_storage: bool,
 }
 
 impl slog::KV for ExecutionConfig {
@@ -160,6 +162,7 @@ impl Execution {
         ));
         ext.prefetch_running_count = self.cfg.prefetch_running_count as usize;
         ext.prefetch_buffer_count = self.cfg.prefetch_buffer_count as usize;
+        ext.from_replication_storage = self.cfg.from_replication_storage;
 
         let ExecuteCtx {
             ref storage,
@@ -175,7 +178,7 @@ impl Execution {
         hooks.before_execution_started(cx).await?;
 
         let storage = Arc::clone(storage);
-        let meta = StreamMetaStorage::load_from_ext(&storage, ext).await?;
+        let meta = StreamMetaStorage::load_from_ext(&storage, ext.clone()).await?;
         let stream = meta.flat_map(|file| match file {
             Ok(file) => stream::iter(file.into_logs()).map(Ok).left_stream(),
             Err(err) => stream::once(futures::future::err(err)).right_stream(),
@@ -254,6 +257,7 @@ impl Execution {
         let cx = AfterFinishCtx {
             async_rt: &Handle::current(),
             storage: &storage,
+            ext,
         };
         hooks.after_execution_finished(cx).await?;
 

--- a/components/compact-log-backup/src/execute/test.rs
+++ b/components/compact-log-backup/src/execute/test.rs
@@ -73,6 +73,7 @@ pub fn create_compaction(st: StorageBackend) -> Execution {
             compression_level: None,
             prefetch_buffer_count: 128,
             prefetch_running_count: 128,
+            from_replication_storage: false,
         },
         max_concurrent_subcompaction: 3,
         external_storage: st,

--- a/components/compact-log-backup/src/storage.rs
+++ b/components/compact-log-backup/src/storage.rs
@@ -7,9 +7,10 @@ use std::{
     pin::Pin,
     sync::Arc,
     task::{Context, Poll, ready},
+    time::Duration,
 };
 
-use cloud::blob::read_to_end;
+use cloud::blob::{ReplicationStatus, read_to_end};
 use derive_more::Display;
 use external_storage::{BlobObject, ExternalStorage, UnpinReader};
 use futures::{
@@ -42,6 +43,7 @@ pub const METADATA_PREFIX: &str = "v1/backupmeta";
 pub const DEFAULT_COMPACTION_OUT_PREFIX: &str = "v1/compaction_out";
 pub const MIGRATION_PREFIX: &str = "v1/migrations";
 pub const LOCK_PREFIX: &str = "v1/LOCK";
+const WAIT_FILE_SYNC_CONCURRENCY: usize = 16;
 
 /// The in-memory presentation of the message [`brpb::Metadata`].
 #[derive(Debug, PartialEq, Eq)]
@@ -195,6 +197,7 @@ impl std::fmt::Debug for LogFileId {
     }
 }
 
+#[derive(Clone)]
 /// Extra config for loading metadata.
 pub struct LoadFromExt<'a> {
     /// The [`tracing::Span`] of loading remote tasks.
@@ -208,6 +211,8 @@ pub struct LoadFromExt<'a> {
     pub prefetch_running_count: usize,
     /// Max number of spawning tasks to fetch metadatas
     pub prefetch_buffer_count: usize,
+    /// Whether to start from a replication external storage.
+    pub from_replication_storage: bool,
 }
 
 impl LoadFromExt<'_> {
@@ -223,6 +228,7 @@ impl Default for LoadFromExt<'_> {
             meta_prefix: METADATA_PREFIX,
             prefetch_running_count: 128,
             prefetch_buffer_count: 1024,
+            from_replication_storage: false,
         }
     }
 }
@@ -417,7 +423,8 @@ impl<'a> StreamMetaStorage<'a> {
     ) -> Result<Self> {
         let files = s.iter_prefix(ext.meta_prefix).fuse();
         let mig_ext = MigrationStorageWrapper::new(s);
-        let skip_map = MetaEditFilters::from_migrations(mig_ext.load().await?);
+        let skip_map =
+            MetaEditFilters::from_migrations(mig_ext.load(ext.from_replication_storage).await?);
         Ok(Self {
             prefetch: VecDeque::new(),
             files,
@@ -730,6 +737,8 @@ impl MetaEditFilter {
 pub struct MigrationStorageWrapper<'a> {
     storage: &'a dyn ExternalStorage,
     migrations_prefix: &'a str,
+
+    wait_time: Duration,
 }
 
 impl<'a> MigrationStorageWrapper<'a> {
@@ -737,10 +746,11 @@ impl<'a> MigrationStorageWrapper<'a> {
         Self {
             storage,
             migrations_prefix: MIGRATION_PREFIX,
+            wait_time: Duration::from_secs(3),
         }
     }
 
-    pub async fn load(&self) -> Result<Vec<Migration>> {
+    pub async fn load(&self, from_replication_storage: bool) -> Result<Vec<Migration>> {
         self.storage
             .iter_prefix(self.migrations_prefix)
             .err_into()
@@ -748,6 +758,9 @@ impl<'a> MigrationStorageWrapper<'a> {
                 let mut content = vec![];
                 read_to_end(self.storage.read(&item.key), &mut content).await?;
                 protobuf::parse_from_bytes(&content).adapt_err()
+            })
+            .try_filter_map(|m: Migration| async move {
+                Ok((!from_replication_storage || m.replicated).then_some(m))
             })
             .try_collect()
             .await
@@ -774,6 +787,7 @@ impl<'a> MigrationStorageWrapper<'a> {
         )
         .await
         .map_err(|err| err.0)?;
+        self.try_wait_for_sync(&full_name, migration).await?;
         Ok(())
     }
 
@@ -792,6 +806,72 @@ impl<'a> MigrationStorageWrapper<'a> {
             })
             .try_fold(u64::MIN, |val, new| futures::future::ok(val.max(new)))
             .await
+    }
+
+    // wait for the migration and its compactions to be synced to the downstream
+    // storage.
+    async fn try_wait_for_sync(
+        &self,
+        migration_filename: &str,
+        mut migration: Migration,
+    ) -> Result<()> {
+        use protobuf::Message;
+
+        if self.wait_file_for_sync(migration_filename).await?.is_none() {
+            return Ok(());
+        };
+
+        for compaction in migration.get_compactions() {
+            for dir in [compaction.get_artifacts(), compaction.get_generated_files()] {
+                if dir.is_empty() {
+                    continue;
+                }
+                self.storage
+                    .iter_prefix(dir)
+                    .err_into::<Error>()
+                    .try_for_each_concurrent(WAIT_FILE_SYNC_CONCURRENCY, |file| async move {
+                        self.wait_file_for_sync(&file.key).await.map(|_| ())
+                    })
+                    .await?;
+            }
+        }
+
+        migration.set_replicated(true);
+        let bytes = migration.write_to_bytes()?;
+        retry_expr!(
+            self.storage
+                .write(
+                    migration_filename,
+                    UnpinReader(Box::new(Cursor::new(&bytes))),
+                    bytes.len() as u64
+                )
+                .map_err(|err| JustRetry(err))
+        )
+        .await
+        .map_err(|err| err.0)?;
+
+        Ok(())
+    }
+
+    async fn wait_file_for_sync(&self, filename: &str) -> Result<Option<()>> {
+        loop {
+            let replication_status = retry_expr!(
+                self.storage
+                    .head_object(filename)
+                    .map_err(|err| JustRetry(err))
+            )
+            .await
+            .map_err(|err| err.0)?
+            .replication_status;
+            match replication_status {
+                None => return Ok(None),
+                // Storage backends without replication status should skip this waiting.
+                Some(ReplicationStatus::Replicated) => return Ok(Some(())),
+                Some(ReplicationStatus::Pending) => {
+                    tokio::time::sleep(self.wait_time).await;
+                }
+            }
+        }
     }
 }
 
@@ -845,18 +925,131 @@ pub fn hash_meta_edit(meta_edit: &brpb::MetaEdit) -> u64 {
 
 #[cfg(test)]
 mod test {
-    use std::sync::Arc;
+    use std::{
+        collections::HashMap,
+        io,
+        sync::{Arc, Mutex},
+    };
 
-    use external_storage::ExternalStorage;
-    use futures::stream::TryStreamExt;
+    use external_storage::{BlobObject, BlobObjectHeader, ExternalStorage, UnpinReader};
+    use futures::{
+        AsyncReadExt,
+        future::LocalBoxFuture,
+        stream::{LocalBoxStream, StreamExt, TryStreamExt},
+    };
     use kvproto::brpb::{DeleteSpansOfFile, MetaEdit, Migration, Span};
-    use protobuf::Chars;
+    use protobuf::{Chars, parse_from_bytes};
+    use url::Url;
 
     use super::{LoadFromExt, MetaFile, StreamMetaStorage};
     use crate::{
-        storage::{LogFileId, MetaEditFilters, MigrationStorageWrapper},
+        storage::{LogFileId, MetaEditFilters, MigrationStorageWrapper, ReplicationStatus},
         test_util::{KvGen, LogFileBuilder, TmpStorage, gen_step},
     };
+
+    struct MockReplicationStorage {
+        data: Mutex<HashMap<String, Vec<u8>>>,
+        head_calls: Mutex<HashMap<String, usize>>,
+        replication_status: Mutex<Option<ReplicationStatus>>,
+    }
+
+    impl MockReplicationStorage {
+        fn new(initial_replication_status: Option<ReplicationStatus>) -> Self {
+            Self {
+                data: Default::default(),
+                head_calls: Default::default(),
+                replication_status: Mutex::new(initial_replication_status),
+            }
+        }
+
+        fn insert_bytes(&self, key: String, bytes: Vec<u8>) {
+            self.data.lock().unwrap().insert(key, bytes);
+        }
+
+        fn get_bytes(&self, key: &str) -> Vec<u8> {
+            self.data
+                .lock()
+                .unwrap()
+                .get(key)
+                .cloned()
+                .unwrap_or_default()
+        }
+
+        fn head_calls_total(&self) -> usize {
+            self.head_calls.lock().unwrap().values().sum::<usize>()
+        }
+
+        fn head_calls_for(&self, key: &str) -> usize {
+            *self.head_calls.lock().unwrap().get(key).unwrap_or(&0)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ExternalStorage for MockReplicationStorage {
+        fn name(&self) -> &'static str {
+            "mock-replication-storage"
+        }
+
+        fn url(&self) -> io::Result<Url> {
+            Url::parse("mock://localhost").map_err(|e| io::Error::other(e.to_string()))
+        }
+
+        async fn write(
+            &self,
+            name: &str,
+            mut reader: UnpinReader<'_>,
+            _content_length: u64,
+        ) -> io::Result<()> {
+            let mut bytes = Vec::new();
+            // Read all contents from the async reader into memory.
+            reader.0.read_to_end(&mut bytes).await?;
+            self.insert_bytes(name.to_string(), bytes);
+            Ok(())
+        }
+
+        fn read(&self, name: &str) -> external_storage::ExternalData<'_> {
+            let bytes = self.get_bytes(name);
+            Box::new(futures::io::Cursor::new(bytes))
+        }
+
+        fn read_part(&self, name: &str, off: u64, len: u64) -> external_storage::ExternalData<'_> {
+            let bytes = self.get_bytes(name);
+            let off = off as usize;
+            let end = (off + len as usize).min(bytes.len());
+            Box::new(futures::io::Cursor::new(bytes[off..end].to_vec()))
+        }
+
+        fn iter_prefix(&self, prefix: &str) -> LocalBoxStream<'_, io::Result<BlobObject>> {
+            let keys = self
+                .data
+                .lock()
+                .unwrap()
+                .keys()
+                .filter(|k| k.starts_with(prefix))
+                .cloned()
+                .collect::<Vec<_>>();
+            futures::stream::iter(keys.into_iter().map(|key| Ok(BlobObject { key }))).boxed_local()
+        }
+
+        fn delete(&self, name: &str) -> LocalBoxFuture<'_, io::Result<()>> {
+            let name = name.to_string();
+            Box::pin(async move {
+                self.data.lock().unwrap().remove(&name);
+                Ok(())
+            })
+        }
+
+        async fn head_object(&self, name: &str) -> io::Result<BlobObjectHeader> {
+            let mut head_calls = self.head_calls.lock().unwrap();
+            let mut replication_status = self.replication_status.lock().unwrap();
+            let current_replication_status = replication_status.clone();
+            *replication_status = Some(cloud::blob::ReplicationStatus::Replicated);
+            *head_calls.entry(name.to_string()).or_insert(0) += 1;
+            Ok(BlobObjectHeader {
+                replication_status: current_replication_status,
+            })
+        }
+    }
 
     async fn construct_storage(
         st: &TmpStorage,
@@ -1071,5 +1264,99 @@ mod test {
         let stat = sst.take_statistic();
         assert_eq!(stat.log_filtered_out_by_migration, 12);
         assert_eq!(stat.meta_filtered_out_by_migration, 1);
+    }
+
+    #[tokio::test]
+    async fn test_load_from_replication_storage_filters_replicated() {
+        let st = TmpStorage::create();
+        let s = MigrationStorageWrapper::new(st.storage().as_ref());
+
+        let mut mig_not_replicated = Migration::new();
+        mig_not_replicated.set_replicated(false);
+        s.write(mig_not_replicated.clone().into()).await.unwrap();
+
+        let mut mig_replicated = Migration::new();
+        mig_replicated.set_replicated(true);
+        s.write(mig_replicated.clone().into()).await.unwrap();
+
+        let loaded_replicated = s.load(true).await.unwrap();
+        assert_eq!(loaded_replicated.len(), 1);
+        assert!(loaded_replicated[0].get_replicated());
+
+        let loaded_all = s.load(false).await.unwrap();
+        assert_eq!(loaded_all.len(), 2);
+    }
+
+    async fn prepare_migration_and_compaction_files(
+        storage: Arc<MockReplicationStorage>,
+    ) -> (Migration, Vec<String>, Vec<String>) {
+        let mut wrapped = MigrationStorageWrapper::new(storage.as_ref());
+        wrapped.wait_time = core::time::Duration::from_secs(0);
+
+        // Seed a dummy migration so `largest_id()` returns 0 and the new migration gets
+        // id=1.
+        let dummy = format!("{}/00000000_dummy.mgrt", super::MIGRATION_PREFIX);
+        storage.insert_bytes(dummy, vec![]);
+
+        // Seed compaction artifacts & outputs files.
+        let artifacts_dir = "v1/compaction_out/test1/metas".to_string();
+        let outputs_dir = "v1/compaction_out/test1/outputs".to_string();
+        let artifacts_files = [
+            format!("{}/file-0.cmeta", artifacts_dir),
+            format!("{}/file-1.cmeta", artifacts_dir),
+        ];
+        let outputs_files = [
+            format!("{}/file-0.sst", outputs_dir),
+            format!("{}/file-1.sst", outputs_dir),
+        ];
+        for f in artifacts_files.iter().chain(outputs_files.iter()) {
+            storage.insert_bytes(f.clone(), vec![1, 2, 3]);
+        }
+
+        // Create a migration that points to both directories.
+        let mut migration = Migration::new();
+        migration.set_replicated(false);
+        let mut compaction = kvproto::brpb::LogFileCompaction::new();
+        compaction.set_artifacts(artifacts_dir);
+        compaction.set_generated_files(outputs_dir);
+        migration.mut_compactions().push(compaction);
+
+        // This will indirectly call `try_wait_for_sync` inside `write`.
+        wrapped.write(migration.clone().into()).await.unwrap();
+
+        (migration, artifacts_files.to_vec(), outputs_files.to_vec())
+    }
+
+    #[tokio::test]
+    async fn test_try_wait_for_sync_iterates_compaction_files() {
+        let storage = Arc::new(MockReplicationStorage::new(Some(
+            ReplicationStatus::Pending,
+        )));
+
+        let (migration, artifacts_files, outputs_files) =
+            prepare_migration_and_compaction_files(storage.clone()).await;
+
+        let expected_name = super::name_of_migration(1, &migration);
+        let expected_key = format!("{}/{}", super::MIGRATION_PREFIX, expected_name);
+        let migration_bytes = storage.get_bytes(&expected_key);
+        let parsed: Migration = parse_from_bytes(&migration_bytes).unwrap();
+        assert!(parsed.get_replicated());
+
+        // Expect head_object to be called for:
+        // - the migration itself (1)
+        // - all files under artifacts/ & outputs/ (2 + 2)
+        assert_eq!(storage.head_calls_total(), 6);
+        for f in artifacts_files.iter().chain(outputs_files.iter()) {
+            assert_eq!(storage.head_calls_for(f), 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_try_wait_but_no_replication() {
+        let storage = Arc::new(MockReplicationStorage::new(None));
+
+        let _ = prepare_migration_and_compaction_files(storage.clone()).await;
+
+        assert_eq!(storage.head_calls_total(), 1);
     }
 }

--- a/components/external_storage/src/export.rs
+++ b/components/external_storage/src/export.rs
@@ -5,7 +5,7 @@ use std::{io, path::Path, sync::Arc};
 use async_trait::async_trait;
 pub use aws::{Config as S3Config, S3Storage};
 pub use azure::{AzureStorage, Config as AzureConfig};
-pub use cloud::blob::BlobObject;
+pub use cloud::blob::{BlobObject, BlobObjectHeader};
 use cloud::blob::{BlobStorage, DeletableStorage, IterableStorage, PutResource};
 use encryption::DataKeyManager;
 use futures_util::{future::LocalBoxFuture, stream::LocalBoxStream};
@@ -237,6 +237,10 @@ impl<S: ExternalStorage> ExternalStorage for AutoEncryptLocalRestoredFileExterna
     fn delete(&self, name: &str) -> LocalBoxFuture<'_, io::Result<()>> {
         self.storage.delete(name)
     }
+
+    async fn head_object(&self, name: &str) -> io::Result<BlobObjectHeader> {
+        self.storage.head_object(name).await
+    }
 }
 
 #[async_trait]
@@ -277,6 +281,10 @@ impl<Blob: BlobStorage + IterableStorage + DeletableStorage> ExternalStorage for
 
     fn delete(&self, name: &str) -> LocalBoxFuture<'_, io::Result<()>> {
         (**self).delete(name)
+    }
+
+    async fn head_object(&self, name: &str) -> io::Result<BlobObjectHeader> {
+        (**self).head_object(name).await
     }
 }
 

--- a/components/external_storage/src/hdfs.rs
+++ b/components/external_storage/src/hdfs.rs
@@ -3,7 +3,7 @@
 use std::{io, path, process::Stdio};
 
 use async_trait::async_trait;
-use cloud::blob::BlobObject;
+use cloud::blob::{BlobObject, BlobObjectHeader};
 use futures_util::{
     future::{FutureExt, LocalBoxFuture},
     stream::LocalBoxStream,
@@ -157,6 +157,12 @@ impl ExternalStorage for HdfsStorage {
 
     fn delete(&self, _name: &str) -> LocalBoxFuture<'_, io::Result<()>> {
         Box::pin(futures::future::err(crate::unimplemented()))
+    }
+
+    async fn head_object(&self, _name: &str) -> io::Result<BlobObjectHeader> {
+        Ok(BlobObjectHeader {
+            replication_status: None,
+        })
     }
 }
 

--- a/components/external_storage/src/lib.rs
+++ b/components/external_storage/src/lib.rs
@@ -36,7 +36,7 @@ use tokio_util::compat::{FuturesAsyncReadCompatExt, TokioAsyncReadCompatExt};
 use url::Url;
 
 mod hdfs;
-pub use cloud::blob::{BlobObject, IterableStorage};
+pub use cloud::blob::{BlobObject, BlobObjectHeader, IterableStorage};
 pub use hdfs::{HdfsConfig, HdfsStorage};
 pub mod local;
 pub use local::LocalStorage;
@@ -191,6 +191,8 @@ pub trait ExternalStorage: 'static + Send + Sync + Any {
     ) -> LocalBoxStream<'_, std::result::Result<BlobObject, io::Error>>;
 
     fn delete(&self, name: &str) -> LocalBoxFuture<'_, io::Result<()>>;
+
+    async fn head_object(&self, name: &str) -> io::Result<BlobObjectHeader>;
 }
 
 #[track_caller]
@@ -260,6 +262,10 @@ impl ExternalStorage for Arc<dyn ExternalStorage> {
     fn delete(&self, name: &str) -> LocalBoxFuture<'_, io::Result<()>> {
         (**self).delete(name)
     }
+
+    async fn head_object(&self, name: &str) -> io::Result<BlobObjectHeader> {
+        (**self).head_object(name).await
+    }
 }
 
 #[async_trait]
@@ -317,6 +323,10 @@ impl ExternalStorage for Box<dyn ExternalStorage> {
 
     fn delete(&self, name: &str) -> LocalBoxFuture<'_, io::Result<()>> {
         self.as_ref().delete(name)
+    }
+
+    async fn head_object(&self, name: &str) -> io::Result<BlobObjectHeader> {
+        self.as_ref().head_object(name).await
     }
 }
 

--- a/components/external_storage/src/local.rs
+++ b/components/external_storage/src/local.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use cloud::blob::BlobObject;
+use cloud::blob::{BlobObject, BlobObjectHeader};
 use futures::{io::AllowStdIo, prelude::Stream};
 use futures_util::{
     future::{FutureExt, LocalBoxFuture},
@@ -241,6 +241,12 @@ impl ExternalStorage for LocalStorage {
             self.base_dir.sync_all().await
         }
         .boxed_local()
+    }
+
+    async fn head_object(&self, _name: &str) -> io::Result<BlobObjectHeader> {
+        Ok(BlobObjectHeader {
+            replication_status: None,
+        })
     }
 }
 

--- a/components/external_storage/src/noop.rs
+++ b/components/external_storage/src/noop.rs
@@ -1,7 +1,7 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 use async_trait::async_trait;
-use cloud::blob::BlobObject;
+use cloud::blob::{BlobObject, BlobObjectHeader};
 use futures_util::{
     future::{self, LocalBoxFuture},
     stream::{self, LocalBoxStream},
@@ -60,6 +60,12 @@ impl ExternalStorage for NoopStorage {
 
     fn delete(&self, _name: &str) -> LocalBoxFuture<'_, io::Result<()>> {
         Box::pin(future::ok(()))
+    }
+
+    async fn head_object(&self, _name: &str) -> io::Result<BlobObjectHeader> {
+        Ok(BlobObjectHeader {
+            replication_status: None,
+        })
     }
 }
 

--- a/deny.toml
+++ b/deny.toml
@@ -118,4 +118,4 @@ exceptions = [
 [sources]
 unknown-git = "deny"
 unknown-registry = "deny"
-allow-org = { github = ["tikv", "pingcap", "rust-lang"] }
+allow-org = { github = ["tikv", "pingcap", "rust-lang", "leavrth"] }


### PR DESCRIPTION
…cated to the downstream storage

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #xxx

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
waiting migration for sync to make sure the compactions are all replicated
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--from-replication-storage` flag to compact log backup command for improved replication control
  * Implemented replication status tracking for cloud-stored backup objects, providing visibility into synchronization status
  
* **Improvements**
  * Enhanced migration metadata handling with automatic replication synchronization verification before backup finalization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->