### PR TITLE
sst_importer: prevent path traversal in remove_dir

### DIFF
--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -5517,19 +5517,19 @@ mod tests {
         .unwrap();
 
         // Non-existent valid subdirectory: no-op, should succeed.
-        assert!(importer.remove_dir("subdir").is_ok());
+        importer.remove_dir("subdir").unwrap();
 
         // Existing valid subdirectory: should be removed.
         let legit = import_dir.path().join("legit");
         std::fs::create_dir_all(&legit).unwrap();
         assert!(legit.exists());
-        assert!(importer.remove_dir("legit").is_ok());
+        importer.remove_dir("legit").unwrap();
         assert!(!legit.exists());
 
         // Nested valid subdirectory.
         let nested = import_dir.path().join("a").join("b");
         std::fs::create_dir_all(&nested).unwrap();
-        assert!(importer.remove_dir("a/b").is_ok());
+        importer.remove_dir("a/b").unwrap();
         assert!(!nested.exists());
 
         // `..` component: must be rejected before path.exists() is called.


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #19515 

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```
    The `prefix` parameter in `SstImporter::remove_dir()` comes from
    RPC requests (`clear_files`) without validation. A malicious prefix
    like "../../" could escape the import root directory and delete
    arbitrary directories via `remove_dir_all`.

    Add canonicalization and containment check to ensure the resolved
    path stays within the import root directory, returning
    `Error::InvalidSstPath` otherwise.

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```
Improved validation for SST import directory removal: rejects absolute or traversal prefixes, canonicalizes paths to verify containment and prevent symlink escape, preserves the original user-supplied prefix in invalid-path errors

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened validation for SST import directory removal: rejects absolute paths and parent-traversal segments, canonicalizes paths to prevent deletions outside the import root (including symlink escapes), preserves the original user-supplied prefix in errors, and logs the canonical path on successful deletion.

* **Tests**
  * Added unit tests for traversal and absolute-path rejection, root-resolution cases, error-prefix preservation, and symlink-escape scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->