### PR TITLE
server, tests: replace paste with pastey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5382,6 +5382,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5d65c4d95931acda4498f675e332fcbdc9a06705cd07086c510e9b6009cd1c1"
 
 [[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+
+[[package]]
 name = "pd_client"
 version = "0.1.0"
 dependencies = [
@@ -8219,7 +8225,7 @@ dependencies = [
  "log_wrappers",
  "more-asserts",
  "online_config",
- "paste",
+ "pastey",
  "pd_client",
  "perfcnt",
  "profiler",
@@ -8558,7 +8564,7 @@ dependencies = [
  "openssl",
  "panic_hook",
  "parking_lot 0.12.1",
- "paste",
+ "pastey",
  "pd_client",
  "pin-project",
  "pnet_datalink",
@@ -9270,7 +9276,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ num_cpus = "1"
 online_config = { workspace = true }
 openssl = { workspace = true }
 parking_lot = "0.12"
-pastey="0.2.1"
+pastey = "0.2.1"
 pd_client = { workspace = true }
 pin-project = "1.0"
 pnet_datalink = "0.23"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ num_cpus = "1"
 online_config = { workspace = true }
 openssl = { workspace = true }
 parking_lot = "0.12"
-paste = "1.0"
+pastey="0.2.1"
 pd_client = { workspace = true }
 pin-project = "1.0"
 pnet_datalink = "0.23"

--- a/src/server/proxy.rs
+++ b/src/server/proxy.rs
@@ -182,7 +182,7 @@ macro_rules! forward_unary {
         let addr = $crate::server::get_target_address(&$ctx);
         if !addr.is_empty() {
             $ctx.spawn($proxy.call_on(addr, move |client| {
-                let f = paste::paste! {
+                let f = pastey::paste! {
                     client.[<$func _async>](&$req).unwrap()
                 };
                 client.spawn(async move {

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -92,7 +92,7 @@ kvproto = { workspace = true }
 log_wrappers = { workspace = true }
 more-asserts = "0.2"
 online_config = { workspace = true }
-paste = "1.0"
+pastey = "0.2.1"
 pd_client = { workspace = true }
 protobuf = { version = "2.8", features = ["bytes"] }
 raft = { workspace = true }

--- a/tests/integrations/server/kv_service.rs
+++ b/tests/integrations/server/kv_service.rs
@@ -2082,14 +2082,14 @@ macro_rules! test_func {
         req.set_context($ctx.clone());
 
         // Not setting forwarding should lead to store not match.
-        let resp = paste::paste! {
+        let resp = pastey::paste! {
             $client.[<$func _opt>](&req, CallOption::default().timeout(Duration::from_secs(3))).unwrap()
         };
         let err = resp.get_region_error();
         assert!(err.has_store_not_match() || err.has_not_leader(), "{:?}", resp);
 
         // Proxy should redirect the request to the correct store.
-        let resp = paste::paste! {
+        let resp = pastey::paste! {
             $client.[<$func _opt>](&req, $call_opt.clone()).unwrap()
         };
         let err = resp.get_region_error();


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: close #19472

This PR replaces the unmaintained `paste` crate (v1.0) with `pastey` (v0.2.1), which is the maintained successor. This resolves the security advisory [RUSTSEC-2024-0436](https://rustsec.org/advisories/RUSTSEC-2024-0436).

**Changes:**
1. Updated root `Cargo.toml` and `tests/Cargo.toml` dependencies from `paste = "1.0"` to `pastey = "0.2.1"`
2. Updated macro call sites from `paste::paste!` to `pastey::paste!` in:
   - `src/server/proxy.rs`
   - `tests/integrations/server/kv_service.rs`

`pastey` is a drop-in replacement with identical API, so no functional changes are required.

```commit-message
Replace paste with pastey for improved maintenance

The paste crate (v1.0) is unmaintained and flagged by RUSTSEC-2024-0436.
Migrate to pastey (v0.2.1), the maintained successor, which provides the same
API and functionality.

- Update Cargo.toml dependencies in root and tests
- Update macro calls from paste::paste! to pastey::paste!
- Verify cargo check passes with no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Replaced an internal build-time macro dependency across the project and test suite.
  * Updated proxy and test code to use the new macro provider, ensuring tests and runtime code remain aligned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->