### PR TITLE
tidb_query_expr: fix TRIM BOTH semantics for overlapping remstr

### DIFF
--- a/components/tidb_query_expr/src/impl_string.rs
+++ b/components/tidb_query_expr/src/impl_string.rs
@@ -890,30 +890,26 @@ fn trim<'a>(string: &'a [u8], pattern: &[u8], direction: TrimDirection) -> &'a [
     if pattern.is_empty() {
         return string;
     }
-    let pat_length = pattern.len();
-    let s_length = string.len();
 
-    let left_position = match direction {
-        TrimDirection::Trailing => 0,
-        _ => string
-            .chunks(pat_length)
-            .position(|chunk| chunk != pattern)
-            .map(|pos| pos * pat_length)
-            .unwrap_or(s_length - (s_length % pat_length)),
+    let trim_leading = |mut s: &'a [u8]| {
+        while s.starts_with(pattern) {
+            s = &s[pattern.len()..];
+        }
+        s
     };
 
-    let right_position = match direction {
-        TrimDirection::Leading => s_length,
-        _ => string
-            .rchunks(pat_length)
-            .position(|chunk| chunk != pattern)
-            .map(|pos| s_length - pos * pat_length)
-            .unwrap_or(s_length % pat_length),
+    let trim_trailing = |mut s: &'a [u8]| {
+        while s.ends_with(pattern) {
+            s = &s[..s.len() - pattern.len()];
+        }
+        s
     };
 
-    let right_position = right_position.max(left_position);
-
-    &string[left_position..right_position]
+    match direction {
+        TrimDirection::Leading => trim_leading(string),
+        TrimDirection::Trailing => trim_trailing(string),
+        TrimDirection::Both => trim_trailing(trim_leading(string)),
+    }
 }
 
 #[rpn_fn]
@@ -4068,6 +4064,9 @@ mod tests {
             (Some(""), Some("x"), Some("")),
             (Some("张三和张三"), Some("张三"), Some("和")),
             (Some("xxxbarxxxxx"), Some("x"), Some("bar")),
+            (Some("aaaaa"), Some("aaa"), Some("aa")),
+            (Some("ppp"), Some("pp"), Some("p")),
+            (Some("xyxyx"), Some("xyx"), Some("yx")),
         ];
 
         for (arg, pat, expect) in test_cases {
@@ -4127,6 +4126,24 @@ mod tests {
                 Some("x"),
                 Some(TrimDirection::Both as i64),
                 Some("bar"),
+            ),
+            (
+                Some("aaaaa"),
+                Some("aaa"),
+                Some(TrimDirection::Both as i64),
+                Some("aa"),
+            ),
+            (
+                Some("ppp"),
+                Some("pp"),
+                Some(TrimDirection::Both as i64),
+                Some("p"),
+            ),
+            (
+                Some("xyxyx"),
+                Some("xyx"),
+                Some(TrimDirection::Both as i64),
+                Some("yx"),
             ),
         ];
         for (arg, pat, direction, exp) in tests {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #xxx  https://github.com/pingcap/tidb/issues/67520

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
- Update TRIM implementation in TiKV string expressions
- Make BOTH-side trimming proceed sequentially:
  - trim from the left first
  - then trim from the right on the intermediate result
- Keep `trim_2_args` / `trim_3_args(BOTH)` aligned with TiDB behavior
- Add regression tests for overlapping removable-part cases
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * String trimming logic rewritten for more reliable and consistent behavior across leading, trailing, and both-direction trims.

* **Tests**
  * Test coverage expanded with additional cases for overlapping and multi-match patterns to ensure correctness in edge scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->