### PR TITLE
*: ignore RUSTSEC-2026-0097 for rand unsound advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -94,6 +94,11 @@ ignore = [
     # raft-engine revision in this workspace still hard-pins serde = 1.0.228,
     # so this cannot be resolved with a lockfile-only update.
     "RUSTSEC-2026-0009",
+    # Ignore RUSTSEC-2026-0097 (unsound issue in rand with a custom logger using
+    # rand::rng()). The vulnerability requires a custom logger that calls
+    # rand::rng() / thread_rng() during logging, which TiKV does not do.
+    # TODO: Upgrade rand to >=0.9.3 or >=0.10.1 when possible.
+    "RUSTSEC-2026-0097",
 ]
 
 # TiKV is licensed under Apache 2.0, according to ASF 3RD PARTY LICENSE POLICY,


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #19525 
<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```
    rand 0.8.x is affected by RUSTSEC-2026-0097, which describes an unsound
    issue when a custom logger calls rand::rng()/thread_rng() during a
    ThreadRng reseed. TiKV does not have custom loggers that access rand in
    this way, so the issue does not affect us in practice.

    Ignore the advisory in deny.toml until rand can be upgraded to >=0.9.3
    or >=0.10.1.

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```
Ignore the advisory in deny.toml until rand can be upgraded to >=0.9.3 or >=0.10.1.

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security advisory configuration to temporarily acknowledge a known issue in a third-party dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->