### PR TITLE
fix pushdown cast to datetime from float

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6842,9 +6842,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6842,9 +6842,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/components/tidb_query_datatype/src/codec/mysql/time/mod.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/time/mod.rs
@@ -691,7 +691,10 @@ mod parser {
                 let whole_time = parse_from_i64(ctx, result, time_type, fsp)?;
                 if whole_time.is_zero() {
                     // Should handle zero properly to match TiDB behaviors.
-                    return handle_zero_date(ctx, TimeArgs::zero(fsp as i8, time_type)).ok()??;
+                    return match handle_zero_date(ctx, TimeArgs::zero(fsp as i8, time_type)) {
+                        Ok(Some(args)) => Time::new(ctx, args).ok(),
+                        _ => None,
+                    };
                 }
                 let mut whole = [
                     whole_time.get_year(),

--- a/components/tidb_query_datatype/src/codec/mysql/time/mod.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/time/mod.rs
@@ -689,6 +689,10 @@ mod parser {
             1 | 2 => {
                 let result: i64 = components[0].convert(ctx).ok()?;
                 let whole_time = parse_from_i64(ctx, result, time_type, fsp)?;
+                if whole_time.is_zero() {
+                    // Should handle zero properly to match TiDB behaviors.
+                    return handle_zero_date(ctx, TimeArgs::zero(fsp as i8, time_type)).ok()??;
+                }
                 let mut whole = [
                     whole_time.get_year(),
                     whole_time.get_month(),

--- a/components/tidb_query_datatype/src/codec/mysql/time/mod.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/time/mod.rs
@@ -3091,6 +3091,8 @@ mod tests {
     #[test]
     fn test_parse_from_real() -> Result<()> {
         let cases = vec![
+            ("0000-00-00 00:00:00", "0", 0),
+            ("0000-00-00 00:00:00.0", "0.0", 1),
             ("2000-03-05 00:00:00", "305", 0),
             ("2000-12-03 00:00:00", "1203", 0),
             ("2003-12-05 00:00:00.0", "31205", 1),
@@ -3123,6 +3125,28 @@ mod tests {
             Time::parse_from_real(&mut ctx, &case, TimeType::DateTime, 0, true).unwrap_err();
         }
         Ok(())
+    }
+
+    #[test]
+    fn test_parse_from_real_zero_date() {
+        let mut ctx = EvalContext::default();
+        for input in ["0", "0.0", "0.000"] {
+            let actual =
+                parser::parse_from_float_string(&mut ctx, input.to_string(), TimeType::DateTime, 0, true);
+            assert!(actual.is_some());
+            assert_eq!(actual.unwrap().to_string(), "0000-00-00 00:00:00");
+        }
+
+        let mut ctx = EvalContext::from(TimeEnv {
+            no_zero_date: true,
+            strict_mode: true,
+            ..TimeEnv::default()
+        });
+        for input in ["0", "0.0", "0.000"] {
+            let actual =
+                parser::parse_from_float_string(&mut ctx, input.to_string(), TimeType::DateTime, 0, true);
+            assert!(actual.is_none());
+        }
     }
 
     #[test]

--- a/components/tidb_query_datatype/src/codec/mysql/time/mod.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/time/mod.rs
@@ -3131,8 +3131,13 @@ mod tests {
     fn test_parse_from_real_zero_date() {
         let mut ctx = EvalContext::default();
         for input in ["0", "0.0", "0.000"] {
-            let actual =
-                parser::parse_from_float_string(&mut ctx, input.to_string(), TimeType::DateTime, 0, true);
+            let actual = parser::parse_from_float_string(
+                &mut ctx,
+                input.to_string(),
+                TimeType::DateTime,
+                0,
+                true,
+            );
             assert!(actual.is_some());
             assert_eq!(actual.unwrap().to_string(), "0000-00-00 00:00:00");
         }
@@ -3143,8 +3148,13 @@ mod tests {
             ..TimeEnv::default()
         });
         for input in ["0", "0.0", "0.000"] {
-            let actual =
-                parser::parse_from_float_string(&mut ctx, input.to_string(), TimeType::DateTime, 0, true);
+            let actual = parser::parse_from_float_string(
+                &mut ctx,
+                input.to_string(),
+                TimeType::DateTime,
+                0,
+                true,
+            );
             assert!(actual.is_none());
         }
     }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #19534, ref https://github.com/pingcap/tidb/pull/44135

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
properly handle zero date when cast 0.xx float to datetime
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
properly handle zero date when cast 0.xx float to datetime
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed zero-date handling when parsing numeric/float-like time inputs so all-zero parses consistently follow the zero-date path, returning either a valid zero-time or None based on strict/NO_ZERO_DATE rules.
* **Tests**
  * Added tests covering "0" and "0.0" inputs and validating behavior under default and NO_ZERO_DATE strict modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->