### PR TITLE
resolved_ts: optimize LeadershipResolver's memory usage

### DIFF
--- a/components/resolved_ts/src/advance.rs
+++ b/components/resolved_ts/src/advance.rs
@@ -24,7 +24,7 @@ use kvproto::{
     tikvpb::TikvClient,
 };
 use pd_client::PdClient;
-use protobuf::Message;
+use protobuf::{Message, RepeatedField};
 use raftstore::{
     router::CdcHandle,
     store::{msg::Callback, util::RegionReadProgressRegistry},
@@ -49,6 +49,8 @@ use crate::{TsSource, endpoint::Task, metrics::*};
 pub(crate) const DEFAULT_CHECK_LEADER_TIMEOUT_DURATION: Duration = Duration::from_secs(5); // 5s
 const DEFAULT_GRPC_GZIP_COMPRESSION_LEVEL: usize = 2;
 const DEFAULT_GRPC_MIN_MESSAGE_SIZE_TO_COMPRESS: usize = 4096;
+const CHECK_LEADER_REQ_REGIONS_SHRINK_FACTOR: usize = 4;
+const CHECK_LEADER_REQ_REGIONS_MIN_RETAIN_CAPACITY: usize = 1024;
 
 pub struct AdvanceTsWorker {
     pd_client: Arc<dyn PdClient>,
@@ -219,8 +221,7 @@ impl LeadershipResolver {
 
     fn clear(&mut self) {
         for v in self.store_req_map.values_mut() {
-            v.regions.clear();
-            v.ts = 0;
+            reset_check_leader_request(v);
         }
         for v in self.progresses.values_mut() {
             v.clear();
@@ -288,11 +289,7 @@ impl LeadershipResolver {
                         // because performing stale read on learners require it.
                         store_req_map
                             .entry(peer.store_id)
-                            .or_insert_with(|| {
-                                let mut req = CheckLeaderRequest::default();
-                                req.regions = Vec::with_capacity(registry.len()).into();
-                                req
-                            })
+                            .or_insert_with(CheckLeaderRequest::default)
                             .regions
                             .push(leader_info.clone());
                         if peer.get_role() != PeerRole::Learner {
@@ -437,6 +434,19 @@ impl LeadershipResolver {
         }
         res
     }
+}
+
+fn reset_check_leader_request(req: &mut CheckLeaderRequest) {
+    let retained_len = req.regions.len();
+    let shrink_threshold = retained_len
+        .saturating_mul(CHECK_LEADER_REQ_REGIONS_SHRINK_FACTOR)
+        .max(CHECK_LEADER_REQ_REGIONS_MIN_RETAIN_CAPACITY);
+    if req.regions.capacity() > shrink_threshold {
+        req.regions = RepeatedField::from_vec(Vec::with_capacity(retained_len));
+    } else {
+        req.regions.clear();
+    }
+    req.ts = 0;
 }
 
 pub async fn resolve_by_raft<T, E>(regions: Vec<u64>, min_ts: TimeStamp, cdc_handle: T) -> Vec<u64>
@@ -600,6 +610,7 @@ mod tests {
     use grpcio::{self, ChannelBuilder, EnvBuilder, Server, ServerBuilder};
     use kvproto::{metapb::Region, tikvpb::Tikv, tikvpb_grpc::create_tikv};
     use pd_client::PdClient;
+    use protobuf::RepeatedField;
     use raftstore::store::util::RegionReadProgress;
     use tikv_util::store::new_peer;
 
@@ -638,6 +649,18 @@ mod tests {
         let channel = ChannelBuilder::new(env).connect(&addr);
         let client = TikvClient::new(channel);
         (server, client, rx)
+    }
+
+    fn new_progress(region_id: u64, remote_store_id: u64) -> Arc<RegionReadProgress> {
+        let mut region = Region::default();
+        region.id = region_id;
+        region.peers.push(new_peer(1, region_id));
+        region
+            .peers
+            .push(new_peer(remote_store_id, region_id + 10_000));
+        let progress = RegionReadProgress::new(&region, 1, 1, region_id);
+        progress.update_leader_info(region_id, 1, &region);
+        Arc::new(progress)
     }
 
     #[tokio::test]
@@ -697,6 +720,91 @@ mod tests {
             .resolve(vec![], TimeStamp::new(1), None)
             .await;
         rx.recv_timeout(Duration::from_secs(1)).unwrap_err();
+
+        let _ = server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_resolve_request_capacity_ignores_registry_size() {
+        let env = Arc::new(EnvBuilder::new().build());
+        let (mut server, tikv_client, rx) = new_rpc_suite(env.clone());
+
+        let mut leader_resolver = LeadershipResolver::new(
+            1, // store id
+            Arc::new(MockPdClient {}),
+            env.clone(),
+            Arc::new(SecurityManager::default()),
+            RegionReadProgressRegistry::new(),
+            Duration::from_secs(1),
+        );
+        leader_resolver
+            .tikv_clients
+            .lock()
+            .await
+            .insert(2 /* store id */, tikv_client);
+        for region_id in 1..=2048 {
+            leader_resolver
+                .region_read_progress
+                .insert(region_id, new_progress(region_id, 2));
+        }
+
+        leader_resolver
+            .resolve(vec![1], TimeStamp::new(1), None)
+            .await;
+        let req = rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        assert_eq!(req.regions.len(), 1);
+
+        let retained_req = leader_resolver.store_req_map.get(&2).unwrap();
+        assert_eq!(retained_req.regions.len(), 1);
+        assert!(
+            retained_req.regions.capacity() < 64,
+            "unexpected request capacity {} for a single checked region",
+            retained_req.regions.capacity()
+        );
+
+        let _ = server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_resolve_shrinks_oversized_request_buffer_on_reuse() {
+        let env = Arc::new(EnvBuilder::new().build());
+        let (mut server, tikv_client, rx) = new_rpc_suite(env.clone());
+
+        let mut leader_resolver = LeadershipResolver::new(
+            1, // store id
+            Arc::new(MockPdClient {}),
+            env.clone(),
+            Arc::new(SecurityManager::default()),
+            RegionReadProgressRegistry::new(),
+            Duration::from_secs(60),
+        );
+        leader_resolver
+            .tikv_clients
+            .lock()
+            .await
+            .insert(2 /* store id */, tikv_client);
+        leader_resolver
+            .region_read_progress
+            .insert(1, new_progress(1, 2));
+
+        let mut req = CheckLeaderRequest::default();
+        req.regions = RepeatedField::from_vec(Vec::with_capacity(4096));
+        req.regions.push(Default::default());
+        leader_resolver.store_req_map.insert(2, req);
+
+        leader_resolver
+            .resolve(vec![1], TimeStamp::new(1), None)
+            .await;
+        let req = rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        assert_eq!(req.regions.len(), 1);
+
+        let retained_req = leader_resolver.store_req_map.get(&2).unwrap();
+        assert_eq!(retained_req.regions.len(), 1);
+        assert!(
+            retained_req.regions.capacity() < 64,
+            "oversized request buffer was not shrunk, capacity {}",
+            retained_req.regions.capacity()
+        );
 
         let _ = server.shutdown().await;
     }

--- a/components/resolved_ts/src/advance.rs
+++ b/components/resolved_ts/src/advance.rs
@@ -289,7 +289,7 @@ impl LeadershipResolver {
                         // because performing stale read on learners require it.
                         store_req_map
                             .entry(peer.store_id)
-                            .or_insert_with(CheckLeaderRequest::default)
+                            .or_default()
                             .regions
                             .push(leader_info.clone());
                         if peer.get_role() != PeerRole::Learner {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #19535

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

The previous implementation allocate a vec with a length of the region number while only a small portion of the regions need to be checked. From a production cluster, I observe the LeadershipResolver consumes ~1.4GB memory. The cluster contains ~90 instance with each ~250k region. So the memory usage of `store_req_map` in theory is about: 250_000 * 90 * 56 (mem::size_of::<CheckLeaderRequest>()) = ~1.2GB, which matches the real memory usage scale. While from the metrics, I was the real number of region that need to be checked is only a few thousand.

```commit-message
Optimize the memory usage of LeadershipResolver when the region number is large.
```


### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fix the bug that resolved_ts module consumes too much memory when the region number is large
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added async/unit tests to verify request buffer sizing, prevent unbounded capacity growth, and ensure oversized buffers are shrunk on reuse.

* **Refactor**
  * Improved memory efficiency of request caching by introducing controlled buffer reuse and capacity-shrinking logic to keep request memory stable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->