### PR TITLE
release: fix TiKV version for release-fts-202602

### DIFF
--- a/.github/workflows/tikv-clippy-darwin.yml
+++ b/.github/workflows/tikv-clippy-darwin.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - master
       - 'feature/**'
+      - release-fts-202602
     paths-ignore:
       - '**.md'
       - '**.png'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7409,7 +7409,7 @@ dependencies = [
 
 [[package]]
 name = "tikv"
-version = "9.0.0-beta.2"
+version = "8.5.0"
 dependencies = [
  "anyhow",
  "api_version",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tikv"
-version = "9.0.0-beta.2"
+version = "8.5.0"
 authors = ["The TiKV Authors"]
 description = "A distributed transactional key-value database powered by Rust and Raft"
 license = "Apache-2.0"

--- a/deny.toml
+++ b/deny.toml
@@ -99,6 +99,10 @@ ignore = [
     # time@0.3.47 requires rustc 1.88.0. 
     # TODO: Upgrade rust toolchain and remove this ignore.
     "RUSTSEC-2026-0009",
+    # Ignore RUSTSEC-2026-0097 because the advisory requires calling rand from a
+    # custom logger, while TiKV's logger implementations don't use rand. Keep the
+    # release branch change minimal until dependencies can be upgraded safely.
+    "RUSTSEC-2026-0097",
 ]
 
 # TiKV is licensed under Apache 2.0, according to ASF 3RD PARTY LICENSE POLICY,
@@ -125,4 +129,3 @@ exceptions = [
 unknown-git = "deny"
 unknown-registry = "deny"
 allow-org = { github = ["tikv", "pingcap", "rust-lang"] }
-


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Close #19541

What's Changed:

```commit-message
release: fix TiKV version for release-fts-202602
```

This PR changes the TiKV package version metadata on `release-fts-202602` from `9.0.0-beta.2` to `8.5.0`, so TiDB release-fts CI uses a TiKV build compatible with BR 8.5.x.

It also allows the Darwin Clippy GitHub Action to run for PRs targeting `release-fts-202602`.

The Linux clippy CI also hit `RUSTSEC-2026-0097` from `rand`; this PR adds the advisory to `deny.toml` because TiKV's logger implementations do not call rand from the logging path.

Related TiDB PR: https://github.com/pingcap/tidb/pull/67936

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests

- [x] Manual test (add detailed scripts or steps below)

Manual test:

- `cargo metadata --locked --no-deps --format-version 1`
- YAML syntax check for `.github/workflows/tikv-clippy-darwin.yml`
- `git diff --check`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
None
```