### PR TITLE
server: reduce raft_client's message queue capacity when there are more the 1 connection per store

### DIFF
--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -150,6 +150,11 @@ pub struct Config {
     // When merge raft messages into a batch message, leave a buffer.
     #[online_config(skip)]
     pub raft_client_grpc_send_msg_buffer: usize,
+    // NOTE: the memory of a single item is 216B, so with 16k capacity, the memory of a single
+    // queue is ~3MB.
+    /// the total capacity of raft_client's message queue to specific store.
+    /// The capacity of a single raft_client is:  raft_client_queue_size /
+    /// grpc_raft_conn_num.
     #[online_config(skip)]
     pub raft_client_queue_size: usize,
     // Test only
@@ -500,6 +505,12 @@ impl Config {
         }
         if self.graceful_shutdown_timeout.0.as_secs() == 0 {
             warn!("graceful shutdown timeout is disabled");
+        }
+
+        if self.grpc_raft_conn_num == 0 {
+            return Err(box_err!(
+                "server.grpc_raft_conn_num must be greater than 0"
+            ));
         }
         Ok(())
     }

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -152,9 +152,9 @@ pub struct Config {
     pub raft_client_grpc_send_msg_buffer: usize,
     // NOTE: the memory of a single item is 216B, so with 16k capacity, the memory of a single
     // queue is ~3MB.
-    /// the total capacity of raft_client's message queue to specific store.
-    /// The capacity of a single raft_client is:  raft_client_queue_size /
-    /// grpc_raft_conn_num.
+    /// The total capacity of the raft client's message queues for a specific store.
+    /// The capacity of a single connection is `raft_client_queue_size /
+    /// grpc_raft_conn_num`.
     #[online_config(skip)]
     pub raft_client_queue_size: usize,
     // Test only
@@ -509,9 +509,14 @@ impl Config {
 
         if self.grpc_raft_conn_num == 0 {
             return Err(box_err!(
-                "server.grpc_raft_conn_num must be greater than 0"
+                "server.grpc-raft-conn-num must be greater than 0."
             ));
         }
+        if self.raft_client_queue_size < self.grpc_raft_conn_num {
+             return Err(box_err!(
+                 "server.raft-client-queue-size must be greater than or equal to server.grpc-raft-conn-num"
+             ));
+         }
         Ok(())
     }
 

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -152,9 +152,9 @@ pub struct Config {
     pub raft_client_grpc_send_msg_buffer: usize,
     // NOTE: the memory of a single item is 216B, so with 16k capacity, the memory of a single
     // queue is ~3MB.
-    /// The total capacity of the raft client's message queues for a specific store.
-    /// The capacity of a single connection is `raft_client_queue_size /
-    /// grpc_raft_conn_num`.
+    /// The total capacity of the raft client's message queues for a specific
+    /// store. The capacity of a single connection is
+    /// `raft_client_queue_size / grpc_raft_conn_num`.
     #[online_config(skip)]
     pub raft_client_queue_size: usize,
     // Test only
@@ -513,10 +513,10 @@ impl Config {
             ));
         }
         if self.raft_client_queue_size < self.grpc_raft_conn_num {
-             return Err(box_err!(
-                 "server.raft-client-queue-size must be greater than or equal to server.grpc-raft-conn-num"
-             ));
-         }
+            return Err(box_err!(
+                "server.raft-client-queue-size must be greater than or equal to server.grpc-raft-conn-num"
+            ));
+        }
         Ok(())
     }
 

--- a/src/server/raft_client.rs
+++ b/src/server/raft_client.rs
@@ -1130,9 +1130,11 @@ where
                 .connections
                 .entry((store_id, conn_id))
                 .or_insert_with(|| {
-                    let queue = Arc::new(Queue::with_capacity(
-                        self.builder.cfg.value().raft_client_queue_size,
-                    ));
+                    let queue_capacity = {
+                        let cfg = self.builder.cfg.value();
+                        cfg.raft_client_queue_size / cfg.grpc_raft_conn_num
+                    };
+                    let queue = Arc::new(Queue::with_capacity(queue_capacity));
                     if need_pause {
                         queue.set_conn_state(ConnState::Paused);
                     }


### PR DESCRIPTION

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #19542

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Change raft_client's message queue's capacity from `raft_client_queue_size` to `raft_client_queue_size /grpc_raft_conn_num` to reduce the memory usage.
```

Alternative:

Another approach is to replace the current `ArrayQueue` with `SegQueue` so the memory can shrink to very small when the queue is empty. But as this is a very hot path, it may have negative performanNonece impact.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Reduce the memory usage of raft-client when raft_client_queue_size > 1
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation now rejects zero gRPC connection counts and enforces that configured queue size is at least the number of connections.
  * Per-connection message queue capacity is calculated by dividing the configured total across connections to avoid oversized per-connection queues.

* **Documentation**
  * Clarified how queue capacity relates to connection count and the resulting memory implications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->