### PR TITLE
DNM: Release 7.5.5 hotfix 20260424

### DIFF
--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -408,9 +408,16 @@ where
         }
     }
 
-    pub fn maybe_hibernate(&mut self) -> bool {
-        self.hibernate_state
-            .maybe_hibernate(self.peer.peer_id(), self.peer.region())
+    /// The condition for leader hibernation includes:
+    /// - all alive peers have voted for hibernate request
+    /// - enough hibernate votes to form a quorum
+    pub fn maybe_hibernate(&mut self, down_peer_ids: &[u64]) -> (bool, Vec<u64>) {
+        self.hibernate_state.maybe_hibernate(
+            |vote_ids| self.peer.raft_group.raft.prs().has_quorum(vote_ids),
+            self.peer.peer_id(),
+            self.peer.region(),
+            down_peer_ids,
+        )
     }
 
     pub fn update_memory_trace(&mut self, event: &mut TraceEvent) {
@@ -2247,6 +2254,7 @@ where
         self.check_force_leader();
 
         let mut res = None;
+        let down_peer_ids = self.fsm.peer.get_down_peer_ids();
         if self.ctx.cfg.hibernate_regions {
             if self.fsm.hibernate_state.group_state() == GroupState::Idle {
                 // missing_ticks should be less than election timeout ticks otherwise
@@ -2279,7 +2287,11 @@ where
                 }
                 return;
             }
-            res = Some(self.fsm.peer.check_before_tick(&self.ctx.cfg));
+            res = Some(
+                self.fsm
+                    .peer
+                    .check_before_tick(&self.ctx.cfg, &down_peer_ids),
+            );
             if self.fsm.missing_ticks > 0 {
                 for _ in 0..self.fsm.missing_ticks {
                     if self.fsm.peer.raft_group.tick() {
@@ -2302,7 +2314,7 @@ where
         // hibernate timeout.
         if res.is_none() /* hibernate_region is false */ ||
             !self.fsm.peer.check_after_tick(self.fsm.hibernate_state.group_state(), res.unwrap()) ||
-            (self.fsm.peer.is_leader() && !self.all_agree_to_hibernate())
+            (self.fsm.peer.is_leader() && !self.quorum_agree_to_hibernate(&down_peer_ids))
         {
             self.register_raft_base_tick();
             // We need pd heartbeat tick to collect down peers and pending peers.
@@ -2776,8 +2788,9 @@ where
         Ok(())
     }
 
-    fn all_agree_to_hibernate(&mut self) -> bool {
-        if self.fsm.maybe_hibernate() {
+    fn quorum_agree_to_hibernate(&mut self, down_peer_ids: &[u64]) -> bool {
+        let (result, hibernate_vote_peer_ids) = self.fsm.maybe_hibernate(down_peer_ids);
+        if result {
             return true;
         }
         if !self
@@ -2787,6 +2800,21 @@ where
         {
             return false;
         }
+        // If non hibernate vote peers are all unreachable, leader can skip
+        // broadcasting hibernate request. Because non hibernate vote peers may
+        // be down, and they have not been detected as down peers. Down peers
+        // are expected to encounter heartbeat timeout and be in probe state.
+        // Using 3 times of raft_heartbeat_interval as heartbeat_timeout_duration to
+        // determine whether a peer is unreachable.
+        let heartbeat_timeout_duration = self.ctx.cfg.raft_heartbeat_interval() * 3;
+        if self.fsm.peer.all_non_hibernate_vote_peers_unreachable(
+            &hibernate_vote_peer_ids,
+            heartbeat_timeout_duration,
+        ) {
+            // Skip broadcast hibernate request.
+            return false;
+        }
+        // Broadcast hibernate request to all peers.
         for peer in self.fsm.peer.region().get_peers() {
             if peer.get_id() == self.fsm.peer.peer_id() {
                 continue;

--- a/components/raftstore/src/store/hibernate_state.rs
+++ b/components/raftstore/src/store/hibernate_state.rs
@@ -1,12 +1,13 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
 // #[PerformanceCriticalPath]
+use collections::HashSet;
 use kvproto::metapb::Region;
 use pd_client::{Feature, FeatureGate};
 use serde_derive::{Deserialize, Serialize};
+use tikv_util::debug;
 
 use crate::store::metrics::*;
-
 /// Because negotiation protocol can't be recognized by old version of binaries,
 /// so enabling it directly can cause a lot of connection reset.
 const NEGOTIATION_HIBERNATE: Feature = Feature::require(5, 0, 0);
@@ -85,28 +86,72 @@ impl HibernateState {
         gate.can_enable(NEGOTIATION_HIBERNATE)
     }
 
-    pub fn maybe_hibernate(&mut self, my_id: u64, region: &Region) -> bool {
+    pub fn maybe_hibernate<F>(
+        &mut self,
+        has_quorum: F,
+        my_id: u64,
+        region: &Region,
+        down_peer_ids: &[u64],
+    ) -> (bool, Vec<u64>)
+    where
+        F: Fn(&HashSet<u64>) -> bool,
+    {
+        let mut hibernate_vote_peer_ids = HashSet::default();
+        hibernate_vote_peer_ids.insert(my_id); // leader always votes for itself
         let peers = region.get_peers();
         let v = match &mut self.leader {
             LeaderState::Awaken => {
                 self.leader = LeaderState::Poll(Vec::with_capacity(peers.len()));
-                return false;
+                return (false, vec![]);
             }
             LeaderState::Poll(v) => v,
-            LeaderState::Hibernated => return true,
+            LeaderState::Hibernated => {
+                return (true, vec![]);
+            }
         };
+        hibernate_vote_peer_ids.extend(v.iter());
+        let vote_peer_ids: Vec<u64> = hibernate_vote_peer_ids.iter().cloned().collect();
+        let mut alive_non_hibernate_vote_peer = None; // whether alive non-hibernate-vote peer exists
+        for peer in peers {
+            let peer_id = peer.get_id();
+            if peer_id == my_id {
+                continue;
+            }
+            if !v.contains(&peer_id) && !down_peer_ids.contains(&peer_id) {
+                debug!(
+                    "peer is alive but not voted for hibernate";
+                    "peer_id" => peer_id,
+                    "my_id" => my_id,
+                    "region_id" => region.get_id(),
+                );
+                alive_non_hibernate_vote_peer = Some(peer_id);
+                break;
+            }
+        }
         // 1 is for leader itself, which is not counted into votes.
         if v.len() + 1 < peers.len() {
-            return false;
+            if alive_non_hibernate_vote_peer.is_some() || !has_quorum(&hibernate_vote_peer_ids) {
+                return (false, vote_peer_ids);
+            } else {
+                // No alive non-hibernate-voter peer, and enough votes to form a quorum.
+                // We can proceed to do the following final check.
+                debug!(
+                    "hibernate vote check passed by quorum with down peers";
+                    "my_id" => my_id,
+                    "votes" => v.len(),
+                    "down_peer_ids" => ?down_peer_ids,
+                    "vote_peer_ids" => ?v,
+                    "region_id" => region.get_id(),
+                );
+            }
         }
-        if peers
-            .iter()
-            .all(|p| p.get_id() == my_id || v.contains(&p.get_id()))
-        {
+        if peers.iter().all(|p| {
+            p.get_id() == my_id || v.contains(&p.get_id()) || down_peer_ids.contains(&p.get_id())
+        }) {
             self.leader = LeaderState::Hibernated;
-            true
+            (true, vote_peer_ids)
         } else {
-            false
+            (false, vote_peer_ids)
         }
     }
 }

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -1452,10 +1452,54 @@ where
         &self.region_buckets_info
     }
 
+    fn is_peer_heartbeat_timeout(
+        &self,
+        peer_id: u64,
+        heartbeat_timeout_duration: Duration,
+    ) -> bool {
+        if let Some(instant) = self.peer_heartbeats.get(&peer_id) {
+            let elapsed = instant.saturating_elapsed();
+            return elapsed >= heartbeat_timeout_duration;
+        }
+        true // If no heartbeat record, consider it as timeout.
+    }
+
+    /// Checks if all peers that have not sent a hibernate vote are unreachable.
+    /// If one peer is unreachable, it must be in probe state and encounter
+    /// heartbeat timeout.
+    pub fn all_non_hibernate_vote_peers_unreachable(
+        &self,
+        hibernate_vote_peer_ids: &[u64],
+        heartbeat_timeout_duration: Duration,
+    ) -> bool {
+        let status = self.raft_group.status();
+        let progress = match status.progress {
+            Some(progress) => progress,
+            None => return false,
+        };
+        // Check each peer in the raft group
+        for (id, pr) in progress.iter() {
+            if *id == self.peer.get_id() {
+                continue;
+            }
+            if !hibernate_vote_peer_ids.contains(id) {
+                if pr.state != ProgressState::Probe {
+                    // Found a non-hibernate-vote peer not in probe state, return false
+                    return false;
+                }
+                if !self.is_peer_heartbeat_timeout(*id, heartbeat_timeout_duration) {
+                    // Found a non-hibernate-vote peer not in heartbeat timeout, return false
+                    return false;
+                }
+            }
+        }
+        true
+    }
+
     /// Check whether the peer can be hibernated.
     ///
     /// This should be used with `check_after_tick` to get a correct conclusion.
-    pub fn check_before_tick(&self, cfg: &Config) -> CheckTickResult {
+    pub fn check_before_tick(&self, cfg: &Config, down_peer_ids: &[u64]) -> CheckTickResult {
         let mut res = CheckTickResult::default();
         if !self.is_leader() {
             return res;
@@ -1466,17 +1510,29 @@ where
         }
         let status = self.raft_group.status();
         let last_index = self.raft_group.raft.raft_log.last_index();
+        let mut matched_peer_ids = HashSet::default();
+        matched_peer_ids.insert(self.peer.get_id());
         for (id, pr) in status.progress.unwrap().iter() {
-            // Even a recent inactive node is also considered. If we put leader into sleep,
-            // followers or learners may not sync its logs for a long time and become
-            // unavailable. We choose availability instead of performance in this case.
+            // Leader can sleep when every alive peer is in sync and all alive peers reach
+            // majority. If we put leader into sleep when some alive peer lags,
+            // followers or learners may not sync its logs for a long time and
+            // become unavailable. We choose availability instead of performance in this
+            // case.
             if *id == self.peer.get_id() {
                 continue;
             }
-            if pr.matched != last_index {
+            if pr.matched != last_index && !down_peer_ids.contains(id) {
+                // Prevent leader from sleeping when some alive peer is still replicating logs.
                 res.reason = "replication";
                 return res;
             }
+            if pr.matched == last_index {
+                matched_peer_ids.insert(*id);
+            }
+        }
+        if !self.raft_group.raft.prs().has_quorum(&matched_peer_ids) {
+            res.reason = "not enough matched peers";
+            return res;
         }
         if self.raft_group.raft.pending_read_count() > 0 {
             res.reason = "pending read";
@@ -1990,6 +2046,14 @@ where
             self.refill_disk_full_peers(ctx);
         }
         down_peers
+    }
+
+    /// Returns the current list of down peer ids.
+    ///
+    /// This clones the internal `down_peer_ids` vector so callers can use it
+    /// without borrowing `self` mutably.
+    pub fn get_down_peer_ids(&self) -> Vec<u64> {
+        self.down_peer_ids.clone()
     }
 
     /// Collects all pending peers and update `peers_start_pending_time`.

--- a/components/test_raftstore/src/util.rs
+++ b/components/test_raftstore/src/util.rs
@@ -685,7 +685,9 @@ pub fn configure_for_hibernate(config: &mut Config) {
     // Uses long check interval to make leader keep sleeping during tests.
     config.raft_store.abnormal_leader_missing_duration = ReadableDuration::secs(20);
     config.raft_store.max_leader_missing_duration = ReadableDuration::secs(40);
-    config.raft_store.peer_stale_state_check_interval = ReadableDuration::secs(10);
+    config.raft_store.peer_stale_state_check_interval = ReadableDuration::secs(5);
+    // speed up down peer detection
+    config.raft_store.max_peer_down_duration = ReadableDuration::secs(5);
 }
 
 pub fn configure_for_snapshot(config: &mut Config) {

--- a/tests/integrations/raftstore/test_hibernate.rs
+++ b/tests/integrations/raftstore/test_hibernate.rs
@@ -6,11 +6,14 @@ use std::{
     time::Duration,
 };
 
+use engine_rocks::RocksSnapshot;
 use futures::executor::block_on;
+use kvproto::raft_cmdpb::RaftCmdRequest;
 use pd_client::PdClient;
 use raft::eraftpb::{ConfChangeType, MessageType};
+use raftstore::store::msg::*;
 use test_raftstore::*;
-use tikv_util::{time::Instant, HandyRwLock};
+use tikv_util::{config::ReadableDuration, time::Instant, HandyRwLock};
 
 #[test]
 fn test_proposal_prevent_sleep() {
@@ -498,4 +501,443 @@ fn test_leader_demoted_when_hibernated() {
     // be demoted as learner.
     cluster.must_put(b"k1", b"v1");
     cluster.must_put(b"k2", b"v2");
+}
+
+/// Tests whether leader can hibernate when some voters are down.
+#[test]
+fn test_hibernate_quorum_feature_basic() {
+    let mut cluster = new_node_cluster(0, 3);
+    configure_for_hibernate(&mut cluster.cfg);
+    cluster.run();
+    cluster.must_transfer_leader(1, new_peer(1, 1));
+    cluster.must_put(b"k1", b"v1");
+    must_get_equal(&cluster.get_engine(3), b"k1", b"v1");
+    // Wait till leader peer goes to sleep.
+    thread::sleep(
+        cluster.cfg.raft_store.raft_base_tick_interval.0
+            * 3
+            * cluster.cfg.raft_store.raft_election_timeout_ticks as u32,
+    );
+    let awakened = Arc::new(AtomicBool::new(false));
+    let filter = Arc::new(AtomicBool::new(false));
+    let a = awakened.clone();
+    cluster.add_send_filter(CloneFilterFactory(
+        RegionPacketFilter::new(1, 1)
+            .direction(Direction::Send)
+            .set_msg_callback(Arc::new(move |_| {
+                a.store(true, Ordering::SeqCst);
+            }))
+            .when(filter.clone()),
+    ));
+    filter.store(true, Ordering::SeqCst);
+    thread::sleep(cluster.cfg.raft_store.raft_heartbeat_interval() * 2);
+    assert!(!awakened.load(Ordering::SeqCst));
+
+    // Put some data to make leader exit hibernation.
+    cluster.clear_send_filters(); // clear filters before putting data
+    cluster.must_put(b"k2", b"v2");
+    must_get_equal(&cluster.get_engine(3), b"k2", b"v2");
+    // Must wait here for replication to finish before stopping node.
+    thread::sleep(Duration::from_millis(1000));
+
+    // Simulate one voter down.
+    cluster.stop_node(3);
+    thread::sleep(cluster.cfg.raft_store.max_peer_down_duration.0 * 2);
+    cluster.must_transfer_leader(1, new_peer(1, 1));
+    cluster.reset_leader_of_region(1);
+    assert_eq!(cluster.leader_of_region(1), Some(new_peer(1, 1)));
+
+    filter.store(false, Ordering::SeqCst);
+    awakened.store(false, Ordering::SeqCst);
+    let a = awakened.clone();
+    cluster.add_send_filter(CloneFilterFactory(
+        RegionPacketFilter::new(1, 1)
+            .direction(Direction::Send)
+            .set_msg_callback(Arc::new(move |_| {
+                a.store(true, Ordering::SeqCst);
+            }))
+            .when(filter.clone()),
+    ));
+    // Wait till leader peer goes to sleep.
+    thread::sleep(
+        cluster.cfg.raft_store.raft_base_tick_interval.0
+            * 3
+            * cluster.cfg.raft_store.raft_election_timeout_ticks as u32,
+    );
+    filter.store(true, Ordering::SeqCst);
+    thread::sleep(cluster.cfg.raft_store.raft_heartbeat_interval() * 2);
+    // Leader can go to sleep as voters can reach majority.
+    assert!(!awakened.load(Ordering::SeqCst));
+
+    // Put some data to make leader exit hibernation when one peer is down.
+    cluster.clear_send_filters(); // clear filters before putting data
+    cluster.must_put(b"k3", b"v3");
+    must_get_equal(&cluster.get_engine(2), b"k3", b"v3");
+    thread::sleep(cluster.cfg.raft_store.max_peer_down_duration.0 * 2);
+    // Check whether leader can go to sleep again.
+    assert_eq!(cluster.leader_of_region(1), Some(new_peer(1, 1)));
+    filter.store(false, Ordering::SeqCst);
+    awakened.store(false, Ordering::SeqCst);
+    let a = awakened.clone();
+    cluster.add_send_filter(CloneFilterFactory(
+        RegionPacketFilter::new(1, 1)
+            .direction(Direction::Send)
+            .set_msg_callback(Arc::new(move |_| {
+                a.store(true, Ordering::SeqCst);
+            }))
+            .when(filter.clone()),
+    ));
+    // Wait till leader peer goes to sleep.
+    thread::sleep(
+        cluster.cfg.raft_store.raft_base_tick_interval.0
+            * 3
+            * cluster.cfg.raft_store.raft_election_timeout_ticks as u32,
+    );
+    filter.store(true, Ordering::SeqCst);
+    thread::sleep(cluster.cfg.raft_store.raft_heartbeat_interval() * 2);
+    // Leader can go to sleep as voters can reach majority.
+    assert!(!awakened.load(Ordering::SeqCst));
+
+    // Start voter again.
+    cluster.clear_send_filters();
+    cluster.run_node(3).unwrap();
+    thread::sleep(cluster.cfg.raft_store.max_peer_down_duration.0 * 2);
+    cluster.must_transfer_leader(1, new_peer(1, 1));
+    cluster.reset_leader_of_region(1);
+    assert_eq!(cluster.leader_of_region(1), Some(new_peer(1, 1)));
+    // add send filter again
+    filter.store(false, Ordering::SeqCst);
+    awakened.store(false, Ordering::SeqCst);
+    let a = awakened.clone();
+    cluster.add_send_filter(CloneFilterFactory(
+        RegionPacketFilter::new(1, 1)
+            .direction(Direction::Send)
+            .set_msg_callback(Arc::new(move |_| {
+                a.store(true, Ordering::SeqCst);
+            }))
+            .when(filter.clone()),
+    ));
+    // Wait till leader peer goes to sleep.
+    thread::sleep(
+        cluster.cfg.raft_store.raft_base_tick_interval.0
+            * 3
+            * cluster.cfg.raft_store.raft_election_timeout_ticks as u32,
+    );
+    filter.store(true, Ordering::SeqCst);
+    thread::sleep(cluster.cfg.raft_store.raft_heartbeat_interval() * 2);
+    // Leader can go to sleep after down voter recover.
+    assert!(!awakened.load(Ordering::SeqCst));
+
+    cluster.clear_send_filters(); // clear filters before putting data
+    cluster.must_put(b"k4", b"v4");
+    must_get_equal(&cluster.get_engine(3), b"k4", b"v4");
+}
+
+/// Tests whether leader can hibernate when one learner is down.
+#[test]
+fn test_hibernate_quorum_feature_down_learner() {
+    let mut cluster = new_server_cluster(0, 4);
+    configure_for_hibernate(&mut cluster.cfg);
+    cluster.cfg.raft_store.raft_log_gc_count_limit = Some(20);
+    cluster.pd_client.disable_default_operator();
+    cluster.run_conf_change();
+    cluster.pd_client.must_add_peer(1, new_peer(2, 2));
+    cluster.pd_client.must_add_peer(1, new_peer(3, 3));
+
+    cluster.pd_client.must_add_peer(1, new_learner_peer(4, 4));
+    cluster.must_put(b"k1", b"v1");
+    must_get_equal(&cluster.get_engine(4), b"k1", b"v1");
+
+    cluster.must_transfer_leader(1, new_peer(1, 1));
+    // Wait till leader peer goes to sleep.
+    thread::sleep(
+        cluster.cfg.raft_store.raft_base_tick_interval.0
+            * 3
+            * cluster.cfg.raft_store.raft_election_timeout_ticks as u32,
+    );
+    let awakened = Arc::new(AtomicBool::new(false));
+    let filter = Arc::new(AtomicBool::new(false));
+    let a = awakened.clone();
+    cluster.add_send_filter(CloneFilterFactory(
+        RegionPacketFilter::new(1, 1)
+            .direction(Direction::Send)
+            .set_msg_callback(Arc::new(move |_| {
+                a.store(true, Ordering::SeqCst);
+            }))
+            .when(filter.clone()),
+    ));
+    filter.store(true, Ordering::SeqCst);
+    thread::sleep(cluster.cfg.raft_store.raft_heartbeat_interval() * 2);
+    assert!(!awakened.load(Ordering::SeqCst));
+
+    // Simulate one learner down.
+    cluster.stop_node(4);
+    thread::sleep(cluster.cfg.raft_store.max_peer_down_duration.0 * 2);
+    cluster.must_transfer_leader(1, new_peer(1, 1));
+    cluster.reset_leader_of_region(1);
+    assert_eq!(cluster.leader_of_region(1), Some(new_peer(1, 1)));
+
+    filter.store(false, Ordering::SeqCst);
+    awakened.store(false, Ordering::SeqCst);
+    // Wait till leader peer goes to sleep.
+    thread::sleep(
+        cluster.cfg.raft_store.raft_base_tick_interval.0
+            * 3
+            * cluster.cfg.raft_store.raft_election_timeout_ticks as u32,
+    );
+    filter.store(true, Ordering::SeqCst);
+    thread::sleep(cluster.cfg.raft_store.raft_heartbeat_interval() * 2);
+    // Leader can go to sleep as voters can reach majority.
+    assert!(!awakened.load(Ordering::SeqCst));
+
+    // Start learner again.
+    cluster.clear_send_filters();
+    cluster.run_node(4).unwrap();
+    thread::sleep(cluster.cfg.raft_store.max_peer_down_duration.0 * 2);
+    cluster.must_transfer_leader(1, new_peer(1, 1));
+    cluster.reset_leader_of_region(1);
+    assert_eq!(cluster.leader_of_region(1), Some(new_peer(1, 1)));
+    // add send filter again
+    filter.store(false, Ordering::SeqCst);
+    awakened.store(false, Ordering::SeqCst);
+    let a = awakened.clone();
+    cluster.add_send_filter(CloneFilterFactory(
+        RegionPacketFilter::new(1, 1)
+            .direction(Direction::Send)
+            .set_msg_callback(Arc::new(move |_| {
+                a.store(true, Ordering::SeqCst);
+            }))
+            .when(filter.clone()),
+    ));
+    // Wait till leader peer goes to sleep.
+    thread::sleep(
+        cluster.cfg.raft_store.raft_base_tick_interval.0
+            * 3
+            * cluster.cfg.raft_store.raft_election_timeout_ticks as u32,
+    );
+    filter.store(true, Ordering::SeqCst);
+    thread::sleep(cluster.cfg.raft_store.raft_heartbeat_interval() * 2);
+    // Leader can go to sleep after down learner recover.
+    assert!(!awakened.load(Ordering::SeqCst));
+
+    cluster.clear_send_filters(); // clear filters before putting data
+    cluster.must_put(b"k3", b"v3");
+    must_get_equal(&cluster.get_engine(4), b"k3", b"v3");
+}
+
+/// Test senario: keep max_peer_down_duration unchanged and down one voter to
+/// check whether leader cannot hibernate in short time(before
+/// max_peer_down_duration elapsed).
+#[test]
+fn test_hibernate_quorum_feature_voter_down_shortly() {
+    let mut cluster = new_node_cluster(0, 3);
+    configure_for_hibernate(&mut cluster.cfg);
+    cluster.cfg.raft_store.max_peer_down_duration = ReadableDuration::secs(600); // keep it unchanged
+    cluster.run();
+    cluster.must_transfer_leader(1, new_peer(1, 1));
+    cluster.must_put(b"k1", b"v1");
+    must_get_equal(&cluster.get_engine(3), b"k1", b"v1");
+    // Wait till leader peer goes to sleep.
+    thread::sleep(
+        cluster.cfg.raft_store.raft_base_tick_interval.0
+            * 3
+            * cluster.cfg.raft_store.raft_election_timeout_ticks as u32,
+    );
+    let awakened = Arc::new(AtomicBool::new(false));
+    let filter = Arc::new(AtomicBool::new(false));
+    let a = awakened.clone();
+    cluster.add_send_filter(CloneFilterFactory(
+        RegionPacketFilter::new(1, 1)
+            .direction(Direction::Send)
+            .set_msg_callback(Arc::new(move |_| {
+                a.store(true, Ordering::SeqCst);
+            }))
+            .when(filter.clone()),
+    ));
+    filter.store(true, Ordering::SeqCst);
+    thread::sleep(cluster.cfg.raft_store.raft_heartbeat_interval() * 2);
+    assert!(!awakened.load(Ordering::SeqCst));
+
+    cluster.clear_send_filters(); // clear filters before putting data
+    cluster.must_put(b"k2", b"v2");
+    must_get_equal(&cluster.get_engine(3), b"k2", b"v2");
+    // Must wait for replication to finish before stopping node.
+    thread::sleep(Duration::from_millis(1000));
+
+    // Simulate one voter down.
+    cluster.stop_node(3);
+    // Ensure leader is node 1.
+    cluster.must_transfer_leader(1, new_peer(1, 1));
+    cluster.reset_leader_of_region(1);
+    assert_eq!(cluster.leader_of_region(1), Some(new_peer(1, 1)));
+    // change leader to node 2 to make sure leader knows node-3 is down
+    cluster.must_transfer_leader(1, new_peer(2, 2));
+    cluster.reset_leader_of_region(1);
+    assert_eq!(cluster.leader_of_region(1), Some(new_peer(2, 2)));
+    // Besides changing leader, we can also put some data to make leader know voter
+    // is down. cluster.must_put(b"k3", b"v3");
+    // must_get_equal(&cluster.get_engine(1), b"k3", b"v3");
+    // add send filter again
+    filter.store(false, Ordering::SeqCst);
+    awakened.store(false, Ordering::SeqCst);
+    let a = awakened.clone();
+    cluster.add_send_filter(CloneFilterFactory(
+        RegionPacketFilter::new(1, 2)
+            .direction(Direction::Send)
+            .set_msg_callback(Arc::new(move |_| {
+                a.store(true, Ordering::SeqCst);
+            }))
+            .when(filter.clone()),
+    ));
+    // Wait till leader peer goes to sleep.
+    thread::sleep(
+        cluster.cfg.raft_store.raft_base_tick_interval.0
+            * 3
+            * cluster.cfg.raft_store.raft_election_timeout_ticks as u32,
+    );
+    filter.store(true, Ordering::SeqCst);
+    thread::sleep(cluster.cfg.raft_store.raft_heartbeat_interval() * 2);
+    // Leader is awake because down voter is not detected (need 10min).
+    assert!(awakened.load(Ordering::SeqCst));
+
+    cluster.clear_send_filters();
+    cluster.must_put(b"k3", b"v3");
+    must_get_equal(&cluster.get_engine(1), b"k3", b"v3");
+}
+
+fn make_proposed_cb(cmd: &RaftCmdRequest) -> (Callback<RocksSnapshot>, ProposedCbReceivers) {
+    let (proposed_tx, proposed_rx) = mpsc::channel();
+    let (cb, _applied_rx) = make_cb_ext(
+        cmd,
+        Some(Box::new(move || proposed_tx.send(()).unwrap())),
+        None,
+    );
+    (
+        cb,
+        ProposedCbReceivers {
+            proposed: proposed_rx,
+        },
+    )
+}
+
+fn make_write_req(cluster: &mut Cluster<NodeCluster>, k: &[u8], v: &[u8]) -> RaftCmdRequest {
+    let r = cluster.get_region(k);
+    let mut req = new_request(
+        r.get_id(),
+        r.get_region_epoch().clone(),
+        vec![new_put_cmd(k, v)],
+        false,
+    );
+    let leader = cluster.leader_of_region(r.get_id()).unwrap();
+    req.mut_header().set_peer(leader);
+    req
+}
+
+struct ProposedCbReceivers {
+    proposed: mpsc::Receiver<()>,
+}
+
+impl ProposedCbReceivers {
+    fn assert_proposed_ok(&self) {
+        self.proposed.recv_timeout(Duration::from_secs(1)).unwrap();
+    }
+}
+
+/// Tests that leader cannot hibernate when matched peers don't form a quorum.
+/// This covers the scenario of quorum check failure in peer.rs
+/// check_before_tick().
+#[test]
+fn test_hibernate_not_enough_matched_peers() {
+    let mut cluster = new_node_cluster(0, 3);
+    configure_for_hibernate(&mut cluster.cfg);
+    // Make sure max_peer_down_duration < election_timeout so that leader can detect
+    // down peers before stepping down.
+    // base_tick = 50ms
+    // election_timeout = 20 * 50ms = 1000ms
+    // max_peer_down_duration = 200ms
+    cluster.cfg.raft_store.raft_base_tick_interval = ReadableDuration::millis(50);
+    cluster.cfg.raft_store.raft_election_timeout_ticks = 20;
+    cluster.cfg.raft_store.peer_stale_state_check_interval = ReadableDuration::millis(2500); // must larger than 2*election_timeout
+    cluster.cfg.raft_store.pd_heartbeat_tick_interval = ReadableDuration::millis(100); // call collect_down_peers()
+    cluster.cfg.raft_store.max_peer_down_duration = ReadableDuration::millis(200);
+    cluster.run();
+    cluster.must_transfer_leader(1, new_peer(1, 1));
+    cluster.must_put(b"k1", b"v1");
+    must_get_equal(&cluster.get_engine(3), b"k1", b"v1");
+    // Wait till leader peer goes to sleep.
+    thread::sleep(
+        cluster.cfg.raft_store.raft_base_tick_interval.0
+            * 3
+            * cluster.cfg.raft_store.raft_election_timeout_ticks as u32,
+    );
+    let awakened = Arc::new(AtomicBool::new(false));
+    let filter = Arc::new(AtomicBool::new(false));
+    let a = awakened.clone();
+    cluster.add_send_filter(CloneFilterFactory(
+        RegionPacketFilter::new(1, 1)
+            .direction(Direction::Send)
+            .set_msg_callback(Arc::new(move |_| {
+                a.store(true, Ordering::SeqCst);
+            }))
+            .when(filter.clone()),
+    ));
+    filter.store(true, Ordering::SeqCst);
+    thread::sleep(cluster.cfg.raft_store.raft_heartbeat_interval() * 2);
+    assert!(!awakened.load(Ordering::SeqCst)); // leader hibernated successfully.
+
+    cluster.clear_send_filters(); // clear filters before putting data
+
+    // Add monitor filter again to check if leader keeps sending messages
+    let awakened = Arc::new(AtomicBool::new(false));
+    let filter = Arc::new(AtomicBool::new(false));
+    let a = awakened.clone();
+    cluster.add_send_filter(CloneFilterFactory(
+        RegionPacketFilter::new(1, 1)
+            .direction(Direction::Send)
+            .set_msg_callback(Arc::new(move |_| {
+                a.store(true, Ordering::SeqCst);
+            }))
+            .when(filter.clone()),
+    ));
+
+    // Filter both AppendResponse (to keep matched index low) and HeartbeatResponse
+    // (to make peers down)
+    let recv_filter = Box::new(
+        RegionPacketFilter::new(1, 1)
+            .direction(Direction::Recv)
+            .msg_type(MessageType::MsgAppendResponse)
+            .msg_type(MessageType::MsgHeartbeatResponse),
+    );
+    cluster.add_recv_filter_on_node(1, recv_filter);
+
+    let write_req = make_write_req(&mut cluster, b"k2", b"v2");
+    let (cb, cb_receivers) = make_proposed_cb(&write_req);
+    cluster
+        .sim
+        .rl()
+        .async_command_on_node(1, write_req, cb)
+        .unwrap();
+    cb_receivers.assert_proposed_ok();
+
+    // Wait for leader to detect down peers (max_peer_down_duration = 200ms)
+    // But NOT wait too long to cause Leader Step Down (election_timeout = 1000ms)
+    thread::sleep(Duration::from_millis(500));
+
+    // Verify leader cannot hibernate because matched peers don't form quorum
+    // 1. Peers 2 & 3 are detected as Down (no heartbeat response for > 200ms).
+    // 2. check_before_tick skips "replication" check because peers are Down.
+    // 3. matched_peer_ids only contains Leader (1), because peers 2 & 3 matched
+    //    index is old (no AppendResponse).
+    // 4. has_quorum({1}) returns false.
+    // 5. check_before_tick returns "not enough matched peers".
+    // 6. Leader stays awake.
+    filter.store(true, Ordering::SeqCst);
+    thread::sleep(cluster.cfg.raft_store.raft_heartbeat_interval() * 2);
+    assert!(awakened.load(Ordering::SeqCst));
+
+    cluster.clear_send_filters();
+    cluster.clear_recv_filter_on_node(1);
+    thread::sleep(Duration::from_secs(1));
+    must_get_equal(&cluster.get_engine(2), b"k2", b"v2");
+    must_get_equal(&cluster.get_engine(3), b"k2", b"v2");
 }


### PR DESCRIPTION
close tikv/tikv#19070

1. Hibernate condition optimization: leader no need wait for all peers' hibernate votes if any non-voter peer is down and votes reach majority.
2. If non hibernate vote peers are all unreachable, leader can skip broadcasting hibernate request. This can reduce the number of messages before down peer is detected (10min by default).

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #xxx

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note

```
