### PR TITLE
in-memory-engine: retry unresolved cache=always manual ranges

### DIFF
--- a/components/in_memory_engine/src/background.rs
+++ b/components/in_memory_engine/src/background.rs
@@ -174,13 +174,39 @@ impl Drop for BgWorkManager {
     }
 }
 
-pub struct PdRangeHintService(Arc<RpcClient>);
+/// Source for `cache=always` region-label rules that drive IME manual
+/// preload.
+///
+/// In production this watches PD via a real gRPC client. In test harnesses
+/// that use an in-process simulated PD (e.g. `test_raftstore`), a no-op
+/// variant is provided under the `testexport` feature so callers can still
+/// preserve the "start the hint service after raftstore is ready" contract
+/// without needing an RPC-compatible PD client.
+pub enum PdRangeHintService {
+    /// Watches region labels on a real PD gRPC client.
+    Pd(Arc<RpcClient>),
+    /// Test-only no-op: does not spawn a PD watcher. Intended so tests that
+    /// build a hybrid engine can still call `start_hint_service` after
+    /// raftstore is up, keeping the invocation contract identical to
+    /// production even when no real PD is available.
+    #[cfg(feature = "testexport")]
+    Noop,
+}
 
 impl RangeHintService for PdRangeHintService {}
 
 impl From<Arc<RpcClient>> for PdRangeHintService {
     fn from(pd_client: Arc<RpcClient>) -> Self {
-        PdRangeHintService(pd_client)
+        PdRangeHintService::Pd(pd_client)
+    }
+}
+
+#[cfg(feature = "testexport")]
+impl PdRangeHintService {
+    /// Construct a no-op hint service for test harnesses that do not have a
+    /// real PD gRPC client available.
+    pub fn noop() -> Self {
+        PdRangeHintService::Noop
     }
 }
 
@@ -201,7 +227,18 @@ impl PdRangeHintService {
     where
         F: Fn(&CacheRegion, bool) + Send + Sync + 'static,
     {
-        let pd_client = self.0.clone();
+        let pd_client = match self {
+            PdRangeHintService::Pd(pd_client) => pd_client.clone(),
+            #[cfg(feature = "testexport")]
+            PdRangeHintService::Noop => {
+                // The callback is intentionally not invoked; test harnesses
+                // that use this variant do not have a PD gRPC client to
+                // watch region labels from.
+                drop((remote, range_manager_load_cb));
+                info!("ime hint service started as no-op (testexport)");
+                return;
+            }
+        };
         let region_label_changed_cb: RegionLabelChangedCallback = Arc::new(
             move |label_rule: &LabelRule, is_add: bool| {
                 if !label_rule
@@ -1381,6 +1418,20 @@ impl Runnable for BackgroundRunner {
                             .collect()
                     };
                     for cache_region in unknown {
+                        // Re-check `manual_load_range` membership immediately
+                        // before loading. Between the `manual_load_ranges()`
+                        // snapshot above and this point, the PD watcher
+                        // callback may have removed or shrunk the rule and
+                        // already evicted the region. Without this check we
+                        // would race-load it back and make `cache=always`
+                        // label removals timing-dependent.
+                        let still_manual = {
+                            let regions_map = region_manager.regions_map().read();
+                            regions_map.overlap_with_manual_load_range(&cache_region)
+                        };
+                        if !still_manual {
+                            continue;
+                        }
                         if let Err(e) = region_manager.load_region(cache_region.clone()) {
                             if !e.is_caused_by_same_region() {
                                 warn!(

--- a/components/in_memory_engine/src/background.rs
+++ b/components/in_memory_engine/src/background.rs
@@ -3026,6 +3026,103 @@ pub mod tests {
         pd_server.stop();
     }
 
+    // Regression test for "cache=always regions not loaded after TiKV restart".
+    //
+    // Reproduces the race condition that motivates starting the IME hint
+    // service only AFTER raftstore has registered its regions to
+    // `RegionInfoProvider`. When the hint service fires while the provider is
+    // still empty, the `cache=always` range is recorded in `manual_load_range`,
+    // but the corresponding regions are never translated and loaded: the
+    // callback calls `get_regions_in_range` once, gets an empty list, and does
+    // not retry. No subsequent role-change re-triggers the load for regions
+    // that are already leaders on this node.
+    //
+    // The fix in `components/server/src/server.rs` delays `start_hint_service`
+    // until after raftstore is ready, so this race does not occur during
+    // normal startup. This test pins the underlying callback behavior so a
+    // future change that re-introduces the early-startup ordering can be
+    // detected.
+    #[test]
+    fn test_hint_service_misses_regions_not_yet_in_provider() {
+        let region_info_provider = Arc::new(MockRegionInfoProvider::default());
+
+        let mut engine = RegionCacheMemoryEngine::with_region_info_provider(
+            InMemoryEngineContext::new_for_tests(Arc::new(VersionTrack::new(
+                InMemoryEngineConfig::config_for_test(),
+            ))),
+            Some(region_info_provider.clone()),
+            None,
+        );
+        let path = Builder::new()
+            .prefix("test_hint_service_misses_regions_not_yet_in_provider")
+            .tempdir()
+            .unwrap();
+        let path_str = path.path().to_str().unwrap();
+        let rocks_engine = new_engine(path_str, DATA_CFS).unwrap();
+        engine.set_disk_engine(rocks_engine.clone());
+
+        // Intentionally do NOT add the region to the provider here; this
+        // simulates the pre-fix timing where the hint service callback fires
+        // before raftstore has populated `RegionInfoProvider`.
+        let region = new_region(1, format!("k{:08}", 10), format!("k{:08}", 15));
+        let cache_region = CacheRegion::from_region(&region);
+
+        let (mut pd_server, pd_client) =
+            new_test_server_and_client(ReadableDuration::millis(100));
+        let cluster_id = pd_client.get_cluster_id().unwrap();
+        let pd_client = Arc::new(pd_client);
+        engine.start_hint_service(PdRangeHintService::from(pd_client.clone()));
+        let meta_client = region_label_meta_client(pd_client.clone());
+        let label_rule = new_region_label_rule(
+            "cache/0",
+            &hex::encode(format!("k{:08}", 0).into_bytes()),
+            &hex::encode(format!("k{:08}", 20).into_bytes()),
+        );
+        add_region_label_rule(meta_client, cluster_id, &label_rule);
+
+        // Wait until the callback has fired and recorded the range into
+        // `manual_load_range`. At this point `get_regions_in_range` has
+        // already been called with an empty provider and returned nothing.
+        test_util::eventually(
+            Duration::from_millis(10),
+            Duration::from_millis(2000),
+            || {
+                engine
+                    .core
+                    .region_manager()
+                    .regions_map()
+                    .read()
+                    .overlap_with_manual_load_range(&cache_region)
+            },
+        );
+
+        // The region is registered to the provider after the callback has
+        // already fired. With the current callback implementation, this does
+        // not trigger any automatic load.
+        region_info_provider.add_region(region.clone());
+
+        // Give background workers a chance to notice; nothing should happen.
+        std::thread::sleep(Duration::from_millis(500));
+
+        // The region must not be registered in IME: no role-change occurs in
+        // this test and no background worker re-scans `manual_load_range`.
+        assert!(
+            engine
+                .core
+                .region_manager()
+                .regions_map()
+                .read()
+                .region_meta(region.get_id())
+                .is_none(),
+            "Regression: a region registered AFTER the hint service callback \
+             fired must not be silently auto-loaded. This is exactly the race \
+             that the startup-ordering fix (start_hint_service after raftstore \
+             is ready) prevents."
+        );
+
+        pd_server.stop();
+    }
+
     fn verify_load(
         region: &Region,
         engine: &RegionCacheMemoryEngine,

--- a/components/in_memory_engine/src/background.rs
+++ b/components/in_memory_engine/src/background.rs
@@ -99,6 +99,12 @@ pub enum BackgroundTask {
     ),
     SetRocksEngine(RocksEngine),
     CheckLoadPendingRegions(Scheduler<BackgroundTask>),
+    // Re-resolve all `cache=always` manual-load ranges against the region
+    // info provider and load any regions that are not yet registered in IME.
+    // This is a safety net for the startup race where the hint callback's
+    // one-shot `get_regions_in_range` runs before raftstore has populated
+    // `RegionInfoProvider`.
+    ResolveManualLoadRanges,
 }
 
 impl fmt::Display for BackgroundTask {
@@ -119,6 +125,9 @@ impl fmt::Display for BackgroundTask {
             BackgroundTask::SetRocksEngine(_) => f.debug_struct("SetDiskEngine").finish(),
             BackgroundTask::CheckLoadPendingRegions(_) => {
                 f.debug_struct("CheckLoadPendingRegions").finish()
+            }
+            BackgroundTask::ResolveManualLoadRanges => {
+                f.debug_struct("ResolveManualLoadRanges").finish()
             }
         }
     }
@@ -365,6 +374,20 @@ impl BgWorkManager {
             });
             Duration::from_secs(5)
         })();
+        // Retry interval for re-resolving `cache=always` manual ranges that
+        // could not be translated into regions when the hint callback first
+        // fired (e.g. on startup, before raftstore has registered this
+        // node's regions to `RegionInfoProvider`). Kept relatively short so
+        // a restarted node does not spend long without its `cache=always`
+        // regions warmed up, but long enough that the steady-state cost of
+        // walking the (small) manual-range set is negligible.
+        let resolve_manual_load_ranges_interval = (|| {
+            fail_point!("ime_background_resolve_manual_load_ranges_interval", |t| {
+                let t = t.unwrap().parse::<u64>().unwrap();
+                Duration::from_millis(t)
+            });
+            Duration::from_secs(10)
+        })();
         ticker.spawn_interval_task(interval, move || {
             let mut gc_run_interval = config.value().gc_run_interval.0;
             let mut gc_ticker = tick(gc_run_interval);
@@ -372,6 +395,7 @@ impl BgWorkManager {
             let mut load_evict_ticker = tick(load_evict_interval);
             let mut tso_timeout = std::cmp::min(gc_run_interval, TIMTOUT_FOR_TSO);
             let check_pending_region_ticker = tick(check_load_pending_interval);
+            let resolve_manual_load_ranges_ticker = tick(resolve_manual_load_ranges_interval);
             'LOOP: loop {
                 select! {
                     recv(gc_ticker) -> _ => {
@@ -429,6 +453,14 @@ impl BgWorkManager {
                         if let Err(e) = scheduler.schedule(BackgroundTask::CheckLoadPendingRegions(s)) {
                             error!(
                                 "ime schedule check pending regions failed";
+                                "err" => ?e,
+                            );
+                        }
+                    }
+                    recv(resolve_manual_load_ranges_ticker) -> _ => {
+                        if let Err(e) = scheduler.schedule(BackgroundTask::ResolveManualLoadRanges) {
+                            error!(
+                                "ime schedule resolve manual load ranges failed";
                                 "err" => ?e,
                             );
                         }
@@ -814,6 +846,11 @@ pub struct BackgroundRunner {
     // RocksEngine is used to get the oldest snapshot sequence number.
     rocks_engine: Option<RocksEngine>,
     raft_casual_router: Option<Box<dyn CasualRouter<RocksEngine>>>,
+    // Retained so the `ResolveManualLoadRanges` task can re-resolve
+    // `cache=always` manual ranges that could not be resolved when the
+    // hint service callback first fired (e.g. when raftstore had not yet
+    // populated the provider with this node's regions on startup).
+    region_info_provider: Option<Arc<dyn RegionInfoProvider>>,
 }
 
 impl Drop for BackgroundRunner {
@@ -862,7 +899,7 @@ impl BackgroundRunner {
         let load_evict_worker = Worker::new("ime-evict");
         let load_evict_remote = load_evict_worker.remote();
 
-        let region_stats_manager = region_info_provider.map(|region_info_provider| {
+        let region_stats_manager = region_info_provider.clone().map(|region_info_provider| {
             RegionStatsManager::new(
                 config.clone(),
                 DEFAULT_EVICT_MIN_DURATION,
@@ -892,6 +929,7 @@ impl BackgroundRunner {
                 last_seqno: 0,
                 rocks_engine: None,
                 raft_casual_router,
+                region_info_provider,
             },
             delete_range_scheduler,
         )
@@ -1290,6 +1328,79 @@ impl Runnable for BackgroundRunner {
                 let _ =
                     cross_check_worker.start_with_timer("cross-check-runner", cross_check_runner);
                 self.cross_check_worker = Some(cross_check_worker);
+            }
+            BackgroundTask::ResolveManualLoadRanges => {
+                let Some(ref info_provider) = self.region_info_provider else {
+                    return;
+                };
+                let region_manager = self.core.engine.region_manager();
+                // Snapshot the manual ranges so we don't hold the read lock
+                // across the provider call or `load_region` (which takes the
+                // write lock).
+                let ranges: Vec<CacheRegion> = {
+                    let regions_map = region_manager.regions_map().read();
+                    regions_map.manual_load_ranges().to_vec()
+                };
+                if ranges.is_empty() {
+                    return;
+                }
+                let mut resolved_total = 0usize;
+                for range in &ranges {
+                    let start = origin_key(&range.start);
+                    let end = origin_end_key(&range.end);
+                    let regions = match info_provider.get_regions_in_range(start, end) {
+                        Ok(r) => r,
+                        Err(e) => {
+                            warn!(
+                                "ime resolve manual load ranges: get regions in range failed";
+                                "err" => ?e,
+                                "start" => ?log_wrappers::Value(start),
+                                "end" => ?log_wrappers::Value(end),
+                            );
+                            continue;
+                        }
+                    };
+                    if regions.is_empty() {
+                        continue;
+                    }
+                    // Only load regions that are not yet known to IME. Already
+                    // registered regions either completed loading or are
+                    // already in flight; `load_region` for them would just
+                    // return the "same region" error.
+                    let unknown: Vec<CacheRegion> = {
+                        let regions_map = region_manager.regions_map().read();
+                        regions
+                            .into_iter()
+                            .filter_map(|r| {
+                                if regions_map.region_meta(r.get_id()).is_none() {
+                                    Some(CacheRegion::from_region(&r))
+                                } else {
+                                    None
+                                }
+                            })
+                            .collect()
+                    };
+                    for cache_region in unknown {
+                        if let Err(e) = region_manager.load_region(cache_region.clone()) {
+                            if !e.is_caused_by_same_region() {
+                                warn!(
+                                    "ime resolve manual load ranges: load region failed";
+                                    "err" => ?e,
+                                    "region" => ?cache_region,
+                                );
+                            }
+                        } else {
+                            resolved_total += 1;
+                        }
+                    }
+                }
+                if resolved_total > 0 {
+                    info!(
+                        "ime resolve manual load ranges: newly registered regions";
+                        "count" => resolved_total,
+                        "ranges" => ranges.len(),
+                    );
+                }
             }
             BackgroundTask::CheckLoadPendingRegions(s) => {
                 if let Some(router) = &self.raft_casual_router
@@ -3026,24 +3137,27 @@ pub mod tests {
         pd_server.stop();
     }
 
-    // Regression test for "cache=always regions not loaded after TiKV restart".
+    // Pins the behavior of the hint-service callback when the
+    // `RegionInfoProvider` is empty at label-rule time (which happens on a
+    // startup where raftstore has not yet registered this node's regions).
     //
-    // Reproduces the race condition that motivates starting the IME hint
-    // service only AFTER raftstore has registered its regions to
-    // `RegionInfoProvider`. When the hint service fires while the provider is
-    // still empty, the `cache=always` range is recorded in `manual_load_range`,
-    // but the corresponding regions are never translated and loaded: the
-    // callback calls `get_regions_in_range` once, gets an empty list, and does
-    // not retry. No subsequent role-change re-triggers the load for regions
-    // that are already leaders on this node.
-    //
-    // The fix in `components/server/src/server.rs` delays `start_hint_service`
-    // until after raftstore is ready, so this race does not occur during
-    // normal startup. This test pins the underlying callback behavior so a
-    // future change that re-introduces the early-startup ordering can be
-    // detected.
+    // With the `ResolveManualLoadRanges` retry task *disabled*, the callback
+    // alone records the `cache=always` range in `manual_load_range` but
+    // never materializes the load, even after the region is later added to
+    // the provider. This confirms that the hint callback is one-shot and is
+    // why the periodic retry task in `BgWorkManager` is required for
+    // correctness.
+    #[cfg(feature = "failpoints")]
     #[test]
-    fn test_hint_service_misses_regions_not_yet_in_provider() {
+    fn test_hint_service_callback_alone_misses_late_regions() {
+        // Effectively disable the periodic retry for this test so we can
+        // observe the callback-only behavior.
+        fail::cfg(
+            "ime_background_resolve_manual_load_ranges_interval",
+            "return(3600000)",
+        )
+        .unwrap();
+
         let region_info_provider = Arc::new(MockRegionInfoProvider::default());
 
         let mut engine = RegionCacheMemoryEngine::with_region_info_provider(
@@ -3054,7 +3168,7 @@ pub mod tests {
             None,
         );
         let path = Builder::new()
-            .prefix("test_hint_service_misses_regions_not_yet_in_provider")
+            .prefix("test_hint_service_callback_alone_misses_late_regions")
             .tempdir()
             .unwrap();
         let path_str = path.path().to_str().unwrap();
@@ -3062,8 +3176,8 @@ pub mod tests {
         engine.set_disk_engine(rocks_engine.clone());
 
         // Intentionally do NOT add the region to the provider here; this
-        // simulates the pre-fix timing where the hint service callback fires
-        // before raftstore has populated `RegionInfoProvider`.
+        // simulates the startup timing where the hint callback fires before
+        // raftstore has populated `RegionInfoProvider`.
         let region = new_region(1, format!("k{:08}", 10), format!("k{:08}", 15));
         let cache_region = CacheRegion::from_region(&region);
 
@@ -3097,15 +3211,15 @@ pub mod tests {
         );
 
         // The region is registered to the provider after the callback has
-        // already fired. With the current callback implementation, this does
-        // not trigger any automatic load.
+        // already fired. Without the retry task, this does not trigger any
+        // automatic load.
         region_info_provider.add_region(region.clone());
 
-        // Give background workers a chance to notice; nothing should happen.
+        // Give background workers a chance to notice; nothing should happen
+        // because the retry interval is configured to be effectively
+        // infinite for this test.
         std::thread::sleep(Duration::from_millis(500));
 
-        // The region must not be registered in IME: no role-change occurs in
-        // this test and no background worker re-scans `manual_load_range`.
         assert!(
             engine
                 .core
@@ -3114,13 +3228,107 @@ pub mod tests {
                 .read()
                 .region_meta(region.get_id())
                 .is_none(),
-            "Regression: a region registered AFTER the hint service callback \
-             fired must not be silently auto-loaded. This is exactly the race \
-             that the startup-ordering fix (start_hint_service after raftstore \
-             is ready) prevents."
+            "hint callback is one-shot: a region registered AFTER the \
+             callback fired must not be silently auto-loaded by the \
+             callback alone; the periodic retry task is what actually \
+             recovers this case"
         );
 
         pd_server.stop();
+        fail::remove("ime_background_resolve_manual_load_ranges_interval");
+    }
+
+    // Regression test for the real fix: the periodic `ResolveManualLoadRanges`
+    // task re-resolves manual ranges against the provider, so a `cache=always`
+    // region that is only registered to `RegionInfoProvider` *after* the hint
+    // callback fires (typical on TiKV restart, where raftstore populates the
+    // provider asynchronously) is eventually loaded into IME.
+    //
+    // This is the behavior that makes `cache=always` reliable across node
+    // restarts and rolling upgrades.
+    #[cfg(feature = "failpoints")]
+    #[test]
+    fn test_resolve_manual_load_ranges_retry_loads_late_regions() {
+        // Run the retry task every 50ms for this test.
+        fail::cfg(
+            "ime_background_resolve_manual_load_ranges_interval",
+            "return(50)",
+        )
+        .unwrap();
+
+        let region_info_provider = Arc::new(MockRegionInfoProvider::default());
+
+        let mut engine = RegionCacheMemoryEngine::with_region_info_provider(
+            InMemoryEngineContext::new_for_tests(Arc::new(VersionTrack::new(
+                InMemoryEngineConfig::config_for_test(),
+            ))),
+            Some(region_info_provider.clone()),
+            None,
+        );
+        let path = Builder::new()
+            .prefix("test_resolve_manual_load_ranges_retry_loads_late_regions")
+            .tempdir()
+            .unwrap();
+        let path_str = path.path().to_str().unwrap();
+        let rocks_engine = new_engine(path_str, DATA_CFS).unwrap();
+        engine.set_disk_engine(rocks_engine.clone());
+
+        // Simulate the startup ordering: the hint service fires against an
+        // empty provider, records the range in `manual_load_range`, but
+        // cannot translate it into any region.
+        let region = new_region(1, format!("k{:08}", 10), format!("k{:08}", 15));
+        let cache_region = CacheRegion::from_region(&region);
+
+        let (mut pd_server, pd_client) =
+            new_test_server_and_client(ReadableDuration::millis(100));
+        let cluster_id = pd_client.get_cluster_id().unwrap();
+        let pd_client = Arc::new(pd_client);
+        engine.start_hint_service(PdRangeHintService::from(pd_client.clone()));
+        let meta_client = region_label_meta_client(pd_client.clone());
+        let label_rule = new_region_label_rule(
+            "cache/0",
+            &hex::encode(format!("k{:08}", 0).into_bytes()),
+            &hex::encode(format!("k{:08}", 20).into_bytes()),
+        );
+        add_region_label_rule(meta_client, cluster_id, &label_rule);
+
+        // Wait until the callback has fired and recorded the range.
+        test_util::eventually(
+            Duration::from_millis(10),
+            Duration::from_millis(2000),
+            || {
+                engine
+                    .core
+                    .region_manager()
+                    .regions_map()
+                    .read()
+                    .overlap_with_manual_load_range(&cache_region)
+            },
+        );
+
+        // Simulate raftstore populating the provider asynchronously, which
+        // is what happens shortly after `init_servers` returns on restart.
+        region_info_provider.add_region(region.clone());
+
+        // The retry task must pick up the range on its next tick and load
+        // the region into IME even though no role-change was emitted and the
+        // hint callback already fired.
+        test_util::eventually(
+            Duration::from_millis(50),
+            Duration::from_millis(5000),
+            || {
+                engine
+                    .core
+                    .region_manager()
+                    .regions_map()
+                    .read()
+                    .region_meta(region.get_id())
+                    .is_some()
+            },
+        );
+
+        pd_server.stop();
+        fail::remove("ime_background_resolve_manual_load_ranges_interval");
     }
 
     fn verify_load(

--- a/components/in_memory_engine/src/lib.rs
+++ b/components/in_memory_engine/src/lib.rs
@@ -31,7 +31,7 @@ mod statistics;
 pub mod test_util;
 mod write_batch;
 
-pub use background::{BackgroundRunner, BackgroundTask, GcTask};
+pub use background::{BackgroundRunner, BackgroundTask, GcTask, PdRangeHintService};
 pub use config::InMemoryEngineConfig;
 pub use engine::{RegionCacheMemoryEngine, SkiplistHandle};
 pub use keys::{

--- a/components/in_memory_engine/src/region_manager.rs
+++ b/components/in_memory_engine/src/region_manager.rs
@@ -517,6 +517,10 @@ impl RegionMetaMap {
         self.manual_load_range.iter().any(|r| r.overlaps(range))
     }
 
+    pub fn manual_load_ranges(&self) -> &[CacheRegion] {
+        &self.manual_load_range
+    }
+
     pub fn add_manual_load_range(&mut self, range: CacheRegion) {
         let mut union = range;
         self.manual_load_range.retain(|r| {

--- a/components/server/src/common.rs
+++ b/components/server/src/common.rs
@@ -718,17 +718,16 @@ pub fn build_hybrid_engine(
     // Note: `start_hint_service` is intentionally NOT started here.
     //
     // The hint service watches `cache=always` region label rules on PD and,
-    // when a rule is seen, it must translate the key range into existing
-    // regions via `RegionInfoProvider::get_regions_in_range` and load them
-    // into IME immediately. If the hint service is started before raftstore
-    // has finished registering its regions to the `RegionInfoProvider`, that
-    // translation returns an empty set and the target regions are never
-    // loaded, even if this node later becomes leader for them (no additional
-    // role-change is emitted for the initial leader state after restart).
-    //
-    // To keep `cache=always` reliable across node restarts and rolling
-    // upgrades, the caller is responsible for invoking `start_hint_service`
-    // after raftstore is ready; see `run_impl` in `server.rs`.
+    // when a rule is seen, it translates the key range into existing regions
+    // via `RegionInfoProvider::get_regions_in_range` and loads them into
+    // IME. If the hint service fires before raftstore has finished
+    // registering its regions to the provider, that translation returns an
+    // empty set. To keep `cache=always` reliable across node restarts and
+    // rolling upgrades, the caller is responsible for invoking
+    // `start_hint_service` after raftstore has been started; see `run_impl`
+    // in `server.rs`. The background `ResolveManualLoadRanges` task in the
+    // in-memory engine provides the correctness guarantee by re-resolving
+    // any range that could not be translated on the first try.
 
     memory_engine.start_cross_check(
         disk_engine.clone(),

--- a/components/server/src/common.rs
+++ b/components/server/src/common.rs
@@ -704,7 +704,6 @@ impl<T: fmt::Display + Send + 'static> Stop for LazyWorker<T> {
 pub fn build_hybrid_engine(
     region_cache_engine_context: InMemoryEngineContext,
     disk_engine: RocksEngine,
-    pd_client: Option<Arc<RpcClient>>,
     region_info_provider: Option<Arc<dyn RegionInfoProvider>>,
     casual_router: Box<dyn CasualRouter<RocksEngine>>,
 ) -> HybridEngine<RocksEngine, RegionCacheMemoryEngine> {
@@ -715,13 +714,21 @@ pub fn build_hybrid_engine(
         Some(casual_router),
     );
     memory_engine.set_disk_engine(disk_engine.clone());
-    if let Some(pd_client) = pd_client.as_ref() {
-        memory_engine.start_hint_service(
-            <RegionCacheMemoryEngine as RegionCacheEngine>::RangeHintService::from(
-                pd_client.clone(),
-            ),
-        )
-    }
+
+    // Note: `start_hint_service` is intentionally NOT started here.
+    //
+    // The hint service watches `cache=always` region label rules on PD and,
+    // when a rule is seen, it must translate the key range into existing
+    // regions via `RegionInfoProvider::get_regions_in_range` and load them
+    // into IME immediately. If the hint service is started before raftstore
+    // has finished registering its regions to the `RegionInfoProvider`, that
+    // translation returns an empty set and the target regions are never
+    // loaded, even if this node later becomes leader for them (no additional
+    // role-change is emitted for the initial leader state after restart).
+    //
+    // To keep `cache=always` reliable across node restarts and rolling
+    // upgrades, the caller is responsible for invoking `start_hint_service`
+    // after raftstore is ready; see `run_impl` in `server.rs`.
 
     memory_engine.start_cross_check(
         disk_engine.clone(),

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -187,13 +187,22 @@ fn run_impl<CER, F>(
     let (engines, engines_info, in_memory_engine) = tikv.init_raw_engines(listener);
     tikv.init_engines(engines.clone());
     let server_config = tikv.init_servers();
-    // Start the IME hint service only after raftstore has been started inside
-    // `init_servers`. At that point the `RegionInfoProvider` is being populated
-    // with the regions this node hosts, so when the hint service fetches the
-    // existing `cache=always` label rules from PD, it can translate those key
-    // ranges into concrete regions and load them into IME. Starting the hint
-    // service before raftstore is ready would race with the initial leader
-    // election and leave `cache=always` regions un-cached after a restart.
+    // Start the IME hint service after raftstore has been started inside
+    // `init_servers`. This is a best-effort optimization to reduce the
+    // window in which the hint service's initial `cache=always` label
+    // fetch fires against an empty `RegionInfoProvider` (which would leave
+    // `cache=always` ranges recorded in `manual_load_range` but not
+    // materialized as loads).
+    //
+    // IMPORTANT: `init_servers` returning is NOT a strict readiness
+    // barrier for `RegionInfoProvider` — raftstore registers regions
+    // asynchronously, so the initial fetch may still observe an empty
+    // provider. The actual correctness guarantee for eventually loading
+    // `cache=always` regions comes from the periodic
+    // `BackgroundTask::ResolveManualLoadRanges` retry in
+    // `components/in_memory_engine/src/background.rs`, which re-resolves
+    // every recorded manual range against the provider on a fixed
+    // interval. This ordering simply makes the common case faster.
     if let Some(engine) = in_memory_engine.as_ref() {
         engine.start_hint_service(PdRangeHintService::from(tikv.pd_client.clone()));
     }

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -37,8 +37,8 @@ use engine_rocks::{
 };
 use engine_rocks_helper::sst_recovery::{DEFAULT_CHECK_INTERVAL, RecoveryRunner};
 use engine_traits::{
-    CF_DEFAULT, CF_WRITE, Engines, KvEngine, MiscExt, RaftEngine, SingletonFactory, TabletContext,
-    TabletRegistry,
+    CF_DEFAULT, CF_WRITE, Engines, KvEngine, MiscExt, RaftEngine, RegionCacheEngine,
+    SingletonFactory, TabletContext, TabletRegistry,
 };
 use file_system::{BytesFetcher, MetricsManager as IoMetricsManager, get_io_rate_limiter};
 use futures::executor::block_on;
@@ -49,8 +49,8 @@ use hybrid_engine::observer::{
     RegionCacheWriteBatchObserver,
 };
 use in_memory_engine::{
-    InMemoryEngineContext, InMemoryEngineStatistics, RegionCacheMemoryEngine,
-    config::InMemoryEngineConfigManager,
+    InMemoryEngineContext, InMemoryEngineStatistics, PdRangeHintService,
+    RegionCacheMemoryEngine, config::InMemoryEngineConfigManager,
 };
 use kvproto::{
     brpb::create_backup, cdcpb::create_change_data, deadlock::create_deadlock,
@@ -187,6 +187,16 @@ fn run_impl<CER, F>(
     let (engines, engines_info, in_memory_engine) = tikv.init_raw_engines(listener);
     tikv.init_engines(engines.clone());
     let server_config = tikv.init_servers();
+    // Start the IME hint service only after raftstore has been started inside
+    // `init_servers`. At that point the `RegionInfoProvider` is being populated
+    // with the regions this node hosts, so when the hint service fetches the
+    // existing `cache=always` label rules from PD, it can translate those key
+    // ranges into concrete regions and load them into IME. Starting the hint
+    // service before raftstore is ready would race with the initial leader
+    // election and leave `cache=always` regions un-cached after a restart.
+    if let Some(engine) = in_memory_engine.as_ref() {
+        engine.start_hint_service(PdRangeHintService::from(tikv.pd_client.clone()));
+    }
     tikv.register_services();
     tikv.init_metrics_flusher(fetcher, engines_info);
     tikv.init_cgroup_monitor();
@@ -1849,7 +1859,6 @@ where
             let in_memory_engine = build_hybrid_engine(
                 in_memory_engine_context,
                 kv_engine.clone(),
-                Some(self.pd_client.clone()),
                 Some(Arc::new(self.region_info_accessor.clone().unwrap())),
                 Box::new(self.router.clone()),
             );

--- a/components/test_raftstore/Cargo.toml
+++ b/components/test_raftstore/Cargo.toml
@@ -37,7 +37,7 @@ futures = "0.3"
 grpcio = { workspace = true }
 health_controller = { workspace = true }
 hybrid_engine = { workspace = true }
-in_memory_engine = { workspace = true }
+in_memory_engine = { workspace = true, features = ["testexport"] }
 keys = { workspace = true }
 kvproto = { workspace = true }
 lazy_static = "1.3"

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -15,14 +15,16 @@ use concurrency_manager::ConcurrencyManager;
 use encryption_export::DataKeyManager;
 use engine_rocks::{FlowInfo, RocksEngine, RocksSnapshot};
 use engine_test::raft::RaftTestEngine;
-use engine_traits::{Engines, MiscExt};
+use engine_traits::{Engines, MiscExt, RegionCacheEngine};
 use futures::executor::block_on;
 use grpcio::{ChannelBuilder, EnvBuilder, Environment, Error as GrpcError, Service};
 use health_controller::HealthController;
 use hybrid_engine::observer::{
     HybridSnapshotObserver, LoadEvictionObserver, RegionCacheWriteBatchObserver,
 };
-use in_memory_engine::{InMemoryEngineConfig, InMemoryEngineContext, RegionCacheMemoryEngine};
+use in_memory_engine::{
+    InMemoryEngineConfig, InMemoryEngineContext, PdRangeHintService, RegionCacheMemoryEngine,
+};
 use kvproto::{
     deadlock::create_deadlock,
     debugpb::{DebugClient, create_debug},
@@ -714,6 +716,22 @@ impl ServerCluster {
             GrpcServiceManager::dummy(),
             self.gc_safe_point.clone(),
         )?;
+
+        // Start the IME hint service after raftstore has been started, to
+        // mirror the production startup contract in `components/server/src/server.rs`.
+        // `test_raftstore` uses an in-process simulated PD (`TestPdClient`) that
+        // does not expose a gRPC meta-storage watch compatible with
+        // `PdRangeHintService::Pd`, so we install the `Noop` variant instead.
+        // This keeps the invocation order identical to production (so future
+        // `cache=always` tests cannot silently forget to start the hint
+        // service) while avoiding a dependency on a real PD gRPC endpoint.
+        // The `ResolveManualLoadRanges` retry task still drives `cache=always`
+        // preload from `manual_load_range` entries that test code injects
+        // directly.
+        if let Some(ref in_memory_engine) = in_memory_engine {
+            in_memory_engine.start_hint_service(PdRangeHintService::noop());
+        }
+
         assert!(node_id == 0 || node_id == node.id());
         let node_id = node.id();
         if let Some(tmp) = tmp {

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -348,7 +348,6 @@ impl ServerCluster {
             let in_memory_engine = build_hybrid_engine(
                 in_memory_engine_context,
                 engines.kv.clone(),
-                None,
                 Some(Arc::new(region_info_accessor.clone())),
                 Box::new(router.clone()),
             );

--- a/tests/failpoints/cases/test_in_memory_engine.rs
+++ b/tests/failpoints/cases/test_in_memory_engine.rs
@@ -1259,6 +1259,82 @@ fn test_eviction_when_destroy_uninitialized_peer() {
     cluster.must_region_exist(region.get_id(), 2);
 }
 
+// This test reproduces the startup preload bug for cache=always labeled regions.
+//
+// When `cache=always` is configured for a key range (via ALTER TABLE ...
+// ATTRIBUTES 'cache=always'), TiKV's PdRangeHintService calls two things:
+//   1. `add_manual_load_range(range)` – records the intent to always cache this range
+//   2. `get_regions_in_range(start, end)` + `load_region()` – immediately loads regions
+//
+// During startup (or after a TiKV restart), the PdRangeHintService task runs
+// asynchronously. There is a race window where regions have already elected
+// leaders (firing `try_load_region(for_manual_range: true)`) before
+// `add_manual_load_range` is populated, AND the subsequent
+// `get_regions_in_range` call returns empty because `RegionInfoProvider` is
+// not yet fully populated. In that case:
+//   - The role-change event fires before `manual_load_range` is set → no load
+//   - `get_regions_in_range` returns empty → no direct load
+//   - `add_manual_load_range` is set, but no future role-change fires → no load
+//   - `CheckLoadPendingRegions` only rescues `RegionState::Pending` regions → no help
+//
+// Result: regions remain un-cached despite `cache=always` being configured,
+// and queries are slow until the auto-load heuristic eventually picks them up
+// (which can take up to ~2 hours per tikv/tikv#17562).
+//
+// This test simulates that race by:
+//   1. Starting the cluster (regions become leaders)
+//   2. Adding `manual_load_range` WITHOUT calling `load_region` (simulates the
+//      degenerate case where `get_regions_in_range` returned empty)
+//   3. Asserting the region is NOT in IME even after a wait
+#[test]
+fn test_cache_always_not_preloaded_when_label_applied_after_leader_election() {
+    // Use a short check_pending interval so CheckLoadPendingRegions runs quickly,
+    // to confirm it does NOT help in this scenario.
+    fail::cfg("ime_background_check_load_pending_interval", "return(500)").unwrap();
+
+    let mut cluster = new_server_cluster_with_hybrid_engine(0, 1);
+    cluster.run();
+
+    // Ensure the region leader is fully elected and stable before we proceed.
+    cluster.must_put(b"k", b"v");
+    let r = cluster.get_region(b"k");
+    assert!(
+        cluster.leader_of_region(r.id).is_some(),
+        "region must have a leader"
+    );
+
+    let region_cache_engine = cluster.sim.rl().get_region_cache_engine(1);
+    let cache_region = CacheRegion::from_region(&r);
+
+    // Step 1: Simulate only `add_manual_load_range` being called (as would happen
+    // when `get_regions_in_range` returned empty during startup).
+    // We intentionally do NOT call `load_region` here.
+    region_cache_engine
+        .core()
+        .region_manager()
+        .regions_map()
+        .write()
+        .add_manual_load_range(cache_region.clone());
+
+    // Step 2: Wait long enough for:
+    //   - CheckLoadPendingRegions to fire multiple times (interval = 500ms above)
+    //   - Any other background rescue mechanism to kick in
+    sleep(Duration::from_secs(3));
+
+    // Step 3: Assert the region is NOT in IME.
+    // This demonstrates the bug: add_manual_load_range alone, set after the
+    // initial leader election, never triggers a region load.
+    assert!(
+        region_cache_engine
+            .snapshot(cache_region.clone(), u64::MAX, u64::MAX)
+            .is_err(),
+        "BUG: region must NOT be in IME when manual_load_range is set after \
+         leader election and get_regions_in_range returned empty during startup"
+    );
+
+    fail::remove("ime_background_check_load_pending_interval");
+}
+
 // IME must not panic when warmup an uninitialized peer.
 #[test]
 fn test_transfer_leader_warmup_uninitialized_peer() {

--- a/tests/failpoints/cases/test_in_memory_engine.rs
+++ b/tests/failpoints/cases/test_in_memory_engine.rs
@@ -1259,43 +1259,41 @@ fn test_eviction_when_destroy_uninitialized_peer() {
     cluster.must_region_exist(region.get_id(), 2);
 }
 
-// This test reproduces the startup preload bug for cache=always labeled regions.
+// Regression test for the startup preload issue for `cache=always` regions
+// (tikv/tikv#19555).
 //
-// When `cache=always` is configured for a key range (via ALTER TABLE ...
-// ATTRIBUTES 'cache=always'), TiKV's PdRangeHintService calls two things:
-//   1. `add_manual_load_range(range)` – records the intent to always cache this range
-//   2. `get_regions_in_range(start, end)` + `load_region()` – immediately loads regions
+// When `cache=always` is configured for a key range, the PdRangeHintService
+// does two things:
+//   1. `add_manual_load_range(range)` – records the intent to always cache
+//      this range in IME.
+//   2. `get_regions_in_range(start, end)` + `load_region()` – immediately
+//      tries to materialize the load.
 //
-// During startup (or after a TiKV restart), the PdRangeHintService task runs
-// asynchronously. There is a race window where regions have already elected
-// leaders (firing `try_load_region(for_manual_range: true)`) before
-// `add_manual_load_range` is populated, AND the subsequent
-// `get_regions_in_range` call returns empty because `RegionInfoProvider` is
-// not yet fully populated. In that case:
-//   - The role-change event fires before `manual_load_range` is set → no load
-//   - `get_regions_in_range` returns empty → no direct load
-//   - `add_manual_load_range` is set, but no future role-change fires → no load
-//   - `CheckLoadPendingRegions` only rescues `RegionState::Pending` regions → no help
+// On a TiKV restart, step (2) can fire before raftstore has registered this
+// node's regions to `RegionInfoProvider`. In that case `get_regions_in_range`
+// returns empty, the callback does not retry, and no role-change event
+// re-triggers the load (role changes for regions that are already leaders on
+// this node after restart do not fire here). The range remains in
+// `manual_load_range` but the corresponding regions are never loaded.
 //
-// Result: regions remain un-cached despite `cache=always` being configured,
-// and queries are slow until the auto-load heuristic eventually picks them up
-// (which can take up to ~2 hours per tikv/tikv#17562).
-//
-// This test simulates that race by:
-//   1. Starting the cluster (regions become leaders)
-//   2. Adding `manual_load_range` WITHOUT calling `load_region` (simulates the
-//      degenerate case where `get_regions_in_range` returned empty)
-//   3. Asserting the region is NOT in IME even after a wait
+// The fix introduces a periodic `ResolveManualLoadRanges` background task
+// that walks every range in `manual_load_range` and re-resolves it against
+// the current provider, loading any regions that are not yet registered in
+// IME. This test asserts that behavior at the cluster level: if we record a
+// manual range for a region *without* calling `load_region`, the retry task
+// must eventually load the region on its own.
 #[test]
-fn test_cache_always_not_preloaded_when_label_applied_after_leader_election() {
-    // Use a short check_pending interval so CheckLoadPendingRegions runs quickly,
-    // to confirm it does NOT help in this scenario.
+fn test_cache_always_preloaded_via_manual_load_range_retry() {
     fail::cfg("ime_background_check_load_pending_interval", "return(500)").unwrap();
+    fail::cfg(
+        "ime_background_resolve_manual_load_ranges_interval",
+        "return(500)",
+    )
+    .unwrap();
 
     let mut cluster = new_server_cluster_with_hybrid_engine(0, 1);
     cluster.run();
 
-    // Ensure the region leader is fully elected and stable before we proceed.
     cluster.must_put(b"k", b"v");
     let r = cluster.get_region(b"k");
     assert!(
@@ -1306,9 +1304,9 @@ fn test_cache_always_not_preloaded_when_label_applied_after_leader_election() {
     let region_cache_engine = cluster.sim.rl().get_region_cache_engine(1);
     let cache_region = CacheRegion::from_region(&r);
 
-    // Step 1: Simulate only `add_manual_load_range` being called (as would happen
-    // when `get_regions_in_range` returned empty during startup).
-    // We intentionally do NOT call `load_region` here.
+    // Simulate the degenerate startup case: only `add_manual_load_range` is
+    // called (as if `get_regions_in_range` had returned empty). We do NOT
+    // call `load_region` here.
     region_cache_engine
         .core()
         .region_manager()
@@ -1316,22 +1314,15 @@ fn test_cache_always_not_preloaded_when_label_applied_after_leader_election() {
         .write()
         .add_manual_load_range(cache_region.clone());
 
-    // Step 2: Wait long enough for:
-    //   - CheckLoadPendingRegions to fire multiple times (interval = 500ms above)
-    //   - Any other background rescue mechanism to kick in
-    sleep(Duration::from_secs(3));
-
-    // Step 3: Assert the region is NOT in IME.
-    // This demonstrates the bug: add_manual_load_range alone, set after the
-    // initial leader election, never triggers a region load.
-    assert!(
+    // The retry task must re-resolve the manual range against the provider
+    // and load the region into IME on its own, without any role change.
+    eventually(Duration::from_millis(100), Duration::from_secs(10), || {
         region_cache_engine
             .snapshot(cache_region.clone(), u64::MAX, u64::MAX)
-            .is_err(),
-        "BUG: region must NOT be in IME when manual_load_range is set after \
-         leader election and get_regions_in_range returned empty during startup"
-    );
+            .is_ok()
+    });
 
+    fail::remove("ime_background_resolve_manual_load_ranges_interval");
     fail::remove("ime_background_check_load_pending_interval");
 }
 


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Close #19555

What's Changed:

This change makes `cache=always` manual-load ranges resilient to startup races,
leader transfers after a restart, and concurrent label removals.

- `components/in_memory_engine`: add a periodic
  `BackgroundTask::ResolveManualLoadRanges` that re-resolves every range in
  `manual_load_range` against `RegionInfoProvider` on a fixed interval
  (default 10s, failpoint-overridable) and loads any region not yet registered
  in IME. Re-check `manual_load_range` membership immediately before each
  `load_region` so a concurrent label removal stays durable. This is the
  correctness guarantee.
- `components/server`: move `start_hint_service` to after `init_servers()` in
  `run_impl`. This is a best-effort latency optimization, not a strict
  readiness barrier; comments explicitly call out that the retry task is the
  real guarantee.
- `components/test_raftstore`: mirror the same start-after-raftstore contract
  via a `PdRangeHintService::Noop` variant gated by a new `testexport`
  feature on `in_memory_engine`, so future tests cannot silently forget to
  wire the hint service up.

Effect on the issue scenarios: a `cache=always` region is loaded within at
most one retry interval of the local node having both the hint range in
`manual_load_range` and the region visible in `RegionInfoProvider`, instead
of staying cold indefinitely. Restart preload and post-restart
leader-transfer cases are both bounded.

```commit-message
in-memory-engine: retry unresolved cache=always manual ranges

Add a periodic BackgroundTask::ResolveManualLoadRanges that re-resolves
every range in manual_load_range against RegionInfoProvider and loads any
region not yet registered in IME. The retry task re-checks
manual_load_range membership immediately before load_region so concurrent
label removals stay durable.

Move start_hint_service to after init_servers() in run_impl as a
best-effort latency optimization (the retry task is the real correctness
guarantee).

Mirror the same start-after-raftstore contract in test_raftstore via a
PdRangeHintService::Noop variant gated by a new testexport feature on
in_memory_engine, so future cache=always tests cannot silently forget to
wire the hint service up.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests

- [x] Unit test
  - `components/in_memory_engine/src/background.rs` (feature `failpoints`):
    - `test_hint_service_callback_alone_misses_late_regions` — pins the
      one-shot nature of the hint callback when retry is disabled.
    - `test_resolve_manual_load_ranges_retry_loads_late_regions` —
      late-arriving region is loaded by the retry task.
- [x] Integration test
  - `tests/failpoints/cases/test_in_memory_engine.rs`:
    - `test_cache_always_preloaded_via_manual_load_range_retry` —
      cluster-level: a manual range recorded without an immediate
      `load_region` is loaded by retry alone.
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
in-memory-engine: ensure `cache=always` manual-load ranges are reliably
applied after node restart and leader transfer by re-resolving unresolved
ranges against the region info provider on a periodic background task.
```
