### PR TITLE
fix arm64 build (#18473)

### DIFF
--- a/components/backup-stream/src/router.rs
+++ b/components/backup-stream/src/router.rs
@@ -103,7 +103,7 @@ pub enum TaskSelectorRef<'a> {
     All,
 }
 
-impl<'a> std::fmt::Debug for TaskSelectorRef<'a> {
+impl std::fmt::Debug for TaskSelectorRef<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::ByName(name) => f.debug_tuple("ByName").field(name).finish(),
@@ -121,7 +121,7 @@ impl<'a> std::fmt::Debug for TaskSelectorRef<'a> {
     }
 }
 
-impl<'a> TaskSelectorRef<'a> {
+impl TaskSelectorRef<'_> {
     fn matches<'c, 'd>(
         self,
         task_name: &str,

--- a/components/backup-stream/src/subscription_track.rs
+++ b/components/backup-stream/src/subscription_track.rs
@@ -414,7 +414,7 @@ pub trait RefMut: Ref {
     fn value_mut(&mut self) -> &mut <Self as Ref>::Value;
 }
 
-impl<'a> Ref for ActiveSubscriptionRef<'a> {
+impl Ref for ActiveSubscriptionRef<'_> {
     type Key = u64;
     type Value = ActiveSubscription;
 
@@ -427,7 +427,7 @@ impl<'a> Ref for ActiveSubscriptionRef<'a> {
     }
 }
 
-impl<'a> RefMut for ActiveSubscriptionRef<'a> {
+impl RefMut for ActiveSubscriptionRef<'_> {
     fn value_mut(&mut self) -> &mut <Self as Ref>::Value {
         self.sub_mut()
     }

--- a/components/backup-stream/src/utils.rs
+++ b/components/backup-stream/src/utils.rs
@@ -104,7 +104,7 @@ pub type SlotMap<K, V, S = RandomState> = RwLock<HashMap<K, Slot<V>, S>>;
 /// to DSTs.
 struct RangeToInclusiveRef<'a, T: ?Sized>(&'a T);
 
-impl<'a, T: ?Sized> RangeBounds<T> for RangeToInclusiveRef<'a, T> {
+impl<T: ?Sized> RangeBounds<T> for RangeToInclusiveRef<'_, T> {
     fn start_bound(&self) -> Bound<&T> {
         Bound::Unbounded
     }
@@ -116,7 +116,7 @@ impl<'a, T: ?Sized> RangeBounds<T> for RangeToInclusiveRef<'a, T> {
 
 struct RangeToExclusiveRef<'a, T: ?Sized>(&'a T);
 
-impl<'a, T: ?Sized> RangeBounds<T> for RangeToExclusiveRef<'a, T> {
+impl<T: ?Sized> RangeBounds<T> for RangeToExclusiveRef<'_, T> {
     fn start_bound(&self) -> Bound<&T> {
         Bound::Unbounded
     }
@@ -393,7 +393,7 @@ impl Drop for Work {
 
 pub struct WaitAll<'a>(&'a FutureWaitGroup);
 
-impl<'a> Future for WaitAll<'a> {
+impl Future for WaitAll<'_> {
     type Output = ();
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -705,7 +705,7 @@ pub fn debug_key_range<'ret, 'a: 'ret, 'b: 'ret>(
 
 struct DebugKeyRange<'start, 'end>(&'start [u8], &'end [u8]);
 
-impl<'start, 'end> std::fmt::Debug for DebugKeyRange<'start, 'end> {
+impl std::fmt::Debug for DebugKeyRange<'_, '_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let end_key = if self.1.is_empty() {
             Either::Left("inf")
@@ -734,7 +734,7 @@ pub fn debug_region(r: &Region) -> impl std::fmt::Debug + '_ {
 
 struct DebugRegion<'a>(&'a Region);
 
-impl<'a> std::fmt::Debug for DebugRegion<'a> {
+impl std::fmt::Debug for DebugRegion<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let r = self.0;
         f.debug_struct("Region")
@@ -755,7 +755,7 @@ impl<'a> std::fmt::Debug for DebugRegion<'a> {
 
 struct SlogRegion<'a>(&'a Region);
 
-impl<'a> slog::KV for SlogRegion<'a> {
+impl slog::KV for SlogRegion<'_> {
     fn serialize(
         &self,
         _record: &slog::Record<'_>,

--- a/components/cloud/gcp/src/gcs.rs
+++ b/components/cloud/gcp/src/gcs.rs
@@ -412,7 +412,7 @@ struct GcsPrefixIter<'cli> {
     finished: bool,
 }
 
-impl<'cli> GcsPrefixIter<'cli> {
+impl GcsPrefixIter<'_> {
     async fn one_page(&mut self) -> io::Result<Option<Vec<BlobObject>>> {
         if self.finished {
             return Ok(None);

--- a/components/cloud/src/blob.rs
+++ b/components/cloud/src/blob.rs
@@ -23,7 +23,7 @@ pub struct PutResource<'a>(pub Box<dyn AsyncRead + Send + Unpin + 'a>);
 
 pub type BlobStream<'a> = Box<dyn AsyncRead + Unpin + Send + 'a>;
 
-impl<'a> AsyncRead for PutResource<'a> {
+impl AsyncRead for PutResource<'_> {
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,

--- a/components/codec/src/byte.rs
+++ b/components/codec/src/byte.rs
@@ -1374,6 +1374,9 @@ mod benches {
             }
 
             if desc {
+                // SEE: https://github.com/rust-lang/rust-clippy/issues/14685
+                // We can remove this after upgrading to a newer toolchain.
+                #[allow(clippy::manual_slice_fill)]
                 for k in &mut key {
                     *k = !*k;
                 }

--- a/components/compact-log-backup/src/statistic.rs
+++ b/components/compact-log-backup/src/statistic.rs
@@ -122,7 +122,7 @@ pub mod prom {
 
     struct ShowPromHist<'a>(&'a Histogram);
 
-    impl<'a> Serialize for ShowPromHist<'a> {
+    impl Serialize for ShowPromHist<'_> {
         fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
         where
             S: serde::Serializer,

--- a/components/compact-log-backup/src/storage.rs
+++ b/components/compact-log-backup/src/storage.rs
@@ -210,13 +210,13 @@ pub struct LoadFromExt<'a> {
     pub prefetch_buffer_count: usize,
 }
 
-impl<'a> LoadFromExt<'a> {
+impl LoadFromExt<'_> {
     fn enter_load_span(&self) -> Option<Entered<'_>> {
         self.loading_content_span.as_ref().map(|span| span.enter())
     }
 }
 
-impl<'a> Default for LoadFromExt<'a> {
+impl Default for LoadFromExt<'_> {
     fn default() -> Self {
         Self {
             loading_content_span: None,
@@ -304,7 +304,7 @@ impl<F: Future> FusedFuture for Prefetch<F> {
     }
 }
 
-impl<'a> Stream for StreamMetaStorage<'a> {
+impl Stream for StreamMetaStorage<'_> {
     type Item = Result<MetaFile>;
 
     fn poll_next(

--- a/components/compact-log-backup/src/util.rs
+++ b/components/compact-log-backup/src/util.rs
@@ -174,7 +174,7 @@ pub fn redact(k: &[u8]) -> log_wrappers::Value<'_> {
 #[derive(Eq, PartialEq)]
 pub struct EndKey<'a>(pub &'a [u8]);
 
-impl<'a> PartialOrd for EndKey<'a> {
+impl PartialOrd for EndKey<'_> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         use std::cmp::Ordering::*;
         match (self, other) {
@@ -186,7 +186,7 @@ impl<'a> PartialOrd for EndKey<'a> {
     }
 }
 
-impl<'a> Ord for EndKey<'a> {
+impl Ord for EndKey<'_> {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.partial_cmp(other).unwrap()
     }

--- a/components/encryption/src/config.rs
+++ b/components/encryption/src/config.rs
@@ -300,7 +300,7 @@ mod encryption_method_serde {
     {
         struct EncryptionMethodVisitor;
 
-        impl<'de> Visitor<'de> for EncryptionMethodVisitor {
+        impl Visitor<'_> for EncryptionMethodVisitor {
             type Value = EncryptionMethod;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/components/encryption/src/manager/mod.rs
+++ b/components/encryption/src/manager/mod.rs
@@ -1118,7 +1118,7 @@ impl<'a> DataKeyImporter<'a> {
     }
 }
 
-impl<'a> Drop for DataKeyImporter<'a> {
+impl Drop for DataKeyImporter<'_> {
     fn drop(&mut self) {
         if !self.committed {
             if let Err(e) = self.rollback() {

--- a/components/engine_rocks/src/config.rs
+++ b/components/engine_rocks/src/config.rs
@@ -179,7 +179,7 @@ pub mod compression_type_serde {
         D: Deserializer<'de>,
     {
         struct StrVistor;
-        impl<'de> Visitor<'de> for StrVistor {
+        impl Visitor<'_> for StrVistor {
             type Value = DBCompressionType;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -280,7 +280,7 @@ pub mod checksum_serde {
         D: Deserializer<'de>,
     {
         struct StrVistor;
-        impl<'de> Visitor<'de> for StrVistor {
+        impl Visitor<'_> for StrVistor {
             type Value = ChecksumType;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -337,7 +337,7 @@ pub mod prepopulate_block_cache_serde {
         D: Deserializer<'de>,
     {
         struct StrVistor;
-        impl<'de> Visitor<'de> for StrVistor {
+        impl Visitor<'_> for StrVistor {
             type Value = PrepopulateBlockCache;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/components/engine_rocks/src/properties.rs
+++ b/components/engine_rocks/src/properties.rs
@@ -152,7 +152,7 @@ impl DecodeProperties for UserProperties {
 // type until the engine abstraction situation is straightened out.
 pub struct UserCollectedPropertiesDecoder<'a>(pub &'a UserCollectedProperties);
 
-impl<'a> DecodeProperties for UserCollectedPropertiesDecoder<'a> {
+impl DecodeProperties for UserCollectedPropertiesDecoder<'_> {
     fn decode(&self, k: &str) -> Result<&[u8]> {
         match self.0.get(k.as_bytes()) {
             Some(v) => Ok(v),

--- a/components/external_storage/src/locking.rs
+++ b/components/external_storage/src/locking.rs
@@ -230,7 +230,7 @@ pub mod requirements {
     }
 }
 
-impl<'a> ExclusiveWriteCtx<'a> {
+impl ExclusiveWriteCtx<'_> {
     pub fn txn_id(&self) -> uuid::Uuid {
         self.txn_id
     }

--- a/components/file_system/src/lib.rs
+++ b/components/file_system/src/lib.rs
@@ -325,7 +325,7 @@ impl<'de> Deserialize<'de> for IoPriority {
     {
         use serde::de::{Error, Unexpected, Visitor};
         struct StrVistor;
-        impl<'de> Visitor<'de> for StrVistor {
+        impl Visitor<'_> for StrVistor {
             type Value = IoPriority;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/components/file_system/src/rate_limiter.rs
+++ b/components/file_system/src/rate_limiter.rs
@@ -81,7 +81,7 @@ impl<'de> Deserialize<'de> for IoRateLimitMode {
     {
         use serde::de::{Error, Unexpected, Visitor};
         struct StrVistor;
-        impl<'de> Visitor<'de> for StrVistor {
+        impl Visitor<'_> for StrVistor {
             type Value = IoRateLimitMode;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/components/in_memory_engine/src/keys.rs
+++ b/components/in_memory_engine/src/keys.rs
@@ -156,7 +156,7 @@ pub struct InternalKey<'a> {
     pub sequence: u64,
 }
 
-impl<'a> fmt::Debug for InternalKey<'a> {
+impl fmt::Debug for InternalKey<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,

--- a/components/log_wrappers/src/lib.rs
+++ b/components/log_wrappers/src/lib.rs
@@ -109,7 +109,7 @@ impl<'de> Deserialize<'de> for RedactOption {
     {
         struct RedactOptionVisitor;
 
-        impl<'de> de::Visitor<'de> for RedactOptionVisitor {
+        impl de::Visitor<'_> for RedactOptionVisitor {
             type Value = RedactOption;
 
             fn expecting(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -169,7 +169,7 @@ impl<'a> Value<'a> {
     }
 }
 
-impl<'a> slog::Value for Value<'a> {
+impl slog::Value for Value<'_> {
     #[inline]
     fn serialize(
         &self,
@@ -195,7 +195,7 @@ impl<'a> slog::Value for Value<'a> {
     }
 }
 
-impl<'a> fmt::Display for Value<'a> {
+impl fmt::Display for Value<'_> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match REDACT_INFO_LOG.load(Ordering::Relaxed) {
@@ -219,7 +219,7 @@ impl<'a> fmt::Display for Value<'a> {
     }
 }
 
-impl<'a> fmt::Debug for Value<'a> {
+impl fmt::Debug for Value<'_> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(self, f)

--- a/components/pd_client/src/tso.rs
+++ b/components/pd_client/src/tso.rs
@@ -174,7 +174,7 @@ struct TsoRequestStream<'a> {
     self_waker: Rc<AtomicWaker>,
 }
 
-impl<'a> Stream for TsoRequestStream<'a> {
+impl Stream for TsoRequestStream<'_> {
     type Item = (TsoRequest, WriteFlags);
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {

--- a/components/raftstore-v2/src/operation/bucket.rs
+++ b/components/raftstore-v2/src/operation/bucket.rs
@@ -185,7 +185,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
     }
 }
 
-impl<'a, EK, ER, T: Transport> PeerFsmDelegate<'a, EK, ER, T>
+impl<EK, ER, T: Transport> PeerFsmDelegate<'_, EK, ER, T>
 where
     EK: KvEngine,
     ER: RaftEngine,

--- a/components/raftstore-v2/src/operation/command/admin/compact_log.rs
+++ b/components/raftstore-v2/src/operation/command/admin/compact_log.rs
@@ -105,7 +105,7 @@ impl CompactLogContext {
     }
 }
 
-impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> PeerFsmDelegate<'a, EK, ER, T> {
+impl<EK: KvEngine, ER: RaftEngine, T: Transport> PeerFsmDelegate<'_, EK, ER, T> {
     pub fn on_compact_log_tick(&mut self, force: bool) {
         // Might read raft logs.
         debug_assert!(self.fsm.peer().serving());

--- a/components/raftstore-v2/src/operation/command/write/ingest.rs
+++ b/components/raftstore-v2/src/operation/command/write/ingest.rs
@@ -21,7 +21,7 @@ use crate::{
     worker::tablet,
 };
 
-impl<'a, EK: KvEngine, ER: RaftEngine, T> StoreFsmDelegate<'a, EK, ER, T> {
+impl<EK: KvEngine, ER: RaftEngine, T> StoreFsmDelegate<'_, EK, ER, T> {
     #[inline]
     pub fn on_cleanup_import_sst(&mut self) {
         if let Err(e) = self.fsm.store.on_cleanup_import_sst(self.store_ctx) {

--- a/components/raftstore-v2/src/operation/misc.rs
+++ b/components/raftstore-v2/src/operation/misc.rs
@@ -13,7 +13,7 @@ use crate::{
     worker::tablet,
 };
 
-impl<'a, EK: KvEngine, ER: RaftEngine, T> StoreFsmDelegate<'a, EK, ER, T> {
+impl<EK: KvEngine, ER: RaftEngine, T> StoreFsmDelegate<'_, EK, ER, T> {
     #[inline]
     pub fn on_snapshot_gc(&mut self) {
         if let Err(e) = self.fsm.store.on_snapshot_gc(self.store_ctx) {

--- a/components/raftstore-v2/src/operation/pd.rs
+++ b/components/raftstore-v2/src/operation/pd.rs
@@ -19,7 +19,7 @@ use crate::{
     worker::pd,
 };
 
-impl<'a, EK: KvEngine, ER: RaftEngine, T> StoreFsmDelegate<'a, EK, ER, T> {
+impl<EK: KvEngine, ER: RaftEngine, T> StoreFsmDelegate<'_, EK, ER, T> {
     #[inline]
     pub fn on_pd_store_heartbeat(&mut self) {
         self.fsm.store.store_heartbeat_pd(self.store_ctx, None);
@@ -85,7 +85,7 @@ impl Store {
     }
 }
 
-impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> PeerFsmDelegate<'a, EK, ER, T> {
+impl<EK: KvEngine, ER: RaftEngine, T: Transport> PeerFsmDelegate<'_, EK, ER, T> {
     #[inline]
     pub fn on_pd_heartbeat(&mut self) {
         self.fsm.peer_mut().update_peer_statistics();

--- a/components/raftstore-v2/src/operation/query/capture.rs
+++ b/components/raftstore-v2/src/operation/query/capture.rs
@@ -27,9 +27,7 @@ use crate::{
     router::{ApplyTask, QueryResChannel, QueryResult, message::CaptureChange},
 };
 
-impl<'a, EK: KvEngine, ER: RaftEngine, T: raftstore::store::Transport>
-    PeerFsmDelegate<'a, EK, ER, T>
-{
+impl<EK: KvEngine, ER: RaftEngine, T: raftstore::store::Transport> PeerFsmDelegate<'_, EK, ER, T> {
     pub fn on_leader_callback(&mut self, ch: QueryResChannel) {
         let peer = self.fsm.peer();
         let mut msg = new_read_index_request(

--- a/components/raftstore-v2/src/operation/query/lease.rs
+++ b/components/raftstore-v2/src/operation/query/lease.rs
@@ -356,7 +356,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
     }
 }
 
-impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> PeerFsmDelegate<'a, EK, ER, T> {
+impl<EK: KvEngine, ER: RaftEngine, T: Transport> PeerFsmDelegate<'_, EK, ER, T> {
     fn register_check_leader_lease_tick(&mut self) {
         self.schedule_tick(PeerTick::CheckLeaderLease)
     }

--- a/components/raftstore-v2/src/operation/query/local.rs
+++ b/components/raftstore-v2/src/operation/query/local.rs
@@ -576,7 +576,7 @@ struct SnapRequestInspector<'r> {
     logger: &'r Logger,
 }
 
-impl<'r> SnapRequestInspector<'r> {
+impl SnapRequestInspector<'_> {
     fn inspect(&mut self, req: &RaftCmdRequest) -> Result<ReadRequestPolicy> {
         assert!(!req.has_admin_request());
         if req.get_requests().len() != 1

--- a/components/raftstore-v2/src/operation/query/mod.rs
+++ b/components/raftstore-v2/src/operation/query/mod.rs
@@ -49,9 +49,7 @@ mod replica;
 
 pub(crate) use self::local::{LocalReader, ReadDelegatePair, SharedReadTablet};
 
-impl<'a, EK: KvEngine, ER: RaftEngine, T: raftstore::store::Transport>
-    PeerFsmDelegate<'a, EK, ER, T>
-{
+impl<EK: KvEngine, ER: RaftEngine, T: raftstore::store::Transport> PeerFsmDelegate<'_, EK, ER, T> {
     fn inspect_read(&mut self, req: &RaftCmdRequest) -> Result<RequestPolicy> {
         if req.get_header().get_read_quorum() {
             return Ok(RequestPolicy::ReadIndex);

--- a/components/raftstore-v2/src/operation/ready/mod.rs
+++ b/components/raftstore-v2/src/operation/ready/mod.rs
@@ -151,7 +151,7 @@ impl Store {
     }
 }
 
-impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> PeerFsmDelegate<'a, EK, ER, T> {
+impl<EK: KvEngine, ER: RaftEngine, T: Transport> PeerFsmDelegate<'_, EK, ER, T> {
     /// Raft relies on periodic ticks to keep the state machine sync with other
     /// peers.
     pub fn on_raft_tick(&mut self) {

--- a/components/raftstore-v2/src/router/response_channel.rs
+++ b/components/raftstore-v2/src/router/response_channel.rs
@@ -153,7 +153,7 @@ fn check_bit(e: u64, fired_bit: u64) -> Option<bool> {
     None
 }
 
-impl<'a, Res> Future for WaitEvent<'a, Res> {
+impl<Res> Future for WaitEvent<'_, Res> {
     type Output = bool;
 
     #[inline]
@@ -187,7 +187,7 @@ struct WaitResult<'a, Res> {
     sub: &'a BaseSubscriber<Res>,
 }
 
-impl<'a, Res> Future for WaitResult<'a, Res> {
+impl<Res> Future for WaitResult<'_, Res> {
     type Output = Option<Res>;
 
     #[inline]

--- a/components/raftstore/src/coprocessor/mod.rs
+++ b/components/raftstore/src/coprocessor/mod.rs
@@ -73,7 +73,7 @@ pub struct ObserverContext<'a> {
     pub bypass: bool,
 }
 
-impl<'a> ObserverContext<'a> {
+impl ObserverContext<'_> {
     pub fn new(region: &Region) -> ObserverContext<'_> {
         ObserverContext {
             region,

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -7575,7 +7575,7 @@ mod tests {
         epoch: Rc<RefCell<RegionEpoch>>,
     }
 
-    impl<'a, E> SplitResultChecker<'a, E>
+    impl<E> SplitResultChecker<'_, E>
     where
         E: KvEngine,
     {

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -7162,7 +7162,7 @@ where
     }
 }
 
-impl<'a, EK, ER, T: Transport> PeerFsmDelegate<'a, EK, ER, T>
+impl<EK, ER, T: Transport> PeerFsmDelegate<'_, EK, ER, T>
 where
     EK: KvEngine,
     ER: RaftEngine,
@@ -7504,7 +7504,7 @@ fn new_compact_log_request(
     request
 }
 
-impl<'a, EK, ER, T: Transport> PeerFsmDelegate<'a, EK, ER, T>
+impl<EK, ER, T: Transport> PeerFsmDelegate<'_, EK, ER, T>
 where
     EK: KvEngine,
     ER: RaftEngine,

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -799,8 +799,8 @@ struct StoreFsmDelegate<'a, EK: KvEngine + 'static, ER: RaftEngine + 'static, T:
     ctx: &'a mut PollContext<EK, ER, T>,
 }
 
-impl<'a, EK: KvEngine + 'static, ER: RaftEngine + 'static, T: Transport>
-    StoreFsmDelegate<'a, EK, ER, T>
+impl<EK: KvEngine + 'static, ER: RaftEngine + 'static, T: Transport>
+    StoreFsmDelegate<'_, EK, ER, T>
 {
     fn on_tick(&mut self, tick: StoreTick) {
         let timer = TiInstant::now_coarse();
@@ -2086,7 +2086,7 @@ enum CheckMsgStatus {
     NewPeerFirst,
 }
 
-impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER, T> {
+impl<EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'_, EK, ER, T> {
     /// Checks if the message is targeting a stale peer.
     fn check_msg(&mut self, msg: &RaftMessage) -> Result<CheckMsgStatus> {
         let region_id = msg.get_region_id();
@@ -3083,7 +3083,7 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
 // we will remove 1-week old version 1 SST files.
 const VERSION_1_SST_CLEANUP_DURATION: Duration = Duration::from_secs(7 * 24 * 60 * 60);
 
-impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER, T> {
+impl<EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'_, EK, ER, T> {
     fn on_cleanup_import_sst(&mut self) -> Result<()> {
         let mut delete_ssts = Vec::new();
 

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -6250,7 +6250,7 @@ struct PollContextReader<'a, EK, ER> {
     engines: &'a Engines<EK, ER>,
 }
 
-impl<'a, EK, ER> ReadExecutor for PollContextReader<'a, EK, ER>
+impl<EK, ER> ReadExecutor for PollContextReader<'_, EK, ER>
 where
     EK: KvEngine,
     ER: RaftEngine,

--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -1248,7 +1248,7 @@ struct Inspector<'r> {
     delegate: &'r ReadDelegate,
 }
 
-impl<'r> RequestInspector for Inspector<'r> {
+impl RequestInspector for Inspector<'_> {
     fn has_applied_to_current_term(&mut self) -> bool {
         if self.delegate.applied_term == self.delegate.term {
             true

--- a/components/snap_recovery/src/leader_keeper.rs
+++ b/components/snap_recovery/src/leader_keeper.rs
@@ -152,7 +152,7 @@ mod test {
         leaders: RefCell<HashSet<u64>>,
     }
 
-    impl<'a, EK, Router> LeaderKeeper<'a, EK, Router> {
+    impl<EK, Router> LeaderKeeper<'_, EK, Router> {
         fn mut_router(&mut self) -> &mut Router {
             &mut self.router
         }

--- a/components/test_util/src/logging.rs
+++ b/components/test_util/src/logging.rs
@@ -14,7 +14,7 @@ use slog::{self, Drain, OwnedKVList, Record};
 
 struct Serializer<'a>(&'a mut dyn std::io::Write);
 
-impl<'a> slog::Serializer for Serializer<'a> {
+impl slog::Serializer for Serializer<'_> {
     fn emit_arguments(&mut self, key: slog::Key, val: &std::fmt::Arguments<'_>) -> slog::Result {
         write!(self.0, ", {}: {}", key, val)?;
         Ok(())

--- a/components/tidb_query_datatype/src/codec/convert.rs
+++ b/components/tidb_query_datatype/src/codec/convert.rs
@@ -111,7 +111,7 @@ where
     }
 }
 
-impl<'a> ConvertTo<Real> for JsonRef<'a> {
+impl ConvertTo<Real> for JsonRef<'_> {
     #[inline]
     fn convert(&self, ctx: &mut EvalContext) -> Result<Real> {
         let val = self.convert(ctx)?;
@@ -120,7 +120,7 @@ impl<'a> ConvertTo<Real> for JsonRef<'a> {
     }
 }
 
-impl<'a> ConvertTo<String> for JsonRef<'a> {
+impl ConvertTo<String> for JsonRef<'_> {
     #[inline]
     fn convert(&self, _: &mut EvalContext) -> Result<String> {
         // FIXME: There is an additional step `ProduceStrWithSpecifiedTp` in TiDB.
@@ -128,14 +128,14 @@ impl<'a> ConvertTo<String> for JsonRef<'a> {
     }
 }
 
-impl<'a> ConvertTo<Bytes> for JsonRef<'a> {
+impl ConvertTo<Bytes> for JsonRef<'_> {
     #[inline]
     fn convert(&self, _: &mut EvalContext) -> Result<Bytes> {
         Ok(self.to_string_value().into_bytes())
     }
 }
 
-impl<'a> ConvertTo<Bytes> for EnumRef<'a> {
+impl ConvertTo<Bytes> for EnumRef<'_> {
     #[inline]
     fn convert(&self, _: &mut EvalContext) -> Result<Bytes> {
         Ok(self.to_string_value().into_bytes())
@@ -514,7 +514,7 @@ impl ToInt for Json {
     }
 }
 
-impl<'a> ToInt for JsonRef<'a> {
+impl ToInt for JsonRef<'_> {
     // Port from TiDB's types.ConvertJSONToInt
     #[inline]
     fn to_int(&self, ctx: &mut EvalContext, tp: FieldTypeTp) -> Result<i64> {

--- a/components/tidb_query_datatype/src/codec/data_type/bit_vec.rs
+++ b/components/tidb_query_datatype/src/codec/data_type/bit_vec.rs
@@ -106,7 +106,7 @@ impl<'a> BitAndIterator<'a> {
     }
 }
 
-impl<'a> Iterator for BitAndIterator<'a> {
+impl Iterator for BitAndIterator<'_> {
     type Item = bool;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/components/tidb_query_datatype/src/codec/data_type/logical_rows.rs
+++ b/components/tidb_query_datatype/src/codec/data_type/logical_rows.rs
@@ -90,7 +90,7 @@ pub struct LogicalRowsIterator<'a> {
     idx: usize,
 }
 
-impl<'a> Iterator for LogicalRowsIterator<'a> {
+impl Iterator for LogicalRowsIterator<'_> {
     type Item = usize;
     fn next(&mut self) -> Option<Self::Item> {
         let result = if self.idx < self.logical_rows.len() {

--- a/components/tidb_query_datatype/src/codec/data_type/mod.rs
+++ b/components/tidb_query_datatype/src/codec/data_type/mod.rs
@@ -88,7 +88,7 @@ impl AsMySqlBool for Bytes {
     }
 }
 
-impl<'a> AsMySqlBool for BytesRef<'a> {
+impl AsMySqlBool for BytesRef<'_> {
     #[inline]
     fn as_mysql_bool(&self, context: &mut EvalContext) -> Result<bool> {
         Ok(!self.is_empty() && ConvertTo::<f64>::convert(self, context)? != 0f64)
@@ -113,31 +113,31 @@ impl AsMySqlBool for VectorFloat32 {
     }
 }
 
-impl<'a> AsMySqlBool for JsonRef<'a> {
+impl AsMySqlBool for JsonRef<'_> {
     fn as_mysql_bool(&self, _context: &mut EvalContext) -> Result<bool> {
         Ok(!self.is_zero())
     }
 }
 
-impl<'a> AsMySqlBool for VectorFloat32Ref<'a> {
+impl AsMySqlBool for VectorFloat32Ref<'_> {
     fn as_mysql_bool(&self, _context: &mut EvalContext) -> Result<bool> {
         Ok(!self.is_empty())
     }
 }
 
-impl<'a> AsMySqlBool for EnumRef<'a> {
+impl AsMySqlBool for EnumRef<'_> {
     fn as_mysql_bool(&self, _context: &mut EvalContext) -> Result<bool> {
         Ok(!self.is_empty())
     }
 }
 
-impl<'a> AsMySqlBool for SetRef<'a> {
+impl AsMySqlBool for SetRef<'_> {
     fn as_mysql_bool(&self, _context: &mut EvalContext) -> Result<bool> {
         Ok(!self.is_empty())
     }
 }
 
-impl<'a> AsMySqlBool for Option<BytesRef<'a>> {
+impl AsMySqlBool for Option<BytesRef<'_>> {
     fn as_mysql_bool(&self, context: &mut EvalContext) -> Result<bool> {
         match self {
             None => Ok(false),
@@ -146,7 +146,7 @@ impl<'a> AsMySqlBool for Option<BytesRef<'a>> {
     }
 }
 
-impl<'a> AsMySqlBool for Option<JsonRef<'a>> {
+impl AsMySqlBool for Option<JsonRef<'_>> {
     fn as_mysql_bool(&self, context: &mut EvalContext) -> Result<bool> {
         match self {
             None => Ok(false),
@@ -155,7 +155,7 @@ impl<'a> AsMySqlBool for Option<JsonRef<'a>> {
     }
 }
 
-impl<'a> AsMySqlBool for Option<VectorFloat32Ref<'a>> {
+impl AsMySqlBool for Option<VectorFloat32Ref<'_>> {
     fn as_mysql_bool(&self, context: &mut EvalContext) -> Result<bool> {
         match self {
             None => Ok(false),
@@ -164,7 +164,7 @@ impl<'a> AsMySqlBool for Option<VectorFloat32Ref<'a>> {
     }
 }
 
-impl<'a> AsMySqlBool for Option<EnumRef<'a>> {
+impl AsMySqlBool for Option<EnumRef<'_>> {
     fn as_mysql_bool(&self, context: &mut EvalContext) -> Result<bool> {
         match self {
             None => Ok(false),
@@ -173,7 +173,7 @@ impl<'a> AsMySqlBool for Option<EnumRef<'a>> {
     }
 }
 
-impl<'a> AsMySqlBool for Option<SetRef<'a>> {
+impl AsMySqlBool for Option<SetRef<'_>> {
     fn as_mysql_bool(&self, context: &mut EvalContext) -> Result<bool> {
         match self {
             None => Ok(false),
@@ -502,31 +502,31 @@ impl<'a> EvaluableRef<'a> for BytesRef<'a> {
     }
 }
 
-impl<'a> UnsafeRefInto<BytesRef<'static>> for BytesRef<'a> {
+impl UnsafeRefInto<BytesRef<'static>> for BytesRef<'_> {
     unsafe fn unsafe_into(self) -> BytesRef<'static> {
         std::mem::transmute(self)
     }
 }
 
-impl<'a> UnsafeRefInto<JsonRef<'static>> for JsonRef<'a> {
+impl UnsafeRefInto<JsonRef<'static>> for JsonRef<'_> {
     unsafe fn unsafe_into(self) -> JsonRef<'static> {
         std::mem::transmute(self)
     }
 }
 
-impl<'a> UnsafeRefInto<EnumRef<'static>> for EnumRef<'a> {
+impl UnsafeRefInto<EnumRef<'static>> for EnumRef<'_> {
     unsafe fn unsafe_into(self) -> EnumRef<'static> {
         std::mem::transmute(self)
     }
 }
 
-impl<'a> UnsafeRefInto<SetRef<'static>> for SetRef<'a> {
+impl UnsafeRefInto<SetRef<'static>> for SetRef<'_> {
     unsafe fn unsafe_into(self) -> SetRef<'static> {
         std::mem::transmute(self)
     }
 }
 
-impl<'a> UnsafeRefInto<VectorFloat32Ref<'static>> for VectorFloat32Ref<'a> {
+impl UnsafeRefInto<VectorFloat32Ref<'static>> for VectorFloat32Ref<'_> {
     unsafe fn unsafe_into(self) -> VectorFloat32Ref<'static> {
         std::mem::transmute(self)
     }

--- a/components/tidb_query_datatype/src/codec/data_type/scalar.rs
+++ b/components/tidb_query_datatype/src/codec/data_type/scalar.rs
@@ -208,7 +208,7 @@ pub enum ScalarValueRef<'a> {
     VectorFloat32(Option<VectorFloat32Ref<'a>>),
 }
 
-impl<'a> ScalarValueRef<'a> {
+impl ScalarValueRef<'_> {
     #[inline]
     #[allow(clippy::clone_on_copy)]
     pub fn to_owned(self) -> ScalarValue {
@@ -500,14 +500,14 @@ impl<'a> ScalarValueRef<'a> {
     }
 }
 
-impl<'a> Ord for ScalarValueRef<'a> {
+impl Ord for ScalarValueRef<'_> {
     fn cmp(&self, other: &Self) -> Ordering {
         self.partial_cmp(other)
             .expect("Cannot compare two ScalarValueRef in different type")
     }
 }
 
-impl<'a> PartialOrd for ScalarValueRef<'a> {
+impl PartialOrd for ScalarValueRef<'_> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         match_template_evaltype! {
             TT, match (self, other) {
@@ -520,13 +520,13 @@ impl<'a> PartialOrd for ScalarValueRef<'a> {
     }
 }
 
-impl<'a> PartialEq<ScalarValue> for ScalarValueRef<'a> {
+impl PartialEq<ScalarValue> for ScalarValueRef<'_> {
     fn eq(&self, other: &ScalarValue) -> bool {
         self == &other.as_scalar_value_ref()
     }
 }
 
-impl<'a> PartialEq<ScalarValueRef<'a>> for ScalarValue {
+impl PartialEq<ScalarValueRef<'_>> for ScalarValue {
     fn eq(&self, other: &ScalarValueRef<'_>) -> bool {
         other == self
     }

--- a/components/tidb_query_datatype/src/codec/datum.rs
+++ b/components/tidb_query_datatype/src/codec/datum.rs
@@ -854,7 +854,7 @@ impl<'a> From<&'a [u8]> for Datum {
     }
 }
 
-impl<'a> From<Cow<'a, [u8]>> for Datum {
+impl From<Cow<'_, [u8]>> for Datum {
     fn from(data: Cow<'_, [u8]>) -> Datum {
         data.into_owned().into()
     }

--- a/components/tidb_query_datatype/src/codec/mysql/decimal.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/decimal.rs
@@ -1879,7 +1879,7 @@ impl ConvertTo<Decimal> for Json {
     }
 }
 
-impl<'a> ConvertTo<Decimal> for JsonRef<'a> {
+impl ConvertTo<Decimal> for JsonRef<'_> {
     /// Port from TiDB's types.ConvertJSONToDecimal
     #[inline]
     fn convert(&self, ctx: &mut EvalContext) -> Result<Decimal> {

--- a/components/tidb_query_datatype/src/codec/mysql/enums.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/enums.rs
@@ -148,7 +148,7 @@ impl<'a> EnumRef<'a> {
     }
 }
 
-impl<'a> Display for EnumRef<'a> {
+impl Display for EnumRef<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         if *self.value == 0 {
             return Ok(());
@@ -158,27 +158,27 @@ impl<'a> Display for EnumRef<'a> {
     }
 }
 
-impl<'a> Eq for EnumRef<'a> {}
+impl Eq for EnumRef<'_> {}
 
-impl<'a> PartialEq for EnumRef<'a> {
+impl PartialEq for EnumRef<'_> {
     fn eq(&self, other: &Self) -> bool {
         self.value == other.value
     }
 }
 
-impl<'a> Ord for EnumRef<'a> {
+impl Ord for EnumRef<'_> {
     fn cmp(&self, other: &Self) -> Ordering {
         self.value.cmp(other.value)
     }
 }
 
-impl<'a> PartialOrd for EnumRef<'a> {
+impl PartialOrd for EnumRef<'_> {
     fn partial_cmp(&self, right: &Self) -> Option<Ordering> {
         Some(self.cmp(right))
     }
 }
 
-impl<'a> ToInt for EnumRef<'a> {
+impl ToInt for EnumRef<'_> {
     fn to_int(&self, _ctx: &mut EvalContext, _tp: FieldTypeTp) -> Result<i64> {
         Ok(*self.value as i64)
     }
@@ -188,7 +188,7 @@ impl<'a> ToInt for EnumRef<'a> {
     }
 }
 
-impl<'a> ToStringValue for EnumRef<'a> {
+impl ToStringValue for EnumRef<'_> {
     fn to_string_value(&self) -> String {
         String::from_utf8_lossy(self.name).to_string()
     }

--- a/components/tidb_query_datatype/src/codec/mysql/json/comparison.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/json/comparison.rs
@@ -28,7 +28,7 @@ fn compare_f64_with_epsilon(x: f64, y: f64) -> Option<Ordering> {
     }
 }
 
-impl<'a> JsonRef<'a> {
+impl JsonRef<'_> {
     fn get_precedence(&self) -> i32 {
         match self.get_type() {
             JsonType::Object => PRECEDENCE_OBJECT,
@@ -64,21 +64,21 @@ impl<'a> JsonRef<'a> {
     }
 }
 
-impl<'a> Eq for JsonRef<'a> {}
+impl Eq for JsonRef<'_> {}
 
-impl<'a> Ord for JsonRef<'a> {
+impl Ord for JsonRef<'_> {
     fn cmp(&self, right: &JsonRef<'_>) -> Ordering {
         self.partial_cmp(right).unwrap()
     }
 }
 
-impl<'a> PartialEq for JsonRef<'a> {
+impl PartialEq for JsonRef<'_> {
     fn eq(&self, right: &JsonRef<'_>) -> bool {
         self.partial_cmp(right)
             .is_some_and(|r| r == Ordering::Equal)
     }
 }
-impl<'a> PartialOrd for JsonRef<'a> {
+impl PartialOrd for JsonRef<'_> {
     // See `CompareBinary` in TiDB `types/json/binary_functions.go`
     fn partial_cmp(&self, right: &JsonRef<'_>) -> Option<Ordering> {
         let precedence_diff = self.get_precedence() - right.get_precedence();

--- a/components/tidb_query_datatype/src/codec/mysql/json/jcodec.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/json/jcodec.rs
@@ -10,7 +10,7 @@ use crate::{
     codec::{Error, Result},
 };
 
-impl<'a> JsonRef<'a> {
+impl JsonRef<'_> {
     fn encoded_len(&self) -> usize {
         match self.type_code {
             // Literal is encoded inline with value-entry, so nothing will be

--- a/components/tidb_query_datatype/src/codec/mysql/json/json_contains.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/json/json_contains.rs
@@ -4,7 +4,7 @@ use std::cmp::Ordering;
 
 use super::{super::Result, JsonRef, JsonType};
 
-impl<'a> JsonRef<'a> {
+impl JsonRef<'_> {
     /// `json_contains` is the implementation for JSON_CONTAINS in mysql
     /// <https://dev.mysql.com/doc/refman/5.7/en/json-search-functions.html#function_json-contains>
     /// See `ContainsBinaryJSON()` in TiDB `types/json_binary_functions.go`

--- a/components/tidb_query_datatype/src/codec/mysql/json/json_depth.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/json/json_depth.rs
@@ -2,7 +2,7 @@
 
 use super::{super::Result, JsonRef, JsonType};
 
-impl<'a> JsonRef<'a> {
+impl JsonRef<'_> {
     /// Returns maximum depth of JSON document
     pub fn depth(&self) -> Result<i64> {
         depth_json(self)

--- a/components/tidb_query_datatype/src/codec/mysql/json/json_extract.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/json/json_extract.rs
@@ -9,7 +9,7 @@ use super::{
 };
 use crate::codec::mysql::json::path_expr::{ArrayIndex, ArraySelection, KeySelection};
 
-impl<'a> JsonRef<'a> {
+impl JsonRef<'_> {
     /// `extract` receives several path expressions as arguments, matches them
     /// in j, and returns the target JSON matched any path expressions, which
     /// may be autowrapped as an array. If there is no any expression matched,
@@ -42,13 +42,13 @@ impl<'a> JsonRef<'a> {
 #[derive(Eq)]
 struct RefEqualJsonWrapper<'a>(JsonRef<'a>);
 
-impl<'a> PartialEq for RefEqualJsonWrapper<'a> {
+impl PartialEq for RefEqualJsonWrapper<'_> {
     fn eq(&self, other: &Self) -> bool {
         self.0.ref_eq(&other.0)
     }
 }
 
-impl<'a> std::hash::Hash for RefEqualJsonWrapper<'a> {
+impl std::hash::Hash for RefEqualJsonWrapper<'_> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.0.value.as_ptr().hash(state)
     }

--- a/components/tidb_query_datatype/src/codec/mysql/json/json_keys.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/json/json_keys.rs
@@ -4,7 +4,7 @@ use std::str;
 
 use super::{super::Result, Json, JsonRef, JsonType, path_expr::PathExpression};
 
-impl<'a> JsonRef<'a> {
+impl JsonRef<'_> {
     /// Evaluates a (possibly empty) list of values and returns a JSON array
     /// containing those values specified by `path_expr_list`
     pub fn keys(&self, path_expr_list: &[PathExpression]) -> Result<Option<Json>> {

--- a/components/tidb_query_datatype/src/codec/mysql/json/json_length.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/json/json_length.rs
@@ -2,7 +2,7 @@
 
 use super::{super::Result, JsonRef, JsonType, path_expr::PathExpression};
 
-impl<'a> JsonRef<'a> {
+impl JsonRef<'_> {
     fn len(&self) -> i64 {
         match self.get_type() {
             JsonType::Array | JsonType::Object => self.get_elem_count() as i64,

--- a/components/tidb_query_datatype/src/codec/mysql/json/json_memberof.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/json/json_memberof.rs
@@ -4,7 +4,7 @@ use std::cmp::Ordering;
 
 use super::{super::Result, JsonRef, JsonType};
 
-impl<'a> JsonRef<'a> {
+impl JsonRef<'_> {
     /// `member_of` is the implementation for MEMBER OF in mysql
     /// <https://dev.mysql.com/doc/refman/8.0/en/json-search-functions.html#operator_member-of>
     /// See `builtinJSONMemberOfSig` in TiDB `expression/builtin_json.go`

--- a/components/tidb_query_datatype/src/codec/mysql/json/json_merge.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/json/json_merge.rs
@@ -94,7 +94,7 @@ enum MergeUnit<'a> {
     Owned(Json),
 }
 
-impl<'a> MergeUnit<'a> {
+impl MergeUnit<'_> {
     fn as_ref(&self) -> JsonRef<'_> {
         match self {
             MergeUnit::Ref(r) => *r,

--- a/components/tidb_query_datatype/src/codec/mysql/json/json_modify.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/json/json_modify.rs
@@ -13,7 +13,7 @@ pub enum ModifyType {
     Set,
 }
 
-impl<'a> JsonRef<'a> {
+impl JsonRef<'_> {
     /// Modifies a Json object by insert, replace or set.
     /// All path expressions cannot contain * or ** wildcard.
     /// If any error occurs, the input won't be changed.

--- a/components/tidb_query_datatype/src/codec/mysql/json/json_remove.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/json/json_remove.rs
@@ -2,7 +2,7 @@
 
 use super::{super::Result, Json, JsonRef, modifier::BinaryModifier, path_expr::PathExpression};
 
-impl<'a> JsonRef<'a> {
+impl JsonRef<'_> {
     /// Removes elements from Json,
     /// All path expressions cannot contain * or ** wildcard.
     /// If any error occurs, the input won't be changed.

--- a/components/tidb_query_datatype/src/codec/mysql/json/json_type.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/json/json_type.rs
@@ -18,7 +18,7 @@ const JSON_TYPE_DATE: &[u8] = b"DATE";
 const JSON_TYPE_DATETIME: &[u8] = b"DATETIME";
 const JSON_TYPE_TIME: &[u8] = b"TIME";
 
-impl<'a> JsonRef<'a> {
+impl JsonRef<'_> {
     /// `json_type` is the implementation for
     /// <https://dev.mysql.com/doc/refman/5.7/en/json-attribute-functions.html#function_json-type>
     pub fn json_type(&self) -> &'static [u8] {

--- a/components/tidb_query_datatype/src/codec/mysql/json/json_unquote.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/json/json_unquote.rs
@@ -13,7 +13,7 @@ const CHAR_LINEFEED: char = '\x0A';
 const CHAR_FORMFEED: char = '\x0C';
 const CHAR_CARRIAGE_RETURN: char = '\x0D';
 
-impl<'a> JsonRef<'a> {
+impl JsonRef<'_> {
     /// `unquote` recognizes the escape sequences shown in:
     /// <https://dev.mysql.com/doc/refman/5.7/en/json-modification-functions.html>
     /// json-unquote-character-escape-sequences

--- a/components/tidb_query_datatype/src/codec/mysql/json/mod.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/json/mod.rs
@@ -490,7 +490,7 @@ impl ConvertTo<f64> for Json {
     }
 }
 
-impl<'a> ConvertTo<f64> for JsonRef<'a> {
+impl ConvertTo<f64> for JsonRef<'_> {
     ///  Keep compatible with TiDB's `ConvertJSONToFloat` function.
     #[inline]
     fn convert(&self, ctx: &mut EvalContext) -> Result<f64> {

--- a/components/tidb_query_datatype/src/codec/mysql/json/serde.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/json/serde.rs
@@ -57,7 +57,7 @@ impl MySqlFormatter {
     }
 }
 
-impl<'a> ToStringValue for JsonRef<'a> {
+impl ToStringValue for JsonRef<'_> {
     /// This function is a simple combination and rewrite of serde_json's
     /// `to_writer_pretty`
     fn to_string_value(&self) -> String {
@@ -71,7 +71,7 @@ impl<'a> ToStringValue for JsonRef<'a> {
     }
 }
 
-impl<'a> Serialize for JsonRef<'a> {
+impl Serialize for JsonRef<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,

--- a/components/tidb_query_datatype/src/codec/mysql/set.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/set.rs
@@ -103,7 +103,7 @@ impl<'a> SetRef<'a> {
     }
 }
 
-impl<'a> Display for SetRef<'a> {
+impl Display for SetRef<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut buf: Vec<u8> = Vec::new();
         if self.value > 0 {
@@ -124,21 +124,21 @@ impl<'a> Display for SetRef<'a> {
     }
 }
 
-impl<'a> Eq for SetRef<'a> {}
+impl Eq for SetRef<'_> {}
 
-impl<'a> PartialEq for SetRef<'a> {
+impl PartialEq for SetRef<'_> {
     fn eq(&self, other: &Self) -> bool {
         self.value == other.value
     }
 }
 
-impl<'a> Ord for SetRef<'a> {
+impl Ord for SetRef<'_> {
     fn cmp(&self, other: &Self) -> Ordering {
         self.value.cmp(&other.value)
     }
 }
 
-impl<'a> PartialOrd for SetRef<'a> {
+impl PartialOrd for SetRef<'_> {
     fn partial_cmp(&self, right: &Self) -> Option<Ordering> {
         Some(self.cmp(right))
     }

--- a/components/tidb_query_datatype/src/codec/mysql/time/interval.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/time/interval.rs
@@ -622,7 +622,7 @@ pub trait ConvertToIntervalStr {
     ) -> Result<String>;
 }
 
-impl<'a> ConvertToIntervalStr for BytesRef<'a> {
+impl ConvertToIntervalStr for BytesRef<'_> {
     #[inline]
     fn to_interval_string(
         &self,

--- a/components/tidb_query_datatype/src/codec/mysql/vector.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/vector.rs
@@ -102,7 +102,7 @@ pub struct VectorFloat32Ref<'a> {
     value: &'a [u8],
 }
 
-impl<'a> Ord for VectorFloat32Ref<'a> {
+impl Ord for VectorFloat32Ref<'_> {
     fn cmp(&self, other: &Self) -> Ordering {
         let la = self.len();
         let lb = other.len();
@@ -118,7 +118,7 @@ impl<'a> Ord for VectorFloat32Ref<'a> {
     }
 }
 
-impl<'a> PartialOrd for VectorFloat32Ref<'a> {
+impl PartialOrd for VectorFloat32Ref<'_> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }

--- a/components/tidb_query_expr/src/impl_time.rs
+++ b/components/tidb_query_expr/src/impl_time.rs
@@ -952,7 +952,7 @@ pub trait AddSubDateConvertToTime {
     fn to_time(&self, ctx: &mut EvalContext, metadata: &AddSubDateMeta) -> CodecResult<Time>;
 }
 
-impl<'a> AddSubDateConvertToTime for BytesRef<'a> {
+impl AddSubDateConvertToTime for BytesRef<'_> {
     #[inline]
     fn to_time(&self, ctx: &mut EvalContext, metadata: &AddSubDateMeta) -> CodecResult<Time> {
         let input = std::str::from_utf8(self).map_err(Error::Encoding)?;

--- a/components/tidb_query_expr/src/types/expr_eval.rs
+++ b/components/tidb_query_expr/src/types/expr_eval.rs
@@ -35,7 +35,7 @@ pub enum RpnStackNodeVectorValue<'a> {
     },
 }
 
-impl<'a> RpnStackNodeVectorValue<'a> {
+impl RpnStackNodeVectorValue<'_> {
     /// Gets a reference to the inner physical vector value.
     pub fn as_ref(&self) -> &VectorValue {
         match self {
@@ -120,7 +120,7 @@ pub enum RpnStackNode<'a> {
     },
 }
 
-impl<'a> RpnStackNode<'a> {
+impl RpnStackNode<'_> {
     /// Gets the field type.
     #[inline]
     pub fn field_type(&self) -> &FieldType {

--- a/components/tikv_kv/src/raftstore_impls.rs
+++ b/components/tikv_kv/src/raftstore_impls.rs
@@ -26,7 +26,7 @@ pub struct RegionSnapshotExt<'a, S: Snapshot> {
     snapshot: &'a RegionSnapshot<S>,
 }
 
-impl<'a, S: Snapshot> SnapshotExt for RegionSnapshotExt<'a, S> {
+impl<S: Snapshot> SnapshotExt for RegionSnapshotExt<'_, S> {
     #[inline]
     fn get_data_version(&self) -> Option<u64> {
         self.snapshot.get_data_version().ok()

--- a/components/tikv_util/src/buffer_vec.rs
+++ b/components/tikv_util/src/buffer_vec.rs
@@ -321,7 +321,7 @@ impl<'a> WithConcatExtend<'a> {
     }
 }
 
-impl<'a> Extend<u8> for WithConcatExtend<'a> {
+impl Extend<u8> for WithConcatExtend<'_> {
     fn extend<I>(&mut self, iter: I)
     where
         I: IntoIterator<Item = u8>,
@@ -330,7 +330,7 @@ impl<'a> Extend<u8> for WithConcatExtend<'a> {
     }
 }
 
-impl<'a, 'b> Extend<&'a u8> for WithConcatExtend<'b> {
+impl<'a> Extend<&'a u8> for WithConcatExtend<'_> {
     fn extend<I>(&mut self, iter: I)
     where
         I: IntoIterator<Item = &'a u8>,
@@ -339,7 +339,7 @@ impl<'a, 'b> Extend<&'a u8> for WithConcatExtend<'b> {
     }
 }
 
-impl<'a> BufferWriter for WithConcatExtend<'a> {
+impl BufferWriter for WithConcatExtend<'_> {
     unsafe fn bytes_mut(&mut self, size: usize) -> &mut [u8] {
         self.0.data.bytes_mut(size)
     }
@@ -409,7 +409,7 @@ impl<'a> Iterator for Iter<'a> {
     }
 }
 
-impl<'a> ExactSizeIterator for Iter<'a> {}
+impl ExactSizeIterator for Iter<'_> {}
 
 #[cfg(test)]
 mod tests {

--- a/components/tikv_util/src/codec/bytes.rs
+++ b/components/tikv_util/src/codec/bytes.rs
@@ -213,6 +213,9 @@ pub fn decode_bytes(data: &mut BytesSlice<'_>, desc: bool) -> Result<Vec<u8>> {
         }
 
         if desc {
+            // TODO: remove this after updating to a new toolchain,
+            // See: https://github.com/rust-lang/rust-clippy/issues/14685
+            #[allow(clippy::manual_slice_fill)]
             for k in &mut key {
                 *k = !*k;
             }

--- a/components/tikv_util/src/config.rs
+++ b/components/tikv_util/src/config.rs
@@ -237,7 +237,7 @@ impl<'de> Deserialize<'de> for ReadableSize {
     {
         struct SizeVisitor;
 
-        impl<'de> Visitor<'de> for SizeVisitor {
+        impl Visitor<'_> for SizeVisitor {
             type Value = ReadableSize;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -516,7 +516,7 @@ impl<'de> Deserialize<'de> for ReadableDuration {
     {
         struct DurVisitor;
 
-        impl<'de> Visitor<'de> for DurVisitor {
+        impl Visitor<'_> for DurVisitor {
             type Value = ReadableDuration;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -691,7 +691,7 @@ impl<'de> Deserialize<'de> for ReadableOffsetTime {
     {
         struct OffTimeVisitor;
 
-        impl<'de> Visitor<'de> for OffTimeVisitor {
+        impl Visitor<'_> for OffTimeVisitor {
             type Value = ReadableOffsetTime;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -1544,7 +1544,7 @@ macro_rules! numeric_enum_serializing_mod {
             {
                 struct EnumVisitor;
 
-                impl<'de> Visitor<'de> for EnumVisitor {
+                impl Visitor<'_> for EnumVisitor {
                     type Value = $enum;
 
                     fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/components/tikv_util/src/log.rs
+++ b/components/tikv_util/src/log.rs
@@ -104,7 +104,7 @@ struct FormatKeyValueList<'a, W> {
     written: bool,
 }
 
-impl<'a, W: Write> slog::Serializer for FormatKeyValueList<'a, W> {
+impl<W: Write> slog::Serializer for FormatKeyValueList<'_, W> {
     fn emit_arguments(&mut self, key: slog::Key, val: &fmt::Arguments<'_>) -> slog::Result {
         if !self.written {
             write!(&mut self.buffer, "[{}={}]", key, val).unwrap();
@@ -122,7 +122,7 @@ impl<'a, W: Write> slog::Serializer for FormatKeyValueList<'a, W> {
 /// processing.
 pub struct SlogFormat<'a>(pub &'a slog::Logger);
 
-impl<'a> Display for SlogFormat<'a> {
+impl Display for SlogFormat<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut formatter = FormatKeyValueList {
             buffer: f,

--- a/components/tikv_util/src/logger/mod.rs
+++ b/components/tikv_util/src/logger/mod.rs
@@ -673,11 +673,7 @@ impl<'a> Serializer<'a> {
     fn finish(self) {}
 }
 
-impl<'a> Drop for Serializer<'a> {
-    fn drop(&mut self) {}
-}
-
-impl<'a> slog::Serializer for Serializer<'a> {
+impl slog::Serializer for Serializer<'_> {
     fn emit_none(&mut self, key: Key) -> slog::Result {
         self.emit_arguments(key, &format_args!("None"))
     }

--- a/components/tikv_util/src/quota_limiter.rs
+++ b/components/tikv_util/src/quota_limiter.rs
@@ -144,7 +144,7 @@ pub struct CpuObserveGuard<'a> {
     sample: &'a mut Sample,
 }
 
-impl<'a> Drop for CpuObserveGuard<'a> {
+impl Drop for CpuObserveGuard<'_> {
     fn drop(&mut self) {
         if let Some(timer) = self.timer {
             self.sample.add_cpu_time(timer.elapsed());

--- a/components/tikv_util/src/range_latch.rs
+++ b/components/tikv_util/src/range_latch.rs
@@ -72,11 +72,7 @@ impl RangeLatch {
     ///
     /// Deadlocks cannot occur in the current scenario, as each caller thread
     /// holds at most one lock at a time.
-    pub fn acquire<'a>(
-        self: &'a Arc<Self>,
-        start_key: Vec<u8>,
-        end_key: Vec<u8>,
-    ) -> RangeLatchGuard<'a> {
+    pub fn acquire(self: &Arc<Self>, start_key: Vec<u8>, end_key: Vec<u8>) -> RangeLatchGuard<'_> {
         loop {
             let mut range_latches = self.range_latches.lock().unwrap();
 
@@ -136,7 +132,7 @@ pub struct RangeLatchGuard<'a> {
     handle: &'a RangeLatch,
 }
 
-impl<'a> Drop for RangeLatchGuard<'a> {
+impl Drop for RangeLatchGuard<'_> {
     fn drop(&mut self) {
         let mut range_latches = self.handle.range_latches.lock().unwrap();
         range_latches.remove(&self.start_key);

--- a/components/tikv_util/src/resource_control.rs
+++ b/components/tikv_util/src/resource_control.rs
@@ -20,7 +20,7 @@ pub struct TaskMetadata<'a> {
     metadata: Cow<'a, [u8]>,
 }
 
-impl<'a> TaskMetadata<'a> {
+impl TaskMetadata<'_> {
     pub fn deep_clone(&self) -> TaskMetadata<'static> {
         TaskMetadata {
             metadata: Cow::Owned(self.metadata.to_vec()),

--- a/components/tracker/src/slab.rs
+++ b/components/tracker/src/slab.rs
@@ -189,7 +189,7 @@ impl Default for TrackerToken {
 }
 
 pub struct TrackerTokenArray<'a>(&'a [TrackerToken]);
-impl<'a> slog::Value for TrackerTokenArray<'a> {
+impl slog::Value for TrackerTokenArray<'_> {
     fn serialize(
         &self,
         _record: &slog::Record<'_>,

--- a/components/txn_types/src/lock.rs
+++ b/components/txn_types/src/lock.rs
@@ -657,7 +657,7 @@ pub enum TxnLockRef<'a> {
     Persisted(&'a Lock),
 }
 
-impl<'a> TxnLockRef<'a> {
+impl TxnLockRef<'_> {
     pub fn get_start_ts(&self) -> TimeStamp {
         match self {
             TxnLockRef::InMemory(pessimistic_lock) => pessimistic_lock.start_ts,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,5 @@
 [toolchain]
-channel = "nightly-2025-04-03"
+#WARN: Before upgrading to a new toolchain, please ensure https://github.com/rust-lang/rust/issues/141306 is fixed.
+channel = "nightly-2025-02-28"
 components = ["rustfmt", "clippy", "rust-src", "rust-analyzer"]
 profile = "minimal"

--- a/src/server/gc_worker/compaction_filter.rs
+++ b/src/server/gc_worker/compaction_filter.rs
@@ -913,7 +913,7 @@ pub mod test_utils {
         pub(super) callbacks_on_drop: Vec<Arc<dyn Fn(&WriteCompactionFilter) + Send + Sync>>,
     }
 
-    impl<'a> TestGcRunner<'a> {
+    impl TestGcRunner<'_> {
         pub fn new(safe_point: u64) -> Self {
             let (gc_scheduler, gc_receiver) = dummy_scheduler();
 
@@ -930,7 +930,7 @@ pub mod test_utils {
         }
     }
 
-    impl<'a> TestGcRunner<'a> {
+    impl TestGcRunner<'_> {
         pub fn safe_point(&mut self, sp: u64) -> &mut Self {
             self.safe_point = sp;
             self

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -3554,7 +3554,7 @@ impl<S: Snapshot> Snapshot for TxnTestSnapshot<S> {
 
 pub struct TxnTestSnapshotExt<'a>(&'a Arc<TxnExt>);
 
-impl<'a> SnapshotExt for TxnTestSnapshotExt<'a> {
+impl SnapshotExt for TxnTestSnapshotExt<'_> {
     fn get_txn_ext(&self) -> Option<&Arc<TxnExt>> {
         Some(self.0)
     }

--- a/src/storage/txn/actions/prewrite.rs
+++ b/src/storage/txn/actions/prewrite.rs
@@ -226,7 +226,7 @@ pub struct TransactionProperties<'a> {
     pub txn_source: u64,
 }
 
-impl<'a> TransactionProperties<'a> {
+impl TransactionProperties<'_> {
     fn max_commit_ts(&self) -> TimeStamp {
         match &self.commit_kind {
             CommitKind::TwoPc => unreachable!(),

--- a/src/storage/txn/commands/mod.rs
+++ b/src/storage/txn/commands/mod.rs
@@ -657,7 +657,7 @@ impl<'a, S: Snapshot> ReaderWithStats<'a, S> {
     }
 }
 
-impl<'a, S: Snapshot> Deref for ReaderWithStats<'a, S> {
+impl<S: Snapshot> Deref for ReaderWithStats<'_, S> {
     type Target = SnapshotReader<S>;
 
     fn deref(&self) -> &Self::Target {
@@ -665,13 +665,13 @@ impl<'a, S: Snapshot> Deref for ReaderWithStats<'a, S> {
     }
 }
 
-impl<'a, S: Snapshot> DerefMut for ReaderWithStats<'a, S> {
+impl<S: Snapshot> DerefMut for ReaderWithStats<'_, S> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.reader
     }
 }
 
-impl<'a, S: Snapshot> Drop for ReaderWithStats<'a, S> {
+impl<S: Snapshot> Drop for ReaderWithStats<'_, S> {
     fn drop(&mut self) {
         self.statistics.add(&self.reader.take_statistics())
     }


### PR DESCRIPTION
This is a cherry-pick PR, origin link: https://github.com/tikv/tikv/pull/18473
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #xxx

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
