### PR TITLE
raftstore: relax load base split thresholds and improve observability

### DIFF
--- a/components/raftstore/src/store/metrics.rs
+++ b/components/raftstore/src/store/metrics.rs
@@ -843,7 +843,7 @@ lazy_static! {
 
     pub static ref LOAD_BASE_SPLIT_REGION_LOAD_VEC: HistogramVec = register_histogram_vec!(
         "tikv_load_base_split_region_load",
-        "Histogram of normalized region load observed by load base split on this TiKV. The type label is cpu_millicores, qps, or bytes_kib.",
+        "Histogram of region load observed when load base split evaluates hot regions on this TiKV. The type label is cpu_millicores, qps, or bytes_kib.",
         &["type"],
         exponential_buckets(1.0, 2.0, 28).unwrap()
     ).unwrap();

--- a/components/raftstore/src/store/metrics.rs
+++ b/components/raftstore/src/store/metrics.rs
@@ -264,6 +264,10 @@ make_static_metric! {
         cpu_fallback_region_not_busy,
         // CPU fallback is blocked because gRPC poll threads are busy.
         cpu_fallback_grpc_busy,
+        // Load-base split admin command succeeds.
+        split_success,
+        // Load-base split admin command fails.
+        split_failed,
         // Hottest key range for the top hot CPU region could not be found.
         empty_hottest_key_range,
         // The top hot CPU region could not be split.

--- a/components/raftstore/src/store/metrics.rs
+++ b/components/raftstore/src/store/metrics.rs
@@ -256,6 +256,14 @@ make_static_metric! {
         no_uncross_key,
         // Split info for the top hot CPU region has been collected, ready to split.
         ready_to_split_cpu_top,
+        // Normal split-key selection failed.
+        normal_key_failed,
+        // CPU fallback is skipped because the unified read pool is not busy.
+        cpu_fallback_unified_not_busy,
+        // CPU fallback is skipped because the region CPU is not hot enough.
+        cpu_fallback_region_not_busy,
+        // CPU fallback is blocked because gRPC poll threads are busy.
+        cpu_fallback_grpc_busy,
         // Hottest key range for the top hot CPU region could not be found.
         empty_hottest_key_range,
         // The top hot CPU region could not be split.
@@ -827,6 +835,13 @@ lazy_static! {
         "Histogram of query balance",
         &["type"],
         linear_buckets(0.0, 0.05, 20).unwrap()
+    ).unwrap();
+
+    pub static ref LOAD_BASE_SPLIT_REGION_LOAD_VEC: HistogramVec = register_histogram_vec!(
+        "tikv_load_base_split_region_load",
+        "Histogram of normalized region load observed by load base split on this TiKV. The type label is cpu_millicores, qps, or bytes_kib.",
+        &["type"],
+        exponential_buckets(1.0, 2.0, 28).unwrap()
     ).unwrap();
 
     pub static ref LOAD_BASE_SPLIT_DURATION_HISTOGRAM : Histogram = register_histogram!(

--- a/components/raftstore/src/store/metrics.rs
+++ b/components/raftstore/src/store/metrics.rs
@@ -843,7 +843,7 @@ lazy_static! {
 
     pub static ref LOAD_BASE_SPLIT_REGION_LOAD_VEC: HistogramVec = register_histogram_vec!(
         "tikv_load_base_split_region_load",
-        "Histogram of region load observed when load base split evaluates hot regions on this TiKV. The type label is cpu_millicores, qps, or bytes_kib.",
+        "Histogram of region load observed before load-fit filtering when load base split evaluates regions on this TiKV. The type label is cpu_millicores, qps, or bytes_kib.",
         &["type"],
         exponential_buckets(1.0, 2.0, 28).unwrap()
     ).unwrap();

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -1299,6 +1299,7 @@ where
         if reason != pdpb::SplitReason::Admin && split_validator.is_disabled(region.get_id()) {
             return;
         }
+        let is_load_split = reason == pdpb::SplitReason::Load;
         let resp = pd_client.ask_batch_split(region.clone(), split_keys.len(), reason);
         let f = async move {
             match resp.await {
@@ -1319,7 +1320,12 @@ where
                     );
                     let region_id = region.get_id();
                     let epoch = region.take_region_epoch();
-                    send_admin_request(
+                    let callback = if is_load_split {
+                        Self::load_base_split_callback(callback)
+                    } else {
+                        callback
+                    };
+                    if !send_admin_request(
                         &router,
                         region_id,
                         epoch,
@@ -1327,7 +1333,10 @@ where
                         req,
                         callback,
                         Default::default(),
-                    );
+                    ) && is_load_split
+                    {
+                        LOAD_BASE_SPLIT_EVENT.split_failed.inc();
+                    }
                 }
                 // When rolling update, there might be some old version tikvs that don't support
                 // batch split in cluster. In this situation, PD version check would refuse
@@ -1415,6 +1424,17 @@ where
             }
         };
         self.remote.spawn(f);
+    }
+
+    fn load_base_split_callback(callback: Callback<EK::Snapshot>) -> Callback<EK::Snapshot> {
+        Callback::write(Box::new(move |resp| {
+            if resp.response.get_header().has_error() {
+                LOAD_BASE_SPLIT_EVENT.split_failed.inc();
+            } else {
+                LOAD_BASE_SPLIT_EVENT.split_success.inc();
+            }
+            callback.invoke_with_response(resp.response);
+        }))
     }
 
     fn handle_store_heartbeat(
@@ -2812,7 +2832,8 @@ fn send_admin_request<EK, ER>(
     request: AdminRequest,
     callback: Callback<EK::Snapshot>,
     extra_opts: RaftCmdExtraOpts,
-) where
+) -> bool
+where
     EK: KvEngine,
     ER: RaftEngine,
 {
@@ -2830,7 +2851,9 @@ fn send_admin_request<EK, ER>(
             "send request failed";
             "region_id" => region_id, "cmd_type" => ?cmd_type, "err" => ?e,
         );
+        return false;
     }
+    true
 }
 
 /// Sends a raft message to destroy the specified stale Peer

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -152,6 +152,7 @@ where
         right_derive: bool,
         share_source_region_size: bool,
         callback: Callback<EK::Snapshot>,
+        split_reason: pdpb::SplitReason,
     },
     AskBatchSplit {
         region: metapb::Region,
@@ -1230,9 +1231,11 @@ where
         share_source_region_size: bool,
         callback: Callback<EK::Snapshot>,
         task: String,
+        split_reason: pdpb::SplitReason,
     ) {
         let router = self.router.clone();
         let resp = self.pd_client.ask_split(region.clone());
+        let is_load_split = split_reason == pdpb::SplitReason::Load;
         let f = async move {
             match resp.await {
                 Ok(mut resp) => {
@@ -1253,7 +1256,12 @@ where
                     );
                     let region_id = region.get_id();
                     let epoch = region.take_region_epoch();
-                    send_admin_request(
+                    let callback = if is_load_split {
+                        Self::load_base_split_callback(callback)
+                    } else {
+                        callback
+                    };
+                    if !send_admin_request(
                         &router,
                         region_id,
                         epoch,
@@ -1261,13 +1269,19 @@ where
                         req,
                         callback,
                         Default::default(),
-                    );
+                    ) && is_load_split
+                    {
+                        LOAD_BASE_SPLIT_EVENT.split_failed.inc();
+                    }
                 }
                 Err(e) => {
                     warn!("failed to ask split";
                     "region_id" => region.get_id(),
                     "err" => ?e,
                     "task"=>task);
+                    if is_load_split {
+                        LOAD_BASE_SPLIT_EVENT.split_failed.inc();
+                    }
                 }
             }
         };
@@ -1355,6 +1369,7 @@ where
                         right_derive,
                         share_source_region_size,
                         callback,
+                        split_reason: reason,
                     };
                     if let Err(ScheduleError::Stopped(t)) = scheduler.schedule(task) {
                         error!(
@@ -1363,7 +1378,14 @@ where
                             "peer_id" =>  peer_id
                         );
                         match t {
-                            Task::AskSplit { callback, .. } => {
+                            Task::AskSplit {
+                                callback,
+                                split_reason,
+                                ..
+                            } => {
+                                if split_reason == pdpb::SplitReason::Load {
+                                    LOAD_BASE_SPLIT_EVENT.split_failed.inc();
+                                }
                                 callback.invoke_with_response(new_error(box_err!(
                                     "failed to split: Stopped"
                                 )));
@@ -1378,6 +1400,9 @@ where
                         "region_id" => region.get_id(),
                         "err" => ?e,
                     );
+                    if is_load_split {
+                        LOAD_BASE_SPLIT_EVENT.split_failed.inc();
+                    }
                 }
             }
         };
@@ -2458,6 +2483,7 @@ where
                 right_derive,
                 share_source_region_size,
                 callback,
+                split_reason,
             } => self.handle_ask_split(
                 region,
                 split_key,
@@ -2466,6 +2492,7 @@ where
                 share_source_region_size,
                 callback,
                 String::from("ask_split"),
+                split_reason,
             ),
             Task::AskBatchSplit {
                 region,

--- a/components/raftstore/src/store/worker/split_config.rs
+++ b/components/raftstore/src/store/worker/split_config.rs
@@ -22,7 +22,7 @@ pub const DEFAULT_BIG_REGION_BYTE_THRESHOLD: usize = 100 * 1024 * 1024;
 // We get balance score by
 // abs(sample.left-sample.right)/(sample.right+sample.left). It will be used to
 // measure left and right balance
-const DEFAULT_SPLIT_BALANCE_SCORE: f64 = 0.25;
+const DEFAULT_SPLIT_BALANCE_SCORE: f64 = 0.8;
 // We get contained score by
 // sample.contained/(sample.right+sample.left+sample.contained). It will be used
 // to avoid to split regions requested by range.
@@ -39,14 +39,14 @@ const DEFAULT_SPLIT_CONTAINED_SCORE: f64 = 0.5;
 // `REGION_CPU_OVERLOAD_THRESHOLD_RATIO` are exceeded to prevent from increasing
 // the gRPC poll CPU usage.
 const DEFAULT_GRPC_THREAD_CPU_OVERLOAD_THRESHOLD_RATIO: f64 = 0.5;
-// When the Unified Read Poll thread CPU usage is higher than Unified Read Poll
+// When the Unified Read Pool thread CPU usage is higher than Unified Read Pool
 // thread count *
 // `DEFAULT_UNIFIED_READ_POOL_THREAD_CPU_OVERLOAD_THRESHOLD_RATIO`,
 // the CPU-based split will try to check and record the top hot CPU region.
-const DEFAULT_UNIFIED_READ_POOL_THREAD_CPU_OVERLOAD_THRESHOLD_RATIO: f64 = 0.8;
-// When the Unified Read Poll is hot and the region's CPU usage reaches
+const DEFAULT_UNIFIED_READ_POOL_THREAD_CPU_OVERLOAD_THRESHOLD_RATIO: f64 = 0.4;
+// When the Unified Read Pool is hot and the region's CPU usage reaches
 // `REGION_CPU_OVERLOAD_THRESHOLD_RATIO` as a percentage of the Unified Read
-// Poll, it will be added into the hot region list and may be split later as the
+// Pool, it will be added into the hot region list and may be split later as the
 // top hot CPU region.
 pub const REGION_CPU_OVERLOAD_THRESHOLD_RATIO: f64 = 0.25;
 pub const BIG_REGION_CPU_OVERLOAD_THRESHOLD_RATIO: f64 = 0.75;

--- a/components/raftstore/src/store/worker/split_controller.rs
+++ b/components/raftstore/src/store/worker/split_controller.rs
@@ -814,11 +814,13 @@ impl AutoSplitController {
                 .fold(0, |flow, region_info| flow + region_info.flow.read_bytes);
             region_qps_histogram.observe(qps as f64);
             region_bytes_histogram.observe(byte as f64 / 1024.0);
-            let (cpu_usage, hottest_key_range) = region_cpu_map
-                .get(&region_id)
-                .map(|(cpu_usage, key_range)| (*cpu_usage, key_range.clone()))
-                .unwrap_or((0.0, None));
-            region_cpu_histogram.observe(cpu_usage * 1000.0);
+            let (cpu_usage, hottest_key_range) =
+                if let Some((cpu_usage, key_range)) = region_cpu_map.get(&region_id) {
+                    region_cpu_histogram.observe(cpu_usage * 1000.0);
+                    (*cpu_usage, key_range.clone())
+                } else {
+                    (0.0, None)
+                };
             let is_region_busy = self.is_region_busy(unified_read_pool_thread_usage, cpu_usage);
             debug!("load base split params";
                 "region_id" => region_id,

--- a/components/raftstore/src/store/worker/split_controller.rs
+++ b/components/raftstore/src/store/worker/split_controller.rs
@@ -232,6 +232,8 @@ impl Samples {
             LOAD_BASE_SPLIT_SAMPLE_VEC
                 .with_label_values(&["balance_score"])
                 .observe(balance_score);
+            let contained_score = sample.contained as f64 / evaluated_key_num;
+            let final_score = balance_score + contained_score;
             if balance_score >= split_balance_score {
                 LOAD_BASE_SPLIT_EVENT.no_balance_key.inc();
                 continue;
@@ -240,7 +242,6 @@ impl Samples {
             // The contained score is the ratio of a sample key that are contained in the
             // requested key. The larger the contained score, the more RPCs the
             // cluster will receive after this splitting.
-            let contained_score = sample.contained as f64 / evaluated_key_num;
             LOAD_BASE_SPLIT_SAMPLE_VEC
                 .with_label_values(&["contained_score"])
                 .observe(contained_score);
@@ -252,7 +253,6 @@ impl Samples {
             // We try to find a split key that has the smallest balance score and the
             // smallest contained score to make the splitting keep the load
             // balanced while not increasing too many RPCs.
-            let final_score = balance_score + contained_score;
             if final_score < best_score {
                 best_index = index as i32;
                 best_score = final_score;
@@ -797,6 +797,11 @@ impl AutoSplitController {
 
         // Start to record the read stats info.
         let mut split_infos = vec![];
+        let region_cpu_histogram =
+            LOAD_BASE_SPLIT_REGION_LOAD_VEC.with_label_values(&["cpu_millicores"]);
+        let region_qps_histogram = LOAD_BASE_SPLIT_REGION_LOAD_VEC.with_label_values(&["qps"]);
+        let region_bytes_histogram =
+            LOAD_BASE_SPLIT_REGION_LOAD_VEC.with_label_values(&["bytes_kib"]);
         for (region_id, region_infos) in region_infos_map {
             if split_validator.is_disabled(region_id) {
                 continue;
@@ -807,10 +812,13 @@ impl AutoSplitController {
             let byte = region_infos
                 .iter()
                 .fold(0, |flow, region_info| flow + region_info.flow.read_bytes);
+            region_qps_histogram.observe(qps as f64);
+            region_bytes_histogram.observe(byte as f64 / 1024.0);
             let (cpu_usage, hottest_key_range) = region_cpu_map
                 .get(&region_id)
                 .map(|(cpu_usage, key_range)| (*cpu_usage, key_range.clone()))
                 .unwrap_or((0.0, None));
+            region_cpu_histogram.observe(cpu_usage * 1000.0);
             let is_region_busy = self.is_region_busy(unified_read_pool_thread_usage, cpu_usage);
             debug!("load base split params";
                 "region_id" => region_id,
@@ -878,9 +886,19 @@ impl AutoSplitController {
                     ));
                     LOAD_BASE_SPLIT_EVENT.ready_to_split.inc();
                     self.recorders.remove(&region_id);
-                } else if is_unified_read_pool_busy && is_region_busy {
-                    LOAD_BASE_SPLIT_EVENT.cpu_load_fit.inc();
-                    top_cpu_usage.push(region_id);
+                } else {
+                    LOAD_BASE_SPLIT_EVENT.normal_key_failed.inc();
+                    if !is_unified_read_pool_busy {
+                        LOAD_BASE_SPLIT_EVENT.cpu_fallback_unified_not_busy.inc();
+                    } else if !is_region_busy {
+                        LOAD_BASE_SPLIT_EVENT.cpu_fallback_region_not_busy.inc();
+                    } else {
+                        LOAD_BASE_SPLIT_EVENT.cpu_load_fit.inc();
+                        if is_grpc_poll_busy {
+                            LOAD_BASE_SPLIT_EVENT.cpu_fallback_grpc_busy.inc();
+                        }
+                        top_cpu_usage.push(region_id);
+                    }
                 }
             } else {
                 LOAD_BASE_SPLIT_EVENT.not_ready_to_split.inc();

--- a/metrics/grafana/tikv_details.dashboard.py
+++ b/metrics/grafana/tikv_details.dashboard.py
@@ -2829,20 +2829,57 @@ def RaftAdmin() -> RowPanel:
     )
     layout.row(
         [
-            graph_panel_histogram_quantiles(
+            graph_panel(
                 title="Observed region CPU for load-base split",
                 description=(
                     "Per-region CPU observed when load-base split evaluates hot "
-                    "regions. Unit: millicores. This is decision input, not the "
-                    "final split result. Use additional_groupby=instance only "
-                    "when drilling into a specific TiKV; keep it as none for "
-                    "large clusters."
+                    "regions. Unit follows other CPU panels: 100% means one CPU "
+                    "core. This is decision input, not the final split result. "
+                    "Use additional_groupby=instance only when drilling into a "
+                    "specific TiKV; keep it as none for large clusters."
                 ),
-                yaxes=yaxes(left_format="mcores"),
-                metric="tikv_load_base_split_region_load",
-                label_selectors=['type="cpu_millicores"'],
-                hide_count=True,
-                additional_groupby=True,
+                yaxes=yaxes(left_format=UNITS.PERCENT_UNIT),
+                targets=[
+                    target(
+                        expr=expr_operator(
+                            expr_histogram_quantile(
+                                0.9999,
+                                "tikv_load_base_split_region_load",
+                                label_selectors=['type="cpu_millicores"'],
+                            ),
+                            "/",
+                            "1000",
+                        ),
+                        legend_format="99.99%",
+                        additional_groupby=True,
+                    ),
+                    target(
+                        expr=expr_operator(
+                            expr_histogram_quantile(
+                                0.99,
+                                "tikv_load_base_split_region_load",
+                                label_selectors=['type="cpu_millicores"'],
+                            ),
+                            "/",
+                            "1000",
+                        ),
+                        legend_format="99%",
+                        additional_groupby=True,
+                    ),
+                    target(
+                        expr=expr_operator(
+                            expr_histogram_avg(
+                                "tikv_load_base_split_region_load",
+                                label_selectors=['type="cpu_millicores"'],
+                                by_labels=[],
+                            ),
+                            "/",
+                            "1000",
+                        ),
+                        legend_format="avg",
+                        additional_groupby=True,
+                    ),
+                ],
             ),
             graph_panel_histogram_quantiles(
                 title="Observed region QPS for load-base split",

--- a/metrics/grafana/tikv_details.dashboard.py
+++ b/metrics/grafana/tikv_details.dashboard.py
@@ -2832,11 +2832,13 @@ def RaftAdmin() -> RowPanel:
             graph_panel(
                 title="Observed region CPU for load-base split",
                 description=(
-                    "Per-region CPU observed when load-base split evaluates hot "
-                    "regions. Unit follows other CPU panels: 100% means one CPU "
-                    "core. This is decision input, not the final split result. "
-                    "Use additional_groupby=instance only when drilling into a "
-                    "specific TiKV; keep it as none for large clusters."
+                    "Per-region CPU observed before load-fit filtering when "
+                    "load-base split evaluates regions. Unit follows other CPU "
+                    "panels: 100% means one CPU core. This is pre-load-fit "
+                    "decision input; use the tail distribution to tune split "
+                    "thresholds. Use additional_groupby=instance only when "
+                    "drilling into a specific TiKV; keep it as none for large "
+                    "clusters."
                 ),
                 yaxes=yaxes(left_format=UNITS.PERCENT_UNIT),
                 targets=[
@@ -2884,10 +2886,12 @@ def RaftAdmin() -> RowPanel:
             graph_panel_histogram_quantiles(
                 title="Observed region QPS for load-base split",
                 description=(
-                    "Per-region QPS observed when load-base split evaluates hot "
-                    "regions. This is decision input, not the final split "
-                    "result. Use additional_groupby=instance only when drilling "
-                    "into a specific TiKV; keep it as none for large clusters."
+                    "Per-region QPS observed before load-fit filtering when "
+                    "load-base split evaluates regions. This is pre-load-fit "
+                    "decision input; use the tail distribution to tune split "
+                    "thresholds. Use additional_groupby=instance only when "
+                    "drilling into a specific TiKV; keep it as none for large "
+                    "clusters."
                 ),
                 yaxes=yaxes(left_format=UNITS.REQUESTS_PER_SEC),
                 metric="tikv_load_base_split_region_load",
@@ -2898,11 +2902,12 @@ def RaftAdmin() -> RowPanel:
             graph_panel_histogram_quantiles(
                 title="Observed region read bytes for load-base split",
                 description=(
-                    "Per-region read bytes observed when load-base split "
-                    "evaluates hot regions. Unit: KiB. This is decision input, "
-                    "not the final split result. Use additional_groupby=instance "
-                    "only when drilling into a specific TiKV; keep it as none "
-                    "for large clusters."
+                    "Per-region read bytes observed before load-fit filtering "
+                    "when load-base split evaluates regions. Unit: KiB. This is "
+                    "pre-load-fit decision input; use the tail distribution to "
+                    "tune split thresholds. Use additional_groupby=instance only "
+                    "when drilling into a specific TiKV; keep it as none for "
+                    "large clusters."
                 ),
                 yaxes=yaxes(left_format=UNITS.KIBI_BYTES),
                 metric="tikv_load_base_split_region_load",

--- a/metrics/grafana/tikv_details.dashboard.py
+++ b/metrics/grafana/tikv_details.dashboard.py
@@ -2829,6 +2829,37 @@ def RaftAdmin() -> RowPanel:
     )
     layout.row(
         [
+            graph_panel_histogram_quantiles(
+                title="Load base split region CPU",
+                description="Per-region CPU observed by load-base split. Unit: millicores.",
+                yaxes=yaxes(left_format=UNITS.SHORT),
+                metric="tikv_load_base_split_region_load",
+                label_selectors=['type="cpu_millicores"'],
+                hide_count=True,
+                additional_groupby=True,
+            ),
+            graph_panel_histogram_quantiles(
+                title="Load base split region QPS",
+                description="Per-region QPS observed by load-base split.",
+                yaxes=yaxes(left_format=UNITS.SHORT),
+                metric="tikv_load_base_split_region_load",
+                label_selectors=['type="qps"'],
+                hide_count=True,
+                additional_groupby=True,
+            ),
+            graph_panel_histogram_quantiles(
+                title="Load base split region bytes",
+                description="Per-region read bytes observed by load-base split. Unit: KiB.",
+                yaxes=yaxes(left_format=UNITS.SHORT),
+                metric="tikv_load_base_split_region_load",
+                label_selectors=['type="bytes_kib"'],
+                hide_count=True,
+                additional_groupby=True,
+            ),
+        ]
+    )
+    layout.row(
+        [
             graph_panel(
                 title="Peer in Flashback State",
                 targets=[

--- a/metrics/grafana/tikv_details.dashboard.py
+++ b/metrics/grafana/tikv_details.dashboard.py
@@ -2830,27 +2830,44 @@ def RaftAdmin() -> RowPanel:
     layout.row(
         [
             graph_panel_histogram_quantiles(
-                title="Load base split region CPU",
-                description="Per-region CPU observed by load-base split. Unit: millicores.",
-                yaxes=yaxes(left_format=UNITS.SHORT),
+                title="Observed region CPU for load-base split",
+                description=(
+                    "Per-region CPU observed when load-base split evaluates hot "
+                    "regions. Unit: millicores. This is decision input, not the "
+                    "final split result. Use additional_groupby=instance only "
+                    "when drilling into a specific TiKV; keep it as none for "
+                    "large clusters."
+                ),
+                yaxes=yaxes(left_format="mcores"),
                 metric="tikv_load_base_split_region_load",
                 label_selectors=['type="cpu_millicores"'],
                 hide_count=True,
                 additional_groupby=True,
             ),
             graph_panel_histogram_quantiles(
-                title="Load base split region QPS",
-                description="Per-region QPS observed by load-base split.",
-                yaxes=yaxes(left_format=UNITS.SHORT),
+                title="Observed region QPS for load-base split",
+                description=(
+                    "Per-region QPS observed when load-base split evaluates hot "
+                    "regions. This is decision input, not the final split "
+                    "result. Use additional_groupby=instance only when drilling "
+                    "into a specific TiKV; keep it as none for large clusters."
+                ),
+                yaxes=yaxes(left_format=UNITS.REQUESTS_PER_SEC),
                 metric="tikv_load_base_split_region_load",
                 label_selectors=['type="qps"'],
                 hide_count=True,
                 additional_groupby=True,
             ),
             graph_panel_histogram_quantiles(
-                title="Load base split region bytes",
-                description="Per-region read bytes observed by load-base split. Unit: KiB.",
-                yaxes=yaxes(left_format=UNITS.SHORT),
+                title="Observed region read bytes for load-base split",
+                description=(
+                    "Per-region read bytes observed when load-base split "
+                    "evaluates hot regions. Unit: KiB. This is decision input, "
+                    "not the final split result. Use additional_groupby=instance "
+                    "only when drilling into a specific TiKV; keep it as none "
+                    "for large clusters."
+                ),
+                yaxes=yaxes(left_format=UNITS.KIBI_BYTES),
                 metric="tikv_load_base_split_region_load",
                 label_selectors=['type="bytes_kib"'],
                 hide_count=True,

--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -29429,7 +29429,7 @@
           "bars": false,
           "cacheTimeout": null,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "Per-region CPU observed by load-base split. Unit: millicores.",
+          "description": "Per-region CPU observed when load-base split evaluates hot regions. Unit: millicores. This is decision input, not the final split result. Use additional_groupby=instance only when drilling into a specific TiKV; keep it as none for large clusters.",
           "editable": true,
           "error": false,
           "fieldConfig": {
@@ -29584,7 +29584,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Load base split region CPU",
+          "title": "Observed region CPU for load-base split",
           "tooltip": {
             "msResolution": true,
             "shared": true,
@@ -29603,7 +29603,7 @@
           "yaxes": [
             {
               "decimals": null,
-              "format": "short",
+              "format": "mcores",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -29630,7 +29630,7 @@
           "bars": false,
           "cacheTimeout": null,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "Per-region QPS observed by load-base split.",
+          "description": "Per-region QPS observed when load-base split evaluates hot regions. This is decision input, not the final split result. Use additional_groupby=instance only when drilling into a specific TiKV; keep it as none for large clusters.",
           "editable": true,
           "error": false,
           "fieldConfig": {
@@ -29785,7 +29785,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Load base split region QPS",
+          "title": "Observed region QPS for load-base split",
           "tooltip": {
             "msResolution": true,
             "shared": true,
@@ -29804,7 +29804,7 @@
           "yaxes": [
             {
               "decimals": null,
-              "format": "short",
+              "format": "reqps",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -29831,7 +29831,7 @@
           "bars": false,
           "cacheTimeout": null,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "Per-region read bytes observed by load-base split. Unit: KiB.",
+          "description": "Per-region read bytes observed when load-base split evaluates hot regions. Unit: KiB. This is decision input, not the final split result. Use additional_groupby=instance only when drilling into a specific TiKV; keep it as none for large clusters.",
           "editable": true,
           "error": false,
           "fieldConfig": {
@@ -29986,7 +29986,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Load base split region bytes",
+          "title": "Observed region read bytes for load-base split",
           "tooltip": {
             "msResolution": true,
             "shared": true,
@@ -30005,7 +30005,7 @@
           "yaxes": [
             {
               "decimals": null,
-              "format": "short",
+              "format": "kbytes",
               "label": null,
               "logBase": 1,
               "max": null,

--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -29429,7 +29429,7 @@
           "bars": false,
           "cacheTimeout": null,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "Per-region CPU observed when load-base split evaluates hot regions. Unit: millicores. This is decision input, not the final split result. Use additional_groupby=instance only when drilling into a specific TiKV; keep it as none for large clusters.",
+          "description": "Per-region CPU observed when load-base split evaluates hot regions. Unit follows other CPU panels: 100% means one CPU core. This is decision input, not the final split result. Use additional_groupby=instance only when drilling into a specific TiKV; keep it as none for large clusters.",
           "editable": true,
           "error": false,
           "fieldConfig": {
@@ -29492,37 +29492,14 @@
           "renderer": "flot",
           "repeat": null,
           "repeatDirection": null,
-          "seriesOverrides": [
-            {
-              "alias": "/^count/",
-              "bars": false,
-              "dashLength": 1,
-              "dashes": true,
-              "fill": 2,
-              "fillBelowTo": null,
-              "lines": true,
-              "spaceLength": 1,
-              "transform": "negative-Y",
-              "yaxis": 2,
-              "zindex": -3
-            },
-            {
-              "alias": "/^avg/",
-              "bars": false,
-              "fill": 7,
-              "fillBelowTo": null,
-              "lines": true,
-              "yaxis": 1,
-              "zindex": 0
-            }
-          ],
+          "seriesOverrides": [],
           "span": null,
           "stack": false,
           "steppedLine": false,
           "targets": [
             {
               "datasource": "${DS_TEST-CLUSTER}",
-              "expr": "histogram_quantile(0.9999,(\n    sum(rate(\n    tikv_load_base_split_region_load_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"cpu_millicores\"}\n    [$__rate_interval]\n)) by (le, $additional_groupby) \n    \n    \n))  ",
+              "expr": "(histogram_quantile(0.9999,(\n    sum(rate(\n    tikv_load_base_split_region_load_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"cpu_millicores\"}\n    [$__rate_interval]\n)) by (le, $additional_groupby) \n    \n    \n))   / 1000)",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -29530,14 +29507,14 @@
               "intervalFactor": 1,
               "legendFormat": "99.99% {{$additional_groupby}}",
               "metric": "",
-              "query": "histogram_quantile(0.9999,(\n    sum(rate(\n    tikv_load_base_split_region_load_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"cpu_millicores\"}\n    [$__rate_interval]\n)) by (le, $additional_groupby) \n    \n    \n))  ",
+              "query": "(histogram_quantile(0.9999,(\n    sum(rate(\n    tikv_load_base_split_region_load_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"cpu_millicores\"}\n    [$__rate_interval]\n)) by (le, $additional_groupby) \n    \n    \n))   / 1000)",
               "refId": "",
               "step": 10,
               "target": ""
             },
             {
               "datasource": "${DS_TEST-CLUSTER}",
-              "expr": "histogram_quantile(0.99,(\n    sum(rate(\n    tikv_load_base_split_region_load_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"cpu_millicores\"}\n    [$__rate_interval]\n)) by (le, $additional_groupby) \n    \n    \n))  ",
+              "expr": "(histogram_quantile(0.99,(\n    sum(rate(\n    tikv_load_base_split_region_load_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"cpu_millicores\"}\n    [$__rate_interval]\n)) by (le, $additional_groupby) \n    \n    \n))   / 1000)",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -29545,14 +29522,14 @@
               "intervalFactor": 1,
               "legendFormat": "99% {{$additional_groupby}}",
               "metric": "",
-              "query": "histogram_quantile(0.99,(\n    sum(rate(\n    tikv_load_base_split_region_load_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"cpu_millicores\"}\n    [$__rate_interval]\n)) by (le, $additional_groupby) \n    \n    \n))  ",
+              "query": "(histogram_quantile(0.99,(\n    sum(rate(\n    tikv_load_base_split_region_load_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"cpu_millicores\"}\n    [$__rate_interval]\n)) by (le, $additional_groupby) \n    \n    \n))   / 1000)",
               "refId": "",
               "step": 10,
               "target": ""
             },
             {
               "datasource": "${DS_TEST-CLUSTER}",
-              "expr": "(sum(rate(\n    tikv_load_base_split_region_load_sum\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"cpu_millicores\"}\n    [$__rate_interval]\n)) by ($additional_groupby)  / sum(rate(\n    tikv_load_base_split_region_load_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"cpu_millicores\"}\n    [$__rate_interval]\n)) by ($additional_groupby) )",
+              "expr": "((sum(rate(\n    tikv_load_base_split_region_load_sum\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"cpu_millicores\"}\n    [$__rate_interval]\n)) by ($additional_groupby)  / sum(rate(\n    tikv_load_base_split_region_load_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"cpu_millicores\"}\n    [$__rate_interval]\n)) by ($additional_groupby) ) / 1000)",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -29560,22 +29537,7 @@
               "intervalFactor": 1,
               "legendFormat": "avg {{$additional_groupby}}",
               "metric": "",
-              "query": "(sum(rate(\n    tikv_load_base_split_region_load_sum\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"cpu_millicores\"}\n    [$__rate_interval]\n)) by ($additional_groupby)  / sum(rate(\n    tikv_load_base_split_region_load_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"cpu_millicores\"}\n    [$__rate_interval]\n)) by ($additional_groupby) )",
-              "refId": "",
-              "step": 10,
-              "target": ""
-            },
-            {
-              "datasource": "${DS_TEST-CLUSTER}",
-              "expr": "sum(rate(\n    tikv_load_base_split_region_load_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"cpu_millicores\"}\n    [$__rate_interval]\n)) by ($additional_groupby) ",
-              "format": "time_series",
-              "hide": true,
-              "instant": false,
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "count {{$additional_groupby}}",
-              "metric": "",
-              "query": "sum(rate(\n    tikv_load_base_split_region_load_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"cpu_millicores\"}\n    [$__rate_interval]\n)) by ($additional_groupby) ",
+              "query": "((sum(rate(\n    tikv_load_base_split_region_load_sum\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"cpu_millicores\"}\n    [$__rate_interval]\n)) by ($additional_groupby)  / sum(rate(\n    tikv_load_base_split_region_load_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"cpu_millicores\"}\n    [$__rate_interval]\n)) by ($additional_groupby) ) / 1000)",
               "refId": "",
               "step": 10,
               "target": ""
@@ -29603,7 +29565,7 @@
           "yaxes": [
             {
               "decimals": null,
-              "format": "mcores",
+              "format": "percentunit",
               "label": null,
               "logBase": 1,
               "max": null,

--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -29429,6 +29429,609 @@
           "bars": false,
           "cacheTimeout": null,
           "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Per-region CPU observed by load-base split. Unit: millicores.",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 0,
+            "y": 21
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 212,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [
+            {
+              "alias": "/^count/",
+              "bars": false,
+              "dashLength": 1,
+              "dashes": true,
+              "fill": 2,
+              "fillBelowTo": null,
+              "lines": true,
+              "spaceLength": 1,
+              "transform": "negative-Y",
+              "yaxis": 2,
+              "zindex": -3
+            },
+            {
+              "alias": "/^avg/",
+              "bars": false,
+              "fill": 7,
+              "fillBelowTo": null,
+              "lines": true,
+              "yaxis": 1,
+              "zindex": 0
+            }
+          ],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "histogram_quantile(0.9999,(\n    sum(rate(\n    tikv_load_base_split_region_load_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"cpu_millicores\"}\n    [$__rate_interval]\n)) by (le, $additional_groupby) \n    \n    \n))  ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "99.99% {{$additional_groupby}}",
+              "metric": "",
+              "query": "histogram_quantile(0.9999,(\n    sum(rate(\n    tikv_load_base_split_region_load_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"cpu_millicores\"}\n    [$__rate_interval]\n)) by (le, $additional_groupby) \n    \n    \n))  ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "histogram_quantile(0.99,(\n    sum(rate(\n    tikv_load_base_split_region_load_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"cpu_millicores\"}\n    [$__rate_interval]\n)) by (le, $additional_groupby) \n    \n    \n))  ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "99% {{$additional_groupby}}",
+              "metric": "",
+              "query": "histogram_quantile(0.99,(\n    sum(rate(\n    tikv_load_base_split_region_load_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"cpu_millicores\"}\n    [$__rate_interval]\n)) by (le, $additional_groupby) \n    \n    \n))  ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "(sum(rate(\n    tikv_load_base_split_region_load_sum\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"cpu_millicores\"}\n    [$__rate_interval]\n)) by ($additional_groupby)  / sum(rate(\n    tikv_load_base_split_region_load_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"cpu_millicores\"}\n    [$__rate_interval]\n)) by ($additional_groupby) )",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "avg {{$additional_groupby}}",
+              "metric": "",
+              "query": "(sum(rate(\n    tikv_load_base_split_region_load_sum\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"cpu_millicores\"}\n    [$__rate_interval]\n)) by ($additional_groupby)  / sum(rate(\n    tikv_load_base_split_region_load_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"cpu_millicores\"}\n    [$__rate_interval]\n)) by ($additional_groupby) )",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum(rate(\n    tikv_load_base_split_region_load_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"cpu_millicores\"}\n    [$__rate_interval]\n)) by ($additional_groupby) ",
+              "format": "time_series",
+              "hide": true,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "count {{$additional_groupby}}",
+              "metric": "",
+              "query": "sum(rate(\n    tikv_load_base_split_region_load_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"cpu_millicores\"}\n    [$__rate_interval]\n)) by ($additional_groupby) ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Load base split region CPU",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Per-region QPS observed by load-base split.",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 8,
+            "y": 21
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 213,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [
+            {
+              "alias": "/^count/",
+              "bars": false,
+              "dashLength": 1,
+              "dashes": true,
+              "fill": 2,
+              "fillBelowTo": null,
+              "lines": true,
+              "spaceLength": 1,
+              "transform": "negative-Y",
+              "yaxis": 2,
+              "zindex": -3
+            },
+            {
+              "alias": "/^avg/",
+              "bars": false,
+              "fill": 7,
+              "fillBelowTo": null,
+              "lines": true,
+              "yaxis": 1,
+              "zindex": 0
+            }
+          ],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "histogram_quantile(0.9999,(\n    sum(rate(\n    tikv_load_base_split_region_load_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"qps\"}\n    [$__rate_interval]\n)) by (le, $additional_groupby) \n    \n    \n))  ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "99.99% {{$additional_groupby}}",
+              "metric": "",
+              "query": "histogram_quantile(0.9999,(\n    sum(rate(\n    tikv_load_base_split_region_load_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"qps\"}\n    [$__rate_interval]\n)) by (le, $additional_groupby) \n    \n    \n))  ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "histogram_quantile(0.99,(\n    sum(rate(\n    tikv_load_base_split_region_load_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"qps\"}\n    [$__rate_interval]\n)) by (le, $additional_groupby) \n    \n    \n))  ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "99% {{$additional_groupby}}",
+              "metric": "",
+              "query": "histogram_quantile(0.99,(\n    sum(rate(\n    tikv_load_base_split_region_load_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"qps\"}\n    [$__rate_interval]\n)) by (le, $additional_groupby) \n    \n    \n))  ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "(sum(rate(\n    tikv_load_base_split_region_load_sum\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"qps\"}\n    [$__rate_interval]\n)) by ($additional_groupby)  / sum(rate(\n    tikv_load_base_split_region_load_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"qps\"}\n    [$__rate_interval]\n)) by ($additional_groupby) )",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "avg {{$additional_groupby}}",
+              "metric": "",
+              "query": "(sum(rate(\n    tikv_load_base_split_region_load_sum\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"qps\"}\n    [$__rate_interval]\n)) by ($additional_groupby)  / sum(rate(\n    tikv_load_base_split_region_load_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"qps\"}\n    [$__rate_interval]\n)) by ($additional_groupby) )",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum(rate(\n    tikv_load_base_split_region_load_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"qps\"}\n    [$__rate_interval]\n)) by ($additional_groupby) ",
+              "format": "time_series",
+              "hide": true,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "count {{$additional_groupby}}",
+              "metric": "",
+              "query": "sum(rate(\n    tikv_load_base_split_region_load_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"qps\"}\n    [$__rate_interval]\n)) by ($additional_groupby) ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Load base split region QPS",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Per-region read bytes observed by load-base split. Unit: KiB.",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 16,
+            "y": 21
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 214,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [
+            {
+              "alias": "/^count/",
+              "bars": false,
+              "dashLength": 1,
+              "dashes": true,
+              "fill": 2,
+              "fillBelowTo": null,
+              "lines": true,
+              "spaceLength": 1,
+              "transform": "negative-Y",
+              "yaxis": 2,
+              "zindex": -3
+            },
+            {
+              "alias": "/^avg/",
+              "bars": false,
+              "fill": 7,
+              "fillBelowTo": null,
+              "lines": true,
+              "yaxis": 1,
+              "zindex": 0
+            }
+          ],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "histogram_quantile(0.9999,(\n    sum(rate(\n    tikv_load_base_split_region_load_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"bytes_kib\"}\n    [$__rate_interval]\n)) by (le, $additional_groupby) \n    \n    \n))  ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "99.99% {{$additional_groupby}}",
+              "metric": "",
+              "query": "histogram_quantile(0.9999,(\n    sum(rate(\n    tikv_load_base_split_region_load_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"bytes_kib\"}\n    [$__rate_interval]\n)) by (le, $additional_groupby) \n    \n    \n))  ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "histogram_quantile(0.99,(\n    sum(rate(\n    tikv_load_base_split_region_load_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"bytes_kib\"}\n    [$__rate_interval]\n)) by (le, $additional_groupby) \n    \n    \n))  ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "99% {{$additional_groupby}}",
+              "metric": "",
+              "query": "histogram_quantile(0.99,(\n    sum(rate(\n    tikv_load_base_split_region_load_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"bytes_kib\"}\n    [$__rate_interval]\n)) by (le, $additional_groupby) \n    \n    \n))  ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "(sum(rate(\n    tikv_load_base_split_region_load_sum\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"bytes_kib\"}\n    [$__rate_interval]\n)) by ($additional_groupby)  / sum(rate(\n    tikv_load_base_split_region_load_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"bytes_kib\"}\n    [$__rate_interval]\n)) by ($additional_groupby) )",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "avg {{$additional_groupby}}",
+              "metric": "",
+              "query": "(sum(rate(\n    tikv_load_base_split_region_load_sum\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"bytes_kib\"}\n    [$__rate_interval]\n)) by ($additional_groupby)  / sum(rate(\n    tikv_load_base_split_region_load_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"bytes_kib\"}\n    [$__rate_interval]\n)) by ($additional_groupby) )",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum(rate(\n    tikv_load_base_split_region_load_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"bytes_kib\"}\n    [$__rate_interval]\n)) by ($additional_groupby) ",
+              "format": "time_series",
+              "hide": true,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "count {{$additional_groupby}}",
+              "metric": "",
+              "query": "sum(rate(\n    tikv_load_base_split_region_load_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"bytes_kib\"}\n    [$__rate_interval]\n)) by ($additional_groupby) ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Load base split region bytes",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
           "description": null,
           "editable": true,
           "error": false,
@@ -29452,11 +30055,11 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 21
+            "y": 28
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 212,
+          "id": 215,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -29592,7 +30195,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 213,
+      "id": 216,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -29631,7 +30234,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 214,
+          "id": 217,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -29779,7 +30382,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 215,
+          "id": 218,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -29927,7 +30530,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 216,
+          "id": 219,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -30060,7 +30663,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 217,
+          "id": 220,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -30193,7 +30796,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 218,
+          "id": 221,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -30326,7 +30929,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 219,
+          "id": 222,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -30459,7 +31062,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 220,
+          "id": 223,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -30592,7 +31195,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 221,
+          "id": 224,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -30725,7 +31328,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 222,
+          "id": 225,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -30902,7 +31505,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 223,
+      "id": 226,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -30941,7 +31544,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 224,
+          "id": 227,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -31104,7 +31707,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 225,
+          "id": 228,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -31305,7 +31908,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 226,
+          "id": 229,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -31453,7 +32056,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 227,
+          "id": 230,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -31616,7 +32219,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 228,
+          "id": 231,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -31817,7 +32420,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 229,
+          "id": 232,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -31995,7 +32598,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 230,
+          "id": 233,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -32158,7 +32761,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 231,
+          "id": 234,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -32321,7 +32924,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 232,
+          "id": 235,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -32454,7 +33057,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 233,
+          "id": 236,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -32658,7 +33261,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 234,
+      "id": 237,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -32697,7 +33300,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 235,
+          "id": 238,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -32890,7 +33493,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 236,
+          "id": 239,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -33068,7 +33671,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 237,
+          "id": 240,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -33276,7 +33879,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 238,
+          "id": 241,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -33454,7 +34057,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 239,
+          "id": 242,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -33617,7 +34220,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 240,
+          "id": 243,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -33795,7 +34398,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 241,
+          "id": 244,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -33928,7 +34531,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 242,
+          "id": 245,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -34106,7 +34709,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 243,
+          "id": 246,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -34279,7 +34882,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 244,
+          "id": 247,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -34457,7 +35060,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 245,
+          "id": 248,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -34590,7 +35193,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 246,
+          "id": 249,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -34768,7 +35371,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 247,
+          "id": 250,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -34946,7 +35549,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 248,
+          "id": 251,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -35124,7 +35727,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 249,
+          "id": 252,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -35257,7 +35860,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 250,
+          "id": 253,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -35390,7 +35993,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 251,
+          "id": 254,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -35523,7 +36126,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 252,
+          "id": 255,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -35746,7 +36349,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 253,
+          "id": 256,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -35939,7 +36542,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 254,
+          "id": 257,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -36102,7 +36705,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 255,
+          "id": 258,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -36295,7 +36898,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 256,
+          "id": 259,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -36443,7 +37046,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 257,
+          "id": 260,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -36576,7 +37179,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 258,
+          "id": 261,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -36724,7 +37327,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 259,
+          "id": 262,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -36902,7 +37505,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 260,
+          "id": 263,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -37065,7 +37668,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 261,
+          "id": 264,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -37243,7 +37846,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 262,
+          "id": 265,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -37376,7 +37979,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 263,
+          "id": 266,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -37509,7 +38112,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 264,
+          "id": 267,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -37642,7 +38245,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 265,
+          "id": 268,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -37775,7 +38378,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 266,
+          "id": 269,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -37908,7 +38511,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 267,
+          "id": 270,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -38048,7 +38651,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 268,
+          "id": 271,
           "interval": null,
           "legend": {
             "show": false
@@ -38146,7 +38749,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 269,
+          "id": 272,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -38347,7 +38950,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 270,
+          "id": 273,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -38480,7 +39083,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 271,
+          "id": 274,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -38628,7 +39231,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 272,
+          "id": 275,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -38761,7 +39364,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 273,
+          "id": 276,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -38939,7 +39542,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 274,
+          "id": 277,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -39072,7 +39675,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 275,
+          "id": 278,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -39208,7 +39811,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 276,
+      "id": 279,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -39247,7 +39850,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 277,
+          "id": 280,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -39395,7 +39998,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 278,
+          "id": 281,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -39543,7 +40146,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 279,
+          "id": 282,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -39676,7 +40279,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 280,
+          "id": 283,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -39809,7 +40412,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 281,
+          "id": 284,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -39987,7 +40590,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 282,
+          "id": 285,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -40165,7 +40768,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 283,
+          "id": 286,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -40343,7 +40946,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 284,
+          "id": 287,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -40476,7 +41079,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 285,
+          "id": 288,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -40654,7 +41257,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 286,
+          "id": 289,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -40787,7 +41390,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 287,
+          "id": 290,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -40950,7 +41553,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 288,
+          "id": 291,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -41128,7 +41731,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 289,
+          "id": 292,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -41306,7 +41909,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 290,
+          "id": 293,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -41484,7 +42087,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 291,
+          "id": 294,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -41617,7 +42220,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 292,
+          "id": 295,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -41795,7 +42398,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 293,
+          "id": 296,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -41928,7 +42531,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 294,
+          "id": 297,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -42106,7 +42709,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 295,
+          "id": 298,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -42239,7 +42842,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 296,
+          "id": 299,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -42372,7 +42975,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 297,
+          "id": 300,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -42550,7 +43153,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 298,
+          "id": 301,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -42728,7 +43331,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 299,
+          "id": 302,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -42861,7 +43464,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 300,
+          "id": 303,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -43039,7 +43642,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 301,
+          "id": 304,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -43172,7 +43775,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 302,
+          "id": 305,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -43350,7 +43953,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 303,
+          "id": 306,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -43486,7 +44089,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 304,
+      "id": 307,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -43525,7 +44128,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 305,
+          "id": 308,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -43658,7 +44261,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 306,
+          "id": 309,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -43806,7 +44409,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 307,
+          "id": 310,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -44007,7 +44610,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 308,
+          "id": 311,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -44140,7 +44743,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 309,
+          "id": 312,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -44273,7 +44876,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 310,
+          "id": 313,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -44406,7 +45009,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 311,
+          "id": 314,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -44539,7 +45142,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 312,
+          "id": 315,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -44672,7 +45275,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 313,
+          "id": 316,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -44812,7 +45415,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 314,
+          "id": 317,
           "interval": null,
           "legend": {
             "show": false
@@ -44917,7 +45520,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 315,
+          "id": 318,
           "interval": null,
           "legend": {
             "show": false
@@ -45015,7 +45618,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 316,
+          "id": 319,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -45155,7 +45758,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 317,
+          "id": 320,
           "interval": null,
           "legend": {
             "show": false
@@ -45253,7 +45856,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 318,
+          "id": 321,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -45386,7 +45989,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 319,
+          "id": 322,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -45526,7 +46129,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 320,
+          "id": 323,
           "interval": null,
           "legend": {
             "show": false
@@ -45624,7 +46227,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 321,
+          "id": 324,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -45832,7 +46435,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 322,
+          "id": 325,
           "interval": null,
           "legend": {
             "show": false
@@ -45930,7 +46533,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 323,
+          "id": 326,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -46131,7 +46734,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 324,
+          "id": 327,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -46339,7 +46942,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 325,
+          "id": 328,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -46517,7 +47120,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 326,
+          "id": 329,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -46650,7 +47253,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 327,
+          "id": 330,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -46783,7 +47386,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 328,
+          "id": 331,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -46916,7 +47519,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 329,
+          "id": 332,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -47056,7 +47659,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 330,
+          "id": 333,
           "interval": null,
           "legend": {
             "show": false
@@ -47161,7 +47764,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 331,
+          "id": 334,
           "interval": null,
           "legend": {
             "show": false
@@ -47266,7 +47869,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 332,
+          "id": 335,
           "interval": null,
           "legend": {
             "show": false
@@ -47371,7 +47974,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 333,
+          "id": 336,
           "interval": null,
           "legend": {
             "show": false
@@ -47472,7 +48075,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 334,
+      "id": 337,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -47511,7 +48114,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 335,
+          "id": 338,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -47659,7 +48262,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 336,
+          "id": 339,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -47799,7 +48402,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 337,
+          "id": 340,
           "interval": null,
           "legend": {
             "show": false
@@ -47897,7 +48500,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 338,
+          "id": 341,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -48030,7 +48633,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 339,
+          "id": 342,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -48163,7 +48766,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 340,
+          "id": 343,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -48341,7 +48944,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 341,
+          "id": 344,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -48504,7 +49107,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 342,
+          "id": 345,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -48652,7 +49255,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 343,
+          "id": 346,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -48785,7 +49388,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 344,
+          "id": 347,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -48921,7 +49524,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 345,
+      "id": 348,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -48960,7 +49563,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 346,
+          "id": 349,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -49108,7 +49711,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 347,
+          "id": 350,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -49241,7 +49844,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 348,
+          "id": 351,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -49374,7 +49977,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 349,
+          "id": 352,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -49507,7 +50110,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 350,
+          "id": 353,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -49640,7 +50243,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 351,
+          "id": 354,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -49795,7 +50398,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 352,
+          "id": 355,
           "interval": null,
           "legend": {
             "show": false
@@ -49900,7 +50503,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 353,
+          "id": 356,
           "interval": null,
           "legend": {
             "show": false
@@ -50001,7 +50604,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 354,
+      "id": 357,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -50040,7 +50643,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 355,
+          "id": 358,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -50173,7 +50776,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 356,
+          "id": 359,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -50306,7 +50909,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 357,
+          "id": 360,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -50446,7 +51049,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 358,
+          "id": 361,
           "interval": null,
           "legend": {
             "show": false
@@ -50544,7 +51147,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 359,
+          "id": 362,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -50677,7 +51280,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 360,
+          "id": 363,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -50878,7 +51481,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 361,
+          "id": 364,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -51079,7 +51682,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 362,
+          "id": 365,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -51283,7 +51886,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 363,
+      "id": 366,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -51322,7 +51925,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 364,
+          "id": 367,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -51470,7 +52073,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 365,
+          "id": 368,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -51671,7 +52274,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 366,
+          "id": 369,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -51872,7 +52475,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 367,
+          "id": 370,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -52073,7 +52676,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 368,
+          "id": 371,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -52274,7 +52877,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 369,
+          "id": 372,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -52407,7 +53010,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 370,
+          "id": 373,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -52540,7 +53143,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 371,
+          "id": 374,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -52673,7 +53276,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 372,
+          "id": 375,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -52806,7 +53409,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 373,
+          "id": 376,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -53007,7 +53610,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 374,
+          "id": 377,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -53215,7 +53818,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 375,
+          "id": 378,
           "interval": null,
           "legend": {
             "show": false
@@ -53316,7 +53919,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 376,
+      "id": 379,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -53362,7 +53965,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 377,
+          "id": 380,
           "interval": null,
           "legend": {
             "show": false
@@ -53460,7 +54063,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 378,
+          "id": 381,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -53661,7 +54264,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 379,
+          "id": 382,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -53794,7 +54397,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 380,
+          "id": 383,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -53927,7 +54530,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 381,
+          "id": 384,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -54060,7 +54663,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 382,
+          "id": 385,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -54261,7 +54864,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 383,
+          "id": 386,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -54394,7 +54997,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 384,
+          "id": 387,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -54527,7 +55130,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 385,
+          "id": 388,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -54663,7 +55266,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 386,
+      "id": 389,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -54702,7 +55305,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 387,
+          "id": 390,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -54903,7 +55506,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 388,
+          "id": 391,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -55104,7 +55707,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 389,
+          "id": 392,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -55305,7 +55908,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 390,
+          "id": 393,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -55506,7 +56109,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 391,
+          "id": 394,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -55639,7 +56242,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 392,
+          "id": 395,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -55772,7 +56375,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 393,
+          "id": 396,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -55905,7 +56508,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 394,
+          "id": 397,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -56038,7 +56641,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 395,
+          "id": 398,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -56171,7 +56774,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 396,
+          "id": 399,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -56311,7 +56914,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 397,
+          "id": 400,
           "interval": null,
           "legend": {
             "show": false
@@ -56409,7 +57012,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 398,
+          "id": 401,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -56617,7 +57220,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 399,
+          "id": 402,
           "interval": null,
           "legend": {
             "show": false
@@ -56715,7 +57318,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 400,
+          "id": 403,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -56916,7 +57519,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 401,
+          "id": 404,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -57052,7 +57655,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 402,
+      "id": 405,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -57091,7 +57694,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 403,
+          "id": 406,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -57224,7 +57827,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 404,
+          "id": 407,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -57357,7 +57960,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 405,
+          "id": 408,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -57497,7 +58100,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 406,
+          "id": 409,
           "interval": null,
           "legend": {
             "show": false
@@ -57595,7 +58198,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 407,
+          "id": 410,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -57728,7 +58331,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 408,
+          "id": 411,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -57929,7 +58532,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 409,
+          "id": 412,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -58130,7 +58733,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 410,
+          "id": 413,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -58334,7 +58937,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 411,
+      "id": 414,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -58373,7 +58976,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 412,
+          "id": 415,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -58551,7 +59154,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 413,
+          "id": 416,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -58752,7 +59355,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 414,
+          "id": 417,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -58885,7 +59488,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 415,
+          "id": 418,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -59018,7 +59621,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 416,
+          "id": 419,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -59151,7 +59754,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 417,
+          "id": 420,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -59284,7 +59887,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 418,
+          "id": 421,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -59417,7 +60020,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 419,
+          "id": 422,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -59546,7 +60149,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 420,
+          "id": 423,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -59621,7 +60224,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 421,
+          "id": 424,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -59700,7 +60303,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 422,
+          "id": 425,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -59953,7 +60556,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 423,
+          "id": 426,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -60086,7 +60689,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 424,
+          "id": 427,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -60219,7 +60822,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 425,
+          "id": 428,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -60420,7 +61023,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 426,
+          "id": 429,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -60568,7 +61171,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 427,
+          "id": 430,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -60769,7 +61372,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 428,
+          "id": 431,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -60970,7 +61573,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 429,
+          "id": 432,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -61171,7 +61774,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 430,
+          "id": 433,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -61375,7 +61978,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 431,
+      "id": 434,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -61414,7 +62017,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 432,
+          "id": 435,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -61562,7 +62165,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 433,
+          "id": 436,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -61695,7 +62298,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 434,
+          "id": 437,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -61896,7 +62499,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 435,
+          "id": 438,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -62044,7 +62647,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 436,
+          "id": 439,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -62245,7 +62848,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 437,
+          "id": 440,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -62378,7 +62981,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 438,
+          "id": 441,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -62511,7 +63114,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 439,
+          "id": 442,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -62644,7 +63247,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 440,
+          "id": 443,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -62777,7 +63380,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 441,
+          "id": 444,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -62917,7 +63520,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 442,
+          "id": 445,
           "interval": null,
           "legend": {
             "show": false
@@ -63015,7 +63618,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 443,
+          "id": 446,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -63219,7 +63822,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 444,
+      "id": 447,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -63258,7 +63861,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 445,
+          "id": 448,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -63391,7 +63994,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 446,
+          "id": 449,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -63524,7 +64127,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 447,
+          "id": 450,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -63657,7 +64260,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 448,
+          "id": 451,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -63793,7 +64396,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 449,
+      "id": 452,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -63832,7 +64435,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 450,
+          "id": 453,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -63965,7 +64568,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 451,
+          "id": 454,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -64098,7 +64701,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 452,
+          "id": 455,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -64246,7 +64849,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 453,
+          "id": 456,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -64379,7 +64982,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 454,
+          "id": 457,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -64512,7 +65115,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 455,
+          "id": 458,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -64645,7 +65248,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 456,
+          "id": 459,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -64781,7 +65384,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 457,
+      "id": 460,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -64820,7 +65423,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 458,
+          "id": 461,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -64953,7 +65556,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 459,
+          "id": 462,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -65086,7 +65689,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 460,
+          "id": 463,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -65219,7 +65822,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 461,
+          "id": 464,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -65352,7 +65955,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 462,
+          "id": 465,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -65485,7 +66088,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 463,
+          "id": 466,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -65621,7 +66224,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 464,
+      "id": 467,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -65660,7 +66263,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 465,
+          "id": 468,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -65793,7 +66396,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 466,
+          "id": 469,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -65941,7 +66544,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 467,
+          "id": 470,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -66089,7 +66692,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 468,
+          "id": 471,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -66252,7 +66855,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 469,
+          "id": 472,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -66385,7 +66988,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 470,
+          "id": 473,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -66518,7 +67121,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 471,
+          "id": 474,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -66681,7 +67284,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 472,
+          "id": 475,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -66829,7 +67432,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 473,
+          "id": 476,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -66965,7 +67568,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 474,
+      "id": 477,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -67004,7 +67607,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 475,
+          "id": 478,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -67137,7 +67740,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 476,
+          "id": 479,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -67270,7 +67873,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 477,
+          "id": 480,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -67403,7 +68006,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 478,
+          "id": 481,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -67536,7 +68139,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 479,
+          "id": 482,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -67669,7 +68272,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 480,
+          "id": 483,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -67802,7 +68405,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 481,
+          "id": 484,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -67935,7 +68538,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 482,
+          "id": 485,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -68068,7 +68671,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 483,
+          "id": 486,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -68208,7 +68811,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 484,
+          "id": 487,
           "interval": null,
           "legend": {
             "show": false
@@ -68306,7 +68909,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 485,
+          "id": 488,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -68439,7 +69042,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 486,
+          "id": 489,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -68587,7 +69190,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 487,
+          "id": 490,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -68735,7 +69338,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 488,
+          "id": 491,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -68875,7 +69478,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 489,
+          "id": 492,
           "interval": null,
           "legend": {
             "show": false
@@ -68973,7 +69576,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 490,
+          "id": 493,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -69106,7 +69709,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 491,
+          "id": 494,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -69242,7 +69845,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 492,
+      "id": 495,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -69281,7 +69884,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 493,
+          "id": 496,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -69414,7 +70017,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 494,
+          "id": 497,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -69577,7 +70180,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 495,
+          "id": 498,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -69725,7 +70328,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 496,
+          "id": 499,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -69858,7 +70461,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 497,
+          "id": 500,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -69998,7 +70601,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 498,
+          "id": 501,
           "interval": null,
           "legend": {
             "show": false
@@ -70103,7 +70706,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 499,
+          "id": 502,
           "interval": null,
           "legend": {
             "show": false
@@ -70208,7 +70811,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 500,
+          "id": 503,
           "interval": null,
           "legend": {
             "show": false
@@ -70306,7 +70909,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 501,
+          "id": 504,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -70446,7 +71049,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 502,
+          "id": 505,
           "interval": null,
           "legend": {
             "show": false
@@ -70551,7 +71154,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 503,
+          "id": 506,
           "interval": null,
           "legend": {
             "show": false
@@ -70656,7 +71259,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 504,
+          "id": 507,
           "interval": null,
           "legend": {
             "show": false
@@ -70754,7 +71357,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 505,
+          "id": 508,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -70887,7 +71490,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 506,
+          "id": 509,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -71020,7 +71623,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 507,
+          "id": 510,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -71160,7 +71763,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 508,
+          "id": 511,
           "interval": null,
           "legend": {
             "show": false
@@ -71258,7 +71861,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 509,
+          "id": 512,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -71394,7 +71997,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 510,
+      "id": 513,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -71433,7 +72036,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 511,
+          "id": 514,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -71596,7 +72199,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 512,
+          "id": 515,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -71729,7 +72332,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 513,
+          "id": 516,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -71869,7 +72472,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 514,
+          "id": 517,
           "interval": null,
           "legend": {
             "show": false
@@ -71974,7 +72577,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 515,
+          "id": 518,
           "interval": null,
           "legend": {
             "show": false
@@ -72072,7 +72675,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 516,
+          "id": 519,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -72227,7 +72830,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 517,
+          "id": 520,
           "interval": null,
           "legend": {
             "show": false
@@ -72332,7 +72935,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 518,
+          "id": 521,
           "interval": null,
           "legend": {
             "show": false
@@ -72437,7 +73040,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 519,
+          "id": 522,
           "interval": null,
           "legend": {
             "show": false
@@ -72535,7 +73138,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 520,
+          "id": 523,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -72705,7 +73308,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 521,
+          "id": 524,
           "interval": null,
           "legend": {
             "show": false
@@ -72803,7 +73406,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 522,
+          "id": 525,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -73004,7 +73607,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 523,
+          "id": 526,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -73205,7 +73808,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 524,
+          "id": 527,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -73338,7 +73941,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 525,
+          "id": 528,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -73501,7 +74104,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 526,
+          "id": 529,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -73634,7 +74237,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 527,
+          "id": 530,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -73767,7 +74370,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 528,
+          "id": 531,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -73968,7 +74571,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 529,
+          "id": 532,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -74101,7 +74704,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 530,
+          "id": 533,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -74241,7 +74844,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 531,
+          "id": 534,
           "interval": null,
           "legend": {
             "show": false
@@ -74346,7 +74949,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 532,
+          "id": 535,
           "interval": null,
           "legend": {
             "show": false
@@ -74451,7 +75054,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 533,
+          "id": 536,
           "interval": null,
           "legend": {
             "show": false
@@ -74556,7 +75159,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 534,
+          "id": 537,
           "interval": null,
           "legend": {
             "show": false
@@ -74661,7 +75264,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 535,
+          "id": 538,
           "interval": null,
           "legend": {
             "show": false
@@ -74766,7 +75369,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 536,
+          "id": 539,
           "interval": null,
           "legend": {
             "show": false
@@ -74871,7 +75474,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 537,
+          "id": 540,
           "interval": null,
           "legend": {
             "show": false
@@ -74969,7 +75572,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 538,
+          "id": 541,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -75117,7 +75720,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 539,
+          "id": 542,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -75250,7 +75853,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 540,
+          "id": 543,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -75383,7 +75986,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 541,
+          "id": 544,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -75531,7 +76134,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 542,
+          "id": 545,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -75667,7 +76270,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 543,
+      "id": 546,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -75718,7 +76321,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 544,
+          "id": 547,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -75814,7 +76417,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 545,
+          "id": 548,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -75889,7 +76492,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 546,
+          "id": 549,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -75964,7 +76567,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 547,
+          "id": 550,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -76039,7 +76642,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 548,
+          "id": 551,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -76114,7 +76717,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 549,
+          "id": 552,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -76189,7 +76792,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 550,
+          "id": 553,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -76264,7 +76867,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 551,
+          "id": 554,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -76343,7 +76946,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 552,
+          "id": 555,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -76476,7 +77079,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 553,
+          "id": 556,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -76609,7 +77212,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 554,
+          "id": 557,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -76742,7 +77345,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 555,
+          "id": 558,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -76875,7 +77478,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 556,
+          "id": 559,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -77008,7 +77611,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 557,
+          "id": 560,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -77156,7 +77759,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 558,
+          "id": 561,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -77289,7 +77892,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 559,
+          "id": 562,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -77422,7 +78025,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 560,
+          "id": 563,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -77588,7 +78191,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 561,
+          "id": 564,
           "interval": null,
           "legend": {
             "show": false
@@ -77693,7 +78296,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 562,
+          "id": 565,
           "interval": null,
           "legend": {
             "show": false
@@ -77798,7 +78401,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 563,
+          "id": 566,
           "interval": null,
           "legend": {
             "show": false
@@ -77903,7 +78506,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 564,
+          "id": 567,
           "interval": null,
           "legend": {
             "show": false
@@ -78008,7 +78611,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 565,
+          "id": 568,
           "interval": null,
           "legend": {
             "show": false
@@ -78113,7 +78716,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 566,
+          "id": 569,
           "interval": null,
           "legend": {
             "show": false
@@ -78218,7 +78821,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 567,
+          "id": 570,
           "interval": null,
           "legend": {
             "show": false
@@ -78323,7 +78926,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 568,
+          "id": 571,
           "interval": null,
           "legend": {
             "show": false
@@ -78421,7 +79024,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 569,
+          "id": 572,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -78554,7 +79157,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 570,
+          "id": 573,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -78687,7 +79290,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 571,
+          "id": 574,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -78820,7 +79423,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 572,
+          "id": 575,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -78953,7 +79556,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 573,
+          "id": 576,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -79086,7 +79689,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 574,
+          "id": 577,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -79219,7 +79822,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 575,
+          "id": 578,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -79352,7 +79955,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 576,
+          "id": 579,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -79485,7 +80088,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 577,
+          "id": 580,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -79618,7 +80221,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 578,
+          "id": 581,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -79758,7 +80361,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 579,
+          "id": 582,
           "interval": null,
           "legend": {
             "show": false
@@ -79863,7 +80466,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 580,
+          "id": 583,
           "interval": null,
           "legend": {
             "show": false
@@ -79961,7 +80564,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 581,
+          "id": 584,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -80094,7 +80697,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 582,
+          "id": 585,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -80227,7 +80830,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 583,
+          "id": 586,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -80360,7 +80963,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 584,
+          "id": 587,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -80493,7 +81096,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 585,
+          "id": 588,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -80626,7 +81229,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 586,
+          "id": 589,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -80759,7 +81362,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 587,
+          "id": 590,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -80892,7 +81495,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 588,
+          "id": 591,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81025,7 +81628,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 589,
+          "id": 592,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81158,7 +81761,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 590,
+          "id": 593,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81294,7 +81897,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 591,
+      "id": 594,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -81333,7 +81936,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 592,
+          "id": 595,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81481,7 +82084,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 593,
+          "id": 596,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81614,7 +82217,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 594,
+          "id": 597,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81747,7 +82350,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 595,
+          "id": 598,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81883,7 +82486,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 596,
+      "id": 599,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -81922,7 +82525,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 597,
+          "id": 600,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82055,7 +82658,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 598,
+          "id": 601,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82188,7 +82791,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 599,
+          "id": 602,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82321,7 +82924,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 600,
+          "id": 603,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82454,7 +83057,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 601,
+          "id": 604,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82587,7 +83190,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 602,
+          "id": 605,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82723,7 +83326,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 603,
+      "id": 606,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -82762,7 +83365,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 604,
+          "id": 607,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82895,7 +83498,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 605,
+          "id": 608,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -83028,7 +83631,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 606,
+          "id": 609,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -83191,7 +83794,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 607,
+          "id": 610,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -83327,7 +83930,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 608,
+      "id": 611,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -83366,7 +83969,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 609,
+          "id": 612,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -83567,7 +84170,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 610,
+          "id": 613,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -83703,7 +84306,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 611,
+      "id": 614,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -83742,7 +84345,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 612,
+          "id": 615,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -83875,7 +84478,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 613,
+          "id": 616,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -84008,7 +84611,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 614,
+          "id": 617,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -84141,7 +84744,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 615,
+          "id": 618,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -84274,7 +84877,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 616,
+          "id": 619,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -84422,7 +85025,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 617,
+          "id": 620,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -84626,7 +85229,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 618,
+      "id": 621,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -84665,7 +85268,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 619,
+          "id": 622,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -84798,7 +85401,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 620,
+          "id": 623,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -84931,7 +85534,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 621,
+          "id": 624,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -85064,7 +85667,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 622,
+          "id": 625,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -85197,7 +85800,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 623,
+          "id": 626,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -85394,7 +85997,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 624,
+          "id": 627,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -85476,7 +86079,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 625,
+      "id": 628,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -85545,7 +86148,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 626,
+          "id": 629,
           "interval": null,
           "links": [],
           "mappings": [],
@@ -85662,7 +86265,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 627,
+          "id": 630,
           "interval": null,
           "links": [],
           "mappings": [],
@@ -85779,7 +86382,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 628,
+          "id": 631,
           "interval": null,
           "links": [],
           "mappings": [],
@@ -85896,7 +86499,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 629,
+          "id": 632,
           "interval": null,
           "links": [],
           "mappings": [],

--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -29429,7 +29429,7 @@
           "bars": false,
           "cacheTimeout": null,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "Per-region CPU observed when load-base split evaluates hot regions. Unit follows other CPU panels: 100% means one CPU core. This is decision input, not the final split result. Use additional_groupby=instance only when drilling into a specific TiKV; keep it as none for large clusters.",
+          "description": "Per-region CPU observed before load-fit filtering when load-base split evaluates regions. Unit follows other CPU panels: 100% means one CPU core. This is pre-load-fit decision input; use the tail distribution to tune split thresholds. Use additional_groupby=instance only when drilling into a specific TiKV; keep it as none for large clusters.",
           "editable": true,
           "error": false,
           "fieldConfig": {
@@ -29592,7 +29592,7 @@
           "bars": false,
           "cacheTimeout": null,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "Per-region QPS observed when load-base split evaluates hot regions. This is decision input, not the final split result. Use additional_groupby=instance only when drilling into a specific TiKV; keep it as none for large clusters.",
+          "description": "Per-region QPS observed before load-fit filtering when load-base split evaluates regions. This is pre-load-fit decision input; use the tail distribution to tune split thresholds. Use additional_groupby=instance only when drilling into a specific TiKV; keep it as none for large clusters.",
           "editable": true,
           "error": false,
           "fieldConfig": {
@@ -29793,7 +29793,7 @@
           "bars": false,
           "cacheTimeout": null,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "Per-region read bytes observed when load-base split evaluates hot regions. Unit: KiB. This is decision input, not the final split result. Use additional_groupby=instance only when drilling into a specific TiKV; keep it as none for large clusters.",
+          "description": "Per-region read bytes observed before load-fit filtering when load-base split evaluates regions. Unit: KiB. This is pre-load-fit decision input; use the tail distribution to tune split thresholds. Use additional_groupby=instance only when drilling into a specific TiKV; keep it as none for large clusters.",
           "editable": true,
           "error": false,
           "fieldConfig": {

--- a/metrics/grafana/tikv_details.json.sha256
+++ b/metrics/grafana/tikv_details.json.sha256
@@ -1,1 +1,1 @@
-cc68aa63b2ecb89592789177350d41af2a547c4674cfc413046741ca40997159  ./metrics/grafana/tikv_details.json
+d5188c3a38b0a8f24ed4a7f31b2d3f47764e58a87867e61bc20535c2f7efa0dd  ./metrics/grafana/tikv_details.json

--- a/metrics/grafana/tikv_details.json.sha256
+++ b/metrics/grafana/tikv_details.json.sha256
@@ -1,1 +1,1 @@
-d10f662ae81721cb6d31dca84c2228a12f2b92683b5b5535ad31fca850b9d2e1  metrics/grafana/tikv_details.json
+cc68aa63b2ecb89592789177350d41af2a547c4674cfc413046741ca40997159  ./metrics/grafana/tikv_details.json

--- a/metrics/grafana/tikv_details.json.sha256
+++ b/metrics/grafana/tikv_details.json.sha256
@@ -1,1 +1,1 @@
-4f9781a5713706fa67ad9a809cceb8543bcc7d3c6970321626d33b0b26637c2a  ./metrics/grafana/tikv_details.json
+fa08a3a023f21fb578564e765369ada14763bc9132e5b0afdf7bdeffccd7be02  metrics/grafana/tikv_details.json

--- a/metrics/grafana/tikv_details.json.sha256
+++ b/metrics/grafana/tikv_details.json.sha256
@@ -1,1 +1,1 @@
-d5188c3a38b0a8f24ed4a7f31b2d3f47764e58a87867e61bc20535c2f7efa0dd  ./metrics/grafana/tikv_details.json
+bca2edb7896a9ecfce44176aa1db05df9157247be4e13bb7001a18ab3ffe3d06  ./metrics/grafana/tikv_details.json


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #18932

This PR relaxes load-based split defaults and adds low-cardinality observability so we can tune the split-key and CPU fallback path with production metrics instead of relying on debug logs.

### What is changed and how does it work?

1. Lower the unified read pool CPU fallback threshold from `0.8` to `0.4`.
   - On a 32c TiKV, the unified read pool max thread count is capped at 25.
   - The old `0.8` threshold requires about `20` cores before CPU fallback can select the hottest region.
   - We have seen problematic nodes around `1000%` CPU, which maps to about `10` cores. The new `0.4` threshold lets CPU fallback cover this class of load.

2. Relax the normal split-key balance threshold from `0.25` to `0.8`, while keeping the contained threshold unchanged.
   - `balance_score = abs(left - right) / (left + right)`.
   - `0.8` allows roughly a `9:1` left/right load ratio.
   - This improves coverage for skewed read hotspots where the old threshold rejects nearly all candidate keys.
   - In 26 representative high-unified production windows, `balance<=0.8` covered about `27%` on average (`22%` median), while `balance<=0.6/0.7` only covered about `19%/23%`. `no_balance_key` was consistently much larger than `no_uncross_key`, so balance was the first blocker.
   - In one representative window, `load_fit≈200.6k`, `no_balance_key≈192.5k`, `no_uncross_key≈41.8k`, `ready_to_split_cpu_top≈1`, and `balance p50/p75/p90≈0.73/0.94/0.95`, showing the old `0.25` threshold rejected most candidates.
   - The contained threshold remains `0.5` to avoid increasing cross-region scan cost by default.
   - The worst expected accepted split result is still around a `300 QPS` / `3 MiB/s` region, which is acceptable for load-based split.

3. Add metrics for tuning and debugging the decision path.
   - Add CPU fallback gate reason counters: `normal_key_failed`, `cpu_fallback_unified_not_busy`, `cpu_fallback_region_not_busy`, and `cpu_fallback_grpc_busy`.
   - Add `tikv_load_base_split_region_load{type="cpu_millicores|qps|bytes_kib"}` to observe per-flush normalized region CPU, QPS, and bytes distributions without high-cardinality labels. The Grafana dashboard shows these three units in separate panels to avoid mixing different scales on one y-axis.
   - Add load-base split result counters `split_success` and `split_failed` to close the loop from `ready_to_split*` decision events to actual split completion/error.
   - These metrics help distinguish whether split is blocked by split-key selection, unified read pool gate, region CPU gate, gRPC busy gate, or by the final split execution path.

### Check List

Tests

- Unit test
- Manual test
<img width="3704" height="930" alt="image" src="https://github.com/user-attachments/assets/950f5ffa-492d-4f4d-b2e4-03c03e64cd4e" />

### Release note

```release-note
Relax load-based split thresholds and add observability for split-key and CPU fallback decisions.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new per-region histogram metric to expose observed load (CPU/QPS/bytes) during load-based splits.
  * Adjusted split tuning: increased split-balance threshold and lowered CPU overload threshold to change split sensitivity.
  * Expanded CPU-fallback reporting with additional outcome categories and improved per-region observations for better diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

