### PR TITLE
compact-log-backup: reduce remote reads and metadata memory overhead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1707,6 +1707,7 @@ dependencies = [
  "kvproto",
  "lazy_static",
  "log_wrappers",
+ "parking_lot 0.12.1",
  "pin-project",
  "pprof",
  "prometheus",

--- a/cmd/tikv-ctl/src/cmd.rs
+++ b/cmd/tikv-ctl/src/cmd.rs
@@ -671,7 +671,16 @@ pub enum Cmd {
                 files contains any record within the [--from, --until) will be selected."
             )
         )]
-        until_ts: u64,
+        until_ts: Option<u64>,
+        #[structopt(
+            long = "replication-status-sub-prefix",
+            help(
+                "subdirectory in external storage that contains resume-state.json. \
+                When --until is not specified, compact-log-backup reads \
+                last_checkpoint from this file as the until timestamp."
+            )
+        )]
+        replication_status_sub_prefix: Option<String>,
         #[structopt(
             long = "cal-shift-ts",
             help(
@@ -1005,6 +1014,36 @@ mod tests {
 
         match opt.cmd.unwrap() {
             Cmd::CompactLogBackup { cal_shift_ts, .. } => assert!(cal_shift_ts),
+            cmd => panic!("unexpected command: {:?}", std::mem::discriminant(&cmd)),
+        }
+    }
+
+    #[test]
+    fn compact_log_backup_replication_status_sub_prefix_allows_omitting_until() {
+        let opt = Opt::from_iter_safe([
+            "tikv-ctl",
+            "compact-log-backup",
+            "--from",
+            "1",
+            "--storage-base64",
+            "AA==",
+            "--replication-status-sub-prefix",
+            "replication/status",
+        ])
+        .unwrap();
+
+        match opt.cmd.unwrap() {
+            Cmd::CompactLogBackup {
+                until_ts,
+                replication_status_sub_prefix,
+                ..
+            } => {
+                assert_eq!(until_ts, None);
+                assert_eq!(
+                    replication_status_sub_prefix.as_deref(),
+                    Some("replication/status")
+                );
+            }
             cmd => panic!("unexpected command: {:?}", std::mem::discriminant(&cmd)),
         }
     }

--- a/cmd/tikv-ctl/src/cmd.rs
+++ b/cmd/tikv-ctl/src/cmd.rs
@@ -667,8 +667,9 @@ pub enum Cmd {
         #[structopt(
             long = "until",
             help(
-                "until when we need to include files into the compaction.\
-                files contains any record within the [--from, --until) will be selected."
+                "optional upper timestamp bound for selecting files into the compaction. \
+                Files containing any record within [--from, --until) will be selected. \
+                If omitted, compact-log-backup reads the bound from checkpoint state."
             )
         )]
         until_ts: Option<u64>,

--- a/cmd/tikv-ctl/src/cmd.rs
+++ b/cmd/tikv-ctl/src/cmd.rs
@@ -744,6 +744,16 @@ pub enum Cmd {
         prefetch_buffer_count: u64,
 
         #[structopt(
+            long,
+            default_value = "0",
+            help(
+                "specify memory reserved for caching physical log files, such as 64G. \
+                Zero disables the cache."
+            )
+        )]
+        physical_file_cache_capacity: ReadableSize,
+
+        #[structopt(
             long = "gcp-v2-enable",
             parse(try_from_str),
             default_value = "true",

--- a/cmd/tikv-ctl/src/main.rs
+++ b/cmd/tikv-ctl/src/main.rs
@@ -408,6 +408,7 @@ fn main() {
             minimal_compaction_size,
             prefetch_running_count,
             prefetch_buffer_count,
+            physical_file_cache_capacity,
             gcp_v2_enable,
         } => {
             let maybe_external_storage = base64::decode(storage_base64)
@@ -438,6 +439,7 @@ fn main() {
                 until_ts,
                 prefetch_running_count,
                 prefetch_buffer_count,
+                physical_file_cache_capacity: physical_file_cache_capacity.0,
                 compression,
                 compression_level,
             };

--- a/cmd/tikv-ctl/src/main.rs
+++ b/cmd/tikv-ctl/src/main.rs
@@ -404,6 +404,7 @@ fn main() {
             name,
             shard,
             cal_shift_ts,
+            replication_status_sub_prefix,
             force_regenerate,
             minimal_compaction_size,
             prefetch_running_count,
@@ -429,6 +430,52 @@ fn main() {
                         info: None,
                     }
                     .exit();
+                }
+            };
+            let storage =
+                match compact_log::create_storage_with_gcp_v2(&external_storage, gcp_v2_enable) {
+                    Ok(storage) => storage,
+                    Err(err) => {
+                        clap::Error {
+                            message: format!("failed to create external storage: {}", err),
+                            kind: ErrorKind::Io,
+                            info: None,
+                        }
+                        .exit();
+                    }
+                };
+            let runtime = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .expect("failed to build runtime for compact-log-backup");
+            let until_ts_unspecified = until_ts.is_none();
+            let until_ts = match until_ts {
+                Some(until_ts) => until_ts,
+                None => {
+                    match runtime.block_on(compact_log::load_until_ts_from_checkpoint(
+                        storage.as_ref(),
+                        replication_status_sub_prefix.as_deref(),
+                    )) {
+                        Ok(until_ts) => {
+                            tikv_util::info!(
+                                "Loaded compact log backup until-ts from checkpoint.";
+                                "until_ts" => until_ts,
+                                "replication_status_sub_prefix" => ?replication_status_sub_prefix,
+                            );
+                            until_ts
+                        }
+                        Err(err) => {
+                            clap::Error {
+                                message: format!(
+                                    "failed to load compact-log-backup checkpoint: {}",
+                                    err
+                                ),
+                                kind: ErrorKind::Io,
+                                info: None,
+                            }
+                            .exit();
+                        }
+                    }
                 }
             };
             let ccfg = compact_log::ExecutionConfig {
@@ -499,7 +546,13 @@ fn main() {
             let log_to_term = compact_log_hooks::observability::Observability::default();
             let save_meta = compact_log_hooks::save_meta::SaveMeta::default();
             let checkpoint = Some(compact_log_hooks::checkpoint::Checkpoint::default());
-            let with_lock = compact_log_hooks::consistency::StorageConsistencyGuard::default();
+            let with_lock = if until_ts_unspecified {
+                compact_log_hooks::consistency::StorageConsistencyGuard::without_checkpoint_check()
+            } else if let Some(sub_prefix) = replication_status_sub_prefix {
+                compact_log_hooks::consistency::StorageConsistencyGuard::with_replication_status_sub_prefix(sub_prefix)
+            } else {
+                compact_log_hooks::consistency::StorageConsistencyGuard::default()
+            };
             let with_status_server = ExportTiKVInfo { cfg: cfg.clone() };
             let skip_small_compaction = SkipSmallCompaction::new(minimal_compaction_size.0);
             let hooks = (
@@ -509,7 +562,7 @@ fn main() {
                 ),
                 (save_meta, with_lock),
             );
-            match exec.run(hooks) {
+            match runtime.block_on(exec.run_with_storage_async(storage, hooks)) {
                 Ok(()) => tikv_util::info!("Compact log backup successfully."),
                 Err(err) => {
                     tikv_util::error!("Failed to compact log backup."; "err" => %err, "err_verbose" => ?err);

--- a/components/compact-log-backup/Cargo.toml
+++ b/components/compact-log-backup/Cargo.toml
@@ -33,6 +33,7 @@ keys = { workspace = true }
 kvproto = { workspace = true }
 lazy_static = "1.4"
 log_wrappers = { workspace = true }
+parking_lot = "0.12"
 pin-project = "1.0"
 prometheus = { version = "0.13", default-features = false, features = [
   "nightly",

--- a/components/compact-log-backup/src/cache.rs
+++ b/components/compact-log-backup/src/cache.rs
@@ -305,7 +305,7 @@ impl PhysicalFileCache {
     ) -> io::Result<Option<(Bytes, u64)>> {
         let mut physical_bytes_in = 0;
         loop {
-            match self.cache_decision(&name, offset, length)? {
+            match self.cache_decision(name, offset, length)? {
                 CacheDecision::Ready(content) => return Ok(Some((content, physical_bytes_in))),
                 CacheDecision::Wait(notified) => notified.await,
                 CacheDecision::Bypass => return Ok(None),
@@ -315,7 +315,7 @@ impl PhysicalFileCache {
                 } => {
                     let guard = DownloadGuard::new(self, name.clone(), notify);
                     let download_res = self
-                        .download_physical_file(storage.as_ref(), &name, physical_size)
+                        .download_physical_file(storage.as_ref(), name, physical_size)
                         .await;
                     match download_res {
                         Ok((content, read_size)) => {

--- a/components/compact-log-backup/src/cache.rs
+++ b/components/compact-log-backup/src/cache.rs
@@ -1,0 +1,482 @@
+// Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
+use std::{
+    collections::{
+        HashMap,
+        hash_map::{DefaultHasher, Entry},
+    },
+    hash::{Hash, Hasher},
+    io,
+    sync::{
+        Arc,
+        atomic::{AtomicU64 as StdAtomicU64, Ordering},
+    },
+};
+
+use bytes::Bytes;
+use cloud::blob::read_to_end;
+use external_storage::ExternalStorage;
+use parking_lot::Mutex;
+use protobuf::Chars;
+use slog_global::{debug, info};
+use tokio::sync::futures::OwnedNotified;
+
+use crate::compaction::Input;
+
+const PHYSICAL_FILE_CACHE_SHARDS: usize = 256;
+
+enum CacheDecision {
+    Ready(Bytes),
+    Download {
+        notify: Arc<tokio::sync::Notify>,
+        physical_size: u64,
+    },
+    Wait(OwnedNotified),
+    Bypass,
+}
+
+pub enum RegisterPhysicalFileResult {
+    Registered,
+    Full(OwnedNotified),
+    Bypass,
+}
+
+struct CacheEntry {
+    remaining_refs: usize,
+    round: u64,
+    physical_size: u64,
+    content: Option<Bytes>,
+    loading: bool,
+    notify: Arc<tokio::sync::Notify>,
+}
+
+impl CacheEntry {
+    fn new(physical_size: u64, round: u64) -> Self {
+        Self {
+            remaining_refs: 0,
+            round,
+            physical_size,
+            content: None,
+            loading: false,
+            notify: Arc::new(tokio::sync::Notify::new()),
+        }
+    }
+
+    fn add_ref(&mut self, ref_count: usize) {
+        assert!(ref_count > 0);
+        self.remaining_refs += ref_count;
+    }
+
+    fn drop_ref(&mut self) -> bool {
+        assert!(self.remaining_refs > 0);
+        self.remaining_refs -= 1;
+        self.remaining_refs == 0
+    }
+}
+
+#[derive(Default)]
+struct CacheShard {
+    entries: HashMap<Chars, CacheEntry>,
+}
+
+#[derive(Default)]
+struct CacheRoundState {
+    current_round: u64,
+    last_round_left_files: usize,
+    current_round_left_files: usize,
+}
+
+/// A bounded cache for raw physical log files.
+///
+/// The cache reserves capacity when a physical file is registered, then stores
+/// the physical object as one `Bytes` allocation once it is first loaded.
+/// Logical files are returned as zero-copy slices. When the last logical-file
+/// reference of a physical file is consumed or dropped, the entry is removed
+/// and the reserved capacity is released.
+pub struct PhysicalFileCache {
+    capacity: u64,
+    reserved_bytes: StdAtomicU64,
+    capacity_notify: Arc<tokio::sync::Notify>,
+    /// Tracks cache windows split by forced compaction. A new forced
+    /// compaction is allowed only after every physical file from the previous
+    /// forced window has released its cache ref.
+    round_state: Mutex<CacheRoundState>,
+    shards: Box<[Mutex<CacheShard>]>,
+}
+
+/// Cleans up an in-flight physical-file download if the future is dropped.
+///
+/// A downloader sets `CacheEntry::loading` and releases the shard lock before
+/// awaiting remote storage. If that await is cancelled, waiters would otherwise
+/// keep waiting forever.
+struct DownloadGuard<'a> {
+    cache: &'a PhysicalFileCache,
+    name: Chars,
+    notify: Arc<tokio::sync::Notify>,
+    finished: bool,
+}
+
+impl<'a> DownloadGuard<'a> {
+    fn new(cache: &'a PhysicalFileCache, name: Chars, notify: Arc<tokio::sync::Notify>) -> Self {
+        Self {
+            cache,
+            name,
+            notify,
+            finished: false,
+        }
+    }
+
+    fn finish(mut self, content: Option<Bytes>) {
+        self.cache
+            .finish_download(&self.name, &self.notify, content);
+        self.finished = true;
+    }
+}
+
+impl Drop for DownloadGuard<'_> {
+    fn drop(&mut self) {
+        if !self.finished {
+            self.cache.finish_download(&self.name, &self.notify, None);
+        }
+    }
+}
+
+impl PhysicalFileCache {
+    pub fn new(capacity: u64) -> Self {
+        info!("create physical file cache"; "capacity" => capacity);
+        Self {
+            capacity,
+            reserved_bytes: StdAtomicU64::new(0),
+            capacity_notify: Arc::new(tokio::sync::Notify::new()),
+            round_state: Mutex::new(CacheRoundState::default()),
+            shards: (0..PHYSICAL_FILE_CACHE_SHARDS)
+                .map(|_| Mutex::new(CacheShard::default()))
+                .collect(),
+        }
+    }
+
+    fn shard(&self, name: &Chars) -> &Mutex<CacheShard> {
+        let mut hasher = DefaultHasher::new();
+        name.hash(&mut hasher);
+        &self.shards[hasher.finish() as usize % self.shards.len()]
+    }
+
+    fn reserved_bytes(&self) -> u64 {
+        self.reserved_bytes.load(Ordering::Relaxed)
+    }
+
+    fn try_reserve(&self, physical_size: u64) -> Option<u64> {
+        let mut current = self.reserved_bytes();
+        loop {
+            let next = current.checked_add(physical_size)?;
+            if next > self.capacity {
+                return None;
+            }
+            match self.reserved_bytes.compare_exchange_weak(
+                current,
+                next,
+                Ordering::AcqRel,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return Some(next),
+                Err(actual) => current = actual,
+            }
+        }
+    }
+
+    fn release_reserved(&self, physical_size: u64) {
+        let mut current = self.reserved_bytes();
+        loop {
+            let next = current.saturating_sub(physical_size);
+            match self.reserved_bytes.compare_exchange_weak(
+                current,
+                next,
+                Ordering::AcqRel,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => {
+                    self.capacity_notify.notify_one();
+                    return;
+                }
+                Err(actual) => current = actual,
+            }
+        }
+    }
+
+    fn register_current_round_file(&self) -> u64 {
+        let mut state = self.round_state.lock();
+        let round = state.current_round;
+        state.current_round_left_files += 1;
+        round
+    }
+
+    fn release_round_file(&self, round: u64) {
+        let mut state = self.round_state.lock();
+        if round == state.current_round {
+            assert!(state.current_round_left_files > 0);
+            state.current_round_left_files -= 1;
+        } else {
+            assert!(state.last_round_left_files > 0);
+            state.last_round_left_files -= 1;
+        }
+    }
+
+    pub(crate) fn can_force_compaction(&self) -> bool {
+        self.round_state.lock().last_round_left_files == 0
+    }
+
+    pub(crate) fn advance_round_after_force_compaction(&self) {
+        let mut state = self.round_state.lock();
+        assert_eq!(state.last_round_left_files, 0);
+        state.current_round += 1;
+        state.last_round_left_files = state.current_round_left_files;
+        state.current_round_left_files = 0;
+    }
+
+    pub fn register_physical_file(
+        &self,
+        file_name: &Chars,
+        file_size: u64,
+        ref_count: usize,
+    ) -> RegisterPhysicalFileResult {
+        if ref_count == 0 {
+            return RegisterPhysicalFileResult::Registered;
+        }
+        if file_size > self.capacity {
+            return RegisterPhysicalFileResult::Bypass;
+        }
+        let mut shard = self.shard(file_name).lock();
+        let entry = match shard.entries.entry(file_name.clone()) {
+            Entry::Occupied(entry) => {
+                let entry = entry.into_mut();
+                entry.physical_size = file_size;
+                entry.add_ref(ref_count);
+                return RegisterPhysicalFileResult::Registered;
+            }
+            Entry::Vacant(entry) => {
+                let wait = Arc::clone(&self.capacity_notify).notified_owned();
+                if self.try_reserve(file_size).is_none() {
+                    return RegisterPhysicalFileResult::Full(wait);
+                }
+                let round = self.register_current_round_file();
+                entry.insert(CacheEntry::new(file_size, round))
+            }
+        };
+        entry.physical_size = file_size;
+        entry.add_ref(ref_count);
+        RegisterPhysicalFileResult::Registered
+    }
+
+    pub fn drop_input_ref(&self, input: &Input) {
+        self.drop_physical_file_ref(&input.id.name);
+    }
+
+    /// Marks one registered logical file in this physical file as consumed.
+    ///
+    /// For cache hits, call this only after the returned slice has been fully
+    /// processed. Otherwise a retry could consume the same ref twice, or the
+    /// capacity reservation could be released while the slice still keeps the
+    /// physical allocation alive.
+    pub(crate) fn drop_physical_file_ref(&self, file_name: &Chars) {
+        let mut release_size = None;
+        let mut release_round = None;
+        {
+            let mut shard = self.shard(file_name).lock();
+            if let Entry::Occupied(mut entry) = shard.entries.entry(file_name.clone()) {
+                let item = entry.get_mut();
+                if item.drop_ref() {
+                    release_size = Some(item.physical_size);
+                    release_round = Some(item.round);
+                    entry.remove();
+                }
+            }
+        }
+        if let (Some(physical_size), Some(round)) = (release_size, release_round) {
+            self.release_round_file(round);
+            self.release_reserved(physical_size);
+        }
+    }
+
+    pub async fn load_part(
+        &self,
+        storage: Arc<dyn ExternalStorage>,
+        name: &Chars,
+        offset: u64,
+        length: u64,
+    ) -> io::Result<Option<(Bytes, u64)>> {
+        let mut physical_bytes_in = 0;
+        loop {
+            match self.cache_decision(&name, offset, length)? {
+                CacheDecision::Ready(content) => return Ok(Some((content, physical_bytes_in))),
+                CacheDecision::Wait(notified) => notified.await,
+                CacheDecision::Bypass => return Ok(None),
+                CacheDecision::Download {
+                    notify,
+                    physical_size,
+                } => {
+                    let guard = DownloadGuard::new(self, name.clone(), notify);
+                    let download_res = self
+                        .download_physical_file(storage.as_ref(), &name, physical_size)
+                        .await;
+                    match download_res {
+                        Ok((content, read_size)) => {
+                            physical_bytes_in += read_size;
+                            guard.finish(Some(content));
+                        }
+                        Err(err) => {
+                            guard.finish(None);
+                            return Err(err);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn cache_decision(&self, name: &Chars, offset: u64, length: u64) -> io::Result<CacheDecision> {
+        let decision = {
+            let mut shard = self.shard(name).lock();
+            match shard.entries.entry(name.clone()) {
+                Entry::Vacant(_) => CacheDecision::Bypass,
+                Entry::Occupied(mut occupied) => {
+                    let entry = occupied.get_mut();
+                    if let Some(content) = entry.content.as_ref() {
+                        let part = checked_get_range(name, content, offset, length)?;
+                        CacheDecision::Ready(part)
+                    } else if entry.loading {
+                        CacheDecision::Wait(Arc::clone(&entry.notify).notified_owned())
+                    } else {
+                        entry.loading = true;
+                        CacheDecision::Download {
+                            notify: Arc::clone(&entry.notify),
+                            physical_size: entry.physical_size,
+                        }
+                    }
+                }
+            }
+        };
+        Ok(decision)
+    }
+
+    async fn download_physical_file(
+        &self,
+        storage: &dyn ExternalStorage,
+        name: &Chars,
+        physical_size: u64,
+    ) -> io::Result<(Bytes, u64)> {
+        let mut content = Vec::with_capacity(physical_size as usize);
+        let read_size = read_to_end(storage.read(name), &mut content).await?;
+        debug!("loaded physical file into cache"; "name" => name.to_string(), "size" => read_size);
+        Ok((Bytes::from(content), read_size))
+    }
+
+    fn finish_download(&self, name: &Chars, notify: &tokio::sync::Notify, content: Option<Bytes>) {
+        let mut shard = self.shard(name).lock();
+        if let Some(entry) = shard.entries.get_mut(name) {
+            if let Some(content) = content {
+                entry.content = Some(content);
+            }
+            entry.loading = false;
+        }
+        notify.notify_waiters();
+    }
+}
+
+fn checked_get_range(name: &Chars, content: &Bytes, offset: u64, length: u64) -> io::Result<Bytes> {
+    let start = usize::try_from(offset).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("log file {name} offset {offset} is too large"),
+        )
+    })?;
+    let end = usize::try_from(offset.checked_add(length).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("log file {name} length {offset} + {length} is too large"),
+        )
+    })?)
+    .map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("log file {name} length {offset} + {length} is too large"),
+        )
+    })?;
+    if end > content.len() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "log file {name} range [{start}, {end}) exceeds cached physical file {} length {}",
+                name,
+                content.len()
+            ),
+        ));
+    }
+    Ok(content.slice(start..end))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ready_part(decision: CacheDecision) -> Bytes {
+        match decision {
+            CacheDecision::Ready(part) => part,
+            _ => panic!("expected cached part to be ready"),
+        }
+    }
+
+    #[test]
+    fn test_download_guard_clears_loading_on_drop() {
+        let cache = PhysicalFileCache::new(8);
+        let name = Chars::from("physical.log");
+        cache.register_physical_file(&name, 8, 1);
+
+        let notify = match cache.cache_decision(&name, 0, 4).unwrap() {
+            CacheDecision::Download { notify, .. } => notify,
+            _ => panic!("expected cache download"),
+        };
+        assert_eq!(cache.reserved_bytes(), 8);
+        {
+            let shard = cache.shard(&name).lock();
+            assert!(shard.entries.get(&name).unwrap().loading);
+        }
+
+        drop(DownloadGuard::new(&cache, name.clone(), notify));
+
+        assert_eq!(cache.reserved_bytes(), 8);
+        let shard = cache.shard(&name).lock();
+        let entry = shard.entries.get(&name).unwrap();
+        assert!(!entry.loading);
+        assert!(entry.content.is_none());
+    }
+
+    #[test]
+    fn test_reserved_bytes_released_after_cached_parts_are_consumed() {
+        let cache = PhysicalFileCache::new(10);
+        let name = Chars::from("physical.log");
+        cache.register_physical_file(&name, 10, 2);
+        assert_eq!(cache.reserved_bytes(), 10);
+        let notify = tokio::sync::Notify::new();
+        cache.finish_download(&name, &notify, Some(Bytes::from_static(b"0123456789")));
+
+        let part1 = ready_part(cache.cache_decision(&name, 0, 5).unwrap());
+        assert_eq!(part1, Bytes::from_static(b"01234"));
+        assert_eq!(cache.reserved_bytes(), 10);
+        cache.drop_physical_file_ref(&name);
+        assert_eq!(cache.reserved_bytes(), 10);
+
+        let part2 = ready_part(cache.cache_decision(&name, 5, 5).unwrap());
+        assert_eq!(part2, Bytes::from_static(b"56789"));
+        assert_eq!(cache.reserved_bytes(), 10);
+        cache.drop_physical_file_ref(&name);
+        assert_eq!(cache.reserved_bytes(), 0);
+        {
+            let shard = cache.shard(&name).lock();
+            assert!(!shard.entries.contains_key(&name));
+        }
+
+        drop(part2);
+        assert_eq!(cache.reserved_bytes(), 0);
+        drop(part1);
+        assert_eq!(cache.reserved_bytes(), 0);
+    }
+}

--- a/components/compact-log-backup/src/cache.rs
+++ b/components/compact-log-backup/src/cache.rs
@@ -391,13 +391,13 @@ fn checked_get_range(name: &Chars, content: &Bytes, offset: u64, length: u64) ->
     let end = usize::try_from(offset.checked_add(length).ok_or_else(|| {
         io::Error::new(
             io::ErrorKind::InvalidData,
-            format!("log file {name} length {offset} + {length} is too large"),
+            format!("log file {name} offset {offset} + length {length} overflows"),
         )
     })?)
     .map_err(|_| {
         io::Error::new(
             io::ErrorKind::InvalidData,
-            format!("log file {name} length {offset} + {length} is too large"),
+            format!("log file {name} offset {offset} + length {length} is too large"),
         )
     })?;
     if end > content.len() {

--- a/components/compact-log-backup/src/cache.rs
+++ b/components/compact-log-backup/src/cache.rs
@@ -42,7 +42,6 @@ pub enum RegisterPhysicalFileResult {
 
 struct CacheEntry {
     remaining_refs: usize,
-    round: u64,
     physical_size: u64,
     content: Option<Bytes>,
     loading: bool,
@@ -50,10 +49,9 @@ struct CacheEntry {
 }
 
 impl CacheEntry {
-    fn new(physical_size: u64, round: u64) -> Self {
+    fn new(physical_size: u64) -> Self {
         Self {
             remaining_refs: 0,
-            round,
             physical_size,
             content: None,
             loading: false,
@@ -78,13 +76,6 @@ struct CacheShard {
     entries: HashMap<Chars, CacheEntry>,
 }
 
-#[derive(Default)]
-struct CacheRoundState {
-    current_round: u64,
-    last_round_left_files: usize,
-    current_round_left_files: usize,
-}
-
 /// A bounded cache for raw physical log files.
 ///
 /// The cache reserves capacity when a physical file is registered, then stores
@@ -96,11 +87,29 @@ pub struct PhysicalFileCache {
     capacity: u64,
     reserved_bytes: StdAtomicU64,
     capacity_notify: Arc<tokio::sync::Notify>,
-    /// Tracks cache windows split by forced compaction. A new forced
-    /// compaction is allowed only after every physical file from the previous
-    /// forced window has released its cache ref.
-    round_state: Mutex<CacheRoundState>,
     shards: Box<[Mutex<CacheShard>]>,
+}
+
+pub(crate) struct PhysicalFileCacheRefGuard {
+    cache: Arc<PhysicalFileCache>,
+    file_names: Vec<Chars>,
+}
+
+impl PhysicalFileCacheRefGuard {
+    pub(crate) fn new(cache: Arc<PhysicalFileCache>, inputs: &[Input]) -> Self {
+        Self {
+            cache,
+            file_names: inputs.iter().map(|input| input.id.name.clone()).collect(),
+        }
+    }
+}
+
+impl Drop for PhysicalFileCacheRefGuard {
+    fn drop(&mut self) {
+        for name in self.file_names.drain(..) {
+            self.cache.drop_physical_file_ref(&name);
+        }
+    }
 }
 
 /// Cleans up an in-flight physical-file download if the future is dropped.
@@ -147,7 +156,6 @@ impl PhysicalFileCache {
             capacity,
             reserved_bytes: StdAtomicU64::new(0),
             capacity_notify: Arc::new(tokio::sync::Notify::new()),
-            round_state: Mutex::new(CacheRoundState::default()),
             shards: (0..PHYSICAL_FILE_CACHE_SHARDS)
                 .map(|_| Mutex::new(CacheShard::default()))
                 .collect(),
@@ -202,46 +210,13 @@ impl PhysicalFileCache {
         }
     }
 
-    fn register_current_round_file(&self) -> u64 {
-        let mut state = self.round_state.lock();
-        let round = state.current_round;
-        state.current_round_left_files += 1;
-        round
-    }
-
-    fn release_round_file(&self, round: u64) {
-        let mut state = self.round_state.lock();
-        if round == state.current_round {
-            assert!(state.current_round_left_files > 0);
-            state.current_round_left_files -= 1;
-        } else {
-            assert!(state.last_round_left_files > 0);
-            state.last_round_left_files -= 1;
-        }
-    }
-
-    pub(crate) fn can_force_compaction(&self) -> bool {
-        self.round_state.lock().last_round_left_files == 0
-    }
-
-    pub(crate) fn advance_round_after_force_compaction(&self) {
-        let mut state = self.round_state.lock();
-        assert_eq!(state.last_round_left_files, 0);
-        state.current_round += 1;
-        state.last_round_left_files = state.current_round_left_files;
-        state.current_round_left_files = 0;
-    }
-
     pub fn register_physical_file(
         &self,
         file_name: &Chars,
         file_size: u64,
         ref_count: usize,
     ) -> RegisterPhysicalFileResult {
-        if ref_count == 0 {
-            return RegisterPhysicalFileResult::Registered;
-        }
-        if file_size > self.capacity {
+        if ref_count == 0 || file_size > self.capacity {
             return RegisterPhysicalFileResult::Bypass;
         }
         let mut shard = self.shard(file_name).lock();
@@ -257,17 +232,12 @@ impl PhysicalFileCache {
                 if self.try_reserve(file_size).is_none() {
                     return RegisterPhysicalFileResult::Full(wait);
                 }
-                let round = self.register_current_round_file();
-                entry.insert(CacheEntry::new(file_size, round))
+                entry.insert(CacheEntry::new(file_size))
             }
         };
         entry.physical_size = file_size;
         entry.add_ref(ref_count);
         RegisterPhysicalFileResult::Registered
-    }
-
-    pub fn drop_input_ref(&self, input: &Input) {
-        self.drop_physical_file_ref(&input.id.name);
     }
 
     /// Marks one registered logical file in this physical file as consumed.
@@ -278,20 +248,17 @@ impl PhysicalFileCache {
     /// physical allocation alive.
     pub(crate) fn drop_physical_file_ref(&self, file_name: &Chars) {
         let mut release_size = None;
-        let mut release_round = None;
         {
             let mut shard = self.shard(file_name).lock();
             if let Entry::Occupied(mut entry) = shard.entries.entry(file_name.clone()) {
                 let item = entry.get_mut();
                 if item.drop_ref() {
                     release_size = Some(item.physical_size);
-                    release_round = Some(item.round);
                     entry.remove();
                 }
             }
         }
-        if let (Some(physical_size), Some(round)) = (release_size, release_round) {
-            self.release_round_file(round);
+        if let Some(physical_size) = release_size {
             self.release_reserved(physical_size);
         }
     }

--- a/components/compact-log-backup/src/compaction/collector.rs
+++ b/components/compact-log-backup/src/compaction/collector.rs
@@ -156,10 +156,6 @@ impl SubcompactionCollector {
         file.is_meta || file.max_ts < compact_from_ts || file.min_ts > self.cfg.compact_to_ts
     }
 
-    fn is_empty(&self) -> bool {
-        self.items.is_empty()
-    }
-
     fn try_filter_out(&mut self, file: &LogFile) -> bool {
         if self.should_filter_out(file) {
             self.stat.files_filtered_out += 1;
@@ -215,6 +211,14 @@ impl SubcompactionCollector {
             c.form(&key, &self.cfg)
         })
     }
+
+    /// Force create one undersized subcompaction from the current pending
+    /// unformed subcompactions.
+    fn take_one_pending_subcompaction(&mut self) -> Option<Subcompaction> {
+        let item = { self.items.extract_if(|_, _| true).next() };
+        let (key, item) = item?;
+        Some(item.form(&key, &self.cfg))
+    }
 }
 
 impl<S: Stream<Item = Result<LogFile>>> Stream for CollectSubcompaction<S> {
@@ -264,16 +268,16 @@ impl<S: Stream<Item = Result<PhysicalLogFile>>> Stream for CollectCachedSubcompa
     ) -> std::task::Poll<Option<Self::Item>> {
         let mut this = self.project();
         loop {
-            if let Some(wait) = this.cache_wait.as_mut().as_pin_mut() {
-                ready!(wait.poll(cx));
-                this.cache_wait.set(None);
-            }
             if let Some(ready) = this.ready_compactions.pop_front() {
                 if ready.update_stat_on_yield {
                     this.collector.stat.bytes_out += ready.compaction.size;
                     this.collector.stat.compactions_out += 1;
                 }
                 return Poll::Ready(Some(Ok(ready.compaction)));
+            }
+            if let Some(wait) = this.cache_wait.as_mut().as_pin_mut() {
+                ready!(wait.poll(cx));
+                this.cache_wait.set(None);
             }
 
             let (item, already_filtered) = match this.deferred_file.take() {
@@ -282,8 +286,7 @@ impl<S: Stream<Item = Result<PhysicalLogFile>>> Stream for CollectCachedSubcompa
             };
             match item {
                 None => {
-                    let pending: Vec<_> = this.collector.take_pending_subcompactions().collect();
-                    for compaction in pending {
+                    for compaction in this.collector.take_pending_subcompactions() {
                         this.ready_compactions.push_back(ReadySubcompaction {
                             compaction,
                             update_stat_on_yield: true,
@@ -316,26 +319,14 @@ impl<S: Stream<Item = Result<PhysicalLogFile>>> Stream for CollectCachedSubcompa
                         RegisterPhysicalFileResult::Bypass => {}
                         RegisterPhysicalFileResult::Full(wait) => {
                             *this.deferred_file = Some(physical_file);
-                            if this.collector.is_empty()
-                                || !this.physical_file_cache.can_force_compaction()
-                            {
-                                this.cache_wait.set(Some(wait));
-                                continue;
-                            }
-                            let pending: Vec<_> =
-                                this.collector.take_pending_subcompactions().collect();
-                            if !pending.is_empty() {
-                                this.physical_file_cache
-                                    .advance_round_after_force_compaction();
-                            }
-                            for compaction in pending {
-                                this.ready_compactions.push_back(ReadySubcompaction {
-                                    compaction,
-                                    update_stat_on_yield: true,
-                                });
-                            }
-                            if this.ready_compactions.is_empty() {
-                                this.cache_wait.set(Some(wait));
+                            match this.collector.take_one_pending_subcompaction() {
+                                Some(compaction) => {
+                                    this.ready_compactions.push_back(ReadySubcompaction {
+                                        compaction,
+                                        update_stat_on_yield: true,
+                                    });
+                                }
+                                None => this.cache_wait.set(Some(wait)),
                             }
                             continue;
                         }
@@ -373,7 +364,7 @@ mod test {
         SubcompactionCollectKey,
     };
     use crate::{
-        cache::PhysicalFileCache,
+        cache::{PhysicalFileCache, PhysicalFileCacheRefGuard},
         compaction::EpochHint,
         errors::{Error, ErrorKind, Result},
         storage::{Epoch, LogFile, LogFileId, PhysicalLogFile},
@@ -466,18 +457,23 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_collect_cached_subcompaction_flushes_pending_when_cache_is_full() {
+    async fn test_collect_cached_subcompaction_forces_one_pending_when_cache_is_full() {
         let r = SubcompactionCollectKey::of_region;
         let items = vec![
             PhysicalLogFile {
                 name: Chars::from("001"),
-                size: 60,
-                files: vec![log_file("001", 20, r(1))],
+                size: 40,
+                files: vec![log_file("001", 10, r(1))],
             },
             PhysicalLogFile {
                 name: Chars::from("002"),
-                size: 60,
+                size: 40,
                 files: vec![log_file("002", 30, r(2))],
+            },
+            PhysicalLogFile {
+                name: Chars::from("003"),
+                size: 40,
+                files: vec![log_file("003", 20, r(3))],
             },
         ];
         let physical_file_cache = Arc::new(PhysicalFileCache::new(100));
@@ -494,18 +490,28 @@ mod test {
         tokio::pin!(collector);
 
         let first = collector.as_mut().next().await.unwrap().unwrap();
-        assert_eq!((first.size, first.region_id), (20, 1));
-        for input in &first.inputs {
-            physical_file_cache.drop_input_ref(input);
-        }
         let second = collector.as_mut().next().await.unwrap().unwrap();
-        assert_eq!((second.size, second.region_id), (30, 2));
+        let mut forced = vec![
+            (first.size, first.region_id),
+            (second.size, second.region_id),
+        ];
+        forced.sort();
+        assert_eq!(forced, vec![(10, 1), (30, 2)]);
+        assert!(collector.as_mut().next().now_or_never().is_none());
+
+        drop(PhysicalFileCacheRefGuard::new(
+            Arc::clone(&physical_file_cache),
+            &first.inputs,
+        ));
+
+        let third = collector.as_mut().next().await.unwrap().unwrap();
+        assert_eq!((third.size, third.region_id), (20, 3));
         assert!(collector.as_mut().next().await.is_none());
         let stat = collector.as_mut().take_statistic();
-        assert_eq!(stat.files_in, 2);
-        assert_eq!(stat.bytes_in, 50);
-        assert_eq!(stat.bytes_out, 50);
-        assert_eq!(stat.compactions_out, 2);
+        assert_eq!(stat.files_in, 3);
+        assert_eq!(stat.bytes_in, 60);
+        assert_eq!(stat.bytes_out, 60);
+        assert_eq!(stat.compactions_out, 3);
         assert_eq!(stat.files_filtered_out, 0);
     }
 
@@ -541,16 +547,17 @@ mod test {
         assert_eq!((first.size, first.region_id), (20, 1));
         assert!(collector.as_mut().next().now_or_never().is_none());
 
-        for input in &first.inputs {
-            physical_file_cache.drop_input_ref(input);
-        }
+        drop(PhysicalFileCacheRefGuard::new(
+            Arc::clone(&physical_file_cache),
+            &first.inputs,
+        ));
 
         let second = collector.as_mut().next().await.unwrap().unwrap();
         assert_eq!((second.size, second.region_id), (30, 2));
     }
 
     #[tokio::test]
-    async fn test_collect_cached_subcompaction_waits_before_second_forced_round() {
+    async fn test_collect_cached_subcompaction_forces_pending_until_empty() {
         let r = SubcompactionCollectKey::of_region;
         let items = vec![
             PhysicalLogFile {
@@ -593,27 +600,23 @@ mod test {
         tokio::pin!(collector);
 
         let first = collector.as_mut().next().await.unwrap().unwrap();
+        assert!(matches!(first.region_id, 1 | 2));
+        assert_eq!(first.size, 40);
         let second = collector.as_mut().next().await.unwrap().unwrap();
-        let mut first_round_ids = vec![first.region_id, second.region_id];
-        first_round_ids.sort();
-        assert_eq!(first_round_ids, vec![1, 2]);
-        assert_eq!((first.size, second.size), (40, 40));
+        assert_eq!(second.size, 40);
+        let mut first_forced_ids = vec![first.region_id, second.region_id];
+        first_forced_ids.sort();
+        assert_eq!(first_forced_ids, vec![1, 2]);
 
-        for input in &first.inputs {
-            physical_file_cache.drop_input_ref(input);
-        }
         assert!(collector.as_mut().next().now_or_never().is_none());
 
-        for input in &second.inputs {
-            physical_file_cache.drop_input_ref(input);
-        }
+        drop(PhysicalFileCacheRefGuard::new(
+            Arc::clone(&physical_file_cache),
+            &first.inputs,
+        ));
 
         let third = collector.as_mut().next().await.unwrap().unwrap();
-        let fourth = collector.as_mut().next().await.unwrap().unwrap();
-        let mut second_round_ids = vec![third.region_id, fourth.region_id];
-        second_round_ids.sort();
-        assert_eq!(second_round_ids, vec![3, 4]);
-        assert_eq!((third.size, fourth.size), (40, 40));
+        assert_eq!((third.size, third.region_id), (40, 3));
     }
 
     #[tokio::test]

--- a/components/compact-log-backup/src/compaction/collector.rs
+++ b/components/compact-log-backup/src/compaction/collector.rs
@@ -66,6 +66,56 @@ struct ReadySubcompaction {
     update_stat_on_yield: bool,
 }
 
+fn sort_ready_compactions(mut compactions: Vec<Subcompaction>) -> Vec<Subcompaction> {
+    compactions.sort_by(|lhs, rhs| {
+        rhs.inputs
+            .len()
+            .cmp(&lhs.inputs.len())
+            .then_with(|| rhs.size.cmp(&lhs.size))
+            .then_with(|| lhs.region_id.cmp(&rhs.region_id))
+            .then_with(|| lhs.cf.cmp(rhs.cf))
+            .then_with(|| (lhs.ty as i32).cmp(&(rhs.ty as i32)))
+            .then_with(|| lhs.is_meta.cmp(&rhs.is_meta))
+            .then_with(|| lhs.table_id.cmp(&rhs.table_id))
+    });
+    compactions
+}
+
+fn enqueue_ready_compactions(
+    ready_compactions: &mut VecDeque<ReadySubcompaction>,
+    compactions: Vec<Subcompaction>,
+) {
+    ready_compactions.extend(
+        sort_ready_compactions(compactions)
+            .into_iter()
+            .map(|compaction| ReadySubcompaction {
+                compaction,
+                update_stat_on_yield: true,
+            }),
+    );
+}
+
+fn pop_ready_compaction(
+    ready_compactions: &mut VecDeque<ReadySubcompaction>,
+    collector: &mut SubcompactionCollector,
+) -> Option<Subcompaction> {
+    let mut ready = ready_compactions.pop_front()?;
+    if let Some(pending) = collector
+        .take_pending_subcompaction_by_key(ready.compaction.subc_key, ready.compaction.size)
+    {
+        let pending_size = pending.size;
+        ready.compaction.merge(pending);
+        if !ready.update_stat_on_yield {
+            collector.stat.bytes_out += pending_size;
+        }
+    }
+    if ready.update_stat_on_yield {
+        collector.stat.bytes_out += ready.compaction.size;
+        collector.stat.compactions_out += 1;
+    }
+    Some(ready.compaction)
+}
+
 impl<S: Stream<Item = Result<PhysicalLogFile>>> CollectCachedSubcompaction<S> {
     /// Get delta of statistic between last call to this.
     pub fn take_statistic(self: Pin<&mut Self>) -> CollectSubcompactionStatistic {
@@ -212,12 +262,19 @@ impl SubcompactionCollector {
         })
     }
 
-    /// Force create one undersized subcompaction from the current pending
-    /// unformed subcompactions.
-    fn take_one_pending_subcompaction(&mut self) -> Option<Subcompaction> {
-        let item = { self.items.extract_if(|_, _| true).next() };
-        let (key, item) = item?;
-        Some(item.form(&key, &self.cfg))
+    fn take_pending_subcompaction_by_key(
+        &mut self,
+        key: SubcompactionCollectKey,
+        base_size: u64,
+    ) -> Option<Subcompaction> {
+        if self
+            .items
+            .get(&key)
+            .is_none_or(|c| base_size + c.size > self.cfg.subcompaction_size_threshold)
+        {
+            return None;
+        }
+        self.items.remove(&key).map(|c| c.form(&key, &self.cfg))
     }
 }
 
@@ -268,12 +325,22 @@ impl<S: Stream<Item = Result<PhysicalLogFile>>> Stream for CollectCachedSubcompa
     ) -> std::task::Poll<Option<Self::Item>> {
         let mut this = self.project();
         loop {
-            if let Some(ready) = this.ready_compactions.pop_front() {
-                if ready.update_stat_on_yield {
-                    this.collector.stat.bytes_out += ready.compaction.size;
-                    this.collector.stat.compactions_out += 1;
+            if !this.ready_compactions.is_empty() {
+                if let Some(wait) = this.cache_wait.as_mut().as_pin_mut() {
+                    match wait.poll(cx) {
+                        Poll::Ready(()) => this.cache_wait.set(None),
+                        Poll::Pending => {
+                            return pop_ready_compaction(this.ready_compactions, this.collector)
+                                .map(Ok)
+                                .into();
+                        }
+                    }
                 }
-                return Poll::Ready(Some(Ok(ready.compaction)));
+                if this.deferred_file.is_none() {
+                    return pop_ready_compaction(this.ready_compactions, this.collector)
+                        .map(Ok)
+                        .into();
+                }
             }
             if let Some(wait) = this.cache_wait.as_mut().as_pin_mut() {
                 ready!(wait.poll(cx));
@@ -286,12 +353,8 @@ impl<S: Stream<Item = Result<PhysicalLogFile>>> Stream for CollectCachedSubcompa
             };
             match item {
                 None => {
-                    for compaction in this.collector.take_pending_subcompactions() {
-                        this.ready_compactions.push_back(ReadySubcompaction {
-                            compaction,
-                            update_stat_on_yield: true,
-                        });
-                    }
+                    let pending = this.collector.take_pending_subcompactions().collect();
+                    enqueue_ready_compactions(this.ready_compactions, pending);
                     if this.ready_compactions.is_empty() {
                         return Poll::Ready(None);
                     }
@@ -319,15 +382,9 @@ impl<S: Stream<Item = Result<PhysicalLogFile>>> Stream for CollectCachedSubcompa
                         RegisterPhysicalFileResult::Bypass => {}
                         RegisterPhysicalFileResult::Full(wait) => {
                             *this.deferred_file = Some(physical_file);
-                            match this.collector.take_one_pending_subcompaction() {
-                                Some(compaction) => {
-                                    this.ready_compactions.push_back(ReadySubcompaction {
-                                        compaction,
-                                        update_stat_on_yield: true,
-                                    });
-                                }
-                                None => this.cache_wait.set(Some(wait)),
-                            }
+                            let pending = this.collector.take_pending_subcompactions().collect();
+                            enqueue_ready_compactions(this.ready_compactions, pending);
+                            this.cache_wait.set(Some(wait));
                             continue;
                         }
                     }
@@ -457,7 +514,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_collect_cached_subcompaction_forces_one_pending_when_cache_is_full() {
+    async fn test_collect_cached_subcompaction_drains_pending_when_cache_is_full() {
         let r = SubcompactionCollectKey::of_region;
         let items = vec![
             PhysicalLogFile {
@@ -617,6 +674,118 @@ mod test {
 
         let third = collector.as_mut().next().await.unwrap().unwrap();
         assert_eq!((third.size, third.region_id), (40, 3));
+    }
+
+    #[tokio::test]
+    async fn test_collect_cached_subcompaction_merges_matching_pending_before_yielding_ready() {
+        let r = SubcompactionCollectKey::of_region;
+        let items = vec![
+            PhysicalLogFile {
+                name: Chars::from("001"),
+                size: 40,
+                files: vec![log_file("001", 50, r(1))],
+            },
+            PhysicalLogFile {
+                name: Chars::from("002"),
+                size: 40,
+                files: vec![log_file("002", 40, r(2))],
+            },
+            PhysicalLogFile {
+                name: Chars::from("003"),
+                size: 40,
+                files: vec![log_file("003", 30, r(2))],
+            },
+        ];
+        let physical_file_cache = Arc::new(PhysicalFileCache::new(100));
+        let collector = CollectCachedSubcompaction::new(
+            stream::iter(items).map(Result::Ok),
+            CollectSubcompactionConfig {
+                compact_shift_from_ts: 0,
+                compact_from_ts: 0,
+                compact_to_ts: u64::MAX,
+                subcompaction_size_threshold: u64::MAX,
+            },
+            Arc::clone(&physical_file_cache),
+        );
+        tokio::pin!(collector);
+
+        let first = collector.as_mut().next().await.unwrap().unwrap();
+        assert_eq!((first.size, first.region_id), (50, 1));
+
+        drop(PhysicalFileCacheRefGuard::new(
+            Arc::clone(&physical_file_cache),
+            &first.inputs,
+        ));
+
+        let second = collector.as_mut().next().await.unwrap().unwrap();
+        assert_eq!((second.size, second.region_id), (70, 2));
+        assert_eq!(second.inputs.len(), 2);
+        assert!(collector.as_mut().next().await.is_none());
+
+        let stat = collector.as_mut().take_statistic();
+        assert_eq!(stat.files_in, 3);
+        assert_eq!(stat.bytes_in, 120);
+        assert_eq!(stat.bytes_out, 120);
+        assert_eq!(stat.compactions_out, 2);
+        assert_eq!(stat.files_filtered_out, 0);
+    }
+
+    #[tokio::test]
+    async fn test_collect_cached_subcompaction_does_not_merge_over_threshold_pending() {
+        let r = SubcompactionCollectKey::of_region;
+        let items = vec![
+            PhysicalLogFile {
+                name: Chars::from("001"),
+                size: 40,
+                files: vec![log_file("001", 60, r(1))],
+            },
+            PhysicalLogFile {
+                name: Chars::from("002"),
+                size: 40,
+                files: vec![log_file("002", 40, r(2))],
+            },
+            PhysicalLogFile {
+                name: Chars::from("003"),
+                size: 40,
+                files: vec![log_file("003", 70, r(2))],
+            },
+        ];
+        let physical_file_cache = Arc::new(PhysicalFileCache::new(100));
+        let collector = CollectCachedSubcompaction::new(
+            stream::iter(items).map(Result::Ok),
+            CollectSubcompactionConfig {
+                compact_shift_from_ts: 0,
+                compact_from_ts: 0,
+                compact_to_ts: u64::MAX,
+                subcompaction_size_threshold: 100,
+            },
+            Arc::clone(&physical_file_cache),
+        );
+        tokio::pin!(collector);
+
+        let first = collector.as_mut().next().await.unwrap().unwrap();
+        assert_eq!((first.size, first.region_id), (60, 1));
+
+        drop(PhysicalFileCacheRefGuard::new(
+            Arc::clone(&physical_file_cache),
+            &first.inputs,
+        ));
+
+        let second = collector.as_mut().next().await.unwrap().unwrap();
+        assert_eq!((second.size, second.region_id), (40, 2));
+        assert_eq!(second.inputs.len(), 1);
+
+        let third = collector.as_mut().next().await.unwrap().unwrap();
+        assert_eq!((third.size, third.region_id), (70, 2));
+        assert_eq!(third.inputs.len(), 1);
+        assert!(collector.as_mut().next().await.is_none());
+
+        let stat = collector.as_mut().take_statistic();
+        assert_eq!(stat.files_in, 3);
+        assert_eq!(stat.bytes_in, 170);
+        assert_eq!(stat.bytes_out, 170);
+        assert_eq!(stat.compactions_out, 3);
+        assert_eq!(stat.files_filtered_out, 0);
     }
 
     #[tokio::test]

--- a/components/compact-log-backup/src/compaction/collector.rs
+++ b/components/compact-log-backup/src/compaction/collector.rs
@@ -1,15 +1,22 @@
 // Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
-use std::{collections::HashMap, task::ready};
+use std::{
+    collections::{HashMap, VecDeque},
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Poll, ready},
+};
 
 use engine_traits::{CF_DEFAULT, CfName};
 use tokio_stream::Stream;
 
 use super::{SubcompactionCollectKey, UnformedSubcompaction};
 use crate::{
+    cache::{PhysicalFileCache, RegisterPhysicalFileResult},
     compaction::Subcompaction,
     errors::{Result, TraceResultExt},
     statistic::CollectSubcompactionStatistic,
-    storage::LogFile,
+    storage::{LogFile, PhysicalLogFile},
 };
 
 /// A collecting subcompaction.
@@ -33,6 +40,45 @@ impl<S: Stream<Item = Result<LogFile>>> CollectSubcompaction<S> {
     /// Get the mutable internal stream.
     pub fn get_mut(&mut self) -> &mut S {
         &mut self.inner
+    }
+}
+
+/// Collects subcompactions in physical-file cache windows.
+///
+/// Unlike [`CollectSubcompaction`], this stream emits all pending
+/// subcompactions in a window when adding the next physical file would exceed
+/// the cache capacity. This lets the cache mode compact whatever is already
+/// cacheable, even when some groups are smaller than the normal size threshold.
+#[pin_project::pin_project]
+pub struct CollectCachedSubcompaction<S: Stream<Item = Result<PhysicalLogFile>>> {
+    #[pin]
+    inner: S,
+    #[pin]
+    cache_wait: Option<tokio::sync::futures::OwnedNotified>,
+    deferred_file: Option<PhysicalLogFile>,
+    collector: SubcompactionCollector,
+    ready_compactions: VecDeque<ReadySubcompaction>,
+    physical_file_cache: Arc<PhysicalFileCache>,
+}
+
+struct ReadySubcompaction {
+    compaction: Subcompaction,
+    update_stat_on_yield: bool,
+}
+
+impl<S: Stream<Item = Result<PhysicalLogFile>>> CollectCachedSubcompaction<S> {
+    /// Get delta of statistic between last call to this.
+    pub fn take_statistic(self: Pin<&mut Self>) -> CollectSubcompactionStatistic {
+        let this = self.project();
+        std::mem::take(&mut this.collector.stat)
+    }
+
+    /// Get the mutable internal stream.
+    pub fn get_inner_mut(self: Pin<&mut Self>) -> &mut S
+    where
+        S: Unpin,
+    {
+        self.project().inner.get_mut()
     }
 }
 
@@ -65,6 +111,27 @@ impl<S: Stream<Item = Result<LogFile>>> CollectSubcompaction<S> {
     }
 }
 
+impl<S: Stream<Item = Result<PhysicalLogFile>>> CollectCachedSubcompaction<S> {
+    pub fn new(
+        s: S,
+        cfg: CollectSubcompactionConfig,
+        physical_file_cache: Arc<PhysicalFileCache>,
+    ) -> Self {
+        CollectCachedSubcompaction {
+            inner: s,
+            cache_wait: None,
+            deferred_file: None,
+            collector: SubcompactionCollector {
+                cfg,
+                items: HashMap::new(),
+                stat: CollectSubcompactionStatistic::default(),
+            },
+            ready_compactions: VecDeque::new(),
+            physical_file_cache,
+        }
+    }
+}
+
 /// Collects subcompactions by upstream log files.
 /// For now, we collect subcompactions by grouping the input files with
 /// [`SubcompactionCollectKey`]. When each group grows to the specified size, a
@@ -84,20 +151,38 @@ impl SubcompactionCollector {
         }
     }
 
+    fn should_filter_out(&self, file: &LogFile) -> bool {
+        let compact_from_ts = self.lower_bound_of(file.cf);
+        file.is_meta || file.max_ts < compact_from_ts || file.min_ts > self.cfg.compact_to_ts
+    }
+
+    fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+
+    fn try_filter_out(&mut self, file: &LogFile) -> bool {
+        if self.should_filter_out(file) {
+            self.stat.files_filtered_out += 1;
+            return true;
+        }
+        false
+    }
+
     /// Adding a new log file input to the collector.
     fn add_new_file(&mut self, file: LogFile) -> Option<Subcompaction> {
-        use std::collections::hash_map::Entry;
-        let key = SubcompactionCollectKey::by_file(&file);
-        let compact_from_ts = self.lower_bound_of(file.cf);
-
         // Skip out-of-range files and schema meta files.
         // Meta files need to have a simpler format so other BR client can easily open
         // and rewrite it. (Perhaps we can also compact them.)
-        if file.is_meta || file.max_ts < compact_from_ts || file.min_ts > self.cfg.compact_to_ts {
+        if self.should_filter_out(&file) {
             self.stat.files_filtered_out += 1;
             return None;
         }
+        self.add_filtered_in_file(file)
+    }
 
+    fn add_filtered_in_file(&mut self, file: LogFile) -> Option<Subcompaction> {
+        use std::collections::hash_map::Entry;
+        let key = SubcompactionCollectKey::by_file(&file);
         self.stat.bytes_in += file.file_real_size;
         self.stat.files_in += 1;
 
@@ -170,21 +255,128 @@ impl<S: Stream<Item = Result<LogFile>>> Stream for CollectSubcompaction<S> {
     }
 }
 
+impl<S: Stream<Item = Result<PhysicalLogFile>>> Stream for CollectCachedSubcompaction<S> {
+    type Item = Result<Subcompaction>;
+
+    fn poll_next(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        let mut this = self.project();
+        loop {
+            if let Some(wait) = this.cache_wait.as_mut().as_pin_mut() {
+                ready!(wait.poll(cx));
+                this.cache_wait.set(None);
+            }
+            if let Some(ready) = this.ready_compactions.pop_front() {
+                if ready.update_stat_on_yield {
+                    this.collector.stat.bytes_out += ready.compaction.size;
+                    this.collector.stat.compactions_out += 1;
+                }
+                return Poll::Ready(Some(Ok(ready.compaction)));
+            }
+
+            let (item, already_filtered) = match this.deferred_file.take() {
+                Some(file) => (Some(Ok(file)), true),
+                None => (ready!(this.inner.as_mut().poll_next(cx)), false),
+            };
+            match item {
+                None => {
+                    let pending: Vec<_> = this.collector.take_pending_subcompactions().collect();
+                    for compaction in pending {
+                        this.ready_compactions.push_back(ReadySubcompaction {
+                            compaction,
+                            update_stat_on_yield: true,
+                        });
+                    }
+                    if this.ready_compactions.is_empty() {
+                        return Poll::Ready(None);
+                    }
+                }
+                Some(Err(err)) => return Some(Err(err).trace_err()).into(),
+                Some(Ok(mut physical_file)) => {
+                    let physical_file_name = physical_file.name.clone();
+                    let physical_file_size = physical_file.size;
+                    if !already_filtered {
+                        physical_file
+                            .files
+                            .retain(|file| !this.collector.try_filter_out(file));
+                    }
+                    let ref_count = physical_file.files.len();
+                    if ref_count == 0 {
+                        continue;
+                    }
+
+                    match this.physical_file_cache.register_physical_file(
+                        &physical_file_name,
+                        physical_file_size,
+                        ref_count,
+                    ) {
+                        RegisterPhysicalFileResult::Registered => {}
+                        RegisterPhysicalFileResult::Bypass => {}
+                        RegisterPhysicalFileResult::Full(wait) => {
+                            *this.deferred_file = Some(physical_file);
+                            if this.collector.is_empty()
+                                || !this.physical_file_cache.can_force_compaction()
+                            {
+                                this.cache_wait.set(Some(wait));
+                                continue;
+                            }
+                            let pending: Vec<_> =
+                                this.collector.take_pending_subcompactions().collect();
+                            if !pending.is_empty() {
+                                this.physical_file_cache
+                                    .advance_round_after_force_compaction();
+                            }
+                            for compaction in pending {
+                                this.ready_compactions.push_back(ReadySubcompaction {
+                                    compaction,
+                                    update_stat_on_yield: true,
+                                });
+                            }
+                            if this.ready_compactions.is_empty() {
+                                this.cache_wait.set(Some(wait));
+                            }
+                            continue;
+                        }
+                    }
+
+                    for file in physical_file.files {
+                        if let Some(compaction) = this.collector.add_filtered_in_file(file) {
+                            this.ready_compactions.push_back(ReadySubcompaction {
+                                compaction,
+                                update_stat_on_yield: false,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use std::sync::Arc;
 
     use bytes::Bytes;
     use engine_traits::{CF_DEFAULT, CF_WRITE};
-    use futures::stream::{self, StreamExt, TryStreamExt};
+    use futures::{
+        FutureExt,
+        stream::{self, StreamExt, TryStreamExt},
+    };
     use kvproto::brpb;
     use protobuf::Chars;
 
-    use super::{CollectSubcompaction, CollectSubcompactionConfig, SubcompactionCollectKey};
+    use super::{
+        CollectCachedSubcompaction, CollectSubcompaction, CollectSubcompactionConfig,
+        SubcompactionCollectKey,
+    };
     use crate::{
+        cache::PhysicalFileCache,
         compaction::EpochHint,
         errors::{Error, ErrorKind, Result},
-        storage::{Epoch, LogFile, LogFileId},
+        storage::{Epoch, LogFile, LogFileId, PhysicalLogFile},
     };
 
     fn log_file(name: &str, len: u64, key: SubcompactionCollectKey) -> LogFile {
@@ -271,6 +463,157 @@ mod test {
         assert_eq!(stat.bytes_out, 342);
         assert_eq!(stat.compactions_out, 4);
         assert_eq!(stat.files_filtered_out, 0);
+    }
+
+    #[tokio::test]
+    async fn test_collect_cached_subcompaction_flushes_pending_when_cache_is_full() {
+        let r = SubcompactionCollectKey::of_region;
+        let items = vec![
+            PhysicalLogFile {
+                name: Chars::from("001"),
+                size: 60,
+                files: vec![log_file("001", 20, r(1))],
+            },
+            PhysicalLogFile {
+                name: Chars::from("002"),
+                size: 60,
+                files: vec![log_file("002", 30, r(2))],
+            },
+        ];
+        let physical_file_cache = Arc::new(PhysicalFileCache::new(100));
+        let collector = CollectCachedSubcompaction::new(
+            stream::iter(items).map(Result::Ok),
+            CollectSubcompactionConfig {
+                compact_shift_from_ts: 0,
+                compact_from_ts: 0,
+                compact_to_ts: u64::MAX,
+                subcompaction_size_threshold: u64::MAX,
+            },
+            Arc::clone(&physical_file_cache),
+        );
+        tokio::pin!(collector);
+
+        let first = collector.as_mut().next().await.unwrap().unwrap();
+        assert_eq!((first.size, first.region_id), (20, 1));
+        for input in &first.inputs {
+            physical_file_cache.drop_input_ref(input);
+        }
+        let second = collector.as_mut().next().await.unwrap().unwrap();
+        assert_eq!((second.size, second.region_id), (30, 2));
+        assert!(collector.as_mut().next().await.is_none());
+        let stat = collector.as_mut().take_statistic();
+        assert_eq!(stat.files_in, 2);
+        assert_eq!(stat.bytes_in, 50);
+        assert_eq!(stat.bytes_out, 50);
+        assert_eq!(stat.compactions_out, 2);
+        assert_eq!(stat.files_filtered_out, 0);
+    }
+
+    #[tokio::test]
+    async fn test_collect_cached_subcompaction_waits_for_cache_capacity() {
+        let r = SubcompactionCollectKey::of_region;
+        let items = vec![
+            PhysicalLogFile {
+                name: Chars::from("001"),
+                size: 60,
+                files: vec![log_file("001", 20, r(1))],
+            },
+            PhysicalLogFile {
+                name: Chars::from("002"),
+                size: 60,
+                files: vec![log_file("002", 30, r(2))],
+            },
+        ];
+        let physical_file_cache = Arc::new(PhysicalFileCache::new(100));
+        let collector = CollectCachedSubcompaction::new(
+            stream::iter(items).map(Result::Ok),
+            CollectSubcompactionConfig {
+                compact_shift_from_ts: 0,
+                compact_from_ts: 0,
+                compact_to_ts: u64::MAX,
+                subcompaction_size_threshold: 0,
+            },
+            Arc::clone(&physical_file_cache),
+        );
+        tokio::pin!(collector);
+
+        let first = collector.as_mut().next().await.unwrap().unwrap();
+        assert_eq!((first.size, first.region_id), (20, 1));
+        assert!(collector.as_mut().next().now_or_never().is_none());
+
+        for input in &first.inputs {
+            physical_file_cache.drop_input_ref(input);
+        }
+
+        let second = collector.as_mut().next().await.unwrap().unwrap();
+        assert_eq!((second.size, second.region_id), (30, 2));
+    }
+
+    #[tokio::test]
+    async fn test_collect_cached_subcompaction_waits_before_second_forced_round() {
+        let r = SubcompactionCollectKey::of_region;
+        let items = vec![
+            PhysicalLogFile {
+                name: Chars::from("000"),
+                size: 40,
+                files: vec![log_file("000", 40, r(1))],
+            },
+            PhysicalLogFile {
+                name: Chars::from("001"),
+                size: 40,
+                files: vec![log_file("001", 40, r(2))],
+            },
+            PhysicalLogFile {
+                name: Chars::from("002"),
+                size: 40,
+                files: vec![log_file("002", 40, r(3))],
+            },
+            PhysicalLogFile {
+                name: Chars::from("003"),
+                size: 40,
+                files: vec![log_file("003", 40, r(4))],
+            },
+            PhysicalLogFile {
+                name: Chars::from("004"),
+                size: 40,
+                files: vec![log_file("004", 40, r(5))],
+            },
+        ];
+        let physical_file_cache = Arc::new(PhysicalFileCache::new(100));
+        let collector = CollectCachedSubcompaction::new(
+            stream::iter(items).map(Result::Ok),
+            CollectSubcompactionConfig {
+                compact_shift_from_ts: 0,
+                compact_from_ts: 0,
+                compact_to_ts: u64::MAX,
+                subcompaction_size_threshold: u64::MAX,
+            },
+            Arc::clone(&physical_file_cache),
+        );
+        tokio::pin!(collector);
+
+        let first = collector.as_mut().next().await.unwrap().unwrap();
+        let second = collector.as_mut().next().await.unwrap().unwrap();
+        let mut first_round_ids = vec![first.region_id, second.region_id];
+        first_round_ids.sort();
+        assert_eq!(first_round_ids, vec![1, 2]);
+        assert_eq!((first.size, second.size), (40, 40));
+
+        for input in &first.inputs {
+            physical_file_cache.drop_input_ref(input);
+        }
+        assert!(collector.as_mut().next().now_or_never().is_none());
+
+        for input in &second.inputs {
+            physical_file_cache.drop_input_ref(input);
+        }
+
+        let third = collector.as_mut().next().await.unwrap().unwrap();
+        let fourth = collector.as_mut().next().await.unwrap().unwrap();
+        let mut second_round_ids = vec![third.region_id, fourth.region_id];
+        second_round_ids.sort();
+        assert_eq!(second_round_ids, vec![3, 4]);
+        assert_eq!((third.size, fourth.size), (40, 40));
     }
 
     #[tokio::test]

--- a/components/compact-log-backup/src/compaction/exec.rs
+++ b/components/compact-log-backup/src/compaction/exec.rs
@@ -21,6 +21,7 @@ use txn_types::{WriteRef, WriteType};
 
 use super::{EpochHint, Subcompaction, SubcompactionResult};
 use crate::{
+    cache::PhysicalFileCache,
     compaction::SST_OUT_REL,
     errors::{OtherErrExt, Result, TraceResultExt},
     source::{Record, Source},
@@ -73,12 +74,14 @@ pub struct SubcompactionExecArg<DB> {
     pub db: Option<DB>,
     /// The output storage.
     pub storage: Arc<dyn ExternalStorage>,
+    /// Optional cache for raw physical input files.
+    pub physical_file_cache: Option<Arc<PhysicalFileCache>>,
 }
 
 impl<DB> From<SubcompactionExecArg<DB>> for SubcompactionExec<DB> {
     fn from(value: SubcompactionExecArg<DB>) -> Self {
         Self {
-            source: Source::new(Arc::clone(&value.storage)),
+            source: Source::new(Arc::clone(&value.storage), value.physical_file_cache),
             output: value.storage,
             out_prefix: value
                 .out_prefix
@@ -99,6 +102,7 @@ impl SubcompactionExec<RocksEngine> {
             storage,
             out_prefix: None,
             db: None,
+            physical_file_cache: None,
         })
     }
 }

--- a/components/compact-log-backup/src/compaction/exec.rs
+++ b/components/compact-log-backup/src/compaction/exec.rs
@@ -259,6 +259,7 @@ where
     ) -> Result<impl Iterator<Item = Vec<Record>>> {
         let mut eext = ExecuteAllExt::default();
         eext.max_concurrency = ext.max_load_concurrency;
+        let _cache_refs = self.source.cache_input_refs(&c.inputs);
 
         let items = super::util::execute_all_ext(
             c.inputs

--- a/components/compact-log-backup/src/compaction/meta.rs
+++ b/components/compact-log-backup/src/compaction/meta.rs
@@ -1,9 +1,7 @@
 // Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
-use std::{
-    collections::{BTreeSet, HashMap},
-    sync::Arc,
-};
+use std::{collections::HashMap, sync::Arc};
 
+use bytes::Bytes;
 use external_storage::ExternalStorage;
 use futures::stream::TryStreamExt;
 use kvproto::brpb::{self, DeleteSpansOfFile};
@@ -148,18 +146,33 @@ impl LogFileId {
     }
 }
 
-#[derive(Eq, PartialEq, Debug)]
-struct SortByOffset(LogFileId);
-
-impl PartialOrd for SortByOffset {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.0.offset.partial_cmp(&other.0.offset)
-    }
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct SortByOffset {
+    offset: u64,
+    length: u64,
 }
 
-impl Ord for SortByOffset {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.0.offset.cmp(&other.0.offset)
+impl SortByOffset {
+    fn new(id: &LogFileId) -> Self {
+        Self {
+            offset: id.offset,
+            length: id.length,
+        }
+    }
+
+    fn offset(&self) -> u64 {
+        self.offset
+    }
+
+    fn length(&self) -> u64 {
+        self.length
+    }
+
+    fn span(&self) -> brpb::Span {
+        let mut span = brpb::Span::default();
+        span.set_offset(self.offset);
+        span.set_length(self.length);
+        span
     }
 }
 
@@ -168,7 +181,7 @@ impl Ord for SortByOffset {
 /// Finally, it calculates which files can be deleted.
 #[derive(Debug)]
 pub struct CompactionRunInfoBuilder {
-    files: HashMap<Chars, BTreeSet<SortByOffset>>,
+    files: HashMap<Bytes, Vec<SortByOffset>>,
     compaction: brpb::LogFileCompaction,
 }
 
@@ -243,13 +256,14 @@ impl CompactionRunInfoBuilder {
 
     pub fn add_origin_subcompaction(&mut self, c: &Subcompaction) {
         for file in &c.inputs {
-            if !self.files.contains_key(&file.id.name) {
-                self.files.insert(file.id.name.clone(), Default::default());
+            if let Some(spans) = self.files.get_mut(file.id.name.as_bytes()) {
+                spans.push(SortByOffset::new(&file.id));
+            } else {
+                let mut spans = Vec::with_capacity(16);
+                spans.push(SortByOffset::new(&file.id));
+                self.files
+                    .insert(Bytes::copy_from_slice(file.id.name.as_bytes()), spans);
             }
-            self.files
-                .get_mut(&file.id.name)
-                .unwrap()
-                .insert(SortByOffset(file.id.clone()));
         }
         self.compaction.artifacts_hash ^= c.crc64();
         self.compaction.input_min_ts = self.compaction.input_min_ts.min(c.input_min_ts);
@@ -265,10 +279,11 @@ impl CompactionRunInfoBuilder {
     }
 
     pub async fn write_migration(
-        &self,
+        &mut self,
         s: Arc<dyn ExternalStorage>,
         shard: Option<ShardConfig>,
     ) -> Result<()> {
+        self.normalize_spans();
         let migration = self.migration_of(self.find_expiring_files(s.clone(), shard).await?);
         let wrapped_storage = MigrationStorageWrapper::new(s.as_ref());
         wrapped_storage.write(migration.into()).await?;
@@ -314,15 +329,15 @@ impl CompactionRunInfoBuilder {
     }
 
     fn full_covers(&self, file: &PhysicalLogFile) -> bool {
-        match self.files.get(&file.name) {
+        match self.files.get(file.name.as_bytes()) {
             None => false,
             Some(spans) => {
                 let mut cur_offset = 0;
                 for span in spans {
-                    if span.0.offset != cur_offset {
+                    if span.offset() != cur_offset {
                         return false;
                     }
-                    cur_offset += span.0.length
+                    cur_offset += span.length()
                 }
                 assert!(
                     cur_offset <= file.size,
@@ -336,6 +351,13 @@ impl CompactionRunInfoBuilder {
         }
     }
 
+    fn normalize_spans(&mut self) {
+        for spans in self.files.values_mut() {
+            spans.sort_unstable();
+            spans.dedup();
+        }
+    }
+
     fn expiring(&self, file: &MetaFile) -> ExpiringFilesOfMeta {
         let mut result = ExpiringFilesOfMeta::of(&file.name);
         let mut all_full_covers = true;
@@ -345,13 +367,13 @@ impl CompactionRunInfoBuilder {
             if full_covers {
                 result.logs.push(p.name.clone());
             } else {
-                if let Some(vs) = self.files.get(&p.name) {
+                if let Some(vs) = self.files.get(p.name.as_bytes()) {
                     let segs = result
                         .spans_of_file
                         .entry(p.name.clone())
                         .or_insert_with(|| (vec![], p.size));
                     for f in vs {
-                        segs.0.push(f.0.span());
+                        segs.0.push(f.span());
                     }
                 }
                 all_full_covers = false;
@@ -395,7 +417,8 @@ mod test {
     };
 
     impl CompactionRunInfoBuilder {
-        async fn mig(&self, s: Arc<dyn ExternalStorage>) -> crate::Result<brpb::Migration> {
+        async fn mig(&mut self, s: Arc<dyn ExternalStorage>) -> crate::Result<brpb::Migration> {
+            self.normalize_spans();
             Ok(self.migration_of(self.find_expiring_files(s, None).await?))
         }
     }

--- a/components/compact-log-backup/src/compaction/mod.rs
+++ b/components/compact-log-backup/src/compaction/mod.rs
@@ -18,6 +18,7 @@ pub const META_OUT_REL: &str = "metas";
 #[derive(Debug, Clone)]
 pub struct Input {
     pub id: LogFileId,
+    pub file_real_size: u64,
     pub compression: brpb::CompressionType,
     pub crc64xor: u64,
     pub key_value_size: u64,
@@ -187,6 +188,7 @@ impl SubcompactionCollectKey {
 fn to_input(file: &LogFile) -> Input {
     Input {
         id: file.id.clone(),
+        file_real_size: file.file_real_size,
         compression: file.compression,
         crc64xor: file.crc64xor,
         key_value_size: file.hacky_key_value_size(),

--- a/components/compact-log-backup/src/compaction/mod.rs
+++ b/components/compact-log-backup/src/compaction/mod.rs
@@ -76,6 +76,42 @@ impl Deref for Subcompaction {
     }
 }
 
+impl Subcompaction {
+    fn merge(&mut self, other: Subcompaction) {
+        let Subcompaction {
+            inputs,
+            size,
+            subc_key,
+            input_max_ts,
+            input_min_ts,
+            compact_from_ts,
+            compact_to_ts,
+            min_key,
+            max_key,
+            epoch_hints,
+        } = other;
+
+        debug_assert_eq!(self.subc_key, subc_key);
+        debug_assert_eq!(self.compact_from_ts, compact_from_ts);
+        debug_assert_eq!(self.compact_to_ts, compact_to_ts);
+
+        self.inputs.extend(inputs);
+        self.size += size;
+        self.input_min_ts = self.input_min_ts.min(input_min_ts);
+        self.input_max_ts = self.input_max_ts.max(input_max_ts);
+        if self.min_key > min_key {
+            self.min_key = min_key;
+        }
+        if self.max_key < max_key {
+            self.max_key = max_key;
+        }
+
+        let mut merged_hints: HashSet<_> = self.epoch_hints.drain(..).collect();
+        merged_hints.extend(epoch_hints);
+        self.epoch_hints = merged_hints.into_iter().collect();
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct SubcompactionResult {
     /// The origin subcompaction.

--- a/components/compact-log-backup/src/exec_hooks/consistency.rs
+++ b/components/compact-log-backup/src/exec_hooks/consistency.rs
@@ -17,7 +17,9 @@ use crate::{
 enum CheckpointSource {
     #[default]
     Storage,
-    ReplicationStatus { sub_prefix: String },
+    ReplicationStatus {
+        sub_prefix: String,
+    },
 }
 
 #[derive(Default)]

--- a/components/compact-log-backup/src/exec_hooks/consistency.rs
+++ b/components/compact-log-backup/src/exec_hooks/consistency.rs
@@ -6,7 +6,7 @@ use futures::{io::AsyncReadExt, stream::TryStreamExt};
 use tikv_util::warn;
 
 use crate::{
-    ErrorKind, TraceResultExt,
+    ErrorKind, OtherErrExt, TraceResultExt,
     errors::Result,
     execute::hooking::{AbortedCtx, AfterFinishCtx, BeforeStartCtx, ExecHooks},
     storage::LOCK_PREFIX,
@@ -14,11 +14,49 @@ use crate::{
 };
 
 #[derive(Default)]
-pub struct StorageConsistencyGuard {
-    lock: Option<RemoteLock>,
+enum CheckpointSource {
+    #[default]
+    Storage,
+    ReplicationStatus { sub_prefix: String },
 }
 
-async fn load_storage_checkpoint(storage: &dyn ExternalStorage) -> Result<Option<u64>> {
+#[derive(Default)]
+pub struct StorageConsistencyGuard {
+    lock: Option<RemoteLock>,
+    checkpoint_source: CheckpointSource,
+    skip_checkpoint_check: bool,
+}
+
+impl StorageConsistencyGuard {
+    pub fn with_replication_status_sub_prefix(sub_prefix: String) -> Self {
+        Self {
+            lock: None,
+            checkpoint_source: CheckpointSource::ReplicationStatus { sub_prefix },
+            skip_checkpoint_check: false,
+        }
+    }
+
+    pub fn without_checkpoint_check() -> Self {
+        Self {
+            lock: None,
+            checkpoint_source: CheckpointSource::Storage,
+            skip_checkpoint_check: true,
+        }
+    }
+
+    async fn load_checkpoint(&self, storage: &dyn ExternalStorage) -> Result<Option<u64>> {
+        match &self.checkpoint_source {
+            CheckpointSource::Storage => load_storage_checkpoint(storage).await,
+            CheckpointSource::ReplicationStatus { sub_prefix } => {
+                load_replication_status_checkpoint(storage, sub_prefix)
+                    .await
+                    .map(Some)
+            }
+        }
+    }
+}
+
+pub async fn load_storage_checkpoint(storage: &dyn ExternalStorage) -> Result<Option<u64>> {
     let path = "v1/global_checkpoint/";
     storage
         .iter_prefix(path)
@@ -48,34 +86,73 @@ async fn load_storage_checkpoint(storage: &dyn ExternalStorage) -> Result<Option
         .await
 }
 
+pub async fn load_replication_status_checkpoint(
+    storage: &dyn ExternalStorage,
+    sub_prefix: &str,
+) -> Result<u64> {
+    let sub_prefix_trimmed = sub_prefix.trim_matches('/');
+    let path = if sub_prefix_trimmed.is_empty() {
+        "resume-state.json".to_owned()
+    } else {
+        format!("{}/resume-state.json", sub_prefix_trimmed)
+    };
+    let mut content = Vec::new();
+    storage
+        .read(&path)
+        .read_to_end(&mut content)
+        .await
+        .adapt_err()
+        .annotate(format!(
+            "failed to read replication status checkpoint {path}"
+        ))?;
+    let value: serde_json::Value = serde_json::from_slice(&content)
+        .map_err(|err| ErrorKind::Other(format!("failed to parse {path}: {err}")))?;
+    match value.get("last_checkpoint") {
+        Some(value) => {
+            if let Some(ts) = value.as_u64() {
+                return Ok(ts);
+            }
+            Err(ErrorKind::Other(format!(
+                "`last_checkpoint` in {path} must be a u64"
+            )))?
+        }
+        None => Err(ErrorKind::Other(format!(
+            "`last_checkpoint` is missing in {path}"
+        )))?,
+    }
+}
+
 impl ExecHooks for StorageConsistencyGuard {
     async fn before_execution_started(&mut self, cx: BeforeStartCtx<'_>) -> Result<()> {
         use external_storage::locking::LockExt;
 
-        let cp = load_storage_checkpoint(cx.storage)
-            .await
-            .annotate("failed to load storage checkpoint")?;
-        match cp {
-            Some(cp) => {
-                if cx.this.cfg.until_ts > cp {
-                    let err_msg = format!(
-                        "The `--until`({}) is greater than the checkpoint({}). We cannot compact unstable content for now.",
-                        cx.this.cfg.until_ts, cp
-                    );
+        if !self.skip_checkpoint_check {
+            let cp = self
+                .load_checkpoint(cx.storage)
+                .await
+                .annotate("failed to load checkpoint")?;
+            match cp {
+                Some(cp) => {
+                    if cx.this.cfg.until_ts > cp {
+                        let err_msg = format!(
+                            "The `--until`({}) is greater than the checkpoint({}). We cannot compact unstable content for now.",
+                            cx.this.cfg.until_ts, cp
+                        );
 
-                    // We use `?` instead of return here to keep the stack frame in the error.
-                    // Or if we use `.into()` the frame attached will be the default implementation
-                    // of `Into`...
-                    Err(ErrorKind::Other(err_msg))?;
+                        // We use `?` instead of return here to keep the stack frame in the error.
+                        // Or if we use `.into()` the frame attached will be the default
+                        // implementation of `Into`...
+                        Err(ErrorKind::Other(err_msg))?;
+                    }
                 }
-            }
-            None => {
-                let url = storage_url(cx.storage);
-                warn!("No checkpoint loaded, maybe wrong storage used?"; "url" => %url);
-                Err(ErrorKind::Other(format!(
-                    "Cannot load checkpoint from {}",
-                    url
-                )))?;
+                None => {
+                    let url = storage_url(cx.storage);
+                    warn!("No checkpoint loaded, maybe wrong storage used?"; "url" => %url);
+                    Err(ErrorKind::Other(format!(
+                        "Cannot load checkpoint from {}",
+                        url
+                    )))?;
+                }
             }
         }
 

--- a/components/compact-log-backup/src/execute/mod.rs
+++ b/components/compact-log-backup/src/execute/mod.rs
@@ -4,7 +4,7 @@ pub mod hooking;
 #[cfg(test)]
 mod test;
 
-use std::{borrow::Cow, cell::Cell, path::Path, str::FromStr, sync::Arc};
+use std::{borrow::Cow, cell::Cell, path::Path, pin::Pin, str::FromStr, sync::Arc};
 
 use chrono::Utc;
 use engine_rocks::RocksEngine;
@@ -21,19 +21,23 @@ use tokio::{
     runtime::Handle,
     task::{JoinError, JoinHandle},
 };
+use tokio_stream::Stream;
 use tracing::trace_span;
 use tracing_active_tree::{frame, root};
 
 use self::hooking::AbortedCtx;
 use super::{
     compaction::{
-        collector::{CollectSubcompaction, CollectSubcompactionConfig},
+        Subcompaction,
+        collector::{CollectCachedSubcompaction, CollectSubcompaction, CollectSubcompactionConfig},
         exec::{SubcompactExt, SubcompactionExec},
     },
-    storage::{CountObjectsExt, LoadFromExt, StreamMetaStorage},
+    statistic::{CollectSubcompactionStatistic, LoadMetaStatistic},
+    storage::{CountObjectsExt, LoadFromExt, LogFile, PhysicalLogFile, StreamMetaStorage},
 };
 use crate::{
     ErrorKind,
+    cache::PhysicalFileCache,
     compaction::{SubcompactionResult, exec::SubcompactionExecArg},
     errors::{Result, TraceResultExt},
     execute::hooking::SubcompactionSkippedCtx,
@@ -149,6 +153,9 @@ pub struct ExecutionConfig {
     pub prefetch_running_count: u64,
     /// The max count of saved prefetch tasks in the queue.
     pub prefetch_buffer_count: u64,
+    /// Bytes reserved for caching raw physical log files. Zero disables the
+    /// cache and keeps the historical per-logical-file range downloads.
+    pub physical_file_cache_capacity: u64,
     /// The compress algorithm we are going to use for output.
     pub compression: SstCompressionType,
     /// The compress level we are going to use.
@@ -183,8 +190,34 @@ impl slog::KV for ExecutionConfig {
         if let Some(level) = self.compression_level {
             serializer.emit_i32("compression.level", level)?;
         }
+        serializer.emit_u64(
+            "physical_file_cache_capacity",
+            self.physical_file_cache_capacity,
+        )?;
 
         Ok(())
+    }
+}
+
+type FinishedCompaction = Result<(SubcompactionResult, CId)>;
+type CompactJoin = tokio::task::JoinHandle<FinishedCompaction>;
+
+trait TakeLoadMetaStatistic {
+    fn take_load_meta_statistic(&mut self) -> LoadMetaStatistic;
+}
+
+impl TakeLoadMetaStatistic for StreamMetaStorage<'_> {
+    fn take_load_meta_statistic(&mut self) -> LoadMetaStatistic {
+        self.take_statistic()
+    }
+}
+
+impl<St, U, F> TakeLoadMetaStatistic for futures::stream::FlatMap<St, U, F>
+where
+    St: TakeLoadMetaStatistic,
+{
+    fn take_load_meta_statistic(&mut self) -> LoadMetaStatistic {
+        self.get_mut().take_load_meta_statistic()
     }
 }
 
@@ -203,6 +236,7 @@ impl ExecutionConfig {
         }
         hasher.write(&self.from_ts.to_le_bytes());
         hasher.write(&self.until_ts.to_le_bytes());
+        hasher.write(&self.physical_file_cache_capacity.to_le_bytes());
         hasher.write(&[self.calculate_shift_ts as u8]);
         hasher.write(&util::compression_type_to_u8(self.compression).to_le_bytes());
         hasher.write(&self.compression_level.unwrap_or(0).to_le_bytes());
@@ -280,6 +314,205 @@ impl Execution {
         )
     }
 
+    async fn drain_compactions(
+        &self,
+        pending: &mut Vec<CompactJoin>,
+        storage: &dyn ExternalStorage,
+        hooks: &mut impl ExecHooks,
+    ) -> Result<()> {
+        while let Some(join) = pending.pop() {
+            let (cres, cid) = Self::unpack_compaction_join(frame!("final_wait"; join).await)?;
+            self.on_compaction_finish(cid, &cres, storage, hooks)
+                .await?;
+        }
+        Ok(())
+    }
+
+    fn subcompact_ext(&self) -> SubcompactExt {
+        let mut ext = SubcompactExt::default();
+        ext.max_load_concurrency = 32;
+        ext.compression = self.cfg.compression;
+        ext.compression_level = self.cfg.compression_level;
+        ext
+    }
+
+    fn spawn_subcompaction(
+        &self,
+        storage: &Arc<dyn ExternalStorage>,
+        c: Subcompaction,
+        cid: CId,
+        physical_file_cache: Option<Arc<PhysicalFileCache>>,
+    ) -> CompactJoin {
+        let compact_args = SubcompactionExecArg {
+            out_prefix: Some(Path::new(&self.out_prefix).to_owned()),
+            db: self.db.clone(),
+            storage: Arc::clone(storage),
+            physical_file_cache,
+        };
+        let compact_worker = SubcompactionExec::from(compact_args);
+        let ext = self.subcompact_ext();
+
+        let compact_work = async move {
+            let res = compact_worker.run(c, ext).await.trace_err()?;
+            res.verify_checksum()
+                .annotate(format_args!("the compaction is {:?}", res.origin))?;
+            Result::Ok((res, cid))
+        };
+        tokio::spawn(root!(compact_work))
+    }
+
+    async fn wait_one_compaction(
+        &self,
+        pending: &mut Vec<CompactJoin>,
+        storage: &dyn ExternalStorage,
+        hooks: &mut impl ExecHooks,
+    ) -> Result<()> {
+        let join = util::select_vec(pending);
+        let (cres, cid) = Self::unpack_compaction_join(frame!("wait_for_compaction"; join).await)?;
+        self.on_compaction_finish(cid, &cres, storage, hooks)
+            .await?;
+        Ok(())
+    }
+
+    async fn push_subcompaction(
+        &self,
+        pending: &mut Vec<CompactJoin>,
+        storage: &Arc<dyn ExternalStorage>,
+        hooks: &mut impl ExecHooks,
+        c: Subcompaction,
+        cid: CId,
+        physical_file_cache: Option<Arc<PhysicalFileCache>>,
+    ) -> Result<()> {
+        let join = self.spawn_subcompaction(storage, c, cid, physical_file_cache);
+        pending.push(join);
+        if pending.len() >= self.max_concurrent_subcompaction as _ {
+            self.wait_one_compaction(pending, storage.as_ref(), hooks)
+                .await?;
+        }
+        Ok(())
+    }
+
+    async fn prepare_subcompaction(
+        &self,
+        next_id: &mut u64,
+        hooks: &mut impl ExecHooks,
+        c: &Subcompaction,
+        cstat: CollectSubcompactionStatistic,
+        lstat: LoadMetaStatistic,
+    ) -> Option<CId> {
+        let cid = CId(*next_id);
+        let skip = Cell::new(None);
+        let cx = SubcompactionStartCtx {
+            subc: &c,
+            load_stat_diff: &lstat,
+            collect_compaction_stat_diff: &cstat,
+            skip: &skip,
+        };
+        hooks.before_a_subcompaction_start(cid, cx);
+        if let Some(reason) = skip.get() {
+            let skipped_cx = SubcompactionSkippedCtx { subc: &c, reason };
+            hooks.on_subcompaction_skipped(skipped_cx).await;
+            return None;
+        }
+        *next_id += 1;
+        Some(cid)
+    }
+
+    async fn run_streaming_subcompactions<S>(
+        &self,
+        compact_stream: &mut CollectSubcompaction<S>,
+        storage: &Arc<dyn ExternalStorage>,
+        hooks: &mut impl ExecHooks,
+        pending: &mut Vec<CompactJoin>,
+    ) -> Result<()>
+    where
+        S: Stream<Item = Result<LogFile>> + TakeLoadMetaStatistic + Unpin,
+    {
+        let mut id = 0;
+        while let Some(c) = compact_stream.next().await {
+            let cstat = compact_stream.take_statistic();
+            let lstat = compact_stream.get_mut().take_load_meta_statistic();
+            let c = c?;
+            if let Some(cid) = self
+                .prepare_subcompaction(&mut id, hooks, &c, cstat, lstat)
+                .await
+            {
+                self.push_subcompaction(pending, storage, hooks, c, cid, None)
+                    .await?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn run_streaming_cached_subcompactions<S>(
+        &self,
+        mut compact_stream: Pin<&mut CollectCachedSubcompaction<S>>,
+        physical_file_cache: Arc<PhysicalFileCache>,
+        storage: &Arc<dyn ExternalStorage>,
+        hooks: &mut impl ExecHooks,
+        pending: &mut Vec<CompactJoin>,
+    ) -> Result<()>
+    where
+        S: Stream<Item = Result<PhysicalLogFile>> + TakeLoadMetaStatistic + Unpin,
+    {
+        let mut id = 0;
+        loop {
+            let Some(c) = (if pending.is_empty() {
+                compact_stream.as_mut().next().await
+            } else {
+                let mut stream = compact_stream.as_mut();
+                let next_compaction = stream.next();
+                let finished_compaction = frame!("wait_for_compaction"; util::select_vec(pending));
+                tokio::pin!(next_compaction);
+                tokio::pin!(finished_compaction);
+                // If a pending compaction finishes first, drop `next_compaction`
+                // and then run the finish hook outside the select race.
+                // `wait_one_compaction` itself must not be selected here: after
+                // removing a completed join from `pending`, it awaits the finish
+                // hook, and cancelling it at that point would lose the result.
+                // Therefore `CollectCachedSubcompaction::poll_next` must be
+                // cancellation-safe and keep deferred files, cache waiters, and
+                // ready compactions in the stream state before returning Pending.
+                tokio::select! {
+                    c = &mut next_compaction => c,
+                    join = &mut finished_compaction => {
+                        let (cres, cid) = Self::unpack_compaction_join(join)?;
+                        self.on_compaction_finish(cid, &cres, storage.as_ref(), hooks).await?;
+                        continue;
+                    }
+                }
+            }) else {
+                break;
+            };
+
+            let cstat = compact_stream.as_mut().take_statistic();
+            let lstat = compact_stream
+                .as_mut()
+                .get_inner_mut()
+                .take_load_meta_statistic();
+            let c = c?;
+            if let Some(cid) = self
+                .prepare_subcompaction(&mut id, hooks, &c, cstat, lstat)
+                .await
+            {
+                self.push_subcompaction(
+                    pending,
+                    storage,
+                    hooks,
+                    c,
+                    cid,
+                    Some(Arc::clone(&physical_file_cache)),
+                )
+                .await?;
+            } else {
+                for input in c.inputs {
+                    physical_file_cache.drop_input_ref(&input);
+                }
+            }
+        }
+        Ok(())
+    }
+
     async fn run_prepared(&mut self, cx: &mut ExecuteCtx<'_, impl ExecHooks>) -> Result<()> {
         let mut ext = LoadFromExt::default();
         ext.prefetch_running_count = self.cfg.prefetch_running_count as usize;
@@ -317,114 +550,57 @@ impl Execution {
 
         let storage = Arc::clone(storage);
         let meta = StreamMetaStorage::load_from_ext(&storage, ext).await?;
-        let stream = meta.flat_map(move |file| match file {
-            Ok(file) => stream::iter(file.into_logs()).map(Ok).left_stream(),
-            Err(err) => stream::once(futures::future::err(err)).right_stream(),
-        });
-        let mut compact_stream = CollectSubcompaction::new(
-            stream,
-            CollectSubcompactionConfig {
-                compact_shift_from_ts: self.cfg.shift_ts,
-                compact_from_ts: self.cfg.from_ts,
-                compact_to_ts: self.cfg.until_ts,
-                subcompaction_size_threshold: ReadableSize::mb(128).0,
-            },
-        );
+        let collect_cfg = CollectSubcompactionConfig {
+            compact_shift_from_ts: self.cfg.shift_ts,
+            compact_from_ts: self.cfg.from_ts,
+            compact_to_ts: self.cfg.until_ts,
+            subcompaction_size_threshold: ReadableSize::mb(128).0,
+        };
         let mut pending = Vec::new();
-        let mut id = 0;
-        let mut first_err: Option<crate::Error> = None;
+        let schedule_res = if self.cfg.physical_file_cache_capacity > 0 {
+            let physical_file_cache = Arc::new(PhysicalFileCache::new(
+                self.cfg.physical_file_cache_capacity,
+            ));
+            let stream = meta.flat_map(move |file| match file {
+                Ok(file) => stream::iter(file.into_physical_logs())
+                    .map(Ok)
+                    .left_stream(),
+                Err(err) => stream::once(futures::future::err(err)).right_stream(),
+            });
+            let compact_stream = CollectCachedSubcompaction::new(
+                stream,
+                collect_cfg,
+                Arc::clone(&physical_file_cache),
+            );
+            tokio::pin!(compact_stream);
+            self.run_streaming_cached_subcompactions(
+                compact_stream.as_mut(),
+                physical_file_cache,
+                &storage,
+                *hooks,
+                &mut pending,
+            )
+            .await
+        } else {
+            let stream = meta.flat_map(move |file| match file {
+                Ok(file) => stream::iter(file.into_logs()).map(Ok).left_stream(),
+                Err(err) => stream::once(futures::future::err(err)).right_stream(),
+            });
+            let mut compact_stream = CollectSubcompaction::new(stream, collect_cfg);
+            self.run_streaming_subcompactions(&mut compact_stream, &storage, *hooks, &mut pending)
+                .await
+        };
 
-        while let Some(c) = compact_stream.next().await {
-            let cstat = compact_stream.take_statistic();
-            let lstat = compact_stream.get_mut().get_mut().take_statistic();
-
-            let c = match c {
-                Ok(c) => c,
-                Err(err) => {
-                    first_err = Some(err);
-                    break;
-                }
-            };
-            let cid = CId(id);
-            let skip = Cell::new(None);
-            let cx = SubcompactionStartCtx {
-                subc: &c,
-                load_stat_diff: &lstat,
-                collect_compaction_stat_diff: &cstat,
-                skip: &skip,
-            };
-            hooks.before_a_subcompaction_start(cid, cx);
-            if let Some(reason) = skip.get() {
-                let skipped_cx = SubcompactionSkippedCtx { subc: &c, reason };
-                hooks.on_subcompaction_skipped(skipped_cx).await;
-                continue;
-            }
-
-            id += 1;
-
-            let compact_args = SubcompactionExecArg {
-                out_prefix: Some(Path::new(&self.out_prefix).to_owned()),
-                db: self.db.clone(),
-                storage: Arc::clone(&storage),
-            };
-            let compact_worker = SubcompactionExec::from(compact_args);
-            let mut ext = SubcompactExt::default();
-            ext.max_load_concurrency = 32;
-            ext.compression = self.cfg.compression;
-            ext.compression_level = self.cfg.compression_level;
-
-            let compact_work = async move {
-                let res = compact_worker.run(c, ext).await.trace_err()?;
-                res.verify_checksum()
-                    .annotate(format_args!("the compaction is {:?}", res.origin))?;
-                Result::Ok((res, cid))
-            };
-            let join_handle = tokio::spawn(root!(compact_work));
-            pending.push(join_handle);
-
-            if pending.len() >= self.max_concurrent_subcompaction as _ {
-                let join = util::select_vec(&mut pending);
-                let (cres, cid) =
-                    match Self::unpack_compaction_join(frame!("wait_for_compaction"; join).await) {
-                        Ok(v) => v,
-                        Err(err) => {
-                            first_err = Some(err);
-                            break;
-                        }
-                    };
-                if let Err(err) = self
-                    .on_compaction_finish(cid, &cres, storage.as_ref(), *hooks)
-                    .await
-                {
-                    first_err = Some(err);
-                    break;
-                }
-            }
-        }
-        // Close spans created while loading metadata as early as possible.
-        drop(compact_stream);
-
-        if let Some(err) = first_err {
+        if let Err(err) = schedule_res {
             Self::abort_and_drain(&mut pending).await;
             return Err(err);
         }
 
-        while let Some(join) = pending.pop() {
-            let (cres, cid) = match Self::unpack_compaction_join(frame!("final_wait"; join).await) {
-                Ok(v) => v,
-                Err(err) => {
-                    Self::abort_and_drain(&mut pending).await;
-                    return Err(err);
-                }
-            };
-            if let Err(err) = self
-                .on_compaction_finish(cid, &cres, storage.as_ref(), *hooks)
-                .await
-            {
-                Self::abort_and_drain(&mut pending).await;
-                return Err(err);
-            }
+        if let Err(err) = self.drain_compactions(&mut pending, &storage, *hooks).await {
+            Self::abort_and_drain(&mut pending).await;
+            return Err(err);
         }
+
         let cx = AfterFinishCtx {
             async_rt: &Handle::current(),
             this: self,

--- a/components/compact-log-backup/src/execute/mod.rs
+++ b/components/compact-log-backup/src/execute/mod.rs
@@ -46,6 +46,34 @@ use crate::{
 
 const COMPACTION_V1_PREFIX: &str = "v1/compactions";
 
+pub fn create_storage_with_gcp_v2(
+    storage_backend: &StorageBackend,
+    gcp_v2_enable: bool,
+) -> Result<Arc<dyn ExternalStorage>> {
+    let backend_config = BackendConfig {
+        gcp_v2_enable,
+        ..Default::default()
+    };
+    let storage = external_storage::create_storage(storage_backend, backend_config)?;
+    Ok(Arc::from(storage))
+}
+
+pub async fn load_until_ts_from_checkpoint(
+    storage: &dyn ExternalStorage,
+    replication_status_sub_prefix: Option<&str>,
+) -> Result<u64> {
+    if let Some(sub_prefix) = replication_status_sub_prefix {
+        crate::exec_hooks::consistency::load_replication_status_checkpoint(storage, sub_prefix)
+            .await
+    } else {
+        crate::exec_hooks::consistency::load_storage_checkpoint(storage)
+            .await?
+            .ok_or_else(|| {
+                ErrorKind::Other("Cannot load checkpoint from external storage".to_owned()).into()
+            })
+    }
+}
+
 /// Sharding configuration for `compact-log-backup`.
 ///
 /// Sharding is defined as: `hash(store_id.to_le_bytes()) % total == index - 1`,
@@ -403,14 +431,14 @@ impl Execution {
         let cid = CId(*next_id);
         let skip = Cell::new(None);
         let cx = SubcompactionStartCtx {
-            subc: &c,
+            subc: c,
             load_stat_diff: &lstat,
             collect_compaction_stat_diff: &cstat,
             skip: &skip,
         };
         hooks.before_a_subcompaction_start(cid, cx);
         if let Some(reason) = skip.get() {
-            let skipped_cx = SubcompactionSkippedCtx { subc: &c, reason };
+            let skipped_cx = SubcompactionSkippedCtx { subc: c, reason };
             hooks.on_subcompaction_skipped(skipped_cx).await;
             return None;
         }
@@ -611,7 +639,8 @@ impl Execution {
         Result::Ok(())
     }
 
-    pub fn run(mut self, mut hooks: impl ExecHooks) -> Result<()> {
+    #[cfg(test)]
+    pub fn run(self, hooks: impl ExecHooks) -> Result<()> {
         let storage =
             external_storage::create_storage(&self.external_storage, self.backend_config.clone())?;
         let storage: Arc<dyn ExternalStorage> = Arc::from(storage);
@@ -619,7 +648,14 @@ impl Execution {
             .enable_all()
             .build()
             .unwrap();
+        runtime.block_on(self.run_with_storage_async(storage, hooks))
+    }
 
+    pub async fn run_with_storage_async(
+        mut self,
+        storage: Arc<dyn ExternalStorage>,
+        mut hooks: impl ExecHooks,
+    ) -> Result<()> {
         let mut cx = ExecuteCtx {
             storage: &storage,
             hooks: &mut hooks,
@@ -644,7 +680,7 @@ impl Execution {
             res
         };
 
-        runtime.block_on(root!(guarded))
+        root!(guarded).await
     }
 
     async fn on_compaction_finish(

--- a/components/compact-log-backup/src/execute/mod.rs
+++ b/components/compact-log-backup/src/execute/mod.rs
@@ -37,7 +37,7 @@ use super::{
 };
 use crate::{
     ErrorKind,
-    cache::PhysicalFileCache,
+    cache::{PhysicalFileCache, PhysicalFileCacheRefGuard},
     compaction::{SubcompactionResult, exec::SubcompactionExecArg},
     errors::{Result, TraceResultExt},
     execute::hooking::SubcompactionSkippedCtx,
@@ -249,6 +249,38 @@ where
     }
 }
 
+trait TakeStreamingSubcompactionStatistic {
+    fn take_collect_statistic(&mut self) -> CollectSubcompactionStatistic;
+
+    fn take_load_meta_statistic(&mut self) -> LoadMetaStatistic;
+}
+
+impl<S> TakeStreamingSubcompactionStatistic for CollectSubcompaction<S>
+where
+    S: Stream<Item = Result<LogFile>> + TakeLoadMetaStatistic,
+{
+    fn take_collect_statistic(&mut self) -> CollectSubcompactionStatistic {
+        self.take_statistic()
+    }
+
+    fn take_load_meta_statistic(&mut self) -> LoadMetaStatistic {
+        self.get_mut().take_load_meta_statistic()
+    }
+}
+
+impl<S> TakeStreamingSubcompactionStatistic for Pin<&mut CollectCachedSubcompaction<S>>
+where
+    S: Stream<Item = Result<PhysicalLogFile>> + TakeLoadMetaStatistic + Unpin,
+{
+    fn take_collect_statistic(&mut self) -> CollectSubcompactionStatistic {
+        self.as_mut().take_statistic()
+    }
+
+    fn take_load_meta_statistic(&mut self) -> LoadMetaStatistic {
+        self.as_mut().get_inner_mut().take_load_meta_statistic()
+    }
+}
+
 impl ExecutionConfig {
     /// Create a suitable (but not forced) prefix for the artifices of the
     /// compaction.
@@ -427,6 +459,7 @@ impl Execution {
         c: &Subcompaction,
         cstat: CollectSubcompactionStatistic,
         lstat: LoadMetaStatistic,
+        physical_file_cache: Option<&Arc<PhysicalFileCache>>,
     ) -> Option<CId> {
         let cid = CId(*next_id);
         let skip = Cell::new(None);
@@ -438,6 +471,8 @@ impl Execution {
         };
         hooks.before_a_subcompaction_start(cid, cx);
         if let Some(reason) = skip.get() {
+            let _cache_refs = physical_file_cache
+                .map(|cache| PhysicalFileCacheRefGuard::new(Arc::clone(cache), &c.inputs));
             let skipped_cx = SubcompactionSkippedCtx { subc: c, reason };
             hooks.on_subcompaction_skipped(skipped_cx).await;
             return None;
@@ -448,79 +483,29 @@ impl Execution {
 
     async fn run_streaming_subcompactions<S>(
         &self,
-        compact_stream: &mut CollectSubcompaction<S>,
+        compact_stream: &mut S,
+        physical_file_cache: Option<Arc<PhysicalFileCache>>,
         storage: &Arc<dyn ExternalStorage>,
         hooks: &mut impl ExecHooks,
         pending: &mut Vec<CompactJoin>,
     ) -> Result<()>
     where
-        S: Stream<Item = Result<LogFile>> + TakeLoadMetaStatistic + Unpin,
+        S: Stream<Item = Result<Subcompaction>> + TakeStreamingSubcompactionStatistic + Unpin,
     {
         let mut id = 0;
         while let Some(c) = compact_stream.next().await {
-            let cstat = compact_stream.take_statistic();
-            let lstat = compact_stream.get_mut().take_load_meta_statistic();
+            let cstat = compact_stream.take_collect_statistic();
+            let lstat = compact_stream.take_load_meta_statistic();
             let c = c?;
             if let Some(cid) = self
-                .prepare_subcompaction(&mut id, hooks, &c, cstat, lstat)
-                .await
-            {
-                self.push_subcompaction(pending, storage, hooks, c, cid, None)
-                    .await?;
-            }
-        }
-        Ok(())
-    }
-
-    async fn run_streaming_cached_subcompactions<S>(
-        &self,
-        mut compact_stream: Pin<&mut CollectCachedSubcompaction<S>>,
-        physical_file_cache: Arc<PhysicalFileCache>,
-        storage: &Arc<dyn ExternalStorage>,
-        hooks: &mut impl ExecHooks,
-        pending: &mut Vec<CompactJoin>,
-    ) -> Result<()>
-    where
-        S: Stream<Item = Result<PhysicalLogFile>> + TakeLoadMetaStatistic + Unpin,
-    {
-        let mut id = 0;
-        loop {
-            let Some(c) = (if pending.is_empty() {
-                compact_stream.as_mut().next().await
-            } else {
-                let mut stream = compact_stream.as_mut();
-                let next_compaction = stream.next();
-                let finished_compaction = frame!("wait_for_compaction"; util::select_vec(pending));
-                tokio::pin!(next_compaction);
-                tokio::pin!(finished_compaction);
-                // If a pending compaction finishes first, drop `next_compaction`
-                // and then run the finish hook outside the select race.
-                // `wait_one_compaction` itself must not be selected here: after
-                // removing a completed join from `pending`, it awaits the finish
-                // hook, and cancelling it at that point would lose the result.
-                // Therefore `CollectCachedSubcompaction::poll_next` must be
-                // cancellation-safe and keep deferred files, cache waiters, and
-                // ready compactions in the stream state before returning Pending.
-                tokio::select! {
-                    c = &mut next_compaction => c,
-                    join = &mut finished_compaction => {
-                        let (cres, cid) = Self::unpack_compaction_join(join)?;
-                        self.on_compaction_finish(cid, &cres, storage.as_ref(), hooks).await?;
-                        continue;
-                    }
-                }
-            }) else {
-                break;
-            };
-
-            let cstat = compact_stream.as_mut().take_statistic();
-            let lstat = compact_stream
-                .as_mut()
-                .get_inner_mut()
-                .take_load_meta_statistic();
-            let c = c?;
-            if let Some(cid) = self
-                .prepare_subcompaction(&mut id, hooks, &c, cstat, lstat)
+                .prepare_subcompaction(
+                    &mut id,
+                    hooks,
+                    &c,
+                    cstat,
+                    lstat,
+                    physical_file_cache.as_ref(),
+                )
                 .await
             {
                 self.push_subcompaction(
@@ -529,13 +514,9 @@ impl Execution {
                     hooks,
                     c,
                     cid,
-                    Some(Arc::clone(&physical_file_cache)),
+                    physical_file_cache.clone(),
                 )
                 .await?;
-            } else {
-                for input in c.inputs {
-                    physical_file_cache.drop_input_ref(&input);
-                }
             }
         }
         Ok(())
@@ -601,9 +582,10 @@ impl Execution {
                 Arc::clone(&physical_file_cache),
             );
             tokio::pin!(compact_stream);
-            self.run_streaming_cached_subcompactions(
-                compact_stream.as_mut(),
-                physical_file_cache,
+            let mut compact_stream = compact_stream.as_mut();
+            self.run_streaming_subcompactions(
+                &mut compact_stream,
+                Some(physical_file_cache),
                 &storage,
                 *hooks,
                 &mut pending,
@@ -615,8 +597,14 @@ impl Execution {
                 Err(err) => stream::once(futures::future::err(err)).right_stream(),
             });
             let mut compact_stream = CollectSubcompaction::new(stream, collect_cfg);
-            self.run_streaming_subcompactions(&mut compact_stream, &storage, *hooks, &mut pending)
-                .await
+            self.run_streaming_subcompactions(
+                &mut compact_stream,
+                None,
+                &storage,
+                *hooks,
+                &mut pending,
+            )
+            .await
         };
 
         if let Err(err) = schedule_res {

--- a/components/compact-log-backup/src/execute/test.rs
+++ b/components/compact-log-backup/src/execute/test.rs
@@ -78,6 +78,7 @@ pub fn create_compaction(st: StorageBackend) -> Execution {
             compression_level: None,
             prefetch_buffer_count: 128,
             prefetch_running_count: 128,
+            physical_file_cache_capacity: 0,
         },
         max_concurrent_subcompaction: 3,
         external_storage: st,

--- a/components/compact-log-backup/src/lib.rs
+++ b/components/compact-log-backup/src/lib.rs
@@ -3,6 +3,7 @@
 #![feature(test)]
 #![feature(custom_test_frameworks)]
 
+mod cache;
 mod compaction;
 mod errors;
 mod source;

--- a/components/compact-log-backup/src/source.rs
+++ b/components/compact-log-backup/src/source.rs
@@ -17,7 +17,11 @@ use tikv_util::{
 use txn_types::Key;
 
 use super::{statistic::LoadStatistic, util::Cooperate};
-use crate::{cache::PhysicalFileCache, compaction::Input, errors::Result};
+use crate::{
+    cache::{PhysicalFileCache, PhysicalFileCacheRefGuard},
+    compaction::Input,
+    errors::Result,
+};
 
 /// The manager of fetching log files from remote for compacting.
 #[derive(Clone)]
@@ -35,6 +39,12 @@ impl Source {
             inner,
             physical_file_cache,
         }
+    }
+
+    pub(crate) fn cache_input_refs(&self, inputs: &[Input]) -> Option<PhysicalFileCacheRefGuard> {
+        self.physical_file_cache
+            .as_ref()
+            .map(|cache| PhysicalFileCacheRefGuard::new(Arc::clone(cache), inputs))
     }
 }
 
@@ -60,7 +70,7 @@ impl Record {
 impl Source {
     /// Load the content of an input.
     #[tracing::instrument(skip_all)]
-    pub async fn load_remote(
+    pub(crate) async fn load_remote(
         &self,
         input: Input,
         stat: &mut Option<&mut LoadStatistic>,
@@ -84,7 +94,6 @@ impl Source {
                         let (content, _) =
                             load_compressed(compression, Cursor::new(content), file_real_size)
                                 .await?;
-                        cache.drop_physical_file_ref(&id.name);
                         return std::io::Result::Ok((content, physical_bytes_in));
                     }
                 }
@@ -101,9 +110,8 @@ impl Source {
         Ok(content)
     }
 
-    /// Load key value pairs from remote.
     #[tracing::instrument(skip_all, fields(id=?input.id))]
-    pub async fn load(
+    pub(crate) async fn load(
         &self,
         input: Input,
         mut stat: Option<&mut LoadStatistic>,
@@ -158,11 +166,16 @@ fn decompress(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use protobuf::Chars;
+
     use super::Source;
     use crate::{
+        cache::{PhysicalFileCache, PhysicalFileCacheRefGuard, RegisterPhysicalFileResult},
         compaction::{Input, Subcompaction},
         statistic::LoadStatistic,
-        storage::{LogFile, MetaFile},
+        storage::{LogFile, LogFileId, MetaFile},
         test_util::{KvGen, LogFileBuilder, TmpStorage, gen_adjacent_with_ts},
     };
 
@@ -202,6 +215,44 @@ mod tests {
 
     fn as_input(l: &LogFile) -> Input {
         Subcompaction::singleton(l.clone()).inputs.pop().unwrap()
+    }
+
+    fn input_of_physical_file(name: &Chars) -> Input {
+        Input {
+            id: LogFileId {
+                name: name.clone(),
+                offset: 0,
+                length: 0,
+            },
+            file_real_size: 0,
+            compression: kvproto::brpb::CompressionType::Zstd,
+            crc64xor: 0,
+            key_value_size: 0,
+            num_of_entries: 0,
+        }
+    }
+
+    #[test]
+    fn test_cached_input_refs_releases_remaining_refs_on_drop() {
+        let cache = Arc::new(PhysicalFileCache::new(10));
+        let name = Chars::from("physical.log");
+        assert!(matches!(
+            cache.register_physical_file(&name, 10, 2),
+            RegisterPhysicalFileResult::Registered
+        ));
+
+        let input = input_of_physical_file(&name);
+        let refs = PhysicalFileCacheRefGuard::new(Arc::clone(&cache), &[input.clone(), input]);
+        assert!(matches!(
+            cache.register_physical_file(&Chars::from("another.log"), 10, 1),
+            RegisterPhysicalFileResult::Full(_)
+        ));
+
+        drop(refs);
+        assert!(matches!(
+            cache.register_physical_file(&Chars::from("another.log"), 10, 1),
+            RegisterPhysicalFileResult::Registered
+        ));
     }
 
     #[tokio::test]

--- a/components/compact-log-backup/src/source.rs
+++ b/components/compact-log-backup/src/source.rs
@@ -7,7 +7,7 @@ use std::{
 use async_compression::futures::write::ZstdDecoder;
 use external_storage::ExternalStorage;
 use futures::io::{AsyncWriteExt, Cursor};
-use futures_io::AsyncWrite;
+use futures_io::{AsyncRead, AsyncWrite};
 use kvproto::brpb;
 use prometheus::core::{Atomic, AtomicU64};
 use tikv_util::{
@@ -17,17 +17,24 @@ use tikv_util::{
 use txn_types::Key;
 
 use super::{statistic::LoadStatistic, util::Cooperate};
-use crate::{compaction::Input, errors::Result};
+use crate::{cache::PhysicalFileCache, compaction::Input, errors::Result};
 
 /// The manager of fetching log files from remote for compacting.
 #[derive(Clone)]
 pub struct Source {
     inner: Arc<dyn ExternalStorage>,
+    physical_file_cache: Option<Arc<PhysicalFileCache>>,
 }
 
 impl Source {
-    pub fn new(inner: Arc<dyn ExternalStorage>) -> Self {
-        Self { inner }
+    pub fn new(
+        inner: Arc<dyn ExternalStorage>,
+        physical_file_cache: Option<Arc<PhysicalFileCache>>,
+    ) -> Self {
+        Self {
+            inner,
+            physical_file_cache,
+        }
     }
 }
 
@@ -64,17 +71,26 @@ impl Source {
             .with_fail_hook(move |_: &JustRetry<std::io::Error>| counter.inc_by(1));
         let fetch = || {
             let storage = self.inner.clone();
+            let physical_file_cache = self.physical_file_cache.clone();
             let id = input.id.clone();
             let compression = input.compression;
+            let file_real_size = input.file_real_size;
             async move {
-                let mut content = Vec::with_capacity(id.length as _);
-                let item = pin!(Cursor::new(&mut content));
-                let mut decompress = decompress(compression, item)?;
+                if let Some(cache) = physical_file_cache {
+                    if let Some((content, physical_bytes_in)) = cache
+                        .load_part(storage.clone(), &id.name, id.offset, id.length)
+                        .await?
+                    {
+                        let (content, _) =
+                            load_compressed(compression, Cursor::new(content), file_real_size)
+                                .await?;
+                        cache.drop_physical_file_ref(&id.name);
+                        return std::io::Result::Ok((content, physical_bytes_in));
+                    }
+                }
+
                 let source = storage.read_part(&id.name, id.offset, id.length);
-                let n = futures::io::copy(source, &mut decompress).await?;
-                decompress.flush().await?;
-                drop(decompress);
-                std::io::Result::Ok((content, n))
+                load_compressed(compression, source, file_real_size).await
             }
         };
         let (content, size) = retry_all_ext(fetch, ext).await?;
@@ -111,6 +127,20 @@ impl Source {
         }
         Ok(())
     }
+}
+
+async fn load_compressed(
+    compression: brpb::CompressionType,
+    source: impl AsyncRead + Unpin,
+    file_real_size: u64,
+) -> std::io::Result<(Vec<u8>, u64)> {
+    let mut content = Vec::with_capacity(file_real_size as usize);
+    let item = pin!(Cursor::new(&mut content));
+    let mut decompress = decompress(compression, item)?;
+    let n = futures::io::copy(source, &mut decompress).await?;
+    decompress.flush().await?;
+    drop(decompress);
+    Ok((content, n))
 }
 
 fn decompress(
@@ -179,7 +209,7 @@ mod tests {
         let st = TmpStorage::create();
         let m = construct_storage(&st).await;
 
-        let so = Source::new(st.storage().clone());
+        let so = Source::new(st.storage().clone(), None);
         for epoch in 0..NUM_FLUSH {
             for seg in 0..NUM_REGION {
                 let input = as_input(&m[epoch].physical_files[0].files[seg]);

--- a/components/compact-log-backup/src/storage.rs
+++ b/components/compact-log-backup/src/storage.rs
@@ -95,6 +95,10 @@ impl MetaFile {
             .into_iter()
             .flat_map(|g| g.files.into_iter())
     }
+
+    pub fn into_physical_logs(self) -> impl Iterator<Item = PhysicalLogFile> {
+        self.physical_files.into_iter()
+    }
 }
 
 /// The in-memory presentation of the message [`brpb::DataFileGroup`].


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #19587

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
compact-log-backup: optimize large log compaction

Add an optional physical-file cache for compact-log-backup to reduce repeated
remote reads of logical ranges from the same physical log file. The cached path
registers physical files by cache window, reuses cached physical content for
logical inputs, and releases memory once all refs are consumed.

Reduce migration metadata memory usage by storing owned physical file names and
compact offset/length spans, then sorting/deduping spans before writing the
migration.

Also make --until optional. When omitted, compact-log-backup derives it from
checkpoint state, optionally from {--replication-status-sub-prefix}/resume-state.json.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `--until` is now optional for compact-log-backup; if omitted the command can load the checkpoint timestamp from storage or from a replication-status checkpoint via `--replication-status-sub-prefix`.
  * New `--physical-file-cache-capacity` option to enable/disable an optional physical-file cache for cached remote log reads and cache-aware scheduling.
* **Tests**
  * Added unit and async tests covering checkpoint parsing, cache lifecycle, and cache-driven subcompaction behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tikv/tikv/pull/19588)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->