### PR TITLE
raft-rs: upgrade raft-rs to refine the memory usage.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5974,7 +5974,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash 2.1.1",
  "rustls",
@@ -6024,14 +6024,13 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 [[package]]
 name = "raft"
 version = "0.7.0"
-source = "git+https://github.com/tikv/raft-rs?branch=master#1fd05e000fb094015507c5c985849d370100fb72"
+source = "git+https://github.com/tikv/raft-rs?branch=master#ad13f3d90780f53aea2488c6a4b76c0d334bf136"
 dependencies = [
  "bytes",
  "fxhash",
  "getset",
- "protobuf 2.8.0",
  "raft-proto",
- "rand 0.8.5",
+ "rand 0.9.4",
  "slog",
  "thiserror 1.0.40",
 ]
@@ -6083,7 +6082,7 @@ dependencies = [
 [[package]]
 name = "raft-proto"
 version = "0.7.0"
-source = "git+https://github.com/tikv/raft-rs?branch=master#1fd05e000fb094015507c5c985849d370100fb72"
+source = "git+https://github.com/tikv/raft-rs?branch=master#ad13f3d90780f53aea2488c6a4b76c0d334bf136"
 dependencies = [
  "bytes",
  "protobuf 2.8.0",
@@ -6255,9 +6254,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -412,6 +412,15 @@ where
         self.hibernate_state.reset(state);
         if state == GroupState::Idle {
             self.peer.raft_group.raft.maybe_free_inflight_buffers();
+            // For hibernated regions, proactively release the empty unstable
+            // entry buffer to save memory.
+            self.peer
+                .raft_group
+                .raft
+                .r
+                .raft_log
+                .unstable
+                .release_entry_buffer();
         }
     }
 

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -1323,14 +1323,22 @@ where
                 if store.is_applying_snapshot() {
                     local_state.set_state(PeerState::Applying);
                 }
-                cb(RegionMeta::new(
+                let mut meta = RegionMeta::new(
                     &local_state,
                     store.apply_state(),
                     self.fsm.hibernate_state.group_state(),
                     peer.raft_group.status(),
                     peer.raft_group.raft.raft_log.last_index(),
                     peer.raft_group.raft.raft_log.persisted,
-                ))
+                );
+                #[cfg(any(test, feature = "testexport"))]
+                {
+                    let unstable = &peer.raft_group.raft.raft_log.unstable;
+                    meta.raft_status.unstable_entries_len = unstable.entries.len();
+                    meta.raft_status.unstable_entries_capacity = unstable.entries.capacity();
+                    meta.raft_status.unstable_entries_size = unstable.entries_size;
+                }
+                cb(meta)
             }
             CasualMessage::QueryRegionLeaderResp { region, leader } => {
                 // the leader already updated

--- a/components/raftstore/src/store/region_meta.rs
+++ b/components/raftstore/src/store/region_meta.rs
@@ -95,6 +95,12 @@ pub struct RaftStatus {
     pub learners: HashMap<u64, RaftProgress>,
     pub last_index: u64,
     pub persisted_index: u64,
+    #[cfg(any(test, feature = "testexport"))]
+    pub unstable_entries_len: usize,
+    #[cfg(any(test, feature = "testexport"))]
+    pub unstable_entries_capacity: usize,
+    #[cfg(any(test, feature = "testexport"))]
+    pub unstable_entries_size: usize,
 }
 
 impl<'a> From<raft::Status<'a>> for RaftStatus {
@@ -130,6 +136,12 @@ impl<'a> From<raft::Status<'a>> for RaftStatus {
             learners,
             last_index: 0,
             persisted_index: 0,
+            #[cfg(any(test, feature = "testexport"))]
+            unstable_entries_len: 0,
+            #[cfg(any(test, feature = "testexport"))]
+            unstable_entries_capacity: 0,
+            #[cfg(any(test, feature = "testexport"))]
+            unstable_entries_size: 0,
         }
     }
 }

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -1195,6 +1195,25 @@ impl<T: Simulator> Cluster<T> {
         status_resp.take_region_detail()
     }
 
+    pub fn unstable_entries_stat(&self, region_id: u64, store_id: u64) -> (usize, usize, usize) {
+        let router = self.sim.rl().get_router(store_id).unwrap();
+        let (tx, rx) = mpsc::channel();
+        CasualRouter::send(
+            &router,
+            region_id,
+            CasualMessage::AccessPeer(Box::new(move |meta| {
+                tx.send((
+                    meta.raft_status.unstable_entries_len,
+                    meta.raft_status.unstable_entries_capacity,
+                    meta.raft_status.unstable_entries_size,
+                ))
+                .unwrap();
+            })),
+        )
+        .unwrap();
+        rx.recv_timeout(Duration::from_secs(5)).unwrap()
+    }
+
     pub fn truncated_state(&self, region_id: u64, store_id: u64) -> RaftTruncatedState {
         self.apply_state(region_id, store_id).take_truncated_state()
     }

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -1196,6 +1196,15 @@ impl<T: Simulator> Cluster<T> {
     }
 
     pub fn unstable_entries_stat(&self, region_id: u64, store_id: u64) -> (usize, usize, usize) {
+        let (_, len, cap, size) = self.unstable_entries_state(region_id, store_id);
+        (len, cap, size)
+    }
+
+    pub fn unstable_entries_state(
+        &self,
+        region_id: u64,
+        store_id: u64,
+    ) -> (GroupState, usize, usize, usize) {
         let router = self.sim.rl().get_router(store_id).unwrap();
         let (tx, rx) = mpsc::channel();
         CasualRouter::send(
@@ -1203,6 +1212,7 @@ impl<T: Simulator> Cluster<T> {
             region_id,
             CasualMessage::AccessPeer(Box::new(move |meta| {
                 tx.send((
+                    meta.group_state,
                     meta.raft_status.unstable_entries_len,
                     meta.raft_status.unstable_entries_capacity,
                     meta.raft_status.unstable_entries_size,

--- a/tests/failpoints/cases/test_async_io.rs
+++ b/tests/failpoints/cases/test_async_io.rs
@@ -336,3 +336,50 @@ fn test_async_io_cannot_handle_ready_when_persist_snapshot() {
 
     must_get_equal(&cluster.get_engine(3), b"k29", b"v1");
 }
+
+#[test]
+fn test_async_io_unstable_entries_shrink_after_persist() {
+    let mut cluster = new_node_cluster(0, 3);
+    cluster.cfg.raft_store.raft_log_gc_threshold = 10_000;
+    cluster.cfg.raft_store.raft_log_gc_count_limit = Some(10_000);
+    let pd_client = Arc::clone(&cluster.pd_client);
+    pd_client.disable_default_operator();
+
+    cluster.run();
+
+    let region = pd_client.get_region(b"k1").unwrap();
+    let peer_1 = find_peer(&region, 1).cloned().unwrap();
+    cluster.must_transfer_leader(region.get_id(), peer_1);
+    let before = cluster.unstable_entries_stat(region.get_id(), 3);
+
+    cluster.add_send_filter(IsolationFilterFactory::new(3));
+
+    let value = vec![b'v'; 32];
+    for i in 0..600 {
+        let key = format!("k{:04}", i + 1);
+        cluster.must_put(key.as_bytes(), &value);
+    }
+
+    cluster.clear_send_filters();
+    must_get_equal(&cluster.get_engine(3), b"k0600", &value);
+
+    let mut after = cluster.unstable_entries_stat(region.get_id(), 3);
+    for _ in 0..50 {
+        if after.0 == 0 {
+            break;
+        }
+        sleep_ms(100);
+        after = cluster.unstable_entries_stat(region.get_id(), 3);
+    }
+    assert_eq!(
+        after.0, 0,
+        "unstable entries should be fully persisted: {:?}",
+        after
+    );
+    assert!(
+        after.1 <= 128,
+        "unstable entries capacity should shrink after persist, before={:?}, after={:?}",
+        before,
+        after
+    );
+}

--- a/tests/failpoints/cases/test_hibernate.rs
+++ b/tests/failpoints/cases/test_hibernate.rs
@@ -3,12 +3,13 @@
 use std::{
     sync::{atomic::*, mpsc::channel, *},
     thread,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use kvproto::raft_serverpb::{ExtraMessage, ExtraMessageType, RaftMessage};
+use pd_client::PdClient;
 use raft::eraftpb::MessageType;
-use raftstore::store::{PeerMsg, PeerTick};
+use raftstore::store::{GroupState, PeerMsg, PeerTick};
 use test_raftstore::*;
 use tikv_util::{HandyRwLock, config::ReadableDuration};
 
@@ -239,6 +240,73 @@ fn test_restart_peer_busy_on_apply() {
     let stats = cluster.pd_client.get_store_stats(3).unwrap();
     assert!(!stats.is_busy);
     fail::remove("on_check_peer_complete_apply_1003");
+}
+
+#[test]
+fn test_hibernate_region_releases_unstable_entry_buffer() {
+    let mut cluster = new_node_cluster(0, 3);
+    let base_tick_ms = 50;
+    cluster.cfg.raft_store.raft_base_tick_interval = ReadableDuration::millis(base_tick_ms);
+    cluster.cfg.raft_store.raft_heartbeat_ticks = 2;
+    cluster.cfg.raft_store.raft_election_timeout_ticks = 10;
+    cluster.cfg.raft_store.raft_min_election_timeout_ticks = 10;
+    cluster.cfg.raft_store.raft_max_election_timeout_ticks = 11;
+    cluster.cfg.raft_store.raft_log_gc_threshold = 10_000;
+    cluster.cfg.raft_store.raft_log_gc_count_limit = Some(10_000);
+    configure_for_hibernate(&mut cluster.cfg);
+    cluster.pd_client.disable_default_operator();
+
+    cluster.run();
+
+    let region = cluster.pd_client.get_region(b"k1").unwrap();
+    let peer_1 = find_peer(&region, 1).cloned().unwrap();
+    cluster.must_transfer_leader(region.get_id(), peer_1);
+
+    cluster.add_send_filter(IsolationFilterFactory::new(3));
+
+    let value = vec![b'v'; 32];
+    for i in 0..600 {
+        let key = format!("k{:04}", i + 1);
+        cluster.must_put(key.as_bytes(), &value);
+    }
+
+    cluster.clear_send_filters();
+    must_get_equal(&cluster.get_engine(3), b"k0600", &value);
+
+    let mut persisted = cluster.unstable_entries_state(region.get_id(), 3);
+    for _ in 0..50 {
+        if persisted.1 == 0 {
+            break;
+        }
+        thread::sleep(Duration::from_millis(100));
+        persisted = cluster.unstable_entries_state(region.get_id(), 3);
+    }
+    assert_eq!(
+        persisted.1, 0,
+        "unstable entries should be fully persisted before hibernation: {:?}",
+        persisted
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut hibernated = persisted;
+    while Instant::now() < deadline {
+        hibernated = cluster.unstable_entries_state(region.get_id(), 3);
+        if hibernated.0 == GroupState::Idle {
+            break;
+        }
+        thread::sleep(Duration::from_millis(base_tick_ms));
+    }
+    assert_eq!(
+        hibernated.0,
+        GroupState::Idle,
+        "peer should eventually hibernate after catch-up: {:?}",
+        hibernated
+    );
+    assert_eq!(
+        hibernated.2, 0,
+        "hibernated peer should release the unstable entry buffer: {:?}",
+        hibernated
+    );
 }
 
 #[test]


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->


### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close https://github.com/tikv/tikv/issues/19593

#### Background

`tikv#19593` reports a retained-memory issue on the Raft path. The main root cause is that `raft::Unstable.entries` may keep a large backing buffer even after entries have already been persisted and logically consumed.

In our validation, the old dependency could reproduce the problem in a TiKV-side failpoint-amplified scenario:

- before catch-up: `before=(0, 4, 0)`
- after catch-up/persist on the old dependency: `after=(0, 600, 0)`

This means `len` already returned to `0`, but `capacity` was still retained at `600`.

`raft-rs#589` directly fixes this path by shrinking / releasing the `Unstable.entries` buffer on the relevant lifecycle transitions.

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
#### What's Changed:

This PR upgrades `raft-rs` / `raft-proto` to commit `ad13f3d90780f53aea2488c6a4b76c0d334bf136`, which includes `raft-rs#589`, and adds a TiKV failpoints regression test for validating the effectiveness.

- Upgrade `raft` / `raft-proto` in `Cargo.lock` from `1fd05e00...` to `ad13f3d90780f53aea2488c6a4b76c0d334bf136`
- Update the lockfile-resolved `rand` dependency from `0.9.2` to `0.9.4` to satisfy the newer `raft-rs` dependency graph
- Add a permanent failpoints regression test:
  - `tests/failpoints/cases/test_async_io.rs`
  - `test_async_io_unstable_entries_shrink_after_persist`
- Add minimal test-only observability for follower-side `raft_log.unstable.entries` stats:
  - `len`
  - `capacity`
  - `size`

The observability is gated behind `#[cfg(any(test, feature = "testexport"))]` and does not affect normal production behavior.

#### Why add this regression test

The new test exercises the exact retained-capacity shape behind `tikv#19593`:

1. isolate a follower
2. let the leader append a large number of entries
3. heal the isolation so the follower catches up
4. wait until entries are persisted
5. assert that `unstable.entries.len()` goes back to `0`
6. also assert that `unstable.entries.capacity()` shrinks back instead of staying oversized

This makes the bug directly observable from TiKV's side and provides a long-term regression guard for future `raft-rs` upgrades.

```commit-message
Upgrades `raft-rs` / `raft-proto` to commit `ad13f3d90780f53aea2488c6a4b76c0d334bf136` to refine the memory usage of raft-rs.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

```bash
cargo test -p tests --test failpoints test_async_io_unstable_entries_shrink_after_persist --features failpoints,testexport -- --nocapture
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Upgrades `raft-rs` / `raft-proto` to commit `ad13f3d90780f53aea2488c6a4b76c0d334bf136` to refine the memory usage of raft-rs.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests and tooling to monitor raft log unstable-entry metrics (length, capacity, size).
  * Added integration tests verifying unstable entries persist, shrink after persistence, and that hibernating regions release the unstable-entry buffer.

* **Chores**
  * Improved internal raft status diagnostics in test builds to expose unstable-entry metrics for observability and testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tikv/tikv/pull/19596)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->