### PR TITLE
raftstore: support split reason for release-8.5-20251208-v8.5.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5257,6 +5257,7 @@ dependencies = [
  "concurrency_manager",
  "crc32fast",
  "crossbeam",
+ "crossbeam-skiplist 0.1.3",
  "derivative",
  "encryption",
  "encryption_export",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3690,7 +3690,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git?branch=release-8.5#97d984880071228de123095a1550a9236e92d224"
+source = "git+https://github.com/pingcap/kvproto.git?branch=release-8.5-20251208-v8.5.4#ca8835cfa7218cc2aff979162d997c9d79b9a466"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -430,7 +430,7 @@ grpcio-health = { version = "0.10.4", default-features = false, features = [
   "protobuf-codec",
 ] }
 tipb = { git = "https://github.com/pingcap/tipb.git" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-8.5" }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-8.5-20251208-v8.5.4" }
 yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
 tokio-timer = { git = "https://github.com/tikv/tokio", branch = "tokio-timer-hotfix" }
 tokio-executor = { git = "https://github.com/tikv/tokio", branch = "tokio-timer-hotfix" }

--- a/components/pd_client/src/client.rs
+++ b/components/pd_client/src/client.rs
@@ -718,6 +718,7 @@ impl PdClient for RpcClient {
         &self,
         region: metapb::Region,
         count: usize,
+        reason: pdpb::SplitReason,
     ) -> PdFuture<pdpb::AskBatchSplitResponse> {
         let timer = Instant::now();
 
@@ -725,6 +726,7 @@ impl PdClient for RpcClient {
         req.set_header(self.header());
         req.set_region(region);
         req.set_split_count(count as u32);
+        req.set_reason(reason);
 
         let executor = move |client: &Client, req: pdpb::AskBatchSplitRequest| {
             let handler = {

--- a/components/pd_client/src/client_v2.rs
+++ b/components/pd_client/src/client_v2.rs
@@ -607,6 +607,7 @@ pub trait PdClient {
         &mut self,
         region: metapb::Region,
         count: usize,
+        reason: pdpb::SplitReason,
     ) -> PdFuture<pdpb::AskBatchSplitResponse>;
 
     fn store_heartbeat(
@@ -1097,12 +1098,14 @@ impl PdClient for RpcClient {
         &mut self,
         region: metapb::Region,
         count: usize,
+        reason: pdpb::SplitReason,
     ) -> PdFuture<pdpb::AskBatchSplitResponse> {
         let timer = Instant::now_coarse();
 
         let mut req = pdpb::AskBatchSplitRequest::default();
         req.set_region(region);
         req.set_split_count(count as u32);
+        req.set_reason(reason);
 
         let mut raw_client = self.raw_client.clone();
         Box::pin(async move {

--- a/components/pd_client/src/lib.rs
+++ b/components/pd_client/src/lib.rs
@@ -436,6 +436,7 @@ pub trait PdClient: Send + Sync {
         &self,
         _region: metapb::Region,
         _count: usize,
+        _reason: pdpb::SplitReason,
     ) -> PdFuture<pdpb::AskBatchSplitResponse> {
         unimplemented!();
     }

--- a/components/raftstore-v2/src/operation/command/admin/split.rs
+++ b/components/raftstore-v2/src/operation/command/admin/split.rs
@@ -37,7 +37,7 @@ use futures::channel::oneshot;
 use kvproto::{
     kvrpcpb::DiskFullOpt,
     metapb::{self, Region, RegionEpoch},
-    pdpb::CheckPolicy,
+    pdpb::{CheckPolicy, SplitReason},
     raft_cmdpb::{AdminRequest, AdminResponse, RaftCmdRequest, SplitRequest},
     raft_serverpb::{RaftMessage, RaftSnapshotData},
 };
@@ -409,7 +409,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             region.clone(),
             rhs.start_key,
             rhs.end_key,
-            false,
+            SplitReason::Admin,
             rhs.policy,
             split_check_bucket_ranges,
         );

--- a/components/raftstore-v2/src/worker/pd/mod.rs
+++ b/components/raftstore-v2/src/worker/pd/mod.rs
@@ -14,8 +14,8 @@ use kvproto::{metapb, pdpb};
 use pd_client::{BucketStat, PdClient};
 use raftstore::store::{
     AutoSplitController, Config, FlowStatsReporter, NUM_COLLECT_STORE_INFOS_PER_HEARTBEAT,
-    PdStatsMonitor, ReadStats, SplitInfo, StoreStatsReporter, TabletSnapManager, TxnExt,
-    WriteStats, metrics::STORE_INSPECT_DURATION_HISTOGRAM, util::KeysInfoFormatter,
+    PdStatsMonitor, ReadStats, SplitInfo, SplitValidator, StoreStatsReporter, TabletSnapManager,
+    TxnExt, WriteStats, metrics::STORE_INSPECT_DURATION_HISTOGRAM, util::KeysInfoFormatter,
 };
 use resource_metering::{Collector, CollectorRegHandle, RawRecords};
 use service::service_manager::GrpcServiceManager;
@@ -260,7 +260,11 @@ where
             std::time::Duration::default(),
             PdReporter::new(pd_scheduler, logger.clone()),
         );
-        stats_monitor.start(auto_split_controller, collector_reg_handle)?;
+        stats_monitor.start(
+            auto_split_controller,
+            collector_reg_handle,
+            SplitValidator::new(),
+        )?;
         let slowness_stats = slowness::SlownessStatistics::new(&cfg.value());
         Ok(Self {
             store_id,

--- a/components/raftstore-v2/src/worker/pd/split.rs
+++ b/components/raftstore-v2/src/worker/pd/split.rs
@@ -63,6 +63,7 @@ where
             right_derive,
             share_source_region_size,
             Some(ch),
+            pdpb::SplitReason::Size,
         );
     }
 
@@ -77,6 +78,7 @@ where
         right_derive: bool,
         share_source_region_size: bool,
         ch: Option<CmdResChannel>,
+        reason: pdpb::SplitReason,
     ) {
         if split_keys.is_empty() {
             info!(
@@ -86,7 +88,7 @@ where
             );
             return;
         }
-        let resp = pd_client.ask_batch_split(region.clone(), split_keys.len());
+        let resp = pd_client.ask_batch_split(region.clone(), split_keys.len(), reason);
         let router = router.clone();
         let logger = logger.clone();
         let f = async move {
@@ -159,6 +161,7 @@ where
                         true,
                         false,
                         None,
+                        pdpb::SplitReason::Load,
                     );
                 // Try to split the region on half within the given key
                 // range if there is no `split_key` been given.

--- a/components/raftstore/Cargo.toml
+++ b/components/raftstore/Cargo.toml
@@ -31,6 +31,7 @@ collections = { workspace = true }
 concurrency_manager = { workspace = true }
 crc32fast = "1.2"
 crossbeam = { workspace = true }
+crossbeam-skiplist = { workspace = true }
 derivative = "2"
 encryption = { workspace = true }
 engine_rocks = { workspace = true, optional = true }

--- a/components/raftstore/src/coprocessor/dispatcher.rs
+++ b/components/raftstore/src/coprocessor/dispatcher.rs
@@ -6,7 +6,7 @@ use std::{borrow::Cow, marker::PhantomData, mem, ops::Deref};
 use engine_traits::{CfName, KvEngine, WriteBatch};
 use kvproto::{
     metapb::{Region, RegionEpoch},
-    pdpb::CheckPolicy,
+    pdpb::{CheckPolicy, SplitReason},
     raft_cmdpb::{CmdType, ComputeHashRequest, RaftCmdRequest},
     raft_serverpb::RaftMessage,
 };
@@ -832,10 +832,10 @@ impl<E: KvEngine> CoprocessorHost<E> {
         &'a self,
         region: &Region,
         engine: &E,
-        auto_split: bool,
+        reason: SplitReason,
         policy: CheckPolicy,
     ) -> SplitCheckerHost<'a, E> {
-        let mut host = SplitCheckerHost::new(auto_split, &self.cfg);
+        let mut host = SplitCheckerHost::new(reason, &self.cfg);
         loop_ob!(
             region,
             &self.registry.split_check_observers,

--- a/components/raftstore/src/coprocessor/split_check/half.rs
+++ b/components/raftstore/src/coprocessor/split_check/half.rs
@@ -1,7 +1,10 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
 
 use engine_traits::{KvEngine, Range};
-use kvproto::{metapb::Region, pdpb::CheckPolicy};
+use kvproto::{
+    metapb::Region,
+    pdpb::{CheckPolicy, SplitReason},
+};
 use tikv_util::{box_try, config::ReadableSize};
 
 use super::{
@@ -86,7 +89,7 @@ where
         _: &E,
         policy: CheckPolicy,
     ) {
-        if host.auto_split() {
+        if host.split_reason() == SplitReason::Size {
             return;
         }
         host.add_checker(Box::new(Checker::new(
@@ -146,6 +149,98 @@ mod tests {
         },
         store::{BucketRange, SplitCheckRunner, SplitCheckTask},
     };
+
+    /// SplitCheckerHost should pick Half/Size/Keys observers based on
+    /// SplitReason
+    #[test]
+    fn test_new_split_checker_host_with_different_split_reasons() {
+        let mut region = Region::default();
+        region.set_id(1);
+        region.mut_peers().push(Default::default());
+
+        let (tx, _rx) = mpsc::sync_channel(100);
+        let mut cfg = Config::default();
+        cfg.region_max_size = Some(ReadableSize(0));
+        cfg.region_max_keys = Some(0);
+        let host = CoprocessorHost::new(tx, cfg.clone());
+
+        let engine = engine_test::kv::new_engine(
+            Builder::new()
+                .prefix("test-new-split-checker-host")
+                .tempdir()
+                .unwrap()
+                .path()
+                .to_str()
+                .unwrap(),
+            ALL_CFS,
+        )
+        .unwrap();
+
+        let split_host =
+            host.new_split_checker_host(&region, &engine, SplitReason::Size, CheckPolicy::Scan);
+        assert_eq!(split_host.checkers_count(), 2);
+
+        let split_host =
+            host.new_split_checker_host(&region, &engine, SplitReason::Load, CheckPolicy::Scan);
+        assert_eq!(split_host.checkers_count(), 3);
+
+        let split_host =
+            host.new_split_checker_host(&region, &engine, SplitReason::Admin, CheckPolicy::Scan);
+        assert_eq!(split_host.checkers_count(), 3);
+    }
+
+    /// Load split should use HalfCheckObserver to find the midpoint split key
+    #[test]
+    fn test_load_split_finds_correct_split_key() {
+        let path = Builder::new().prefix("test-load-split").tempdir().unwrap();
+        let engine = engine_test::kv::new_engine(path.path().to_str().unwrap(), ALL_CFS).unwrap();
+
+        let mut region = Region::default();
+        region.set_id(1);
+        region.mut_peers().push(Peer::default());
+        region.mut_region_epoch().set_version(2);
+        region.mut_region_epoch().set_conf_ver(5);
+
+        let (tx, rx) = mpsc::sync_channel(100);
+        let cfg = Config {
+            region_max_size: Some(ReadableSize(100)),
+            ..Default::default()
+        };
+        let mut host = CoprocessorHost::new(tx.clone(), cfg);
+        host.registry
+            .register_split_check_observer(100, BoxSplitCheckObserver::new(HalfCheckObserver));
+        host.registry.register_split_check_observer(
+            200,
+            BoxSplitCheckObserver::new(SizeCheckObserver::new(tx.clone())),
+        );
+        host.registry.register_split_check_observer(
+            300,
+            BoxSplitCheckObserver::new(KeysCheckObserver::new(tx.clone())),
+        );
+
+        let mut runnable = SplitCheckRunner::new(engine.clone(), tx, host, None);
+
+        for i in 0..11 {
+            let k = format!("{:04}", i).into_bytes();
+            let k = keys::data_key(Key::from_raw(&k).as_encoded());
+            engine.put_cf(CF_DEFAULT, &k, &k).unwrap();
+            engine.flush_cf(CF_DEFAULT, true).unwrap();
+        }
+
+        let start_key = Key::from_raw(b"0000").into_encoded();
+        let end_key = Key::from_raw(b"0010").into_encoded();
+        runnable.run(SplitCheckTask::split_check_key_range(
+            region.clone(),
+            Some(start_key),
+            Some(end_key),
+            SplitReason::Load,
+            CheckPolicy::Scan,
+            None,
+        ));
+
+        let expected_split_key = Key::from_raw(b"0006");
+        must_split_at(&rx, &region, vec![expected_split_key.into_encoded()]);
+    }
 
     #[test]
     fn test_split_check() {
@@ -336,7 +431,8 @@ mod tests {
             Some(vec![bucket_range]),
         ));
 
-        let host = cop_host.new_split_checker_host(&region, &engine, true, CheckPolicy::Scan);
+        let host =
+            cop_host.new_split_checker_host(&region, &engine, SplitReason::Size, CheckPolicy::Scan);
         assert_eq!(host.policy(), CheckPolicy::Scan);
 
         must_generate_buckets(&rx, &exp_bucket_keys);
@@ -362,7 +458,8 @@ mod tests {
             CheckPolicy::Scan,
             Some(vec![bucket_range]),
         ));
-        let host = cop_host.new_split_checker_host(&region, &engine, true, CheckPolicy::Scan);
+        let host =
+            cop_host.new_split_checker_host(&region, &engine, SplitReason::Size, CheckPolicy::Scan);
         assert_eq!(host.policy(), CheckPolicy::Scan);
 
         must_generate_buckets(&rx, &exp_bucket_keys);

--- a/components/raftstore/src/coprocessor/split_check/half.rs
+++ b/components/raftstore/src/coprocessor/split_check/half.rs
@@ -129,7 +129,7 @@ mod tests {
     use engine_traits::{ALL_CFS, CF_DEFAULT, LARGE_CFS, MiscExt, SyncMutable};
     use kvproto::{
         metapb::{Peer, Region},
-        pdpb::CheckPolicy,
+        pdpb::{CheckPolicy, SplitReason},
     };
     use tempfile::Builder;
     use tikv_util::{config::ReadableSize, escape, worker::Runnable};
@@ -233,7 +233,7 @@ mod tests {
             region.clone(),
             Some(start_key),
             Some(end_key),
-            false,
+            SplitReason::Admin,
             CheckPolicy::Scan,
             None,
         ));
@@ -245,7 +245,7 @@ mod tests {
             region.clone(),
             Some(start_key),
             Some(end_key),
-            false,
+            SplitReason::Admin,
             CheckPolicy::Scan,
             None,
         ));
@@ -257,7 +257,7 @@ mod tests {
             region.clone(),
             Some(start_key),
             Some(end_key),
-            false,
+            SplitReason::Admin,
             CheckPolicy::Scan,
             None,
         ));

--- a/components/raftstore/src/coprocessor/split_check/mod.rs
+++ b/components/raftstore/src/coprocessor/split_check/mod.rs
@@ -5,7 +5,10 @@ mod keys;
 mod size;
 mod table;
 
-use kvproto::{metapb::Region, pdpb::CheckPolicy};
+use kvproto::{
+    metapb::Region,
+    pdpb::{CheckPolicy, SplitReason},
+};
 use tikv_util::box_try;
 
 pub use self::{
@@ -18,22 +21,22 @@ use super::{Bucket, KeyEntry, ObserverContext, SplitChecker, config::Config, err
 
 pub struct Host<'a, E> {
     checkers: Vec<Box<dyn SplitChecker<E>>>,
-    auto_split: bool,
+    split_reason: SplitReason,
     cfg: &'a Config,
 }
 
 impl<'a, E> Host<'a, E> {
-    pub fn new(auto_split: bool, cfg: &'a Config) -> Host<'a, E> {
+    pub fn new(split_reason: SplitReason, cfg: &'a Config) -> Host<'a, E> {
         Host {
-            auto_split,
+            split_reason,
             checkers: vec![],
             cfg,
         }
     }
 
     #[inline]
-    pub fn auto_split(&self) -> bool {
-        self.auto_split
+    pub fn split_reason(&self) -> SplitReason {
+        self.split_reason
     }
 
     #[inline]
@@ -126,6 +129,11 @@ impl<'a, E> Host<'a, E> {
     #[inline]
     pub fn region_bucket_size(&self) -> u64 {
         self.cfg.region_bucket_size.0
+    }
+
+    #[cfg(test)]
+    pub fn checkers_count(&self) -> usize {
+        self.checkers.len()
     }
 }
 

--- a/components/raftstore/src/coprocessor/split_check/size.rs
+++ b/components/raftstore/src/coprocessor/split_check/size.rs
@@ -246,7 +246,7 @@ pub mod tests {
     };
     use kvproto::{
         metapb::{Peer, Region},
-        pdpb::CheckPolicy,
+        pdpb::{CheckPolicy, SplitReason},
     };
     use tempfile::Builder;
     use tikv_util::{config::ReadableSize, worker::Runnable};
@@ -613,7 +613,8 @@ pub mod tests {
             None,
         ));
 
-        let host = cop_host.new_split_checker_host(&region, &engine, true, CheckPolicy::Scan);
+        let host =
+            cop_host.new_split_checker_host(&region, &engine, SplitReason::Size, CheckPolicy::Scan);
         assert_eq!(host.policy(), CheckPolicy::Approximate);
 
         if !mvcc {
@@ -643,7 +644,8 @@ pub mod tests {
             CheckPolicy::Approximate,
             Some(vec![BucketRange(start.clone(), end.clone())]),
         ));
-        let host = cop_host.new_split_checker_host(&region, &engine, true, CheckPolicy::Scan);
+        let host =
+            cop_host.new_split_checker_host(&region, &engine, SplitReason::Size, CheckPolicy::Scan);
         assert_eq!(host.policy(), CheckPolicy::Approximate);
 
         if !mvcc {
@@ -726,12 +728,14 @@ pub mod tests {
         }
 
         let cop_host = CoprocessorHost::new(tx.clone(), cfg.clone());
-        let host = cop_host.new_split_checker_host(&region, &engine, true, CheckPolicy::Scan);
+        let host =
+            cop_host.new_split_checker_host(&region, &engine, SplitReason::Size, CheckPolicy::Scan);
         assert_eq!(host.policy(), CheckPolicy::Scan);
 
         cfg.prefer_approximate_bucket = true;
         let cop_host = CoprocessorHost::new(tx, cfg);
-        let host = cop_host.new_split_checker_host(&region, &engine, true, CheckPolicy::Scan);
+        let host =
+            cop_host.new_split_checker_host(&region, &engine, SplitReason::Size, CheckPolicy::Scan);
         assert_eq!(host.policy(), CheckPolicy::Approximate);
     }
 

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -31,7 +31,7 @@ use kvproto::{
     import_sstpb::SwitchMode,
     kvrpcpb::DiskFullOpt,
     metapb::{self, Region, RegionEpoch},
-    pdpb::{self, CheckPolicy},
+    pdpb::{self, CheckPolicy, SplitReason},
     raft_cmdpb::{
         AdminCmdType, AdminRequest, CmdType, PutRequest, RaftCmdRequest, RaftCmdResponse, Request,
         StatusCmdType, StatusResponse,
@@ -6439,6 +6439,11 @@ where
             return;
         }
         let region = self.fsm.peer.region();
+        let split_reason = match source {
+            "split_checker_by_size" => SplitReason::Size,
+            "split_checker_by_load" => SplitReason::Load,
+            _ => SplitReason::Admin,
+        };
         let task = PdTask::AskBatchSplit {
             region: region.clone(),
             split_keys,
@@ -6446,6 +6451,7 @@ where
             right_derive: self.ctx.cfg.right_derive_when_split,
             share_source_region_size,
             callback: cb,
+            split_reason,
         };
         if let Err(ScheduleError::Stopped(t)) = self.ctx.pd_scheduler.schedule(task) {
             warn!(
@@ -6708,11 +6714,16 @@ where
         if source == "bucket" {
             return;
         }
+        let reason = if source == "auto_split" {
+            SplitReason::Load
+        } else {
+            SplitReason::Admin
+        };
         let task = SplitCheckTask::split_check_key_range(
             region.clone(),
             start_key,
             end_key,
-            false,
+            reason,
             policy,
             split_check_bucket_ranges,
         );

--- a/components/raftstore/src/store/mod.rs
+++ b/components/raftstore/src/store/mod.rs
@@ -94,7 +94,8 @@ pub use self::{
         LocalReaderCore, NUM_COLLECT_STORE_INFOS_PER_HEARTBEAT, PdStatsMonitor, PdTask,
         REGION_CPU_OVERLOAD_THRESHOLD_RATIO, ReadDelegate, ReadExecutor, ReadExecutorProvider,
         ReadProgress, ReadStats, RefreshConfigTask, RegionTask, SnapGenTask, SplitCheckRunner,
-        SplitCheckTask, SplitConfig, SplitConfigManager, SplitInfo, StoreMetaDelegate,
-        StoreStatsReporter, TrackVer, WriteStats, WriterContoller, metrics as worker_metrics,
+        SplitCheckTask, SplitConfig, SplitConfigManager, SplitInfo, SplitValidator,
+        StoreMetaDelegate, StoreStatsReporter, TrackVer, WriteStats, WriterContoller,
+        metrics as worker_metrics,
     },
 };

--- a/components/raftstore/src/store/worker/mod.rs
+++ b/components/raftstore/src/store/worker/mod.rs
@@ -17,6 +17,7 @@ mod snap_gen;
 mod split_check;
 mod split_config;
 mod split_controller;
+mod split_validator;
 
 pub use self::{
     check_leader::{Runner as CheckLeaderRunner, Task as CheckLeaderTask},
@@ -53,4 +54,5 @@ pub use self::{
         REGION_CPU_OVERLOAD_THRESHOLD_RATIO, SplitConfig, SplitConfigManager,
     },
     split_controller::{AutoSplitController, ReadStats, SplitConfigChange, SplitInfo, WriteStats},
+    split_validator::SplitValidator,
 };

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -68,7 +68,7 @@ use crate::{
         },
         util::{KeysInfoFormatter, is_epoch_stale},
         worker::{
-            AutoSplitController, ReadStats, SplitConfigChange, WriteStats,
+            AutoSplitController, ReadStats, SplitConfigChange, SplitValidator, WriteStats,
             split_controller::{SplitInfo, TOP_N},
         },
     },
@@ -156,6 +156,7 @@ where
         right_derive: bool,
         share_source_region_size: bool,
         callback: Callback<EK::Snapshot>,
+        split_reason: pdpb::SplitReason,
     },
     AutoSplit {
         split_infos: Vec<SplitInfo>,
@@ -692,6 +693,7 @@ where
         &mut self,
         mut auto_split_controller: AutoSplitController,
         collector_reg_handle: CollectorRegHandle,
+        split_validator: SplitValidator,
     ) -> Result<(), io::Error> {
         if self.collect_tick_interval
             < cmp::min(
@@ -751,6 +753,7 @@ where
                 let mut region_cpu_records_collector = None;
                 let mut auto_split_controller_ctx =
                     AutoSplitControllerContext::new(STATS_CHANNEL_CAPACITY_LIMIT);
+                let split_validator = split_validator;
                 // Register the region CPU records collector.
                 if auto_split_controller
                     .cfg
@@ -779,6 +782,7 @@ where
                             &reporter,
                             &collector_reg_handle,
                             &mut region_cpu_records_collector,
+                            &split_validator,
                         );
                     }
                     if is_enable_tick(timer_cnt, update_raftdisk_latency_stats_interval) {
@@ -813,6 +817,7 @@ where
         reporter: &T,
         collector_reg_handle: &CollectorRegHandle,
         region_cpu_records_collector: &mut Option<CollectorGuard>,
+        split_validator: &SplitValidator,
     ) {
         let start_time = TiInstant::now();
         match auto_split_controller.refresh_and_check_cfg() {
@@ -833,6 +838,7 @@ where
             read_stats_receiver,
             cpu_stats_receiver,
             thread_stats,
+            split_validator,
         );
         auto_split_controller.clear();
         auto_split_controller_ctx.maybe_gc();
@@ -944,6 +950,8 @@ where
 
     // Service manager for grpc service.
     grpc_service_manager: GrpcServiceManager,
+
+    split_validator: SplitValidator,
 }
 
 impl<EK, ER, T> Runner<EK, ER, T>
@@ -978,7 +986,12 @@ where
             cfg.inspect_kvdb_interval.0,
             WrappedScheduler(scheduler.clone()),
         );
-        if let Err(e) = stats_monitor.start(auto_split_controller, collector_reg_handle) {
+        let split_validator = SplitValidator::new();
+        if let Err(e) = stats_monitor.start(
+            auto_split_controller,
+            collector_reg_handle,
+            split_validator.clone(),
+        ) {
             error!("failed to start stats collector, error = {:?}", e);
         }
 
@@ -1031,6 +1044,7 @@ where
             coprocessor_host,
             causal_ts_provider,
             grpc_service_manager,
+            split_validator,
         }
     }
 
@@ -1094,6 +1108,7 @@ where
         router: RaftRouter<EK, ER>,
         scheduler: Scheduler<Task<EK>>,
         pd_client: Arc<T>,
+        split_validator: SplitValidator,
         mut region: metapb::Region,
         mut split_keys: Vec<Vec<u8>>,
         peer: metapb::Peer,
@@ -1102,13 +1117,17 @@ where
         callback: Callback<EK::Snapshot>,
         task: String,
         remote: Remote<yatp::task::future::TaskCell>,
+        reason: pdpb::SplitReason,
     ) {
         if split_keys.is_empty() {
             info!("empty split key, skip ask batch split";
                 "region_id" => region.get_id());
             return;
         }
-        let resp = pd_client.ask_batch_split(region.clone(), split_keys.len());
+        if reason != pdpb::SplitReason::Admin && split_validator.is_disabled(region.get_id()) {
+            return;
+        }
+        let resp = pd_client.ask_batch_split(region.clone(), split_keys.len(), reason);
         let f = async move {
             match resp.await {
                 Ok(mut resp) => {
@@ -1593,12 +1612,21 @@ where
     fn schedule_heartbeat_receiver(&mut self) {
         let router = self.router.clone();
         let store_id = self.store_id;
+        let split_validator = self.split_validator.clone();
 
         let fut = self.pd_client
             .handle_region_heartbeat_response(self.store_id, move |mut resp| {
                 let region_id = resp.get_region_id();
                 let epoch = resp.take_region_epoch();
                 let peer = resp.take_target_peer();
+
+                if resp.has_change_split() {
+                    if resp.get_change_split().get_auto_split_enabled() {
+                        split_validator.enable(region_id);
+                    } else {
+                        split_validator.disable(region_id);
+                    }
+                }
 
                 if resp.has_change_peer() {
                     PD_HEARTBEAT_COUNTER_VEC
@@ -2161,10 +2189,12 @@ where
                 right_derive,
                 share_source_region_size,
                 callback,
+                split_reason,
             } => Self::handle_ask_batch_split(
                 self.router.clone(),
                 self.scheduler.clone(),
                 self.pd_client.clone(),
+                self.split_validator.clone(),
                 region,
                 split_keys,
                 peer,
@@ -2173,12 +2203,14 @@ where
                 callback,
                 String::from("batch_split"),
                 self.remote.clone(),
+                split_reason,
             ),
             Task::AutoSplit { split_infos } => {
                 let pd_client = self.pd_client.clone();
                 let router = self.router.clone();
                 let scheduler = self.scheduler.clone();
                 let remote = self.remote.clone();
+                let split_validator = self.split_validator.clone();
 
                 let f = async move {
                     for split_info in split_infos {
@@ -2193,6 +2225,7 @@ where
                                 router.clone(),
                                 scheduler.clone(),
                                 pd_client.clone(),
+                                split_validator.clone(),
                                 region,
                                 vec![split_key],
                                 split_info.peer,
@@ -2201,6 +2234,7 @@ where
                                 Callback::None,
                                 String::from("auto_split"),
                                 remote.clone(),
+                                pdpb::SplitReason::Load,
                             );
                         // Try to split the region on half within the given key
                         // range if there is no `split_key` been given.
@@ -2647,6 +2681,7 @@ mod tests {
                 if let Err(e) = stats_monitor.start(
                     AutoSplitController::default(),
                     CollectorRegHandle::new_for_test(),
+                    SplitValidator::new(),
                 ) {
                     error!("failed to start stats collector, error = {:?}", e);
                 }
@@ -2892,6 +2927,7 @@ mod tests {
             .start(
                 AutoSplitController::default(),
                 CollectorRegHandle::new_for_test(),
+                SplitValidator::new(),
             )
             .unwrap();
         // Add some read stats and cpu stats to the stats monitor.

--- a/components/raftstore/src/store/worker/split_check.rs
+++ b/components/raftstore/src/store/worker/split_check.rs
@@ -16,7 +16,7 @@ use file_system::{IoType, WithIoType};
 use itertools::Itertools;
 use kvproto::{
     metapb::{Region, RegionEpoch},
-    pdpb::CheckPolicy,
+    pdpb::{CheckPolicy, SplitReason},
 };
 use online_config::{ConfigChange, OnlineConfig};
 use pd_client::{BucketMeta, BucketStat};
@@ -376,7 +376,7 @@ where
         region: Region,
         start_key: Option<Vec<u8>>,
         end_key: Option<Vec<u8>>,
-        auto_split: bool,
+        split_reason: SplitReason,
         policy: CheckPolicy,
         bucket_ranges: Option<Vec<BucketRange>>,
     },
@@ -405,7 +405,11 @@ where
             region,
             start_key: None,
             end_key: None,
-            auto_split,
+            split_reason: if auto_split {
+                SplitReason::Size
+            } else {
+                SplitReason::Admin
+            },
             policy,
             bucket_ranges,
         }
@@ -415,7 +419,7 @@ where
         region: Region,
         start_key: Option<Vec<u8>>,
         end_key: Option<Vec<u8>>,
-        auto_split: bool,
+        split_reason: SplitReason,
         policy: CheckPolicy,
         bucket_ranges: Option<Vec<BucketRange>>,
     ) -> Self {
@@ -423,7 +427,7 @@ where
             region,
             start_key,
             end_key,
-            auto_split,
+            split_reason,
             policy,
             bucket_ranges,
         }
@@ -440,15 +444,15 @@ where
                 region,
                 start_key,
                 end_key,
-                auto_split,
+                split_reason,
                 ..
             } => write!(
                 f,
-                "[split check worker] Split Check Task for {}, start_key: {:?}, end_key: {:?}, auto_split: {:?}",
+                "[split check worker] Split Check Task for {}, start_key: {:?}, end_key: {:?}, split_reason: {:?}",
                 region.get_id(),
                 start_key,
                 end_key,
-                auto_split
+                split_reason
             ),
             Task::ChangeConfig(_) => write!(f, "[split check worker] Change Config Task"),
             Task::CompactedEvent { .. } => {
@@ -602,10 +606,11 @@ impl<EK: KvEngine, S: StoreHandle> Runner<EK, S> {
         region: &Region,
         start_key: Option<Vec<u8>>,
         end_key: Option<Vec<u8>>,
-        auto_split: bool,
+        split_reason: SplitReason,
         policy: CheckPolicy,
         bucket_ranges: Option<Vec<BucketRange>>,
     ) {
+        let auto_split = split_reason != SplitReason::Admin;
         let mut cached;
         let tablet = match &self.engine {
             Either::Left(e) => e,
@@ -746,8 +751,13 @@ impl<EK: KvEngine, S: StoreHandle> Runner<EK, S> {
             );
 
             let region_epoch = region.get_region_epoch().clone();
+            let source = match split_reason {
+                SplitReason::Size => "split_checker_by_size",
+                SplitReason::Load => "split_checker_by_load",
+                _ => "split_checker_by_admin",
+            };
             self.router
-                .ask_split(region_id, region_epoch, split_keys, "split checker".into());
+                .ask_split(region_id, region_epoch, split_keys, source.into());
             CHECK_SPILT_COUNTER.success.inc();
         } else {
             debug!(
@@ -973,14 +983,14 @@ where
                 region,
                 start_key,
                 end_key,
-                auto_split,
+                split_reason,
                 policy,
                 bucket_ranges,
             } => self.check_split_and_bucket(
                 &region,
                 start_key,
                 end_key,
-                auto_split,
+                split_reason,
                 policy,
                 bucket_ranges,
             ),

--- a/components/raftstore/src/store/worker/split_check.rs
+++ b/components/raftstore/src/store/worker/split_check.rs
@@ -606,11 +606,10 @@ impl<EK: KvEngine, S: StoreHandle> Runner<EK, S> {
         region: &Region,
         start_key: Option<Vec<u8>>,
         end_key: Option<Vec<u8>>,
-        split_reason: SplitReason,
+        reason: SplitReason,
         policy: CheckPolicy,
         bucket_ranges: Option<Vec<BucketRange>>,
     ) {
-        let auto_split = split_reason != SplitReason::Admin;
         let mut cached;
         let tablet = match &self.engine {
             Either::Left(e) => e,
@@ -649,7 +648,7 @@ impl<EK: KvEngine, S: StoreHandle> Runner<EK, S> {
         CHECK_SPILT_COUNTER.all.inc();
         let mut host = self
             .coprocessor
-            .new_split_checker_host(region, tablet, auto_split, policy);
+            .new_split_checker_host(region, tablet, reason, policy);
 
         if host.skip() {
             debug!("skip split check";
@@ -751,7 +750,7 @@ impl<EK: KvEngine, S: StoreHandle> Runner<EK, S> {
             );
 
             let region_epoch = region.get_region_epoch().clone();
-            let source = match split_reason {
+            let source = match reason {
                 SplitReason::Size => "split_checker_by_size",
                 SplitReason::Load => "split_checker_by_load",
                 _ => "split_checker_by_admin",
@@ -1014,7 +1013,10 @@ where
                     let mut host = self.coprocessor.new_split_checker_host(
                         &region,
                         tablet,
-                        false,
+                        // Only estimates and refreshes region bucket information.
+                        // No split keys are generated and no split is triggered.
+                        // Treated as an Admin operation.
+                        SplitReason::Admin,
                         CheckPolicy::Approximate,
                     );
                     if let Err(e) = self.approximate_check_bucket(tablet, &region, &mut host, None)

--- a/components/raftstore/src/store/worker/split_controller.rs
+++ b/components/raftstore/src/store/worker/split_controller.rs
@@ -29,7 +29,10 @@ use tikv_util::{
 use crate::store::{
     metrics::*,
     util::build_key_range,
-    worker::{FlowStatistics, SplitConfig, SplitConfigManager, split_config::get_sample_num},
+    worker::{
+        FlowStatistics, SplitConfig, SplitConfigManager, SplitValidator,
+        split_config::get_sample_num,
+    },
 };
 
 const DEFAULT_MAX_SAMPLE_LOOP_COUNT: usize = 10000;
@@ -760,6 +763,7 @@ impl AutoSplitController {
         read_stats_receiver: &Receiver<ReadStats>,
         cpu_stats_receiver: &Receiver<Arc<RawRecords>>,
         thread_stats: &mut ThreadInfoStatistics,
+        split_validator: &SplitValidator,
     ) -> (Vec<usize>, Vec<SplitInfo>) {
         let mut top_cpu_usage = vec![];
         let mut top_qps = BinaryHeap::with_capacity(TOP_N);
@@ -791,6 +795,9 @@ impl AutoSplitController {
         // Start to record the read stats info.
         let mut split_infos = vec![];
         for (region_id, region_infos) in region_infos_map {
+            if split_validator.is_disabled(region_id) {
+                continue;
+            }
             let qps_prefix_sum = prefix_sum(region_infos.iter(), RegionInfo::get_read_qps);
             // region_infos is not empty, so it's safe to unwrap here.
             let qps = *qps_prefix_sum.last().unwrap();
@@ -1330,6 +1337,7 @@ mod tests {
                 &read_stats_receiver,
                 &cpu_stats_receiver,
                 &mut ThreadInfoStatistics::default(),
+                &SplitValidator::new(),
             );
             if (i + 1) % hub.cfg.detect_times != 0 {
                 continue;
@@ -1369,6 +1377,7 @@ mod tests {
                 &read_stats_receiver,
                 &cpu_stats_receiver,
                 &mut ThreadInfoStatistics::default(),
+                &SplitValidator::new(),
             );
             if (i + 1) % hub.cfg.detect_times != 0 {
                 continue;
@@ -1461,6 +1470,7 @@ mod tests {
                 &read_stats_receiver,
                 &cpu_stats_receiver,
                 &mut ThreadInfoStatistics::default(),
+                &SplitValidator::new(),
             );
         }
 
@@ -1482,6 +1492,7 @@ mod tests {
             &read_stats_receiver,
             &cpu_stats_receiver,
             &mut ThreadInfoStatistics::default(),
+            &SplitValidator::new(),
         );
     }
 
@@ -2040,6 +2051,7 @@ mod tests {
                 &read_stats_receiver,
                 &cpu_stats_receiver,
                 &mut threads,
+                &SplitValidator::new(),
             );
         });
     }

--- a/components/raftstore/src/store/worker/split_validator.rs
+++ b/components/raftstore/src/store/worker/split_validator.rs
@@ -1,0 +1,244 @@
+// Copyright 2025 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::{
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
+
+use crossbeam_skiplist::{SkipMap, map::Entry};
+
+// CAPACITY is the cache capacity. When it is exceeded, GC will be triggered.
+// If each Region is counted as 128 MiB, the total size needed to fully exhaust
+// CAPACITY would be 4 TiB, which is practically impossible to reach in real
+// workloads.
+const CAPACITY: usize = 0x8000;
+// GC_ENTRY_LIMIT is the number of iterations during a single GC operation.
+const GC_ENTRY_LIMIT: usize = 0x80;
+// GC_LIFETIME is the effective time of the cache, in seconds.
+const GC_LIFETIME: Duration = Duration::from_secs(600);
+
+// SplitValidator can disable split for a specific Region within GC_LIFETIME via
+// disable(regionID). It uses a SkipMap internally for concurrent access. When
+// the number of entries exceeds CAPACITY, a full GC round is triggered, and
+// each GC in `disable` scans at most GC_ENTRY_LIMIT entries to avoid
+// excessively long execution time.
+struct SplitValidatorCore<P> {
+    disabled_region_ids: SkipMap<u64, Instant>,
+    capacity: usize,
+    gc_offset: Mutex<u64>,
+    gc_filter: P,
+}
+
+impl<P> SplitValidatorCore<P>
+where
+    P: Fn(&Entry<'_, u64, Instant>) -> bool,
+{
+    #[inline]
+    pub fn new(gc_filter: P, capacity: usize) -> Self {
+        Self {
+            disabled_region_ids: SkipMap::new(),
+            capacity,
+            gc_offset: Mutex::new(0),
+            gc_filter,
+        }
+    }
+
+    #[inline]
+    pub fn is_disabled(&self, region_id: u64) -> bool {
+        let Some(entry) = self.disabled_region_ids.get(&region_id) else {
+            return false;
+        };
+
+        if (self.gc_filter)(&entry) {
+            entry.remove();
+            return false;
+        }
+
+        true
+    }
+
+    #[inline]
+    pub fn disable(&self, region_id: u64) {
+        self.disabled_region_ids.insert(region_id, Instant::now());
+        self.gc()
+    }
+
+    #[inline]
+    pub fn enable(&self, region_id: u64) {
+        self.disabled_region_ids.remove(&region_id);
+    }
+
+    fn gc(&self) {
+        let _ = self.gc_offset.try_lock().map(|mut gc_offset| {
+            if *gc_offset == 0 && self.disabled_region_ids.len() < self.capacity {
+                // If capacity is not reached, GC will not be performed.
+                // When gc_offset is not 0, the current GC round will be completed.
+                return;
+            }
+            let mut count = 0;
+            self.disabled_region_ids
+                .range(*gc_offset..)
+                .take(GC_ENTRY_LIMIT)
+                .filter(|e| {
+                    count += 1;
+                    *gc_offset = e.key() + 1;
+                    (self.gc_filter)(e)
+                })
+                .for_each(|e| {
+                    e.remove();
+                });
+            if count < GC_ENTRY_LIMIT {
+                *gc_offset = 0;
+            }
+        });
+    }
+}
+
+#[derive(Clone)]
+pub struct SplitValidator {
+    core: Arc<SplitValidatorCore<fn(&Entry<'_, u64, Instant>) -> bool>>,
+}
+
+impl SplitValidator {
+    #[inline]
+    pub fn new() -> Self {
+        Self {
+            core: Arc::new(SplitValidatorCore::new(
+                |e| e.value().elapsed() > GC_LIFETIME,
+                CAPACITY,
+            )),
+        }
+    }
+
+    #[inline]
+    pub fn is_disabled(&self, region_id: u64) -> bool {
+        self.core.is_disabled(region_id)
+    }
+
+    #[inline]
+    pub fn disable(&self, region_id: u64) {
+        self.core.disable(region_id);
+    }
+
+    #[inline]
+    pub fn enable(&self, region_id: u64) {
+        self.core.enable(region_id);
+    }
+}
+
+impl Default for SplitValidator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::Rng;
+    use test::{Bencher, black_box};
+
+    use super::*;
+    #[test]
+    fn test_multiple_regions_management() {
+        let validator = SplitValidator::new();
+        let region1 = 1;
+        let region2 = 2;
+
+        assert!(!validator.is_disabled(region1));
+        assert!(!validator.is_disabled(region2));
+        assert!(validator.core.disabled_region_ids.is_empty());
+
+        validator.disable(region1);
+        validator.disable(region2);
+        assert!(validator.is_disabled(region1));
+        assert!(validator.is_disabled(region2));
+        assert_eq!(validator.core.disabled_region_ids.len(), 2);
+
+        validator.enable(region1);
+        assert!(!validator.is_disabled(region1));
+        assert!(validator.is_disabled(region2));
+        assert_eq!(validator.core.disabled_region_ids.len(), 1);
+    }
+
+    #[test]
+    fn test_enable_non_disabled_region() {
+        let validator = SplitValidator::new();
+        let region_id = 1;
+
+        validator.enable(region_id);
+        assert!(!validator.is_disabled(region_id));
+        assert!(validator.core.disabled_region_ids.is_empty());
+    }
+
+    #[test]
+    fn test_expired() {
+        let validator = SplitValidatorCore::new(|e| e.key() & 1 == 0, 300);
+        validator.disable(1);
+        assert!(validator.is_disabled(1));
+        validator.disable(2);
+        assert!(!validator.is_disabled(2));
+    }
+
+    #[test]
+    fn test_gc_removes_expired_entries() {
+        let validator = SplitValidatorCore::new(|e| e.key() & 1 == 0, 300);
+        for i in 0..200 {
+            validator.disabled_region_ids.insert(i, Instant::now());
+        }
+        validator.gc();
+        assert_eq!(*validator.gc_offset.lock().unwrap(), 0);
+        assert_eq!(validator.disabled_region_ids.len(), 200);
+        for i in 200..300 {
+            validator.disabled_region_ids.insert(i, Instant::now());
+        }
+        validator.gc();
+        assert_eq!(*validator.gc_offset.lock().unwrap(), 128);
+        validator.gc();
+        assert_eq!(*validator.gc_offset.lock().unwrap(), 256);
+        validator.gc();
+        assert_eq!(*validator.gc_offset.lock().unwrap(), 0);
+        assert_eq!(validator.disabled_region_ids.len(), 150);
+        validator.gc();
+        assert_eq!(*validator.gc_offset.lock().unwrap(), 0);
+        assert_eq!(validator.disabled_region_ids.len(), 150);
+    }
+
+    #[test]
+    fn test_disable_trigger_gc() {
+        let validator = SplitValidatorCore::new(|e| e.key() & 1 == 0, 300);
+        for i in 0..200 {
+            validator.disable(i);
+        }
+        assert_eq!(validator.disabled_region_ids.len(), 200);
+        for i in 200..300 {
+            validator.disable(i);
+        }
+        assert_eq!(validator.disabled_region_ids.len(), 236);
+        validator.disable(300);
+        assert_eq!(validator.disabled_region_ids.len(), 173);
+        validator.disable(301);
+        assert_eq!(validator.disabled_region_ids.len(), 151);
+        validator.disable(302);
+        assert_eq!(validator.disabled_region_ids.len(), 152);
+    }
+
+    #[bench]
+    fn bench_1m_regions_mixed_ops(b: &mut Bencher) {
+        const TOTAL_REGIONS: u64 = 1_000_000;
+
+        let validator = SplitValidator::new();
+        let mut rng = rand::thread_rng();
+
+        for i in 0..=TOTAL_REGIONS {
+            validator.disable(i);
+        }
+        b.iter(|| {
+            let region_id = rng.gen_range(0..TOTAL_REGIONS);
+            if rng.gen() {
+                validator.disable(black_box(region_id));
+            } else {
+                validator.enable(black_box(region_id));
+            }
+        });
+    }
+}

--- a/components/test_pd_client/src/pd.rs
+++ b/components/test_pd_client/src/pd.rs
@@ -1812,6 +1812,7 @@ impl PdClient for TestPdClient {
         &self,
         region: metapb::Region,
         count: usize,
+        _reason: pdpb::SplitReason,
     ) -> PdFuture<pdpb::AskBatchSplitResponse> {
         if self.is_incompatible {
             return Box::pin(err(Error::Incompatible));

--- a/tests/failpoints/cases/test_pd_client.rs
+++ b/tests/failpoints/cases/test_pd_client.rs
@@ -9,7 +9,7 @@ use std::{
 
 use futures::executor::block_on;
 use grpcio::EnvBuilder;
-use kvproto::metapb::*;
+use kvproto::{metapb::*, pdpb};
 use pd_client::{PdClientV2, RegionInfo, RpcClientV2};
 use security::{SecurityConfig, SecurityManager};
 use test_pd::{Server as MockServer, mocker::*, util::*};
@@ -64,7 +64,7 @@ fn test_pd_client_deadlock() {
         request!(client => get_region_info(b"")),
         request!(client => block_on(get_region_by_id(0))),
         request!(client => block_on(ask_split(Region::default()))),
-        request!(client => block_on(ask_batch_split(Region::default(), 1))),
+        request!(client => block_on(ask_batch_split(Region::default(), 1, pdpb::SplitReason::Admin))),
         request!(client => block_on(store_heartbeat(Default::default(), None, None))),
         request!(client => block_on(report_batch_split(vec![]))),
         request!(client => scatter_region(RegionInfo::new(Region::default(), None))),
@@ -222,7 +222,7 @@ fn test_retry() {
     test_retry_success(&mut client, |c| c.get_region_info(b""));
     test_retry_success(&mut client, |c| block_on(c.get_region_by_id(0)));
     test_retry_success(&mut client, |c| {
-        block_on(c.ask_batch_split(Region::default(), 1))
+        block_on(c.ask_batch_split(Region::default(), 1, pdpb::SplitReason::Admin))
     });
     test_retry_success(&mut client, |c| {
         block_on(c.store_heartbeat(Default::default(), None, None))

--- a/tests/failpoints/cases/test_pd_client_legacy.rs
+++ b/tests/failpoints/cases/test_pd_client_legacy.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use grpcio::EnvBuilder;
-use kvproto::metapb::*;
+use kvproto::{metapb::*, pdpb};
 use pd_client::{PdClient, RegionInfo, RegionStat, RpcClient};
 use security::{SecurityConfig, SecurityManager};
 use test_pd::{Server as MockServer, mocker::*, util::*};
@@ -65,7 +65,7 @@ fn test_pd_client_deadlock() {
         request!(client => block_on(get_region_by_id(0))),
         request!(client => block_on(region_heartbeat(0, Region::default(), Peer::default(), RegionStat::default(), None))),
         request!(client => block_on(ask_split(Region::default()))),
-        request!(client => block_on(ask_batch_split(Region::default(), 1))),
+        request!(client => block_on(ask_batch_split(Region::default(), 1, pdpb::SplitReason::Admin))),
         request!(client => block_on(store_heartbeat(Default::default(), None, None))),
         request!(client => block_on(report_batch_split(vec![]))),
         request!(client => scatter_region(RegionInfo::new(Region::default(), None))),

--- a/tests/integrations/pd/test_rpc_client.rs
+++ b/tests/integrations/pd/test_rpc_client.rs
@@ -142,7 +142,8 @@ fn test_rpc_client() {
         None,
     ))
     .unwrap();
-    block_on(client.ask_batch_split(metapb::Region::default(), 1)).unwrap();
+    block_on(client.ask_batch_split(metapb::Region::default(), 1, pdpb::SplitReason::Admin))
+        .unwrap();
     block_on(client.report_batch_split(vec![metapb::Region::default(), metapb::Region::default()]))
         .unwrap();
 
@@ -327,7 +328,8 @@ fn test_incompatible_version() {
 
     let mut client = new_client_v2(eps, None);
 
-    let resp = block_on(client.ask_batch_split(metapb::Region::default(), 2));
+    let resp =
+        block_on(client.ask_batch_split(metapb::Region::default(), 2, pdpb::SplitReason::Admin));
     assert_eq!(
         resp.unwrap_err().to_string(),
         PdError::Incompatible.to_string()

--- a/tests/integrations/pd/test_rpc_client_legacy.rs
+++ b/tests/integrations/pd/test_rpc_client_legacy.rs
@@ -133,7 +133,8 @@ fn test_rpc_client() {
         None,
     ))
     .unwrap();
-    block_on(client.ask_batch_split(metapb::Region::default(), 1)).unwrap();
+    block_on(client.ask_batch_split(metapb::Region::default(), 1, pdpb::SplitReason::Admin))
+        .unwrap();
     block_on(client.report_batch_split(vec![metapb::Region::default(), metapb::Region::default()]))
         .unwrap();
 
@@ -389,7 +390,8 @@ fn test_incompatible_version() {
 
     let client = new_client(eps, None);
 
-    let resp = block_on(client.ask_batch_split(metapb::Region::default(), 2));
+    let resp =
+        block_on(client.ask_batch_split(metapb::Region::default(), 2, pdpb::SplitReason::Admin));
     assert_eq!(
         resp.unwrap_err().to_string(),
         PdError::Incompatible.to_string()


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: ref #19013, ref #19014, ref #19221

What's Changed:

```commit-message
Backport split-reason support to the v8.5.4 release branch.

This PR is rebased onto tikv:release-8.5-20251208-v8.5.4 at b2ff5c6c3 and contains:
- kvproto update to pingcap/kvproto:release-8.5-20251208-v8.5.4#ca8835c, which includes pingcap/kvproto#1464
- #19212: support split reason and disable auto split on release-8.5
- #19223: use SplitReason in SplitCheckerHost on release-8.5
```

### Cherry-pick conflict handling

Base: `tikv/tikv@b2ff5c6c3`
Head: `lhy1024/tikv@a18774046`

Conflict handling for #19212 (`f609172ca` -> `0344f1eae`):
- `Cargo.lock`: kept `pingcap/kvproto.git?branch=release-8.5-20251208-v8.5.4#ca8835c` instead of the old `release-8.5#ed676560` lock from the original cherry-pick.
- `components/raftstore-v2/src/worker/pd/mod.rs`: import conflict only; kept the latest release-branch imports and added `SplitValidator`.
- `components/raftstore/src/store/mod.rs`: export conflict only; kept the latest release-branch exports and added `SplitValidator`.
- `components/raftstore/src/store/worker/pd.rs`: import conflict only; kept the latest release-branch ordering and added `SplitValidator`.
- `components/raftstore/src/store/worker/split_controller.rs`: import conflict only; kept the latest release-branch ordering and added `SplitValidator`.

Conflict handling for #19223 (`3083a6cfb` -> `a18774046`):
- `components/raftstore/src/coprocessor/split_check/half.rs`: test import-order conflict only; kept the latest release-branch ordering. No behavior change beyond the original #19223 split-reason logic.

After resolving conflicts, `cargo fmt --all` was applied and the format-only changes were folded into the relevant cherry-pick commit.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch
- Related kvproto PR: https://github.com/pingcap/kvproto/pull/1464

### Check List

Tests

- [x] Manual test (add detailed scripts or steps below)

```bash
cargo fmt --all -- --check
cargo check --locked -p tikv-server
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
Support carrying split reasons in TiKV batch split requests.
```
