### PR TITLE
[DO NOT MERGE / test bundle] coprocessor: support paging_size_bytes for byte-budget paging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4420,7 +4420,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#678ff92b1edd0cf321336a0ac4530edcb9686995"
+source = "git+https://github.com/JmPotato/kvproto?branch=demo/ru-paging-size#48e3f28d9c74bf31ff30841155976ee2eec8fb97"
 dependencies = [
  "bytes",
  "futures 0.3.15",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4420,7 +4420,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/YuhaoZhang00/kvproto?branch=rc-precharge-classic-test#6392d3ef70069d71eeefbd74de6de080c5a8daee"
+source = "git+https://github.com/YuhaoZhang00/kvproto?branch=rc-precharge-classic-test#acfca8a6521fa57cd7bd7a5b26e6a775e15041d2"
 dependencies = [
  "bytes",
  "futures 0.3.15",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,8 +222,8 @@ sysinfo = { git = "https://github.com/tikv/sysinfo", branch = "0.26-fix-cpu" }
 # When you modify TiKV cooperatively with kvproto, this will be useful to submit the PR to TiKV and the PR to
 # kvproto at the same time.
 # After the PR to kvproto is merged, remember to comment this out and run `cargo update -p kvproto`.
-# [patch.'https://github.com/pingcap/kvproto']
-# kvproto = { git = "https://github.com/your_github_id/kvproto", branch = "your_branch" }
+[patch.'https://github.com/pingcap/kvproto']
+kvproto = { git = "https://github.com/JmPotato/kvproto", branch = "demo/ru-paging-size" }
 #
 # After the PR to rust-rocksdb is merged, remember to comment this out and run `cargo update -p rocksdb`.
 # [patch.'https://github.com/tikv/rust-rocksdb']

--- a/components/tidb_query_executors/src/runner.rs
+++ b/components/tidb_query_executors/src/runner.rs
@@ -5,7 +5,7 @@ use std::{convert::TryFrom, iter, sync::Arc};
 use api_version::KvFormat;
 use fail::fail_point;
 use itertools::Itertools;
-use kvproto::coprocessor::KeyRange;
+use kvproto::coprocessor::{KeyRange, PagingBreakReason};
 use protobuf::Message;
 use tidb_query_common::{
     Result,
@@ -91,9 +91,9 @@ pub struct BatchExecutorsRunner<SS> {
     /// current page.
     paging_size: Option<u64>,
 
-    /// If set, paging_size_bytes indicates the byte budget for the current page.
-    /// When accumulated MVCC scanned bytes reach this limit, the scan stops
-    /// early.
+    /// If set, paging_size_bytes indicates the byte budget for the current
+    /// page. When accumulated MVCC scanned bytes reach this limit, the scan
+    /// stops early.
     paging_size_bytes: Option<u64>,
 
     quota_limiter: Arc<QuotaLimiter>,
@@ -655,8 +655,8 @@ impl<SS: 'static + Default> BatchExecutorsRunner<SS> {
             ranges,
             config.clone(),
             is_streaming || paging_size.is_some() || paging_size_bytes.is_some(), /* For streaming and paging request,
-                                                    * executors will continue scan from range
-                                                    * end where last scan is finished */
+                                                                                   * executors will continue scan from range
+                                                                                   * end where last scan is finished */
         )?;
 
         let req_encode_type = req.get_encode_type();
@@ -766,7 +766,9 @@ impl<SS: 'static + Default> BatchExecutorsRunner<SS> {
     /// IntervalRange records whole range scanned though there are gaps in multi
     /// ranges. e.g.: [(k1 -> k2), (k4 -> k5)] may got response (k1, k2, k4)
     /// with IntervalRange like (k1, k4).
-    pub async fn handle_request(&mut self) -> Result<(SelectResponse, Option<IntervalRange>)> {
+    pub async fn handle_request(
+        &mut self,
+    ) -> Result<(SelectResponse, Option<IntervalRange>, PagingBreakReason)> {
         let mut chunks = vec![];
         let mut batch_size = Self::batch_initial_size();
         let mut warnings = self.config.new_eval_warnings();
@@ -822,20 +824,18 @@ impl<SS: 'static + Default> BatchExecutorsRunner<SS> {
             if self.paging_size_bytes.is_some() {
                 self.out_most_executor
                     .collect_storage_stats(&mut self.accumulated_storage_stats);
-                scanned_bytes_all =
-                    (self.scanned_bytes_fn)(&self.accumulated_storage_stats);
+                scanned_bytes_all = (self.scanned_bytes_fn)(&self.accumulated_storage_stats);
             }
 
             if chunk.has_rows_data() {
                 chunks.push(chunk);
             }
 
-            if drained.stop()
-                || self.paging_size.is_some_and(|p| record_all >= p as usize)
-                || self
-                    .paging_size_bytes
-                    .is_some_and(|p| scanned_bytes_all >= p as usize)
-            {
+            let row_limit_reached = self.paging_size.is_some_and(|p| record_all >= p as usize);
+            let byte_limit_reached = self
+                .paging_size_bytes
+                .is_some_and(|p| scanned_bytes_all >= p as usize);
+            if drained.stop() || row_limit_reached || byte_limit_reached {
                 self.out_most_executor
                     .collect_exec_stats(&mut self.exec_stats);
                 tidb_query_common::metrics::record_coprocessor_executor_iterations(
@@ -845,14 +845,20 @@ impl<SS: 'static + Default> BatchExecutorsRunner<SS> {
                         .map(|s| s.num_iterations as u64)
                         .sum(),
                 );
-                let is_paging =
-                    self.paging_size.is_some() || self.paging_size_bytes.is_some();
-                let range = if drained == BatchExecIsDrain::Drain {
-                    None
+                let is_paging = self.paging_size.is_some() || self.paging_size_bytes.is_some();
+                let (range, paging_break_reason) = if drained == BatchExecIsDrain::Drain {
+                    (None, PagingBreakReason::PagingBreakReasonRangeEnd)
                 } else if is_paging {
-                    Some(self.out_most_executor.take_scanned_range())
+                    let reason = if byte_limit_reached {
+                        PagingBreakReason::PagingBreakReasonByteLimit
+                    } else if row_limit_reached {
+                        PagingBreakReason::PagingBreakReasonRowLimit
+                    } else {
+                        PagingBreakReason::PagingBreakReasonUnknown
+                    };
+                    (Some(self.out_most_executor.take_scanned_range()), reason)
                 } else {
-                    None
+                    (None, PagingBreakReason::PagingBreakReasonUnknown)
                 };
 
                 let mut sel_resp = SelectResponse::default();
@@ -892,7 +898,7 @@ impl<SS: 'static + Default> BatchExecutorsRunner<SS> {
 
                 sel_resp.set_warnings(warnings.warnings.into());
                 sel_resp.set_warning_count(warnings.warning_cnt as i64);
-                return Ok((sel_resp, range));
+                return Ok((sel_resp, range, paging_break_reason));
             }
 
             // Grow batch size
@@ -1165,7 +1171,7 @@ mod tests {
     use api_version::ApiV1;
     use async_trait::async_trait;
     use futures::executor::block_on;
-    use kvproto::metapb::Region;
+    use kvproto::{coprocessor::PagingBreakReason, metapb::Region};
     use tidb_query_common::execute_stats::ExecSummaryCollectorEnabled;
     use tidb_query_datatype::{
         FieldTypeTp,
@@ -2100,7 +2106,7 @@ mod tests {
             output_offsets: vec![0],
             schema: field_types.clone(),
         }];
-        let (mut resp, range) = block_on(runner.handle_request()).unwrap();
+        let (mut resp, range, _) = block_on(runner.handle_request()).unwrap();
         // no paging
         assert!(range.is_none());
         // check the main result
@@ -2191,7 +2197,7 @@ mod tests {
             output_offsets: vec![0],
             schema: field_types.clone(),
         }];
-        let (mut resp, range) = block_on(paging_runner.handle_request()).unwrap();
+        let (mut resp, range, _) = block_on(paging_runner.handle_request()).unwrap();
         assert_eq!(Some(expected_range), range);
         let main_chunks = resp.take_chunks();
         // the results should stop for paging in the second loop
@@ -2401,6 +2407,7 @@ mod tests {
 
     fn build_runner_with_mock_stats(
         executor: MockStatsExecutor,
+        paging_size: Option<u64>,
         paging_size_bytes: Option<u64>,
     ) -> BatchExecutorsRunner<MockStats> {
         let config = Arc::new(EvalConfig::default());
@@ -2413,7 +2420,7 @@ mod tests {
             exec_stats: ExecuteStats::new(1),
             stream_row_limit: 1024,
             encode_type: EncodeType::TypeChunk,
-            paging_size: None,
+            paging_size,
             paging_size_bytes,
             quota_limiter: Arc::new(QuotaLimiter::default()),
             intermediate_channels: vec![],
@@ -2444,11 +2451,12 @@ mod tests {
             vec![1000, 1000, 1000],
         );
 
-        let mut runner = build_runner_with_mock_stats(executor, Some(1500));
-        let (resp, range) = block_on(runner.handle_request()).unwrap();
+        let mut runner = build_runner_with_mock_stats(executor, None, Some(1500));
+        let (resp, range, reason) = block_on(runner.handle_request()).unwrap();
 
-        // Paging should have truncated — range returned for next page.
+        // Paging should have truncated: range returned for next page.
         assert!(range.is_some(), "should return scanned range for paging");
+        assert_eq!(reason, PagingBreakReason::PagingBreakReasonByteLimit);
         // Only 2 batches processed, so 2 chunks.
         assert_eq!(resp.get_chunks().len(), 2);
     }
@@ -2474,9 +2482,10 @@ mod tests {
         );
 
         // Budget 1200: batch 1 (500) + batch 2 (800) = 1300 >= 1200, truncate.
-        let mut runner = build_runner_with_mock_stats(executor, Some(1200));
-        let (_resp, range) = block_on(runner.handle_request()).unwrap();
+        let mut runner = build_runner_with_mock_stats(executor, None, Some(1200));
+        let (_resp, range, reason) = block_on(runner.handle_request()).unwrap();
         assert!(range.is_some());
+        assert_eq!(reason, PagingBreakReason::PagingBreakReasonByteLimit);
 
         // The final collect_storage_stats must return complete stats from all
         // processed batches, not just the last one.
@@ -2496,21 +2505,19 @@ mod tests {
         let field_types: Vec<FieldType> = vec![FieldTypeTp::Long.into()];
         let executor = MockStatsExecutor::new(
             field_types,
-            vec![
-                build_n_rows_int_result(0, 2),
-                {
-                    let mut r = build_n_rows_int_result(10, 3);
-                    r.is_drained = Ok(BatchExecIsDrain::Drain);
-                    r
-                },
-            ],
+            vec![build_n_rows_int_result(0, 2), {
+                let mut r = build_n_rows_int_result(10, 3);
+                r.is_drained = Ok(BatchExecIsDrain::Drain);
+                r
+            }],
             vec![500, 800],
         );
 
         // No paging — all batches processed, no incremental drain in loop.
-        let mut runner = build_runner_with_mock_stats(executor, None);
-        let (_resp, range) = block_on(runner.handle_request()).unwrap();
+        let mut runner = build_runner_with_mock_stats(executor, None, None);
+        let (_resp, range, reason) = block_on(runner.handle_request()).unwrap();
         assert!(range.is_none(), "non-paging should not return range");
+        assert_eq!(reason, PagingBreakReason::PagingBreakReasonRangeEnd);
 
         // Final collect_storage_stats drains everything at once.
         let mut stats = MockStats::default();
@@ -2519,5 +2526,33 @@ mod tests {
             stats.scanned_bytes, 1300,
             "non-paging path must collect all stats"
         );
+    }
+
+    #[test]
+    fn test_paging_size_reports_row_limit_reason() {
+        let field_types: Vec<FieldType> = vec![FieldTypeTp::Long.into()];
+        let executor = MockStatsExecutor::new(
+            field_types,
+            vec![
+                build_n_rows_int_result(0, 1),
+                build_n_rows_int_result(10, 1),
+                {
+                    let mut r = build_n_rows_int_result(20, 1);
+                    r.is_drained = Ok(BatchExecIsDrain::Drain);
+                    r
+                },
+            ],
+            vec![100, 100, 100],
+        );
+
+        let mut runner = build_runner_with_mock_stats(executor, Some(2), Some(10_000));
+        let (resp, range, reason) = block_on(runner.handle_request()).unwrap();
+
+        assert!(
+            range.is_some(),
+            "row-count paging should return scanned range"
+        );
+        assert_eq!(reason, PagingBreakReason::PagingBreakReasonRowLimit);
+        assert_eq!(resp.get_chunks().len(), 2);
     }
 }

--- a/components/tidb_query_executors/src/runner.rs
+++ b/components/tidb_query_executors/src/runner.rs
@@ -92,10 +92,8 @@ pub struct BatchExecutorsRunner<SS> {
     paging_size: Option<u64>,
 
     /// If set, paging_size_bytes indicates the byte budget for the current page.
-    /// When accumulated output bytes reach this limit, the scan stops early.
-    /// TODO: Currently tracks encoded output bytes (chunk rows_data). For
-    /// accurate RU alignment, this should track processed_versions_size (MVCC
-    /// scanned bytes) from the storage layer instead.
+    /// When accumulated MVCC scanned bytes reach this limit, the scan stops
+    /// early.
     paging_size_bytes: Option<u64>,
 
     quota_limiter: Arc<QuotaLimiter>,
@@ -108,6 +106,13 @@ pub struct BatchExecutorsRunner<SS> {
     /// It is None when BatchExecutorsRunner is created
     /// and will be set to Some by the inner code by demand
     reserved_intermediate_results: Option<Vec<Vec<BatchExecuteResult>>>,
+
+    /// Function to extract scanned bytes from storage stats.
+    scanned_bytes_fn: fn(&SS) -> usize,
+    /// Storage stats accumulated across all batches. collect_storage_stats
+    /// adds to (not overwrites) dest, so draining into the same object each
+    /// iteration naturally accumulates complete stats for RU accounting.
+    accumulated_storage_stats: SS,
 }
 
 // We assign a dummy type `()` so that we can omit the type when calling
@@ -609,7 +614,7 @@ pub fn build_executors<S: Storage + 'static, F: KvFormat>(
     Ok(executor)
 }
 
-impl<SS: 'static> BatchExecutorsRunner<SS> {
+impl<SS: 'static + Default> BatchExecutorsRunner<SS> {
     pub fn from_request<S: Storage<Statistics = SS> + 'static, F: KvFormat>(
         mut req: DagRequest,
         ranges: Vec<KeyRange>,
@@ -620,6 +625,7 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
         is_streaming: bool,
         paging_size: Option<u64>,
         paging_size_bytes: Option<u64>,
+        scanned_bytes_fn: fn(&SS) -> usize,
         quota_limiter: Arc<QuotaLimiter>,
     ) -> Result<Self> {
         let executors_len = req.get_executors().len();
@@ -710,6 +716,8 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
             quota_limiter,
             intermediate_channels,
             reserved_intermediate_results: None,
+            scanned_bytes_fn,
+            accumulated_storage_stats: SS::default(),
         })
     }
 
@@ -751,10 +759,9 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
         let mut warnings = self.config.new_eval_warnings();
         let mut ctx = EvalContext::new(self.config.clone());
         let mut record_all = 0;
-        // TODO: bytes_all accumulates encoded output bytes (rows_data). For
-        // production use, replace with processed_versions_size from the storage
-        // layer to align with RU accounting.
-        let mut bytes_all: usize = 0;
+        // Accumulates MVCC scanned bytes from the storage layer for
+        // paging_size_bytes truncation, collected via collect_storage_stats.
+        let mut scanned_bytes_all: usize = 0;
         let mut intermediate_output_chunks = if self.intermediate_channels.is_empty() {
             vec![]
         } else {
@@ -795,8 +802,15 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
             if record_len > 0 {
                 record_all += record_len;
             }
-            if read_bytes_len > 0 {
-                bytes_all += read_bytes_len;
+
+            // Drain incremental storage stats into the accumulator.
+            // collect_storage_stats adds to (not overwrites) dest, so the
+            // accumulator naturally holds complete stats across all batches.
+            if self.paging_size_bytes.is_some() {
+                self.out_most_executor
+                    .collect_storage_stats(&mut self.accumulated_storage_stats);
+                scanned_bytes_all =
+                    (self.scanned_bytes_fn)(&self.accumulated_storage_stats);
             }
 
             if chunk.has_rows_data() {
@@ -807,7 +821,7 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
                 || self.paging_size.is_some_and(|p| record_all >= p as usize)
                 || self
                     .paging_size_bytes
-                    .is_some_and(|p| bytes_all >= p as usize)
+                    .is_some_and(|p| scanned_bytes_all >= p as usize)
             {
                 self.out_most_executor
                     .collect_exec_stats(&mut self.exec_stats);
@@ -920,7 +934,11 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
     }
 
     pub fn collect_storage_stats(&mut self, dest: &mut SS) {
-        self.out_most_executor.collect_storage_stats(dest);
+        // Drain any remaining stats from the executor into the accumulator,
+        // then move the complete accumulated stats to the caller.
+        self.out_most_executor
+            .collect_storage_stats(&mut self.accumulated_storage_stats);
+        std::mem::swap(dest, &mut self.accumulated_storage_stats);
     }
 
     pub fn can_be_cached(&self) -> bool {
@@ -1132,6 +1150,7 @@ mod tests {
     use std::{any::type_name, time::Duration};
 
     use api_version::ApiV1;
+    use async_trait::async_trait;
     use futures::executor::block_on;
     use kvproto::metapb::Region;
     use tidb_query_common::execute_stats::ExecSummaryCollectorEnabled;
@@ -1327,6 +1346,8 @@ mod tests {
             1024,
             false,
             None,
+            None,
+            |_: &()| 0,
             Arc::new(QuotaLimiter::default()),
         )
     }
@@ -2279,6 +2300,211 @@ mod tests {
         assert!(
             err.to_string()
                 .contains("invalid parent index: 3, for executor with index: 3, executors len: 5")
+        );
+    }
+
+    // --- Tests for paging_size_bytes with MVCC scanned bytes ---
+
+    /// Stats type that carries scanned byte information for testing.
+    #[derive(Default, Debug, Clone)]
+    struct MockStats {
+        scanned_bytes: usize,
+    }
+
+    /// Mock executor that simulates real TikvStorage drain semantics:
+    /// `next_batch` accumulates pending bytes, `collect_storage_stats` drains
+    /// them into dest. This matches how `TikvStorage::collect_statistics`
+    /// adds to dest and resets its backlog.
+    struct MockStatsExecutor {
+        schema: Vec<FieldType>,
+        results: std::vec::IntoIter<BatchExecuteResult>,
+        bytes_per_batch: Vec<usize>,
+        batch_idx: usize,
+        pending_bytes: usize,
+    }
+
+    impl MockStatsExecutor {
+        fn new(
+            schema: Vec<FieldType>,
+            results: Vec<BatchExecuteResult>,
+            bytes_per_batch: Vec<usize>,
+        ) -> Self {
+            assert_eq!(results.len(), bytes_per_batch.len());
+            Self {
+                schema,
+                results: results.into_iter(),
+                bytes_per_batch,
+                batch_idx: 0,
+                pending_bytes: 0,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl BatchExecutor for MockStatsExecutor {
+        type StorageStats = MockStats;
+
+        fn schema(&self) -> &[FieldType] {
+            &self.schema
+        }
+
+        fn intermediate_schema(&self, _: usize) -> Result<&[FieldType]> {
+            unreachable!()
+        }
+
+        fn consume_and_fill_intermediate_results(
+            &mut self,
+            _: &mut [Vec<BatchExecuteResult>],
+        ) -> Result<()> {
+            Ok(())
+        }
+
+        async fn next_batch(&mut self, _scan_rows: usize) -> BatchExecuteResult {
+            if self.batch_idx < self.bytes_per_batch.len() {
+                self.pending_bytes += self.bytes_per_batch[self.batch_idx];
+                self.batch_idx += 1;
+            }
+            self.results.next().unwrap()
+        }
+
+        fn collect_exec_stats(&mut self, _dest: &mut ExecuteStats) {}
+
+        fn collect_storage_stats(&mut self, dest: &mut MockStats) {
+            dest.scanned_bytes += self.pending_bytes;
+            self.pending_bytes = 0;
+        }
+
+        fn take_scanned_range(&mut self) -> IntervalRange {
+            IntervalRange {
+                lower_inclusive: vec![0],
+                upper_exclusive: vec![0xFF],
+            }
+        }
+
+        fn can_be_cached(&self) -> bool {
+            false
+        }
+    }
+
+    fn build_runner_with_mock_stats(
+        executor: MockStatsExecutor,
+        paging_size_bytes: Option<u64>,
+    ) -> BatchExecutorsRunner<MockStats> {
+        let config = Arc::new(EvalConfig::default());
+        BatchExecutorsRunner {
+            deadline: Deadline::from_now(Duration::from_secs(300)),
+            out_most_executor: Box::new(executor),
+            output_offsets: vec![0],
+            config,
+            collect_exec_summary: false,
+            exec_stats: ExecuteStats::new(1),
+            stream_row_limit: 1024,
+            encode_type: EncodeType::TypeChunk,
+            paging_size: None,
+            paging_size_bytes,
+            quota_limiter: Arc::new(QuotaLimiter::default()),
+            intermediate_channels: vec![],
+            reserved_intermediate_results: None,
+            scanned_bytes_fn: |s: &MockStats| s.scanned_bytes,
+            accumulated_storage_stats: MockStats::default(),
+        }
+    }
+
+    /// Verifies that paging_size_bytes truncates based on MVCC scanned bytes,
+    /// not encoded output bytes.
+    #[test]
+    fn test_paging_size_bytes_truncates_on_scanned_bytes() {
+        let field_types: Vec<FieldType> = vec![FieldTypeTp::Long.into()];
+        // 3 batches, each with 1 row but reporting 1000 scanned bytes.
+        // With paging_size_bytes=1500, should stop after batch 2 (2000 >= 1500).
+        let executor = MockStatsExecutor::new(
+            field_types,
+            vec![
+                build_n_rows_int_result(0, 1),
+                build_n_rows_int_result(10, 1),
+                {
+                    let mut r = build_n_rows_int_result(20, 1);
+                    r.is_drained = Ok(BatchExecIsDrain::Drain);
+                    r
+                },
+            ],
+            vec![1000, 1000, 1000],
+        );
+
+        let mut runner = build_runner_with_mock_stats(executor, Some(1500));
+        let (resp, range) = block_on(runner.handle_request()).unwrap();
+
+        // Paging should have truncated — range returned for next page.
+        assert!(range.is_some(), "should return scanned range for paging");
+        // Only 2 batches processed, so 2 chunks.
+        assert_eq!(resp.get_chunks().len(), 2);
+    }
+
+    /// Verifies that stats collected during the paging loop are fully preserved
+    /// for the final collect_storage_stats call (used by endpoint.rs for RU
+    /// accounting).
+    #[test]
+    fn test_paging_size_bytes_preserves_complete_stats() {
+        let field_types: Vec<FieldType> = vec![FieldTypeTp::Long.into()];
+        let executor = MockStatsExecutor::new(
+            field_types,
+            vec![
+                build_n_rows_int_result(0, 1),
+                build_n_rows_int_result(10, 1),
+                {
+                    let mut r = build_n_rows_int_result(20, 1);
+                    r.is_drained = Ok(BatchExecIsDrain::Drain);
+                    r
+                },
+            ],
+            vec![500, 800, 700],
+        );
+
+        // Budget 1200: batch 1 (500) + batch 2 (800) = 1300 >= 1200, truncate.
+        let mut runner = build_runner_with_mock_stats(executor, Some(1200));
+        let (_resp, range) = block_on(runner.handle_request()).unwrap();
+        assert!(range.is_some());
+
+        // The final collect_storage_stats must return complete stats from all
+        // processed batches, not just the last one.
+        let mut stats = MockStats::default();
+        runner.collect_storage_stats(&mut stats);
+        assert_eq!(
+            stats.scanned_bytes, 1300,
+            "must preserve complete stats for RU accounting"
+        );
+    }
+
+    /// Verifies the non-paging stats path is not broken: when paging_size_bytes
+    /// is None, collect_storage_stats still returns complete stats via the
+    /// standard single-drain path.
+    #[test]
+    fn test_no_paging_bytes_stats_path_unchanged() {
+        let field_types: Vec<FieldType> = vec![FieldTypeTp::Long.into()];
+        let executor = MockStatsExecutor::new(
+            field_types,
+            vec![
+                build_n_rows_int_result(0, 2),
+                {
+                    let mut r = build_n_rows_int_result(10, 3);
+                    r.is_drained = Ok(BatchExecIsDrain::Drain);
+                    r
+                },
+            ],
+            vec![500, 800],
+        );
+
+        // No paging — all batches processed, no incremental drain in loop.
+        let mut runner = build_runner_with_mock_stats(executor, None);
+        let (_resp, range) = block_on(runner.handle_request()).unwrap();
+        assert!(range.is_none(), "non-paging should not return range");
+
+        // Final collect_storage_stats drains everything at once.
+        let mut stats = MockStats::default();
+        runner.collect_storage_stats(&mut stats);
+        assert_eq!(
+            stats.scanned_bytes, 1300,
+            "non-paging path must collect all stats"
         );
     }
 }

--- a/components/tidb_query_executors/src/runner.rs
+++ b/components/tidb_query_executors/src/runner.rs
@@ -91,6 +91,13 @@ pub struct BatchExecutorsRunner<SS> {
     /// current page.
     paging_size: Option<u64>,
 
+    /// If set, paging_size_bytes indicates the byte budget for the current page.
+    /// When accumulated output bytes reach this limit, the scan stops early.
+    /// TODO: Currently tracks encoded output bytes (chunk rows_data). For
+    /// accurate RU alignment, this should track processed_versions_size (MVCC
+    /// scanned bytes) from the storage layer instead.
+    paging_size_bytes: Option<u64>,
+
     quota_limiter: Arc<QuotaLimiter>,
 
     /// Information for intermediate output channels.
@@ -612,6 +619,7 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
         stream_row_limit: usize,
         is_streaming: bool,
         paging_size: Option<u64>,
+        paging_size_bytes: Option<u64>,
         quota_limiter: Arc<QuotaLimiter>,
     ) -> Result<Self> {
         let executors_len = req.get_executors().len();
@@ -627,7 +635,7 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
             extra_storage_accessor,
             ranges,
             config.clone(),
-            is_streaming || paging_size.is_some(), /* For streaming and paging request,
+            is_streaming || paging_size.is_some() || paging_size_bytes.is_some(), /* For streaming and paging request,
                                                     * executors will continue scan from range
                                                     * end where last scan is finished */
         )?;
@@ -698,6 +706,7 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
             stream_row_limit,
             encode_type,
             paging_size,
+            paging_size_bytes,
             quota_limiter,
             intermediate_channels,
             reserved_intermediate_results: None,
@@ -742,6 +751,10 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
         let mut warnings = self.config.new_eval_warnings();
         let mut ctx = EvalContext::new(self.config.clone());
         let mut record_all = 0;
+        // TODO: bytes_all accumulates encoded output bytes (rows_data). For
+        // production use, replace with processed_versions_size from the storage
+        // layer to align with RU accounting.
+        let mut bytes_all: usize = 0;
         let mut intermediate_output_chunks = if self.intermediate_channels.is_empty() {
             vec![]
         } else {
@@ -782,12 +795,20 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
             if record_len > 0 {
                 record_all += record_len;
             }
+            if read_bytes_len > 0 {
+                bytes_all += read_bytes_len;
+            }
 
             if chunk.has_rows_data() {
                 chunks.push(chunk);
             }
 
-            if drained.stop() || self.paging_size.is_some_and(|p| record_all >= p as usize) {
+            if drained.stop()
+                || self.paging_size.is_some_and(|p| record_all >= p as usize)
+                || self
+                    .paging_size_bytes
+                    .is_some_and(|p| bytes_all >= p as usize)
+            {
                 self.out_most_executor
                     .collect_exec_stats(&mut self.exec_stats);
                 tidb_query_common::metrics::record_coprocessor_executor_iterations(
@@ -797,12 +818,14 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
                         .map(|s| s.num_iterations as u64)
                         .sum(),
                 );
+                let is_paging =
+                    self.paging_size.is_some() || self.paging_size_bytes.is_some();
                 let range = if drained == BatchExecIsDrain::Drain {
                     None
+                } else if is_paging {
+                    Some(self.out_most_executor.take_scanned_range())
                 } else {
-                    // It's not allowed to stop paging when BatchExecIsDrain::PagingDrain.
-                    self.paging_size
-                        .map(|_| self.out_most_executor.take_scanned_range())
+                    None
                 };
 
                 let mut sel_resp = SelectResponse::default();

--- a/src/coprocessor/dag/mod.rs
+++ b/src/coprocessor/dag/mod.rs
@@ -183,6 +183,7 @@ impl BatchDagHandler {
                 is_streaming,
                 paging_size,
                 paging_size_bytes,
+                |s: &Statistics| s.processed_size,
                 quota_limiter,
             )?,
             data_version,

--- a/src/coprocessor/dag/mod.rs
+++ b/src/coprocessor/dag/mod.rs
@@ -7,7 +7,7 @@ use std::{marker::PhantomData, sync::Arc};
 use api_version::KvFormat;
 use async_trait::async_trait;
 use kvproto::{
-    coprocessor::{KeyRange, Response},
+    coprocessor::{KeyRange, PagingBreakReason, Response},
     metapb::Region,
 };
 use protobuf::Message;
@@ -212,7 +212,7 @@ impl RequestHandler for BatchDagHandler {
 }
 
 fn handle_qe_response(
-    result: tidb_query_common::Result<(SelectResponse, Option<IntervalRange>)>,
+    result: tidb_query_common::Result<(SelectResponse, Option<IntervalRange>, PagingBreakReason)>,
     can_be_cached: bool,
     data_version: Option<u64>,
 ) -> Result<Response> {
@@ -221,7 +221,7 @@ fn handle_qe_response(
     use crate::coprocessor::Error;
 
     match result {
-        Ok((sel_resp, range)) => {
+        Ok((sel_resp, range, paging_break_reason)) => {
             let mut resp = Response::default();
             if let Some(range) = range {
                 resp.mut_range().set_start(range.lower_inclusive);
@@ -230,6 +230,7 @@ fn handle_qe_response(
             resp.set_data(box_try!(sel_resp.write_to_bytes()));
             resp.set_can_be_cached(can_be_cached);
             resp.set_is_cache_hit(false);
+            resp.set_paging_break_reason(paging_break_reason);
             if let Some(v) = data_version {
                 resp.set_cache_last_version(v);
             }
@@ -295,10 +296,18 @@ mod tests {
     #[test]
     fn test_handle_qe_response() {
         // Ok Response
-        let ok_res = Ok((SelectResponse::default(), None));
+        let ok_res = Ok((
+            SelectResponse::default(),
+            None,
+            PagingBreakReason::PagingBreakReasonRangeEnd,
+        ));
         let res = handle_qe_response(ok_res, true, Some(1)).unwrap();
         assert!(res.can_be_cached);
         assert_eq!(res.get_cache_last_version(), 1);
+        assert_eq!(
+            res.get_paging_break_reason(),
+            PagingBreakReason::PagingBreakReasonRangeEnd
+        );
         let mut select_res = SelectResponse::new();
         Message::merge_from_bytes(&mut select_res, res.get_data()).unwrap();
         assert!(!select_res.has_error());

--- a/src/coprocessor/dag/mod.rs
+++ b/src/coprocessor/dag/mod.rs
@@ -42,6 +42,7 @@ where
     is_streaming: bool,
     is_cache_enabled: bool,
     paging_size: Option<u64>,
+    paging_size_bytes: Option<u64>,
     quota_limiter: Arc<QuotaLimiter>,
     _phantom: PhantomData<F>,
 }
@@ -62,6 +63,7 @@ where
         is_streaming: bool,
         is_cache_enabled: bool,
         paging_size: Option<u64>,
+        paging_size_bytes: Option<u64>,
         quota_limiter: Arc<QuotaLimiter>,
     ) -> Self {
         DagHandlerBuilder {
@@ -75,6 +77,7 @@ where
             is_streaming,
             is_cache_enabled,
             paging_size,
+            paging_size_bytes,
             quota_limiter,
             _phantom: PhantomData,
         }
@@ -99,6 +102,7 @@ where
             self.batch_row_limit,
             self.is_streaming,
             self.paging_size,
+            self.paging_size_bytes,
             self.quota_limiter,
         )?
         .into_boxed())
@@ -163,6 +167,7 @@ impl BatchDagHandler {
         streaming_batch_limit: usize,
         is_streaming: bool,
         paging_size: Option<u64>,
+        paging_size_bytes: Option<u64>,
         quota_limiter: Arc<QuotaLimiter>,
     ) -> Result<Self> {
         let extra_storage_accessor =
@@ -177,6 +182,7 @@ impl BatchDagHandler {
                 streaming_batch_limit,
                 is_streaming,
                 paging_size,
+                paging_size_bytes,
                 quota_limiter,
             )?,
             data_version,

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -272,6 +272,10 @@ impl<E: Engine> Endpoint<E> {
                         0 => None,
                         i => Some(i),
                     };
+                    let paging_size_bytes = match req.get_paging_size_bytes() {
+                        0 => None,
+                        i => Some(i),
+                    };
 
                     let extra_store_accessor =
                         ExtraSnapStoreAccessor::<E>::new(req_ctx.clone(), concurrency_manager);
@@ -285,6 +289,7 @@ impl<E: Engine> Endpoint<E> {
                         is_streaming,
                         req.get_is_cache_enabled(),
                         paging_size,
+                        paging_size_bytes,
                         quota_limiter,
                     )
                     .data_version(data_version)


### PR DESCRIPTION
Draft / test-bundle PR for the `rc-precharge-classic-test` integration bundle (classic / non-Premium variant of the RC paging pre-charge feature).

## Summary
- `coprocessor`: support `paging_size_bytes` for byte-budget paging
- use MVCC scanned bytes for `paging_size_bytes` truncation

## Sibling PRs (test bundle)
- pingcap/kvproto `rc-precharge-classic-test`
- tikv/pd `rc-precharge-classic-test`
- tikv/client-go `rc-precharge-classic-test`
- pingcap/tidb `rc-precharge-classic-test`

This branch exists for upstream CI / cross-repo integration testing. Not intended to be merged as-is.