### PR TITLE
[cherry-pick] Picks optimizations on OOM for hotfix to v8.5.4-20251209

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5153,7 +5153,7 @@ dependencies = [
 [[package]]
 name = "raft-engine"
 version = "0.4.2"
-source = "git+https://github.com/tikv/raft-engine.git?branch=tikv-8.5#2f9f6888dc2c88d3e2b582187c26e196b88b8ef3"
+source = "git+https://github.com/tikv/raft-engine.git?branch=tikv-8.5#3d844051b8a922d3df0d45f2d523ab8e9d537721"
 dependencies = [
  "byteorder",
  "crc32fast",
@@ -5187,7 +5187,7 @@ dependencies = [
 [[package]]
 name = "raft-engine-ctl"
 version = "0.4.2"
-source = "git+https://github.com/tikv/raft-engine.git?branch=tikv-8.5#2f9f6888dc2c88d3e2b582187c26e196b88b8ef3"
+source = "git+https://github.com/tikv/raft-engine.git?branch=tikv-8.5#3d844051b8a922d3df0d45f2d523ab8e9d537721"
 dependencies = [
  "clap 3.1.6",
  "env_logger 0.10.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c80b57a86234ee3e9238f5f2d33d37f8fd5c7ff168c07f2d5147d410e86db33"
 dependencies = [
  "home",
- "libc 0.2.151",
+ "libc 0.2.186",
  "rustc_version 0.4.0",
  "xdg",
 ]
@@ -61,7 +61,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "once_cell",
  "version_check 0.9.4",
- "zerocopy",
+ "zerocopy 0.7.32",
 ]
 
 [[package]]
@@ -94,7 +94,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
- "libc 0.2.151",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -265,7 +265,7 @@ version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 dependencies = [
- "libc 0.2.151",
+ "libc 0.2.186",
  "winapi 0.3.9",
 ]
 
@@ -822,7 +822,7 @@ dependencies = [
  "addr2line",
  "cc",
  "cfg-if 1.0.0",
- "libc 0.2.151",
+ "libc 0.2.186",
  "miniz_oxide 0.4.4",
  "object",
  "rustc-demangle",
@@ -986,7 +986,7 @@ dependencies = [
  "bcc-sys",
  "bitflags 1.3.2",
  "byteorder",
- "libc 0.2.151",
+ "libc 0.2.186",
  "regex",
  "thiserror 1.0.40",
 ]
@@ -1157,7 +1157,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
 dependencies = [
  "cc",
- "libc 0.2.151",
+ "libc 0.2.186",
  "pkg-config",
 ]
 
@@ -1183,7 +1183,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7f788eaf239475a3c1e1acf89951255a46c4b9b46cf3e866fc4d0707b4b9e36"
 dependencies = [
- "libc 0.2.151",
+ "libc 0.2.186",
  "valgrind_request",
 ]
 
@@ -1262,7 +1262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c"
 dependencies = [
  "jobserver",
- "libc 0.2.151",
+ "libc 0.2.186",
  "shlex",
 ]
 
@@ -1391,7 +1391,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f54d78e30b388d4815220c8dd03fea5656b6c6d32adb59e89061552a102f8da1"
 dependencies = [
  "glob",
- "libc 0.2.151",
+ "libc 0.2.186",
  "libloading",
 ]
 
@@ -1477,7 +1477,7 @@ version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71367d3385c716342014ad17e3d19f7788ae514885a1f4c24f500260fb365e1a"
 dependencies = [
- "libc 0.2.151",
+ "libc 0.2.186",
  "once_cell",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
@@ -1490,7 +1490,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "error_code",
- "libc 0.2.151",
+ "libc 0.2.186",
  "panic_hook",
  "protobuf 2.8.0",
  "rand 0.8.5",
@@ -1579,7 +1579,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
 dependencies = [
  "core-foundation-sys",
- "libc 0.2.151",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -1594,7 +1594,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9e393a7668fe1fad3075085b86c781883000b4ede868f43627b34a87c8b7ded"
 dependencies = [
- "libc 0.2.151",
+ "libc 0.2.186",
  "winapi 0.3.9",
 ]
 
@@ -1604,7 +1604,7 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
- "libc 0.2.151",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -1690,7 +1690,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63aaaf47e457badbcb376c65a49d0f182c317ebd97dc6d1ced94c8e1d09c0f3a"
 dependencies = [
  "criterion 0.3.5",
- "libc 0.2.151",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -1974,7 +1974,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
- "libc 0.2.151",
+ "libc 0.2.186",
  "redox_users",
  "winapi 0.3.9",
 ]
@@ -2259,7 +2259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
 dependencies = [
  "errno-dragonfly",
- "libc 0.2.151",
+ "libc 0.2.186",
  "winapi 0.3.9",
 ]
 
@@ -2269,7 +2269,7 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
- "libc 0.2.151",
+ "libc 0.2.186",
  "windows-sys 0.52.0",
 ]
 
@@ -2280,7 +2280,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
- "libc 0.2.151",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -2408,7 +2408,7 @@ dependencies = [
  "fail",
  "fs2",
  "lazy_static",
- "libc 0.2.151",
+ "libc 0.2.186",
  "online_config",
  "openssl",
  "parking_lot 0.12.1",
@@ -2430,7 +2430,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed3d8a5e20435ff00469e51a0d82049bae66504b5c429920dadf9bb54d47b3f"
 dependencies = [
- "libc 0.2.151",
+ "libc 0.2.186",
  "thiserror 1.0.40",
  "winapi 0.3.9",
 ]
@@ -2442,7 +2442,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
 dependencies = [
  "cfg-if 1.0.0",
- "libc 0.2.151",
+ "libc 0.2.186",
  "redox_syscall 0.2.11",
  "winapi 0.3.9",
 ]
@@ -2455,7 +2455,7 @@ checksum = "d691fdb3f817632d259d09220d4cf0991dbb2c9e59e044a02a59194bf6e14484"
 dependencies = [
  "cc",
  "lazy_static",
- "libc 0.2.151",
+ "libc 0.2.186",
  "winapi 0.3.9",
 ]
 
@@ -2486,7 +2486,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2adaffba6388640136149e18ed080b77a78611c1e1d6de75aedcdf78df5d4682"
 dependencies = [
  "crc32fast",
- "libc 0.2.151",
+ "libc 0.2.186",
  "libz-sys",
  "miniz_oxide 0.3.7",
 ]
@@ -2538,7 +2538,7 @@ name = "fs2"
 version = "0.4.3"
 source = "git+https://github.com/tikv/fs2-rs?branch=tikv#cd503764a19a99d74c1ab424dd13d6bcd093fcae"
 dependencies = [
- "libc 0.2.151",
+ "libc 0.2.186",
  "winapi 0.3.9",
 ]
 
@@ -2564,7 +2564,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0"
 dependencies = [
- "libc 0.2.151",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -2815,7 +2815,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
 dependencies = [
  "cfg-if 0.1.10",
- "libc 0.2.151",
+ "libc 0.2.186",
  "wasi 0.7.0",
 ]
 
@@ -2827,9 +2827,21 @@ checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
- "libc 0.2.151",
+ "libc 0.2.186",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc 0.2.186",
+ "r-efi",
+ "wasip2",
 ]
 
 [[package]]
@@ -2876,7 +2888,7 @@ dependencies = [
  "futures-executor",
  "futures-util",
  "grpcio-sys",
- "libc 0.2.151",
+ "libc 0.2.186",
  "log",
  "parking_lot 0.11.1",
  "protobuf 2.8.0",
@@ -2913,7 +2925,7 @@ dependencies = [
  "bindgen 0.59.2",
  "cc",
  "cmake",
- "libc 0.2.151",
+ "libc 0.2.186",
  "libz-sys",
  "openssl-sys",
  "pkg-config",
@@ -3023,7 +3035,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
- "libc 0.2.151",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -3441,7 +3453,7 @@ dependencies = [
  "keys",
  "kvproto",
  "lazy_static",
- "libc 0.2.151",
+ "libc 0.2.186",
  "log_wrappers",
  "online_config",
  "parking_lot 0.12.1",
@@ -3528,7 +3540,7 @@ checksum = "4816c66d2c8ae673df83366c18341538f234a26d65a9ecea5c348b453ac1d02f"
 dependencies = [
  "bitflags 1.3.2",
  "inotify-sys",
- "libc 0.2.151",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -3537,7 +3549,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
- "libc 0.2.151",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -3564,7 +3576,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
 dependencies = [
- "libc 0.2.151",
+ "libc 0.2.186",
  "windows-sys 0.42.0",
 ]
 
@@ -3574,7 +3586,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
- "libc 0.2.151",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -3631,7 +3643,7 @@ version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
- "libc 0.2.151",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -3707,9 +3719,9 @@ checksum = "e32a70cf75e5846d53a673923498228bbec6a8624708a9ea5645f075d6276122"
 
 [[package]]
 name = "libc"
-version = "0.2.151"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -3755,7 +3767,7 @@ dependencies = [
  "bzip2-sys",
  "cc",
  "cmake",
- "libc 0.2.151",
+ "libc 0.2.186",
  "libtitan_sys",
  "libz-sys",
  "lz4-sys",
@@ -3773,7 +3785,7 @@ dependencies = [
  "bzip2-sys",
  "cc",
  "cmake",
- "libc 0.2.151",
+ "libc 0.2.186",
  "libz-sys",
  "lz4-sys",
  "snappy-sys",
@@ -3787,7 +3799,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
 dependencies = [
  "cc",
- "libc 0.2.151",
+ "libc 0.2.186",
  "pkg-config",
  "vcpkg",
 ]
@@ -3870,7 +3882,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9764018d143cc854c9f17f0b907de70f14393b1f502da6375dce70f00514eb3"
 dependencies = [
  "cc",
- "libc 0.2.151",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -3927,7 +3939,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
 dependencies = [
- "libc 0.2.151",
+ "libc 0.2.186",
  "winapi 0.3.9",
 ]
 
@@ -3937,7 +3949,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45fd3a57831bf88bc63f8cebc0cf956116276e97fef3966103e96416209f7c92"
 dependencies = [
- "libc 0.2.151",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -4017,7 +4029,7 @@ dependencies = [
  "fuchsia-zircon-sys",
  "iovec",
  "kernel32-sys",
- "libc 0.2.151",
+ "libc 0.2.186",
  "log",
  "miow",
  "net2",
@@ -4031,7 +4043,7 @@ version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
- "libc 0.2.151",
+ "libc 0.2.186",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
@@ -4124,7 +4136,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
 dependencies = [
  "lazy_static",
- "libc 0.2.151",
+ "libc 0.2.186",
  "log",
  "openssl",
  "openssl-probe",
@@ -4142,7 +4154,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
 dependencies = [
  "cfg-if 0.1.10",
- "libc 0.2.151",
+ "libc 0.2.186",
  "winapi 0.3.9",
 ]
 
@@ -4154,7 +4166,7 @@ checksum = "8f17df307904acd05aa8e32e97bb20f2a0df1728bbc2d771ae8f9a90463441e9"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if 1.0.0",
- "libc 0.2.151",
+ "libc 0.2.186",
  "memoffset 0.6.4",
 ]
 
@@ -4166,7 +4178,7 @@ checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if 1.0.0",
- "libc 0.2.151",
+ "libc 0.2.186",
  "memoffset 0.7.1",
  "pin-utils",
  "static_assertions",
@@ -4225,7 +4237,7 @@ dependencies = [
  "fsevent",
  "fsevent-sys",
  "inotify",
- "libc 0.2.151",
+ "libc 0.2.186",
  "mio 0.6.23",
  "mio-extras",
  "walkdir",
@@ -4371,7 +4383,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi 0.3.9",
- "libc 0.2.151",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -4380,7 +4392,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
 dependencies = [
- "libc 0.2.151",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -4451,7 +4463,7 @@ dependencies = [
  "bitflags 2.4.1",
  "cfg-if 1.0.0",
  "foreign-types",
- "libc 0.2.151",
+ "libc 0.2.186",
  "once_cell",
  "openssl-macros",
  "openssl-sys",
@@ -4490,7 +4502,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db7e971c2c2bba161b2d2fdf37080177eff520b3bc044787c7f1f5f9e78d869b"
 dependencies = [
  "cc",
- "libc 0.2.151",
+ "libc 0.2.186",
  "openssl-src",
  "pkg-config",
  "vcpkg",
@@ -4526,7 +4538,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebde548fbbf1ea81a99b128872779c437752fb99f217c45245e1a61dcd9edcd"
 dependencies = [
- "libc 0.2.151",
+ "libc 0.2.186",
  "winapi 0.3.9",
 ]
 
@@ -4569,7 +4581,7 @@ checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
 dependencies = [
  "cfg-if 1.0.0",
  "instant",
- "libc 0.2.151",
+ "libc 0.2.186",
  "redox_syscall 0.2.11",
  "smallvec",
  "winapi 0.3.9",
@@ -4582,7 +4594,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
 dependencies = [
  "cfg-if 1.0.0",
- "libc 0.2.151",
+ "libc 0.2.186",
  "redox_syscall 0.2.11",
  "smallvec",
  "windows-sys 0.32.0",
@@ -4658,7 +4670,7 @@ checksum = "b8f94885300e262ef461aa9fd1afbf7df3caf9e84e271a74925d1c6c8b24830f"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",
- "libc 0.2.151",
+ "libc 0.2.186",
  "mmap",
  "nom 4.2.3",
  "phf",
@@ -4791,7 +4803,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d27361d7578b410d0eb5fe815c2b2105b01ab770a7c738cb9a231457a809fcc7"
 dependencies = [
  "ipnetwork",
- "libc 0.2.151",
+ "libc 0.2.186",
  "pnet_base",
  "pnet_sys",
  "winapi 0.2.8",
@@ -4803,7 +4815,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82f881a6d75ac98c5541db6144682d1773bb14c6fc50c6ebac7086c8f7f23c29"
 dependencies = [
- "libc 0.2.151",
+ "libc 0.2.186",
  "winapi 0.2.8",
  "ws2_32-sys",
 ]
@@ -4825,7 +4837,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "findshlibs",
  "inferno",
- "libc 0.2.151",
+ "libc 0.2.186",
  "log",
  "nix 0.26.2",
  "once_cell",
@@ -4840,9 +4852,12 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.10"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy 0.8.27",
+]
 
 [[package]]
 name = "predicates"
@@ -4933,7 +4948,7 @@ dependencies = [
  "byteorder",
  "hex 0.4.3",
  "lazy_static",
- "libc 0.2.151",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -4942,7 +4957,7 @@ version = "0.4.2"
 source = "git+https://github.com/tikv/procinfo-rs?rev=7693954bd1dd86eb1709572fd7b62fd5f7ff2ea1#7693954bd1dd86eb1709572fd7b62fd5f7ff2ea1"
 dependencies = [
  "byteorder",
- "libc 0.2.151",
+ "libc 0.2.186",
  "nom 2.2.1",
  "rustc_version 0.2.3",
 ]
@@ -4967,7 +4982,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "fnv",
  "lazy_static",
- "libc 0.2.151",
+ "libc 0.2.186",
  "memchr",
  "parking_lot 0.11.1",
  "protobuf 2.8.0",
@@ -5136,16 +5151,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "raft"
 version = "0.7.0"
-source = "git+https://github.com/tikv/raft-rs?branch=master#1fd05e000fb094015507c5c985849d370100fb72"
+source = "git+https://github.com/tikv/raft-rs?branch=master#ad13f3d90780f53aea2488c6a4b76c0d334bf136"
 dependencies = [
  "bytes",
  "fxhash",
  "getset",
- "protobuf 2.8.0",
  "raft-proto",
- "rand 0.8.5",
+ "rand 0.9.4",
  "slog",
  "thiserror 1.0.40",
 ]
@@ -5164,7 +5184,7 @@ dependencies = [
  "hex 0.4.3",
  "if_chain",
  "lazy_static",
- "libc 0.2.151",
+ "libc 0.2.186",
  "log",
  "lz4-sys",
  "memmap2",
@@ -5197,7 +5217,7 @@ dependencies = [
 [[package]]
 name = "raft-proto"
 version = "0.7.0"
-source = "git+https://github.com/tikv/raft-rs?branch=master#1fd05e000fb094015507c5c985849d370100fb72"
+source = "git+https://github.com/tikv/raft-rs?branch=master#ad13f3d90780f53aea2488c6a4b76c0d334bf136"
 dependencies = [
  "bytes",
  "protobuf 2.8.0",
@@ -5349,7 +5369,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 dependencies = [
  "fuchsia-cprng",
- "libc 0.2.151",
+ "libc 0.2.186",
  "rand_core 0.3.1",
  "rdrand",
  "winapi 0.3.9",
@@ -5362,7 +5382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom 0.1.12",
- "libc 0.2.151",
+ "libc 0.2.186",
  "rand_chacha 0.2.1",
  "rand_core 0.5.1",
  "rand_hc",
@@ -5374,9 +5394,19 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "libc 0.2.151",
+ "libc 0.2.186",
  "rand_chacha 0.3.0",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -5397,6 +5427,16 @@ checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -5430,6 +5470,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.11",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -5749,7 +5798,7 @@ name = "rocksdb"
 version = "0.3.0"
 source = "git+https://github.com/tikv/rust-rocksdb.git#a6b0bb0483986cbcec14530064f53b7f14facfa2"
 dependencies = [
- "libc 0.2.151",
+ "libc 0.2.186",
  "librocksdb_sys",
 ]
 
@@ -5822,7 +5871,7 @@ dependencies = [
  "bitflags 1.3.2",
  "errno 0.2.8",
  "io-lifetimes",
- "libc 0.2.151",
+ "libc 0.2.186",
  "linux-raw-sys 0.1.4",
  "windows-sys 0.42.0",
 ]
@@ -5835,7 +5884,7 @@ checksum = "ac5ffa1efe7548069688cd7028f32591853cd7b5b756d41bcffd2353e4fc75b4"
 dependencies = [
  "bitflags 2.4.1",
  "errno 0.3.8",
- "libc 0.2.151",
+ "libc 0.2.186",
  "linux-raw-sys 0.4.12",
  "windows-sys 0.48.0",
 ]
@@ -5917,7 +5966,7 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
- "libc 0.2.151",
+ "libc 0.2.186",
  "security-framework-sys",
 ]
 
@@ -5928,7 +5977,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3676258fd3cfe2c9a0ec99ce3038798d847ce3e4bb17746373eb9f0f1ac16339"
 dependencies = [
  "core-foundation-sys",
- "libc 0.2.151",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -6130,7 +6179,7 @@ dependencies = [
  "in_memory_engine",
  "keys",
  "kvproto",
- "libc 0.2.151",
+ "libc 0.2.186",
  "log_wrappers",
  "pd_client",
  "prometheus",
@@ -6209,7 +6258,7 @@ version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
 dependencies = [
- "libc 0.2.151",
+ "libc 0.2.186",
  "signal-hook-registry",
 ]
 
@@ -6219,7 +6268,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
- "libc 0.2.151",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -6350,7 +6399,7 @@ version = "0.1.0"
 source = "git+https://github.com/tikv/rust-snappy.git?branch=static-link#8c12738bad811397600455d6982aff754ea2ac44"
 dependencies = [
  "cmake",
- "libc 0.2.151",
+ "libc 0.2.186",
  "pkg-config",
 ]
 
@@ -6378,7 +6427,7 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
- "libc 0.2.151",
+ "libc 0.2.186",
  "windows-sys 0.52.0",
 ]
 
@@ -6614,7 +6663,7 @@ source = "git+https://github.com/tikv/sysinfo?branch=0.26-fix-cpu#5a1bcf08816979
 dependencies = [
  "cfg-if 1.0.0",
  "core-foundation-sys",
- "libc 0.2.151",
+ "libc 0.2.186",
  "ntapi",
  "once_cell",
  "rayon",
@@ -7324,7 +7373,7 @@ dependencies = [
  "keys",
  "kvproto",
  "lazy_static",
- "libc 0.2.151",
+ "libc 0.2.186",
  "libloading",
  "log",
  "log_wrappers",
@@ -7448,7 +7497,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e37706572f4b151dff7a0146e040804e9c26fe3a3118591112f05cf12a4216c1"
 dependencies = [
- "libc 0.2.151",
+ "libc 0.2.186",
  "paste",
  "tikv-jemalloc-sys",
 ]
@@ -7461,7 +7510,7 @@ checksum = "aeab4310214fe0226df8bfeb893a291a58b19682e8a07e1e1d4483ad4200d315"
 dependencies = [
  "cc",
  "fs_extra",
- "libc 0.2.151",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -7470,7 +7519,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20612db8a13a6c06d57ec83953694185a367e16945f66565e8028d2c0bd76979"
 dependencies = [
- "libc 0.2.151",
+ "libc 0.2.186",
  "tikv-jemalloc-sys",
 ]
 
@@ -7497,7 +7546,7 @@ version = "0.1.0"
 dependencies = [
  "fxhash",
  "lazy_static",
- "libc 0.2.151",
+ "libc 0.2.186",
  "mimalloc",
  "snmalloc-rs",
  "tcmalloc",
@@ -7565,7 +7614,7 @@ dependencies = [
  "http 0.2.12",
  "kvproto",
  "lazy_static",
- "libc 0.2.151",
+ "libc 0.2.186",
  "log",
  "log_wrappers",
  "nix 0.24.1",
@@ -7612,7 +7661,7 @@ version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
- "libc 0.2.151",
+ "libc 0.2.186",
  "winapi 0.3.9",
 ]
 
@@ -7624,7 +7673,7 @@ checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa 1.0.1",
- "libc 0.2.151",
+ "libc 0.2.186",
  "num-conv",
  "num_threads",
  "powerfmt",
@@ -7712,7 +7761,7 @@ checksum = "68722da18b0fc4a05fdc1120b302b82051265792a1e1b399086e9b204b10ad3d"
 dependencies = [
  "backtrace",
  "bytes",
- "libc 0.2.151",
+ "libc 0.2.186",
  "mio 0.8.11",
  "num_cpus",
  "parking_lot 0.12.1",
@@ -8101,7 +8150,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
- "libc 0.2.151",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -8142,6 +8191,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -8229,7 +8287,7 @@ checksum = "2a5a7e487e921cf220206864a94a89b6c6905bfc19f1057fa26a4cb360e5c1d2"
 dependencies = [
  "either",
  "lazy_static",
- "libc 0.2.151",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -8526,6 +8584,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8627,7 +8691,16 @@ version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.7.32",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+dependencies = [
+ "zerocopy-derive 0.8.27",
 ]
 
 [[package]]
@@ -8635,6 +8708,17 @@ name = "zerocopy-derive"
 version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -403,6 +403,15 @@ where
         self.hibernate_state.reset(state);
         if state == GroupState::Idle {
             self.peer.raft_group.raft.maybe_free_inflight_buffers();
+            // For hibernated regions, proactively release the empty unstable
+            // entry buffer to save memory.
+            self.peer
+                .raft_group
+                .raft
+                .r
+                .raft_log
+                .unstable
+                .release_entry_buffer();
         }
     }
 
@@ -1249,14 +1258,22 @@ where
                 if store.is_applying_snapshot() {
                     local_state.set_state(PeerState::Applying);
                 }
-                cb(RegionMeta::new(
+                let mut meta = RegionMeta::new(
                     &local_state,
                     store.apply_state(),
                     self.fsm.hibernate_state.group_state(),
                     peer.raft_group.status(),
                     peer.raft_group.raft.raft_log.last_index(),
                     peer.raft_group.raft.raft_log.persisted,
-                ))
+                );
+                #[cfg(any(test, feature = "testexport"))]
+                {
+                    let unstable = &peer.raft_group.raft.raft_log.unstable;
+                    meta.raft_status.unstable_entries_len = unstable.entries.len();
+                    meta.raft_status.unstable_entries_capacity = unstable.entries.capacity();
+                    meta.raft_status.unstable_entries_size = unstable.entries_size;
+                }
+                cb(meta)
             }
             CasualMessage::QueryRegionLeaderResp { region, leader } => {
                 // the leader already updated

--- a/components/raftstore/src/store/region_meta.rs
+++ b/components/raftstore/src/store/region_meta.rs
@@ -95,6 +95,12 @@ pub struct RaftStatus {
     pub learners: HashMap<u64, RaftProgress>,
     pub last_index: u64,
     pub persisted_index: u64,
+    #[cfg(any(test, feature = "testexport"))]
+    pub unstable_entries_len: usize,
+    #[cfg(any(test, feature = "testexport"))]
+    pub unstable_entries_capacity: usize,
+    #[cfg(any(test, feature = "testexport"))]
+    pub unstable_entries_size: usize,
 }
 
 impl<'a> From<raft::Status<'a>> for RaftStatus {
@@ -130,6 +136,12 @@ impl<'a> From<raft::Status<'a>> for RaftStatus {
             learners,
             last_index: 0,
             persisted_index: 0,
+            #[cfg(any(test, feature = "testexport"))]
+            unstable_entries_len: 0,
+            #[cfg(any(test, feature = "testexport"))]
+            unstable_entries_capacity: 0,
+            #[cfg(any(test, feature = "testexport"))]
+            unstable_entries_size: 0,
         }
     }
 }

--- a/components/resolved_ts/src/advance.rs
+++ b/components/resolved_ts/src/advance.rs
@@ -24,7 +24,7 @@ use kvproto::{
     tikvpb::TikvClient,
 };
 use pd_client::PdClient;
-use protobuf::Message;
+use protobuf::{Message, RepeatedField};
 use raftstore::{
     router::CdcHandle,
     store::{msg::Callback, util::RegionReadProgressRegistry},
@@ -48,6 +48,8 @@ use crate::{TsSource, endpoint::Task, metrics::*};
 pub(crate) const DEFAULT_CHECK_LEADER_TIMEOUT_DURATION: Duration = Duration::from_secs(5); // 5s
 const DEFAULT_GRPC_GZIP_COMPRESSION_LEVEL: usize = 2;
 const DEFAULT_GRPC_MIN_MESSAGE_SIZE_TO_COMPRESS: usize = 4096;
+const CHECK_LEADER_REQ_REGIONS_SHRINK_FACTOR: usize = 4;
+const CHECK_LEADER_REQ_REGIONS_MIN_RETAIN_CAPACITY: usize = 1024;
 
 pub struct AdvanceTsWorker {
     pd_client: Arc<dyn PdClient>,
@@ -218,8 +220,7 @@ impl LeadershipResolver {
 
     fn clear(&mut self) {
         for v in self.store_req_map.values_mut() {
-            v.regions.clear();
-            v.ts = 0;
+            reset_check_leader_request(v);
         }
         for v in self.progresses.values_mut() {
             v.clear();
@@ -287,11 +288,7 @@ impl LeadershipResolver {
                         // because performing stale read on learners require it.
                         store_req_map
                             .entry(peer.store_id)
-                            .or_insert_with(|| {
-                                let mut req = CheckLeaderRequest::default();
-                                req.regions = Vec::with_capacity(registry.len()).into();
-                                req
-                            })
+                            .or_default()
                             .regions
                             .push(leader_info.clone());
                         if peer.get_role() != PeerRole::Learner {
@@ -436,6 +433,19 @@ impl LeadershipResolver {
         }
         res
     }
+}
+
+fn reset_check_leader_request(req: &mut CheckLeaderRequest) {
+    let retained_len = req.regions.len();
+    let shrink_threshold = retained_len
+        .saturating_mul(CHECK_LEADER_REQ_REGIONS_SHRINK_FACTOR)
+        .max(CHECK_LEADER_REQ_REGIONS_MIN_RETAIN_CAPACITY);
+    if req.regions.capacity() > shrink_threshold {
+        req.regions = RepeatedField::from_vec(Vec::with_capacity(retained_len));
+    } else {
+        req.regions.clear();
+    }
+    req.ts = 0;
 }
 
 pub async fn resolve_by_raft<T, E>(regions: Vec<u64>, min_ts: TimeStamp, cdc_handle: T) -> Vec<u64>
@@ -599,6 +609,7 @@ mod tests {
     use grpcio::{self, ChannelBuilder, EnvBuilder, Server, ServerBuilder};
     use kvproto::{metapb::Region, tikvpb::Tikv, tikvpb_grpc::create_tikv};
     use pd_client::PdClient;
+    use protobuf::RepeatedField;
     use raftstore::store::util::RegionReadProgress;
     use tikv_util::store::new_peer;
 
@@ -637,6 +648,18 @@ mod tests {
         let channel = ChannelBuilder::new(env).connect(&addr);
         let client = TikvClient::new(channel);
         (server, client, rx)
+    }
+
+    fn new_progress(region_id: u64, remote_store_id: u64) -> Arc<RegionReadProgress> {
+        let mut region = Region::default();
+        region.id = region_id;
+        region.peers.push(new_peer(1, region_id));
+        region
+            .peers
+            .push(new_peer(remote_store_id, region_id + 10_000));
+        let progress = RegionReadProgress::new(&region, 1, 1, region_id);
+        progress.update_leader_info(region_id, 1, &region);
+        Arc::new(progress)
     }
 
     #[tokio::test]
@@ -696,6 +719,91 @@ mod tests {
             .resolve(vec![], TimeStamp::new(1), None)
             .await;
         rx.recv_timeout(Duration::from_secs(1)).unwrap_err();
+
+        let _ = server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_resolve_request_capacity_ignores_registry_size() {
+        let env = Arc::new(EnvBuilder::new().build());
+        let (mut server, tikv_client, rx) = new_rpc_suite(env.clone());
+
+        let mut leader_resolver = LeadershipResolver::new(
+            1, // store id
+            Arc::new(MockPdClient {}),
+            env.clone(),
+            Arc::new(SecurityManager::default()),
+            RegionReadProgressRegistry::new(),
+            Duration::from_secs(1),
+        );
+        leader_resolver
+            .tikv_clients
+            .lock()
+            .await
+            .insert(2 /* store id */, tikv_client);
+        for region_id in 1..=2048 {
+            leader_resolver
+                .region_read_progress
+                .insert(region_id, new_progress(region_id, 2));
+        }
+
+        leader_resolver
+            .resolve(vec![1], TimeStamp::new(1), None)
+            .await;
+        let req = rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        assert_eq!(req.regions.len(), 1);
+
+        let retained_req = leader_resolver.store_req_map.get(&2).unwrap();
+        assert_eq!(retained_req.regions.len(), 1);
+        assert!(
+            retained_req.regions.capacity() < 64,
+            "unexpected request capacity {} for a single checked region",
+            retained_req.regions.capacity()
+        );
+
+        let _ = server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_resolve_shrinks_oversized_request_buffer_on_reuse() {
+        let env = Arc::new(EnvBuilder::new().build());
+        let (mut server, tikv_client, rx) = new_rpc_suite(env.clone());
+
+        let mut leader_resolver = LeadershipResolver::new(
+            1, // store id
+            Arc::new(MockPdClient {}),
+            env.clone(),
+            Arc::new(SecurityManager::default()),
+            RegionReadProgressRegistry::new(),
+            Duration::from_secs(60),
+        );
+        leader_resolver
+            .tikv_clients
+            .lock()
+            .await
+            .insert(2 /* store id */, tikv_client);
+        leader_resolver
+            .region_read_progress
+            .insert(1, new_progress(1, 2));
+
+        let mut req = CheckLeaderRequest::default();
+        req.regions = RepeatedField::from_vec(Vec::with_capacity(4096));
+        req.regions.push(Default::default());
+        leader_resolver.store_req_map.insert(2, req);
+
+        leader_resolver
+            .resolve(vec![1], TimeStamp::new(1), None)
+            .await;
+        let req = rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        assert_eq!(req.regions.len(), 1);
+
+        let retained_req = leader_resolver.store_req_map.get(&2).unwrap();
+        assert_eq!(retained_req.regions.len(), 1);
+        assert!(
+            retained_req.regions.capacity() < 64,
+            "oversized request buffer was not shrunk, capacity {}",
+            retained_req.regions.capacity()
+        );
 
         let _ = server.shutdown().await;
     }

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -1195,6 +1195,35 @@ impl<T: Simulator> Cluster<T> {
         status_resp.take_region_detail()
     }
 
+    pub fn unstable_entries_stat(&self, region_id: u64, store_id: u64) -> (usize, usize, usize) {
+        let (_, len, cap, size) = self.unstable_entries_state(region_id, store_id);
+        (len, cap, size)
+    }
+
+    pub fn unstable_entries_state(
+        &self,
+        region_id: u64,
+        store_id: u64,
+    ) -> (GroupState, usize, usize, usize) {
+        let router = self.sim.rl().get_router(store_id).unwrap();
+        let (tx, rx) = mpsc::channel();
+        CasualRouter::send(
+            &router,
+            region_id,
+            CasualMessage::AccessPeer(Box::new(move |meta| {
+                tx.send((
+                    meta.group_state,
+                    meta.raft_status.unstable_entries_len,
+                    meta.raft_status.unstable_entries_capacity,
+                    meta.raft_status.unstable_entries_size,
+                ))
+                .unwrap();
+            })),
+        )
+        .unwrap();
+        rx.recv_timeout(Duration::from_secs(5)).unwrap()
+    }
+
     pub fn truncated_state(&self, region_id: u64, store_id: u64) -> RaftTruncatedState {
         self.apply_state(region_id, store_id).take_truncated_state()
     }

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -148,6 +148,11 @@ pub struct Config {
     // When merge raft messages into a batch message, leave a buffer.
     #[online_config(skip)]
     pub raft_client_grpc_send_msg_buffer: usize,
+    // NOTE: the memory of a single item is 216B, so with 16k capacity, the memory of a single
+    // queue is ~3MB.
+    /// The total capacity of the raft client's message queues for a specific
+    /// store. The capacity of a single connection is
+    /// `raft_client_queue_size / grpc_raft_conn_num`.
     #[online_config(skip)]
     pub raft_client_queue_size: usize,
     // Test only
@@ -474,6 +479,16 @@ impl Config {
             self.heavy_load_threshold = 75;
         }
 
+        if self.grpc_raft_conn_num == 0 {
+            return Err(box_err!(
+                "server.grpc-raft-conn-num must be greater than 0."
+            ));
+        }
+        if self.raft_client_queue_size < self.grpc_raft_conn_num {
+            return Err(box_err!(
+                "server.raft-client-queue-size must be greater than or equal to server.grpc-raft-conn-num"
+            ));
+        }
         Ok(())
     }
 

--- a/src/server/raft_client.rs
+++ b/src/server/raft_client.rs
@@ -1024,9 +1024,11 @@ where
                 .connections
                 .entry((store_id, conn_id))
                 .or_insert_with(|| {
-                    let queue = Arc::new(Queue::with_capacity(
-                        self.builder.cfg.value().raft_client_queue_size,
-                    ));
+                    let queue_capacity = {
+                        let cfg = self.builder.cfg.value();
+                        cfg.raft_client_queue_size / cfg.grpc_raft_conn_num
+                    };
+                    let queue = Arc::new(Queue::with_capacity(queue_capacity));
                     if need_pause {
                         queue.set_conn_state(ConnState::Paused);
                     }

--- a/tests/failpoints/cases/test_async_io.rs
+++ b/tests/failpoints/cases/test_async_io.rs
@@ -336,3 +336,50 @@ fn test_async_io_cannot_handle_ready_when_persist_snapshot() {
 
     must_get_equal(&cluster.get_engine(3), b"k29", b"v1");
 }
+
+#[test]
+fn test_async_io_unstable_entries_shrink_after_persist() {
+    let mut cluster = new_node_cluster(0, 3);
+    cluster.cfg.raft_store.raft_log_gc_threshold = 10_000;
+    cluster.cfg.raft_store.raft_log_gc_count_limit = Some(10_000);
+    let pd_client = Arc::clone(&cluster.pd_client);
+    pd_client.disable_default_operator();
+
+    cluster.run();
+
+    let region = pd_client.get_region(b"k1").unwrap();
+    let peer_1 = find_peer(&region, 1).cloned().unwrap();
+    cluster.must_transfer_leader(region.get_id(), peer_1);
+    let before = cluster.unstable_entries_stat(region.get_id(), 3);
+
+    cluster.add_send_filter(IsolationFilterFactory::new(3));
+
+    let value = vec![b'v'; 32];
+    for i in 0..600 {
+        let key = format!("k{:04}", i + 1);
+        cluster.must_put(key.as_bytes(), &value);
+    }
+
+    cluster.clear_send_filters();
+    must_get_equal(&cluster.get_engine(3), b"k0600", &value);
+
+    let mut after = cluster.unstable_entries_stat(region.get_id(), 3);
+    for _ in 0..50 {
+        if after.0 == 0 {
+            break;
+        }
+        sleep_ms(100);
+        after = cluster.unstable_entries_stat(region.get_id(), 3);
+    }
+    assert_eq!(
+        after.0, 0,
+        "unstable entries should be fully persisted: {:?}",
+        after
+    );
+    assert!(
+        after.1 <= 128,
+        "unstable entries capacity should shrink after persist, before={:?}, after={:?}",
+        before,
+        after
+    );
+}

--- a/tests/failpoints/cases/test_hibernate.rs
+++ b/tests/failpoints/cases/test_hibernate.rs
@@ -3,12 +3,13 @@
 use std::{
     sync::{atomic::*, mpsc::channel, *},
     thread,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use kvproto::raft_serverpb::{ExtraMessage, ExtraMessageType, RaftMessage};
+use pd_client::PdClient;
 use raft::eraftpb::MessageType;
-use raftstore::store::{PeerMsg, PeerTick};
+use raftstore::store::{GroupState, PeerMsg, PeerTick};
 use test_raftstore::*;
 use tikv_util::{HandyRwLock, config::ReadableDuration};
 
@@ -151,6 +152,73 @@ fn test_restart_peer_busy_on_apply() {
     thread::sleep(Duration::from_millis(base_tick_ms));
     let stats = cluster.pd_client.get_store_stats(3).unwrap();
     assert!(!stats.is_busy);
+}
+
+#[test]
+fn test_hibernate_region_releases_unstable_entry_buffer() {
+    let mut cluster = new_node_cluster(0, 3);
+    let base_tick_ms = 50;
+    cluster.cfg.raft_store.raft_base_tick_interval = ReadableDuration::millis(base_tick_ms);
+    cluster.cfg.raft_store.raft_heartbeat_ticks = 2;
+    cluster.cfg.raft_store.raft_election_timeout_ticks = 10;
+    cluster.cfg.raft_store.raft_min_election_timeout_ticks = 10;
+    cluster.cfg.raft_store.raft_max_election_timeout_ticks = 11;
+    cluster.cfg.raft_store.raft_log_gc_threshold = 10_000;
+    cluster.cfg.raft_store.raft_log_gc_count_limit = Some(10_000);
+    configure_for_hibernate(&mut cluster.cfg);
+    cluster.pd_client.disable_default_operator();
+
+    cluster.run();
+
+    let region = cluster.pd_client.get_region(b"k1").unwrap();
+    let peer_1 = find_peer(&region, 1).cloned().unwrap();
+    cluster.must_transfer_leader(region.get_id(), peer_1);
+
+    cluster.add_send_filter(IsolationFilterFactory::new(3));
+
+    let value = vec![b'v'; 32];
+    for i in 0..600 {
+        let key = format!("k{:04}", i + 1);
+        cluster.must_put(key.as_bytes(), &value);
+    }
+
+    cluster.clear_send_filters();
+    must_get_equal(&cluster.get_engine(3), b"k0600", &value);
+
+    let mut persisted = cluster.unstable_entries_state(region.get_id(), 3);
+    for _ in 0..50 {
+        if persisted.1 == 0 {
+            break;
+        }
+        thread::sleep(Duration::from_millis(100));
+        persisted = cluster.unstable_entries_state(region.get_id(), 3);
+    }
+    assert_eq!(
+        persisted.1, 0,
+        "unstable entries should be fully persisted before hibernation: {:?}",
+        persisted
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut hibernated = persisted;
+    while Instant::now() < deadline {
+        hibernated = cluster.unstable_entries_state(region.get_id(), 3);
+        if hibernated.0 == GroupState::Idle {
+            break;
+        }
+        thread::sleep(Duration::from_millis(base_tick_ms));
+    }
+    assert_eq!(
+        hibernated.0,
+        GroupState::Idle,
+        "peer should eventually hibernate after catch-up: {:?}",
+        hibernated
+    );
+    assert_eq!(
+        hibernated.2, 0,
+        "hibernated peer should release the unstable entry buffer: {:?}",
+        hibernated
+    );
 }
 
 #[test]


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close https://github.com/tikv/tikv/issues/19535, https://github.com/tikv/tikv/issues/19542, https://github.com/tikv/tikv/issues/19544, https://github.com/tikv/tikv/issues/19593

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

Backport upstream memory optimizations to `v8.5.4-20251208`, including:
- resolved_ts memory reduction (#19536)
- raft_client queue memory reduction (#19543)
- raft-engine bump to 3d844051
- raft-rs / raft-proto bump plus unstable-entry buffer release improvements (#19596)
- cleanup of unused ExtraRegionOverride code path

```commit-message
Backport upstream memory optimizations to `v8.5.4-20251208`.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Backport upstream memory optimizations to `v8.5.4-20251208`
```
