### PR TITLE
cdc, tikv_kv: avoid repeated old value cursor prev in incremental scan

### DIFF
--- a/components/cdc/src/initializer.rs
+++ b/components/cdc/src/initializer.rs
@@ -670,7 +670,7 @@ mod tests {
         collections::BTreeMap,
         fmt::Display,
         sync::{
-            Arc,
+            Arc, Mutex,
             atomic::AtomicBool,
             mpsc::{Receiver, RecvTimeoutError, Sender, channel, sync_channel},
         },
@@ -683,17 +683,22 @@ mod tests {
     use kvproto::{
         cdcpb::{Event_oneof_event, EventLogType},
         errorpb::Error as ErrorHeader,
+        kvrpcpb::{AssertionLevel, Context},
     };
     use raftstore::{coprocessor::ObserveHandle, router::CdcRaftRouter};
     use test_raftstore::MockRaftStoreRouter;
     use tikv::{
         config::DbConfig,
         storage::{
-            TestEngineBuilder,
+            TestEngineBuilder, TestStorageBuilderApiV1,
             kv::Engine,
-            txn::tests::{
-                must_acquire_pessimistic_lock, must_commit, must_prewrite_delete,
-                must_prewrite_put, must_prewrite_put_with_txn_soucre,
+            lock_manager::MockLockManager,
+            txn::{
+                commands,
+                tests::{
+                    must_acquire_pessimistic_lock, must_commit, must_prewrite_delete,
+                    must_prewrite_put, must_prewrite_put_with_txn_soucre,
+                },
             },
         },
     };
@@ -704,9 +709,12 @@ mod tests {
         worker::{LazyWorker, Runnable},
     };
     use tokio::runtime::{Builder, Runtime};
+    use txn_types::Mutation;
 
     use super::*;
     use crate::txn_source::TxnSource;
+
+    static OLD_VALUE_SCAN_METRICS_LOCK: Mutex<()> = Mutex::new(());
 
     struct ReceiverRunnable<T: Display + Send> {
         tx: Sender<T>,
@@ -1044,6 +1052,190 @@ mod tests {
             .flush_cf(CF_WRITE, false)
             .unwrap();
         check_handling_old_value_seek_write(&mut engine, v_suffix); // For TxnEntry::Commit.
+    }
+
+    #[test]
+    fn test_async_incremental_scan_not_call_old_value_prev() {
+        const INSERT_LOCK_COUNT: usize = 64;
+        const MAX_SCAN_BATCH_SIZE: usize = 7;
+
+        let mut engine = TestEngineBuilder::new().build_without_cache().unwrap();
+        let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(
+            engine.clone(),
+            MockLockManager::new(),
+        )
+        .build()
+        .unwrap();
+        let sched_prewrite_put =
+            |key: &[u8], value: &[u8], start_ts: u64| -> tikv::storage::Result<()> {
+                let (tx, rx) = channel();
+                storage
+                    .sched_txn_command(
+                        commands::Prewrite::new(
+                            vec![Mutation::make_put(Key::from_raw(key), value.to_vec())],
+                            key.to_vec(),
+                            start_ts.into(),
+                            0,
+                            false,
+                            0,
+                            TimeStamp::zero(),
+                            TimeStamp::zero(),
+                            None,
+                            false,
+                            AssertionLevel::Off,
+                            Context::default(),
+                        ),
+                        Box::new(move |res| tx.send(res.map(|_| ())).unwrap()),
+                    )
+                    .unwrap();
+                rx.recv().unwrap()
+            };
+        let sched_commit =
+            |key: &[u8], start_ts: u64, commit_ts: u64| -> tikv::storage::Result<()> {
+                let (tx, rx) = channel();
+                storage
+                    .sched_txn_command(
+                        commands::Commit::new(
+                            vec![Key::from_raw(key)],
+                            start_ts.into(),
+                            commit_ts.into(),
+                            None,
+                            Context::default(),
+                        ),
+                        Box::new(move |res| tx.send(res.map(|_| ())).unwrap()),
+                    )
+                    .unwrap();
+                rx.recv().unwrap()
+            };
+        let checkpoint_ts = TimeStamp::new(150);
+        let tail_key = b"zz-old-value-tail";
+        let tail_old_value = b"tail-old-value";
+        let tail_lock_value = b"tail-lock-value";
+
+        // The committed write is intentionally after every insert-like lock key in
+        // user-key order. It is older than checkpoint_ts and flushed to SST, so the
+        // incremental scanner enables the write-CF ts filter and returns
+        // OldValue::SeekWrite for lock keys whose old writes may have been filtered.
+        sched_prewrite_put(tail_key, tail_old_value, 80).unwrap();
+        sched_commit(tail_key, 80, 90).unwrap();
+        engine
+            .kv_engine()
+            .unwrap()
+            .flush_cf(CF_WRITE, true)
+            .unwrap();
+
+        let insert_lock_keys: Vec<Vec<u8>> = (0..INSERT_LOCK_COUNT)
+            .map(|i| format!("za-insert-miss-{i:03}").into_bytes())
+            .collect();
+        for (i, key) in insert_lock_keys.iter().enumerate() {
+            // Use Storage scheduler prewrite commands to leave insert-like Put locks.
+            // These keys have no committed old write; old-value lookup should miss.
+            sched_prewrite_put(key, format!("lock-value-{i:03}").as_bytes(), 200 + i as u64)
+                .unwrap();
+        }
+        // Also leave an update lock exactly on the cached missing range upper user key.
+        // This covers the correctness side: a missing_range hit must keep the old-value
+        // cursor on the boundary write and still load the real old value.
+        sched_prewrite_put(tail_key, tail_lock_value, 300).unwrap();
+
+        let _metrics_guard = OLD_VALUE_SCAN_METRICS_LOCK.lock().unwrap();
+        let write_prev_counter =
+            CDC_OLD_VALUE_SCAN_DETAILS.with_label_values(&["write", "prev", TAG_INCREMENTAL_SCAN]);
+        let write_hit_missing_range_counter = CDC_OLD_VALUE_SCAN_DETAILS.with_label_values(&[
+            "write",
+            "hit_missing_range",
+            TAG_INCREMENTAL_SCAN,
+        ]);
+        let write_cache_missing_range_counter = CDC_OLD_VALUE_SCAN_DETAILS.with_label_values(&[
+            "write",
+            "cache_missing_range",
+            TAG_INCREMENTAL_SCAN,
+        ]);
+        let prev_before = write_prev_counter.get();
+        let hit_missing_range_before = write_hit_missing_range_counter.get();
+        let cache_missing_range_before = write_cache_missing_range_counter.get();
+        let snap = engine.snapshot(Default::default()).unwrap();
+        let (mut worker, pool, mut initializer, _rx, mut drain) = mock_initializer(
+            usize::MAX,
+            usize::MAX,
+            1000,
+            engine.kv_engine(),
+            ChangeDataRequestKvApi::TiDb,
+            false,
+        );
+        initializer.build_resolver.store(false, Ordering::Release);
+        initializer.checkpoint_ts = checkpoint_ts;
+        initializer.max_scan_batch_size = MAX_SCAN_BATCH_SIZE;
+
+        let th = pool.spawn(async move {
+            initializer
+                .async_incremental_scan(snap, Region::default())
+                .await
+                .unwrap();
+        });
+
+        let mut insert_prewrite_count = 0;
+        let mut tail_prewrite_count = 0;
+        let mut initialized = false;
+        while let Some((event, _)) = block_on(drain.drain().next()) {
+            let CdcEvent::Event(event) = event else {
+                continue;
+            };
+            let Some(event) = event.event else {
+                continue;
+            };
+            let Event_oneof_event::Entries(mut entries) = event else {
+                continue;
+            };
+            for entry in entries.take_entries().into_iter() {
+                match entry.get_type() {
+                    EventLogType::Prewrite
+                        if insert_lock_keys.iter().any(|key| entry.get_key() == key) =>
+                    {
+                        assert!(
+                            entry.get_old_value().is_empty(),
+                            "insert-like lock should have no old value: key={:?}",
+                            entry.get_key()
+                        );
+                        insert_prewrite_count += 1;
+                    }
+                    EventLogType::Prewrite if entry.get_key() == tail_key => {
+                        assert_eq!(entry.get_value(), tail_lock_value);
+                        assert_eq!(entry.get_old_value(), tail_old_value);
+                        tail_prewrite_count += 1;
+                    }
+                    EventLogType::Initialized => initialized = true,
+                    _ => {}
+                }
+            }
+        }
+        block_on(th).unwrap();
+        worker.stop();
+
+        let prev_delta = write_prev_counter.get() - prev_before;
+        let hit_missing_range_delta =
+            write_hit_missing_range_counter.get() - hit_missing_range_before;
+        let cache_missing_range_delta =
+            write_cache_missing_range_counter.get() - cache_missing_range_before;
+        println!(
+            "scheduler_insert_locks_miss old_value_write_prev_delta={prev_delta} old_value_write_hit_missing_range_delta={hit_missing_range_delta} old_value_write_cache_missing_range_delta={cache_missing_range_delta} insert_prewrite_count={insert_prewrite_count} tail_prewrite_count={tail_prewrite_count}"
+        );
+
+        assert_eq!(insert_prewrite_count, INSERT_LOCK_COUNT);
+        assert_eq!(tail_prewrite_count, 1);
+        assert!(initialized);
+        assert_eq!(
+            prev_delta, 0,
+            "missing range cache should prevent repeated old-value cursor prev after the first miss leaves the cursor on {tail_key:?}"
+        );
+        assert_eq!(
+            hit_missing_range_delta, INSERT_LOCK_COUNT as u64,
+            "later monotonic insert-like lock misses and the boundary update lock should hit the cached missing range"
+        );
+        assert_eq!(
+            cache_missing_range_delta, 1,
+            "the first insert-like lock miss should cache the missing range before the tail write"
+        );
     }
 
     #[test]

--- a/components/cdc/src/initializer.rs
+++ b/components/cdc/src/initializer.rs
@@ -1053,7 +1053,7 @@ mod tests {
     }
 
     #[test]
-    fn test_async_incremental_scan_not_call_old_value_prev() {
+    fn test_old_value_missing_range_cache_avoids_prev() {
         const INSERT_LOCK_COUNT: usize = 64;
 
         let mut engine = TestEngineBuilder::new().build_without_cache().unwrap();

--- a/components/cdc/src/initializer.rs
+++ b/components/cdc/src/initializer.rs
@@ -670,7 +670,7 @@ mod tests {
         collections::BTreeMap,
         fmt::Display,
         sync::{
-            Arc, Mutex,
+            Arc,
             atomic::AtomicBool,
             mpsc::{Receiver, RecvTimeoutError, Sender, channel, sync_channel},
         },
@@ -713,8 +713,6 @@ mod tests {
 
     use super::*;
     use crate::txn_source::TxnSource;
-
-    static OLD_VALUE_SCAN_METRICS_LOCK: Mutex<()> = Mutex::new(());
 
     struct ReceiverRunnable<T: Display + Send> {
         tx: Sender<T>,
@@ -1057,7 +1055,6 @@ mod tests {
     #[test]
     fn test_async_incremental_scan_not_call_old_value_prev() {
         const INSERT_LOCK_COUNT: usize = 64;
-        const MAX_SCAN_BATCH_SIZE: usize = 7;
 
         let mut engine = TestEngineBuilder::new().build_without_cache().unwrap();
         let storage = TestStorageBuilderApiV1::from_engine_and_lock_mgr(
@@ -1138,102 +1135,98 @@ mod tests {
         // cursor on the boundary write and still load the real old value.
         sched_prewrite_put(tail_key, tail_lock_value, 300).unwrap();
 
-        let _metrics_guard = OLD_VALUE_SCAN_METRICS_LOCK.lock().unwrap();
-        let write_prev_counter =
-            CDC_OLD_VALUE_SCAN_DETAILS.with_label_values(&["write", "prev", TAG_INCREMENTAL_SCAN]);
-        let write_hit_missing_range_counter = CDC_OLD_VALUE_SCAN_DETAILS.with_label_values(&[
-            "write",
-            "hit_missing_range",
-            TAG_INCREMENTAL_SCAN,
-        ]);
-        let write_cache_missing_range_counter = CDC_OLD_VALUE_SCAN_DETAILS.with_label_values(&[
-            "write",
-            "cache_missing_range",
-            TAG_INCREMENTAL_SCAN,
-        ]);
-        let prev_before = write_prev_counter.get();
-        let hit_missing_range_before = write_hit_missing_range_counter.get();
-        let cache_missing_range_before = write_cache_missing_range_counter.get();
         let snap = engine.snapshot(Default::default()).unwrap();
-        let (mut worker, pool, mut initializer, _rx, mut drain) = mock_initializer(
-            usize::MAX,
-            usize::MAX,
-            1000,
-            engine.kv_engine(),
-            ChangeDataRequestKvApi::TiDb,
-            false,
-        );
-        initializer.build_resolver.store(false, Ordering::Release);
-        initializer.checkpoint_ts = checkpoint_ts;
-        initializer.max_scan_batch_size = MAX_SCAN_BATCH_SIZE;
-
-        let th = pool.spawn(async move {
-            initializer
-                .async_incremental_scan(snap, Region::default())
-                .await
-                .unwrap();
-        });
-
+        let mut old_value_cursors = OldValueCursors::new(&snap);
+        let mut scanner = ScannerBuilder::new(snap, TimeStamp::max())
+            .fill_cache(false)
+            .range(Some(Key::from_encoded_slice(b"")), None)
+            // Force the same old-value lookup path used by incremental scan
+            // when the write-CF ts filter is enabled.
+            .hint_min_ts(Some(checkpoint_ts))
+            .build_delta_scanner(checkpoint_ts, TxnExtraOp::ReadOldValue)
+            .unwrap();
+        let mut old_value_stats = Statistics::default();
         let mut insert_prewrite_count = 0;
         let mut tail_prewrite_count = 0;
-        let mut initialized = false;
-        while let Some((event, _)) = block_on(drain.drain().next()) {
-            let CdcEvent::Event(event) = event else {
-                continue;
-            };
-            let Some(event) = event.event else {
-                continue;
-            };
-            let Event_oneof_event::Entries(mut entries) = event else {
-                continue;
-            };
-            for entry in entries.take_entries().into_iter() {
-                match entry.get_type() {
-                    EventLogType::Prewrite
-                        if insert_lock_keys.iter().any(|key| entry.get_key() == key) =>
-                    {
-                        assert!(
-                            entry.get_old_value().is_empty(),
-                            "insert-like lock should have no old value: key={:?}",
-                            entry.get_key()
-                        );
-                        insert_prewrite_count += 1;
-                    }
-                    EventLogType::Prewrite if entry.get_key() == tail_key => {
-                        assert_eq!(entry.get_value(), tail_lock_value);
-                        assert_eq!(entry.get_old_value(), tail_old_value);
-                        tail_prewrite_count += 1;
-                    }
-                    EventLogType::Initialized => initialized = true,
-                    _ => {}
-                }
+
+        fn resolve_old_value<S: Snapshot>(
+            key: &Key,
+            cursors: &mut OldValueCursors<S>,
+            statistics: &mut Statistics,
+        ) -> OldValue {
+            match near_seek_old_value(
+                key,
+                &mut cursors.write,
+                Either::<&S, _>::Right(&mut cursors.default),
+                statistics,
+            )
+            .unwrap()
+            {
+                Some(value) => OldValue::value(value),
+                None => OldValue::None,
             }
         }
-        block_on(th).unwrap();
-        worker.stop();
 
-        let prev_delta = write_prev_counter.get() - prev_before;
-        let hit_missing_range_delta =
-            write_hit_missing_range_counter.get() - hit_missing_range_before;
-        let cache_missing_range_delta =
-            write_cache_missing_range_counter.get() - cache_missing_range_before;
+        while let Some(entry) = scanner.next_entry().unwrap() {
+            let TxnEntry::Prewrite {
+                lock, old_value, ..
+            } = entry
+            else {
+                continue;
+            };
+            let key = Key::from_encoded(lock.0.clone()).into_raw().unwrap();
+            let old_value = match old_value {
+                OldValue::SeekWrite(key) => {
+                    resolve_old_value(&key, &mut old_value_cursors, &mut old_value_stats)
+                }
+                old_value => old_value,
+            };
+            match key.as_slice() {
+                key if insert_lock_keys
+                    .iter()
+                    .any(|insert_key| key == insert_key.as_slice()) =>
+                {
+                    assert!(
+                        matches!(old_value, OldValue::None),
+                        "insert-like lock should have no old value: key={:?}",
+                        key
+                    );
+                    insert_prewrite_count += 1;
+                }
+                key if key == tail_key.as_slice() => {
+                    let parsed_lock = txn_types::parse_lock(&lock.1)
+                        .unwrap()
+                        .left()
+                        .expect("put lock should be parsed");
+                    assert_eq!(
+                        parsed_lock.short_value.as_deref(),
+                        Some(tail_lock_value.as_slice())
+                    );
+                    assert_eq!(old_value, OldValue::value(tail_old_value.to_vec()));
+                    tail_prewrite_count += 1;
+                }
+                _ => {}
+            }
+        }
         println!(
-            "scheduler_insert_locks_miss old_value_write_prev_delta={prev_delta} old_value_write_hit_missing_range_delta={hit_missing_range_delta} old_value_write_cache_missing_range_delta={cache_missing_range_delta} insert_prewrite_count={insert_prewrite_count} tail_prewrite_count={tail_prewrite_count}"
+            "scheduler_insert_locks_miss old_value_write_prev={} old_value_write_hit_missing_range={} old_value_write_cache_missing_range={} insert_prewrite_count={insert_prewrite_count} tail_prewrite_count={tail_prewrite_count}",
+            old_value_stats.write.prev,
+            old_value_stats.write.hit_missing_range,
+            old_value_stats.write.cache_missing_range,
         );
 
         assert_eq!(insert_prewrite_count, INSERT_LOCK_COUNT);
         assert_eq!(tail_prewrite_count, 1);
-        assert!(initialized);
         assert_eq!(
-            prev_delta, 0,
+            old_value_stats.write.prev, 0,
             "missing range cache should prevent repeated old-value cursor prev after the first miss leaves the cursor on {tail_key:?}"
         );
         assert_eq!(
-            hit_missing_range_delta, INSERT_LOCK_COUNT as u64,
+            old_value_stats.write.hit_missing_range, INSERT_LOCK_COUNT,
             "later monotonic insert-like lock misses and the boundary update lock should hit the cached missing range"
         );
         assert_eq!(
-            cache_missing_range_delta, 1,
+            old_value_stats.write.cache_missing_range, 1,
             "the first insert-like lock miss should cache the missing range before the tail write"
         );
     }

--- a/components/cdc/src/initializer.rs
+++ b/components/cdc/src/initializer.rs
@@ -1208,12 +1208,6 @@ mod tests {
                 _ => {}
             }
         }
-        println!(
-            "scheduler_insert_locks_miss old_value_write_prev={} old_value_write_hit_missing_range={} old_value_write_cache_missing_range={} insert_prewrite_count={insert_prewrite_count} tail_prewrite_count={tail_prewrite_count}",
-            old_value_stats.write.prev,
-            old_value_stats.write.hit_missing_range,
-            old_value_stats.write.cache_missing_range,
-        );
 
         assert_eq!(insert_prewrite_count, INSERT_LOCK_COUNT);
         assert_eq!(tail_prewrite_count, 1);

--- a/components/cdc/src/old_value.rs
+++ b/components/cdc/src/old_value.rs
@@ -165,6 +165,7 @@ pub fn new_old_value_cursor<S: EngineSnapshot>(snapshot: &S, cf: &'static str) -
         .fill_cache(false)
         .scan_mode(ScanMode::Mixed)
         .range(lower, upper)
+        .missing_range(cf == CF_WRITE)
         .build()
         .unwrap()
 }

--- a/components/tikv_kv/src/btree_engine.rs
+++ b/components/tikv_kv/src/btree_engine.rs
@@ -377,6 +377,7 @@ pub mod tests {
             snap.iter(CF_DEFAULT, iter_op).unwrap(),
             ScanMode::Forward,
             false,
+            false,
         );
         assert!(!cursor.seek(&Key::from_raw(b"a5"), &mut statistics).unwrap());
 
@@ -386,6 +387,7 @@ pub mod tests {
         let mut cursor = Cursor::new(
             snap.iter(CF_DEFAULT, iter_op).unwrap(),
             ScanMode::Forward,
+            false,
             false,
         );
 

--- a/components/tikv_kv/src/cursor.rs
+++ b/components/tikv_kv/src/cursor.rs
@@ -104,6 +104,14 @@ impl<I: Iterator> Cursor<I> {
         }
 
         if !self.valid()? || self.key(statistics) != upper.as_slice() {
+            // This cache is tied to both the missing range and the iterator
+            // position: [lower, upper) is known to be empty only while the
+            // cursor still points at `upper`, the first key >= the original
+            // seek target. If another seek/next/prev has invalidated the
+            // iterator or moved it away from `upper`, the cache is out of sync
+            // with the current iterator state. Reusing it could incorrectly
+            // skip the normal seek path and break seek's "first key >= target"
+            // contract.
             self.missing_range_cache = None;
             return Ok(false);
         }

--- a/components/tikv_kv/src/cursor.rs
+++ b/components/tikv_kv/src/cursor.rs
@@ -27,6 +27,14 @@ pub struct Cursor<I: Iterator> {
     // `value()` don't need to have `&mut self`.
     cur_key_has_read: Cell<bool>,
     cur_value_has_read: Cell<bool>,
+
+    // Optional cache for repeated forward seek misses. When enabled for Mixed
+    // cursors, a seek landing at `upper` records that `[lower, upper)` has no
+    // entry. Later `seek`/`near_seek` calls inside the missing range can keep the
+    // cursor at `upper` instead of taking the mixed-mode `prev` path, while
+    // preserving the "first key >= target" semantics.
+    missing_range: bool,
+    missing_range_cache: Option<(Vec<u8>, Vec<u8>)>,
 }
 
 macro_rules! near_loop {
@@ -43,7 +51,7 @@ macro_rules! near_loop {
 }
 
 impl<I: Iterator> Cursor<I> {
-    pub fn new(iter: I, mode: ScanMode, prefix_seek: bool) -> Self {
+    pub fn new(iter: I, mode: ScanMode, prefix_seek: bool, missing_range: bool) -> Self {
         Self {
             iter,
             scan_mode: mode,
@@ -53,7 +61,55 @@ impl<I: Iterator> Cursor<I> {
 
             cur_key_has_read: Cell::new(false),
             cur_value_has_read: Cell::new(false),
+
+            missing_range: missing_range && mode == ScanMode::Mixed && !prefix_seek,
+            missing_range_cache: None,
         }
+    }
+
+    #[inline]
+    fn cache_missing_range(&mut self, key: &Key, statistics: &mut CfStatistics) -> Result<()> {
+        if !self.missing_range {
+            return Ok(());
+        }
+
+        if !self.valid()? {
+            self.missing_range_cache = None;
+            return Ok(());
+        }
+
+        let cursor_key = self.key(statistics);
+        if cursor_key <= key.as_encoded().as_slice() {
+            self.missing_range_cache = None;
+            return Ok(());
+        }
+
+        self.missing_range_cache = Some((key.as_encoded().to_vec(), cursor_key.to_vec()));
+        statistics.cache_missing_range += 1;
+        Ok(())
+    }
+
+    #[inline]
+    fn hit_missing_range(&mut self, key: &Key, statistics: &mut CfStatistics) -> Result<bool> {
+        if !self.missing_range {
+            return Ok(false);
+        }
+
+        let Some((lower, upper)) = self.missing_range_cache.as_ref() else {
+            return Ok(false);
+        };
+        let encoded_key = key.as_encoded().as_slice();
+        if encoded_key < lower.as_slice() || encoded_key >= upper.as_slice() {
+            return Ok(false);
+        }
+
+        if !self.valid()? || self.key(statistics) != upper.as_slice() {
+            self.missing_range_cache = None;
+            return Ok(false);
+        }
+
+        statistics.hit_missing_range += 1;
+        Ok(true)
     }
 
     /// Mark key and value as unread. It will be invoked once cursor is moved.
@@ -95,6 +151,10 @@ impl<I: Iterator> Cursor<I> {
             return Ok(true);
         }
 
+        if self.hit_missing_range(key, statistics)? {
+            return Ok(true);
+        }
+
         if !self.internal_seek(key, statistics)? {
             // Do not set `max_key` when prefix seek enabled.
             // `max_key` is used to record the last key before the iter reaches
@@ -108,6 +168,7 @@ impl<I: Iterator> Cursor<I> {
             }
             return Ok(false);
         }
+        self.cache_missing_range(key, statistics)?;
         Ok(true)
     }
 
@@ -131,6 +192,9 @@ impl<I: Iterator> Cursor<I> {
             return Ok(false);
         }
         if ord == Ordering::Greater {
+            if self.hit_missing_range(key, statistics)? {
+                return Ok(true);
+            }
             near_loop!(
                 self.prev(statistics) && self.key(statistics) > key.as_encoded().as_slice(),
                 self.seek(key, statistics),
@@ -170,6 +234,7 @@ impl<I: Iterator> Cursor<I> {
             }
             return Ok(false);
         }
+        self.cache_missing_range(key, statistics)?;
         Ok(true)
     }
 
@@ -431,6 +496,7 @@ pub struct CursorBuilder<'a, S: Snapshot> {
     hint_max_ts: Option<Bound<TimeStamp>>,
     key_only: bool,
     max_skippable_internal_keys: u64,
+    missing_range: bool,
 }
 
 impl<'a, S: 'a + Snapshot> CursorBuilder<'a, S> {
@@ -449,6 +515,7 @@ impl<'a, S: 'a + Snapshot> CursorBuilder<'a, S> {
             hint_max_ts: None,
             key_only: false,
             max_skippable_internal_keys: 0,
+            missing_range: false,
         }
     }
 
@@ -528,6 +595,13 @@ impl<'a, S: 'a + Snapshot> CursorBuilder<'a, S> {
         self
     }
 
+    #[inline]
+    #[must_use]
+    pub fn missing_range(mut self, enabled: bool) -> Self {
+        self.missing_range = enabled;
+        self
+    }
+
     /// Build `Cursor` from the current configuration.
     pub fn build(self) -> Result<Cursor<S::Iter>> {
         let l_bound = if let Some(b) = self.lower_bound {
@@ -562,6 +636,7 @@ impl<'a, S: 'a + Snapshot> CursorBuilder<'a, S> {
             self.snapshot.iter(self.cf, iter_opt)?,
             self.scan_mode,
             self.prefix_seek,
+            self.missing_range,
         ))
     }
 }
@@ -579,7 +654,7 @@ mod tests {
     use tempfile::Builder;
     use txn_types::Key;
 
-    use crate::{CfStatistics, Cursor, ScanMode};
+    use crate::{CfStatistics, Cursor, CursorBuilder, ScanMode};
 
     type DataSet = Vec<(Vec<u8>, Vec<u8>)>;
 
@@ -629,7 +704,7 @@ mod tests {
         iter_opt.use_prefix_seek();
         iter_opt.set_prefix_same_as_start(true);
         let it = snap.iter(CF_DEFAULT, iter_opt).unwrap();
-        let mut iter = Cursor::new(it, ScanMode::Mixed, true);
+        let mut iter = Cursor::new(it, ScanMode::Mixed, true, false);
 
         assert!(
             !iter
@@ -657,6 +732,299 @@ mod tests {
     }
 
     #[test]
+    fn test_missing_range_cache_seek_and_near_seek_cases() {
+        let path = Builder::new()
+            .prefix("test_missing_range_cache_seek_and_near_seek_cases")
+            .tempdir()
+            .unwrap();
+        let engine = new_engine_opt(
+            path.path().to_str().unwrap(),
+            RocksDbOptions::default(),
+            vec![(CF_DEFAULT, RocksCfOptions::default())],
+        )
+        .unwrap();
+
+        let (region, _) = load_default_dataset(engine.clone());
+        let snap = RegionSnapshot::<RocksSnapshot>::from_raw(engine, region);
+
+        #[derive(Clone, Copy, Debug)]
+        enum Op {
+            Seek,
+            NearSeek,
+        }
+
+        #[derive(Clone, Copy)]
+        struct Step {
+            op: Op,
+            key: &'static [u8],
+            found: bool,
+            current: Option<(&'static [u8], &'static [u8])>,
+        }
+
+        #[derive(Clone, Copy)]
+        struct ExpectedStats {
+            hit_missing_range: usize,
+            cache_missing_range: usize,
+            seek: usize,
+            prev: usize,
+            next: usize,
+        }
+
+        struct Case {
+            name: &'static str,
+            steps: &'static [Step],
+            stats_without_missing_range: ExpectedStats,
+            stats_with_missing_range: ExpectedStats,
+        }
+
+        let cases = [
+            Case {
+                name: "near_seek keeps first key after a cached missing range",
+                steps: &[
+                    Step {
+                        op: Op::NearSeek,
+                        key: b"a4",
+                        found: true,
+                        current: Some((b"a5", b"v5")),
+                    },
+                    Step {
+                        op: Op::NearSeek,
+                        key: b"a4x",
+                        found: true,
+                        current: Some((b"a5", b"v5")),
+                    },
+                ],
+                stats_without_missing_range: ExpectedStats {
+                    hit_missing_range: 0,
+                    cache_missing_range: 0,
+                    seek: 1,
+                    prev: 1,
+                    next: 1,
+                },
+                stats_with_missing_range: ExpectedStats {
+                    hit_missing_range: 1,
+                    cache_missing_range: 1,
+                    seek: 1,
+                    prev: 0,
+                    next: 0,
+                },
+            },
+            Case {
+                name: "seek reuses a cached missing range",
+                steps: &[
+                    Step {
+                        op: Op::NearSeek,
+                        key: b"a4",
+                        found: true,
+                        current: Some((b"a5", b"v5")),
+                    },
+                    Step {
+                        op: Op::Seek,
+                        key: b"a4x",
+                        found: true,
+                        current: Some((b"a5", b"v5")),
+                    },
+                ],
+                stats_without_missing_range: ExpectedStats {
+                    hit_missing_range: 0,
+                    cache_missing_range: 0,
+                    seek: 2,
+                    prev: 0,
+                    next: 0,
+                },
+                stats_with_missing_range: ExpectedStats {
+                    hit_missing_range: 1,
+                    cache_missing_range: 1,
+                    seek: 1,
+                    prev: 0,
+                    next: 0,
+                },
+            },
+            Case {
+                name: "missing range does not hide its upper bound key",
+                steps: &[
+                    Step {
+                        op: Op::NearSeek,
+                        key: b"a4",
+                        found: true,
+                        current: Some((b"a5", b"v5")),
+                    },
+                    Step {
+                        op: Op::Seek,
+                        key: b"a5",
+                        found: true,
+                        current: Some((b"a5", b"v5")),
+                    },
+                ],
+                stats_without_missing_range: ExpectedStats {
+                    hit_missing_range: 0,
+                    cache_missing_range: 0,
+                    seek: 2,
+                    prev: 0,
+                    next: 0,
+                },
+                stats_with_missing_range: ExpectedStats {
+                    hit_missing_range: 0,
+                    cache_missing_range: 1,
+                    seek: 2,
+                    prev: 0,
+                    next: 0,
+                },
+            },
+            Case {
+                name: "range end miss is still handled by max_key",
+                steps: &[
+                    Step {
+                        op: Op::NearSeek,
+                        key: b"a6",
+                        found: false,
+                        current: None,
+                    },
+                    Step {
+                        op: Op::NearSeek,
+                        key: b"a6x",
+                        found: false,
+                        current: None,
+                    },
+                ],
+                stats_without_missing_range: ExpectedStats {
+                    hit_missing_range: 0,
+                    cache_missing_range: 0,
+                    seek: 1,
+                    prev: 0,
+                    next: 0,
+                },
+                stats_with_missing_range: ExpectedStats {
+                    hit_missing_range: 0,
+                    cache_missing_range: 0,
+                    seek: 1,
+                    prev: 0,
+                    next: 0,
+                },
+            },
+            Case {
+                name: "moved cursor does not hit a stale missing range",
+                steps: &[
+                    Step {
+                        op: Op::NearSeek,
+                        key: b"a4",
+                        found: true,
+                        current: Some((b"a5", b"v5")),
+                    },
+                    Step {
+                        op: Op::Seek,
+                        key: b"a3",
+                        found: true,
+                        current: Some((b"a3", b"v3")),
+                    },
+                    Step {
+                        op: Op::NearSeek,
+                        key: b"a4x",
+                        found: true,
+                        current: Some((b"a5", b"v5")),
+                    },
+                ],
+                stats_without_missing_range: ExpectedStats {
+                    hit_missing_range: 0,
+                    cache_missing_range: 0,
+                    seek: 2,
+                    prev: 0,
+                    next: 1,
+                },
+                stats_with_missing_range: ExpectedStats {
+                    hit_missing_range: 0,
+                    cache_missing_range: 2,
+                    seek: 2,
+                    prev: 0,
+                    next: 1,
+                },
+            },
+        ];
+
+        for case in cases {
+            for (missing_range, expected_stats) in [
+                (false, case.stats_without_missing_range),
+                (true, case.stats_with_missing_range),
+            ] {
+                let mut cursor = CursorBuilder::new(&snap, CF_DEFAULT)
+                    .scan_mode(ScanMode::Mixed)
+                    .missing_range(missing_range)
+                    .build()
+                    .unwrap();
+                let mut statistics = CfStatistics::default();
+
+                for step in case.steps {
+                    let found = match step.op {
+                        Op::Seek => cursor
+                            .seek(&Key::from_encoded_slice(step.key), &mut statistics)
+                            .unwrap(),
+                        Op::NearSeek => cursor
+                            .near_seek(&Key::from_encoded_slice(step.key), &mut statistics)
+                            .unwrap(),
+                    };
+                    assert_eq!(
+                        found, step.found,
+                        "case={} missing_range={} op={:?} key={:?}",
+                        case.name, missing_range, step.op, step.key
+                    );
+
+                    match step.current {
+                        Some((key, value)) => {
+                            assert_eq!(
+                                cursor.key(&mut statistics),
+                                key,
+                                "case={} missing_range={} op={:?} key={:?}",
+                                case.name,
+                                missing_range,
+                                step.op,
+                                step.key
+                            );
+                            assert_eq!(
+                                cursor.value(&mut statistics),
+                                value,
+                                "case={} missing_range={} op={:?} key={:?}",
+                                case.name,
+                                missing_range,
+                                step.op,
+                                step.key
+                            );
+                        }
+                        None => assert!(
+                            !cursor.valid().unwrap(),
+                            "case={} missing_range={} op={:?} key={:?}",
+                            case.name,
+                            missing_range,
+                            step.op,
+                            step.key
+                        ),
+                    }
+                }
+
+                assert_eq!(
+                    (
+                        statistics.hit_missing_range,
+                        statistics.cache_missing_range,
+                        statistics.seek,
+                        statistics.prev,
+                        statistics.next,
+                    ),
+                    (
+                        expected_stats.hit_missing_range,
+                        expected_stats.cache_missing_range,
+                        expected_stats.seek,
+                        expected_stats.prev,
+                        expected_stats.next,
+                    ),
+                    "case={} missing_range={} statistics={:?}",
+                    case.name,
+                    missing_range,
+                    statistics
+                );
+            }
+        }
+    }
+
+    #[test]
     fn test_reverse_iterate() {
         let path = Builder::new()
             .prefix("test_reverse_iterate")
@@ -674,7 +1042,7 @@ mod tests {
         let snap = RegionSnapshot::<RocksSnapshot>::from_raw(engine.clone(), region);
         let mut statistics = CfStatistics::default();
         let it = snap.iter(CF_DEFAULT, IterOptions::default()).unwrap();
-        let mut iter = Cursor::new(it, ScanMode::Mixed, false);
+        let mut iter = Cursor::new(it, ScanMode::Mixed, false, false);
         assert!(
             !iter
                 .reverse_seek(&Key::from_encoded_slice(b"a2"), &mut statistics)
@@ -728,7 +1096,7 @@ mod tests {
         region.mut_peers().push(Peer::default());
         let snap = RegionSnapshot::<RocksSnapshot>::from_raw(engine, region);
         let it = snap.iter(CF_DEFAULT, IterOptions::default()).unwrap();
-        let mut iter = Cursor::new(it, ScanMode::Mixed, false);
+        let mut iter = Cursor::new(it, ScanMode::Mixed, false, false);
         assert!(
             !iter
                 .reverse_seek(&Key::from_encoded_slice(b"a1"), &mut statistics)

--- a/components/tikv_kv/src/cursor.rs
+++ b/components/tikv_kv/src/cursor.rs
@@ -849,6 +849,68 @@ mod tests {
                 },
             },
             Case {
+                name: "cached missing range includes its lower bound",
+                steps: &[
+                    Step {
+                        op: Op::NearSeek,
+                        key: b"a4",
+                        found: true,
+                        current: Some((b"a5", b"v5")),
+                    },
+                    Step {
+                        op: Op::Seek,
+                        key: b"a4",
+                        found: true,
+                        current: Some((b"a5", b"v5")),
+                    },
+                ],
+                stats_without_missing_range: ExpectedStats {
+                    hit_missing_range: 0,
+                    cache_missing_range: 0,
+                    seek: 2,
+                    prev: 0,
+                    next: 0,
+                },
+                stats_with_missing_range: ExpectedStats {
+                    hit_missing_range: 1,
+                    cache_missing_range: 1,
+                    seek: 1,
+                    prev: 0,
+                    next: 0,
+                },
+            },
+            Case {
+                name: "key below cached missing range lower does not hit",
+                steps: &[
+                    Step {
+                        op: Op::NearSeek,
+                        key: b"a4",
+                        found: true,
+                        current: Some((b"a5", b"v5")),
+                    },
+                    Step {
+                        op: Op::NearSeek,
+                        key: b"a3x",
+                        found: true,
+                        current: Some((b"a5", b"v5")),
+                    },
+                ],
+                stats_without_missing_range: ExpectedStats {
+                    hit_missing_range: 0,
+                    cache_missing_range: 0,
+                    seek: 1,
+                    prev: 1,
+                    next: 1,
+                },
+                stats_with_missing_range: ExpectedStats {
+                    hit_missing_range: 0,
+                    cache_missing_range: 2,
+                    seek: 1,
+                    prev: 1,
+                    next: 1,
+                },
+            },
+            Case {
                 name: "missing range does not hide its upper bound key",
                 steps: &[
                     Step {
@@ -880,6 +942,37 @@ mod tests {
                 },
             },
             Case {
+                name: "key above cached missing range upper does not hit",
+                steps: &[
+                    Step {
+                        op: Op::NearSeek,
+                        key: b"a4",
+                        found: true,
+                        current: Some((b"a5", b"v5")),
+                    },
+                    Step {
+                        op: Op::NearSeek,
+                        key: b"a5x",
+                        found: false,
+                        current: None,
+                    },
+                ],
+                stats_without_missing_range: ExpectedStats {
+                    hit_missing_range: 0,
+                    cache_missing_range: 0,
+                    seek: 1,
+                    prev: 0,
+                    next: 1,
+                },
+                stats_with_missing_range: ExpectedStats {
+                    hit_missing_range: 0,
+                    cache_missing_range: 1,
+                    seek: 1,
+                    prev: 0,
+                    next: 1,
+                },
+            },
+            Case {
                 name: "range end miss is still handled by max_key",
                 steps: &[
                     Step {
@@ -908,6 +1001,43 @@ mod tests {
                     seek: 1,
                     prev: 0,
                     next: 0,
+                },
+            },
+            Case {
+                name: "invalid cursor clears stale missing range",
+                steps: &[
+                    Step {
+                        op: Op::NearSeek,
+                        key: b"a4",
+                        found: true,
+                        current: Some((b"a5", b"v5")),
+                    },
+                    Step {
+                        op: Op::NearSeek,
+                        key: b"a6",
+                        found: false,
+                        current: None,
+                    },
+                    Step {
+                        op: Op::NearSeek,
+                        key: b"a4x",
+                        found: true,
+                        current: Some((b"a5", b"v5")),
+                    },
+                ],
+                stats_without_missing_range: ExpectedStats {
+                    hit_missing_range: 0,
+                    cache_missing_range: 0,
+                    seek: 2,
+                    prev: 0,
+                    next: 1,
+                },
+                stats_with_missing_range: ExpectedStats {
+                    hit_missing_range: 0,
+                    cache_missing_range: 2,
+                    seek: 2,
+                    prev: 0,
+                    next: 1,
                 },
             },
             Case {

--- a/components/tikv_kv/src/lib.rs
+++ b/components/tikv_kv/src/lib.rs
@@ -933,6 +933,7 @@ pub mod tests {
             snapshot.iter(CF_DEFAULT, IterOptions::default()).unwrap(),
             ScanMode::Mixed,
             false,
+            false,
         );
         let mut statistics = CfStatistics::default();
         cursor.seek(&Key::from_raw(key), &mut statistics).unwrap();
@@ -945,6 +946,7 @@ pub mod tests {
         let mut cursor = Cursor::new(
             snapshot.iter(CF_DEFAULT, IterOptions::default()).unwrap(),
             ScanMode::Mixed,
+            false,
             false,
         );
         let mut statistics = CfStatistics::default();
@@ -1044,6 +1046,7 @@ pub mod tests {
             snapshot.iter(CF_DEFAULT, IterOptions::default()).unwrap(),
             ScanMode::Mixed,
             false,
+            false,
         );
         let mut statistics = CfStatistics::default();
         assert!(
@@ -1067,6 +1070,7 @@ pub mod tests {
         let mut cursor = Cursor::new(
             snapshot.iter(CF_DEFAULT, IterOptions::default()).unwrap(),
             ScanMode::Mixed,
+            false,
             false,
         );
         assert_near_seek(&mut cursor, b"x", (b"x", b"1"));
@@ -1092,6 +1096,7 @@ pub mod tests {
             snapshot.iter(CF_DEFAULT, IterOptions::default()).unwrap(),
             ScanMode::Mixed,
             false,
+            false,
         );
         assert_near_seek(&mut cursor, b"x", (b"x", b"1"));
         assert_near_seek(&mut cursor, b"z", (b"z", b"2"));
@@ -1109,6 +1114,7 @@ pub mod tests {
         let mut cursor = Cursor::new(
             snapshot.iter(CF_DEFAULT, IterOptions::default()).unwrap(),
             ScanMode::Mixed,
+            false,
             false,
         );
         let mut statistics = CfStatistics::default();
@@ -1184,10 +1190,12 @@ pub mod tests {
             snapshot.iter(CF_DEFAULT, IterOptions::default()).unwrap(),
             mode,
             false,
+            false,
         );
         let mut near_cursor = Cursor::new(
             snapshot.iter(CF_DEFAULT, IterOptions::default()).unwrap(),
             mode,
+            false,
             false,
         );
         let limit = (SEEK_BOUND as usize * 10 + 50 - 1) * 2;
@@ -1327,6 +1335,7 @@ pub mod tests {
         let mut iter = Cursor::new(
             snapshot.iter(CF_DEFAULT, IterOptions::default()).unwrap(),
             ScanMode::Forward,
+            false,
             false,
         );
 

--- a/components/tikv_kv/src/metrics.rs
+++ b/components/tikv_kv/src/metrics.rs
@@ -29,6 +29,8 @@ make_auto_flush_static_metric! {
         seek_tombstone,
         seek_for_prev_tombstone,
         raw_value_tombstone,
+        hit_missing_range,
+        cache_missing_range,
     }
 
     pub struct GcKeysCounterVec: LocalIntCounter {

--- a/components/tikv_kv/src/stats.rs
+++ b/components/tikv_kv/src/stats.rs
@@ -21,6 +21,8 @@ const STAT_SEEK_TOMBSTONE: &str = "seek_tombstone";
 const STAT_SEEK_FOR_PREV_TOMBSTONE: &str = "seek_for_prev_tombstone";
 /// Statistics of raw value tombstone by RawKV TTL expired or logical deleted.
 const STAT_RAW_VALUE_TOMBSTONE: &str = "raw_value_tombstone";
+const STAT_HIT_MISSING_RANGE: &str = "hit_missing_range";
+const STAT_CACHE_MISSING_RANGE: &str = "cache_missing_range";
 
 thread_local! {
     pub static RAW_VALUE_TOMBSTONE : RefCell<usize> = const{ RefCell::new(0)};
@@ -111,9 +113,11 @@ pub struct CfStatistics {
     pub seek_tombstone: usize,
     pub seek_for_prev_tombstone: usize,
     pub raw_value_tombstone: usize,
+    pub hit_missing_range: usize,
+    pub cache_missing_range: usize,
 }
 
-const STATS_COUNT: usize = 12;
+const STATS_COUNT: usize = 14;
 
 impl CfStatistics {
     #[inline]
@@ -135,6 +139,8 @@ impl CfStatistics {
             (STAT_SEEK_TOMBSTONE, self.seek_tombstone),
             (STAT_SEEK_FOR_PREV_TOMBSTONE, self.seek_for_prev_tombstone),
             (STAT_RAW_VALUE_TOMBSTONE, self.raw_value_tombstone),
+            (STAT_HIT_MISSING_RANGE, self.hit_missing_range),
+            (STAT_CACHE_MISSING_RANGE, self.cache_missing_range),
         ]
     }
 
@@ -155,6 +161,8 @@ impl CfStatistics {
                 self.seek_for_prev_tombstone,
             ),
             (GcKeysDetail::raw_value_tombstone, self.raw_value_tombstone),
+            (GcKeysDetail::hit_missing_range, self.hit_missing_range),
+            (GcKeysDetail::cache_missing_range, self.cache_missing_range),
         ]
     }
 
@@ -177,6 +185,12 @@ impl CfStatistics {
         self.raw_value_tombstone = self
             .raw_value_tombstone
             .saturating_add(other.raw_value_tombstone);
+        self.hit_missing_range = self
+            .hit_missing_range
+            .saturating_add(other.hit_missing_range);
+        self.cache_missing_range = self
+            .cache_missing_range
+            .saturating_add(other.cache_missing_range);
     }
 
     /// Deprecated

--- a/src/coprocessor/metrics.rs
+++ b/src/coprocessor/metrics.rs
@@ -57,6 +57,8 @@ make_auto_flush_static_metric! {
         seek_tombstone,
         seek_for_prev_tombstone,
         raw_value_tombstone,
+        hit_missing_range,
+        cache_missing_range,
     }
 
     pub label_enum WaitType {
@@ -284,6 +286,8 @@ impl From<GcKeysDetail> for ScanKind {
             GcKeysDetail::seek_tombstone => ScanKind::seek_tombstone,
             GcKeysDetail::seek_for_prev_tombstone => ScanKind::seek_for_prev_tombstone,
             GcKeysDetail::raw_value_tombstone => ScanKind::raw_value_tombstone,
+            GcKeysDetail::hit_missing_range => ScanKind::hit_missing_range,
+            GcKeysDetail::cache_missing_range => ScanKind::cache_missing_range,
         }
     }
 }

--- a/src/storage/kv/test_engine_builder.rs
+++ b/src/storage/kv/test_engine_builder.rs
@@ -230,6 +230,7 @@ mod tests {
             snapshot.iter(CF_DEFAULT, iter_opt).unwrap(),
             ScanMode::Forward,
             false,
+            false,
         );
 
         let mut statistics = CfStatistics::default();
@@ -258,6 +259,7 @@ mod tests {
         let mut iter = Cursor::new(
             snapshot.iter(CF_DEFAULT, IterOptions::default()).unwrap(),
             ScanMode::Forward,
+            false,
             false,
         );
 

--- a/src/storage/metrics.rs
+++ b/src/storage/metrics.rs
@@ -218,6 +218,8 @@ make_auto_flush_static_metric! {
         seek_tombstone,
         seek_for_prev_tombstone,
         raw_value_tombstone,
+        hit_missing_range,
+        cache_missing_range,
     }
 
     pub label_enum CheckMemLockResult {
@@ -312,6 +314,8 @@ impl From<ServerGcKeysDetail> for GcKeysDetail {
             ServerGcKeysDetail::seek_tombstone => GcKeysDetail::seek_tombstone,
             ServerGcKeysDetail::seek_for_prev_tombstone => GcKeysDetail::seek_for_prev_tombstone,
             ServerGcKeysDetail::raw_value_tombstone => GcKeysDetail::raw_value_tombstone,
+            ServerGcKeysDetail::hit_missing_range => GcKeysDetail::hit_missing_range,
+            ServerGcKeysDetail::cache_missing_range => GcKeysDetail::cache_missing_range,
         }
     }
 }

--- a/src/storage/raw/store.rs
+++ b/src/storage/raw/store.rs
@@ -197,7 +197,12 @@ impl<'a, S: Snapshot, F: KvFormat> RawStoreInner<S, F> {
         if limit == 0 {
             return Ok(vec![]);
         }
-        let mut cursor = Cursor::new(self.snapshot.iter(cf, option)?, ScanMode::Forward, false);
+        let mut cursor = Cursor::new(
+            self.snapshot.iter(cf, option)?,
+            ScanMode::Forward,
+            false,
+            false,
+        );
         let statistics = statistics.mut_cf_statistics(cf);
         if !cursor.seek(start_key, statistics)? {
             return Ok(vec![]);
@@ -249,7 +254,12 @@ impl<'a, S: Snapshot, F: KvFormat> RawStoreInner<S, F> {
         if limit == 0 {
             return Ok(vec![]);
         }
-        let mut cursor = Cursor::new(self.snapshot.iter(cf, option)?, ScanMode::Backward, false);
+        let mut cursor = Cursor::new(
+            self.snapshot.iter(cf, option)?,
+            ScanMode::Backward,
+            false,
+            false,
+        );
         let statistics = statistics.mut_cf_statistics(cf);
         if !cursor.reverse_seek(start_key, statistics)? {
             return Ok(vec![]);
@@ -300,7 +310,12 @@ impl<'a, S: Snapshot, F: KvFormat> RawStoreInner<S, F> {
             let cf_stats = stats.mut_cf_statistics(cf);
             let mut opts = IterOptions::new(None, None, false);
             opts.set_upper_bound(r.get_end_key(), DATA_KEY_PREFIX_LEN);
-            let mut cursor = Cursor::new(self.snapshot.iter(cf, opts)?, ScanMode::Forward, false);
+            let mut cursor = Cursor::new(
+                self.snapshot.iter(cf, opts)?,
+                ScanMode::Forward,
+                false,
+                false,
+            );
             cursor.seek(&Key::from_encoded(r.get_start_key().to_vec()), cf_stats)?;
             while cursor.valid()? {
                 row_count += 1;

--- a/tests/integrations/storage/test_raftkv.rs
+++ b/tests/integrations/storage/test_raftkv.rs
@@ -454,6 +454,7 @@ fn assert_seek<E: Engine>(
         snapshot.iter(cf, IterOptions::default()).unwrap(),
         ScanMode::Mixed,
         false,
+        false,
     );
     let mut statistics = CfStatistics::default();
     cursor.seek(&Key::from_raw(key), &mut statistics).unwrap();
@@ -533,6 +534,7 @@ fn seek<E: Engine>(ctx: SnapContext<'_>, engine: &mut E) {
         snapshot.iter(CF_DEFAULT, IterOptions::default()).unwrap(),
         ScanMode::Mixed,
         false,
+        false,
     );
     let mut statistics = CfStatistics::default();
     assert!(
@@ -551,6 +553,7 @@ fn near_seek<E: Engine>(ctx: SnapContext<'_>, engine: &mut E) {
     let mut cursor = Cursor::new(
         snapshot.iter(CF_DEFAULT, IterOptions::default()).unwrap(),
         ScanMode::Mixed,
+        false,
         false,
     );
     assert_near_seek(&mut cursor, b"x", (b"x", b"1"));


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Close #19565

See: https://github.com/tikv/tikv/issues/19565#issuecomment-4497043662

What's Changed:

Add an opt-in missing range cache to mixed cursors. When a seek lands on a later key, the cursor can cache the empty [lower, upper) range and let later seek/near_seek calls inside that range keep the cursor on upper instead of taking the mixed-mode prev path.

Enable the cache for CDC old-value write cursors so incremental scan can avoid repeated old-value cursor prev operations for insert-like Put locks whose old writes are missing. Expose hit_missing_range and cache_missing_range through CfStatistics for observability.

Before this PR:

After the workload stops, it takes more than an hour for the checkpoint to catch up. 
If the workload does not stop, the checkpoint will not advance or will advance very slowly. 
The CDC Worker CPU is very high and stays at 100% after the workload stops. 
There are a large number of prev calls.

<img width="1796" height="508" alt="img_v3_0211s_606913e5-d6ec-4b80-b9ba-de3a216436dg" src="https://github.com/user-attachments/assets/b3613d24-900b-4b84-a313-57ed3c1d92ea" />
<img width="1434" height="540" alt="img_v3_0211s_cf279ea3-93aa-4898-b336-2afcbb83ed3g" src="https://github.com/user-attachments/assets/e2a9381b-6b10-4514-81e8-54f1b0d8a265" />
<img width="2886" height="1310" alt="img_v3_0211s_c1d08418-4abd-4bec-b66c-4d559103c20g" src="https://github.com/user-attachments/assets/16b03ad1-2ee3-482b-a653-1deab1ec47e9" />
<img width="2890" height="1346" alt="img_v3_0211s_f6935723-30a0-4336-af79-0aa4d0ae2f9g" src="https://github.com/user-attachments/assets/4c09abcf-f336-491b-b62d-22df288ea944" />
<img width="2868" height="1308" alt="img_v3_0211s_6e80e592-8dcb-4cd1-b540-cfacf536d19g" src="https://github.com/user-attachments/assets/f66fe3b5-ce1b-4e6e-9c82-1e54fe3a52f9" />

After this PR:

While the workload continues, the maximum checkpoint lag is no more than two minutes, CDC Worker CPU usage does not exceed 100%, and the large number of prev calls have been converted into cheap hit_missing_range calls. After the workload stops, the checkpoint catches up quickly.

<img width="1438" height="536" alt="img_v3_0211s_e2b205f8-3980-4231-90c5-846d3f44f5fg" src="https://github.com/user-attachments/assets/f3dd3a10-ba6b-42aa-8dac-6955aabfefe3" />
<img width="2176" height="580" alt="img_v3_0211s_8fafee64-bb5c-4e79-b28f-65fb2a79358g" src="https://github.com/user-attachments/assets/9b87843f-b598-4670-b1e4-c1b3f31549cd" />
<img width="1452" height="556" alt="img_v3_0211s_212194ec-fff1-4dc8-b648-7a90306e129g" src="https://github.com/user-attachments/assets/8534dc08-65a2-41b1-8d83-aff7a8c4185e" />


### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
Reduce unnecessary old-value cursor prev operations during CDC incremental scan when scanning insert-like prewrite locks.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Missing-range caching for scan cursors to reduce repeated lookups and improve scan efficiency.

* **Tests**
  * Expanded seek/near-seek and incremental-scan tests, including a new incremental test validating old-value lookup behavior with the missing-range cache and updates to cursor-related tests.

* **Chores**
  * Added metrics and statistics to report missing-range cache hits and cache events.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tikv/tikv/pull/19614?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->